### PR TITLE
Authenticated WebView improvement [Part 1]

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/analytics/hub/AnalyticsHubFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/analytics/hub/AnalyticsHubFragment.kt
@@ -93,8 +93,8 @@ class AnalyticsHubFragment : BaseFragment(R.layout.fragment_analytics) {
 
             is AnalyticsViewEvent.OpenUrl -> ChromeCustomTabUtils.launchUrl(requireContext(), event.url)
 
-            is AnalyticsViewEvent.OpenWPComWebView -> findNavController()
-                .navigate(NavGraphMainDirections.actionGlobalWPComWebViewFragment(urlToLoad = event.url))
+            is AnalyticsViewEvent.OpenAuthenticatedWebView -> findNavController()
+                .navigate(NavGraphMainDirections.actionGlobalAuthenticatedWebViewFragment(urlToLoad = event.url))
 
             is AnalyticsViewEvent.OpenDatePicker -> showDateRangePicker(
                 event.fromMillis,

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/analytics/hub/AnalyticsHubViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/analytics/hub/AnalyticsHubViewModel.kt
@@ -201,7 +201,7 @@ class AnalyticsHubViewModel @Inject constructor(
         trackSeeReportInteraction(card)
         selectedSite.getOrNull()?.let { site ->
             val event = if (site.isWpComStore) {
-                AnalyticsViewEvent.OpenWPComWebView(url)
+                AnalyticsViewEvent.OpenAuthenticatedWebView(url)
             } else {
                 AnalyticsViewEvent.OpenUrl(url)
             }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/analytics/hub/AnalyticsHubViewState.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/analytics/hub/AnalyticsHubViewState.kt
@@ -13,7 +13,7 @@ data class AnalyticsViewState(
 
 sealed class AnalyticsViewEvent : MultiLiveEvent.Event() {
     data class OpenUrl(val url: String) : AnalyticsViewEvent()
-    data class OpenWPComWebView(val url: String) : AnalyticsViewEvent()
+    data class OpenAuthenticatedWebView(val url: String) : AnalyticsViewEvent()
     data class OpenDatePicker(val fromMillis: Long, val toMillis: Long) : MultiLiveEvent.Event()
     object OpenDateRangeSelector : AnalyticsViewEvent()
     object SendFeedback : AnalyticsViewEvent()

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/blaze/creation/payment/BlazeCampaignPaymentMethodsListScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/blaze/creation/payment/BlazeCampaignPaymentMethodsListScreen.kt
@@ -256,7 +256,7 @@ fun AddPaymentMethodWebView(
     WCWebView(
         url = state.formUrl,
         userAgent = state.userAgent,
-        wpComAuthenticator = state.wpComWebViewAuthenticator,
+        authenticator = state.webViewAuthenticator,
         onUrlLoaded = state.onUrlLoaded,
         modifier = modifier
     )

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/blaze/creation/payment/BlazeCampaignPaymentMethodsListViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/blaze/creation/payment/BlazeCampaignPaymentMethodsListViewModel.kt
@@ -9,7 +9,7 @@ import com.woocommerce.android.analytics.AnalyticsEvent.BLAZE_CREATION_ADD_PAYME
 import com.woocommerce.android.analytics.AnalyticsTrackerWrapper
 import com.woocommerce.android.ui.blaze.BlazeRepository
 import com.woocommerce.android.ui.blaze.BlazeRepository.PaymentMethod
-import com.woocommerce.android.ui.common.wpcomwebview.WPComWebViewAuthenticator
+import com.woocommerce.android.ui.common.webview.WebViewAuthenticator
 import com.woocommerce.android.ui.login.AccountRepository
 import com.woocommerce.android.util.WooLog
 import com.woocommerce.android.viewmodel.MultiLiveEvent
@@ -26,7 +26,7 @@ class BlazeCampaignPaymentMethodsListViewModel @Inject constructor(
     savedStateHandle: SavedStateHandle,
     private val accountRepository: AccountRepository,
     private val userAgent: UserAgent,
-    private val wpComWebViewAuthenticator: WPComWebViewAuthenticator,
+    private val webViewAuthenticator: WebViewAuthenticator,
     private val analyticsTrackerWrapper: AnalyticsTrackerWrapper,
     private val blazeRepository: BlazeRepository
 ) : ScopedViewModel(savedStateHandle) {
@@ -64,7 +64,7 @@ class BlazeCampaignPaymentMethodsListViewModel @Inject constructor(
     private fun addPaymentMethodWebView(): ViewState = ViewState.AddPaymentMethodWebView(
         formUrl = navArgs.paymentMethodsData.addPaymentMethodUrls.formUrl,
         userAgent = userAgent,
-        wpComWebViewAuthenticator = wpComWebViewAuthenticator,
+        webViewAuthenticator = webViewAuthenticator,
         onUrlLoaded = { url ->
             viewModelScope.launch {
                 val urls = navArgs.paymentMethodsData.addPaymentMethodUrls
@@ -114,7 +114,7 @@ class BlazeCampaignPaymentMethodsListViewModel @Inject constructor(
         data class AddPaymentMethodWebView(
             val formUrl: String,
             val userAgent: UserAgent,
-            val wpComWebViewAuthenticator: WPComWebViewAuthenticator,
+            val webViewAuthenticator: WebViewAuthenticator,
             val onUrlLoaded: (String) -> Unit,
             override val onDismiss: () -> Unit
         ) : ViewState

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/blaze/detail/BlazeCampaignDetailWebViewFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/blaze/detail/BlazeCampaignDetailWebViewFragment.kt
@@ -10,7 +10,7 @@ import androidx.fragment.app.viewModels
 import androidx.navigation.fragment.findNavController
 import com.woocommerce.android.extensions.navigateBackWithResult
 import com.woocommerce.android.ui.base.BaseFragment
-import com.woocommerce.android.ui.common.wpcomwebview.WPComWebViewAuthenticator
+import com.woocommerce.android.ui.common.webview.WebViewAuthenticator
 import com.woocommerce.android.ui.compose.theme.WooThemeWithBackground
 import com.woocommerce.android.ui.main.AppBarStatus
 import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.Exit
@@ -31,7 +31,7 @@ class BlazeCampaignDetailWebViewFragment : BaseFragment() {
     private val viewModel: BlazeCampaignDetailWebViewViewModel by viewModels()
 
     @Inject
-    lateinit var wpComAuthenticator: WPComWebViewAuthenticator
+    lateinit var authenticator: WebViewAuthenticator
 
     @Inject
     lateinit var userAgent: UserAgent
@@ -44,7 +44,7 @@ class BlazeCampaignDetailWebViewFragment : BaseFragment() {
                 WooThemeWithBackground {
                     BlazeCampaignDetailWebViewScreen(
                         viewModel = viewModel,
-                        wpComAuthenticator = wpComAuthenticator,
+                        authenticator = authenticator,
                         userAgent = userAgent,
                         onUrlLoaded = viewModel::onUrlLoaded,
                         onDismiss = viewModel::onDismiss

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/blaze/detail/BlazeCampaignDetailWebViewScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/blaze/detail/BlazeCampaignDetailWebViewScreen.kt
@@ -6,7 +6,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
 import com.woocommerce.android.R
-import com.woocommerce.android.ui.common.wpcomwebview.WPComWebViewAuthenticator
+import com.woocommerce.android.ui.common.webview.WebViewAuthenticator
 import com.woocommerce.android.ui.compose.component.Toolbar
 import com.woocommerce.android.ui.compose.component.web.WCWebView
 import org.wordpress.android.fluxc.network.UserAgent
@@ -14,7 +14,7 @@ import org.wordpress.android.fluxc.network.UserAgent
 @Composable
 fun BlazeCampaignDetailWebViewScreen(
     viewModel: BlazeCampaignDetailWebViewViewModel,
-    wpComAuthenticator: WPComWebViewAuthenticator,
+    authenticator: WebViewAuthenticator,
     userAgent: UserAgent,
     onUrlLoaded: (String) -> Unit,
     onDismiss: () -> Unit,
@@ -30,7 +30,7 @@ fun BlazeCampaignDetailWebViewScreen(
         WCWebView(
             url = viewModel.viewState.urlToLoad,
             userAgent = userAgent,
-            wpComAuthenticator = wpComAuthenticator,
+            authenticator = authenticator,
             onUrlLoaded = onUrlLoaded,
             modifier = Modifier.padding(paddingValues)
         )

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/blaze/detail/BlazeCampaignDetailWebViewScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/blaze/detail/BlazeCampaignDetailWebViewScreen.kt
@@ -32,7 +32,6 @@ fun BlazeCampaignDetailWebViewScreen(
             userAgent = userAgent,
             wpComAuthenticator = wpComAuthenticator,
             onUrlLoaded = onUrlLoaded,
-            clearCache = true,
             modifier = Modifier.padding(paddingValues)
         )
     }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/common/webview/AuthenticatedWebViewFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/common/webview/AuthenticatedWebViewFragment.kt
@@ -1,4 +1,4 @@
-package com.woocommerce.android.ui.common.wpcomwebview
+package com.woocommerce.android.ui.common.webview
 
 import android.os.Bundle
 import android.view.LayoutInflater
@@ -20,7 +20,7 @@ import dagger.hilt.android.AndroidEntryPoint
  * This fragments allows loading specific pages from WordPress.com with the current user logged in.
  */
 @AndroidEntryPoint
-class WPComWebViewFragment : BaseFragment(R.layout.fragment_wpcom_webview) {
+class AuthenticatedWebViewFragment : BaseFragment(R.layout.fragment_wpcom_webview) {
     companion object {
         const val WEBVIEW_RESULT = "webview-result"
         const val WEBVIEW_DISMISSED = "webview-dismissed"
@@ -29,7 +29,7 @@ class WPComWebViewFragment : BaseFragment(R.layout.fragment_wpcom_webview) {
     override val activityAppBarStatus: AppBarStatus
         get() = AppBarStatus.Hidden
 
-    private val viewModel: WPComWebViewViewModel by viewModels()
+    private val viewModel: AuthenticatedWebViewViewModel by viewModels()
 
     override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View {
         return ComposeView(requireContext()).apply {
@@ -37,7 +37,7 @@ class WPComWebViewFragment : BaseFragment(R.layout.fragment_wpcom_webview) {
 
             setContent {
                 WooThemeWithBackground {
-                    WPComWebViewScreen(viewModel)
+                    AuthenticatedWebViewScreen(viewModel)
                 }
             }
         }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/common/webview/AuthenticatedWebViewScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/common/webview/AuthenticatedWebViewScreen.kt
@@ -1,4 +1,4 @@
-package com.woocommerce.android.ui.common.wpcomwebview
+package com.woocommerce.android.ui.common.webview
 
 import androidx.activity.compose.BackHandler
 import androidx.compose.foundation.layout.fillMaxSize
@@ -11,17 +11,17 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
 import com.woocommerce.android.R
-import com.woocommerce.android.ui.common.wpcomwebview.WPComWebViewViewModel.DisplayMode.MODAL
-import com.woocommerce.android.ui.common.wpcomwebview.WPComWebViewViewModel.DisplayMode.REGULAR
+import com.woocommerce.android.ui.common.webview.AuthenticatedWebViewViewModel.DisplayMode.MODAL
+import com.woocommerce.android.ui.common.webview.AuthenticatedWebViewViewModel.DisplayMode.REGULAR
 import com.woocommerce.android.ui.compose.component.Toolbar
 import com.woocommerce.android.ui.compose.component.web.WCWebView
 import org.wordpress.android.fluxc.network.UserAgent
 
 @Composable
-fun WPComWebViewScreen(viewViewModel: WPComWebViewViewModel) {
-    WPComWebViewScreen(
+fun AuthenticatedWebViewScreen(viewViewModel: AuthenticatedWebViewViewModel) {
+    AuthenticatedWebViewScreen(
         viewState = viewViewModel.viewState,
-        wpcomWebViewAuthenticator = viewViewModel.wpComWebViewAuthenticator,
+        wpcomWebViewAuthenticator = viewViewModel.webViewAuthenticator,
         userAgent = viewViewModel.userAgent,
         onUrlLoaded = viewViewModel::onUrlLoaded,
         onClose = viewViewModel::onClose
@@ -29,9 +29,9 @@ fun WPComWebViewScreen(viewViewModel: WPComWebViewViewModel) {
 }
 
 @Composable
-fun WPComWebViewScreen(
-    viewState: WPComWebViewViewModel.ViewState,
-    wpcomWebViewAuthenticator: WPComWebViewAuthenticator,
+private fun AuthenticatedWebViewScreen(
+    viewState: AuthenticatedWebViewViewModel.ViewState,
+    wpcomWebViewAuthenticator: WebViewAuthenticator,
     userAgent: UserAgent,
     onUrlLoaded: (String) -> Unit,
     onClose: () -> Unit
@@ -52,7 +52,7 @@ fun WPComWebViewScreen(
         WCWebView(
             url = viewState.urlToLoad,
             userAgent = userAgent,
-            wpComAuthenticator = wpcomWebViewAuthenticator,
+            authenticator = wpcomWebViewAuthenticator,
             onUrlLoaded = onUrlLoaded,
             captureBackPresses = viewState.captureBackButton,
             modifier = Modifier

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/common/webview/AuthenticatedWebViewViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/common/webview/AuthenticatedWebViewViewModel.kt
@@ -1,9 +1,9 @@
-package com.woocommerce.android.ui.common.wpcomwebview
+package com.woocommerce.android.ui.common.webview
 
 import androidx.lifecycle.SavedStateHandle
-import com.woocommerce.android.ui.common.wpcomwebview.WPComWebViewViewModel.UrlComparisonMode.EQUALITY
-import com.woocommerce.android.ui.common.wpcomwebview.WPComWebViewViewModel.UrlComparisonMode.PARTIAL
-import com.woocommerce.android.ui.common.wpcomwebview.WPComWebViewViewModel.UrlComparisonMode.STARTS_WITH
+import com.woocommerce.android.ui.common.webview.AuthenticatedWebViewViewModel.UrlComparisonMode.EQUALITY
+import com.woocommerce.android.ui.common.webview.AuthenticatedWebViewViewModel.UrlComparisonMode.PARTIAL
+import com.woocommerce.android.ui.common.webview.AuthenticatedWebViewViewModel.UrlComparisonMode.STARTS_WITH
 import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.Exit
 import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.ExitWithResult
 import com.woocommerce.android.viewmodel.ScopedViewModel
@@ -13,12 +13,12 @@ import org.wordpress.android.fluxc.network.UserAgent
 import javax.inject.Inject
 
 @HiltViewModel
-class WPComWebViewViewModel @Inject constructor(
+class AuthenticatedWebViewViewModel @Inject constructor(
     savedStateHandle: SavedStateHandle,
-    val wpComWebViewAuthenticator: WPComWebViewAuthenticator,
+    val webViewAuthenticator: WebViewAuthenticator,
     val userAgent: UserAgent
 ) : ScopedViewModel(savedStateHandle) {
-    private val navArgs: WPComWebViewFragmentArgs by savedStateHandle.navArgs()
+    private val navArgs: AuthenticatedWebViewFragmentArgs by savedStateHandle.navArgs()
     private var isExiting = false
 
     val viewState = navArgs.let {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/common/webview/UrlInterceptor.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/common/webview/UrlInterceptor.kt
@@ -1,5 +1,0 @@
-package com.woocommerce.android.ui.common.webview
-
-interface UrlInterceptor {
-    fun onLoadUrl(url: String)
-}

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/common/webview/UrlInterceptor.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/common/webview/UrlInterceptor.kt
@@ -1,4 +1,4 @@
-package com.woocommerce.android.ui.common.wpcomwebview
+package com.woocommerce.android.ui.common.webview
 
 interface UrlInterceptor {
     fun onLoadUrl(url: String)

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/common/webview/WebViewAuthenticator.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/common/webview/WebViewAuthenticator.kt
@@ -1,4 +1,4 @@
-package com.woocommerce.android.ui.common.wpcomwebview
+package com.woocommerce.android.ui.common.webview
 
 import android.webkit.WebView
 import com.woocommerce.android.extensions.isNotNullOrEmpty
@@ -12,7 +12,7 @@ import javax.inject.Inject
 
 private const val WPCOM_LOGIN_URL = "https://wordpress.com/wp-login.php"
 
-class WPComWebViewAuthenticator @Inject constructor(
+class WebViewAuthenticator @Inject constructor(
     private val accountStore: AccountStore
 ) {
     fun authenticateAndLoadUrl(webView: WebView, url: String) {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/common/wpcomwebview/WPComWebViewScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/common/wpcomwebview/WPComWebViewScreen.kt
@@ -34,8 +34,7 @@ fun WPComWebViewScreen(
     wpcomWebViewAuthenticator: WPComWebViewAuthenticator,
     userAgent: UserAgent,
     onUrlLoaded: (String) -> Unit,
-    onClose: () -> Unit,
-    clearCache: Boolean = false
+    onClose: () -> Unit
 ) {
     BackHandler(onBack = onClose)
     Scaffold(
@@ -56,7 +55,6 @@ fun WPComWebViewScreen(
             wpComAuthenticator = wpcomWebViewAuthenticator,
             onUrlLoaded = onUrlLoaded,
             captureBackPresses = viewState.captureBackButton,
-            clearCache = clearCache,
             modifier = Modifier
                 .padding(paddingValues)
                 .fillMaxSize()

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/compose/component/web/DefaultWebViewClient.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/compose/component/web/DefaultWebViewClient.kt
@@ -1,0 +1,55 @@
+package com.woocommerce.android.ui.compose.component.web
+
+import android.webkit.WebResourceError
+import android.webkit.WebResourceRequest
+import android.webkit.WebResourceResponse
+import android.webkit.WebView
+import android.webkit.WebViewClient
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.flow.asSharedFlow
+
+open class DefaultWebViewClient : WebViewClient() {
+    private val _eventsObservable = MutableSharedFlow<WebViewEvent>(extraBufferCapacity = Int.MAX_VALUE)
+    val eventsObservable: Flow<WebViewEvent> = _eventsObservable.asSharedFlow()
+
+    override fun doUpdateVisitedHistory(view: WebView?, url: String?, isReload: Boolean) {
+        url?.let { _eventsObservable.tryEmit(WebViewEvent.UrlLoaded(it)) }
+    }
+
+    override fun onLoadResource(view: WebView?, url: String?) {
+        url?.let { _eventsObservable.tryEmit(WebViewEvent.UrlLoaded(it)) }
+    }
+
+    override fun onPageFinished(view: WebView?, url: String?) {
+        url?.let { _eventsObservable.tryEmit(WebViewEvent.PageFinished(it)) }
+    }
+
+    override fun onReceivedError(
+        view: WebView?,
+        request: WebResourceRequest?,
+        error: WebResourceError?
+    ) {
+        request?.url?.let { url ->
+            _eventsObservable.tryEmit(WebViewEvent.UrlFailed(url.toString(), error?.errorCode))
+        }
+    }
+
+    override fun onReceivedHttpError(
+        view: WebView?,
+        request: WebResourceRequest?,
+        errorResponse: WebResourceResponse?
+    ) {
+        request?.url?.let { url ->
+            _eventsObservable.tryEmit(WebViewEvent.UrlFailed(url.toString(), errorResponse?.statusCode))
+        }
+    }
+
+    sealed interface WebViewEvent {
+        val url: String
+
+        data class UrlLoaded(override val url: String) : WebViewEvent
+        data class PageFinished(override val url: String) : WebViewEvent
+        data class UrlFailed(override val url: String, val errorCode: Int?) : WebViewEvent
+    }
+}

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/compose/component/web/WCWebChromeClient.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/compose/component/web/WCWebChromeClient.kt
@@ -8,7 +8,7 @@ import androidx.activity.ComponentActivity
 import androidx.activity.result.contract.ActivityResultContracts
 import com.woocommerce.android.extensions.findActivity
 
-open class ComposeWebChromeClient : WebChromeClient() {
+open class WCWebChromeClient : WebChromeClient() {
     var onProgressChanged: (Int) -> Unit = {}
 
     /**

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/compose/component/web/WCWebView.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/compose/component/web/WCWebView.kt
@@ -2,8 +2,6 @@ package com.woocommerce.android.ui.compose.component.web
 
 import android.annotation.SuppressLint
 import android.view.ViewGroup
-import android.webkit.CookieManager
-import android.webkit.WebStorage
 import android.webkit.WebView
 import androidx.activity.compose.BackHandler
 import androidx.compose.foundation.layout.Box
@@ -51,12 +49,7 @@ fun WCWebView(
     webViewNavigator: WebViewNavigator = rememberWebViewNavigator(),
     webViewClient: DefaultWebViewClient = remember { DefaultWebViewClient() },
     webChromeClient: ComposeWebChromeClient = remember { ComposeWebChromeClient() },
-    loadWithOverviewMode: Boolean = false,
-    useWideViewPort: Boolean = false,
-    isJavaScriptEnabled: Boolean = true,
-    isDomStorageEnabled: Boolean = true,
-    isReadOnly: Boolean = false,
-    initialScale: Int = 0,
+    settings: WCWebViewSettings = WCWebViewSettings(),
     clearCache: Boolean = false,
     progressIndicator: WebViewProgressIndicator = Linear()
 ) {
@@ -93,6 +86,18 @@ fun WCWebView(
             wpComAuthenticator?.authenticateAndLoadUrl(webView, url) ?: webView.loadUrl(url)
             canGoBack = webView.canGoBack()
         }
+
+        LaunchedEffect(settings) {
+            if (settings.isReadOnly) {
+                webView.setOnTouchListener { _, _ -> true }
+            }
+            webView.setInitialScale(settings.initialScale)
+
+            webView.settings.useWideViewPort = settings.useWideViewPort
+            webView.settings.loadWithOverviewMode = settings.loadWithOverviewMode
+            webView.settings.javaScriptEnabled = settings.isJavaScriptEnabled
+            webView.settings.domStorageEnabled = settings.isDomStorageEnabled
+        }
     }
 
     Box(modifier = modifier) {
@@ -126,15 +131,6 @@ fun WCWebView(
                         onProgressChanged = { newProgress -> progress = newProgress }
                     }
 
-                    if (isReadOnly) {
-                        this.setOnTouchListener { _, _ -> true }
-                    }
-
-                    this.setInitialScale(initialScale)
-                    this.settings.useWideViewPort = useWideViewPort
-                    this.settings.loadWithOverviewMode = loadWithOverviewMode
-                    this.settings.javaScriptEnabled = isJavaScriptEnabled
-                    this.settings.domStorageEnabled = isDomStorageEnabled
                     this.settings.userAgentString = userAgent.userAgent
                     if (clearCache) {
                         WebStorage.getInstance().deleteAllData()

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/compose/component/web/WCWebView.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/compose/component/web/WCWebView.kt
@@ -16,6 +16,7 @@ import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.Stable
+import androidx.compose.runtime.derivedStateOf
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableIntStateOf
 import androidx.compose.runtime.mutableStateOf
@@ -95,18 +96,21 @@ fun WCWebView(
     }
 
     Box(modifier = modifier) {
-        fun getWebViewAlpha(): Float {
-            return if (progressIndicator is Circular ||
-                progressIndicator is Linear && progressIndicator.message != null
-            ) {
-                if (progress == 100) 1f else 0f
-            } else {
-                1f
+        val webViewAlpha by remember {
+            derivedStateOf {
+                if (progressIndicator is Circular ||
+                    progressIndicator is Linear && progressIndicator.message != null
+                ) {
+                    if (progress == 100) 1f else 0f
+                } else {
+                    1f
+                }
             }
         }
-
-        fun getProgressAlpha(): Float {
-            return if (progress == 100) 0f else 1f
+        val progressAlpha by remember {
+            derivedStateOf {
+                if (progress == 100) 0f else 1f
+            }
         }
 
         AndroidView(
@@ -147,7 +151,7 @@ fun WCWebView(
                 }.also { webView = it }
             },
             modifier = Modifier
-                .alpha(getWebViewAlpha())
+                .alpha(webViewAlpha)
         )
 
         if (progressIndicator is Linear) {
@@ -155,7 +159,7 @@ fun WCWebView(
                 progress = (progress / 100f),
                 modifier = Modifier
                     .fillMaxWidth()
-                    .alpha(getProgressAlpha())
+                    .alpha(progressAlpha)
             )
 
             if (progressIndicator.message != null) {
@@ -163,14 +167,14 @@ fun WCWebView(
                     text = progressIndicator.message,
                     modifier = Modifier
                         .align(Alignment.Center)
-                        .alpha(getProgressAlpha())
+                        .alpha(progressAlpha)
                 )
             }
         } else if (progressIndicator is Circular) {
             Column(
                 modifier = Modifier
                     .align(Alignment.Center)
-                    .alpha(getProgressAlpha())
+                    .alpha(progressAlpha)
             ) {
                 CircularProgressIndicator(
                     modifier = Modifier

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/compose/component/web/WCWebView.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/compose/component/web/WCWebView.kt
@@ -27,7 +27,7 @@ import androidx.compose.ui.res.dimensionResource
 import androidx.compose.ui.viewinterop.AndroidView
 import com.woocommerce.android.R.dimen
 import com.woocommerce.android.ui.common.wpcomwebview.WPComWebViewAuthenticator
-import com.woocommerce.android.ui.compose.component.web.DefaultWebViewClient.WebViewEvent
+import com.woocommerce.android.ui.compose.component.web.WCWebViewClient.WebViewEvent
 import com.woocommerce.android.ui.compose.component.web.WebViewProgressIndicator.Circular
 import com.woocommerce.android.ui.compose.component.web.WebViewProgressIndicator.Linear
 import kotlinx.coroutines.flow.MutableSharedFlow
@@ -47,8 +47,8 @@ fun WCWebView(
     captureBackPresses: Boolean = true,
     wpComAuthenticator: WPComWebViewAuthenticator? = null,
     webViewNavigator: WebViewNavigator = rememberWebViewNavigator(),
-    webViewClient: DefaultWebViewClient = remember { DefaultWebViewClient() },
-    webChromeClient: ComposeWebChromeClient = remember { ComposeWebChromeClient() },
+    webViewClient: WCWebViewClient = remember { WCWebViewClient() },
+    webChromeClient: WCWebChromeClient = remember { WCWebChromeClient() },
     settings: WCWebViewSettings = WCWebViewSettings(),
     progressIndicator: WebViewProgressIndicator = Linear()
 ) {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/compose/component/web/WCWebView.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/compose/component/web/WCWebView.kt
@@ -27,7 +27,6 @@ import androidx.compose.ui.res.dimensionResource
 import androidx.compose.ui.viewinterop.AndroidView
 import com.woocommerce.android.R.dimen
 import com.woocommerce.android.ui.common.webview.WebViewAuthenticator
-import com.woocommerce.android.ui.compose.component.web.WCWebViewClient.WebViewEvent
 import com.woocommerce.android.ui.compose.component.web.WebViewProgressIndicator.Circular
 import com.woocommerce.android.ui.compose.component.web.WebViewProgressIndicator.Linear
 import kotlinx.coroutines.flow.MutableSharedFlow

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/compose/component/web/WCWebView.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/compose/component/web/WCWebView.kt
@@ -26,7 +26,8 @@ import androidx.compose.ui.draw.alpha
 import androidx.compose.ui.res.dimensionResource
 import androidx.compose.ui.viewinterop.AndroidView
 import com.woocommerce.android.R.dimen
-import com.woocommerce.android.ui.common.wpcomwebview.WPComWebViewAuthenticator
+import com.woocommerce.android.ui.common.webview.WebViewAuthenticator
+import com.woocommerce.android.ui.compose.component.web.WCWebViewClient.WebViewEvent
 import com.woocommerce.android.ui.compose.component.web.WebViewProgressIndicator.Circular
 import com.woocommerce.android.ui.compose.component.web.WebViewProgressIndicator.Linear
 import kotlinx.coroutines.flow.MutableSharedFlow
@@ -44,7 +45,7 @@ fun WCWebView(
     onPageFinished: (String) -> Unit = {},
     onUrlFailed: (String, Int?) -> Unit = { _, _ -> },
     captureBackPresses: Boolean = true,
-    wpComAuthenticator: WPComWebViewAuthenticator? = null,
+    authenticator: WebViewAuthenticator? = null,
     webViewNavigator: WebViewNavigator = rememberWebViewNavigator(),
     webViewClient: WCWebViewClient = remember { WCWebViewClient() },
     webChromeClient: WCWebChromeClient = remember { WCWebChromeClient() },
@@ -81,7 +82,7 @@ fun WCWebView(
 
     webView?.let { webView ->
         LaunchedEffect(url) {
-            wpComAuthenticator?.authenticateAndLoadUrl(webView, url) ?: webView.loadUrl(url)
+            authenticator?.authenticateAndLoadUrl(webView, url) ?: webView.loadUrl(url)
             canGoBack = webView.canGoBack()
         }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/compose/component/web/WCWebView.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/compose/component/web/WCWebView.kt
@@ -61,7 +61,6 @@ fun WCWebView(
 ) {
     var webView by remember { mutableStateOf<WebView?>(null) }
     var progress by remember { mutableIntStateOf(0) }
-    var lastLoadedUrl by remember { mutableStateOf("") }
     var canGoBack by remember { mutableStateOf(false) }
 
     BackHandler(captureBackPresses && canGoBack) {
@@ -86,6 +85,13 @@ fun WCWebView(
                     is WebViewEvent.UrlFailed -> onUrlFailed(it.url, it.errorCode)
                 }
             }
+    }
+
+    webView?.let { webView ->
+        LaunchedEffect(url) {
+            wpComAuthenticator?.authenticateAndLoadUrl(webView, url) ?: webView.loadUrl(url)
+            canGoBack = webView.canGoBack()
+        }
     }
 
     Box(modifier = modifier) {
@@ -142,12 +148,7 @@ fun WCWebView(
             },
             modifier = Modifier
                 .alpha(getWebViewAlpha())
-        ) { webView ->
-            if (lastLoadedUrl == url) return@AndroidView
-            lastLoadedUrl = url
-            wpComAuthenticator?.authenticateAndLoadUrl(webView, url) ?: webView.loadUrl(url)
-            canGoBack = webView.canGoBack()
-        }
+        )
 
         if (progressIndicator is Linear) {
             LinearProgressIndicator(

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/compose/component/web/WCWebView.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/compose/component/web/WCWebView.kt
@@ -27,7 +27,6 @@ import androidx.compose.ui.res.dimensionResource
 import androidx.compose.ui.viewinterop.AndroidView
 import com.woocommerce.android.R.dimen
 import com.woocommerce.android.ui.common.wpcomwebview.WPComWebViewAuthenticator
-import com.woocommerce.android.ui.compose.component.web.WCWebViewClient.WebViewEvent
 import com.woocommerce.android.ui.compose.component.web.WebViewProgressIndicator.Circular
 import com.woocommerce.android.ui.compose.component.web.WebViewProgressIndicator.Linear
 import kotlinx.coroutines.flow.MutableSharedFlow
@@ -70,12 +69,12 @@ fun WCWebView(
         webViewClient.eventsObservable
             .collect {
                 when (it) {
-                    is WebViewEvent.UrlLoaded -> onUrlLoaded(it.url)
-                    is WebViewEvent.PageFinished -> {
+                    is WCWebViewEvent.UrlLoaded -> onUrlLoaded(it.url)
+                    is WCWebViewEvent.PageFinished -> {
                         onPageFinished(it.url)
                         canGoBack = webView?.canGoBack() == true
                     }
-                    is WebViewEvent.UrlFailed -> onUrlFailed(it.url, it.errorCode)
+                    is WCWebViewEvent.UrlFailed -> onUrlFailed(it.url, it.errorCode)
                 }
             }
     }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/compose/component/web/WCWebView.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/compose/component/web/WCWebView.kt
@@ -50,7 +50,6 @@ fun WCWebView(
     webViewClient: DefaultWebViewClient = remember { DefaultWebViewClient() },
     webChromeClient: ComposeWebChromeClient = remember { ComposeWebChromeClient() },
     settings: WCWebViewSettings = WCWebViewSettings(),
-    clearCache: Boolean = false,
     progressIndicator: WebViewProgressIndicator = Linear()
 ) {
     var webView by remember { mutableStateOf<WebView?>(null) }
@@ -132,18 +131,6 @@ fun WCWebView(
                     }
 
                     this.settings.userAgentString = userAgent.userAgent
-                    if (clearCache) {
-                        WebStorage.getInstance().deleteAllData()
-
-                        // Clear all the cookies
-                        CookieManager.getInstance().removeAllCookies(null)
-                        CookieManager.getInstance().flush()
-
-                        this.clearCache(true)
-                        this.clearFormData()
-                        this.clearHistory()
-                        this.clearSslPreferences()
-                    }
                 }.also { webView = it }
             },
             modifier = Modifier

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/compose/component/web/WCWebView.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/compose/component/web/WCWebView.kt
@@ -3,12 +3,8 @@ package com.woocommerce.android.ui.compose.component.web
 import android.annotation.SuppressLint
 import android.view.ViewGroup
 import android.webkit.CookieManager
-import android.webkit.WebResourceError
-import android.webkit.WebResourceRequest
-import android.webkit.WebResourceResponse
 import android.webkit.WebStorage
 import android.webkit.WebView
-import android.webkit.WebViewClient
 import androidx.activity.compose.BackHandler
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -32,6 +28,7 @@ import androidx.compose.ui.res.dimensionResource
 import androidx.compose.ui.viewinterop.AndroidView
 import com.woocommerce.android.R.dimen
 import com.woocommerce.android.ui.common.wpcomwebview.WPComWebViewAuthenticator
+import com.woocommerce.android.ui.compose.component.web.DefaultWebViewClient.WebViewEvent
 import com.woocommerce.android.ui.compose.component.web.WebViewProgressIndicator.Circular
 import com.woocommerce.android.ui.compose.component.web.WebViewProgressIndicator.Linear
 import kotlinx.coroutines.flow.MutableSharedFlow
@@ -51,6 +48,7 @@ fun WCWebView(
     captureBackPresses: Boolean = true,
     wpComAuthenticator: WPComWebViewAuthenticator? = null,
     webViewNavigator: WebViewNavigator = rememberWebViewNavigator(),
+    webViewClient: DefaultWebViewClient = remember { DefaultWebViewClient() },
     webChromeClient: ComposeWebChromeClient = remember { ComposeWebChromeClient() },
     loadWithOverviewMode: Boolean = false,
     useWideViewPort: Boolean = false,
@@ -76,6 +74,20 @@ fun WCWebView(
         }
     }
 
+    LaunchedEffect(webViewClient) {
+        webViewClient.eventsObservable
+            .collect {
+                when (it) {
+                    is WebViewEvent.UrlLoaded -> onUrlLoaded(it.url)
+                    is WebViewEvent.PageFinished -> {
+                        onPageFinished(it.url)
+                        canGoBack = webView?.canGoBack() == true
+                    }
+                    is WebViewEvent.UrlFailed -> onUrlFailed(it.url, it.errorCode)
+                }
+            }
+    }
+
     Box(modifier = modifier) {
         fun getWebViewAlpha(): Float {
             return if (progressIndicator is Circular ||
@@ -99,41 +111,7 @@ fun WCWebView(
                         ViewGroup.LayoutParams.MATCH_PARENT
                     )
 
-                    this.webViewClient = object : WebViewClient() {
-                        override fun doUpdateVisitedHistory(view: WebView?, url: String?, isReload: Boolean) {
-                            url?.let { onUrlLoaded(it) }
-                        }
-
-                        override fun onLoadResource(view: WebView?, url: String?) {
-                            url?.let { onUrlLoaded(it) }
-                        }
-
-                        override fun onPageFinished(view: WebView?, url: String?) {
-                            url?.let { onPageFinished(it) }
-                            canGoBack = view?.canGoBack() ?: false
-                        }
-
-                        override fun onReceivedError(
-                            view: WebView?,
-                            request: WebResourceRequest?,
-                            error: WebResourceError?
-                        ) {
-                            request?.url?.let { url ->
-                                onUrlFailed(url.toString(), error?.errorCode)
-                            }
-                        }
-
-                        override fun onReceivedHttpError(
-                            view: WebView?,
-                            request: WebResourceRequest?,
-                            errorResponse: WebResourceResponse?
-                        ) {
-                            request?.url?.let { url ->
-                                onUrlFailed(url.toString(), errorResponse?.statusCode)
-                            }
-                        }
-                    }
-
+                    this.webViewClient = webViewClient
                     this.webChromeClient = webChromeClient.apply {
                         onProgressChanged = { newProgress -> progress = newProgress }
                     }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/compose/component/web/WCWebViewClient.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/compose/component/web/WCWebViewClient.kt
@@ -9,7 +9,7 @@ import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.asSharedFlow
 
-open class DefaultWebViewClient : WebViewClient() {
+open class WCWebViewClient : WebViewClient() {
     private val _eventsObservable = MutableSharedFlow<WebViewEvent>(extraBufferCapacity = Int.MAX_VALUE)
     val eventsObservable: Flow<WebViewEvent> = _eventsObservable.asSharedFlow()
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/compose/component/web/WCWebViewClient.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/compose/component/web/WCWebViewClient.kt
@@ -10,19 +10,19 @@ import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.asSharedFlow
 
 open class WCWebViewClient : WebViewClient() {
-    private val _eventsObservable = MutableSharedFlow<WebViewEvent>(extraBufferCapacity = Int.MAX_VALUE)
-    val eventsObservable: Flow<WebViewEvent> = _eventsObservable.asSharedFlow()
+    private val _eventsObservable = MutableSharedFlow<WCWebViewEvent>(extraBufferCapacity = Int.MAX_VALUE)
+    val eventsObservable: Flow<WCWebViewEvent> = _eventsObservable.asSharedFlow()
 
     override fun doUpdateVisitedHistory(view: WebView?, url: String?, isReload: Boolean) {
-        url?.let { _eventsObservable.tryEmit(WebViewEvent.UrlLoaded(it)) }
+        url?.let { _eventsObservable.tryEmit(WCWebViewEvent.UrlLoaded(it)) }
     }
 
     override fun onLoadResource(view: WebView?, url: String?) {
-        url?.let { _eventsObservable.tryEmit(WebViewEvent.UrlLoaded(it)) }
+        url?.let { _eventsObservable.tryEmit(WCWebViewEvent.UrlLoaded(it)) }
     }
 
     override fun onPageFinished(view: WebView?, url: String?) {
-        url?.let { _eventsObservable.tryEmit(WebViewEvent.PageFinished(it)) }
+        url?.let { _eventsObservable.tryEmit(WCWebViewEvent.PageFinished(it)) }
     }
 
     override fun onReceivedError(
@@ -31,7 +31,7 @@ open class WCWebViewClient : WebViewClient() {
         error: WebResourceError?
     ) {
         request?.url?.let { url ->
-            _eventsObservable.tryEmit(WebViewEvent.UrlFailed(url.toString(), error?.errorCode))
+            _eventsObservable.tryEmit(WCWebViewEvent.UrlFailed(url.toString(), error?.errorCode))
         }
     }
 
@@ -41,15 +41,7 @@ open class WCWebViewClient : WebViewClient() {
         errorResponse: WebResourceResponse?
     ) {
         request?.url?.let { url ->
-            _eventsObservable.tryEmit(WebViewEvent.UrlFailed(url.toString(), errorResponse?.statusCode))
+            _eventsObservable.tryEmit(WCWebViewEvent.UrlFailed(url.toString(), errorResponse?.statusCode))
         }
-    }
-
-    sealed interface WebViewEvent {
-        val url: String
-
-        data class UrlLoaded(override val url: String) : WebViewEvent
-        data class PageFinished(override val url: String) : WebViewEvent
-        data class UrlFailed(override val url: String, val errorCode: Int?) : WebViewEvent
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/compose/component/web/WCWebViewEvent.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/compose/component/web/WCWebViewEvent.kt
@@ -1,0 +1,9 @@
+package com.woocommerce.android.ui.compose.component.web
+
+sealed interface WCWebViewEvent {
+    val url: String
+
+    data class UrlLoaded(override val url: String) : WCWebViewEvent
+    data class PageFinished(override val url: String) : WCWebViewEvent
+    data class UrlFailed(override val url: String, val errorCode: Int?) : WCWebViewEvent
+}

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/compose/component/web/WCWebViewSettings.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/compose/component/web/WCWebViewSettings.kt
@@ -1,0 +1,10 @@
+package com.woocommerce.android.ui.compose.component.web
+
+data class WCWebViewSettings(
+    val loadWithOverviewMode: Boolean = false,
+    val useWideViewPort: Boolean = false,
+    val isJavaScriptEnabled: Boolean = true,
+    val isDomStorageEnabled: Boolean = true,
+    val isReadOnly: Boolean = false,
+    val initialScale: Int = 0,
+)

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/google/webview/GoogleAdsWebViewScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/google/webview/GoogleAdsWebViewScreen.kt
@@ -11,7 +11,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
 import com.woocommerce.android.R
-import com.woocommerce.android.ui.common.wpcomwebview.WPComWebViewAuthenticator
+import com.woocommerce.android.ui.common.webview.WebViewAuthenticator
 import com.woocommerce.android.ui.compose.component.Toolbar
 import com.woocommerce.android.ui.compose.component.web.WCWebView
 import com.woocommerce.android.ui.google.webview.GoogleAdsWebViewViewModel.DisplayMode.MODAL
@@ -20,7 +20,7 @@ import org.wordpress.android.fluxc.network.UserAgent
 
 @Composable
 fun GoogleAdsWebViewScreen(viewViewModel: GoogleAdsWebViewViewModel) {
-    val authenticator = viewViewModel.wpComWebViewAuthenticator.takeIf {
+    val authenticator = viewViewModel.webViewAuthenticator.takeIf {
         viewViewModel.viewState.canUseAutoLoginWebview
     }
 
@@ -38,7 +38,7 @@ fun GoogleAdsWebViewScreen(viewViewModel: GoogleAdsWebViewViewModel) {
 @Composable
 fun GoogleAdsWebViewScreen(
     viewState: GoogleAdsWebViewViewModel.ViewState,
-    wpcomWebViewAuthenticator: WPComWebViewAuthenticator?,
+    wpcomWebViewAuthenticator: WebViewAuthenticator?,
     userAgent: UserAgent,
     onUrlLoaded: (String) -> Unit,
     onPageFinished: (String) -> Unit,
@@ -61,7 +61,7 @@ fun GoogleAdsWebViewScreen(
         WCWebView(
             url = viewState.urlToLoad,
             userAgent = userAgent,
-            wpComAuthenticator = wpcomWebViewAuthenticator,
+            authenticator = wpcomWebViewAuthenticator,
             onUrlLoaded = onUrlLoaded,
             onPageFinished = onPageFinished,
             onUrlFailed = onUrlFailed,

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/google/webview/GoogleAdsWebViewScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/google/webview/GoogleAdsWebViewScreen.kt
@@ -43,8 +43,7 @@ fun GoogleAdsWebViewScreen(
     onUrlLoaded: (String) -> Unit,
     onPageFinished: (String) -> Unit,
     onUrlFailed: (String, Int?) -> Unit,
-    onClose: () -> Unit,
-    clearCache: Boolean = false
+    onClose: () -> Unit
 ) {
     BackHandler(onBack = onClose)
     Scaffold(
@@ -67,7 +66,6 @@ fun GoogleAdsWebViewScreen(
             onPageFinished = onPageFinished,
             onUrlFailed = onUrlFailed,
             captureBackPresses = viewState.captureBackButton,
-            clearCache = clearCache,
             modifier = Modifier
                 .padding(paddingValues)
                 .fillMaxSize()

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/google/webview/GoogleAdsWebViewViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/google/webview/GoogleAdsWebViewViewModel.kt
@@ -5,7 +5,7 @@ import com.woocommerce.android.AppUrls
 import com.woocommerce.android.analytics.AnalyticsEvent
 import com.woocommerce.android.analytics.AnalyticsTracker
 import com.woocommerce.android.analytics.AnalyticsTrackerWrapper
-import com.woocommerce.android.ui.common.wpcomwebview.WPComWebViewAuthenticator
+import com.woocommerce.android.ui.common.webview.WebViewAuthenticator
 import com.woocommerce.android.ui.google.CanUseAutoLoginWebview
 import com.woocommerce.android.ui.google.webview.GoogleAdsWebViewViewModel.UrlComparisonMode.EQUALITY
 import com.woocommerce.android.ui.google.webview.GoogleAdsWebViewViewModel.UrlComparisonMode.PARTIAL
@@ -21,7 +21,7 @@ import javax.inject.Inject
 @HiltViewModel
 class GoogleAdsWebViewViewModel @Inject constructor(
     savedStateHandle: SavedStateHandle,
-    val wpComWebViewAuthenticator: WPComWebViewAuthenticator,
+    val webViewAuthenticator: WebViewAuthenticator,
     val canUseAutoLoginWebview: CanUseAutoLoginWebview,
     val userAgent: UserAgent,
     private val analyticsTrackerWrapper: AnalyticsTrackerWrapper

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/accountmismatch/AccountMismatchErrorScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/accountmismatch/AccountMismatchErrorScreen.kt
@@ -46,7 +46,7 @@ import coil.compose.AsyncImage
 import coil.request.ImageRequest.Builder
 import com.woocommerce.android.AppUrls
 import com.woocommerce.android.R
-import com.woocommerce.android.ui.common.wpcomwebview.WPComWebViewAuthenticator
+import com.woocommerce.android.ui.common.webview.WebViewAuthenticator
 import com.woocommerce.android.ui.compose.annotatedStringRes
 import com.woocommerce.android.ui.compose.component.ProgressDialog
 import com.woocommerce.android.ui.compose.component.ToolbarWithHelpButton
@@ -94,7 +94,7 @@ fun AccountMismatchErrorScreen(viewModel: AccountMismatchErrorViewModel) {
                     )
                     is ViewState.JetpackWebViewState -> JetpackConnectionWebView(
                         viewState = targetState,
-                        wpComWebViewAuthenticator = viewModel.wpComWebViewAuthenticator,
+                        webViewAuthenticator = viewModel.webViewAuthenticator,
                         webViewNavigator = webViewNavigator,
                         userAgent = viewModel.userAgent,
                         modifier = Modifier.padding(paddingValues)
@@ -324,14 +324,14 @@ private fun ButtonBar(
 @Composable
 private fun JetpackConnectionWebView(
     viewState: ViewState.JetpackWebViewState,
-    wpComWebViewAuthenticator: WPComWebViewAuthenticator,
+    webViewAuthenticator: WebViewAuthenticator,
     webViewNavigator: WebViewNavigator,
     userAgent: UserAgent,
     modifier: Modifier = Modifier
 ) {
     WCWebView(
         url = viewState.connectionUrl,
-        wpComAuthenticator = wpComWebViewAuthenticator,
+        authenticator = webViewAuthenticator,
         userAgent = userAgent,
         webViewNavigator = webViewNavigator,
         onUrlLoaded = { url: String ->

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/accountmismatch/AccountMismatchErrorViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/accountmismatch/AccountMismatchErrorViewModel.kt
@@ -14,7 +14,7 @@ import com.woocommerce.android.analytics.AnalyticsTrackerWrapper
 import com.woocommerce.android.model.UiString.UiStringRes
 import com.woocommerce.android.model.UiString.UiStringText
 import com.woocommerce.android.support.help.HelpOrigin.LOGIN_SITE_ADDRESS
-import com.woocommerce.android.ui.common.wpcomwebview.WPComWebViewAuthenticator
+import com.woocommerce.android.ui.common.webview.WebViewAuthenticator
 import com.woocommerce.android.ui.login.AccountRepository
 import com.woocommerce.android.ui.login.UnifiedLoginTracker
 import com.woocommerce.android.ui.login.accountmismatch.AccountMismatchErrorViewModel.AccountMismatchErrorType.WPCOM_ACCOUNT_MISMATCH
@@ -60,7 +60,7 @@ class AccountMismatchErrorViewModel @Inject constructor(
     private val resourceProvider: ResourceProvider,
     private val analyticsTrackerWrapper: AnalyticsTrackerWrapper,
     private val unifiedLoginTracker: UnifiedLoginTracker,
-    val wpComWebViewAuthenticator: WPComWebViewAuthenticator,
+    val webViewAuthenticator: WebViewAuthenticator,
     val userAgent: UserAgent
 ) : ScopedViewModel(savedStateHandle) {
     companion object {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/jetpack/connection/JetpackActivationWebViewFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/jetpack/connection/JetpackActivationWebViewFragment.kt
@@ -4,6 +4,8 @@ import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
+import android.webkit.CookieManager
+import android.webkit.WebStorage
 import androidx.compose.ui.platform.ComposeView
 import androidx.compose.ui.platform.ViewCompositionStrategy
 import androidx.fragment.app.viewModels
@@ -48,6 +50,8 @@ class JetpackActivationWebViewFragment : BaseFragment() {
         }
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        clearWebViewData()
+
         viewModel.event.observe(viewLifecycleOwner) { event ->
             when (event) {
                 is JetpackActivationWebViewViewModel.ConnectionResult -> navigateBackWithResult(
@@ -56,5 +60,13 @@ class JetpackActivationWebViewFragment : BaseFragment() {
                 )
             }
         }
+    }
+
+    private fun clearWebViewData() {
+        WebStorage.getInstance().deleteAllData()
+
+        // Clear all the WebView cookies
+        CookieManager.getInstance().removeAllCookies(null)
+        CookieManager.getInstance().flush()
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/jetpack/connection/JetpackActivationWebViewFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/jetpack/connection/JetpackActivationWebViewFragment.kt
@@ -11,7 +11,7 @@ import androidx.compose.ui.platform.ViewCompositionStrategy
 import androidx.fragment.app.viewModels
 import com.woocommerce.android.extensions.navigateBackWithResult
 import com.woocommerce.android.ui.base.BaseFragment
-import com.woocommerce.android.ui.common.wpcomwebview.WPComWebViewAuthenticator
+import com.woocommerce.android.ui.common.webview.WebViewAuthenticator
 import com.woocommerce.android.ui.main.AppBarStatus
 import dagger.hilt.android.AndroidEntryPoint
 import org.wordpress.android.fluxc.network.UserAgent
@@ -28,7 +28,7 @@ class JetpackActivationWebViewFragment : BaseFragment() {
     private val viewModel: JetpackActivationWebViewViewModel by viewModels()
 
     @Inject
-    lateinit var wpComAuthenticator: WPComWebViewAuthenticator
+    lateinit var authenticator: WebViewAuthenticator
 
     @Inject
     lateinit var userAgent: UserAgent
@@ -40,7 +40,7 @@ class JetpackActivationWebViewFragment : BaseFragment() {
             setContent {
                 JetpackActivationWebViewScreen(
                     viewModel = viewModel,
-                    wpComAuthenticator = wpComAuthenticator,
+                    authenticator = authenticator,
                     userAgent = userAgent,
                     onUrlLoaded = viewModel::onUrlLoaded,
                     onUrlFailed = viewModel::onUrlFailed,

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/jetpack/connection/JetpackActivationWebViewScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/jetpack/connection/JetpackActivationWebViewScreen.kt
@@ -37,7 +37,6 @@ fun JetpackActivationWebViewScreen(
             wpComAuthenticator = wpComAuthenticator,
             onUrlLoaded = onUrlLoaded,
             onUrlFailed = onUrlFailed,
-            clearCache = true,
             modifier = Modifier.padding(paddingValues)
         )
     }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/jetpack/connection/JetpackActivationWebViewScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/jetpack/connection/JetpackActivationWebViewScreen.kt
@@ -8,7 +8,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
 import com.woocommerce.android.R
-import com.woocommerce.android.ui.common.wpcomwebview.WPComWebViewAuthenticator
+import com.woocommerce.android.ui.common.webview.WebViewAuthenticator
 import com.woocommerce.android.ui.compose.component.Toolbar
 import com.woocommerce.android.ui.compose.component.web.WCWebView
 import org.wordpress.android.fluxc.network.UserAgent
@@ -16,7 +16,7 @@ import org.wordpress.android.fluxc.network.UserAgent
 @Composable
 fun JetpackActivationWebViewScreen(
     viewModel: JetpackActivationWebViewViewModel,
-    wpComAuthenticator: WPComWebViewAuthenticator,
+    authenticator: WebViewAuthenticator,
     userAgent: UserAgent,
     onUrlLoaded: (String) -> Unit,
     onUrlFailed: (String, Int?) -> Unit,
@@ -34,7 +34,7 @@ fun JetpackActivationWebViewScreen(
         WCWebView(
             url = viewModel.urlToLoad,
             userAgent = userAgent,
-            wpComAuthenticator = wpComAuthenticator,
+            authenticator = authenticator,
             onUrlLoaded = onUrlLoaded,
             onUrlFailed = onUrlFailed,
             modifier = Modifier.padding(paddingValues)

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/main/MainActivity.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/main/MainActivity.kt
@@ -937,7 +937,7 @@ class MainActivity :
 
     private fun navigateToWebView(event: ViewUrlInWebView) {
         navController.navigate(
-            NavGraphMainDirections.actionGlobalWPComWebViewFragment(
+            NavGraphMainDirections.actionGlobalAuthenticatedWebViewFragment(
                 urlToLoad = event.url
             )
         )

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/onboarding/aboutyourstore/AboutYourStoreFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/onboarding/aboutyourstore/AboutYourStoreFragment.kt
@@ -9,7 +9,7 @@ import androidx.compose.ui.platform.ViewCompositionStrategy
 import androidx.fragment.app.viewModels
 import androidx.navigation.fragment.findNavController
 import com.woocommerce.android.ui.base.BaseFragment
-import com.woocommerce.android.ui.common.wpcomwebview.WPComWebViewAuthenticator
+import com.woocommerce.android.ui.common.webview.WebViewAuthenticator
 import com.woocommerce.android.ui.compose.theme.WooThemeWithBackground
 import com.woocommerce.android.ui.main.AppBarStatus
 import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.Exit
@@ -23,7 +23,7 @@ class AboutYourStoreFragment : BaseFragment() {
 
     @Inject lateinit var userAgent: UserAgent
 
-    @Inject lateinit var authenticator: WPComWebViewAuthenticator
+    @Inject lateinit var authenticator: WebViewAuthenticator
 
     override val activityAppBarStatus: AppBarStatus
         get() = AppBarStatus.Hidden

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/onboarding/aboutyourstore/AboutYourStoreScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/onboarding/aboutyourstore/AboutYourStoreScreen.kt
@@ -14,7 +14,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
 import com.woocommerce.android.R
-import com.woocommerce.android.ui.common.wpcomwebview.WPComWebViewAuthenticator
+import com.woocommerce.android.ui.common.webview.WebViewAuthenticator
 import com.woocommerce.android.ui.compose.component.Toolbar
 import com.woocommerce.android.ui.compose.component.web.WCWebView
 import com.woocommerce.android.ui.onboarding.aboutyourstore.AboutYourStoreViewModel.ViewState.LoadingState
@@ -25,7 +25,7 @@ import org.wordpress.android.fluxc.network.UserAgent
 fun AboutYourStoreScreen(
     viewModel: AboutYourStoreViewModel,
     userAgent: UserAgent,
-    authenticator: WPComWebViewAuthenticator
+    authenticator: WebViewAuthenticator
 ) {
     viewModel.viewState.observeAsState(LoadingState).value.let { state ->
         Scaffold(topBar = {
@@ -76,13 +76,13 @@ private fun ProgressIndicator(modifier: Modifier) {
 private fun WpAdmin(
     viewState: WebViewState,
     userAgent: UserAgent,
-    authenticator: WPComWebViewAuthenticator?,
+    authenticator: WebViewAuthenticator?,
     modifier: Modifier
 ) {
     WCWebView(
         url = viewState.url,
         userAgent = userAgent,
-        wpComAuthenticator = authenticator,
+        authenticator = authenticator,
         modifier = modifier
     )
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/onboarding/launchstore/LaunchStoreScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/onboarding/launchstore/LaunchStoreScreen.kt
@@ -34,6 +34,7 @@ import com.woocommerce.android.ui.compose.component.Toolbar
 import com.woocommerce.android.ui.compose.component.WCColoredButton
 import com.woocommerce.android.ui.compose.component.WCOutlinedButton
 import com.woocommerce.android.ui.compose.component.web.WCWebView
+import com.woocommerce.android.ui.compose.component.web.WCWebViewSettings
 import com.woocommerce.android.ui.compose.component.web.WebViewProgressIndicator.Circular
 import com.woocommerce.android.ui.compose.drawShadow
 import com.woocommerce.android.ui.onboarding.launchstore.LaunchStoreViewModel.LaunchStoreState
@@ -69,7 +70,7 @@ fun LaunchStoreScreen(viewModel: LaunchStoreViewModel) {
 }
 
 @Composable
-fun LaunchStoreScreen(
+private fun LaunchStoreScreen(
     state: LaunchStoreState,
     userAgent: UserAgent,
     authenticator: WPComWebViewAuthenticator,
@@ -144,8 +145,10 @@ private fun WebView(
         userAgent = userAgent,
         wpComAuthenticator = authenticator,
         captureBackPresses = false,
-        loadWithOverviewMode = true,
-        isReadOnly = isReadOnly,
+        settings = WCWebViewSettings(
+            loadWithOverviewMode = true,
+            isReadOnly = isReadOnly
+        ),
         progressIndicator = Circular(
             stringResource(id = string.store_onboarding_launch_store_rendering_preview_label)
         ),
@@ -213,7 +216,7 @@ private fun ActionsFooter(
 
 @Composable
 @SuppressLint("SetJavaScriptEnabled", "ClickableViewAccessibility")
-fun SitePreview(
+private fun SitePreview(
     url: String,
     userAgent: UserAgent,
     authenticator: WPComWebViewAuthenticator,

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/onboarding/launchstore/LaunchStoreScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/onboarding/launchstore/LaunchStoreScreen.kt
@@ -29,7 +29,7 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
 import com.woocommerce.android.R
 import com.woocommerce.android.R.string
-import com.woocommerce.android.ui.common.wpcomwebview.WPComWebViewAuthenticator
+import com.woocommerce.android.ui.common.webview.WebViewAuthenticator
 import com.woocommerce.android.ui.compose.component.Toolbar
 import com.woocommerce.android.ui.compose.component.WCColoredButton
 import com.woocommerce.android.ui.compose.component.WCOutlinedButton
@@ -56,7 +56,7 @@ fun LaunchStoreScreen(viewModel: LaunchStoreViewModel) {
             LaunchStoreScreen(
                 state = state,
                 userAgent = viewModel.userAgent,
-                authenticator = viewModel.wpComWebViewAuthenticator,
+                authenticator = viewModel.webViewAuthenticator,
                 onLaunchStoreClicked = viewModel::launchStore,
                 onShareStoreUrl = viewModel::shareStoreUrl,
                 onBackToStoreClicked = viewModel::onBackPressed,
@@ -73,7 +73,7 @@ fun LaunchStoreScreen(viewModel: LaunchStoreViewModel) {
 private fun LaunchStoreScreen(
     state: LaunchStoreState,
     userAgent: UserAgent,
-    authenticator: WPComWebViewAuthenticator,
+    authenticator: WebViewAuthenticator,
     onLaunchStoreClicked: () -> Unit,
     onShareStoreUrl: () -> Unit,
     onBackToStoreClicked: () -> Unit,
@@ -137,13 +137,13 @@ private fun LaunchStoreScreen(
 private fun WebView(
     url: String,
     userAgent: UserAgent,
-    authenticator: WPComWebViewAuthenticator,
+    authenticator: WebViewAuthenticator,
     isReadOnly: Boolean
 ) {
     WCWebView(
         url = url,
         userAgent = userAgent,
-        wpComAuthenticator = authenticator,
+        authenticator = authenticator,
         captureBackPresses = false,
         settings = WCWebViewSettings(
             loadWithOverviewMode = true,
@@ -219,7 +219,7 @@ private fun ActionsFooter(
 private fun SitePreview(
     url: String,
     userAgent: UserAgent,
-    authenticator: WPComWebViewAuthenticator,
+    authenticator: WebViewAuthenticator,
     modifier: Modifier = Modifier
 ) {
     Box(

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/onboarding/launchstore/LaunchStoreViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/onboarding/launchstore/LaunchStoreViewModel.kt
@@ -10,7 +10,7 @@ import com.woocommerce.android.analytics.AnalyticsTracker
 import com.woocommerce.android.analytics.AnalyticsTrackerWrapper
 import com.woocommerce.android.extensions.isFreeTrial
 import com.woocommerce.android.tools.SelectedSite
-import com.woocommerce.android.ui.common.wpcomwebview.WPComWebViewAuthenticator
+import com.woocommerce.android.ui.common.webview.WebViewAuthenticator
 import com.woocommerce.android.ui.onboarding.StoreOnboardingRepository
 import com.woocommerce.android.ui.onboarding.StoreOnboardingRepository.Error
 import com.woocommerce.android.ui.onboarding.StoreOnboardingRepository.LaunchStoreError.ALREADY_LAUNCHED
@@ -33,7 +33,7 @@ class LaunchStoreViewModel @Inject constructor(
     private val launchStoreOnboardingRepository: StoreOnboardingRepository,
     private val selectedSite: SelectedSite,
     private val analyticsTrackerWrapper: AnalyticsTrackerWrapper,
-    val wpComWebViewAuthenticator: WPComWebViewAuthenticator,
+    val webViewAuthenticator: WebViewAuthenticator,
     val userAgent: UserAgent
 ) : ScopedViewModel(savedStateHandle), DefaultLifecycleObserver {
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/onboarding/payments/GetPaidFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/onboarding/payments/GetPaidFragment.kt
@@ -10,7 +10,7 @@ import androidx.fragment.app.viewModels
 import androidx.navigation.fragment.findNavController
 import com.woocommerce.android.extensions.navigateSafely
 import com.woocommerce.android.ui.base.BaseFragment
-import com.woocommerce.android.ui.common.wpcomwebview.WPComWebViewAuthenticator
+import com.woocommerce.android.ui.common.webview.WebViewAuthenticator
 import com.woocommerce.android.ui.compose.theme.WooThemeWithBackground
 import com.woocommerce.android.ui.main.AppBarStatus
 import com.woocommerce.android.ui.onboarding.payments.GetPaidViewModel.ShowWooPaymentsSetupSuccess
@@ -27,7 +27,7 @@ class GetPaidFragment : BaseFragment() {
     lateinit var userAgent: UserAgent
 
     @Inject
-    lateinit var authenticator: WPComWebViewAuthenticator
+    lateinit var authenticator: WebViewAuthenticator
 
     override val activityAppBarStatus: AppBarStatus
         get() = AppBarStatus.Hidden

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/onboarding/payments/GetPaidScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/onboarding/payments/GetPaidScreen.kt
@@ -7,7 +7,7 @@ import androidx.compose.runtime.livedata.observeAsState
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
 import com.woocommerce.android.R.string
-import com.woocommerce.android.ui.common.wpcomwebview.WPComWebViewAuthenticator
+import com.woocommerce.android.ui.common.webview.WebViewAuthenticator
 import com.woocommerce.android.ui.compose.component.Toolbar
 import com.woocommerce.android.ui.compose.component.web.WCWebView
 import org.wordpress.android.fluxc.network.UserAgent
@@ -16,7 +16,7 @@ import org.wordpress.android.fluxc.network.UserAgent
 fun GetPaidScreen(
     viewModel: GetPaidViewModel,
     userAgent: UserAgent,
-    authenticator: WPComWebViewAuthenticator
+    authenticator: WebViewAuthenticator
 ) {
     viewModel.viewState.observeAsState(null).value?.let { state ->
         Scaffold(topBar = {
@@ -28,7 +28,7 @@ fun GetPaidScreen(
             WCWebView(
                 url = state.url,
                 userAgent = userAgent,
-                wpComAuthenticator = if (state.shouldAuthenticate) authenticator else null,
+                authenticator = if (state.shouldAuthenticate) authenticator else null,
                 onUrlLoaded = viewModel::onUrlLoaded,
                 modifier = Modifier.padding(padding)
             )

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/list/OrderListFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/list/OrderListFragment.kt
@@ -574,7 +574,7 @@ class OrderListFragment :
                 is ShowOrderFilters -> showOrderFilters()
                 is OrderListViewModel.OrderListEvent.OpenPurchaseCardReaderLink -> {
                     findNavController().navigate(
-                        NavGraphMainDirections.actionGlobalWPComWebViewFragment(
+                        NavGraphMainDirections.actionGlobalAuthenticatedWebViewFragment(
                             urlToLoad = event.url,
                             title = resources.getString(event.titleRes)
                         )

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/EditShippingLabelPaymentFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/EditShippingLabelPaymentFragment.kt
@@ -20,7 +20,7 @@ import com.woocommerce.android.extensions.navigateSafely
 import com.woocommerce.android.extensions.takeIfNotEqualTo
 import com.woocommerce.android.ui.base.BaseFragment
 import com.woocommerce.android.ui.base.UIMessageResolver
-import com.woocommerce.android.ui.common.wpcomwebview.WPComWebViewFragment
+import com.woocommerce.android.ui.common.webview.AuthenticatedWebViewFragment
 import com.woocommerce.android.ui.main.AppBarStatus
 import com.woocommerce.android.ui.main.MainActivity.Companion.BackPressListener
 import com.woocommerce.android.ui.orders.shippinglabels.creation.EditShippingLabelPaymentViewModel.AddPaymentMethod
@@ -199,7 +199,7 @@ class EditShippingLabelPaymentFragment :
             when (event) {
                 is AddPaymentMethod -> {
                     findNavController().navigateSafely(
-                        NavGraphOrdersDirections.actionGlobalWPComWebViewFragment(
+                        NavGraphOrdersDirections.actionGlobalAuthenticatedWebViewFragment(
                             urlToLoad = AppUrls.WPCOM_ADD_PAYMENT_METHOD,
                             urlsToTriggerExit = arrayOf(FETCH_PAYMENT_METHOD_URL_PATH),
                             title = getFragmentTitle()
@@ -215,7 +215,7 @@ class EditShippingLabelPaymentFragment :
     }
 
     private fun setupResultHandlers() {
-        handleNotice(WPComWebViewFragment.WEBVIEW_RESULT) {
+        handleNotice(AuthenticatedWebViewFragment.WEBVIEW_RESULT) {
             viewModel.onPaymentMethodAdded()
         }
     }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/cardreader/connect/CardReaderConnectDialogFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/cardreader/connect/CardReaderConnectDialogFragment.kt
@@ -266,9 +266,9 @@ class CardReaderConnectDialogFragment : PaymentsBaseDialogFragment(R.layout.card
                     ToastUtils.showToast(requireContext(), getString(event.message))
                 is CardReaderConnectEvent.ShowToastString ->
                     ToastUtils.showToast(requireContext(), event.message)
-                is CardReaderConnectEvent.OpenWPComWebView ->
+                is CardReaderConnectEvent.OpenAuthenticatedWebView ->
                     findNavController().navigateSafely(
-                        NavGraphPaymentFlowDirections.actionGlobalWPComWebViewFragment(urlToLoad = event.url)
+                        NavGraphPaymentFlowDirections.actionGlobalAuthenticatedWebViewFragment(urlToLoad = event.url)
                     )
                 is CardReaderConnectEvent.OpenGenericWebView ->
                     ChromeCustomTabUtils.launchUrl(requireContext(), event.url)

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/cardreader/connect/CardReaderConnectEvent.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/cardreader/connect/CardReaderConnectEvent.kt
@@ -43,7 +43,7 @@ sealed class CardReaderConnectEvent : MultiLiveEvent.Event() {
 
     data class ShowToastString(val message: String) : CardReaderConnectEvent()
 
-    data class OpenWPComWebView(val url: String) : CardReaderConnectEvent()
+    data class OpenAuthenticatedWebView(val url: String) : CardReaderConnectEvent()
 
     data class OpenGenericWebView(val url: String) : CardReaderConnectEvent()
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/cardreader/connect/CardReaderConnectViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/cardreader/connect/CardReaderConnectViewModel.kt
@@ -33,10 +33,10 @@ import com.woocommerce.android.ui.payments.cardreader.connect.CardReaderConnectE
 import com.woocommerce.android.ui.payments.cardreader.connect.CardReaderConnectEvent.CheckBluetoothPermissionsGiven
 import com.woocommerce.android.ui.payments.cardreader.connect.CardReaderConnectEvent.CheckLocationEnabled
 import com.woocommerce.android.ui.payments.cardreader.connect.CardReaderConnectEvent.CheckLocationPermissions
+import com.woocommerce.android.ui.payments.cardreader.connect.CardReaderConnectEvent.OpenAuthenticatedWebView
 import com.woocommerce.android.ui.payments.cardreader.connect.CardReaderConnectEvent.OpenGenericWebView
 import com.woocommerce.android.ui.payments.cardreader.connect.CardReaderConnectEvent.OpenLocationSettings
 import com.woocommerce.android.ui.payments.cardreader.connect.CardReaderConnectEvent.OpenPermissionsSettings
-import com.woocommerce.android.ui.payments.cardreader.connect.CardReaderConnectEvent.OpenWPComWebView
 import com.woocommerce.android.ui.payments.cardreader.connect.CardReaderConnectEvent.RequestBluetoothRuntimePermissions
 import com.woocommerce.android.ui.payments.cardreader.connect.CardReaderConnectEvent.RequestEnableBluetooth
 import com.woocommerce.android.ui.payments.cardreader.connect.CardReaderConnectEvent.RequestLocationPermissions
@@ -491,7 +491,7 @@ class CardReaderConnectViewModel @Inject constructor(
         result: CardReaderLocationRepository.LocationIdFetchingResult.Error.MissingAddress
     ) {
         if (selectedSite.getIfExists()?.isWPCom == true || selectedSite.getIfExists()?.isWPComAtomic == true) {
-            triggerEvent(OpenWPComWebView(result.url))
+            triggerEvent(OpenAuthenticatedWebView(result.url))
         } else {
             triggerEvent(OpenGenericWebView(result.url))
             exitFlow(connected = false)

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/cardreader/payment/CardReaderPaymentDialogFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/cardreader/payment/CardReaderPaymentDialogFragment.kt
@@ -141,7 +141,7 @@ class CardReaderPaymentDialogFragment : PaymentsBaseDialogFragment(R.layout.card
 
     private fun openPurchaseCardReaderScreen(url: String) {
         findNavController().navigate(
-            NavGraphPaymentFlowDirections.actionGlobalWPComWebViewFragment(urlToLoad = url)
+            NavGraphPaymentFlowDirections.actionGlobalAuthenticatedWebViewFragment(urlToLoad = url)
         )
     }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/hub/PaymentsHubFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/hub/PaymentsHubFragment.kt
@@ -89,7 +89,7 @@ class PaymentsHubFragment : BaseFragment(R.layout.fragment_payments_hub) {
                 }
                 is PaymentsHubViewModel.PaymentsHubEvents.NavigateToPurchaseCardReaderFlow -> {
                     findNavController().navigate(
-                        NavGraphPaymentFlowDirections.actionGlobalWPComWebViewFragment(
+                        NavGraphPaymentFlowDirections.actionGlobalAuthenticatedWebViewFragment(
                             urlToLoad = event.url,
                             title = resources.getString(event.titleRes)
                         )

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/domain/DomainPurchaseFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/domain/DomainPurchaseFragment.kt
@@ -10,7 +10,7 @@ import androidx.fragment.app.viewModels
 import androidx.navigation.fragment.findNavController
 import com.woocommerce.android.extensions.navigateSafely
 import com.woocommerce.android.ui.base.BaseFragment
-import com.woocommerce.android.ui.common.wpcomwebview.WPComWebViewAuthenticator
+import com.woocommerce.android.ui.common.webview.WebViewAuthenticator
 import com.woocommerce.android.ui.compose.theme.WooThemeWithBackground
 import com.woocommerce.android.ui.main.AppBarStatus
 import com.woocommerce.android.ui.prefs.domain.DomainPurchaseViewModel.NavigateToSuccessScreen
@@ -23,7 +23,7 @@ import javax.inject.Inject
 class DomainPurchaseFragment : BaseFragment() {
     private val viewModel: DomainPurchaseViewModel by viewModels()
 
-    @Inject internal lateinit var authenticator: WPComWebViewAuthenticator
+    @Inject internal lateinit var authenticator: WebViewAuthenticator
 
     @Inject internal lateinit var userAgent: UserAgent
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/domain/DomainPurchaseScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/domain/DomainPurchaseScreen.kt
@@ -9,7 +9,7 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
-import com.woocommerce.android.ui.common.wpcomwebview.WPComWebViewAuthenticator
+import com.woocommerce.android.ui.common.webview.WebViewAuthenticator
 import com.woocommerce.android.ui.compose.component.ProgressIndicator
 import com.woocommerce.android.ui.compose.component.web.WCWebView
 import com.woocommerce.android.ui.prefs.domain.DomainPurchaseViewModel.ViewState.CheckoutState
@@ -21,7 +21,7 @@ import org.wordpress.android.fluxc.network.UserAgent
 @Composable
 fun DomainRegistrationCheckoutScreen(
     viewModel: DomainPurchaseViewModel,
-    authenticator: WPComWebViewAuthenticator,
+    authenticator: WebViewAuthenticator,
     userAgent: UserAgent
 ) {
     viewModel.viewState.observeAsState(LoadingState).value.let { state ->
@@ -43,7 +43,7 @@ fun DomainRegistrationCheckoutScreen(
 @Composable
 private fun WebViewPayment(
     viewState: CheckoutState,
-    authenticator: WPComWebViewAuthenticator,
+    authenticator: WebViewAuthenticator,
     userAgent: UserAgent,
     onDomainPurchased: () -> Unit,
     onExitTriggered: () -> Unit
@@ -52,7 +52,7 @@ private fun WebViewPayment(
 
     WCWebView(
         url = viewState.startUrl,
-        wpComAuthenticator = authenticator,
+        authenticator = authenticator,
         userAgent = userAgent,
         onUrlLoaded = { url: String ->
             WooLog.d(T.ONBOARDING, "Webview: $url")

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/plugins/PluginsFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/plugins/PluginsFragment.kt
@@ -49,7 +49,7 @@ class PluginsFragment : BaseFragment() {
                 is MultiLiveEvent.Event.Exit -> findNavController().navigateUp()
                 is PluginsEvent.NavigateToPluginsWeb -> {
                     findNavController()
-                        .navigate(NavGraphSettingsDirections.actionGlobalWPComWebViewFragment(event.url))
+                        .navigate(NavGraphSettingsDirections.actionGlobalAuthenticatedWebViewFragment(event.url))
                 }
             }
         }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/sitepicker/SitePickerFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/sitepicker/SitePickerFragment.kt
@@ -30,7 +30,7 @@ import com.woocommerce.android.support.help.HelpActivity
 import com.woocommerce.android.support.help.HelpOrigin
 import com.woocommerce.android.ui.base.BaseFragment
 import com.woocommerce.android.ui.base.UIMessageResolver
-import com.woocommerce.android.ui.common.wpcomwebview.WPComWebViewFragment
+import com.woocommerce.android.ui.common.webview.AuthenticatedWebViewFragment
 import com.woocommerce.android.ui.login.LoginActivity
 import com.woocommerce.android.ui.login.LoginEmailHelpDialogFragment
 import com.woocommerce.android.ui.login.accountmismatch.AccountMismatchErrorFragment
@@ -39,11 +39,11 @@ import com.woocommerce.android.ui.main.AppBarStatus
 import com.woocommerce.android.ui.main.MainActivity
 import com.woocommerce.android.ui.sitepicker.SitePickerViewModel.SitePickerEvent.NavigateToAccountMismatchScreen
 import com.woocommerce.android.ui.sitepicker.SitePickerViewModel.SitePickerEvent.NavigateToAddStoreEvent
+import com.woocommerce.android.ui.sitepicker.SitePickerViewModel.SitePickerEvent.NavigateToAuthenticatedWebView
 import com.woocommerce.android.ui.sitepicker.SitePickerViewModel.SitePickerEvent.NavigateToEmailHelpDialogEvent
 import com.woocommerce.android.ui.sitepicker.SitePickerViewModel.SitePickerEvent.NavigateToHelpFragmentEvent
 import com.woocommerce.android.ui.sitepicker.SitePickerViewModel.SitePickerEvent.NavigateToMainActivityEvent
 import com.woocommerce.android.ui.sitepicker.SitePickerViewModel.SitePickerEvent.NavigateToNewToWooEvent
-import com.woocommerce.android.ui.sitepicker.SitePickerViewModel.SitePickerEvent.NavigateToWPComWebView
 import com.woocommerce.android.ui.sitepicker.SitePickerViewModel.SitePickerEvent.ShowWooUpgradeDialogEvent
 import com.woocommerce.android.ui.sitepicker.SitePickerViewModel.SitePickerState.NoStoreState
 import com.woocommerce.android.ui.sitepicker.SitePickerViewModel.SitePickerState.SimpleWPComState
@@ -229,7 +229,7 @@ class SitePickerFragment :
                 is NavigateToNewToWooEvent -> navigateToNewToWooScreen()
                 is NavigateToAddStoreEvent -> navigateToAddStoreScreen()
                 is NavigateToEmailHelpDialogEvent -> navigateToNeedHelpFindingEmailScreen()
-                is NavigateToWPComWebView -> navigateToWPComWebView(event)
+                is NavigateToAuthenticatedWebView -> navigateToAuthenticatedWebView(event)
                 is NavigateToAccountMismatchScreen -> navigateToAccountMismatchScreen(event)
                 is ShowSnackbar -> uiMessageResolver.getSnack(stringResId = event.message, stringArgs = event.args)
                     .show()
@@ -243,11 +243,11 @@ class SitePickerFragment :
     }
 
     private fun handleResults() {
-        handleNotice(WPComWebViewFragment.WEBVIEW_RESULT) {
+        handleNotice(AuthenticatedWebViewFragment.WEBVIEW_RESULT) {
             AnalyticsTracker.track(AnalyticsEvent.LOGIN_WOOCOMMERCE_SETUP_COMPLETED)
             viewModel.onWooInstalled()
         }
-        handleNotice(WPComWebViewFragment.WEBVIEW_DISMISSED) {
+        handleNotice(AuthenticatedWebViewFragment.WEBVIEW_DISMISSED) {
             AnalyticsTracker.track(AnalyticsEvent.LOGIN_WOOCOMMERCE_SETUP_DISMISSED)
         }
         handleResult<String>(SitePickerSiteDiscoveryFragment.SITE_PICKER_SITE_ADDRESS_RESULT) {
@@ -354,9 +354,9 @@ class SitePickerFragment :
         }
     }
 
-    private fun navigateToWPComWebView(event: NavigateToWPComWebView) {
+    private fun navigateToAuthenticatedWebView(event: NavigateToAuthenticatedWebView) {
         findNavController().navigate(
-            NavGraphMainDirections.actionGlobalWPComWebViewFragment(
+            NavGraphMainDirections.actionGlobalAuthenticatedWebViewFragment(
                 urlToLoad = event.url,
                 urlsToTriggerExit = arrayOf(event.validationUrl),
                 title = event.title

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/sitepicker/SitePickerViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/sitepicker/SitePickerViewModel.kt
@@ -23,7 +23,7 @@ import com.woocommerce.android.ui.login.UnifiedLoginTracker
 import com.woocommerce.android.ui.login.accountmismatch.AccountMismatchErrorViewModel.AccountMismatchPrimaryButton
 import com.woocommerce.android.ui.sitepicker.SitePickerViewModel.SitePickerEvent.NavigateToAccountMismatchScreen
 import com.woocommerce.android.ui.sitepicker.SitePickerViewModel.SitePickerEvent.NavigateToAddStoreEvent
-import com.woocommerce.android.ui.sitepicker.SitePickerViewModel.SitePickerEvent.NavigateToWPComWebView
+import com.woocommerce.android.ui.sitepicker.SitePickerViewModel.SitePickerEvent.NavigateToAuthenticatedWebView
 import com.woocommerce.android.ui.sitepicker.SitePickerViewModel.SitesListItem.Header
 import com.woocommerce.android.ui.sitepicker.SitePickerViewModel.SitesListItem.NonWooSiteUiModel
 import com.woocommerce.android.ui.sitepicker.SitePickerViewModel.SitesListItem.WooSiteUiModel
@@ -576,7 +576,7 @@ class SitePickerViewModel @Inject constructor(
     fun onInstallWooClicked() {
         loginSiteAddress?.let {
             triggerEvent(
-                NavigateToWPComWebView(
+                NavigateToAuthenticatedWebView(
                     url = "$WOOCOMMERCE_INSTALLATION_URL${UrlUtils.removeScheme(it)}",
                     validationUrl = WOOCOMMERCE_INSTALLATION_DONE_URL,
                     title = resourceProvider.getString(string.login_install_woo)
@@ -741,7 +741,7 @@ class SitePickerViewModel @Inject constructor(
         object NavigateToNewToWooEvent : SitePickerEvent()
         object NavigateToAddStoreEvent : SitePickerEvent()
         data class NavigateToHelpFragmentEvent(val origin: HelpOrigin) : SitePickerEvent()
-        data class NavigateToWPComWebView(
+        data class NavigateToAuthenticatedWebView(
             val url: String,
             val validationUrl: String,
             val title: String? = null

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/sitepicker/sitediscovery/SitePickerSiteDiscoveryFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/sitepicker/sitediscovery/SitePickerSiteDiscoveryFragment.kt
@@ -19,8 +19,8 @@ import com.woocommerce.android.model.JetpackStatus
 import com.woocommerce.android.support.help.HelpOrigin
 import com.woocommerce.android.support.requests.SupportRequestFormActivity
 import com.woocommerce.android.ui.base.BaseFragment
-import com.woocommerce.android.ui.common.wpcomwebview.WPComWebViewFragment
-import com.woocommerce.android.ui.common.wpcomwebview.WPComWebViewViewModel
+import com.woocommerce.android.ui.common.webview.AuthenticatedWebViewFragment
+import com.woocommerce.android.ui.common.webview.AuthenticatedWebViewViewModel
 import com.woocommerce.android.ui.compose.theme.WooThemeWithBackground
 import com.woocommerce.android.ui.login.LoginActivity
 import com.woocommerce.android.ui.login.accountmismatch.AccountMismatchErrorFragment
@@ -81,7 +81,7 @@ class SitePickerSiteDiscoveryFragment : BaseFragment() {
     }
 
     private fun setupResultHandlers() {
-        handleNotice(WPComWebViewFragment.WEBVIEW_RESULT) {
+        handleNotice(AuthenticatedWebViewFragment.WEBVIEW_RESULT) {
             viewModel.onJetpackInstalled()
         }
         handleNotice(AccountMismatchErrorFragment.JETPACK_CONNECTED_NOTICE) {
@@ -96,10 +96,10 @@ class SitePickerSiteDiscoveryFragment : BaseFragment() {
             "&from=mobile"
 
         findNavController().navigate(
-            NavGraphMainDirections.actionGlobalWPComWebViewFragment(
+            NavGraphMainDirections.actionGlobalAuthenticatedWebViewFragment(
                 urlToLoad = url,
                 urlsToTriggerExit = arrayOf(JETPACK_CONNECTED_REDIRECT_URL),
-                urlComparisonMode = WPComWebViewViewModel.UrlComparisonMode.EQUALITY,
+                urlComparisonMode = AuthenticatedWebViewViewModel.UrlComparisonMode.EQUALITY,
                 title = getString(R.string.login_jetpack_install)
             )
         )

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/themes/ThemePreviewFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/themes/ThemePreviewFragment.kt
@@ -40,7 +40,7 @@ class ThemePreviewFragment : BaseFragment() {
                     ThemePreviewScreen(
                         viewModel = viewModel,
                         userAgent = viewModel.userAgent,
-                        wpComWebViewAuthenticator = viewModel.wpComWebViewAuthenticator
+                        webViewAuthenticator = viewModel.webViewAuthenticator
                     )
                 }
             }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/themes/ThemePreviewScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/themes/ThemePreviewScreen.kt
@@ -51,7 +51,7 @@ import com.woocommerce.android.R.color
 import com.woocommerce.android.R.dimen
 import com.woocommerce.android.R.drawable
 import com.woocommerce.android.R.string
-import com.woocommerce.android.ui.common.wpcomwebview.WPComWebViewAuthenticator
+import com.woocommerce.android.ui.common.webview.WebViewAuthenticator
 import com.woocommerce.android.ui.compose.component.BottomSheetHandle
 import com.woocommerce.android.ui.compose.component.Toolbar
 import com.woocommerce.android.ui.compose.component.WCColoredButton
@@ -70,13 +70,13 @@ import org.wordpress.android.fluxc.network.UserAgent
 fun ThemePreviewScreen(
     viewModel: ThemePreviewViewModel,
     userAgent: UserAgent,
-    wpComWebViewAuthenticator: WPComWebViewAuthenticator
+    webViewAuthenticator: WebViewAuthenticator
 ) {
     viewModel.viewState.observeAsState().value?.let { viewState ->
         ThemePreviewScreen(
             state = viewState,
             userAgent = userAgent,
-            wpComWebViewAuthenticator = wpComWebViewAuthenticator,
+            webViewAuthenticator = webViewAuthenticator,
             viewModel::onPageSelected,
             viewModel::onBackNavigationClicked,
             viewModel::onActivateThemeClicked,
@@ -90,7 +90,7 @@ fun ThemePreviewScreen(
 fun ThemePreviewScreen(
     state: ViewState,
     userAgent: UserAgent,
-    wpComWebViewAuthenticator: WPComWebViewAuthenticator,
+    webViewAuthenticator: WebViewAuthenticator,
     onPageSelected: (ThemeDemoPage) -> Unit,
     onBackNavigationClicked: () -> Unit,
     onActivateThemeClicked: () -> Unit,
@@ -142,7 +142,7 @@ fun ThemePreviewScreen(
                 ThemePreviewWebView(
                     url = state.currentPageUri,
                     userAgent = userAgent,
-                    wpComAuthenticator = wpComWebViewAuthenticator,
+                    authenticator = webViewAuthenticator,
                     modifier = Modifier
                         .weight(1f)
                         .align(Alignment.CenterHorizontally),

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/themes/ThemePreviewViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/themes/ThemePreviewViewModel.kt
@@ -9,7 +9,7 @@ import com.woocommerce.android.analytics.AnalyticsEvent
 import com.woocommerce.android.analytics.AnalyticsTracker
 import com.woocommerce.android.analytics.AnalyticsTrackerWrapper
 import com.woocommerce.android.model.Theme
-import com.woocommerce.android.ui.common.wpcomwebview.WPComWebViewAuthenticator
+import com.woocommerce.android.ui.common.webview.WebViewAuthenticator
 import com.woocommerce.android.ui.themes.ThemePreviewViewModel.ViewState.PreviewType
 import com.woocommerce.android.util.WooLog
 import com.woocommerce.android.viewmodel.MultiLiveEvent
@@ -37,7 +37,7 @@ import javax.inject.Inject
 @HiltViewModel
 class ThemePreviewViewModel @Inject constructor(
     savedStateHandle: SavedStateHandle,
-    val wpComWebViewAuthenticator: WPComWebViewAuthenticator,
+    val webViewAuthenticator: WebViewAuthenticator,
     val userAgent: UserAgent,
     private val themeCoroutineStore: ThemeCoroutineStore,
     private val resourceProvider: ResourceProvider,

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/themes/ThemePreviewWebView.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/themes/ThemePreviewWebView.kt
@@ -11,7 +11,7 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
-import com.woocommerce.android.ui.common.wpcomwebview.WPComWebViewAuthenticator
+import com.woocommerce.android.ui.common.webview.WebViewAuthenticator
 import com.woocommerce.android.ui.compose.Screen
 import com.woocommerce.android.ui.compose.Screen.ScreenType
 import com.woocommerce.android.ui.compose.component.web.WCWebView
@@ -27,7 +27,7 @@ fun ThemePreviewWebView(
     url: String,
     userAgent: UserAgent,
     modifier: Modifier = Modifier,
-    wpComAuthenticator: WPComWebViewAuthenticator? = null,
+    authenticator: WebViewAuthenticator? = null,
     previewType: PreviewType
 ) {
     val screen = rememberScreen()
@@ -53,7 +53,7 @@ fun ThemePreviewWebView(
         WCWebView(
             url = url,
             userAgent = userAgent,
-            wpComAuthenticator = wpComAuthenticator,
+            authenticator = authenticator,
             settings = webViewSettings,
             progressIndicator = WebViewProgressIndicator.Linear()
         )

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/themes/ThemePreviewWebView.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/themes/ThemePreviewWebView.kt
@@ -1,25 +1,22 @@
 package com.woocommerce.android.ui.themes
 
-import android.view.ViewGroup
-import android.webkit.WebChromeClient
-import android.webkit.WebView
-import android.webkit.WebViewClient
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.widthIn
-import androidx.compose.material.LinearProgressIndicator
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.draw.alpha
 import androidx.compose.ui.unit.dp
-import androidx.compose.ui.viewinterop.AndroidView
 import com.woocommerce.android.ui.common.wpcomwebview.WPComWebViewAuthenticator
 import com.woocommerce.android.ui.compose.Screen
 import com.woocommerce.android.ui.compose.Screen.ScreenType
+import com.woocommerce.android.ui.compose.component.web.WCWebView
+import com.woocommerce.android.ui.compose.component.web.WCWebViewSettings
+import com.woocommerce.android.ui.compose.component.web.WebViewProgressIndicator
 import com.woocommerce.android.ui.compose.rememberScreen
 import com.woocommerce.android.ui.themes.ThemePreviewViewModel.ViewState.PreviewType
 import org.wordpress.android.fluxc.network.UserAgent
@@ -34,11 +31,13 @@ fun ThemePreviewWebView(
     previewType: PreviewType
 ) {
     val screen = rememberScreen()
+    var webViewSettings by remember { mutableStateOf(WCWebViewSettings()) }
 
-    var webView by remember { mutableStateOf<WebView?>(null) }
-    var progress by remember { mutableStateOf(0) }
-    var lastLoadedUrl by remember { mutableStateOf("") }
-    var lastPreviewType by remember { mutableStateOf(previewType) }
+    LaunchedEffect(previewType) {
+        webViewSettings = webViewSettings.copy(
+            initialScale = previewType.initialScale(screen)
+        )
+    }
 
     Box(
         modifier = modifier.then(
@@ -51,45 +50,12 @@ fun ThemePreviewWebView(
             }
         )
     ) {
-        fun getProgressAlpha(): Float {
-            return if (progress == 100) 0f else 1f
-        }
-
-        AndroidView(
-            factory = { context ->
-                WebView(context).apply {
-                    layoutParams = ViewGroup.LayoutParams(
-                        ViewGroup.LayoutParams.MATCH_PARENT,
-                        ViewGroup.LayoutParams.MATCH_PARENT
-                    )
-
-                    this.webChromeClient = object : WebChromeClient() {
-                        override fun onProgressChanged(view: WebView?, newProgress: Int) {
-                            progress = newProgress
-                        }
-                    }
-
-                    this.webViewClient = WebViewClient()
-                    this.setInitialScale(previewType.initialScale(screen))
-                    this.settings.userAgentString = userAgent.userAgent
-                }.also { webView = it }
-            },
-        ) { webView ->
-            if (lastPreviewType != previewType) {
-                lastPreviewType = previewType
-                webView.setInitialScale(previewType.initialScale(screen))
-                wpComAuthenticator?.authenticateAndLoadUrl(webView, url) ?: webView.loadUrl(url)
-            }
-            if (lastLoadedUrl == url) return@AndroidView
-            lastLoadedUrl = url
-            wpComAuthenticator?.authenticateAndLoadUrl(webView, url) ?: webView.loadUrl(url)
-        }
-
-        LinearProgressIndicator(
-            progress = (progress / 100f),
-            modifier = Modifier
-                .fillMaxWidth()
-                .alpha(getProgressAlpha())
+        WCWebView(
+            url = url,
+            userAgent = userAgent,
+            wpComAuthenticator = wpComAuthenticator,
+            settings = webViewSettings,
+            progressIndicator = WebViewProgressIndicator.Linear()
         )
     }
 }

--- a/WooCommerce/src/main/res/navigation/nav_graph_main.xml
+++ b/WooCommerce/src/main/res/navigation/nav_graph_main.xml
@@ -502,9 +502,9 @@
         android:label="fragment_user_eligibility_error"
         tools:layout="@layout/fragment_user_eligibility_error" />
     <fragment
-        android:id="@+id/WPComWebViewFragment"
-        android:name="com.woocommerce.android.ui.common.wpcomwebview.WPComWebViewFragment"
-        android:label="WPComWebViewFragment"
+        android:id="@+id/AuthenticatedWebViewFragment"
+        android:name="com.woocommerce.android.ui.common.webview.AuthenticatedWebViewFragment"
+        android:label="AuthenticatedWebViewFragment"
         tools:layout="@layout/fragment_wpcom_webview">
         <argument
             android:name="urlToLoad"
@@ -526,19 +526,19 @@
         <argument
             android:name="displayMode"
             android:defaultValue="REGULAR"
-            app:argType="com.woocommerce.android.ui.common.wpcomwebview.WPComWebViewViewModel$DisplayMode" />
+            app:argType="com.woocommerce.android.ui.common.webview.AuthenticatedWebViewViewModel$DisplayMode" />
         <argument
             android:name="urlComparisonMode"
             android:defaultValue="PARTIAL"
-            app:argType="com.woocommerce.android.ui.common.wpcomwebview.WPComWebViewViewModel$UrlComparisonMode" />
+            app:argType="com.woocommerce.android.ui.common.webview.AuthenticatedWebViewViewModel$UrlComparisonMode" />
         <argument
             android:name="clearCache"
             android:defaultValue="false"
             app:argType="boolean" />
     </fragment>
     <action
-        android:id="@+id/action_global_WPComWebViewFragment"
-        app:destination="@id/WPComWebViewFragment" />
+        android:id="@+id/action_global_AuthenticatedWebViewFragment"
+        app:destination="@id/AuthenticatedWebViewFragment" />
     <fragment
         android:id="@+id/GoogleAdsWebViewFragment"
         android:name="com.woocommerce.android.ui.google.webview.GoogleAdsWebViewFragment"

--- a/WooCommerce/src/main/res/navigation/nav_graph_orders.xml
+++ b/WooCommerce/src/main/res/navigation/nav_graph_orders.xml
@@ -487,12 +487,12 @@
         tools:layout="@layout/fragment_edit_shipping_label_payment">
     </fragment>
     <action
-        android:id="@+id/action_global_WPComWebViewFragment"
-        app:destination="@id/WPComWebViewFragment" />
+        android:id="@+id/action_global_AuthenticatedWebViewFragment"
+        app:destination="@id/AuthenticatedWebViewFragment" />
     <fragment
-        android:id="@+id/WPComWebViewFragment"
-        android:name="com.woocommerce.android.ui.common.wpcomwebview.WPComWebViewFragment"
-        android:label="WPComWebViewFragment"
+        android:id="@+id/AuthenticatedWebViewFragment"
+        android:name="com.woocommerce.android.ui.common.webview.AuthenticatedWebViewFragment"
+        android:label="AuthenticatedWebViewFragment"
         tools:layout="@layout/fragment_wpcom_webview">
         <argument
             android:name="urlToLoad"
@@ -514,11 +514,11 @@
         <argument
             android:name="displayMode"
             android:defaultValue="REGULAR"
-            app:argType="com.woocommerce.android.ui.common.wpcomwebview.WPComWebViewViewModel$DisplayMode" />
+            app:argType="com.woocommerce.android.ui.common.webview.AuthenticatedWebViewViewModel$DisplayMode" />
         <argument
             android:name="urlComparisonMode"
             android:defaultValue="PARTIAL"
-            app:argType="com.woocommerce.android.ui.common.wpcomwebview.WPComWebViewViewModel$UrlComparisonMode" />
+            app:argType="com.woocommerce.android.ui.common.webview.AuthenticatedWebViewViewModel$UrlComparisonMode" />
         <argument
             android:name="clearCache"
             android:defaultValue="false"

--- a/WooCommerce/src/main/res/navigation/nav_graph_payment_flow.xml
+++ b/WooCommerce/src/main/res/navigation/nav_graph_payment_flow.xml
@@ -385,13 +385,13 @@
     </dialog>
 
     <action
-        android:id="@+id/action_global_WPComWebViewFragment"
-        app:destination="@id/WPComWebViewFragment" />
+        android:id="@+id/action_global_AuthenticatedWebViewFragment"
+        app:destination="@id/AuthenticatedWebViewFragment" />
 
     <fragment
-        android:id="@+id/WPComWebViewFragment"
-        android:name="com.woocommerce.android.ui.common.wpcomwebview.WPComWebViewFragment"
-        android:label="WPComWebViewFragment"
+        android:id="@+id/AuthenticatedWebViewFragment"
+        android:name="com.woocommerce.android.ui.common.webview.AuthenticatedWebViewFragment"
+        android:label="AuthenticatedWebViewFragment"
         tools:layout="@layout/fragment_wpcom_webview">
         <argument
             android:name="urlToLoad"
@@ -413,11 +413,11 @@
         <argument
             android:name="displayMode"
             android:defaultValue="REGULAR"
-            app:argType="com.woocommerce.android.ui.common.wpcomwebview.WPComWebViewViewModel$DisplayMode" />
+            app:argType="com.woocommerce.android.ui.common.webview.AuthenticatedWebViewViewModel$DisplayMode" />
         <argument
             android:name="urlComparisonMode"
             android:defaultValue="PARTIAL"
-            app:argType="com.woocommerce.android.ui.common.wpcomwebview.WPComWebViewViewModel$UrlComparisonMode" />
+            app:argType="com.woocommerce.android.ui.common.webview.AuthenticatedWebViewViewModel$UrlComparisonMode" />
         <argument
             android:name="clearCache"
             android:defaultValue="false"

--- a/WooCommerce/src/main/res/navigation/nav_graph_settings.xml
+++ b/WooCommerce/src/main/res/navigation/nav_graph_settings.xml
@@ -130,9 +130,9 @@
             app:nullable="false" />
     </dialog>
     <fragment
-        android:id="@+id/WPComWebViewFragment"
-        android:name="com.woocommerce.android.ui.common.wpcomwebview.WPComWebViewFragment"
-        android:label="WPComWebViewFragment"
+        android:id="@+id/AuthenticatedWebViewFragment"
+        android:name="com.woocommerce.android.ui.common.webview.AuthenticatedWebViewFragment"
+        android:label="AuthenticatedWebViewFragment"
         tools:layout="@layout/fragment_wpcom_webview">
         <argument
             android:name="urlToLoad"
@@ -154,19 +154,19 @@
         <argument
             android:name="displayMode"
             android:defaultValue="REGULAR"
-            app:argType="com.woocommerce.android.ui.common.wpcomwebview.WPComWebViewViewModel$DisplayMode" />
+            app:argType="com.woocommerce.android.ui.common.webview.AuthenticatedWebViewViewModel$DisplayMode" />
         <argument
             android:name="urlComparisonMode"
             android:defaultValue="PARTIAL"
-            app:argType="com.woocommerce.android.ui.common.wpcomwebview.WPComWebViewViewModel$UrlComparisonMode" />
+            app:argType="com.woocommerce.android.ui.common.webview.AuthenticatedWebViewViewModel$UrlComparisonMode" />
         <argument
             android:name="clearCache"
             android:defaultValue="false"
             app:argType="boolean" />
     </fragment>
     <action
-        android:id="@+id/action_global_WPComWebViewFragment"
-        app:destination="@id/WPComWebViewFragment" />
+        android:id="@+id/action_global_AuthenticatedWebViewFragment"
+        app:destination="@id/AuthenticatedWebViewFragment" />
     <fragment
         android:id="@+id/developerOptionsFragment"
         android:name="com.woocommerce.android.ui.prefs.developer.DeveloperOptionsFragment"

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/analytics/AnalyticsHubViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/analytics/AnalyticsHubViewModelTest.kt
@@ -776,7 +776,7 @@ class AnalyticsHubViewModelTest : BaseUnitTest() {
         whenever(selectedSite.getOrNull()).thenReturn(SiteModel().apply { setIsWpComStore(true) })
         sut = givenAViewModel()
         sut.onSeeReport("https://report-url", ReportCard.Revenue)
-        assertThat(sut.event.value).isInstanceOf(AnalyticsViewEvent.OpenWPComWebView::class.java)
+        assertThat(sut.event.value).isInstanceOf(AnalyticsViewEvent.OpenAuthenticatedWebView::class.java)
     }
 
     @Test

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/blaze/creation/payment/BlazeCampaignPaymentMethodsListViewModelTests.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/blaze/creation/payment/BlazeCampaignPaymentMethodsListViewModelTests.kt
@@ -35,7 +35,7 @@ class BlazeCampaignPaymentMethodsListViewModelTests : BaseUnitTest() {
             ).toSavedStateHandle(),
             accountRepository = accountRepository,
             userAgent = mock(),
-            wpComWebViewAuthenticator = mock(),
+            webViewAuthenticator = mock(),
             analyticsTrackerWrapper = mock(),
             blazeRepository = blazeRepository
         )

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/payments/cardreader/connect/CardReaderConnectViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/payments/cardreader/connect/CardReaderConnectViewModelTest.kt
@@ -20,10 +20,10 @@ import com.woocommerce.android.ui.payments.cardreader.connect.CardReaderConnectE
 import com.woocommerce.android.ui.payments.cardreader.connect.CardReaderConnectEvent.CheckBluetoothPermissionsGiven
 import com.woocommerce.android.ui.payments.cardreader.connect.CardReaderConnectEvent.CheckLocationEnabled
 import com.woocommerce.android.ui.payments.cardreader.connect.CardReaderConnectEvent.CheckLocationPermissions
+import com.woocommerce.android.ui.payments.cardreader.connect.CardReaderConnectEvent.OpenAuthenticatedWebView
 import com.woocommerce.android.ui.payments.cardreader.connect.CardReaderConnectEvent.OpenGenericWebView
 import com.woocommerce.android.ui.payments.cardreader.connect.CardReaderConnectEvent.OpenLocationSettings
 import com.woocommerce.android.ui.payments.cardreader.connect.CardReaderConnectEvent.OpenPermissionsSettings
-import com.woocommerce.android.ui.payments.cardreader.connect.CardReaderConnectEvent.OpenWPComWebView
 import com.woocommerce.android.ui.payments.cardreader.connect.CardReaderConnectEvent.RequestBluetoothRuntimePermissions
 import com.woocommerce.android.ui.payments.cardreader.connect.CardReaderConnectEvent.RequestEnableBluetooth
 import com.woocommerce.android.ui.payments.cardreader.connect.CardReaderConnectEvent.RequestLocationPermissions
@@ -735,10 +735,10 @@ class CardReaderConnectViewModelTest : BaseUnitTest() {
                 .onPrimaryActionClicked.invoke()
 
             assertThat(viewModel.event.value).isInstanceOf(
-                OpenWPComWebView::class.java
+                OpenAuthenticatedWebView::class.java
             )
             assertThat(
-                (viewModel.event.value as OpenWPComWebView).url
+                (viewModel.event.value as OpenAuthenticatedWebView).url
             ).isEqualTo(url)
         }
 
@@ -757,10 +757,10 @@ class CardReaderConnectViewModelTest : BaseUnitTest() {
                 .onPrimaryActionClicked.invoke()
 
             assertThat(viewModel.event.value).isInstanceOf(
-                OpenWPComWebView::class.java
+                OpenAuthenticatedWebView::class.java
             )
             assertThat(
-                (viewModel.event.value as OpenWPComWebView).url
+                (viewModel.event.value as OpenAuthenticatedWebView).url
             ).isEqualTo(url)
         }
 

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/sitepicker/SitePickerViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/sitepicker/SitePickerViewModelTest.kt
@@ -708,7 +708,7 @@ class SitePickerViewModelTest : BaseUnitTest() {
         viewModel.onInstallWooClicked()
 
         val event = viewModel.event.captureValues().last()
-        assertThat(event).isInstanceOf(SitePickerEvent.NavigateToWPComWebView::class.java)
+        assertThat(event).isInstanceOf(SitePickerEvent.NavigateToAuthenticatedWebView::class.java)
     }
 
     @Test


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Part of: #13467 
<!-- Id number of the GitHub issue this PR addresses. -->

> [!TIP]
> Excluding the commit f0ce7cd458ee1dc2ea19d4c5170704dc71c79a00 when reviewing would make the review easier, this commit just renames few classes. 

### Description
This PR is a preparation for the next PR that implements the improvements suggested in pe5sF9-3QB-p2, it handles the following changes:

1. It simplifies the code of the `WCWebView` composable, and make some changes to make it more use better Compose idiomatic approaches.
2. It removes some unused code (more details in the comments below)
3. It allows setting a custom `WebViewClient`, this turned out to be not needed for this feature, but I believe it can be useful for other features.
4. Rename the various classes related to the Authenticated WebView from `WPComWebView...` to `AuthenticatedWebView...` to align better with the new roles.

### Steps to reproduce
This PR shouldn't introduce any behavior changes (except one for Blaze campaign details that I will explain below), so just testing few areas that use the `WCWebView` and the `AuthenticatedWebView`, for example:
1. Order card reader from the Payments hub.
2. Theme settings for Atomic websites.
3. Analytics reports for Atomic websites.


### Testing information
- Confirm that there are no regressions.

### The tests that have been performed
^

- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.

## Reviewer (or Author, in the case of optional code reviews):

Please make sure these conditions are met before approving the PR, or request changes if the PR needs improvement:

- [ ] The PR is small and has a clear, single focus, or a valid explanation is provided in the description. If needed, please request to split it into smaller PRs.
- [ ] Ensure Adequate Unit Test Coverage: The changes are reasonably covered by unit tests or an explanation is provided in the PR description.
- [ ] Manual Testing: The author listed all the tests they ran, including smoke tests when needed (e.g., for refactorings). The reviewer confirmed that the PR works as expected on big (tablet) and small (phone) in case of UI changes, and no regressions are added.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->