### PR TITLE
Settings: Fix overlap issue on WooCommerce Version string.

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -3,6 +3,7 @@
 *** For entries which are touching the Android Wear app's, start entry with `[WEAR]` too.
 21.4
 -----
+- [*] Fixed overlap issue in Settings > WooCommerce Version  [https://github.com/woocommerce/woocommerce-android/pull/13183]
 
 
 21.3

--- a/WooCommerce/src/main/res/layout/fragment_settings_main.xml
+++ b/WooCommerce/src/main/res/layout/fragment_settings_main.xml
@@ -64,24 +64,23 @@
                     android:id="@+id/woo_plugin_info"
                     android:textAppearance="?attr/textAppearanceSubtitle1"
                     app:layout_constraintTop_toTopOf="parent"
-                    app:layout_constraintBottom_toBottomOf="parent"
                     app:layout_constraintStart_toStartOf="parent"
-                    android:layout_width="wrap_content"
+                    app:layout_constraintEnd_toEndOf="parent"
+                    android:layout_width="0dp"
                     android:layout_height="wrap_content"
                     android:layout_marginStart="@dimen/margin_app_title_aligned"
                     android:text="@string/settings_woo_plugin_version" />
 
-
                 <com.google.android.material.textview.MaterialTextView
                     android:id="@+id/woo_plugin_version"
-                    android:textAppearance="?attr/textAppearanceBody1"
-                    app:layout_constraintTop_toTopOf="parent"
+                    android:textAppearance="?attr/textAppearanceBody2"
+                    app:layout_constraintTop_toBottomOf="@id/woo_plugin_info"
+                    app:layout_constraintStart_toStartOf="parent"
                     app:layout_constraintEnd_toEndOf="parent"
-                    app:layout_constraintBottom_toBottomOf="parent"
-                    android:layout_marginHorizontal="@dimen/major_100"
-                    tools:text="8.6.1"
-                    android:layout_width="wrap_content"
-                    android:layout_height="wrap_content" />
+                    android:layout_width="0dp"
+                    android:layout_height="wrap_content"
+                    android:layout_marginStart="@dimen/margin_app_title_aligned"
+                    tools:text="8.6.1" />
 
             </androidx.constraintlayout.widget.ConstraintLayout>
 


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #12996 
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

The text "WooCommerce Version" and its value in Settings screen might overlap on bigger font size setting.

This PR updates it so those two string are displayed separately in two lines so there's no overlap issue.

### Steps to reproduce
<!-- Step-by-step testing instructions. For new user flows, consider instead stating the goal of the workflow and see if your PR reviewer can accomplish the workflow without specific steps! -->

1. Set simulator to biggest font size, then run app,
2. Check Settings and compare like in screenshot, ensure there's no overlap.



### The tests that have been performed
<!-- To give the reviewer an idea of what could be missed in terms of testing -->

The above

### Images/gif
<!-- Include before and after images or gifs when appropriate. -->

| Before | After |
|-|-|
| ![Screenshot_1734855631](https://github.com/user-attachments/assets/9ea3d27d-b077-45a9-ae72-7d9c1b674f03) | ![Screenshot_1734855631](https://github.com/user-attachments/assets/e999ab77-2f91-48ab-b671-99bcb71f9275) |


- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.

## Reviewer (or Author, in the case of optional code reviews):

Please make sure these conditions are met before approving the PR, or request changes if the PR needs improvement:

- [x] The PR is small and has a clear, single focus, or a valid explanation is provided in the description. If needed, please request to split it into smaller PRs.
- [x] Ensure Adequate Unit Test Coverage: The changes are reasonably covered by unit tests or an explanation is provided in the PR description.
- [x] Manual Testing: The author listed all the tests they ran, including smoke tests when needed (e.g., for refactorings). The reviewer confirmed that the PR works as expected on big (tablet) and small (phone) in case of UI changes, and no regressions are added.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->