### PR TITLE
Update primary colors

### DIFF
--- a/WooCommerce-Wear/src/main/java/com/woocommerce/android/wear/compose/theme/WooColors.kt
+++ b/WooCommerce-Wear/src/main/java/com/woocommerce/android/wear/compose/theme/WooColors.kt
@@ -5,7 +5,7 @@ import androidx.wear.compose.material.Colors
 
 @Suppress("MagicNumber")
 object WooColors {
-    val md_theme_dark_primary = Color(0xFFB17FD4)
+    val md_theme_dark_primary = Color(0xFFA77EFF)
     val md_theme_dark_onPrimary = Color(0xFF000000)
     val md_theme_dark_primary_variant = Color(0xFF7F54B3)
     val md_theme_dark_secondary = Color(0xFFEB6594)

--- a/WooCommerce-Wear/src/main/res/values/colors_base.xml
+++ b/WooCommerce-Wear/src/main/res/values/colors_base.xml
@@ -88,7 +88,7 @@
     <color name="woo_black_alpha_008">#14212121</color>
 
     <!-- General colors -->
-    <color name="color_primary">@color/woo_purple_60</color>
+    <color name="color_primary">@color/woo_purple_40</color>
     <color name="color_primary_surface">@color/woo_purple_60</color>
     <color name="color_primary_variant">@color/woo_purple_80</color>
     <color name="color_secondary">@color/woo_pink_50</color>

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/compose/theme/WooColors.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/compose/theme/WooColors.kt
@@ -19,7 +19,7 @@ object WooColors {
     val md_theme_light_surface = Color(0xFFFFFFFF)
     val md_theme_light_onSurface = Color(0xFF000000)
 
-    val md_theme_dark_primary = Color(0xFF873EFF)
+    val md_theme_dark_primary = Color(0xFFA77EFF)
     val md_theme_dark_onPrimary = Color(0xFF000000)
     val md_theme_dark_primary_variant = Color(0xFF7F54B3)
     val md_theme_dark_secondary = Color(0xFFEB6594)

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/common/composeui/WooPosTheme.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/common/composeui/WooPosTheme.kt
@@ -34,7 +34,6 @@ private object WooPosColors {
     // Woo POS specific colors:
 
     // Adding missing colors from the old code to match exactly
-    val primary = Color(0xFF9C70D3)
     val oldGrayLight = Color(0xFFF2EBFF)
     val oldGrayMedium = Color(0xFF8D8D8D)
 
@@ -139,7 +138,7 @@ private object WooPosColors {
 }
 
 private val DarkColorPalette = darkColors(
-    primary = WooPosColors.primary,
+    primary = WooPosColors.WooPurple30,
     primaryVariant = WooPosColors.primaryVariant,
     onPrimary = Color.Black,
     secondary = WooPosColors.secondary,
@@ -151,7 +150,7 @@ private val DarkColorPalette = darkColors(
 )
 
 private val LightColorPalette = lightColors(
-    primary = WooPosColors.WooPurple50,
+    primary = WooPosColors.WooPurple40,
     primaryVariant = WooPosColors.primaryVariant,
     onPrimary = Color.White,
     secondary = WooPosColors.lightColorPaletteSecondary,

--- a/WooCommerce/src/main/res/values-night/colors_base.xml
+++ b/WooCommerce/src/main/res/values-night/colors_base.xml
@@ -3,7 +3,7 @@
     <!--
         General colors
     -->
-    <color name="color_primary">@color/woo_purple_40</color>
+    <color name="color_primary">@color/woo_purple_30</color>
     <color name="color_primary_surface">@color/woo_black_90</color>
     <color name="color_primary_variant">@color/woo_purple_50</color>
     <color name="color_secondary">@color/woo_pink_30</color>


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Parent: woocommerce/woomobile-private#381
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
- This updates the primary color from Purple 40 to Purple 30 for the dark mode. It is already Purple 30 on `trunk`.  (Internal link for the decision: woocommerce/woocommerce-android#13147),
- Aligns the Woo Pos color with the app's colors. (Internal link for the decision: p1734458294117119/1734454071.869999-slack-C025A8VV728)
- This also changes the primary color for Wear, but it doesn’t affect the Wear app. I checked the before/after screens, and the colors remain the same. We are likely using custom colors for the Wear app.

### Steps to reproduce
<!-- Step-by-step testing instructions. For new user flows, consider instead stating the goal of the workflow and see if your PR reviewer can accomplish the workflow without specific steps! -->
Run the app and navigate to screens such as “My Store” and “Product Detail.”

### The tests that have been performed
<!-- To give the reviewer an idea of what could be missed in terms of testing -->
Tested screens and shared screenshots.

### Images/gif
<!-- Include before and after images or gifs when appropriate. -->
|before|after|
|-|-|
|<img src="https://github.com/user-attachments/assets/1e647fd1-c7b4-46cd-83d8-53e488dc90a8" width=300>|<img src="https://github.com/user-attachments/assets/e3ea44be-6635-4b46-8b52-41e6c9cff636" width=300>|
|<img src="https://github.com/user-attachments/assets/61f3898f-61a6-47cf-8f52-3201030083b1" width=300>|<img src="https://github.com/user-attachments/assets/f7effd20-3bbd-4d0c-84ad-6128c37dcff3" width=300>|
|<img src="https://github.com/user-attachments/assets/a703307f-f9eb-4b54-b016-a0ac2c4e0d47" width=300>|<img src="https://github.com/user-attachments/assets/7ae05c32-03b9-4a6e-9a9b-735583d30e64" width=300>|
|<img src="https://github.com/user-attachments/assets/284e23fd-dcaa-4ccf-a7de-7cc792e5ac86" width=300>|<img src="https://github.com/user-attachments/assets/30e1c91d-e9fe-4db9-80e8-57aa86ad7018" width=300>|

- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.

## Reviewer (or Author, in the case of optional code reviews):

Please make sure these conditions are met before approving the PR, or request changes if the PR needs improvement:

- [ ] The PR is small and has a clear, single focus, or a valid explanation is provided in the description. If needed, please request to split it into smaller PRs.
- [ ] Ensure Adequate Unit Test Coverage: The changes are reasonably covered by unit tests or an explanation is provided in the PR description.
- [ ] Manual Testing: The author listed all the tests they ran, including smoke tests when needed (e.g., for refactorings). The reviewer confirmed that the PR works as expected on big (tablet) and small (phone) in case of UI changes, and no regressions are added.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->