### PR TITLE
Edit origin address controls

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/address/WooShippingEditAddressScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/address/WooShippingEditAddressScreen.kt
@@ -1,0 +1,315 @@
+package com.woocommerce.android.ui.orders.wooshippinglabels.address
+
+import androidx.compose.animation.AnimatedContent
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.text.BasicTextField
+import androidx.compose.foundation.text.KeyboardOptions
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material.Icon
+import androidx.compose.material.MaterialTheme
+import androidx.compose.material.Scaffold
+import androidx.compose.material.Text
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material.icons.filled.Add
+import androidx.compose.material.icons.filled.ArrowDropDown
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.colorResource
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.input.KeyboardType
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import com.woocommerce.android.R
+import com.woocommerce.android.extensions.isNotNullOrEmpty
+import com.woocommerce.android.ui.compose.component.Toolbar
+import com.woocommerce.android.ui.orders.wooshippinglabels.RoundedCornerBoxWithBorder
+
+@Composable
+fun WooShippingEditAddressScreen(
+    modifier: Modifier = Modifier
+) {
+    Scaffold(
+        topBar = {
+            Toolbar(
+                title = stringResource(id = R.string.woo_shipping_edit_origin_address_title),
+                onNavigationButtonClick = {},
+                navigationIcon = Icons.AutoMirrored.Filled.ArrowBack
+            )
+        },
+        backgroundColor = MaterialTheme.colors.surface
+    ) { padding ->
+        Column(
+            modifier
+                .verticalScroll(rememberScrollState())
+                .padding(padding)
+        ) {
+            RoundedBorderTextFieldWithLabel(
+                label = "${stringResource(id = R.string.woo_shipping_label_name)} *",
+                text = "",
+                onTextChange = {},
+            )
+
+            var isExpanded by remember { mutableStateOf(false) }
+
+            CollapsedField(
+                isExpanded = isExpanded,
+                label = stringResource(id = R.string.woo_shipping_label_company),
+                onExpand = { isExpanded = !isExpanded },
+                modifier = Modifier.fillMaxWidth()
+            ) {
+                RoundedBorderTextFieldWithLabel(
+                    label = stringResource(id = R.string.woo_shipping_label_company),
+                    text = "",
+                    onTextChange = {},
+                    modifier = Modifier.padding(top = 8.dp)
+                )
+            }
+
+            RoundedBorderDropDownWithLabel(
+                label = "${stringResource(id = R.string.woo_shipping_label_country)} *",
+                text = "United States",
+                modifier = Modifier.padding(top = 24.dp),
+                onClick = {}
+            )
+            RoundedBorderTextFieldWithLabel(
+                label = "${stringResource(id = R.string.woo_shipping_label_address)} *",
+                text = "",
+                onTextChange = {},
+                modifier = Modifier.padding(top = 8.dp)
+            )
+            RoundedBorderTextFieldWithLabel(
+                label = "${stringResource(id = R.string.woo_shipping_label_city)} *",
+                text = "",
+                onTextChange = {},
+                modifier = Modifier.padding(top = 8.dp)
+            )
+
+            Row {
+                RoundedBorderDropDownWithLabel(
+                    label = "${stringResource(id = R.string.woo_shipping_label_state)} *",
+                    text = "United States",
+                    modifier = Modifier
+                        .padding(top = 8.dp)
+                        .weight(1f),
+                    onClick = {}
+                )
+                Spacer(modifier = Modifier.size(8.dp))
+                RoundedBorderTextFieldWithLabel(
+                    label = "${stringResource(id = R.string.woo_shipping_label_post_code)} *",
+                    text = "",
+                    keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Number),
+                    onTextChange = {},
+                    modifier = Modifier
+                        .padding(top = 8.dp)
+                        .weight(1f)
+                )
+            }
+
+            RoundedBorderTextFieldWithLabel(
+                label = "${stringResource(id = R.string.woo_shipping_label_email)} *",
+                text = "",
+                onTextChange = {},
+                modifier = Modifier.padding(top = 32.dp)
+            )
+            RoundedBorderTextFieldWithLabel(
+                label = "${stringResource(id = R.string.woo_shipping_label_phone)} *",
+                text = "",
+                onTextChange = {},
+                modifier = Modifier.padding(top = 8.dp)
+            )
+        }
+    }
+}
+
+@Composable
+internal fun RoundedBorderTextFieldWithLabel(
+    label: String,
+    text: String,
+    onTextChange: (String) -> Unit,
+    modifier: Modifier = Modifier,
+    hint: String = "",
+    error: String? = null,
+    keyboardOptions: KeyboardOptions = KeyboardOptions.Default,
+    endSection: @Composable () -> Unit = {}
+) {
+    val hasError = error.isNotNullOrEmpty()
+    val color = if (hasError) {
+        MaterialTheme.colors.error
+    } else {
+        colorResource(R.color.divider_color)
+    }
+    Column(modifier = modifier) {
+        Text(
+            text = label,
+            style = MaterialTheme.typography.body2,
+            modifier = Modifier.padding(vertical = 8.dp)
+        )
+        RoundedCornerBoxWithBorder(
+            borderColor = color
+        ) {
+            Row(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(16.dp)
+            ) {
+                Box(modifier = Modifier.weight(1f)) {
+                    BasicTextField(
+                        modifier = Modifier.fillMaxWidth(),
+                        value = text,
+                        onValueChange = onTextChange,
+                        keyboardOptions = keyboardOptions,
+                        textStyle = MaterialTheme.typography.body2.copy(color = MaterialTheme.colors.onSurface),
+
+                    )
+                    if (text.isEmpty()) {
+                        Text(
+                            text = hint,
+                            style = MaterialTheme.typography.body2,
+                            color = colorResource(id = R.color.color_on_surface_disabled)
+                        )
+                    }
+                }
+                endSection()
+            }
+        }
+        error?.let {
+            Text(
+                text = error,
+                style = MaterialTheme.typography.body2,
+                color = MaterialTheme.colors.error,
+                modifier = Modifier.padding(vertical = 8.dp)
+            )
+        }
+    }
+}
+
+@Preview
+@Composable
+private fun RoundedBorderTextFieldWithLabelPreview() {
+    Column(
+        modifier = Modifier
+            .background(MaterialTheme.colors.background)
+            .padding(16.dp)
+    ) {
+        RoundedBorderTextFieldWithLabel(
+            label = "Label",
+            text = "123",
+            onTextChange = {},
+            hint = "Hint"
+        )
+        Spacer(modifier = Modifier.padding(8.dp))
+        RoundedBorderTextFieldWithLabel(
+            label = "Empty text field",
+            text = "",
+            onTextChange = {},
+            hint = "Hint"
+        )
+        Spacer(modifier = Modifier.padding(8.dp))
+        RoundedBorderTextFieldWithLabel(
+            label = "Required field",
+            text = "",
+            onTextChange = {},
+            hint = "Hint",
+            error = "This field is required"
+        )
+    }
+}
+
+@Composable
+private fun RoundedBorderDropDownWithLabel(
+    label: String,
+    text: String,
+    onClick: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    Column(modifier = modifier) {
+        Text(
+            text = label,
+            style = MaterialTheme.typography.body2,
+            modifier = Modifier.padding(vertical = 8.dp)
+        )
+        RoundedCornerBoxWithBorder(innerModifier = Modifier.clickable { onClick() }) {
+            Row(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(12.dp),
+                verticalAlignment = androidx.compose.ui.Alignment.CenterVertically
+            ) {
+                Text(
+                    text = text,
+                    style = MaterialTheme.typography.body2,
+                    modifier = Modifier.weight(1f)
+                )
+                Icon(
+                    imageVector = Icons.Filled.ArrowDropDown,
+                    contentDescription = null,
+                    tint = MaterialTheme.colors.onSurface
+                )
+            }
+        }
+    }
+}
+
+@Preview
+@Composable
+private fun RoundedBorderDropDownWithLabelPreview() {
+    Column(
+        modifier = Modifier
+            .background(MaterialTheme.colors.background)
+            .padding(16.dp)
+    ) {
+        RoundedBorderDropDownWithLabel(
+            label = "Label",
+            text = "Text",
+            onClick = {}
+        )
+    }
+}
+
+@Composable
+private fun CollapsedField(
+    label: String,
+    isExpanded: Boolean,
+    onExpand: () -> Unit,
+    modifier: Modifier = Modifier,
+    content: @Composable () -> Unit
+) {
+    AnimatedContent(targetState = isExpanded, label = "expand_field_animation") { value ->
+        if (value) {
+            content()
+        } else {
+            Row(
+                modifier = modifier
+                    .clickable { onExpand() }
+                    .padding(vertical = 16.dp, horizontal = 8.dp),
+            ) {
+                Icon(
+                    imageVector = Icons.Filled.Add,
+                    contentDescription = null,
+                    tint = MaterialTheme.colors.primary
+                )
+                Text(
+                    text = stringResource(id = R.string.add, label.lowercase()),
+                    color = MaterialTheme.colors.primary,
+                    modifier = Modifier.padding(start = 8.dp),
+                    fontWeight = FontWeight.Bold
+                )
+            }
+        }
+    }
+}

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/address/origin/WooShippingEditOriginAddressFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/address/origin/WooShippingEditOriginAddressFragment.kt
@@ -2,18 +2,20 @@ package com.woocommerce.android.ui.orders.wooshippinglabels.address.origin
 
 import android.os.Bundle
 import android.view.LayoutInflater
