### PR TITLE
Fix design issues

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/WooShippingLabelCreationFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/WooShippingLabelCreationFragment.kt
@@ -17,6 +17,7 @@ import com.woocommerce.android.ui.main.AppBarStatus
 import com.woocommerce.android.ui.orders.wooshippinglabels.WooShippingLabelCreationViewModel.StartPackageSelection
 import com.woocommerce.android.ui.orders.wooshippinglabels.packages.WooShippingLabelPackageCreationFragment.Companion.PACKAGE_SELECTION_RESULT
 import com.woocommerce.android.ui.orders.wooshippinglabels.packages.ui.PackageData
+import com.woocommerce.android.viewmodel.MultiLiveEvent
 import dagger.hilt.android.AndroidEntryPoint
 
 @AndroidEntryPoint
@@ -58,6 +59,7 @@ class WooShippingLabelCreationFragment : BaseFragment() {
                             purchaseData = event.purchaseData
                         ).let { findNavController().navigateSafely(it) }
                 }
+                is MultiLiveEvent.Event.Exit -> findNavController().navigateUp()
             }
         }
     }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/WooShippingLabelCreationScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/WooShippingLabelCreationScreen.kt
@@ -93,6 +93,7 @@ fun WooShippingLabelCreationScreen(viewModel: WooShippingLabelCreationViewModel)
                 onCustomWeightChange = viewModel::onCustomWeightChange,
                 markOrderComplete = viewState.markOrderComplete,
                 onMarkOrderCompleteChange = viewModel::onMarkOrderCompleteChange,
+                onNavigateBack = viewModel::onNavigateBack,
                 purchaseState = viewState.purchaseState
             )
         }
