### PR TITLE
[Woo POS][TPV tracking] Send channel metadata in payment intent

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/cardreader/payment/controller/CardReaderPaymentController.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/cardreader/payment/controller/CardReaderPaymentController.kt
@@ -81,7 +81,6 @@ import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
-import kotlinx.coroutines.isActive
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 import org.wordpress.android.fluxc.store.WooCommerceStore
@@ -295,7 +294,8 @@ class CardReaderPaymentController(
                 storeName = selectedSite.get().name.ifEmpty { null },
                 siteUrl = selectedSite.get().url.ifEmpty { null },
                 countryCode = countryCode,
-                feeAmount = calculateFeeInCents(countryCode)
+                feeAmount = calculateFeeInCents(countryCode),
+                channel = determinePaymentChannel(paymentOrRefund)
             )
         ).collect { paymentStatus ->
             onPaymentStatusChanged(
@@ -320,6 +320,7 @@ class CardReaderPaymentController(
                 _paymentState.value =
                     CardReaderPaymentState.LoadingData(::onCancelPaymentFlow)
             }
+
             CollectingPayment -> {
                 _paymentState.value = paymentStateProvider.provideCollectingPaymentState(
                     cardReaderType,
@@ -425,6 +426,7 @@ class CardReaderPaymentController(
             InitializingInteracRefund -> {
                 _paymentState.value = CardReaderInteracRefundState.LoadingData(::onCancelPaymentFlow)
             }
+
             CollectingInteracRefund -> {
                 _paymentState.value = CardReaderInteracRefundState.CollectingInteracRefund(
                     amountWithCurrencyLabel = amountLabel,
@@ -435,6 +437,7 @@ class CardReaderPaymentController(
             ProcessingInteracRefund -> {
                 _paymentState.value = CardReaderInteracRefundState.ProcessingInteracRefund(amountLabel)
             }
+
             is InteracRefundSuccess -> {
                 _paymentState.value = CardReaderInteracRefundState.InteracRefundSuccessful(amountLabel)
                 triggerEvent(CardReaderPaymentEvent.InteracRefundSuccessful)
@@ -569,6 +572,7 @@ class CardReaderPaymentController(
             ),
             onCancel = ::onBackPressed
         )
+
         is PaymentFlowError.BuiltInReader.NfcDisabled -> paymentStateProvider.provideCancellableFailedPaymentState(
             cardReaderType = cardReaderType,
             errorType = errorType,
@@ -579,12 +583,14 @@ class CardReaderPaymentController(
                 onCallToActionTapped = { onEnableNfcClicked() }
             )
         )
+
         is PaymentFlowError.NonRetryableError -> paymentStateProvider.provideCancellableFailedPaymentState(
             cardReaderType = cardReaderType,
             errorType = errorType,
             amountWithCurrencyLabel = amountLabel,
             onCancel = ::onBackPressed,
         )
+
         is PaymentFlowError.PurchaseHardwareReaderError -> paymentStateProvider.provideCancellableFailedPaymentState(
             cardReaderType = cardReaderType,
             cta = CardReaderPaymentOrRefundState.CallToAction(
@@ -595,6 +601,7 @@ class CardReaderPaymentController(
             amountWithCurrencyLabel = amountLabel,
             onCancel = ::onBackPressed,
         )
+
         else -> paymentStateProvider.provideCancellableFailedPaymentState(
             cardReaderType = cardReaderType,
             errorType = errorType,
@@ -867,5 +874,21 @@ class CardReaderPaymentController(
             CANADA_FEE_FLAT_IN_CENTS
         } else {
             null
+        }
+
+    private fun determinePaymentChannel(flow: CardReaderFlowParam.PaymentOrRefund): PaymentInfo.PaymentChannel =
+        when (flow) {
+            is CardReaderFlowParam.PaymentOrRefund.Payment -> {
+                when (flow.paymentType) {
+                    CardReaderFlowParam.PaymentOrRefund.Payment.PaymentType.WOO_POS -> PaymentInfo.PaymentChannel.Pos
+                    CardReaderFlowParam.PaymentOrRefund.Payment.PaymentType.SIMPLE,
+                    CardReaderFlowParam.PaymentOrRefund.Payment.PaymentType.ORDER,
+                    CardReaderFlowParam.PaymentOrRefund.Payment.PaymentType.ORDER_CREATION,
+                    CardReaderFlowParam.PaymentOrRefund.Payment.PaymentType.TRY_TAP_TO_PAY ->
+                        PaymentInfo.PaymentChannel.StoreManager
+                }
+            }
+
+            is CardReaderFlowParam.PaymentOrRefund.Refund -> PaymentInfo.PaymentChannel.StoreManager
         }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/cardreader/payment/controller/CardReaderPaymentController.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/cardreader/payment/controller/CardReaderPaymentController.kt
@@ -876,7 +876,7 @@ class CardReaderPaymentController(
             null
         }
 
-    private fun determinePaymentChannel(flow: CardReaderFlowParam.PaymentOrRefund): PaymentInfo.PaymentChannel =
+    private fun determinePaymentChannel(flow: CardReaderFlowParam.PaymentOrRefund): PaymentInfo.PaymentChannel? =
         when (flow) {
             is CardReaderFlowParam.PaymentOrRefund.Payment -> {
                 when (flow.paymentType) {
@@ -889,6 +889,6 @@ class CardReaderPaymentController(
                 }
             }
 
-            is CardReaderFlowParam.PaymentOrRefund.Refund -> PaymentInfo.PaymentChannel.StoreManager
+            is CardReaderFlowParam.PaymentOrRefund.Refund -> null
         }
 }

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/payments/cardreader/payment/controller/CardReaderPaymentControllerTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/payments/cardreader/payment/controller/CardReaderPaymentControllerTest.kt
@@ -45,6 +45,7 @@ import com.woocommerce.android.tools.SelectedSite
 import com.woocommerce.android.ui.orders.details.OrderDetailRepository
 import com.woocommerce.android.ui.payments.cardreader.CardReaderCountryConfigProvider
 import com.woocommerce.android.ui.payments.cardreader.onboarding.CardReaderFlowParam
+import com.woocommerce.android.ui.payments.cardreader.onboarding.CardReaderFlowParam.PaymentOrRefund
 import com.woocommerce.android.ui.payments.cardreader.onboarding.CardReaderFlowParam.PaymentOrRefund.Payment.PaymentType.ORDER
 import com.woocommerce.android.ui.payments.cardreader.onboarding.CardReaderOnboardingChecker
 import com.woocommerce.android.ui.payments.cardreader.onboarding.CardReaderType
@@ -495,6 +496,86 @@ class CardReaderPaymentControllerTest : BaseUnitTest() {
 
             verify(cardReaderManager).collectPayment(captor.capture())
             assertThat(captor.firstValue.statementDescriptor.value).isEqualTo(expectedResult)
+        }
+
+    @Test
+    fun `given payment type WOO_POS, when start, then pos channel passed`() =
+        testBlocking {
+            val captor = argumentCaptor<PaymentInfo>()
+            createController(
+                cardReaderFlowParam = PaymentOrRefund.Payment(
+                    ORDER_ID,
+                    PaymentOrRefund.Payment.PaymentType.WOO_POS
+                )
+            )
+            controller.start()
+
+            verify(cardReaderManager).collectPayment(captor.capture())
+            assertThat(captor.firstValue.channel).isEqualTo(PaymentInfo.PaymentChannel.Pos)
+        }
+
+    @Test
+    fun `given payment type ORDER, when start, then store manager channel passed`() =
+        testBlocking {
+            val captor = argumentCaptor<PaymentInfo>()
+            createController(
+                cardReaderFlowParam = PaymentOrRefund.Payment(
+                    ORDER_ID,
+                    ORDER
+                )
+            )
+            controller.start()
+
+            verify(cardReaderManager).collectPayment(captor.capture())
+            assertThat(captor.firstValue.channel).isEqualTo(PaymentInfo.PaymentChannel.StoreManager)
+        }
+
+    @Test
+    fun `given payment type SIMPLE, when start, then store manager channel passed`() =
+        testBlocking {
+            val captor = argumentCaptor<PaymentInfo>()
+            createController(
+                cardReaderFlowParam = PaymentOrRefund.Payment(
+                    ORDER_ID,
+                    PaymentOrRefund.Payment.PaymentType.SIMPLE
+                )
+            )
+            controller.start()
+
+            verify(cardReaderManager).collectPayment(captor.capture())
+            assertThat(captor.firstValue.channel).isEqualTo(PaymentInfo.PaymentChannel.StoreManager)
+        }
+
+    @Test
+    fun `given payment type ORDER_CREATION, when paymentCollect, then store manager channel passed`() =
+        testBlocking {
+            val captor = argumentCaptor<PaymentInfo>()
+            createController(
+                cardReaderFlowParam = PaymentOrRefund.Payment(
+                    ORDER_ID,
+                    PaymentOrRefund.Payment.PaymentType.ORDER_CREATION
+                )
+            )
+            controller.start()
+
+            verify(cardReaderManager).collectPayment(captor.capture())
+            assertThat(captor.firstValue.channel).isEqualTo(PaymentInfo.PaymentChannel.StoreManager)
+        }
+
+    @Test
+    fun `given payment type TRY_TAP_TO_PAY, when paymentCollect, then store manager channel passed`() =
+        testBlocking {
+            val captor = argumentCaptor<PaymentInfo>()
+            createController(
+                cardReaderFlowParam = PaymentOrRefund.Payment(
+                    ORDER_ID,
+                    PaymentOrRefund.Payment.PaymentType.TRY_TAP_TO_PAY
+                )
+            )
+            controller.start()
+
+            verify(cardReaderManager).collectPayment(captor.capture())
+            assertThat(captor.firstValue.channel).isEqualTo(PaymentInfo.PaymentChannel.StoreManager)
         }
 
     @Test
@@ -3590,7 +3671,7 @@ class CardReaderPaymentControllerTest : BaseUnitTest() {
                 MutableStateFlow(CardReaderStatus.Connected(cardReader))
             )
             isTTPinProgress = true
-            createController(cardReaderType = BUILT_IN,)
+            createController(cardReaderType = BUILT_IN)
 
             controller.start()
 

--- a/libs/cardreader/src/main/java/com/woocommerce/android/cardreader/internal/payments/MetaDataKeys.kt
+++ b/libs/cardreader/src/main/java/com/woocommerce/android/cardreader/internal/payments/MetaDataKeys.kt
@@ -55,7 +55,7 @@ internal enum class MetaDataKeys(val key: String) {
      * The channel used to collect the payment, e.g. `mobile_store_management` or `mobile_pos`
      * This key is used for identifying the channel for in-person payments in analytics.
      */
-    CHANNEL("channel"),
+    CHANNEL("ipp_channel"),
 
     /**
      * The platform used to collect the payment, `android` in our case

--- a/libs/cardreader/src/main/java/com/woocommerce/android/cardreader/internal/payments/MetaDataKeys.kt
+++ b/libs/cardreader/src/main/java/com/woocommerce/android/cardreader/internal/payments/MetaDataKeys.kt
@@ -52,6 +52,12 @@ internal enum class MetaDataKeys(val key: String) {
     READER_MODEL("reader_model"),
 
     /**
+     * The channel used to collect the payment, e.g. `mobile_store_management` or `mobile_pos`
+     * This key is used for identifying the channel for in-person payments in analytics.
+     */
+    CHANNEL("channel"),
+
+    /**
      * The platform used to collect the payment, `android` in our case
      */
     PLATFORM("platform");

--- a/libs/cardreader/src/main/java/com/woocommerce/android/cardreader/internal/payments/actions/CreatePaymentAction.kt
+++ b/libs/cardreader/src/main/java/com/woocommerce/android/cardreader/internal/payments/actions/CreatePaymentAction.kt
@@ -114,7 +114,9 @@ internal class CreatePaymentAction(
         // TODO cardreader Needs to be fixed when we add support for recurring payments
         map[MetaDataKeys.PAYMENT_TYPE.key] = MetaDataKeys.PaymentTypes.SINGLE.key
 
-        map[MetaDataKeys.CHANNEL.key] = paymentInfo.channel.value
+        paymentInfo.channel?.let {
+            map[MetaDataKeys.CHANNEL.key] = it.value
+        }
 
         return map
     }

--- a/libs/cardreader/src/main/java/com/woocommerce/android/cardreader/internal/payments/actions/CreatePaymentAction.kt
+++ b/libs/cardreader/src/main/java/com/woocommerce/android/cardreader/internal/payments/actions/CreatePaymentAction.kt
@@ -113,6 +113,9 @@ internal class CreatePaymentAction(
 
         // TODO cardreader Needs to be fixed when we add support for recurring payments
         map[MetaDataKeys.PAYMENT_TYPE.key] = MetaDataKeys.PaymentTypes.SINGLE.key
+
+        map[MetaDataKeys.CHANNEL.key] = paymentInfo.channel.value
+
         return map
     }
 

--- a/libs/cardreader/src/main/java/com/woocommerce/android/cardreader/payments/PaymentInfo.kt
+++ b/libs/cardreader/src/main/java/com/woocommerce/android/cardreader/payments/PaymentInfo.kt
@@ -15,7 +15,7 @@ data class PaymentInfo(
     val siteUrl: String?,
     val orderKey: String?,
     val feeAmount: Long?,
-    val channel: PaymentChannel,
+    val channel: PaymentChannel?,
     internal val countryCode: String? = null,
 ) {
     sealed class PaymentChannel(val value: String) {

--- a/libs/cardreader/src/main/java/com/woocommerce/android/cardreader/payments/PaymentInfo.kt
+++ b/libs/cardreader/src/main/java/com/woocommerce/android/cardreader/payments/PaymentInfo.kt
@@ -15,5 +15,11 @@ data class PaymentInfo(
     val siteUrl: String?,
     val orderKey: String?,
     val feeAmount: Long?,
+    val channel: PaymentChannel,
     internal val countryCode: String? = null,
-)
+) {
+    sealed class PaymentChannel(val value: String) {
+        data object StoreManager: PaymentChannel("mobile_store_management")
+        data object Pos: PaymentChannel("mobile_pos")
+    }
+}

--- a/libs/cardreader/src/main/java/com/woocommerce/android/cardreader/payments/PaymentInfo.kt
+++ b/libs/cardreader/src/main/java/com/woocommerce/android/cardreader/payments/PaymentInfo.kt
@@ -19,7 +19,7 @@ data class PaymentInfo(
     internal val countryCode: String? = null,
 ) {
     sealed class PaymentChannel(val value: String) {
-        data object StoreManager: PaymentChannel("mobile_store_management")
-        data object Pos: PaymentChannel("mobile_pos")
+        data object StoreManager : PaymentChannel("mobile_store_management")
+        data object Pos : PaymentChannel("mobile_pos")
     }
 }

--- a/libs/cardreader/src/test/java/com/woocommerce/android/cardreader/internal/payments/PaymentManagerTest.kt
+++ b/libs/cardreader/src/test/java/com/woocommerce/android/cardreader/internal/payments/PaymentManagerTest.kt
@@ -668,5 +668,6 @@ class PaymentManagerTest : CardReaderBaseUnitTest() {
             statementDescriptor = StatementDescriptor(statementDescriptor),
             countryCode = countryCode,
             feeAmount = feeAmount,
+            channel = PaymentInfo.PaymentChannel.StoreManager
         )
 }

--- a/libs/cardreader/src/test/java/com/woocommerce/android/cardreader/internal/payments/actions/CreatePaymentActionTest.kt
+++ b/libs/cardreader/src/test/java/com/woocommerce/android/cardreader/internal/payments/actions/CreatePaymentActionTest.kt
@@ -420,6 +420,45 @@ internal class CreatePaymentActionTest : CardReaderBaseUnitTest() {
         assertThat(captor.firstValue["platform"]).isEqualTo("android")
     }
 
+    @Test
+    fun `given payment info with pos channel, when creating payment intent, then channel is set`() = testBlocking {
+        val captor = argumentCaptor<Map<String, String>>()
+        whenever(terminal.createPaymentIntent(any(), any())).thenAnswer {
+            (it.arguments[1] as PaymentIntentCallback).onSuccess(mock())
+        }
+
+        action.createPaymentIntent(createPaymentInfo(channel = PaymentInfo.PaymentChannel.Pos)).toList()
+        verify(intentParametersBuilder).setMetadata(captor.capture())
+
+        assertThat(captor.firstValue[MetaDataKeys.CHANNEL.key]).isEqualTo("mobile_pos")
+    }
+
+    @Test
+    fun `given payment info with store manager channel, when creating payment intent, then channel is set`() = testBlocking {
+        val captor = argumentCaptor<Map<String, String>>()
+        whenever(terminal.createPaymentIntent(any(), any())).thenAnswer {
+            (it.arguments[1] as PaymentIntentCallback).onSuccess(mock())
+        }
+
+        action.createPaymentIntent(createPaymentInfo(channel = PaymentInfo.PaymentChannel.StoreManager)).toList()
+        verify(intentParametersBuilder).setMetadata(captor.capture())
+
+        assertThat(captor.firstValue[MetaDataKeys.CHANNEL.key]).isEqualTo("mobile_store_management")
+    }
+
+    @Test
+    fun `given payment info with no channel, when creating payment intent, then channel is not set`() = testBlocking {
+        val captor = argumentCaptor<Map<String, String>>()
+        whenever(terminal.createPaymentIntent(any(), any())).thenAnswer {
+            (it.arguments[1] as PaymentIntentCallback).onSuccess(mock())
+        }
+
+        action.createPaymentIntent(createPaymentInfo(channel = null)).toList()
+        verify(intentParametersBuilder).setMetadata(captor.capture())
+
+        assertThat(captor.firstValue[MetaDataKeys.CHANNEL.key]).isNull()
+    }
+
     private fun createPaymentInfo(
         paymentDescription: String = "",
         orderId: Long = 1L,
@@ -434,6 +473,7 @@ internal class CreatePaymentActionTest : CardReaderBaseUnitTest() {
         countryCode: String? = "US",
         statementDescriptor: String? = null,
         feeAmount: Long? = null,
+        channel: PaymentInfo.PaymentChannel? = null,
     ): PaymentInfo =
         PaymentInfo(
             paymentDescription = paymentDescription,
@@ -449,5 +489,6 @@ internal class CreatePaymentActionTest : CardReaderBaseUnitTest() {
             countryCode = countryCode,
             statementDescriptor = StatementDescriptor(statementDescriptor),
             feeAmount = feeAmount,
+            channel = channel,
         )
 }


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #13000
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
Adds channel to the metadata of a payment intent to calculate TPV separately for POS/Store manager

### Testing information
<!-- This is your opportunity to break out individual scenarios that need testing (when necessary) and/or include a checklist for the reviewer to go through. Consider documenting the following from your own completed testing: devices used, alternate workflows, edge cases, affected areas, critical flows, areas not tested, and any remaining unknowns. Provide feedback on this new section of the PR template through Sept 30, 2024 to Apps Quality; additional context here: p91TBi-b8z-p2#comment-12036 -->
* Use JN store using secret store with ID 12613
* Make IPP/TTP transactions from the POS and from the main app
* The channel should show In-Person (POS) for POS transactions in wp-admin > Payments > Transactions
* And In-Person for the rest

### The tests that have been performed
<!-- To give the reviewer an idea of what could be missed in terms of testing -->
Anove

### Images/gif
<!-- Include before and after images or gifs when appropriate. -->

<img width="2335" alt="image" src="https://github.com/user-attachments/assets/a114547e-b6a5-4cd8-b63b-de903448da5d" />

- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.

## Reviewer (or Author, in the case of optional code reviews):

Please make sure these conditions are met before approving the PR, or request changes if the PR needs improvement:

- [x] The PR is small and has a clear, single focus, or a valid explanation is provided in the description. If needed, please request to split it into smaller PRs.
- [x] Ensure Adequate Unit Test Coverage: The changes are reasonably covered by unit tests or an explanation is provided in the PR description.
- [x] Manual Testing: The author listed all the tests they ran, including smoke tests when needed (e.g., for refactorings). The reviewer confirmed that the PR works as expected on big (tablet) and small (phone) in case of UI changes, and no regressions are added.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->