### PR TITLE
[Woo POS][Cash & Receipts] Do not play animations when coming back from receipts screens

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/totals/payment/success/WooPosTotalsPaymentSuccessScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/totals/payment/success/WooPosTotalsPaymentSuccessScreen.kt
@@ -1,8 +1,6 @@
 package com.woocommerce.android.ui.woopos.home.totals.payment.success
 
-import androidx.compose.animation.core.Spring
 import androidx.compose.animation.core.animateDpAsState
-import androidx.compose.animation.core.spring
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.fillMaxSize
@@ -18,10 +16,11 @@ import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Check
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
-import androidx.compose.runtime.setValue
+import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
@@ -37,6 +36,8 @@ import com.woocommerce.android.ui.woopos.common.composeui.component.WooPosOutlin
 import com.woocommerce.android.ui.woopos.common.composeui.toAdaptivePadding
 import com.woocommerce.android.ui.woopos.home.totals.WooPosTotalsViewState
 import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.update
 
 @Composable
 fun WooPosPaymentSuccessScreen(
@@ -44,30 +45,30 @@ fun WooPosPaymentSuccessScreen(
     onReceiptClicked: () -> Unit,
     onNewTransactionClicked: () -> Unit,
 ) {
-    var bottomAnimationStarted by remember { mutableStateOf(false) }
-    var iconAnimationStarted by remember { mutableStateOf(false) }
+    val savedAnimationStage = rememberSaveable { mutableStateOf(AnimationStage.INITIAL) }
+    val animationStateFlow = remember { MutableStateFlow(savedAnimationStage.value) }
 
     LaunchedEffect(Unit) {
-        delay(300)
-        bottomAnimationStarted = true
-        delay(300)
-        iconAnimationStarted = true
+        if (animationStateFlow.value != AnimationStage.FINISHED) {
+            startAnimations(animationStateFlow)
+        }
     }
+
+    val animationState = animationStateFlow.collectAsState().value
+    savedAnimationStage.value = animationState
 
     WooPosPaymentSuccessScreen(
         state = state,
-        iconAnimationStarted = iconAnimationStarted,
-        bottomAnimationStarted = bottomAnimationStarted,
+        animationStage = animationState,
         onReceiptClicked = onReceiptClicked,
         onNewTransactionClicked = onNewTransactionClicked,
     )
 }
 
 @Composable
-fun WooPosPaymentSuccessScreen(
+private fun WooPosPaymentSuccessScreen(
     state: WooPosTotalsViewState.PaymentSuccess,
-    iconAnimationStarted: Boolean,
-    bottomAnimationStarted: Boolean,
+    animationStage : AnimationStage,
     onReceiptClicked: () -> Unit,
     onNewTransactionClicked: () -> Unit,
 ) {
@@ -78,7 +79,7 @@ fun WooPosPaymentSuccessScreen(
         contentAlignment = Alignment.Center
     ) {
         val marginBetweenButtonAndText by animateDpAsState(
-            targetValue = if (bottomAnimationStarted) 80.dp else 16.dp,
+            targetValue = if (animationStage >= AnimationStage.BUTTONS) 80.dp else 16.dp,
             label = "Check mark size"
         )
         @Suppress("DestructuringDeclarationWithTooManyEntries")
@@ -87,7 +88,7 @@ fun WooPosPaymentSuccessScreen(
 
             val checkMarkIconMargin = 56.dp.toAdaptivePadding()
             CheckMarkIcon(
-                animationStarted = iconAnimationStarted,
+                animationStage = animationStage,
                 modifier = Modifier.constrainAs(icon) {
                     start.linkTo(parent.start)
                     end.linkTo(parent.end)
@@ -161,27 +162,17 @@ fun WooPosPaymentSuccessScreen(
 
 @Composable
 private fun CheckMarkIcon(
-    animationStarted: Boolean,
+    animationStage : AnimationStage,
     modifier: Modifier = Modifier,
 ) {
     val size by animateDpAsState(
-        targetValue = if (animationStarted) 164.dp else 0.dp,
-        label = "Check mark size"
+        targetValue = if (animationStage >= AnimationStage.CIRCLE) 164.dp else 0.dp,
+        label = "Circle Size"
     )
-
-    var iconAnimationStarted by remember { mutableStateOf(false) }
     val iconSize by animateDpAsState(
-        targetValue = if (iconAnimationStarted) 72.dp else 0.dp,
-        animationSpec = spring(dampingRatio = Spring.DampingRatioMediumBouncy),
+        targetValue = if (animationStage >= AnimationStage.ICON) 72.dp else 0.dp,
         label = "Icon Size"
     )
-
-    LaunchedEffect(animationStarted) {
-        if (animationStarted) {
-            delay(300)
-            iconAnimationStarted = true
-        }
-    }
 
     Box(
         contentAlignment = Alignment.Center,
@@ -199,6 +190,24 @@ private fun CheckMarkIcon(
     }
 }
 
+private suspend fun startAnimations(stateFlow: MutableStateFlow<AnimationStage>) {
+    stateFlow.update { AnimationStage.BUTTONS }
+    delay(300)
+    stateFlow.update { AnimationStage.CIRCLE }
+    delay(300)
+    stateFlow.update { AnimationStage.ICON }
+    delay(300)
+    stateFlow.update { AnimationStage.FINISHED }
+}
+
+private enum class AnimationStage {
+    INITIAL,
+    BUTTONS,
+    CIRCLE,
+    ICON,
+    FINISHED,
+}
+
 @WooPosPreview
 @Composable
 fun WooPosPaymentSuccessScreenPreview() {
@@ -208,8 +217,7 @@ fun WooPosPaymentSuccessScreenPreview() {
                 orderTotalText = "A payment of 13.18 was successfully made",
                 isReceiptAvailable = true,
             ),
-            bottomAnimationStarted = true,
-            iconAnimationStarted = true,
+            animationStage = AnimationStage.FINISHED,
             onReceiptClicked = {},
             onNewTransactionClicked = {}
         )
@@ -225,8 +233,7 @@ fun WooPosPaymentSuccessWithoutReceiptScreenPreview() {
                 orderTotalText = "A payment of 13.18 was successfully made",
                 isReceiptAvailable = false,
             ),
-            bottomAnimationStarted = true,
-            iconAnimationStarted = true,
+            animationStage = AnimationStage.FINISHED,
             onReceiptClicked = {},
             onNewTransactionClicked = {}
         )

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/totals/payment/success/WooPosTotalsPaymentSuccessScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/totals/payment/success/WooPosTotalsPaymentSuccessScreen.kt
@@ -68,7 +68,7 @@ fun WooPosPaymentSuccessScreen(
 @Composable
 private fun WooPosPaymentSuccessScreen(
     state: WooPosTotalsViewState.PaymentSuccess,
-    animationStage : AnimationStage,
+    animationStage: AnimationStage,
     onReceiptClicked: () -> Unit,
     onNewTransactionClicked: () -> Unit,
 ) {
@@ -162,7 +162,7 @@ private fun WooPosPaymentSuccessScreen(
 
 @Composable
 private fun CheckMarkIcon(
-    animationStage : AnimationStage,
+    animationStage: AnimationStage,
     modifier: Modifier = Modifier,
 ) {
     val size by animateDpAsState(
@@ -190,13 +190,13 @@ private fun CheckMarkIcon(
     }
 }
 
+@Suppress("MagicNumber")
 private suspend fun startAnimations(stateFlow: MutableStateFlow<AnimationStage>) {
     stateFlow.update { AnimationStage.BUTTONS }
     delay(300)
     stateFlow.update { AnimationStage.CIRCLE }
     delay(300)
     stateFlow.update { AnimationStage.ICON }
-    delay(300)
     stateFlow.update { AnimationStage.FINISHED }
 }
 


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #13154 
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
Before this PR the animation of the succcess screen was played everytime it was open. Now only when it's open after successful payment

### Testing information
<!-- This is your opportunity to break out individual scenarios that need testing (when necessary) and/or include a checklist for the reviewer to go through. Consider documenting the following from your own completed testing: devices used, alternate workflows, edge cases, affected areas, critical flows, areas not tested, and any remaining unknowns. Provide feedback on this new section of the PR template through Sept 30, 2024 to Apps Quality; additional context here: p91TBi-b8z-p2#comment-12036 -->
Validate that the animation is the same and played only after successful payment, both after card and cash payment

### The tests that have been performed
<!-- To give the reviewer an idea of what could be missed in terms of testing -->

### Images/gif
<!-- Include before and after images or gifs when appropriate. -->

https://github.com/user-attachments/assets/8c7b4e93-8822-4671-bb72-f45cdc8f12f7


- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.

## Reviewer (or Author, in the case of optional code reviews):

Please make sure these conditions are met before approving the PR, or request changes if the PR needs improvement:

- [x] The PR is small and has a clear, single focus, or a valid explanation is provided in the description. If needed, please request to split it into smaller PRs.
- [x] Ensure Adequate Unit Test Coverage: The changes are reasonably covered by unit tests or an explanation is provided in the PR description.
- [x] Manual Testing: The author listed all the tests they ran, including smoke tests when needed (e.g., for refactorings). The reviewer confirmed that the PR works as expected on big (tablet) and small (phone) in case of UI changes, and no regressions are added.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->