### PR TITLE
[Bulk Update Orders] Persist selection on configuration change and load more

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/DefaultOrderListItemLookup.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/DefaultOrderListItemLookup.kt
@@ -30,12 +30,3 @@ class DefaultOrderItemDetailsLookup(
     override fun getPosition() = position
     override fun getSelectionKey() = orderId
 }
-
-class SelectableOrderItemDetailsLookup(
-    private val position: Int,
-    private val orderId: Long
-) : ItemDetailsLookup.ItemDetails<Long>() {
-    override fun getPosition() = position
-    override fun getSelectionKey() = orderId
-    override fun inSelectionHotspot(e: MotionEvent) = true
-}

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/OrderSelectionItemKeyProvider.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/OrderSelectionItemKeyProvider.kt
@@ -17,10 +17,6 @@ class OrderSelectionItemKeyProvider(private val recyclerView: RecyclerView) :
         }
     }
 
-    override fun getPosition(key: Long): Int {
-        return (recyclerView.adapter as? OrderListAdapter)?.currentList
-            ?.indexOfFirst { item ->
-                item is OrderListItemUIType.OrderListItemUI && item.orderId == key
-            } ?: RecyclerView.NO_POSITION
-    }
+    override fun getPosition(key: Long): Int =
+        (recyclerView.adapter as? OrderListAdapter)?.orderIdAndPosition[key] ?: RecyclerView.NO_POSITION
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/list/OrderListAdapter.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/list/OrderListAdapter.kt
@@ -25,6 +25,7 @@ import com.woocommerce.android.ui.orders.list.OrderListItemUIType.SectionHeader
 import com.woocommerce.android.util.CurrencyFormatter
 import com.woocommerce.android.widgets.tags.TagView
 import org.wordpress.android.fluxc.model.WCOrderStatusModel
+
 class OrderListAdapter(
     val listener: OrderListListener,
     val currencyFormatter: CurrencyFormatter
@@ -62,10 +63,12 @@ class OrderListAdapter(
                     )
                 )
             }
+
             VIEW_TYPE_LOADING -> {
                 val view = inflater.inflate(R.layout.skeleton_order_list_item_auto, parent, false)
                 LoadingViewHolder(view)
             }
+
             VIEW_TYPE_SECTION_HEADER -> {
                 SectionHeaderViewHolder(
                     OrderListHeaderBinding.inflate(
@@ -75,6 +78,7 @@ class OrderListAdapter(
                     )
                 )
             }
+
             else -> {
                 // Fail fast if a new view type is added so we can handle it
                 throw IllegalStateException("The view type '$viewType' needs to be handled")
@@ -100,6 +104,7 @@ class OrderListAdapter(
                 )
                 orderIdAndPosition[item.orderId] = position
             }
+
             is SectionHeaderViewHolder -> {
                 if (BuildConfig.DEBUG && item !is SectionHeader) {
                     error(
@@ -109,6 +114,7 @@ class OrderListAdapter(
                 }
                 holder.onBind((item as SectionHeader))
             }
+
             else -> {}
         }
     }
@@ -190,6 +196,7 @@ class OrderListAdapter(
                         viewBinding.root.context.getColor(R.color.color_item_selected)
                     )
                 }
+
                 else -> {
                     viewBinding.orderItemLayout.setBackgroundColor(Color.TRANSPARENT)
                 }
