### PR TITLE
[Login] Fix issue of showing the password fallback button for passwordless accounts

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/LoginActivity.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/LoginActivity.kt
@@ -451,7 +451,7 @@ class LoginActivity :
     }
 
     override fun showMagicLinkSentScreen(email: String?, allowPassword: Boolean) {
-        val loginMagicLinkSentFragment = LoginMagicLinkSentImprovedFragment.newInstance(email, true)
+        val loginMagicLinkSentFragment = LoginMagicLinkSentImprovedFragment.newInstance(email, allowPassword)
         changeFragment(loginMagicLinkSentFragment, true, LoginMagicLinkSentImprovedFragment.TAG, false)
     }
 


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #13187 
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
This PR fixes a long standing bug that we had in the app, since the introduction of the magic link experiment more than 2 years ago, we accidentally [ignored](https://github.com/woocommerce/woocommerce-android/commit/b179261e12c7ae104372d1c3ed4b125b9be61483) the `allowPassword` argument, and this issue persisted after removing the experiment and also after introducing QR code scanning feature.

### Steps to reproduce
1. Use a passwordless account (or alternatively use the ApiFaker to fake the endpoint `/v1.1/users/%/auth-options` to return `{"passwordless": true,  "email_verified": true }`)
2. Log out, then log in.
3. Check the magic link screen.

### Testing information
Confirm that the button "Or log in with password" is hidden.

### The tests that have been performed
^

- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.

## Reviewer (or Author, in the case of optional code reviews):

Please make sure these conditions are met before approving the PR, or request changes if the PR needs improvement:

- [ ] The PR is small and has a clear, single focus, or a valid explanation is provided in the description. If needed, please request to split it into smaller PRs.
- [ ] Ensure Adequate Unit Test Coverage: The changes are reasonably covered by unit tests or an explanation is provided in the PR description.
- [ ] Manual Testing: The author listed all the tests they ran, including smoke tests when needed (e.g., for refactorings). The reviewer confirmed that the PR works as expected on big (tablet) and small (phone) in case of UI changes, and no regressions are added.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->