### PR TITLE
Crash the debug app when accessing a non-SDK API

### DIFF
--- a/WooCommerce/src/debug/kotlin/com/woocommerce/android/NonSdkApiViolationHandler.kt
+++ b/WooCommerce/src/debug/kotlin/com/woocommerce/android/NonSdkApiViolationHandler.kt
@@ -1,0 +1,19 @@
+package com.woocommerce.android
+
+import android.os.Build
+import android.os.Process
+import android.os.StrictMode.OnVmViolationListener
+import android.os.strictmode.NonSdkApiUsedViolation
+import android.os.strictmode.Violation
+import androidx.annotation.RequiresApi
+import kotlin.system.exitProcess
+
+@RequiresApi(Build.VERSION_CODES.P)
+class NonSdkApiViolationHandler : OnVmViolationListener {
+    override fun onVmViolation(v: Violation) {
+        if (v !is NonSdkApiUsedViolation) return
+        System.err.println("Non-SDK API violation detected: ${v.message}")
+        Process.killProcess(Process.myPid())
+        exitProcess(10)
+    }
+}

--- a/WooCommerce/src/debug/kotlin/com/woocommerce/android/NonSdkApiViolationHandler.kt
+++ b/WooCommerce/src/debug/kotlin/com/woocommerce/android/NonSdkApiViolationHandler.kt
@@ -9,6 +9,7 @@ import androidx.annotation.RequiresApi
 import kotlin.system.exitProcess
 
 @RequiresApi(Build.VERSION_CODES.P)
+@Suppress("MagicNumber")
 class NonSdkApiViolationHandler : OnVmViolationListener {
     override fun onVmViolation(v: Violation) {
         if (v !is NonSdkApiUsedViolation) return

--- a/WooCommerce/src/debug/kotlin/com/woocommerce/android/NonSdkApiViolationHandler.kt
+++ b/WooCommerce/src/debug/kotlin/com/woocommerce/android/NonSdkApiViolationHandler.kt
@@ -5,6 +5,7 @@ import android.os.Process
 import android.os.StrictMode.OnVmViolationListener
 import android.os.strictmode.NonSdkApiUsedViolation
 import android.os.strictmode.Violation
+import android.util.Log
 import androidx.annotation.RequiresApi
 import kotlin.system.exitProcess
 
@@ -13,7 +14,10 @@ import kotlin.system.exitProcess
 class NonSdkApiViolationHandler : OnVmViolationListener {
     override fun onVmViolation(v: Violation) {
         if (v !is NonSdkApiUsedViolation) return
-        System.err.println("Non-SDK API violation detected: ${v.message}")
+        Log.e(
+            NonSdkApiViolationHandler::class.simpleName,
+            "Non-SDK API violation detected: ${v.message}\n${v.stackTraceToString()}"
+        )
         Process.killProcess(Process.myPid())
         exitProcess(10)
     }

--- a/WooCommerce/src/debug/kotlin/com/woocommerce/android/WooCommerceDebug.kt
+++ b/WooCommerce/src/debug/kotlin/com/woocommerce/android/WooCommerceDebug.kt
@@ -64,6 +64,7 @@ class WooCommerceDebug : WooCommerce() {
                 .apply {
                     if (SystemVersionUtils.isAtLeastP()) {
                         detectNonSdkApiUsage()
+                        penaltyListener(mainExecutor, NonSdkApiViolationHandler())
                     }
                 }
                 .build()


### PR DESCRIPTION
### Description
As discussed here p91TBi-cHS-p2#comment-13866, this PR adds a specific violation listener that crashes the app when accessing a non-SDK API.

### Steps to reproduce
1. Apply this patch
```
Index: WooCommerce/src/main/kotlin/com/woocommerce/android/ui/main/MainActivity.kt
IDEA additional info:
Subsystem: com.intellij.openapi.diff.impl.patch.CharsetEP
<+>UTF-8
===================================================================
diff --git a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/main/MainActivity.kt b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/main/MainActivity.kt
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/main/MainActivity.kt	(revision 7e4de2adeb58c708177098b25f7d5097df87f2f1)
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/main/MainActivity.kt	(date 1737391199303)
@@ -289,6 +289,10 @@
     override fun onCreate(savedInstanceState: Bundle?) {
         installSplashScreen()
 
+        val function = Activity::class.java.getDeclaredMethod("setDisablePreviewScreenshots", Boolean::class.java)
+        function.isAccessible = true
+        function.invoke(this, true)
+
         super.onCreate(savedInstanceState)
 
         ChromeCustomTabUtils.registerForPartialTabUsage(this)
```
2. Use a device with Android 12 (API 31). (I couldn't find an API to use with newer devices)
3. Launch the app on debug.
4. Confirm the app crashes and logs the following:
`Non-SDK API violation detected: Landroid/app/Activity;->setDisablePreviewScreenshots(Z)V`

### Testing information
- Confirm the app crashes with this PR changes.

### The tests that have been performed
^

- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.

## Reviewer (or Author, in the case of optional code reviews):

Please make sure these conditions are met before approving the PR, or request changes if the PR needs improvement:

- [ ] The PR is small and has a clear, single focus, or a valid explanation is provided in the description. If needed, please request to split it into smaller PRs.
- [ ] Ensure Adequate Unit Test Coverage: The changes are reasonably covered by unit tests or an explanation is provided in the PR description.
- [ ] Manual Testing: The author listed all the tests they ran, including smoke tests when needed (e.g., for refactorings). The reviewer confirmed that the PR works as expected on big (tablet) and small (phone) in case of UI changes, and no regressions are added.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->