### PR TITLE
[Shipping Labels Revamp] Add Customs requirement check

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/WooShippingLabelCreationScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/WooShippingLabelCreationScreen.kt
@@ -62,6 +62,8 @@ import com.woocommerce.android.R
 import com.woocommerce.android.ui.compose.component.WCColoredButton
 import com.woocommerce.android.ui.compose.modifiers.dashedBorder
 import com.woocommerce.android.ui.compose.theme.WooThemeWithBackground
+import com.woocommerce.android.ui.orders.wooshippinglabels.WooShippingLabelCreationViewModel.CustomsState
+import com.woocommerce.android.ui.orders.wooshippinglabels.WooShippingLabelCreationViewModel.CustomsState.NotRequired
 import com.woocommerce.android.ui.orders.wooshippinglabels.WooShippingLabelCreationViewModel.PackageSelectionState
 import com.woocommerce.android.ui.orders.wooshippinglabels.WooShippingLabelCreationViewModel.PackageSelectionState.DataAvailable
 import com.woocommerce.android.ui.orders.wooshippinglabels.WooShippingLabelCreationViewModel.PackageSelectionState.NotSelected
@@ -93,6 +95,7 @@ fun WooShippingLabelCreationScreen(viewModel: WooShippingLabelCreationViewModel)
                 shippingAddresses = viewState.shippingAddresses,
                 shippingRatesState = viewState.shippingRates,
                 packageSelectionState = viewState.packageSelection,
+                customsState = viewState.customsState,
                 onShippingFromAddressChange = viewModel::onShippingFromAddressChange,
                 onEditOriginAddress = viewModel::onEditOriginAddress,
                 onSelectedRateSortOrderChanged = viewModel::onSelectedRateSortOrderChanged,
