### PR TITLE
[Order list] Remove order creation survey

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -4,9 +4,9 @@
 21.6
 -----
 - [*] Updated tablet detection logic to consider both width and height dimensions, enhancing compatibility with larger phones and tablets, particularly in landscape mode [https://github.com/woocommerce/woocommerce-android/pull/13228]
-
 - [**] The UK customers have access to the POS now [https://github.com/woocommerce/woocommerce-android/pull/13386]
 - [Internal] [*] Fixed a bug that could lead to a crash when formatting dates and times [https://github.com/woocommerce/woocommerce-android/pull/13393]
+- [Internal] [*] Removed order creation survey from the order's list [https://github.com/woocommerce/woocommerce-android/pull/13423]
 
 21.5
 -----

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/AppUrls.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/AppUrls.kt
@@ -38,8 +38,6 @@ object AppUrls {
 
     const val CROWDSIGNAL_ANALYTICS_HUB_SURVEY = "https://automattic.survey.fm/woo-app-analytics-hub-production"
 
-    const val ORDER_CREATION_SURVEY = "https://automattic.survey.fm/woo-app-order-creation-production"
-
     const val ADDONS_SURVEY = "https://automattic.survey.fm/woo-app-addons-production"
 
     const val CROWDSIGNAL_STORE_SETUP_SURVEY =

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/analytics/AnalyticsTracker.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/analytics/AnalyticsTracker.kt
@@ -366,7 +366,6 @@ class AnalyticsTracker private constructor(
         const val VALUE_STATE_OFF = "off"
 
         const val VALUE_SIMPLE_PAYMENTS_FLOW = "simple_payment"
-        const val VALUE_SIMPLE_PAYMENTS_FEEDBACK = "simple_payments"
         const val VALUE_SIMPLE_PAYMENTS_COLLECT_CARD = "card"
         const val VALUE_SIMPLE_PAYMENTS_COLLECT_CASH = "cash"
         const val VALUE_SIMPLE_PAYMENTS_COLLECT_LINK = "payment_link"

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/model/FeatureFeedbackSettings.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/model/FeatureFeedbackSettings.kt
@@ -25,14 +25,9 @@ data class FeatureFeedbackSettings(
 
     enum class Feature {
         PRODUCT_ADDONS,
-        SIMPLE_PAYMENTS_AND_ORDER_CREATION,
         ANALYTICS_HUB,
         ORDER_SHIPPING_LINES
     }
 
     fun isFeedbackMoreThanDaysAgo(days: Int) = Date(settingChangeDate).pastTimeDeltaFromNowInDays greaterThan days
-
-    fun isFeedbackGivenMoreThanDaysAgo(days: Int) =
-        feedbackState == FeedbackState.GIVEN &&
-            Date(settingChangeDate).pastTimeDeltaFromNowInDays greaterThan days
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/feedback/FeedbackSurveyFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/feedback/FeedbackSurveyFragment.kt
@@ -24,7 +24,6 @@ import com.woocommerce.android.analytics.AnalyticsTracker.Companion.VALUE_FEEDBA
 import com.woocommerce.android.analytics.AnalyticsTracker.Companion.VALUE_FEEDBACK_STORE_SETUP_CONTEXT
 import com.woocommerce.android.analytics.AnalyticsTracker.Companion.VALUE_ORDER_SHIPPING_LINES_FEEDBACK
 import com.woocommerce.android.analytics.AnalyticsTracker.Companion.VALUE_PRODUCT_ADDONS_FEEDBACK
-import com.woocommerce.android.analytics.AnalyticsTracker.Companion.VALUE_SIMPLE_PAYMENTS_FEEDBACK
 import com.woocommerce.android.databinding.FragmentFeedbackSurveyBinding
 import com.woocommerce.android.extensions.navigateSafely
 import com.woocommerce.android.ui.base.BaseFragment
@@ -50,7 +49,6 @@ class FeedbackSurveyFragment : BaseFragment(R.layout.fragment_feedback_survey) {
             SurveyType.MAIN -> VALUE_FEEDBACK_GENERAL_CONTEXT
             SurveyType.PRODUCT -> VALUE_FEEDBACK_PRODUCT_M3_CONTEXT
             SurveyType.STORE_ONBOARDING -> VALUE_FEEDBACK_STORE_SETUP_CONTEXT
-            SurveyType.ORDER_CREATION -> VALUE_SIMPLE_PAYMENTS_FEEDBACK
             SurveyType.ADDONS -> VALUE_PRODUCT_ADDONS_FEEDBACK
             SurveyType.ANALYTICS_HUB -> VALUE_ANALYTICS_HUB_FEEDBACK
             SurveyType.ORDER_SHIPPING_LINES -> VALUE_ORDER_SHIPPING_LINES_FEEDBACK

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/feedback/SurveyType.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/feedback/SurveyType.kt
@@ -6,7 +6,6 @@ import com.woocommerce.android.BuildConfig
 @Suppress("MagicNumber")
 enum class SurveyType(private val untaggedUrl: String, private val milestone: Int? = null) {
     PRODUCT(AppUrls.CROWDSIGNAL_PRODUCT_SURVEY, 4),
-    ORDER_CREATION(AppUrls.ORDER_CREATION_SURVEY, 1),
     MAIN(AppUrls.CROWDSIGNAL_MAIN_SURVEY),
     ADDONS(AppUrls.ADDONS_SURVEY),
     STORE_ONBOARDING(AppUrls.CROWDSIGNAL_STORE_SETUP_SURVEY),

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/list/OrderListFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/list/OrderListFragment.kt
@@ -1,6 +1,5 @@
 package com.woocommerce.android.ui.orders.list
 
-import org.wordpress.android.util.ActivityUtils as WPActivityUtils
 import android.os.Bundle
 import android.os.Handler
 import android.os.Looper
@@ -81,6 +80,7 @@ import dagger.hilt.android.AndroidEntryPoint
 import org.wordpress.android.util.DisplayUtils
 import org.wordpress.android.util.ToastUtils
 import javax.inject.Inject
+import org.wordpress.android.util.ActivityUtils as WPActivityUtils
 
 @AndroidEntryPoint
 @Suppress("LargeClass")

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/list/OrderListFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/list/OrderListFragment.kt
@@ -1,5 +1,6 @@
 package com.woocommerce.android.ui.orders.list
 
+import org.wordpress.android.util.ActivityUtils as WPActivityUtils
 import android.os.Bundle
 import android.os.Handler
 import android.os.Looper
@@ -46,9 +47,6 @@ import com.woocommerce.android.extensions.isTwoPanesShouldBeUsed
 import com.woocommerce.android.extensions.navigateSafely
 import com.woocommerce.android.extensions.pinFabAboveBottomNavigationBar
 import com.woocommerce.android.extensions.takeIfNotEqualTo
-import com.woocommerce.android.model.FeatureFeedbackSettings
-import com.woocommerce.android.model.FeatureFeedbackSettings.Feature.SIMPLE_PAYMENTS_AND_ORDER_CREATION
-import com.woocommerce.android.model.FeatureFeedbackSettings.FeedbackState
 import com.woocommerce.android.model.Order
 import com.woocommerce.android.support.help.HelpOrigin
 import com.woocommerce.android.support.requests.SupportRequestFormActivity
@@ -57,7 +55,6 @@ import com.woocommerce.android.tracker.OrderDurationRecorder
 import com.woocommerce.android.ui.barcodescanner.BarcodeScanningFragment.Companion.KEY_BARCODE_SCANNING_SCAN_STATUS
 import com.woocommerce.android.ui.base.TopLevelFragment
 import com.woocommerce.android.ui.base.UIMessageResolver
-import com.woocommerce.android.ui.feedback.SurveyType
 import com.woocommerce.android.ui.jitm.JitmFragment
 import com.woocommerce.android.ui.jitm.JitmMessagePathsProvider
 import com.woocommerce.android.ui.main.AppBarStatus
@@ -84,7 +81,6 @@ import dagger.hilt.android.AndroidEntryPoint
 import org.wordpress.android.util.DisplayUtils
 import org.wordpress.android.util.ToastUtils
 import javax.inject.Inject
-import org.wordpress.android.util.ActivityUtils as WPActivityUtils
 
 @AndroidEntryPoint
 @Suppress("LargeClass")
@@ -720,11 +716,6 @@ class OrderListFragment :
             new.jitmEnabled.takeIfNotEqualTo(old?.jitmEnabled) { jitmEnabled ->
                 initJitm(jitmEnabled)
             }
-            new.isSimplePaymentsAndOrderCreationFeedbackVisible.takeIfNotEqualTo(
-                old?.isSimplePaymentsAndOrderCreationFeedbackVisible
-            ) {
-                displaySimplePaymentsWIPCard(it)
-            }
             new.isErrorFetchingDataBannerVisible.takeIfNotEqualTo(old?.isErrorFetchingDataBannerVisible) {
                 displayErrorParsingOrdersCard(it)
             }
@@ -1120,45 +1111,6 @@ class OrderListFragment :
 
     override fun shouldExpandToolbar(): Boolean {
         return binding.orderListView.ordersList.computeVerticalScrollOffset() == 0 && !viewModel.isSearching
-    }
-
-    private fun displaySimplePaymentsWIPCard(show: Boolean) {
-        if (!show) {
-            binding.simplePaymentsWIPcard.isVisible = false
-            return
-        }
-
-        binding.simplePaymentsWIPcard.isVisible = true
-        binding.simplePaymentsWIPcard.initView(
-            getString(R.string.orderlist_simple_payments_wip_title),
-            getString(R.string.orderlist_simple_payments_wip_message_enabled),
-            onGiveFeedbackClick = { onGiveFeedbackClicked() },
-            onDismissClick = {
-                FeatureFeedbackSettings(
-                    FeatureFeedbackSettings.Feature.SIMPLE_PAYMENTS_AND_ORDER_CREATION,
-                    FeedbackState.DISMISSED
-                ).registerItself(feedbackPrefs)
-                viewModel.onDismissOrderCreationSimplePaymentsFeedback()
-            },
-            showFeedbackButton = true
-        )
-    }
-
-    private fun onGiveFeedbackClicked() {
-        AnalyticsTracker.track(
-            AnalyticsEvent.FEATURE_FEEDBACK_BANNER,
-            mapOf(
-                AnalyticsTracker.KEY_FEEDBACK_CONTEXT to AnalyticsTracker.VALUE_SIMPLE_PAYMENTS_FEEDBACK,
-                AnalyticsTracker.KEY_FEEDBACK_ACTION to AnalyticsTracker.VALUE_FEEDBACK_GIVEN
-            )
-        )
-        FeatureFeedbackSettings(
-            SIMPLE_PAYMENTS_AND_ORDER_CREATION,
-            FeedbackState.GIVEN
-        ).registerItself(feedbackPrefs)
-        NavGraphMainDirections
-            .actionGlobalFeedbackSurveyFragment(SurveyType.ORDER_CREATION)
-            .apply { findNavController().navigateSafely(this) }
     }
 
     override fun onSwiped(gestureSource: OrderStatusUpdateSource.SwipeToCompleteGesture) {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/list/OrderListViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/list/OrderListViewModel.kt
@@ -19,7 +19,6 @@ import androidx.paging.PagedList
 import com.google.android.material.snackbar.Snackbar
 import com.woocommerce.android.AppPrefsWrapper
 import com.woocommerce.android.BuildConfig
-import com.woocommerce.android.FeedbackPrefs
 import com.woocommerce.android.R
 import com.woocommerce.android.analytics.AnalyticsEvent
 import com.woocommerce.android.analytics.AnalyticsEvent.ORDERS_LIST_AUTOMATIC_TIMEOUT_RETRY
@@ -35,7 +34,6 @@ import com.woocommerce.android.extensions.drop
 import com.woocommerce.android.extensions.filter
 import com.woocommerce.android.extensions.filterNotNull
 import com.woocommerce.android.extensions.runWithContext
-import com.woocommerce.android.model.FeatureFeedbackSettings
 import com.woocommerce.android.model.Order
 import com.woocommerce.android.model.RequestResult.SUCCESS
 import com.woocommerce.android.network.ConnectionChangeReceiver.ConnectionChangeEvent
@@ -116,7 +114,6 @@ class OrderListViewModel @Inject constructor(
     private val orderListTransactionLauncher: OrderListTransactionLauncher,
     private val shouldShowCreateTestOrderScreen: ShouldShowCreateTestOrderScreen,
     private val analyticsTracker: AnalyticsTrackerWrapper,
-    private val feedbackPrefs: FeedbackPrefs,
     private val barcodeScanningTracker: BarcodeScanningTracker,
     private val notificationChannelsHandler: NotificationChannelsHandler,
     private val appPrefs: AppPrefsWrapper,
@@ -137,11 +134,6 @@ class OrderListViewModel @Inject constructor(
 
     override val lifecycle: Lifecycle
         get() = lifecycleRegistry
-
-    private val simplePaymentsAndOrderCreationFeedbackState
-        get() = feedbackPrefs.getFeatureFeedbackSettings(
-            FeatureFeedbackSettings.Feature.SIMPLE_PAYMENTS_AND_ORDER_CREATION
-        )?.feedbackState ?: FeatureFeedbackSettings.FeedbackState.UNANSWERED
 
     val performanceObserver: LifecycleObserver = orderListTransactionLauncher
 
@@ -207,14 +199,6 @@ class OrderListViewModel @Inject constructor(
 
     private var dismissListErrors = false
     var searchQuery = ""
-
-    private val isSimplePaymentsAndOrderCreationFeedbackVisible: Boolean
-        get() {
-            val simplePaymentsAndOrderFeedbackDismissed =
-                simplePaymentsAndOrderCreationFeedbackState == FeatureFeedbackSettings.FeedbackState.DISMISSED
-            val isTroubleshootingBannerVisible = viewState.shouldDisplayTroubleshootingBanner
-            return !simplePaymentsAndOrderFeedbackDismissed && !isTroubleshootingBannerVisible
-        }
 
     private var _lastUpdateOrdersList = MutableStateFlow<Long?>(null)
     val lastUpdateOrdersList: LiveData<String?> = _lastUpdateOrdersList
@@ -313,7 +297,6 @@ class OrderListViewModel @Inject constructor(
     fun changeTroubleshootingBannerVisibility(show: Boolean) {
         viewState = viewState.copy(
             shouldDisplayTroubleshootingBanner = show,
-            isSimplePaymentsAndOrderCreationFeedbackVisible = !show
         )
     }
 
@@ -486,7 +469,6 @@ class OrderListViewModel @Inject constructor(
                     PARSE_ERROR -> {
                         viewState = viewState.copy(
                             isErrorFetchingDataBannerVisible = true,
-                            isSimplePaymentsAndOrderCreationFeedbackVisible = false
                         )
                     }
 
@@ -517,13 +499,12 @@ class OrderListViewModel @Inject constructor(
     private fun displayOrdersBannerOrJitm() {
         viewModelScope.launch {
             when {
-                !isSimplePaymentsAndOrderCreationFeedbackVisible -> {
+                !viewState.shouldDisplayTroubleshootingBanner -> {
                     viewState = viewState.copy(
                         jitmEnabled = true
                     )
                 }
             }
-            refreshOrdersBannerVisibility()
         }
     }
 
@@ -794,23 +775,6 @@ class OrderListViewModel @Inject constructor(
                 }
             }
         }
-    }
-
-    private fun refreshOrdersBannerVisibility() {
-        viewState = viewState.copy(
-            isSimplePaymentsAndOrderCreationFeedbackVisible = isSimplePaymentsAndOrderCreationFeedbackVisible
-        )
-    }
-
-    fun onDismissOrderCreationSimplePaymentsFeedback() {
-        analyticsTracker.track(
-            AnalyticsEvent.FEATURE_FEEDBACK_BANNER,
-            mapOf(
-                AnalyticsTracker.KEY_FEEDBACK_CONTEXT to AnalyticsTracker.VALUE_SIMPLE_PAYMENTS_FEEDBACK,
-                AnalyticsTracker.KEY_FEEDBACK_ACTION to AnalyticsTracker.VALUE_FEEDBACK_DISMISSED
-            )
-        )
-        refreshOrdersBannerVisibility()
     }
 
     private fun checkChaChingSoundSettings() {
@@ -1137,7 +1101,6 @@ class OrderListViewModel @Inject constructor(
         val isRefreshPending: Boolean = false,
         val arePaymentGatewaysFetched: Boolean = false,
         val filterCount: Int = 0,
-        val isSimplePaymentsAndOrderCreationFeedbackVisible: Boolean = false,
         val jitmEnabled: Boolean = false,
         val isErrorFetchingDataBannerVisible: Boolean = false,
         val shouldDisplayTroubleshootingBanner: Boolean = false,

--- a/WooCommerce/src/main/res/layout/fragment_order_list.xml
+++ b/WooCommerce/src/main/res/layout/fragment_order_list.xml
@@ -42,17 +42,6 @@
                 app:layout_constraintTop_toBottomOf="@id/toolbar"
                 tools:visibility="visible" />
 
-            <com.woocommerce.android.ui.products.FeatureWIPNoticeCard
-                android:id="@+id/simplePaymentsWIPcard"
-                style="@style/Woo.Card.Expandable"
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content"
-                android:visibility="gone"
-                app:layout_constraintEnd_toEndOf="parent"
-                app:layout_constraintStart_toStartOf="parent"
-                app:layout_constraintTop_toBottomOf="@+id/error_troubleshooting_card"
-                tools:visibility="visible" />
-
             <com.woocommerce.android.ui.orders.filters.OrderFiltersCard
                 android:id="@+id/order_filters_card"
                 style="@style/Woo.Card"
@@ -60,7 +49,7 @@
                 android:layout_height="wrap_content"
                 app:layout_constraintEnd_toEndOf="parent"
                 app:layout_constraintStart_toStartOf="parent"
-                app:layout_constraintTop_toBottomOf="@+id/simplePaymentsWIPcard" />
+                app:layout_constraintTop_toBottomOf="@+id/error_troubleshooting_card" />
 
             <androidx.fragment.app.FragmentContainerView
                 android:id="@+id/jitmOrdersFragment"

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -580,8 +580,6 @@
     <string name="orderlist_loading">Looking up your orders…</string>
     <string name="orderlist_no_filters_title">All Orders</string>
     <string name="orderlist_filters_title">Filtered Orders</string>
-    <string name="orderlist_simple_payments_wip_title">Create orders from your device!</string>
-    <string name="orderlist_simple_payments_wip_message_enabled">We\'ve been working on making it possible to create orders from your device! You can try this feature out by tapping on the "+" button</string>
     <string name="orderlist_simple_payments_menu">Simple payment</string>
     <string name="order_card_transition_name">order_card_%1$s</string>
     <string name="order_card_detail_transition_name">order_card_detail</string>

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/OrderListViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/OrderListViewModelTest.kt
@@ -4,14 +4,11 @@ import androidx.lifecycle.MutableLiveData
 import androidx.paging.PagedList
 import com.google.android.material.snackbar.Snackbar
 import com.woocommerce.android.AppPrefsWrapper
-import com.woocommerce.android.FeedbackPrefs
 import com.woocommerce.android.R
 import com.woocommerce.android.analytics.AnalyticsEvent
-import com.woocommerce.android.analytics.AnalyticsTracker
 import com.woocommerce.android.analytics.AnalyticsTrackerWrapper
 import com.woocommerce.android.extensions.NotificationReceivedEvent
 import com.woocommerce.android.extensions.takeIfNotEqualTo
-import com.woocommerce.android.model.FeatureFeedbackSettings
 import com.woocommerce.android.model.Order
 import com.woocommerce.android.model.RequestResult
 import com.woocommerce.android.notifications.NotificationChannelType
@@ -118,7 +115,6 @@ class OrderListViewModelTest : BaseUnitTest() {
     private val getSelectedOrderFiltersCount: GetSelectedOrderFiltersCount = mock()
     private val shouldShowCreateTestOrderScreen: ShouldShowCreateTestOrderScreen = mock()
     private val analyticsTracker: AnalyticsTrackerWrapper = mock()
-    private val feedbackPrefs = mock<FeedbackPrefs>()
     private val barcodeScanningTracker = mock<BarcodeScanningTracker>()
     private val notificationChannelsHandler = mock<NotificationChannelsHandler>()
     private val appPrefs = mock<AppPrefsWrapper>()
@@ -172,7 +168,6 @@ class OrderListViewModelTest : BaseUnitTest() {
         orderListTransactionLauncher = mock(),
         shouldShowCreateTestOrderScreen = shouldShowCreateTestOrderScreen,
         analyticsTracker = analyticsTracker,
-        feedbackPrefs = feedbackPrefs,
         barcodeScanningTracker = barcodeScanningTracker,
         notificationChannelsHandler = notificationChannelsHandler,
         appPrefs = appPrefs,
@@ -560,7 +555,7 @@ class OrderListViewModelTest : BaseUnitTest() {
 
         // Then the order status is changed optimistically
         val optimisticChangeEvent = viewModel.event.getOrAwaitValue()
-        assertTrue(optimisticChangeEvent is Event.ShowUndoSnackbar)
+        assertTrue(optimisticChangeEvent is ShowUndoSnackbar)
 
         advanceTimeBy(1_001)
 
@@ -595,7 +590,7 @@ class OrderListViewModelTest : BaseUnitTest() {
 
         // Then the order status is changed optimistically
         val optimisticChangeEvent = viewModel.event.getOrAwaitValue()
-        assertTrue(optimisticChangeEvent is Event.ShowUndoSnackbar)
+        assertTrue(optimisticChangeEvent is ShowUndoSnackbar)
 
         advanceTimeBy(1_001)
 
@@ -603,42 +598,6 @@ class OrderListViewModelTest : BaseUnitTest() {
         val resultEvent = viewModel.event.getOrAwaitValue()
         assertTrue(resultEvent is OrderListEvent.ShowRetryErrorSnack)
     }
-
-    @Test
-    fun `when onDismissOrderCreationSimplePaymentsFeedback called, then FEATURE_FEEDBACK_BANNER tracked`() =
-        testBlocking {
-            // when
-            viewModel.onDismissOrderCreationSimplePaymentsFeedback()
-
-            // then
-            verify(analyticsTracker).track(
-                AnalyticsEvent.FEATURE_FEEDBACK_BANNER,
-                mapOf(
-                    AnalyticsTracker.KEY_FEEDBACK_CONTEXT to AnalyticsTracker.VALUE_SIMPLE_PAYMENTS_FEEDBACK,
-                    AnalyticsTracker.KEY_FEEDBACK_ACTION to AnalyticsTracker.VALUE_FEEDBACK_DISMISSED
-                )
-            )
-        }
-
-    @Test
-    fun `when onDismissOrderCreationSimplePaymentsFeedback called, then order banner visibility changed`() =
-        testBlocking {
-            // given
-            val featureFeedbackSettings = mock<FeatureFeedbackSettings> {
-                on { feedbackState }.thenReturn(FeatureFeedbackSettings.FeedbackState.DISMISSED)
-            }
-            whenever(
-                feedbackPrefs.getFeatureFeedbackSettings(
-                    FeatureFeedbackSettings.Feature.SIMPLE_PAYMENTS_AND_ORDER_CREATION
-                )
-            ).thenReturn(featureFeedbackSettings)
-
-            // when
-            viewModel.onDismissOrderCreationSimplePaymentsFeedback()
-
-            // then
-            assertThat(viewModel.viewState.isSimplePaymentsAndOrderCreationFeedbackVisible).isEqualTo(false)
-        }
 
     @Test
     fun `when fetching orders for the first time fails with timeout, then trigger a retry event`() = testBlocking {
@@ -997,7 +956,7 @@ class OrderListViewModelTest : BaseUnitTest() {
         assertNotNull(isFetchingFirstPage)
 
         // Check that isFetchingFirstPage is reset to default value (false) on clearLiveDataSources
-        assertFalse(isFetchingFirstPage!!)
+        assertFalse(isFetchingFirstPage)
     }
 
     @Test


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #13421
<!-- Id number of the GitHub issue this PR addresses. -->

Maybe affects https://github.com/woocommerce/woocommerce-android/issues/13259 too, in positive way =)

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
Removes the survey which is not in use

### Testing information
<!-- This is your opportunity to break out individual scenarios that need testing (when necessary) and/or include a checklist for the reviewer to go through. Consider documenting the following from your own completed testing: devices used, alternate workflows, edge cases, affected areas, critical flows, areas not tested, and any remaining unknowns. Provide feedback on this new section of the PR template through Sept 30, 2024 to Apps Quality; additional context here: p91TBi-b8z-p2#comment-12036 -->

Validate that there is no regression on the order list screen both in 1 and 2 panes modes

### The tests that have been performed
<!-- To give the reviewer an idea of what could be missed in terms of testing -->
Aboce

### Images/gif
<!-- Include before and after images or gifs when appropriate. -->

- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.

## Reviewer (or Author, in the case of optional code reviews):

Please make sure these conditions are met before approving the PR, or request changes if the PR needs improvement:

- [x] The PR is small and has a clear, single focus, or a valid explanation is provided in the description. If needed, please request to split it into smaller PRs.
- [x] Ensure Adequate Unit Test Coverage: The changes are reasonably covered by unit tests or an explanation is provided in the PR description.
- [x] Manual Testing: The author listed all the tests they ran, including smoke tests when needed (e.g., for refactorings). The reviewer confirmed that the PR works as expected on big (tablet) and small (phone) in case of UI changes, and no regressions are added.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->