### PR TITLE
[Shipping labels]: Get account settings

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/FetchAccountSettings.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/FetchAccountSettings.kt
@@ -1,0 +1,28 @@
+package com.woocommerce.android.ui.orders.wooshippinglabels
+
+import com.woocommerce.android.tools.SelectedSite
+import com.woocommerce.android.ui.orders.wooshippinglabels.models.StoreOptionsModel
+import com.woocommerce.android.ui.orders.wooshippinglabels.networking.WooShippingLabelRepository
+import javax.inject.Inject
+
+class FetchAccountSettings @Inject constructor(
+    private val shippingRepository: WooShippingLabelRepository,
+    private val selectedSite: SelectedSite
+) {
+    suspend operator fun invoke(): Result<StoreOptionsModel> {
+        return selectedSite.getOrNull()?.let {
+            val response = shippingRepository.fetchAccountSettings(it)
+            val result = response.model
+            when {
+                response.isError.not() && result != null && result != StoreOptionsModel.EMPTY -> {
+                    Result.success(result)
+                }
+
+                else -> {
+                    val message = response.error?.message ?: "Unknown error"
+                    Result.failure(Exception(message))
+                }
+            }
+        } ?: Result.failure(Exception("No site selected"))
+    }
+}

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/WooShippingLabelCreationViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/WooShippingLabelCreationViewModel.kt
@@ -46,15 +46,10 @@ class WooShippingLabelCreationViewModel @Inject constructor(
     private val getShippableItems: GetShippableItems,
     private val currencyFormatter: CurrencyFormatter,
     private val observeOriginAddresses: ObserveOriginAddresses,
-    private val getShippingRates: GetShippingRates
+    private val getShippingRates: GetShippingRates,
+    private val fetchAccountSettings: FetchAccountSettings
 ) : ScopedViewModel(savedState) {
     private val navArgs: WooShippingLabelCreationFragmentArgs by savedState.navArgs()
-    private val mockStoreOptions = StoreOptionsModel(
-        currencySymbol = "$",
-        dimensionUnit = "cm",
-        weightUnit = "kg",
-        originCountry = "US"
-    )
 
     private val emptyOrder = Order.getEmptyOrder(Date(), Date())
     private val order = MutableStateFlow<Order?>(emptyOrder)
@@ -103,7 +98,16 @@ class WooShippingLabelCreationViewModel @Inject constructor(
     }
 
     private fun getStoreOptions() {
-        storeOptions.value = mockStoreOptions
+        launch {
+            fetchAccountSettings().fold(
+                onSuccess = {
+                    storeOptions.value = it
+                },
+                onFailure = {
+                    storeOptions.value = null
+                }
+            )
+        }
     }
 
     @Suppress("ComplexCondition")
@@ -179,14 +183,18 @@ class WooShippingLabelCreationViewModel @Inject constructor(
     }
 
     private suspend fun observePackageChanges() {
-        packageSelected.combine(packageWeight) { packageSelected, packageWeight ->
+        combine(
+            packageSelected,
+            packageWeight,
+            storeOptions
+        ) { packageSelected, packageWeight, storeOptions ->
             if (packageSelected == null || packageWeight == null) {
                 NotSelected
             } else {
                 DataAvailable(
                     selectedPackage = packageSelected,
                     defaultWeight = packageWeight.defaultWeight.toString(),
-                    weightUnit = mockStoreOptions.weightUnit
+                    weightUnit = storeOptions?.weightUnit ?: ""
                 )
             }
         }.collectLatest {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/networking/DTOs.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/networking/DTOs.kt
@@ -1,0 +1,14 @@
+package com.woocommerce.android.ui.orders.wooshippinglabels.networking
+
+import com.google.gson.annotations.SerializedName
+
+data class AccountSettingsDTO(
+    val storeOptions: StoreOptionsDTO
+)
+
+data class StoreOptionsDTO(
+    @SerializedName("currency_symbol") val currencySymbol: String? = null,
+    @SerializedName("dimension_unit") val dimensionUnit: String? = null,
+    @SerializedName("weight_unit") val weightUnit: String? = null,
+    @SerializedName("origin_country") val originCountry: String? = null
+)

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/networking/WooShippingLabelRepository.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/networking/WooShippingLabelRepository.kt
@@ -4,7 +4,8 @@ import org.wordpress.android.fluxc.model.SiteModel
 import javax.inject.Inject
 
 class WooShippingLabelRepository @Inject constructor(
-    private val restClient: WooShippingLabelRestClient
+    private val restClient: WooShippingLabelRestClient,
+    private val mapper: WooShippingNetworkingMapper
 ) {
     suspend fun fetchShippingLabelPrinting(
         site: SiteModel,
@@ -15,4 +16,10 @@ class WooShippingLabelRepository @Inject constructor(
         labelIds = labelIds,
         paperSize = paperSize
     ).asWooResult()
+
+    suspend fun fetchAccountSettings(
+        site: SiteModel,
+    ) = restClient.fetchAccountSettings(
+        site = site,
+    ).asWooResult { mapper(it.storeOptions) }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/networking/WooShippingLabelRestClient.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/networking/WooShippingLabelRestClient.kt
@@ -27,4 +27,18 @@ class WooShippingLabelRestClient @Inject constructor(
             clazz = ShippingLabelPrintingResponse::class.java,
         ).toWooPayload()
     }
+
+    suspend fun fetchAccountSettings(
+        site: SiteModel,
+    ): WooPayload<AccountSettingsDTO> {
+        val url = "/wcshipping/v1/account/settings/"
+
+        val result = wooNetwork.executeGetGsonRequest(
+            site = site,
+            path = url,
+            clazz = AccountSettingsDTO::class.java,
+        )
+
+        return result.toWooPayload()
+    }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/networking/WooShippingNetworkingMapper.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/networking/WooShippingNetworkingMapper.kt
@@ -1,0 +1,15 @@
+package com.woocommerce.android.ui.orders.wooshippinglabels.networking
+
+import com.woocommerce.android.ui.orders.wooshippinglabels.models.StoreOptionsModel
+import javax.inject.Inject
+
+class WooShippingNetworkingMapper @Inject constructor() {
+    operator fun invoke(storeOptionsDTO: StoreOptionsDTO): StoreOptionsModel {
+        return StoreOptionsModel(
+            currencySymbol = storeOptionsDTO.currencySymbol.orEmpty(),
+            dimensionUnit = storeOptionsDTO.dimensionUnit.orEmpty(),
+            weightUnit = storeOptionsDTO.weightUnit.orEmpty(),
+            originCountry = storeOptionsDTO.originCountry.orEmpty()
+        )
+    }
+}

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/FetchAccountSettingsTests.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/FetchAccountSettingsTests.kt
@@ -1,0 +1,76 @@
+package com.woocommerce.android.ui.orders.wooshippinglabels
+
+import com.woocommerce.android.tools.SelectedSite
+import com.woocommerce.android.ui.orders.wooshippinglabels.models.StoreOptionsModel
+import com.woocommerce.android.ui.orders.wooshippinglabels.networking.WooShippingLabelRepository
+import com.woocommerce.android.viewmodel.BaseUnitTest
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import org.mockito.kotlin.any
+import org.mockito.kotlin.doReturn
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.whenever
+import org.wordpress.android.fluxc.model.SiteModel
+import org.wordpress.android.fluxc.network.BaseRequest
+import org.wordpress.android.fluxc.network.rest.wpcom.wc.WooError
+import org.wordpress.android.fluxc.network.rest.wpcom.wc.WooErrorType
+import org.wordpress.android.fluxc.network.rest.wpcom.wc.WooResult
+import kotlin.test.Test
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class FetchAccountSettingsTests : BaseUnitTest() {
+    private val shippingRepository: WooShippingLabelRepository = mock()
+    private val selectedSite: SelectedSite = mock {
+        on { getOrNull() } doReturn SiteModel().apply {
+            url = "https://example.com"
+        }
+    }
+
+    private val defaultStoreOptions = StoreOptionsModel(
+        weightUnit = "kg",
+        currencySymbol = "$",
+        dimensionUnit = "cm",
+        originCountry = "US"
+    )
+
+    val sut = FetchAccountSettings(
+        shippingRepository = shippingRepository,
+        selectedSite = selectedSite
+    )
+
+    @Test
+    fun `when selected site is null then return failure`() = testBlocking {
+        whenever(selectedSite.getOrNull()).doReturn(null)
+        val result = sut.invoke()
+        assert(result.isFailure)
+    }
+
+    @Test
+    fun `when fetch account settings fails then return failure`() = testBlocking {
+        whenever(shippingRepository.fetchAccountSettings(any())).doReturn(
+            WooResult(WooError(WooErrorType.GENERIC_ERROR, BaseRequest.GenericErrorType.UNKNOWN))
+        )
+
+        val result = sut.invoke()
+        assert(result.isFailure)
+    }
+
+    @Test
+    fun `when fetch account settings is empty then return failure`() = testBlocking {
+        whenever(shippingRepository.fetchAccountSettings(any())).doReturn(
+            WooResult(StoreOptionsModel.EMPTY)
+        )
+
+        val result = sut.invoke()
+        assert(result.isFailure)
+    }
+
+    @Test
+    fun `when fetch account settings succeed then return success`() = testBlocking {
+        whenever(shippingRepository.fetchAccountSettings(any())).doReturn(
+            WooResult(defaultStoreOptions)
+        )
+
+        val result = sut.invoke()
+        assert(result.isSuccess)
+    }
+}

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/WooShippingLabelCreationViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/WooShippingLabelCreationViewModelTest.kt
@@ -11,6 +11,7 @@ import com.woocommerce.android.ui.orders.wooshippinglabels.WooShippingLabelCreat
 import com.woocommerce.android.ui.orders.wooshippinglabels.WooShippingLabelCreationViewModel.WooShippingViewState.DataState
 import com.woocommerce.android.ui.orders.wooshippinglabels.models.OriginShippingAddress
 import com.woocommerce.android.ui.orders.wooshippinglabels.models.ShippableItemModel
+import com.woocommerce.android.ui.orders.wooshippinglabels.models.StoreOptionsModel
 import com.woocommerce.android.ui.orders.wooshippinglabels.models.WooShippingCarrier
 import com.woocommerce.android.ui.orders.wooshippinglabels.packages.ui.PackageData
 import com.woocommerce.android.ui.orders.wooshippinglabels.rates.datasource.WooShippingRateModel
@@ -86,6 +87,12 @@ class WooShippingLabelCreationViewModelTest : BaseUnitTest() {
     private val defaultShipToAddress = Address.EMPTY.copy(
         address1 = "1278 24st Perito AVE"
     )
+    private val defaultStoreOptions = StoreOptionsModel(
+        weightUnit = "kg",
+        currencySymbol = "$",
+        dimensionUnit = "cm",
+        originCountry = "US"
+    )
 
     private val defaultPackageData = PackageData(
         id = "1",
@@ -152,6 +159,7 @@ class WooShippingLabelCreationViewModelTest : BaseUnitTest() {
 
     private val observeOriginAddresses: ObserveOriginAddresses = mock()
     private val getShippingRates: GetShippingRates = mock()
+    private val fetchAccountSettings: FetchAccountSettings = mock()
 
     private lateinit var sut: WooShippingLabelCreationViewModel
 
@@ -162,6 +170,7 @@ class WooShippingLabelCreationViewModelTest : BaseUnitTest() {
             currencyFormatter = currencyFormatter,
             observeOriginAddresses = observeOriginAddresses,
             getShippingRates = getShippingRates,
+            fetchAccountSettings = fetchAccountSettings,
             savedState = savedState
         )
     }
@@ -178,6 +187,7 @@ class WooShippingLabelCreationViewModelTest : BaseUnitTest() {
         whenever(orderDetailRepository.getOrderById(any())) doReturn order
         whenever(getShippableItems(any())) doReturn defaultShippableItems
         whenever(observeOriginAddresses()) doReturn flowOf(defaultOriginAddresses)
+        whenever(fetchAccountSettings()) doReturn Result.success(defaultStoreOptions)
 
         createViewModel()
 
@@ -201,6 +211,7 @@ class WooShippingLabelCreationViewModelTest : BaseUnitTest() {
         whenever(orderDetailRepository.getOrderById(any())) doReturn order
         whenever(getShippableItems(any())) doReturn defaultShippableItems
         whenever(observeOriginAddresses()) doReturn flowOf(defaultOriginAddresses)
+        whenever(fetchAccountSettings()) doReturn Result.success(defaultStoreOptions)
 
         createViewModel()
 
@@ -251,6 +262,7 @@ class WooShippingLabelCreationViewModelTest : BaseUnitTest() {
         whenever(orderDetailRepository.getOrderById(any())) doReturn order
         whenever(getShippableItems(any())) doReturn defaultShippableItems
         whenever(observeOriginAddresses()) doReturn flowOf(defaultOriginAddresses)
+        whenever(fetchAccountSettings()) doReturn Result.success(defaultStoreOptions)
 
         createViewModel()
 
@@ -279,6 +291,7 @@ class WooShippingLabelCreationViewModelTest : BaseUnitTest() {
         whenever(
             getShippingRates(any(), any(), any(), any(), any(), any())
         ) doReturn Result.success(defaultShippingRates)
+        whenever(fetchAccountSettings()) doReturn Result.success(defaultStoreOptions)
 
         createViewModel()
 
@@ -307,6 +320,7 @@ class WooShippingLabelCreationViewModelTest : BaseUnitTest() {
         whenever(
             getShippingRates(any(), any(), any(), any(), any(), any())
         ) doReturn Result.failure(Exception("Random error"))
+        whenever(fetchAccountSettings()) doReturn Result.success(defaultStoreOptions)
 
         createViewModel()
         sut.onPackageSelected(defaultPackageData)
@@ -329,7 +343,6 @@ class WooShippingLabelCreationViewModelTest : BaseUnitTest() {
             )
         )
         whenever(orderDetailRepository.getOrderById(any())) doReturn order
-        whenever(getShippableItems(any())) doReturn defaultShippableItems
         whenever(observeOriginAddresses()) doReturn flowOf(defaultOriginAddresses)
         whenever(
             getShippingRates(any(), any(), any(), any(), any(), any())
@@ -358,7 +371,6 @@ class WooShippingLabelCreationViewModelTest : BaseUnitTest() {
             )
         )
         whenever(orderDetailRepository.getOrderById(any())) doReturn order
-        whenever(getShippableItems(any())) doReturn defaultShippableItems
         whenever(observeOriginAddresses()) doReturn flowOf(defaultOriginAddresses)
         whenever(
             getShippingRates(any(), any(), any(), any(), any(), any())
@@ -387,7 +399,6 @@ class WooShippingLabelCreationViewModelTest : BaseUnitTest() {
             )
         )
         whenever(orderDetailRepository.getOrderById(any())) doReturn order
-        whenever(getShippableItems(any())) doReturn defaultShippableItems
         whenever(observeOriginAddresses()) doReturn flowOf(defaultOriginAddresses)
         whenever(
             getShippingRates(any(), any(), any(), any(), any(), any())
@@ -415,6 +426,7 @@ class WooShippingLabelCreationViewModelTest : BaseUnitTest() {
         whenever(orderDetailRepository.getOrderById(any())) doReturn order
         whenever(getShippableItems(any())) doReturn defaultShippableItems
         whenever(observeOriginAddresses()) doReturn flowOf(defaultOriginAddresses)
+        whenever(fetchAccountSettings()) doReturn Result.success(defaultStoreOptions)
 
         createViewModel()
 
@@ -454,6 +466,7 @@ class WooShippingLabelCreationViewModelTest : BaseUnitTest() {
         whenever(orderDetailRepository.getOrderById(any())) doReturn order
         whenever(getShippableItems(any())) doReturn defaultShippableItems
         whenever(observeOriginAddresses()) doReturn flowOf(defaultOriginAddresses)
+        whenever(fetchAccountSettings()) doReturn Result.success(defaultStoreOptions)
 
         createViewModel()
 

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/networking/WooShippingNetworkingMapperTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/networking/WooShippingNetworkingMapperTest.kt
@@ -1,0 +1,43 @@
+package com.woocommerce.android.ui.orders.wooshippinglabels.networking
+
+import com.woocommerce.android.ui.orders.wooshippinglabels.models.StoreOptionsModel
+import com.woocommerce.android.viewmodel.BaseUnitTest
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class WooShippingNetworkingMapperTest : BaseUnitTest() {
+    val sut = WooShippingNetworkingMapper()
+
+    @Test
+    fun `when all field are null then return empty model`() {
+        val emptyDTO = StoreOptionsDTO(
+            weightUnit = null,
+            currencySymbol = null,
+            dimensionUnit = null,
+            originCountry = null
+        )
+
+        val result = sut.invoke(emptyDTO)
+
+        assert(result == StoreOptionsModel.EMPTY)
+    }
+
+    @Test
+    fun `when a dto is received then return the expected model`() {
+        val dto = StoreOptionsDTO(
+            weightUnit = "kg",
+            currencySymbol = "$",
+            dimensionUnit = "cm",
+            originCountry = "US"
+        )
+
+        val result = sut.invoke(dto)
+
+        assertEquals(result.currencySymbol, dto.currencySymbol)
+        assertEquals(result.weightUnit, dto.weightUnit)
+        assertEquals(result.dimensionUnit, dto.dimensionUnit)
+        assertEquals(result.originCountry, dto.originCountry)
+    }
+}


### PR DESCRIPTION
Closes: #12289

### Description
This PR fetches the account settings from the API and uses it in the purchase shipping label flow.

### Testing information
1. Open the app
2. Navigate to the Orders section
3. Open an order eligible for shipping label creation
4. Tap on create shipping label
5. Check that the account settings used are the ones fetched from there API

### The tests that have been performed
1. Checked that the UI keeps working as expected
2. Checked that the settings fetched are used on the UI

### Images/gif

https://github.com/user-attachments/assets/0e5f4115-b4f1-4c2c-b81a-ebfb9c283435

- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.

## Reviewer (or Author, in the case of optional code reviews):

Please make sure these conditions are met before approving the PR, or request changes if the PR needs improvement:

- [x] The PR is small and has a clear, single focus, or a valid explanation is provided in the description. If needed, please request to split it into smaller PRs.
- [x] Ensure Adequate Unit Test Coverage: The changes are reasonably covered by unit tests or an explanation is provided in the PR description.
- [x] Manual Testing: The author listed all the tests they ran, including smoke tests when needed (e.g., for refactorings). The reviewer confirmed that the PR works as expected on big (tablet) and small (phone) in case of UI changes, and no regressions are added.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md --