### PR TITLE
[Buildkite] Test Android Staging on `ami-0953ca1d949c23a58` -> `ami-0f976e0b4de96aa28`

### DIFF
--- a/.buildkite/commands/save-cache.sh
+++ b/.buildkite/commands/save-cache.sh
@@ -3,7 +3,7 @@
 set -euo pipefail
 
 echo "--- 📦 Download Dependencies"
-./gradlew downloadDependencies androidDependencies
+./gradlew downloadDependencies
 echo ""
 
 echo "--- 💾 Save Cache"

--- a/.buildkite/commands/save-cache.sh
+++ b/.buildkite/commands/save-cache.sh
@@ -2,40 +2,8 @@
 
 set -euo pipefail
 
-echo "--- :rubygems: Setting up Gems"
-install_gems
-
-echo "--- :closed_lock_with_key: Installing Secrets"
-bundle exec fastlane run configure_apply
-
-# .buildkite/commands/prototype-build.sh -> build_and_upload_prototype_build
-# -> prototype_flavor = 'Jalapeno'
-# -> prototype_build_type = 'Debug'
-echo "--- 🛠 Download Mobile App Dependencies [Assemble Mobile App]"
-./gradlew :WooCommerce:assembleJalapenoDebug
-echo ""
-
-# .buildkite/commands/prototype-build.sh -> build_and_upload_prototype_build
-# -> prototype_flavor = 'Jalapeno'
-# -> prototype_build_type = 'Debug'
-echo "--- 🛠 Download Wear App Dependencies [Assemble Wear App]"
-./gradlew :WooCommerce-Wear:assembleJalapenoDebug
-echo ""
-
-# .buildkite/commands/lint.sh -> ./gradlew :WooCommerce:lintJalapenoDebug
-echo "--- 🧹 Download Lint Dependencies [Lint Mobile App]"
-./gradlew :WooCommerce:lintJalapenoDebug
-echo ""
-
-# .buildkite/commands/run-unit-tests.sh -> ./gradlew testJalapenoDebugUnitTest testDebugUnitTest
-echo "--- 🧪 Download Unit Test Dependencies [Assemble Unit Tests]"
-./gradlew assembleJalapenoDebugUnitTest assembleDebugUnitTest
-echo ""
-
-# .buildkite/commands/run-instrumented-tests.sh -> build_and_instrumented_test
-#  -> gradle(tasks: %w[assembleVanillaDebug assembleVanillaDebugAndroidTest])
-echo "--- 🧪 Download Android Test Dependencies [Assemble Android Tests]"
-./gradlew assembleJalapenoDebugAndroidTest
+echo "--- 📦 Download Dependencies"
+./gradlew downloadDependencies androidDependencies
 echo ""
 
 echo "--- 💾 Save Cache"

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -9,7 +9,7 @@ common_params:
       format: "junit"
 
 agents:
-  queue: "android"
+  queue: "android-staging"
 
 steps:
   - label: Gradle Wrapper Validation

--- a/.buildkite/release-builds.yml
+++ b/.buildkite/release-builds.yml
@@ -5,7 +5,7 @@
 # only used for release builds
 
 agents:
-  queue: "android"
+  queue: "android-staging"
 
 steps:
   - label: "Gradle Wrapper Validation"

--- a/.buildkite/schedules/dependency-analysis.yml
+++ b/.buildkite/schedules/dependency-analysis.yml
@@ -2,7 +2,7 @@
 ---
 
 agents:
-  queue: "android"
+  queue: "android-staging"
 
 steps:
   - label: "dependency analysis"

--- a/.buildkite/schedules/dependency-cache.yml
+++ b/.buildkite/schedules/dependency-cache.yml
@@ -2,7 +2,7 @@
 ---
 
 agents:
-  queue: "android"
+  queue: "android-staging"
 
 steps:
   - label: "dependency cache"

--- a/.buildkite/shared-pipeline-vars
+++ b/.buildkite/shared-pipeline-vars
@@ -3,5 +3,5 @@
 # This file is `source`'d before calling `buildkite-agent pipeline upload`, and can be used
 # to set up some variables that will be interpolated in the `.yml` pipeline before uploading it.
 
-export CI_TOOLKIT="automattic/a8c-ci-toolkit#3.9.1"
+export CI_TOOLKIT="automattic/a8c-ci-toolkit#4aed409fb7535d16c4e08794997fad3773389a9b"
 export TEST_COLLECTOR="test-collector#v1.10.1"