+import android.view.Surface
 import android.view.View
 import android.view.ViewGroup
-import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.material.Text
-import androidx.compose.ui.Alignment
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material.Surface
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.ComposeView
 import androidx.compose.ui.platform.ViewCompositionStrategy.DisposeOnViewTreeLifecycleDestroyed
+import androidx.compose.ui.unit.dp
 import com.woocommerce.android.ui.base.BaseFragment
 import com.woocommerce.android.ui.compose.theme.WooThemeWithBackground
 import com.woocommerce.android.ui.main.AppBarStatus
+import com.woocommerce.android.ui.orders.wooshippinglabels.address.WooShippingEditAddressScreen
 import dagger.hilt.android.AndroidEntryPoint
 
 @AndroidEntryPoint
@@ -26,8 +28,12 @@ class WooShippingEditOriginAddressFragment : BaseFragment() {
             setViewCompositionStrategy(DisposeOnViewTreeLifecycleDestroyed)
             setContent {
                 WooThemeWithBackground {
-                    Box(modifier = Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
-                        Text("Edit Origin Address")
+                    Surface {
+                        WooShippingEditAddressScreen(
+                            modifier = Modifier
+                                .fillMaxSize()
+                                .padding(16.dp)
+                        )
                     }
                 }
             }

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -163,7 +163,7 @@
     <string name="receipt_fetching_error">Sorry, we couldn\'t load a receipt for this order</string>
     <string name="store_name_default">Store name</string>
     <string name="sorted_by">Sorted by 1%s</string>
-
+    <string name="add">Add %s</string>
     <!--
         Date/Time Labels
     -->
@@ -4457,4 +4457,15 @@
     <string name="woo_shipping_labels_package_creation_error_proceed">Proceed</string>
     <string name="woo_shipping_labels_package_creation_error_cancel">Cancel</string>
     <string name="email_not_registered_wpcom">Hmm, we can\'t find a WordPress.com account connected to this email address.</string>
+
+    <string name="woo_shipping_edit_origin_address_title">Edit Origin</string>
+    <string name="woo_shipping_label_name">Name</string>
+    <string name="woo_shipping_label_company">Company</string>
+    <string name="woo_shipping_label_country">Country</string>
+    <string name="woo_shipping_label_address">Address</string>
+    <string name="woo_shipping_label_city">City</string>
+    <string name="woo_shipping_label_state">State</string>
+    <string name="woo_shipping_label_post_code">Postal Code</string>
+    <string name="woo_shipping_label_email">Email</string>
+    <string name="woo_shipping_label_phone">Phone</string>
 </resources>


### PR DESCRIPTION
Part of: #12439

### Description
This PR adds the basic UI to the Edit origin address screen. In this PR, I included the styles input fields, dropdown, and expandable control. The changes submitted here are UI-focused only. In the next PR, I will work on managing the control state and the field validation.

### Testing information

1. Open the orders tab
2. Tap on an order eligible for shipping label creation
3. Expand the shipment details section
4. Expand on the origin address selection (3 dots)
5. Tap on the pencil
6. Check that the UI navigates to the edit origin address screen
7. Check that the screen design is the expected
8. Check that tapping on add company expands the company field

### The tests that have been performed
Check that the UI works as expected

### Images/gif

https://github.com/user-attachments/assets/f3cbfb17-9114-4785-b3b0-f38416575860


- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.

## Reviewer (or Author, in the case of optional code reviews):

Please make sure these conditions are met before approving the PR, or request changes if the PR needs improvement:

- [x] The PR is small and has a clear, single focus, or a valid explanation is provided in the description. If needed, please request to split it into smaller PRs.
- [x] Ensure Adequate Unit Test Coverage: The changes are reasonably covered by unit tests or an explanation is provided in the PR description.
- [x] Manual Testing: The author listed all the tests they ran, including smoke tests when needed (e.g., for refactorings). The reviewer confirmed that the PR works as expected on big (tablet) and small (phone) in case of UI changes, and no regressions are added.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->