### PR TITLE
[Woo POS][Non-Simple Products] Remove variation quantity in Products and Variations screen

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/items/WooPosItemsList.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/items/WooPosItemsList.kt
@@ -211,7 +211,7 @@ private fun ProductInfo(item: WooPosItem) {
         Spacer(modifier = Modifier.height(8.dp))
         when (item) {
             is SimpleProduct -> SimpleProductDetails(item = item)
-            is VariableProduct -> VariableProductDetails(item = item)
+            is VariableProduct -> VariableProductDetails()
             is Variation -> VariationProductDetails(item = item)
         }
     }
@@ -249,9 +249,9 @@ private fun SimpleProductDetails(item: SimpleProduct) {
 }
 
 @Composable
-private fun VariableProductDetails(item: VariableProduct) {
+private fun VariableProductDetails() {
     Text(
-        text = "${item.numOfVariations} Variations",
+        text = stringResource(id = R.string.woopos_variations_options_available_text),
         style = MaterialTheme.typography.h6,
         fontWeight = FontWeight.Normal
     )

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/items/variations/WooPosVariationsScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/items/variations/WooPosVariationsScreen.kt
@@ -235,19 +235,6 @@ private fun VariationsToolbar(
                 top.linkTo(parent.top, margin = 8.dp)
             }
         )
-
-        Text(
-            text = stringResource(
-                id = R.string.woopos_items_list_variable_product_variations,
-                variableProductData.numOfVariations
-            ),
-            style = MaterialTheme.typography.h6,
-            color = MaterialTheme.colors.onSurface.copy(alpha = 0.6f),
-            modifier = Modifier.constrainAs(variationsCount) {
-                start.linkTo(productName.start)
-                top.linkTo(productName.bottom, margin = 4.dp)
-            }
-        )
     }
 }
 

--- a/WooCommerce/src/main/res/values-ar/strings.xml
+++ b/WooCommerce/src/main/res/values-ar/strings.xml
@@ -9,7 +9,6 @@ Language: ar
     <string name="woopos_variations_loading_error_title">خطأ في تحميل الأشكال</string>
     <string name="woopos_variations_screen_pagination_error">\"فشل تحميل مزيد من العناصر. يرجى المحاولة مرة أخرى\".</string>
     <string name="woopos_variations_back_content_description">رجوع</string>
-    <string name="woopos_items_list_variable_product_variations">⁦%1$d⁩ من الأشكال</string>
     <string name="woopos_variation_item_content_description">الشكل %s، الشعر %s</string>
     <string name="woopos_variable_product_item_content_description">المنتج المتغير %s، السعر %s</string>
     <string name="blaze_campaign_edit_ad_change_description_empty_error">يتعذر أن يكون الوصف فارغًا</string>

--- a/WooCommerce/src/main/res/values-de/strings.xml
+++ b/WooCommerce/src/main/res/values-de/strings.xml
@@ -9,7 +9,6 @@ Language: de
     <string name="woopos_variations_loading_error_title">Beim Laden der Varianten ist ein Fehler aufgetreten</string>
     <string name="woopos_variations_screen_pagination_error">„Es ist ein Fehler beim Laden weiterer Artikel aufgetreten. Bitte versuche es erneut.“</string>
     <string name="woopos_variations_back_content_description">Zurück</string>
-    <string name="woopos_items_list_variable_product_variations">%1$d Varianten</string>
     <string name="woopos_variation_item_content_description">Variante: %s, Preis: %s</string>
     <string name="woopos_variable_product_item_content_description">Variables Produkt: %s, Preis: %s</string>
     <string name="blaze_campaign_edit_ad_change_description_empty_error">Beschreibung darf nicht leer sein</string>

--- a/WooCommerce/src/main/res/values-es/strings.xml
+++ b/WooCommerce/src/main/res/values-es/strings.xml
@@ -9,7 +9,6 @@ Language: es
     <string name="woopos_variations_loading_error_title">Error al cargar variaciones</string>
     <string name="woopos_variations_screen_pagination_error">\"No se han podido cargar más elementos. Inténtalo de nuevo\".</string>
     <string name="woopos_variations_back_content_description">Volver</string>
