### PR TITLE
[Shipping Label Revamp] Add Shipping Label status observer in Purchased UI

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/WooShippingLabelCreationViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/WooShippingLabelCreationViewModel.kt
@@ -374,6 +374,7 @@ class WooShippingLabelCreationViewModel @Inject constructor(
                     ?.labels
                     ?.firstOrNull()
                     ?.toPurchasedShippingLabelData(
+                        orderId = orderId,
                         totalWeight = packageWeight.value?.totalWeight.toString(),
                         dimensionUnit = storeOptions.value?.dimensionUnit.orEmpty(),
                         weightUnit = storeOptions.value?.weightUnit.orEmpty(),
@@ -418,12 +419,14 @@ class WooShippingLabelCreationViewModel @Inject constructor(
     }
 
     private fun ShippingLabelModel.toPurchasedShippingLabelData(
+        orderId: Long,
         totalWeight: String,
         dimensionUnit: String,
         weightUnit: String,
         shippableItems: List<ShippableItemModel>,
     ) = PurchasedShippingLabelData(
         labelId = labelId,
+        orderId = orderId,
         carrierId = carrierId,
         trackingNumber = tracking,
         totalWeight = totalWeight,

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/purchased/ObserveShippingLabelStatus.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/purchased/ObserveShippingLabelStatus.kt
@@ -17,20 +17,32 @@ class ObserveShippingLabelStatus @Inject constructor(
     suspend operator fun invoke(
         orderId: Long,
         labelId: Long
-    ): Flow<ShippingLabelStatus> {
+    ): Flow<ShippingLabelStatus?> {
         return flow {
+            var attempts = 0
             var latestStatus = Unknown
             emit(latestStatus)
 
             do {
+                if (attempts >= CHECK_ATTEMPTS_BEFORE_GIVING_UP) {
+                    emit(null)
+                    break
+                }
+
                 latestStatus = labelRepository.fetchShippingLabelStatus(
                     site = selectedSite.get(),
                     orderId = orderId,
                     labelId = labelId
                 ).takeIf { it.isError.not() }?.model ?: Unknown
                 emit(latestStatus)
-                delay(5000)
+                attempts++
+                delay(DELAY_BETWEEN_STATUS_CHECKS)
             } while (latestStatus == PurchaseInProgress || latestStatus == Unknown)
         }
+    }
+
+    companion object {
+        private const val DELAY_BETWEEN_STATUS_CHECKS = 2000L
+        private const val CHECK_ATTEMPTS_BEFORE_GIVING_UP = 10
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/purchased/ObserveShippingLabelStatus.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/purchased/ObserveShippingLabelStatus.kt
@@ -1,0 +1,25 @@
+package com.woocommerce.android.ui.orders.wooshippinglabels.purchased
+
+import com.woocommerce.android.tools.SelectedSite
+import com.woocommerce.android.ui.orders.wooshippinglabels.models.ShippingLabelStatus
+import com.woocommerce.android.ui.orders.wooshippinglabels.models.ShippingLabelStatus.PurchaseInProgress
+import com.woocommerce.android.ui.orders.wooshippinglabels.models.ShippingLabelStatus.Unknown
+import com.woocommerce.android.ui.orders.wooshippinglabels.networking.WooShippingLabelRepository
+import javax.inject.Inject
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.flow
+
+class ObserveShippingLabelStatus @Inject constructor(
+    private val selectedSite: SelectedSite,
+    private val labelRepository: WooShippingLabelRepository
+) {
+    suspend operator fun invoke(
+        orderId: Long,
+        labelId: Long
+    ): Flow<ShippingLabelStatus> {
+        return flow {
+
+        }
+    }
+}

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/purchased/ObserveShippingLabelStatus.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/purchased/ObserveShippingLabelStatus.kt
@@ -5,10 +5,10 @@ import com.woocommerce.android.ui.orders.wooshippinglabels.models.ShippingLabelS
 import com.woocommerce.android.ui.orders.wooshippinglabels.models.ShippingLabelStatus.PurchaseInProgress
 import com.woocommerce.android.ui.orders.wooshippinglabels.models.ShippingLabelStatus.Unknown
 import com.woocommerce.android.ui.orders.wooshippinglabels.networking.WooShippingLabelRepository
-import javax.inject.Inject
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.flow
+import javax.inject.Inject
 
 class ObserveShippingLabelStatus @Inject constructor(
     private val selectedSite: SelectedSite,

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/purchased/ObserveShippingLabelStatus.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/purchased/ObserveShippingLabelStatus.kt
@@ -19,7 +19,18 @@ class ObserveShippingLabelStatus @Inject constructor(
         labelId: Long
     ): Flow<ShippingLabelStatus> {
         return flow {
+            var latestStatus = Unknown
+            emit(latestStatus)
 
+            do {
+                latestStatus = labelRepository.fetchShippingLabelStatus(
+                    site = selectedSite.get(),
+                    orderId = orderId,
+                    labelId = labelId
+                ).takeIf { it.isError.not() }?.model ?: Unknown
+                emit(latestStatus)
+                delay(5000)
+            } while (latestStatus == PurchaseInProgress || latestStatus == Unknown)
         }
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/purchased/ObserveShippingLabelStatus.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/purchased/ObserveShippingLabelStatus.kt
@@ -17,32 +17,24 @@ class ObserveShippingLabelStatus @Inject constructor(
     suspend operator fun invoke(
         orderId: Long,
         labelId: Long
-    ): Flow<ShippingLabelStatus?> {
+    ): Flow<ShippingLabelStatus> {
         return flow {
-            var attempts = 0
-            var latestStatus = Unknown
+            var latestStatus = PurchaseInProgress
             emit(latestStatus)
 
             do {
-                if (attempts >= CHECK_ATTEMPTS_BEFORE_GIVING_UP) {
-                    emit(null)
-                    break
-                }
-
                 latestStatus = labelRepository.fetchShippingLabelStatus(
                     site = selectedSite.get(),
                     orderId = orderId,
                     labelId = labelId
                 ).takeIf { it.isError.not() }?.model ?: Unknown
                 emit(latestStatus)
-                attempts++
                 delay(DELAY_BETWEEN_STATUS_CHECKS)
-            } while (latestStatus == PurchaseInProgress || latestStatus == Unknown)
+            } while (latestStatus == PurchaseInProgress)
         }
     }
 
     companion object {
         private const val DELAY_BETWEEN_STATUS_CHECKS = 2000L
-        private const val CHECK_ATTEMPTS_BEFORE_GIVING_UP = 10
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/purchased/PurchasedShippingLabelData.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/purchased/PurchasedShippingLabelData.kt
@@ -6,6 +6,7 @@ import kotlinx.parcelize.Parcelize
 @Parcelize
 data class PurchasedShippingLabelData(
     val labelId: Long,
+    val orderId: Long,
     val carrierId: String,
     val totalWeight: String,
     val formattedTotalPrice: String,

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/purchased/WooShippingLabelPurchasedFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/purchased/WooShippingLabelPurchasedFragment.kt
@@ -17,7 +17,6 @@ import com.woocommerce.android.ui.orders.wooshippinglabels.purchased.WooShipping
 import com.woocommerce.android.ui.orders.wooshippinglabels.purchased.WooShippingLabelPurchasedViewModel.OpenShippingLabelFile
 import com.woocommerce.android.ui.orders.wooshippinglabels.purchased.WooShippingLabelPurchasedViewModel.OpenUrl
 import com.woocommerce.android.ui.orders.wooshippinglabels.purchased.WooShippingLabelPurchasedViewModel.ShowError
-import com.woocommerce.android.ui.orders.wooshippinglabels.purchased.WooShippingLabelPurchasedViewModel.ShowErrorAndExit
 import com.woocommerce.android.util.ActivityUtils
 import com.woocommerce.android.util.ChromeCustomTabUtils
 import dagger.hilt.android.AndroidEntryPoint
@@ -54,7 +53,6 @@ class WooShippingLabelPurchasedFragment : BaseFragment() {
                 is OpenLearnMoreScreen -> openLearnMoreView()
                 is OpenUrl -> openUrl(event.url)
                 is ShowError -> showErrorDialog(event.errorResId)
-                is ShowErrorAndExit -> showTerminalErrorDialog(event.errorResId)
             }
         }
     }
@@ -79,17 +77,6 @@ class WooShippingLabelPurchasedFragment : BaseFragment() {
             titleId = R.string.error_generic,
             messageId = messageResId,
             positiveButtonId = R.string.dialog_ok
-        )
-    }
-
-    private fun showTerminalErrorDialog(messageResId: Int) {
-        WooDialog.showDialog(
-            activity = requireActivity(),
-            titleId = R.string.error_generic,
-            messageId = messageResId,
-            positiveButtonId = R.string.dialog_ok,
-            posBtnAction = { _, _ -> findNavController().popBackStack() },
-            onDismiss = { findNavController().popBackStack() }
         )
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/purchased/WooShippingLabelPurchasedFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/purchased/WooShippingLabelPurchasedFragment.kt
@@ -17,6 +17,7 @@ import com.woocommerce.android.ui.orders.wooshippinglabels.purchased.WooShipping
 import com.woocommerce.android.ui.orders.wooshippinglabels.purchased.WooShippingLabelPurchasedViewModel.OpenShippingLabelFile
 import com.woocommerce.android.ui.orders.wooshippinglabels.purchased.WooShippingLabelPurchasedViewModel.OpenUrl
 import com.woocommerce.android.ui.orders.wooshippinglabels.purchased.WooShippingLabelPurchasedViewModel.ShowError
+import com.woocommerce.android.ui.orders.wooshippinglabels.purchased.WooShippingLabelPurchasedViewModel.ShowErrorAndExit
 import com.woocommerce.android.util.ActivityUtils
 import com.woocommerce.android.util.ChromeCustomTabUtils
 import dagger.hilt.android.AndroidEntryPoint
@@ -53,6 +54,7 @@ class WooShippingLabelPurchasedFragment : BaseFragment() {
                 is OpenLearnMoreScreen -> openLearnMoreView()
                 is OpenUrl -> openUrl(event.url)
                 is ShowError -> showErrorDialog(event.errorResId)
+                is ShowErrorAndExit -> showTerminalErrorDialog(event.errorResId)
             }
         }
     }
@@ -77,6 +79,17 @@ class WooShippingLabelPurchasedFragment : BaseFragment() {
             titleId = R.string.error_generic,
             messageId = messageResId,
             positiveButtonId = R.string.dialog_ok
+        )
+    }
+
+    private fun showTerminalErrorDialog(messageResId: Int) {
+        WooDialog.showDialog(
+            activity = requireActivity(),
+            titleId = R.string.error_generic,
+            messageId = messageResId,
+            positiveButtonId = R.string.dialog_ok,
+            posBtnAction = { _, _ -> findNavController().popBackStack() },
+            onDismiss = { findNavController().popBackStack() }
         )
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/purchased/WooShippingLabelPurchasedScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/purchased/WooShippingLabelPurchasedScreen.kt
@@ -68,7 +68,7 @@ val Colors.successSurface: Color get() = if (isLight) lightGreen else darkGreen
 fun WooShippingLabelPurchasedScreen(viewModel: WooShippingLabelPurchasedViewModel) {
     val viewState = viewModel.viewState.observeAsState()
     WooShippingLabelPurchasedScreen(
-        isLoading = viewState.value?.isPrintingInProgress ?: false,
+        isLoading = viewState.value?.isLoadingData ?: false,
         shippingData = viewState.value?.shippableItems,
         selectedLabelPaperSizeOption = viewState.value?.paperSizeOption ?: WooShippingLabelPaperSize.LEGAL,
         onLabelPaperSizeOptionSelected = { viewModel.onLabelPaperSizeOptionSelected(it) },

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/purchased/WooShippingLabelPurchasedScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/purchased/WooShippingLabelPurchasedScreen.kt
@@ -69,6 +69,7 @@ fun WooShippingLabelPurchasedScreen(viewModel: WooShippingLabelPurchasedViewMode
     val viewState = viewModel.viewState.observeAsState()
     WooShippingLabelPurchasedScreen(
         isLoading = viewState.value?.isLoadingData ?: false,
+        isPurchaseFinished = viewState.value?.isPurchaseFinished,
         shippingData = viewState.value?.shippableItems,
         selectedLabelPaperSizeOption = viewState.value?.paperSizeOption ?: WooShippingLabelPaperSize.LEGAL,
         onLabelPaperSizeOptionSelected = { viewModel.onLabelPaperSizeOptionSelected(it) },
@@ -83,6 +84,7 @@ fun WooShippingLabelPurchasedScreen(viewModel: WooShippingLabelPurchasedViewMode
 @Composable
 internal fun WooShippingLabelPurchasedScreen(
     isLoading: Boolean,
+    isPurchaseFinished: Boolean?,
     shippingData: ShippableItemsUI?,
     selectedLabelPaperSizeOption: WooShippingLabelPaperSize,
     onLabelPaperSizeOptionSelected: (WooShippingLabelPaperSize) -> Unit,
@@ -98,18 +100,34 @@ internal fun WooShippingLabelPurchasedScreen(
             .padding(16.dp)
             .verticalScroll(rememberScrollState())
     ) {
+        val (titleResId, messageResId) = when(isPurchaseFinished) {
+            true -> Pair(
+                R.string.shipping_label_purchased_success_title,
+                R.string.shipping_label_purchased_success_message
+            )
+            false -> Pair(
+                R.string.shipping_label_purchased_in_progress_title,
+                R.string.shipping_label_purchased_in_progress_message
+            )
+            null -> Pair(
+                R.string.shipping_label_purchased_failure_title,
+                R.string.shipping_label_purchased_failure_message
+            )
+        }
+
         Text(
-            text = stringResource(id = R.string.shipping_label_purchased_title),
+            text = stringResource(id = titleResId),
             style = MaterialTheme.typography.subtitle1,
             fontWeight = FontWeight.Bold,
         )
         Text(
-            text = stringResource(id = R.string.shipping_label_purchased_message),
+            text = stringResource(id = messageResId),
             modifier = Modifier.padding(top = 8.dp),
             style = MaterialTheme.typography.subtitle1,
         )
         Spacer(modifier = Modifier.padding(top = 16.dp))
         PrintShippingLabelCard(
+            isPrintButtonEnabled = isPurchaseFinished == true,
             selectedLabelPaperSizeOption = selectedLabelPaperSizeOption,
             onLabelPaperSizeOptionSelected = onLabelPaperSizeOptionSelected,
             onPrintShippingLabelClicked = onPrintShippingLabelClicked,
@@ -161,6 +179,7 @@ internal fun WooShippingLabelPurchasedScreen(
 
 @Composable
 private fun PrintShippingLabelCard(
+    isPrintButtonEnabled: Boolean,
     selectedLabelPaperSizeOption: WooShippingLabelPaperSize,
     onLabelPaperSizeOptionSelected: (WooShippingLabelPaperSize) -> Unit,
     onPrintShippingLabelClicked: () -> Unit,
@@ -189,6 +208,7 @@ private fun PrintShippingLabelCard(
         }
 
         WCColoredButton(
+            enabled = isPrintButtonEnabled,
             text = stringResource(id = R.string.shipping_label_print_button),
             onClick = { onPrintShippingLabelClicked() },
             modifier = Modifier
@@ -337,6 +357,7 @@ internal fun WooShippingLabelPurchasedScreenPreview() {
             val selectedLabelPaperSizeOption = remember { mutableStateOf(WooShippingLabelPaperSize.LEGAL) }
             WooShippingLabelPurchasedScreen(
                 isLoading = false,
+                isPurchaseFinished = true,
                 shippingData = ShippableItemsUI(
                     shippableItems = generateItems(6),
                     formattedTotalWeight = "8.5kg",

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/purchased/WooShippingLabelPurchasedScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/purchased/WooShippingLabelPurchasedScreen.kt
@@ -100,7 +100,7 @@ internal fun WooShippingLabelPurchasedScreen(
             .padding(16.dp)
             .verticalScroll(rememberScrollState())
     ) {
-        val (titleResId, messageResId) = when(isPurchaseFinished) {
+        val (titleResId, messageResId) = when (isPurchaseFinished) {
             true -> Pair(
                 R.string.shipping_label_purchased_success_title,
                 R.string.shipping_label_purchased_success_message

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/purchased/WooShippingLabelPurchasedViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/purchased/WooShippingLabelPurchasedViewModel.kt
@@ -10,7 +10,6 @@ import com.woocommerce.android.ui.orders.wooshippinglabels.ShippableItemUI
 import com.woocommerce.android.ui.orders.wooshippinglabels.ShippableItemsUI
 import com.woocommerce.android.ui.orders.wooshippinglabels.models.ShippingLabelStatus.PurchaseInProgress
 import com.woocommerce.android.ui.orders.wooshippinglabels.models.ShippingLabelStatus.Purchased
-import com.woocommerce.android.ui.orders.wooshippinglabels.models.ShippingLabelStatus.Unknown
 import com.woocommerce.android.ui.orders.wooshippinglabels.purchased.WooShippingLabelPaperSize.LABEL
 import com.woocommerce.android.ui.orders.wooshippinglabels.purchased.printing.FetchShippingLabelFile
 import com.woocommerce.android.viewmodel.MultiLiveEvent
@@ -122,7 +121,7 @@ class WooShippingLabelPurchasedViewModel @Inject constructor(
                 labelId = purchaseData.labelId
             ).onEach { status ->
                 when (status) {
-                    Unknown, PurchaseInProgress -> {
+                    PurchaseInProgress -> {
                         _viewState.update { it.copy(isLoadingData = true) }
                     }
                     Purchased -> {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/purchased/WooShippingLabelPurchasedViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/purchased/WooShippingLabelPurchasedViewModel.kt
@@ -122,13 +122,13 @@ class WooShippingLabelPurchasedViewModel @Inject constructor(
             ).onEach { status ->
                 when (status) {
                     PurchaseInProgress -> {
-                        _viewState.update { it.copy(isLoadingData = true) }
+                        _viewState.update { it.copy(isPurchaseFinished = false) }
                     }
                     Purchased -> {
-                        _viewState.update { it.copy(isLoadingData = false) }
+                        _viewState.update { it.copy(isPurchaseFinished = true) }
                     }
                     else -> {
-                        triggerEvent(ShowErrorAndExit(R.string.shipping_label_purchased_purchase_failed_error))
+                        _viewState.update { it.copy(isPurchaseFinished = null) }
                     }
                 }
             }.launchIn(this)
@@ -139,13 +139,13 @@ class WooShippingLabelPurchasedViewModel @Inject constructor(
     data class ViewState(
         val paperSizeOption: WooShippingLabelPaperSize,
         val shippableItems: ShippableItemsUI? = null,
-        val isLoadingData: Boolean = false
+        val isLoadingData: Boolean = false,
+        val isPurchaseFinished: Boolean? = false
     ) : Parcelable
 
     data class OpenShippingLabelFile(val file: File) : MultiLiveEvent.Event()
     data class OpenUrl(val url: String) : MultiLiveEvent.Event()
     data class ShowError(val errorResId: Int) : MultiLiveEvent.Event()
-    data class ShowErrorAndExit(val errorResId: Int) : MultiLiveEvent.Event()
     object StartRefundRequest : MultiLiveEvent.Event()
     object OpenLearnMoreScreen : MultiLiveEvent.Event()
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/purchased/WooShippingLabelPurchasedViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/purchased/WooShippingLabelPurchasedViewModel.kt
@@ -8,6 +8,9 @@ import com.woocommerce.android.R
 import com.woocommerce.android.ui.orders.shippinglabels.ShipmentTrackingUrls
 import com.woocommerce.android.ui.orders.wooshippinglabels.ShippableItemUI
 import com.woocommerce.android.ui.orders.wooshippinglabels.ShippableItemsUI
+import com.woocommerce.android.ui.orders.wooshippinglabels.models.ShippingLabelStatus.PurchaseInProgress
+import com.woocommerce.android.ui.orders.wooshippinglabels.models.ShippingLabelStatus.Purchased
+import com.woocommerce.android.ui.orders.wooshippinglabels.models.ShippingLabelStatus.Unknown
 import com.woocommerce.android.ui.orders.wooshippinglabels.purchased.WooShippingLabelPaperSize.LABEL
 import com.woocommerce.android.ui.orders.wooshippinglabels.purchased.printing.FetchShippingLabelFile
 import com.woocommerce.android.viewmodel.MultiLiveEvent
@@ -47,8 +50,8 @@ class WooShippingLabelPurchasedViewModel @Inject constructor(
     val viewState = _viewState.asLiveData()
 
     init {
-        extractPurchaseDataToViewState()
         observeShippingLabelPurchaseStatus()
+        extractPurchaseDataToViewState()
     }
 
     fun onPrintShippingLabelClicked() {
@@ -106,8 +109,7 @@ class WooShippingLabelPurchasedViewModel @Inject constructor(
                             imageUrl = it.imageUrl
                         )
                     }
-                ),
-                isLoadingData = true
+                )
             )
         }
     }
@@ -118,7 +120,17 @@ class WooShippingLabelPurchasedViewModel @Inject constructor(
                 orderId = 0L,
                 labelId = navArgs.purchaseData.labelId
             ).onEach { status ->
-
+                when (status) {
+                    Unknown, PurchaseInProgress -> {
+                        _viewState.update { it.copy(isLoadingData = true) }
+                    }
+                    Purchased -> {
+                        _viewState.update { it.copy(isLoadingData = false) }
+                    }
+                    else -> {
+                        triggerEvent(ShowErrorAndExit(R.string.shipping_label_purchased_purchase_failed_error))
+                    }
+                }
             }.launchIn(viewModelScope)
         }
     }
@@ -133,6 +145,7 @@ class WooShippingLabelPurchasedViewModel @Inject constructor(
     data class OpenShippingLabelFile(val file: File) : MultiLiveEvent.Event()
     data class OpenUrl(val url: String) : MultiLiveEvent.Event()
     data class ShowError(val errorResId: Int) : MultiLiveEvent.Event()
+    data class ShowErrorAndExit(val errorResId: Int) : MultiLiveEvent.Event()
     object StartRefundRequest : MultiLiveEvent.Event()
     object OpenLearnMoreScreen : MultiLiveEvent.Event()
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/purchased/WooShippingLabelPurchasedViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/purchased/WooShippingLabelPurchasedViewModel.kt
@@ -47,29 +47,8 @@ class WooShippingLabelPurchasedViewModel @Inject constructor(
     val viewState = _viewState.asLiveData()
 
     init {
-        val purchasedLabelData = navArgs.purchaseData
-
-        _viewState.update { state ->
-            state.copy(
-                shippableItems = ShippableItemsUI(
-                    formattedTotalWeight = purchasedLabelData.formattedTotalWeight,
-                    formattedTotalPrice = purchasedLabelData.formattedTotalPrice,
-                    shippableItems = purchasedLabelData.items.map {
-                        ShippableItemUI(
-                            itemId = it.itemId,
-                            productId = it.productId,
-                            title = it.title,
-                            formattedSize = it.dimensions,
-                            formattedWeight = it.weight,
-                            formattedPrice = it.formattedPrice,
-                            quantity = it.quantity,
-                            imageUrl = it.imageUrl
-                        )
-                    }
-                ),
-                isLoadingData = true
-            )
-        }
+        extractPurchaseDataToViewState()
+        observeShippingLabelPurchaseStatus()
     }
 
     fun onPrintShippingLabelClicked() {
@@ -108,6 +87,41 @@ class WooShippingLabelPurchasedViewModel @Inject constructor(
     fun onRefundClicked() { triggerEvent(StartRefundRequest) }
 
     fun onLearnMoreClicked() { triggerEvent(OpenLearnMoreScreen) }
+
+    private fun extractPurchaseDataToViewState() {
+        _viewState.update { state ->
+            state.copy(
+                shippableItems = ShippableItemsUI(
+                    formattedTotalWeight = navArgs.purchaseData.formattedTotalWeight,
+                    formattedTotalPrice = navArgs.purchaseData.formattedTotalPrice,
+                    shippableItems = navArgs.purchaseData.items.map {
+                        ShippableItemUI(
+                            itemId = it.itemId,
+                            productId = it.productId,
+                            title = it.title,
+                            formattedSize = it.dimensions,
+                            formattedWeight = it.weight,
+                            formattedPrice = it.formattedPrice,
+                            quantity = it.quantity,
+                            imageUrl = it.imageUrl
+                        )
+                    }
+                ),
+                isLoadingData = true
+            )
+        }
+    }
+
+    private fun observeShippingLabelPurchaseStatus() {
+        launch {
+            observeShippingLabelStatus(
+                orderId = 0L,
+                labelId = navArgs.purchaseData.labelId
+            ).onEach { status ->
+
+            }.launchIn(viewModelScope)
+        }
+    }
 
     @Parcelize
     data class ViewState(

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/purchased/WooShippingLabelPurchasedViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/purchased/WooShippingLabelPurchasedViewModel.kt
@@ -18,14 +18,14 @@ import com.woocommerce.android.viewmodel.ScopedViewModel
 import com.woocommerce.android.viewmodel.getStateFlow
 import com.woocommerce.android.viewmodel.navArgs
 import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.flow.launchIn
+import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 import kotlinx.parcelize.Parcelize
 import java.io.File
 import java.util.Locale
 import javax.inject.Inject
-import kotlinx.coroutines.flow.launchIn
-import kotlinx.coroutines.flow.onEach
 
 @HiltViewModel
 class WooShippingLabelPurchasedViewModel @Inject constructor(

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/purchased/WooShippingLabelPurchasedViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/purchased/WooShippingLabelPurchasedViewModel.kt
@@ -34,11 +34,12 @@ class WooShippingLabelPurchasedViewModel @Inject constructor(
     private val observeShippingLabelStatus: ObserveShippingLabelStatus
 ) : ScopedViewModel(savedState) {
     private val navArgs by savedState.navArgs<WooShippingLabelPurchasedFragmentArgs>()
+    private val purchaseData = navArgs.purchaseData
 
     private val trackingLink: String?
         get() = ShipmentTrackingUrls.fromCarrier(
-            carrierId = navArgs.purchaseData.carrierId,
-            trackingNumber = navArgs.purchaseData.trackingNumber
+            carrierId = purchaseData.carrierId,
+            trackingNumber = purchaseData.trackingNumber
         )
 
     private val _viewState = savedState.getStateFlow(
@@ -59,7 +60,7 @@ class WooShippingLabelPurchasedViewModel @Inject constructor(
         launch {
             val paperSize = _viewState.value.paperSizeOption
             val labelFile = fetchShippingLabelFile(
-                labelIds = listOf(navArgs.purchaseData.labelId),
+                labelIds = listOf(purchaseData.labelId),
                 paperSize = paperSize.name.lowercase(Locale.US)
             )
 
@@ -82,7 +83,7 @@ class WooShippingLabelPurchasedViewModel @Inject constructor(
     }
 
     fun onSchedulePickUpClicked() {
-        Carrier.fromCarrierId(navArgs.purchaseData.carrierId)?.let {
+        Carrier.fromCarrierId(purchaseData.carrierId)?.let {
             triggerEvent(OpenUrl(it.pickupUrl))
         } ?: triggerEvent(ShowError(R.string.shipping_label_purchased_pickup_error))
     }
@@ -95,9 +96,9 @@ class WooShippingLabelPurchasedViewModel @Inject constructor(
         _viewState.update { state ->
             state.copy(
                 shippableItems = ShippableItemsUI(
-                    formattedTotalWeight = navArgs.purchaseData.formattedTotalWeight,
-                    formattedTotalPrice = navArgs.purchaseData.formattedTotalPrice,
-                    shippableItems = navArgs.purchaseData.items.map {
+                    formattedTotalWeight = purchaseData.formattedTotalWeight,
+                    formattedTotalPrice = purchaseData.formattedTotalPrice,
+                    shippableItems = purchaseData.items.map {
                         ShippableItemUI(
                             itemId = it.itemId,
                             productId = it.productId,
@@ -117,8 +118,8 @@ class WooShippingLabelPurchasedViewModel @Inject constructor(
     private fun observeShippingLabelPurchaseStatus() {
         launch {
             observeShippingLabelStatus(
-                orderId = 0L,
-                labelId = navArgs.purchaseData.labelId
+                orderId = purchaseData.orderId,
+                labelId = purchaseData.labelId
             ).onEach { status ->
                 when (status) {
                     Unknown, PurchaseInProgress -> {
@@ -131,7 +132,7 @@ class WooShippingLabelPurchasedViewModel @Inject constructor(
                         triggerEvent(ShowErrorAndExit(R.string.shipping_label_purchased_purchase_failed_error))
                     }
                 }
-            }.launchIn(viewModelScope)
+            }.launchIn(this)
         }
     }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/purchased/WooShippingLabelPurchasedViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/purchased/WooShippingLabelPurchasedViewModel.kt
@@ -21,11 +21,14 @@ import kotlinx.parcelize.Parcelize
 import java.io.File
 import java.util.Locale
 import javax.inject.Inject
+import kotlinx.coroutines.flow.launchIn
+import kotlinx.coroutines.flow.onEach
 
 @HiltViewModel
 class WooShippingLabelPurchasedViewModel @Inject constructor(
     savedState: SavedStateHandle,
-    private val fetchShippingLabelFile: FetchShippingLabelFile
+    private val fetchShippingLabelFile: FetchShippingLabelFile,
+    private val observeShippingLabelStatus: ObserveShippingLabelStatus
 ) : ScopedViewModel(savedState) {
     private val navArgs by savedState.navArgs<WooShippingLabelPurchasedFragmentArgs>()
 
@@ -44,12 +47,14 @@ class WooShippingLabelPurchasedViewModel @Inject constructor(
     val viewState = _viewState.asLiveData()
 
     init {
+        val purchasedLabelData = navArgs.purchaseData
+
         _viewState.update { state ->
             state.copy(
                 shippableItems = ShippableItemsUI(
-                    formattedTotalWeight = navArgs.purchaseData.formattedTotalWeight,
-                    formattedTotalPrice = navArgs.purchaseData.formattedTotalPrice,
-                    shippableItems = navArgs.purchaseData.items.map {
+                    formattedTotalWeight = purchasedLabelData.formattedTotalWeight,
+                    formattedTotalPrice = purchasedLabelData.formattedTotalPrice,
+                    shippableItems = purchasedLabelData.items.map {
                         ShippableItemUI(
                             itemId = it.itemId,
                             productId = it.productId,
@@ -61,13 +66,14 @@ class WooShippingLabelPurchasedViewModel @Inject constructor(
                             imageUrl = it.imageUrl
                         )
                     }
-                )
+                ),
+                isLoadingData = true
             )
         }
     }
 
     fun onPrintShippingLabelClicked() {
-        _viewState.update { it.copy(isPrintingInProgress = true) }
+        _viewState.update { it.copy(isLoadingData = true) }
         launch {
             val paperSize = _viewState.value.paperSizeOption
             val labelFile = fetchShippingLabelFile(
@@ -79,7 +85,7 @@ class WooShippingLabelPurchasedViewModel @Inject constructor(
                 triggerEvent(OpenShippingLabelFile(it))
             } ?: triggerEvent(ShowError(R.string.shipping_label_purchased_print_error))
 
-            _viewState.update { it.copy(isPrintingInProgress = false) }
+            _viewState.update { it.copy(isLoadingData = false) }
         }
     }
 
@@ -107,7 +113,7 @@ class WooShippingLabelPurchasedViewModel @Inject constructor(
     data class ViewState(
         val paperSizeOption: WooShippingLabelPaperSize,
         val shippableItems: ShippableItemsUI? = null,
-        val isPrintingInProgress: Boolean = false
+        val isLoadingData: Boolean = false
     ) : Parcelable
 
     data class OpenShippingLabelFile(val file: File) : MultiLiveEvent.Event()

--- a/WooCommerce/src/main/res/navigation/nav_graph_orders.xml
+++ b/WooCommerce/src/main/res/navigation/nav_graph_orders.xml
@@ -740,7 +740,8 @@
             app:destination="@id/wooShippingLabelPackageCreationFragment" />
         <action
             android:id="@+id/action_wooShippingLabelCreationFragment_to_wooShippingLabelPurchasedFragment"
-            app:destination="@id/wooShippingLabelPurchasedFragment" />
+            app:destination="@id/wooShippingLabelPurchasedFragment"
+            app:popUpTo="@id/orderDetailFragment" />
     </fragment>
     <fragment
         android:id="@+id/wooShippingLabelPackageCreationFragment"

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -1290,6 +1290,7 @@
     <string name="shipping_label_purchased_pickup_error">We currently do not support Pick ups for this carrier</string>
     <string name="shipping_label_purchased_tracking_error">We currently do not support Tracking for this carrier</string>
     <string name="shipping_label_purchased_print_error">Something went wrong with this Shipping Label, try again later</string>
+    <string name="shipping_label_purchased_purchase_failed_error">We can\'t confirm the Shipping Label purchase right now, try again later</string>
 
 
     <!--

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -1279,8 +1279,12 @@
     <string name="shipping_label_shipping_rates_sort_option_cheapest">Cheapest</string>
     <string name="shipping_label_shipping_rates_sort_option_fastest">Fastest</string>
     <string name="shipping_label_shipping_service_title">Shipping service</string>
-    <string name="shipping_label_purchased_title">Your shipping label is ready to print</string>
-    <string name="shipping_label_purchased_message">From here you can print the shipping label again or change the paper size of the label.</string>
+    <string name="shipping_label_purchased_success_title">Your shipping label is ready to print</string>
+    <string name="shipping_label_purchased_success_message">From here you can print the shipping label again or change the paper size of the label.</string>
+    <string name="shipping_label_purchased_in_progress_title">Your shipping label is being processed</string>
+    <string name="shipping_label_purchased_in_progress_message">Once it\'s finished, you will be able to print the shipping label with a selected paper size</string>
+    <string name="shipping_label_purchased_failure_title">We couldn\'t process your shipping label</string>
+    <string name="shipping_label_purchased_failure_message">Please try again later</string>
     <string name="shipping_label_purchased_note">Note: Reusing a printed label is a violation of our terms of service and may result in criminal charges.</string>
     <string name="shipping_label_purchased_learn_how_to_print">Learn how to print from your mobile device</string>
     <string name="shipping_label_purchased_track_shipment">Track shipment</string>

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/WooShippingLabelCreationViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/WooShippingLabelCreationViewModelTest.kt
@@ -118,6 +118,7 @@ class WooShippingLabelCreationViewModelTest : BaseUnitTest() {
 
     private val defaultPurchasedShippingLabelData = PurchasedShippingLabelData(
         labelId = 12L,
+        orderId = 1L,
         carrierId = WooShippingCarrier.UPS.name,
         totalWeight = "13.0",
         formattedTotalPrice = "$ 0",

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/purchased/ObserveShippingLabelStatusTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/purchased/ObserveShippingLabelStatusTest.kt
@@ -1,0 +1,94 @@
+import com.woocommerce.android.ui.orders.wooshippinglabels.models.ShippingLabelStatus
+import com.woocommerce.android.ui.orders.wooshippinglabels.networking.WooShippingLabelRepository
+import com.woocommerce.android.tools.SelectedSite
+import com.woocommerce.android.ui.orders.wooshippinglabels.purchased.ObserveShippingLabelStatus
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.toList
+import kotlinx.coroutines.test.runTest
+import org.junit.Before
+import org.junit.Test
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.whenever
+import kotlin.test.assertEquals
+import org.mockito.kotlin.any
+import org.wordpress.android.fluxc.network.rest.wpcom.wc.WooResult
+
+@ExperimentalCoroutinesApi
+class ObserveShippingLabelStatusTest {
+
+    private lateinit var observeShippingLabelStatus: ObserveShippingLabelStatus
+    private val selectedSite: SelectedSite = mock()
+    private val labelRepository: WooShippingLabelRepository = mock()
+
+    @Before
+    fun setup() {
+        observeShippingLabelStatus = ObserveShippingLabelStatus(selectedSite, labelRepository)
+    }
+
+    @Test
+    fun `initial state is Unknown`() = runTest {
+        whenever(labelRepository.fetchShippingLabelStatus(any(), any(), any()))
+            .thenReturn(WooResult(ShippingLabelStatus.Unknown))
+
+        val result = observeShippingLabelStatus(0L, 0L).toList()
+
+        assertEquals(listOf(ShippingLabelStatus.Unknown), result)
+    }
+
+    @Test
+    fun `state transitions from PurchaseInProgress to Purchased`() = runTest {
+        whenever(labelRepository.fetchShippingLabelStatus(any(), any(), any()))
+            .thenReturn(WooResult(ShippingLabelStatus.PurchaseInProgress))
+            .thenReturn(WooResult(ShippingLabelStatus.Purchased))
+
+        val result = observeShippingLabelStatus(0L, 0L).toList()
+
+        assertEquals(
+            listOf(
+                ShippingLabelStatus.Unknown,
+                ShippingLabelStatus.PurchaseInProgress,
+                ShippingLabelStatus.Purchased
+            ), result
+        )
+    }
+
+    @Test
+    fun `state remains Unknown if status is not updated`() = runTest {
+        whenever(labelRepository.fetchShippingLabelStatus(any(), any(), any()))
+            .thenReturn(WooResult(ShippingLabelStatus.Unknown))
+
+        val result = observeShippingLabelStatus(0L, 0L).toList()
+
+        assertEquals(
+            listOf(
+                ShippingLabelStatus.Unknown,
+                ShippingLabelStatus.Unknown,
+                ShippingLabelStatus.Unknown
+            ), result
+        )
+    }
+
+    @Test
+    fun `flow emits null after maximum number of attempts`() = runTest {
+        whenever(labelRepository.fetchShippingLabelStatus(any(), any(), any()))
+            .thenReturn(WooResult(ShippingLabelStatus.Unknown))
+
+        val result = observeShippingLabelStatus(0L, 0L).toList()
+
+        assertEquals(
+            listOf(
+                ShippingLabelStatus.Unknown,
+                ShippingLabelStatus.Unknown,
+                ShippingLabelStatus.Unknown,
+                ShippingLabelStatus.Unknown,
+                ShippingLabelStatus.Unknown,
+                ShippingLabelStatus.Unknown,
+                ShippingLabelStatus.Unknown,
+                ShippingLabelStatus.Unknown,
+                ShippingLabelStatus.Unknown,
+                ShippingLabelStatus.Unknown,
+                null
+            ), result
+        )
+    }
+}

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/purchased/ObserveShippingLabelStatusTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/purchased/ObserveShippingLabelStatusTest.kt
@@ -19,6 +19,9 @@ import kotlinx.coroutines.test.advanceUntilIdle
 import org.mockito.kotlin.times
 import org.mockito.kotlin.verify
 import org.wordpress.android.fluxc.model.SiteModel
+import org.wordpress.android.fluxc.network.BaseRequest
+import org.wordpress.android.fluxc.network.rest.wpcom.wc.WooError
+import org.wordpress.android.fluxc.network.rest.wpcom.wc.WooErrorType
 
 @ExperimentalCoroutinesApi
 class ObserveShippingLabelStatusTest {
@@ -38,7 +41,7 @@ class ObserveShippingLabelStatusTest {
     }
 
     @Test
-    fun `When response is unknown, then observation stops`() = runTest {
+    fun `When status response is unknown, then observation stops`() = runTest {
         whenever(labelRepository.fetchShippingLabelStatus(mockSite, mockOrderId, mockLabelId))
             .thenReturn(WooResult(Unknown))
 
@@ -50,7 +53,7 @@ class ObserveShippingLabelStatusTest {
     }
 
     @Test
-    fun `When response is PurchaseInProgress, continue trying until it changes`() = runTest {
+    fun `When status response is PurchaseInProgress, continue trying until it changes`() = runTest {
         var statusCallCount = 0
         whenever(labelRepository.fetchShippingLabelStatus(mockSite, mockOrderId, mockLabelId))
             .then {
@@ -66,5 +69,18 @@ class ObserveShippingLabelStatusTest {
 
         verify(labelRepository, times(2)).fetchShippingLabelStatus(mockSite, mockOrderId, mockLabelId)
         assertEquals(listOf(PurchaseInProgress, PurchaseInProgress, Purchased), result)
+    }
+
+    @Test
+    fun `When status response is error, then fallback to Unknown status`() = runTest {
+        val error = WooError(WooErrorType.GENERIC_ERROR, BaseRequest.GenericErrorType.UNKNOWN)
+        whenever(labelRepository.fetchShippingLabelStatus(mockSite, mockOrderId, mockLabelId))
+            .thenReturn(WooResult(error))
+
+        val result = observeShippingLabelStatus(mockOrderId, mockLabelId).toList()
+        advanceUntilIdle()
+
+        verify(labelRepository, times(1)).fetchShippingLabelStatus(mockSite, mockOrderId, mockLabelId)
+        assertEquals(listOf(PurchaseInProgress, Unknown), result)
     }
 }

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/purchased/ObserveShippingLabelStatusTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/purchased/ObserveShippingLabelStatusTest.kt
@@ -1,30 +1,28 @@
 import com.woocommerce.android.tools.SelectedSite
-import com.woocommerce.android.ui.orders.wooshippinglabels.models.ShippingLabelStatus
 import com.woocommerce.android.ui.orders.wooshippinglabels.models.ShippingLabelStatus.PurchaseInProgress
 import com.woocommerce.android.ui.orders.wooshippinglabels.models.ShippingLabelStatus.Purchased
 import com.woocommerce.android.ui.orders.wooshippinglabels.models.ShippingLabelStatus.Unknown
 import com.woocommerce.android.ui.orders.wooshippinglabels.networking.WooShippingLabelRepository
 import com.woocommerce.android.ui.orders.wooshippinglabels.purchased.ObserveShippingLabelStatus
+import com.woocommerce.android.viewmodel.BaseUnitTest
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.toList
-import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.test.advanceUntilIdle
 import org.junit.Before
 import org.junit.Test
-import org.mockito.kotlin.any
 import org.mockito.kotlin.mock
-import org.mockito.kotlin.whenever
-import org.wordpress.android.fluxc.network.rest.wpcom.wc.WooResult
-import kotlin.test.assertEquals
-import kotlinx.coroutines.test.advanceUntilIdle
 import org.mockito.kotlin.times
 import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
 import org.wordpress.android.fluxc.model.SiteModel
 import org.wordpress.android.fluxc.network.BaseRequest
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.WooError
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.WooErrorType
+import org.wordpress.android.fluxc.network.rest.wpcom.wc.WooResult
+import kotlin.test.assertEquals
 
 @ExperimentalCoroutinesApi
-class ObserveShippingLabelStatusTest {
+class ObserveShippingLabelStatusTest : BaseUnitTest() {
 
     private lateinit var observeShippingLabelStatus: ObserveShippingLabelStatus
     private val selectedSite: SelectedSite = mock()
@@ -41,7 +39,7 @@ class ObserveShippingLabelStatusTest {
     }
 
     @Test
-    fun `When status response is unknown, then observation stops`() = runTest {
+    fun `When status response is unknown, then observation stops`() = testBlocking {
         whenever(labelRepository.fetchShippingLabelStatus(mockSite, mockOrderId, mockLabelId))
             .thenReturn(WooResult(Unknown))
 
@@ -53,7 +51,7 @@ class ObserveShippingLabelStatusTest {
     }
 
     @Test
-    fun `When status response is PurchaseInProgress, continue trying until it changes`() = runTest {
+    fun `When status response is PurchaseInProgress, continue trying until it changes`() = testBlocking {
         var statusCallCount = 0
         whenever(labelRepository.fetchShippingLabelStatus(mockSite, mockOrderId, mockLabelId))
             .then {
@@ -72,7 +70,7 @@ class ObserveShippingLabelStatusTest {
     }
 
     @Test
-    fun `When status response is error, then fallback to Unknown status`() = runTest {
+    fun `When status response is error, then fallback to Unknown status`() = testBlocking {
         val error = WooError(WooErrorType.GENERIC_ERROR, BaseRequest.GenericErrorType.UNKNOWN)
         whenever(labelRepository.fetchShippingLabelStatus(mockSite, mockOrderId, mockLabelId))
             .thenReturn(WooResult(error))

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/purchased/ObserveShippingLabelStatusTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/purchased/ObserveShippingLabelStatusTest.kt
@@ -1,5 +1,8 @@
 import com.woocommerce.android.tools.SelectedSite
 import com.woocommerce.android.ui.orders.wooshippinglabels.models.ShippingLabelStatus
+import com.woocommerce.android.ui.orders.wooshippinglabels.models.ShippingLabelStatus.PurchaseInProgress
+import com.woocommerce.android.ui.orders.wooshippinglabels.models.ShippingLabelStatus.Purchased
+import com.woocommerce.android.ui.orders.wooshippinglabels.models.ShippingLabelStatus.Unknown
 import com.woocommerce.android.ui.orders.wooshippinglabels.networking.WooShippingLabelRepository
 import com.woocommerce.android.ui.orders.wooshippinglabels.purchased.ObserveShippingLabelStatus
 import kotlinx.coroutines.ExperimentalCoroutinesApi
@@ -12,6 +15,10 @@ import org.mockito.kotlin.mock
 import org.mockito.kotlin.whenever
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.WooResult
 import kotlin.test.assertEquals
+import kotlinx.coroutines.test.advanceUntilIdle
+import org.mockito.kotlin.times
+import org.mockito.kotlin.verify
+import org.wordpress.android.fluxc.model.SiteModel
 
 @ExperimentalCoroutinesApi
 class ObserveShippingLabelStatusTest {
@@ -20,78 +27,44 @@ class ObserveShippingLabelStatusTest {
     private val selectedSite: SelectedSite = mock()
     private val labelRepository: WooShippingLabelRepository = mock()
 
+    private val mockSite = SiteModel().apply { id = 123 }
+    private val mockOrderId = 456L
+    private val mockLabelId = 789L
+
     @Before
     fun setup() {
+        whenever(selectedSite.get()).thenReturn(mockSite)
         observeShippingLabelStatus = ObserveShippingLabelStatus(selectedSite, labelRepository)
     }
 
     @Test
-    fun `initial state is Unknown`() = runTest {
-        whenever(labelRepository.fetchShippingLabelStatus(any(), any(), any()))
-            .thenReturn(WooResult(ShippingLabelStatus.Unknown))
+    fun `When response is unknown, then observation stops`() = runTest {
+        whenever(labelRepository.fetchShippingLabelStatus(mockSite, mockOrderId, mockLabelId))
+            .thenReturn(WooResult(Unknown))
 
-        val result = observeShippingLabelStatus(0L, 0L).toList()
+        val result = observeShippingLabelStatus(mockOrderId, mockLabelId).toList()
+        advanceUntilIdle()
 
-        assertEquals(listOf(ShippingLabelStatus.Unknown), result)
+        verify(labelRepository).fetchShippingLabelStatus(mockSite, mockOrderId, mockLabelId)
+        assertEquals(listOf(PurchaseInProgress, Unknown), result)
     }
 
     @Test
-    fun `state transitions from PurchaseInProgress to Purchased`() = runTest {
-        whenever(labelRepository.fetchShippingLabelStatus(any(), any(), any()))
-            .thenReturn(WooResult(ShippingLabelStatus.PurchaseInProgress))
-            .thenReturn(WooResult(ShippingLabelStatus.Purchased))
+    fun `When response is PurchaseInProgress, continue trying until it changes`() = runTest {
+        var statusCallCount = 0
+        whenever(labelRepository.fetchShippingLabelStatus(mockSite, mockOrderId, mockLabelId))
+            .then {
+                if (statusCallCount++ == 0) {
+                    WooResult(PurchaseInProgress)
+                } else {
+                    WooResult(Purchased)
+                }
+            }
 
-        val result = observeShippingLabelStatus(0L, 0L).toList()
+        val result = observeShippingLabelStatus(mockOrderId, mockLabelId).toList()
+        advanceUntilIdle()
 
-        assertEquals(
-            listOf(
-                ShippingLabelStatus.Unknown,
-                ShippingLabelStatus.PurchaseInProgress,
-                ShippingLabelStatus.Purchased
-            ),
-            result
-        )
-    }
-
-    @Test
-    fun `state remains Unknown if status is not updated`() = runTest {
-        whenever(labelRepository.fetchShippingLabelStatus(any(), any(), any()))
-            .thenReturn(WooResult(ShippingLabelStatus.Unknown))
-
-        val result = observeShippingLabelStatus(0L, 0L).toList()
-
-        assertEquals(
-            listOf(
-                ShippingLabelStatus.Unknown,
-                ShippingLabelStatus.Unknown,
-                ShippingLabelStatus.Unknown
-            ),
-            result
-        )
-    }
-
-    @Test
-    fun `flow emits null after maximum number of attempts`() = runTest {
-        whenever(labelRepository.fetchShippingLabelStatus(any(), any(), any()))
-            .thenReturn(WooResult(ShippingLabelStatus.Unknown))
-
-        val result = observeShippingLabelStatus(0L, 0L).toList()
-
-        assertEquals(
-            listOf(
-                ShippingLabelStatus.Unknown,
-                ShippingLabelStatus.Unknown,
-                ShippingLabelStatus.Unknown,
-                ShippingLabelStatus.Unknown,
-                ShippingLabelStatus.Unknown,
-                ShippingLabelStatus.Unknown,
-                ShippingLabelStatus.Unknown,
-                ShippingLabelStatus.Unknown,
-                ShippingLabelStatus.Unknown,
-                ShippingLabelStatus.Unknown,
-                null
-            ),
-            result
-        )
+        verify(labelRepository, times(2)).fetchShippingLabelStatus(mockSite, mockOrderId, mockLabelId)
+        assertEquals(listOf(PurchaseInProgress, PurchaseInProgress, Purchased), result)
     }
 }

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/purchased/ObserveShippingLabelStatusTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/purchased/ObserveShippingLabelStatusTest.kt
@@ -1,17 +1,17 @@
+import com.woocommerce.android.tools.SelectedSite
 import com.woocommerce.android.ui.orders.wooshippinglabels.models.ShippingLabelStatus
 import com.woocommerce.android.ui.orders.wooshippinglabels.networking.WooShippingLabelRepository
-import com.woocommerce.android.tools.SelectedSite
 import com.woocommerce.android.ui.orders.wooshippinglabels.purchased.ObserveShippingLabelStatus
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.toList
 import kotlinx.coroutines.test.runTest
 import org.junit.Before
 import org.junit.Test
+import org.mockito.kotlin.any
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.whenever
-import kotlin.test.assertEquals
-import org.mockito.kotlin.any
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.WooResult
+import kotlin.test.assertEquals
 
 @ExperimentalCoroutinesApi
 class ObserveShippingLabelStatusTest {
@@ -48,7 +48,8 @@ class ObserveShippingLabelStatusTest {
                 ShippingLabelStatus.Unknown,
                 ShippingLabelStatus.PurchaseInProgress,
                 ShippingLabelStatus.Purchased
-            ), result
+            ),
+            result
         )
     }
 
@@ -64,7 +65,8 @@ class ObserveShippingLabelStatusTest {
                 ShippingLabelStatus.Unknown,
                 ShippingLabelStatus.Unknown,
                 ShippingLabelStatus.Unknown
-            ), result
+            ),
+            result
         )
     }
 
@@ -88,7 +90,8 @@ class ObserveShippingLabelStatusTest {
                 ShippingLabelStatus.Unknown,
                 ShippingLabelStatus.Unknown,
                 null
-            ), result
+            ),
+            result
         )
     }
 }

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/purchased/WooShippingLabelPurchasedViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/purchased/WooShippingLabelPurchasedViewModelTest.kt
@@ -69,9 +69,9 @@ class WooShippingLabelPurchasedViewModelTest : BaseUnitTest() {
         viewModel.onPrintShippingLabelClicked()
 
         assertThat(viewStateUpdates).hasSize(3)
-        assertThat(viewStateUpdates[0].isPrintingInProgress).isFalse()
-        assertThat(viewStateUpdates[1].isPrintingInProgress).isTrue()
-        assertThat(viewStateUpdates[2].isPrintingInProgress).isFalse()
+        assertThat(viewStateUpdates[0].isLoadingData).isFalse()
+        assertThat(viewStateUpdates[1].isLoadingData).isTrue()
+        assertThat(viewStateUpdates[2].isLoadingData).isFalse()
     }
 
     @Test

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/purchased/WooShippingLabelPurchasedViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/purchased/WooShippingLabelPurchasedViewModelTest.kt
@@ -153,7 +153,9 @@ class WooShippingLabelPurchasedViewModelTest : BaseUnitTest() {
     @Test
     fun `on Shipping Label Status is PurchaseInProgress, ViewState isLoadingData is true`() = testBlocking {
         var latestState: ViewState? = null
-        whenever(observeShippingLabelStatus.invoke(labelId = 4158L, orderId = 1234L)).thenReturn(flowOf(PurchaseInProgress))
+        whenever(
+            observeShippingLabelStatus.invoke(labelId = 4158L, orderId = 1234L)
+        ).thenReturn(flowOf(PurchaseInProgress))
 
         createSut()
         viewModel.viewState.observeForever { latestState = it }

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/purchased/WooShippingLabelPurchasedViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/purchased/WooShippingLabelPurchasedViewModelTest.kt
@@ -16,7 +16,6 @@ import com.woocommerce.android.viewmodel.MultiLiveEvent
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.flowOf
 import org.assertj.core.api.Assertions.assertThat
-import org.junit.Before
 import org.junit.Test
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.verify
@@ -27,8 +26,8 @@ import java.io.File
 class WooShippingLabelPurchasedViewModelTest : BaseUnitTest() {
 
     private lateinit var viewModel: WooShippingLabelPurchasedViewModel
-    private lateinit var observeShippingLabelStatus: ObserveShippingLabelStatus
     private val fetchShippingLabelFile: FetchShippingLabelFile = mock()
+    private val observeShippingLabelStatus: ObserveShippingLabelStatus = mock()
     private val file: File = mock()
 
     private val mockPurchaseData = PurchasedShippingLabelData(
@@ -46,19 +45,9 @@ class WooShippingLabelPurchasedViewModelTest : BaseUnitTest() {
         purchaseData = mockPurchaseData
     )
 
-    @Before
-    fun setup() {
-        observeShippingLabelStatus = mock<ObserveShippingLabelStatus>()
-
-        viewModel = WooShippingLabelPurchasedViewModel(
-            savedState = navArgs.toSavedStateHandle(),
-            fetchShippingLabelFile = fetchShippingLabelFile,
-            observeShippingLabelStatus = observeShippingLabelStatus
-        )
-    }
-
     @Test
     fun `onPrintShippingLabelClicked triggers OpenShippingLabelFile event`() = testBlocking {
+        createSut()
         var latestEvent: MultiLiveEvent.Event? = null
         viewModel.event.observeForever { latestEvent = it }
         whenever(fetchShippingLabelFile(listOf(navArgs.purchaseData.labelId), "label")).thenReturn(file)
@@ -71,6 +60,7 @@ class WooShippingLabelPurchasedViewModelTest : BaseUnitTest() {
 
     @Test
     fun `onPrintShippingLabelClicked triggers Loading state correctly`() = testBlocking {
+        createSut()
         val viewStateUpdates: MutableList<ViewState> = mutableListOf()
         viewModel.viewState.observeForever { viewStateUpdates.add(it) }
         whenever(fetchShippingLabelFile(listOf(navArgs.purchaseData.labelId), "label")).thenReturn(file)
@@ -85,6 +75,7 @@ class WooShippingLabelPurchasedViewModelTest : BaseUnitTest() {
 
     @Test
     fun `ViewState starts with LABEL paper size as default`() {
+        createSut()
         var latestViewState: ViewState? = null
         viewModel.viewState.observeForever { latestViewState = it }
 
@@ -94,6 +85,7 @@ class WooShippingLabelPurchasedViewModelTest : BaseUnitTest() {
 
     @Test
     fun `onLabelPaperSizeOptionSelected updates the ViewState as expected`() {
+        createSut()
         var latestViewState: ViewState? = null
         viewModel.viewState.observeForever { latestViewState = it }
 
@@ -105,6 +97,7 @@ class WooShippingLabelPurchasedViewModelTest : BaseUnitTest() {
 
     @Test
     fun `onTrackShipmentClicked triggers OpenUrl event`() = testBlocking {
+        createSut()
         var latestEvent: MultiLiveEvent.Event? = null
         viewModel.event.observeForever { latestEvent = it }
 
@@ -115,6 +108,7 @@ class WooShippingLabelPurchasedViewModelTest : BaseUnitTest() {
 
     @Test
     fun `onSchedulePickUpClicked triggers OpenUrl event`() = testBlocking {
+        createSut()
         var latestEvent: MultiLiveEvent.Event? = null
         viewModel.event.observeForever { latestEvent = it }
 
@@ -125,6 +119,7 @@ class WooShippingLabelPurchasedViewModelTest : BaseUnitTest() {
 
     @Test
     fun `onRefundClicked triggers StartRefundRequest event`() = testBlocking {
+        createSut()
         var latestEvent: MultiLiveEvent.Event? = null
         viewModel.event.observeForever { latestEvent = it }
 
@@ -135,6 +130,7 @@ class WooShippingLabelPurchasedViewModelTest : BaseUnitTest() {
 
     @Test
     fun `onLearnMoreClicked triggers OpenLearnMoreScreen event`() = testBlocking {
+        createSut()
         var latestEvent: MultiLiveEvent.Event? = null
         viewModel.event.observeForever { latestEvent = it }
 
@@ -145,53 +141,42 @@ class WooShippingLabelPurchasedViewModelTest : BaseUnitTest() {
 
     @Test
     fun `on Shipping Label Status is Unknown, ViewState isLoadingData is true`() = testBlocking {
-        val viewStateUpdates: MutableList<ViewState> = mutableListOf()
-        whenever(observeShippingLabelStatus(0L, 0L)).thenReturn(flowOf(Unknown))
+        var latestState: ViewState? = null
+        whenever(observeShippingLabelStatus(labelId = 4158L, orderId = 1234L)).thenReturn(flowOf(Unknown))
 
-        viewModel = WooShippingLabelPurchasedViewModel(
-            savedState = navArgs.toSavedStateHandle(),
-            fetchShippingLabelFile = fetchShippingLabelFile,
-            observeShippingLabelStatus = observeShippingLabelStatus
-        )
-        viewModel.viewState.observeForever { viewStateUpdates.add(it) }
+        createSut()
+        viewModel.viewState.observeForever { latestState = it }
 
-        assertThat(viewStateUpdates).hasSize(2)
-        assertThat(viewStateUpdates[0].isLoadingData).isFalse()
-        assertThat(viewStateUpdates[1].isLoadingData).isTrue()
+        assertThat(latestState?.isPurchaseFinished).isNull()
     }
 
     @Test
     fun `on Shipping Label Status is PurchaseInProgress, ViewState isLoadingData is true`() = testBlocking {
-        val viewStateUpdates: MutableList<ViewState> = mutableListOf()
-        whenever(observeShippingLabelStatus(0L, 0L)).thenReturn(flowOf(PurchaseInProgress))
+        var latestState: ViewState? = null
+        whenever(observeShippingLabelStatus.invoke(labelId = 4158L, orderId = 1234L)).thenReturn(flowOf(PurchaseInProgress))
 
-        viewModel = WooShippingLabelPurchasedViewModel(
-            savedState = navArgs.toSavedStateHandle(),
-            fetchShippingLabelFile = fetchShippingLabelFile,
-            observeShippingLabelStatus = observeShippingLabelStatus
-        )
-        viewModel.viewState.observeForever { viewStateUpdates.add(it) }
+        createSut()
+        viewModel.viewState.observeForever { latestState = it }
 
-        assertThat(viewStateUpdates).hasSize(2)
-        assertThat(viewStateUpdates[0].isLoadingData).isFalse()
-        assertThat(viewStateUpdates[1].isLoadingData).isTrue()
+        assertThat(latestState?.isPurchaseFinished).isFalse()
     }
 
     @Test
     fun `on Shipping Label Status is Purchased, ViewState isLoadingData is false`() = testBlocking {
-        val viewStateUpdates: MutableList<ViewState> = mutableListOf()
-        whenever(observeShippingLabelStatus(0L, 0L)).thenReturn(flowOf(Unknown, Purchased))
+        var latestState: ViewState? = null
+        whenever(observeShippingLabelStatus(labelId = 4158L, orderId = 1234L)).thenReturn(flowOf(Unknown, Purchased))
 
+        createSut()
+        viewModel.viewState.observeForever { latestState = it }
+
+        assertThat(latestState?.isPurchaseFinished).isTrue()
+    }
+
+    private fun createSut() {
         viewModel = WooShippingLabelPurchasedViewModel(
             savedState = navArgs.toSavedStateHandle(),
             fetchShippingLabelFile = fetchShippingLabelFile,
             observeShippingLabelStatus = observeShippingLabelStatus
         )
-        viewModel.viewState.observeForever { viewStateUpdates.add(it) }
-
-        assertThat(viewStateUpdates).hasSize(2)
-        assertThat(viewStateUpdates[0].isLoadingData).isFalse()
-        assertThat(viewStateUpdates[1].isLoadingData).isTrue()
-        assertThat(viewStateUpdates[2].isLoadingData).isFalse()
     }
 }

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/purchased/WooShippingLabelPurchasedViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/purchased/WooShippingLabelPurchasedViewModelTest.kt
@@ -33,6 +33,7 @@ class WooShippingLabelPurchasedViewModelTest : BaseUnitTest() {
 
     private val mockPurchaseData = PurchasedShippingLabelData(
         labelId = 4158L,
+        orderId = 1234L,
         carrierId = "usps",
         totalWeight = "1.5",
         formattedTotalPrice = "10.00",

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/purchased/WooShippingLabelPurchasedViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/purchased/WooShippingLabelPurchasedViewModelTest.kt
@@ -14,6 +14,7 @@ import com.woocommerce.android.ui.orders.wooshippinglabels.purchased.printing.Fe
 import com.woocommerce.android.viewmodel.BaseUnitTest
 import com.woocommerce.android.viewmodel.MultiLiveEvent
 import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.flowOf
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.Before
 import org.junit.Test
@@ -21,7 +22,6 @@ import org.mockito.kotlin.mock
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
 import java.io.File
-import kotlinx.coroutines.flow.flowOf
 
 @ExperimentalCoroutinesApi
 class WooShippingLabelPurchasedViewModelTest : BaseUnitTest() {
@@ -194,6 +194,4 @@ class WooShippingLabelPurchasedViewModelTest : BaseUnitTest() {
         assertThat(viewStateUpdates[1].isLoadingData).isTrue()
         assertThat(viewStateUpdates[2].isLoadingData).isFalse()
     }
-
-
 }

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/purchased/WooShippingLabelPurchasedViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/purchased/WooShippingLabelPurchasedViewModelTest.kt
@@ -1,5 +1,8 @@
 package com.woocommerce.android.ui.orders.wooshippinglabels.purchased
 
+import com.woocommerce.android.ui.orders.wooshippinglabels.models.ShippingLabelStatus.PurchaseInProgress
+import com.woocommerce.android.ui.orders.wooshippinglabels.models.ShippingLabelStatus.Purchased
+import com.woocommerce.android.ui.orders.wooshippinglabels.models.ShippingLabelStatus.Unknown
 import com.woocommerce.android.ui.orders.wooshippinglabels.purchased.WooShippingLabelPaperSize.LABEL
 import com.woocommerce.android.ui.orders.wooshippinglabels.purchased.WooShippingLabelPaperSize.LETTER
 import com.woocommerce.android.ui.orders.wooshippinglabels.purchased.WooShippingLabelPurchasedViewModel.OpenLearnMoreScreen
@@ -18,11 +21,13 @@ import org.mockito.kotlin.mock
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
 import java.io.File
+import kotlinx.coroutines.flow.flowOf
 
 @ExperimentalCoroutinesApi
 class WooShippingLabelPurchasedViewModelTest : BaseUnitTest() {
 
     private lateinit var viewModel: WooShippingLabelPurchasedViewModel
+    private lateinit var observeShippingLabelStatus: ObserveShippingLabelStatus
     private val fetchShippingLabelFile: FetchShippingLabelFile = mock()
     private val file: File = mock()
 
@@ -42,9 +47,12 @@ class WooShippingLabelPurchasedViewModelTest : BaseUnitTest() {
 
     @Before
     fun setup() {
+        observeShippingLabelStatus = mock<ObserveShippingLabelStatus>()
+
         viewModel = WooShippingLabelPurchasedViewModel(
             savedState = navArgs.toSavedStateHandle(),
-            fetchShippingLabelFile = fetchShippingLabelFile
+            fetchShippingLabelFile = fetchShippingLabelFile,
+            observeShippingLabelStatus = observeShippingLabelStatus
         )
     }
 
@@ -133,4 +141,58 @@ class WooShippingLabelPurchasedViewModelTest : BaseUnitTest() {
 
         assertThat(latestEvent).isEqualTo(OpenLearnMoreScreen)
     }
+
+    @Test
+    fun `on Shipping Label Status is Unknown, ViewState isLoadingData is true`() = testBlocking {
+        val viewStateUpdates: MutableList<ViewState> = mutableListOf()
+        whenever(observeShippingLabelStatus(0L, 0L)).thenReturn(flowOf(Unknown))
+
+        viewModel = WooShippingLabelPurchasedViewModel(
+            savedState = navArgs.toSavedStateHandle(),
+            fetchShippingLabelFile = fetchShippingLabelFile,
+            observeShippingLabelStatus = observeShippingLabelStatus
+        )
+        viewModel.viewState.observeForever { viewStateUpdates.add(it) }
+
+        assertThat(viewStateUpdates).hasSize(2)
+        assertThat(viewStateUpdates[0].isLoadingData).isFalse()
+        assertThat(viewStateUpdates[1].isLoadingData).isTrue()
+    }
+
+    @Test
+    fun `on Shipping Label Status is PurchaseInProgress, ViewState isLoadingData is true`() = testBlocking {
+        val viewStateUpdates: MutableList<ViewState> = mutableListOf()
+        whenever(observeShippingLabelStatus(0L, 0L)).thenReturn(flowOf(PurchaseInProgress))
+
+        viewModel = WooShippingLabelPurchasedViewModel(
+            savedState = navArgs.toSavedStateHandle(),
+            fetchShippingLabelFile = fetchShippingLabelFile,
+            observeShippingLabelStatus = observeShippingLabelStatus
+        )
+        viewModel.viewState.observeForever { viewStateUpdates.add(it) }
+
+        assertThat(viewStateUpdates).hasSize(2)
+        assertThat(viewStateUpdates[0].isLoadingData).isFalse()
+        assertThat(viewStateUpdates[1].isLoadingData).isTrue()
+    }
+
+    @Test
+    fun `on Shipping Label Status is Purchased, ViewState isLoadingData is false`() = testBlocking {
+        val viewStateUpdates: MutableList<ViewState> = mutableListOf()
+        whenever(observeShippingLabelStatus(0L, 0L)).thenReturn(flowOf(Unknown, Purchased))
+
+        viewModel = WooShippingLabelPurchasedViewModel(
+            savedState = navArgs.toSavedStateHandle(),
+            fetchShippingLabelFile = fetchShippingLabelFile,
+            observeShippingLabelStatus = observeShippingLabelStatus
+        )
+        viewModel.viewState.observeForever { viewStateUpdates.add(it) }
+
+        assertThat(viewStateUpdates).hasSize(2)
+        assertThat(viewStateUpdates[0].isLoadingData).isFalse()
+        assertThat(viewStateUpdates[1].isLoadingData).isTrue()
+        assertThat(viewStateUpdates[2].isLoadingData).isFalse()
+    }
+
+
 }


### PR DESCRIPTION
Summary
==========
Fix issue #12707 by adding the Shipping Label Status observation to allow the Printing action to only be available once the Label is available.

Screen Capture
==========
https://github.com/user-attachments/assets/72e19269-2eba-493c-bebb-2b5f9fbb58b8

How to Test
==========
1. Open the main Shipping Label screen
2. Complete the Shipping Label creation form
3. Hit the Purchase button
4. Once in the Purchased Screen, verify that the Shipping data is correctly presented, with a waiting message at the top.
5. Wait for the Purchase to be completed and verify the Label can be printed successfully.

Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

## Reviewer (or Author, in the case of optional code reviews):

Please make sure these conditions are met before approving the PR, or request changes if the PR needs improvement:

- [ ] The PR is small and has a clear, single focus, or a valid explanation is provided in the description. If needed, please request to split it into smaller PRs.
- [ ] Ensure Adequate Unit Test Coverage: The changes are reasonably covered by unit tests or an explanation is provided in the PR description.
- [ ] Manual Testing: The author listed all the tests they ran, including smoke tests when needed (e.g., for refactorings). The reviewer confirmed that the PR works as expected on big (tablet) and small (phone) in case of UI changes, and no regressions are added.