### PR TITLE
[Shipping labels] Shipping labels networking

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/models/ShippingLabelModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/models/ShippingLabelModel.kt
@@ -1,0 +1,30 @@
+package com.woocommerce.android.ui.orders.wooshippinglabels.models
+
+import java.math.BigDecimal
+import java.util.Date
+
+data class ShippingLabelModel(
+    val labelId: Long,
+    val tracking: String,
+    val refundableAmount: BigDecimal,
+    val status: ShippingLabelStatus,
+    val created: Date?,
+    val carrierId: String,
+    val serviceName: String,
+    val commercialInvoiceUrl: String,
+    val isCommercialInvoiceSubmittedElectronically: Boolean,
+    val packageName: String,
+    val isLetter: Boolean,
+    val productNames: List<String>,
+    val productIds: List<Long>,
+    val receiptItemId: Long,
+    val createdDate: Date?,
+    val mainReceiptId: Long,
+    val rate: BigDecimal,
+    val currency: String,
+    val expiryDate: Long,
+)
+
+enum class ShippingLabelStatus {
+    Unknown, PurchaseInProgress, Purchased, PurchaseError, Anonymized
+}

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/networking/DTOs.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/networking/DTOs.kt
@@ -1,6 +1,7 @@
 package com.woocommerce.android.ui.orders.wooshippinglabels.networking
 
 import com.google.gson.annotations.SerializedName