-    <string name="woopos_items_list_variable_product_variations">%1$d variaciones</string>
     <string name="woopos_variation_item_content_description">Variación: %s; Precio: %s</string>
     <string name="woopos_variable_product_item_content_description">Producto variable: %s; Precio: %s</string>
     <string name="blaze_campaign_edit_ad_change_description_empty_error">La descripción no puede estar vacía.</string>

--- a/WooCommerce/src/main/res/values-fr/strings.xml
+++ b/WooCommerce/src/main/res/values-fr/strings.xml
@@ -9,7 +9,6 @@ Language: fr
     <string name="woopos_variations_loading_error_title">Erreur lors du chargement des variantes</string>
     <string name="woopos_variations_screen_pagination_error">« Échec du chargement d’éléments supplémentaires. Veuillez réessayer. »</string>
     <string name="woopos_variations_back_content_description">Retour</string>
-    <string name="woopos_items_list_variable_product_variations">%1$d variantes</string>
     <string name="woopos_variation_item_content_description">Variante %s, prix %s</string>
     <string name="woopos_variable_product_item_content_description">Produit variable %s, prix %s</string>
     <string name="blaze_campaign_edit_ad_change_description_empty_error">La description ne peut pas être vide</string>

--- a/WooCommerce/src/main/res/values-he/strings.xml
+++ b/WooCommerce/src/main/res/values-he/strings.xml
@@ -9,7 +9,6 @@ Language: he_IL
     <string name="woopos_variations_loading_error_title">שגיאה בטעינת הסוגים</string>
     <string name="woopos_variations_screen_pagination_error">\"הטעינה של פריטים נוספים נכשלה. יש לנסות שוב.\"</string>
     <string name="woopos_variations_back_content_description">חזרה</string>
-    <string name="woopos_items_list_variable_product_variations">⁦%1$d⁩ סוגים</string>
     <string name="woopos_variation_item_content_description">סוג %s, מחיר %s</string>
     <string name="woopos_variable_product_item_content_description">מוצר עם סוגים %s, מחיר %s</string>
     <string name="blaze_campaign_edit_ad_change_description_empty_error">התיאור לא יכול להיות ריק</string>

--- a/WooCommerce/src/main/res/values-id/strings.xml
+++ b/WooCommerce/src/main/res/values-id/strings.xml
@@ -9,7 +9,6 @@ Language: id
     <string name="woopos_variations_loading_error_title">Error saat memuat variasi</string>
     <string name="woopos_variations_screen_pagination_error">\"Gagal memuat item lain. Harap coba lagi.\"</string>
     <string name="woopos_variations_back_content_description">Kembali</string>
-    <string name="woopos_items_list_variable_product_variations">%1$d variasi</string>
     <string name="woopos_variation_item_content_description">Variasi %s, Harga %s</string>
     <string name="woopos_variable_product_item_content_description">Produk Variabel %s, Harga %s</string>
     <string name="blaze_campaign_edit_ad_change_description_empty_error">Deskripsi tidak boleh kosong</string>

--- a/WooCommerce/src/main/res/values-it/strings.xml
+++ b/WooCommerce/src/main/res/values-it/strings.xml
@@ -9,7 +9,6 @@ Language: it
     <string name="woopos_variations_loading_error_title">Errore nel caricamento delle varianti</string>
     <string name="woopos_variations_screen_pagination_error">\"Impossibile caricare altri articoli. Riprova\".</string>
     <string name="woopos_variations_back_content_description">Indietro</string>
-    <string name="woopos_items_list_variable_product_variations">%1$d varianti</string>
     <string name="woopos_variation_item_content_description">Variante %s, prezzo %s</string>
     <string name="woopos_variable_product_item_content_description">Prodotto variabile %s, prezzo %s</string>
     <string name="blaze_campaign_edit_ad_change_description_empty_error">La descrizione non può essere vuota</string>

