### PR TITLE
[Woo POS] Crash parcelizing lambda

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/totals/WooPosTotalsScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/totals/WooPosTotalsScreen.kt
@@ -276,7 +276,7 @@ private fun ReaderDisconnected(
         )
         Spacer(modifier = Modifier.height(40.dp.toAdaptivePadding()))
         WooPosButton(
-            text = status.actionButonLabel,
+            text = status.actionButtonLabel,
             onClick = status.onAction,
             modifier = Modifier
                 .fillMaxWidth()
@@ -440,7 +440,7 @@ fun WooPosTotalsScreenPreviewReaderNotConnected(modifier: Modifier = Modifier) {
                 readerStatus = WooPosTotalsViewState.ReaderStatus.Disconnected(
                     title = "Reader not connected",
                     subtitle = "To process this payment, please connect your reader.",
-                    actionButonLabel = "Connect to a reader",
+                    actionButtonLabel = "Connect to a reader",
                     onAction = {}
                 )
             ),
@@ -463,7 +463,7 @@ fun WooPosTotalsScreenPreviewWithCashPaymentAvailable() {
                 readerStatus = WooPosTotalsViewState.ReaderStatus.Disconnected(
                     title = "Reader not connected",
                     subtitle = "To process this payment, please connect your reader.",
-                    actionButonLabel = "Connect to a reader",
+                    actionButtonLabel = "Connect to a reader",
                     onAction = {}
                 )
             ),
@@ -478,7 +478,7 @@ fun TotalsErrorPreview() {
     val readerStatus = WooPosTotalsViewState.ReaderStatus.Disconnected(
         title = "Reader not connected",
         subtitle = "To process this payment, please connect your reader.",
-        actionButonLabel = "Connect to a reader",
+        actionButtonLabel = "Connect to a reader",
         onAction = {}
     )
     WooPosTheme {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/totals/WooPosTotalsScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/totals/WooPosTotalsScreen.kt
@@ -161,7 +161,7 @@ private fun TotalsLoaded(
         ) {
             when (val readerStatus = state.readerStatus) {
                 is WooPosTotalsViewState.ReaderStatus.Disconnected -> {
-                    ReaderDisconnected(modifier = Modifier, status = readerStatus)
+                    ReaderDisconnected(modifier = Modifier, status = readerStatus, onUIEvent = onUIEvent)
                 }
 
                 is WooPosTotalsViewState.ReaderStatus.Preparing,
@@ -244,7 +244,8 @@ private fun ReaderReadyForPayment(readerStatus: WooPosTotalsViewState.ReaderStat
 @Composable
 private fun ReaderDisconnected(
     modifier: Modifier = Modifier,
-    status: WooPosTotalsViewState.ReaderStatus.Disconnected
+    status: WooPosTotalsViewState.ReaderStatus.Disconnected,
+    onUIEvent: (WooPosTotalsUIEvent) -> Unit,
 ) {
     Column(
         modifier = modifier.padding(40.dp.toAdaptivePadding()),
@@ -277,7 +278,7 @@ private fun ReaderDisconnected(
         Spacer(modifier = Modifier.height(40.dp.toAdaptivePadding()))
         WooPosButton(
             text = status.actionButtonLabel,
-            onClick = status.onAction,
+            onClick = { onUIEvent(WooPosTotalsUIEvent.ConnectReaderClicked) },
             modifier = Modifier
                 .fillMaxWidth()
                 .height(80.dp)
@@ -441,7 +442,6 @@ fun WooPosTotalsScreenPreviewReaderNotConnected(modifier: Modifier = Modifier) {
                     title = "Reader not connected",
                     subtitle = "To process this payment, please connect your reader.",
                     actionButtonLabel = "Connect to a reader",
-                    onAction = {}
                 )
             ),
             onUIEvent = {},
@@ -464,7 +464,6 @@ fun WooPosTotalsScreenPreviewWithCashPaymentAvailable() {
                     title = "Reader not connected",
                     subtitle = "To process this payment, please connect your reader.",
                     actionButtonLabel = "Connect to a reader",
-                    onAction = {}
                 )
             ),
             onUIEvent = {},
@@ -479,10 +478,9 @@ fun TotalsErrorPreview() {
         title = "Reader not connected",
         subtitle = "To process this payment, please connect your reader.",
         actionButtonLabel = "Connect to a reader",
-        onAction = {}
     )
     WooPosTheme {
-        ReaderDisconnected(modifier = Modifier, status = readerStatus)
+        ReaderDisconnected(modifier = Modifier, status = readerStatus) {}
     }
 }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/totals/WooPosTotalsUIEvent.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/totals/WooPosTotalsUIEvent.kt
@@ -7,4 +7,5 @@ sealed class WooPosTotalsUIEvent {
     data object RetryOrderCreationClicked : WooPosTotalsUIEvent()
     data object OnStartReceiptFlowClicked : WooPosTotalsUIEvent()
     data object OnCashPaymentClicked : WooPosTotalsUIEvent()
+    data object ConnectReaderClicked : WooPosTotalsUIEvent()
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/totals/WooPosTotalsViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/totals/WooPosTotalsViewModel.kt
@@ -452,7 +452,7 @@ class WooPosTotalsViewModel @Inject constructor(
         WooPosTotalsViewState.ReaderStatus.Disconnected(
             title = resourceProvider.getString(R.string.woopos_success_totals_error_reader_not_connected_title),
             subtitle = resourceProvider.getString(R.string.woopos_success_totals_error_reader_not_connected_subtitle),
-            actionButonLabel = resourceProvider.getString(
+            actionButtonLabel = resourceProvider.getString(
                 R.string.woopos_success_totals_error_reader_not_connected_cta_button_label
             ),
             onAction = { cardReaderFacade.connectToReader() }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/totals/WooPosTotalsViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/totals/WooPosTotalsViewModel.kt
@@ -207,6 +207,8 @@ class WooPosTotalsViewModel @Inject constructor(
                     }
                 }
             }
+
+            WooPosTotalsUIEvent.ConnectReaderClicked -> cardReaderFacade.connectToReader()
         }
     }
 
@@ -455,7 +457,6 @@ class WooPosTotalsViewModel @Inject constructor(
             actionButtonLabel = resourceProvider.getString(
                 R.string.woopos_success_totals_error_reader_not_connected_cta_button_label
             ),
-            onAction = { cardReaderFacade.connectToReader() }
         )
 
     private fun initIsReceiptSendingSupportedValue() {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/totals/WooPosTotalsViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/totals/WooPosTotalsViewModel.kt
@@ -149,6 +149,7 @@ class WooPosTotalsViewModel @Inject constructor(
         cardReaderPaymentController?.stop()
     }
 
+    @Suppress("LongMethod")
     fun onUIEvent(event: WooPosTotalsUIEvent) {
         when (event) {
             is WooPosTotalsUIEvent.OnNewTransactionClicked -> {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/totals/WooPosTotalsViewState.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/totals/WooPosTotalsViewState.kt
@@ -56,7 +56,6 @@ sealed class WooPosTotalsViewState : Parcelable {
             override val title: String,
             override val subtitle: String,
             val actionButtonLabel: String,
-            val onAction: () -> Unit,
         ) : ReaderStatus(
             title = title,
             subtitle = subtitle

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/totals/WooPosTotalsViewState.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/totals/WooPosTotalsViewState.kt
@@ -1,7 +1,6 @@
 package com.woocommerce.android.ui.woopos.home.totals
 
 import android.os.Parcelable
-import com.woocommerce.android.ui.woopos.home.totals.WooPosTotalsViewState.ReaderStatus
 import kotlinx.parcelize.Parcelize
 
 @Parcelize
@@ -56,7 +55,7 @@ sealed class WooPosTotalsViewState : Parcelable {
         data class Disconnected(
             override val title: String,
             override val subtitle: String,
-            val actionButonLabel: String,
+            val actionButtonLabel: String,
             val onAction: () -> Unit,
         ) : ReaderStatus(
             title = title,

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/home/totals/WooPosTotalsViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/home/totals/WooPosTotalsViewModelTest.kt
@@ -694,9 +694,8 @@ class WooPosTotalsViewModelTest {
 
         // WHEN
         val viewModel = createViewModelAndSetupForSuccessfulOrderCreation()
-        assertThat(viewModel.state.value is WooPosTotalsViewState.Totals).isTrue()
-        val state = viewModel.state.value as WooPosTotalsViewState.Totals
-        (state.readerStatus as WooPosTotalsViewState.ReaderStatus.Disconnected).onAction()
+        assertThat(viewModel.state.value).isInstanceOf(WooPosTotalsViewState.Totals::class.java)
+        viewModel.onUIEvent(WooPosTotalsUIEvent.ConnectReaderClicked)
 
         // THEN
         verify(cardReaderFacade).connectToReader()

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/home/totals/WooPosTotalsViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/home/totals/WooPosTotalsViewModelTest.kt
@@ -670,7 +670,7 @@ class WooPosTotalsViewModelTest {
         with(state.readerStatus as WooPosTotalsViewState.ReaderStatus.Disconnected) {
             assertThat(title).isEqualTo("Reader not connected")
             assertThat(subtitle).isEqualTo("To process this payment, please connect your reader.")
-            assertThat(actionButonLabel).isEqualTo("Connect to reader")
+            assertThat(actionButtonLabel).isEqualTo("Connect to reader")
         }
     }
 


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->
Fix for crash: 
```kotlin
java.lang.ClassCastException
com.woocommerce.android.ui.woopos.home.totals.WooPosTotalsViewState$ReaderStatus$Disconnected.writeToParcel
```

Closes: #13146
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
This PR fixes the above crash by removing lambda from the state model, and handling button click by passing event to `VM::onUIEvent` method.

### Steps to reproduce
<!-- Step-by-step testing instructions. For new user flows, consider instead stating the goal of the workflow and see if your PR reviewer can accomplish the workflow without specific steps! -->
1. Open Point of sale (More > Point of sale)
2. Ensure reader is disconnected
3. Add item to cart and click "Checkout"
4. Wait for totals table to show up
5. Move app to background and observe crash

### Testing information
<!-- This is your opportunity to break out individual scenarios that need testing (when necessary) and/or include a checklist for the reviewer to go through. Consider documenting the following from your own completed testing: devices used, alternate workflows, edge cases, affected areas, critical flows, areas not tested, and any remaining unknowns. Provide feedback on this new section of the PR template through Sept 30, 2024 to Apps Quality; additional context here: p91TBi-b8z-p2#comment-12036 -->
The above scenario must not result in crashing.

### The tests that have been performed
<!-- To give the reviewer an idea of what could be missed in terms of testing -->
I tested that the crash is not happening, and the "Connect reader" button works.

### Images/gif
<!-- Include before and after images or gifs when appropriate. -->
–

- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.

## Reviewer (or Author, in the case of optional code reviews):

Please make sure these conditions are met before approving the PR, or request changes if the PR needs improvement:

- [ ] The PR is small and has a clear, single focus, or a valid explanation is provided in the description. If needed, please request to split it into smaller PRs.
- [ ] Ensure Adequate Unit Test Coverage: The changes are reasonably covered by unit tests or an explanation is provided in the PR description.
- [ ] Manual Testing: The author listed all the tests they ran, including smoke tests when needed (e.g., for refactorings). The reviewer confirmed that the PR works as expected on big (tablet) and small (phone) in case of UI changes, and no regressions are added.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->