### PR TITLE
[Android SDK] Edge-to-edge to WooLogViewer activity

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/support/WooLogViewerActivity.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/support/WooLogViewerActivity.kt
@@ -35,7 +35,7 @@ class WooLogViewerActivity : AppCompatActivity() {
         intent.putExtra(Intent.EXTRA_SUBJECT, getString(R.string.app_name) + " " + title)
         try {
             startActivity(Intent.createChooser(intent, getString(R.string.share)))
-        } catch (ex: android.content.ActivityNotFoundException) {
+        } catch (_: android.content.ActivityNotFoundException) {
             ToastUtils.showToast(this, R.string.logviewer_share_error)
         }
     }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/support/WooLogViewerScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/support/WooLogViewerScreen.kt
@@ -3,10 +3,14 @@ package com.woocommerce.android.support
 import androidx.annotation.ColorRes
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.statusBars
+import androidx.compose.foundation.layout.windowInsetsPadding
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.itemsIndexed
 import androidx.compose.foundation.text.selection.SelectionContainer
@@ -42,27 +46,35 @@ fun WooLogViewerScreen(
 ) {
     Scaffold(
         topBar = {
-            Toolbar(
-                title = stringResource(id = R.string.logviewer_activity_title),
-                onNavigationButtonClick = onBackPress,
-                actions = {
-                    IconButton(onClick = { onCopyButtonClick() }) {
-                        Icon(
-                            painter = painterResource(R.drawable.ic_copy_white_24dp),
-                            contentDescription = stringResource(id = R.string.copy),
-                            tint = colorResource(id = R.color.color_icon_menu)
-                        )
-                    }
-                    IconButton(onClick = { onShareButtonClick() }) {
-                        Icon(
-                            Icons.Filled.Share,
-                            contentDescription = stringResource(id = R.string.share),
-                            tint = colorResource(id = R.color.color_icon_menu)
-                        )
-                    }
-                }
-            )
-        }
+            Box(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .background(color = colorResource(id = R.color.color_toolbar))
+            ) {
+                Toolbar(
+                    title = stringResource(id = R.string.logviewer_activity_title),
+                    onNavigationButtonClick = onBackPress,
+                    actions = {
+                        IconButton(onClick = { onCopyButtonClick() }) {
+                            Icon(
+                                painter = painterResource(R.drawable.ic_copy_white_24dp),
+                                contentDescription = stringResource(id = R.string.copy),
+                                tint = colorResource(id = R.color.color_icon_menu)
+                            )
+                        }
+                        IconButton(onClick = { onShareButtonClick() }) {
+                            Icon(
+                                Icons.Filled.Share,
+                                contentDescription = stringResource(id = R.string.share),
+                                tint = colorResource(id = R.color.color_icon_menu)
+                            )
+                        }
+                    },
+                    modifier = Modifier
+                        .windowInsetsPadding(WindowInsets.statusBars)
+                )
+            }
+        },
     ) { padding ->
         LogViewerEntries(
             entries,


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
Adds insets as padding. Make the color of the whole top part the same color as toolbar

### Steps to reproduce
<!-- Step-by-step testing instructions. For new user flows, consider instead stating the goal of the workflow and see if your PR reviewer can accomplish the workflow without specific steps! -->
More -> Settings -> Help -> View logs

### Testing information
<!-- This is your opportunity to break out individual scenarios that need testing (when necessary) and/or include a checklist for the reviewer to go through. Consider documenting the following from your own completed testing: devices used, alternate workflows, edge cases, affected areas, critical flows, areas not tested, and any remaining unknowns. Provide feedback on this new section of the PR template through Sept 30, 2024 to Apps Quality; additional context here: p91TBi-b8z-p2#comment-12036 -->
Notice that it both dark and light modes looks as edge to edge. Both on android 35 or lower devices

### The tests that have been performed
<!-- To give the reviewer an idea of what could be missed in terms of testing -->

### Images/gif
<!-- Include before and after images or gifs when appropriate. -->
<img width="552" alt="image" src="https://github.com/user-attachments/assets/9417834c-35dc-412c-82fc-067621038e74" />
<img width="1033" alt="image" src="https://github.com/user-attachments/assets/65c8a69f-2490-4e47-816b-fe6edeb79c56" />

- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.

## Reviewer (or Author, in the case of optional code reviews):

Please make sure these conditions are met before approving the PR, or request changes if the PR needs improvement:

- [x] The PR is small and has a clear, single focus, or a valid explanation is provided in the description. If needed, please request to split it into smaller PRs.
- [x] Ensure Adequate Unit Test Coverage: The changes are reasonably covered by unit tests or an explanation is provided in the PR description.
- [x] Manual Testing: The author listed all the tests they ran, including smoke tests when needed (e.g., for refactorings). The reviewer confirmed that the PR works as expected on big (tablet) and small (phone) in case of UI changes, and no regressions are added.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->