### PR TITLE
Remove custom modal bottom sheet implementation

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/compose/component/WCModalBottomSheetLayout.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/compose/component/WCModalBottomSheetLayout.kt
@@ -1,41 +1,17 @@
 package com.woocommerce.android.ui.compose.component
 
-import android.util.TypedValue
-import androidx.compose.foundation.background
 import androidx.compose.foundation.isSystemInDarkTheme
-import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.ColumnScope
-import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.imePadding
-import androidx.compose.foundation.layout.navigationBarsPadding
-import androidx.compose.foundation.layout.statusBarsPadding
 import androidx.compose.foundation.shape.RoundedCornerShape
-import androidx.compose.material.MaterialTheme
 import androidx.compose.material.ModalBottomSheetDefaults
 import androidx.compose.material.ModalBottomSheetLayout
 import androidx.compose.material.ModalBottomSheetState
-import androidx.compose.material.ModalBottomSheetValue
-import androidx.compose.material.contentColorFor
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.DisposableEffect
-import androidx.compose.runtime.LaunchedEffect
-import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.remember
-import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.Shape
-import androidx.compose.ui.graphics.toArgb
-import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.colorResource
 import androidx.compose.ui.res.dimensionResource
-import androidx.compose.ui.unit.Dp
-import androidx.core.view.WindowCompat
 import com.woocommerce.android.R
-import com.woocommerce.android.extensions.findActivity
-import com.woocommerce.android.util.SystemVersionUtils
 
 /**
  * A wrapper around [ModalBottomSheetLayout] that provides default values for the sheet shape and scrim color.
@@ -51,121 +27,14 @@ fun WCModalBottomSheetLayout(
     ),
     content: @Composable () -> Unit
 ) {
-    if (SystemVersionUtils.isAtMostU()) {
-        ModalBottomSheetLayoutWithStatusBarWorkaround(
-            sheetContent = sheetContent,
-            sheetShape = sheetShape,
-            sheetState = sheetState,
-            modifier = modifier,
-            content = content,
-        )
-    } else {
-        ModalBottomSheetLayout(
-            sheetContent = sheetContent,
-            sheetShape = sheetShape,
-            sheetState = sheetState,
-            scrimColor = scrimColor(),
-            modifier = modifier,
-            content = content
-        )
-    }
-}
-
-/*
- * This is a custom implementation of the ModalBottomSheetLayout that fixes the scrim color of the status bar
- * and the show animation.
- *
- * Source: https://stackoverflow.com/a/76998328
- *
- */
-@Suppress("DEPRECATION")
-@Composable
-private fun ModalBottomSheetLayoutWithStatusBarWorkaround(
-    sheetContent: @Composable ColumnScope.() -> Unit,
-    modifier: Modifier = Modifier,
-    sheetState: ModalBottomSheetState,
-    sheetShape: Shape = MaterialTheme.shapes.large,
-    sheetElevation: Dp = ModalBottomSheetDefaults.Elevation,
-    sheetBackgroundColor: Color = colorResource(id = R.color.bottom_sheet_background),
-    sheetContentColor: Color = contentColorFor(sheetBackgroundColor),
-    content: @Composable () -> Unit
-): Unit = ModalBottomSheetLayout(
-    sheetContent = {
-        Box(
-            modifier = Modifier
-                .fillMaxWidth()
-        ) {
-            sheetContent.invoke(this@ModalBottomSheetLayout)
-        }
-    },
-    sheetState = sheetState,
-    sheetShape = sheetShape,
-    sheetElevation = sheetElevation,
-    sheetBackgroundColor = sheetBackgroundColor,
-    sheetContentColor = sheetContentColor,
-    scrimColor = scrimColor(),
-    modifier = modifier
-        .imePadding()
-        .navigationBarsPadding()
-) {
-    val context = LocalContext.current
-    var statusBarColor by remember { mutableStateOf(Color.Transparent) }
-    val backgroundColor = remember {
-        val typedValue = TypedValue()
-        if (context.findActivity()?.theme?.resolveAttribute(
-                android.R.attr.windowBackground,
-                typedValue,
-                true
-            ) == true
-        ) {
-            Color(typedValue.data)
-        } else {
-            sheetBackgroundColor
-        }
-    }
-
-    Box(
-        modifier = Modifier
-            .fillMaxWidth()
-            .background(statusBarColor)
-            .statusBarsPadding()
-    ) {
-        Box(
-            modifier = Modifier
-                .background(backgroundColor)
-                .fillMaxSize()
-                .navigationBarsPadding()
-        ) {
-            content()
-        }
-    }
-
-    val window = remember { context.findActivity()?.window }
-    if (window == null) return@ModalBottomSheetLayout
-
-    val originalNavigationBarColor = remember { window.navigationBarColor }
-
-    LaunchedEffect(sheetState.currentValue) {
-        if (sheetState.currentValue != ModalBottomSheetValue.Hidden) {
-            window.navigationBarColor = sheetBackgroundColor.toArgb()
-        } else {
-            window.navigationBarColor = originalNavigationBarColor
-        }
-    }
-
-    DisposableEffect(Unit) {
-        val originalStatusBarColor = window.statusBarColor
-        statusBarColor = Color(originalStatusBarColor)
-
-        window.statusBarColor = android.graphics.Color.TRANSPARENT
-        WindowCompat.setDecorFitsSystemWindows(window, false)
-
-        onDispose {
-            window.statusBarColor = originalStatusBarColor
-            window.navigationBarColor = originalNavigationBarColor
-            WindowCompat.setDecorFitsSystemWindows(window, true)
-        }
-    }
+    ModalBottomSheetLayout(
+        sheetContent = sheetContent,
+        sheetShape = sheetShape,
+        sheetState = sheetState,
+        scrimColor = scrimColor(),
+        modifier = modifier,
+        content = content
+    )
 }
 
 // Overriding scrim color for dark theme because of the following bug affecting ModalBottomSheetLayout:


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #13495 
<!-- Id number of the GitHub issue this PR addresses. -->

