### PR TITLE
[Woo POS] Crash when plugin either attempted to be installed or activated by a show manager

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -4,6 +4,7 @@
 21.4
 -----
 - [*] Fixed overlap issue in Settings > WooCommerce Version  [https://github.com/woocommerce/woocommerce-android/pull/13183]
+- [**] Fixed a crash when a shop manager was trying to install or activate plugin in the POS onboarding [https://github.com/woocommerce/woocommerce-android/pull/13203]
 
 
 21.3

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/cardreader/WooPosCardReaderActivity.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/cardreader/WooPosCardReaderActivity.kt
@@ -39,7 +39,7 @@ class WooPosCardReaderActivity : AppCompatActivity(R.layout.activity_woo_pos_car
     private fun setupTopAndBottomInsets() {
         window.navigationBarColor = ContextCompat.getColor(this, android.R.color.transparent)
         WindowCompat.setDecorFitsSystemWindows(window, false)
-        val rootView = findViewById<View>(R.id.root)
+        val rootView = findViewById<View>(R.id.snack_root)
         ViewCompat.setOnApplyWindowInsetsListener(rootView) { view, insets ->
             insets.toWindowInsets()?.let { windowInsets ->
                 val insetsCompat = WindowInsetsCompat.toWindowInsetsCompat(windowInsets, view)

--- a/WooCommerce/src/main/res/layout/activity_woo_pos_card_reader.xml
+++ b/WooCommerce/src/main/res/layout/activity_woo_pos_card_reader.xml
@@ -1,12 +1,8 @@
 <androidx.coordinatorlayout.widget.CoordinatorLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
-    android:id="@+id/root"
+    android:id="@+id/snack_root"
     android:layout_width="match_parent"
-    android:layout_height="match_parent"
-    app:layout_constraintBottom_toTopOf="@+id/trial_bar"
-    app:layout_constraintEnd_toEndOf="parent"
-    app:layout_constraintStart_toStartOf="parent"
-    app:layout_constraintTop_toTopOf="parent">
+    android:layout_height="match_parent">
 
     <androidx.fragment.app.FragmentContainerView
         android:id="@+id/woopos_card_reader_nav_host_fragment"


### PR DESCRIPTION
Closes: #12957
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
It's been crashing when in the POS during the onboarding flow a shop manager was trying to install or activate WooPayments/Stripe

The crash caused by `uiMessageResolver.showSnack(event.message)` inside of `CardReaderOnboardingFragment`, as `UiMessageResolver` uses hardcoded `snack_root` id for `CoordinatorLayout`, which was called differently in `WooPosCardReaderActivity`

### Steps to reproduce
<!-- Step-by-step testing instructions. For new user flows, consider instead stating the goal of the workflow and see if your PR reviewer can accomplish the workflow without specific steps! -->
* Login with a user in a shop manager role
* Disable Woo Payments
* Go to the POS
* Try to connect to a reader
* Try to activate the plugin from the app
* Notice the crash


### The tests that have been performed
<!-- To give the reviewer an idea of what could be missed in terms of testing -->
Above

### Images/gif
<!-- Include before and after images or gifs when appropriate. -->

https://github.com/user-attachments/assets/0af51322-21e2-43f4-8177-aee5c9e74a2b


- [ ] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.

## Reviewer (or Author, in the case of optional code reviews):

Please make sure these conditions are met before approving the PR, or request changes if the PR needs improvement:

- [x] The PR is small and has a clear, single focus, or a valid explanation is provided in the description. If needed, please request to split it into smaller PRs.
- [x] Ensure Adequate Unit Test Coverage: The changes are reasonably covered by unit tests or an explanation is provided in the PR description.
- [x] Manual Testing: The author listed all the tests they ran, including smoke tests when needed (e.g., for refactorings). The reviewer confirmed that the PR works as expected on big (tablet) and small (phone) in case of UI changes, and no regressions are added.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->