### PR TITLE
[Bulk Update Orders] Limit selection to maximum of 100 Orders at once

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/list/OrderListFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/list/OrderListFragment.kt
@@ -124,7 +124,9 @@ class OrderListFragment :
 
     private var tracker: SelectionTracker<Long>? = null
     private var actionMode: ActionMode? = null
-    private val selectionPredicate = MutableMultipleSelectionPredicate<Long>()
+    private val selectionPredicate = MutableMultipleSelectionPredicate<Long>(
+        maxSelectionCount = OrderListViewModel.BULK_UPDATE_COUNT_LIMIT
+    )
     private val viewModel: OrderListViewModel by viewModels()
     private val communicationViewModel: OrdersCommunicationViewModel by activityViewModels()
     private var snackBar: Snackbar? = null
@@ -275,6 +277,8 @@ class OrderListFragment :
             object : SelectionTracker.SelectionObserver<Long>() {
                 override fun onSelectionChanged() {
                     val selectionCount = tracker?.selection?.size() ?: 0
+                    selectionPredicate.currentSelectionCount = selectionCount
+
                     viewModel.onSelectionChanged(selectionCount)
                 }
             }
@@ -615,6 +619,7 @@ class OrderListFragment :
                     showBulkUpdateStatusDialog(event.currentStatus, event.orderStatusList)
                 }
 
+                is OrderListViewModel.OrderListEvent.ShowErrorString -> uiMessageResolver.showSnack(event.message)
                 is MultiLiveEvent.Event.ShowSnackbar -> uiMessageResolver.showSnack(event.message)
 
                 else -> event.isHandled = false

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/list/OrderListFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/list/OrderListFragment.kt
@@ -619,7 +619,7 @@ class OrderListFragment :
                     showBulkUpdateStatusDialog(event.currentStatus, event.orderStatusList)
                 }
 
