### PR TITLE
[Receipts] IO Exception crash

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/receipt/preview/ReceiptPreviewFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/receipt/preview/ReceiptPreviewFragment.kt
@@ -39,6 +39,8 @@ class ReceiptPreviewFragment : BaseFragment(R.layout.fragment_receipt_preview), 
     private var _binding: FragmentReceiptPreviewBinding? = null
     private val binding get() = _binding!!
 
+    private var urlToLoad: String? = null
+
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
 
@@ -59,10 +61,12 @@ class ReceiptPreviewFragment : BaseFragment(R.layout.fragment_receipt_preview), 
                 viewModel.onPrintClicked()
                 true
             }
+
             R.id.menu_send -> {
                 viewModel.onShareClicked()
                 true
             }
+
             else -> false
         }
     }
@@ -102,9 +106,12 @@ class ReceiptPreviewFragment : BaseFragment(R.layout.fragment_receipt_preview), 
                     override fun shouldInterceptRequest(
                         view: WebView,
                         request: WebResourceRequest
-                    ): WebResourceResponse? {
-                        return interceptAndModifyReceiptResponse(request)
-                    }
+                    ): WebResourceResponse? =
+                        if (request.url.toString() == urlToLoad) {
+                            interceptAndModifyReceiptResponse(request)
+                        } else {
+                            null
+                        }
 
                     override fun onPageFinished(view: WebView, url: String) {
                         viewModel.onReceiptLoaded()
@@ -142,7 +149,10 @@ class ReceiptPreviewFragment : BaseFragment(R.layout.fragment_receipt_preview), 
         }
         viewModel.event.observe(viewLifecycleOwner) {
             when (it) {
-                is LoadUrl -> binding.receiptPreviewPreviewWebview.loadUrl(it.url)
+                is LoadUrl -> {
+                    urlToLoad = it.url
+                    binding.receiptPreviewPreviewWebview.loadUrl(it.url)
+                }
                 is PrintReceipt -> printHtmlHelper.printReceipt(requireActivity(), it.receiptUrl, it.documentName)
                 is ShowSnackbar -> uiMessageResolver.showSnack(it.message)
                 else -> it.isHandled = false

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/receipt/preview/ReceiptPreviewFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/receipt/preview/ReceiptPreviewFragment.kt
@@ -116,7 +116,6 @@ class ReceiptPreviewFragment : BaseFragment(R.layout.fragment_receipt_preview), 
 
     private fun interceptAndModifyReceiptResponse(request: WebResourceRequest): WebResourceResponse? {
         return try {
-            println("request.url: ${request.url}")
             val connection = URL(request.url.toString()).openConnection()
             val inputStream = connection.getInputStream()
             val originalHtml = inputStream.bufferedReader().use { it.readText() }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/receipt/preview/ReceiptPreviewFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/receipt/preview/ReceiptPreviewFragment.kt
@@ -18,6 +18,7 @@ import com.woocommerce.android.ui.base.BaseFragment
 import com.woocommerce.android.ui.base.UIMessageResolver
 import com.woocommerce.android.util.PrintHtmlHelper
 import com.woocommerce.android.util.UiHelpers
+import com.woocommerce.android.util.WooLog
 import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.ShowSnackbar
 import dagger.hilt.android.AndroidEntryPoint
 import java.io.IOException
@@ -115,6 +116,7 @@ class ReceiptPreviewFragment : BaseFragment(R.layout.fragment_receipt_preview), 
 
     private fun interceptAndModifyReceiptResponse(request: WebResourceRequest): WebResourceResponse? {
         return try {
+            println("request.url: ${request.url}")
             val connection = URL(request.url.toString()).openConnection()
             val inputStream = connection.getInputStream()
             val originalHtml = inputStream.bufferedReader().use { it.readText() }
@@ -129,7 +131,8 @@ class ReceiptPreviewFragment : BaseFragment(R.layout.fragment_receipt_preview), 
         } catch (e: MalformedURLException) {
             throw IllegalArgumentException("Invalid receipt URL: ${request.url}", e)
         } catch (e: IOException) {
-            throw IOException("Failed to read content from receipt URL: ${request.url}", e)
+            WooLog.e(WooLog.T.ORDERS, "Failed to read content from receipt URL: ${request.url}", e)
+            null
         }
     }
 


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #13410 
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
We are crashing on IOException when loading a receipt. The PR logs the case and return null which means keep loading

### Steps to reproduce
<!-- Step-by-step testing instructions. For new user flows, consider instead stating the goal of the workflow and see if your PR reviewer can accomplish the workflow without specific steps! -->
* Put break point on `openConnection`
* Load a receipt
* When break point hits it, disabled internet
* Resume -> Notice crash

### The tests that have been performed
<!-- To give the reviewer an idea of what could be missed in terms of testing -->
Above

- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.

## Reviewer (or Author, in the case of optional code reviews):

Please make sure these conditions are met before approving the PR, or request changes if the PR needs improvement:

- [x] The PR is small and has a clear, single focus, or a valid explanation is provided in the description. If needed, please request to split it into smaller PRs.
- [x] Ensure Adequate Unit Test Coverage: The changes are reasonably covered by unit tests or an explanation is provided in the PR description.
- [x] Manual Testing: The author listed all the tests they ran, including smoke tests when needed (e.g., for refactorings). The reviewer confirmed that the PR works as expected on big (tablet) and small (phone) in case of UI changes, and no regressions are added.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->