### PR TITLE
[Woo POS][Non-Simple Products] Change variation display order

### DIFF
--- a/libs/fluxc-plugin/src/main/kotlin/org/wordpress/android/fluxc/persistence/ProductSqlUtils.kt
+++ b/libs/fluxc-plugin/src/main/kotlin/org/wordpress/android/fluxc/persistence/ProductSqlUtils.kt
@@ -445,7 +445,7 @@ object ProductSqlUtils {
                 .equals(WCProductVariationModelTable.REMOTE_PRODUCT_ID, remoteProductId)
                 .equals(WCProductVariationModelTable.LOCAL_SITE_ID, site.id)
                 .endGroup().endWhere()
-                .orderBy(WCProductVariationModelTable.DATE_CREATED, SelectQuery.ORDER_ASCENDING)
+                .orderBy(WCProductVariationModelTable.MENU_ORDER, SelectQuery.ORDER_ASCENDING)
                 .asModel
     }
 


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #13528 
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
This PR fixes an inconsistency in the fetching logic of variations from the database. Previously, variations were ordered by `menu_order` when making the API call but retrieved from the database using `date_created`, leading to pagination issues. This update ensures that variations are consistently ordered by menu_order in both the API request and database retrieval, aligning the display order and preventing unexpected pagination behaviour.

### Steps to reproduce
<!-- Step-by-step testing instructions. For new user flows, consider instead stating the goal of the workflow and see if your PR reviewer can accomplish the workflow without specific steps! -->
1. In your store's wp-admin, edit an existing variable product that already has some variations.
2. Add a couple more variations to this product and save the changes.
3. In the WooCommerce app, navigate to Menu → POS.
4. Open the specific variable product where you added new variations.
5. Scroll down the first page of variations.
6. Observe that when pagination occurs, the variations appear in an unexpected order.


### The tests that have been performed
<!-- To give the reviewer an idea of what could be missed in terms of testing -->
Tested this on Pixel tablet emulator

### Images/gif
<!-- Include before and after images or gifs when appropriate. -->

https://github.com/user-attachments/assets/9f0b2d50-309d-4254-8891-57521d106105


- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.

## Reviewer (or Author, in the case of optional code reviews):

Please make sure these conditions are met before approving the PR, or request changes if the PR needs improvement:

- [x] The PR is small and has a clear, single focus, or a valid explanation is provided in the description. If needed, please request to split it into smaller PRs.
- [x] Ensure Adequate Unit Test Coverage: The changes are reasonably covered by unit tests or an explanation is provided in the PR description.
- [x] Manual Testing: The author listed all the tests they ran, including smoke tests when needed (e.g., for refactorings). The reviewer confirmed that the PR works as expected on big (tablet) and small (phone) in case of UI changes, and no regressions are added.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->