### PR TITLE
Fix issue with displaying refunded items

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -20,6 +20,7 @@
 - [**] Improved UX of card reader payment flow in Point of Sale, allowing faster payment collection [https://github.com/woocommerce/woocommerce-android/pull/12977]
 - [*] Fixed crash when trying to open barcode scanner on device without camera [https://github.com/woocommerce/woocommerce-android/pull/13172]
 - [Internal] Woo POS now accepts cash payments and there is a functionality of sending receipts [https://github.com/woocommerce/woocommerce-android/pull/13157]
+- [**] Fixed a bug that caused the app to not show the list of refunded products in the order details screen [https://github.com/woocommerce/woocommerce-android/pull/13261]
 
 -----
 21.2

--- a/WooCommerce-Wear/src/main/java/com/woocommerce/android/wear/model/Refund.kt
+++ b/WooCommerce-Wear/src/main/java/com/woocommerce/android/wear/model/Refund.kt
@@ -55,7 +55,7 @@ fun WCRefundModel.WCRefundItem.toAppModel(): Refund.Item {
         -totalTax, // WCRefundItem.totalTax is NEGATIVE
         sku ?: "",
         price ?: BigDecimal.ZERO,
-        metaData?.get(0)?.value?.toString()?.toLongOrNull() ?: -1
+        metaData?.get(0)?.value?.stringValue?.toLongOrNull() ?: -1
     )
 }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/model/Refund.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/model/Refund.kt
@@ -5,7 +5,9 @@ import com.woocommerce.android.ui.products.ProductHelper
 import kotlinx.parcelize.IgnoredOnParcel
 import kotlinx.parcelize.Parcelize
 import org.wordpress.android.fluxc.model.refunds.WCRefundModel
-import org.wordpress.android.fluxc.model.refunds.WCRefundModel.*
+import org.wordpress.android.fluxc.model.refunds.WCRefundModel.WCRefundFeeLine
+import org.wordpress.android.fluxc.model.refunds.WCRefundModel.WCRefundItem
+import org.wordpress.android.fluxc.model.refunds.WCRefundModel.WCRefundShippingLine
 import java.math.BigDecimal
 import java.math.RoundingMode.HALF_UP
 import java.util.Date
@@ -94,13 +96,13 @@ fun WCRefundItem.toAppModel(): Refund.Item {
         -totalTax, // WCRefundItem.totalTax is NEGATIVE
         sku ?: "",
         price ?: BigDecimal.ZERO,
-        metaData?.get(0)?.value?.toString()?.toLongOrNull() ?: -1
+        metaData?.get(0)?.value?.stringValue?.toLongOrNull() ?: -1
     )
 }
 
 fun WCRefundShippingLine.toAppModel(): Refund.ShippingLine {
     return Refund.ShippingLine(
-        itemId = metaData?.get(0)?.value?.toString()?.toLongOrNull() ?: -1,
+        itemId = metaData?.get(0)?.value?.stringValue?.toLongOrNull() ?: -1,
         methodId = methodId ?: "",
         methodTitle = methodTitle ?: "",
         totalTax = -totalTax, // WCRefundShippineLine.totalTax is NEGATIVE
@@ -110,7 +112,7 @@ fun WCRefundShippingLine.toAppModel(): Refund.ShippingLine {
 
 fun WCRefundFeeLine.toAppModel(): Refund.FeeLine {
     return Refund.FeeLine(
-        id = metaData?.get(0)?.value?.toString()?.toLongOrNull() ?: -1,
+        id = metaData?.get(0)?.value?.stringValue?.toLongOrNull() ?: -1,
         name = name,
         totalTax = -totalTax, // WCRefundFeeLine.totalTax is NEGATIVE
         total = (total), // WCRefundFeeLine.total is NEGATIVE

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/model/RefundMapperTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/model/RefundMapperTest.kt
@@ -1,0 +1,99 @@
+package com.woocommerce.android.model
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+import org.wordpress.android.fluxc.model.metadata.WCMetaData
+import org.wordpress.android.fluxc.model.metadata.WCMetaDataValue
+import org.wordpress.android.fluxc.model.refunds.WCRefundModel
+import java.math.BigDecimal
+
+class RefundMapperTest {
+    @Test
+    fun `when mapping refund item from domain model, then extract its properties correctly`() {
+        val domainModel = WCRefundModel.WCRefundItem(
+            productId = 1,
+            quantity = -1,
+            itemId = 2,
+            name = "name",
+            variationId = null,
+            subtotal = BigDecimal.TEN,
+            total = BigDecimal.TEN,
+            totalTax = BigDecimal.TEN,
+            sku = "sku",
+            price = BigDecimal.TEN,
+            metaData = listOf(WCMetaData(id = 0, key = "_refunded_item_id", value = WCMetaDataValue(10)))
+        )
+
+        val appModel = domainModel.toAppModel()
+
+        assertEquals(1, appModel.productId)
+        assertEquals(1, appModel.quantity)
+        assertEquals(2, appModel.id)
+        assertEquals("name", appModel.name)
+        assertEquals(-1, appModel.variationId)
+        assertEquals(BigDecimal.TEN.negate(), appModel.subtotal)
+        assertEquals(BigDecimal.TEN.negate(), appModel.total)
+        assertEquals(BigDecimal.TEN.negate(), appModel.totalTax)
+        assertEquals("sku", appModel.sku)
+        assertEquals(BigDecimal.TEN, appModel.price)
+        assertEquals(10, appModel.orderItemId)
+    }
+
+    @Test
+    fun `given item ID is wrapped as String, when mapping refund item from domain model, then extract it correctly`() {
+        val domainModel = WCRefundModel.WCRefundItem(
+            productId = 1,
+            quantity = -1,
+            itemId = 2,
+            name = "name",
+            variationId = null,
+            subtotal = BigDecimal.TEN,
+            total = BigDecimal.TEN,
+            totalTax = BigDecimal.TEN,
+            sku = "sku",
+            price = BigDecimal.TEN,
+            metaData = listOf(WCMetaData(id = 0, key = "_refunded_item_id", value = WCMetaDataValue("10")))
+        )
+
+        val appModel = domainModel.toAppModel()
+
+        assertEquals(10, appModel.orderItemId)
+    }
+
+    @Test
+    fun `when mapping shipping lines from domain model, then extract its properties correctly`() {
+        val domainModel = WCRefundModel.WCRefundShippingLine(
+            id = 1,
+            methodId = "methodId",
+            methodTitle = "methodTitle",
+            totalTax = BigDecimal.TEN,
+            total = BigDecimal.TEN,
+            metaData = listOf(WCMetaData(id = 0, key = "_refunded_item_id", value = WCMetaDataValue(10)))
+        )
+
+        val appModel = domainModel.toAppModel()
+
+        // Intentionally not checking all properties, we have an inconsistency in the function where
+        // we negate the totalTax but not the total, and there is no explanation for this.
+        // See https://github.com/woocommerce/woocommerce-android/pull/5517#discussion_r774573314
+        // We should update the test when we have a clear understanding of the expected behavior.
+        // Note: these properties are not used in the app currently.
+        assertEquals(10, appModel.itemId)
+    }
+
+    @Test
+    fun `when mapping fee lines from domain model, then extract its properties correctly`() {
+        val domainModel = WCRefundModel.WCRefundFeeLine(
+            id = 1,
+            name = "name",
+            totalTax = BigDecimal.TEN,
+            total = BigDecimal.TEN,
+            metaData = listOf(WCMetaData(id = 0, key = "_refunded_item_id", value = WCMetaDataValue(10)))
+        )
+
+        val appModel = domainModel.toAppModel()
+
+        // See comment in the previous test.
+        assertEquals(10, appModel.id)
+    }
+}


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #13258 
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
This PR fixes the linked issue, the cause of the bug was that with the custom fields, we had to refactor how `WCMetaData` values are represented, and with it, the behavior of `value.toString()` changed, leading to an issue with retrieving the item's ID.
This PR updates all of the usages that were missed during the refactoring to start using `stringValue` instead.

### Steps to reproduce
1. Create an order with some products.
2. Refund the order.
3. Open the order details.
4. Tap on the "X items" button.

### Testing information
Confirm the refunded items are shown.

### The tests that have been performed
^

### Images/gif
<img src=https://github.com/user-attachments/assets/c0387402-a210-4506-8ccf-77cb8b9d08ab width=360 />

- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.

## Reviewer (or Author, in the case of optional code reviews):

Please make sure these conditions are met before approving the PR, or request changes if the PR needs improvement:

- [x] The PR is small and has a clear, single focus, or a valid explanation is provided in the description. If needed, please request to split it into smaller PRs.
- [x] Ensure Adequate Unit Test Coverage: The changes are reasonably covered by unit tests or an explanation is provided in the PR description.
- [x] Manual Testing: The author listed all the tests they ran, including smoke tests when needed (e.g., for refactorings). The reviewer confirmed that the PR works as expected on big (tablet) and small (phone) in case of UI changes, and no regressions are added.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->