### PR TITLE
Update dark version of ic_not_found icon

### DIFF
--- a/WooCommerce/src/main/res/drawable-night/ic_not_found.xml
+++ b/WooCommerce/src/main/res/drawable-night/ic_not_found.xml
@@ -6,19 +6,19 @@
     <group>
         <clip-path android:pathData="M0.5,0h104v104H0.5z" />
         <path
-            android:fillColor="#949494"
+            android:fillColor="#3C434A"
             android:pathData="m66.88,22.25 l-3.05,3.06 15.27,15.33 3.05,-3.06 -15.27,-15.33Z" />
         <path
-            android:fillColor="#949494"
+            android:fillColor="#3C434A"
             android:pathData="M79.1,22.26 L63.83,37.59l3.05,3.06 15.27,-15.33 -3.05,-3.06Z" />
         <path
-            android:fillColor="#DDDDDD"
+            android:fillColor="#646970"
             android:pathData="M50.55,47.63 L14.82,83.49l6.11,6.13L56.66,53.76l-6.11,-6.13Z" />
         <path
-            android:fillColor="#949494"
+            android:fillColor="#3C434A"
             android:pathData="M20.28,101.06c4.5,-5.1 28.41,-32.56 28.41,-32.56L35.86,55.63S8.5,79.63 3.42,84.15c-4.61,4.1 -3.39,8.61 1.04,13.06l2.81,2.82c4.43,4.45 8.92,5.67 13.01,1.04v-0Z" />
         <path
-            android:fillColor="#DDDDDD"
+            android:fillColor="#646970"
             android:pathData="M73.17,62.9c-17.27,0 -31.33,-14.11 -31.33,-31.45S55.9,0 73.17,0c17.28,0 31.33,14.11 31.33,31.45S90.45,62.9 73.17,62.9v0ZM73.17,8.67c-12.51,0 -22.69,10.22 -22.69,22.78s10.18,22.78 22.69,22.78c12.51,0 22.69,-10.22 22.69,-22.78S85.68,8.67 73.17,8.67Z" />
     </group>
 </vector>


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Part of: woocommerce/woomobile-private#379
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
This updates the not found icon color for the dark mode.

### Steps to reproduce
<!-- Step-by-step testing instructions. For new user flows, consider instead stating the goal of the workflow and see if your PR reviewer can accomplish the workflow without specific steps! -->
1. Tap the calendar icon on the "Top performers" card.
2. Select an empty day.

### The tests that have been performed
<!-- To give the reviewer an idea of what could be missed in terms of testing -->

### Images/gif
<!-- Include before and after images or gifs when appropriate. -->
|Before|After|
|-|-|
|<img src="https://github.com/user-attachments/assets/c68f40dd-78df-47a9-8e50-d2b0b4455649" width=480>|<img src="https://github.com/user-attachments/assets/43eaa126-9a63-4b81-a2d1-50a8ef0232b8" width=480>|

- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.

## Reviewer (or Author, in the case of optional code reviews):

Please make sure these conditions are met before approving the PR, or request changes if the PR needs improvement:

- [ ] The PR is small and has a clear, single focus, or a valid explanation is provided in the description. If needed, please request to split it into smaller PRs.
- [ ] Ensure Adequate Unit Test Coverage: The changes are reasonably covered by unit tests or an explanation is provided in the PR description.
- [ ] Manual Testing: The author listed all the tests they ran, including smoke tests when needed (e.g., for refactorings). The reviewer confirmed that the PR works as expected on big (tablet) and small (phone) in case of UI changes, and no regressions are added.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->