### PR TITLE
[Woo POS][Non-Simple Products] Remove unsupported products from paginated results 

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/selector/ProductListHandler.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/selector/ProductListHandler.kt
@@ -77,10 +77,16 @@ class ProductListHandler @Inject constructor(private val repository: ProductSele
 
     // The implementation of loadMore has limited functionality. Essentially, more items from local cache are loaded
     // only after the remote request to fetch the previous page finishes successfully.
-    suspend fun loadMore(orderCurrency: String? = null) = mutex.withLock {
+    suspend fun loadMore(
+        includeTypes: List<WCProductStore.IncludeType> = emptyList(),
+        orderCurrency: String? = null
+    ) = mutex.withLock {
         if (!canLoadMore.get()) return@withLock Result.success(Unit)
         if (searchQuery.value.isEmpty()) {
-            fetchProducts(orderCurrency = orderCurrency)
+            fetchProducts(
+                includeTypes = includeTypes,
+                orderCurrency = orderCurrency
+            )
         } else {
             searchInCache()
             remoteSearch()

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/selector/ProductSelectorViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/selector/ProductSelectorViewModel.kt
@@ -540,7 +540,7 @@ class ProductSelectorViewModel @Inject constructor(
         loadMoreJob?.cancel()
         loadMoreJob = viewModelScope.launch {
             loadingState.value = APPENDING
-            listHandler.loadMore(navArgs.orderCurrency)
+            listHandler.loadMore(orderCurrency = navArgs.orderCurrency)
             loadingState.value = IDLE
         }
     }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/items/products/WooPosProductsDataSource.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/items/products/WooPosProductsDataSource.kt
@@ -61,7 +61,9 @@ class WooPosProductsDataSource @Inject constructor(
     }.flowOn(Dispatchers.IO).take(2)
 
     suspend fun loadMore(): Result<List<Product>> = withContext(Dispatchers.IO) {
-        val result = handler.loadMore()
+        val result = handler.loadMore(
+            includeTypes = listOf(WCProductStore.IncludeType.Simple, WCProductStore.IncludeType.Variable),
+        )
         if (result.isSuccess) {
             val moreProducts = handler.productsFlow.first()
             updateProductCache(moreProducts)

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/home/items/WooPosProductsDataSourceTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/home/items/WooPosProductsDataSourceTest.kt
@@ -15,6 +15,7 @@ import org.mockito.kotlin.any
 import org.mockito.kotlin.eq
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.whenever
+import org.wordpress.android.fluxc.store.WCProductStore
 import java.util.concurrent.atomic.AtomicBoolean
 import kotlin.test.Test
 import kotlin.test.assertEquals
@@ -214,7 +215,12 @@ class WooPosProductsDataSourceTest {
             whenever(handler.canLoadMore).thenReturn(AtomicBoolean(true))
             whenever(handler.productsFlow).thenReturn(flowOf(sampleProducts))
             val exception = Exception("Load more failed")
-            whenever(handler.loadMore()).thenReturn(Result.failure(exception))
+            whenever(
+                handler.loadMore(
+                    includeTypes = listOf(WCProductStore.IncludeType.Simple, WCProductStore.IncludeType.Variable),
+                    orderCurrency = null
+                )
+            ).thenReturn(Result.failure(exception))
             val sut = WooPosProductsDataSource(handler)
 
             sut.loadSimpleProducts(forceRefreshProducts = false).first()


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #13529
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
This PR passes in `include_types` parameter while loading more products. Without this parameter, the API returns all kinds of products which we do not want in POS. 

With this change, we pass in `simple` and `variable` type and the API returns just these.

### Steps to reproduce
<!-- Step-by-step testing instructions. For new user flows, consider instead stating the goal of the workflow and see if your PR reviewer can accomplish the workflow without specific steps! -->
1. Navigate to POS (menu -> POS)
2. Scroll down products list
3. When it paginates, notice that it starts displaying products other than Simple and Variable products

### The tests that have been performed
<!-- To give the reviewer an idea of what could be missed in terms of testing -->
Tested on Pixel tablet emulator

### Images/gif
<!-- Include before and after images or gifs when appropriate. -->

https://github.com/user-attachments/assets/29d95110-17f9-47be-8962-ce4aa2eb67c9



- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.

## Reviewer (or Author, in the case of optional code reviews):

Please make sure these conditions are met before approving the PR, or request changes if the PR needs improvement:

- [ ] The PR is small and has a clear, single focus, or a valid explanation is provided in the description. If needed, please request to split it into smaller PRs.
- [ ] Ensure Adequate Unit Test Coverage: The changes are reasonably covered by unit tests or an explanation is provided in the PR description.
- [ ] Manual Testing: The author listed all the tests they ran, including smoke tests when needed (e.g., for refactorings). The reviewer confirmed that the PR works as expected on big (tablet) and small (phone) in case of UI changes, and no regressions are added.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->