### PR TITLE
[Woo POS][Cash & Receipts] Go directly forward to the payment success screen from cash payment

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/cashpayment/WooPosCashPaymentNavigation.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/cashpayment/WooPosCashPaymentNavigation.kt
@@ -8,6 +8,7 @@ import androidx.navigation.NavType
 import androidx.navigation.compose.composable
 import androidx.navigation.navArgument
 import com.woocommerce.android.ui.woopos.home.HOME_ROUTE
+import com.woocommerce.android.ui.woopos.home.IsHomePaymentCompletedViaCash
 import com.woocommerce.android.ui.woopos.root.navigation.WooPosNavigationEvent
 import com.woocommerce.android.ui.woopos.root.navigation.navigateOnce
 
@@ -33,8 +34,19 @@ fun NavGraphBuilder.cashPaymentScreen(
         },
         exitTransition = {
             slideOutHorizontally(
-                targetOffsetX = { fullWidth -> fullWidth },
+                targetOffsetX = { fullWidth -> -fullWidth },
             )
+        },
+        popExitTransition = {
+            if (targetState.IsHomePaymentCompletedViaCash) {
+                slideOutHorizontally(
+                    targetOffsetX = { fullWidth -> -fullWidth },
+                )
+            } else {
+                slideOutHorizontally(
+                    targetOffsetX = { fullWidth -> fullWidth },
+                )
+            }
         },
     ) { backStackEntry ->
         WooPosCashPaymentScreen(

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/WooPosHomeNavigation.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/WooPosHomeNavigation.kt
@@ -5,6 +5,7 @@ import androidx.compose.animation.core.tween
 import androidx.compose.animation.fadeIn
 import androidx.compose.animation.slideInHorizontally
 import androidx.compose.animation.slideOutHorizontally
+import androidx.navigation.NavBackStackEntry
 import androidx.navigation.NavController
 import androidx.navigation.NavGraphBuilder
 import androidx.navigation.compose.composable
@@ -23,7 +24,10 @@ fun NavController.navigateToHomeScreenAfterSuccessfulCashPayment() {
         ?.savedStateHandle
         ?.set(HOME_PAYMENT_COMPLETED_VIA_CASH_KEY, true)
 
-    popBackStack()
+    navigate(HOME_ROUTE) {
+        popUpTo(HOME_ROUTE) { inclusive = false }
+        launchSingleTop = true
+    }
 }
 
 fun NavGraphBuilder.homeScreen(
@@ -46,12 +50,19 @@ fun NavGraphBuilder.homeScreen(
             )
         },
         popEnterTransition = {
-            slideInHorizontally(
-                initialOffsetX = { fullWidth -> -fullWidth },
-            )
+            if (targetState.IsHomePaymentCompletedViaCash) {
+                slideInHorizontally(
+                    initialOffsetX = { fullWidth -> fullWidth },
+                )
+            } else {
+                slideInHorizontally(
+                    initialOffsetX = { fullWidth -> -fullWidth },
+                )
+            }
         },
     ) { entry ->
         val savedStateHandle = entry.savedStateHandle
+
         val isPaymentCompletedViaCash = savedStateHandle.get<Boolean>(HOME_PAYMENT_COMPLETED_VIA_CASH_KEY) == true
         if (isPaymentCompletedViaCash) {
             savedStateHandle[HOME_PAYMENT_COMPLETED_VIA_CASH_KEY] = false
@@ -63,3 +74,6 @@ fun NavGraphBuilder.homeScreen(
         )
     }
 }
+
+val NavBackStackEntry.IsHomePaymentCompletedViaCash: Boolean
+    get() = savedStateHandle.get<Boolean>(HOME_PAYMENT_COMPLETED_VIA_CASH_KEY) == true

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/WooPosHomeScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/WooPosHomeScreen.kt
@@ -46,7 +46,6 @@ import com.woocommerce.android.ui.woopos.root.navigation.WooPosNavigationEvent
 import com.woocommerce.android.ui.woopos.root.navigation.WooPosNavigationEvent.ExitPosClicked
 import com.woocommerce.android.ui.woopos.root.navigation.WooPosNavigationEvent.OpenCashPayment
 import com.woocommerce.android.ui.woopos.root.navigation.WooPosNavigationEvent.OpenEmailReceipt
-import kotlinx.coroutines.delay
 import org.wordpress.android.util.ToastUtils
 
 @Composable
@@ -60,7 +59,6 @@ fun WooPosHomeScreen(
 
     LaunchedEffect(Unit) {
         if (isPaymentCompletedViaCash) {
-            delay(800)
             viewModel.onUIEvent(WooPosHomeUIEvent.OnPaymentCompletedViaCash)
         }
     }


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #13142 
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
The PR changes the transtion animation from cash payments screen to the payment success screen

### Testing information
<!-- This is your opportunity to break out individual scenarios that need testing (when necessary) and/or include a checklist for the reviewer to go through. Consider documenting the following from your own completed testing: devices used, alternate workflows, edge cases, affected areas, critical flows, areas not tested, and any remaining unknowns. Provide feedback on this new section of the PR template through Sept 30, 2024 to Apps Quality; additional context here: https://woomobilep2.wordpress.com/2024/05/06/woocommerce-mobile-quality-report-march-april/#comment-12036 -->
* POS -> Order -> Cash Payment
* Make the payment
* Notice that the animation is changed and now "success" payment screen is animated without showing the totals

Validate that the rest of the animations from/to home screen are validate to
### The tests that have been performed
<!-- To give the reviewer an idea of what could be missed in terms of testing -->
above

### Images/gif
<!-- Include before and after images or gifs when appropriate. -->

https://github.com/user-attachments/assets/3446d6b4-e1fe-4e8b-bf6a-303a7a26b6c8


- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.

## Reviewer (or Author, in the case of optional code reviews):

Please make sure these conditions are met before approving the PR, or request changes if the PR needs improvement:

- [x] The PR is small and has a clear, single focus, or a valid explanation is provided in the description. If needed, please request to split it into smaller PRs.
- [x] Ensure Adequate Unit Test Coverage: The changes are reasonably covered by unit tests or an explanation is provided in the PR description.
- [x] Manual Testing: The author listed all the tests they ran, including smoke tests when needed (e.g., for refactorings). The reviewer confirmed that the PR works as expected on big (tablet) and small (phone) in case of UI changes, and no regressions are added.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