--- a/WooCommerce/src/main/res/values-ja/strings.xml
+++ b/WooCommerce/src/main/res/values-ja/strings.xml
@@ -9,7 +9,6 @@ Language: ja_JP
     <string name="woopos_variations_loading_error_title">バリエーションの読み込み中にエラーが発生しました</string>
     <string name="woopos_variations_screen_pagination_error">「その他のアイテムの読み込みに失敗しました。 もう一度実行してください」</string>
     <string name="woopos_variations_back_content_description">戻る</string>
-    <string name="woopos_items_list_variable_product_variations">%1$d個のバリエーション</string>
     <string name="woopos_variation_item_content_description">バリエーション %s、価格 %s</string>
     <string name="woopos_variable_product_item_content_description">バリエーションのある商品 %s、価格 %s</string>
     <string name="blaze_campaign_edit_ad_change_description_empty_error">説明を空にすることはできません</string>

--- a/WooCommerce/src/main/res/values-ko/strings.xml
+++ b/WooCommerce/src/main/res/values-ko/strings.xml
@@ -9,7 +9,6 @@ Language: ko_KR
     <string name="woopos_variations_loading_error_title">상품 옵션 로드 오류</string>
     <string name="woopos_variations_screen_pagination_error">\"아이템을 더 로드하지 못했습니다. 다시 시도하세요”</string>
     <string name="woopos_variations_back_content_description">뒤로</string>
-    <string name="woopos_items_list_variable_product_variations">%1$d개 변형</string>
     <string name="woopos_variation_item_content_description">상품 옵션 %s, 가격 %s</string>
     <string name="woopos_variable_product_item_content_description">변형 상품 %s, 가격 %s</string>
     <string name="blaze_campaign_edit_ad_change_description_empty_error">설명은 비워 둘 수 없음</string>

--- a/WooCommerce/src/main/res/values-nl/strings.xml
+++ b/WooCommerce/src/main/res/values-nl/strings.xml
@@ -9,7 +9,6 @@ Language: nl
     <string name="woopos_variations_loading_error_title">Fout bij laden van variaties</string>
     <string name="woopos_variations_screen_pagination_error">\'Meer items laden mislukt. Probeer het opnieuw.\'</string>
     <string name="woopos_variations_back_content_description">Terug</string>
-    <string name="woopos_items_list_variable_product_variations">%1$d variaties</string>
     <string name="woopos_variation_item_content_description">Variatie %s, prijs %s</string>
     <string name="woopos_variable_product_item_content_description">Variabel product %s, prijs %s</string>
     <string name="blaze_campaign_edit_ad_change_description_empty_error">De omschrijving mag niet leeg zijn</string>

--- a/WooCommerce/src/main/res/values-pt-rBR/strings.xml
+++ b/WooCommerce/src/main/res/values-pt-rBR/strings.xml
@@ -9,7 +9,6 @@ Language: pt_BR
     <string name="woopos_variations_loading_error_title">Erro ao carregar variações</string>
     <string name="woopos_variations_screen_pagination_error">\"Falha ao carregar mais itens. Tente novamente.\"</string>
     <string name="woopos_variations_back_content_description">Voltar</string>
-    <string name="woopos_items_list_variable_product_variations">%1$d variações</string>
     <string name="woopos_variation_item_content_description">Variação: %s; preço: %s</string>
     <string name="woopos_variable_product_item_content_description">Produto variável: %s; preço: %s</string>
     <string name="blaze_campaign_edit_ad_change_description_empty_error">A descrição não pode ficar em branco</string>

--- a/WooCommerce/src/main/res/values-ru/strings.xml
+++ b/WooCommerce/src/main/res/values-ru/strings.xml
@@ -9,7 +9,6 @@ Language: ru
     <string name="woopos_variations_loading_error_title">Ошибка при загрузке вариантов</string>
     <string name="woopos_variations_screen_pagination_error">«Не удалось загрузить другие товары. Повторите попытку».</string>
     <string name="woopos_variations_back_content_description">Назад</string>
