### PR TITLE
Remove `wordpress-login` lib from fastlane

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -42,13 +42,6 @@ PROMO_SCREENSHOTS_DIR = File.join(Dir.pwd, 'screenshots', 'promo_screenshots')
 FROZEN_STRINGS_PATH = File.join(Dir.pwd, 'resources', 'values', 'strings.xml')
 REMOTE_LIBRARIES_STRINGS_PATHS = [
   {
-    name: 'Login Library',
-    import_key: 'wordpress-login',
-    repository: 'wordpress-mobile/WordPress-Login-Flow-Android',
-    strings_file_path: 'WordPressLoginFlow/src/main/res/values/strings.xml',
-    exclusions: ['default_web_client_id']
-  },
-  {
     name: 'About Library',
     import_key: 'automattic-about', # key used in libs.versions.toml file to reference the version
     repository: 'Automattic/about-automattic-android',


### PR DESCRIPTION
The goal of this PR is to fix failing 
`Run bundle exec fastlane complete_code_freeze.` step of the [release](https://mc.a8c.com/releases-v2/release.php?product=WCAndroid&version=21.7#milestone-99570) process.

This PR removes `wordpress-login` lib from `REMOTE_LIBRARIES_STRINGS_PATHS` in the Fastlane script. 

After FluxC and Wordpress-login dependencies were merged into `woocommerce-android` we don't need to download these dependencies anymore, since they are local modules in the project now.

