### PR TITLE
Shipping rates custom weight support

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/WooShippingLabelCreationScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/WooShippingLabelCreationScreen.kt
@@ -14,6 +14,8 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.text.BasicTextField
+import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.BottomSheetScaffold
 import androidx.compose.material.BottomSheetScaffoldState
@@ -42,6 +44,7 @@ import androidx.compose.ui.res.dimensionResource
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.Devices
 import androidx.compose.ui.tooling.preview.Preview
@@ -80,7 +83,9 @@ fun WooShippingLabelCreationScreen(viewModel: WooShippingLabelCreationViewModel)
                 onShippingFromAddressChange = viewModel::onShippingFromAddressChange,
                 onShippingToAddressChange = viewModel::onShippingToAddressChange,
                 onSelectedRateSortOrderChanged = viewModel::onSelectedRateSortOrderChanged,
-                onRefreshShippingRates = viewModel::onRefreshShippingRates
+                onRefreshShippingRates = viewModel::onRefreshShippingRates,
+                customWeight = viewModel.customWeight,
+                onCustomWeightChange = viewModel::onCustomWeightChange,
             )
         }
 
@@ -105,6 +110,8 @@ fun WooShippingLabelCreationScreen(
     onPurchaseShippingLabel: () -> Unit,
     onSelectedRateSortOrderChanged: (ShippingSortOption) -> Unit,
     onRefreshShippingRates: () -> Unit,
+    onCustomWeightChange: (String) -> Unit,
+    customWeight: String,
     modifier: Modifier = Modifier
 ) {
     val scaffoldState = rememberBottomSheetScaffoldState()
@@ -121,7 +128,9 @@ fun WooShippingLabelCreationScreen(
             onShippingFromAddressChange = onShippingFromAddressChange,
             onShippingToAddressChange = onShippingToAddressChange,
             onSelectedRateSortOrderChanged = onSelectedRateSortOrderChanged,
-            onRefreshShippingRates = onRefreshShippingRates
+            onRefreshShippingRates = onRefreshShippingRates,
+            customWeight = customWeight,
+            onCustomWeightChange = onCustomWeightChange
         )
         val isDarkTheme = isSystemInDarkTheme()
         val isCollapsed = scaffoldState.bottomSheetState.isCollapsed
@@ -164,6 +173,8 @@ private fun LabelCreationScreenWithBottomSheet(
     onShippingToAddressChange: (Address) -> Unit,
     onSelectedRateSortOrderChanged: (ShippingSortOption) -> Unit,
     onRefreshShippingRates: () -> Unit,
+    customWeight: String,
+    onCustomWeightChange: (String) -> Unit,
     scaffoldState: BottomSheetScaffoldState,
     modifier: Modifier = Modifier
 ) {
@@ -223,7 +234,9 @@ private fun LabelCreationScreenWithBottomSheet(
                 PackageCard(
                     modifier = Modifier.padding(16.dp),
                     packageSelectionState = packageSelectionState,
-                    onSelectPackageClick = onSelectPackageClick
+                    onSelectPackageClick = onSelectPackageClick,
+                    customWeight = customWeight,
+                    onCustomWeightChange = onCustomWeightChange
                 )
                 ShippingRatesSection(
                     shippingRatesState = shippingRatesState,
@@ -275,17 +288,24 @@ internal fun HazmatCard(
 private fun PackageCard(
     modifier: Modifier = Modifier,
     packageSelectionState: PackageSelectionState,
-    onSelectPackageClick: () -> Unit
+    customWeight: String,
+    onSelectPackageClick: () -> Unit,
+    onCustomWeightChange: (String) -> Unit,
 ) {
     when (packageSelectionState) {
         is NotSelected -> SelectPackageCard(
             modifier = modifier,
             onSelectPackageClick = onSelectPackageClick
         )
+
         is DataAvailable -> PackageSelectionAvailableCard(
             modifier = modifier,
             packageData = packageSelectionState.selectedPackage,
-            onSelectPackageClick = onSelectPackageClick
+            onSelectPackageClick = onSelectPackageClick,
+            defaultWeight = packageSelectionState.defaultWeight,
+            customWeight = customWeight,
+            customWeightUnit = packageSelectionState.weightUnit,
+            onCustomWeightChange = onCustomWeightChange
         )
     }
 }
@@ -344,7 +364,11 @@ private fun SelectPackageCard(
 private fun PackageSelectionAvailableCard(
     modifier: Modifier = Modifier,
     packageData: PackageData,
-    onSelectPackageClick: () -> Unit
+    defaultWeight: String,
+    customWeight: String,
+    customWeightUnit: String,
+    onSelectPackageClick: () -> Unit,
+    onCustomWeightChange: (String) -> Unit
 ) {
     Column(modifier = modifier.background(color = MaterialTheme.colors.surface)) {
         Row(
@@ -420,6 +444,42 @@ private fun PackageSelectionAvailableCard(
                 }
             }
         }
+        Text(
+            modifier = Modifier.padding(
+                top = dimensionResource(id = R.dimen.major_100),
+                bottom = dimensionResource(id = R.dimen.minor_100)
+            ),
+            text = stringResource(id = R.string.shipping_label_total_shipment_weight),
+            style = MaterialTheme.typography.body2
+        )
+        RoundedCornerBoxWithBorder {
+            Row(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(16.dp)
+            ) {
+                Box(modifier = Modifier.weight(1f)) {
+                    BasicTextField(
+                        modifier = Modifier.fillMaxWidth(),
+                        value = customWeight,
+                        onValueChange = onCustomWeightChange,
+                        keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Number)
+                    )
+                    if (customWeight.isEmpty()) {
+                        Text(
+                            text = defaultWeight,
+                            style = MaterialTheme.typography.body2,
+                            color = colorResource(id = R.color.color_on_surface_disabled)
+                        )
+                    }
+                }
+                Text(
+                    text = customWeightUnit,
+                    style = MaterialTheme.typography.body2,
+                    color = colorResource(id = R.color.color_on_surface_disabled)
+                )
+            }
+        }
     }
 }
 
@@ -465,7 +525,9 @@ private fun WooShippingLabelCreationScreenPreview() {
             onShippingFromAddressChange = {},
             onShippingToAddressChange = {},
             onRefreshShippingRates = {},
-            onSelectedRateSortOrderChanged = {}
+            onSelectedRateSortOrderChanged = {},
+            customWeight = "",
+            onCustomWeightChange = {}
         )
     }
 }
@@ -485,7 +547,9 @@ private fun PackageNotSelectedPreview() {
         PackageCard(
             modifier = Modifier.padding(16.dp),
             packageSelectionState = NotSelected,
-            onSelectPackageClick = {}
+            customWeight = "",
+            onSelectPackageClick = {},
+            onCustomWeightChange = {}
         )
     }
 }
@@ -505,9 +569,12 @@ private fun PackageSelectedPreview() {
                     isLetter = false,
                     id = "1",
                 ),
-                totalWeight = "1.5"
+                defaultWeight = "1",
+                weightUnit = "kg",
             ),
