### PR TITLE
[Tooling] Extract download translations to separate process

### DIFF
--- a/.buildkite/release-pipelines/download-release-translations.yml
+++ b/.buildkite/release-pipelines/download-release-translations.yml
@@ -1,0 +1,23 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/buildkite/pipeline-schema/main/schema.json
+---
+
+steps:
+  - label: "Download Release Translations"
+    plugins: [$CI_TOOLKIT]
+    command: |
+      echo '--- :robot_face: Use bot for git operations'
+      source use-bot-for-git
+
+      .buildkite/commands/checkout-release-branch.sh "$RELEASE_VERSION"
+
+      echo '--- :ruby: Setup Ruby Tools'
+      install_gems
+
+      echo '--- :globe_with_meridians: Download Release Translations'
+      bundle exec fastlane download_release_translations skip_confirm:true include_wear_app:"${INCLUDE_WEAR_APP:-false}"
+    agents:
+        queue: "tumblr-metal"
+    retry:
+      manual:
+        # If those jobs fail, one should always prefer re-triggering a new build from ReleaseV2 rather than retrying the individual job from Buildkite
+        allowed: false

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -431,6 +431,40 @@ platform :android do
     )
   end
 
+  # This lane downloads the latest translations and commits them
+  #
+  # @param [Boolean] skip_confirm (default: false) If set, will skip the confirmation prompt before running the rest of the lane
+  # @param [Boolean] include_wear_app (default: false) If true, will also download translations for the Wear app
+  #
+  # @example Running the lane
+  #          bundle exec fastlane download_release_translations skip_confirm:true include_wear_app:true
+  #
+  desc 'Downloads and commits the latest translations before finalizing a release'
+  lane :download_release_translations do |skip_confirm: false, include_wear_app: false|
+    ensure_git_status_clean
+    ensure_git_branch_is_release_branch!
+
+    UI.important("Downloading latest translations for release: #{release_version_current}")
+    UI.user_error!("Terminating as requested. Don't forget to run the remainder of this automation manually.") unless skip_confirm || UI.confirm('Do you want to continue?')
+
+    configure_apply(force: is_ci)
+
+    # Don't check translation coverage in CI
+    check_translation_progress_all unless is_ci
+    download_translations
+
+    # Download metadata strings for both apps
+    download_metadata_strings(version: release_version_current, app: MOBILE_APP)
+    download_metadata_strings(version: release_version_current, app: WEAR_APP) if include_wear_app
+
+    UI.important('Pushing changes to remote')
+    UI.user_error!("Terminating as requested. Don't forget to run the remainder of this automation manually.") unless is_ci || UI.confirm('Do you want to continue?')
+
+    push_to_git_remote(tags: false)
+
+    UI.success("Successfully downloaded and committed latest translations for #{release_version_current}")
+  end
+
   # This lane finalizes a release: updates store metadata and runs the release checks.
   #
   # @param [Boolean] skip_confirm (default: false) If set, will skip the confirmation prompt before running the rest of the lane
@@ -450,10 +484,6 @@ platform :android do
 
     configure_apply(force: is_ci)
 
-    # Don't check translation coverage in CI
-    check_translation_progress_all unless is_ci
-    download_translations
-
     # Bump the release version and build code
     UI.message 'Bumping final release version and build code...'
     VERSION_FILE.write_version(
@@ -464,9 +494,6 @@ platform :android do
     UI.success("Done! New Release Version: #{release_version_current}. New Build Code: #{build_code_current}")
 
     version = release_version_current
-
-    download_metadata_strings(version: version, app: MOBILE_APP)
-    download_metadata_strings(version: version, app: WEAR_APP) if include_wear_app
 
     # Start the build
     UI.important('Pushing changes to remote and triggering the release build')


### PR DESCRIPTION
Internal request: https://wp.me/pdnsEh-210-p2

## Description
This PR extracts the lane `download_release_translations` from the `finalize_release` lane, containing the calls to download the translations and creates a corresponding `download-release-translations.yml` release pipeline.
