### PR TITLE
Edit origin address navigation

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/WooShippingLabelCreationFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/WooShippingLabelCreationFragment.kt
@@ -60,6 +60,13 @@ class WooShippingLabelCreationFragment : BaseFragment(), BackPressListener {
                             purchaseData = event.purchaseData
                         ).let { findNavController().navigateSafely(it) }
                 }
+
+                is WooShippingLabelCreationViewModel.StartOriginAddressEdit ->
+                    WooShippingLabelCreationFragmentDirections
+                        .actionWooShippingLabelCreationFragmentToWooShippingEditOriginAddressFragment(
+                            originAddress = event.originAddress
+                        ).let { findNavController().navigateSafely(it) }
+
                 is MultiLiveEvent.Event.Exit -> findNavController().navigateUp()
             }
         }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/WooShippingLabelCreationScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/WooShippingLabelCreationScreen.kt
@@ -94,6 +94,7 @@ fun WooShippingLabelCreationScreen(viewModel: WooShippingLabelCreationViewModel)
                 shippingRatesState = viewState.shippingRates,
                 packageSelectionState = viewState.packageSelection,
                 onShippingFromAddressChange = viewModel::onShippingFromAddressChange,
+                onEditOriginAddress = viewModel::onEditOriginAddress,
                 onSelectedRateSortOrderChanged = viewModel::onSelectedRateSortOrderChanged,
                 onRefreshShippingRates = viewModel::onRefreshShippingRates,
                 onSelectedSippingRateChanged = viewModel::onSelectedSippingRateChanged,
