### PR TITLE
Update origin address endpoint

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/networking/WooShippingLabelRestClient.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/networking/WooShippingLabelRestClient.kt
@@ -111,7 +111,7 @@ class WooShippingLabelRestClient @Inject constructor(
     suspend fun fetchOriginAddresses(
         site: SiteModel,
     ): WooPayload<Array<OriginAddressDTO>> {
-        val url = "/wcshipping/v1/origin-addresses/"
+        val url = "/wcshipping/v1/address/origins"
         return wooNetwork.executeGetGsonRequest(
             site = site,
             path = url,


### PR DESCRIPTION
Part of: #12437

### Description
This PR updates the get origin addresses endpoint to use the `address/origins` route, not the deprecated `origin-addresses`.

More context p1735753074739799/1734441247.830119-slack-C05VBLKHHV1

### Testing information
Make sure CI passes

### The tests that have been performed
Check that the endpoint retrieves the expected information

- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.

## Reviewer (or Author, in the case of optional code reviews):

Please make sure these conditions are met before approving the PR, or request changes if the PR needs improvement:

- [x] The PR is small and has a clear, single focus, or a valid explanation is provided in the description. If needed, please request to split it into smaller PRs.
- [x] Ensure Adequate Unit Test Coverage: The changes are reasonably covered by unit tests or an explanation is provided in the PR description.
- [x] Manual Testing: The author listed all the tests they ran, including smoke tests when needed (e.g., for refactorings). The reviewer confirmed that the PR works as expected on big (tablet) and small (phone) in case of UI changes, and no regressions are added.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->