### PR TITLE
Add missing notes to RELEASE-NOTES for Wear release

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -16,6 +16,7 @@
 - [*] Adds new "Cover" tag to clearly indicate which of the product photos will be the cover [https://github.com/woocommerce/woocommerce-android/pull/13344]
 - [*] Optimizes product image fetching for faster loading [https://github.com/woocommerce/woocommerce-android/issues/13357]
 - [*] [Internal] Improved login flow for accounts using emails marked as suspicious during Jetpack Setup [https://github.com/woocommerce/woocommerce-android/pull/13409]
+- [**] [WEAR] Updated the app look and feel to match the new WooCommerce branding [https://github.com/woocommerce/woocommerce-android/pull/13254]
 
 21.5
 -----

--- a/fastlane/metadata/PlayStoreStrings.pot
+++ b/fastlane/metadata/PlayStoreStrings.pot
@@ -12,7 +12,7 @@ msgstr ""
 
 #. translators: Release notes for the latest Wear App version to be displayed in the Play Store. Limit to 500 characters including spaces and commas!
 msgctxt "wear_release_note"
-msgid "In this update, we’ve made a few small bug fixes and enhancements to ensure a smoother experience. Thanks for using our app, and stay tuned for more exciting features coming soon!"
+msgid "Our latest update brings a refreshed look and feel, aligning the app with the new WooCommerce branding. Enjoy a fresh, modern design!"
 msgstr ""
 
 #. translators: Release notes for this version to be displayed in the Play Store. Limit to 500 characters including spaces and commas!

--- a/fastlane/metadata/wear/en-US/changelogs/default.txt
+++ b/fastlane/metadata/wear/en-US/changelogs/default.txt
@@ -1,1 +1,1 @@
-In this update, we’ve made a few small bug fixes and enhancements to ensure a smoother experience. Thanks for using our app, and stay tuned for more exciting features coming soon!
+Our latest update brings a refreshed look and feel, aligning the app with the new WooCommerce branding. Enjoy a fresh, modern design!


### PR DESCRIPTION
I forgot to add the release notes for Wear in the 21.6 release. This PR includes the missing note.