-    <string name="woopos_items_list_variable_product_variations">Вариантов: %1$d</string>
     <string name="woopos_variation_item_content_description">Вариант %s, цена %s</string>
     <string name="woopos_variable_product_item_content_description">Товар с вариантами %s, цена %s</string>
     <string name="blaze_campaign_edit_ad_change_description_empty_error">Описание не может быть пустым</string>

--- a/WooCommerce/src/main/res/values-sv/strings.xml
+++ b/WooCommerce/src/main/res/values-sv/strings.xml
@@ -9,7 +9,6 @@ Language: sv_SE
     <string name="woopos_variations_loading_error_title">Ett fel uppstod när variationer hämtades</string>
     <string name="woopos_variations_screen_pagination_error">\"Det gick inte att ladda fler objekt. Försök igen.\"</string>
     <string name="woopos_variations_back_content_description">Tillbaka</string>
-    <string name="woopos_items_list_variable_product_variations">%1$d variationer</string>
     <string name="woopos_variation_item_content_description">Variation %s, Pris %s</string>
     <string name="woopos_variable_product_item_content_description">Variabel produkt%s, Pris %s</string>
     <string name="blaze_campaign_edit_ad_change_description_empty_error">Beskrivning kan inte vara tom</string>

--- a/WooCommerce/src/main/res/values-tr/strings.xml
+++ b/WooCommerce/src/main/res/values-tr/strings.xml
@@ -9,7 +9,6 @@ Language: tr
     <string name="woopos_variations_loading_error_title">Varyasyonlar yüklenirken hata oluştu</string>
     <string name="woopos_variations_screen_pagination_error">\"Daha fazla öğe yüklenemedi. Lütfen yeniden deneyin.\"</string>
     <string name="woopos_variations_back_content_description">Geri</string>
-    <string name="woopos_items_list_variable_product_variations">%1$d varyasyon</string>
     <string name="woopos_variation_item_content_description">%s Varyasyon, %s Fiyat</string>
     <string name="woopos_variable_product_item_content_description">%s Varyasyonlu Ürün, %s Fiyat</string>
     <string name="blaze_campaign_edit_ad_change_description_empty_error">Açıklama boş olamaz</string>

--- a/WooCommerce/src/main/res/values-zh-rCN/strings.xml
+++ b/WooCommerce/src/main/res/values-zh-rCN/strings.xml
@@ -9,7 +9,6 @@ Language: zh_CN
     <string name="woopos_variations_loading_error_title">加载变体时出错</string>
     <string name="woopos_variations_screen_pagination_error">“无法加载更多项目。 请重试。”</string>
     <string name="woopos_variations_back_content_description">返回</string>
-    <string name="woopos_items_list_variable_product_variations">%1$d 个变体</string>
     <string name="woopos_variation_item_content_description">变体 %s，价格 %s</string>
     <string name="woopos_variable_product_item_content_description">可变产品 %s，价格 %s</string>
     <string name="blaze_campaign_edit_ad_change_description_empty_error">描述不能为空</string>

--- a/WooCommerce/src/main/res/values-zh-rTW/strings.xml
+++ b/WooCommerce/src/main/res/values-zh-rTW/strings.xml
@@ -9,7 +9,6 @@ Language: zh_TW
     <string name="woopos_variations_loading_error_title">載入款式時發生錯誤</string>
     <string name="woopos_variations_screen_pagination_error">「無法載入更多項目， 請再試一次。」</string>
     <string name="woopos_variations_back_content_description">返回</string>
