### PR TITLE
[Dependency Cache] Remove Restore Cache CI Hook

### DIFF
--- a/.buildkite/hooks/pre-command
+++ b/.buildkite/hooks/pre-command
@@ -1,8 +1,0 @@
-#!/bin/bash
-
-# Note that as the script is sourced, not run directly, the shebang line will be ignored
-# See https://buildkite.com/docs/agent/v3/hooks#creating-hook-scripts
-
-set -e
-
-restore_gradle_dependency_cache || true


### PR DESCRIPTION
Project Thread: paaHJt-7CE-p2
(Softly) Required By: [a8c-ci-toolkit#135](https://github.com/Automattic/a8c-ci-toolkit-buildkite-plugin/pull/135)

<!-- Remember about a good descriptive title. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

This PR removes the CI `pre-command` hook that was responsible to trigger `restore_gradle_dependency_cache`.

With this hook present, every build and its within jobs are all restoring the dependency cache, even when this is not really needed, and as such, potentially, unnecessarily delaying some jobs, while also consuming unnecessary resources (downloading from s3, (un)compressing, etc).

FYI: It is better to use `restore_gradle_dependency_cache` only on those jobs that could really benefit from it.

PS: Also, based on the current state of things, with the dependency cache save/restore mechanism being stale, this
`restore_gradle_dependency_cache` command is not working as expected. No cache entry is found for `GRADLE_DEPENDENCY_CACHE` is being output on every build/job that runs on an `android` agent, plus an this `GRADLE_RO_DEP_CACHE: unbound variable` is being output on every build/job that runs on another agent (like the `linter` agent).

----

### Testing information
<!-- This is your opportunity to break out individual scenarios that need testing (when necessary) and/or include a checklist for the reviewer to go through. Consider documenting the following from your own completed testing: devices used, alternate workflows, edge cases, affected areas, critical flows, areas not tested, and any remaining unknowns. Provide feedback on this new section of the PR template through Sept 30, 2024 to Apps Quality; additional context here: p91TBi-b8z-p2#comment-12036 -->

Just verify that all the CI checks are successful. 

----

- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.

## Reviewer (or Author, in the case of optional code reviews):

Please make sure these conditions are met before approving the PR, or request changes if the PR needs improvement: `N/A`

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->