### PR TITLE
[Android SDK] Edge to edge main activity doesnt handle well 3 button navigation

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/main/MainActivity.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/main/MainActivity.kt
@@ -304,7 +304,7 @@ class MainActivity :
         binding = ActivityMainBinding.inflate(layoutInflater)
         setContentView(binding.root)
 
-        edgeToEdgeHelper.applyEdgeToEdgeSettings(binding.appBarLayout, binding.snackRoot)
+        edgeToEdgeHelper.applyEdgeToEdgeSettings(binding)
 
         toolbar = binding.toolbar.toolbar
 
@@ -1272,10 +1272,6 @@ class MainActivity :
 
     override fun showBottomNav() {
         viewModel.showBottomNav()
-    }
-
-    fun isBottomNavVisible(): Boolean {
-        return binding.bottomNav.visibility == View.VISIBLE
     }
 
     /**

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/main/MainActivity.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/main/MainActivity.kt
@@ -304,7 +304,7 @@ class MainActivity :
         binding = ActivityMainBinding.inflate(layoutInflater)
         setContentView(binding.root)
 
-        edgeToEdgeHelper.applyEdgeToEdgeSettings(binding.appBarLayout)
+        edgeToEdgeHelper.applyEdgeToEdgeSettings(binding.appBarLayout, binding.snackRoot)
 
         toolbar = binding.toolbar.toolbar
 
@@ -1272,6 +1272,10 @@ class MainActivity :
 
     override fun showBottomNav() {
         viewModel.showBottomNav()
+    }
+
+    fun isBottomNavVisible(): Boolean {
+        return binding.bottomNav.visibility == View.VISIBLE
     }
 
     /**

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/main/MainActivityEdgeToEdgeHelper.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/main/MainActivityEdgeToEdgeHelper.kt
@@ -5,14 +5,29 @@ import androidx.core.view.ViewCompat
 import androidx.core.view.WindowInsetsCompat
 import javax.inject.Inject
 
-class MainActivityEdgeToEdgeHelper @Inject constructor() {
-    fun applyEdgeToEdgeSettings(viewToApplyPadding: View) {
-        ViewCompat.setOnApplyWindowInsetsListener(viewToApplyPadding) { v, insets ->
-            val innerPadding = insets.getInsets(
-                WindowInsetsCompat.Type.systemBars()
-                    or WindowInsetsCompat.Type.displayCutout()
+class MainActivityEdgeToEdgeHelper @Inject constructor(private val activity: MainActivity) {
+    fun applyEdgeToEdgeSettings(appBarLayout: View, contentView: View) {
+        ViewCompat.setOnApplyWindowInsetsListener(appBarLayout) { v, insets ->
+            val systemInsets = insets.getInsets(
+                WindowInsetsCompat.Type.systemBars() or WindowInsetsCompat.Type.displayCutout()
             )
-            v.setPadding(0, innerPadding.top, 0, 0)
+
+            v.setPadding(0, systemInsets.top, 0, 0)
+            insets
+        }
+
+        ViewCompat.setOnApplyWindowInsetsListener(contentView) { v, insets ->
+            val systemInsets = insets.getInsets(
+                WindowInsetsCompat.Type.systemBars() or WindowInsetsCompat.Type.displayCutout()
+            )
+
+            val isBottomNavVisible = activity.isBottomNavVisible()
+
+            // Apply bottom padding only if bottom nav is hidden
+            // because bottom nav is already handling the padding
+            val bottomPadding = if (!isBottomNavVisible) systemInsets.bottom else 0
+
+            v.setPadding(v.paddingLeft, v.paddingTop, v.paddingRight, bottomPadding)
             insets
         }
     }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/main/MainActivityEdgeToEdgeHelper.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/main/MainActivityEdgeToEdgeHelper.kt
@@ -3,11 +3,12 @@ package com.woocommerce.android.ui.main
 import android.view.View
 import androidx.core.view.ViewCompat
 import androidx.core.view.WindowInsetsCompat
+import com.woocommerce.android.databinding.ActivityMainBinding
 import javax.inject.Inject
 
 class MainActivityEdgeToEdgeHelper @Inject constructor(private val activity: MainActivity) {
-    fun applyEdgeToEdgeSettings(appBarLayout: View, contentView: View) {
-        ViewCompat.setOnApplyWindowInsetsListener(appBarLayout) { v, insets ->
+    fun applyEdgeToEdgeSettings(binding: ActivityMainBinding) {
+        ViewCompat.setOnApplyWindowInsetsListener(binding.appBarLayout) { v, insets ->
             val systemInsets = insets.getInsets(
                 WindowInsetsCompat.Type.systemBars() or WindowInsetsCompat.Type.displayCutout()
             )
@@ -16,12 +17,12 @@ class MainActivityEdgeToEdgeHelper @Inject constructor(private val activity: Mai
             insets
         }
 
-        ViewCompat.setOnApplyWindowInsetsListener(contentView) { v, insets ->
+        ViewCompat.setOnApplyWindowInsetsListener(binding.snackRoot) { v, insets ->
             val systemInsets = insets.getInsets(
                 WindowInsetsCompat.Type.systemBars() or WindowInsetsCompat.Type.displayCutout()
             )
 
-            val isBottomNavVisible = activity.isBottomNavVisible()
+            val isBottomNavVisible = binding.bottomNav.visibility == View.VISIBLE
 
             // Apply bottom padding only if bottom nav is hidden
             // because bottom nav is already handling the padding

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/main/MainActivityEdgeToEdgeHelper.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/main/MainActivityEdgeToEdgeHelper.kt
@@ -6,7 +6,7 @@ import androidx.core.view.WindowInsetsCompat
 import com.woocommerce.android.databinding.ActivityMainBinding
 import javax.inject.Inject
 
-class MainActivityEdgeToEdgeHelper @Inject constructor(private val activity: MainActivity) {
+class MainActivityEdgeToEdgeHelper @Inject constructor() {
     fun applyEdgeToEdgeSettings(binding: ActivityMainBinding) {
         ViewCompat.setOnApplyWindowInsetsListener(binding.appBarLayout) { v, insets ->
             val systemInsets = insets.getInsets(

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/main/MainActivityEdgeToEdgeHelper.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/main/MainActivityEdgeToEdgeHelper.kt
@@ -25,9 +25,9 @@ class MainActivityEdgeToEdgeHelper @Inject constructor(private val activity: Mai
 
             // Apply bottom padding only if bottom nav is hidden
             // because bottom nav is already handling the padding
-            val bottomPadding = if (!isBottomNavVisible) systemInsets.bottom else 0
+            val bottomPadding = if (isBottomNavVisible) 0 else systemInsets.bottom
 
-            v.setPadding(v.paddingLeft, v.paddingTop, v.paddingRight, bottomPadding)
+            v.setPadding(systemInsets.left, 0, systemInsets.right, bottomPadding)
             insets
         }
     }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/totals/OrderCreateEditTotalsFullView.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/totals/OrderCreateEditTotalsFullView.kt
@@ -19,6 +19,7 @@ import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.navigationBarsPadding
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
@@ -62,12 +63,17 @@ import com.woocommerce.android.ui.orders.creation.OrderCreateEditViewModel
 @Composable
 fun OrderCreateEditTotalsView(viewModel: OrderCreateEditViewModel) {
     viewModel.totalsData.observeAsState().value?.let { state ->
-        OrderCreateEditTotalsView(
-            state,
-            modifier = Modifier.onGloballyPositioned {
-                state.onHeightChanged(it.size.height)
-            }
-        )
+        Box(
+            modifier = Modifier
+                .navigationBarsPadding()
+        ) {
+            OrderCreateEditTotalsView(
+                state,
+                modifier = Modifier.onGloballyPositioned {
+                    state.onHeightChanged(it.size.height)
+                }
+            )
+        }
     }
 }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/totals/OrderCreateEditTotalsFullView.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/totals/OrderCreateEditTotalsFullView.kt
@@ -19,7 +19,6 @@ import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
-import androidx.compose.foundation.layout.navigationBarsPadding
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
@@ -63,17 +62,12 @@ import com.woocommerce.android.ui.orders.creation.OrderCreateEditViewModel
 @Composable
 fun OrderCreateEditTotalsView(viewModel: OrderCreateEditViewModel) {
     viewModel.totalsData.observeAsState().value?.let { state ->
-        Box(
-            modifier = Modifier
-                .navigationBarsPadding()
-        ) {
-            OrderCreateEditTotalsView(
-                state,
-                modifier = Modifier.onGloballyPositioned {
-                    state.onHeightChanged(it.size.height)
-                }
-            )
-        }
+        OrderCreateEditTotalsView(
+            state,
+            modifier = Modifier.onGloballyPositioned {
+                state.onHeightChanged(it.size.height)
+            }
+        )
     }
 }
 


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #13455
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
I noticed that as not all fragments in the main activity use bottom navigation, then in the cases when 3 buttons navigation is used, part of the fragment is hidden behind the navigation. The ideal solution would be to adopt all the fragments, but it's out of the scope for the target SDK project

Also, thanks to @atorresveiga, I realized that the main activity doesn't handle the case when a phone in landscape mode with three-button navigation, then the buttons are placed on a side (I beleave that in older versions they were on the bottom)
This PR also addresses that

### Testing information
<!-- This is your opportunity to break out individual scenarios that need testing (when necessary) and/or include a checklist for the reviewer to go through. Consider documenting the following from your own completed testing: devices used, alternate workflows, edge cases, affected areas, critical flows, areas not tested, and any remaining unknowns. Provide feedback on this new section of the PR template through Sept 30, 2024 to Apps Quality; additional context here: p91TBi-b8z-p2#comment-12036 -->
* Try Android 35 and below
* Try landscape and portrait  mode with 3 button navigation enabled and without
* Try different fragments on the main screen

### The tests that have been performed
<!-- To give the reviewer an idea of what could be missed in terms of testing -->
above

### Images/gif
<!-- Include before and after images or gifs when appropriate. -->
<img width="421" alt="image" src="https://github.com/user-attachments/assets/add9d33a-d5b7-4857-8817-ddf50eab10cb" />
<img width="742" alt="image" src="https://github.com/user-attachments/assets/3100f851-205d-46b1-a04c-ecf5ebeaa15f" />


- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.

## Reviewer (or Author, in the case of optional code reviews):

Please make sure these conditions are met before approving the PR, or request changes if the PR needs improvement:

- [x] The PR is small and has a clear, single focus, or a valid explanation is provided in the description. If needed, please request to split it into smaller PRs.
- [x] Ensure Adequate Unit Test Coverage: The changes are reasonably covered by unit tests or an explanation is provided in the PR description.
- [x] Manual Testing: The author listed all the tests they ran, including smoke tests when needed (e.g., for refactorings). The reviewer confirmed that the PR works as expected on big (tablet) and small (phone) in case of UI changes, and no regressions are added.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->