### PR TITLE
[Image Uploads Improvement] Use low quality images in the product images gallery.

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/widgets/WCProductImageGalleryView.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/widgets/WCProductImageGalleryView.kt
@@ -422,7 +422,12 @@ class WCProductImageGalleryView @JvmOverloads constructor(
             if (viewType == VIEW_TYPE_PLACEHOLDER) {
                 glideRequest.load(Uri.parse(image.source)).apply(glideTransform).into(viewBinding.productImage)
             } else if (viewType == VIEW_TYPE_IMAGE) {
-                val photonUrl = PhotonUtils.getPhotonImageUrl(image.source, 0, imageSize)
+                val photonUrl = PhotonUtils.getPhotonImageUrl(
+                    image.source,
+                    0,
+                    imageSize,
+                    PhotonUtils.Quality.LOW
+                )
                 glideRequest.load(photonUrl).apply(glideTransform).into(viewBinding.productImage)
             }
 


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #13357 
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

Previously, the app fetches images to be shown on the image gallery `WCProductImageGalleryView` on Product Details and Product Images screen (also on variable product) using the default file quality setting. The default is `PhotonUtils.Quality.MEDIUM`, which translates to 65. This PR updates that value to use `PhotonUtils.Quality.LOW`, which translates to 35.

Because the thumbnails are relatively small, switching to lower quality images are not likely to cause severe degradation. I put some examples on issue #13357 , where there's little quality changes between LOW and MEDIUM values.

On the other hand, this should improve loading time and add saving in data transfer as well, since each image is now will be smaller in size.

### Steps to reproduce
<!-- Step-by-step testing instructions. For new user flows, consider instead stating the goal of the workflow and see if your PR reviewer can accomplish the workflow without specific steps! -->

Generally you just need to smoke test Product Details and Product Images screen. Add images and/or check existing product images, and check if they still look OK. Generally you want to ensure the image is still identifiable (e.g: if it's a photo of an item being sold, you can tell what item it is).

Finally ensure that when tapping an image in Product Images, the full quality image is still shown correctly.

### Testing information
<!-- This is your opportunity to break out individual scenarios that need testing (when necessary) and/or include a checklist for the reviewer to go through. Consider documenting the following from your own completed testing: devices used, alternate workflows, edge cases, affected areas, critical flows, areas not tested, and any remaining unknowns. Provide feedback on this new section of the PR template through Sept 30, 2024 to Apps Quality; additional context here: p91TBi-b8z-p2#comment-12036 -->

n/a

### The tests that have been performed
<!-- To give the reviewer an idea of what could be missed in terms of testing -->

As above, and there's results posted on #13357 as well

### Images/gif
<!-- Include before and after images or gifs when appropriate. -->
 
n/a

- [ ] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.

## Reviewer (or Author, in the case of optional code reviews):

Please make sure these conditions are met before approving the PR, or request changes if the PR needs improvement:

- [ ] The PR is small and has a clear, single focus, or a valid explanation is provided in the description. If needed, please request to split it into smaller PRs.
- [ ] Ensure Adequate Unit Test Coverage: The changes are reasonably covered by unit tests or an explanation is provided in the PR description.
- [ ] Manual Testing: The author listed all the tests they ran, including smoke tests when needed (e.g., for refactorings). The reviewer confirmed that the PR works as expected on big (tablet) and small (phone) in case of UI changes, and no regressions are added.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->13357