### PR TITLE
Remove Purple 15 color

### DIFF
--- a/WooCommerce-Wear/src/main/res/values/colors_base.xml
+++ b/WooCommerce-Wear/src/main/res/values/colors_base.xml
@@ -3,7 +3,6 @@
     <!-- Woo Colors -->
     <color name="woo_purple_0">#F2EDFF</color>
     <color name="woo_purple_10">#F7EDF7</color>
-    <color name="woo_purple_15">#E5CFE8</color>
     <color name="woo_purple_20">#C792E0</color>
     <color name="woo_purple_30">#B17FD4</color>
     <color name="woo_purple_40">#AF7DD1</color>

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/common/composeui/WooPosTheme.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/common/composeui/WooPosTheme.kt
@@ -76,7 +76,6 @@ private object WooPosColors {
     val WooPurple100 = Color(0xFF140E1F)
 
     val Purple10 = Color(0xFFF7EDF7)
-    val Purple15 = Color(0xFFE5CFE8)
     val Purple20 = Color(0xFFC792E0)
     val Purple30 = Color(0xFFB17FD4)
     val Purple40 = Color(0xFFAF7DD1)

--- a/WooCommerce/src/main/res/values-night/colors_base.xml
+++ b/WooCommerce/src/main/res/values-night/colors_base.xml
@@ -219,7 +219,7 @@
     <color name="payout_summary_status_paid_background">@color/woo_green_50</color>
     <color name="payout_summary_status_paid_text">@color/woo_green_0</color>
     <color name="payout_summary_status_canceled_background">@color/woo_purple_80</color>
-    <color name="payout_summary_status_canceled_text">@color/woo_purple_15</color>
+    <color name="payout_summary_status_canceled_text">@color/woo_purple_10</color>
     <color name="payout_summary_status_failed_background">@color/woo_red_70</color>
     <color name="payout_summary_status_failed_text">@color/woo_red_5</color>
     <color name="payout_summary_status_unknown_background">@color/woo_gray_80</color>

--- a/WooCommerce/src/main/res/values/colors_base.xml
+++ b/WooCommerce/src/main/res/values/colors_base.xml
@@ -120,7 +120,7 @@
     <color name="tag_bg_on_hold">@color/woo_orange_5</color>
     <color name="tag_bg_completed">@color/woo_blue_5</color>
     <color name="tag_bg_other">@color/woo_gray_5</color>
-    <color name="tag_bg_main">@color/woo_purple_15</color>
+    <color name="tag_bg_main">@color/woo_purple_10</color>
     <color name="tag_text_main">@color/color_primary</color>
     <color name="tag_task_label">@color/woo_gray_6</color>
     <color name="tag_task_label_text">@color/woo_black_90_alpha_060</color>
@@ -313,7 +313,7 @@
     <color name="payout_summary_status_in_transit_text">@color/woo_orange_70</color>
     <color name="payout_summary_status_paid_background">@color/woo_green_0</color>
     <color name="payout_summary_status_paid_text">@color/woo_green_50</color>
-    <color name="payout_summary_status_canceled_background">@color/woo_purple_15</color>
+    <color name="payout_summary_status_canceled_background">@color/woo_purple_10</color>
     <color name="payout_summary_status_canceled_text">@color/woo_purple_80</color>
     <color name="payout_summary_status_failed_background">@color/woo_red_5</color>
     <color name="payout_summary_status_failed_text">@color/woo_red_70</color>

--- a/WooCommerce/src/main/res/values/wc_colors_base.xml
+++ b/WooCommerce/src/main/res/values/wc_colors_base.xml
@@ -2,7 +2,6 @@
 <resources>
     <color name="woo_purple_0">#F2EDFF</color>
     <color name="woo_purple_10">#F7EDF7</color>
-    <color name="woo_purple_15">#E5CFE8</color>
     <color name="woo_purple_20">#C792E0</color>
     <color name="woo_purple_30">#B17FD4</color>
     <color name="woo_purple_40">#AF7DD1</color>


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Parent: woocommerce/woomobile-private#381
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

We don’t have Purple 15 in the [Woo Color Studio](https://color-studio.blog/). I removed it and used Purple 10 instead. Currently, Purple 15 is used as the background for tags and the warning message on the product creation screen with AI.
iOS already uses Purple 10 for the tag background, and now Android matches this design.
I didn’t add any tests since this is just a simple color change PR.

### Testing information
<!-- This is your opportunity to break out individual scenarios that need testing (when necessary) and/or include a checklist for the reviewer to go through. Consider documenting the following from your own completed testing: devices used, alternate workflows, edge cases, affected areas, critical flows, areas not tested, and any remaining unknowns. Provide feedback on this new section of the PR template through Sept 30, 2024 to Apps Quality; additional context here: p91TBi-b8z-p2#comment-12036 -->
No testing is needed. Please confirm that Purple 10 looks good on the screens I mentioned and check if I missed any screens.

### The tests that have been performed
<!-- To give the reviewer an idea of what could be missed in terms of testing -->
Tested tags and AI warning background.

### Images/gif
<!-- Include before and after images or gifs when appropriate. -->
|before|after|iOS|
|-|-|-|
|<img src="https://github.com/user-attachments/assets/6909a568-45c2-4c87-b217-a95ce77991b5" width=270>|<img src="https://github.com/user-attachments/assets/8979b142-5039-4c8d-ae21-a6f858fdf979" width=270>|<img src="https://github.com/user-attachments/assets/7173fe53-8722-4a99-b934-976b475d3f83" width=300>|
|<img width="367" alt="before" src="https://github.com/user-attachments/assets/0b0e9a1f-2adf-487c-bea5-ec7284ffd12d" />|<img width="367" alt="after" src="https://github.com/user-attachments/assets/fbc5feeb-0f2d-4afe-8e91-58ccd3b983c0" />||
|<img src="https://github.com/user-attachments/assets/34c42769-94d9-4c40-825d-7d21b362456a" width=270>|<img src="https://github.com/user-attachments/assets/09eabe8b-5f56-47c9-8f36-67e38ced321b" width=270>||)

- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.

## Reviewer (or Author, in the case of optional code reviews):

Please make sure these conditions are met before approving the PR, or request changes if the PR needs improvement:

- [ ] The PR is small and has a clear, single focus, or a valid explanation is provided in the description. If needed, please request to split it into smaller PRs.
- [ ] Ensure Adequate Unit Test Coverage: The changes are reasonably covered by unit tests or an explanation is provided in the PR description.
- [ ] Manual Testing: The author listed all the tests they ran, including smoke tests when needed (e.g., for refactorings). The reviewer confirmed that the PR works as expected on big (tablet) and small (phone) in case of UI changes, and no regressions are added.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->