### PR TITLE
[Woo POS] The exit animation from the onboarding screen in pos doesn't match with the enter animation

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/extensions/ActivityExt.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/extensions/ActivityExt.kt
@@ -1,9 +1,13 @@
 package com.woocommerce.android.extensions
 
 import android.app.Activity
+import android.app.Activity.OVERRIDE_TRANSITION_CLOSE
+import android.app.Activity.OVERRIDE_TRANSITION_OPEN
+import androidx.annotation.AnimRes
 import androidx.fragment.app.FragmentActivity
 import com.woocommerce.android.support.help.HelpActivity
 import com.woocommerce.android.support.help.HelpOrigin
+import com.woocommerce.android.util.SystemVersionUtils
 
 /**
  * Used for starting the HelpActivity in a wrapped way whenever a troubleshooting URL click happens
@@ -22,3 +26,21 @@ var Activity.currentScreenBrightness: Float
     set(value) {
         window.attributes = window.attributes.apply { screenBrightness = value }
     }
+
+
+fun Activity.adjustActivityTransition(
+    overrideTransitionOpen: Boolean = true,
+    @AnimRes enterAnim: Int,
+    @AnimRes exitAnim: Int,
+) {
+    if (SystemVersionUtils.isAtLeastU()) {
+        overrideActivityTransition(
+            if (overrideTransitionOpen) OVERRIDE_TRANSITION_OPEN else OVERRIDE_TRANSITION_CLOSE,
+            enterAnim,
+            exitAnim
+        )
+    } else {
+        @Suppress("DEPRECATION")
+        overridePendingTransition(enterAnim, exitAnim)
+    }
+}

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/extensions/ActivityExt.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/extensions/ActivityExt.kt
@@ -27,7 +27,6 @@ var Activity.currentScreenBrightness: Float
         window.attributes = window.attributes.apply { screenBrightness = value }
     }
 
-
 fun Activity.adjustActivityTransition(
     overrideTransitionOpen: Boolean = true,
     @AnimRes enterAnim: Int,

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/support/requests/SupportRequestFormActivity.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/support/requests/SupportRequestFormActivity.kt
@@ -2,7 +2,6 @@ package com.woocommerce.android.support.requests
 
 import android.content.Context
 import android.content.Intent
-import android.graphics.Color
 import android.os.Bundle
 import android.view.MenuItem
 import androidx.activity.viewModels
@@ -13,6 +12,7 @@ import com.woocommerce.android.R
 import com.woocommerce.android.analytics.AnalyticsEvent
 import com.woocommerce.android.analytics.AnalyticsTracker
 import com.woocommerce.android.databinding.ActivitySupportRequestFormBinding
+import com.woocommerce.android.extensions.adjustActivityTransition
 import com.woocommerce.android.extensions.serializable
 import com.woocommerce.android.support.SupportHelper
 import com.woocommerce.android.support.help.HelpOrigin
@@ -22,7 +22,6 @@ import com.woocommerce.android.support.requests.SupportRequestFormViewModel.Show
 import com.woocommerce.android.support.zendesk.TicketType
 import com.woocommerce.android.support.zendesk.ZendeskSettings
 import com.woocommerce.android.ui.dialog.WooDialog
-import com.woocommerce.android.util.SystemVersionUtils
 import com.woocommerce.android.widgets.CustomProgressDialog
 import dagger.hilt.android.AndroidEntryPoint
 import javax.inject.Inject
@@ -58,7 +57,13 @@ class SupportRequestFormActivity : AppCompatActivity() {
         }
         viewModel.onViewCreated()
 
-        adjustActivityTransitions()
+        if (isPOS()) {
+            adjustActivityTransition(
+                overrideTransitionOpen = true,
+                enterAnim = R.anim.woopos_slide_in_right,
+                exitAnim = R.anim.woopos_slide_out_left,
+            )
+        }
     }
 
     override fun finish() {
@@ -66,35 +71,10 @@ class SupportRequestFormActivity : AppCompatActivity() {
         adjustExitTransition()
     }
 
-    private fun SupportRequestFormActivity.adjustActivityTransitions() {
-        if (isPOS()) {
-            if (SystemVersionUtils.isAtLeastU()) {
-                overrideActivityTransition(
-                    OVERRIDE_TRANSITION_CLOSE,
-                    R.anim.woopos_slide_in_left,
-                    R.anim.woopos_slide_out_right,
-                    Color.TRANSPARENT
-                )
-                overrideActivityTransition(
-                    OVERRIDE_TRANSITION_OPEN,
-                    R.anim.woopos_slide_in_right,
-                    R.anim.woopos_slide_out_left,
-                    Color.TRANSPARENT
-                )
-            } else {
-                @Suppress("DEPRECATION")
-                overridePendingTransition(
-                    R.anim.woopos_slide_in_right,
-                    R.anim.woopos_slide_out_left
-                )
-            }
-        }
-    }
-
     private fun adjustExitTransition() {
-        if (isPOS() && SystemVersionUtils.isAtMostT()) {
-            @Suppress("DEPRECATION")
-            overridePendingTransition(
+        if (isPOS()) {
+            adjustActivityTransition(
+                overrideTransitionOpen = false,
                 R.anim.woopos_slide_in_left,
                 R.anim.woopos_slide_out_right
             )

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/cardreader/onboarding/CardReaderOnboardingFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/cardreader/onboarding/CardReaderOnboardingFragment.kt
@@ -23,6 +23,7 @@ import com.woocommerce.android.databinding.FragmentCardReaderOnboardingSelectPay
 import com.woocommerce.android.databinding.FragmentCardReaderOnboardingStripeBinding
 import com.woocommerce.android.databinding.FragmentCardReaderOnboardingUnsupportedBinding
 import com.woocommerce.android.databinding.FragmentCardReaderOnboardingWcpayBinding
+import com.woocommerce.android.extensions.adjustActivityTransition
 import com.woocommerce.android.extensions.startHelpActivity
 import com.woocommerce.android.support.help.HelpOrigin
 import com.woocommerce.android.ui.base.BaseFragment
@@ -58,8 +59,12 @@ class CardReaderOnboardingFragment : BaseFragment(R.layout.fragment_card_reader_
             object : OnBackPressedCallback(true) {
                 override fun handleOnBackPressed() {
                     if (viewModel.isPos) {
-                        // If the user is in POS, we should navigate back skipping everything
                         requireActivity().finish()
+                        requireActivity().adjustActivityTransition(
+                            overrideTransitionOpen = false,
+                            R.anim.woopos_slide_in_left,
+                            R.anim.woopos_slide_out_right
+                        )
                     } else {
                         findNavController().popBackStack()
                     }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/cardreader/WooPosCardReaderActivity.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/cardreader/WooPosCardReaderActivity.kt
@@ -12,6 +12,7 @@ import androidx.core.view.WindowInsetsCompat
 import androidx.core.view.updatePadding
 import androidx.navigation.fragment.NavHostFragment
 import com.woocommerce.android.R
+import com.woocommerce.android.extensions.adjustActivityTransition
 import com.woocommerce.android.ui.payments.cardreader.onboarding.CardReaderFlowParam
 import com.woocommerce.android.ui.payments.cardreader.onboarding.CardReaderType
 import com.woocommerce.android.ui.payments.cardreader.statuschecker.CardReaderStatusCheckerDialogFragmentArgs
@@ -61,8 +62,11 @@ class WooPosCardReaderActivity : AppCompatActivity(R.layout.activity_woo_pos_car
 
     override fun finish() {
         super.finish()
-        @Suppress("DEPRECATION")
-        overridePendingTransition(android.R.anim.fade_in, android.R.anim.fade_out)
+        adjustActivityTransition(
+            overrideTransitionOpen = true,
+            enterAnim = android.R.anim.fade_in,
+            exitAnim = android.R.anim.fade_out,
+        )
     }
 
     private fun observeResult(navHostFragment: NavHostFragment) {


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #13210
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
The PR makes the animation look similar to other left-to-right animations. Also it extracts the common code to an extension

### Testing information
<!-- This is your opportunity to break out individual scenarios that need testing (when necessary) and/or include a checklist for the reviewer to go through. Consider documenting the following from your own completed testing: devices used, alternate workflows, edge cases, affected areas, critical flows, areas not tested, and any remaining unknowns. Provide feedback on this new section of the PR template through Sept 30, 2024 to Apps Quality; additional context here: p91TBi-b8z-p2#comment-12036 -->

Try on the SDKs 34 above and below too
* Try opening support activity in the POS
* Use a store with unfinished onboarding and try to connect to a reader
Notice that the transition between activities looks alike

### The tests that have been performed
<!-- To give the reviewer an idea of what could be missed in terms of testing -->
Above

### Images/gif
<!-- Include before and after images or gifs when appropriate. -->


https://github.com/user-attachments/assets/8dc160c8-2ea0-401f-874c-bc88a818e1ac


- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.

## Reviewer (or Author, in the case of optional code reviews):

Please make sure these conditions are met before approving the PR, or request changes if the PR needs improvement:

- [x] The PR is small and has a clear, single focus, or a valid explanation is provided in the description. If needed, please request to split it into smaller PRs.
- [x] Ensure Adequate Unit Test Coverage: The changes are reasonably covered by unit tests or an explanation is provided in the PR description.
- [x] Manual Testing: The author listed all the tests they ran, including smoke tests when needed (e.g., for refactorings). The reviewer confirmed that the PR works as expected on big (tablet) and small (phone) in case of UI changes, and no regressions are added.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->