### PR TITLE
Use safe cast to enable enableEdgeToEdge

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/util/ApplicationEdgeToEdgeEnabler.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/util/ApplicationEdgeToEdgeEnabler.kt
@@ -9,7 +9,7 @@ import javax.inject.Inject
 
 class ApplicationEdgeToEdgeEnabler @Inject constructor() : Application.ActivityLifecycleCallbacks {
     override fun onActivityCreated(activity: Activity, bindle: Bundle?) {
-        (activity as ComponentActivity).enableEdgeToEdge()
+        (activity as? ComponentActivity)?.enableEdgeToEdge()
     }
 
     override fun onActivityStarted(activity: Activity) {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/util/ApplicationEdgeToEdgeEnabler.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/util/ApplicationEdgeToEdgeEnabler.kt
@@ -12,11 +12,43 @@ class ApplicationEdgeToEdgeEnabler @Inject constructor(
     private val crashLogger: CrashLogging
 ) : Application.ActivityLifecycleCallbacks {
 
+    /**
+     * Set of activity class names that should not be edge-to-edge.
+     */
     private val unsupportedEdgeToEdgeActivities = setOf(
         "leakcanary.internal.RequestPermissionActivity"
     )
 
-    override fun onActivityCreated(activity: Activity, bindle: Bundle?) {
+    /**
+     * Called when an activity has been created.
+     *
+     * This function checks if edge-to-edge display is supported and, if so, enables it.
+     * It handles different scenarios based on the debug/release build type and whether the
+     * activity is a ComponentActivity.
+     *
+     * @param activity The activity that has been created.
+     * @param bundle  A Bundle containing the activity's previously frozen state, if there was one.
+     *                This parameter is not used within this method but is part of the lifecycle callback.
+     *
+     * @throws ClassCastException if `isEdgeToEdgeSupported` is true and the activity is not an instance of `ComponentActivity`,
+     *                            a `ClassCastException` is thrown. The exception is caught and logged by the crashLogger.
+     *
+     * Behavior:
+     *   - Checks if edge-to-edge is supported using `isEdgeToEdgeSupported(activity)`.
+     *   - **Debug Build:**
+     *     - If edge-to-edge is supported, it calls `enableEdgeToEdge()` directly on the activity,
+     *       assuming it's a `ComponentActivity`.
+     *   - **Release Build or Edge-to-Edge Not Supported in Debug build:**
+     *     - If the activity is a `ComponentActivity`, it calls `enableEdgeToEdge()`.
+     *     - If the activity is not a `ComponentActivity` but edge-to-edge is supported, it logs a
+     *       `ClassCastException` using `crashLogger.sendReport()`.
+     *     - If the activity is not a `ComponentActivity` and edge-to-edge isn't supported, nothing happens.
+     *
+     * Edge Case Handling:
+     *  - In release builds, the code gracefully handles non-ComponentActivities when edge-to-edge is supported by logging the issue instead of crashing.
+     *  - In debug builds, the code will attempt to cast the activity to a `ComponentActivity`. If the cast fails, then a `ClassCastException` will be thrown by the application.
+     */
+    override fun onActivityCreated(activity: Activity, bundle: Bundle?) {
         val isEdgeToEdgeSupported = isEdgeToEdgeSupported(activity)
         if (PackageUtils.isDebugBuild() && isEdgeToEdgeSupported) {
             (activity as ComponentActivity).enableEdgeToEdge()

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/util/ApplicationEdgeToEdgeEnabler.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/util/ApplicationEdgeToEdgeEnabler.kt
@@ -5,11 +5,36 @@ import android.app.Application
 import android.os.Bundle
 import androidx.activity.ComponentActivity
 import androidx.activity.enableEdgeToEdge
+import com.automattic.android.tracks.crashlogging.CrashLogging
 import javax.inject.Inject
 
-class ApplicationEdgeToEdgeEnabler @Inject constructor() : Application.ActivityLifecycleCallbacks {
+class ApplicationEdgeToEdgeEnabler @Inject constructor(
+    private val crashLogger: CrashLogging
+) : Application.ActivityLifecycleCallbacks {
+
+    private val unsupportedEdgeToEdgeActivities = setOf(
+        "leakcanary.internal.RequestPermissionActivity"
+    )
+
     override fun onActivityCreated(activity: Activity, bindle: Bundle?) {
-        (activity as? ComponentActivity)?.enableEdgeToEdge()
+        val isEdgeToEdgeSupported = isEdgeToEdgeSupported(activity)
+        if (PackageUtils.isDebugBuild() && isEdgeToEdgeSupported) {
+            (activity as ComponentActivity).enableEdgeToEdge()
+        } else {
+            (activity as? ComponentActivity)?.enableEdgeToEdge() ?: run {
+                if (isEdgeToEdgeSupported) {
+                    val message = "Activity $activity is not a ComponentActivity"
+                    crashLogger.sendReport(
+                        exception = ClassCastException(message),
+                        message = message
+                    )
+                }
+            }
+        }
+    }
+
+    private fun isEdgeToEdgeSupported(activity: Activity): Boolean {
+        return (activity::class.java.name in unsupportedEdgeToEdgeActivities).not()
     }
 
     override fun onActivityStarted(activity: Activity) {


### PR DESCRIPTION
### Description
This small PR fixes a crash I detected when enabling edge-to-edge on non-ComponentActivities. The fix added here is to use Kotlin's safe cast to check if the activity is a ComponentActivity.

### Testing information
I could reproduce the crash when Leak Canary tried to analyze the app's memory on the app's login flow.

Steps to reproduce
1. Log out from the app
2. Try to log in again until leak canary is triggered
3. Check that the app crashes

### The tests that have been performed
- Checking that the app does not crash when Leak Canary is triggered.

### Images/gif
Crash log:
<img width="700" src="https://github.com/user-attachments/assets/a472db2a-19c7-4ade-ab92-fe20f77b2e78" />


- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.

## Reviewer (or Author, in the case of optional code reviews):

Please make sure these conditions are met before approving the PR, or request changes if the PR needs improvement:

- [x] The PR is small and has a clear, single focus, or a valid explanation is provided in the description. If needed, please request to split it into smaller PRs.
- [x] Ensure Adequate Unit Test Coverage: The changes are reasonably covered by unit tests or an explanation is provided in the PR description.
- [x] Manual Testing: The author listed all the tests they ran, including smoke tests when needed (e.g., for refactorings). The reviewer confirmed that the PR works as expected on big (tablet) and small (phone) in case of UI changes, and no regressions are added.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->