### PR TITLE
Update address name

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/address/AddressSection.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/address/AddressSection.kt
@@ -40,7 +40,6 @@ import androidx.compose.ui.tooling.preview.Preview
 import androidx.constraintlayout.compose.ConstraintLayout
 import androidx.constraintlayout.compose.Dimension
 import com.woocommerce.android.R
-import com.woocommerce.android.extensions.isNotNullOrEmpty
 import com.woocommerce.android.model.Address
 import com.woocommerce.android.model.AmbiguousLocation
 import com.woocommerce.android.model.Location

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/address/AddressSection.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/address/AddressSection.kt
@@ -11,6 +11,8 @@ import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.Divider
 import androidx.compose.material.Icon
@@ -367,20 +369,22 @@ fun AddressSelection(
                     bottom = dimensionResource(id = R.dimen.minor_100)
                 )
             )
-            originAddresses.forEach { option ->
-                val isSelected = option == shipFrom
-                AddressSelectionItem(
-                    address = option,
-                    isSelected = isSelected,
-                    onClick = {
-                        onShippingFromAddressChange(option)
-                    },
-                    modifier = Modifier.padding(
-                        top = dimensionResource(id = R.dimen.minor_100),
-                        start = dimensionResource(id = R.dimen.major_100),
-                        end = dimensionResource(id = R.dimen.major_100)
+            LazyColumn {
+                items(originAddresses) { option ->
+                    val isSelected = option == shipFrom
+                    AddressSelectionItem(
+                        address = option,
+                        isSelected = isSelected,
+                        onClick = {
+                            onShippingFromAddressChange(option)
+                        },
+                        modifier = Modifier.padding(
+                            top = dimensionResource(id = R.dimen.minor_100),
+                            start = dimensionResource(id = R.dimen.major_100),
+                            end = dimensionResource(id = R.dimen.major_100)
+                        )
                     )
-                )
+                }
             }
             Spacer(modifier = Modifier.height(dimensionResource(id = R.dimen.major_100)))
         },
@@ -425,7 +429,7 @@ fun AddressSelectionItem(
         Row {
             Column(modifier = Modifier.weight(1f)) {
                 Text(
-                    text = address.getFormatedName(LocalContext.current),
+                    text = address.getFormattedName(LocalContext.current),
                     fontWeight = FontWeight.Bold,
                     modifier = Modifier
                 )
@@ -496,12 +500,13 @@ internal fun getShipTo() = Address(
     state = AmbiguousLocation.Defined(Location("CA", "California", "USA"))
 )
 
-fun OriginShippingAddress.getFormatedName(context: Context): String {
-    val name = if (firstName.isNotNullOrEmpty() || lastName.isNotNullOrEmpty()) {
-        "$firstName $lastName"
-    } else {
-        company
-            ?: context.getString(R.string.shipping_label_select_origin_address)
+fun OriginShippingAddress.getFormattedName(context: Context): String {
+    val name = when {
+        !firstName.isNullOrEmpty() && !lastName.isNullOrEmpty() -> "$firstName $lastName"
+        !firstName.isNullOrEmpty() -> firstName
+        !lastName.isNullOrEmpty() -> lastName
+        !company.isNullOrEmpty() -> company
+        else -> context.getString(R.string.shipping_label_select_origin_address)
     }
     return if (this.isDefault) {
         context.getString(R.string.shipping_label_select_origin_default_address, name)

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/address/AddressSection.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/address/AddressSection.kt
@@ -1,5 +1,6 @@
 package com.woocommerce.android.ui.orders.wooshippinglabels.address
 
+import android.content.Context
 import androidx.compose.animation.animateColorAsState
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Box
@@ -26,6 +27,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.colorResource
 import androidx.compose.ui.res.dimensionResource
 import androidx.compose.ui.res.painterResource
@@ -36,6 +38,7 @@ import androidx.compose.ui.tooling.preview.Preview
 import androidx.constraintlayout.compose.ConstraintLayout
 import androidx.constraintlayout.compose.Dimension
 import com.woocommerce.android.R
+import com.woocommerce.android.extensions.isNotNullOrEmpty
 import com.woocommerce.android.model.Address
 import com.woocommerce.android.model.AmbiguousLocation
 import com.woocommerce.android.model.Location
@@ -422,7 +425,7 @@ fun AddressSelectionItem(
         Row {
             Column(modifier = Modifier.weight(1f)) {
                 Text(
-                    text = "Address Name",
+                    text = address.getFormatedName(LocalContext.current),
                     fontWeight = FontWeight.Bold,
                     modifier = Modifier
                 )
@@ -492,3 +495,17 @@ internal fun getShipTo() = Address(
     country = Location("US", "USA"),
     state = AmbiguousLocation.Defined(Location("CA", "California", "USA"))
 )
+
+fun OriginShippingAddress.getFormatedName(context: Context): String {
+    val name = if (firstName.isNotNullOrEmpty() || lastName.isNotNullOrEmpty()) {
+        "$firstName $lastName"
+    } else {
+        company
+            ?: context.getString(R.string.shipping_label_select_origin_address)
+    }
+    return if (this.isDefault) {
+        context.getString(R.string.shipping_label_select_origin_default_address, name)
+    } else {
+        name
+    }
+}

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -1309,6 +1309,8 @@
     <string name="shipping_label_purchased_tracking_error">We currently do not support Tracking for this carrier</string>
     <string name="shipping_label_purchased_print_error">Something went wrong with this Shipping Label, try again later</string>
     <string name="shipping_label_purchased_purchase_failed_error">We can\'t confirm the Shipping Label purchase right now, try again later</string>
+    <string name="shipping_label_select_origin_default_address">%s (default)</string>
+    <string name="shipping_label_select_origin_address">Address</string>
 
 
     <!--


### PR DESCRIPTION
Part of: #12439

### Description
This small PR updates the address name in the origin address selector control. The address item now will display the address name as a combination of the first name and last name or using the company field. When the names and company are `null`, the text Address will be used.

### Testing information

1. Open the orders section
2. Open an order eligible for shipping label creation
3. Tap on create shipping label
4. Expand the shipment details section
5. Tap on the more(3 dots) icon next to the selected ship from address
6. Check that the address selection bottom sheets expand with all the origin addresses
7. Check that the select ship from address feature works as expected

### The tests that have been performed
Checking the select address control displays the right name

### Images/gif

https://github.com/user-attachments/assets/52a329b3-7567-46d3-8c1d-b4cb96d481dc


- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.

## Reviewer (or Author, in the case of optional code reviews):

Please make sure these conditions are met before approving the PR, or request changes if the PR needs improvement:

- [x] The PR is small and has a clear, single focus, or a valid explanation is provided in the description. If needed, please request to split it into smaller PRs.
- [x] Ensure Adequate Unit Test Coverage: The changes are reasonably covered by unit tests or an explanation is provided in the PR description.
- [x] Manual Testing: The author listed all the tests they ran, including smoke tests when needed (e.g., for refactorings). The reviewer confirmed that the PR works as expected on big (tablet) and small (phone) in case of UI changes, and no regressions are added.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