@@ -124,6 +125,7 @@ fun WooShippingLabelCreationScreen(
     markOrderComplete: Boolean,
     onMarkOrderCompleteChange: (Boolean) -> Unit,
     purchaseState: WooShippingLabelCreationViewModel.PurchaseState,
+    onNavigateBack: () -> Unit,
     modifier: Modifier = Modifier
 ) {
     val scaffoldState = rememberBottomSheetScaffoldState()
@@ -145,6 +147,7 @@ fun WooShippingLabelCreationScreen(
             onCustomWeightChange = onCustomWeightChange,
             onSelectedSippingRateChanged = onSelectedSippingRateChanged,
             markOrderComplete = markOrderComplete,
+            onNavigateBack = onNavigateBack,
             onMarkOrderCompleteChange = onMarkOrderCompleteChange
         )
         val isDarkTheme = isSystemInDarkTheme()
@@ -214,6 +217,7 @@ private fun LabelCreationScreenWithBottomSheet(
     scaffoldState: BottomSheetScaffoldState,
     markOrderComplete: Boolean,
     onMarkOrderCompleteChange: (Boolean) -> Unit,
+    onNavigateBack: () -> Unit,
     modifier: Modifier = Modifier
 ) {
     val isPurchaseButtonDisplayed = shippingRatesState is WooShippingLabelCreationViewModel.ShippingRatesState.DataState
@@ -242,7 +246,7 @@ private fun LabelCreationScreenWithBottomSheet(
             TopAppBar(
                 title = { Text(stringResource(id = R.string.shipping_label_create_title)) },
                 navigationIcon = {
-                    IconButton({}) {
+                    IconButton(onNavigateBack) {
                         Icon(
                             imageVector = Icons.AutoMirrored.Filled.ArrowBack,
                             contentDescription = stringResource(id = R.string.back)
@@ -577,6 +581,7 @@ private fun WooShippingLabelCreationScreenPreview() {
             onSelectedSippingRateChanged = {},
             markOrderComplete = true,
             onMarkOrderCompleteChange = {},
+            onNavigateBack = {},
             purchaseState = WooShippingLabelCreationViewModel.PurchaseState.NoStarted
         )
     }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/WooShippingLabelCreationScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/WooShippingLabelCreationScreen.kt
@@ -511,7 +511,9 @@ private fun PackageSelectionAvailableCard(
                         modifier = Modifier.fillMaxWidth(),
                         value = customWeight,
                         onValueChange = onCustomWeightChange,
-                        keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Number)
+                        keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Number),
+                        textStyle = MaterialTheme.typography.body2.copy(color = MaterialTheme.colors.onSurface),
+
                     )
                     if (customWeight.isEmpty()) {
                         Text(

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/WooShippingLabelCreationScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/WooShippingLabelCreationScreen.kt
@@ -222,6 +222,7 @@ private fun LabelCreationScreenWithBottomSheet(
 ) {
     val isPurchaseButtonDisplayed = shippingRatesState is WooShippingLabelCreationViewModel.ShippingRatesState.DataState
     val bottomSheetPeekHeight = if (isPurchaseButtonDisplayed) 132.dp else 76.dp
+    val paddingBottom = if (isPurchaseButtonDisplayed) 74.dp else 0.dp
     val shippingRateSummary =
         (shippingRatesState as? WooShippingLabelCreationViewModel.ShippingRatesState.DataState)?.selectedRate?.summary
 
@@ -237,7 +238,7 @@ private fun LabelCreationScreenWithBottomSheet(
                 onShippingFromAddressChange = onShippingFromAddressChange,
                 onShippingToAddressChange = onShippingToAddressChange,
                 shippingRateSummary = shippingRateSummary,
-                modifier = Modifier.padding(bottom = 74.dp),
+                modifier = Modifier.padding(bottom = paddingBottom),
             )
         },
         sheetPeekHeight = bottomSheetPeekHeight,

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/WooShippingLabelCreationViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/WooShippingLabelCreationViewModel.kt
@@ -429,6 +429,10 @@ class WooShippingLabelCreationViewModel @Inject constructor(
         customWeight = input
     }
 
+    fun onNavigateBack() {
+        triggerEvent(Event.Exit)
+    }
+
     data object StartPackageSelection : Event()
     data class LabelPurchased(val purchaseData: PurchasedShippingLabelData) : Event()
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/WooShippingProductsCard.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/WooShippingProductsCard.kt
@@ -294,6 +294,7 @@ private fun ShippingProductDetails(
                 modifier = Modifier
                     .align(Alignment.TopEnd)
                     .graphicsLayer {
+                        translationY = -quantityPadding.toPx()
                         translationX = quantityPadding.toPx()
                     }
             )

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/packages/ui/WooShippingCarrierPackageScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/packages/ui/WooShippingCarrierPackageScreen.kt
@@ -122,6 +122,7 @@ fun WooShippingCarrierPackageContent(
             pagerState = pagerState,
             carriers = carrierPackages.keys.toList()
         )
+        Divider(modifier = Modifier.fillMaxWidth())
         PackageListPager(
             modifier = modifier
                 .weight(1f),
@@ -155,6 +156,7 @@ private fun CarrierTabRow(
         edgePadding = dimensionResource(R.dimen.major_100),
         backgroundColor = MaterialTheme.colors.surface,
         contentColor = MaterialTheme.colors.primary,
+        divider = {}
     ) {
         carriers.forEachIndexed { index, carrier ->
             val textColor = if (index == pagerState.currentPage) {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/rates/ui/ShippingRatesCard.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/rates/ui/ShippingRatesCard.kt
@@ -10,6 +10,7 @@ import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
@@ -19,12 +20,14 @@ import androidx.compose.foundation.pager.rememberPagerState
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.CircularProgressIndicator
 import androidx.compose.material.Colors
+import androidx.compose.material.Divider
 import androidx.compose.material.DropdownMenu
 import androidx.compose.material.DropdownMenuItem
 import androidx.compose.material.Icon
 import androidx.compose.material.LeadingIconTab
 import androidx.compose.material.MaterialTheme
 import androidx.compose.material.ScrollableTabRow
+import androidx.compose.material.TabRowDefaults
 import androidx.compose.material.Text
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.ArrowDropDown
@@ -234,6 +237,7 @@ fun ShippingRates(
         edgePadding = dimensionResource(R.dimen.major_100),
         backgroundColor = MaterialTheme.colors.surface,
         contentColor = MaterialTheme.colors.primary,
+        divider = {},
         modifier = tabModifier
     ) {
         shippingRates.keys.forEachIndexed { index, carrier ->
@@ -262,6 +266,8 @@ fun ShippingRates(
             )
         }
     }
+
+    Divider(modifier = Modifier.fillMaxWidth())
 
     HorizontalPager(
         state = pagerState,

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/rates/ui/ShippingRatesCard.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/rates/ui/ShippingRatesCard.kt
@@ -10,7 +10,6 @@ import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
-import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
@@ -27,7 +26,6 @@ import androidx.compose.material.Icon
 import androidx.compose.material.LeadingIconTab
 import androidx.compose.material.MaterialTheme
 import androidx.compose.material.ScrollableTabRow
-import androidx.compose.material.TabRowDefaults
 import androidx.compose.material.Text
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.ArrowDropDown


### PR DESCRIPTION
### Description
This PR fixes some minor design issues on the shipping label support for the M1.

#### 1. Fix badge position

This change updates the top alignment of the quantity badge. d7dddc4

| Before  | After |
| ------------- | ------------- |
| <img width="300" src="https://github.com/user-attachments/assets/5b133279-a682-406e-9778-0046aab8c44f" />  | <img width="300" src="https://github.com/user-attachments/assets/d6bdf81d-c9ac-4d11-aaf2-28fa3b6e5bb1" />  |


#### 2. Add nav back support
Add support for back navigation using the Toolbar. Fixed here 1929f5a

https://github.com/user-attachments/assets/1ffc224e-01a5-4365-95ef-f15f8bd8a014

#### 3. Carrier divider using the screen width
This change updates the carrier's tab divider to use the screen width.  99e5603

| Before  | After |
| ------------- | ------------- |
| <img width="300" src="https://github.com/user-attachments/assets/67873835-528b-4c5c-ba37-0648026f89bb" /> | <img width="300" src="https://github.com/user-attachments/assets/1c3eb9b4-9d35-45ef-bb83-e11643ea3918" />  |


#### 4. Fix custom weight dark mode

This change fixes dark mode support for the custom weight text field 89c70ba

| Before  | After |
| ------------- | ------------- |
| <img width="300" src="https://github.com/user-attachments/assets/790c4510-1be6-4559-9a72-441f601bfd8a" />  | <img width="300" src="https://github.com/user-attachments/assets/68db00af-7e4f-4679-aafd-2d20d6e18529" />  |


#### 5. Fix incorrect padding

This change fixes the bottom padding when there is no information about shipping rates (the purchase button is not yet visible) d423bf1

| Before  | After |
| ------------- | ------------- |
| <img width="300" src="https://github.com/user-attachments/assets/183250f4-06a7-4e9f-83c7-01bd509a3bb4" />  | <img width="300" src="https://github.com/user-attachments/assets/43607654-e29c-4cf2-80fd-2ff2f72adceb" /> |

### Testing information
TC1 

1. Open the orders section
2. Open an order eligible for shipping label creation
3. Expand the products section
4. Check the quantity badge position

TC2 

1. Open the orders section
2. Open an order eligible for shipping label creation
3. Tap on the back arrow in the Toolbar
4. Check that the app navigates to the order details screen

TC3

1. Open the orders section
2. Open an order eligible for shipping label creation
3. Select a package
4. Check that the carrier tab divider matches the screen width

TC4

1. Open the orders section
2. Open an order eligible for shipping label creation
3. Select a package
4. Turn on dark mode
5. Type a value on the custom weight
6. Check that the value is visible

TC5 
1. Open the orders section
2. Open an order eligible for shipping label creation
3. Expand the shipment section
4. Check that the mark order complete control does not have an unnecessary margin

### The tests that have been performed
- Checking that the UI works as expected

- [ ] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.

## Reviewer (or Author, in the case of optional code reviews):

Please make sure these conditions are met before approving the PR, or request changes if the PR needs improvement:

- [ ] The PR is small and has a clear, single focus, or a valid explanation is provided in the description. If needed, please request to split it into smaller PRs.
- [ ] Ensure Adequate Unit Test Coverage: The changes are reasonably covered by unit tests or an explanation is provided in the PR description.
- [ ] Manual Testing: The author listed all the tests they ran, including smoke tests when needed (e.g., for refactorings). The reviewer confirmed that the PR works as expected on big (tablet) and small (phone) in case of UI changes, and no regressions are added.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->