### PR TITLE
[Shipping Labels Revamp] Add Weight support to custom package creation

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/packages/WooShippingLabelPackageCreationScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/packages/WooShippingLabelPackageCreationScreen.kt
@@ -132,21 +132,21 @@ fun WooShippingLabelsPackageCreationScreenPreview() {
                     savedPackages = listOf(
                         PackageData(
                             name = "Small Flat Rate Box",
-                            dimensions = "10 x 10 x 10 cm",
+                            dimensions = "10 x 10 x 10",
                             weight = "10",
                             isSelected = true,
                             isLetter = true
                         ),
                         PackageData(
                             name = "Small Flat Rate Box",
-                            dimensions = "20 x 20 x 20 cm",
+                            dimensions = "20 x 20 x 20",
                             weight = "10",
                             isSelected = false,
                             isLetter = false
                         ),
                         PackageData(
                             name = "Small Flat Rate Box",
-                            dimensions = "30 x 30 x 30 cm",
+                            dimensions = "30 x 30 x 30",
                             weight = "10",
                             isSelected = false,
                             isLetter = false

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/packages/WooShippingLabelPackageCreationScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/packages/WooShippingLabelPackageCreationScreen.kt
@@ -133,18 +133,21 @@ fun WooShippingLabelsPackageCreationScreenPreview() {
                         PackageData(
                             name = "Small Flat Rate Box",
                             dimensions = "10 x 10 x 10 cm",
+                            weight = "10",
                             isSelected = true,
                             isLetter = true
                         ),
                         PackageData(
                             name = "Small Flat Rate Box",
                             dimensions = "20 x 20 x 20 cm",
+                            weight = "10",
                             isSelected = false,
                             isLetter = false
                         ),
                         PackageData(
                             name = "Small Flat Rate Box",
                             dimensions = "30 x 30 x 30 cm",
+                            weight = "10",
                             isSelected = false,
                             isLetter = false
                         )

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/packages/WooShippingLabelPackageCreationScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/packages/WooShippingLabelPackageCreationScreen.kt
@@ -114,6 +114,7 @@ fun WooShippingLabelsPackageCreationScreenPreview() {
                     packageLength = "10",
                     packageWidth = "10",
                     packageHeight = "10",
+                    packageWeight = "10",
                     isAddPackageEnabled = true,
                     isSaveAsTemplateChecked = true,
                     onAddPackageClick = {},
@@ -121,8 +122,9 @@ fun WooShippingLabelsPackageCreationScreenPreview() {
                     onLengthChange = {},
                     onWidthChange = {},
                     onHeightChange = {},
+                    onWeightChange = {},
                     onPackageNameChange = {},
-                    onSavePackageChanged = { }
+                    onSavePackageChanged = {}
                 )
             },
             createSavedPackageScreen = {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/packages/WooShippingLabelPackageCreationViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/packages/WooShippingLabelPackageCreationViewModel.kt
@@ -152,6 +152,13 @@ class WooShippingLabelPackageCreationViewModel @Inject constructor(
         }
     }
 
+    fun onWeightChange(weight: String) {
+        _viewState.update {
+            val newPackageData = it.customPackageCreationData.copy(weight = weight)
+            it.copy(customPackageCreationData = newPackageData)
+        }
+    }
+
     fun onSavePackageChanged(checked: Boolean) {
         _viewState.update {
             val newPackageData = it.customPackageCreationData.copy(saveAsTemplate = checked)
@@ -191,7 +198,7 @@ class WooShippingLabelPackageCreationViewModel @Inject constructor(
                         innerDimensions = it.dimensions,
                         boxWeight = 0.0,
                         isUserDefined = true,
-                        maxWeight = 0.0
+                        maxWeight = it.weight.toDoubleOrNull() ?: 0.0
                     )
                 }.let { listOf(it) }
             )

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/packages/WooShippingLabelPackageCreationViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/packages/WooShippingLabelPackageCreationViewModel.kt
@@ -198,7 +198,7 @@ class WooShippingLabelPackageCreationViewModel @Inject constructor(
                         innerDimensions = it.dimensions,
                         boxWeight = 0.0,
                         isUserDefined = true,
-                        maxWeight = it.weight.toDoubleOrNull() ?: 0.0
+                        maxWeight = it.weight?.toDoubleOrNull() ?: 0.0
                     )
                 }.let { listOf(it) }
             )

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/packages/WooShippingLabelPackageCreationViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/packages/WooShippingLabelPackageCreationViewModel.kt
@@ -196,9 +196,9 @@ class WooShippingLabelPackageCreationViewModel @Inject constructor(
                         name = it.name,
                         isLetter = it.type == PackageType.ENVELOPE,
                         innerDimensions = it.dimensions,
-                        boxWeight = 0.0,
+                        boxWeight = it.weight?.toDoubleOrNull() ?: 0.0,
                         isUserDefined = true,
-                        maxWeight = it.weight?.toDoubleOrNull() ?: 0.0
+                        maxWeight = 0.0
                     )
                 }.let { listOf(it) }
             )

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/packages/components/WooShippingPackageListItem.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/packages/components/WooShippingPackageListItem.kt
@@ -51,8 +51,8 @@ fun WooSavedPackageListItem(
                 Text(
                     text = packageData.weight
                         .takeIf { it.isNotEmpty() }
-                        ?.let { "${packageData.dimensions} • $it" }
-                        ?: packageData.dimensions,
+                        ?.let { "${packageData.dimensionForDisplay} • ${packageData.weightForDisplay}" }
+                        ?: packageData.dimensionForDisplay,
                     style = MaterialTheme.typography.body2
                 )
             }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/packages/components/WooShippingPackageListItem.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/packages/components/WooShippingPackageListItem.kt