@@ -124,6 +125,7 @@ fun WooShippingLabelCreationScreen(
     packageSelectionState: PackageSelectionState,
     shippingAddresses: WooShippingAddresses,
     onShippingFromAddressChange: (OriginShippingAddress) -> Unit,
+    onEditOriginAddress: (OriginShippingAddress) -> Unit,
     onSelectPackageClick: () -> Unit,
     onPurchaseShippingLabel: () -> Unit,
     onSelectedRateSortOrderChanged: (ShippingSortOption) -> Unit,
@@ -185,6 +187,7 @@ fun WooShippingLabelCreationScreen(
             shippingRatesState = shippingRatesState,
             packageSelectionState = packageSelectionState,
             onShippingFromAddressChange = onShippingFromAddressChange,
+            onEditOriginAddress = onEditOriginAddress,
             onSelectedRateSortOrderChanged = onSelectedRateSortOrderChanged,
             onRefreshShippingRates = onRefreshShippingRates,
             customWeight = customWeight,
@@ -253,6 +256,7 @@ private fun LabelCreationScreenWithBottomSheet(
     packageSelectionState: PackageSelectionState,
     onSelectPackageClick: () -> Unit,
     shippingAddresses: WooShippingAddresses,
+    onEditOriginAddress: (OriginShippingAddress) -> Unit,
     onShippingFromAddressChange: (OriginShippingAddress) -> Unit,
     onSelectedRateSortOrderChanged: (ShippingSortOption) -> Unit,
     onRefreshShippingRates: () -> Unit,
@@ -281,6 +285,7 @@ private fun LabelCreationScreenWithBottomSheet(
                 onShippingFromAddressChange = onShippingFromAddressChange,
                 modalBottomSheetState = shipFromSelectionBottomSheetState,
                 modifier = Modifier.padding(bottom = paddingBottom),
+                onEditOriginAddress = onEditOriginAddress
             ) {
                 ShipmentDetails(
                     shippableItems = shippableItems,
@@ -638,6 +643,7 @@ private fun WooShippingLabelCreationScreenPreview() {
             onSelectedSippingRateChanged = {},
             onMarkOrderCompleteChange = {},
             onNavigateBack = {},
+            onEditOriginAddress = {},
             purchaseState = WooShippingLabelCreationViewModel.PurchaseState.NoStarted,
             uiState = WooShippingLabelCreationViewModel.UIControlsState(
                 markOrderComplete = false,

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/WooShippingLabelCreationViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/WooShippingLabelCreationViewModel.kt
@@ -304,6 +304,10 @@ class WooShippingLabelCreationViewModel @Inject constructor(
         }
     }
 
+    fun onEditOriginAddress(address: OriginShippingAddress) {
+        triggerEvent(StartOriginAddressEdit(address))
+    }
+
     fun onShippingToAddressChange(address: Address) {
         shippingAddresses.value?.let {
             shippingAddresses.value = it.copy(shipTo = address)
@@ -452,16 +456,19 @@ class WooShippingLabelCreationViewModel @Inject constructor(
                 uiState.update { it.copy(isAddressSelectionExpanded = false) }
                 false
             }
+
             state.isShipmentDetailsExpanded -> {
                 uiState.update { it.copy(isShipmentDetailsExpanded = false) }
                 false
             }
+
             else -> true
         }
     }
 
     data object StartPackageSelection : Event()
     data class LabelPurchased(val purchaseData: PurchasedShippingLabelData) : Event()
+    data class StartOriginAddressEdit(val originAddress: OriginShippingAddress) : Event()
 
     sealed class WooShippingViewState {
         data object Error : WooShippingViewState()

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/address/AddressSection.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/address/AddressSection.kt
@@ -348,6 +348,7 @@ fun AddressSelection(
     shipFrom: OriginShippingAddress,
     originAddresses: List<OriginShippingAddress>,
     onShippingFromAddressChange: (OriginShippingAddress) -> Unit,
+    onEditOriginAddress: (OriginShippingAddress) -> Unit,
     modifier: Modifier = Modifier,
     content: @Composable () -> Unit = {}
 ) {
@@ -374,6 +375,7 @@ fun AddressSelection(
                     AddressSelectionItem(
                         address = option,
                         isSelected = isSelected,
+                        onEdit = onEditOriginAddress,
                         onClick = {
                             onShippingFromAddressChange(option)
                         },
@@ -400,6 +402,7 @@ fun AddressSelectionItem(
     address: OriginShippingAddress,
     isSelected: Boolean,
     onClick: () -> Unit,
+    onEdit: (OriginShippingAddress) -> Unit,
     modifier: Modifier = Modifier
 ) {
     val borderColor = if (isSelected) {
@@ -438,7 +441,7 @@ fun AddressSelectionItem(
                 )
             }
             IconButton(
-                onClick = { }
+                onClick = { onEdit(address) }
             ) {
                 Icon(
                     painter = painterResource(id = R.drawable.ic_edit_pencil),

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/address/origin/WooShippingEditOriginAddressFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/address/origin/WooShippingEditOriginAddressFragment.kt
@@ -1,0 +1,36 @@
+package com.woocommerce.android.ui.orders.wooshippinglabels.address.origin
+
+import android.os.Bundle
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.material.Text
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.ComposeView
+import androidx.compose.ui.platform.ViewCompositionStrategy.DisposeOnViewTreeLifecycleDestroyed
+import com.woocommerce.android.ui.base.BaseFragment
+import com.woocommerce.android.ui.compose.theme.WooThemeWithBackground
+import com.woocommerce.android.ui.main.AppBarStatus
+import dagger.hilt.android.AndroidEntryPoint
+
+@AndroidEntryPoint
+class WooShippingEditOriginAddressFragment : BaseFragment() {
+
+    override val activityAppBarStatus: AppBarStatus = AppBarStatus.Hidden
+
+    override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View {
+        return ComposeView(requireContext()).apply {
+            setViewCompositionStrategy(DisposeOnViewTreeLifecycleDestroyed)
+            setContent {
+                WooThemeWithBackground {
+                    Box(modifier = Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
+                        Text("Edit Origin Address")
+                    }
+                }
+            }
+        }
+    }
+}

--- a/WooCommerce/src/main/res/navigation/nav_graph_orders.xml
+++ b/WooCommerce/src/main/res/navigation/nav_graph_orders.xml
@@ -745,6 +745,9 @@
             android:id="@+id/action_wooShippingLabelCreationFragment_to_wooShippingLabelPurchasedFragment"
             app:destination="@id/wooShippingLabelPurchasedFragment"
             app:popUpTo="@id/orderDetailFragment" />
+        <action
+            android:id="@+id/action_wooShippingLabelCreationFragment_to_wooShippingEditOriginAddressFragment"
+            app:destination="@id/wooShippingEditOriginAddressFragment" />
     </fragment>
     <fragment
         android:id="@+id/wooShippingLabelPackageCreationFragment"
@@ -767,5 +770,13 @@
         <action
             android:id="@+id/action_wooShippingLabelPurchasedFragment_to_printShippingLabelInfoFragment"
             app:destination="@id/printShippingLabelInfoFragment" />
+    </fragment>
+    <fragment
+        android:id="@+id/wooShippingEditOriginAddressFragment"
+        android:name="com.woocommerce.android.ui.orders.wooshippinglabels.address.origin.WooShippingEditOriginAddressFragment"
+        android:label="WooShippingEditOriginAddressFragment" >
+        <argument
+            android:name="originAddress"
+            app:argType="com.woocommerce.android.ui.orders.wooshippinglabels.models.OriginShippingAddress" />
     </fragment>
 </navigation>


### PR DESCRIPTION
Part of: #12439

### Description
This PR adds the necessary changes to navigate from the origin order selection to the edit origin order fragment. The PR focuses only on the navigation part; in the next PR, I will work on the edit origin order fragment UI, the address validation, and returning the edited address to the main flow.

### Testing information

1. Open the orders tab
2. Tap on an order eligible for shipping label creation
3. Expand the shipment details section
4. Expand on the origin address selection (3 dots)
5. Tap on the pencil
6. Check that the UI navigates to the edit origin address screen

### The tests that have been performed
Checking that the navigation works as expected

### Images/gif

https://github.com/user-attachments/assets/6c40f109-2ff8-40e2-82ef-93ed24e20272


- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.

## Reviewer (or Author, in the case of optional code reviews):

Please make sure these conditions are met before approving the PR, or request changes if the PR needs improvement:

- [x] The PR is small and has a clear, single focus, or a valid explanation is provided in the description. If needed, please request to split it into smaller PRs.
- [x] Ensure Adequate Unit Test Coverage: The changes are reasonably covered by unit tests or an explanation is provided in the PR description.
- [x] Manual Testing: The author listed all the tests they ran, including smoke tests when needed (e.g., for refactorings). The reviewer confirmed that the PR works as expected on big (tablet) and small (phone) in case of UI changes, and no regressions are added.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->