### PR TITLE
Authenticated WebView improvement [Part 3]

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/common/webview/WebViewAuthenticationFlowResolver.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/common/webview/WebViewAuthenticationFlowResolver.kt
@@ -14,7 +14,7 @@ class WebViewAuthenticationFlowResolver @Inject constructor(
 ) {
     // A list of domains that we know that wordpress.com supports redirecting to
     private val wpComAuthAcceptedDomains
-        get() = listOf("wordpress.com", "wp.com", "jetpack.com", "woocommerce.com")
+        get() = listOf("wordpress.com", "wp.com", "jetpack.com", "jetpack.wordpress.com", "woocommerce.com")
 
     fun resolve(url: String): WebViewAuthenticationFlow {
         val currentSite = selectedSite.getOrNull()

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/common/webview/WebViewAuthenticationFlowResolver.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/common/webview/WebViewAuthenticationFlowResolver.kt
@@ -24,8 +24,7 @@ class WebViewAuthenticationFlowResolver @Inject constructor(
 
         return if (isWPComAuthenticated) {
             when {
-                wpComAuthAcceptedDomains.any { it == urlDomain } ||
-                    (currentSite?.isWPComAtomic == true && url.isPartOf(currentSite)) -> {
+                wpComAuthAcceptedDomains.any { it == urlDomain } -> {
                     WebViewAuthenticationFlow.WPCom
                 }
 

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/common/webview/WebViewAuthenticationFlowResolverTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/common/webview/WebViewAuthenticationFlowResolverTest.kt
@@ -49,20 +49,6 @@ class WebViewAuthenticationFlowResolverTest {
     }
 
     @Test
-    fun `given WPCom authenticated and an atomic site, when resolving the authentication flow, then it should return WPCom`() {
-        givenWPComAuthenticated()
-        givenSite {
-            setIsWPComAtomic(true)
-            url = "https://example.com"
-        }
-        val url = "https://example.com/test"
-
-        val result = sut.resolve(url)
-
-        assertThat(result).isEqualTo(WebViewAuthenticationFlowResolver.WebViewAuthenticationFlow.WPCom)
-    }
-
-    @Test
     fun `given WPCom authenticated and a Jetpack SSO site, when resolving the authentication flow, then it should return JetpackSSO`() {
         givenWPComAuthenticated()
         givenSite {


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #13467 
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
~~This PR builds on top of what was added in #13487 and adds an additional handling for WebView authentication to the atomic sites, it fixes an issue that I identified while testing the Product Previews in #13494, for more details on the issue itself check: pe5sF9-3QB-p2#comment-4374.~~

~~For the fix, now we do the following for non-admin URLs:~~
~~1. We handle the Bearer token authentication with WordPress.com.~~
~~2. Then we load the site login URL with the redirect.~~

Edit: with new findings, this PR is now simpler, it just updates the flow to treat all Jetpack sites similarly, including Atomic sites, in other words, we don't have any specific check for atomic sites. Please check p1739778574675709-slack-C03L1NF1EA3 for more information.

With this PR, we now implement the whole flow as represented in this document pe5sF9-3Si-p2

### Steps to reproduce
For testing, please test the TC1 in #13494 using an Atomic website.

### Testing information
Confirm that the Authenticated WebView works well with non-admin URLs in atomic websites.

### The tests that have been performed
^

- [ ] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.

## Reviewer (or Author, in the case of optional code reviews):

Please make sure these conditions are met before approving the PR, or request changes if the PR needs improvement:

- [ ] The PR is small and has a clear, single focus, or a valid explanation is provided in the description. If needed, please request to split it into smaller PRs.
- [ ] Ensure Adequate Unit Test Coverage: The changes are reasonably covered by unit tests or an explanation is provided in the PR description.
- [ ] Manual Testing: The author listed all the tests they ran, including smoke tests when needed (e.g., for refactorings). The reviewer confirmed that the PR works as expected on big (tablet) and small (phone) in case of UI changes, and no regressions are added.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->