@@ -49,7 +49,10 @@ fun WooSavedPackageListItem(
                     style = MaterialTheme.typography.body1
                 )
                 Text(
-                    text = packageData.dimensions,
+                    text = packageData.weight
+                        .takeIf { it.isNotEmpty() }
+                        ?.let { "${packageData.dimensions} • $it" }
+                        ?: packageData.dimensions,
                     style = MaterialTheme.typography.body2
                 )
             }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/packages/datasource/FetchPredefinedPackagesFromStore.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/packages/datasource/FetchPredefinedPackagesFromStore.kt
@@ -37,7 +37,9 @@ class FetchPredefinedPackagesFromStore @Inject constructor(
                 dimensions = packageDAO.dimensions,
                 weight = packageDAO.weight,
                 isSelected = false,
-                isLetter = packageDAO.isLetter
+                isLetter = packageDAO.isLetter,
+                dimensionUnit = packageDAO.dimensionUnit,
+                weightUnit = packageDAO.weightUnit
             )
         }
 
@@ -63,7 +65,9 @@ class FetchPredefinedPackagesFromStore @Inject constructor(
                         dimensions = packageItem.dimensions,
                         weight = packageItem.weight,
                         isSelected = false,
-                        isLetter = packageItem.isLetter
+                        isLetter = packageItem.isLetter,
+                        dimensionUnit = packageItem.dimensionUnit,
+                        weightUnit = packageItem.weightUnit
                     )
                 }
             )

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/packages/datasource/FetchPredefinedPackagesFromStore.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/packages/datasource/FetchPredefinedPackagesFromStore.kt
@@ -35,6 +35,7 @@ class FetchPredefinedPackagesFromStore @Inject constructor(
             PackageData(
                 name = packageDAO.name,
                 dimensions = packageDAO.dimensions,
+                weight = packageDAO.weight,
                 isSelected = false,
                 isLetter = packageDAO.isLetter
             )
@@ -60,6 +61,7 @@ class FetchPredefinedPackagesFromStore @Inject constructor(
                     PackageData(
                         name = packageItem.name,
                         dimensions = packageItem.dimensions,
+                        weight = packageItem.weight,
                         isSelected = false,
                         isLetter = packageItem.isLetter
                     )

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/packages/datasource/PackageDAOs.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/packages/datasource/PackageDAOs.kt
@@ -9,6 +9,7 @@ data class PackageDAO(
     val id: String,
     val name: String,
     val dimensions: String,
+    val weight: String,
     val isLetter: Boolean
 )
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/packages/datasource/PackageDAOs.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/packages/datasource/PackageDAOs.kt
@@ -10,7 +10,9 @@ data class PackageDAO(
     val name: String,
     val dimensions: String,
     val weight: String,
-    val isLetter: Boolean
+    val isLetter: Boolean,
+    val dimensionUnit: String,
+    val weightUnit: String
 )
 
 data class CarrierDAO(

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/packages/datasource/WooShippingLabelPackageMapper.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/packages/datasource/WooShippingLabelPackageMapper.kt
@@ -7,6 +7,7 @@ import com.woocommerce.android.ui.orders.wooshippinglabels.packages.networking.C
 import com.woocommerce.android.ui.orders.wooshippinglabels.packages.networking.CustomPackageCreationResponse
 import com.woocommerce.android.ui.orders.wooshippinglabels.packages.networking.CustomPackageDTO
 import com.woocommerce.android.ui.orders.wooshippinglabels.packages.networking.PackageResponse
+import com.woocommerce.android.ui.orders.wooshippinglabels.packages.networking.PackageStoreOptionsDTO
 import javax.inject.Inject
 
 class WooShippingLabelPackageMapper @Inject constructor() {
@@ -14,50 +15,60 @@ class WooShippingLabelPackageMapper @Inject constructor() {
         val savedPackagesResponse = response.packages?.saved?.custom ?: emptyList()
 
         return StorePackagesDAO(
-            savedPackages = mapSavedPackages(savedPackagesResponse),
-            carrierPackages = mapCarrierPackages(response.packages?.predefined)
+            savedPackages = mapSavedPackages(savedPackagesResponse, response.storeOptions),
+            carrierPackages = mapCarrierPackages(response.packages?.predefined, response.storeOptions)
         )
     }
 
-    operator fun invoke(resopnse: CustomPackageCreationResponse): List<PackageDAO> {
-        return resopnse.custom?.map {
+    operator fun invoke(
+        response: CustomPackageCreationResponse
+    ): List<PackageDAO> {
+        return response.custom?.map {
             PackageDAO(
                 id = it.id.orEmpty(),
                 name = it.name.orEmpty(),
                 dimensions = it.dimensions.orEmpty(),
                 weight = it.boxWeight?.toString().orEmpty(),
-                isLetter = it.isLetter ?: false
+                isLetter = it.isLetter ?: false,
+                dimensionUnit = "",
+                weightUnit = ""
             )
         } ?: emptyList()
     }
 
-    private fun mapSavedPackages(savedResponse: List<CustomPackageDTO>): List<PackageDAO> {
+    private fun mapSavedPackages(
+        savedResponse: List<CustomPackageDTO>,
+        storeOptions: PackageStoreOptionsDTO?
+    ): List<PackageDAO> {
         return savedResponse.map {
             PackageDAO(
                 id = it.id.orEmpty(),
                 name = it.name.orEmpty(),
                 dimensions = it.dimensions.orEmpty(),
                 weight = it.boxWeight?.toString().orEmpty(),
-                isLetter = it.isLetter ?: false
+                isLetter = it.isLetter ?: false,
+                dimensionUnit = storeOptions?.dimensionUnit.orEmpty(),
+                weightUnit = storeOptions?.weightUnit.orEmpty()
             )
         }
     }
 
     private fun mapCarrierPackages(
-        carrierPackagesResponse: CarrierPredefinedPackagesDTO?
+        carrierPackagesResponse: CarrierPredefinedPackagesDTO?,
+        storeOptions: PackageStoreOptionsDTO?
     ): Map<CarrierType, CarrierDAO> {
         val uspsPackages = mutableListOf<CarrierPackageGroupDAO>().apply {
             carrierPackagesResponse?.usps?.let { usps ->
-                usps.flatBoxes?.toCarrierGroup()?.let { add(it) }
-                usps.boxes?.toCarrierGroup()?.let { add(it) }
-                usps.expressBoxes?.toCarrierGroup()?.let { add(it) }
-                usps.envelopes?.toCarrierGroup()?.let { add(it) }
+                usps.flatBoxes?.toCarrierGroup(storeOptions)?.let { add(it) }
+                usps.boxes?.toCarrierGroup(storeOptions)?.let { add(it) }
+                usps.expressBoxes?.toCarrierGroup(storeOptions)?.let { add(it) }
+                usps.envelopes?.toCarrierGroup(storeOptions)?.let { add(it) }
             }
         }.let { CarrierDAO(it) }
 
         val dhlPackages = mutableListOf<CarrierPackageGroupDAO>().apply {
             carrierPackagesResponse?.dhlExpress?.let { dhl ->
-                dhl.domesticAndInternationalPackages?.toCarrierGroup()?.let { add(it) }
+                dhl.domesticAndInternationalPackages?.toCarrierGroup(storeOptions)?.let { add(it) }
             }
         }.let { CarrierDAO(it) }
 
@@ -67,7 +78,9 @@ class WooShippingLabelPackageMapper @Inject constructor() {
         )
     }
 
-    private fun CarrierPackageGroupDTO.toCarrierGroup() = CarrierPackageGroupDAO(
+    private fun CarrierPackageGroupDTO.toCarrierGroup(
+        storeOptions: PackageStoreOptionsDTO?
+    ) = CarrierPackageGroupDAO(
         description = title.orEmpty(),
         packages = definitions?.map {
             PackageDAO(
@@ -75,7 +88,9 @@ class WooShippingLabelPackageMapper @Inject constructor() {
                 name = it.name.orEmpty(),
                 dimensions = it.outerDimensions.orEmpty(),
                 weight = it.boxWeight?.toString().orEmpty(),
-                isLetter = it.isLetter ?: false
+                isLetter = it.isLetter ?: false,
+                dimensionUnit = storeOptions?.dimensionUnit.orEmpty(),
+                weightUnit = storeOptions?.weightUnit.orEmpty()
             )
         } ?: emptyList()
     )

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/packages/datasource/WooShippingLabelPackageMapper.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/packages/datasource/WooShippingLabelPackageMapper.kt
@@ -25,6 +25,7 @@ class WooShippingLabelPackageMapper @Inject constructor() {
                 id = it.id.orEmpty(),
                 name = it.name.orEmpty(),
                 dimensions = it.dimensions.orEmpty(),
+                weight = it.boxWeight?.toString().orEmpty(),
                 isLetter = it.isLetter ?: false
             )
         } ?: emptyList()
@@ -36,6 +37,7 @@ class WooShippingLabelPackageMapper @Inject constructor() {
                 id = it.id.orEmpty(),
                 name = it.name.orEmpty(),
                 dimensions = it.dimensions.orEmpty(),
+                weight = it.boxWeight?.toString().orEmpty(),
                 isLetter = it.isLetter ?: false
             )
         }
@@ -72,6 +74,7 @@ class WooShippingLabelPackageMapper @Inject constructor() {
                 id = it.id.orEmpty(),
                 name = it.name.orEmpty(),
                 dimensions = it.outerDimensions.orEmpty(),
+                weight = it.boxWeight?.toString().orEmpty(),
                 isLetter = it.isLetter ?: false
             )
         } ?: emptyList()

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/packages/ui/UIModels.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/packages/ui/UIModels.kt
@@ -21,24 +21,12 @@ data class PackageData(
 }
 
 @Parcelize
-data class PredefinedPackage(
-    val boxWeight: Double,
-    val isFlatRate: Boolean,
-    val id: String,
-    val name: String,
-    val dimensions: String,
-    val maxWeight: Double,
-    val isLetter: Boolean,
-    val groupId: String,
-    val canShipInternational: Boolean
-) : Parcelable
-
-@Parcelize
 data class CustomPackageCreationData(
     val type: PackageType,
     val length: String,
     val width: String,
     val height: String,
+    val weight: String,
     val saveAsTemplate: Boolean,
     val name: String? = null
 ) : Parcelable {
@@ -68,6 +56,7 @@ data class CustomPackageCreationData(
             length = "",
             width = "",
             height = "",
+            weight = "",
             saveAsTemplate = false
         )
     }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/packages/ui/UIModels.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/packages/ui/UIModels.kt
@@ -27,7 +27,7 @@ data class CustomPackageCreationData(
     val width: String,
     val height: String,
     val saveAsTemplate: Boolean,
-    val weight: String ? = null,
+    val weight: String? = null,
     val name: String? = null
 ) : Parcelable {
     val isValid: Boolean

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/packages/ui/UIModels.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/packages/ui/UIModels.kt
@@ -12,7 +12,9 @@ data class PackageData(
     val dimensions: String,
     val weight: String,
     val isSelected: Boolean,
-    val isLetter: Boolean
+    val isLetter: Boolean,
+    val dimensionUnit: String = "cm",
+    val weightUnit: String = "kg"
 ) : Parcelable {
     val descriptionResId: Int
         get() = when (isLetter) {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/packages/ui/UIModels.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/packages/ui/UIModels.kt
@@ -26,8 +26,8 @@ data class CustomPackageCreationData(
     val length: String,
     val width: String,
     val height: String,
-    val weight: String,
     val saveAsTemplate: Boolean,
+    val weight: String ? = null,
     val name: String? = null
 ) : Parcelable {
     val isValid: Boolean
@@ -40,7 +40,7 @@ data class CustomPackageCreationData(
         get() {
             if (saveAsTemplate.not()) return true
 
-            return name.isNotNullOrEmpty()
+            return name.isNotNullOrEmpty() && weight.isNotNullOrEmpty()
         }
 
     fun toPackageData(dimensionUnit: String = "cm") = PackageData(

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/packages/ui/UIModels.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/packages/ui/UIModels.kt
@@ -10,6 +10,7 @@ import kotlinx.parcelize.Parcelize
 data class PackageData(
     val name: String,
     val dimensions: String,
+    val weight: String,
     val isSelected: Boolean,
     val isLetter: Boolean
 ) : Parcelable {
@@ -46,6 +47,7 @@ data class CustomPackageCreationData(
     fun toPackageData(dimensionUnit: String = "cm") = PackageData(
         name = "",
         dimensions = "$length x $width x $height $dimensionUnit",
+        weight = weight.orEmpty(),
         isSelected = true,
         isLetter = type == PackageType.ENVELOPE
     )

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/packages/ui/UIModels.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/packages/ui/UIModels.kt
@@ -21,6 +21,12 @@ data class PackageData(
             true -> R.string.woo_shipping_labels_package_creation_envelope_type
             false -> R.string.woo_shipping_labels_package_creation_box_type
         }
+
+    val dimensionForDisplay
+        get() = "$dimensions $dimensionUnit"
+
+    val weightForDisplay
+        get() = "$weight $weightUnit"
 }
 
 @Parcelize

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/packages/ui/WooShippingCarrierPackageScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/packages/ui/WooShippingCarrierPackageScreen.kt
@@ -232,12 +232,14 @@ fun WooShippingCarrierPackageScreenPreview() {
                             PackageData(
                                 name = "Package 1 - Carrier 1",
                                 dimensions = "10 x 10 x 10 cm",
+                                weight = "10",
                                 isSelected = false,
                                 isLetter = false
                             ),
                             PackageData(
                                 name = "Package 2 - Carrier 1",
                                 dimensions = "20 x 20 x 20 cm",
+                                weight = "20",
                                 isSelected = false,
                                 isLetter = false
                             )
@@ -249,12 +251,14 @@ fun WooShippingCarrierPackageScreenPreview() {
                             PackageData(
                                 name = "Package 3 - Carrier 1",
                                 dimensions = "30 x 30 x 30 cm",
+                                weight = "30",
                                 isSelected = false,
                                 isLetter = false
                             ),
                             PackageData(
                                 name = "Package 4 - Carrier 1",
                                 dimensions = "40 x 40 x 40 cm",
+                                weight = "40",
                                 isSelected = false,
                                 isLetter = false
                             )
@@ -268,12 +272,14 @@ fun WooShippingCarrierPackageScreenPreview() {
                             PackageData(
                                 name = "Package 1 - Carrier 2",
                                 dimensions = "10 x 10 x 10 cm",
+                                weight = "10",
                                 isSelected = false,
                                 isLetter = false
                             ),
                             PackageData(
                                 name = "Package 2 Carrier - 2",
                                 dimensions = "20 x 20 x 20 cm",
+                                weight = "20",
                                 isSelected = false,
                                 isLetter = false
                             )

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/packages/ui/WooShippingCarrierPackageScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/packages/ui/WooShippingCarrierPackageScreen.kt
@@ -231,14 +231,14 @@ fun WooShippingCarrierPackageScreenPreview() {
                         packages = listOf(
                             PackageData(
                                 name = "Package 1 - Carrier 1",
-                                dimensions = "10 x 10 x 10 cm",
+                                dimensions = "10 x 10 x 10",
                                 weight = "10",
                                 isSelected = false,
                                 isLetter = false
                             ),
                             PackageData(
                                 name = "Package 2 - Carrier 1",
-                                dimensions = "20 x 20 x 20 cm",
+                                dimensions = "20 x 20 x 20",
                                 weight = "20",
                                 isSelected = false,
                                 isLetter = false
@@ -250,14 +250,14 @@ fun WooShippingCarrierPackageScreenPreview() {
                         packages = listOf(
                             PackageData(
                                 name = "Package 3 - Carrier 1",
-                                dimensions = "30 x 30 x 30 cm",
+                                dimensions = "30 x 30 x 30",
                                 weight = "30",
                                 isSelected = false,
                                 isLetter = false
                             ),
                             PackageData(
                                 name = "Package 4 - Carrier 1",
-                                dimensions = "40 x 40 x 40 cm",
+                                dimensions = "40 x 40 x 40",
                                 weight = "40",
                                 isSelected = false,
                                 isLetter = false
@@ -271,14 +271,14 @@ fun WooShippingCarrierPackageScreenPreview() {
                         packages = listOf(
                             PackageData(
                                 name = "Package 1 - Carrier 2",
-                                dimensions = "10 x 10 x 10 cm",
+                                dimensions = "10 x 10 x 10",
                                 weight = "10",
                                 isSelected = false,
                                 isLetter = false
                             ),
                             PackageData(
                                 name = "Package 2 Carrier - 2",
-                                dimensions = "20 x 20 x 20 cm",
+                                dimensions = "20 x 20 x 20",
                                 weight = "20",
                                 isSelected = false,
                                 isLetter = false

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/packages/ui/WooShippingCustomPackageScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/packages/ui/WooShippingCustomPackageScreen.kt
@@ -41,6 +41,7 @@ fun WooShippingCustomPackageCreationScreen(viewModel: WooShippingLabelPackageCre
         packageHeight = viewState?.customPackageCreationData?.height.orEmpty(),
         packageLength = viewState?.customPackageCreationData?.length.orEmpty(),
         packageWidth = viewState?.customPackageCreationData?.width.orEmpty(),
+        packageWeight = viewState?.customPackageCreationData?.weight.orEmpty(),
         isAddPackageEnabled = viewState?.customPackageCreationData?.isValid ?: false,
         isSaveAsTemplateChecked = viewState?.customPackageCreationData?.saveAsTemplate ?: false,
         onAddPackageClick = viewModel::onAddCustomPackageClick,
@@ -48,6 +49,7 @@ fun WooShippingCustomPackageCreationScreen(viewModel: WooShippingLabelPackageCre
         onLengthChange = viewModel::onLengthChange,
         onWidthChange = viewModel::onWidthChange,
         onHeightChange = viewModel::onHeightChange,
+        onWeightChange = viewModel::onWeightChange,
         onPackageNameChange = viewModel::onPackageNameChange,
         onSavePackageChanged = viewModel::onSavePackageChanged
     )
@@ -61,6 +63,7 @@ fun WooShippingCustomPackageCreationScreen(
     packageLength: String,
     packageWidth: String,
     packageHeight: String,
+    packageWeight: String,
     isAddPackageEnabled: Boolean,
     isSaveAsTemplateChecked: Boolean,
     onAddPackageClick: (saveAsTemplate: Boolean) -> Unit,
@@ -68,6 +71,7 @@ fun WooShippingCustomPackageCreationScreen(
     onLengthChange: (String) -> Unit,
     onWidthChange: (String) -> Unit,
     onHeightChange: (String) -> Unit,
+    onWeightChange: (String) -> Unit,
     onPackageNameChange: (String) -> Unit,
     onSavePackageChanged: (Boolean) -> Unit
 ) {
@@ -170,6 +174,7 @@ fun PreviewWooShippingCustomPackageCreationScreen() {
             packageLength = "10",
             packageWidth = "10",
             packageHeight = "10",
+            packageWeight = "10",
             isAddPackageEnabled = true,
             isSaveAsTemplateChecked = true,
             onAddPackageClick = {},
@@ -177,6 +182,7 @@ fun PreviewWooShippingCustomPackageCreationScreen() {
             onLengthChange = {},
             onWidthChange = {},
             onHeightChange = {},
+            onWeightChange = {},
             onPackageNameChange = {},
             onSavePackageChanged = {}
         )

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/packages/ui/WooShippingCustomPackageScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/packages/ui/WooShippingCustomPackageScreen.kt
@@ -21,6 +21,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.input.ImeAction
+import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import com.woocommerce.android.R
@@ -102,7 +103,10 @@ fun WooShippingCustomPackageCreationScreen(
                     onValueChange = onLengthChange,
                     label = stringResource(id = R.string.woo_shipping_labels_package_creation_length),
                     singleLine = true,
-                    keyboardOptions = KeyboardOptions(imeAction = ImeAction.Next),
+                    keyboardOptions = KeyboardOptions(
+                        keyboardType = KeyboardType.Number,
+                        imeAction = ImeAction.Next
+                    ),
                     modifier = modifier.weight(1f)
                 )
 
@@ -111,7 +115,10 @@ fun WooShippingCustomPackageCreationScreen(
                     onValueChange = onWidthChange,
                     label = stringResource(id = R.string.woo_shipping_labels_package_creation_width),
                     singleLine = true,
-                    keyboardOptions = KeyboardOptions(imeAction = ImeAction.Next),
+                    keyboardOptions = KeyboardOptions(
+                        keyboardType = KeyboardType.Number,
+                        imeAction = ImeAction.Next
+                    ),
                     modifier = modifier.weight(1f)
                 )
 
@@ -120,7 +127,10 @@ fun WooShippingCustomPackageCreationScreen(
                     onValueChange = onHeightChange,
                     label = stringResource(id = R.string.woo_shipping_labels_package_creation_height),
                     singleLine = true,
-                    keyboardOptions = KeyboardOptions(imeAction = ImeAction.Next),
+                    keyboardOptions = KeyboardOptions(
+                        keyboardType = KeyboardType.Number,
+                        imeAction = ImeAction.Next
+                    ),
                     modifier = modifier.weight(1f)
                 )
             }
@@ -148,7 +158,10 @@ fun WooShippingCustomPackageCreationScreen(
                         onValueChange = onWeightChange,
                         label = stringResource(id = R.string.woo_shipping_labels_package_creation_weight),
                         singleLine = true,
-                        keyboardOptions = KeyboardOptions(imeAction = ImeAction.Next),
+                        keyboardOptions = KeyboardOptions(
+                            keyboardType = KeyboardType.Number,
+                            imeAction = ImeAction.Next
+                        ),
                         modifier = modifier.fillMaxWidth()
                     )
                 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/packages/ui/WooShippingCustomPackageScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/packages/ui/WooShippingCustomPackageScreen.kt
@@ -144,6 +144,16 @@ fun WooShippingCustomPackageCreationScreen(
             if (isSaveAsTemplateChecked) {
                 Column(modifier = modifier) {
                     WCOutlinedTextField(
+                        value = packageWeight,
+                        onValueChange = onWeightChange,
+                        label = stringResource(id = R.string.woo_shipping_labels_package_creation_weight),
+                        singleLine = true,
+                        keyboardOptions = KeyboardOptions(imeAction = ImeAction.Next),
+                        modifier = modifier.fillMaxWidth()
+                    )
+                }
+                Column(modifier = modifier) {
+                    WCOutlinedTextField(
                         value = packageName,
                         onValueChange = onPackageNameChange,
                         label = stringResource(id = R.string.woo_shipping_labels_package_creation_package_name),

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/packages/ui/WooShippingSavedPackageScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/packages/ui/WooShippingSavedPackageScreen.kt
@@ -82,18 +82,21 @@ fun WooShippingSavedPackageScreenPreview() {
                 PackageData(
                     name = "Small Flat Rate Box",
                     dimensions = "10 x 10 x 10 cm",
+                    weight = "10",
                     isSelected = true,
                     isLetter = true
                 ),
                 PackageData(
                     name = "Small Flat Rate Box",
                     dimensions = "20 x 20 x 20 cm",
+                    weight = "20",
                     isSelected = false,
                     isLetter = false
                 ),
                 PackageData(
                     name = "Small Flat Rate Box",
                     dimensions = "30 x 30 x 30 cm",
+                    weight = "30",
                     isSelected = false,
                     isLetter = false
                 )

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -4377,6 +4377,7 @@
     <string name="woo_shipping_labels_package_creation_length">Length</string>
     <string name="woo_shipping_labels_package_creation_width">Width</string>
     <string name="woo_shipping_labels_package_creation_height">Height</string>
+    <string name="woo_shipping_labels_package_creation_weight">Weight</string>
     <string name="woo_shipping_labels_package_creation_package_name">Package Name</string>
     <string name="woo_shipping_labels_package_creation_save_package_option">Save this as a new package template</string>
     <string name="woo_shipping_labels_package_creation_add_package">Add Package</string>

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/packages/WooShippingLabelPackageCreationViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/packages/WooShippingLabelPackageCreationViewModelTest.kt
@@ -174,13 +174,15 @@ class WooShippingLabelPackageCreationViewModelTest : BaseUnitTest() {
         var lastViewState: ViewState? = null
         val package1 = PackageData(
             name = "Package 1",
-            dimensions = "10 x 10 x 10 cm",
+            dimensions = "10 x 10 x 10",
+            weight = "10",
             isSelected = false,
             isLetter = false
         )
         val package2 = PackageData(
             name = "Package 2",
-            dimensions = "20 x 20 x 20 cm",
+            dimensions = "20 x 20 x 20",
+            weight = "20",
             isSelected = false,
             isLetter = true
         )
@@ -215,13 +217,15 @@ class WooShippingLabelPackageCreationViewModelTest : BaseUnitTest() {
         val carrier: Carrier = Carrier.DHL
         val package1 = PackageData(
             name = "Package 1",
-            dimensions = "10 x 10 x 10 cm",
+            dimensions = "10 x 10 x 10",
+            weight = "10",
             isSelected = false,
             isLetter = false
         )
         val package2 = PackageData(
             name = "Package 2",
-            dimensions = "20 x 20 x 20 cm",
+            dimensions = "20 x 20 x 20",
+            weight = "20",
             isSelected = false,
             isLetter = true
         )
@@ -268,25 +272,29 @@ class WooShippingLabelPackageCreationViewModelTest : BaseUnitTest() {
         val carrier2: Carrier = Carrier.USPS
         val package1 = PackageData(
             name = "Package 1 - Carrier 1",
-            dimensions = "10 x 10 x 10 cm",
+            dimensions = "10 x 10 x 10",
+            weight = "10",
             isSelected = false,
             isLetter = false
         )
         val package2 = PackageData(
             name = "Package 2 - Carrier 1",
-            dimensions = "20 x 20 x 20 cm",
+            dimensions = "20 x 20 x 20",
+            weight = "20",
             isSelected = false,
             isLetter = true
         )
         val package3 = PackageData(
             name = "Package 1 - Carrier 2",
-            dimensions = "30 x 30 x 30 cm",
+            dimensions = "30 x 30 x 30",
+            weight = "30",
             isSelected = false,
             isLetter = false
         )
         val package4 = PackageData(
             name = "Package 2 - Carrier 2",
-            dimensions = "40 x 40 x 40 cm",
+            dimensions = "40 x 40 x 40",
+            weight = "40",
             isSelected = false,
             isLetter = true
         )

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/packages/WooShippingLabelPackageCreationViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/packages/WooShippingLabelPackageCreationViewModelTest.kt
@@ -73,12 +73,16 @@ class WooShippingLabelPackageCreationViewModelTest : BaseUnitTest() {
             length = "10",
             width = "10",
             height = "10",
+            weight = "20",
+            name = "Test Package",
             saveAsTemplate = true
         )
 
         sut.onLengthChange("10")
         sut.onWidthChange("10")
         sut.onHeightChange("10")
+        sut.onWeightChange("20")
+        sut.onPackageNameChange("Test Package")
         sut.onSavePackageChanged(true)
         sut.onPackageTypeSelected(PackageType.ENVELOPE)
 

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/packages/datasource/FetchPredefinedPackagesFromStoreTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/packages/datasource/FetchPredefinedPackagesFromStoreTest.kt
@@ -39,12 +39,14 @@ class FetchPredefinedPackagesFromStoreTest : BaseUnitTest() {
             PackageData(
                 name = "Saved Package 1",
                 dimensions = "dimensions",
+                weight = "weight",
                 isSelected = false,
                 isLetter = false
             ),
             PackageData(
                 name = "Saved Package 2",
                 dimensions = "dimensions",
+                weight = "weight",
                 isSelected = false,
                 isLetter = false
             )
@@ -56,6 +58,7 @@ class FetchPredefinedPackagesFromStoreTest : BaseUnitTest() {
                     PackageData(
                         name = "Carrier Package 1",
                         dimensions = "dimensions",
+                        weight = "weight",
                         isSelected = false,
                         isLetter = false
                     )
@@ -91,13 +94,19 @@ class FetchPredefinedPackagesFromStoreTest : BaseUnitTest() {
                 id = "1",
                 name = "Saved Package 1",
                 dimensions = "dimensions",
-                isLetter = false
+                weight = "weight",
+                isLetter = false,
+                dimensionUnit = "cm",
+                weightUnit = "kg"
             ),
             PackageDAO(
                 id = "2",
                 name = "Saved Package 2",
                 dimensions = "dimensions",
-                isLetter = false
+                weight = "weight",
+                isLetter = false,
+                dimensionUnit = "cm",
+                weightUnit = "kg"
             )
         ),
         carrierPackages = mapOf(
@@ -110,7 +119,10 @@ class FetchPredefinedPackagesFromStoreTest : BaseUnitTest() {
                                 id = "1",
                                 name = "Carrier Package 1",
                                 dimensions = "dimensions",
-                                isLetter = false
+                                weight = "weight",
+                                isLetter = false,
+                                dimensionUnit = "cm",
+                                weightUnit = "kg"
                             )
                         )
                     )

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/packages/ui/CustomPackageCreationDataTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/packages/ui/CustomPackageCreationDataTest.kt
@@ -1,0 +1,100 @@
+package com.woocommerce.android.ui.orders.wooshippinglabels.packages.ui
+
+import com.woocommerce.android.ui.orders.wooshippinglabels.packages.WooShippingLabelPackageCreationViewModel.PackageType
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.Test
+
+class CustomPackageCreationDataTest {
+
+    @Test
+    fun `isValid returns true when all fields are filled and saveAsTemplate is false`() {
+        val data = CustomPackageCreationData(
+            type = PackageType.BOX,
+            length = "10",
+            width = "10",
+            height = "10",
+            saveAsTemplate = false
+        )
+
+        assertThat(data.isValid).isTrue
+    }
+
+    @Test
+    fun `isValid returns false when any dimension field is empty`() {
+        val data = CustomPackageCreationData(
+            type = PackageType.BOX,
+            length = "",
+            width = "10",
+            height = "10",
+            saveAsTemplate = false
+        )
+
+        assertThat(data.isValid).isFalse
+    }
+
+    @Test
+    fun `isValid returns false when saveAsTemplate is true and name or weight is empty`() {
+        val data = CustomPackageCreationData(
+            type = PackageType.BOX,
+            length = "10",
+            width = "10",
+            height = "10",
+            saveAsTemplate = true,
+            name = "",
+            weight = "1"
+        )
+
+        assertThat(data.isValid).isFalse
+    }
+
+    @Test
+    fun `isValid returns true when saveAsTemplate is true and name and weight are filled`() {
+        val data = CustomPackageCreationData(
+            type = PackageType.BOX,
+            length = "10",
+            width = "10",
+            height = "10",
+            saveAsTemplate = true,
+            name = "Package",
+            weight = "1"
+        )
+
+        assertThat(data.isValid).isTrue
+    }
+
+    @Test
+    fun `toPackageData returns PackageData with correct values`() {
+        val data = CustomPackageCreationData(
+            type = PackageType.BOX,
+            length = "10",
+            width = "10",
+            height = "10",
+            saveAsTemplate = false
+        )
+
+        val packageData = data.toPackageData()
+
+        assertThat(packageData.name).isEqualTo("")
+        assertThat(packageData.dimensions).isEqualTo("10 x 10 x 10 cm")
+        assertThat(packageData.isSelected).isTrue
+        assertThat(packageData.isLetter).isFalse
+    }
+
+    @Test
+    fun `toPackageData returns PackageData with correct values for envelope type`() {
+        val data = CustomPackageCreationData(
+            type = PackageType.ENVELOPE,
+            length = "10",
+            width = "10",
+            height = "10",
+            saveAsTemplate = false
+        )
+
+        val packageData = data.toPackageData()
+
+        assertThat(packageData.name).isEqualTo("")
+        assertThat(packageData.dimensions).isEqualTo("10 x 10 x 10 cm")
+        assertThat(packageData.isSelected).isTrue
+        assertThat(packageData.isLetter).isTrue
+    }
+}


### PR DESCRIPTION
Summary
==========
This enhancement to issue #12283 adds the full `weight` support through the Packages and enforces the field as required when saving the package as a template.

It also uses the Store defined units for weight and dimensions to avoid incorrect unit representations.

Screen Capture
==========
https://github.com/user-attachments/assets/b8d331a4-0f3b-46ba-8e0c-00ff06a613bb

How to Test
==========
1. Go to the new Shipping Labels form
2. Hit the `Select Package` button
3. In the Custom package tab, fill the package form. Ensure the `Save this as a new package template` option is checked.
4. Hit the `Add Package` button
5. The UI is not currently exiting the Package selection UI, so exit from the Package selection UI manually and hit the `Select Package` again. 
6. Go to the Saved Package tab and verify that the new Package is listed there.

Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

## Reviewer (or Author, in the case of optional code reviews):

Please make sure these conditions are met before approving the PR, or request changes if the PR needs improvement:

- [x] The PR is small and has a clear, single focus, or a valid explanation is provided in the description. If needed, please request to split it into smaller PRs.
- [x] Ensure Adequate Unit Test Coverage: The changes are reasonably covered by unit tests or an explanation is provided in the PR description.
- [x] Manual Testing: The author listed all the tests they ran, including smoke tests when needed (e.g., for refactorings). The reviewer confirmed that the PR works as expected on big (tablet) and small (phone) in case of UI changes, and no regressions are added.
