### PR TITLE
Navigation bar issue on prologue screens for low APIs

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/LoginActivity.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/LoginActivity.kt
@@ -11,6 +11,7 @@ import androidx.activity.SystemBarStyle
 import androidx.activity.enableEdgeToEdge
 import androidx.appcompat.app.AppCompatActivity
 import androidx.core.view.ViewCompat
+import androidx.core.view.WindowCompat
 import androidx.core.view.WindowInsetsCompat
 import androidx.core.view.updatePadding
 import androidx.fragment.app.DialogFragment
@@ -352,7 +353,10 @@ class LoginActivity :
     }
 
     override fun disableDynamicEdgeToEdge() {
+        // Call again to reset the statusBarStyle to its default setting
         enableEdgeToEdge()
+
+        WindowCompat.setDecorFitsSystemWindows(window, true)
 
         // Add system bar insets to the fragment's root
         ViewCompat.setOnApplyWindowInsetsListener(binding.snackRoot) { v, windowInsets ->

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/LoginPrologueCarouselFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/LoginPrologueCarouselFragment.kt
@@ -54,9 +54,9 @@ class LoginPrologueCarouselFragment : Fragment(R.layout.fragment_login_prologue_
         val binding = FragmentLoginPrologueCarouselBinding.bind(view)
 
         val isTablet = DisplayUtils.isTablet(context) || DisplayUtils.isXLargeTablet(context)
-        ViewCompat.setOnApplyWindowInsetsListener(binding.buttonSkip) { v, windowInsets ->
+        ViewCompat.setOnApplyWindowInsetsListener(binding.root) { _, windowInsets ->
             val insets = windowInsets.getInsets(WindowInsetsCompat.Type.systemBars())
-            v.updateLayoutParams<MarginLayoutParams> {
+            binding.buttonSkip.updateLayoutParams<MarginLayoutParams> {
                 val currentBottomMargin = resources.getDimension(R.dimen.prologue_button_skip_bottom_margin)
                 bottomMargin = currentBottomMargin.roundToInt() + insets.bottom
                 if (!isTablet) {


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Part of: woocommerce/woomobile-private#376
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
 Enabling and disabling carousel and prologue screens was not working properly on API 29 devices. This fixes issues:
- On API 29 devices, SKIP button on the carousel screen was under the navigation bar.
- On API 29 devices, the Continue button on the login screen was under the keyboard.

### Steps to reproduce
<!-- Step-by-step testing instructions. For new user flows, consider instead stating the goal of the workflow and see if your PR reviewer can accomplish the workflow without specific steps! -->
1. Launch the app on an API 29 device.
2. Test the first screen, which is carousel screen.
3. Continue the flow and test the screen that asks store address.

### Testing information
<!-- This is your opportunity to break out individual scenarios that need testing (when necessary) and/or include a checklist for the reviewer to go through. Consider documenting the following from your own completed testing: devices used, alternate workflows, edge cases, affected areas, critical flows, areas not tested, and any remaining unknowns. Provide feedback on this new section of the PR template through Sept 30, 2024 to Apps Quality; additional context here: p91TBi-b8z-p2#comment-12036 -->
Please also test on the latest API (API 35).

### The tests that have been performed
<!-- To give the reviewer an idea of what could be missed in terms of testing -->
Steps above

### Images/gif
<!-- Include before and after images or gifs when appropriate. -->
|Before|After|
|-|-|
|<img src="https://github.com/user-attachments/assets/c028db0a-848c-4ae7-8490-bd0a03265a84" width=480>|<img src="https://github.com/user-attachments/assets/9ffaeb20-a3ad-4c58-837f-e8e56847612e" width=480>|
|<img src="https://github.com/user-attachments/assets/da20c943-389f-467b-8b1b-8692f5c76665" width=480>|<img src="https://github.com/user-attachments/assets/ad1c5eae-6834-413b-ad9b-f829562828d6" width=480>|

- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.

## Reviewer (or Author, in the case of optional code reviews):

Please make sure these conditions are met before approving the PR, or request changes if the PR needs improvement:

- [ ] The PR is small and has a clear, single focus, or a valid explanation is provided in the description. If needed, please request to split it into smaller PRs.
- [ ] Ensure Adequate Unit Test Coverage: The changes are reasonably covered by unit tests or an explanation is provided in the PR description.
- [ ] Manual Testing: The author listed all the tests they ran, including smoke tests when needed (e.g., for refactorings). The reviewer confirmed that the PR works as expected on big (tablet) and small (phone) in case of UI changes, and no regressions are added.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->