@@ -215,6 +222,7 @@ class OrderListAdapter(
             extras[SwipeToComplete.OLD_STATUS] = orderItemUI.status
 
             this.itemView.setOnClickListener {
+                if (shouldPreventDetailNavigation(orderId)) return@setOnClickListener
                 listener.openOrderDetail(
                     orderId = orderItemUI.orderId,
                     allOrderIds = allOrderIds,
@@ -222,6 +230,23 @@ class OrderListAdapter(
                     sharedView = viewBinding.root,
                 )
             }
+        }
+
+        //  Some edge cases in order selection mode, like tapping the screen with 4 fingers or using TalkBack,
+        //  cause the order's onClick listener to gain focus over the selection tracker.
+        //  This quick fix will prevent the app from entering an unexpected status when the app is in selection mode.
+        private fun shouldPreventDetailNavigation(orderId: Long): Boolean {
+            if (tracker?.selection?.size() != 0) {
+                tracker?.let { selectionTracker ->
+                    if (selectionTracker.isSelected(orderId)) {
+                        selectionTracker.deselect(orderId)
+                    } else {
+                        selectionTracker.select(orderId)
+                    }
+                }
+                return true
+            }
+            return false
         }
 
         /**

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/list/OrderListAdapter.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/list/OrderListAdapter.kt
@@ -38,6 +38,7 @@ class OrderListAdapter(
     var activeOrderStatusMap: Map<String, WCOrderStatusModel> = emptyMap()
     var allOrderIds: List<Long> = listOf()
     var tracker: SelectionTracker<Long>? = null
+    val orderIdAndPosition = mutableMapOf<Long, Int>()
 
     override fun getItemViewType(position: Int): Int {
         return when (getItem(position)) {
@@ -97,6 +98,7 @@ class OrderListAdapter(
                     allOrderIds,
                     isActivated = tracker?.isSelected(item.orderId) ?: false
                 )
+                orderIdAndPosition[item.orderId] = position
             }
             is SectionHeaderViewHolder -> {
                 if (BuildConfig.DEBUG && item !is SectionHeader) {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/list/OrderListAdapter.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/list/OrderListAdapter.kt
@@ -126,7 +126,11 @@ class OrderListAdapter(
     fun setOrderStatusOptions(orderStatusOptions: Map<String, WCOrderStatusModel>) {
         if (orderStatusOptions.keys != activeOrderStatusMap.keys) {
             this.activeOrderStatusMap = orderStatusOptions
-            notifyDataSetChanged()
+            for (position in 0 until itemCount) {
+                if (getItem(position) is OrderListItemUI) {
+                    notifyItemChanged(position)
+                }
+            }
         }
     }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/list/OrderListAdapter.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/list/OrderListAdapter.kt
@@ -38,7 +38,7 @@ class OrderListAdapter(
     var activeOrderStatusMap: Map<String, WCOrderStatusModel> = emptyMap()
     var allOrderIds: List<Long> = listOf()
     var tracker: SelectionTracker<Long>? = null
-    val orderIdAndPosition = mutableMapOf<Long, Int>()
+    var orderIdAndPosition = mutableMapOf<Long, Int>()
 
     override fun getItemViewType(position: Int): Int {
         return when (getItem(position)) {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/list/OrderListFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/list/OrderListFragment.kt
@@ -413,7 +413,7 @@ class OrderListFragment :
         tracker?.run {
             onRestoreInstanceState(savedInstanceState)
             if (hasSelection()) {
-                viewModel.onRestoreSelection(selection.toList())
+                setItemsSelected(selection.toList(), true)
             }
         }
 
@@ -628,7 +628,6 @@ class OrderListFragment :
                 is OrderListViewModel.OrderListEvent.ShowUpdateStatusDialog -> {
                     showBulkUpdateStatusDialog(event.currentStatus, event.orderStatusList)
                 }
-                is OrderListViewModel.OrderListEvent.SelectOrders -> tracker?.setItemsSelected(event.ordersIds, true)
 
                 is MultiLiveEvent.Event.ShowSnackbar -> uiMessageResolver.showSnack(event.message)
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/list/OrderListFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/list/OrderListFragment.kt
@@ -916,23 +916,6 @@ class OrderListFragment :
         binding.orderListView.submitPagedList(pagedListData)
     }
 
-    //  Some edge cases in order selection mode, like tapping the screen with 4 fingers or using TalkBack,
-    //  cause the order's onClick listener to gain focus over the selection tracker.
-    //  This quick fix will prevent the app from entering an unexpected status when the app is in selection mode.
-    private fun shouldPreventDetailNavigation(orderId: Long): Boolean {
-        if (viewModel.isSelecting()) {
-            tracker?.let { selectionTracker ->
-                if (selectionTracker.isSelected(orderId)) {
-                    selectionTracker.deselect(orderId)
-                } else {
-                    selectionTracker.select(orderId)
-                }
-            }
-            return true
-        }
-        return false
-    }
-
     override fun openOrderDetail(
         orderId: Long,
         allOrderIds: List<Long>,
@@ -940,8 +923,6 @@ class OrderListFragment :
         sharedView: View?,
         startPaymentsFlow: Boolean,
     ) {
-        if (shouldPreventDetailNavigation(orderId)) return
-
         viewModel.trackOrderClickEvent(
             orderId,
             orderStatus,

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/list/OrderListFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/list/OrderListFragment.kt
@@ -412,9 +412,6 @@ class OrderListFragment :
     override fun onViewStateRestored(savedInstanceState: Bundle?) {
         tracker?.run {
             onRestoreInstanceState(savedInstanceState)
-            if (hasSelection()) {
-                setItemsSelected(selection.toList(), true)
-            }
         }
 
         super.onViewStateRestored(savedInstanceState)

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/list/OrderListFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/list/OrderListFragment.kt
@@ -412,8 +412,8 @@ class OrderListFragment :
         }
         tracker?.onSaveInstanceState(outState)
         viewModel.orderIdAndPositionBackup =
-            ((binding.orderListView.ordersList.adapter as? OrderListAdapter)?.orderIdAndPosition
-                ?: emptyMap()) as MutableMap<Long, Int>
+            ((binding.orderListView.ordersList.adapter as? OrderListAdapter)?.orderIdAndPosition ?: emptyMap())
+                as MutableMap<Long, Int>
     }
 
     override fun onViewStateRestored(savedInstanceState: Bundle?) {
@@ -631,9 +631,11 @@ class OrderListFragment :
                     actionText = event.actionText,
                     action = event.action
                 )
+
                 is OrderListViewModel.OrderListEvent.RetryLoadingOrders -> refreshOrders()
                 is OrderListViewModel.OrderListEvent.OpenOrderCreationWithSimplePaymentsMigration ->
                     openOrderCreationFragment(indicateSimplePaymentsMigration = true)
+
                 is OrderListViewModel.OrderListEvent.ShowUpdateStatusDialog -> {
                     showBulkUpdateStatusDialog(event.currentStatus, event.orderStatusList)
                 }
@@ -650,6 +652,7 @@ class OrderListFragment :
                     viewModel.trashOrder(event.orderId)
                     selectedOrder.selectOrder(-1L)
                 }
+
                 else -> event.isHandled = false
             }
         }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/list/OrderListFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/list/OrderListFragment.kt
@@ -406,6 +406,18 @@ class OrderListFragment :
                 outState.putBoolean(LAST_WINDOW_SIZE_WAS_LARGER_THAN_COMPACT, true)
             }
         }
+        tracker?.onSaveInstanceState(outState)
+    }
+
+    override fun onViewStateRestored(savedInstanceState: Bundle?) {
+        tracker?.run {
+            onRestoreInstanceState(savedInstanceState)
+            if (hasSelection()) {
+                viewModel.onRestoreSelection(selection.toList())
+            }
+        }
+
+        super.onViewStateRestored(savedInstanceState)
     }
 
     override fun onDestroyView() {
@@ -414,6 +426,8 @@ class OrderListFragment :
         searchView = null
         orderListMenu = null
         searchMenuItem = null
+        tracker = null
+        actionMode = null
         super.onDestroyView()
         _binding = null
     }
@@ -614,6 +628,7 @@ class OrderListFragment :
                 is OrderListViewModel.OrderListEvent.ShowUpdateStatusDialog -> {
                     showBulkUpdateStatusDialog(event.currentStatus, event.orderStatusList)
                 }
+                is OrderListViewModel.OrderListEvent.SelectOrders -> tracker?.setItemsSelected(event.ordersIds, true)
 
                 is MultiLiveEvent.Event.ShowSnackbar -> uiMessageResolver.showSnack(event.message)
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/list/OrderListFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/list/OrderListFragment.kt
@@ -407,11 +407,19 @@ class OrderListFragment :
             }
         }
         tracker?.onSaveInstanceState(outState)
+        viewModel.orderIdAndPositionBackup =
+            ((binding.orderListView.ordersList.adapter as? OrderListAdapter)?.orderIdAndPosition
+                ?: emptyMap()) as MutableMap<Long, Int>
     }
 
     override fun onViewStateRestored(savedInstanceState: Bundle?) {
         tracker?.run {
             onRestoreInstanceState(savedInstanceState)
+            (binding.orderListView.ordersList.adapter as? OrderListAdapter)?.orderIdAndPosition =
+                viewModel.orderIdAndPositionBackup
+            if (hasSelection()) {
+                setItemsSelected(selection.toList(), true)
+            }
         }
 
         super.onViewStateRestored(savedInstanceState)

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/list/OrderListFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/list/OrderListFragment.kt
@@ -356,7 +356,11 @@ class OrderListFragment :
 
     private fun adjustLayoutForNonTablet(savedInstanceState: Bundle?) {
         if (wasLastWindowSizeLargerThanCompact(savedInstanceState)) {
-            displayDetailPaneOnly()
+            if (viewModel.isSelecting()) {
+                displayListPaneOnly()
+            } else {
+                displayDetailPaneOnly()
+            }
         } else {
             displayListPaneOnly()
         }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/list/OrderListViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/list/OrderListViewModel.kt
@@ -182,6 +182,8 @@ class OrderListViewModel @Inject constructor(
 
     val orderId: LiveData<Long> = savedState.getLiveData<Long>("orderId")
 
+    var orderIdAndPositionBackup = mutableMapOf<Long, Int>()
+
     private val _emptyViewType: ThrottleLiveData<EmptyViewType?> by lazy {
         ThrottleLiveData(
             offset = EMPTY_VIEW_THROTTLE,

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/list/OrderListViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/list/OrderListViewModel.kt
@@ -55,6 +55,7 @@ import com.woocommerce.android.ui.orders.filters.domain.GetWCOrderListDescriptor
 import com.woocommerce.android.ui.orders.filters.domain.GetWCOrderListDescriptorWithFiltersAndSearchQuery
 import com.woocommerce.android.ui.orders.filters.domain.ShouldShowCreateTestOrderScreen
 import com.woocommerce.android.ui.orders.list.OrderListViewModel.OrderListEvent.RetryLoadingOrders
+import com.woocommerce.android.ui.orders.list.OrderListViewModel.OrderListEvent.SelectOrders
 import com.woocommerce.android.ui.orders.list.OrderListViewModel.OrderListEvent.ShowErrorSnack
 import com.woocommerce.android.ui.orders.list.OrderListViewModel.OrderListEvent.ShowOrderFilters
 import com.woocommerce.android.util.CoroutineDispatchers
@@ -989,6 +990,10 @@ class OrderListViewModel @Inject constructor(
         exitSelectionMode()
     }
 
+    fun onRestoreSelection(selectedOrdersIds: List<Long>) {
+        triggerEvent(SelectOrders(selectedOrdersIds))
+    }
+
     sealed class OrderListEvent : Event() {
         data class ShowErrorSnack(@StringRes val messageRes: Int) : OrderListEvent()
         object ShowOrderFilters : OrderListEvent()
@@ -1046,6 +1051,8 @@ class OrderListViewModel @Inject constructor(
                 return result
             }
         }
+
+        data class SelectOrders(val ordersIds: List<Long>) : OrderListEvent()
     }
 
     @Parcelize

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/list/OrderListViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/list/OrderListViewModel.kt
@@ -55,7 +55,6 @@ import com.woocommerce.android.ui.orders.filters.domain.GetWCOrderListDescriptor
 import com.woocommerce.android.ui.orders.filters.domain.GetWCOrderListDescriptorWithFiltersAndSearchQuery
 import com.woocommerce.android.ui.orders.filters.domain.ShouldShowCreateTestOrderScreen
 import com.woocommerce.android.ui.orders.list.OrderListViewModel.OrderListEvent.RetryLoadingOrders
-import com.woocommerce.android.ui.orders.list.OrderListViewModel.OrderListEvent.SelectOrders
 import com.woocommerce.android.ui.orders.list.OrderListViewModel.OrderListEvent.ShowErrorSnack
 import com.woocommerce.android.ui.orders.list.OrderListViewModel.OrderListEvent.ShowOrderFilters
 import com.woocommerce.android.util.CoroutineDispatchers
@@ -990,10 +989,6 @@ class OrderListViewModel @Inject constructor(
         exitSelectionMode()
     }
 
-    fun onRestoreSelection(selectedOrdersIds: List<Long>) {
-        triggerEvent(SelectOrders(selectedOrdersIds))
-    }
-
     sealed class OrderListEvent : Event() {
         data class ShowErrorSnack(@StringRes val messageRes: Int) : OrderListEvent()
         object ShowOrderFilters : OrderListEvent()
@@ -1051,8 +1046,6 @@ class OrderListViewModel @Inject constructor(
                 return result
             }
         }
-
-        data class SelectOrders(val ordersIds: List<Long>) : OrderListEvent()
     }
 
     @Parcelize


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #13218, #13231
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

This PR adds various fixes and updates to the code so that:
1. Selection state persists after configuration changes (e.g: theme changes, layout changes)
2. Selection state persists after loading more items by scrolling down.

### Steps to reproduce
<!-- Step-by-step testing instructions. For new user flows, consider instead stating the goal of the workflow and see if your PR reviewer can accomplish the workflow without specific steps! -->

TC 1: Config change
1. Run app, go to Orders, then long press an Order to enable bulk selection mode and select some more items.
2. Toggle device's dark/light mode. The selection state should persist (toolbar shows same number of items, correct Orders are checked)
3. Rotate device from portait to landscape, the selection should persist.
4. Go back to portrait, the selection should persist.

TC 2: Load more
1. Need a test site with many Orders on this (ideally 100 or more),
2. Run app, go to Orders, do pull to refresh to ensure not all items are loaded yet
3. Long press an Order to enable bulk selection mode and select some more items.
4. Scroll way down until the load more animation and behavior are triggered.
5. Once more Orders are loaded, ensure that selection state persists (toolbar shows same number of items, correct Orders are checked)

### Testing information
<!-- This is your opportunity to break out individual scenarios that need testing (when necessary) and/or include a checklist for the reviewer to go through. Consider documenting the following from your own completed testing: devices used, alternate workflows, edge cases, affected areas, critical flows, areas not tested, and any remaining unknowns. Provide feedback on this new section of the PR template through Sept 30, 2024 to Apps Quality; additional context here: p91TBi-b8z-p2#comment-12036 -->


### The tests that have been performed
<!-- To give the reviewer an idea of what could be missed in terms of testing -->

Tested this both on phone and tablet simulator for both TCs.

### Images/gif
<!-- Include before and after images or gifs when appropriate. -->

Videos incoming.

- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.

## Reviewer (or Author, in the case of optional code reviews):

Please make sure these conditions are met before approving the PR, or request changes if the PR needs improvement:

- [ ] The PR is small and has a clear, single focus, or a valid explanation is provided in the description. If needed, please request to split it into smaller PRs.
- [ ] Ensure Adequate Unit Test Coverage: The changes are reasonably covered by unit tests or an explanation is provided in the PR description.
- [ ] Manual Testing: The author listed all the tests they ran, including smoke tests when needed (e.g., for refactorings). The reviewer confirmed that the PR works as expected on big (tablet) and small (phone) in case of UI changes, and no regressions are added.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->