### PR TITLE
[Gradle] Update Build Scans Config (`Develocity`)

### DIFF
--- a/WooCommerce/build.gradle
+++ b/WooCommerce/build.gradle
@@ -163,7 +163,7 @@ android {
     }
 
     lintOptions {
-        sarifReport System.getenv('CI') ? true : false
+        sarifReport gradle.ext.isCi
         checkDependencies true
         disable 'InvalidPackage'
     }

--- a/build.gradle
+++ b/build.gradle
@@ -34,7 +34,7 @@ ext {
 measureBuilds {
     enable = secretProperties.get('measureBuildsEnabled')?.toBoolean() ?: false
     automatticProject = MeasureBuildsExtension.AutomatticProject.WooCommerce
-    attachGradleScanId = true
+    attachGradleScanId = false
     authToken = secretProperties.get('appsMetricsToken')
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -24,8 +24,6 @@ ext {
             file("${rootDir}/defaults.properties"),
             file("${System.getProperty("user.home")}/.configure/woocommerce-android/secrets/secrets.properties")
     )
-    userEnabledTracking = secretProperties.get('measureBuildsEnabled')?.toBoolean() ?: false
-
     developerProperties = loadPropertiesWithFallback(
             logger,
             file("${rootDir}/developer.properties-example"),
@@ -34,7 +32,7 @@ ext {
 }
 
 measureBuilds {
-    enable = userEnabledTracking
+    enable = secretProperties.get('measureBuildsEnabled')?.toBoolean() ?: false
     automatticProject = MeasureBuildsExtension.AutomatticProject.WooCommerce
     attachGradleScanId = true
     authToken = secretProperties.get('appsMetricsToken')

--- a/build.gradle
+++ b/build.gradle
@@ -112,4 +112,3 @@ tasks.register("installGitHooks", Copy) {
 }
 
 apply from: './config/gradle/jacoco.gradle'
-apply from: './config/gradle/gradle_build_scan.gradle'

--- a/config/gradle/gradle_build_cache.gradle
+++ b/config/gradle/gradle_build_cache.gradle
@@ -1,6 +1,6 @@
 
 // Only run build cache on CI builds.
-if (System.getenv('CI')) {
+if (gradle.ext.isCi) {
     buildCache {
         remote(HttpBuildCache) {
             url = "http://10.0.2.215:5071/cache/"

--- a/config/gradle/gradle_build_scan.gradle
+++ b/config/gradle/gradle_build_scan.gradle
@@ -1,11 +1,13 @@
 Boolean isBuildOnCI = (System.getenv('CI') ?: false).toBoolean()
 
 if (isBuildOnCI) {
-    buildScan {
-        termsOfServiceUrl = 'https://gradle.com/terms-of-service'
-        termsOfServiceAgree = 'yes'
-        publishAlways()
-        tag 'CI'
-        uploadInBackground = false
+    develocity {
+        buildScan {
+            termsOfUseUrl = 'https://gradle.com/terms-of-service'
+            termsOfUseAgree = 'yes'
+            tag 'CI'
+            publishing.onlyIf { true }
+            uploadInBackground = false
+        }
     }
 }

--- a/config/gradle/gradle_build_scan.gradle
+++ b/config/gradle/gradle_build_scan.gradle
@@ -5,15 +5,7 @@ if (isBuildOnCI) {
         termsOfServiceUrl = 'https://gradle.com/terms-of-service'
         termsOfServiceAgree = 'yes'
         publishAlways()
-        if (isBuildOnCI) {
-            tag 'CI'
-            uploadInBackground = false
-        } else {
-            obfuscation {
-                username { username -> username.digest('SHA-1') }
-                hostname { _ -> "" }
-                ipAddresses { addresses -> addresses.collect { address -> "0.0.0.0" } }
-            }
-        }
+        tag 'CI'
+        uploadInBackground = false
     }
 }

--- a/config/gradle/gradle_build_scan.gradle
+++ b/config/gradle/gradle_build_scan.gradle
@@ -10,4 +10,10 @@ if (isBuildOnCI) {
             uploadInBackground = false
         }
     }
+} else {
+    develocity {
+        buildScan {
+            publishing.onlyIf { false }
+        }
+    }
 }

--- a/config/gradle/gradle_build_scan.gradle
+++ b/config/gradle/gradle_build_scan.gradle
@@ -1,6 +1,6 @@
 Boolean isBuildOnCI = (System.getenv('CI') ?: false).toBoolean()
 
-if (isBuildOnCI || userEnabledTracking) {
+if (isBuildOnCI) {
     buildScan {
         termsOfServiceUrl = 'https://gradle.com/terms-of-service'
         termsOfServiceAgree = 'yes'

--- a/config/gradle/gradle_build_scan.gradle
+++ b/config/gradle/gradle_build_scan.gradle
@@ -1,6 +1,6 @@
-Boolean isBuildOnCI = (System.getenv('CI') ?: false).toBoolean()
 
-if (isBuildOnCI) {
+// Only run build scan on CI builds.
+if (gradle.ext.isCi) {
     develocity {
         buildScan {
             termsOfUseUrl = 'https://gradle.com/terms-of-service'

--- a/settings.gradle
+++ b/settings.gradle
@@ -17,7 +17,7 @@ pluginManagement {
 }
 
 plugins {
-    id 'com.gradle.enterprise' version '3.17.2'
+    id 'com.gradle.develocity' version '3.19'
 }
 
 dependencyResolutionManagement {

--- a/settings.gradle
+++ b/settings.gradle
@@ -94,4 +94,5 @@ gradle.ext {
 
 apply from: './config/gradle/include_builds.gradle'
 apply from: './config/gradle/gradle_build_cache.gradle'
+apply from: './config/gradle/gradle_build_scan.gradle'
 include ':WooCommerce-Wear'

--- a/settings.gradle
+++ b/settings.gradle
@@ -20,6 +20,8 @@ plugins {
     id 'com.gradle.develocity' version '3.19'
 }
 
+gradle.ext.isCi = System.getenv('CI')?.toBoolean() ?: false
+
 dependencyResolutionManagement {
     repositoriesMode.set(RepositoriesMode.FAIL_ON_PROJECT_REPOS)
     repositories {


### PR DESCRIPTION
Check Also: [JP/WPAndroid#21234](https://github.com/wordpress-mobile/WordPress-Android/pull/21234)

<!-- Remember about a good descriptive title. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

This PR updates [build scans](https://gradle.com/develocity/product/build-scan/) configuration for this project. Also, it updates from `com.gradle.enterprise` pointing to `3.17.2` into the latest `com.gradle.develocity` version ([3.19](https://plugins.gradle.org/plugin/com.gradle.develocity/3.19)). 🏗️

The main goal of this PR is to make the `buildScan` related configuration consistent with the rest of the projects (as discussed: p1737118736712299/1737108520.561709-slack-C030U03RC8Y). As such, the main changes that is happening here are:

1. The `userEnabledTracking` configuration is removed. No more having `buildScan` running by default locally for (at least) internal developers. (965aff3bf2aa265ccfc9e04c2d3e4156b2e1952e)
2. The `obfuscation` configuration is removed. Now that `buildScan` is not running locally by default, this is not really needed. (b218109175cd81366a0a9fd97cc54efc2f1cded2)
3. `com.gradle.enterprise` updated to `com.gradle.develocity` version ([3.19](https://plugins.gradle.org/plugin/com.gradle.develocity/3.19)). (71a97f291ff167fffc6f3f309a224a06bda29e80)
4. The `attachGradleScanId` is being disabled. This feature wasn't very useful, not used once, and it is
planned to be removed. (140fa3fd68c6bd35722ffd458a4f7e603800deaf)

> [!Note]
> Unrelated to anything Gradle [build scans](https://gradle.com/develocity/product/build-scan/), but as part of this 15ab1cf7c7cf1e3cc29b3a4eae1b795ffee7284a change I noticed that both, the [includeSourceContext & autoUploadSourceContext](https://github.com/woocommerce/woocommerce-android/blob/51f62d3e94e3f7a18489e3a6e40a374747e96a57/WooCommerce/build.gradle#L34-L35) are `true` (for both the `Mobile` and `Wear` app). However, when comparing that configuration to how [JP/WPAndroid](https://github.com/wordpress-mobile/WordPress-Android) is configured, I noticed that the same configuration is based on the `isCI` flag (see [includeSourceContext & includeProguardMapping](https://github.com/wordpress-mobile/WordPress-Android/blob/bf8cad0173c37e9824086b42f6c396b2ad09da88/WordPress/build.gradle#L77-L78)). My question being, shouldn't we depend on the `isCI` flag for this project as well? 🤔 

---

### Testing information
<!-- This is your opportunity to break out individual scenarios that need testing (when necessary) and/or include a checklist for the reviewer to go through. Consider documenting the following from your own completed testing: devices used, alternate workflows, edge cases, affected areas, critical flows, areas not tested, and any remaining unknowns. Provide feedback on this new section of the PR template through Sept 30, 2024 to Apps Quality; additional context here: p91TBi-b8z-p2#comment-12036 -->

- For `local` builds:
  - Run any `gradlew` task (ie. `assembleJalapenoDebug`) and notice that, at the very end, there is no build scan publishing happening.
  - Run any `gradlew` task (ie. `assembleJalapenoDebug`) with `--scan` and make sure that issuing a build scan on demand works as expected.
- For `ci` builds:
  - Per specific build job (below), notice that build scan is being published and a `gradle.com/s/xyz` link is available for that build job/task (example [Prototype Build](https://buildkite.com/automattic/woocommerce-android/builds/26667#019474c2-0acd-4ecc-b1a5-ee29dcf838a6/235-533) -> [Build Scan](https://scans.gradle.com/s/yuwlmwrbktraw)).

PS: Just because of this 71a97f291ff167fffc6f3f309a224a06bda29e80 commit, which updates to [3.19](https://plugins.gradle.org/plugin/com.gradle.develocity/3.19), you would also want to verify that everything is still working as expected with `build cache`:

[Prototype Build](https://buildkite.com/automattic/woocommerce-android/builds/26667#019474c2-0acd-4ecc-b1a5-ee29dcf838a6/235-533) -> [Build Scan](https://scans.gradle.com/s/yuwlmwrbktraw) -> [Performance [Build Cache]](https://scans.gradle.com/s/yuwlmwrbktraw/performance/build-cache) -> Check `Remote cache -> Configuration -> URL` & Any Other Configurations

---

- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.

## Reviewer (or Author, in the case of optional code reviews):

Please make sure these conditions are met before approving the PR, or request changes if the PR needs improvement:

- [x] The PR is small and has a clear, single focus, or a valid explanation is provided in the description. If needed, please request to split it into smaller PRs.
- [x] Ensure Adequate Unit Test Coverage: The changes are reasonably covered by unit tests or an explanation is provided in the PR description.
- [x] Manual Testing: The author listed all the tests they ran, including smoke tests when needed (e.g., for refactorings). The reviewer confirmed that the PR works as expected on big (tablet) and small (phone) in case of UI changes, and no regressions are added.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->