### PR TITLE
Fix order details crash on rotation

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/OrderSelectionItemKeyProvider.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/OrderSelectionItemKeyProvider.kt
@@ -18,5 +18,5 @@ class OrderSelectionItemKeyProvider(private val recyclerView: RecyclerView) :
     }
 
     override fun getPosition(key: Long): Int =
-        (recyclerView.adapter as? OrderListAdapter)?.orderIdAndPosition[key] ?: RecyclerView.NO_POSITION
+        (recyclerView.adapter as? OrderListAdapter)?.orderIdAndPosition?.get(key) ?: RecyclerView.NO_POSITION
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/list/OrderListFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/list/OrderListFragment.kt
@@ -415,18 +415,27 @@ class OrderListFragment :
             }
         }
         tracker?.onSaveInstanceState(outState)
-        viewModel.orderIdAndPositionBackup =
-            ((binding.orderListView.ordersList.adapter as? OrderListAdapter)?.orderIdAndPosition ?: emptyMap())
-                as MutableMap<Long, Int>
+
+        _binding?.let { binding ->
+            val adapter = binding.orderListView.ordersList.adapter as? OrderListAdapter
+            adapter?.let {
+                viewModel.orderIdAndPositionBackup = it.orderIdAndPosition
+            }
+        }
     }
 
     override fun onViewStateRestored(savedInstanceState: Bundle?) {
         tracker?.run {
             onRestoreInstanceState(savedInstanceState)
-            (binding.orderListView.ordersList.adapter as? OrderListAdapter)?.orderIdAndPosition =
-                viewModel.orderIdAndPositionBackup
-            if (hasSelection()) {
-                setItemsSelected(selection.toList(), true)
+
+            _binding?.let { binding ->
+                val adapter = binding.orderListView.ordersList.adapter as? OrderListAdapter
+                adapter?.let {
+                    it.orderIdAndPosition = viewModel.orderIdAndPositionBackup
+                    if (hasSelection()) {
+                        setItemsSelected(selection.toList(), true)
+                    }
+                }
             }
         }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/list/OrderListFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/list/OrderListFragment.kt
@@ -427,19 +427,22 @@ class OrderListFragment :
     override fun onViewStateRestored(savedInstanceState: Bundle?) {
         tracker?.run {
             onRestoreInstanceState(savedInstanceState)
-
             _binding?.let { binding ->
-                val adapter = binding.orderListView.ordersList.adapter as? OrderListAdapter
-                adapter?.let {
-                    it.orderIdAndPosition = viewModel.orderIdAndPositionBackup
-                    if (hasSelection()) {
-                        setItemsSelected(selection.toList(), true)
-                    }
+                restoreAdapterBulkSelectionState(binding)
+                if (hasSelection()) {
+                    setItemsSelected(selection.toList(), true)
                 }
             }
         }
 
         super.onViewStateRestored(savedInstanceState)
+    }
+
+    private fun restoreAdapterBulkSelectionState(binding: FragmentOrderListBinding) {
+        val adapter = binding.orderListView.ordersList.adapter as? OrderListAdapter
+        if (adapter != null) {
+            adapter.orderIdAndPosition = viewModel.orderIdAndPositionBackup
+        }
     }
 
     override fun onDestroyView() {


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

[In this PR](https://github.com/woocommerce/woocommerce-android/pull/13227) for Bulk Order Status Update project, we added a mechanism to save selected items and restore it during configuration change.

This creates a crash in a case in this situation:
1. Open Order List,
2. Tap an Order to open its Order Details,
3. Rotate the screen

What happens here is that `binding` becomes null when navigating to Order Details but `OrderListFragment` is still active, so when the call for `binding` is done in `onSaveInstanceState`, it creates a crash.

This PR adds null check to prevent that crash. I also added similar check in `onViewStateRestored` for extra safety, and a small fix in `OrderSelectionItemKeyProvider` that came from Android Studio's suggestion.

### Steps to reproduce
<!-- Step-by-step testing instructions. For new user flows, consider instead stating the goal of the workflow and see if your PR reviewer can accomplish the workflow without specific steps! -->

TC1:
1. Open Order List,
2. Tap an Order to open its Order Details,
3. Rotate the screen,
4. Ensure there's no crash

TC2: ensure bulk selection still work
1. Open Order List,
2. Long press an Order to enable bulk selection mode,
3. select a few more Orders,
4. Rotate the screen,
5. Ensure there's no crash, and the selected Orders remain selected

### Testing information
<!-- This is your opportunity to break out individual scenarios that need testing (when necessary) and/or include a checklist for the reviewer to go through. Consider documenting the following from your own completed testing: devices used, alternate workflows, edge cases, affected areas, critical flows, areas not tested, and any remaining unknowns. Provide feedback on this new section of the PR template through Sept 30, 2024 to Apps Quality; additional context here: p91TBi-b8z-p2#comment-12036 -->

n/a

### The tests that have been performed
<!-- To give the reviewer an idea of what could be missed in terms of testing -->

I tested both TCs in phone mode as that's where the crash happens. In tablet the case is a bit different (Order List and Details appear all the time in two panel mode) and the crash does not happen in my check.

### Images/gif
<!-- Include before and after images or gifs when appropriate. -->

n/a

- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.

## Reviewer (or Author, in the case of optional code reviews):

Please make sure these conditions are met before approving the PR, or request changes if the PR needs improvement:

- [ ] The PR is small and has a clear, single focus, or a valid explanation is provided in the description. If needed, please request to split it into smaller PRs.
- [ ] Ensure Adequate Unit Test Coverage: The changes are reasonably covered by unit tests or an explanation is provided in the PR description.
- [ ] Manual Testing: The author listed all the tests they ran, including smoke tests when needed (e.g., for refactorings). The reviewer confirmed that the PR works as expected on big (tablet) and small (phone) in case of UI changes, and no regressions are added.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->