### PR TITLE
Handle crash in Bulk Order Update when item position is -1

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/DefaultOrderListItemLookup.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/DefaultOrderListItemLookup.kt
@@ -1,6 +1,7 @@
 package com.woocommerce.android.ui.orders
 
 import android.view.MotionEvent
+import android.view.View
 import androidx.recyclerview.selection.ItemDetailsLookup
 import androidx.recyclerview.widget.RecyclerView
 import com.woocommerce.android.ui.orders.list.OrderListAdapter
@@ -10,17 +11,24 @@ class DefaultOrderListItemLookup(private val recyclerView: RecyclerView) : ItemD
     override fun getItemDetails(event: MotionEvent): ItemDetails<Long>? =
         recyclerView
             .findChildViewUnder(event.x, event.y)
-            ?.let { view ->
-                recyclerView.getChildViewHolder(view)?.let { viewHolder ->
-                    val position = viewHolder.bindingAdapterPosition
-                    val item = (recyclerView.adapter as? OrderListAdapter)?.currentList?.get(position)
-                    if (item is OrderListItemUI) {
-                        DefaultOrderItemDetailsLookup(position, item.orderId)
-                    } else {
-                        null
-                    }
+            ?.let { view -> getDetailsFromView(view) }
+
+    private fun getDetailsFromView(view: View): ItemDetails<Long>? {
+        val viewHolder = recyclerView.getChildViewHolder(view) ?: return null
+        val position = viewHolder.bindingAdapterPosition
+
+        return when {
+            position == RecyclerView.NO_POSITION -> null
+            else -> {
+                val item = (recyclerView.adapter as? OrderListAdapter)?.currentList?.get(position)
+                if (item is OrderListItemUI) {
+                    DefaultOrderItemDetailsLookup(position, item.orderId)
+                } else {
+                    null
                 }
             }
+        }
+    }
 }
 
 class DefaultOrderItemDetailsLookup(


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: https://github.com/woocommerce/woocommerce-android/issues/13358
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

I can't reproduce the issue reported in the linked Sentry issue. [The docs for `getBindingAdapterPosition` says:](https://developer.android.com/reference/androidx/recyclerview/widget/RecyclerView.ViewHolder#getBindingAdapterPosition())

> The adapter position of the item if it still exists in the adapter. [NO_POSITION](https://developer.android.com/reference/androidx/recyclerview/widget/RecyclerView#NO_POSITION()) if item has been removed from the adapter, [notifyDataSetChanged](https://developer.android.com/reference/androidx/recyclerview/widget/RecyclerView.Adapter#notifyDataSetChanged()) has been called after the last layout pass or the ViewHolder has already been recycled.


Nevertheless, since it's a possibility that `viewHolder.bindingAdapterPosition` returns `RecyclerView.NO_POSITION` which is equal to `-1`, this PR adds handling for that by simply returning null when that happens. This makes the selection not happen on the item with no position, but it won't crash anymore. 

### Steps to reproduce
<!-- Step-by-step testing instructions. For new user flows, consider instead stating the goal of the workflow and see if your PR reviewer can accomplish the workflow without specific steps! -->

Since I'm not sure how to test the issue, it's probably good to smoke test the bulk update order feature to ensure that it still works after this PR.

### Testing information
<!-- This is your opportunity to break out individual scenarios that need testing (when necessary) and/or include a checklist for the reviewer to go through. Consider documenting the following from your own completed testing: devices used, alternate workflows, edge cases, affected areas, critical flows, areas not tested, and any remaining unknowns. Provide feedback on this new section of the PR template through Sept 30, 2024 to Apps Quality; additional context here: p91TBi-b8z-p2#comment-12036 -->

n/a

### The tests that have been performed
<!-- To give the reviewer an idea of what could be missed in terms of testing -->

Smoke-tested the feature to ensure it still works with the changes in this PR.

### Images/gif
<!-- Include before and after images or gifs when appropriate. -->

- [ ] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.

## Reviewer (or Author, in the case of optional code reviews):

Please make sure these conditions are met before approving the PR, or request changes if the PR needs improvement:

- [ ] The PR is small and has a clear, single focus, or a valid explanation is provided in the description. If needed, please request to split it into smaller PRs.
- [ ] Ensure Adequate Unit Test Coverage: The changes are reasonably covered by unit tests or an explanation is provided in the PR description.
- [ ] Manual Testing: The author listed all the tests they ran, including smoke tests when needed (e.g., for refactorings). The reviewer confirmed that the PR works as expected on big (tablet) and small (phone) in case of UI changes, and no regressions are added.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->