### PR TITLE
Show currently selected site in site visibility editor screen

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/sitepicker/sitevisibility/StoreVisibilityScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/sitepicker/sitevisibility/StoreVisibilityScreen.kt
@@ -116,7 +116,7 @@ fun WooSitesVisibilityScreen(
                 style = WooTypography.caption,
                 color = MaterialTheme.colors.onSurface,
             )
-            Spacer(Modifier.height(16.dp))
+            Spacer(Modifier.height(24.dp))
             Text(
                 modifier = Modifier.padding(top = 16.dp, bottom = 8.dp),
                 text = stringResource(R.string.site_picker_edit_store_list_header),
@@ -153,9 +153,9 @@ private fun AvailableStoresForHiding(
         itemsIndexed(state.wooStores) { index, wooStore ->
             Row(
                 modifier = Modifier
+                    .fillMaxWidth()
                     .clickable { onSiteSelected(wooStore) }
-                    .padding(horizontal = 16.dp)
-                    .fillMaxWidth(),
+                    .padding(start = 16.dp),
                 verticalAlignment = Alignment.CenterVertically
             ) {
                 SelectionCheck(
@@ -165,7 +165,7 @@ private fun AvailableStoresForHiding(
                 StoreItem(
                     wooStore = wooStore,
                     showDivider = index < state.wooStores.size - 1,
-                    modifier = Modifier.padding(start = 16.dp, end = 16.dp, top = 16.dp)
+                    modifier = Modifier.padding(start = 16.dp, top = 16.dp)
                 )
             }
         }
@@ -186,6 +186,7 @@ private fun StoreItem(
         )
         Spacer(Modifier.height(4.dp))
         Text(
+            modifier = Modifier.padding(end = 8.dp),
             text = wooStore.siteUrl,
             style = WooTypography.body2,
             color = colorResource(id = R.color.color_on_surface_medium)
@@ -214,7 +215,8 @@ fun StoreVisibilityScreenPreview() {
                     siteUrl = "https://example.com",
                     siteId = 1,
                     isSelected = true
-                ), WooStoreUi(
+                ),
+                WooStoreUi(
                     siteName = "Some Store",
                     siteUrl = "https://example.com",
                     siteId = 1,

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/sitepicker/sitevisibility/StoreVisibilityScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/sitepicker/sitevisibility/StoreVisibilityScreen.kt
@@ -101,6 +101,12 @@ fun WooSitesVisibilityScreen(
                 style = WooTypography.subtitle1,
                 color = MaterialTheme.colors.onSurface,
             )
+            Text(
+                modifier = Modifier.padding(bottom = 8.dp),
+                text = stringResource(R.string.site_picker_edit_store_current_site_footer),
+                style = WooTypography.caption,
+                color = MaterialTheme.colors.onSurface,
+            )
             StoreItem(
                 wooStore = state.currentSite,
                 modifier = Modifier
@@ -112,17 +118,17 @@ fun WooSitesVisibilityScreen(
                     )
                     .padding(start = 16.dp, end = 16.dp, top = 16.dp),
             )
-            Text(
-                modifier = Modifier.padding(vertical = 8.dp),
-                text = stringResource(R.string.site_picker_edit_store_current_site_footer),
-                style = WooTypography.caption,
-                color = MaterialTheme.colors.onSurface,
-            )
             Spacer(Modifier.height(24.dp))
             Text(
                 modifier = Modifier.padding(top = 16.dp, bottom = 8.dp),
                 text = stringResource(R.string.site_picker_edit_store_list_header),
                 style = WooTypography.subtitle1,
+                color = MaterialTheme.colors.onSurface,
+            )
+            Text(
+                modifier = Modifier.padding(bottom = 8.dp),
+                text = stringResource(R.string.site_picker_edit_store_list_footer),
+                style = WooTypography.caption,
                 color = MaterialTheme.colors.onSurface,
             )
             AvailableStoresForHiding(
@@ -134,12 +140,7 @@ fun WooSitesVisibilityScreen(
                         color = borderColor,
                         shape = RoundedCornerShape(8.dp)
                     )
-            )
-            Text(
-                modifier = Modifier.padding(vertical = 8.dp),
-                text = stringResource(R.string.site_picker_edit_store_list_footer),
-                style = WooTypography.caption,
-                color = MaterialTheme.colors.onSurface,
+                    .padding(bottom = 16.dp)
             )
         }
     }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/sitepicker/sitevisibility/StoreVisibilityScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/sitepicker/sitevisibility/StoreVisibilityScreen.kt
@@ -91,14 +91,14 @@ fun WooSitesVisibilityScreen(
                 color = MaterialTheme.colors.onSurface,
             )
             StoreItem(
-                wooStore = state.wooStores.first(),
+                wooStore = state.currentSite,
                 modifier = Modifier
                     .background(MaterialTheme.colors.surface)
                     .padding(start = 16.dp, end = 16.dp, top = 16.dp),
             )
             Text(
                 modifier = Modifier.padding(horizontal = 16.dp, vertical = 8.dp),
-                text = stringResource(R.string.site_picker_edit_store_list_footer),
+                text = stringResource(R.string.site_picker_edit_store_current_site_footer),
                 style = WooTypography.caption,
                 color = MaterialTheme.colors.onSurface,
             )
@@ -185,25 +185,31 @@ fun StoreVisibilityScreenPreview() {
         state = WooStoresUiState(
             wooStores = listOf(
                 WooStoreUi(
-                    siteName = "My Store",
+                    siteName = "Another Store",
                     siteUrl = "https://example.com",
                     siteId = 1,
                     isSelected = true
                 ),
                 WooStoreUi(
-                    siteName = "My Store",
+                    siteName = "Any Store",
                     siteUrl = "https://example.com",
                     siteId = 1,
                     isSelected = true
                 ), WooStoreUi(
-                    siteName = "My Store",
+                    siteName = "Some Store",
                     siteUrl = "https://example.com",
                     siteId = 1,
                     isSelected = true
                 )
 
             ),
-            isSaveButtonEnabled = true
+            isSaveButtonEnabled = true,
+            currentSite = WooStoreUi(
+                siteName = "Current Store",
+                siteUrl = "https://myselectedSite.com",
+                siteId = 1,
+                isSelected = true
+            )
         ),
         onBack = {},
         onSaveTapped = {},

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/sitepicker/sitevisibility/StoreVisibilityScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/sitepicker/sitevisibility/StoreVisibilityScreen.kt
@@ -7,6 +7,7 @@ import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
@@ -91,6 +92,7 @@ fun WooSitesVisibilityScreen(
             modifier = modifier
                 .padding(padding)
                 .background(MaterialTheme.colors.surface)
+                .fillMaxSize()
                 .verticalScroll(rememberScrollState())
                 .padding(horizontal = 16.dp)
         ) {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/sitepicker/sitevisibility/StoreVisibilityScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/sitepicker/sitevisibility/StoreVisibilityScreen.kt
@@ -177,8 +177,8 @@ private fun AvailableStoresForHiding(
 @Composable
 private fun StoreItem(
     wooStore: WooStoreUi,
-    showDivider: Boolean = false,
-    modifier: Modifier = Modifier
+    modifier: Modifier = Modifier,
+    showDivider: Boolean = false
 ) {
     Column(modifier = modifier) {
         Text(

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/sitepicker/sitevisibility/StoreVisibilityScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/sitepicker/sitevisibility/StoreVisibilityScreen.kt
@@ -2,6 +2,7 @@ package com.woocommerce.android.ui.sitepicker.sitevisibility
 
 import androidx.activity.compose.BackHandler
 import androidx.compose.foundation.background
+import androidx.compose.foundation.border
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
@@ -11,6 +12,7 @@ import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.itemsIndexed
+import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.Divider
 import androidx.compose.material.Icon
 import androidx.compose.material.IconButton
@@ -83,9 +85,16 @@ fun WooSitesVisibilityScreen(
             elevation = 0.dp
         )
     }) { padding ->
-        Column(modifier = modifier.padding(padding)) {
+        val borderWidth = 1.dp
+        val borderColor = colorResource(id = R.color.divider_color)
+        Column(
+            modifier = modifier
+                .background(MaterialTheme.colors.surface)
+                .padding(padding)
+                .padding(horizontal = 16.dp)
+        ) {
             Text(
-                modifier = Modifier.padding(start = 16.dp, top = 16.dp, bottom = 8.dp),
+                modifier = Modifier.padding(top = 16.dp, bottom = 8.dp),
                 text = stringResource(R.string.site_picker_edit_store_current_site_header),
                 style = WooTypography.subtitle1,
                 color = MaterialTheme.colors.onSurface,
@@ -94,17 +103,22 @@ fun WooSitesVisibilityScreen(
                 wooStore = state.currentSite,
                 modifier = Modifier
                     .fillMaxWidth()
-                    .background(MaterialTheme.colors.surface)
+                    .border(
+                        width = borderWidth,
+                        color = borderColor,
+                        shape = RoundedCornerShape(8.dp)
+                    )
                     .padding(start = 16.dp, end = 16.dp, top = 16.dp),
             )
             Text(
-                modifier = Modifier.padding(horizontal = 16.dp, vertical = 8.dp),
+                modifier = Modifier.padding(vertical = 8.dp),
                 text = stringResource(R.string.site_picker_edit_store_current_site_footer),
                 style = WooTypography.caption,
                 color = MaterialTheme.colors.onSurface,
             )
+            Spacer(Modifier.height(16.dp))
             Text(
-                modifier = Modifier.padding(start = 16.dp, top = 16.dp, bottom = 8.dp),
+                modifier = Modifier.padding(top = 16.dp, bottom = 8.dp),
                 text = stringResource(R.string.site_picker_edit_store_list_header),
                 style = WooTypography.subtitle1,
                 color = MaterialTheme.colors.onSurface,
@@ -112,10 +126,15 @@ fun WooSitesVisibilityScreen(
             AvailableStoresForHiding(
                 state = state,
                 onSiteSelected = onSiteSelected,
-                modifier = Modifier.background(MaterialTheme.colors.surface)
+                modifier = Modifier
+                    .border(
+                        width = borderWidth,
+                        color = borderColor,
+                        shape = RoundedCornerShape(8.dp)
+                    )
             )
             Text(
-                modifier = Modifier.padding(horizontal = 16.dp, vertical = 16.dp),
+                modifier = Modifier.padding(vertical = 8.dp),
                 text = stringResource(R.string.site_picker_edit_store_list_footer),
                 style = WooTypography.caption,
                 color = MaterialTheme.colors.onSurface,

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/sitepicker/sitevisibility/StoreVisibilityScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/sitepicker/sitevisibility/StoreVisibilityScreen.kt
@@ -7,13 +7,12 @@ import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
-import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.lazy.LazyColumn
-import androidx.compose.foundation.lazy.itemsIndexed
+import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.Divider
 import androidx.compose.material.Icon
 import androidx.compose.material.IconButton
@@ -90,9 +89,9 @@ fun WooSitesVisibilityScreen(
         val borderColor = colorResource(id = R.color.divider_color)
         Column(
             modifier = modifier
-                .fillMaxSize()
-                .background(MaterialTheme.colors.surface)
                 .padding(padding)
+                .background(MaterialTheme.colors.surface)
+                .verticalScroll(rememberScrollState())
                 .padding(horizontal = 16.dp)
         ) {
             Text(
@@ -118,9 +117,8 @@ fun WooSitesVisibilityScreen(
                     )
                     .padding(start = 16.dp, end = 16.dp, top = 16.dp),
             )
-            Spacer(Modifier.height(24.dp))
             Text(
-                modifier = Modifier.padding(top = 16.dp, bottom = 8.dp),
+                modifier = Modifier.padding(top = 24.dp, bottom = 8.dp),
                 text = stringResource(R.string.site_picker_edit_store_list_header),
                 style = WooTypography.subtitle1,
                 color = MaterialTheme.colors.onSurface,
@@ -135,12 +133,12 @@ fun WooSitesVisibilityScreen(
                 state = state,
                 onSiteSelected = onSiteSelected,
                 modifier = Modifier
+                    .padding(bottom = 16.dp)
                     .border(
                         width = borderWidth,
                         color = borderColor,
                         shape = RoundedCornerShape(8.dp)
                     )
-                    .padding(bottom = 16.dp)
             )
         }
     }
@@ -152,8 +150,8 @@ private fun AvailableStoresForHiding(
     onSiteSelected: (WooStoreUi) -> Unit,
     modifier: Modifier = Modifier,
 ) {
-    LazyColumn(modifier = modifier) {
-        itemsIndexed(state.wooStores) { index, wooStore ->
+    Column(modifier = modifier) {
+        state.wooStores.forEachIndexed { index, wooStore ->
             Row(
                 modifier = Modifier
                     .fillMaxWidth()

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/sitepicker/sitevisibility/StoreVisibilityScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/sitepicker/sitevisibility/StoreVisibilityScreen.kt
@@ -93,6 +93,7 @@ fun WooSitesVisibilityScreen(
             StoreItem(
                 wooStore = state.currentSite,
                 modifier = Modifier
+                    .fillMaxWidth()
                     .background(MaterialTheme.colors.surface)
                     .padding(start = 16.dp, end = 16.dp, top = 16.dp),
             )
@@ -111,9 +112,7 @@ fun WooSitesVisibilityScreen(
             AvailableStoresForHiding(
                 state = state,
                 onSiteSelected = onSiteSelected,
-                modifier = Modifier
-                    .background(MaterialTheme.colors.surface)
-                    .padding(horizontal = 16.dp)
+                modifier = Modifier.background(MaterialTheme.colors.surface)
             )
             Text(
                 modifier = Modifier.padding(horizontal = 16.dp, vertical = 16.dp),
@@ -135,8 +134,9 @@ private fun AvailableStoresForHiding(
         itemsIndexed(state.wooStores) { index, wooStore ->
             Row(
                 modifier = Modifier
-                    .fillMaxWidth()
-                    .clickable { onSiteSelected(wooStore) },
+                    .clickable { onSiteSelected(wooStore) }
+                    .padding(horizontal = 16.dp)
+                    .fillMaxWidth(),
                 verticalAlignment = Alignment.CenterVertically
             ) {
                 SelectionCheck(

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/sitepicker/sitevisibility/StoreVisibilityScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/sitepicker/sitevisibility/StoreVisibilityScreen.kt
@@ -7,6 +7,7 @@ import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
@@ -89,6 +90,7 @@ fun WooSitesVisibilityScreen(
         val borderColor = colorResource(id = R.color.divider_color)
         Column(
             modifier = modifier
+                .fillMaxSize()
                 .background(MaterialTheme.colors.surface)
                 .padding(padding)
                 .padding(horizontal = 16.dp)

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/sitepicker/sitevisibility/StoreVisibilityScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/sitepicker/sitevisibility/StoreVisibilityScreen.kt
@@ -83,50 +83,97 @@ fun WooSitesVisibilityScreen(
             elevation = 0.dp
         )
     }) { padding ->
-        Column {
-            LazyColumn(
-                modifier = modifier
-                    .padding(padding)
-                    .background(MaterialTheme.colors.surface)
-                    .padding(horizontal = 16.dp)
-            ) {
-                itemsIndexed(state.wooStores) { index, wooStore ->
-                    Row(
-                        modifier = Modifier.clickable { onSiteSelected(wooStore) },
-                        verticalAlignment = Alignment.CenterVertically
-                    ) {
-                        SelectionCheck(
-                            isSelected = wooStore.isSelected,
-                            onSelectionChange = null,
-                        )
-                        Column(
-                            Modifier.padding(start = 16.dp, end = 16.dp, top = 16.dp)
-                        ) {
-                            Text(
-                                text = wooStore.siteName,
-                                style = WooTypography.body1,
-                                fontWeight = FontWeight.SemiBold
-                            )
-                            Spacer(Modifier.height(4.dp))
-                            Text(
-                                text = wooStore.siteUrl,
-                                style = WooTypography.body2,
-                                color = colorResource(id = R.color.color_on_surface_medium)
-                            )
-                            Spacer(Modifier.height(16.dp))
-                            if (index < state.wooStores.size - 1) {
-                                Divider()
-                            }
-                        }
-                    }
-                }
-            }
+        Column(modifier = modifier.padding(padding)) {
             Text(
-                modifier = Modifier.padding(16.dp),
+                modifier = Modifier.padding(start = 16.dp, top = 16.dp, bottom = 8.dp),
+                text = stringResource(R.string.site_picker_edit_store_current_site_header),
+                style = WooTypography.subtitle1,
+                color = MaterialTheme.colors.onSurface,
+            )
+            StoreItem(
+                wooStore = state.wooStores.first(),
+                modifier = Modifier
+                    .background(MaterialTheme.colors.surface)
+                    .padding(start = 16.dp, end = 16.dp, top = 16.dp),
+            )
+            Text(
+                modifier = Modifier.padding(horizontal = 16.dp, vertical = 8.dp),
                 text = stringResource(R.string.site_picker_edit_store_list_footer),
                 style = WooTypography.caption,
                 color = MaterialTheme.colors.onSurface,
             )
+            Text(
+                modifier = Modifier.padding(start = 16.dp, top = 16.dp, bottom = 8.dp),
+                text = stringResource(R.string.site_picker_edit_store_list_header),
+                style = WooTypography.subtitle1,
+                color = MaterialTheme.colors.onSurface,
+            )
+            AvailableStoresForHiding(
+                state = state,
+                onSiteSelected = onSiteSelected,
+                modifier = Modifier
+                    .background(MaterialTheme.colors.surface)
+                    .padding(horizontal = 16.dp)
+            )
+            Text(
+                modifier = Modifier.padding(horizontal = 16.dp, vertical = 16.dp),
+                text = stringResource(R.string.site_picker_edit_store_list_footer),
+                style = WooTypography.caption,
+                color = MaterialTheme.colors.onSurface,
+            )
+        }
+    }
+}
+
+@Composable
+private fun AvailableStoresForHiding(
+    state: WooStoresUiState,
+    onSiteSelected: (WooStoreUi) -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    LazyColumn(modifier = modifier) {
+        itemsIndexed(state.wooStores) { index, wooStore ->
+            Row(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .clickable { onSiteSelected(wooStore) },
+                verticalAlignment = Alignment.CenterVertically
+            ) {
+                SelectionCheck(
+                    isSelected = wooStore.isSelected,
+                    onSelectionChange = null,
+                )
+                StoreItem(
+                    wooStore = wooStore,
+                    showDivider = index < state.wooStores.size - 1,
+                    modifier = Modifier.padding(start = 16.dp, end = 16.dp, top = 16.dp)
+                )
+            }
+        }
+    }
+}
+
+@Composable
+private fun StoreItem(
+    wooStore: WooStoreUi,
+    showDivider: Boolean = false,
+    modifier: Modifier = Modifier
+) {
+    Column(modifier = modifier) {
+        Text(
+            text = wooStore.siteName,
+            style = WooTypography.body1,
+            fontWeight = FontWeight.SemiBold
+        )
+        Spacer(Modifier.height(4.dp))
+        Text(
+            text = wooStore.siteUrl,
+            style = WooTypography.body2,
+            color = colorResource(id = R.color.color_on_surface_medium)
+        )
+        Spacer(Modifier.height(16.dp))
+        if (showDivider) {
+            Divider()
         }
     }
 }
@@ -142,7 +189,19 @@ fun StoreVisibilityScreenPreview() {
                     siteUrl = "https://example.com",
                     siteId = 1,
                     isSelected = true
+                ),
+                WooStoreUi(
+                    siteName = "My Store",
+                    siteUrl = "https://example.com",
+                    siteId = 1,
+                    isSelected = true
+                ), WooStoreUi(
+                    siteName = "My Store",
+                    siteUrl = "https://example.com",
+                    siteId = 1,
+                    isSelected = true
                 )
+
             ),
             isSaveButtonEnabled = true
         ),

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/sitepicker/sitevisibility/WooSitesVisibilityViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/sitepicker/sitevisibility/WooSitesVisibilityViewModel.kt
@@ -34,6 +34,10 @@ class WooSitesVisibilityViewModel @Inject constructor(
                 wooStores = sitePickerRepository.getSites()
                     .filter { it.hasWooCommerce && it.siteId != selectedSite.get().siteId }
                     .map { it.toWooStoreUi() }
+                +
+                sitePickerRepository.getSites()
+                    .filter { it.hasWooCommerce && it.siteId != selectedSite.get().siteId }
+                    .map { it.toWooStoreUi() }
             )
             initiallySelectedSiteIds = _wooStores.value.wooStores
                 .filter { it.isSelected }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/sitepicker/sitevisibility/WooSitesVisibilityViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/sitepicker/sitevisibility/WooSitesVisibilityViewModel.kt
@@ -34,10 +34,6 @@ class WooSitesVisibilityViewModel @Inject constructor(
                 wooStores = sitePickerRepository.getSites()
                     .filter { it.hasWooCommerce && it.siteId != selectedSite.get().siteId }
                     .map { it.toWooStoreUi() }
-                +
-                sitePickerRepository.getSites()
-                    .filter { it.hasWooCommerce && it.siteId != selectedSite.get().siteId }
-                    .map { it.toWooStoreUi() }
             )
             initiallySelectedSiteIds = _wooStores.value.wooStores
                 .filter { it.isSelected }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/sitepicker/sitevisibility/WooSitesVisibilityViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/sitepicker/sitevisibility/WooSitesVisibilityViewModel.kt
@@ -2,23 +2,27 @@ package com.woocommerce.android.ui.sitepicker.sitevisibility
 
 import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.asLiveData
+import com.woocommerce.android.tools.SelectedSite
 import com.woocommerce.android.ui.sitepicker.SitePickerRepository
 import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.Exit
 import com.woocommerce.android.viewmodel.ScopedViewModel
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.launch
+import org.wordpress.android.fluxc.model.SiteModel
 import javax.inject.Inject
 
 @HiltViewModel
 class WooSitesVisibilityViewModel @Inject constructor(
     private val sitePickerRepository: SitePickerRepository,
+    private val selectedSite: SelectedSite,
     savedStateHandle: SavedStateHandle
 ) : ScopedViewModel(savedStateHandle) {
     private var initiallySelectedSiteIds: List<Long> = emptyList()
     private val _wooStores = MutableStateFlow(
         WooStoresUiState(
             wooStores = emptyList(),
+            currentSite = selectedSite.get().toWooStoreUi(),
             isSaveButtonEnabled = false
         )
     )
@@ -28,15 +32,8 @@ class WooSitesVisibilityViewModel @Inject constructor(
         launch {
             _wooStores.value = _wooStores.value.copy(
                 wooStores = sitePickerRepository.getSites()
-                    .filter { it.hasWooCommerce }
-                    .map {
-                        WooStoreUi(
-                            siteName = it.name,
-                            siteUrl = it.url,
-                            siteId = it.siteId,
-                            isSelected = true // TODO remove hardcoded value
-                        )
-                    }
+                    .filter { it.hasWooCommerce && it.siteId != selectedSite.get().siteId }
+                    .map { it.toWooStoreUi() }
             )
             initiallySelectedSiteIds = _wooStores.value.wooStores
                 .filter { it.isSelected }
@@ -68,8 +65,16 @@ class WooSitesVisibilityViewModel @Inject constructor(
         )
     }
 
+    private fun SiteModel.toWooStoreUi() = WooStoreUi(
+        siteName = name,
+        siteUrl = url,
+        siteId = siteId,
+        isSelected = true // TODO remove hardcoded value
+    )
+
     data class WooStoresUiState(
         val wooStores: List<WooStoreUi>,
+        val currentSite: WooStoreUi,
         val isSaveButtonEnabled: Boolean
     )
 

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -374,6 +374,7 @@
     <string name="site_picker_edit_store_list_title">Visible Stores</string>
     <string name="site_picker_edit_store_list_footer">Unselected stores won\'t be shown in the app site\'s picker and won\'t receive push notifications for new orders</string>
     <string name="site_picker_edit_store_current_site_header">Current Store</string>
+    <string name="site_picker_edit_store_current_site_footer">Please switch to another store if you want to hide this one</string>
     <string name="site_picker_edit_store_list_header">Other Stores</string>
 
     <!--

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -372,7 +372,7 @@
     <string name="login_site_picker_new_to_woo">New to WooCommerce</string>
     <string name="site_picker_edit_store_list">Edit Stores</string>
     <string name="site_picker_edit_store_list_title">Visible Stores</string>
-    <string name="site_picker_edit_store_list_footer">Unselected stores won\'t be shown in the app site\'s picker and won\'t receive push notifications for new orders</string>
+    <string name="site_picker_edit_store_list_footer">Unselected stores won\'t be shown in the app site\'s picker and won\'t receive push notifications for new orders or product reviews</string>
     <string name="site_picker_edit_store_current_site_header">Current Store</string>
     <string name="site_picker_edit_store_current_site_footer">Please switch to another store if you want to hide this one</string>
     <string name="site_picker_edit_store_list_header">Other Stores</string>

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -373,6 +373,8 @@
     <string name="site_picker_edit_store_list">Edit Stores</string>
     <string name="site_picker_edit_store_list_title">Visible Stores</string>
     <string name="site_picker_edit_store_list_footer">Unselected stores won\'t be shown in the app site\'s picker and won\'t receive push notifications for new orders</string>
+    <string name="site_picker_edit_store_current_site_header">Current Store</string>
+    <string name="site_picker_edit_store_list_header">Other Stores</string>
 
     <!--
         My Store View

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/sitepicker/sitevisibility/WooSitesVisibilityViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/sitepicker/sitevisibility/WooSitesVisibilityViewModelTest.kt
@@ -1,5 +1,6 @@
 package com.woocommerce.android.ui.sitepicker.sitevisibility
 
+import com.woocommerce.android.tools.SelectedSite
 import com.woocommerce.android.ui.sitepicker.SitePickerRepository
 import com.woocommerce.android.ui.sitepicker.SitePickerTestUtils
 import com.woocommerce.android.ui.sitepicker.sitevisibility.WooSitesVisibilityViewModel.WooStoreUi
@@ -21,7 +22,7 @@ class WooSitesVisibilityViewModelTest : BaseUnitTest() {
                 url = "www.$siteId.com"
             }
         }
-        private val WOO_STORE_DEFAULT_UI = DEFAULT_STORES.first().let {
+        private val WOO_STORE_DEFAULT_UI = DEFAULT_STORES.last().let {
             WooStoreUi(
                 siteName = it.name,
                 siteUrl = it.url,
@@ -34,12 +35,16 @@ class WooSitesVisibilityViewModelTest : BaseUnitTest() {
     private val sitePickerRepository: SitePickerRepository = mock {
         onBlocking { getSites() } doReturn DEFAULT_STORES
     }
+    private val selectedSite: SelectedSite = mock {
+        on { get() }.thenReturn(DEFAULT_STORES.first())
+    }
     private lateinit var viewModel: WooSitesVisibilityViewModel
 
     @Before
     fun setUp() {
         viewModel = WooSitesVisibilityViewModel(
             sitePickerRepository = sitePickerRepository,
+            selectedSite = selectedSite,
             savedStateHandle = mock()
         )
     }
@@ -49,10 +54,9 @@ class WooSitesVisibilityViewModelTest : BaseUnitTest() {
         testBlocking {
             viewModel.onSiteSelected(WOO_STORE_DEFAULT_UI)
 
-            // Assert
             val updatedState = viewModel.viewState.getOrAwaitValue()
-            assert(updatedState?.wooStores?.first()?.isSelected == false)
-            assert(updatedState?.isSaveButtonEnabled == true)
+            assert(!updatedState.wooStores.last().isSelected)
+            assert(updatedState.isSaveButtonEnabled)
         }
 
     @Test
@@ -61,9 +65,8 @@ class WooSitesVisibilityViewModelTest : BaseUnitTest() {
             viewModel.onSiteSelected(WOO_STORE_DEFAULT_UI)
             viewModel.onSiteSelected(WOO_STORE_DEFAULT_UI)
 
-            // Assert
             val updatedState = viewModel.viewState.getOrAwaitValue()
-            assert(updatedState?.wooStores?.first()?.isSelected == true)
-            assert(updatedState?.isSaveButtonEnabled == false)
+            assert(updatedState.wooStores?.first()?.isSelected == true)
+            assert(!updatedState.isSaveButtonEnabled)
         }
 }


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->
Closes: #13159
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
Adds a new section to the "Edit site visibility" screen displaying the currently selected site. Additionally, it filters out the currently selected site from the list. 

### Testing information
1. Log in with an account that has multiple sites
2. Click `Edit Stores` button 
3. Check the currently selected site is displayed on the header
4. Check the currently selected site is not displayed in the editable list of sites

### The tests that have been performed
<!-- To give the reviewer an idea of what could be missed in terms of testing -->
The above

### Images/gif
<!-- Include before and after images or gifs when appropriate. -->
<img width="300"  src="https://github.com/user-attachments/assets/bafae305-ed85-4881-b430-cffc767d0802"> 

- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.

## Reviewer (or Author, in the case of optional code reviews):

Please make sure these conditions are met before approving the PR, or request changes if the PR needs improvement:

- [x] The PR is small and has a clear, single focus, or a valid explanation is provided in the description. If needed, please request to split it into smaller PRs.
- [x] Ensure Adequate Unit Test Coverage: The changes are reasonably covered by unit tests or an explanation is provided in the PR description.
- [x] Manual Testing: The author listed all the tests they ran, including smoke tests when needed (e.g., for refactorings). The reviewer confirmed that the PR works as expected on big (tablet) and small (phone) in case of UI changes, and no regressions are added.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->