### PR TITLE
[Mobile-Payments] Fix Stripe Extension Setup URL and Align WooPayments URL to Use Connect

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -9,6 +9,7 @@
 - [Internal] [*] XMLRPC is not needed now for Jetpack Connection during an Account Mismatch flow [https://github.com/woocommerce/woocommerce-android/pull/13308]
 - [*] Removed the outdated feedback survey for shipping labels [https://github.com/woocommerce/woocommerce-android/pull/13319]
 - [*] Bulk update order status now shows improved result messages, including for partial success. [https://github.com/woocommerce/woocommerce-android/pull/13275]
+- [*] Updated WooPayments to use the recommended Connect URL for onboarding and corrected the Stripe Gateway setup URL to point to the appropriate settings page. [https://github.com/woocommerce/woocommerce-android/pull/13356]
 
 21.4
 -----

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/cardreader/onboarding/CardReaderOnboardingErrorCtaClickHandler.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/cardreader/onboarding/CardReaderOnboardingErrorCtaClickHandler.kt
@@ -91,7 +91,7 @@ class CardReaderOnboardingErrorCtaClickHandler @Inject constructor(
     }
 
     private fun buildReactionToOpenStripeExtensionSetup(): Reaction {
-        val url = selectedSite.get().adminUrlOrDefault.slashJoin(STRIPE_PAYMENTS_TAP_URL)
+        val url = selectedSite.get().adminUrlOrDefault.slashJoin(STRIPE_EXTENSION_PAYMENTS_TAP_URL)
         return Reaction.OpenBrowser(url)
     }
 
@@ -112,8 +112,8 @@ class CardReaderOnboardingErrorCtaClickHandler @Inject constructor(
 
         private const val PAYMENTS_TAP_URL = "/admin.php?page=wc-admin&path=%2Fpayments%2Fconnect"
 
-        private const val STRIPE_PAYMENTS_TAP_URL = "/admin.php?page=wc-settings&tab=checkout&section=stripe" +
-            "&panel=settings"
+        private const val STRIPE_EXTENSION_PAYMENTS_TAP_URL = "/admin.php?page=wc-settings&tab=checkout&" +
+            "section=stripe&panel=settings"
     }
 }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/cardreader/onboarding/CardReaderOnboardingErrorCtaClickHandler.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/cardreader/onboarding/CardReaderOnboardingErrorCtaClickHandler.kt
@@ -53,7 +53,7 @@ class CardReaderOnboardingErrorCtaClickHandler @Inject constructor(
 
             CardReaderOnboardingCTAErrorType.STRIPE_ACCOUNT_OVERDUE_REQUIREMENTS -> {
                 paymentsFlowTracker.trackOnboardingCtaTapped(OnboardingCtaReasonTapped.STRIPE_ACCOUNT_SETUP_TAPPED)
-                buildReactionToOpenWcPaySetup()
+                buildReactionToOpenStripeExtensionSetup()
             }
         }
 
@@ -90,6 +90,11 @@ class CardReaderOnboardingErrorCtaClickHandler @Inject constructor(
         return Reaction.OpenBrowser(url)
     }
 
+    private fun buildReactionToOpenStripeExtensionSetup(): Reaction {
+        val url = selectedSite.get().adminUrlOrDefault.slashJoin(STRIPE_PAYMENTS_TAP_URL)
+        return Reaction.OpenBrowser(url)
+    }
+
     sealed class Reaction {
         data object Refresh : Reaction()
         data class ShowErrorAndRefresh(val message: String) : Reaction()
@@ -105,7 +110,9 @@ class CardReaderOnboardingErrorCtaClickHandler @Inject constructor(
     companion object {
         private const val WC_PAY_SLUG = "woocommerce-payments"
 
-        private const val PAYMENTS_TAP_URL = "/admin.php?page=wc-admin&path=%2Fpayments%2Foverview"
+        private const val PAYMENTS_TAP_URL = "/admin.php?page=wc-admin&path=%2Fpayments%2Fconnect"
+
+        private const val STRIPE_PAYMENTS_TAP_URL = "/admin.php?page=wc-settings&tab=checkout&section=stripe"
     }
 }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/cardreader/onboarding/CardReaderOnboardingErrorCtaClickHandler.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/cardreader/onboarding/CardReaderOnboardingErrorCtaClickHandler.kt
@@ -112,7 +112,8 @@ class CardReaderOnboardingErrorCtaClickHandler @Inject constructor(
 
         private const val PAYMENTS_TAP_URL = "/admin.php?page=wc-admin&path=%2Fpayments%2Fconnect"
 
-        private const val STRIPE_PAYMENTS_TAP_URL = "/admin.php?page=wc-settings&tab=checkout&section=stripe"
+        private const val STRIPE_PAYMENTS_TAP_URL = "/admin.php?page=wc-settings&tab=checkout&section=stripe" +
+            "&panel=settings"
     }
 }
 

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/payments/cardreader/onboarding/CardReaderOnboardingErrorCtaClickHandlerTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/payments/cardreader/onboarding/CardReaderOnboardingErrorCtaClickHandlerTest.kt
@@ -405,7 +405,7 @@ class CardReaderOnboardingErrorCtaClickHandlerTest : BaseUnitTest() {
             // THEN
             assertThat(result).isEqualTo(
                 CardReaderOnboardingErrorCtaClickHandler.Reaction.OpenBrowser(
-                    url = "$adminUrl/admin.php?page=wc-settings&tab=checkout&section=stripe"
+                    url = "$adminUrl/admin.php?page=wc-settings&tab=checkout&section=stripe&panel=settings"
                 )
             )
         }

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/payments/cardreader/onboarding/CardReaderOnboardingErrorCtaClickHandlerTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/payments/cardreader/onboarding/CardReaderOnboardingErrorCtaClickHandlerTest.kt
@@ -371,7 +371,7 @@ class CardReaderOnboardingErrorCtaClickHandlerTest : BaseUnitTest() {
             // THEN
             assertThat(result).isEqualTo(
                 CardReaderOnboardingErrorCtaClickHandler.Reaction.OpenBrowser(
-                    url = "$adminUrl/admin.php?page=wc-admin&path=%2Fpayments%2Foverview"
+                    url = "$adminUrl/admin.php?page=wc-admin&path=%2Fpayments%2Fconnect"
                 )
             )
         }
@@ -405,7 +405,7 @@ class CardReaderOnboardingErrorCtaClickHandlerTest : BaseUnitTest() {
             // THEN
             assertThat(result).isEqualTo(
                 CardReaderOnboardingErrorCtaClickHandler.Reaction.OpenBrowser(
-                    url = "$adminUrl/admin.php?page=wc-admin&path=%2Fpayments%2Foverview"
+                    url = "$adminUrl/admin.php?page=wc-settings&tab=checkout&section=stripe"
                 )
             )
         }


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #13233
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
This PR addresses two key issues:

1. Fixing the onboarding URL for the Stripe Gateway extension to ensure merchants are directed to the correct setup page.
2. Updating the WooPayments onboarding flow to use the recommended Connect URL (`admin.php?page=wc-admin&path=%2Fpayments%2Fconnect`), replacing the previously used Overview URL (`admin.php?page=wc-admin&path=%2Fpayments%2Foverview`). This change aligns with the backend recommendation that WooPayments handles the redirection between these pages based on the store's setup.

Discussion with backend: pdfdoF-5Bo-p2#comment-6655

Discussion with Quark team: p1737370950144139-slack-C055WHLA98D

**Problem:**

1. The Stripe Gateway onboarding URL was incorrectly pointing to the WooPayments Overview URL, causing merchants to experience a broken flow. Stripe Gateway onboarding requires a dedicated setup URL.
2. The WooPayments onboarding flow was using the Overview URL (admin.php?page=wc-admin&path=%2Fpayments%2Foverview) to start onboarding. Backend feedback indicates that the Connect URL is preferred, as it is designed to handle all redirections based on the store's setup and onboarding state.
4. The mobile app’s CTA directing merchants to complete onboarding in a web view also needed to align with these changes for both WooPayments and Stripe Gateway.


**Solution:**

1. **Stripe Gateway Setup URL:**

Updated the onboarding URL for Stripe Gateway to admin.php?page=wc-settings&tab=checkout&section=stripe, which correctly points to the Stripe-specific settings page for onboarding.

2. **WooPayments Setup URL:**

Replaced the previously used Overview URL (admin.php?page=wc-admin&path=%2Fpayments%2Foverview) with the recommended Connect URL (admin.php?page=wc-admin&path=%2Fpayments%2Fconnect).
WooPayments will now rely on its built-in logic to handle redirection between Overview and Connect based on the store’s setup.

3. **Mobile App Flow:**

Ensured that the app dynamically selects the appropriate URL for onboarding:
Stripe Gateway: admin.php?page=wc-settings&tab=checkout&section=stripe.
WooPayments: admin.php?page=wc-admin&path=%2Fpayments%2Fconnect.


### Steps to reproduce
<!-- Step-by-step testing instructions. For new user flows, consider instead stating the goal of the workflow and see if your PR reviewer can accomplish the workflow without specific steps! -->
Since this change affects the existing onboarding flow for all entry points (POS, IPP, Payments menu), I think focusing on testing the most critical flow, IPP, is the best use of time.

**Scenario 1: Mobile App WooPayments Onboarding:**
Prerequisite: store payment gateway is active but isn't set up completely. Alternatively, you can hard code the state by returning `SetupNotCompleted(WOOCOMMERCE_PAYMENTS)` at the beginning of `fetchOnboardingState` in `CardReaderOnboardingChecker` class

1. Log in to the store with site credentials
2. Navigate to more menu -> Payments
3. Ensure you see onboarding incomplete message at the bottom of the screen
5. Click on it and it takes you to onboarding error screen
6. Click on the "Finish setup" CTA
7. Ensure the web view opens appropriate WooPayments page

**Scenario 2: Mobile App Stripe Gateway Onboarding:**
Prerequisite: store payment gateway is active and set up but account has `restricted` && has `OverdueRequirements`. Alternatively, you can hard code the state by returning `StripeAccountOverdueRequirement(PluginType.STRIPE_EXTENSION_GATEWAY)` at the beginning of `fetchOnboardingState` in `CardReaderOnboardingChecker` class

1. Log in to the store with site credentials
2. Navigate to more menu -> Payments
3. Ensure you see onboarding incomplete message at the bottom of the screen
4. Click on it and it takes you to onboarding error screen
5. Click on the "Resolve now" CTA
6. Ensure the web view opens appropriate Stripe setup page


### Images/gif
<!-- Include before and after images or gifs when appropriate. -->

https://github.com/user-attachments/assets/bb58ce89-ed58-45e0-acc5-7d2de8971fa8


https://github.com/user-attachments/assets/e8d7babc-5c5a-416e-a7c3-6d30b54017eb



- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.

## Reviewer (or Author, in the case of optional code reviews):

Please make sure these conditions are met before approving the PR, or request changes if the PR needs improvement:

- [x] The PR is small and has a clear, single focus, or a valid explanation is provided in the description. If needed, please request to split it into smaller PRs.
- [x] Ensure Adequate Unit Test Coverage: The changes are reasonably covered by unit tests or an explanation is provided in the PR description.
- [x] Manual Testing: The author listed all the tests they ran, including smoke tests when needed (e.g., for refactorings). The reviewer confirmed that the PR works as expected on big (tablet) and small (phone) in case of UI changes, and no regressions are added.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->