### PR TITLE
Empty state button on grouped product screen

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/grouped/GroupedProductListFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/grouped/GroupedProductListFragment.kt
@@ -148,7 +148,9 @@ class GroupedProductListFragment :
 
     private fun showEmptyView(show: Boolean) {
         if (show) {
-            binding.emptyView.show(WCEmptyView.EmptyViewType.GROUPED_PRODUCT_LIST)
+            binding.emptyView.show(WCEmptyView.EmptyViewType.GROUPED_PRODUCT_LIST) {
+                viewModel.onAddProductButtonClicked()
+            }
         } else {
             binding.emptyView.hide()
         }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/grouped/GroupedProductListFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/grouped/GroupedProductListFragment.kt
@@ -10,7 +10,9 @@ import com.woocommerce.android.R
 import com.woocommerce.android.analytics.AnalyticsTracker
 import com.woocommerce.android.databinding.FragmentGroupedProductListBinding
 import com.woocommerce.android.extensions.handleResult
+import com.woocommerce.android.extensions.hide
 import com.woocommerce.android.extensions.navigateBackWithResult
+import com.woocommerce.android.extensions.show
 import com.woocommerce.android.extensions.takeIfNotEqualTo
 import com.woocommerce.android.ui.base.BaseFragment
 import com.woocommerce.android.ui.base.UIMessageResolver
@@ -151,8 +153,10 @@ class GroupedProductListFragment :
             binding.emptyView.show(WCEmptyView.EmptyViewType.GROUPED_PRODUCT_LIST) {
                 viewModel.onAddProductButtonClicked()
             }
+            binding.addGroupedProductView.hide()
         } else {
             binding.emptyView.hide()
+            binding.addGroupedProductView.show()
         }
     }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/widgets/WCEmptyView.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/widgets/WCEmptyView.kt
@@ -124,7 +124,7 @@ class WCEmptyView @JvmOverloads constructor(ctx: Context, attrs: AttributeSet? =
                 isTitleBold = false
                 title = null
                 message = context.getString(R.string.product_list_empty)
-                buttonText = null
+                buttonText = context.getString(R.string.grouped_product_add)
                 drawableId = R.drawable.img_empty_grouped_product
             }
 


### PR DESCRIPTION
## Description
Improves the Claude Build Analysis Buildkite integration:

1. **Model upgrade**: Sonnet 4.5 → Sonnet 4.6
2. **Custom fork**: Switches to `iangmaia/claude-summarize` fork with `build_log_mode: "failed"` and `max_log_lines: 1500` for focused log analysis
3. **Smart gating**: Skips Claude analysis entirely when only non-essential jobs (e.g. Danger) fail — no annotation, no noise
4. **Co-failure correctness**: When non-essential jobs fail alongside real failures, Claude still runs. Uses the Buildkite API to count total failures and compare against non-essential failures. Fails safe (runs Claude if API is unreachable).
5. **Prompt improvements**: Tells Claude to ignore Danger, broken jobs, and the analysis job itself. Uses YAML literal scalar (`|`) to preserve list formatting.
6. **Script hardening**: Portable shebang, proper Bash array for step keys, `timed_out` jobs included in failure count.

## Test Steps
1. Push a change that breaks the build → Claude analysis should run and annotate real failures
2. Push a change where only Danger fails → Claude analysis should be skipped entirely (no annotation)
3. If both Danger and a real test fail → Claude should still run

---
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.