+import java.math.BigDecimal
 
 data class AccountSettingsDTO(
     val storeOptions: StoreOptionsDTO
@@ -11,4 +12,32 @@ data class StoreOptionsDTO(
     @SerializedName("dimension_unit") val dimensionUnit: String? = null,
     @SerializedName("weight_unit") val weightUnit: String? = null,
     @SerializedName("origin_country") val originCountry: String? = null
+)
+
+data class GetShippingLabelResponse(
+    @SerializedName("success") val success: Boolean? = null,
+    @SerializedName("labels") val shippingLabels: List<ShippingLabelDTO>? = null
+)
+
+data class ShippingLabelDTO(
+    @SerializedName("label_id") val labelId: Long? = null,
+    @SerializedName("tracking") val tracking: String? = null,
+    @SerializedName("refundable_amount") val refundableAmount: BigDecimal? = null,
+    @SerializedName("status") val status: String? = null,
+    @SerializedName("created") val created: Long? = null,
+    @SerializedName("carrier_id") val carrierId: String? = null,
+    @SerializedName("service_name") val serviceName: String? = null,
+    @SerializedName("commercial_invoice_url") val commercialInvoiceUrl: String? = null,
+    @SerializedName("is_commercial_invoice_submitted_electronically")
+    val isCommercialInvoiceSubmittedElectronically: Boolean? = null,
+    @SerializedName("package_name") val packageName: String? = null,
+    @SerializedName("is_letter") val isLetter: Boolean? = null,
+    @SerializedName("product_names") val productNames: List<String>? = null,
+    @SerializedName("product_ids") val productIds: List<Long>? = null,
+    @SerializedName("receipt_item_id") val receiptItemId: Long? = null,
+    @SerializedName("created_date") val createdDate: Long? = null,
+    @SerializedName("main_receipt_id") val mainReceiptId: Long? = null,
+    @SerializedName("rate") val rate: BigDecimal? = null,
+    @SerializedName("currency") val currency: String? = null,
+    @SerializedName("expiry_date") val expiryDate: Long? = null,
 )

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/networking/DTOs.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/networking/DTOs.kt
@@ -19,6 +19,11 @@ data class GetShippingLabelResponse(
     @SerializedName("labels") val shippingLabels: List<ShippingLabelDTO>? = null
 )
 
+data class GetShippingLabelStatusResponse(
+    @SerializedName("success") val success: Boolean? = null,
+    @SerializedName("label") val shippingLabel: ShippingLabelDTO? = null
+)
+
 data class ShippingLabelDTO(
     @SerializedName("label_id") val labelId: Long? = null,
     @SerializedName("tracking") val tracking: String? = null,

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/networking/WooShippingLabelRepository.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/networking/WooShippingLabelRepository.kt
@@ -1,5 +1,6 @@
 package com.woocommerce.android.ui.orders.wooshippinglabels.networking
 
+import com.woocommerce.android.ui.orders.wooshippinglabels.models.ShippingLabelStatus
 import org.wordpress.android.fluxc.model.SiteModel
 import javax.inject.Inject
 
@@ -30,4 +31,18 @@ class WooShippingLabelRepository @Inject constructor(
         site = site,
         orderId = orderId,
     ).asWooResult { it.shippingLabels?.map { label -> mapper(label) } }
+
+    suspend fun fetchShippingLabelStatus(
+        site: SiteModel,
+        orderId: Long,
+        labelId: Long,
+    ) = restClient.fetchShippingLabelStatus(
+        site = site,
+        orderId = orderId,
+        labelId = labelId,
+    ).asWooResult { response ->
+        response.shippingLabel?.let {
+            mapper(it).status
+        } ?: ShippingLabelStatus.Unknown
+    }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/networking/WooShippingLabelRepository.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/networking/WooShippingLabelRepository.kt
@@ -22,4 +22,12 @@ class WooShippingLabelRepository @Inject constructor(
     ) = restClient.fetchAccountSettings(
         site = site,
     ).asWooResult { mapper(it.storeOptions) }
+
+    suspend fun fetchPurchasedShippingLabels(
+        site: SiteModel,
+        orderId: Long,
+    ) = restClient.fetchPurchasedShippingLabels(
+        site = site,
+        orderId = orderId,
+    ).asWooResult { it.shippingLabels?.map { label -> mapper(label) } }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/networking/WooShippingLabelRestClient.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/networking/WooShippingLabelRestClient.kt
@@ -56,4 +56,20 @@ class WooShippingLabelRestClient @Inject constructor(
 
         return result.toWooPayload()
     }
+
+    suspend fun fetchShippingLabelStatus(
+        site: SiteModel,
+        orderId: Long,
+        labelId: Long,
+    ): WooPayload<GetShippingLabelStatusResponse> {
+        val url = "/wcshipping/v1/label/status/$orderId/$labelId/"
+
+        val result = wooNetwork.executeGetGsonRequest(
+            site = site,
+            path = url,
+            clazz = GetShippingLabelStatusResponse::class.java,
+        )
+
+        return result.toWooPayload()
+    }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/networking/WooShippingLabelRestClient.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/networking/WooShippingLabelRestClient.kt
@@ -41,4 +41,19 @@ class WooShippingLabelRestClient @Inject constructor(
 
         return result.toWooPayload()
     }
+
+    suspend fun fetchPurchasedShippingLabels(
+        site: SiteModel,
+        orderId: Long,
+    ): WooPayload<GetShippingLabelResponse> {
+        val url = "/wcshipping/v1/label/purchase/$orderId/"
+
+        val result = wooNetwork.executeGetGsonRequest(
+            site = site,
+            path = url,
+            clazz = GetShippingLabelResponse::class.java,
+        )
+
+        return result.toWooPayload()
+    }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/networking/WooShippingNetworkingMapper.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/networking/WooShippingNetworkingMapper.kt
@@ -1,6 +1,10 @@
 package com.woocommerce.android.ui.orders.wooshippinglabels.networking
 
+import com.woocommerce.android.ui.orders.wooshippinglabels.models.ShippingLabelModel
+import com.woocommerce.android.ui.orders.wooshippinglabels.models.ShippingLabelStatus
 import com.woocommerce.android.ui.orders.wooshippinglabels.models.StoreOptionsModel
+import java.math.BigDecimal
+import java.util.Date
 import javax.inject.Inject
 
 class WooShippingNetworkingMapper @Inject constructor() {
@@ -11,5 +15,47 @@ class WooShippingNetworkingMapper @Inject constructor() {
             weightUnit = storeOptionsDTO.weightUnit.orEmpty(),
             originCountry = storeOptionsDTO.originCountry.orEmpty()
         )
+    }
+
+    operator fun invoke(shippingLabelDTO: ShippingLabelDTO): ShippingLabelModel {
+        return ShippingLabelModel(
+            labelId = shippingLabelDTO.labelId ?: 0,
+            tracking = shippingLabelDTO.tracking.orEmpty(),
+            refundableAmount = shippingLabelDTO.refundableAmount ?: BigDecimal.ZERO,
+            status = mapShippingLabelStatus(shippingLabelDTO.status),
+            created = shippingLabelDTO.created?.let { Date(it) },
+            carrierId = shippingLabelDTO.carrierId.orEmpty(),
+            serviceName = shippingLabelDTO.serviceName.orEmpty(),
+            commercialInvoiceUrl = shippingLabelDTO.commercialInvoiceUrl.orEmpty(),
+            isCommercialInvoiceSubmittedElectronically =
+            shippingLabelDTO.isCommercialInvoiceSubmittedElectronically ?: false,
+            packageName = shippingLabelDTO.packageName.orEmpty(),
+            isLetter = shippingLabelDTO.isLetter ?: false,
+            productNames = shippingLabelDTO.productNames.orEmpty(),
+            productIds = shippingLabelDTO.productIds.orEmpty(),
+            receiptItemId = shippingLabelDTO.receiptItemId ?: 0,
+            createdDate = shippingLabelDTO.createdDate?.let { Date(it) },
+            mainReceiptId = shippingLabelDTO.mainReceiptId ?: 0,
+            rate = shippingLabelDTO.rate ?: BigDecimal.ZERO,
+            currency = shippingLabelDTO.currency.orEmpty(),
+            expiryDate = shippingLabelDTO.expiryDate ?: 0
+        )
+    }
+
+    private fun mapShippingLabelStatus(status: String?): ShippingLabelStatus {
+        return when (status) {
+            PURCHASE_IN_PROGRESS_KEY -> ShippingLabelStatus.PurchaseInProgress
+            PURCHASED_KEY -> ShippingLabelStatus.Purchased
+            PURCHASE_ERROR_KEY -> ShippingLabelStatus.PurchaseError
+            ANONYMIZED_KEY -> ShippingLabelStatus.Anonymized
+            else -> ShippingLabelStatus.Unknown
+        }
+    }
+
+    companion object {
+        private const val PURCHASE_IN_PROGRESS_KEY = "PURCHASE_IN_PROGRESS"
+        private const val PURCHASED_KEY = "PURCHASED"
+        private const val PURCHASE_ERROR_KEY = "PURCHASE_ERROR"
+        private const val ANONYMIZED_KEY = "ANONYMIZED"
     }
 }

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/networking/WooShippingNetworkingMapperTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/networking/WooShippingNetworkingMapperTest.kt
@@ -1,8 +1,10 @@
 package com.woocommerce.android.ui.orders.wooshippinglabels.networking
 
+import com.woocommerce.android.ui.orders.wooshippinglabels.models.ShippingLabelStatus
 import com.woocommerce.android.ui.orders.wooshippinglabels.models.StoreOptionsModel
 import com.woocommerce.android.viewmodel.BaseUnitTest
 import kotlinx.coroutines.ExperimentalCoroutinesApi
+import java.math.BigDecimal
 import kotlin.test.Test
 import kotlin.test.assertEquals
 
@@ -11,7 +13,7 @@ class WooShippingNetworkingMapperTest : BaseUnitTest() {
     val sut = WooShippingNetworkingMapper()
 
     @Test
-    fun `when all field are null then return empty model`() {
+    fun `when all store option dto fields are null then return empty model`() {
         val emptyDTO = StoreOptionsDTO(
             weightUnit = null,
             currencySymbol = null,
@@ -25,7 +27,7 @@ class WooShippingNetworkingMapperTest : BaseUnitTest() {
     }
 
     @Test
-    fun `when a dto is received then return the expected model`() {
+    fun `when a store option dto is received then return the expected model`() {
         val dto = StoreOptionsDTO(
             weightUnit = "kg",
             currencySymbol = "$",
@@ -39,5 +41,39 @@ class WooShippingNetworkingMapperTest : BaseUnitTest() {
         assertEquals(result.weightUnit, dto.weightUnit)
         assertEquals(result.dimensionUnit, dto.dimensionUnit)
         assertEquals(result.originCountry, dto.originCountry)
+    }
+
+    @Test
+    fun `when a shipping label dto is received then return the expected model`() {
+        val dto = ShippingLabelDTO(
+            labelId = 1234,
+            tracking = "123456789",
+            refundableAmount = BigDecimal.ZERO,
+            status = "PURCHASED"
+        )
+
+        val result = sut.invoke(dto)
+
+        assertEquals(result.labelId, dto.labelId)
+        assertEquals(result.tracking, dto.tracking)
+        assertEquals(result.refundableAmount, dto.refundableAmount)
+        assertEquals(result.status, ShippingLabelStatus.Purchased)
+    }
+
+    @Test
+    fun `when a shipping label dto is received with an unknown status then return the expected model`() {
+        val dto = ShippingLabelDTO(
+            labelId = 1234,
+            tracking = "123456789",
+            refundableAmount = BigDecimal.ZERO,
+            status = "NOT_VALID"
+        )
+
+        val result = sut.invoke(dto)
+
+        assertEquals(result.labelId, dto.labelId)
+        assertEquals(result.tracking, dto.tracking)
+        assertEquals(result.refundableAmount, dto.refundableAmount)
+        assertEquals(result.status, ShippingLabelStatus.Unknown)
     }
 }


### PR DESCRIPTION
Part of: #12707

### Description
This PR adds support for the endpoints Get Label Status(`GET /wcshipping/v1/label/status/{order_id}/{label_id}`) and Retrieve Purchased Labels (`GET /wcshipping/v1/label/purchase/{order_id}`) needed for the after purchase task and the final screen of the purchasing shipping label flow.

### Testing information
Only networking support was added to this PR. To test the changes, you can manually call the repository using the order ID and label id of an order with purchased shipping labels

### The tests that have been performed
1. Tested the responses with valid order is and label id


- [ ] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.

## Reviewer (or Author, in the case of optional code reviews):

Please make sure these conditions are met before approving the PR, or request changes if the PR needs improvement:

- [ ] The PR is small and has a clear, single focus, or a valid explanation is provided in the description. If needed, please request to split it into smaller PRs.
- [ ] Ensure Adequate Unit Test Coverage: The changes are reasonably covered by unit tests or an explanation is provided in the PR description.
- [ ] Manual Testing: The author listed all the tests they ran, including smoke tests when needed (e.g., for refactorings). The reviewer confirmed that the PR works as expected on big (tablet) and small (phone) in case of UI changes, and no regressions are added.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md --