### PR TITLE
Fix incorrect color usages for Purple 10

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/banner/Banner.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/banner/Banner.kt
@@ -156,7 +156,7 @@ private fun BackgroundImage(bannerState: JitmState.Banner) {
 private fun BadgeIcon(bannerState: JitmState.Banner) {
     when (val icon = bannerState.badgeIcon) {
         is JitmState.Banner.LabelOrRemoteIcon.Label -> {
-            val bcgColor = colorResource(id = R.color.woo_purple_10)
+            val bcgColor = colorResource(id = R.color.woo_purple_0)
             Text(
                 text = UiHelpers.getTextOfUiString(LocalContext.current, icon.label),
                 color = colorResource(id = R.color.woo_purple_60),

--- a/WooCommerce/src/main/res/values-night/colors_base.xml
+++ b/WooCommerce/src/main/res/values-night/colors_base.xml
@@ -227,7 +227,7 @@
     <color name="payout_summary_status_paid_background">@color/woo_green_50</color>
     <color name="payout_summary_status_paid_text">@color/woo_green_0</color>
     <color name="payout_summary_status_canceled_background">@color/woo_purple_80</color>
-    <color name="payout_summary_status_canceled_text">@color/woo_purple_10</color>
+    <color name="payout_summary_status_canceled_text">@color/woo_purple_0</color>
     <color name="payout_summary_status_failed_background">@color/woo_red_70</color>
     <color name="payout_summary_status_failed_text">@color/woo_red_5</color>
     <color name="payout_summary_status_unknown_background">@color/woo_gray_80</color>

--- a/WooCommerce/src/main/res/values/colors_base.xml
+++ b/WooCommerce/src/main/res/values/colors_base.xml
@@ -127,7 +127,7 @@
     <color name="tag_bg_on_hold">@color/woo_orange_5</color>
     <color name="tag_bg_completed">@color/woo_blue_5</color>
     <color name="tag_bg_other">@color/woo_gray_5</color>
-    <color name="tag_bg_main">@color/woo_purple_10</color>
+    <color name="tag_bg_main">@color/woo_purple_0</color>
     <color name="tag_text_main">@color/color_primary</color>
     <color name="tag_task_label">@color/woo_gray_6</color>
     <color name="tag_task_label_text">@color/woo_black_90_alpha_060</color>

--- a/WooCommerce/src/main/res/values/colors_base.xml
+++ b/WooCommerce/src/main/res/values/colors_base.xml
@@ -47,7 +47,7 @@
     <!--
         Color resource used to indicate selected state of an item
     -->
-    <color name="woo_item_selected">@color/woo_purple_10</color>
+    <color name="woo_item_selected">@color/woo_purple_0</color>
     <color name="color_item_selected">@color/woo_item_selected</color>
 
     <!--

--- a/WooCommerce/src/main/res/values/colors_base.xml
+++ b/WooCommerce/src/main/res/values/colors_base.xml
@@ -321,7 +321,7 @@
     <color name="payout_summary_status_in_transit_text">@color/woo_orange_70</color>
     <color name="payout_summary_status_paid_background">@color/woo_green_0</color>
     <color name="payout_summary_status_paid_text">@color/woo_green_50</color>
-    <color name="payout_summary_status_canceled_background">@color/woo_purple_10</color>
+    <color name="payout_summary_status_canceled_background">@color/woo_purple_0</color>
     <color name="payout_summary_status_canceled_text">@color/woo_purple_80</color>
     <color name="payout_summary_status_failed_background">@color/woo_red_5</color>
     <color name="payout_summary_status_failed_text">@color/woo_red_70</color>


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
Before the Brand Updates project, Purple 10 was incorrect on Android. [Its color code](https://href.li/?https://github.com/woocommerce/woocommerce-android/blob/e9fb289d4fff75a6364b02daa706c614ba133f71/WooCommerce/src/main/res/values/wc_colors_base.xml) was `#F7EDF7`, but this code is actually Purple 0 from [Color Studio 3.0.3](https://href.li/?https://color-studio.blog/). I fixed this while upgrading to Color Studio 4.1.0. But now, we should point Purple 0 instead of Purple 10. 
This PR changes Purple 10 to Purple 0. Let me know if you think this might require a beta fix.

### Steps to reproduce
<!-- Step-by-step testing instructions. For new user flows, consider instead stating the goal of the workflow and see if your PR reviewer can accomplish the workflow without specific steps! -->
Reproducing is not really necessary since this doesn't include any logic change. Checking screenshots should be enough.

### The tests that have been performed
<!-- To give the reviewer an idea of what could be missed in terms of testing -->
Screens below. However, I didn’t reproduce the payout summary; it’s a preview from Compose.

### Images/gif
<!-- Include before and after images or gifs when appropriate. -->
|Before|After|
|-|-|
|<img src="https://github.com/user-attachments/assets/27788971-b8c2-418a-bc2e-e0672fded0ed" width=480>|<img src="https://github.com/user-attachments/assets/47e091a8-1ecc-4db7-bc4c-c4acf5fb8217" width=480>|
|<img src="https://github.com/user-attachments/assets/5ba5be2e-0ecc-4e99-895c-1c42d66df40d" width=480>|<img src="https://github.com/user-attachments/assets/903656ee-aa04-4e98-b596-43f59aae2366" width=480>|
|<img src="https://github.com/user-attachments/assets/1dc5ba34-af97-4587-93e8-8d454f19fe04" width=480>|<img src="https://github.com/user-attachments/assets/990751de-e81c-49ad-8de9-b820c61c4906" width=480>|
|<img src="https://github.com/user-attachments/assets/7bdc8b1d-c1a4-473e-88e5-eac44f75a6c0" width=480>|<img src="https://github.com/user-attachments/assets/f7f4dfcc-cdee-4a97-bc7a-227c30189311" width=480>|
|<img src="https://github.com/user-attachments/assets/80618bf9-751c-4963-838f-b7880e894ce6" width=480>|<img src="https://github.com/user-attachments/assets/8243704d-d747-4b66-bd59-7f1d0aa5f242" width=480>|

- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.

## Reviewer (or Author, in the case of optional code reviews):

Please make sure these conditions are met before approving the PR, or request changes if the PR needs improvement:

- [ ] The PR is small and has a clear, single focus, or a valid explanation is provided in the description. If needed, please request to split it into smaller PRs.
- [ ] Ensure Adequate Unit Test Coverage: The changes are reasonably covered by unit tests or an explanation is provided in the PR description.
- [ ] Manual Testing: The author listed all the tests they ran, including smoke tests when needed (e.g., for refactorings). The reviewer confirmed that the PR works as expected on big (tablet) and small (phone) in case of UI changes, and no regressions are added.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->