### PR TITLE
[Barcode Scanner] Implement Fallback to Front-Facing Camera if Back Camera is Unavailable

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -7,6 +7,7 @@
 - [*] Fixed overlap issue in Settings > WooCommerce Version  [https://github.com/woocommerce/woocommerce-android/pull/13183]
 - [*] Fixed a crash on the order details [https://github.com/woocommerce/woocommerce-android/pull/13191]
 - [**] Fixed a crash when a shop manager was trying to install or activate plugin in the POS onboarding [https://github.com/woocommerce/woocommerce-android/pull/13203]
+- [**] Introduced fallback logic for the barcode scanner to use the front-facing camera when a back-facing camera is unavailable [https://github.com/woocommerce/woocommerce-android/pull/13230]
 
 21.3
 -----

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/barcodescanner/BarcodeScanner.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/barcodescanner/BarcodeScanner.kt
@@ -57,7 +57,15 @@ fun BarcodeScanner(
         }
     }
     val selector = remember {
-        CameraSelector.Builder().requireLensFacing(CameraSelector.LENS_FACING_BACK).build()
+        val cameraProvider = cameraProviderFuture.get()
+        val hasBackCamera = cameraProvider.hasCamera(CameraSelector.DEFAULT_BACK_CAMERA)
+        val hasFrontCamera = cameraProvider.hasCamera(CameraSelector.DEFAULT_FRONT_CAMERA)
+
+        when {
+            hasBackCamera -> CameraSelector.DEFAULT_BACK_CAMERA
+            hasFrontCamera -> CameraSelector.DEFAULT_FRONT_CAMERA
+            else -> error(IllegalStateException("No available camera"))
+        }
     }
 
     DisposableEffect(lifecycleOwner) {


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #13174 
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
This PR updates the barcode scanner to gracefully handle devices where a back-facing camera is unavailable, such as Chromebooks. The code now checks for available cameras and falls back to the front-facing camera if necessary.


### Steps to reproduce
<!-- Step-by-step testing instructions. For new user flows, consider instead stating the goal of the workflow and see if your PR reviewer can accomplish the workflow without specific steps! -->
#### Devices that have both back and front facing camera
1. Navigate to Orders tab
2. Click on the barcode icon in the toolbar
3. Ensure barcode scanner works as expected

#### Devices that have doesn't have back facing camera (Chromebook)
1. Navigate to Orders tab
2. Click on the barcode icon in the toolbar
3. Ensure barcode scanner works as expected

### The tests that have been performed
<!-- To give the reviewer an idea of what could be missed in terms of testing -->
**Simulated Testing:** Modify the code to skip the back camera temporarily and test fallback to the front camera.

- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.

## Reviewer (or Author, in the case of optional code reviews):

Please make sure these conditions are met before approving the PR, or request changes if the PR needs improvement:

- [ ] The PR is small and has a clear, single focus, or a valid explanation is provided in the description. If needed, please request to split it into smaller PRs.
- [ ] Ensure Adequate Unit Test Coverage: The changes are reasonably covered by unit tests or an explanation is provided in the PR description.
- [ ] Manual Testing: The author listed all the tests they ran, including smoke tests when needed (e.g., for refactorings). The reviewer confirmed that the PR works as expected on big (tablet) and small (phone) in case of UI changes, and no regressions are added.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->