### PR TITLE
Fix crash when Exit event is fired multiple times

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/variations/VariationDetailFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/variations/VariationDetailFragment.kt
@@ -261,6 +261,7 @@ class VariationDetailFragment :
         }
     }
 
+    @Suppress("LongMethod")
     private fun setupObservers(viewModel: VariationDetailViewModel) {
         viewModel.variationViewStateData.observe(viewLifecycleOwner) { old, new ->
             new.variation.takeIfNotEqualTo(old?.variation) { newVariation ->

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/variations/VariationDetailFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/variations/VariationDetailFragment.kt
@@ -318,8 +318,13 @@ class VariationDetailFragment :
                 is ExitWithResult<*> -> navigateBackWithResult(KEY_VARIATION_DETAILS_RESULT, event.data)
                 is ShowDialog -> event.showDialog()
                 is ShowDialogFragment -> event.showIn(parentFragmentManager, this)
-                is Exit -> requireActivity().onBackPressedDispatcher.onBackPressed()
                 is VariationDetailViewModel.ShowUpdateVariationError -> showUpdateVariationError(event.message)
+                is Exit -> {
+                    // Ensure subsequent Exit events are ignored to avoid IllegalStateException
+                    viewModel.event.removeObservers(viewLifecycleOwner)
+                    requireActivity().onBackPressedDispatcher.onBackPressed()
+                }
+
                 else -> event.isHandled = false
             }
         }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/variations/VariationsBulkUpdateBaseFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/variations/VariationsBulkUpdateBaseFragment.kt
@@ -53,6 +53,7 @@ abstract class VariationsBulkUpdateBaseFragment(@LayoutRes layoutId: Int) : Base
                             viewModel.onDoneClicked()
                             true
                         }
+
                         else -> false
                     }
                 }
@@ -68,7 +69,12 @@ abstract class VariationsBulkUpdateBaseFragment(@LayoutRes layoutId: Int) : Base
                     ActivityUtils.hideKeyboard(requireActivity())
                     uiMessageResolver.showSnack(event.message)
                 }
-                is MultiLiveEvent.Event.Exit -> requireActivity().onBackPressedDispatcher.onBackPressed()
+
+                is MultiLiveEvent.Event.Exit -> {
+                    // Ensure subsequent Exit events are ignored to avoid IllegalStateException
+                    viewModel.event.removeObservers(viewLifecycleOwner)
+                    requireActivity().onBackPressedDispatcher.onBackPressed()
+                }
             }
         }
     }


### PR DESCRIPTION
Exit event could potentially be fired more than once, which will make the app crash because it will attempt to navigate back more than once, leading to "IllegalStateException FragmentManager is already executing transactions"

<!-- Remember about a good descriptive title. -->

Closes: #13226 
Closes: #13289
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify the problem and how you’ve fixed it. -->
Tentative fix for crash: 
```
IllegalStateException: FragmentManager is already executing transactions
    at com.woocommerce.android.ui.products.variations.VariationDetailFragment.setupObservers$lambda$24(VariationDetailFragment.kt:320)
    is Exit -> requireActivity().onBackPressedDispatcher.onBackPressed()
    at com.woocommerce.android.ui.products.variations.VariationDetailFragment.$r8$lambda$6j_9a98nQXRa_5YR2Y_XIxTyzTw(VariationDetailFragment.kt:0)
    at com.woocommerce.android.ui.products.variations.VariationDetailFragment$$ExternalSyntheticLambda14.invoke(VariationDetailFragment:0)
    at com.woocommerce.android.ui.products.variations.VariationDetailFragment$sam$androidx_lifecycle_Observer$0.onChanged(VariationDetailFragment.kt:0)
    at com.woocommerce.android.viewmodel.MultiLiveEvent.observe$lambda$0(MultiLiveEvent.kt:43)
    observer.onChanged(t)
```

And for the crash: 
```
java.lang.IllegalStateException: FragmentManager is already executing transactions
    at androidx.fragment.app.FragmentManager.ensureExecReady(FragmentManager.java:1937)
    at androidx.fragment.app.FragmentManager.execPendingActions(FragmentManager.java:1996)
    at androidx.fragment.app.FragmentManager.handleOnBackPressed(FragmentManager.java:862)
    at androidx.fragment.app.FragmentManager$1.handleOnBackPressed(FragmentManager.java:570)
    at androidx.activity.OnBackPressedDispatcher.onBackPressed(OnBackPressedDispatcher.kt:276)
```

Which has a similar stack trace. 

I spent some time trying to replicate the crash but I was unable to. My hypothesis is that the `Exit` event is triggered simultaneously from `VariationDetailViewModel` when the user clicks the back button and when `loadVariation` function fails to load the variation and automatically runs: ` triggerEvent(Event.Exit)`. I tried using APIFaker to make different api calls fail when opening variation detail but wasn't able to reproduce the race condition where 2 Exit events are fired at once. 

The proposed solution is to basically make sure we unsubscribe from LiveData as soon as the first `Exit` event is fired, so that any subsequent call to `triggerEvent(Event.Exit)` will be ignored. 

### Testing information
<!-- This is your opportunity to break out individual scenarios that need testing (when necessary) and/or include a checklist for the reviewer to go through. Consider documenting the following from your own completed testing: devices used, alternate workflows, edge cases, affected areas, critical flows, areas not tested, and any remaining unknowns. Provide feedback on this new section of the PR template through Sept 30, 2024 to Apps Quality; additional context here: p91TBi-b8z-p2#comment-12036 -->
Open a product with variations and check that everything works as expected: 
- Add new variation works as expected
- Opening variation detail and navigating back and forth works as expected
- Deleting variation works as expected 
- Tap on the three dots menu and update several variations in bulk. Check everything works as expected

### The tests that have been performed
<!-- To give the reviewer an idea of what could be missed in terms of testing -->
The above

- [X] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.

## Reviewer (or Author, in the case of optional code reviews):

Please make sure these conditions are met before approving the PR, or request changes if the PR needs improvement:

- [x] The PR is small and has a clear, single focus, or a valid explanation is provided in the description. If needed, please request to split it into smaller PRs.
- [x] Ensure Adequate Unit Test Coverage: The changes are reasonably covered by unit tests or an explanation is provided in the PR description.
- [x] Manual Testing: The author listed all the tests they ran, including smoke tests when needed (e.g., for refactorings). The reviewer confirmed that the PR works as expected on big (tablet) and small (phone) in case of UI changes, and no regressions are added.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->