### PR TITLE
[Crash] Can't represent a size of 16777062 in constraints

### DIFF
--- a/WooCommerce/src/main/res/layout/fragment_order_list.xml
+++ b/WooCommerce/src/main/res/layout/fragment_order_list.xml
@@ -73,7 +73,7 @@
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
                 app:barrierDirection="bottom"
-                app:constraint_referenced_ids="jitmOrdersFragment" />
+                app:constraint_referenced_ids="order_filters_card, jitmOrdersFragment" />
 
             <com.woocommerce.android.ui.orders.list.OrderListView
                 android:id="@+id/order_list_view"

--- a/WooCommerce/src/main/res/layout/fragment_order_list.xml
+++ b/WooCommerce/src/main/res/layout/fragment_order_list.xml
@@ -2,13 +2,12 @@
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
-    android:layout_height="match_parent"
-    android:orientation="horizontal">
+    android:layout_height="match_parent">
 
     <com.woocommerce.android.widgets.ScrollChildSwipeRefreshLayout
         android:id="@+id/listPaneContainer"
         android:layout_width="0dp"
-        android:layout_height="match_parent"
+        android:layout_height="0dp"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintEnd_toStartOf="@id/two_pane_layout_guideline"
         app:layout_constraintTop_toTopOf="parent"
@@ -71,7 +70,7 @@
             <androidx.constraintlayout.widget.Barrier
                 android:id="@+id/orders_list_top_barrier"
                 android:layout_width="match_parent"
-                android:layout_height="wrap_content"
+                android:layout_height="0dp"
                 app:barrierDirection="bottom"
                 app:constraint_referenced_ids="order_filters_card, jitmOrdersFragment" />
 
@@ -101,7 +100,7 @@
     <androidx.constraintlayout.widget.Guideline
         android:id="@+id/two_pane_layout_guideline"
         android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
+        android:layout_height="0dp"
         app:layout_constraintGuide_percent="0.0"
         android:orientation="vertical" />
 
@@ -109,7 +108,7 @@
         android:id="@+id/detailPaneContainer"
         android:name="androidx.navigation.fragment.NavHostFragment"
         android:layout_width="0dp"
-        android:layout_height="match_parent"
+        android:layout_height="0dp"
         app:layout_constraintStart_toEndOf="@id/two_pane_layout_guideline"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintTop_toTopOf="parent"

--- a/WooCommerce/src/main/res/layout/fragment_order_list.xml
+++ b/WooCommerce/src/main/res/layout/fragment_order_list.xml
@@ -102,6 +102,7 @@
         android:id="@+id/two_pane_layout_guideline"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
+        app:layout_constraintGuide_percent="0.0"
         android:orientation="vertical" />
 
     <androidx.fragment.app.FragmentContainerView


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Issue: #13259 (I do not close it as there is a small chance that it actually fixed)
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
I have no idea why this happens, but most probably due to 2 pane support and some specific race conditions. The PR attempts to do changes that may fix it. The changes largerly proposed by the AI

Read this to see the reasoning why we think that it's related to 2 panes and order list

peaMlT-168-p2#comment-2790

### Steps to reproduce
<!-- Step-by-step testing instructions. For new user flows, consider instead stating the goal of the workflow and see if your PR reviewer can accomplish the workflow without specific steps! -->
We don't know how to reproduce

### Testing information
<!-- This is your opportunity to break out individual scenarios that need testing (when necessary) and/or include a checklist for the reviewer to go through. Consider documenting the following from your own completed testing: devices used, alternate workflows, edge cases, affected areas, critical flows, areas not tested, and any remaining unknowns. Provide feedback on this new section of the PR template through Sept 30, 2024 to Apps Quality; additional context here: p91TBi-b8z-p2#comment-12036 -->
Focus on regression testing regarding the UI on the order list. Try both 2 and 1 panes scenarios

### The tests that have been performed
<!-- To give the reviewer an idea of what could be missed in terms of testing -->

### Images/gif
<!-- Include before and after images or gifs when appropriate. -->

- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.

## Reviewer (or Author, in the case of optional code reviews):

Please make sure these conditions are met before approving the PR, or request changes if the PR needs improvement:

- [ ] The PR is small and has a clear, single focus, or a valid explanation is provided in the description. If needed, please request to split it into smaller PRs.
- [ ] Ensure Adequate Unit Test Coverage: The changes are reasonably covered by unit tests or an explanation is provided in the PR description.
- [ ] Manual Testing: The author listed all the tests they ran, including smoke tests when needed (e.g., for refactorings). The reviewer confirmed that the PR works as expected on big (tablet) and small (phone) in case of UI changes, and no regressions are added.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->