-    <string name="woopos_items_list_variable_product_variations">%1$d 種款式</string>
     <string name="woopos_variation_item_content_description">款式 %s，價格 %s</string>
     <string name="woopos_variable_product_item_content_description">多款式商品 %s，價格 %s</string>
     <string name="blaze_campaign_edit_ad_change_description_empty_error">說明不得空白</string>

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -4354,7 +4354,6 @@
     <string name="woopos_floating_toolbar_pop_up_menu_open_content_description">Popup menu with options. Swipe to navigate through items.</string>
     <string name="woopos_no_internet_message">It looks like you\'re not connected to the internet. Ensure your Wi-Fi is turned on. If you\'re using mobile data, make sure it\'s enabled in your device settings.</string>
 
-    <string name="woopos_items_list_variable_product_variations">%1$d variations</string>
     <string name="woopos_variations_back_content_description">Back</string>
     <string name="woopos_items_pagination_try_again_label">Try again</string>
     <string name="woopos_items_pagination_error_title">"Failed to load more items"</string>

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -4361,6 +4361,7 @@
     <string name="woopos_items_pagination_error_description">"An error occurred while loading products."</string>
     <string name="woopos_items_pagination_error_content_description">"Failed to load more items. Double tap to try again."</string>
     <string name="woopos_variations_loading_error_title">Error loading variations</string>
+    <string name="woopos_variations_options_available_text">Options available</string>
 
     <string name="woopos_cash_payment_title">Cash payment</string>
     <string name="woopos_complete_cash_order_button">Mark payment as complete</string>

--- a/fastlane/resources/values/strings.xml
+++ b/fastlane/resources/values/strings.xml
@@ -4345,7 +4345,6 @@
     <string name="woopos_floating_toolbar_pop_up_menu_open_content_description">Popup menu with options. Swipe to navigate through items.</string>
     <string name="woopos_no_internet_message">It looks like you\'re not connected to the internet. Ensure your Wi-Fi is turned on. If you\'re using mobile data, make sure it\'s enabled in your device settings.</string>
 
-    <string name="woopos_items_list_variable_product_variations">%1$d variations</string>
     <string name="woopos_variations_back_content_description">Back</string>
     <string name="woopos_items_pagination_try_again_label">Try again</string>
     <string name="woopos_items_pagination_error_title">"Failed to load more items"</string>


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #13221 
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
This PR removes variation quantity in Products and Variations screen. Since we are filtering some of the variations client side and the variation quantity in the products endpoint includes all the variation. It's error prone to display the exact amount of variation a variable product contains after client side filtering (this filtering happens in the variations screen).

For this reasons, we decided to display "Options available" instead of variation quantity in products screen and remove variation quantity from the toolbar in variations screen.

More context: pdfdoF-62l-p2#comment-7224 

### Steps to reproduce
<!-- Step-by-step testing instructions. For new user flows, consider instead stating the goal of the workflow and see if your PR reviewer can accomplish the workflow without specific steps! -->
#### Products screen
1. Navigate to POS (More menu -> POS)
2. Ensure you see "Options available" instead of variation quantity on a variable product

#### Variations screen
1. Navigate to POS (More menu -> POS)
2. Ensure you do not see variation quantity in the toolbar

### The tests that have been performed
<!-- To give the reviewer an idea of what could be missed in terms of testing -->
Tested both the screens on both light and dark mode

### Images/gif
<!-- Include before and after images or gifs when appropriate. -->

https://github.com/user-attachments/assets/77c87122-cfb8-458c-8e94-36b4d2ffec3e



- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.

## Reviewer (or Author, in the case of optional code reviews):

Please make sure these conditions are met before approving the PR, or request changes if the PR needs improvement:

- [x] The PR is small and has a clear, single focus, or a valid explanation is provided in the description. If needed, please request to split it into smaller PRs.
- [x] Ensure Adequate Unit Test Coverage: The changes are reasonably covered by unit tests or an explanation is provided in the PR description.
- [x] Manual Testing: The author listed all the tests they ran, including smoke tests when needed (e.g., for refactorings). The reviewer confirmed that the PR works as expected on big (tablet) and small (phone) in case of UI changes, and no regressions are added.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->