@@ -124,6 +127,7 @@ fun WooShippingLabelCreationScreen(
     shippingRatesState: WooShippingLabelCreationViewModel.ShippingRatesState,
     packageSelectionState: PackageSelectionState,
     shippingAddresses: WooShippingAddresses,
+    customsState: CustomsState,
     onShippingFromAddressChange: (OriginShippingAddress) -> Unit,
     onEditOriginAddress: (OriginShippingAddress) -> Unit,
     onSelectPackageClick: () -> Unit,
@@ -635,6 +639,7 @@ private fun WooShippingLabelCreationScreenPreview() {
             ),
             shippingRatesState = WooShippingLabelCreationViewModel.ShippingRatesState.NoAvailable,
             packageSelectionState = NotSelected,
+            customsState = NotRequired,
             onShippingFromAddressChange = {},
             onRefreshShippingRates = {},
             onSelectedRateSortOrderChanged = {},

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/WooShippingLabelCreationScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/WooShippingLabelCreationScreen.kt
@@ -418,18 +418,26 @@ private fun CustomsCard(
                     color = MaterialTheme.colors.surface,
                     shape = RoundedCornerShape(dimensionResource(R.dimen.corner_radius_large))
                 )
+                .border(
+                    width = dimensionResource(R.dimen.minor_10),
+                    color = colorResource(R.color.divider_color),
+                    shape = RoundedCornerShape(dimensionResource(R.dimen.corner_radius_large))
+                )
         ) {
             Text(
                 text = stringResource(id = R.string.shipping_labels_customs_title),
                 style = MaterialTheme.typography.subtitle1,
                 color = MaterialTheme.colors.onSurface,
+                textAlign = TextAlign.Start,
+                fontWeight = FontWeight.SemiBold,
                 modifier = Modifier
-                    .padding(dimensionResource(id = R.dimen.major_200))
+                    .padding(24.dp)
                     .align(Alignment.CenterVertically)
+                    .weight(1f)
             )
             Text(
                 text = stringResource(id = R.string.shipping_labels_customs_missing_info_badge),
-                style = MaterialTheme.typography.subtitle1,
+                style = MaterialTheme.typography.caption,
                 color = colorResource(id = R.color.color_on_surface_medium),
                 modifier = Modifier
                     .padding(dimensionResource(id = R.dimen.minor_100))

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/WooShippingLabelCreationScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/WooShippingLabelCreationScreen.kt
@@ -64,6 +64,7 @@ import com.woocommerce.android.ui.compose.modifiers.dashedBorder
 import com.woocommerce.android.ui.compose.theme.WooThemeWithBackground
 import com.woocommerce.android.ui.orders.wooshippinglabels.WooShippingLabelCreationViewModel.CustomsState
 import com.woocommerce.android.ui.orders.wooshippinglabels.WooShippingLabelCreationViewModel.CustomsState.NotRequired
+import com.woocommerce.android.ui.orders.wooshippinglabels.WooShippingLabelCreationViewModel.CustomsState.Unavailable
 import com.woocommerce.android.ui.orders.wooshippinglabels.WooShippingLabelCreationViewModel.PackageSelectionState
 import com.woocommerce.android.ui.orders.wooshippinglabels.WooShippingLabelCreationViewModel.PackageSelectionState.DataAvailable
 import com.woocommerce.android.ui.orders.wooshippinglabels.WooShippingLabelCreationViewModel.PackageSelectionState.NotSelected
@@ -410,14 +411,31 @@ private fun CustomsCard(
     modifier: Modifier = Modifier,
     customsState: CustomsState
 ) {
-    Column(
-        modifier = modifier
-            .background(
-                color = MaterialTheme.colors.surface,
-                shape = RoundedCornerShape(dimensionResource(R.dimen.corner_radius_large))
+    if (customsState !is NotRequired) {
+        Row(
+            modifier = modifier
+                .background(
+                    color = MaterialTheme.colors.surface,
+                    shape = RoundedCornerShape(dimensionResource(R.dimen.corner_radius_large))
+                )
+        ) {
+            Text(
+                text = stringResource(id = R.string.shipping_labels_customs_title),
+                style = MaterialTheme.typography.subtitle1,
+                color = MaterialTheme.colors.onSurface,
+                modifier = Modifier
+                    .padding(dimensionResource(id = R.dimen.major_200))
+                    .align(Alignment.CenterVertically)
             )
-    ) {
-
+            Text(
+                text = stringResource(id = R.string.shipping_labels_customs_missing_info_badge),
+                style = MaterialTheme.typography.subtitle1,
+                color = colorResource(id = R.color.color_on_surface_medium),
+                modifier = Modifier
+                    .padding(dimensionResource(id = R.dimen.minor_100))
+                    .align(Alignment.CenterVertically)
+            )
+        }
     }
 }
 
@@ -663,7 +681,7 @@ private fun WooShippingLabelCreationScreenPreview() {
             ),
             shippingRatesState = WooShippingLabelCreationViewModel.ShippingRatesState.NoAvailable,
             packageSelectionState = NotSelected,
-            customsState = NotRequired,
+            customsState = Unavailable,
             onShippingFromAddressChange = {},
             onRefreshShippingRates = {},
             onSelectedRateSortOrderChanged = {},

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/WooShippingLabelCreationScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/WooShippingLabelCreationScreen.kt
@@ -109,7 +109,8 @@ fun WooShippingLabelCreationScreen(viewModel: WooShippingLabelCreationViewModel)
                 onNavigateBack = viewModel::onNavigateBack,
                 purchaseState = viewState.purchaseState,
                 onShipmentDetailsExpandedChange = viewModel::onShipmentDetailsExpandedChange,
-                onSelectAddressExpandedChange = viewModel::onSelectAddressExpandedChange
+                onSelectAddressExpandedChange = viewModel::onSelectAddressExpandedChange,
+                onEditCustomsClick = {}
             )
         }
 
@@ -143,6 +144,7 @@ fun WooShippingLabelCreationScreen(
     onShipmentDetailsExpandedChange: (Boolean) -> Boolean,
     onSelectAddressExpandedChange: (Boolean) -> Boolean,
     purchaseState: WooShippingLabelCreationViewModel.PurchaseState,
+    onEditCustomsClick: () -> Unit,
     onNavigateBack: () -> Unit,
     modifier: Modifier = Modifier
 ) {
@@ -203,7 +205,8 @@ fun WooShippingLabelCreationScreen(
             onNavigateBack = onNavigateBack,
             onMarkOrderCompleteChange = onMarkOrderCompleteChange,
             shipFromSelectionBottomSheetState = shipFromSelectionBottomSheetState,
-            onShipmentDetailsExpandedChange = onShipmentDetailsExpandedChange
+            onShipmentDetailsExpandedChange = onShipmentDetailsExpandedChange,
+            onEditCustomsClick = onEditCustomsClick
         )
         val isDarkTheme = isSystemInDarkTheme()
         val isCollapsed = scaffoldState.bottomSheetState.isCollapsed
@@ -276,6 +279,7 @@ private fun LabelCreationScreenWithBottomSheet(
     onMarkOrderCompleteChange: (Boolean) -> Unit,
     onNavigateBack: () -> Unit,
     onShipmentDetailsExpandedChange: (Boolean) -> Boolean,
+    onEditCustomsClick: () -> Unit,
     modifier: Modifier = Modifier
 ) {
     val isPurchaseButtonDisplayed = shippingRatesState is WooShippingLabelCreationViewModel.ShippingRatesState.DataState
@@ -348,6 +352,7 @@ private fun LabelCreationScreenWithBottomSheet(
                 )
                 CustomsCard(
                     customsState = customsState,
+                    onEditCustomsClick = onEditCustomsClick,
                     modifier = Modifier
                         .fillMaxWidth()
                         .padding(16.dp)
@@ -409,7 +414,8 @@ internal fun HazmatCard(
 @Composable
 private fun CustomsCard(
     modifier: Modifier = Modifier,
-    customsState: CustomsState
+    customsState: CustomsState,
+    onEditCustomsClick: () -> Unit
 ) {
     if (customsState !is NotRequired) {
         Row(
@@ -449,6 +455,18 @@ private fun CustomsCard(
                     color = MaterialTheme.colors.onSurface,
                     modifier = Modifier
                         .padding(horizontal = 12.dp, vertical = 8.dp)
+                )
+            }
+
+            IconButton(
+                onClick = onEditCustomsClick,
+                modifier = Modifier
+                    .align(Alignment.CenterVertically)
+            ) {
+                Icon(
+                    imageVector = Icons.Filled.Edit,
+                    tint = colorResource(id = R.color.color_icon_menu),
+                    contentDescription = stringResource(id = R.string.shipping_label_package_selected_description)
                 )
             }
         }
@@ -714,7 +732,8 @@ private fun WooShippingLabelCreationScreenPreview() {
                 isAddressSelectionExpanded = false
             ),
             onShipmentDetailsExpandedChange = { true },
-            onSelectAddressExpandedChange = { true }
+            onSelectAddressExpandedChange = { true },
+            onEditCustomsClick = {}
         )
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/WooShippingLabelCreationScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/WooShippingLabelCreationScreen.kt
@@ -188,6 +188,7 @@ fun WooShippingLabelCreationScreen(
             scaffoldState = scaffoldState,
             shippingLines = shippingLines,
             shippingAddresses = shippingAddresses,
+            customsState = customsState,
             shippingRatesState = shippingRatesState,
             packageSelectionState = packageSelectionState,
             onShippingFromAddressChange = onShippingFromAddressChange,
@@ -258,6 +259,7 @@ private fun LabelCreationScreenWithBottomSheet(
     shippingLines: List<ShippingLineSummaryUI>,
     shippingRatesState: WooShippingLabelCreationViewModel.ShippingRatesState,
     packageSelectionState: PackageSelectionState,
+    customsState: CustomsState,
     onSelectPackageClick: () -> Unit,
     shippingAddresses: WooShippingAddresses,
     onEditOriginAddress: (OriginShippingAddress) -> Unit,
@@ -343,6 +345,12 @@ private fun LabelCreationScreenWithBottomSheet(
                         .fillMaxWidth()
                         .padding(start = 4.dp, end = 8.dp)
                 )
+                CustomsCard(
+                    customsState = customsState,
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .padding(16.dp)
+                )
                 PackageCard(
                     modifier = Modifier.padding(16.dp),
                     packageSelectionState = packageSelectionState,
@@ -394,6 +402,22 @@ internal fun HazmatCard(
                 .align(Alignment.CenterVertically)
                 .padding(end = dimensionResource(R.dimen.minor_50))
         )
+    }
+}
+
+@Composable
+private fun CustomsCard(
+    modifier: Modifier = Modifier,
+    customsState: CustomsState
+) {
+    Column(
+        modifier = modifier
+            .background(
+                color = MaterialTheme.colors.surface,
+                shape = RoundedCornerShape(dimensionResource(R.dimen.corner_radius_large))
+            )
+    ) {
+
     }
 }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/WooShippingLabelCreationScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/WooShippingLabelCreationScreen.kt
@@ -435,14 +435,22 @@ private fun CustomsCard(
                     .align(Alignment.CenterVertically)
                     .weight(1f)
             )
-            Text(
-                text = stringResource(id = R.string.shipping_labels_customs_missing_info_badge),
-                style = MaterialTheme.typography.caption,
-                color = colorResource(id = R.color.color_on_surface_medium),
+            Box(
                 modifier = Modifier
-                    .padding(dimensionResource(id = R.dimen.minor_100))
+                    .background(
+                        color = colorResource(id = R.color.woo_red_20),
+                        shape = RoundedCornerShape(dimensionResource(R.dimen.corner_radius_medium))
+                    )
                     .align(Alignment.CenterVertically)
-            )
+            ) {
+                Text(
+                    text = stringResource(id = R.string.shipping_labels_customs_missing_info_badge),
+                    style = MaterialTheme.typography.caption,
+                    color = MaterialTheme.colors.onSurface,
+                    modifier = Modifier
+                        .padding(horizontal = 12.dp, vertical = 8.dp)
+                )
+            }
         }
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/WooShippingLabelCreationScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/WooShippingLabelCreationScreen.kt
@@ -454,7 +454,7 @@ private fun CustomsCard(
                     style = MaterialTheme.typography.caption,
                     color = MaterialTheme.colors.onSurface,
                     modifier = Modifier
-                        .padding(horizontal = 12.dp, vertical = 8.dp)
+                        .padding(horizontal = 16.dp, vertical = 8.dp)
                 )
             }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/WooShippingLabelCreationScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/WooShippingLabelCreationScreen.kt
@@ -413,9 +413,9 @@ internal fun HazmatCard(
 
 @Composable
 private fun CustomsCard(
-    modifier: Modifier = Modifier,
     customsState: CustomsState,
-    onEditCustomsClick: () -> Unit
+    onEditCustomsClick: () -> Unit,
+    modifier: Modifier = Modifier
 ) {
     if (customsState !is NotRequired) {
         Row(
@@ -475,11 +475,11 @@ private fun CustomsCard(
 
 @Composable
 private fun PackageCard(
-    modifier: Modifier = Modifier,
     packageSelectionState: PackageSelectionState,
     customWeight: String,
     onSelectPackageClick: () -> Unit,
     onCustomWeightChange: (String) -> Unit,
+    modifier: Modifier = Modifier,
 ) {
     when (packageSelectionState) {
         is NotSelected -> SelectPackageCard(
@@ -501,8 +501,8 @@ private fun PackageCard(
 
 @Composable
 private fun SelectPackageCard(
-    modifier: Modifier = Modifier,
-    onSelectPackageClick: () -> Unit
+    onSelectPackageClick: () -> Unit,
+    modifier: Modifier = Modifier
 ) {
     Column(
         modifier = modifier
@@ -551,13 +551,13 @@ private fun SelectPackageCard(
 
 @Composable
 private fun PackageSelectionAvailableCard(
-    modifier: Modifier = Modifier,
     packageData: PackageData,
     defaultWeight: String,
     customWeight: String,
     customWeightUnit: String,
     onSelectPackageClick: () -> Unit,
-    onCustomWeightChange: (String) -> Unit
+    onCustomWeightChange: (String) -> Unit,
+    modifier: Modifier = Modifier
 ) {
     Column(modifier = modifier.background(color = MaterialTheme.colors.surface)) {
         Row(

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/WooShippingLabelCreationScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/WooShippingLabelCreationScreen.kt
@@ -429,6 +429,7 @@ private fun CustomsCard(
                     color = colorResource(R.color.divider_color),
                     shape = RoundedCornerShape(dimensionResource(R.dimen.corner_radius_large))
                 )
+                .padding(start = 16.dp, top = 6.dp, bottom = 6.dp, end = 8.dp)
         ) {
             Text(
                 text = stringResource(id = R.string.shipping_labels_customs_title),
@@ -437,7 +438,6 @@ private fun CustomsCard(
                 textAlign = TextAlign.Start,
                 fontWeight = FontWeight.SemiBold,
                 modifier = Modifier
-                    .padding(24.dp)
                     .align(Alignment.CenterVertically)
                     .weight(1f)
             )

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/WooShippingLabelCreationViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/WooShippingLabelCreationViewModel.kt
@@ -13,6 +13,7 @@ import com.woocommerce.android.model.Address
 import com.woocommerce.android.model.Order
 import com.woocommerce.android.ui.orders.details.OrderDetailRepository
 import com.woocommerce.android.ui.orders.wooshippinglabels.WooShippingLabelCreationViewModel.CustomsState.NotRequired
+import com.woocommerce.android.ui.orders.wooshippinglabels.WooShippingLabelCreationViewModel.CustomsState.Unavailable
 import com.woocommerce.android.ui.orders.wooshippinglabels.WooShippingLabelCreationViewModel.PackageSelectionState.DataAvailable
 import com.woocommerce.android.ui.orders.wooshippinglabels.WooShippingLabelCreationViewModel.PackageSelectionState.NotSelected
 import com.woocommerce.android.ui.orders.wooshippinglabels.address.ObserveOriginAddresses
@@ -44,6 +45,8 @@ import kotlinx.coroutines.launch
 import kotlinx.parcelize.Parcelize
 import java.util.Date
 import javax.inject.Inject
+import kotlinx.coroutines.flow.launchIn
+import kotlinx.coroutines.flow.onEach
 
 @HiltViewModel
 class WooShippingLabelCreationViewModel @Inject constructor(
@@ -108,6 +111,7 @@ class WooShippingLabelCreationViewModel @Inject constructor(
         launch { observePackageChanges() }
         launch { observeShippingRates() }
         launch { observeShippingRatesState() }
+        launch { observeCustomsDataChanges() }
     }
 
     private suspend fun getOrderInformation() {
@@ -212,6 +216,19 @@ class WooShippingLabelCreationViewModel @Inject constructor(
         }.collectLatest {
             packageSelection.value = it
         }
+    }
+
+    // This logic will be updated later once the Customs data state is available
+    private suspend fun observeCustomsDataChanges() {
+        combine(
+            shippingAddresses,
+            customsState
+        ) { addresses, _ ->
+            when {
+                addresses != null && shouldRequireCustoms(addresses) -> Unavailable
+                else -> NotRequired
+            }
+        }.collectLatest { customsState.value = it }
     }
 
     private suspend fun getShippingAddresses() {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/WooShippingLabelCreationViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/WooShippingLabelCreationViewModel.kt
@@ -45,8 +45,6 @@ import kotlinx.coroutines.launch
 import kotlinx.parcelize.Parcelize
 import java.util.Date
 import javax.inject.Inject
-import kotlinx.coroutines.flow.launchIn
-import kotlinx.coroutines.flow.onEach
 
 @HiltViewModel
 class WooShippingLabelCreationViewModel @Inject constructor(

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/WooShippingLabelCreationViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/WooShippingLabelCreationViewModel.kt
@@ -12,6 +12,7 @@ import com.woocommerce.android.extensions.sumByFloat
 import com.woocommerce.android.model.Address
 import com.woocommerce.android.model.Order
 import com.woocommerce.android.ui.orders.details.OrderDetailRepository
+import com.woocommerce.android.ui.orders.wooshippinglabels.WooShippingLabelCreationViewModel.CustomsState.NotRequired
 import com.woocommerce.android.ui.orders.wooshippinglabels.WooShippingLabelCreationViewModel.PackageSelectionState.DataAvailable
 import com.woocommerce.android.ui.orders.wooshippinglabels.WooShippingLabelCreationViewModel.PackageSelectionState.NotSelected
 import com.woocommerce.android.ui.orders.wooshippinglabels.address.ObserveOriginAddresses
@@ -68,6 +69,7 @@ class WooShippingLabelCreationViewModel @Inject constructor(
     private val packageSelected = MutableStateFlow<PackageData?>(null)
     private val packageWeight = MutableStateFlow<PackageWeight?>(null)
     private val packageSelection = MutableStateFlow<PackageSelectionState>(NotSelected)
+    private val customsState = MutableStateFlow<CustomsState>(NotRequired)
 
     private val uiState = MutableStateFlow(
         UIControlsState(
@@ -262,7 +264,8 @@ class WooShippingLabelCreationViewModel @Inject constructor(
             packageSelection,
             uiState,
             purchaseState,
-        ) { storeOptions, order, addresses, shippingRates, packageSelection, uiState, purchaseState ->
+            customsState
+        ) { storeOptions, order, addresses, shippingRates, packageSelection, uiState, purchaseState, customsState ->
             if (order == null || storeOptions == null || addresses == null || purchaseState is PurchaseState.Error) {
                 return@combine WooShippingViewState.Error
             }
@@ -287,7 +290,8 @@ class WooShippingLabelCreationViewModel @Inject constructor(
                 shippingRates = shippingRates,
                 packageSelection = packageSelection,
                 uiState = uiState,
-                purchaseState = purchaseState
+                purchaseState = purchaseState,
+                customsState = customsState
             )
         }.collectLatest {
             viewState.value = it
@@ -482,7 +486,8 @@ class WooShippingLabelCreationViewModel @Inject constructor(
             val shippingRates: ShippingRatesState,
             val packageSelection: PackageSelectionState,
             val uiState: UIControlsState,
-            val purchaseState: PurchaseState
+            val purchaseState: PurchaseState,
+            val customsState: CustomsState
         ) : WooShippingViewState()
     }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/WooShippingLabelCreationViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/WooShippingLabelCreationViewModel.kt
@@ -15,6 +15,7 @@ import com.woocommerce.android.ui.orders.details.OrderDetailRepository
 import com.woocommerce.android.ui.orders.wooshippinglabels.WooShippingLabelCreationViewModel.PackageSelectionState.DataAvailable
 import com.woocommerce.android.ui.orders.wooshippinglabels.WooShippingLabelCreationViewModel.PackageSelectionState.NotSelected
 import com.woocommerce.android.ui.orders.wooshippinglabels.address.ObserveOriginAddresses
+import com.woocommerce.android.ui.orders.wooshippinglabels.customs.ShouldRequireCustomsForm
 import com.woocommerce.android.ui.orders.wooshippinglabels.models.OriginShippingAddress
 import com.woocommerce.android.ui.orders.wooshippinglabels.models.ShippableItemModel
 import com.woocommerce.android.ui.orders.wooshippinglabels.models.StoreOptionsModel
@@ -52,7 +53,8 @@ class WooShippingLabelCreationViewModel @Inject constructor(
     private val observeOriginAddresses: ObserveOriginAddresses,
     private val getShippingRates: GetShippingRates,
     private val purchaseShippingLabel: PurchaseShippingLabel,
-    private val observeStoreOptions: ObserveStoreOptions
+    private val observeStoreOptions: ObserveStoreOptions,
+    private val shouldRequireCustoms: ShouldRequireCustomsForm
 ) : ScopedViewModel(savedState) {
     private val navArgs: WooShippingLabelCreationFragmentArgs by savedState.navArgs()
 
@@ -539,6 +541,11 @@ class WooShippingLabelCreationViewModel @Inject constructor(
         val shipTo: Address,
         val weight: Float,
         val currencyCode: String?
+    )
+
+    // This will be extended later with the data coming from the Customs form
+    data class CustomsState(
+        val requiresCustomsForm: Boolean
     )
 
     companion object {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/WooShippingLabelCreationViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/WooShippingLabelCreationViewModel.kt
@@ -543,10 +543,11 @@ class WooShippingLabelCreationViewModel @Inject constructor(
         val currencyCode: String?
     )
 
-    // This will be extended later with the data coming from the Customs form
-    data class CustomsState(
-        val requiresCustomsForm: Boolean
-    )
+    // This will be extended later introducing the state with data coming from the Customs form
+    sealed class CustomsState {
+        data object NotRequired: CustomsState()
+        data object Unavailable: CustomsState()
+    }
 
     companion object {
         private const val TYPING_DELAY = 800L

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/WooShippingLabelCreationViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/WooShippingLabelCreationViewModel.kt
@@ -565,8 +565,8 @@ class WooShippingLabelCreationViewModel @Inject constructor(
 
     // This will be extended later introducing the state with data coming from the Customs form
     sealed class CustomsState {
-        data object NotRequired: CustomsState()
-        data object Unavailable: CustomsState()
+        data object NotRequired : CustomsState()
+        data object Unavailable : CustomsState()
     }
 
     companion object {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/customs/ShouldRequireCustomsForm.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/customs/ShouldRequireCustomsForm.kt
@@ -1,0 +1,8 @@
+package com.woocommerce.android.ui.orders.wooshippinglabels.customs
+
+class ShouldRequireCustomsForm {
+
+    operator fun invoke(): Boolean {
+        return false
+    }
+}

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/customs/ShouldRequireCustomsForm.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/customs/ShouldRequireCustomsForm.kt
@@ -5,8 +5,23 @@ import com.woocommerce.android.ui.orders.wooshippinglabels.WooShippingAddresses
 class ShouldRequireCustomsForm {
 
     operator fun invoke(addressData: WooShippingAddresses): Boolean {
-        return false
+        if (addressData.isDifferentCountryShipment) return true
+
+        val isOriginAddressMilitary = isAddressInMilitaryState(
+            addressData.shipFrom.country,
+            addressData.shipFrom.state.orEmpty()
+        )
+
+        val isShippingAddressMilitary = isAddressInMilitaryState(
+            addressData.shipTo.country.code,
+            addressData.shipTo.state.codeOrRaw
+        )
+
+        return isOriginAddressMilitary || isShippingAddressMilitary
     }
+
+    private val WooShippingAddresses.isDifferentCountryShipment
+        get() = shipFrom.country != shipTo.country.code
 
     private fun isAddressInMilitaryState(
         countryCode: String,

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/customs/ShouldRequireCustomsForm.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/customs/ShouldRequireCustomsForm.kt
@@ -1,8 +1,20 @@
 package com.woocommerce.android.ui.orders.wooshippinglabels.customs
 
+import com.woocommerce.android.ui.orders.wooshippinglabels.WooShippingAddresses
+
 class ShouldRequireCustomsForm {
 
-    operator fun invoke(): Boolean {
+    operator fun invoke(addressData: WooShippingAddresses): Boolean {
         return false
+    }
+
+    private fun isAddressInMilitaryState(
+        countryCode: String,
+        stateCode: String
+    ) = countryCode == US_COUNTRY_CODE && stateCode in US_MILITARY_STATES
+
+    companion object {
+        const val US_COUNTRY_CODE = "US"
+        val US_MILITARY_STATES = arrayOf("AA", "AE", "AP")
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/customs/ShouldRequireCustomsForm.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/customs/ShouldRequireCustomsForm.kt
@@ -1,9 +1,9 @@
 package com.woocommerce.android.ui.orders.wooshippinglabels.customs
 
 import com.woocommerce.android.ui.orders.wooshippinglabels.WooShippingAddresses
+import javax.inject.Inject
 
-class ShouldRequireCustomsForm {
-
+class ShouldRequireCustomsForm @Inject constructor() {
     operator fun invoke(addressData: WooShippingAddresses): Boolean {
         if (addressData.isDifferentCountryShipment) return true
 

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -1312,6 +1312,9 @@
     <string name="shipping_label_purchased_purchase_failed_error">We can\'t confirm the Shipping Label purchase right now, try again later</string>
     <string name="shipping_label_select_origin_default_address">%s (default)</string>
     <string name="shipping_label_select_origin_address">Address</string>
+    <string name="shipping_labels_customs_title">Customs</string>
+    <string name="shipping_labels_customs_missing_info_badge">Missing info</string>
+    <string name="shipping_labels_customs_completed_badge">Completed</string>
 
 
     <!--

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/WooShippingLabelCreationViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/WooShippingLabelCreationViewModelTest.kt
@@ -12,6 +12,7 @@ import com.woocommerce.android.ui.orders.wooshippinglabels.WooShippingLabelCreat
 import com.woocommerce.android.ui.orders.wooshippinglabels.WooShippingLabelCreationViewModel.WooShippingViewState
 import com.woocommerce.android.ui.orders.wooshippinglabels.WooShippingLabelCreationViewModel.WooShippingViewState.DataState
 import com.woocommerce.android.ui.orders.wooshippinglabels.address.ObserveOriginAddresses
+import com.woocommerce.android.ui.orders.wooshippinglabels.customs.ShouldRequireCustomsForm
 import com.woocommerce.android.ui.orders.wooshippinglabels.models.OriginShippingAddress
 import com.woocommerce.android.ui.orders.wooshippinglabels.models.PurchasedLabelData
 import com.woocommerce.android.ui.orders.wooshippinglabels.models.ShippableItemModel
@@ -203,6 +204,10 @@ class WooShippingLabelCreationViewModelTest : BaseUnitTest() {
     private val savedState: SavedStateHandle =
         WooShippingLabelCreationFragmentArgs(orderId = orderId).toSavedStateHandle()
 
+    private val shouldRequireCustomsForm : ShouldRequireCustomsForm = mock {
+        on { invoke(any()) } doReturn true
+    }
+
     private val observeOriginAddresses: ObserveOriginAddresses = mock()
     private val getShippingRates: GetShippingRates = mock()
     private val purchaseShippingLabel: PurchaseShippingLabel = mock()
@@ -219,6 +224,7 @@ class WooShippingLabelCreationViewModelTest : BaseUnitTest() {
             getShippingRates = getShippingRates,
             purchaseShippingLabel = purchaseShippingLabel,
             observeStoreOptions = observeStoreOptions,
+            shouldRequireCustoms = shouldRequireCustomsForm,
             savedState = savedState
         )
     }

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/WooShippingLabelCreationViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/WooShippingLabelCreationViewModelTest.kt
@@ -6,6 +6,7 @@ import com.woocommerce.android.model.Address
 import com.woocommerce.android.model.Order
 import com.woocommerce.android.ui.orders.OrderTestUtils
 import com.woocommerce.android.ui.orders.details.OrderDetailRepository
+import com.woocommerce.android.ui.orders.wooshippinglabels.WooShippingLabelCreationViewModel.CustomsState
 import com.woocommerce.android.ui.orders.wooshippinglabels.WooShippingLabelCreationViewModel.LabelPurchased
 import com.woocommerce.android.ui.orders.wooshippinglabels.WooShippingLabelCreationViewModel.PackageSelectionState.DataAvailable
 import com.woocommerce.android.ui.orders.wooshippinglabels.WooShippingLabelCreationViewModel.PurchaseState
@@ -564,6 +565,58 @@ class WooShippingLabelCreationViewModelTest : BaseUnitTest() {
         assertThat(dataState.packageSelection).isInstanceOf(DataAvailable::class.java)
         val dataAvailable = dataState.packageSelection as DataAvailable
         assertThat(dataAvailable.selectedPackage).isEqualTo(newPackageData)
+    }
+
+    @Test
+    fun `CustomState is NotRequired when shouldRequireCustomsForm returns false`() = testBlocking {
+        var currentViewState: WooShippingViewState? = null
+        val order = OrderTestUtils.generateTestOrder(orderId = orderId).copy(
+            shippingLines = defaultShippingLines
+        )
+        whenever(orderDetailRepository.getOrderById(any())) doReturn order
+        whenever(getShippableItems(any())) doReturn defaultShippableItems
+        whenever(observeOriginAddresses()) doReturn flowOf(defaultOriginAddresses)
+        whenever(observeStoreOptions()) doReturn flowOf(defaultStoreOptions)
+        whenever(shouldRequireCustomsForm.invoke(any())) doReturn false
+
+        createViewModel()
+
+        advanceUntilIdle()
+
+        sut.viewState.asLiveData().observeForever {
+            currentViewState = it
+        }
+
+        assertThat(currentViewState).isInstanceOf(DataState::class.java)
+        val dataState = currentViewState as DataState
+
+        assertThat(dataState.customsState).isEqualTo(CustomsState.NotRequired)
+    }
+
+    @Test
+    fun `CustomState is Unavailable when shouldRequireCustomsForm returns true`() = testBlocking {
+        var currentViewState: WooShippingViewState? = null
+        val order = OrderTestUtils.generateTestOrder(orderId = orderId).copy(
+            shippingLines = defaultShippingLines
+        )
+        whenever(orderDetailRepository.getOrderById(any())) doReturn order
+        whenever(getShippableItems(any())) doReturn defaultShippableItems
+        whenever(observeOriginAddresses()) doReturn flowOf(defaultOriginAddresses)
+        whenever(observeStoreOptions()) doReturn flowOf(defaultStoreOptions)
+        whenever(shouldRequireCustomsForm.invoke(any())) doReturn false
+
+        createViewModel()
+
+        advanceUntilIdle()
+
+        sut.viewState.asLiveData().observeForever {
+            currentViewState = it
+        }
+
+        assertThat(currentViewState).isInstanceOf(DataState::class.java)
+        val dataState = currentViewState as DataState
+
+        assertThat(dataState.customsState).isEqualTo(CustomsState.NotRequired)
     }
 
     @Test

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/WooShippingLabelCreationViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/WooShippingLabelCreationViewModelTest.kt
@@ -205,7 +205,7 @@ class WooShippingLabelCreationViewModelTest : BaseUnitTest() {
     private val savedState: SavedStateHandle =
         WooShippingLabelCreationFragmentArgs(orderId = orderId).toSavedStateHandle()
 
-    private val shouldRequireCustomsForm : ShouldRequireCustomsForm = mock {
+    private val shouldRequireCustomsForm: ShouldRequireCustomsForm = mock {
         on { invoke(any()) } doReturn true
     }
 

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/customs/ShouldRequireCustomsFormTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/customs/ShouldRequireCustomsFormTest.kt
@@ -1,0 +1,13 @@
+package com.woocommerce.android.ui.orders.wooshippinglabels.customs
+
+import org.junit.Before
+
+class ShouldRequireCustomsFormTest {
+
+    private lateinit var shouldRequireCustomsForm: ShouldRequireCustomsForm
+
+    @Before
+    fun setup() {
+        shouldRequireCustomsForm = ShouldRequireCustomsForm()
+    }
+}

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/customs/ShouldRequireCustomsFormTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/customs/ShouldRequireCustomsFormTest.kt
@@ -1,6 +1,14 @@
 package com.woocommerce.android.ui.orders.wooshippinglabels.customs
 
+import com.woocommerce.android.ui.orders.wooshippinglabels.WooShippingAddresses
+import com.woocommerce.android.ui.orders.wooshippinglabels.models.OriginShippingAddress
+import com.woocommerce.android.model.Address
+import com.woocommerce.android.model.AmbiguousLocation
+import com.woocommerce.android.model.Location
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
 import org.junit.Before
+import org.junit.Test
 
 class ShouldRequireCustomsFormTest {
 
@@ -9,5 +17,70 @@ class ShouldRequireCustomsFormTest {
     @Before
     fun setup() {
         shouldRequireCustomsForm = ShouldRequireCustomsForm()
+    }
+
+    @Test
+    fun `should return true for different countries`() {
+        val addressData = WooShippingAddresses(
+            shipFrom = OriginShippingAddress.EMPTY.copy(country = "US", state = "CA"),
+            shipTo = Address.EMPTY.copy(
+                country = Location.EMPTY.copy(code = "CA"),
+                state = AmbiguousLocation.Defined(Location.EMPTY.copy(code = "ON"))
+            ),
+            originAddresses = emptyList()
+        )
+        assertTrue(shouldRequireCustomsForm(addressData))
+    }
+
+    @Test
+    fun `should return false for same country`() {
+        val addressData = WooShippingAddresses(
+            shipFrom = OriginShippingAddress.EMPTY.copy(country = "US", state = "CA"),
+            shipTo = Address.EMPTY.copy(
+                country = Location.EMPTY.copy(code = "US"),
+                state = AmbiguousLocation.Defined(Location.EMPTY.copy(code = "NY"))
+            ),
+            originAddresses = emptyList()
+        )
+        assertFalse(shouldRequireCustomsForm(addressData))
+    }
+
+    @Test
+    fun `should return true for military origin address`() {
+        val addressData = WooShippingAddresses(
+            shipFrom = OriginShippingAddress.EMPTY.copy(country = "US", state = "AA"),
+            shipTo = Address.EMPTY.copy(
+                country = Location.EMPTY.copy(code = "US"),
+                state = AmbiguousLocation.Defined(Location.EMPTY.copy(code = "NY"))
+            ),
+            originAddresses = emptyList()
+        )
+        assertTrue(shouldRequireCustomsForm(addressData))
+    }
+
+    @Test
+    fun `should return true for military shipping address`() {
+        val addressData = WooShippingAddresses(
+            shipFrom = OriginShippingAddress.EMPTY.copy(country = "US", state = "CA"),
+            shipTo = Address.EMPTY.copy(
+                country = Location.EMPTY.copy(code = "US"),
+                state = AmbiguousLocation.Defined(Location.EMPTY.copy(code = "AE"))
+            ),
+            originAddresses = emptyList()
+        )
+        assertTrue(shouldRequireCustomsForm(addressData))
+    }
+
+    @Test
+    fun `should return false for no military addresses`() {
+        val addressData = WooShippingAddresses(
+            shipFrom = OriginShippingAddress.EMPTY.copy(country = "US", state = "CA"),
+            shipTo = Address.EMPTY.copy(
+                country = Location.EMPTY.copy(code = "US"),
+                state = AmbiguousLocation.Defined(Location.EMPTY.copy(code = "NY"))
+            ),
+            originAddresses = emptyList()
+        )
+        assertFalse(shouldRequireCustomsForm(addressData))
     }
 }

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/customs/ShouldRequireCustomsFormTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/customs/ShouldRequireCustomsFormTest.kt
@@ -1,10 +1,10 @@
 package com.woocommerce.android.ui.orders.wooshippinglabels.customs
 
-import com.woocommerce.android.ui.orders.wooshippinglabels.WooShippingAddresses
-import com.woocommerce.android.ui.orders.wooshippinglabels.models.OriginShippingAddress
 import com.woocommerce.android.model.Address
 import com.woocommerce.android.model.AmbiguousLocation
 import com.woocommerce.android.model.Location
+import com.woocommerce.android.ui.orders.wooshippinglabels.WooShippingAddresses
+import com.woocommerce.android.ui.orders.wooshippinglabels.models.OriginShippingAddress
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
 import org.junit.Before


### PR DESCRIPTION
Why
==========
Fix issue #13365 by introducing both the Customs section UI and the Customs requirement logic check.

How
==========
## Customs Section UI

The Customs section UI and state data is introduced through the same Mutable state flow logic using a new `CustomsState`. When no Customs data is required, the state is set as `NotRequired`, when it's required but not available, it's set as `Unavailable`. The `DataAvailable` state option will be added later once the form is finished.

## Customs requirement check

A use case called `ShouldRequireCustomsForm` is introduced, replicating the same logic used in the old Shipping Labels implementation declared at the `ShippingLabelsStateMachine.`

Screen Capture
==========
<img src="https://github.com/user-attachments/assets/d40abada-6900-40d3-b3cf-8651125768a6" width="270" height="570" />

How to Test
==========

## Scenario 1 - Customs required

1. Start the Shipping Labels creation flow
2. Fill the origin and destination address data, or make it pre-filled from the code if filling it is not available yet
3. Ensure the selected country between origin and destination addresses are different from each other
4. Verify the Customs section is displayed

## Scenario 2 - Customs *NOT* required

1. Start the Shipping Labels creation flow
2. Fill the origin and destination address data, or make it pre-filled from the code if filling it is not available yet
3. Ensure the selected country between origin and destination addresses are exactly the same
4. Verify the Customs section is hidden

Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

## Reviewer (or Author, in the case of optional code reviews):

Please make sure these conditions are met before approving the PR, or request changes if the PR needs improvement:

- [ ] The PR is small and has a clear, single focus, or a valid explanation is provided in the description. If needed, please request to split it into smaller PRs.
- [ ] Ensure Adequate Unit Test Coverage: The changes are reasonably covered by unit tests or an explanation is provided in the PR description.
- [ ] Manual Testing: The author listed all the tests they ran, including smoke tests when needed (e.g., for refactorings). The reviewer confirmed that the PR works as expected on big (tablet) and small (phone) in case of UI changes, and no regressions are added.