### PR TITLE
Prevent a crash when tapping back on the variation detail screen

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/variations/VariationDetailFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/variations/VariationDetailFragment.kt
@@ -114,6 +114,8 @@ class VariationDetailFragment :
             onCreateMenu = { toolbar ->
                 toolbar.setNavigationOnClickListener {
                     if (onRequestAllowBackPress()) {
+                        // Ensure Exit events are ignored to avoid IllegalStateException
+                        viewModel.event.removeObservers(viewLifecycleOwner)
                         findNavController().navigateUp()
                     }
                 }


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #13226 
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
Our previous attempt (#13281) didn't fix this crash. I investigated it and here's what I found:
- `requireActivity().onBackPressedDispatcher.onBackPressed()` in `VariationDetailFragment` crashes with `FragmentManager is already executing transactions` message, meaning another process (e.g., onBack or opening a dialog) is in progress when we're trying to call `onBackPressedDispatcher.onBackPressed()`
- All crashes in error logs occur with a network error, meaning `fetchVariation()` is failing.
- We don't know where the `Exit` event is coming from, but when `fetchVariation()` fails, we [trigger Exit](https://github.com/woocommerce/woocommerce-android/blob/trunk/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/variations/VariationDetailViewModel.kt#L388) event without user interaction, which might be causing the crash.
- Another possible cause is [findNavController().navigateUp()](https://github.com/woocommerce/woocommerce-android/blob/a857ec25919a209a7f064e3df3da9f25ea671e5c/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/variations/VariationDetailFragment.kt#L119) which bypasses the `Exit` event when the toolbar back button is clicked.
- Since `Exit` event can be triggered without user interaction while `findNavController().navigateUp()` can be invoked with user interaction, this might be causing the crash.
- I couldn’t reproduce this issue, even after modifying the code to force it.

I removed observers before calling `findNavController().navigateUp()`. I'm not sure if this will fix the issue, but it seems like a reasonable attempt, we’ll see.

### Steps to reproduce
<!-- Step-by-step testing instructions. For new user flows, consider instead stating the goal of the workflow and see if your PR reviewer can accomplish the workflow without specific steps! -->
I can’t reproduce it. Open the variation detail screen and tap the top back button to confirm nothing is broken.

### The tests that have been performed
<!-- To give the reviewer an idea of what could be missed in terms of testing -->
Above

### Images/gif
<!-- Include before and after images or gifs when appropriate. -->
No UI change

- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.

## Reviewer (or Author, in the case of optional code reviews):

Please make sure these conditions are met before approving the PR, or request changes if the PR needs improvement:

- [ ] The PR is small and has a clear, single focus, or a valid explanation is provided in the description. If needed, please request to split it into smaller PRs.
- [ ] Ensure Adequate Unit Test Coverage: The changes are reasonably covered by unit tests or an explanation is provided in the PR description.
- [ ] Manual Testing: The author listed all the tests they ran, including smoke tests when needed (e.g., for refactorings). The reviewer confirmed that the PR works as expected on big (tablet) and small (phone) in case of UI changes, and no regressions are added.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->