### PR TITLE
Connecting origin address with UI

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/address/WooShippingEditAddressScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/address/WooShippingEditAddressScreen.kt
@@ -24,10 +24,6 @@ import androidx.compose.material.icons.filled.Add
 import androidx.compose.material.icons.filled.ArrowDropDown
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
-import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.remember
-import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.colorResource
 import androidx.compose.ui.res.stringResource
@@ -51,6 +47,8 @@ fun WooShippingEditAddressScreen(
         is WooShippingEditOriginViewModel.EditAddressViewState.DataState -> {
             WooShippingEditAddressScreen(
                 editableAddress = viewState.editableAddress,
+                isCompanyExpanded = viewState.isCompanyExpanded,
+                onExpandCompany = viewModel::onExpandCompany,
                 onNameChange = viewModel::onNameChange,
                 onCompanyChange = viewModel::onCompanyChange,
                 onAddressChange = viewModel::onAddressChange,
@@ -67,6 +65,8 @@ fun WooShippingEditAddressScreen(
 @Composable
 fun WooShippingEditAddressScreen(
     editableAddress: EditableAddress,
+    isCompanyExpanded: Boolean,
+    onExpandCompany: () -> Unit,
     onNameChange: (String) -> Unit,
     onCompanyChange: (String) -> Unit,
     onAddressChange: (String) -> Unit,
@@ -98,12 +98,10 @@ fun WooShippingEditAddressScreen(
                 onTextChange = onNameChange,
             )
 
-            var isExpanded by remember { mutableStateOf(false) }
-
             CollapsedField(
-                isExpanded = isExpanded,
+                isExpanded = isCompanyExpanded,
                 label = stringResource(id = R.string.woo_shipping_label_company),
-                onExpand = { isExpanded = !isExpanded },
+                onExpand = onExpandCompany,
                 modifier = Modifier.fillMaxWidth()
             ) {
                 RoundedBorderTextFieldWithLabel(

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/address/origin/WooShippingEditOriginViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/address/origin/WooShippingEditOriginViewModel.kt
@@ -6,6 +6,7 @@ import androidx.compose.runtime.setValue
 import androidx.compose.runtime.snapshotFlow
 import androidx.lifecycle.SavedStateHandle
 import com.woocommerce.android.extensions.combine
+import com.woocommerce.android.extensions.isNotNullOrEmpty
 import com.woocommerce.android.ui.orders.wooshippinglabels.address.AddressValidationHelper
 import com.woocommerce.android.viewmodel.ScopedViewModel
 import com.woocommerce.android.viewmodel.navArgs
@@ -88,6 +89,8 @@ class WooShippingEditOriginViewModel @Inject constructor(
             inputValue.copy(error = addressValidator.validateUSCustomsPhone(inputValue.value))
         }
 
+    private val isCompanyExpanded = MutableStateFlow(false)
+
     private val editableAddress = combine(
         nameValidatedFlow,
         addressValidatedFlow,
@@ -109,8 +112,12 @@ class WooShippingEditOriginViewModel @Inject constructor(
         )
     }
 
-    val viewState: MutableStateFlow<EditAddressViewState> =
-        MutableStateFlow(EditAddressViewState.DataState(EditableAddress()))
+    val viewState: MutableStateFlow<EditAddressViewState> = MutableStateFlow(
+        EditAddressViewState.DataState(
+            isCompanyExpanded = false,
+            editableAddress = EditableAddress()
+        )
+    )
 
     init {
         launch { observeAddressChanges() }
@@ -129,12 +136,22 @@ class WooShippingEditOriginViewModel @Inject constructor(
         postalCode = InputValue(navArgs.originAddress.postcode)
         email = InputValue(navArgs.originAddress.email.orEmpty())
         phone = InputValue(navArgs.originAddress.phone.orEmpty())
+        isCompanyExpanded.value = navArgs.originAddress.company.isNotNullOrEmpty()
+    }
+
+    fun onExpandCompany() {
+        isCompanyExpanded.value = true
     }
 
     private suspend fun observeAddressChanges() {
-        editableAddress
+        editableAddress.combine(isCompanyExpanded) { address, isExpanded ->
+            EditAddressViewState.DataState(
+                isCompanyExpanded = isExpanded,
+                editableAddress = address
+            )
+        }
             .collectLatest {
-                viewState.value = EditAddressViewState.DataState(it)
+                viewState.value = it
             }
     }
 
@@ -168,6 +185,7 @@ class WooShippingEditOriginViewModel @Inject constructor(
 
     sealed class EditAddressViewState {
         data class DataState(
+            val isCompanyExpanded: Boolean,
             val editableAddress: EditableAddress
         ) : EditAddressViewState()
     }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/address/origin/WooShippingEditOriginViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/address/origin/WooShippingEditOriginViewModel.kt
@@ -8,6 +8,7 @@ import androidx.lifecycle.SavedStateHandle
 import com.woocommerce.android.extensions.combine
 import com.woocommerce.android.ui.orders.wooshippinglabels.address.AddressValidationHelper
 import com.woocommerce.android.viewmodel.ScopedViewModel
+import com.woocommerce.android.viewmodel.navArgs
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.delay
@@ -33,6 +34,8 @@ class WooShippingEditOriginViewModel @Inject constructor(
     private var postalCode by mutableStateOf(InputValue(""))
     private var email by mutableStateOf(InputValue(""))
     private var phone by mutableStateOf(InputValue(""))
+
+    private val navArgs: WooShippingEditOriginAddressFragmentArgs by savedState.navArgs()
 
     private val nameValidatedFlow = snapshotFlow { name }
         .combine(snapshotFlow { company }) { name, company ->
@@ -111,6 +114,21 @@ class WooShippingEditOriginViewModel @Inject constructor(
 
     init {
         launch { observeAddressChanges() }
+        fillAddressForm()
+    }
+
+    private fun fillAddressForm() {
+        val fullName = "${navArgs.originAddress.firstName.orEmpty()} ${navArgs.originAddress.lastName.orEmpty()}"
+        val fullAddress = "${navArgs.originAddress.address1.orEmpty()} ${navArgs.originAddress.address2.orEmpty()}"
+        name = InputValue(fullName)
+        company = InputValue(navArgs.originAddress.company.orEmpty())
+        country = navArgs.originAddress.country
+        address = InputValue(fullAddress)
+        city = InputValue(navArgs.originAddress.city.orEmpty())
+        state = navArgs.originAddress.state.orEmpty()
+        postalCode = InputValue(navArgs.originAddress.postcode)
+        email = InputValue(navArgs.originAddress.email.orEmpty())
+        phone = InputValue(navArgs.originAddress.phone.orEmpty())
     }
 
     private suspend fun observeAddressChanges() {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/address/origin/WooShippingEditOriginViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/address/origin/WooShippingEditOriginViewModel.kt
@@ -8,6 +8,7 @@ import androidx.lifecycle.SavedStateHandle
 import com.woocommerce.android.extensions.combine
 import com.woocommerce.android.extensions.isNotNullOrEmpty
 import com.woocommerce.android.ui.orders.wooshippinglabels.address.AddressValidationHelper
+import com.woocommerce.android.util.StringUtils.combineStrings
 import com.woocommerce.android.viewmodel.ScopedViewModel
 import com.woocommerce.android.viewmodel.navArgs
 import dagger.hilt.android.lifecycle.HiltViewModel
@@ -125,8 +126,14 @@ class WooShippingEditOriginViewModel @Inject constructor(
     }
 
     private fun fillAddressForm() {
-        val fullName = "${navArgs.originAddress.firstName.orEmpty()} ${navArgs.originAddress.lastName.orEmpty()}"
-        val fullAddress = "${navArgs.originAddress.address1.orEmpty()} ${navArgs.originAddress.address2.orEmpty()}"
+        val fullName = combineStrings(
+            navArgs.originAddress.firstName.orEmpty(),
+            navArgs.originAddress.lastName.orEmpty()
+        )
+        val fullAddress = combineStrings(
+            navArgs.originAddress.address1.orEmpty(),
+            navArgs.originAddress.address2.orEmpty()
+        )
         name = InputValue(fullName)
         company = InputValue(navArgs.originAddress.company.orEmpty())
         country = navArgs.originAddress.country

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/util/StringUtils.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/util/StringUtils.kt
@@ -9,6 +9,7 @@ import androidx.annotation.StringRes
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.res.stringResource
 import androidx.core.text.HtmlCompat
+import com.woocommerce.android.extensions.appendWithIfNotEmpty
 import com.woocommerce.android.extensions.isInteger
 import com.woocommerce.android.util.WooLog.T.UTILS
 import com.woocommerce.android.viewmodel.ResourceProvider
@@ -285,5 +286,33 @@ object StringUtils {
             WooLog.w(UTILS, "No string array resource found for id $id in locale $locale")
             null
         }
+    }
+
+    /**
+     * Combines a variable number of strings into a single string, separated by spaces.
+     *
+     * This function takes a variable number of string arguments and concatenates them
+     * into a single string. If multiple strings are provided, they are separated by
+     * a single space character. Empty strings are handled gracefully and do not contribute
+     * to extra spaces.
+     *
+     * @param strings A variable number of strings to combine.
+     * @return A new string containing all the input strings concatenated together,
+     *         separated by spaces if there are multiple strings. Returns an empty
+     *         string if no strings are provided.
+     *
+     * @sample
+     *  val combined1 = combineStrings("Hello", "World") // Returns "Hello World"
+     *  val combined2 = combineStrings("One") // Returns "One"
+     *  val combined3 = combineStrings() // Returns ""
+     *  val combined4 = combineStrings("Hello", "", "World") // Returns "Hello World"
+     */
+    fun combineStrings(vararg strings: String): String {
+        val builder = StringBuilder()
+        strings.forEach { string ->
+            val separator = if (builder.isEmpty()) "" else " "
+            builder.appendWithIfNotEmpty(string, separator)
+        }
+        return builder.toString()
     }
 }

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/address/origin/WooShippingEditOriginViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/address/origin/WooShippingEditOriginViewModelTest.kt
@@ -312,4 +312,43 @@ class WooShippingEditOriginViewModelTest : BaseUnitTest() {
 
         assertThat(editableAddress.phone.error).isNull()
     }
+
+    @Test
+    fun `when company is NOT empty, then company control is expanded`() = testBlocking {
+        val company = "company"
+        val address = OriginShippingAddress.EMPTY.copy(
+            company = company
+        )
+        whenever(addressValidator.validateFieldRequired(any())).doReturn(null)
+        Snapshot.withMutableSnapshot {
+            createViewModel(address)
+        }
+
+        advanceUntilIdle()
+
+        val result = sut.viewState.value
+
+        assertThat(result).isInstanceOf(WooShippingEditOriginViewModel.EditAddressViewState::class.java)
+        val isCompanyExpanded = (result as WooShippingEditOriginViewModel.EditAddressViewState.DataState).isCompanyExpanded
+
+        assertThat(isCompanyExpanded).isTrue()
+    }
+
+    @Test
+    fun `when company is empty, then company control is NOT expanded`() = testBlocking {
+        val address = OriginShippingAddress.EMPTY
+        whenever(addressValidator.validateFieldRequired(any())).doReturn(null)
+        Snapshot.withMutableSnapshot {
+            createViewModel(address)
+        }
+
+        advanceUntilIdle()
+
+        val result = sut.viewState.value
+
+        assertThat(result).isInstanceOf(WooShippingEditOriginViewModel.EditAddressViewState::class.java)
+        val isCompanyExpanded = (result as WooShippingEditOriginViewModel.EditAddressViewState.DataState).isCompanyExpanded
+
+        assertThat(isCompanyExpanded).isFalse()
+    }
 }

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/address/origin/WooShippingEditOriginViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/address/origin/WooShippingEditOriginViewModelTest.kt
@@ -14,7 +14,6 @@ import org.mockito.kotlin.eq
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.whenever
 
-
 @OptIn(ExperimentalCoroutinesApi::class)
 class WooShippingEditOriginViewModelTest : BaseUnitTest() {
     private val addressValidator: AddressValidationHelper = mock()
@@ -329,7 +328,8 @@ class WooShippingEditOriginViewModelTest : BaseUnitTest() {
         val result = sut.viewState.value
 
         assertThat(result).isInstanceOf(WooShippingEditOriginViewModel.EditAddressViewState::class.java)
-        val isCompanyExpanded = (result as WooShippingEditOriginViewModel.EditAddressViewState.DataState).isCompanyExpanded
+        val isCompanyExpanded =
+            (result as WooShippingEditOriginViewModel.EditAddressViewState.DataState).isCompanyExpanded
 
         assertThat(isCompanyExpanded).isTrue()
     }
@@ -347,7 +347,8 @@ class WooShippingEditOriginViewModelTest : BaseUnitTest() {
         val result = sut.viewState.value
 
         assertThat(result).isInstanceOf(WooShippingEditOriginViewModel.EditAddressViewState::class.java)
-        val isCompanyExpanded = (result as WooShippingEditOriginViewModel.EditAddressViewState.DataState).isCompanyExpanded
+        val isCompanyExpanded =
+            (result as WooShippingEditOriginViewModel.EditAddressViewState.DataState).isCompanyExpanded
 
         assertThat(isCompanyExpanded).isFalse()
     }

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/address/origin/WooShippingEditOriginViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/address/origin/WooShippingEditOriginViewModelTest.kt
@@ -1,0 +1,315 @@
+package com.woocommerce.android.ui.orders.wooshippinglabels.address.origin
+
+import androidx.compose.runtime.snapshots.Snapshot
+import com.woocommerce.android.ui.orders.wooshippinglabels.address.AddressValidationHelper
+import com.woocommerce.android.ui.orders.wooshippinglabels.models.OriginShippingAddress
+import com.woocommerce.android.viewmodel.BaseUnitTest
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.advanceUntilIdle
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.Test
+import org.mockito.kotlin.any
+import org.mockito.kotlin.doReturn
+import org.mockito.kotlin.eq
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.whenever
+
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class WooShippingEditOriginViewModelTest : BaseUnitTest() {
+    private val addressValidator: AddressValidationHelper = mock()
+
+    private lateinit var sut: WooShippingEditOriginViewModel
+
+    fun createViewModel(originAddress: OriginShippingAddress) {
+        sut = WooShippingEditOriginViewModel(
+            addressValidator = addressValidator,
+            savedState = WooShippingEditOriginAddressFragmentArgs(originAddress).toSavedStateHandle()
+        )
+    }
+
+    @Test
+    fun `when name is not empty and company is empty, then name error is null`() = testBlocking {
+        val name = "name"
+        val company = ""
+        val address = OriginShippingAddress.EMPTY.copy(
+            firstName = name,
+            company = company
+        )
+        whenever(addressValidator.validateFieldRequired(any())).doReturn(null)
+        Snapshot.withMutableSnapshot {
+            createViewModel(address)
+        }
+
+        advanceUntilIdle()
+
+        val result = sut.viewState.value
+
+        assertThat(result).isInstanceOf(WooShippingEditOriginViewModel.EditAddressViewState::class.java)
+        val editableAddress = (result as WooShippingEditOriginViewModel.EditAddressViewState.DataState).editableAddress
+
+        assertThat(editableAddress.name.error).isNull()
+        assertThat(editableAddress.company.error).isNull()
+    }
+
+    @Test
+    fun `when name is empty and company Not is empty, then name error is null`() = testBlocking {
+        val name = ""
+        val company = "company"
+        val address = OriginShippingAddress.EMPTY.copy(
+            firstName = name,
+            company = company
+        )
+        whenever(addressValidator.validateFieldRequired(any())).doReturn(null)
+        Snapshot.withMutableSnapshot {
+            createViewModel(address)
+        }
+
+        advanceUntilIdle()
+
+        val result = sut.viewState.value
+
+        assertThat(result).isInstanceOf(WooShippingEditOriginViewModel.EditAddressViewState::class.java)
+        val editableAddress = (result as WooShippingEditOriginViewModel.EditAddressViewState.DataState).editableAddress
+
+        assertThat(editableAddress.name.error).isNull()
+        assertThat(editableAddress.company.error).isNull()
+    }
+
+    @Test
+    fun `when name is empty and company is empty, then name error is not null`() = testBlocking {
+        val name = ""
+        val company = ""
+        val address = OriginShippingAddress.EMPTY.copy(
+            firstName = name,
+            company = company
+        )
+        whenever(addressValidator.validateAtLeastOneOf(eq(""), eq(""))).doReturn("error")
+        whenever(addressValidator.validateFieldRequired(any())).doReturn(null)
+        Snapshot.withMutableSnapshot {
+            createViewModel(address)
+        }
+
+        advanceUntilIdle()
+
+        val result = sut.viewState.value
+
+        assertThat(result).isInstanceOf(WooShippingEditOriginViewModel.EditAddressViewState::class.java)
+        val editableAddress = (result as WooShippingEditOriginViewModel.EditAddressViewState.DataState).editableAddress
+
+        assertThat(editableAddress.name.error).isNotEmpty()
+        assertThat(editableAddress.company.error).isNull()
+    }
+
+    @Test
+    fun `when address is empty then address error is not null`() = testBlocking {
+        val address = OriginShippingAddress.EMPTY
+        whenever(addressValidator.validateAtLeastOneOf(eq(""), eq(""))).doReturn("error")
+        whenever(addressValidator.validateFieldRequired("")).doReturn("error")
+        Snapshot.withMutableSnapshot {
+            createViewModel(address)
+        }
+
+        advanceUntilIdle()
+
+        val result = sut.viewState.value
+
+        assertThat(result).isInstanceOf(WooShippingEditOriginViewModel.EditAddressViewState::class.java)
+        val editableAddress = (result as WooShippingEditOriginViewModel.EditAddressViewState.DataState).editableAddress
+
+        assertThat(editableAddress.address.error).isNotEmpty()
+    }
+
+    @Test
+    fun `when address is NOT empty then address error is null`() = testBlocking {
+        val address = OriginShippingAddress.EMPTY.copy(address1 = "This is an address")
+        whenever(addressValidator.validateAtLeastOneOf(eq(""), eq(""))).doReturn("error")
+        whenever(addressValidator.validateFieldRequired("")).doReturn("error")
+        Snapshot.withMutableSnapshot {
+            createViewModel(address)
+        }
+
+        advanceUntilIdle()
+
+        val result = sut.viewState.value
+
+        assertThat(result).isInstanceOf(WooShippingEditOriginViewModel.EditAddressViewState::class.java)
+        val editableAddress = (result as WooShippingEditOriginViewModel.EditAddressViewState.DataState).editableAddress
+
+        assertThat(editableAddress.address.error).isNull()
+    }
+
+    @Test
+    fun `when city is empty then address error is not null`() = testBlocking {
+        val address = OriginShippingAddress.EMPTY
+        whenever(addressValidator.validateAtLeastOneOf(eq(""), eq(""))).doReturn("error")
+        whenever(addressValidator.validateFieldRequired("")).doReturn("error")
+        Snapshot.withMutableSnapshot {
+            createViewModel(address)
+        }
+
+        advanceUntilIdle()
+
+        val result = sut.viewState.value
+
+        assertThat(result).isInstanceOf(WooShippingEditOriginViewModel.EditAddressViewState::class.java)
+        val editableAddress = (result as WooShippingEditOriginViewModel.EditAddressViewState.DataState).editableAddress
+
+        assertThat(editableAddress.city.error).isNotEmpty()
+    }
+
+    @Test
+    fun `when city is NOT empty then address error is null`() = testBlocking {
+        val address = OriginShippingAddress.EMPTY.copy(city = "This is a city")
+        whenever(addressValidator.validateAtLeastOneOf(eq(""), eq(""))).doReturn("error")
+        whenever(addressValidator.validateFieldRequired("")).doReturn("error")
+        Snapshot.withMutableSnapshot {
+            createViewModel(address)
+        }
+
+        advanceUntilIdle()
+
+        val result = sut.viewState.value
+
+        assertThat(result).isInstanceOf(WooShippingEditOriginViewModel.EditAddressViewState::class.java)
+        val editableAddress = (result as WooShippingEditOriginViewModel.EditAddressViewState.DataState).editableAddress
+
+        assertThat(editableAddress.city.error).isNull()
+    }
+
+    @Test
+    fun `when postal code is empty then address error is not null`() = testBlocking {
+        val address = OriginShippingAddress.EMPTY
+        whenever(addressValidator.validateAtLeastOneOf(eq(""), eq(""))).doReturn("error")
+        whenever(addressValidator.validateFieldRequired("")).doReturn("error")
+        Snapshot.withMutableSnapshot {
+            createViewModel(address)
+        }
+
+        advanceUntilIdle()
+
+        val result = sut.viewState.value
+
+        assertThat(result).isInstanceOf(WooShippingEditOriginViewModel.EditAddressViewState::class.java)
+        val editableAddress = (result as WooShippingEditOriginViewModel.EditAddressViewState.DataState).editableAddress
+
+        assertThat(editableAddress.postalCode.error).isNotEmpty()
+    }
+
+    @Test
+    fun `when postal code is NOT empty then address error is null`() = testBlocking {
+        val address = OriginShippingAddress.EMPTY.copy(postcode = "This is a post code")
+        whenever(addressValidator.validateAtLeastOneOf(eq(""), eq(""))).doReturn("error")
+        whenever(addressValidator.validateFieldRequired("")).doReturn("error")
+        Snapshot.withMutableSnapshot {
+            createViewModel(address)
+        }
+
+        advanceUntilIdle()
+
+        val result = sut.viewState.value
+
+        assertThat(result).isInstanceOf(WooShippingEditOriginViewModel.EditAddressViewState::class.java)
+        val editableAddress = (result as WooShippingEditOriginViewModel.EditAddressViewState.DataState).editableAddress
+
+        assertThat(editableAddress.postalCode.error).isNull()
+    }
+
+    @Test
+    fun `when email is empty then address error is not null`() = testBlocking {
+        val address = OriginShippingAddress.EMPTY
+        whenever(addressValidator.validateAtLeastOneOf(eq(""), eq(""))).doReturn("error")
+        whenever(addressValidator.validateFieldRequired("")).doReturn("error")
+        Snapshot.withMutableSnapshot {
+            createViewModel(address)
+        }
+
+        advanceUntilIdle()
+
+        val result = sut.viewState.value
+
+        assertThat(result).isInstanceOf(WooShippingEditOriginViewModel.EditAddressViewState::class.java)
+        val editableAddress = (result as WooShippingEditOriginViewModel.EditAddressViewState.DataState).editableAddress
+
+        assertThat(editableAddress.email.error).isNotEmpty()
+    }
+
+    @Test
+    fun `when email is NOT empty then address error is null`() = testBlocking {
+        val address = OriginShippingAddress.EMPTY.copy(email = "This is an email")
+        whenever(addressValidator.validateAtLeastOneOf(eq(""), eq(""))).doReturn("error")
+        whenever(addressValidator.validateFieldRequired("")).doReturn("error")
+        Snapshot.withMutableSnapshot {
+            createViewModel(address)
+        }
+
+        advanceUntilIdle()
+
+        val result = sut.viewState.value
+
+        assertThat(result).isInstanceOf(WooShippingEditOriginViewModel.EditAddressViewState::class.java)
+        val editableAddress = (result as WooShippingEditOriginViewModel.EditAddressViewState.DataState).editableAddress
+
+        assertThat(editableAddress.email.error).isNull()
+    }
+
+    @Test
+    fun `when phone is empty then phone error is not null`() = testBlocking {
+        val address = OriginShippingAddress.EMPTY
+        whenever(addressValidator.validateAtLeastOneOf(eq(""), eq(""))).doReturn("error")
+        whenever(addressValidator.validateFieldRequired("")).doReturn("error")
+        whenever(addressValidator.validateUSCustomsPhone("")).doReturn("error")
+        Snapshot.withMutableSnapshot {
+            createViewModel(address)
+        }
+
+        advanceUntilIdle()
+
+        val result = sut.viewState.value
+
+        assertThat(result).isInstanceOf(WooShippingEditOriginViewModel.EditAddressViewState::class.java)
+        val editableAddress = (result as WooShippingEditOriginViewModel.EditAddressViewState.DataState).editableAddress
+
+        assertThat(editableAddress.phone.error).isNotEmpty()
+    }
+
+    @Test
+    fun `when phone is NOT empty and invalid then phone error is not null`() = testBlocking {
+        val address = OriginShippingAddress.EMPTY.copy(phone = "1234567890")
+        whenever(addressValidator.validateAtLeastOneOf(eq(""), eq(""))).doReturn("error")
+        whenever(addressValidator.validateFieldRequired("")).doReturn("error")
+        whenever(addressValidator.validateUSCustomsPhone("1234567890")).doReturn("error")
+        Snapshot.withMutableSnapshot {
+            createViewModel(address)
+        }
+
+        advanceUntilIdle()
+
+        val result = sut.viewState.value
+
+        assertThat(result).isInstanceOf(WooShippingEditOriginViewModel.EditAddressViewState::class.java)
+        val editableAddress = (result as WooShippingEditOriginViewModel.EditAddressViewState.DataState).editableAddress
+
+        assertThat(editableAddress.phone.error).isNotEmpty()
+    }
+
+    @Test
+    fun `when phone is NOT empty and valid then phone error is null`() = testBlocking {
+        val address = OriginShippingAddress.EMPTY.copy(phone = "1234567890")
+        whenever(addressValidator.validateAtLeastOneOf(eq(""), eq(""))).doReturn("error")
+        whenever(addressValidator.validateFieldRequired("")).doReturn("error")
+        whenever(addressValidator.validateUSCustomsPhone("1234567890")).doReturn(null)
+        Snapshot.withMutableSnapshot {
+            createViewModel(address)
+        }
+
+        advanceUntilIdle()
+
+        val result = sut.viewState.value
+
+        assertThat(result).isInstanceOf(WooShippingEditOriginViewModel.EditAddressViewState::class.java)
+        val editableAddress = (result as WooShippingEditOriginViewModel.EditAddressViewState.DataState).editableAddress
+
+        assertThat(editableAddress.phone.error).isNull()
+    }
+}


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->
Part of: #12439 

### Description
This PR connects the address received in the navigation event with the edit address form and the unit tests for [WooShippingEditOriginViewModelTest](https://github.com/woocommerce/woocommerce-android/pull/13379/commits/5cec2f003c58c23d5b3b79928f16d01367d7a65d). 

### Testing information
TC1

1. Open the orders tab
2. Tap on an order eligible for shipping label creation
3. Expand the shipment details section
4. Expand on the origin address selection (3 dots)
5. Tap on the pencil
6. Check that the UI navigates to the edit origin address screen
7. Check that the address form is filled with the address data received

### The tests that have been performed
- Checked that the address form is filled out with the address data received
- Checked that the company field is expanded when the company value is not empty

### Images/gif

https://github.com/user-attachments/assets/f4692010-f596-4f1c-be89-4e7e8466ceff

- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.

## Reviewer (or Author, in the case of optional code reviews):

Please make sure these conditions are met before approving the PR, or request changes if the PR needs improvement:

- [ ] The PR is small and has a clear, single focus, or a valid explanation is provided in the description. If needed, please request to split it into smaller PRs.
- [ ] Ensure Adequate Unit Test Coverage: The changes are reasonably covered by unit tests or an explanation is provided in the PR description.
- [ ] Manual Testing: The author listed all the tests they ran, including smoke tests when needed (e.g., for refactorings). The reviewer confirmed that the PR works as expected on big (tablet) and small (phone) in case of UI changes, and no regressions are added.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->