### PR TITLE
[Products] Use Authenticated WebView for previewing products

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -15,6 +15,7 @@
 - [*] Improved the Authenticated WebView implementation, and it will now handle opening the Analytics reports directly from the app without requiring additional authentication [https://github.com/woocommerce/woocommerce-android/pull/13487]
 - [*] [Internal] All non-login tracking events will now include the selected site data [https://github.com/woocommerce/woocommerce-android/pull/13575]
 - [*] Fixed a crash that occurred when the app was backgrounded during bulk variations update [https://github.com/woocommerce/woocommerce-android/pull/13584]
+- [*] Improved handling of product previews by using the Authenticated WebView in supported scenarios [https://github.com/woocommerce/woocommerce-android/pull/13494]
 
 21.7
 -----

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/extensions/FragmentExt.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/extensions/FragmentExt.kt
@@ -4,6 +4,8 @@ import android.view.View
 import androidx.annotation.IdRes
 import androidx.fragment.app.Fragment
 import androidx.lifecycle.lifecycleScope
+import androidx.navigation.NavController
+import androidx.navigation.fragment.NavHostFragment
 import androidx.navigation.fragment.findNavController
 import com.google.android.material.appbar.AppBarLayout
 import com.google.android.material.datepicker.CalendarConstraints
@@ -235,4 +237,22 @@ fun Fragment.showDateRangePicker(
 
         onCustomRangeSelected(start, end)
     }
+}
+
+/**
+ * Finds the NavController associated with the NavHostFragment with the given ID,
+ * useful when trying to find a parent NavController from a child fragment used in two-pane layouts.
+ *
+ * @param navHostId The ID of the NavHostFragment
+ * @return The NavController
+ */
+fun Fragment.findNavController(@IdRes navHostId: Int): NavController {
+    var parentFragment = parentFragment
+    while (parentFragment != null) {
+        if (parentFragment is NavHostFragment && parentFragment.id == navHostId) {
+            return parentFragment.navController
+        }
+        parentFragment = parentFragment.parentFragment
+    }
+    throw IllegalStateException("No NavHostFragment found with id $navHostId")
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/extensions/FragmentExt.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/extensions/FragmentExt.kt
@@ -33,11 +33,18 @@ import kotlin.math.abs
  * @param [destinationId] an optional destinationId, that can be used to navigate up to a specified destination
  *
  */
-fun <T> Fragment.navigateBackWithResult(key: String, result: T, @IdRes destinationId: Int? = null) {
+fun <T> Fragment.navigateBackWithResult(
+    key: String,
+    result: T,
+    @IdRes destinationId: Int? = null,
+    @IdRes navHostId: Int? = null,
+) {
+    val navController = if (navHostId != null) findNavController(navHostId) else findNavController()
+
     val entry = if (destinationId != null) {
-        findNavController().getBackStackEntry(destinationId)
+        navController.getBackStackEntry(destinationId)
     } else {
-        findNavController().previousBackStackEntry
+        navController.previousBackStackEntry
     }
     entry?.savedStateHandle?.set(key, result)
 
@@ -56,7 +63,7 @@ fun <T> Fragment.navigateBackWithResult(key: String, result: T, @IdRes destinati
  * @param [key] A unique string that is the same as the one used in [handleResult]
  * @param [result] A result value to be returned
  * @param [childId] an destinationId, that used to navigate up from the specified destination
- *
+ * @param [navHostId] An optional ID of the NavHostFragment, it's useful when the fragment is used in two-pane layouts
  */
 fun <T> Fragment.navigateToParentWithResult(key: String, result: T, @IdRes childId: Int) {
     if (findNavController().currentDestination?.id != childId) {
@@ -72,9 +79,14 @@ fun <T> Fragment.navigateToParentWithResult(key: String, result: T, @IdRes child
  *
  * @param [key] A unique string that is the same as the one used in [handleNotice]
  * @param [destinationId] an optional destinationId, that can be used to navigating up to a specified destination
+ * @param [navHostId] An optional ID of the NavHostFragment, it's useful when the fragment is used in two-pane layouts
  */
-fun Fragment.navigateBackWithNotice(key: String, @IdRes destinationId: Int? = null) {
-    navigateBackWithResult(key, key, destinationId)
+fun Fragment.navigateBackWithNotice(
+    key: String,
+    @IdRes destinationId: Int? = null,
+    @IdRes navHostId: Int? = null,
+) {
+    navigateBackWithResult(key, key, destinationId, navHostId)
 }
 
 /**
@@ -84,17 +96,25 @@ fun Fragment.navigateBackWithNotice(key: String, @IdRes destinationId: Int? = nu
  * @param [key] A unique string that is the same as the one used in [navigateBackWithResult]
  * @param [entryId] An optional ID to identify the correct back stack entry. It's required when calling [handleResult]
  *  from TopLevelFragment or Dialog (otherwise the result will get lost upon configuration change)
+ * @param [navHostId] An optional ID of the NavHostFragment, it's useful when the fragment is used in two-pane layouts
  * @param [handler] A result handler
  *
  * Note: The handler is called only if the value wasn't handled before (i.e. the data is fresh). Once the observer is
  * called, the boolean value is updated. This puts a limit on the number of observers for a particular key-result pair
  * to 1.
  */
-fun <T> Fragment.handleResult(key: String, entryId: Int? = null, handler: (T) -> Unit) {
+fun <T> Fragment.handleResult(
+    key: String,
+    @IdRes entryId: Int? = null,
+    @IdRes navHostId: Int? = null,
+    handler: (T) -> Unit
+) {
+    val navController = if (navHostId != null) findNavController(navHostId) else findNavController()
+
     val entry = if (entryId != null) {
-        findNavController().getBackStackEntry(entryId)
+        navController.getBackStackEntry(entryId)
     } else {
-        findNavController().currentBackStackEntry
+        navController.currentBackStackEntry
     }
 
     entry?.savedStateHandle?.let { saveState ->
@@ -115,14 +135,20 @@ fun <T> Fragment.handleResult(key: String, entryId: Int? = null, handler: (T) ->
  * @param [key] A unique string that is the same as the one used in [navigateBackWithResult]
  * @param [entryId] A mandatory ID to identify the correct back stack entry. It's required when calling [handleResult]
  *  from TopLevelFragment or Dialog (otherwise the result will get lost upon configuration change)
+ * @param [navHostId] An optional ID of the NavHostFragment, it's useful when the fragment is used in two-pane layouts
  * @param [handler] A result handler
  *
  * Note: The handler is called only if the value wasn't handled before (i.e. the data is fresh). Once the observer is
  * called, the value is nulled and the handler won't be called. This puts a limit on the number of observers for
  * a particular key-result pair to 1.
  */
-fun <T> Fragment.handleDialogResult(key: String, entryId: Int, handler: (T) -> Unit) {
-    handleResult(key, entryId, handler)
+fun <T> Fragment.handleDialogResult(
+    key: String,
+    @IdRes entryId: Int,
+    @IdRes navHostId: Int? = null,
+    handler: (T) -> Unit
+) {
+    handleResult(key, entryId, navHostId, handler)
 }
 
 /**
@@ -133,14 +159,19 @@ fun <T> Fragment.handleDialogResult(key: String, entryId: Int, handler: (T) -> U
  * @param [key] A unique string that is the same as the one used in [navigateBackWithNotice]
  * @param [entryId] A mandatory ID to identify the correct back stack entry. It's required when calling [handleNotice]
  *  from TopLevelFragment or Dialog (otherwise the result will get lost upon configuration change)
+ * @param [navHostId] An optional ID of the NavHostFragment, it's useful when the fragment is used in two-pane layouts
  * @param [handler] A result handler
  *
  * Note: The handler is called only if the value wasn't handled before (i.e. the data is fresh). Once the observer is
  * called, the value is nulled and the handler won't be called. This puts a limit on the number of observers for
  * a particular key-result pair to 1.
  */
-fun Fragment.handleDialogNotice(key: String, entryId: Int, handler: () -> Unit) {
-    handleNotice(key, entryId, handler)
+fun Fragment.handleDialogNotice(
+    key: String, @IdRes entryId: Int,
+    @IdRes navHostId: Int? = null,
+    handler: () -> Unit
+) {
+    handleNotice(key, entryId, navHostId, handler)
 }
 
 /**
@@ -150,17 +181,25 @@ fun Fragment.handleDialogNotice(key: String, entryId: Int, handler: () -> Unit) 
  * @param [key] A unique string that is the same as the one used in [navigateBackWithNotice]
  * @param [entryId] A mandatory ID to identify the correct back stack entry. It's required when calling [handleNotice]
  *  from TopLevelFragment or Dialog (otherwise the result will get lost upon configuration change)
+ * @param [navHostId] An optional ID of the NavHostFragment, it's useful when the fragment is used in two-pane layouts
  * @param [handler] A result handler
  *
  * Note: The handler is called only if the value wasn't handled before (i.e. the data is fresh). Once the observer is
  * called, the value is nulled and the handler won't be called. This puts a limit on the number of observers for
  * a particular key-result pair to 1.
  */
-fun Fragment.handleNotice(key: String, entryId: Int? = null, handler: () -> Unit) {
+fun Fragment.handleNotice(
+    key: String,
+    @IdRes entryId: Int? = null,
+    @IdRes navHostId: Int? = null,
+    handler: () -> Unit
+) {
+    val navController = if (navHostId != null) findNavController(navHostId) else findNavController()
+
     val entry = if (entryId != null) {
-        findNavController().getBackStackEntry(entryId)
+        navController.getBackStackEntry(entryId)
     } else {
-        findNavController().currentBackStackEntry
+        navController.currentBackStackEntry
     }
 
     entry?.savedStateHandle?.let { saveState ->

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/extensions/FragmentExt.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/extensions/FragmentExt.kt
@@ -167,7 +167,8 @@ fun <T> Fragment.handleDialogResult(
  * a particular key-result pair to 1.
  */
 fun Fragment.handleDialogNotice(
-    key: String, @IdRes entryId: Int,
+    key: String,
+    @IdRes entryId: Int,
     @IdRes navHostId: Int? = null,
     handler: () -> Unit
 ) {
@@ -293,5 +294,5 @@ fun Fragment.findNavController(@IdRes navHostId: Int): NavController {
         }
         parentFragment = parentFragment.parentFragment
     }
-    throw IllegalStateException("No NavHostFragment found with id $navHostId")
+    error("No NavHostFragment found with id $navHostId")
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/EditShippingLabelPaymentFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/EditShippingLabelPaymentFragment.kt
@@ -6,13 +6,12 @@ import android.view.View
 import androidx.appcompat.content.res.AppCompatResources
 import androidx.core.view.isVisible
 import androidx.fragment.app.viewModels
-import androidx.navigation.fragment.findNavController
 import androidx.recyclerview.widget.LinearLayoutManager
 import com.woocommerce.android.AppUrls
-import com.woocommerce.android.AppUrls.FETCH_PAYMENT_METHOD_URL_PATH
-import com.woocommerce.android.NavGraphOrdersDirections
+import com.woocommerce.android.NavGraphMainDirections
 import com.woocommerce.android.R
 import com.woocommerce.android.databinding.FragmentEditShippingLabelPaymentBinding
+import com.woocommerce.android.extensions.findNavController
 import com.woocommerce.android.extensions.handleNotice
 import com.woocommerce.android.extensions.navigateBackWithNotice
 import com.woocommerce.android.extensions.navigateBackWithResult
@@ -198,10 +197,10 @@ class EditShippingLabelPaymentFragment :
         viewModel.event.observe(viewLifecycleOwner) { event ->
             when (event) {
                 is AddPaymentMethod -> {
-                    findNavController().navigateSafely(
-                        NavGraphOrdersDirections.actionGlobalAuthenticatedWebViewFragment(
+                    findNavController(R.id.nav_host_fragment_main).navigateSafely(
+                        NavGraphMainDirections.actionGlobalAuthenticatedWebViewFragment(
                             urlToLoad = AppUrls.WPCOM_ADD_PAYMENT_METHOD,
-                            urlsToTriggerExit = arrayOf(FETCH_PAYMENT_METHOD_URL_PATH),
+                            urlsToTriggerExit = arrayOf(AppUrls.FETCH_PAYMENT_METHOD_URL_PATH),
                             title = getFragmentTitle()
                         )
                     )
@@ -215,7 +214,7 @@ class EditShippingLabelPaymentFragment :
     }
 
     private fun setupResultHandlers() {
-        handleNotice(AuthenticatedWebViewFragment.WEBVIEW_RESULT) {
+        handleNotice(AuthenticatedWebViewFragment.WEBVIEW_RESULT, navHostId = R.id.nav_host_fragment_main) {
             viewModel.onPaymentMethodAdded()
         }
     }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/details/ProductDetailFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/details/ProductDetailFragment.kt
@@ -20,6 +20,7 @@ import com.google.android.material.dialog.MaterialAlertDialogBuilder
 import com.google.android.material.snackbar.Snackbar
 import com.google.android.material.transition.MaterialContainerTransform
 import com.woocommerce.android.AppUrls
+import com.woocommerce.android.NavGraphMainDirections
 import com.woocommerce.android.R
 import com.woocommerce.android.RequestCodes
 import com.woocommerce.android.analytics.AnalyticsEvent
@@ -85,6 +86,7 @@ import com.woocommerce.android.ui.promobanner.PromoBannerType
 import com.woocommerce.android.util.ChromeCustomTabUtils
 import com.woocommerce.android.util.UiHelpers.getTextOfUiString
 import com.woocommerce.android.util.WooAnimUtils
+import com.woocommerce.android.viewmodel.MultiLiveEvent.Event
 import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.LaunchUrlInChromeTab
 import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.ShowUiStringSnackbar
 import com.woocommerce.android.widgets.CustomProgressDialog
@@ -391,6 +393,9 @@ class ProductDetailFragment :
         viewModel.event.observe(viewLifecycleOwner) { event ->
             when (event) {
                 is LaunchUrlInChromeTab -> ChromeCustomTabUtils.launchUrl(requireContext(), event.url)
+                is Event.LaunchUrlInAuthenticatedWebView -> findNavController().navigateSafely(
+                    NavGraphMainDirections.actionGlobalAuthenticatedWebViewFragment(event.url)
+                )
                 is RefreshMenu -> toolbarHelper.setupToolbar()
 
                 is TrashProduct -> {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/details/ProductDetailFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/details/ProductDetailFragment.kt
@@ -27,6 +27,7 @@ import com.woocommerce.android.analytics.AnalyticsEvent
 import com.woocommerce.android.analytics.AnalyticsTracker
 import com.woocommerce.android.databinding.FragmentProductDetailBinding
 import com.woocommerce.android.extensions.fastStripHtml
+import com.woocommerce.android.extensions.findNavController
 import com.woocommerce.android.extensions.handleNotice
 import com.woocommerce.android.extensions.handleResult
 import com.woocommerce.android.extensions.hide
@@ -393,9 +394,8 @@ class ProductDetailFragment :
         viewModel.event.observe(viewLifecycleOwner) { event ->
             when (event) {
                 is LaunchUrlInChromeTab -> ChromeCustomTabUtils.launchUrl(requireContext(), event.url)
-                is Event.LaunchUrlInAuthenticatedWebView -> findNavController().navigateSafely(
-                    NavGraphMainDirections.actionGlobalAuthenticatedWebViewFragment(event.url)
-                )
+                is Event.LaunchUrlInAuthenticatedWebView -> findNavController(R.id.nav_host_fragment_main)
+                    .navigateSafely(NavGraphMainDirections.actionGlobalAuthenticatedWebViewFragment(event.url))
                 is RefreshMenu -> toolbarHelper.setupToolbar()
 
                 is TrashProduct -> {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/details/ProductDetailViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/details/ProductDetailViewModel.kt
@@ -95,7 +95,6 @@ import com.woocommerce.android.util.IsWindowClassLargeThanCompact
 import com.woocommerce.android.util.WooLog
 import com.woocommerce.android.viewmodel.LiveDataDelegate
 import com.woocommerce.android.viewmodel.MultiLiveEvent.Event
-import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.LaunchUrlInChromeTab
 import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.ShowDialog
 import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.ShowSnackbar
 import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.ShowUiStringSnackbar
@@ -557,9 +556,7 @@ class ProductDetailViewModel @Inject constructor(
     }
 
     fun onLearnMoreClicked() {
-        triggerEvent(
-            LaunchUrlInChromeTab(AppUrls.AUTOMATTIC_AI_GUIDELINES)
-        )
+        triggerEvent(Event.LaunchUrlInChromeTab(AppUrls.AUTOMATTIC_AI_GUIDELINES))
     }
 
     fun onBlazeClicked() {
@@ -1222,7 +1219,11 @@ class ProductDetailViewModel @Inject constructor(
     fun onViewProductOnStoreLinkClicked() {
         tracker.track(AnalyticsEvent.PRODUCT_DETAIL_VIEW_EXTERNAL_TAPPED)
         viewState.productDraft?.permalink?.let { url ->
-            triggerEvent(LaunchUrlInChromeTab(url))
+            if (canAutoAuthenticateInWebView(url)) {
+                triggerEvent(Event.LaunchUrlInAuthenticatedWebView(url))
+            } else {
+                triggerEvent(Event.LaunchUrlInChromeTab(url))
+            }
         }
     }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/details/ProductDetailViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/details/ProductDetailViewModel.kt
@@ -51,6 +51,7 @@ import com.woocommerce.android.tools.SelectedSite
 import com.woocommerce.android.tools.SiteConnectionType
 import com.woocommerce.android.ui.blaze.IsBlazeEnabled
 import com.woocommerce.android.ui.blaze.IsProductCurrentlyPromoted
+import com.woocommerce.android.ui.common.webview.CanAutoAuthenticateInWebView
 import com.woocommerce.android.ui.customfields.CustomFieldsRepository
 import com.woocommerce.android.ui.media.MediaFileUploadHandler
 import com.woocommerce.android.ui.media.getMediaUploadErrorMessage
@@ -72,6 +73,7 @@ import com.woocommerce.android.ui.products.canDisplayMessage
 import com.woocommerce.android.ui.products.categories.ProductCategoriesRepository
 import com.woocommerce.android.ui.products.categories.ProductCategoryItemUiModel
 import com.woocommerce.android.ui.products.details.ProductDetailBottomSheetBuilder.ProductDetailBottomSheetUiItem
+import com.woocommerce.android.ui.products.details.ProductDetailViewModel.Companion.DEFAULT_ADD_NEW_PRODUCT_ID
 import com.woocommerce.android.ui.products.list.ProductListRepository
 import com.woocommerce.android.ui.products.models.ProductPropertyCard
 import com.woocommerce.android.ui.products.models.SiteParameters
@@ -162,7 +164,8 @@ class ProductDetailViewModel @Inject constructor(
     private val isProductCurrentlyPromoted: IsProductCurrentlyPromoted,
     private val isWindowClassLargeThanCompact: IsWindowClassLargeThanCompact,
     private val determineProductPasswordApi: DetermineProductPasswordApi,
-    private val customFieldsRepository: CustomFieldsRepository
+    private val customFieldsRepository: CustomFieldsRepository,
+    private val canAutoAuthenticateInWebView: CanAutoAuthenticateInWebView
 ) : ScopedViewModel(savedState) {
     companion object {
         private const val KEY_PRODUCT_PARAMETERS = "key_product_parameters"
@@ -342,11 +345,16 @@ class ProductDetailViewModel @Inject constructor(
             val showShareOptionAsActionWithText =
                 showShareOption && !showSaveOptionAsActionWithText && !showPublishOption
 
+            // Show "View Product" option only if the product is published or we can auto-authenticate the user
+            // in a WebView.
+            val showViewProductOption = !isProductUnderCreation &&
+                (isProductPublished || canAutoAuthenticateInWebView(productDraft.permalink))
+
             MenuButtonsState(
                 saveOption = showSaveOptionAsActionWithText,
                 saveAsDraftOption = canBeSavedAsDraft,
                 publishOption = showPublishOption,
-                viewProductOption = isProductPublished && !isProductUnderCreation,
+                viewProductOption = showViewProductOption,
                 shareOption = showShareOption,
                 showShareOptionAsActionWithText = showShareOptionAsActionWithText,
                 trashOption = !isProductUnderCreation && navArgs.isTrashEnabled

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/viewmodel/MultiLiveEvent.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/viewmodel/MultiLiveEvent.kt
@@ -129,6 +129,8 @@ open class MultiLiveEvent<T : Event> : MutableLiveData<T>() {
 
         data class ExitWithResult<out T>(val data: T, val key: String? = null) : Event()
 
+        data class LaunchUrlInAuthenticatedWebView(val url: String) : Event()
+
         data class LaunchUrlInChromeTab(val url: String) : Event()
 
         data class ShowDialogFragment(

--- a/WooCommerce/src/main/res/navigation/nav_graph_orders.xml
+++ b/WooCommerce/src/main/res/navigation/nav_graph_orders.xml
@@ -486,44 +486,6 @@
         android:label="EditShippingLabelPaymentFragment"
         tools:layout="@layout/fragment_edit_shipping_label_payment">
     </fragment>
-    <action
-        android:id="@+id/action_global_AuthenticatedWebViewFragment"
-        app:destination="@id/AuthenticatedWebViewFragment" />
-    <fragment
-        android:id="@+id/AuthenticatedWebViewFragment"
-        android:name="com.woocommerce.android.ui.common.webview.AuthenticatedWebViewFragment"
-        android:label="AuthenticatedWebViewFragment"
-        tools:layout="@layout/fragment_wpcom_webview">
-        <argument
-            android:name="urlToLoad"
-            app:argType="string" />
-        <argument
-            android:name="title"
-            android:defaultValue="@null"
-            app:argType="string"
-            app:nullable="true" />
-        <argument
-            android:name="urlsToTriggerExit"
-            android:defaultValue="@null"
-            app:argType="string[]"
-            app:nullable="true" />
-        <argument
-            android:name="captureBackButton"
-            android:defaultValue="true"
-            app:argType="boolean" />
-        <argument
-            android:name="displayMode"
-            android:defaultValue="REGULAR"
-            app:argType="com.woocommerce.android.ui.common.webview.AuthenticatedWebViewViewModel$DisplayMode" />
-        <argument
-            android:name="urlComparisonMode"
-            android:defaultValue="PARTIAL"
-            app:argType="com.woocommerce.android.ui.common.webview.AuthenticatedWebViewViewModel$UrlComparisonMode" />
-        <argument
-            android:name="clearCache"
-            android:defaultValue="false"
-            app:argType="boolean" />
-    </fragment>
     <fragment
         android:id="@+id/shippingCarrierRatesFragment"
         android:name="com.woocommerce.android.ui.orders.shippinglabels.creation.ShippingCarrierRatesFragment"

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/products/details/ProductDetailViewModelGenerateVariationFlowTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/products/details/ProductDetailViewModelGenerateVariationFlowTest.kt
@@ -127,7 +127,8 @@ class ProductDetailViewModelGenerateVariationFlowTest : BaseUnitTest() {
                 isProductCurrentlyPromoted = mock(),
                 isWindowClassLargeThanCompact = isWindowClassLargeThanCompact,
                 determineProductPasswordApi = determineProductPasswordApi,
-                customFieldsRepository = mock()
+                customFieldsRepository = mock(),
+                canAutoAuthenticateInWebView = mock()
             )
         )
 

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/products/details/ProductDetailViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/products/details/ProductDetailViewModelTest.kt
@@ -15,6 +15,7 @@ import com.woocommerce.android.model.UiString.UiStringText
 import com.woocommerce.android.tools.NetworkStatus
 import com.woocommerce.android.tools.SelectedSite
 import com.woocommerce.android.ui.blaze.IsBlazeEnabled
+import com.woocommerce.android.ui.common.webview.CanAutoAuthenticateInWebView
 import com.woocommerce.android.ui.customfields.CustomFieldsRepository
 import com.woocommerce.android.ui.media.MediaFileUploadHandler
 import com.woocommerce.android.ui.products.ParameterRepository
@@ -35,6 +36,7 @@ import com.woocommerce.android.util.CurrencyFormatter
 import com.woocommerce.android.util.IsWindowClassLargeThanCompact
 import com.woocommerce.android.util.ProductUtils
 import com.woocommerce.android.util.getOrAwaitValue
+import com.woocommerce.android.util.runAndCaptureValues
 import com.woocommerce.android.viewmodel.BaseUnitTest
 import com.woocommerce.android.viewmodel.MultiLiveEvent
 import com.woocommerce.android.viewmodel.ResourceProvider
@@ -51,6 +53,7 @@ import org.mockito.kotlin.anyVararg
 import org.mockito.kotlin.clearInvocations
 import org.mockito.kotlin.doReturn
 import org.mockito.kotlin.eq
+import org.mockito.kotlin.given
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.never
 import org.mockito.kotlin.spy
@@ -137,6 +140,7 @@ class ProductDetailViewModelTest : BaseUnitTest() {
     private val customFieldsRepository: CustomFieldsRepository = mock {
         onBlocking { hasDisplayableCustomFields(any()) } doReturn false
     }
+    private val canAutoAuthenticateInWebView: CanAutoAuthenticateInWebView = mock()
 
     private lateinit var viewModel: ProductDetailViewModel
 
@@ -279,7 +283,8 @@ class ProductDetailViewModelTest : BaseUnitTest() {
                 isProductCurrentlyPromoted = mock(),
                 isWindowClassLargeThanCompact = isWindowClassLargeThanCompact,
                 determineProductPasswordApi = determineProductPasswordApi,
-                customFieldsRepository = customFieldsRepository
+                customFieldsRepository = customFieldsRepository,
+                canAutoAuthenticateInWebView = canAutoAuthenticateInWebView,
             )
         )
 
@@ -1336,6 +1341,67 @@ class ProductDetailViewModelTest : BaseUnitTest() {
 
             // THEN
             Assertions.assertThat(viewModel.getProduct().subscriptionDraft).isEqualTo(originalSubscription)
+        }
+
+    @Test
+    fun `when a product is publish, then show the view product button`() = testBlocking {
+        given(productRepository.getProductAggregate(any())).willReturn(
+            productAggregate.copy(
+                product = productAggregate.product.copy(
+                    status = ProductStatus.PUBLISH
+                )
+            )
+        )
+
+        val menuButtonsState = viewModel.menuButtonsState.runAndCaptureValues {
+            viewModel.start()
+            // Observe the view state to trigger the menu buttons state
+            viewModel.productDetailViewStateData.observeForever { _, _ -> }
+        }.last()
+
+        Assertions.assertThat(menuButtonsState.viewProductOption).isTrue()
+    }
+
+    @Test
+    fun `given we can authenticate the user in WebView, when product is private, then show the view product button`() =
+        testBlocking {
+            given(canAutoAuthenticateInWebView.invoke(any())).willReturn(true)
+            given(productRepository.getProductAggregate(any())).willReturn(
+                productAggregate.copy(
+                    product = productAggregate.product.copy(
+                        status = ProductStatus.PRIVATE
+                    )
+                )
+            )
+
+            val menuButtonsState = viewModel.menuButtonsState.runAndCaptureValues {
+                viewModel.start()
+                // Observe the view state to trigger the menu buttons state
+                viewModel.productDetailViewStateData.observeForever { _, _ -> }
+            }.last()
+
+            Assertions.assertThat(menuButtonsState.viewProductOption).isTrue()
+        }
+
+    @Test
+    fun `given we can't authenticate the user in WebView, when product is private, then don't show the view product button`() =
+        testBlocking {
+            given(canAutoAuthenticateInWebView.invoke(any())).willReturn(false)
+            given(productRepository.getProductAggregate(any())).willReturn(
+                productAggregate.copy(
+                    product = productAggregate.product.copy(
+                        status = ProductStatus.PRIVATE
+                    )
+                )
+            )
+
+            val menuButtonsState = viewModel.menuButtonsState.runAndCaptureValues {
+                viewModel.start()
+                // Observe the view state to trigger the menu buttons state
+                viewModel.productDetailViewStateData.observeForever { _, _ -> }
+            }.last()
+
+            Assertions.assertThat(menuButtonsState.viewProductOption).isFalse()
         }
 
     private val productsDraft

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/products/details/ProductDetailViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/products/details/ProductDetailViewModelTest.kt
@@ -1404,6 +1404,32 @@ class ProductDetailViewModelTest : BaseUnitTest() {
             Assertions.assertThat(menuButtonsState.viewProductOption).isFalse()
         }
 
+    @Test
+    fun `given we can authenticate the user in WebView, when tapping on view product, then show authenticated webview`() =
+        testBlocking {
+            given(canAutoAuthenticateInWebView.invoke(any())).willReturn(true)
+            given(productRepository.getProductAggregate(any())).willReturn(productAggregate)
+
+            viewModel.start()
+            viewModel.onViewProductOnStoreLinkClicked()
+
+            Assertions.assertThat(viewModel.event.value)
+                .isEqualTo(MultiLiveEvent.Event.LaunchUrlInAuthenticatedWebView(productAggregate.product.permalink))
+        }
+
+    @Test
+    fun `given we can't authenticate the user in WebView, when tapping on view product, then show Chrome Custom Tab`() =
+        testBlocking {
+            given(canAutoAuthenticateInWebView.invoke(any())).willReturn(false)
+            given(productRepository.getProductAggregate(any())).willReturn(productAggregate)
+
+            viewModel.start()
+            viewModel.onViewProductOnStoreLinkClicked()
+
+            Assertions.assertThat(viewModel.event.value)
+                .isEqualTo(MultiLiveEvent.Event.LaunchUrlInChromeTab(productAggregate.product.permalink))
+        }
+
     private val productsDraft
         get() = viewModel.productDetailViewStateData.liveData.value?.productDraft
 }

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/products/details/ProductDetailViewModel_AddFlowTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/products/details/ProductDetailViewModel_AddFlowTest.kt
@@ -192,6 +192,7 @@ class ProductDetailViewModel_AddFlowTest : BaseUnitTest() {
                 isWindowClassLargeThanCompact = mock(),
                 determineProductPasswordApi = mock(),
                 customFieldsRepository = mock(),
+                canAutoAuthenticateInWebView = mock(),
             )
         )
 


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #13353 
<!-- Id number of the GitHub issue this PR addresses. -->

> [!NOTE]
> Depends on https://github.com/woocommerce/woocommerce-android/pull/13505 

### Description
Currently, when the user taps on the "View Product On Store", we open a Chrome Custom Tab, and given we can't ensure that the user is authenticated in the custom tab, then there could be some issues: if the product is not published or the store is not public.
So far, we have been hiding the button when the product is not public, but the issue was still present if the store is not public (either using WPCom visibility settings, or the new "coming soon" mode of Woo Core), and this PR attempts to improve the situation by using the Authenticated WebView whenever we can authenticate the user.

Given that the Product Details fragment can be hosted in a nested NavHostFragment (when the app is using a multi-pane layout), this PR adds a new way for handling the navigation from nested child fragments to destinations that are part of the root NavGraph, more details about this below in the comments.

**Important:** This doesn't solve all cases, because the issue will still be present for sites that don't support auto-autentication, and for this we are planning to research an alternative solution using a new API in the future.

### Steps to reproduce
##### TC1: Can auto authenticate
1. Use a site which supports auto authentication (Atomic site, Jetpack site with SSO or self-hosted site using site credentials natively)
2. Open product details of an existing product or create a new one.
3. Change the visibility of the product to private.
4. Confirm the button "View product on store" is visible.
5. Tap on the button.
6. Confirm that the Authenticated WebView is launched and you can see the product.
7. Repeat 3-6 with draft status.
8. Open WooCommerce > Settings> Site Visibility in wp-admin, and enable the Coming Soon mode.
9. Repeat 4-6.

##### TC2: Can't auto authenticate
1. Use a site that doesn't support auto authentication (Jetpack site without SSO, or self-hosted site using web authorization).
2. Open product details of an existing product or create a new one.
3. Change the visibility of the product to private.
4. Confirm the button "View product on store" is not shown.
5. Repeat 3-4 with draft status.

##### TC3: Confirm non-regression for shipping labels payment screen
1. Apply this [patch](https://github.com/user-attachments/files/18705724/part1.patch) (the patch will enable multi-pane layout for all devices, and will make testing the flow easier)
2. Make sure [WooCommerce Shipping & Tax](https://wordpress.org/plugins/woocommerce-services/) is installed in your website.
3. Open an order in the app.
4. Tap on Create Shipping Label.
5. This will open the payments directly due to the above patch.
6. Tap on "Add another credit card"
7. Confirm the WebView is opened correctly.
8. Apply this [patch](https://github.com/user-attachments/files/18706181/part.2.patch) (this patch will help simulating adding a new payment method, the webview will auto close upon loading)
9. Repeat 3-6.
10. Check logcat and confirm "DEBUG: WebView result received" was logged.


### Testing information
- Confirm that the "View Product on Store" is shown for products regardless of their visibility when we can authenticate the user.
- Confirm that the button is not shown for non-public products when we can't authenticate the user.
- Confirm that the Product Preview uses the Authenticated WebView when we can authenticate the user.
- Confirm that there is no regression in order details.

### The tests that have been performed
^

- [ ] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.

## Reviewer (or Author, in the case of optional code reviews):

Please make sure these conditions are met before approving the PR, or request changes if the PR needs improvement:

- [x] The PR is small and has a clear, single focus, or a valid explanation is provided in the description. If needed, please request to split it into smaller PRs.
- [x] Ensure Adequate Unit Test Coverage: The changes are reasonably covered by unit tests or an explanation is provided in the PR description.
- [x] Manual Testing: The author listed all the tests they ran, including smoke tests when needed (e.g., for refactorings). The reviewer confirmed that the PR works as expected on big (tablet) and small (phone) in case of UI changes, and no regressions are added.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->