### PR DESCRIPTION
Related: [a8c-ci-toolkit-buildkite-plugin#142](https://github.com/Automattic/a8c-ci-toolkit-buildkite-plugin/pull/142)

AMI Name: `android-build-image-6.12.0v1.5-rc-1`

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

This PR changes the Buildkite agent from `android` to `android-staging`. This change is not meant to be merged, but rather used to verify that the new AMI `ami-0953ca1d949c23a58` works as expected.

---

### Before the Change

---

- [Saving Gradle dependency cache...](https://buildkite.com/automattic/woocommerce-android/builds/26681#01947bde-9c0b-4a45-ba3f-fab98d0702e9/610-611)
  - Duration: [0 minutes and 43 seconds](https://buildkite.com/automattic/woocommerce-android/builds/26681#01947bde-9c0b-4a45-ba3f-fab98d0702e9/610-621)
  - Cache Size: [628.98 MB](https://buildkite.com/automattic/woocommerce-android/builds/26681#01947bde-9c0b-4a45-ba3f-fab98d0702e9/610-622)
- Build Time: [20m 28s](https://buildkite.com/automattic/woocommerce-android/builds/26681#01947bde-9c0b-4a45-ba3f-fab98d0702e9)

-----

- [Restoring Gradle dependency cache...](https://buildkite.com/automattic/woocommerce-android/builds/26799#019497c6-3be1-4c32-a8b9-253181ac7474/185-186)
  - Duration: [0 minutes and 14 seconds](https://buildkite.com/automattic/woocommerce-android/builds/26799#019497c6-3be1-4c32-a8b9-253181ac7474/185-194)
  - Cache Size: [628.98 MB](https://buildkite.com/automattic/woocommerce-android/builds/26799#019497c6-3be1-4c32-a8b9-253181ac7474/185-195)
- [Build](https://buildkite.com/automattic/woocommerce-android/builds/26799#019497c6-3be1-4c32-a8b9-253181ac7474) (`Lint`): [Build Scan](https://buildkite.com/automattic/woocommerce-android/builds/26799#019497c6-3be1-4c32-a8b9-253181ac7474/199-258) -> [Network Activity*](https://scans.gradle.com/s/axqj2agmid3dm/performance/network-activity)
  - Files Downloaded: `12`
  - Network Requests: `37`
  - Time Spent: `4s`

(*) Although, note that these numbers might not be very representative because `trunk` is using a dependency cache that is already outdated (5 days has passed since it was last updated, every Sunday).

---

### After the Change

---

- [Saving Gradle dependency cache...](https://buildkite.com/automattic/woocommerce-android/builds/26803#01949877-fadf-444d-b544-e5a13e487a09/17548-17549)
  - Duration: [1 minutes and 12 seconds](https://buildkite.com/automattic/woocommerce-android/builds/26803#01949877-fadf-444d-b544-e5a13e487a09/17548-17559)
  - Cache Size: [950.32 MB](https://buildkite.com/automattic/woocommerce-android/builds/26803#01949877-fadf-444d-b544-e5a13e487a09/17548-17560)
- Build Time: [7m 14s](https://buildkite.com/automattic/woocommerce-android/builds/26803#01949877-fadf-444d-b544-e5a13e487a09)

-----

- [Restoring Gradle dependency cache...](https://buildkite.com/automattic/woocommerce-android/builds/26805#01949883-7a9b-4a0a-bfe3-bec2fb1eb2c7/187-188)
  - Duration: [0 minutes and 19 seconds](https://buildkite.com/automattic/woocommerce-android/builds/26805#01949883-7a9b-4a0a-bfe3-bec2fb1eb2c7/187-196)
  - Cache Size: [950.32 MB](https://buildkite.com/automattic/woocommerce-android/builds/26805#01949883-7a9b-4a0a-bfe3-bec2fb1eb2c7/187-197)
- [Build](https://buildkite.com/automattic/woocommerce-android/builds/26805#01949883-7a9b-4a0a-bfe3-bec2fb1eb2c7) (`Lint`): [Build Scan](https://buildkite.com/automattic/woocommerce-android/builds/26805#01949883-7a9b-4a0a-bfe3-bec2fb1eb2c7/201-9143) -> [Network Activity](https://scans.gradle.com/s/hwykrfpxihn2a/performance/network-activity)
  - Files Downloaded: `0`
  - Network Requests: `0`
  - Time Spent: `0`

---

### Conclusions

As expected, using `./gradlew downloadDependencies androidDependencies` is:
1. Simpler, much less configuration and reasoning about which tasks to use.
2. Scalable, no need to add any more tasks to the `save-cache.sh` script as the project evolves.
3. Producing a bigger cache,
    - Before: [628.98 MB](https://buildkite.com/automattic/woocommerce-android/builds/26799#019497c6-3be1-4c32-a8b9-253181ac7474/185-195) 
    - After: [950.32 MB](https://buildkite.com/automattic/woocommerce-android/builds/26805#01949883-7a9b-4a0a-bfe3-bec2fb1eb2c7/187-197)
    - Result: `+ 321.34 MB` more data downloaded, which means even less network requests on CI.
4. Slower, both in saving and restoring the cache, which is the only drawable:
    - Save:
        - Before: [0 minutes and 43 seconds](https://buildkite.com/automattic/woocommerce-android/builds/26681#01947bde-9c0b-4a45-ba3f-fab98d0702e9/610-621)
        - After: [1 minutes and 12 seconds](https://buildkite.com/automattic/woocommerce-android/builds/26803#01949877-fadf-444d-b544-e5a13e487a09/17548-17559)
        - Result: `+ 29 seconds` to save the cache.
    - Restore:
        - Before: [0 minutes and 14 seconds](https://buildkite.com/automattic/woocommerce-android/builds/26799#019497c6-3be1-4c32-a8b9-253181ac7474/185-194)
        - After: [0 minutes and 19 seconds](https://buildkite.com/automattic/woocommerce-android/builds/26805#01949883-7a9b-4a0a-bfe3-bec2fb1eb2c7/187-196)
        - Result: `+ 5 seconds` to restore the cache.