-            onSelectPackageClick = {}
+            customWeight = "",
+            onSelectPackageClick = {},
+            onCustomWeightChange = {}
         )
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/WooShippingLabelCreationViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/WooShippingLabelCreationViewModel.kt
@@ -56,9 +56,8 @@ class WooShippingLabelCreationViewModel @Inject constructor(
     private val storeOptions = MutableStateFlow<StoreOptionsModel?>(null)
     private val shippableItems = MutableStateFlow<List<ShippableItemModel>>(emptyList())
 
-    private val selectedRatesSortOrder = MutableStateFlow(ShippingSortOption.FASTEST)
-    private val refreshShippingRates = MutableSharedFlow<Unit>()
-
+    private val packageSelected = MutableStateFlow<PackageData?>(null)
+    private val packageWeight = MutableStateFlow<PackageWeight?>(null)
     private val packageSelection = MutableStateFlow<PackageSelectionState>(NotSelected)
 
     private val cheapestComparator = Comparator<ShippingRateUI> { r1, r2 -> r1.price.compareTo(r2.price) }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/WooShippingLabelCreationViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/WooShippingLabelCreationViewModel.kt
@@ -151,13 +151,17 @@ class WooShippingLabelCreationViewModel @Inject constructor(
     }
 
     private suspend fun getShippingAddresses() {
-        order.filterNotNull().combine(observeOriginAddresses()) { order, originAddresses ->
-            val selectedOriginAddress = getSelectedOriginAddress(originAddresses)
-            WooShippingAddresses(
-                shipFrom = selectedOriginAddress,
-                originAddresses = originAddresses,
-                shipTo = order.shippingAddress
-            )
+        order.combine(observeOriginAddresses()) { order, originAddresses ->
+            if (order != null && originAddresses.isNotEmpty()) {
+                val selectedOriginAddress = getSelectedOriginAddress(originAddresses)
+                WooShippingAddresses(
+                    shipFrom = selectedOriginAddress,
+                    originAddresses = originAddresses,
+                    shipTo = order.shippingAddress
+                )
+            } else {
+                null
+            }
         }.collect { shippingAddresses.value = it }
     }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/WooShippingLabelCreationViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/WooShippingLabelCreationViewModel.kt
@@ -100,9 +100,9 @@ class WooShippingLabelCreationViewModel @Inject constructor(
 
     init {
         launch { observeShippingLabelInformation() }
-        launch { getOrderInformation() }
         launch { getStoreOptions() }
         launch { getShippingAddresses() }
+        launch { getOrderInformation() }
         launch { observePackageWeight() }
         launch { observePackageChanges() }
     }
@@ -175,11 +175,11 @@ class WooShippingLabelCreationViewModel @Inject constructor(
             delay(MULTIPLE_CALLS_DELAY)
 
             val shippingRatesResult = getShippingRates(
-                orderId = shippingRatesInfo.orderId!!,
-                selectedPackage = shippingRatesInfo.packageSelected!!,
-                shipTo = shippingRatesInfo.shipTo!!,
-                shipFrom = shippingRatesInfo.shipFrom!!,
-                weight = shippingRatesInfo.weight!!
+                shippingRatesInfo.orderId!!,
+                shippingRatesInfo.packageSelected!!,
+                shippingRatesInfo.shipTo!!,
+                shippingRatesInfo.shipFrom!!,
+                shippingRatesInfo.weight!!
             )
 
             if (shippingRatesResult.isSuccess && shippingRatesResult.getOrThrow().isNotEmpty()) {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/WooShippingLabelCreationViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/WooShippingLabelCreationViewModel.kt
@@ -1,5 +1,9 @@
 package com.woocommerce.android.ui.orders.wooshippinglabels
 
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.setValue
+import androidx.compose.runtime.snapshotFlow
 import androidx.lifecycle.SavedStateHandle
 import com.woocommerce.android.extensions.formatToString
 import com.woocommerce.android.extensions.sumByFloat
@@ -22,15 +26,18 @@ import com.woocommerce.android.viewmodel.ScopedViewModel
 import com.woocommerce.android.viewmodel.navArgs
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.FlowPreview
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.flow.debounce
 import kotlinx.coroutines.flow.drop
 import kotlinx.coroutines.flow.filterNotNull
 import kotlinx.coroutines.flow.flatMapLatest
 import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.flow.onStart
-import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 import javax.inject.Inject
 
@@ -60,21 +67,32 @@ class WooShippingLabelCreationViewModel @Inject constructor(
     private val packageWeight = MutableStateFlow<PackageWeight?>(null)
     private val packageSelection = MutableStateFlow<PackageSelectionState>(NotSelected)
 
+    private val selectedRatesSortOrder = MutableStateFlow(ShippingSortOption.FASTEST)
+    private val refreshShippingRates = MutableSharedFlow<Unit>()
+    var customWeight by mutableStateOf("")
+        private set
+
     private val cheapestComparator = Comparator<ShippingRateUI> { r1, r2 -> r1.price.compareTo(r2.price) }
     private val fastestComparator = Comparator<ShippingRateUI> { r1, r2 -> r1.deliveryDays.compareTo(r2.deliveryDays) }
 
     @OptIn(ExperimentalCoroutinesApi::class)
     private val shippingRates =
         combine(
-            packageSelection,
+            order,
+            packageSelected,
             shippingAddresses,
+            packageWeight,
             refreshShippingRates.onStart { emit(Unit) }
-        ) { packageSelection, addresses, _ ->
-             Pair(packageSelection, addresses)
-        }.flatMapLatest {
-            val (packageSelection, addresses) = it
-            refreshShippingRates(packageSelection, addresses)
-        }
+        ) { order, selectedPackage, addresses, packageWeight, _ ->
+            ShippingRatesInfo(
+                orderId = order?.id,
+                packageSelected = selectedPackage,
+                shipFrom = addresses?.shipFrom,
+                shipTo = addresses?.shipTo,
+                weight = packageWeight?.totalWeight,
+                currencyCode = order?.currency
+            )
+        }.flatMapLatest { refreshShippingRates(it) }
 
     val viewState: MutableStateFlow<WooShippingViewState> = MutableStateFlow(WooShippingViewState.Loading)
 
@@ -83,16 +101,51 @@ class WooShippingLabelCreationViewModel @Inject constructor(
         launch { getOrderInformation() }
         launch { getStoreOptions() }
         launch { getShippingAddresses() }
+        launch { observePackageWeight() }
+        launch { observePackageChanges() }
     }
 
     private suspend fun getOrderInformation() {
-        orderDetailRepository.getOrderById(navArgs.orderId).let {
-            order.value = it
-        }
+        orderDetailRepository.getOrderById(navArgs.orderId).let { order.value = it }
     }
 
     private fun getStoreOptions() {
         storeOptions.value = mockStoreOptions
+    }
+
+    @OptIn(FlowPreview::class)
+    private suspend fun observePackageWeight() {
+        combine(
+            shippableItems,
+            packageSelected,
+            snapshotFlow { customWeight }.debounce(TYPING_DELAY)
+        ) { shippableItems, selectedPackage, customWeightString ->
+            val itemsWeight = shippableItems.sumByFloat { it.weight }
+            val packageWeight = selectedPackage?.weight?.toFloatOrNull()
+            PackageWeight(
+                itemsWeight = itemsWeight,
+                packageWeight = packageWeight,
+                customWeight = customWeightString.toFloatOrNull()
+            )
+        }.collectLatest {
+            packageWeight.value = it
+        }
+    }
+
+    private suspend fun observePackageChanges() {
+        packageSelected.combine(packageWeight) { packageSelected, packageWeight ->
+            if (packageSelected == null || packageWeight == null) {
+                NotSelected
+            } else {
+                DataAvailable(
+                    selectedPackage = packageSelected,
+                    defaultWeight = packageWeight.defaultWeight.toString(),
+                    weightUnit = mockStoreOptions.weightUnit
+                )
+            }
+        }.collectLatest {
+            packageSelection.value = it
+        }
     }
 
     private suspend fun getShippingAddresses() {
@@ -107,20 +160,29 @@ class WooShippingLabelCreationViewModel @Inject constructor(
     }
 
     private fun refreshShippingRates(
-        packageSelection: PackageSelectionState,
-        addresses: WooShippingAddresses?
+        shippingRatesInfo: ShippingRatesInfo
     ) = flow {
-        if (addresses != null && addresses.shipTo != Address.EMPTY && packageSelection is DataAvailable) {
+        if (shippingRatesInfo.hasRequiredData) {
             val sortOrder = selectedRatesSortOrder.value
             emit(ShippingRatesState.Loading(sortOrder))
+
+            delay(MULTIPLE_CALLS_DELAY)
+
             val shippingRatesResult = getShippingRates(
-                selectedPackage = packageSelection.selectedPackage,
-                sortOrder = sortOrder,
-                shipTo = addresses.shipTo,
-                shipFrom = addresses.shipFrom
+                orderId = shippingRatesInfo.orderId!!,
+                selectedPackage = shippingRatesInfo.packageSelected!!,
+                shipTo = shippingRatesInfo.shipTo!!,
+                shipFrom = shippingRatesInfo.shipFrom!!,
+                weight = shippingRatesInfo.weight!!
             )
-            if (shippingRatesResult.isSuccess) {
-                emit(ShippingRatesState.DataState(sortOrder, shippingRatesResult.getOrThrow()))
+
+            if (shippingRatesResult.isSuccess && shippingRatesResult.getOrThrow().isNotEmpty()) {
+                emit(
+                    ShippingRatesState.DataState(
+                        sortOrder,
+                        sortShippingRates(sortOrder, shippingRatesResult.getOrThrow())
+                    )
+                )
             } else {
                 emit(ShippingRatesState.Error)
             }
@@ -161,7 +223,7 @@ class WooShippingLabelCreationViewModel @Inject constructor(
                 shippingRates = shippingRates,
                 packageSelection = packageSelection
             )
-        }.collect {
+        }.collectLatest {
             viewState.value = it
         }
     }
@@ -225,19 +287,22 @@ class WooShippingLabelCreationViewModel @Inject constructor(
 
     fun onSelectedRateSortOrderChanged(option: ShippingSortOption) {
         selectedRatesSortOrder.value = option
-
-        (viewState.value as? WooShippingViewState.DataState)
-            ?.takeIf { it.shippingRates is ShippingRatesState.DataState }
-            ?.let { currentState ->
-                (currentState.shippingRates as ShippingRatesState.DataState).let { state ->
-                    viewState.value = currentState.copy(
+        when (val currentViewState = viewState.value) {
+            is WooShippingViewState.DataState -> {
+                (currentViewState.shippingRates as? ShippingRatesState.DataState)?.let { currentRatesState ->
+                    viewState.value = currentViewState.copy(
                         shippingRates = ShippingRatesState.DataState(
                             selectedRatesSortOrder = option,
-                            shippingRates = sortShippingRates(option, state.shippingRates)
+                            shippingRates = sortShippingRates(option, currentRatesState.shippingRates)
                         )
                     )
-                }
+                } ?: onRefreshShippingRates()
             }
+
+            else -> {
+                onRefreshShippingRates()
+            }
+        }
     }
 
     private fun sortShippingRates(
@@ -257,16 +322,11 @@ class WooShippingLabelCreationViewModel @Inject constructor(
     }
 
     fun onPackageSelected(packageData: PackageData) {
-        packageSelection.update { content ->
-            when (content) {
-                is NotSelected -> DataAvailable(
-                    selectedPackage = packageData,
-                    totalWeight = packageData.weight
-                )
+        packageSelected.value = packageData
+    }
 
-                is DataAvailable -> content.copy(selectedPackage = packageData)
-            }
-        }
+    fun onCustomWeightChange(input: String) {
+        customWeight = input
     }
 
     data object StartPackageSelection : Event()
@@ -302,8 +362,42 @@ class WooShippingLabelCreationViewModel @Inject constructor(
         data object NotSelected : PackageSelectionState()
         data class DataAvailable(
             val selectedPackage: PackageData,
-            val totalWeight: String
+            val defaultWeight: String,
+            val weightUnit: String
         ) : PackageSelectionState()
+    }
+
+    data class PackageWeight(
+        val itemsWeight: Float,
+        val packageWeight: Float? = null,
+        val customWeight: Float? = null
+    ) {
+        val defaultWeight: Float
+            get() = itemsWeight + (packageWeight ?: 0f)
+        val totalWeight: Float
+            get() = customWeight ?: defaultWeight
+    }
+
+    data class ShippingRatesInfo(
+        val orderId: Long?,
+        val packageSelected: PackageData?,
+        val shipFrom: OriginShippingAddress?,
+        val shipTo: Address?,
+        val weight: Float?,
+        val currencyCode: String?
+    ) {
+        val hasRequiredData: Boolean
+            get() = orderId != null &&
+                packageSelected != null &&
+                shipFrom != null &&
+                shipTo != null &&
+                weight != null &&
+                shipTo != Address.EMPTY
+    }
+
+    companion object {
+        private const val TYPING_DELAY = 800L
+        private const val MULTIPLE_CALLS_DELAY = 50L
     }
 }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/WooShippingLabelCreationViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/WooShippingLabelCreationViewModel.kt
@@ -34,11 +34,11 @@ import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.debounce
 import kotlinx.coroutines.flow.drop
-import kotlinx.coroutines.flow.filterNotNull
 import kotlinx.coroutines.flow.flatMapLatest
 import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.flow.onStart
 import kotlinx.coroutines.launch
+import java.util.Date
 import javax.inject.Inject
 
 @HiltViewModel
@@ -58,9 +58,11 @@ class WooShippingLabelCreationViewModel @Inject constructor(
         originCountry = "US"
     )
 
-    private val order = MutableStateFlow<Order?>(null)
-    private val shippingAddresses = MutableStateFlow<WooShippingAddresses?>(null)
-    private val storeOptions = MutableStateFlow<StoreOptionsModel?>(null)
+    private val emptyOrder = Order.getEmptyOrder(Date(), Date())
+    private val order = MutableStateFlow<Order?>(emptyOrder)
+    private val shippingAddresses = MutableStateFlow<WooShippingAddresses?>(WooShippingAddresses.EMPTY)
+    private val storeOptions = MutableStateFlow<StoreOptionsModel?>(StoreOptionsModel.EMPTY)
+
     private val shippableItems = MutableStateFlow<List<ShippableItemModel>>(emptyList())
 
     private val packageSelected = MutableStateFlow<PackageData?>(null)
@@ -405,4 +407,12 @@ data class WooShippingAddresses(
     val shipFrom: OriginShippingAddress,
     val shipTo: Address,
     val originAddresses: List<OriginShippingAddress>
-)
+) {
+    companion object {
+        val EMPTY = WooShippingAddresses(
+            shipFrom = OriginShippingAddress.EMPTY,
+            shipTo = Address.EMPTY,
+            originAddresses = emptyList()
+        )
+    }
+}

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/WooShippingLabelCreationViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/WooShippingLabelCreationViewModel.kt
@@ -77,6 +77,7 @@ class WooShippingLabelCreationViewModel @Inject constructor(
     private val fastestComparator = Comparator<ShippingRateUI> { r1, r2 -> r1.deliveryDays.compareTo(r2.deliveryDays) }
 
     @OptIn(ExperimentalCoroutinesApi::class, FlowPreview::class)
+    @Suppress("ComplexCondition")
     private val shippingRates =
         combine(
             order.drop(1),
@@ -85,14 +86,23 @@ class WooShippingLabelCreationViewModel @Inject constructor(
             packageWeight,
             refreshShippingRates.onStart { emit(Unit) }
         ) { order, selectedPackage, addresses, packageWeight, _ ->
-            ShippingRatesInfo(
-                orderId = order?.id,
-                packageSelected = selectedPackage,
-                shipFrom = addresses?.shipFrom,
-                shipTo = addresses?.shipTo,
-                weight = packageWeight?.totalWeight,
-                currencyCode = order?.currency
-            )
+            if (order != null &&
+                selectedPackage != null &&
+                addresses != null &&
+                packageWeight != null &&
+                addresses.shipTo != Address.EMPTY
+            ) {
+                ShippingRatesInfo(
+                    orderId = order.id,
+                    packageSelected = selectedPackage,
+                    shipFrom = addresses.shipFrom,
+                    shipTo = addresses.shipTo,
+                    weight = packageWeight.totalWeight,
+                    currencyCode = order.currency
+                )
+            } else {
+                null
+            }
         }
             .debounce(MULTIPLE_CALLS_DELAY)
             .flatMapLatest { refreshShippingRates(it) }
@@ -167,18 +177,18 @@ class WooShippingLabelCreationViewModel @Inject constructor(
     }
 
     private fun refreshShippingRates(
-        shippingRatesInfo: ShippingRatesInfo
+        shippingRatesInfo: ShippingRatesInfo?
     ) = flow {
-        if (shippingRatesInfo.hasRequiredData) {
+        if (shippingRatesInfo != null) {
             val sortOrder = selectedRatesSortOrder.value
             emit(ShippingRatesState.Loading(sortOrder))
 
             val shippingRatesResult = getShippingRates(
-                shippingRatesInfo.orderId!!,
-                shippingRatesInfo.packageSelected!!,
-                shippingRatesInfo.shipTo!!,
-                shippingRatesInfo.shipFrom!!,
-                shippingRatesInfo.weight!!
+                shippingRatesInfo.orderId,
+                shippingRatesInfo.packageSelected,
+                shippingRatesInfo.shipTo,
+                shippingRatesInfo.shipFrom,
+                shippingRatesInfo.weight
             )
 
             if (shippingRatesResult.isSuccess && shippingRatesResult.getOrThrow().isNotEmpty()) {
@@ -384,21 +394,13 @@ class WooShippingLabelCreationViewModel @Inject constructor(
     }
 
     data class ShippingRatesInfo(
-        val orderId: Long?,
-        val packageSelected: PackageData?,
-        val shipFrom: OriginShippingAddress?,
-        val shipTo: Address?,
-        val weight: Float?,
-        val currencyCode: String?
-    ) {
-        val hasRequiredData: Boolean
-            get() = orderId != null &&
-                packageSelected != null &&
-                shipFrom != null &&
-                shipTo != null &&
-                weight != null &&
-                shipTo != Address.EMPTY
-    }
+        val orderId: Long,
+        val packageSelected: PackageData,
+        val shipFrom: OriginShippingAddress,
+        val shipTo: Address,
+        val weight: Float,
+        val currencyCode: String
+    )
 
     companion object {
         private const val TYPING_DELAY = 800L

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/WooShippingLabelCreationViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/WooShippingLabelCreationViewModel.kt
@@ -27,7 +27,6 @@ import com.woocommerce.android.viewmodel.navArgs
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.FlowPreview
-import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.collectLatest
@@ -77,7 +76,7 @@ class WooShippingLabelCreationViewModel @Inject constructor(
     private val cheapestComparator = Comparator<ShippingRateUI> { r1, r2 -> r1.price.compareTo(r2.price) }
     private val fastestComparator = Comparator<ShippingRateUI> { r1, r2 -> r1.deliveryDays.compareTo(r2.deliveryDays) }
 
-    @OptIn(ExperimentalCoroutinesApi::class)
+    @OptIn(ExperimentalCoroutinesApi::class, FlowPreview::class)
     private val shippingRates =
         combine(
             order.drop(1),
@@ -94,7 +93,9 @@ class WooShippingLabelCreationViewModel @Inject constructor(
                 weight = packageWeight?.totalWeight,
                 currencyCode = order?.currency
             )
-        }.flatMapLatest { refreshShippingRates(it) }
+        }
+            .debounce(MULTIPLE_CALLS_DELAY)
+            .flatMapLatest { refreshShippingRates(it) }
 
     val viewState: MutableStateFlow<WooShippingViewState> = MutableStateFlow(WooShippingViewState.Loading)
 
@@ -171,8 +172,6 @@ class WooShippingLabelCreationViewModel @Inject constructor(
         if (shippingRatesInfo.hasRequiredData) {
             val sortOrder = selectedRatesSortOrder.value
             emit(ShippingRatesState.Loading(sortOrder))
-
-            delay(MULTIPLE_CALLS_DELAY)
 
             val shippingRatesResult = getShippingRates(
                 shippingRatesInfo.orderId!!,

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/WooShippingLabelCreationViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/WooShippingLabelCreationViewModel.kt
@@ -80,9 +80,9 @@ class WooShippingLabelCreationViewModel @Inject constructor(
     @OptIn(ExperimentalCoroutinesApi::class)
     private val shippingRates =
         combine(
-            order,
+            order.drop(1),
             packageSelected,
-            shippingAddresses,
+            shippingAddresses.drop(1),
             packageWeight,
             refreshShippingRates.onStart { emit(Unit) }
         ) { order, selectedPackage, addresses, packageWeight, _ ->

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/models/OriginShippingAddress.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/models/OriginShippingAddress.kt
@@ -15,4 +15,23 @@ data class OriginShippingAddress(
     val phone: String?,
     val isDefault: Boolean,
     val isVerified: Boolean
-)
+){
+    companion object {
+        val EMPTY = OriginShippingAddress(
+            id = "",
+            company = null,
+            firstName = null,
+            lastName = null,
+            email = null,
+            address1 = null,
+            address2 = null,
+            city = null,
+            state = null,
+            postcode = "",
+            country = "",
+            phone = null,
+            isDefault = false,
+            isVerified = false
+        )
+    }
+}

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/models/OriginShippingAddress.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/models/OriginShippingAddress.kt
@@ -15,7 +15,7 @@ data class OriginShippingAddress(
     val phone: String?,
     val isDefault: Boolean,
     val isVerified: Boolean
-){
+) {
     companion object {
         val EMPTY = OriginShippingAddress(
             id = "",

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/models/StoreOptionsModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/models/StoreOptionsModel.kt
@@ -5,4 +5,13 @@ data class StoreOptionsModel(
     val dimensionUnit: String,
     val weightUnit: String,
     val originCountry: String
-)
+){
+    companion object {
+        val EMPTY = StoreOptionsModel(
+            currencySymbol = "",
+            dimensionUnit = "",
+            weightUnit = "",
+            originCountry = ""
+        )
+    }
+}

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/models/StoreOptionsModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/models/StoreOptionsModel.kt
@@ -5,7 +5,7 @@ data class StoreOptionsModel(
     val dimensionUnit: String,
     val weightUnit: String,
     val originCountry: String
-){
+) {
     companion object {
         val EMPTY = StoreOptionsModel(
             currencySymbol = "",

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/rates/datasource/WooShippingRatesRepository.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/rates/datasource/WooShippingRatesRepository.kt
@@ -16,9 +16,11 @@ class WooShippingRatesRepository @Inject constructor(
     private val restClient: WooShippingRatesRestClient
 ) {
     suspend fun getShippingRates(
+        orderId: Long,
         selectedPackage: PackageData,
         shipTo: Address,
-        shipFrom: OriginShippingAddress
+        shipFrom: OriginShippingAddress,
+        weight: Float
     ): Result<List<WooShippingRateOptionsModel>> {
         val origin = OriginAddressDTO(
             address = shipFrom.address1,
@@ -45,12 +47,12 @@ class WooShippingRatesRepository @Inject constructor(
             length = selectedPackage.length.toDouble(),
             width = selectedPackage.width.toDouble(),
             height = selectedPackage.height.toDouble(),
-            weight = selectedPackage.weight.toDouble().coerceAtLeast(0.1),
+            weight = weight.toDouble(),
             isLetter = selectedPackage.isLetter
         )
         val result = restClient.getShippingRates(
             site = selectedSite.get(),
-            orderId = "1427",
+            orderId = orderId.toString(),
             origin = origin,
             destination = destination,
             packages = listOf(packageDTO)

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/rates/domain/GetShippingRates.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/rates/domain/GetShippingRates.kt
@@ -6,44 +6,29 @@ import com.woocommerce.android.ui.orders.wooshippinglabels.packages.ui.PackageDa
 import com.woocommerce.android.ui.orders.wooshippinglabels.rates.datasource.WooShippingRatesRepository
 import com.woocommerce.android.ui.orders.wooshippinglabels.rates.ui.CarrierUI
 import com.woocommerce.android.ui.orders.wooshippinglabels.rates.ui.ShippingRateUI
-import com.woocommerce.android.ui.orders.wooshippinglabels.rates.ui.ShippingSortOption
 import javax.inject.Inject
 
 class GetShippingRates @Inject constructor(
     private val repository: WooShippingRatesRepository,
     private val shippingMapper: WooShippingRatesDomainMapper
 ) {
-    private val cheapestComparator = Comparator<ShippingRateUI> { r1, r2 ->
-        r1.price.compareTo(r2.price)
-    }
-
-    private val fastestComparator = Comparator<ShippingRateUI> { r1, r2 ->
-        r1.deliveryDays.compareTo(r2.deliveryDays)
-    }
 
     suspend operator fun invoke(
+        orderId: Long,
         selectedPackage: PackageData,
         shipTo: Address,
         shipFrom: OriginShippingAddress,
-        sortOrder: ShippingSortOption = ShippingSortOption.FASTEST
+        weight: Float
     ): Result<Map<CarrierUI, List<ShippingRateUI>>> {
         val result = repository.getShippingRates(
+            orderId = orderId,
             selectedPackage = selectedPackage,
             shipTo = shipTo,
-            shipFrom = shipFrom
+            shipFrom = shipFrom,
+            weight = weight
         )
-        val comparator = when (sortOrder) {
-            ShippingSortOption.CHEAPEST -> {
-                cheapestComparator
-            }
-
-            ShippingSortOption.FASTEST -> {
-                fastestComparator
-            }
-        }
-
         return if (result.isSuccess) {
-            val sortedRates = shippingMapper(result.getOrThrow()).mapValues { it.value.sortedWith(comparator) }
+            val sortedRates = shippingMapper(result.getOrThrow())
             Result.success(sortedRates)
         } else {
             Result.failure(result.exceptionOrNull() ?: Exception("Failed to get shipping rates"))

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -1283,6 +1283,7 @@
     <string name="shipping_label_purchased_track_shipment">Track shipment</string>
     <string name="shipping_label_purchased_schedule_pick_up">Schedule pickup</string>
     <string name="shipping_label_purchased_request_refund">Request refund</string>
+    <string name="shipping_label_total_shipment_weight">Total shipment weight (with package)</string>
 
 
     <!--

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/WooShippingLabelCreationViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/WooShippingLabelCreationViewModelTest.kt
@@ -174,6 +174,8 @@ class WooShippingLabelCreationViewModelTest : BaseUnitTest() {
 
         createViewModel()
 
+        advanceUntilIdle()
+
         val currentViewState = sut.viewState.value
         assert(currentViewState is DataState)
         val dataState = currentViewState as DataState
@@ -194,6 +196,8 @@ class WooShippingLabelCreationViewModelTest : BaseUnitTest() {
         whenever(observeOriginAddresses()) doReturn flowOf(defaultOriginAddresses)
 
         createViewModel()
+
+        advanceUntilIdle()
 
         val currentViewState = sut.viewState.value
         assert(currentViewState is DataState)
@@ -242,6 +246,8 @@ class WooShippingLabelCreationViewModelTest : BaseUnitTest() {
         whenever(observeOriginAddresses()) doReturn flowOf(defaultOriginAddresses)
 
         createViewModel()
+
+        advanceUntilIdle()
 
         val currentViewState = sut.viewState.value
         assert(currentViewState is DataState)

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/WooShippingLabelCreationViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/WooShippingLabelCreationViewModelTest.kt
@@ -11,6 +11,11 @@ import com.woocommerce.android.ui.orders.wooshippinglabels.WooShippingLabelCreat
 import com.woocommerce.android.ui.orders.wooshippinglabels.WooShippingLabelCreationViewModel.WooShippingViewState.DataState
 import com.woocommerce.android.ui.orders.wooshippinglabels.models.OriginShippingAddress
 import com.woocommerce.android.ui.orders.wooshippinglabels.models.ShippableItemModel
+import com.woocommerce.android.ui.orders.wooshippinglabels.models.WooShippingCarrier
+import com.woocommerce.android.ui.orders.wooshippinglabels.packages.ui.PackageData
+import com.woocommerce.android.ui.orders.wooshippinglabels.rates.datasource.WooShippingRateModel
+import com.woocommerce.android.ui.orders.wooshippinglabels.rates.datasource.WooShippingRateModel.Option
+import com.woocommerce.android.ui.orders.wooshippinglabels.rates.datasource.WooShippingRateOptionsModel
 import com.woocommerce.android.ui.orders.wooshippinglabels.rates.domain.GetShippingRates
 import com.woocommerce.android.ui.orders.wooshippinglabels.rates.ui.CarrierUI
 import com.woocommerce.android.ui.orders.wooshippinglabels.rates.ui.ShippingRateUI
@@ -19,6 +24,7 @@ import com.woocommerce.android.util.CurrencyFormatter
 import com.woocommerce.android.viewmodel.BaseUnitTest
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.test.advanceUntilIdle
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.Test
 import org.mockito.kotlin.any
@@ -81,7 +87,50 @@ class WooShippingLabelCreationViewModelTest : BaseUnitTest() {
         address1 = "1278 24st Perito AVE"
     )
 
-    private val defaultShippingRates = emptyMap<CarrierUI, List<ShippingRateUI>>()
+    private val defaultPackageData = PackageData(
+        id = "1",
+        name = "Package 1",
+        dimensions = "10 x 10 x 10",
+        weight = "10",
+        isSelected = false,
+        isLetter = false
+    )
+
+    private val defaultCarrier = CarrierUI(
+        carrier = WooShippingCarrier.UPS,
+        name = "UPS",
+    )
+
+    private val defaultShippingRates = mapOf(
+        defaultCarrier to defaultShippableItems.map {
+            ShippingRateUI(
+                name = it.title,
+                price = it.price,
+                deliveryDays = 1,
+                formattedPrice = "$12.00",
+                insurance = "$300.00",
+                tracking = true,
+                freePickup = true,
+                options = WooShippingRateOptionsModel(
+                    mapOf(
+                        Option.DEFAULT to WooShippingRateModel(
+                            packageId = "1",
+                            shipmentId = "1",
+                            rateId = "1",
+                            serviceId = "1",
+                            carrierId = "1",
+                            serviceName = "Default",
+                            deliveryDays = 1,
+                            price = BigDecimal(12),
+                            discount = BigDecimal.ZERO,
+                            option = Option.DEFAULT,
+                            carrier = defaultCarrier.carrier,
+                        )
+                    )
+                )
+            )
+        }
+    )
 
     private val orderDetailRepository: OrderDetailRepository = mock()
     private val getShippableItems: GetShippableItems = mock()
@@ -122,7 +171,6 @@ class WooShippingLabelCreationViewModelTest : BaseUnitTest() {
         whenever(orderDetailRepository.getOrderById(any())) doReturn order
         whenever(getShippableItems(any())) doReturn defaultShippableItems
         whenever(observeOriginAddresses()) doReturn flowOf(defaultOriginAddresses)
-        whenever(getShippingRates(any(), any(), any(), any())) doReturn Result.success(defaultShippingRates)
 
         createViewModel()
 
@@ -144,7 +192,6 @@ class WooShippingLabelCreationViewModelTest : BaseUnitTest() {
         whenever(orderDetailRepository.getOrderById(any())) doReturn order
         whenever(getShippableItems(any())) doReturn defaultShippableItems
         whenever(observeOriginAddresses()) doReturn flowOf(defaultOriginAddresses)
-        whenever(getShippingRates(any(), any(), any(), any())) doReturn Result.success(defaultShippingRates)
 
         createViewModel()
 
@@ -163,6 +210,8 @@ class WooShippingLabelCreationViewModelTest : BaseUnitTest() {
 
         createViewModel()
 
+        advanceUntilIdle()
+
         val currentViewState = sut.viewState.value
         assert(currentViewState is WooShippingViewState.Error)
     }
@@ -176,6 +225,8 @@ class WooShippingLabelCreationViewModelTest : BaseUnitTest() {
         whenever(observeOriginAddresses()) doReturn flowOf(emptyList())
 
         createViewModel()
+
+        advanceUntilIdle()
 
         val currentViewState = sut.viewState.value
         assert(currentViewState is WooShippingViewState.Error)
@@ -212,9 +263,14 @@ class WooShippingLabelCreationViewModelTest : BaseUnitTest() {
         whenever(orderDetailRepository.getOrderById(any())) doReturn order
         whenever(getShippableItems(any())) doReturn defaultShippableItems
         whenever(observeOriginAddresses()) doReturn flowOf(defaultOriginAddresses)
-        whenever(getShippingRates(any(), any(), any(), any())) doReturn Result.success(defaultShippingRates)
+        whenever(
+            getShippingRates(any(), any(), any(), any(), any())
+        ) doReturn Result.success(defaultShippingRates)
 
         createViewModel()
+        sut.onPackageSelected(defaultPackageData)
+
+        advanceUntilIdle()
 
         val currentViewState = sut.viewState.value
         assert(currentViewState is DataState)
@@ -234,9 +290,12 @@ class WooShippingLabelCreationViewModelTest : BaseUnitTest() {
         whenever(orderDetailRepository.getOrderById(any())) doReturn order
         whenever(getShippableItems(any())) doReturn defaultShippableItems
         whenever(observeOriginAddresses()) doReturn flowOf(defaultOriginAddresses)
-        whenever(getShippingRates(any(), any(), any(), any())) doReturn Result.failure(Exception("Random error"))
+        whenever(getShippingRates(any(), any(), any(), any(), any())) doReturn Result.failure(Exception("Random error"))
 
         createViewModel()
+        sut.onPackageSelected(defaultPackageData)
+
+        advanceUntilIdle()
 
         val currentViewState = sut.viewState.value
         assert(currentViewState is DataState)
@@ -256,16 +315,23 @@ class WooShippingLabelCreationViewModelTest : BaseUnitTest() {
         whenever(orderDetailRepository.getOrderById(any())) doReturn order
         whenever(getShippableItems(any())) doReturn defaultShippableItems
         whenever(observeOriginAddresses()) doReturn flowOf(defaultOriginAddresses)
-        whenever(getShippingRates(any(), any(), any(), any())) doReturn Result.success(defaultShippingRates)
+        whenever(getShippingRates(any(), any(), any(), any(), any())) doReturn Result.success(defaultShippingRates)
 
         createViewModel()
+
+        sut.onPackageSelected(defaultPackageData)
+
+        advanceUntilIdle()
+
         sut.onRefreshShippingRates()
 
-        verify(getShippingRates, times(2)).invoke(any(), any(), any(), any())
+        advanceUntilIdle()
+
+        verify(getShippingRates, times(2)).invoke(any(), any(), any(), any(), any())
     }
 
     @Test
-    fun `when rates sort order is changed then refresh shipping rates`() = testBlocking {
+    fun `when rates sort order is changed then DON'T refresh shipping rates`() = testBlocking {
         val order = OrderTestUtils.generateTestOrder(orderId = orderId).copy(
             shippingLines = defaultShippingLines,
             customer = Order.Customer(
@@ -276,13 +342,19 @@ class WooShippingLabelCreationViewModelTest : BaseUnitTest() {
         whenever(orderDetailRepository.getOrderById(any())) doReturn order
         whenever(getShippableItems(any())) doReturn defaultShippableItems
         whenever(observeOriginAddresses()) doReturn flowOf(defaultOriginAddresses)
-        whenever(getShippingRates(any(), any(), any(), any())) doReturn Result.success(defaultShippingRates)
+        whenever(getShippingRates(any(), any(), any(), any(), any())) doReturn Result.success(defaultShippingRates)
 
         createViewModel()
 
+        sut.onPackageSelected(defaultPackageData)
+
+        advanceUntilIdle()
+
         sut.onSelectedRateSortOrderChanged(ShippingSortOption.CHEAPEST)
 
-        verify(getShippingRates, times(2)).invoke(any(), any(), any(), any())
+        advanceUntilIdle()
+
+        verify(getShippingRates, times(1)).invoke(any(), any(), any(), any(), any())
     }
 
     @Test
@@ -297,13 +369,19 @@ class WooShippingLabelCreationViewModelTest : BaseUnitTest() {
         whenever(orderDetailRepository.getOrderById(any())) doReturn order
         whenever(getShippableItems(any())) doReturn defaultShippableItems
         whenever(observeOriginAddresses()) doReturn flowOf(defaultOriginAddresses)
-        whenever(getShippingRates(any(), any(), any(), any())) doReturn Result.success(defaultShippingRates)
+        whenever(getShippingRates(any(), any(), any(), any(), any())) doReturn Result.success(defaultShippingRates)
 
         createViewModel()
 
+        sut.onPackageSelected(defaultPackageData)
+
+        advanceUntilIdle()
+
         sut.onSelectedRateSortOrderChanged(ShippingSortOption.FASTEST)
 
-        verify(getShippingRates, times(1)).invoke(any(), any(), any(), any())
+        advanceUntilIdle()
+
+        verify(getShippingRates, times(1)).invoke(any(), any(), any(), any(), any())
     }
 
     @Test
@@ -315,14 +393,17 @@ class WooShippingLabelCreationViewModelTest : BaseUnitTest() {
         whenever(orderDetailRepository.getOrderById(any())) doReturn order
         whenever(getShippableItems(any())) doReturn defaultShippableItems
         whenever(observeOriginAddresses()) doReturn flowOf(defaultOriginAddresses)
-        whenever(getShippingRates(any(), any())) doReturn Result.success(defaultShippingRates)
 
         createViewModel()
+
+        advanceUntilIdle()
+
         sut.viewState.asLiveData().observeForever {
             currentViewState = it
         }
 
         val initialPackageData = PackageData(
+            id = "1",
             name = "Initial Package",
             dimensions = "5 x 5 x 5",
             weight = "0.5",
@@ -331,6 +412,8 @@ class WooShippingLabelCreationViewModelTest : BaseUnitTest() {
         )
 
         sut.onPackageSelected(initialPackageData)
+
+        advanceUntilIdle()
 
         assertThat(currentViewState).isInstanceOf(DataState::class.java)
         val dataState = currentViewState as DataState
@@ -349,14 +432,17 @@ class WooShippingLabelCreationViewModelTest : BaseUnitTest() {
         whenever(orderDetailRepository.getOrderById(any())) doReturn order
         whenever(getShippableItems(any())) doReturn defaultShippableItems
         whenever(observeOriginAddresses()) doReturn flowOf(defaultOriginAddresses)
-        whenever(getShippingRates(any(), any())) doReturn Result.success(defaultShippingRates)
 
         createViewModel()
+
+        advanceUntilIdle()
+
         sut.viewState.asLiveData().observeForever {
             currentViewState = it
         }
 
         val initialPackageData = PackageData(
+            id = "1",
             name = "Initial Package",
             dimensions = "5 x 5 x 5",
             weight = "0.5",
@@ -366,7 +452,10 @@ class WooShippingLabelCreationViewModelTest : BaseUnitTest() {
 
         sut.onPackageSelected(initialPackageData)
 
+        advanceUntilIdle()
+
         val newPackageData = PackageData(
+            id = "2",
             name = "New Package",
             dimensions = "10 x 10 x 10",
             weight = "1.5",
@@ -375,6 +464,8 @@ class WooShippingLabelCreationViewModelTest : BaseUnitTest() {
         )
 
         sut.onPackageSelected(newPackageData)
+
+        advanceUntilIdle()
 
         assertThat(currentViewState).isInstanceOf(DataState::class.java)
         val dataState = currentViewState as DataState

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/packages/WooShippingLabelPackageCreationViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/packages/WooShippingLabelPackageCreationViewModelTest.kt
@@ -178,7 +178,6 @@ class WooShippingLabelPackageCreationViewModelTest : BaseUnitTest() {
             weight = "10",
             isSelected = false,
             isLetter = false,
-            id = "1"
         )
         val package2 = PackageData(
             id = "2",
@@ -187,7 +186,6 @@ class WooShippingLabelPackageCreationViewModelTest : BaseUnitTest() {
             weight = "20",
             isSelected = false,
             isLetter = true,
-            id = "2"
         )
         whenever(fetchPredefinedPackages()).thenReturn(
             PredefinedPackagesState.Data(
@@ -223,7 +221,6 @@ class WooShippingLabelPackageCreationViewModelTest : BaseUnitTest() {
             weight = "10",
             isSelected = false,
             isLetter = false,
-            id = "1"
         )
         val package2 = PackageData(
             id = "2",
@@ -232,7 +229,6 @@ class WooShippingLabelPackageCreationViewModelTest : BaseUnitTest() {
             weight = "20",
             isSelected = false,
             isLetter = true,
-            id = "2"
         )
         val carrierPackages = mapOf(
             carrier to listOf(
@@ -285,7 +281,6 @@ class WooShippingLabelPackageCreationViewModelTest : BaseUnitTest() {
             weight = "10",
             isSelected = false,
             isLetter = false,
-            id = "1"
         )
         val package2 = PackageData(
             id = "2",
@@ -294,7 +289,6 @@ class WooShippingLabelPackageCreationViewModelTest : BaseUnitTest() {
             weight = "20",
             isSelected = false,
             isLetter = true,
-            id = "2"
         )
         val package3 = PackageData(
             id = "3",
@@ -303,7 +297,6 @@ class WooShippingLabelPackageCreationViewModelTest : BaseUnitTest() {
             weight = "30",
             isSelected = false,
             isLetter = false,
-            id = "3"
         )
         val package4 = PackageData(
             id = "4",
@@ -312,7 +305,6 @@ class WooShippingLabelPackageCreationViewModelTest : BaseUnitTest() {
             weight = "40",
             isSelected = false,
             isLetter = true,
-            id = "4"
         )
         val carrierPackages = mapOf(
             carrier1 to listOf(

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/packages/WooShippingLabelPackageCreationViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/packages/WooShippingLabelPackageCreationViewModelTest.kt
@@ -172,6 +172,7 @@ class WooShippingLabelPackageCreationViewModelTest : BaseUnitTest() {
     fun `onSavedPackageSelected selects only one package at a time`() = testBlocking {
         var lastViewState: ViewState? = null
         val package1 = PackageData(
+            id = "1",
             name = "Package 1",
             dimensions = "10 x 10 x 10",
             weight = "10",
@@ -179,6 +180,7 @@ class WooShippingLabelPackageCreationViewModelTest : BaseUnitTest() {
             isLetter = false
         )
         val package2 = PackageData(
+            id = "2",
             name = "Package 2",
             dimensions = "20 x 20 x 20",
             weight = "20",
@@ -213,6 +215,7 @@ class WooShippingLabelPackageCreationViewModelTest : BaseUnitTest() {
         var lastViewState: ViewState? = null
         val carrier: Carrier = Carrier.DHL
         val package1 = PackageData(
+            id = "1",
             name = "Package 1",
             dimensions = "10 x 10 x 10",
             weight = "10",
@@ -220,6 +223,7 @@ class WooShippingLabelPackageCreationViewModelTest : BaseUnitTest() {
             isLetter = false
         )
         val package2 = PackageData(
+            id = "2",
             name = "Package 2",
             dimensions = "20 x 20 x 20",
             weight = "20",
@@ -271,6 +275,7 @@ class WooShippingLabelPackageCreationViewModelTest : BaseUnitTest() {
         val carrier1: Carrier = Carrier.DHL
         val carrier2: Carrier = Carrier.USPS
         val package1 = PackageData(
+            id = "1",
             name = "Package 1 - Carrier 1",
             dimensions = "10 x 10 x 10",
             weight = "10",
@@ -278,6 +283,7 @@ class WooShippingLabelPackageCreationViewModelTest : BaseUnitTest() {
             isLetter = false
         )
         val package2 = PackageData(
+            id = "2",
             name = "Package 2 - Carrier 1",
             dimensions = "20 x 20 x 20",
             weight = "20",
@@ -285,6 +291,7 @@ class WooShippingLabelPackageCreationViewModelTest : BaseUnitTest() {
             isLetter = true
         )
         val package3 = PackageData(
+            id = "3",
             name = "Package 1 - Carrier 2",
             dimensions = "30 x 30 x 30",
             weight = "30",
@@ -292,6 +299,7 @@ class WooShippingLabelPackageCreationViewModelTest : BaseUnitTest() {
             isLetter = false
         )
         val package4 = PackageData(
+            id = "4",
             name = "Package 2 - Carrier 2",
             dimensions = "40 x 40 x 40",
             weight = "40",

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/packages/datasource/FetchPredefinedPackagesFromStoreTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/packages/datasource/FetchPredefinedPackagesFromStoreTest.kt
@@ -45,7 +45,6 @@ class FetchPredefinedPackagesFromStoreTest : BaseUnitTest() {
                 isSelected = false,
                 isLetter = false,
                 isPredefined = true,
-                id = "1"
             ),
             PackageData(
                 id = "2",
@@ -55,7 +54,6 @@ class FetchPredefinedPackagesFromStoreTest : BaseUnitTest() {
                 isSelected = false,
                 isLetter = false,
                 isPredefined = true,
-                id = "2"
             )
         )
         assertThat(result.carrierPackages[Carrier.USPS]).containsExactly(
@@ -70,7 +68,6 @@ class FetchPredefinedPackagesFromStoreTest : BaseUnitTest() {
                         isSelected = false,
                         isLetter = false,
                         isPredefined = true,
-                        id = "1"
                     )
                 )
             )

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/packages/datasource/FetchPredefinedPackagesFromStoreTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/packages/datasource/FetchPredefinedPackagesFromStoreTest.kt
@@ -38,6 +38,7 @@ class FetchPredefinedPackagesFromStoreTest : BaseUnitTest() {
 
         assertThat(result.savedPackages).containsExactly(
             PackageData(
+                id = "1",
                 name = "Saved Package 1",
                 dimensions = "dimensions",
                 weight = "weight",
@@ -46,6 +47,7 @@ class FetchPredefinedPackagesFromStoreTest : BaseUnitTest() {
                 isPredefined = true
             ),
             PackageData(
+                id = "2",
                 name = "Saved Package 2",
                 dimensions = "dimensions",
                 weight = "weight",
@@ -59,6 +61,7 @@ class FetchPredefinedPackagesFromStoreTest : BaseUnitTest() {
                 groupName = "Group 1",
                 packages = listOf(
                     PackageData(
+                        id = "1",
                         name = "Carrier Package 1",
                         dimensions = "dimensions",
                         weight = "weight",

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/packages/ui/PackageDataTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/packages/ui/PackageDataTest.kt
@@ -8,6 +8,7 @@ class PackageDataTest {
     @Test
     fun `length, width, and height are correctly set when dimensions are properly formatted`() {
         val packageData = PackageData(
+            id = "1",
             name = "Test Package",
             dimensions = "10 x 20 x 30",
             weight = "5",
@@ -23,6 +24,7 @@ class PackageDataTest {
     @Test
     fun `length, width, and height are empty when dimensions are not properly formatted`() {
         val packageData = PackageData(
+            id = "1",
             name = "Test Package",
             dimensions = "10 x 20",
             weight = "5",
@@ -38,6 +40,7 @@ class PackageDataTest {
     @Test
     fun `length, width, and height are empty when dimensions are null`() {
         val packageData = PackageData(
+            id = "1",
             name = "Test Package",
             dimensions = "10",
             weight = "5",
@@ -53,6 +56,7 @@ class PackageDataTest {
     @Test
     fun `length, width, and height are empty when dimensions are empty`() {
         val packageData = PackageData(
+            id = "1",
             name = "Test Package",
             dimensions = "",
             weight = "5",

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/packages/ui/PackageDataTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/packages/ui/PackageDataTest.kt
@@ -14,7 +14,6 @@ class PackageDataTest {
             weight = "5",
             isSelected = false,
             isLetter = false,
-            id = "1"
         )
 
         assertThat(packageData.length).isEqualTo("10")
@@ -31,7 +30,6 @@ class PackageDataTest {
             weight = "5",
             isSelected = false,
             isLetter = false,
-            id = "1"
         )
 
         assertThat(packageData.length).isEqualTo("10")
@@ -48,7 +46,6 @@ class PackageDataTest {
             weight = "5",
             isSelected = false,
             isLetter = false,
-            id = "1"
         )
 
         assertThat(packageData.length).isEqualTo("10")
@@ -65,7 +62,6 @@ class PackageDataTest {
             weight = "5",
             isSelected = false,
             isLetter = false,
-            id = "1"
         )
 
         assertThat(packageData.length).isEmpty()

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/rates/datasource/WooShippingRatesRepositoryTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/rates/datasource/WooShippingRatesRepositoryTest.kt
@@ -20,7 +20,6 @@ import org.wordpress.android.fluxc.network.rest.wpcom.wc.WooErrorType
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.WooResult
 import kotlin.test.Test
 
-
 @OptIn(ExperimentalCoroutinesApi::class)
 class WooShippingRatesRepositoryTest : BaseUnitTest() {
     private val currentSite = SiteModel()
@@ -86,7 +85,7 @@ class WooShippingRatesRepositoryTest : BaseUnitTest() {
                 message = "Error"
             )
         )
-        val result = sut.getShippingRates(1L,defaultPackageData, defaultAddress, defaultOriginAddress, 2f)
+        val result = sut.getShippingRates(1L, defaultPackageData, defaultAddress, defaultOriginAddress, 2f)
 
         assert(result.isFailure)
     }
@@ -97,9 +96,8 @@ class WooShippingRatesRepositoryTest : BaseUnitTest() {
             restClient.getShippingRates(any(), any(), any(), any(), any())
         ) doReturn WooResult(emptyMap())
 
-        val result = sut.getShippingRates(1L,defaultPackageData, defaultAddress, defaultOriginAddress, 2f)
+        val result = sut.getShippingRates(1L, defaultPackageData, defaultAddress, defaultOriginAddress, 2f)
 
         assert(result.isSuccess)
     }
-
 }

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/rates/datasource/WooShippingRatesRepositoryTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/rates/datasource/WooShippingRatesRepositoryTest.kt
@@ -86,7 +86,7 @@ class WooShippingRatesRepositoryTest : BaseUnitTest() {
                 message = "Error"
             )
         )
-        val result = sut.getShippingRates(defaultPackageData, defaultAddress, defaultOriginAddress)
+        val result = sut.getShippingRates(1L,defaultPackageData, defaultAddress, defaultOriginAddress, 2f)
 
         assert(result.isFailure)
     }
@@ -97,7 +97,7 @@ class WooShippingRatesRepositoryTest : BaseUnitTest() {
             restClient.getShippingRates(any(), any(), any(), any(), any())
         ) doReturn WooResult(emptyMap())
 
-        val result = sut.getShippingRates(defaultPackageData, defaultAddress, defaultOriginAddress)
+        val result = sut.getShippingRates(1L,defaultPackageData, defaultAddress, defaultOriginAddress, 2f)
 
         assert(result.isSuccess)
     }


### PR DESCRIPTION
Part of: #12286

### Description
This PR supports custom weight in shipping rates by adding the custom view input field and refactoring the main flow's view model to observe and respond to typing events. We are no handling errors in this task, we will work on errors on M2.

### Testing information

1. Open the orders section
2. Select an order that is eligible to create shipping labels (processing state)
3. Tap on create shipping label
4. Select a package
5. Check that shipping rates are fetched from the API
6. Check that the custom weight field is displayed
7. Check that the custom weight hint matches the sum of the package weight and items weight
8. Type a new weight in the custom weight input field
9. Check that a new request is made to refresh the shipping rates

### The tests that have been performed
1. Checked that changing the custom weight refreshes the shipping rates
2. Checked that deleting a custom weight refreshes the shipping rates
3. Checked that the custom weight hint matches  the sum of package weight and items weight
4. Checked that after changing the custom weight, the UI waits for the user to stop typing before requesting the data to the API

### Images/gif

https://github.com/user-attachments/assets/f8aabc9d-364e-47be-a4fb-6e969225ee60

- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.

## Reviewer (or Author, in the case of optional code reviews):

Please make sure these conditions are met before approving the PR, or request changes if the PR needs improvement:

- [ ] The PR is small and has a clear, single focus, or a valid explanation is provided in the description. If needed, please request to split it into smaller PRs.
- [ ] Ensure Adequate Unit Test Coverage: The changes are reasonably covered by unit tests or an explanation is provided in the PR description.
- [x] Manual Testing: The author listed all the tests they ran, including smoke tests when needed (e.g., for refactorings). The reviewer confirmed that the PR works as expected on big (tablet) and small (phone) in case of UI changes, and no regressions are added.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->