### PR TITLE
[Order Creation] Track orders with customers that are registered or not

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/customerlist/CustomerListSelectionViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/customerlist/CustomerListSelectionViewModel.kt
@@ -37,7 +37,7 @@ class CustomerListSelectionViewModel @Inject constructor(
     override fun onCustomerSelected(customerModel: WCCustomerModel) {
         analyticsTracker.track(
             AnalyticsEvent.ORDER_CREATION_CUSTOMER_ADDED,
-            mapOf("is_customer_registered" to (customerModel.remoteCustomerId > 0L))
+            mapOf("is_customer_registered" to (customerModel.remoteCustomerId > 0L).toString())
         )
         when {
             customerModel.remoteCustomerId > 0L -> {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/customerlist/CustomerListSelectionViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/customerlist/CustomerListSelectionViewModel.kt
@@ -35,7 +35,10 @@ class CustomerListSelectionViewModel @Inject constructor(
     private var loadingMoreInfoAboutCustomerJob: Job? = null
 
     override fun onCustomerSelected(customerModel: WCCustomerModel) {
-        analyticsTracker.track(AnalyticsEvent.ORDER_CREATION_CUSTOMER_ADDED)
+        analyticsTracker.track(
+            AnalyticsEvent.ORDER_CREATION_CUSTOMER_ADDED,
+            mapOf("is_customer_registered" to (customerModel.remoteCustomerId > 0L))
+        )
         when {
             customerModel.remoteCustomerId > 0L -> {
                 // this customer is registered, so we may have more info on them

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/creation/customerlist/CustomerListSelectionViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/creation/customerlist/CustomerListSelectionViewModelTest.kt
@@ -863,7 +863,10 @@ class CustomerListSelectionViewModelTest : BaseUnitTest() {
                     )
                 )
             )
-            verify(analyticsTrackerWrapper).track(AnalyticsEvent.ORDER_CREATION_CUSTOMER_ADDED)
+            verify(analyticsTrackerWrapper).track(
+                AnalyticsEvent.ORDER_CREATION_CUSTOMER_ADDED,
+                mapOf("is_customer_registered" to "true")
+            )
         }
 
     @Test
@@ -913,7 +916,10 @@ class CustomerListSelectionViewModelTest : BaseUnitTest() {
             // THEN
             assertThat(states[0].partialLoading).isFalse
             assertThat(states[1].partialLoading).isTrue
-            verify(analyticsTrackerWrapper).track(AnalyticsEvent.ORDER_CREATION_CUSTOMER_ADDED)
+            verify(analyticsTrackerWrapper).track(
+                AnalyticsEvent.ORDER_CREATION_CUSTOMER_ADDED,
+                mapOf("is_customer_registered" to "true")
+            )
         }
 
     @Test
@@ -966,7 +972,10 @@ class CustomerListSelectionViewModelTest : BaseUnitTest() {
                     )
                 )
             )
-            verify(analyticsTrackerWrapper).track(AnalyticsEvent.ORDER_CREATION_CUSTOMER_ADDED)
+            verify(analyticsTrackerWrapper).track(
+                AnalyticsEvent.ORDER_CREATION_CUSTOMER_ADDED,
+                mapOf("is_customer_registered" to "true")
+            )
         }
 
     @Test
@@ -1026,7 +1035,10 @@ class CustomerListSelectionViewModelTest : BaseUnitTest() {
                     )
                 )
             )
-            verify(analyticsTrackerWrapper).track(AnalyticsEvent.ORDER_CREATION_CUSTOMER_ADDED)
+            verify(analyticsTrackerWrapper).track(
+                AnalyticsEvent.ORDER_CREATION_CUSTOMER_ADDED,
+                mapOf("is_customer_registered" to "true")
+            )
         }
 
     @Test
@@ -1076,7 +1088,10 @@ class CustomerListSelectionViewModelTest : BaseUnitTest() {
                     )
                 )
             )
-            verify(analyticsTrackerWrapper).track(AnalyticsEvent.ORDER_CREATION_CUSTOMER_ADDED)
+            verify(analyticsTrackerWrapper).track(
+                AnalyticsEvent.ORDER_CREATION_CUSTOMER_ADDED,
+                mapOf("is_customer_registered" to "false")
+            )
         }
 
     @Test


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #13405
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
The PR adds a property`is_customer_registered` to `ORDER_CREATION_CUSTOMER_ADDED` event
The goal is to eventually have some data on what type of customers our merchants add in the mobile app

### Steps to reproduce
<!-- Step-by-step testing instructions. For new user flows, consider instead stating the goal of the workflow and see if your PR reviewer can accomplish the workflow without specific steps! -->
* Order -> Order creation
* Add a customer registered and not
* Noticed tracking in the logcat:

```
Tracked: woocommerceandroid_order_creation_customer_added, Properties: {"is_customer_registered":"false","blog_id":198349371,"is_wpcom_store":true,"was_ecommerce_trial":false,"plan_product_slug":"business-bundle","store_id":"534e18db-8439-411e-9dfc-467cf73a450f","is_debug":true,"site_url":"https:\/\/paymentwithoutaddress.wpcomstaging.com","cached_woo_core_version":"9.6.0"}
Tracked: woocommerceandroid_order_creation_customer_added, Properties: {"is_customer_registered":"true","blog_id":198349371,"is_wpcom_store":true,"was_ecommerce_trial":false,"plan_product_slug":"business-bundle","store_id":"534e18db-8439-411e-9dfc-467cf73a450f","is_debug":true,"site_url":"https:\/\/paymentwithoutaddress.wpcomstaging.com","cached_woo_core_version":"9.6.0"}
```

### The tests that have been performed
<!-- To give the reviewer an idea of what could be missed in terms of testing -->

Above
### Images/gif
<!-- Include before and after images or gifs when appropriate. -->
No visual changes

- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.

## Reviewer (or Author, in the case of optional code reviews):

Please make sure these conditions are met before approving the PR, or request changes if the PR needs improvement:

- [x] The PR is small and has a clear, single focus, or a valid explanation is provided in the description. If needed, please request to split it into smaller PRs.
- [x] Ensure Adequate Unit Test Coverage: The changes are reasonably covered by unit tests or an explanation is provided in the PR description.
- [x] Manual Testing: The author listed all the tests they ran, including smoke tests when needed (e.g., for refactorings). The reviewer confirmed that the PR works as expected on big (tablet) and small (phone) in case of UI changes, and no regressions are added.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->