### PR TITLE
[Woo POS][Cash & Receipts] Navigate once to the email receipt screen

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/emailreceipt/WooPosEmailReceiptNavigation.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/emailreceipt/WooPosEmailReceiptNavigation.kt
@@ -9,12 +9,13 @@ import androidx.navigation.compose.composable
 import androidx.navigation.navArgument
 import com.woocommerce.android.ui.woopos.home.HOME_ROUTE
 import com.woocommerce.android.ui.woopos.root.navigation.WooPosNavigationEvent
+import com.woocommerce.android.ui.woopos.root.navigation.navigateOnce
 
 const val EMAIL_RECEIPT_ROUTE_ORDER_ID_KEY = "orderId"
 private const val EMAIL_RECEIPT_ROUTE = "$HOME_ROUTE/email_receipt/{$EMAIL_RECEIPT_ROUTE_ORDER_ID_KEY}"
 
 fun NavController.navigateToEmailReceipt(orderId: Long) {
-    navigate(EMAIL_RECEIPT_ROUTE.replace("{$EMAIL_RECEIPT_ROUTE_ORDER_ID_KEY}", orderId.toString()))
+    navigateOnce(EMAIL_RECEIPT_ROUTE.replace("{$EMAIL_RECEIPT_ROUTE_ORDER_ID_KEY}", orderId.toString()))
 }
 
 fun NavGraphBuilder.emailReceiptScreen(


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #13171
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
Make it impossible to open 2 or more instances of the receipts screen

### Testing information
<!-- This is your opportunity to break out individual scenarios that need testing (when necessary) and/or include a checklist for the reviewer to go through. Consider documenting the following from your own completed testing: devices used, alternate workflows, edge cases, affected areas, critical flows, areas not tested, and any remaining unknowns. Provide feedback on this new section of the PR template through Sept 30, 2024 to Apps Quality; additional context here: p91TBi-b8z-p2#comment-12036 -->
* Tap a few times very quickly on email receipts button
* Notice that only 1 instance of the screen is opened

### The tests that have been performed
<!-- To give the reviewer an idea of what could be missed in terms of testing -->
Above

- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.

## Reviewer (or Author, in the case of optional code reviews):

Please make sure these conditions are met before approving the PR, or request changes if the PR needs improvement:

- [ ] The PR is small and has a clear, single focus, or a valid explanation is provided in the description. If needed, please request to split it into smaller PRs.
- [ ] Ensure Adequate Unit Test Coverage: The changes are reasonably covered by unit tests or an explanation is provided in the PR description.
- [ ] Manual Testing: The author listed all the tests they ran, including smoke tests when needed (e.g., for refactorings). The reviewer confirmed that the PR works as expected on big (tablet) and small (phone) in case of UI changes, and no regressions are added.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->