⚠️ Release fix for `21.7`

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs, try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

This adds a quick and temporary fix to the issue where the status bar appears black after entering the Blaze campaign list (or any other screen that has a `WCModalBottomSheetLayout` in it) and navigating back in any Android device below API 15. More details: peaMlT-18m-p2
This issue has started happening since we updated the `compileSdkVersion = 35`. 

See the screenshots in the linked [GH issue](https://github.com/woocommerce/woocommerce-android/issues/13495).

The side effect of the changes applied in this PR is that the bottom sheet now won't be "edge to edge" on Android < 15. Essentially, the status bar won't be covered by the scrim color. But I think is a minor tradeoff considering the unwanted side effect of the workaround we are applying in `ModalBottomSheetLayoutWithStatusBarWorkaround` is causing. See the screen recording below:

https://github.com/user-attachments/assets/ef63ee1b-e511-4d79-932d-d861bce3235e

The proper fix to this is applied in [this PR](https://github.com/woocommerce/woocommerce-android/pull/13506). It is a much bigger change so I'd rather apply this small and safe fix to `release/21.7` and safely merge the bigger changes in `trunk`.

### Steps to reproduce
<!-- Step-by-step testing instructions. For new user flows, consider instead stating the goal of the workflow and see if your PR reviewer can accomplish the workflow without specific steps! -->
From `trunk`: 
1. Run the app and log into a site with Blaze enabled
2. Open Blaze campaign list screen or open Blaze intro screen if you don't have any campaign created
3. Navigate back and start seeing the black toolbar and sometimes navigation bar issue. 

### Testing information
<!-- This is your opportunity to break out individual scenarios that need testing (when necessary) and/or include a checklist for the reviewer to go through. Consider documenting the following from your own completed testing: devices used, alternate workflows, edge cases, affected areas, critical flows, areas not tested, and any remaining unknowns. Provide feedback on this new section of the PR template through Sept 30, 2024 to Apps Quality; additional context here: p91TBi-b8z-p2#comment-12036 -->

Repeat the steps from above and check that the black status bar and toolbar issue is gone. 

### The tests that have been performed
<!-- To give the reviewer an idea of what could be missed in terms of testing -->

The above. 

### Images/gif
<!-- Include before and after images or gifs when appropriate. -->

https://github.com/user-attachments/assets/62acd86f-3183-47c0-b550-850ed4979c0c

- [X] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.

## Reviewer (or Author, in the case of optional code reviews):

Please make sure these conditions are met before approving the PR, or request changes if the PR needs improvement:

- [x] The PR is small and has a clear, single focus, or a valid explanation is provided in the description. If needed, please request to split it into smaller PRs.
- [x] Ensure Adequate Unit Test Coverage: The changes are reasonably covered by unit tests or an explanation is provided in the PR description.
- [x] Manual Testing: The author listed all the tests they ran, including smoke tests when needed (e.g., for refactorings). The reviewer confirmed that the PR works as expected on big (tablet) and small (phone) in case of UI changes, and no regressions are added.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->