-                is OrderListViewModel.OrderListEvent.ShowErrorString -> uiMessageResolver.showSnack(event.message)
+                is OrderListViewModel.OrderListEvent.ShowSnackbarString -> uiMessageResolver.showSnack(event.message)
                 is MultiLiveEvent.Event.ShowSnackbar -> uiMessageResolver.showSnack(event.message)
 
                 else -> event.isHandled = false

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/list/OrderListViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/list/OrderListViewModel.kt
@@ -126,6 +126,10 @@ class OrderListViewModel @Inject constructor(
 ) : ScopedViewModel(savedState), LifecycleOwner {
     private val navArgs: OrderListFragmentArgs by savedState.navArgs()
 
+    companion object {
+        const val BULK_UPDATE_COUNT_LIMIT = 100
+    }
+
     private val lifecycleRegistry: LifecycleRegistry by lazy {
         LifecycleRegistry(this)
     }
@@ -902,9 +906,21 @@ class OrderListViewModel @Inject constructor(
     fun onSelectionChanged(count: Int) {
         when {
             count == 0 -> exitSelectionMode()
+            count >= BULK_UPDATE_COUNT_LIMIT -> {
+                viewState = viewState.copy(selectionCount = count)
+                showMaximumBulkSelectionError()
+            }
             count > 0 && !isSelecting() -> enterSelectionMode(count)
             count > 0 -> viewState = viewState.copy(selectionCount = count)
         }
+    }
+
+    private fun showMaximumBulkSelectionError() {
+        val errorMessage = resourceProvider.getString(
+            R.string.orderlist_bulk_update_maximum_reached,
+            BULK_UPDATE_COUNT_LIMIT
+        )
+        triggerEvent(OrderListEvent.ShowErrorString(errorMessage))
     }
 
     private fun enterSelectionMode(count: Int) {
@@ -978,6 +994,7 @@ class OrderListViewModel @Inject constructor(
 
     sealed class OrderListEvent : Event() {
         data class ShowErrorSnack(@StringRes val messageRes: Int) : OrderListEvent()
+        data class ShowErrorString(val message: String) : OrderListEvent()
         object ShowOrderFilters : OrderListEvent()
         data class OpenPurchaseCardReaderLink(
             val url: String,

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/list/OrderListViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/list/OrderListViewModel.kt
@@ -908,19 +908,19 @@ class OrderListViewModel @Inject constructor(
             count == 0 -> exitSelectionMode()
             count >= BULK_UPDATE_COUNT_LIMIT -> {
                 viewState = viewState.copy(selectionCount = count)
-                showMaximumBulkSelectionError()
+                showMaximumBulkSelectionNotice()
             }
             count > 0 && !isSelecting() -> enterSelectionMode(count)
             count > 0 -> viewState = viewState.copy(selectionCount = count)
         }
     }
 
-    private fun showMaximumBulkSelectionError() {
-        val errorMessage = resourceProvider.getString(
+    private fun showMaximumBulkSelectionNotice() {
+        val message = resourceProvider.getString(
             R.string.orderlist_bulk_update_maximum_reached,
             BULK_UPDATE_COUNT_LIMIT
         )
-        triggerEvent(OrderListEvent.ShowSnackbarString(errorMessage))
+        triggerEvent(OrderListEvent.ShowSnackbarString(message))
     }
 
     private fun enterSelectionMode(count: Int) {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/list/OrderListViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/list/OrderListViewModel.kt
@@ -920,7 +920,7 @@ class OrderListViewModel @Inject constructor(
             R.string.orderlist_bulk_update_maximum_reached,
             BULK_UPDATE_COUNT_LIMIT
         )
-        triggerEvent(OrderListEvent.ShowErrorString(errorMessage))
+        triggerEvent(OrderListEvent.ShowSnackbarString(errorMessage))
     }
 
     private fun enterSelectionMode(count: Int) {
@@ -994,7 +994,7 @@ class OrderListViewModel @Inject constructor(
 
     sealed class OrderListEvent : Event() {
         data class ShowErrorSnack(@StringRes val messageRes: Int) : OrderListEvent()
-        data class ShowErrorString(val message: String) : OrderListEvent()
+        data class ShowSnackbarString(val message: String) : OrderListEvent()
         object ShowOrderFilters : OrderListEvent()
         data class OpenPurchaseCardReaderLink(
             val url: String,

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/MutableMultipleSelectionPredicate.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/MutableMultipleSelectionPredicate.kt
@@ -2,10 +2,16 @@ package com.woocommerce.android.ui.products
 
 import androidx.recyclerview.selection.SelectionTracker
 
-class MutableMultipleSelectionPredicate<K : Any> : SelectionTracker.SelectionPredicate<K>() {
+class MutableMultipleSelectionPredicate<K : Any>(
+    private val maxSelectionCount: Int? = null
+) : SelectionTracker.SelectionPredicate<K>() {
     var selectMultiple = true
+    var currentSelectionCount = 0
 
-    override fun canSetStateForKey(key: K, nextState: Boolean): Boolean = true
+    override fun canSetStateForKey(key: K, nextState: Boolean): Boolean {
+        val limit = maxSelectionCount ?: return true
+        return !(nextState && currentSelectionCount >= limit)
+    }
 
     override fun canSetStateAtPosition(position: Int, nextState: Boolean): Boolean = true
 

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -616,6 +616,7 @@
     <string name="orderlist_selection_count_single">%d order selected</string>
     <string name="orderlist_selection_menu_update_status">Update status</string>
     <string name="orderlist_bulk_update_status_updated">Status updated!</string>
+    <string name="orderlist_bulk_update_maximum_reached">Maximum selection count (%d) is reached.</string>
 
     <!--
          Simple Payments

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/OrderListViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/OrderListViewModelTest.kt
@@ -35,6 +35,7 @@ import com.woocommerce.android.ui.orders.list.OrderListItemIdentifier
 import com.woocommerce.android.ui.orders.list.OrderListItemUIType
 import com.woocommerce.android.ui.orders.list.OrderListRepository
 import com.woocommerce.android.ui.orders.list.OrderListViewModel
+import com.woocommerce.android.ui.orders.list.OrderListViewModel.Companion.BULK_UPDATE_COUNT_LIMIT
 import com.woocommerce.android.ui.orders.list.OrderListViewModel.OrderListEvent
 import com.woocommerce.android.ui.orders.list.OrderListViewModel.OrderListEvent.OnAddingProductViaScanningFailed
 import com.woocommerce.android.ui.orders.list.OrderListViewModel.OrderListEvent.ShowErrorSnack
@@ -994,6 +995,26 @@ class OrderListViewModelTest : BaseUnitTest() {
 
         // Check that isFetchingFirstPage is reset to default value (false) on clearLiveDataSources
         assertFalse(isFetchingFirstPage!!)
+    }
+
+    @Test
+    fun `When selection count reaches limit then show error message`() = testBlocking {
+        // when
+        viewModel.onSelectionChanged(BULK_UPDATE_COUNT_LIMIT)
+
+        // then
+        assertEquals(BULK_UPDATE_COUNT_LIMIT, viewModel.viewState.selectionCount)
+
+        viewModel.event.getOrAwaitValue().let { event ->
+            assertTrue(event is OrderListEvent.ShowSnackbarString)
+            assertEquals(
+                event.message,
+                resourceProvider.getString(
+                    R.string.orderlist_bulk_update_maximum_reached,
+                    BULK_UPDATE_COUNT_LIMIT
+                )
+            )
+        }
     }
 
     private companion object {

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/OrderListViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/OrderListViewModelTest.kt
@@ -998,7 +998,7 @@ class OrderListViewModelTest : BaseUnitTest() {
     }
 
     @Test
-    fun `When selection count reaches limit then show error message`() {
+    fun `when selection count reaches limit, then show error message`() {
         // when
         viewModel.onSelectionChanged(BULK_UPDATE_COUNT_LIMIT)
 

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/OrderListViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/OrderListViewModelTest.kt
@@ -998,7 +998,7 @@ class OrderListViewModelTest : BaseUnitTest() {
     }
 
     @Test
-    fun `When selection count reaches limit then show error message`() = testBlocking {
+    fun `When selection count reaches limit then show error message`() {
         // when
         viewModel.onSelectionChanged(BULK_UPDATE_COUNT_LIMIT)
 


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #13217 
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

The API for bulk updating Orders only support doing 100 Orders at once, and we want to add limiter on the UI side as well.

**Known issue:** When selecting Orders, then scrolling down to load more Orders, then the selection state gets removed. Thus truly selecting 100 items at once will not be possible in this PR. I recommend setting a smaller limit temporarily for testing purposes. More below. (The issue itself is already fixed [in this PR](https://github.com/woocommerce/woocommerce-android/pull/13227))

### Steps to reproduce
<!-- Step-by-step testing instructions. For new user flows, consider instead stating the goal of the workflow and see if your PR reviewer can accomplish the workflow without specific steps! -->

1. Go to `OrderListViewModel` and updating the value of `BULK_UPDATE_COUNT_LIMIT` to something reasonable like 2 or 3 then build the app.
2. Go to Orders, then long press to select Orders. Select Orders up to the maximum limit, ensure that the Snackbar with the notice message is shown,
3. Ensure also that you are not able to select more Orders.
4. Ensure that you are still able to deselect selected Orders.

### The tests that have been performed
<!-- To give the reviewer an idea of what could be missed in terms of testing -->

I tested the steps above, see video below:


### Images/gif
<!-- Include before and after images or gifs when appropriate. -->

(The test below was done with the limit set to 2, to keep things easy)

https://github.com/user-attachments/assets/b4cf165c-7f04-41d5-a578-5b9fcd656ea4



- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.

## Reviewer (or Author, in the case of optional code reviews):

Please make sure these conditions are met before approving the PR, or request changes if the PR needs improvement:

- [x] The PR is small and has a clear, single focus, or a valid explanation is provided in the description. If needed, please request to split it into smaller PRs.
- [x] Ensure Adequate Unit Test Coverage: The changes are reasonably covered by unit tests or an explanation is provided in the PR description.
- [x] Manual Testing: The author listed all the tests they ran, including smoke tests when needed (e.g., for refactorings). The reviewer confirmed that the PR works as expected on big (tablet) and small (phone) in case of UI changes, and no regressions are added.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->