### PR TITLE
Normalize address

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/compose/component/WCModalBottomSheet.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/compose/component/WCModalBottomSheet.kt
@@ -1,6 +1,8 @@
 package com.woocommerce.android.ui.compose.component
 
 import androidx.compose.foundation.layout.ColumnScope
+import androidx.compose.foundation.layout.WindowInsets
+import androidx.compose.material3.BottomSheetDefaults
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.ModalBottomSheet
@@ -20,6 +22,7 @@ fun WCModalBottomSheet(
     sheetState: SheetState,
     onDismissRequest: () -> Unit,
     modifier: Modifier = Modifier,
+    contentWindowInsets: @Composable () -> WindowInsets = { BottomSheetDefaults.windowInsets },
     shape: Shape = RoundedCornerShape(topStart = 8.dp, topEnd = 8.dp),
     content: @Composable ColumnScope.() -> Unit,
 ) {
@@ -28,6 +31,7 @@ fun WCModalBottomSheet(
         onDismissRequest = onDismissRequest,
         modifier = modifier,
         sheetState = sheetState,
+        contentWindowInsets = contentWindowInsets,
         shape = shape,
         content = content
     )

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/compose/component/WCModalBottomSheet.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/compose/component/WCModalBottomSheet.kt
@@ -2,8 +2,8 @@ package com.woocommerce.android.ui.compose.component
 
 import androidx.compose.foundation.layout.ColumnScope
 import androidx.compose.foundation.layout.WindowInsets
-import androidx.compose.material3.BottomSheetDefaults
 import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.BottomSheetDefaults
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.ModalBottomSheet
 import androidx.compose.material3.SheetState

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/ShipmentDetails.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/ShipmentDetails.kt
@@ -225,7 +225,7 @@ private fun ShipmentDetailsLandscape(
 }
 
 @Composable
-internal fun ShipmentDetailsSectionTitle(
+fun ShipmentDetailsSectionTitle(
     title: String,
     modifier: Modifier = Modifier
 ) {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/address/AddressSection.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/address/AddressSection.kt
@@ -372,7 +372,7 @@ fun AddressSelection(
             LazyColumn {
                 items(originAddresses) { option ->
                     val isSelected = option == shipFrom
-                    AddressSelectionItem(
+                    OriginAddressSelectionItem(
                         address = option,
                         isSelected = isSelected,
                         onEdit = onEditOriginAddress,
@@ -398,7 +398,7 @@ fun AddressSelection(
 }
 
 @Composable
-fun AddressSelectionItem(
+fun OriginAddressSelectionItem(
     address: OriginShippingAddress,
     isSelected: Boolean,
     onClick: () -> Unit,

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/address/WooShippingEditAddressScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/address/WooShippingEditAddressScreen.kt
@@ -11,11 +11,15 @@ import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.navigationBars
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.sizeIn
+import androidx.compose.foundation.layout.statusBars
+import androidx.compose.foundation.layout.windowInsetsPadding
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.CornerSize
 import androidx.compose.foundation.shape.RoundedCornerShape
@@ -25,7 +29,6 @@ import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.CircularProgressIndicator
 import androidx.compose.material.Icon
-import androidx.compose.material.IconButton
 import androidx.compose.material.MaterialTheme
 import androidx.compose.material.Scaffold
 import androidx.compose.material.SnackbarDuration
@@ -38,21 +41,23 @@ import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material.icons.filled.Add
 import androidx.compose.material.icons.filled.ArrowDropDown
+import androidx.compose.material.icons.filled.Close
 import androidx.compose.material.icons.outlined.CheckCircleOutline
 import androidx.compose.material.icons.outlined.Info
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.IconButton
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.focus.FocusRequester
 import androidx.compose.ui.focus.focusRequester
-import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalSoftwareKeyboardController
 import androidx.compose.ui.res.colorResource
 import androidx.compose.ui.res.dimensionResource
-import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.input.ImeAction
@@ -65,68 +70,63 @@ import com.woocommerce.android.extensions.isNotNullOrEmpty
 import com.woocommerce.android.model.Address
 import com.woocommerce.android.ui.compose.component.Toolbar
 import com.woocommerce.android.ui.compose.component.WCColoredButton
+import com.woocommerce.android.ui.compose.component.WCModalBottomSheet
+import com.woocommerce.android.ui.compose.component.dismissWCModalBottomSheet
 import com.woocommerce.android.ui.compose.theme.WooThemeWithBackground
 import com.woocommerce.android.ui.orders.wooshippinglabels.RoundedCornerBoxWithBorder
 import com.woocommerce.android.ui.orders.wooshippinglabels.ShipmentDetailsSectionTitle
 import com.woocommerce.android.ui.orders.wooshippinglabels.address.origin.AddressStatus
 import com.woocommerce.android.ui.orders.wooshippinglabels.address.origin.EditableAddress
-import com.woocommerce.android.ui.orders.wooshippinglabels.address.origin.NormalizedAddressSelection
+import com.woocommerce.android.ui.orders.wooshippinglabels.address.origin.NormalizedAddressStatus
 import com.woocommerce.android.ui.orders.wooshippinglabels.address.origin.WooShippingEditOriginViewModel
-import com.woocommerce.android.ui.orders.wooshippinglabels.models.OriginShippingAddress
 import com.woocommerce.android.ui.orders.wooshippinglabels.purchased.successColor
 import com.woocommerce.android.ui.orders.wooshippinglabels.rates.ui.shippingSelectedBackgroundColor
-import com.woocommerce.android.ui.orders.wooshippinglabels.toShippingFromString
 
 @Composable
 fun WooShippingEditAddressScreen(
     viewModel: WooShippingEditOriginViewModel,
     modifier: Modifier = Modifier
 ) {
-    when (val viewState = viewModel.viewState.collectAsState().value) {
-        is WooShippingEditOriginViewModel.EditAddressViewState.DataState -> {
-            EditAddress(
-                editableAddress = viewState.editableAddress,
-                isCompanyExpanded = viewState.isCompanyExpanded,
-                shouldDisplayLoadingCountries = viewState.shouldDisplayLoading,
-                shouldDisplayLoadingCountriesError = viewState.shouldDisplayLoadingCountriesError,
-                shouldUseStatesInput = viewState.shouldUseStatesInput,
-                addressStatus = viewState.addressStatus,
-                onExpandCompany = viewModel::onExpandCompany,
-                onNameChange = viewModel::onNameChange,
-                onCompanyChange = viewModel::onCompanyChange,
-                onAddressChange = viewModel::onAddressChange,
-                onCityChange = viewModel::onCityChange,
-                onPostalCodeChange = viewModel::onPostalCodeChange,
-                onEmailChange = viewModel::onEmailChange,
-                onPhoneChange = viewModel::onPhoneChange,
-                onCountryChange = viewModel::onCountryChange,
-                onRefreshCountries = viewModel::onRefreshCountries,
-                onRawStateChange = viewModel::onRawStateChange,
-                onStateChange = viewModel::onStateChange,
-                onNormalizeAddress = viewModel::onNormalizeAddress,
-                modifier = modifier
-            )
-        }
-
-        is WooShippingEditOriginViewModel.EditAddressViewState.AddressSelectionState -> {
-            SelectAddress(
-                addressSelection = viewState.addressSelection,
-                onAddressSelectionChange = viewModel::onAddressSelectionChange,
-                onCloseAddressSelection = viewModel::onCloseAddressSelection,
-                modifier = modifier
-            )
-        }
-    }
+    val viewState = viewModel.viewState.collectAsState().value
+    WooShippingEditAddressScreen(
+        editableAddress = viewState.editableAddress,
+        isCompanyExpanded = viewState.isCompanyExpanded,
+        shouldDisplayLoadingCountries = viewState.shouldDisplayLoading,
+        shouldDisplayLoadingCountriesError = viewState.shouldDisplayLoadingCountriesError,
+        shouldUseStatesInput = viewState.shouldUseStatesInput,
+        addressStatus = viewState.addressStatus,
+        addressSelection = viewState.addressSelection,
+        onAddressSelectionChange = viewModel::onAddressSelectionChange,
+        onCloseAddressSelection = viewModel::onCloseAddressSelection,
+        onExpandCompany = viewModel::onExpandCompany,
+        onNameChange = viewModel::onNameChange,
+        onCompanyChange = viewModel::onCompanyChange,
+        onAddressChange = viewModel::onAddressChange,
+        onCityChange = viewModel::onCityChange,
+        onPostalCodeChange = viewModel::onPostalCodeChange,
+        onEmailChange = viewModel::onEmailChange,
+        onPhoneChange = viewModel::onPhoneChange,
+        onCountryChange = viewModel::onCountryChange,
+        onRefreshCountries = viewModel::onRefreshCountries,
+        onRawStateChange = viewModel::onRawStateChange,
+        onStateChange = viewModel::onStateChange,
+        onNormalizeAddress = viewModel::onNormalizeAddress,
+        modifier = modifier
+    )
 }
 
+@OptIn(ExperimentalMaterial3Api::class)
 @Composable
-fun EditAddress(
+fun WooShippingEditAddressScreen(
     editableAddress: EditableAddress,
     shouldDisplayLoadingCountries: Boolean,
     shouldDisplayLoadingCountriesError: Boolean,
     shouldUseStatesInput: Boolean,
     isCompanyExpanded: Boolean,
     addressStatus: AddressStatus,
+    addressSelection: NormalizedAddressStatus,
+    onAddressSelectionChange: (NormalizedAddressStatus.AddressSelection) -> Unit,
+    onCloseAddressSelection: () -> Unit,
     onExpandCompany: () -> Unit,
     onNameChange: (String) -> Unit,
     onCompanyChange: (String) -> Unit,
@@ -364,6 +364,43 @@ fun EditAddress(
                     modifier = Modifier
                         .fillMaxWidth()
                         .padding(16.dp)
+                )
+            }
+        }
+
+        val modalSheetState = androidx.compose.material3.rememberModalBottomSheetState(
+            skipPartiallyExpanded = true
+        )
+        val coroutineScope = rememberCoroutineScope()
+
+        LaunchedEffect(addressSelection) {
+            when (addressSelection) {
+                is NormalizedAddressStatus.AddressSelection -> {
+                    modalSheetState.show()
+                }
+
+                else -> {
+                    modalSheetState.hide()
+                }
+            }
+        }
+
+        if (addressSelection is NormalizedAddressStatus.AddressSelection) {
+            WCModalBottomSheet(
+                sheetState = modalSheetState,
+                onDismissRequest = { onCloseAddressSelection() },
+                contentWindowInsets = { WindowInsets.statusBars }
+            ) {
+                SelectAddress(
+                    addressSelection = addressSelection,
+                    onAddressSelectionChange = onAddressSelectionChange,
+                    onCloseAddressSelection = {
+                        dismissWCModalBottomSheet(
+                            coroutineScope = coroutineScope,
+                            modalSheetState = modalSheetState,
+                            invokeOnCompletion = onCloseAddressSelection
+                        )
+                    }
                 )
             }
         }
@@ -636,24 +673,36 @@ private fun CollapsedField(
 
 @Composable
 private fun SelectAddress(
-    addressSelection: NormalizedAddressSelection.AddressSelection,
-    onAddressSelectionChange: (NormalizedAddressSelection.AddressSelection) -> Unit,
+    addressSelection: NormalizedAddressStatus.AddressSelection,
+    onAddressSelectionChange: (NormalizedAddressStatus.AddressSelection) -> Unit,
     onCloseAddressSelection: () -> Unit,
     modifier: Modifier = Modifier
 ) {
     Column(modifier = modifier) {
-        Column(modifier = Modifier
-            .padding(16.dp)
-            .weight(1f)
-            .verticalScroll(rememberScrollState())) {
+        IconButton(onClick = onCloseAddressSelection) {
+            Icon(
+                imageVector = Icons.Filled.Close,
+                contentDescription = null,
+                tint = MaterialTheme.colors.onSurface
+            )
+        }
+        Column(
+            modifier = Modifier
+                .padding(vertical = 24.dp, horizontal = 16.dp)
+                .weight(1f)
+                .verticalScroll(rememberScrollState())
+        ) {
             Text(
                 text = stringResource(id = R.string.woo_shipping_confirm_address_title),
-                style = MaterialTheme.typography.h4,
-                modifier = Modifier.padding(bottom = 16.dp)
+                style = MaterialTheme.typography.h5,
+                modifier = Modifier.padding(bottom = 16.dp),
+                fontWeight = FontWeight.Bold
             )
             Text(
                 text = stringResource(id = R.string.woo_shipping_confirm_address_description),
-                modifier = Modifier.padding(bottom = 16.dp).clickable { onCloseAddressSelection() }
+                modifier = Modifier
+                    .padding(bottom = 16.dp)
+                    .clickable { onCloseAddressSelection() }
             )
             ShipmentDetailsSectionTitle(
                 title = stringResource(id = R.string.woo_shipping_confirm_address_entered),
@@ -668,7 +717,9 @@ private fun SelectAddress(
                         addressSelection.copy(selectedAddress = addressSelection.addressNormalization.address)
                     )
                 },
-                modifier = Modifier.fillMaxWidth().padding(bottom = 16.dp)
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(bottom = 16.dp)
             )
 
             ShipmentDetailsSectionTitle(
@@ -687,6 +738,27 @@ private fun SelectAddress(
                 },
                 modifier = Modifier.fillMaxWidth()
             )
+        }
+
+        val buttonText = if (addressSelection.selectedAddress == addressSelection.addressNormalization.address) {
+            stringResource(id = R.string.woo_shipping_confirm_submit_address_entered)
+        } else {
+            stringResource(id = R.string.woo_shipping_confirm_submit_address_suggested)
+        }
+
+        Surface(elevation = 8.dp) {
+            Box(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(16.dp)
+                    .windowInsetsPadding(WindowInsets.navigationBars)
+            ) {
+                WCColoredButton(
+                    onClick = {},
+                    text = buttonText,
+                    modifier = Modifier.fillMaxWidth()
+                )
+            }
         }
     }
 }
@@ -723,7 +795,6 @@ private fun AddressSelectionItem(
     ) {
         Text(
             text = address.toString(),
-            fontWeight = FontWeight.Bold,
             modifier = Modifier
         )
     }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/address/WooShippingEditAddressScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/address/WooShippingEditAddressScreen.kt
@@ -2,6 +2,7 @@ package com.woocommerce.android.ui.orders.wooshippinglabels.address
 
 import android.content.res.Configuration
 import androidx.compose.animation.AnimatedContent
+import androidx.compose.animation.animateColorAsState
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.focusable
@@ -24,6 +25,7 @@ import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.CircularProgressIndicator
 import androidx.compose.material.Icon
+import androidx.compose.material.IconButton
 import androidx.compose.material.MaterialTheme
 import androidx.compose.material.Scaffold
 import androidx.compose.material.SnackbarDuration
@@ -46,8 +48,11 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.focus.FocusRequester
 import androidx.compose.ui.focus.focusRequester
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalSoftwareKeyboardController
 import androidx.compose.ui.res.colorResource
+import androidx.compose.ui.res.dimensionResource
+import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.input.ImeAction
@@ -57,14 +62,20 @@ import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import com.woocommerce.android.R
 import com.woocommerce.android.extensions.isNotNullOrEmpty
+import com.woocommerce.android.model.Address
 import com.woocommerce.android.ui.compose.component.Toolbar
 import com.woocommerce.android.ui.compose.component.WCColoredButton
 import com.woocommerce.android.ui.compose.theme.WooThemeWithBackground
 import com.woocommerce.android.ui.orders.wooshippinglabels.RoundedCornerBoxWithBorder
+import com.woocommerce.android.ui.orders.wooshippinglabels.ShipmentDetailsSectionTitle
 import com.woocommerce.android.ui.orders.wooshippinglabels.address.origin.AddressStatus
 import com.woocommerce.android.ui.orders.wooshippinglabels.address.origin.EditableAddress
+import com.woocommerce.android.ui.orders.wooshippinglabels.address.origin.NormalizedAddressSelection
 import com.woocommerce.android.ui.orders.wooshippinglabels.address.origin.WooShippingEditOriginViewModel
+import com.woocommerce.android.ui.orders.wooshippinglabels.models.OriginShippingAddress
 import com.woocommerce.android.ui.orders.wooshippinglabels.purchased.successColor
+import com.woocommerce.android.ui.orders.wooshippinglabels.rates.ui.shippingSelectedBackgroundColor
+import com.woocommerce.android.ui.orders.wooshippinglabels.toShippingFromString
 
 @Composable
 fun WooShippingEditAddressScreen(
@@ -73,7 +84,7 @@ fun WooShippingEditAddressScreen(
 ) {
     when (val viewState = viewModel.viewState.collectAsState().value) {
         is WooShippingEditOriginViewModel.EditAddressViewState.DataState -> {
-            WooShippingEditAddressScreen(
+            EditAddress(
                 editableAddress = viewState.editableAddress,
                 isCompanyExpanded = viewState.isCompanyExpanded,
                 shouldDisplayLoadingCountries = viewState.shouldDisplayLoading,
@@ -92,6 +103,16 @@ fun WooShippingEditAddressScreen(
                 onRefreshCountries = viewModel::onRefreshCountries,
                 onRawStateChange = viewModel::onRawStateChange,
                 onStateChange = viewModel::onStateChange,
+                onNormalizeAddress = viewModel::onNormalizeAddress,
+                modifier = modifier
+            )
+        }
+
+        is WooShippingEditOriginViewModel.EditAddressViewState.AddressSelectionState -> {
+            SelectAddress(
+                addressSelection = viewState.addressSelection,
+                onAddressSelectionChange = viewModel::onAddressSelectionChange,
+                onCloseAddressSelection = viewModel::onCloseAddressSelection,
                 modifier = modifier
             )
         }
@@ -99,7 +120,7 @@ fun WooShippingEditAddressScreen(
 }
 
 @Composable
-fun WooShippingEditAddressScreen(
+fun EditAddress(
     editableAddress: EditableAddress,
     shouldDisplayLoadingCountries: Boolean,
     shouldDisplayLoadingCountriesError: Boolean,
@@ -118,6 +139,7 @@ fun WooShippingEditAddressScreen(
     onRefreshCountries: () -> Unit,
     onRawStateChange: (String) -> Unit,
     onStateChange: () -> Unit,
+    onNormalizeAddress: (editableAddress: EditableAddress) -> Unit,
     modifier: Modifier = Modifier
 ) {
     val snackbarHostState = remember { SnackbarHostState() }
@@ -335,8 +357,10 @@ fun WooShippingEditAddressScreen(
                 )
             }
             Surface(elevation = 8.dp) {
-                AddressStatus(
+                AddressStatusSection(
+                    editableAddress = editableAddress,
                     addressStatus = addressStatus,
+                    onNormalizeAddress = onNormalizeAddress,
                     modifier = Modifier
                         .fillMaxWidth()
                         .padding(16.dp)
@@ -353,8 +377,10 @@ fun WooShippingEditAddressScreen(
 }
 
 @Composable
-internal fun AddressStatus(
+internal fun AddressStatusSection(
+    editableAddress: EditableAddress,
     addressStatus: AddressStatus,
+    onNormalizeAddress: (editableAddress: EditableAddress) -> Unit,
     modifier: Modifier = Modifier
 ) {
     Column(
@@ -383,6 +409,20 @@ internal fun AddressStatus(
             AddressStatus.MISSING_INFO -> stringResource(id = R.string.woo_shipping_address_missing_info_hint)
         }
 
+        val buttonAction: () -> Unit = when (addressStatus) {
+            AddressStatus.VERIFIED -> {
+                {}
+            }
+
+            AddressStatus.UNVERIFIED -> {
+                { onNormalizeAddress(editableAddress) }
+            }
+
+            AddressStatus.MISSING_INFO -> {
+                {}
+            }
+        }
+
         Row(modifier = Modifier.padding(bottom = 16.dp)) {
             Icon(
                 imageVector = icon,
@@ -397,7 +437,7 @@ internal fun AddressStatus(
         }
 
         WCColoredButton(
-            onClick = {},
+            onClick = buttonAction,
             enabled = addressStatus != AddressStatus.MISSING_INFO,
             text = buttonText,
             modifier = Modifier.fillMaxWidth()
@@ -591,6 +631,101 @@ private fun CollapsedField(
                 )
             }
         }
+    }
+}
+
+@Composable
+private fun SelectAddress(
+    addressSelection: NormalizedAddressSelection.AddressSelection,
+    onAddressSelectionChange: (NormalizedAddressSelection.AddressSelection) -> Unit,
+    onCloseAddressSelection: () -> Unit,
+    modifier: Modifier = Modifier
+) {
+    Column(modifier = modifier) {
+        Column(modifier = Modifier
+            .padding(16.dp)
+            .weight(1f)
+            .verticalScroll(rememberScrollState())) {
+            Text(
+                text = stringResource(id = R.string.woo_shipping_confirm_address_title),
+                style = MaterialTheme.typography.h4,
+                modifier = Modifier.padding(bottom = 16.dp)
+            )
+            Text(
+                text = stringResource(id = R.string.woo_shipping_confirm_address_description),
+                modifier = Modifier.padding(bottom = 16.dp).clickable { onCloseAddressSelection() }
+            )
+            ShipmentDetailsSectionTitle(
+                title = stringResource(id = R.string.woo_shipping_confirm_address_entered),
+                modifier = Modifier.padding(bottom = 16.dp)
+            )
+
+            AddressSelectionItem(
+                address = addressSelection.addressNormalization.address,
+                isSelected = addressSelection.selectedAddress == addressSelection.addressNormalization.address,
+                onClick = {
+                    onAddressSelectionChange(
+                        addressSelection.copy(selectedAddress = addressSelection.addressNormalization.address)
+                    )
+                },
+                modifier = Modifier.fillMaxWidth().padding(bottom = 16.dp)
+            )
+
+            ShipmentDetailsSectionTitle(
+                title = stringResource(id = R.string.woo_shipping_confirm_address_suggested),
+                modifier = Modifier.padding(bottom = 16.dp)
+            )
+
+            AddressSelectionItem(
+                address = addressSelection.addressNormalization.normalizedAddress,
+                isSelected =
+                addressSelection.selectedAddress == addressSelection.addressNormalization.normalizedAddress,
+                onClick = {
+                    onAddressSelectionChange(
+                        addressSelection.copy(selectedAddress = addressSelection.addressNormalization.normalizedAddress)
+                    )
+                },
+                modifier = Modifier.fillMaxWidth()
+            )
+        }
+    }
+}
+
+@Composable
+private fun AddressSelectionItem(
+    address: Address,
+    isSelected: Boolean,
+    onClick: () -> Unit,
+    modifier: Modifier = Modifier
+) {
+    val borderColor = if (isSelected) {
+        MaterialTheme.colors.primary
+    } else {
+        colorResource(R.color.divider_color)
+    }
+
+    val backgroundColor = if (isSelected) {
+        animateColorAsState(
+            targetValue = MaterialTheme.colors.shippingSelectedBackgroundColor,
+            label = "colorAnimation"
+        )
+    } else {
+        animateColorAsState(targetValue = MaterialTheme.colors.surface, label = "colorAnimation")
+    }
+
+    RoundedCornerBoxWithBorder(
+        modifier = modifier,
+        innerModifier = Modifier
+            .clickable { onClick() }
+            .padding(dimensionResource(id = R.dimen.major_100)),
+        borderColor = borderColor,
+        backgroundColor = backgroundColor.value
+    ) {
+        Text(
+            text = address.toString(),
+            fontWeight = FontWeight.Bold,
+            modifier = Modifier
+        )
     }
 }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/address/WooShippingEditAddressScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/address/WooShippingEditAddressScreen.kt
@@ -95,7 +95,7 @@ fun WooShippingEditAddressScreen(
         shouldDisplayLoadingCountriesError = viewState.shouldDisplayLoadingCountriesError,
         shouldUseStatesInput = viewState.shouldUseStatesInput,
         addressStatus = viewState.addressStatus,
-        addressSelection = viewState.addressSelection,
+        addressSelection = viewState.normalizedAddressStatus,
         onAddressSelectionChange = viewModel::onAddressSelectionChange,
         onCloseAddressSelection = viewModel::onCloseAddressSelection,
         onExpandCompany = viewModel::onExpandCompany,

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/address/WooShippingEditAddressScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/address/WooShippingEditAddressScreen.kt
@@ -91,7 +91,7 @@ fun WooShippingEditAddressScreen(
     WooShippingEditAddressScreen(
         editableAddress = viewState.editableAddress,
         isCompanyExpanded = viewState.isCompanyExpanded,
-        shouldDisplayLoadingCountries = viewState.shouldDisplayLoading,
+        loading = viewState.loading,
         shouldDisplayLoadingCountriesError = viewState.shouldDisplayLoadingCountriesError,
         shouldUseStatesInput = viewState.shouldUseStatesInput,
         addressStatus = viewState.addressStatus,
@@ -119,7 +119,7 @@ fun WooShippingEditAddressScreen(
 @Composable
 fun WooShippingEditAddressScreen(
     editableAddress: EditableAddress,
-    shouldDisplayLoadingCountries: Boolean,
+    loading: WooShippingEditOriginViewModel.LoadingState,
     shouldDisplayLoadingCountriesError: Boolean,
     shouldUseStatesInput: Boolean,
     isCompanyExpanded: Boolean,
@@ -404,12 +404,12 @@ fun WooShippingEditAddressScreen(
                 )
             }
         }
-        if (shouldDisplayLoadingCountries) {
-            LoadingModal(
-                title = stringResource(id = R.string.loading),
-                description = stringResource(id = R.string.woo_shipping_fetching_countries_and_states)
-            )
-        }
+    }
+    if (loading is WooShippingEditOriginViewModel.LoadingState.DisplayLoading) {
+        LoadingModal(
+            title = loading.title,
+            description = loading.message
+        )
     }
 }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/address/origin/NormalizeAddress.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/address/origin/NormalizeAddress.kt
@@ -1,0 +1,27 @@
+package com.woocommerce.android.ui.orders.wooshippinglabels.address.origin
+
+import com.woocommerce.android.model.Address
+import com.woocommerce.android.tools.SelectedSite
+import com.woocommerce.android.ui.orders.wooshippinglabels.models.AddressNormalizationModel
+import com.woocommerce.android.ui.orders.wooshippinglabels.networking.WooShippingLabelRepository
+import javax.inject.Inject
+
+class NormalizeAddress @Inject constructor(
+    private val repository: WooShippingLabelRepository,
+    private val site: SelectedSite,
+) {
+    suspend operator fun invoke(address: Address): Result<AddressNormalizationModel> {
+        return site.getOrNull()?.let {
+            val response = repository.normalizeAddress(it, address)
+            val result = response.model
+            when {
+                response.isError || result == null -> {
+                    val message =
+                        response.error.message ?: if (result == null) "Empty response" else "Unknown error"
+                    Result.failure(Exception(message))
+                }
+                else -> Result.success(result)
+            }
+        } ?: Result.failure(Exception("No site selected"))
+    }
+}

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/address/origin/WooShippingEditOriginViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/address/origin/WooShippingEditOriginViewModel.kt
@@ -7,11 +7,13 @@ import androidx.compose.runtime.snapshotFlow
 import androidx.lifecycle.SavedStateHandle
 import com.woocommerce.android.extensions.combine
 import com.woocommerce.android.extensions.isNotNullOrEmpty
+import com.woocommerce.android.model.Address
 import com.woocommerce.android.model.AmbiguousLocation
 import com.woocommerce.android.model.Location
 import com.woocommerce.android.ui.orders.details.editing.address.LocationCode
 import com.woocommerce.android.ui.orders.wooshippinglabels.address.AddressValidationHelper
 import com.woocommerce.android.ui.orders.wooshippinglabels.address.GetStatesByCountryCode
+import com.woocommerce.android.ui.orders.wooshippinglabels.models.AddressNormalizationModel
 import com.woocommerce.android.util.StringUtils.combineStrings
 import com.woocommerce.android.viewmodel.MultiLiveEvent
 import com.woocommerce.android.viewmodel.ScopedViewModel
@@ -34,6 +36,7 @@ class WooShippingEditOriginViewModel @Inject constructor(
     private val addressValidator: AddressValidationHelper,
     private val getAcceptedOriginCountries: GetAcceptedOriginCountries,
     private val getStatesByCountryCode: GetStatesByCountryCode,
+    private val normalizeAddress: NormalizeAddress,
     savedState: SavedStateHandle
 ) : ScopedViewModel(savedState) {
     private var name by mutableStateOf(InputValue(""))
@@ -58,6 +61,9 @@ class WooShippingEditOriginViewModel @Inject constructor(
 
     private val countriesState = MutableStateFlow<LocationState>(LocationState.Loading)
     private val statesState = MutableStateFlow<LocationState>(LocationState.Loading)
+
+    private val normalizedAddressSelection =
+        MutableStateFlow<NormalizedAddressSelection>(NormalizedAddressSelection.Closed)
 
     private val navArgs: WooShippingEditOriginAddressFragmentArgs by savedState.navArgs()
 
@@ -226,25 +232,35 @@ class WooShippingEditOriginViewModel @Inject constructor(
             editableAddress,
             isCompanyExpanded,
             countriesState,
-            statesState
-        ) { address, isExpanded, countriesState, statesState ->
-            val isLoading =
-                countriesState is LocationState.DisplayLoading || statesState is LocationState.DisplayLoading
+            statesState,
+            normalizedAddressSelection
+        ) { address, isExpanded, countriesState, statesState, addressSelection ->
+            when (addressSelection) {
+                is NormalizedAddressSelection.AddressSelection -> {
+                    EditAddressViewState.AddressSelectionState(addressSelection)
+                }
 
-            val addressStatus = when {
-                hasIncorrectOrMissingData(address) -> AddressStatus.MISSING_INFO
-                isSameAddress(address) && navArgs.originAddress.isVerified -> AddressStatus.VERIFIED
-                else -> AddressStatus.UNVERIFIED
+                else -> {
+                    val isLoading =
+                        countriesState is LocationState.DisplayLoading || statesState is LocationState.DisplayLoading
+
+                    val addressStatus = when {
+                        hasIncorrectOrMissingData(address) -> AddressStatus.MISSING_INFO
+                        isSameAddress(address) && navArgs.originAddress.isVerified -> AddressStatus.VERIFIED
+                        else -> AddressStatus.UNVERIFIED
+                    }
+
+                    EditAddressViewState.DataState(
+                        isCompanyExpanded = isExpanded,
+                        editableAddress = address,
+                        shouldDisplayLoading = isLoading,
+                        shouldDisplayLoadingCountriesError = countriesState is LocationState.Error,
+                        shouldUseStatesInput = statesState is LocationState.Loaded && statesState.locations.isEmpty(),
+                        addressStatus = addressStatus
+                    )
+                }
             }
 
-            EditAddressViewState.DataState(
-                isCompanyExpanded = isExpanded,
-                editableAddress = address,
-                shouldDisplayLoading = isLoading,
-                shouldDisplayLoadingCountriesError = countriesState is LocationState.Error,
-                shouldUseStatesInput = statesState is LocationState.Loaded && statesState.locations.isEmpty(),
-                addressStatus = addressStatus
-            )
         }
             .collectLatest {
                 viewState.value = it
@@ -350,6 +366,29 @@ class WooShippingEditOriginViewModel @Inject constructor(
         selectedState.value = findLocationByCode(code, statesState.value)
     }
 
+    fun onNormalizeAddress(editableAddress: EditableAddress) {
+        launch {
+            val address = editableAddress.toAddress()
+            normalizeAddress(address).fold(
+                onSuccess = {
+                    normalizedAddressSelection.value =
+                        NormalizedAddressSelection.AddressSelection(it, it.normalizedAddress)
+                },
+                onFailure = {
+
+                }
+            )
+        }
+    }
+
+    fun onAddressSelectionChange(addressSelection : NormalizedAddressSelection.AddressSelection) {
+        normalizedAddressSelection.value = addressSelection
+    }
+
+    fun onCloseAddressSelection() {
+        normalizedAddressSelection.value = NormalizedAddressSelection.Closed
+    }
+
     sealed class EditAddressViewState {
         data class DataState(
             val isCompanyExpanded: Boolean,
@@ -358,6 +397,10 @@ class WooShippingEditOriginViewModel @Inject constructor(
             val shouldDisplayLoadingCountriesError: Boolean,
             val shouldUseStatesInput: Boolean,
             val addressStatus: AddressStatus
+        ) : EditAddressViewState()
+
+        data class AddressSelectionState(
+            val addressSelection: NormalizedAddressSelection.AddressSelection
         ) : EditAddressViewState()
     }
 
@@ -401,7 +444,31 @@ data class EditableAddress(
     val postalCode: InputValue = InputValue.EMPTY,
     val email: InputValue = InputValue.EMPTY,
     val phone: InputValue = InputValue.EMPTY
-)
+) {
+    fun toAddress(): Address {
+        return Address(
+            firstName = name.value,
+            lastName = "",
+            company = company.value,
+            address1 = address.value,
+            address2 = "",
+            city = city.value,
+            state = AmbiguousLocation.Defined(state),
+            postcode = postalCode.value,
+            country = country,
+            email = email.value,
+            phone = phone.value
+        )
+    }
+}
+
+sealed class NormalizedAddressSelection {
+    data object Closed : NormalizedAddressSelection()
+    data class AddressSelection(
+        val addressNormalization: AddressNormalizationModel,
+        val selectedAddress: Address
+    ) : NormalizedAddressSelection()
+}
 
 enum class AddressStatus {
     VERIFIED,

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/address/origin/WooShippingEditOriginViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/address/origin/WooShippingEditOriginViewModel.kt
@@ -5,6 +5,7 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.setValue
 import androidx.compose.runtime.snapshotFlow
 import androidx.lifecycle.SavedStateHandle
+import com.woocommerce.android.R
 import com.woocommerce.android.extensions.combine
 import com.woocommerce.android.extensions.isNotNullOrEmpty
 import com.woocommerce.android.model.Address
@@ -16,6 +17,7 @@ import com.woocommerce.android.ui.orders.wooshippinglabels.address.GetStatesByCo
 import com.woocommerce.android.ui.orders.wooshippinglabels.models.AddressNormalizationModel
 import com.woocommerce.android.util.StringUtils.combineStrings
 import com.woocommerce.android.viewmodel.MultiLiveEvent
+import com.woocommerce.android.viewmodel.ResourceProvider
 import com.woocommerce.android.viewmodel.ScopedViewModel
 import com.woocommerce.android.viewmodel.navArgs
 import dagger.hilt.android.lifecycle.HiltViewModel
@@ -37,6 +39,7 @@ class WooShippingEditOriginViewModel @Inject constructor(
     private val getAcceptedOriginCountries: GetAcceptedOriginCountries,
     private val getStatesByCountryCode: GetStatesByCountryCode,
     private val normalizeAddress: NormalizeAddress,
+    private val resourceProvider: ResourceProvider,
     savedState: SavedStateHandle
 ) : ScopedViewModel(savedState) {
     private var name by mutableStateOf(InputValue(""))
@@ -147,7 +150,7 @@ class WooShippingEditOriginViewModel @Inject constructor(
         ViewState(
             isCompanyExpanded = false,
             editableAddress = EditableAddress(),
-            shouldDisplayLoading = false,
+            loading = LoadingState.Hidden,
             shouldDisplayLoadingCountriesError = false,
             shouldUseStatesInput = false,
             addressStatus = AddressStatus.UNVERIFIED,
@@ -237,8 +240,23 @@ class WooShippingEditOriginViewModel @Inject constructor(
             normalizedAddressStatus
         ) { address, isExpanded, countriesState, statesState, addressSelection ->
 
-            val isLoading =
-                countriesState is LocationState.DisplayLoading || statesState is LocationState.DisplayLoading
+            val loading =
+                when {
+                    countriesState is LocationState.DisplayLoading || statesState is LocationState.DisplayLoading -> {
+                        LoadingState.DisplayLoading(
+                            resourceProvider.getString(R.string.loading),
+                            resourceProvider.getString(R.string.woo_shipping_fetching_countries_and_states)
+                        )
+                    }
+                    addressSelection is NormalizedAddressStatus.VerifyingAddress -> {
+                        LoadingState.DisplayLoading(
+                            resourceProvider.getString(R.string.woo_shipping_address_validate_title),
+                            resourceProvider.getString(R.string.woo_shipping_address_validate_message)
+                        )
+                    }
+                    else -> LoadingState.Hidden
+                }
+
 
             val addressStatus = when {
                 hasIncorrectOrMissingData(address) -> AddressStatus.MISSING_INFO
@@ -249,7 +267,7 @@ class WooShippingEditOriginViewModel @Inject constructor(
             ViewState(
                 isCompanyExpanded = isExpanded,
                 editableAddress = address,
-                shouldDisplayLoading = isLoading,
+                loading = loading,
                 shouldDisplayLoadingCountriesError = countriesState is LocationState.Error,
                 shouldUseStatesInput = statesState is LocationState.Loaded && statesState.locations.isEmpty(),
                 addressStatus = addressStatus,
@@ -387,12 +405,20 @@ class WooShippingEditOriginViewModel @Inject constructor(
     data class ViewState(
         val isCompanyExpanded: Boolean,
         val editableAddress: EditableAddress,
-        val shouldDisplayLoading: Boolean,
+        val loading: LoadingState,
         val shouldDisplayLoadingCountriesError: Boolean,
         val shouldUseStatesInput: Boolean,
         val addressStatus: AddressStatus,
         val addressSelection: NormalizedAddressStatus
     )
+
+    sealed class LoadingState {
+        data object Hidden : LoadingState()
+        data class DisplayLoading(
+            val title: String,
+            val message: String
+        ) : LoadingState()
+    }
 
     sealed class LocationState {
         data object Loading : LocationState()
@@ -454,7 +480,7 @@ data class EditableAddress(
 
 sealed class NormalizedAddressStatus {
     data object Closed : NormalizedAddressStatus()
-    data object VerifyingAddress: NormalizedAddressStatus()
+    data object VerifyingAddress : NormalizedAddressStatus()
     data object Failure : NormalizedAddressStatus()
     data class AddressSelection(
         val addressNormalization: AddressNormalizationModel,

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/address/origin/WooShippingEditOriginViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/address/origin/WooShippingEditOriginViewModel.kt
@@ -257,7 +257,6 @@ class WooShippingEditOriginViewModel @Inject constructor(
                     else -> LoadingState.Hidden
                 }
 
-
             val addressStatus = when {
                 hasIncorrectOrMissingData(address) -> AddressStatus.MISSING_INFO
                 isSameAddress(address) && navArgs.originAddress.isVerified -> AddressStatus.VERIFIED

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/address/origin/WooShippingEditOriginViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/address/origin/WooShippingEditOriginViewModel.kt
@@ -154,7 +154,7 @@ class WooShippingEditOriginViewModel @Inject constructor(
             shouldDisplayLoadingCountriesError = false,
             shouldUseStatesInput = false,
             addressStatus = AddressStatus.UNVERIFIED,
-            addressSelection = NormalizedAddressStatus.Closed
+            normalizedAddressStatus = NormalizedAddressStatus.Closed
         )
     )
 
@@ -272,7 +272,7 @@ class WooShippingEditOriginViewModel @Inject constructor(
                 shouldDisplayLoadingCountriesError = countriesState is LocationState.Error,
                 shouldUseStatesInput = statesState is LocationState.Loaded && statesState.locations.isEmpty(),
                 addressStatus = addressStatus,
-                addressSelection = addressSelection
+                normalizedAddressStatus = addressSelection
             )
         }
             .collectLatest {
@@ -410,7 +410,7 @@ class WooShippingEditOriginViewModel @Inject constructor(
         val shouldDisplayLoadingCountriesError: Boolean,
         val shouldUseStatesInput: Boolean,
         val addressStatus: AddressStatus,
-        val addressSelection: NormalizedAddressStatus
+        val normalizedAddressStatus: NormalizedAddressStatus
     )
 
     sealed class LoadingState {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/address/origin/WooShippingEditOriginViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/address/origin/WooShippingEditOriginViewModel.kt
@@ -62,8 +62,8 @@ class WooShippingEditOriginViewModel @Inject constructor(
     private val countriesState = MutableStateFlow<LocationState>(LocationState.Loading)
     private val statesState = MutableStateFlow<LocationState>(LocationState.Loading)
 
-    private val normalizedAddressSelection =
-        MutableStateFlow<NormalizedAddressSelection>(NormalizedAddressSelection.Closed)
+    private val normalizedAddressStatus =
+        MutableStateFlow<NormalizedAddressStatus>(NormalizedAddressStatus.Closed)
 
     private val navArgs: WooShippingEditOriginAddressFragmentArgs by savedState.navArgs()
 
@@ -143,14 +143,15 @@ class WooShippingEditOriginViewModel @Inject constructor(
         )
     }
 
-    val viewState: MutableStateFlow<EditAddressViewState> = MutableStateFlow(
-        EditAddressViewState.DataState(
+    val viewState: MutableStateFlow<ViewState> = MutableStateFlow(
+        ViewState(
             isCompanyExpanded = false,
             editableAddress = EditableAddress(),
             shouldDisplayLoading = false,
             shouldDisplayLoadingCountriesError = false,
             shouldUseStatesInput = false,
-            addressStatus = AddressStatus.UNVERIFIED
+            addressStatus = AddressStatus.UNVERIFIED,
+            addressSelection = NormalizedAddressStatus.Closed
         )
     )
 
@@ -233,34 +234,27 @@ class WooShippingEditOriginViewModel @Inject constructor(
             isCompanyExpanded,
             countriesState,
             statesState,
-            normalizedAddressSelection
+            normalizedAddressStatus
         ) { address, isExpanded, countriesState, statesState, addressSelection ->
-            when (addressSelection) {
-                is NormalizedAddressSelection.AddressSelection -> {
-                    EditAddressViewState.AddressSelectionState(addressSelection)
-                }
 
-                else -> {
-                    val isLoading =
-                        countriesState is LocationState.DisplayLoading || statesState is LocationState.DisplayLoading
+            val isLoading =
+                countriesState is LocationState.DisplayLoading || statesState is LocationState.DisplayLoading
 
-                    val addressStatus = when {
-                        hasIncorrectOrMissingData(address) -> AddressStatus.MISSING_INFO
-                        isSameAddress(address) && navArgs.originAddress.isVerified -> AddressStatus.VERIFIED
-                        else -> AddressStatus.UNVERIFIED
-                    }
-
-                    EditAddressViewState.DataState(
-                        isCompanyExpanded = isExpanded,
-                        editableAddress = address,
-                        shouldDisplayLoading = isLoading,
-                        shouldDisplayLoadingCountriesError = countriesState is LocationState.Error,
-                        shouldUseStatesInput = statesState is LocationState.Loaded && statesState.locations.isEmpty(),
-                        addressStatus = addressStatus
-                    )
-                }
+            val addressStatus = when {
+                hasIncorrectOrMissingData(address) -> AddressStatus.MISSING_INFO
+                isSameAddress(address) && navArgs.originAddress.isVerified -> AddressStatus.VERIFIED
+                else -> AddressStatus.UNVERIFIED
             }
 
+            ViewState(
+                isCompanyExpanded = isExpanded,
+                editableAddress = address,
+                shouldDisplayLoading = isLoading,
+                shouldDisplayLoadingCountriesError = countriesState is LocationState.Error,
+                shouldUseStatesInput = statesState is LocationState.Loaded && statesState.locations.isEmpty(),
+                addressStatus = addressStatus,
+                addressSelection = addressSelection
+            )
         }
             .collectLatest {
                 viewState.value = it
@@ -369,40 +363,36 @@ class WooShippingEditOriginViewModel @Inject constructor(
     fun onNormalizeAddress(editableAddress: EditableAddress) {
         launch {
             val address = editableAddress.toAddress()
+            normalizedAddressStatus.value = NormalizedAddressStatus.VerifyingAddress
             normalizeAddress(address).fold(
                 onSuccess = {
-                    normalizedAddressSelection.value =
-                        NormalizedAddressSelection.AddressSelection(it, it.normalizedAddress)
+                    normalizedAddressStatus.value =
+                        NormalizedAddressStatus.AddressSelection(it, it.normalizedAddress)
                 },
                 onFailure = {
-
+                    normalizedAddressStatus.value = NormalizedAddressStatus.Failure
                 }
             )
         }
     }
 
-    fun onAddressSelectionChange(addressSelection : NormalizedAddressSelection.AddressSelection) {
-        normalizedAddressSelection.value = addressSelection
+    fun onAddressSelectionChange(addressSelection: NormalizedAddressStatus.AddressSelection) {
+        normalizedAddressStatus.value = addressSelection
     }
 
     fun onCloseAddressSelection() {
-        normalizedAddressSelection.value = NormalizedAddressSelection.Closed
+        normalizedAddressStatus.value = NormalizedAddressStatus.Closed
     }
 
-    sealed class EditAddressViewState {
-        data class DataState(
-            val isCompanyExpanded: Boolean,
-            val editableAddress: EditableAddress,
-            val shouldDisplayLoading: Boolean,
-            val shouldDisplayLoadingCountriesError: Boolean,
-            val shouldUseStatesInput: Boolean,
-            val addressStatus: AddressStatus
-        ) : EditAddressViewState()
-
-        data class AddressSelectionState(
-            val addressSelection: NormalizedAddressSelection.AddressSelection
-        ) : EditAddressViewState()
-    }
+    data class ViewState(
+        val isCompanyExpanded: Boolean,
+        val editableAddress: EditableAddress,
+        val shouldDisplayLoading: Boolean,
+        val shouldDisplayLoadingCountriesError: Boolean,
+        val shouldUseStatesInput: Boolean,
+        val addressStatus: AddressStatus,
+        val addressSelection: NormalizedAddressStatus
+    )
 
     sealed class LocationState {
         data object Loading : LocationState()
@@ -462,12 +452,14 @@ data class EditableAddress(
     }
 }
 
-sealed class NormalizedAddressSelection {
-    data object Closed : NormalizedAddressSelection()
+sealed class NormalizedAddressStatus {
+    data object Closed : NormalizedAddressStatus()
+    data object VerifyingAddress: NormalizedAddressStatus()
+    data object Failure : NormalizedAddressStatus()
     data class AddressSelection(
         val addressNormalization: AddressNormalizationModel,
         val selectedAddress: Address
-    ) : NormalizedAddressSelection()
+    ) : NormalizedAddressStatus()
 }
 
 enum class AddressStatus {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/address/origin/WooShippingEditOriginViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/address/origin/WooShippingEditOriginViewModel.kt
@@ -248,12 +248,14 @@ class WooShippingEditOriginViewModel @Inject constructor(
                             resourceProvider.getString(R.string.woo_shipping_fetching_countries_and_states)
                         )
                     }
+
                     addressSelection is NormalizedAddressStatus.VerifyingAddress -> {
                         LoadingState.DisplayLoading(
                             resourceProvider.getString(R.string.woo_shipping_address_validate_title),
                             resourceProvider.getString(R.string.woo_shipping_address_validate_message)
                         )
                     }
+
                     else -> LoadingState.Hidden
                 }
 
@@ -459,22 +461,22 @@ data class EditableAddress(
     val postalCode: InputValue = InputValue.EMPTY,
     val email: InputValue = InputValue.EMPTY,
     val phone: InputValue = InputValue.EMPTY
-) {
-    fun toAddress(): Address {
-        return Address(
-            firstName = name.value,
-            lastName = "",
-            company = company.value,
-            address1 = address.value,
-            address2 = "",
-            city = city.value,
-            state = AmbiguousLocation.Defined(state),
-            postcode = postalCode.value,
-            country = country,
-            email = email.value,
-            phone = phone.value
-        )
-    }
+)
+
+fun EditableAddress.toAddress(): Address {
+    return Address(
+        firstName = name.value,
+        lastName = "",
+        company = company.value,
+        address1 = address.value,
+        address2 = "",
+        city = city.value,
+        state = AmbiguousLocation.Defined(state),
+        postcode = postalCode.value,
+        country = country,
+        email = email.value,
+        phone = phone.value
+    )
 }
 
 sealed class NormalizedAddressStatus {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/models/AddressNormalizationModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/models/AddressNormalizationModel.kt
@@ -1,0 +1,9 @@
+package com.woocommerce.android.ui.orders.wooshippinglabels.models
+
+import com.woocommerce.android.model.Address
+
+data class AddressNormalizationModel(
+    val address: Address,
+    val normalizedAddress: Address,
+    val isTrivial: Boolean
+)

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/networking/DTOs.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/networking/DTOs.kt
@@ -77,7 +77,7 @@ data class ShippingRatePurchaseResponseDTO(
     val deliveryDate: String?
 )
 
-data class OriginAddressDTO(
+data class AddressDTO(
     val id: String? = null,
     @SerializedName("address_1") val address: String? = null,
     @SerializedName("address_2") val address2: String? = null,
@@ -93,4 +93,10 @@ data class OriginAddressDTO(
     @SerializedName("last_name") val lastName: String? = null,
     @SerializedName("is_verified") val isVerified: Boolean = false,
     @SerializedName("default_address") val defaultAddress: Boolean = false,
+)
+
+data class NormalizationResponseDTO(
+    val normalizedAddress: AddressDTO,
+    val address: AddressDTO,
+    val isTrivialNormalization: Boolean
 )

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/networking/WooShippingLabelRepository.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/networking/WooShippingLabelRepository.kt
@@ -3,6 +3,7 @@ package com.woocommerce.android.ui.orders.wooshippinglabels.networking
 import com.woocommerce.android.model.Address
 import com.woocommerce.android.ui.orders.wooshippinglabels.datasource.WooShippingAddressDataStore
 import com.woocommerce.android.ui.orders.wooshippinglabels.datasource.WooShippingConfigurationDataStore
+import com.woocommerce.android.ui.orders.wooshippinglabels.models.AddressNormalizationModel
 import com.woocommerce.android.ui.orders.wooshippinglabels.models.OriginShippingAddress
 import com.woocommerce.android.ui.orders.wooshippinglabels.models.PurchasedLabelData
 import com.woocommerce.android.ui.orders.wooshippinglabels.models.ShippingLabelStatus
@@ -106,4 +107,14 @@ class WooShippingLabelRepository @Inject constructor(
                     addressDataStore.saveOriginAddresses(it)
                 }
         }
+
+    suspend fun normalizeAddress(
+        site: SiteModel,
+        address: Address
+    ): WooResult<AddressNormalizationModel> {
+        return restClient.normalizeAddress(
+            site = site,
+            address = mapper.toAddressDTO(address)
+        ).asWooResult{ mapper(it) }
+    }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/networking/WooShippingLabelRepository.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/networking/WooShippingLabelRepository.kt
@@ -115,6 +115,6 @@ class WooShippingLabelRepository @Inject constructor(
         return restClient.normalizeAddress(
             site = site,
             address = mapper.toAddressDTO(address)
-        ).asWooResult{ mapper(it) }
+        ).asWooResult { mapper(it) }
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/networking/WooShippingLabelRestClient.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/networking/WooShippingLabelRestClient.kt
@@ -110,12 +110,28 @@ class WooShippingLabelRestClient @Inject constructor(
 
     suspend fun fetchOriginAddresses(
         site: SiteModel,
-    ): WooPayload<Array<OriginAddressDTO>> {
+    ): WooPayload<Array<AddressDTO>> {
         val url = "/wcshipping/v1/address/origins"
         return wooNetwork.executeGetGsonRequest(
             site = site,
             path = url,
-            clazz = Array<OriginAddressDTO>::class.java,
+            clazz = Array<AddressDTO>::class.java,
         ).toWooPayload()
+    }
+
+    suspend fun normalizeAddress(
+        site: SiteModel,
+        address: AddressDTO,
+    ): WooPayload<NormalizationResponseDTO> {
+        val url = "/wcshipping/v1/address/normalize/"
+
+        val result = wooNetwork.executePostGsonRequest(
+            site = site,
+            path = url,
+            body = mapOf("address" to address),
+            clazz = NormalizationResponseDTO::class.java,
+        )
+
+        return result.toWooPayload()
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/networking/WooShippingNetworkingMapper.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/networking/WooShippingNetworkingMapper.kt
@@ -1,5 +1,6 @@
 package com.woocommerce.android.ui.orders.wooshippinglabels.networking
 
+import com.woocommerce.android.extensions.isNotNullOrEmpty
 import com.woocommerce.android.model.Address
 import com.woocommerce.android.model.AmbiguousLocation
 import com.woocommerce.android.model.Location
@@ -133,7 +134,7 @@ class WooShippingNetworkingMapper @Inject constructor(
             state = AmbiguousLocation.Raw(addressDTO.state.orEmpty()),
             postcode = addressDTO.postcode.orEmpty(),
             country = AmbiguousLocation.Raw(addressDTO.country.orEmpty()).asLocation(),
-            firstName = addressDTO.firstName.orEmpty(),
+            firstName = if(addressDTO.name.isNullOrEmpty()) addressDTO.firstName.orEmpty() else addressDTO.name,
             lastName = addressDTO.lastName.orEmpty(),
             company = addressDTO.company.orEmpty(),
             phone = addressDTO.phone.orEmpty(),

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/networking/WooShippingNetworkingMapper.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/networking/WooShippingNetworkingMapper.kt
@@ -1,6 +1,5 @@
 package com.woocommerce.android.ui.orders.wooshippinglabels.networking
 
-import com.woocommerce.android.extensions.isNotNullOrEmpty
 import com.woocommerce.android.model.Address
 import com.woocommerce.android.model.AmbiguousLocation
 import com.woocommerce.android.model.Location
@@ -134,7 +133,7 @@ class WooShippingNetworkingMapper @Inject constructor(
             state = AmbiguousLocation.Raw(addressDTO.state.orEmpty()),
             postcode = addressDTO.postcode.orEmpty(),
             country = AmbiguousLocation.Raw(addressDTO.country.orEmpty()).asLocation(),
-            firstName = if(addressDTO.name.isNullOrEmpty()) addressDTO.firstName.orEmpty() else addressDTO.name,
+            firstName = if (addressDTO.name.isNullOrEmpty()) addressDTO.firstName.orEmpty() else addressDTO.name,
             lastName = addressDTO.lastName.orEmpty(),
             company = addressDTO.company.orEmpty(),
             phone = addressDTO.phone.orEmpty(),

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/networking/WooShippingNetworkingMapper.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/networking/WooShippingNetworkingMapper.kt
@@ -3,6 +3,7 @@ package com.woocommerce.android.ui.orders.wooshippinglabels.networking
 import com.woocommerce.android.model.Address
 import com.woocommerce.android.model.AmbiguousLocation
 import com.woocommerce.android.model.Location
+import com.woocommerce.android.ui.orders.wooshippinglabels.models.AddressNormalizationModel
 import com.woocommerce.android.ui.orders.wooshippinglabels.models.OriginShippingAddress
 import com.woocommerce.android.ui.orders.wooshippinglabels.models.PurchasedLabelData
 import com.woocommerce.android.ui.orders.wooshippinglabels.models.ShippingLabelModel
@@ -12,6 +13,7 @@ import com.woocommerce.android.ui.orders.wooshippinglabels.packages.ui.PackageDa
 import com.woocommerce.android.ui.orders.wooshippinglabels.rates.datasource.WooShippingRateModel
 import com.woocommerce.android.ui.orders.wooshippinglabels.rates.datasource.WooShippingRatesDatasourceMapper
 import com.woocommerce.android.ui.orders.wooshippinglabels.rates.networking.DestinationAddressDTO
+import com.woocommerce.android.util.StringUtils.combineStrings
 import java.math.BigDecimal
 import java.util.Date
 import javax.inject.Inject
@@ -102,7 +104,7 @@ class WooShippingNetworkingMapper @Inject constructor(
         )
     }
 
-    operator fun invoke(addressListDTO: Array<OriginAddressDTO>): List<OriginShippingAddress> {
+    operator fun invoke(addressListDTO: Array<AddressDTO>): List<OriginShippingAddress> {
         return addressListDTO.map {
             OriginShippingAddress(
                 id = it.id.orEmpty(),
@@ -121,6 +123,30 @@ class WooShippingNetworkingMapper @Inject constructor(
                 isVerified = it.isVerified,
             )
         }
+    }
+
+    operator fun invoke(addressDTO: AddressDTO): Address {
+        return Address(
+            address1 = addressDTO.address.orEmpty(),
+            address2 = addressDTO.address2.orEmpty(),
+            city = addressDTO.city.orEmpty(),
+            state = AmbiguousLocation.Raw(addressDTO.state.orEmpty()),
+            postcode = addressDTO.postcode.orEmpty(),
+            country = AmbiguousLocation.Raw(addressDTO.country.orEmpty()).asLocation(),
+            firstName = addressDTO.firstName.orEmpty(),
+            lastName = addressDTO.lastName.orEmpty(),
+            company = addressDTO.company.orEmpty(),
+            phone = addressDTO.phone.orEmpty(),
+            email = addressDTO.email.orEmpty(),
+        )
+    }
+
+    operator fun invoke(normalizationResponseDTO: NormalizationResponseDTO): AddressNormalizationModel {
+        return AddressNormalizationModel(
+            address = invoke(normalizationResponseDTO.address),
+            normalizedAddress = invoke(normalizationResponseDTO.normalizedAddress),
+            isTrivial = normalizationResponseDTO.isTrivialNormalization
+        )
     }
 
     fun toOriginAddressPurchaseDTO(address: OriginShippingAddress): OriginAddressPurchaseDTO {
@@ -200,6 +226,21 @@ class WooShippingNetworkingMapper @Inject constructor(
             ANONYMIZED_KEY -> ShippingLabelStatus.Anonymized
             else -> ShippingLabelStatus.Unknown
         }
+    }
+
+    fun toAddressDTO(address: Address): AddressDTO {
+        return AddressDTO(
+            address = address.address1,
+            address2 = address.address2,
+            city = address.city,
+            state = address.state.codeOrRaw,
+            postcode = address.postcode,
+            country = address.country.code,
+            company = address.company,
+            name = combineStrings(address.firstName, address.lastName),
+            phone = address.phone,
+            email = address.email
+        )
     }
 
     companion object {

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -4506,6 +4506,11 @@
     <string name="woo_shipping_address_validate_and_save">Validate &amp; Save</string>
     <string name="woo_shipping_address_missing_info_hint">Add missing information</string>
 
+    <string name="woo_shipping_confirm_address_title">Confirm address</string>
+    <string name="woo_shipping_confirm_address_description">We have slightly modified the entered address.\nIf correct, please use the suggested address to ensure accurate delivery.</string>
+    <string name="woo_shipping_confirm_address_entered">What you entered</string>
+    <string name="woo_shipping_confirm_address_suggested">Suggested</string>
+
 
     <string name="error_user_username_instead_of_email">Please log in using your WordPress.com username instead of your email address.</string>
     <string name="about_automattic_x_item_title">X</string>

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -4514,6 +4514,9 @@
     <string name="woo_shipping_confirm_address_entered">What you entered</string>
     <string name="woo_shipping_confirm_address_suggested">Suggested</string>
 
+    <string name="woo_shipping_confirm_submit_address_suggested">Confirm Suggested Address</string>
+    <string name="woo_shipping_confirm_submit_address_entered">Confirm Entered Address</string>
+
 
     <string name="error_user_username_instead_of_email">Please log in using your WordPress.com username instead of your email address.</string>
     <string name="about_automattic_x_item_title">X</string>

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -4506,6 +4506,9 @@
     <string name="woo_shipping_address_validate_and_save">Validate &amp; Save</string>
     <string name="woo_shipping_address_missing_info_hint">Add missing information</string>
 
+    <string name="woo_shipping_address_validate_title">Validating</string>
+    <string name="woo_shipping_address_validate_message">Validating entered address</string>
+
     <string name="woo_shipping_confirm_address_title">Confirm address</string>
     <string name="woo_shipping_confirm_address_description">We have slightly modified the entered address.\nIf correct, please use the suggested address to ensure accurate delivery.</string>
     <string name="woo_shipping_confirm_address_entered">What you entered</string>

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/address/origin/NormalizeAddressTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/address/origin/NormalizeAddressTest.kt
@@ -1,0 +1,61 @@
+package com.woocommerce.android.ui.orders.wooshippinglabels.address.origin
+
+import com.woocommerce.android.model.Address
+import com.woocommerce.android.tools.SelectedSite
+import com.woocommerce.android.ui.orders.wooshippinglabels.models.AddressNormalizationModel
+import com.woocommerce.android.ui.orders.wooshippinglabels.networking.WooShippingLabelRepository
+import com.woocommerce.android.viewmodel.BaseUnitTest
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.Test
+import org.mockito.Mockito.mock
+import org.mockito.kotlin.any
+import org.mockito.kotlin.whenever
+import org.wordpress.android.fluxc.model.SiteModel
+import org.wordpress.android.fluxc.network.BaseRequest.GenericErrorType.UNKNOWN
+import org.wordpress.android.fluxc.network.rest.wpcom.wc.WooError
+import org.wordpress.android.fluxc.network.rest.wpcom.wc.WooErrorType.GENERIC_ERROR
+import org.wordpress.android.fluxc.network.rest.wpcom.wc.WooResult
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class NormalizeAddressTest : BaseUnitTest() {
+
+    private val repository: WooShippingLabelRepository = mock()
+    private val site: SelectedSite = mock()
+
+    private val sut = NormalizeAddress(repository, site)
+    private val defaultAddress = Address.EMPTY
+    private val defaultNormalizeAddressResponse = AddressNormalizationModel(
+        address = Address.EMPTY.copy(postcode = "1001"),
+        normalizedAddress = Address.EMPTY.copy(postcode = "1001-900"),
+        isTrivial = false
+    )
+
+    @Test
+    fun `when selected site is null then return failure`() = testBlocking {
+        val result = sut.invoke(defaultAddress)
+
+        assert(result.isFailure)
+    }
+
+    @Test
+    fun `when normalize address fails then return failure`() = testBlocking {
+        whenever(site.getOrNull()).thenReturn(SiteModel())
+        whenever(repository.normalizeAddress(any(), any())).thenReturn(WooResult(WooError(GENERIC_ERROR, UNKNOWN)))
+
+        val result = sut.invoke(defaultAddress)
+
+        assert(result.isFailure)
+    }
+
+    @Test
+    fun `when normalize address succeed then return expected data`() = testBlocking {
+        whenever(site.getOrNull()).thenReturn(SiteModel())
+        whenever(repository.normalizeAddress(any(), any())).thenReturn(WooResult(defaultNormalizeAddressResponse))
+
+        val result = sut.invoke(defaultAddress)
+
+        assert(result.isSuccess)
+        assertThat(result.getOrNull()).isEqualTo(defaultNormalizeAddressResponse)
+    }
+}

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/address/origin/WooShippingEditOriginViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/address/origin/WooShippingEditOriginViewModelTest.kt
@@ -6,6 +6,7 @@ import com.woocommerce.android.ui.orders.wooshippinglabels.address.AddressValida
 import com.woocommerce.android.ui.orders.wooshippinglabels.address.GetStatesByCountryCode
 import com.woocommerce.android.ui.orders.wooshippinglabels.models.OriginShippingAddress
 import com.woocommerce.android.viewmodel.BaseUnitTest
+import com.woocommerce.android.viewmodel.ResourceProvider
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.advanceUntilIdle
 import org.assertj.core.api.Assertions.assertThat
@@ -21,6 +22,9 @@ class WooShippingEditOriginViewModelTest : BaseUnitTest() {
     private val addressValidator: AddressValidationHelper = mock()
     private val getAcceptedOriginCountries: GetAcceptedOriginCountries = mock()
     private val getStatesByCountryCode: GetStatesByCountryCode = mock()
+    private val resourceProvider: ResourceProvider = mock()
+    private val normalizeAddress: NormalizeAddress = mock()
+
 
     private val countries = listOf(
         Location("US", "United States"),
@@ -41,7 +45,9 @@ class WooShippingEditOriginViewModelTest : BaseUnitTest() {
             addressValidator = addressValidator,
             savedState = WooShippingEditOriginAddressFragmentArgs(originAddress).toSavedStateHandle(),
             getAcceptedOriginCountries = getAcceptedOriginCountries,
-            getStatesByCountryCode = getStatesByCountryCode
+            getStatesByCountryCode = getStatesByCountryCode,
+            normalizeAddress = normalizeAddress,
+            resourceProvider = resourceProvider
         )
     }
 
@@ -62,11 +68,10 @@ class WooShippingEditOriginViewModelTest : BaseUnitTest() {
 
         val result = sut.viewState.value
 
-        assertThat(result).isInstanceOf(WooShippingEditOriginViewModel.EditAddressViewState::class.java)
-        val editableAddress = (result as WooShippingEditOriginViewModel.EditAddressViewState.DataState).editableAddress
+        assertThat(result).isInstanceOf(WooShippingEditOriginViewModel.ViewState::class.java)
 
-        assertThat(editableAddress.name.error).isNull()
-        assertThat(editableAddress.company.error).isNull()
+        assertThat(result.editableAddress.name.error).isNull()
+        assertThat(result.editableAddress.company.error).isNull()
     }
 
     @Test
@@ -86,11 +91,10 @@ class WooShippingEditOriginViewModelTest : BaseUnitTest() {
 
         val result = sut.viewState.value
 
-        assertThat(result).isInstanceOf(WooShippingEditOriginViewModel.EditAddressViewState::class.java)
-        val editableAddress = (result as WooShippingEditOriginViewModel.EditAddressViewState.DataState).editableAddress
+        assertThat(result).isInstanceOf(WooShippingEditOriginViewModel.ViewState::class.java)
 
-        assertThat(editableAddress.name.error).isNull()
-        assertThat(editableAddress.company.error).isNull()
+        assertThat(result.editableAddress.name.error).isNull()
+        assertThat(result.editableAddress.company.error).isNull()
     }
 
     @Test
@@ -111,11 +115,10 @@ class WooShippingEditOriginViewModelTest : BaseUnitTest() {
 
         val result = sut.viewState.value
 
-        assertThat(result).isInstanceOf(WooShippingEditOriginViewModel.EditAddressViewState::class.java)
-        val editableAddress = (result as WooShippingEditOriginViewModel.EditAddressViewState.DataState).editableAddress
+        assertThat(result).isInstanceOf(WooShippingEditOriginViewModel.ViewState::class.java)
 
-        assertThat(editableAddress.name.error).isNotEmpty()
-        assertThat(editableAddress.company.error).isNull()
+        assertThat(result.editableAddress.name.error).isNotEmpty()
+        assertThat(result.editableAddress.company.error).isNull()
     }
 
     @Test
@@ -131,10 +134,9 @@ class WooShippingEditOriginViewModelTest : BaseUnitTest() {
 
         val result = sut.viewState.value
 
-        assertThat(result).isInstanceOf(WooShippingEditOriginViewModel.EditAddressViewState::class.java)
-        val editableAddress = (result as WooShippingEditOriginViewModel.EditAddressViewState.DataState).editableAddress
+        assertThat(result).isInstanceOf(WooShippingEditOriginViewModel.ViewState::class.java)
 
-        assertThat(editableAddress.address.error).isNotEmpty()
+        assertThat(result.editableAddress.address.error).isNotEmpty()
     }
 
     @Test
@@ -150,10 +152,9 @@ class WooShippingEditOriginViewModelTest : BaseUnitTest() {
 
         val result = sut.viewState.value
 
-        assertThat(result).isInstanceOf(WooShippingEditOriginViewModel.EditAddressViewState::class.java)
-        val editableAddress = (result as WooShippingEditOriginViewModel.EditAddressViewState.DataState).editableAddress
+        assertThat(result).isInstanceOf(WooShippingEditOriginViewModel.ViewState::class.java)
 
-        assertThat(editableAddress.address.error).isNull()
+        assertThat(result.editableAddress.address.error).isNull()
     }
 
     @Test
@@ -169,10 +170,9 @@ class WooShippingEditOriginViewModelTest : BaseUnitTest() {
 
         val result = sut.viewState.value
 
-        assertThat(result).isInstanceOf(WooShippingEditOriginViewModel.EditAddressViewState::class.java)
-        val editableAddress = (result as WooShippingEditOriginViewModel.EditAddressViewState.DataState).editableAddress
+        assertThat(result).isInstanceOf(WooShippingEditOriginViewModel.ViewState::class.java)
 
-        assertThat(editableAddress.city.error).isNotEmpty()
+        assertThat(result.editableAddress.city.error).isNotEmpty()
     }
 
     @Test
@@ -188,10 +188,9 @@ class WooShippingEditOriginViewModelTest : BaseUnitTest() {
 
         val result = sut.viewState.value
 
-        assertThat(result).isInstanceOf(WooShippingEditOriginViewModel.EditAddressViewState::class.java)
-        val editableAddress = (result as WooShippingEditOriginViewModel.EditAddressViewState.DataState).editableAddress
+        assertThat(result).isInstanceOf(WooShippingEditOriginViewModel.ViewState::class.java)
 
-        assertThat(editableAddress.city.error).isNull()
+        assertThat(result.editableAddress.city.error).isNull()
     }
 
     @Test
@@ -207,10 +206,9 @@ class WooShippingEditOriginViewModelTest : BaseUnitTest() {
 
         val result = sut.viewState.value
 
-        assertThat(result).isInstanceOf(WooShippingEditOriginViewModel.EditAddressViewState::class.java)
-        val editableAddress = (result as WooShippingEditOriginViewModel.EditAddressViewState.DataState).editableAddress
+        assertThat(result).isInstanceOf(WooShippingEditOriginViewModel.ViewState::class.java)
 
-        assertThat(editableAddress.postalCode.error).isNotEmpty()
+        assertThat(result.editableAddress.postalCode.error).isNotEmpty()
     }
 
     @Test
@@ -226,10 +224,9 @@ class WooShippingEditOriginViewModelTest : BaseUnitTest() {
 
         val result = sut.viewState.value
 
-        assertThat(result).isInstanceOf(WooShippingEditOriginViewModel.EditAddressViewState::class.java)
-        val editableAddress = (result as WooShippingEditOriginViewModel.EditAddressViewState.DataState).editableAddress
+        assertThat(result).isInstanceOf(WooShippingEditOriginViewModel.ViewState::class.java)
 
-        assertThat(editableAddress.postalCode.error).isNull()
+        assertThat(result.editableAddress.postalCode.error).isNull()
     }
 
     @Test
@@ -245,10 +242,9 @@ class WooShippingEditOriginViewModelTest : BaseUnitTest() {
 
         val result = sut.viewState.value
 
-        assertThat(result).isInstanceOf(WooShippingEditOriginViewModel.EditAddressViewState::class.java)
-        val editableAddress = (result as WooShippingEditOriginViewModel.EditAddressViewState.DataState).editableAddress
+        assertThat(result).isInstanceOf(WooShippingEditOriginViewModel.ViewState::class.java)
 
-        assertThat(editableAddress.email.error).isNotEmpty()
+        assertThat(result.editableAddress.email.error).isNotEmpty()
     }
 
     @Test
@@ -264,10 +260,9 @@ class WooShippingEditOriginViewModelTest : BaseUnitTest() {
 
         val result = sut.viewState.value
 
-        assertThat(result).isInstanceOf(WooShippingEditOriginViewModel.EditAddressViewState::class.java)
-        val editableAddress = (result as WooShippingEditOriginViewModel.EditAddressViewState.DataState).editableAddress
+        assertThat(result).isInstanceOf(WooShippingEditOriginViewModel.ViewState::class.java)
 
-        assertThat(editableAddress.email.error).isNull()
+        assertThat(result.editableAddress.email.error).isNull()
     }
 
     @Test
@@ -284,10 +279,9 @@ class WooShippingEditOriginViewModelTest : BaseUnitTest() {
 
         val result = sut.viewState.value
 
-        assertThat(result).isInstanceOf(WooShippingEditOriginViewModel.EditAddressViewState::class.java)
-        val editableAddress = (result as WooShippingEditOriginViewModel.EditAddressViewState.DataState).editableAddress
+        assertThat(result).isInstanceOf(WooShippingEditOriginViewModel.ViewState::class.java)
 
-        assertThat(editableAddress.phone.error).isNotEmpty()
+        assertThat(result.editableAddress.phone.error).isNotEmpty()
     }
 
     @Test
@@ -304,10 +298,9 @@ class WooShippingEditOriginViewModelTest : BaseUnitTest() {
 
         val result = sut.viewState.value
 
-        assertThat(result).isInstanceOf(WooShippingEditOriginViewModel.EditAddressViewState::class.java)
-        val editableAddress = (result as WooShippingEditOriginViewModel.EditAddressViewState.DataState).editableAddress
+        assertThat(result).isInstanceOf(WooShippingEditOriginViewModel.ViewState::class.java)
 
-        assertThat(editableAddress.phone.error).isNotEmpty()
+        assertThat(result.editableAddress.phone.error).isNotEmpty()
     }
 
     @Test
@@ -324,10 +317,9 @@ class WooShippingEditOriginViewModelTest : BaseUnitTest() {
 
         val result = sut.viewState.value
 
-        assertThat(result).isInstanceOf(WooShippingEditOriginViewModel.EditAddressViewState::class.java)
-        val editableAddress = (result as WooShippingEditOriginViewModel.EditAddressViewState.DataState).editableAddress
+        assertThat(result).isInstanceOf(WooShippingEditOriginViewModel.ViewState::class.java)
 
-        assertThat(editableAddress.phone.error).isNull()
+        assertThat(result.editableAddress.phone.error).isNull()
     }
 
     @Test
@@ -345,11 +337,9 @@ class WooShippingEditOriginViewModelTest : BaseUnitTest() {
 
         val result = sut.viewState.value
 
-        assertThat(result).isInstanceOf(WooShippingEditOriginViewModel.EditAddressViewState::class.java)
-        val isCompanyExpanded =
-            (result as WooShippingEditOriginViewModel.EditAddressViewState.DataState).isCompanyExpanded
+        assertThat(result).isInstanceOf(WooShippingEditOriginViewModel.ViewState::class.java)
 
-        assertThat(isCompanyExpanded).isTrue()
+        assertThat(result.isCompanyExpanded).isTrue()
     }
 
     @Test
@@ -364,11 +354,9 @@ class WooShippingEditOriginViewModelTest : BaseUnitTest() {
 
         val result = sut.viewState.value
 
-        assertThat(result).isInstanceOf(WooShippingEditOriginViewModel.EditAddressViewState::class.java)
-        val isCompanyExpanded =
-            (result as WooShippingEditOriginViewModel.EditAddressViewState.DataState).isCompanyExpanded
+        assertThat(result).isInstanceOf(WooShippingEditOriginViewModel.ViewState::class.java)
 
-        assertThat(isCompanyExpanded).isFalse()
+        assertThat(result.isCompanyExpanded).isFalse()
     }
 
     @Test
@@ -384,11 +372,10 @@ class WooShippingEditOriginViewModelTest : BaseUnitTest() {
 
         val result = sut.viewState.value
 
-        assertThat(result).isInstanceOf(WooShippingEditOriginViewModel.EditAddressViewState::class.java)
-        val dataState = (result as WooShippingEditOriginViewModel.EditAddressViewState.DataState)
+        assertThat(result).isInstanceOf(WooShippingEditOriginViewModel.ViewState::class.java)
 
-        assertThat(dataState.shouldDisplayLoading).isFalse()
-        assertThat(dataState.shouldDisplayLoadingCountriesError).isFalse()
+        assertThat(result.loading).isInstanceOf(WooShippingEditOriginViewModel.LoadingState.Hidden::class.java)
+        assertThat(result.shouldDisplayLoadingCountriesError).isFalse()
     }
 
     @Test
@@ -404,11 +391,10 @@ class WooShippingEditOriginViewModelTest : BaseUnitTest() {
 
         val result = sut.viewState.value
 
-        assertThat(result).isInstanceOf(WooShippingEditOriginViewModel.EditAddressViewState::class.java)
-        val dataState = (result as WooShippingEditOriginViewModel.EditAddressViewState.DataState)
+        assertThat(result).isInstanceOf(WooShippingEditOriginViewModel.ViewState::class.java)
 
-        assertThat(dataState.shouldDisplayLoading).isFalse()
-        assertThat(dataState.shouldDisplayLoadingCountriesError).isTrue()
+        assertThat(result.loading).isInstanceOf(WooShippingEditOriginViewModel.LoadingState.Hidden::class.java)
+        assertThat(result.shouldDisplayLoadingCountriesError).isTrue()
     }
 
     @Test
@@ -425,10 +411,9 @@ class WooShippingEditOriginViewModelTest : BaseUnitTest() {
 
         val result = sut.viewState.value
 
-        assertThat(result).isInstanceOf(WooShippingEditOriginViewModel.EditAddressViewState::class.java)
-        val dataState = (result as WooShippingEditOriginViewModel.EditAddressViewState.DataState)
+        assertThat(result).isInstanceOf(WooShippingEditOriginViewModel.ViewState::class.java)
 
-        assertThat(dataState.shouldUseStatesInput).isTrue()
+        assertThat(result.shouldUseStatesInput).isTrue()
     }
 
     @Test
@@ -445,10 +430,9 @@ class WooShippingEditOriginViewModelTest : BaseUnitTest() {
 
         val result = sut.viewState.value
 
-        assertThat(result).isInstanceOf(WooShippingEditOriginViewModel.EditAddressViewState::class.java)
-        val dataState = (result as WooShippingEditOriginViewModel.EditAddressViewState.DataState)
+        assertThat(result).isInstanceOf(WooShippingEditOriginViewModel.ViewState::class.java)
 
-        assertThat(dataState.shouldUseStatesInput).isFalse()
+        assertThat(result.shouldUseStatesInput).isFalse()
     }
 
     @Test
@@ -465,11 +449,10 @@ class WooShippingEditOriginViewModelTest : BaseUnitTest() {
 
         val result = sut.viewState.value
 
-        assertThat(result).isInstanceOf(WooShippingEditOriginViewModel.EditAddressViewState::class.java)
-        val dataState = (result as WooShippingEditOriginViewModel.EditAddressViewState.DataState)
+        assertThat(result).isInstanceOf(WooShippingEditOriginViewModel.ViewState::class.java)
 
-        assertThat(dataState.shouldUseStatesInput).isFalse()
-        assertThat(dataState.editableAddress.state).isEqualTo(states.first())
+        assertThat(result.shouldUseStatesInput).isFalse()
+        assertThat(result.editableAddress.state).isEqualTo(states.first())
     }
 
     @Test
@@ -486,11 +469,10 @@ class WooShippingEditOriginViewModelTest : BaseUnitTest() {
 
         val result = sut.viewState.value
 
-        assertThat(result).isInstanceOf(WooShippingEditOriginViewModel.EditAddressViewState::class.java)
-        val dataState = (result as WooShippingEditOriginViewModel.EditAddressViewState.DataState)
+        assertThat(result).isInstanceOf(WooShippingEditOriginViewModel.ViewState::class.java)
 
-        assertThat(dataState.shouldUseStatesInput).isTrue()
-        assertThat(dataState.editableAddress.state.name).isEqualTo("")
+        assertThat(result.shouldUseStatesInput).isTrue()
+        assertThat(result.editableAddress.state.name).isEqualTo("")
     }
 
     @Test
@@ -522,10 +504,9 @@ class WooShippingEditOriginViewModelTest : BaseUnitTest() {
 
         val result = sut.viewState.value
 
-        assertThat(result).isInstanceOf(WooShippingEditOriginViewModel.EditAddressViewState::class.java)
-        val dataState = (result as WooShippingEditOriginViewModel.EditAddressViewState.DataState)
+        assertThat(result).isInstanceOf(WooShippingEditOriginViewModel.ViewState::class.java)
 
-        assertThat(dataState.addressStatus).isEqualTo(AddressStatus.VERIFIED)
+        assertThat(result.addressStatus).isEqualTo(AddressStatus.VERIFIED)
     }
 
     @Test
@@ -558,10 +539,9 @@ class WooShippingEditOriginViewModelTest : BaseUnitTest() {
 
         val result = sut.viewState.value
 
-        assertThat(result).isInstanceOf(WooShippingEditOriginViewModel.EditAddressViewState::class.java)
-        val dataState = (result as WooShippingEditOriginViewModel.EditAddressViewState.DataState)
+        assertThat(result).isInstanceOf(WooShippingEditOriginViewModel.ViewState::class.java)
 
-        assertThat(dataState.addressStatus).isEqualTo(AddressStatus.UNVERIFIED)
+        assertThat(result.addressStatus).isEqualTo(AddressStatus.UNVERIFIED)
     }
 
     @Test
@@ -593,10 +573,9 @@ class WooShippingEditOriginViewModelTest : BaseUnitTest() {
 
         val result = sut.viewState.value
 
-        assertThat(result).isInstanceOf(WooShippingEditOriginViewModel.EditAddressViewState::class.java)
-        val dataState = (result as WooShippingEditOriginViewModel.EditAddressViewState.DataState)
+        assertThat(result).isInstanceOf(WooShippingEditOriginViewModel.ViewState::class.java)
 
-        assertThat(dataState.addressStatus).isEqualTo(AddressStatus.UNVERIFIED)
+        assertThat(result.addressStatus).isEqualTo(AddressStatus.UNVERIFIED)
     }
 
     @Test
@@ -628,9 +607,8 @@ class WooShippingEditOriginViewModelTest : BaseUnitTest() {
 
         val result = sut.viewState.value
 
-        assertThat(result).isInstanceOf(WooShippingEditOriginViewModel.EditAddressViewState::class.java)
-        val dataState = (result as WooShippingEditOriginViewModel.EditAddressViewState.DataState)
+        assertThat(result).isInstanceOf(WooShippingEditOriginViewModel.ViewState::class.java)
 
-        assertThat(dataState.addressStatus).isEqualTo(AddressStatus.MISSING_INFO)
+        assertThat(result.addressStatus).isEqualTo(AddressStatus.MISSING_INFO)
     }
 }

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/address/origin/WooShippingEditOriginViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/address/origin/WooShippingEditOriginViewModelTest.kt
@@ -1,9 +1,11 @@
 package com.woocommerce.android.ui.orders.wooshippinglabels.address.origin
 
 import androidx.compose.runtime.snapshots.Snapshot
+import com.woocommerce.android.model.Address
 import com.woocommerce.android.model.Location
 import com.woocommerce.android.ui.orders.wooshippinglabels.address.AddressValidationHelper
 import com.woocommerce.android.ui.orders.wooshippinglabels.address.GetStatesByCountryCode
+import com.woocommerce.android.ui.orders.wooshippinglabels.models.AddressNormalizationModel
 import com.woocommerce.android.ui.orders.wooshippinglabels.models.OriginShippingAddress
 import com.woocommerce.android.viewmodel.BaseUnitTest
 import com.woocommerce.android.viewmodel.ResourceProvider
@@ -610,5 +612,184 @@ class WooShippingEditOriginViewModelTest : BaseUnitTest() {
         assertThat(result).isInstanceOf(WooShippingEditOriginViewModel.ViewState::class.java)
 
         assertThat(result.addressStatus).isEqualTo(AddressStatus.MISSING_INFO)
+    }
+
+    @Test
+    fun `when screen is initialized then normalize address is closed`() = testBlocking {
+        val address = OriginShippingAddress.EMPTY
+        whenever(addressValidator.validateFieldRequired(any())).doReturn(null)
+        whenever(getAcceptedOriginCountries.invoke()).doReturn(Result.success(countries))
+        whenever(getStatesByCountryCode.invoke(any())).doReturn(states)
+        Snapshot.withMutableSnapshot {
+            createViewModel(address)
+        }
+
+        advanceUntilIdle()
+
+        val result = sut.viewState.value
+
+        assertThat(result).isInstanceOf(WooShippingEditOriginViewModel.ViewState::class.java)
+
+        assertThat(result.normalizedAddressStatus).isEqualTo(NormalizedAddressStatus.Closed)
+    }
+
+    @Test
+    fun `when normalize address fails, display error`() = testBlocking {
+        val address = OriginShippingAddress.EMPTY
+        val updatedAddress = EditableAddress(postalCode = InputValue("12345"))
+        whenever(addressValidator.validateFieldRequired(any())).doReturn(null)
+        whenever(getAcceptedOriginCountries.invoke()).doReturn(Result.success(countries))
+        whenever(getStatesByCountryCode.invoke(any())).doReturn(states)
+        whenever(normalizeAddress.invoke(any())).doReturn(Result.failure(Exception("error")))
+        Snapshot.withMutableSnapshot {
+            createViewModel(address)
+        }
+
+        advanceUntilIdle()
+
+        sut.onNormalizeAddress(updatedAddress)
+
+        val result = sut.viewState.value
+
+        assertThat(result).isInstanceOf(WooShippingEditOriginViewModel.ViewState::class.java)
+
+        assertThat(result.normalizedAddressStatus).isEqualTo(NormalizedAddressStatus.Failure)
+    }
+
+    @Test
+    fun `when normalize address succeed, display address selection`() = testBlocking {
+        val address = OriginShippingAddress.EMPTY
+        val updatedAddress = EditableAddress(postalCode = InputValue("12345"))
+        val normalizeAddressResponse = AddressNormalizationModel(
+            address = Address.EMPTY,
+            normalizedAddress = Address.EMPTY,
+            isTrivial = true
+        )
+
+        whenever(addressValidator.validateFieldRequired(any())).doReturn(null)
+        whenever(getAcceptedOriginCountries.invoke()).doReturn(Result.success(countries))
+        whenever(getStatesByCountryCode.invoke(any())).doReturn(states)
+        whenever(normalizeAddress.invoke(any())).doReturn(Result.success(normalizeAddressResponse))
+        Snapshot.withMutableSnapshot {
+            createViewModel(address)
+        }
+
+        advanceUntilIdle()
+
+        sut.onNormalizeAddress(updatedAddress)
+
+        val result = sut.viewState.value
+
+        assertThat(result).isInstanceOf(WooShippingEditOriginViewModel.ViewState::class.java)
+
+        assertThat(result.normalizedAddressStatus).isInstanceOf(NormalizedAddressStatus.AddressSelection::class.java)
+    }
+
+    @Test
+    fun `when normalize address succeed then suggested address is selected`() = testBlocking {
+        val initialAddress = OriginShippingAddress.EMPTY
+        val updatedAddress = EditableAddress(postalCode = InputValue("12345"))
+        val enteredAddress = EditableAddress(postalCode = InputValue("12345")).toAddress()
+        val suggestedAddress = enteredAddress.copy(postcode = "12345-1000")
+
+        val normalizeAddressResponse = AddressNormalizationModel(
+            address = enteredAddress,
+            normalizedAddress = suggestedAddress,
+            isTrivial = false
+        )
+
+        whenever(addressValidator.validateFieldRequired(any())).doReturn(null)
+        whenever(getAcceptedOriginCountries.invoke()).doReturn(Result.success(countries))
+        whenever(getStatesByCountryCode.invoke(any())).doReturn(states)
+        whenever(normalizeAddress.invoke(any())).doReturn(Result.success(normalizeAddressResponse))
+        Snapshot.withMutableSnapshot {
+            createViewModel(initialAddress)
+        }
+
+        advanceUntilIdle()
+
+        sut.onNormalizeAddress(updatedAddress)
+
+        val result = sut.viewState.value
+        assertThat(result).isInstanceOf(WooShippingEditOriginViewModel.ViewState::class.java)
+        val addressSelection = result.normalizedAddressStatus as NormalizedAddressStatus.AddressSelection
+        assertThat(addressSelection.selectedAddress).isEqualTo(suggestedAddress)
+    }
+
+    @Test
+    fun `when normalize address selection changes then address selection is updated`() = testBlocking {
+        val initialAddress = OriginShippingAddress.EMPTY
+        val updatedAddress = EditableAddress(postalCode = InputValue("12345"))
+        val enteredAddress = EditableAddress(postalCode = InputValue("12345")).toAddress()
+        val suggestedAddress = enteredAddress.copy(postcode = "12345-1000")
+
+        val normalizeAddressResponse = AddressNormalizationModel(
+            address = enteredAddress,
+            normalizedAddress = suggestedAddress,
+            isTrivial = false
+        )
+
+        whenever(addressValidator.validateFieldRequired(any())).doReturn(null)
+        whenever(getAcceptedOriginCountries.invoke()).doReturn(Result.success(countries))
+        whenever(getStatesByCountryCode.invoke(any())).doReturn(states)
+        whenever(normalizeAddress.invoke(any())).doReturn(Result.success(normalizeAddressResponse))
+        Snapshot.withMutableSnapshot {
+            createViewModel(initialAddress)
+        }
+
+        advanceUntilIdle()
+
+        sut.onNormalizeAddress(updatedAddress)
+
+        var result = sut.viewState.value
+        assertThat(result).isInstanceOf(WooShippingEditOriginViewModel.ViewState::class.java)
+        var addressSelection = result.normalizedAddressStatus as NormalizedAddressStatus.AddressSelection
+        assertThat(addressSelection.selectedAddress).isEqualTo(suggestedAddress)
+
+
+        sut.onAddressSelectionChange(addressSelection.copy(selectedAddress = enteredAddress))
+
+
+        result = sut.viewState.value
+        assertThat(result).isInstanceOf(WooShippingEditOriginViewModel.ViewState::class.java)
+        addressSelection = result.normalizedAddressStatus as NormalizedAddressStatus.AddressSelection
+        assertThat(addressSelection.selectedAddress).isEqualTo(enteredAddress)
+    }
+
+    @Test
+    fun `when normalize address is closed then close address selection`() = testBlocking {
+        val initialAddress = OriginShippingAddress.EMPTY
+        val updatedAddress = EditableAddress(postalCode = InputValue("12345"))
+        val enteredAddress = EditableAddress(postalCode = InputValue("12345")).toAddress()
+        val suggestedAddress = enteredAddress.copy(postcode = "12345-1000")
+
+        val normalizeAddressResponse = AddressNormalizationModel(
+            address = enteredAddress,
+            normalizedAddress = suggestedAddress,
+            isTrivial = false
+        )
+
+        whenever(addressValidator.validateFieldRequired(any())).doReturn(null)
+        whenever(getAcceptedOriginCountries.invoke()).doReturn(Result.success(countries))
+        whenever(getStatesByCountryCode.invoke(any())).doReturn(states)
+        whenever(normalizeAddress.invoke(any())).doReturn(Result.success(normalizeAddressResponse))
+        Snapshot.withMutableSnapshot {
+            createViewModel(initialAddress)
+        }
+
+        advanceUntilIdle()
+
+        sut.onNormalizeAddress(updatedAddress)
+
+        var result = sut.viewState.value
+        assertThat(result).isInstanceOf(WooShippingEditOriginViewModel.ViewState::class.java)
+        val addressSelection = result.normalizedAddressStatus as NormalizedAddressStatus.AddressSelection
+        assertThat(addressSelection.selectedAddress).isEqualTo(suggestedAddress)
+
+        sut.onCloseAddressSelection()
+
+        result = sut.viewState.value
+        assertThat(result).isInstanceOf(WooShippingEditOriginViewModel.ViewState::class.java)
+        assertThat(result.normalizedAddressStatus).isEqualTo(NormalizedAddressStatus.Closed)
     }
 }

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/address/origin/WooShippingEditOriginViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/address/origin/WooShippingEditOriginViewModelTest.kt
@@ -27,7 +27,6 @@ class WooShippingEditOriginViewModelTest : BaseUnitTest() {
     private val resourceProvider: ResourceProvider = mock()
     private val normalizeAddress: NormalizeAddress = mock()
 
-
     private val countries = listOf(
         Location("US", "United States"),
         Location("UK", "United Kingdom"),
@@ -746,9 +745,7 @@ class WooShippingEditOriginViewModelTest : BaseUnitTest() {
         var addressSelection = result.normalizedAddressStatus as NormalizedAddressStatus.AddressSelection
         assertThat(addressSelection.selectedAddress).isEqualTo(suggestedAddress)
 
-
         sut.onAddressSelectionChange(addressSelection.copy(selectedAddress = enteredAddress))
-
 
         result = sut.viewState.value
         assertThat(result).isInstanceOf(WooShippingEditOriginViewModel.ViewState::class.java)


### PR DESCRIPTION
Part of: #12439

### Description
This PR includes the address normalization logic into the edit origin address flow. 

This PR adds:

1. The normalized address network logic (rest client, repository, dao, mapper)
2. The select suggested address UI
3. The normalized address use case

On top of the above, I also updated the loading UI to include a loading message while the address verification is taking place and some refactors in the view model for simplification. Handling failure will be tackled in the next PR.

⚠️ This PR depends on [this other PR](https://github.com/woocommerce/woocommerce-android/pull/13506) including the bottom sheet material 3 migration.

### Testing information

1. Open the orders tab
2. Tap on an order eligible for shipping label creation
3. Expand the shipment details section
4. Expand the origin address selection (3 dots)
5. Tap on the pencil
6. If the address is verified, update an address field to make the address unverified
7. Tap on validate & save
8. Check a loading dialog is displayed while the verification is taking place
9. Check that after the verification is completed, a confirm address screen is presented with the entered address and the suggested address
10. Check that changing the address selection works as expected (changing the address and the button text).

### The tests that have been performed
- Checked that the happy path works as expected
- Checked that a network request was made to verify the address
- Checked that address selection works as expected

### Images/gif

https://github.com/user-attachments/assets/4fbb629a-141b-46c2-812d-cc6f222b8314

- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.

## Reviewer (or Author, in the case of optional code reviews):

Please make sure these conditions are met before approving the PR, or request changes if the PR needs improvement:

- [ ] The PR is small and has a clear, single focus, or a valid explanation is provided in the description. If needed, please request to split it into smaller PRs.
- [ ] Ensure Adequate Unit Test Coverage: The changes are reasonably covered by unit tests or an explanation is provided in the PR description.
- [ ] Manual Testing: The author listed all the tests they ran, including smoke tests when needed (e.g., for refactorings). The reviewer confirmed that the PR works as expected on big (tablet) and small (phone) in case of UI changes, and no regressions are added.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md --