### PR TITLE
[Tooling] Update GitHub Actions

### DIFF
--- a/.github/workflows/gradle-wrapper-validation.yml
+++ b/.github/workflows/gradle-wrapper-validation.yml
@@ -6,5 +6,5 @@ jobs:
     name: "Validation"
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      - uses: gradle/wrapper-validation-action@v1
+      - uses: actions/checkout@v4
+      - uses: gradle/actions/wrapper-validation@v4


### PR DESCRIPTION
Reference: p7H4VZ-59z-p2

WooCommerce Android doesn't use one of the GitHub Actions about to have its older versions deprecated as `actions/upload-artifact`, `actions/download-artifact` or `actions/cache`, but I used this opportunity to upgrade `actions/checkout` and `gradle/actions/wrapper-validation`.