### PR TITLE
Fix pencil icon color to work both on light and dark mode

### DIFF
--- a/WooCommerce/src/main/res/drawable/ic_edit_pencil.xml
+++ b/WooCommerce/src/main/res/drawable/ic_edit_pencil.xml
@@ -1,5 +1,9 @@
-<vector xmlns:android="http://schemas.android.com/apk/res/android" android:height="24dp" android:tint="#000000" android:viewportHeight="24" android:viewportWidth="24" android:width="24dp">
-      
-    <path android:fillColor="@android:color/white" android:pathData="M14.06,9.02l0.92,0.92L5.92,19L5,19v-0.92l9.06,-9.06M17.66,3c-0.25,0 -0.51,0.1 -0.7,0.29l-1.83,1.83 3.75,3.75 1.83,-1.83c0.39,-0.39 0.39,-1.02 0,-1.41l-2.34,-2.34c-0.2,-0.2 -0.45,-0.29 -0.71,-0.29zM14.06,6.19L3,17.25L3,21h3.75L17.81,9.94l-3.75,-3.75z"/>
-    
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:height="24dp"
+    android:viewportHeight="24"
+    android:viewportWidth="24"
+    android:width="24dp">
+
+    <path android:fillColor="@color/color_primary" android:pathData="M14.06,9.02l0.92,0.92L5.92,19L5,19v-0.92l9.06,-9.06M17.66,3c-0.25,0 -0.51,0.1 -0.7,0.29l-1.83,1.83 3.75,3.75 1.83,-1.83c0.39,-0.39 0.39,-1.02 0,-1.41l-2.34,-2.34c-0.2,-0.2 -0.45,-0.29 -0.71,-0.29zM14.06,6.19L3,17.25L3,21h3.75L17.81,9.94l-3.75,-3.75z"/>
+
 </vector>


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->


<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

When beta testing 21.4, @itsmeichigo reported this issue where the pencil icon for editing status in Order Details is hard to see:

<img src="https://github.com/user-attachments/assets/87883eb3-63c3-4f17-862a-a809bd3beece" width="42%">

This PR sets the icon to use `color_primary`, which is commonly used in other tappable icons in the app. The result is like this:

<img src="https://github.com/user-attachments/assets/d56b55a3-afa7-49b6-aafe-1d375de56508" width="42%">

#### Additional discussion

The affected icon is actually used in different places in the app:

![Screenshot 2025-01-15 at 20 26 24](https://github.com/user-attachments/assets/89c89c38-3cf0-43d4-8873-d9012dbc486b)

However, we're not hearing about color issue in dark mode in other places where this icon is used. This is because whenever it is used, either in Compose or XML, its tint is also set separately there (e.g: with `app:iconTint="@color/color_primary"` or `tint = MaterialTheme.colors.primary`). 

With the change introduced in this PR, technically, those separate color settings are not needed anymore and can be deleted. However, deleting them means it will require us extra time to check each individual area that uses it. This will have to be done not just during PR review, but also later during beta testing. 

Thinking about that trade-off, I decided not to remove the individual setting and just leave them be, to save us time.

### Steps to reproduce
<!-- Step-by-step testing instructions. For new user flows, consider instead stating the goal of the workflow and see if your PR reviewer can accomplish the workflow without specific steps! -->

Build app, then edit an Order in Dark Mode. Ensure the pencil icon next to the Order status is visible in purple color, similar to screenshot above.

### Testing information
<!-- This is your opportunity to break out individual scenarios that need testing (when necessary) and/or include a checklist for the reviewer to go through. Consider documenting the following from your own completed testing: devices used, alternate workflows, edge cases, affected areas, critical flows, areas not tested, and any remaining unknowns. Provide feedback on this new section of the PR template through Sept 30, 2024 to Apps Quality; additional context here: p91TBi-b8z-p2#comment-12036 -->

### The tests that have been performed
<!-- To give the reviewer an idea of what could be missed in terms of testing -->
Listed above. 

### Images/gif
<!-- Include before and after images or gifs when appropriate. -->
Added above.

- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.

## Reviewer (or Author, in the case of optional code reviews):

Please make sure these conditions are met before approving the PR, or request changes if the PR needs improvement:

- [x] The PR is small and has a clear, single focus, or a valid explanation is provided in the description. If needed, please request to split it into smaller PRs.
- [ ] Ensure Adequate Unit Test Coverage: The changes are reasonably covered by unit tests or an explanation is provided in the PR description.
- [x] Manual Testing: The author listed all the tests they ran, including smoke tests when needed (e.g., for refactorings). The reviewer confirmed that the PR works as expected on big (tablet) and small (phone) in case of UI changes, and no regressions are added.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->