### PR TITLE
Update line height for prologue headers

### DIFF
--- a/WooCommerce/src/main/res/layout-land/fragment_login_prologue.xml
+++ b/WooCommerce/src/main/res/layout-land/fragment_login_prologue.xml
@@ -43,7 +43,8 @@
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toBottomOf="@id/image_prologue"
         app:layout_constraintVertical_chainStyle="packed"
-        app:layout_constraintWidth_percent="@dimen/prologue_width_percent" />
+        app:layout_constraintWidth_percent="@dimen/prologue_width_percent"
+        app:lineHeight="29sp" />
 
     <com.google.android.material.textview.MaterialTextView
         android:id="@+id/prologueTitle"

--- a/WooCommerce/src/main/res/layout-land/fragment_login_prologue_viewpager_item.xml
+++ b/WooCommerce/src/main/res/layout-land/fragment_login_prologue_viewpager_item.xml
@@ -23,6 +23,7 @@
         android:breakStrategy="balanced"
         android:gravity="center"
         android:textStyle="bold"
+        app:lineHeight="29sp"
         tools:text="@string/login_prologue_label_analytics" />
 
     <com.google.android.material.textview.MaterialTextView

--- a/WooCommerce/src/main/res/layout-sw600dp/fragment_login_prologue.xml
+++ b/WooCommerce/src/main/res/layout-sw600dp/fragment_login_prologue.xml
@@ -57,7 +57,8 @@
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toBottomOf="@id/imageView"
         app:layout_constraintVertical_chainStyle="packed"
-        app:layout_constraintWidth_percent="@dimen/prologue_width_percent" />
+        app:layout_constraintWidth_percent="@dimen/prologue_width_percent"
+        app:lineHeight="29sp" />
 
     <com.google.android.material.textview.MaterialTextView
         android:id="@+id/prologueTitle"

--- a/WooCommerce/src/main/res/layout/fragment_login_prologue.xml
+++ b/WooCommerce/src/main/res/layout/fragment_login_prologue.xml
@@ -54,7 +54,8 @@
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toBottomOf="@id/imageView"
-        app:layout_constraintVertical_chainStyle="packed" />
+        app:layout_constraintVertical_chainStyle="packed"
+        app:lineHeight="29sp" />
 
     <com.google.android.material.textview.MaterialTextView
         android:id="@+id/prologueTitle"

--- a/WooCommerce/src/main/res/layout/fragment_login_prologue_viewpager_item.xml
+++ b/WooCommerce/src/main/res/layout/fragment_login_prologue_viewpager_item.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
@@ -24,6 +25,7 @@
         android:breakStrategy="balanced"
         android:gravity="center"
         android:textStyle="bold"
+        app:lineHeight="29sp"
         tools:text="@string/login_prologue_label_analytics" />
 
     <com.google.android.material.textview.MaterialTextView


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
This updates the line height of headers on the login prologue screens, as requested from: pffQ75-10m-p2#comment-1027

I set the new line height to 29, which is 1.2 times the text size, as [suggested here](https://m3.material.io/styles/typography/applying-type#469b978d-e7aa-4915-84b9-9b84cfee3a05). I didn't make this change for for all headers since it falls outside the scope of this PR.

### Steps to reproduce
<!-- Step-by-step testing instructions. For new user flows, consider instead stating the goal of the workflow and see if your PR reviewer can accomplish the workflow without specific steps! -->
Clean install

### The tests that have been performed
<!-- To give the reviewer an idea of what could be missed in terms of testing -->
Screens below

### Images/gif
<!-- Include before and after images or gifs when appropriate. -->
|Before|After|
|-|-|
|<img src="https://github.com/user-attachments/assets/85accdbf-9ef0-41d2-9415-38f7648d159d" width=480>|<img src="https://github.com/user-attachments/assets/1e9dae44-ea7a-475d-a7f3-6eea2ae871e5" width=480>|
|<img src="https://github.com/user-attachments/assets/921197a2-2ece-426c-8d17-9f240fd9d3d1" width=480>|<img src="https://github.com/user-attachments/assets/5696e3e3-3315-4e6d-aeb7-721f47787300" width=480>|

- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.

## Reviewer (or Author, in the case of optional code reviews):

Please make sure these conditions are met before approving the PR, or request changes if the PR needs improvement:

- [ ] The PR is small and has a clear, single focus, or a valid explanation is provided in the description. If needed, please request to split it into smaller PRs.
- [ ] Ensure Adequate Unit Test Coverage: The changes are reasonably covered by unit tests or an explanation is provided in the PR description.
- [ ] Manual Testing: The author listed all the tests they ran, including smoke tests when needed (e.g., for refactorings). The reviewer confirmed that the PR works as expected on big (tablet) and small (phone) in case of UI changes, and no regressions are added.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->