### PR TITLE
[Shipping Labels Revamp] Update Carrier and Saved packages data for better state control

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/packages/WooShippingLabelPackageCreationScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/packages/WooShippingLabelPackageCreationScreen.kt
@@ -28,6 +28,7 @@ import com.woocommerce.android.ui.orders.wooshippinglabels.packages.WooShippingL
 import com.woocommerce.android.ui.orders.wooshippinglabels.packages.ui.PackageData
 import com.woocommerce.android.ui.orders.wooshippinglabels.packages.ui.WooShippingCarrierPackageScreen
 import com.woocommerce.android.ui.orders.wooshippinglabels.packages.ui.WooShippingCustomPackageCreationScreen
+import com.woocommerce.android.ui.orders.wooshippinglabels.packages.ui.WooShippingSavedPackageContent
 import com.woocommerce.android.ui.orders.wooshippinglabels.packages.ui.WooShippingSavedPackageScreen
 
 @Composable
@@ -128,7 +129,7 @@ fun WooShippingLabelsPackageCreationScreenPreview() {
                 )
             },
             createSavedPackageScreen = {
-                WooShippingSavedPackageScreen(
+                WooShippingSavedPackageContent(
                     savedPackages = listOf(
                         PackageData(
                             name = "Small Flat Rate Box",

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/packages/WooShippingLabelPackageCreationScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/packages/WooShippingLabelPackageCreationScreen.kt
@@ -25,7 +25,10 @@ import com.woocommerce.android.ui.orders.wooshippinglabels.packages.WooShippingL
 import com.woocommerce.android.ui.orders.wooshippinglabels.packages.WooShippingLabelPackageCreationViewModel.PageType.CARRIER
 import com.woocommerce.android.ui.orders.wooshippinglabels.packages.WooShippingLabelPackageCreationViewModel.PageType.CUSTOM
 import com.woocommerce.android.ui.orders.wooshippinglabels.packages.WooShippingLabelPackageCreationViewModel.PageType.SAVED
+import com.woocommerce.android.ui.orders.wooshippinglabels.packages.ui.Carrier
+import com.woocommerce.android.ui.orders.wooshippinglabels.packages.ui.CarrierPackageGroup
 import com.woocommerce.android.ui.orders.wooshippinglabels.packages.ui.PackageData
+import com.woocommerce.android.ui.orders.wooshippinglabels.packages.ui.WooShippingCarrierPackageContent
 import com.woocommerce.android.ui.orders.wooshippinglabels.packages.ui.WooShippingCarrierPackageScreen
 import com.woocommerce.android.ui.orders.wooshippinglabels.packages.ui.WooShippingCustomPackageCreationScreen
 import com.woocommerce.android.ui.orders.wooshippinglabels.packages.ui.WooShippingSavedPackageContent
@@ -158,7 +161,74 @@ fun WooShippingLabelsPackageCreationScreenPreview() {
                     onSavedPackageSelected = { _, _ -> }
                 )
             },
-            createCarrierPackageScreen = { }
+            createCarrierPackageScreen = {
+                WooShippingCarrierPackageContent(
+                    carrierPackages = mapOf(
+                        Carrier.DHL to listOf(
+                            CarrierPackageGroup(
+                                groupName = "Group 1",
+                                packages = listOf(
+                                    PackageData(
+                                        name = "Package 1 - Carrier 1",
+                                        dimensions = "10 x 10 x 10",
+                                        weight = "10",
+                                        isSelected = false,
+                                        isLetter = false
+                                    ),
+                                    PackageData(
+                                        name = "Package 2 - Carrier 1",
+                                        dimensions = "20 x 20 x 20",
+                                        weight = "20",
+                                        isSelected = false,
+                                        isLetter = false
+                                    )
+                                )
+                            ),
+                            CarrierPackageGroup(
+                                groupName = "Group 2",
+                                packages = listOf(
+                                    PackageData(
+                                        name = "Package 3 - Carrier 1",
+                                        dimensions = "30 x 30 x 30",
+                                        weight = "30",
+                                        isSelected = false,
+                                        isLetter = false
+                                    ),
+                                    PackageData(
+                                        name = "Package 4 - Carrier 1",
+                                        dimensions = "40 x 40 x 40",
+                                        weight = "40",
+                                        isSelected = false,
+                                        isLetter = false
+                                    )
+                                )
+                            )
+                        ),
+                        Carrier.USPS to listOf(
+                            CarrierPackageGroup(
+                                groupName = "Group 2",
+                                packages = listOf(
+                                    PackageData(
+                                        name = "Package 1 - Carrier 2",
+                                        dimensions = "10 x 10 x 10",
+                                        weight = "10",
+                                        isSelected = false,
+                                        isLetter = false
+                                    ),
+                                    PackageData(
+                                        name = "Package 2 Carrier - 2",
+                                        dimensions = "20 x 20 x 20",
+                                        weight = "20",
+                                        isSelected = false,
+                                        isLetter = false
+                                    )
+                                )
+                            )
+                        )
+                    ),
+                    onPackageSelected = { _, _ -> }
+                )
+            }
         )
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/packages/WooShippingLabelPackageCreationViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/packages/WooShippingLabelPackageCreationViewModel.kt
@@ -213,6 +213,15 @@ class WooShippingLabelPackageCreationViewModel @Inject constructor(
         val carrierPackageSection: CarrierPackageSelection = CarrierPackageSelection(emptyMap())
     ) : Parcelable
 
+    sealed class PredefinedPackagesState {
+        data class Data(
+            val savedPackageSelection: SavedPackageSelection = SavedPackageSelection(emptyList()),
+            val carrierPackageSelection: CarrierPackageSelection = CarrierPackageSelection(emptyMap())
+        ) : PredefinedPackagesState()
+        data object Error : PredefinedPackagesState()
+        data object Waiting : PredefinedPackagesState()
+    }
+
     @Parcelize
     data class PageTab(
         val title: String,

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/packages/WooShippingLabelPackageCreationViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/packages/WooShippingLabelPackageCreationViewModel.kt
@@ -57,9 +57,11 @@ class WooShippingLabelPackageCreationViewModel @Inject constructor(
 
     init {
         launch {
-            fetchPredefinedPackages()
-                .let { _viewState.value.copy(predefinedPackagesState = it) }
-                .let { _viewState.update { it } }
+            fetchPredefinedPackages().let { response ->
+                _viewState.update { viewState ->
+                    viewState.copy(predefinedPackagesState = response)
+                }
+            }
 
         }
     }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/packages/WooShippingLabelPackageCreationViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/packages/WooShippingLabelPackageCreationViewModel.kt
@@ -62,7 +62,6 @@ class WooShippingLabelPackageCreationViewModel @Inject constructor(
                     viewState.copy(predefinedPackagesState = response)
                 }
             }
-
         }
     }
 
@@ -71,8 +70,9 @@ class WooShippingLabelPackageCreationViewModel @Inject constructor(
             val predefinedPackages = viewState.predefinedPackagesData
             predefinedPackages?.carrierPackages
                 ?.map { updateCarrierPackagesSelection(it, selectedPackage, isSelected) }
-                ?.let { viewState.copy(predefinedPackagesState = predefinedPackages.copy(carrierPackages = it.toMap())) }
-                ?: _viewState.value
+                ?.let {
+                    viewState.copy(predefinedPackagesState = predefinedPackages.copy(carrierPackages = it.toMap()))
+                } ?: _viewState.value
         }
     }
 
@@ -228,7 +228,6 @@ class WooShippingLabelPackageCreationViewModel @Inject constructor(
                 get() = carrierPackages.values.flatten().find { group ->
                     group.packages.find { it.isSelected } != null
                 } != null
-
 
             val hasSavedSelection: Boolean
                 get() = savedPackages.find { it.isSelected } != null

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/packages/WooShippingLabelPackageCreationViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/packages/WooShippingLabelPackageCreationViewModel.kt
@@ -11,10 +11,8 @@ import com.woocommerce.android.ui.orders.wooshippinglabels.packages.datasource.W
 import com.woocommerce.android.ui.orders.wooshippinglabels.packages.networking.CustomPackageCreationRequestData
 import com.woocommerce.android.ui.orders.wooshippinglabels.packages.ui.Carrier
 import com.woocommerce.android.ui.orders.wooshippinglabels.packages.ui.CarrierPackageGroup
-import com.woocommerce.android.ui.orders.wooshippinglabels.packages.ui.CarrierPackageSelection
 import com.woocommerce.android.ui.orders.wooshippinglabels.packages.ui.CustomPackageCreationData
 import com.woocommerce.android.ui.orders.wooshippinglabels.packages.ui.PackageData
-import com.woocommerce.android.ui.orders.wooshippinglabels.packages.ui.SavedPackageSelection
 import com.woocommerce.android.viewmodel.MultiLiveEvent
 import com.woocommerce.android.viewmodel.ResourceProvider
 import com.woocommerce.android.viewmodel.ScopedViewModel
@@ -62,8 +60,9 @@ class WooShippingLabelPackageCreationViewModel @Inject constructor(
             fetchPredefinedPackages()?.let {
                 _viewState.update { viewState ->
                     viewState.copy(
-                        savedPackageSelection = it.savedPackageSelection,
-                        carrierPackageSection = it.carrierPackageSelection
+                        predefinedPackagesState = PredefinedPackagesState.Data(
+                            it.savedPackages, it.carrierPackages
+                        )
                     )
                 }
             }
@@ -72,34 +71,39 @@ class WooShippingLabelPackageCreationViewModel @Inject constructor(
 
     fun onCarrierPackageSelected(selectedPackage: PackageData, isSelected: Boolean) {
         _viewState.update { viewState ->
-            viewState.carrierPackageSection.carrierPackages
-                .map { updateCarrierPackagesSelection(it, selectedPackage, isSelected) }
-                .let { viewState.copy(carrierPackageSection = CarrierPackageSelection(it.toMap())) }
+            val predefinedPackages = viewState.predefinedPackagesData
+            predefinedPackages?.carrierPackages
+                ?.map { updateCarrierPackagesSelection(it, selectedPackage, isSelected) }
+                ?.let { viewState.copy(predefinedPackagesState = predefinedPackages.copy(carrierPackages = it.toMap())) }
+                ?: _viewState.value
         }
     }
 
     fun onSavedPackageSelected(selectedPackage: PackageData, isSelected: Boolean) {
         _viewState.update { viewState ->
-            viewState.savedPackageSelection.packages
-                .map { it.copy(isSelected = false) }
-                .toMutableList()
-                .safelyUpdate(selectedPackage, selectedPackage.copy(isSelected = isSelected))
-                .let { SavedPackageSelection(it) }
-                .let { viewState.copy(savedPackageSelection = it) }
+            val predefinedPackages = viewState.predefinedPackagesData
+            predefinedPackages?.savedPackages
+                ?.map { it.copy(isSelected = false) }
+                ?.toMutableList()
+                ?.safelyUpdate(selectedPackage, selectedPackage.copy(isSelected = isSelected))
+                ?.let { viewState.copy(predefinedPackagesState = predefinedPackages.copy(savedPackages = it)) }
+                ?: _viewState.value
         }
     }
 
     fun onAddCarrierPackageClick() {
-        _viewState.value.carrierPackageSection.carrierPackages
-            .asSequence()
-            .flatMap { it.value }
-            .flatMap { it.packages }
-            .find { it.isSelected }
+        _viewState.value.predefinedPackagesData?.carrierPackages
+            ?.asSequence()
+            ?.flatMap { it.value }
+            ?.flatMap { it.packages }
+            ?.find { it.isSelected }
             ?.let { triggerEvent(PackageSelected(it)) }
     }
 
     fun onAddSavedPackageClick() {
-        _viewState.value.savedPackageSelection.packages.find { it.isSelected }
+        _viewState.value.predefinedPackagesData
+            ?.savedPackages
+            ?.find { it.isSelected }
             ?.let { triggerEvent(PackageSelected(it)) }
     }
 
@@ -209,17 +213,29 @@ class WooShippingLabelPackageCreationViewModel @Inject constructor(
     data class ViewState(
         val pageTabs: List<PageTab> = emptyList(),
         val customPackageCreationData: CustomPackageCreationData = CustomPackageCreationData.EMPTY,
-        val savedPackageSelection: SavedPackageSelection = SavedPackageSelection(emptyList()),
-        val carrierPackageSection: CarrierPackageSelection = CarrierPackageSelection(emptyMap())
-    ) : Parcelable
+        val predefinedPackagesState: PredefinedPackagesState = PredefinedPackagesState.Waiting,
+    ) : Parcelable {
+        val predefinedPackagesData
+            get() = (predefinedPackagesState as? PredefinedPackagesState.Data)
+    }
 
-    sealed class PredefinedPackagesState {
-        data class Data(
-            val savedPackageSelection: SavedPackageSelection = SavedPackageSelection(emptyList()),
-            val carrierPackageSelection: CarrierPackageSelection = CarrierPackageSelection(emptyMap())
-        ) : PredefinedPackagesState()
+    @Parcelize
+    sealed class PredefinedPackagesState : Parcelable {
         data object Error : PredefinedPackagesState()
         data object Waiting : PredefinedPackagesState()
+        data class Data(
+            val savedPackages: List<PackageData> = emptyList(),
+            val carrierPackages: Map<Carrier, List<CarrierPackageGroup>> = emptyMap()
+        ) : PredefinedPackagesState() {
+            val hasCarrierSelection: Boolean
+                get() = carrierPackages.values.flatten().find { group ->
+                    group.packages.find { it.isSelected } != null
+                } != null
+
+
+            val hasSavedSelection: Boolean
+                get() = savedPackages.find { it.isSelected } != null
+        }
     }
 
     @Parcelize

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/packages/WooShippingLabelPackageCreationViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/packages/WooShippingLabelPackageCreationViewModel.kt
@@ -57,15 +57,10 @@ class WooShippingLabelPackageCreationViewModel @Inject constructor(
 
     init {
         launch {
-            fetchPredefinedPackages()?.let {
-                _viewState.update { viewState ->
-                    viewState.copy(
-                        predefinedPackagesState = PredefinedPackagesState.Data(
-                            it.savedPackages, it.carrierPackages
-                        )
-                    )
-                }
-            }
+            fetchPredefinedPackages()
+                .let { _viewState.value.copy(predefinedPackagesState = it) }
+                .let { _viewState.update { it } }
+
         }
     }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/packages/components/PackageItemComponents.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/packages/components/PackageItemComponents.kt
@@ -4,7 +4,10 @@ import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
 import androidx.compose.material.Divider
 import androidx.compose.material.MaterialTheme
 import androidx.compose.material.Text
@@ -13,13 +16,16 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.colorResource
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import com.woocommerce.android.R
+import com.woocommerce.android.ui.compose.animations.SkeletonView
 import com.woocommerce.android.ui.compose.component.SelectionCheck
+import com.woocommerce.android.ui.compose.theme.WooThemeWithBackground
 import com.woocommerce.android.ui.orders.wooshippinglabels.packages.ui.PackageData
 
 @Composable
-fun WooSavedPackageListItem(
+fun WooShippingPackageListItem(
     modifier: Modifier,
     packageData: PackageData,
     onPackageSelected: (PackageData, Boolean) -> Unit
@@ -58,5 +64,70 @@ fun WooSavedPackageListItem(
             }
         }
         Divider()
+    }
+}
+
+@Composable
+fun WooShippingPackageListItemSkeleton(
+    modifier: Modifier = Modifier
+) {
+    Column(
+        modifier = modifier
+            .padding(top = 8.dp)
+            .fillMaxWidth(),
+        verticalArrangement = Arrangement.spacedBy(16.dp)
+    ) {
+        Row(
+            horizontalArrangement = Arrangement.spacedBy(8.dp),
+            verticalAlignment = Alignment.CenterVertically
+        ) {
+            SkeletonView(
+                modifier = Modifier.size(24.dp)
+            )
+            Column(verticalArrangement = Arrangement.spacedBy(4.dp)) {
+                SkeletonView(
+                    modifier = Modifier
+                        .height(16.dp)
+                        .fillMaxWidth(0.5f)
+                )
+                SkeletonView(
+                    modifier = Modifier
+                        .height(20.dp)
+                        .fillMaxWidth(0.7f)
+                )
+                SkeletonView(
+                    modifier = Modifier
+                        .height(16.dp)
+                        .fillMaxWidth(0.6f)
+                )
+            }
+        }
+        Divider()
+    }
+}
+
+@Preview
+@Composable
+fun WooSavedPackageListItemPreview() {
+    WooThemeWithBackground {
+        WooShippingPackageListItem(
+            modifier = Modifier,
+            packageData = PackageData(
+                name = "Small Flat Rate Box",
+                dimensions = "5 x 5 x 5",
+                weight = "1.5",
+                isLetter = false,
+                isSelected = false
+            ),
+            onPackageSelected = { _, _ -> }
+        )
+    }
+}
+
+@Preview
+@Composable
+fun WooSavedPackageListItemSkeletonPreview() {
+    WooThemeWithBackground {
+        WooShippingPackageListItemSkeleton()
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/packages/datasource/FetchPredefinedPackagesFromStore.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/packages/datasource/FetchPredefinedPackagesFromStore.kt
@@ -3,9 +3,7 @@ package com.woocommerce.android.ui.orders.wooshippinglabels.packages.datasource
 import com.woocommerce.android.tools.SelectedSite
 import com.woocommerce.android.ui.orders.wooshippinglabels.packages.ui.Carrier
 import com.woocommerce.android.ui.orders.wooshippinglabels.packages.ui.CarrierPackageGroup
-import com.woocommerce.android.ui.orders.wooshippinglabels.packages.ui.CarrierPackageSelection
 import com.woocommerce.android.ui.orders.wooshippinglabels.packages.ui.PackageData
-import com.woocommerce.android.ui.orders.wooshippinglabels.packages.ui.SavedPackageSelection
 import com.woocommerce.android.ui.orders.wooshippinglabels.packages.ui.StorePredefinedPackages
 import javax.inject.Inject
 
@@ -21,12 +19,8 @@ class FetchPredefinedPackagesFromStore @Inject constructor(
             ?: return null
 
         return StorePredefinedPackages(
-            savedPackageSelection = storePackages
-                .filterSavedData()
-                .let { SavedPackageSelection(it) },
-            carrierPackageSelection = storePackages
-                .filterCarrierData()
-                .let { CarrierPackageSelection(it) }
+            savedPackages = storePackages.filterSavedData(),
+            carrierPackages = storePackages.filterCarrierData()
         )
     }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/packages/datasource/FetchPredefinedPackagesFromStore.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/packages/datasource/FetchPredefinedPackagesFromStore.kt
@@ -1,24 +1,24 @@
 package com.woocommerce.android.ui.orders.wooshippinglabels.packages.datasource
 
 import com.woocommerce.android.tools.SelectedSite
+import com.woocommerce.android.ui.orders.wooshippinglabels.packages.WooShippingLabelPackageCreationViewModel.PredefinedPackagesState
 import com.woocommerce.android.ui.orders.wooshippinglabels.packages.ui.Carrier
 import com.woocommerce.android.ui.orders.wooshippinglabels.packages.ui.CarrierPackageGroup
 import com.woocommerce.android.ui.orders.wooshippinglabels.packages.ui.PackageData
-import com.woocommerce.android.ui.orders.wooshippinglabels.packages.ui.StorePredefinedPackages
 import javax.inject.Inject
 
 class FetchPredefinedPackagesFromStore @Inject constructor(
     private val selectedSite: SelectedSite,
     private val packageRepository: WooShippingLabelPackageRepository
 ) {
-    suspend operator fun invoke(): StorePredefinedPackages? {
+    suspend operator fun invoke(): PredefinedPackagesState {
         val storePackages = selectedSite.getOrNull()
             ?.let { packageRepository.fetchAllStorePackages(it) }
             ?.takeIf { it.isError.not() }
             ?.model
-            ?: return null
+            ?: return PredefinedPackagesState.Error
 
-        return StorePredefinedPackages(
+        return PredefinedPackagesState.Data(
             savedPackages = storePackages.filterSavedData(),
             carrierPackages = storePackages.filterCarrierData()
         )

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/packages/ui/UIModels.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/packages/ui/UIModels.kt
@@ -116,24 +116,6 @@ sealed class Carrier(
 
 @Parcelize
 data class StorePredefinedPackages(
-    val carrierPackageSelection: CarrierPackageSelection,
-    val savedPackageSelection: SavedPackageSelection
+    val carrierPackages: Map<Carrier, List<CarrierPackageGroup>>,
+    val savedPackages: List<PackageData>
 ) : Parcelable
-
-@Parcelize
-data class CarrierPackageSelection(
-    val carrierPackages: Map<Carrier, List<CarrierPackageGroup>>
-) : Parcelable {
-    val hasSelection: Boolean
-        get() = carrierPackages.values.flatten().find { group ->
-            group.packages.find { it.isSelected } != null
-        } != null
-}
-
-@Parcelize
-data class SavedPackageSelection(
-    val packages: List<PackageData>
-) : Parcelable {
-    val hasSelection: Boolean
-        get() = packages.find { it.isSelected } != null
-}

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/packages/ui/UIModels.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/packages/ui/UIModels.kt
@@ -19,8 +19,10 @@ data class PackageData(
 ) : Parcelable {
     @IgnoredOnParcel
     val length: String
+
     @IgnoredOnParcel
     val width: String
+
     @IgnoredOnParcel
     val height: String
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/packages/ui/UIModels.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/packages/ui/UIModels.kt
@@ -4,6 +4,7 @@ import android.os.Parcelable
 import com.woocommerce.android.R
 import com.woocommerce.android.extensions.isNotNullOrEmpty
 import com.woocommerce.android.ui.orders.wooshippinglabels.packages.WooShippingLabelPackageCreationViewModel.PackageType
+import kotlinx.parcelize.IgnoredOnParcel
 import kotlinx.parcelize.Parcelize
 
 @Parcelize
@@ -16,6 +17,20 @@ data class PackageData(
     val dimensionUnit: String = "cm",
     val weightUnit: String = "kg"
 ) : Parcelable {
+    @IgnoredOnParcel
+    val length: String
+    @IgnoredOnParcel
+    val width: String
+    @IgnoredOnParcel
+    val height: String
+
+    init {
+        val dimensionList = dimensions.split("x")
+        length = dimensionList.getOrNull(0).orEmpty().trim()
+        width = dimensionList.getOrNull(1).orEmpty().trim()
+        height = dimensionList.getOrNull(2).orEmpty().trim()
+    }
+
     val descriptionResId: Int
         get() = when (isLetter) {
             true -> R.string.woo_shipping_labels_package_creation_envelope_type

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/packages/ui/WooShippingCarrierPackageScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/packages/ui/WooShippingCarrierPackageScreen.kt
@@ -1,7 +1,6 @@
 package com.woocommerce.android.ui.orders.wooshippinglabels.packages.ui
 
 import androidx.annotation.DrawableRes
-import androidx.compose.foundation.ExperimentalFoundationApi
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
@@ -15,7 +14,9 @@ import androidx.compose.foundation.layout.wrapContentHeight
 import androidx.compose.foundation.pager.HorizontalPager
 import androidx.compose.foundation.pager.PagerState
 import androidx.compose.foundation.pager.rememberPagerState
+import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.Button
 import androidx.compose.material.Divider
 import androidx.compose.material.Icon
@@ -40,23 +41,70 @@ import androidx.compose.ui.unit.dp
 import com.woocommerce.android.R
 import com.woocommerce.android.ui.compose.theme.WooThemeWithBackground
 import com.woocommerce.android.ui.orders.wooshippinglabels.packages.WooShippingLabelPackageCreationViewModel
+import com.woocommerce.android.ui.orders.wooshippinglabels.packages.WooShippingLabelPackageCreationViewModel.PredefinedPackagesState
 import com.woocommerce.android.ui.orders.wooshippinglabels.packages.components.WooShippingPackageListItem
+import com.woocommerce.android.ui.orders.wooshippinglabels.packages.components.WooShippingPackageListItemSkeleton
 import kotlinx.coroutines.launch
 
 @Composable
 fun WooShippingCarrierPackageScreen(viewModel: WooShippingLabelPackageCreationViewModel) {
     val viewState by viewModel.viewState.observeAsState()
     WooShippingCarrierPackageScreen(
-        carrierPackages = viewState?.predefinedPackagesData?.carrierPackages ?: emptyMap(),
+        packageState = viewState?.predefinedPackagesState ?: PredefinedPackagesState.Waiting,
         isAddPackageEnabled = viewState?.predefinedPackagesData?.hasCarrierSelection ?: false,
         onPackageSelected = viewModel::onCarrierPackageSelected,
         onAddPackageClick = viewModel::onAddCarrierPackageClick
     )
 }
 
-@OptIn(ExperimentalFoundationApi::class)
 @Composable
 fun WooShippingCarrierPackageScreen(
+    modifier: Modifier = Modifier,
+    packageState: PredefinedPackagesState,
+    onPackageSelected: (PackageData, Boolean) -> Unit,
+    isAddPackageEnabled: Boolean = false,
+    onAddPackageClick: () -> Unit = {}
+) {
+    when (packageState) {
+        is PredefinedPackagesState.Data -> {
+            WooShippingCarrierPackageContent(
+                modifier = modifier,
+                carrierPackages = packageState.carrierPackages,
+                onPackageSelected = onPackageSelected,
+                isAddPackageEnabled = isAddPackageEnabled,
+                onAddPackageClick = onAddPackageClick
+            )
+        }
+
+        is PredefinedPackagesState.Error -> {
+            Column(
+                horizontalAlignment = Alignment.CenterHorizontally,
+                modifier = modifier
+                    .fillMaxSize()
+                    .padding(16.dp)
+                    .verticalScroll(rememberScrollState())
+            ) {
+                Text(text = stringResource(id = R.string.woo_shipping_labels_package_creation_error))
+            }
+        }
+
+        is PredefinedPackagesState.Waiting -> {
+            Column(
+                modifier = modifier
+                    .fillMaxSize()
+                    .padding(16.dp)
+                    .verticalScroll(rememberScrollState())
+            ) {
+                WooShippingPackageListItemSkeleton()
+                WooShippingPackageListItemSkeleton()
+                WooShippingPackageListItemSkeleton()
+            }
+        }
+    }
+}
+
+@Composable
+fun WooShippingCarrierPackageContent(
     modifier: Modifier = Modifier,
     carrierPackages: Map<Carrier, List<CarrierPackageGroup>>,
     onPackageSelected: (PackageData, Boolean) -> Unit,
@@ -94,7 +142,6 @@ fun WooShippingCarrierPackageScreen(
     }
 }
 
-@OptIn(ExperimentalFoundationApi::class)
 @Composable
 private fun CarrierTabRow(
     modifier: Modifier,
@@ -137,7 +184,6 @@ private fun CarrierTabRow(
     }
 }
 
-@OptIn(ExperimentalFoundationApi::class)
 @Composable
 private fun PackageListPager(
     modifier: Modifier,
@@ -223,7 +269,7 @@ private fun CarrierLogo(
 @Composable
 fun WooShippingCarrierPackageScreenPreview() {
     WooThemeWithBackground {
-        WooShippingCarrierPackageScreen(
+        WooShippingCarrierPackageContent(
             carrierPackages = mapOf(
                 Carrier.DHL to listOf(
                     CarrierPackageGroup(

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/packages/ui/WooShippingCarrierPackageScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/packages/ui/WooShippingCarrierPackageScreen.kt
@@ -47,8 +47,8 @@ import kotlinx.coroutines.launch
 fun WooShippingCarrierPackageScreen(viewModel: WooShippingLabelPackageCreationViewModel) {
     val viewState by viewModel.viewState.observeAsState()
     WooShippingCarrierPackageScreen(
-        carrierPackages = viewState?.carrierPackageSection?.carrierPackages ?: emptyMap(),
-        isAddPackageEnabled = viewState?.carrierPackageSection?.hasSelection ?: false,
+        carrierPackages = viewState?.predefinedPackagesData?.carrierPackages ?: emptyMap(),
+        isAddPackageEnabled = viewState?.predefinedPackagesData?.hasCarrierSelection ?: false,
         onPackageSelected = viewModel::onCarrierPackageSelected,
         onAddPackageClick = viewModel::onAddCarrierPackageClick
     )

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/packages/ui/WooShippingCarrierPackageScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/packages/ui/WooShippingCarrierPackageScreen.kt
@@ -40,7 +40,7 @@ import androidx.compose.ui.unit.dp
 import com.woocommerce.android.R
 import com.woocommerce.android.ui.compose.theme.WooThemeWithBackground
 import com.woocommerce.android.ui.orders.wooshippinglabels.packages.WooShippingLabelPackageCreationViewModel
-import com.woocommerce.android.ui.orders.wooshippinglabels.packages.components.WooSavedPackageListItem
+import com.woocommerce.android.ui.orders.wooshippinglabels.packages.components.WooShippingPackageListItem
 import kotlinx.coroutines.launch
 
 @Composable
@@ -195,7 +195,7 @@ private fun PackageListSection(
         )
         Divider()
         packages.forEach { packageData ->
-            WooSavedPackageListItem(
+            WooShippingPackageListItem(
                 modifier = Modifier.padding(start = 16.dp),
                 packageData = packageData,
                 onPackageSelected = onPackageSelected

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/packages/ui/WooShippingSavedPackageScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/packages/ui/WooShippingSavedPackageScreen.kt
@@ -65,6 +65,7 @@ fun WooShippingSavedPackageScreen(
                 Text(text = stringResource(id = R.string.woo_shipping_labels_package_creation_error))
             }
         }
+
         is PredefinedPackagesState.Waiting -> {
             Column(
                 modifier = modifier

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/packages/ui/WooShippingSavedPackageScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/packages/ui/WooShippingSavedPackageScreen.kt
@@ -24,8 +24,8 @@ import com.woocommerce.android.ui.orders.wooshippinglabels.packages.components.W
 fun WooShippingSavedPackageScreen(viewModel: WooShippingLabelPackageCreationViewModel) {
     val viewState = viewModel.viewState.observeAsState()
     WooShippingSavedPackageScreen(
-        savedPackages = viewState.value?.savedPackageSelection?.packages.orEmpty(),
-        isAddPackageEnabled = viewState.value?.savedPackageSelection?.hasSelection ?: false,
+        savedPackages = viewState.value?.predefinedPackagesData?.savedPackages.orEmpty(),
+        isAddPackageEnabled = viewState.value?.predefinedPackagesData?.hasSavedSelection ?: false,
         onAddPackageClick = viewModel::onAddSavedPackageClick,
         onSavedPackageSelected = viewModel::onSavedPackageSelected
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/packages/ui/WooShippingSavedPackageScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/packages/ui/WooShippingSavedPackageScreen.kt
@@ -153,3 +153,16 @@ fun WooShippingSavedPackageScreenPreview() {
         )
     }
 }
+
+@Preview
+@Composable
+fun WooShippingSavedPackageScreenLoadingPreview() {
+    WooThemeWithBackground {
+        WooShippingSavedPackageScreen(
+            packageState = PredefinedPackagesState.Waiting,
+            isAddPackageEnabled = false,
+            onAddPackageClick = {},
+            onSavedPackageSelected = { _, _ -> }
+        )
+    }
+}

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/packages/ui/WooShippingSavedPackageScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/packages/ui/WooShippingSavedPackageScreen.kt
@@ -18,13 +18,15 @@ import androidx.compose.ui.unit.dp
 import com.woocommerce.android.R
 import com.woocommerce.android.ui.compose.theme.WooThemeWithBackground
 import com.woocommerce.android.ui.orders.wooshippinglabels.packages.WooShippingLabelPackageCreationViewModel
-import com.woocommerce.android.ui.orders.wooshippinglabels.packages.components.WooSavedPackageListItem
+import com.woocommerce.android.ui.orders.wooshippinglabels.packages.WooShippingLabelPackageCreationViewModel.PredefinedPackagesState
+import com.woocommerce.android.ui.orders.wooshippinglabels.packages.components.WooShippingPackageListItem
+import com.woocommerce.android.ui.orders.wooshippinglabels.packages.components.WooShippingPackageListItemSkeleton
 
 @Composable
 fun WooShippingSavedPackageScreen(viewModel: WooShippingLabelPackageCreationViewModel) {
     val viewState = viewModel.viewState.observeAsState()
     WooShippingSavedPackageScreen(
-        savedPackages = viewState.value?.predefinedPackagesData?.savedPackages.orEmpty(),
+        packageState = viewState.value?.predefinedPackagesState ?: PredefinedPackagesState.Waiting,
         isAddPackageEnabled = viewState.value?.predefinedPackagesData?.hasSavedSelection ?: false,
         onAddPackageClick = viewModel::onAddSavedPackageClick,
         onSavedPackageSelected = viewModel::onSavedPackageSelected
@@ -34,6 +36,50 @@ fun WooShippingSavedPackageScreen(viewModel: WooShippingLabelPackageCreationView
 
 @Composable
 fun WooShippingSavedPackageScreen(
+    modifier: Modifier = Modifier,
+    packageState: PredefinedPackagesState,
+    isAddPackageEnabled: Boolean,
+    onAddPackageClick: () -> Unit,
+    onSavedPackageSelected: (PackageData, Boolean) -> Unit
+) {
+    when (packageState) {
+        is PredefinedPackagesState.Data -> {
+            WooShippingSavedPackageContent(
+                modifier = modifier,
+                savedPackages = packageState.savedPackages,
+                isAddPackageEnabled = isAddPackageEnabled,
+                onAddPackageClick = onAddPackageClick,
+                onSavedPackageSelected = onSavedPackageSelected
+            )
+        }
+
+        is PredefinedPackagesState.Error -> {
+            Column(
+                modifier = modifier
+                    .fillMaxSize()
+                    .padding(16.dp)
+                    .verticalScroll(rememberScrollState())
+            ) {
+                Text("Error")
+            }
+        }
+        is PredefinedPackagesState.Waiting -> {
+            Column(
+                modifier = modifier
+                    .fillMaxSize()
+                    .padding(16.dp)
+                    .verticalScroll(rememberScrollState())
+            ) {
+                WooShippingPackageListItemSkeleton()
+                WooShippingPackageListItemSkeleton()
+                WooShippingPackageListItemSkeleton()
+            }
+        }
+    }
+}
+
+@Composable
+fun WooShippingSavedPackageContent(
     modifier: Modifier = Modifier,
     savedPackages: List<PackageData>,
     isAddPackageEnabled: Boolean,
@@ -51,7 +97,7 @@ fun WooShippingSavedPackageScreen(
                 .verticalScroll(rememberScrollState())
         ) {
             savedPackages.forEach { packageData ->
-                WooSavedPackageListItem(
+                WooShippingPackageListItem(
                     modifier,
                     packageData,
                     onSavedPackageSelected
@@ -77,7 +123,7 @@ fun WooShippingSavedPackageScreen(
 @Composable
 fun WooShippingSavedPackageScreenPreview() {
     WooThemeWithBackground {
-        WooShippingSavedPackageScreen(
+        WooShippingSavedPackageContent(
             savedPackages = listOf(
                 PackageData(
                     name = "Small Flat Rate Box",

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/packages/ui/WooShippingSavedPackageScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/packages/ui/WooShippingSavedPackageScreen.kt
@@ -11,6 +11,7 @@ import androidx.compose.material.Divider
 import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.livedata.observeAsState
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
@@ -55,12 +56,13 @@ fun WooShippingSavedPackageScreen(
 
         is PredefinedPackagesState.Error -> {
             Column(
+                horizontalAlignment = Alignment.CenterHorizontally,
                 modifier = modifier
                     .fillMaxSize()
                     .padding(16.dp)
                     .verticalScroll(rememberScrollState())
             ) {
-                Text("Error")
+                Text(text = stringResource(id = R.string.woo_shipping_labels_package_creation_error))
             }
         }
         is PredefinedPackagesState.Waiting -> {
@@ -160,6 +162,19 @@ fun WooShippingSavedPackageScreenLoadingPreview() {
     WooThemeWithBackground {
         WooShippingSavedPackageScreen(
             packageState = PredefinedPackagesState.Waiting,
+            isAddPackageEnabled = false,
+            onAddPackageClick = {},
+            onSavedPackageSelected = { _, _ -> }
+        )
+    }
+}
+
+@Preview
+@Composable
+fun WooShippingSavedPackageScreenErrorPreview() {
+    WooThemeWithBackground {
+        WooShippingSavedPackageScreen(
+            packageState = PredefinedPackagesState.Error,
             isAddPackageEnabled = false,
             onAddPackageClick = {},
             onSavedPackageSelected = { _, _ -> }

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -4381,6 +4381,7 @@
     <string name="woo_shipping_labels_package_creation_package_name">Package Name</string>
     <string name="woo_shipping_labels_package_creation_save_package_option">Save this as a new package template</string>
     <string name="woo_shipping_labels_package_creation_add_package">Add Package</string>
+    <string name="woo_shipping_labels_package_creation_error">Failed to load the package data</string>
     <string name="woo_shipping_labels_package_creation_box_type">Box</string>
     <string name="woo_shipping_labels_package_creation_envelope_type">Envelope</string>
     <string name="email_not_registered_wpcom">Hmm, we can\'t find a WordPress.com account connected to this email address.</string>

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/packages/WooShippingLabelPackageCreationViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/packages/WooShippingLabelPackageCreationViewModelTest.kt
@@ -18,6 +18,7 @@ import com.woocommerce.android.viewmodel.BaseUnitTest
 import com.woocommerce.android.viewmodel.MultiLiveEvent
 import com.woocommerce.android.viewmodel.ResourceProvider
 import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.advanceUntilIdle
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.Before
 import org.junit.Test
@@ -325,9 +326,11 @@ class WooShippingLabelPackageCreationViewModelTest : BaseUnitTest() {
             fetchPredefinedPackages,
             packageRepository
         )
+
         sut.viewState.observeForever { lastViewState = it }
         sut.onCarrierPackageSelected(package1, true)
         sut.onCarrierPackageSelected(package2, true)
+        advanceUntilIdle()
 
         val selectedPackages = lastViewState
             ?.predefinedPackagesData

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/packages/WooShippingLabelPackageCreationViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/packages/WooShippingLabelPackageCreationViewModelTest.kt
@@ -5,17 +5,15 @@ import com.woocommerce.android.R
 import com.woocommerce.android.tools.SelectedSite
 import com.woocommerce.android.ui.orders.wooshippinglabels.packages.WooShippingLabelPackageCreationViewModel.PackageSelected
 import com.woocommerce.android.ui.orders.wooshippinglabels.packages.WooShippingLabelPackageCreationViewModel.PackageType
+import com.woocommerce.android.ui.orders.wooshippinglabels.packages.WooShippingLabelPackageCreationViewModel.PredefinedPackagesState
 import com.woocommerce.android.ui.orders.wooshippinglabels.packages.WooShippingLabelPackageCreationViewModel.ShowPackageTypeDialog
 import com.woocommerce.android.ui.orders.wooshippinglabels.packages.WooShippingLabelPackageCreationViewModel.ViewState
 import com.woocommerce.android.ui.orders.wooshippinglabels.packages.datasource.FetchPredefinedPackagesFromStore
 import com.woocommerce.android.ui.orders.wooshippinglabels.packages.datasource.WooShippingLabelPackageRepository
 import com.woocommerce.android.ui.orders.wooshippinglabels.packages.ui.Carrier
 import com.woocommerce.android.ui.orders.wooshippinglabels.packages.ui.CarrierPackageGroup
-import com.woocommerce.android.ui.orders.wooshippinglabels.packages.ui.CarrierPackageSelection
 import com.woocommerce.android.ui.orders.wooshippinglabels.packages.ui.CustomPackageCreationData
 import com.woocommerce.android.ui.orders.wooshippinglabels.packages.ui.PackageData
-import com.woocommerce.android.ui.orders.wooshippinglabels.packages.ui.SavedPackageSelection
-import com.woocommerce.android.ui.orders.wooshippinglabels.packages.ui.StorePredefinedPackages
 import com.woocommerce.android.viewmodel.BaseUnitTest
 import com.woocommerce.android.viewmodel.MultiLiveEvent
 import com.woocommerce.android.viewmodel.ResourceProvider
@@ -187,11 +185,9 @@ class WooShippingLabelPackageCreationViewModelTest : BaseUnitTest() {
             isLetter = true
         )
         whenever(fetchPredefinedPackages()).thenReturn(
-            StorePredefinedPackages(
-                carrierPackageSelection = CarrierPackageSelection(emptyMap()),
-                savedPackageSelection = SavedPackageSelection(
-                    listOf(package1, package2)
-                )
+            PredefinedPackagesState.Data(
+                carrierPackages = emptyMap(),
+                savedPackages = listOf(package1, package2)
             )
         )
 
@@ -205,7 +201,7 @@ class WooShippingLabelPackageCreationViewModelTest : BaseUnitTest() {
         sut.viewState.observeForever { lastViewState = it }
         sut.onSavedPackageSelected(package1, true)
 
-        val selectedPackages = lastViewState?.savedPackageSelection?.packages?.filter { it.isSelected }
+        val selectedPackages = lastViewState?.predefinedPackagesData?.savedPackages?.filter { it.isSelected }
         assertThat(selectedPackages).isNotNull
         assertThat(selectedPackages).size().isEqualTo(1)
         assertThat(selectedPackages?.first()).isEqualTo(package1.copy(isSelected = true))
@@ -238,11 +234,9 @@ class WooShippingLabelPackageCreationViewModelTest : BaseUnitTest() {
             )
         )
         whenever(fetchPredefinedPackages()).thenReturn(
-            StorePredefinedPackages(
-                carrierPackageSelection = CarrierPackageSelection(carrierPackages),
-                savedPackageSelection = SavedPackageSelection(
-                    emptyList()
-                )
+            PredefinedPackagesState.Data(
+                carrierPackages = carrierPackages,
+                savedPackages = emptyList()
             )
         )
 
@@ -256,9 +250,14 @@ class WooShippingLabelPackageCreationViewModelTest : BaseUnitTest() {
         sut.viewState.observeForever { lastViewState = it }
         sut.onCarrierPackageSelected(package1, true)
 
-        val selectedPackages = lastViewState?.carrierPackageSection?.carrierPackages?.values?.flatten()?.flatMap {
-            it.packages
-        }?.filter { it.isSelected }
+        val selectedPackages = lastViewState
+            ?.predefinedPackagesData
+            ?.carrierPackages
+            ?.values
+            ?.flatten()
+            ?.flatMap { it.packages }
+            ?.filter { it.isSelected }
+
         assertThat(selectedPackages).isNotNull
         assertThat(selectedPackages).size().isEqualTo(1)
         assertThat(selectedPackages?.first()).isEqualTo(package1.copy(isSelected = true))
@@ -313,11 +312,9 @@ class WooShippingLabelPackageCreationViewModelTest : BaseUnitTest() {
             )
         )
         whenever(fetchPredefinedPackages()).thenReturn(
-            StorePredefinedPackages(
-                carrierPackageSelection = CarrierPackageSelection(carrierPackages),
-                savedPackageSelection = SavedPackageSelection(
-                    emptyList()
-                )
+            PredefinedPackagesState.Data(
+                carrierPackages = carrierPackages,
+                savedPackages = emptyList()
             )
         )
 
@@ -332,9 +329,14 @@ class WooShippingLabelPackageCreationViewModelTest : BaseUnitTest() {
         sut.onCarrierPackageSelected(package1, true)
         sut.onCarrierPackageSelected(package2, true)
 
-        val selectedPackages = lastViewState?.carrierPackageSection?.carrierPackages?.values?.flatten()?.flatMap {
-            it.packages
-        }?.filter { it.isSelected }
+        val selectedPackages = lastViewState
+            ?.predefinedPackagesData
+            ?.carrierPackages
+            ?.values
+            ?.flatten()
+            ?.flatMap { it.packages }
+            ?.filter { it.isSelected }
+
         assertThat(selectedPackages).isNotNull
         assertThat(selectedPackages).size().isEqualTo(1)
         assertThat(selectedPackages?.first()).isEqualTo(package2.copy(isSelected = true))

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/packages/datasource/FetchPredefinedPackagesFromStoreTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/packages/datasource/FetchPredefinedPackagesFromStoreTest.kt
@@ -81,12 +81,12 @@ class FetchPredefinedPackagesFromStoreTest : BaseUnitTest() {
     }
 
     @Test
-    fun `invoke should return null StorePredefinedPackages when site is not available`() = testBlocking {
+    fun `invoke should return Error StorePredefinedPackages when site is not available`() = testBlocking {
         whenever(selectedSite.getOrNull()).thenReturn(null)
 
         val result = fetchPredefinedPackagesFromStore()
 
-        assertThat(result).isNull()
+        assertThat(result).isEqualTo(PredefinedPackagesState.Error)
     }
 
     private fun generatePackagesData() = StorePackagesDAO(

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/packages/datasource/FetchPredefinedPackagesFromStoreTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/packages/datasource/FetchPredefinedPackagesFromStoreTest.kt
@@ -1,6 +1,7 @@
 package com.woocommerce.android.ui.orders.wooshippinglabels.packages.datasource
 
 import com.woocommerce.android.tools.SelectedSite
+import com.woocommerce.android.ui.orders.wooshippinglabels.packages.WooShippingLabelPackageCreationViewModel.PredefinedPackagesState
 import com.woocommerce.android.ui.orders.wooshippinglabels.packages.ui.Carrier
 import com.woocommerce.android.ui.orders.wooshippinglabels.packages.ui.CarrierPackageGroup
 import com.woocommerce.android.ui.orders.wooshippinglabels.packages.ui.PackageData
@@ -33,9 +34,9 @@ class FetchPredefinedPackagesFromStoreTest : BaseUnitTest() {
         whenever(selectedSite.getOrNull()).thenReturn(site)
         whenever(packageRepository.fetchAllStorePackages(site)).thenReturn(WooResult(storePackages))
 
-        val result = fetchPredefinedPackagesFromStore()!!
+        val result = fetchPredefinedPackagesFromStore() as PredefinedPackagesState.Data
 
-        assertThat(result.savedPackageSelection.packages).containsExactly(
+        assertThat(result.savedPackages).containsExactly(
             PackageData(
                 name = "Saved Package 1",
                 dimensions = "dimensions",
@@ -51,7 +52,7 @@ class FetchPredefinedPackagesFromStoreTest : BaseUnitTest() {
                 isLetter = false
             )
         )
-        assertThat(result.carrierPackageSelection.carrierPackages[Carrier.USPS]).containsExactly(
+        assertThat(result.carrierPackages[Carrier.USPS]).containsExactly(
             CarrierPackageGroup(
                 groupName = "Group 1",
                 packages = listOf(
@@ -68,7 +69,7 @@ class FetchPredefinedPackagesFromStoreTest : BaseUnitTest() {
     }
 
     @Test
-    fun `invoke should return null StorePredefinedPackages when fetchAllStorePackages returns error`() = testBlocking {
+    fun `invoke should return Error StorePredefinedPackages when fetchAllStorePackages returns error`() = testBlocking {
         val error = WooError(WooErrorType.GENERIC_ERROR, BaseRequest.GenericErrorType.UNKNOWN)
         val site = SiteModel().apply { id = 1 }
         whenever(selectedSite.getOrNull()).thenReturn(site)
@@ -76,7 +77,7 @@ class FetchPredefinedPackagesFromStoreTest : BaseUnitTest() {
 
         val result = fetchPredefinedPackagesFromStore()
 
-        assertThat(result).isNull()
+        assertThat(result).isEqualTo(PredefinedPackagesState.Error)
     }
 
     @Test

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/packages/ui/PackageDataTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/packages/ui/PackageDataTest.kt
@@ -1,10 +1,9 @@
 package com.woocommerce.android.ui.orders.wooshippinglabels.packages.ui
 
-import kotlin.test.Test
 import org.assertj.core.api.Assertions.assertThat
+import kotlin.test.Test
 
 class PackageDataTest {
-
 
     @Test
     fun `length, width, and height are correctly set when dimensions are properly formatted`() {

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/packages/ui/PackageDataTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/packages/ui/PackageDataTest.kt
@@ -1,0 +1,68 @@
+package com.woocommerce.android.ui.orders.wooshippinglabels.packages.ui
+
+import kotlin.test.Test
+import org.assertj.core.api.Assertions.assertThat
+
+class PackageDataTest {
+
+
+    @Test
+    fun `length, width, and height are correctly set when dimensions are properly formatted`() {
+        val packageData = PackageData(
+            name = "Test Package",
+            dimensions = "10 x 20 x 30",
+            weight = "5",
+            isSelected = false,
+            isLetter = false
+        )
+
+        assertThat(packageData.length).isEqualTo("10")
+        assertThat(packageData.width).isEqualTo("20")
+        assertThat(packageData.height).isEqualTo("30")
+    }
+
+    @Test
+    fun `length, width, and height are empty when dimensions are not properly formatted`() {
+        val packageData = PackageData(
+            name = "Test Package",
+            dimensions = "10 x 20",
+            weight = "5",
+            isSelected = false,
+            isLetter = false
+        )
+
+        assertThat(packageData.length).isEqualTo("10")
+        assertThat(packageData.width).isEqualTo("20")
+        assertThat(packageData.height).isEmpty()
+    }
+
+    @Test
+    fun `length, width, and height are empty when dimensions are null`() {
+        val packageData = PackageData(
+            name = "Test Package",
+            dimensions = "10",
+            weight = "5",
+            isSelected = false,
+            isLetter = false
+        )
+
+        assertThat(packageData.length).isEqualTo("10")
+        assertThat(packageData.width).isEmpty()
+        assertThat(packageData.height).isEmpty()
+    }
+
+    @Test
+    fun `length, width, and height are empty when dimensions are empty`() {
+        val packageData = PackageData(
+            name = "Test Package",
+            dimensions = "",
+            weight = "5",
+            isSelected = false,
+            isLetter = false
+        )
+
+        assertThat(packageData.length).isEmpty()
+        assertThat(packageData.width).isEmpty()
+        assertThat(packageData.height).isEmpty()
+    }
+}


### PR DESCRIPTION
Summary
==========
Partially fix issue #12747 by introducing a series of adjustments to the Carrier and Saved packages data to allow a complete state control with loading and error handling.

The upcoming PR will be focused on triggering the selected package to the main Shipping Labels UI.

Screenshots
==========
https://github.com/user-attachments/assets/3e50c713-66ca-468b-b2d5-cba735535704

How to Test
==========
1. Go to the Order Details of an Order eligible for Shipping Label Creation
2. Hit the Create Shipping Labels button
3. Once inside the new Shipping Labels form, hit the `Select a Package` button
4. Verify that the Carrier and Saved tabs display their loading feedback properly
5. Verify that the `Add Package` button is only enabled for the tab with an actual selected Package
6. Verify that the Custom Package form logic is working as expected

Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

## Reviewer (or Author, in the case of optional code reviews):

Please make sure these conditions are met before approving the PR, or request changes if the PR needs improvement:

- [x] The PR is small and has a clear, single focus, or a valid explanation is provided in the description. If needed, please request to split it into smaller PRs.
- [x] Ensure Adequate Unit Test Coverage: The changes are reasonably covered by unit tests or an explanation is provided in the PR description.
- [x] Manual Testing: The author listed all the tests they ran, including smoke tests when needed (e.g., for refactorings). The reviewer confirmed that the PR works as expected on big (tablet) and small (phone) in case of UI changes, and no regressions are added.
