### PR TITLE
[Woo POS][Non-Simple Products] Font and Color changes to Items and Cart screens

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/cart/WooPosCartScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/cart/WooPosCartScreen.kt
@@ -476,7 +476,7 @@ private fun ProductItem(
                         Text(
                             text = item.description!!,
                             style = MaterialTheme.typography.body1,
-                            maxLines = 1,
+                            maxLines = 2,
                             overflow = TextOverflow.Ellipsis,
                             color = MaterialTheme.colors.secondaryVariant,
                             modifier = Modifier.clearAndSetSemantics { }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/cart/WooPosCartScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/cart/WooPosCartScreen.kt
@@ -435,7 +435,7 @@ private fun ProductItem(
     ) {
         WooPosCard(
             modifier = modifier
-                .height(72.dp)
+                .height(96.dp)
                 .semantics { contentDescription = itemContentDescription },
             elevation = elevation,
             shadowType = ShadowType.Soft,
@@ -455,7 +455,7 @@ private fun ProductItem(
                     placeholder = ColorPainter(WooPosTheme.colors.loadingSkeleton),
                     contentDescription = null,
                     contentScale = ContentScale.Crop,
-                    modifier = Modifier.size(72.dp)
+                    modifier = Modifier.size(96.dp)
                 )
 
                 Spacer(modifier = Modifier.width(16.dp.toAdaptivePadding()))
@@ -466,7 +466,7 @@ private fun ProductItem(
                     Text(
                         text = item.name,
                         style = MaterialTheme.typography.body1,
-                        fontWeight = FontWeight.SemiBold,
+                        fontWeight = FontWeight.Bold,
                         maxLines = 1,
                         overflow = TextOverflow.Ellipsis,
                         modifier = Modifier.clearAndSetSemantics { }
@@ -478,6 +478,7 @@ private fun ProductItem(
                             style = MaterialTheme.typography.body1,
                             maxLines = 1,
                             overflow = TextOverflow.Ellipsis,
+                            color = MaterialTheme.colors.secondaryVariant,
                             modifier = Modifier.clearAndSetSemantics { }
                         )
                         Spacer(modifier = Modifier.height(4.dp.toAdaptivePadding()))
@@ -485,6 +486,7 @@ private fun ProductItem(
                     Text(
                         text = item.price,
                         style = MaterialTheme.typography.body1,
+                        color = MaterialTheme.colors.secondaryVariant,
                         modifier = Modifier.clearAndSetSemantics { }
                     )
                 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/items/WooPosItemsList.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/items/WooPosItemsList.kt
@@ -206,13 +206,13 @@ private fun ProductInfo(item: WooPosItem) {
     Column(
         modifier = Modifier
             .fillMaxHeight()
-            .padding(vertical = 8.dp),
+            .padding(vertical = 16.dp),
         verticalArrangement = Arrangement.Center
     ) {
         Text(
             text = item.name,
-            style = MaterialTheme.typography.h5,
-            fontWeight = FontWeight.SemiBold,
+            style = MaterialTheme.typography.h6,
+            fontWeight = FontWeight.Bold,
             maxLines = 2,
             overflow = TextOverflow.Ellipsis
         )
@@ -252,7 +252,8 @@ private fun SimpleProductDetails(item: SimpleProduct) {
     Text(
         text = item.price,
         style = MaterialTheme.typography.h6,
-        fontWeight = FontWeight.Normal
+        fontWeight = FontWeight.Normal,
+        color = MaterialTheme.colors.secondaryVariant
     )
 }
 
@@ -261,7 +262,8 @@ private fun VariableProductDetails() {
     Text(
         text = stringResource(id = R.string.woopos_variations_options_available_text),
         style = MaterialTheme.typography.h6,
-        fontWeight = FontWeight.Normal
+        fontWeight = FontWeight.Normal,
+        color = MaterialTheme.colors.secondaryVariant
     )
 }
 
@@ -270,7 +272,8 @@ fun VariationProductDetails(item: Variation) {
     Text(
         text = item.price,
         style = MaterialTheme.typography.h6,
-        fontWeight = FontWeight.Normal
+        fontWeight = FontWeight.Normal,
+        color = MaterialTheme.colors.secondaryVariant
     )
 }
 


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #13381
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
This PR makes minor UI changes to Items and Cart screens:
1. Change text style and font weight for Item name
2. Change text color for item price
3. Change font weight of Cart item name
4. Change height of Cart card
5. Allow max of 2 lines for variation names in cart
6. Change text color of variation name in cart

Design: rNAclWFAdQRw7EXEcsNVai-fi-2662_8765

### Steps to reproduce
<!-- Step-by-step testing instructions. For new user flows, consider instead stating the goal of the workflow and see if your PR reviewer can accomplish the workflow without specific steps! -->
Navigate to POS (More menu -> POS) and ensure the Item (including variation screen) and the Cart screen design looks as per Figma design in both Light and Dark mode

### Images/gif
<!-- Include before and after images or gifs when appropriate. -->
![design_change_dark](https://github.com/user-attachments/assets/ad6ffef6-cfae-4d75-9c12-776fd9cb405f)
![design_change_light](https://github.com/user-attachments/assets/90dd941b-fac4-496f-87fd-23e042430709)


- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.

## Reviewer (or Author, in the case of optional code reviews):

Please make sure these conditions are met before approving the PR, or request changes if the PR needs improvement:

- [ ] The PR is small and has a clear, single focus, or a valid explanation is provided in the description. If needed, please request to split it into smaller PRs.
- [ ] Ensure Adequate Unit Test Coverage: The changes are reasonably covered by unit tests or an explanation is provided in the PR description.
- [ ] Manual Testing: The author listed all the tests they ran, including smoke tests when needed (e.g., for refactorings). The reviewer confirmed that the PR works as expected on big (tablet) and small (phone) in case of UI changes, and no regressions are added.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->