### PR TITLE
[Shipping Labels] Handle loading order error

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/WooShippingLabelCreationFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/WooShippingLabelCreationFragment.kt
@@ -12,6 +12,7 @@ import androidx.navigation.fragment.findNavController
 import com.woocommerce.android.extensions.handleResult
 import com.woocommerce.android.extensions.navigateSafely
 import com.woocommerce.android.ui.base.BaseFragment
+import com.woocommerce.android.ui.base.UIMessageResolver
 import com.woocommerce.android.ui.compose.theme.WooThemeWithBackground
 import com.woocommerce.android.ui.main.AppBarStatus
 import com.woocommerce.android.ui.main.MainActivity.Companion.BackPressListener
@@ -21,9 +22,13 @@ import com.woocommerce.android.ui.orders.wooshippinglabels.packages.WooShippingL
 import com.woocommerce.android.ui.orders.wooshippinglabels.packages.ui.PackageData
 import com.woocommerce.android.viewmodel.MultiLiveEvent
 import dagger.hilt.android.AndroidEntryPoint
+import javax.inject.Inject
 
 @AndroidEntryPoint
 class WooShippingLabelCreationFragment : BaseFragment(), BackPressListener {
+    @Inject
+    lateinit var uiMessageResolver: UIMessageResolver
+
     private val viewModel: WooShippingLabelCreationViewModel by viewModels()
 
     override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View {
@@ -73,7 +78,7 @@ class WooShippingLabelCreationFragment : BaseFragment(), BackPressListener {
                         .actionWooShippingLabelCreationFragmentToWooShippingLabelCustomsFormFragment()
                         .let { findNavController().navigateSafely(it) }
                 }
-
+                is MultiLiveEvent.Event.ShowSnackbar -> uiMessageResolver.showSnack(event.message)
                 is MultiLiveEvent.Event.Exit -> findNavController().navigateUp()
             }
         }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/WooShippingLabelCreationViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/WooShippingLabelCreationViewModel.kt
@@ -6,6 +6,7 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.setValue
 import androidx.compose.runtime.snapshotFlow
 import androidx.lifecycle.SavedStateHandle
+import com.woocommerce.android.R
 import com.woocommerce.android.extensions.combine
 import com.woocommerce.android.extensions.formatToString
 import com.woocommerce.android.extensions.sumByFloat
@@ -113,7 +114,12 @@ class WooShippingLabelCreationViewModel @Inject constructor(
     }
 
     private suspend fun getOrderInformation() {
-        orderDetailRepository.getOrderById(navArgs.orderId).let { order.value = it }
+        orderDetailRepository.getOrderById(navArgs.orderId)?.let {
+            order.value = it
+        } ?: run {
+            triggerEvent(Event.ShowSnackbar(R.string.woo_shipping_labels_loading_order_error))
+            postTriggerEvent(Event.Exit)
+        }
     }
 
     private fun getStoreOptions() {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/WooShippingLabelCreationViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/WooShippingLabelCreationViewModel.kt
@@ -61,7 +61,7 @@ class WooShippingLabelCreationViewModel @Inject constructor(
     private val navArgs: WooShippingLabelCreationFragmentArgs by savedState.navArgs()
 
     private val emptyOrder = Order.getEmptyOrder(Date(), Date())
-    private val order = MutableStateFlow<Order?>(emptyOrder)
+    private val order = MutableStateFlow<Order>(emptyOrder)
     private val shippingAddresses = MutableStateFlow<WooShippingAddresses?>(WooShippingAddresses.EMPTY)
     private val storeOptions = MutableStateFlow<StoreOptionsModel?>(StoreOptionsModel.EMPTY)
 
@@ -145,7 +145,7 @@ class WooShippingLabelCreationViewModel @Inject constructor(
                     shipFrom = addresses.shipFrom,
                     shipTo = addresses.shipTo,
                     weight = packageWeight.totalWeight,
-                    currencyCode = order.value?.currency
+                    currencyCode = order.value.currency
                 )
             } else {
                 null
@@ -231,7 +231,7 @@ class WooShippingLabelCreationViewModel @Inject constructor(
 
     private suspend fun getShippingAddresses() {
         order.combine(observeOriginAddresses()) { order, originAddresses ->
-            if (order != null && !originAddresses.isNullOrEmpty()) {
+            if (!originAddresses.isNullOrEmpty()) {
                 val selectedOriginAddress = getSelectedOriginAddress(originAddresses)
                 WooShippingAddresses(
                     shipFrom = selectedOriginAddress,
@@ -281,7 +281,7 @@ class WooShippingLabelCreationViewModel @Inject constructor(
             purchaseState,
             customsState
         ) { storeOptions, order, addresses, shippingRates, packageSelection, uiState, purchaseState, customsState ->
-            if (order == null || storeOptions == null || addresses == null || purchaseState is PurchaseState.Error) {
+            if (storeOptions == null || addresses == null || purchaseState is PurchaseState.Error) {
                 return@combine WooShippingViewState.Error
             }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/viewmodel/ScopedViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/viewmodel/ScopedViewModel.kt
@@ -41,6 +41,11 @@ abstract class ScopedViewModel(
         }
     }
 
+    protected fun postTriggerEvent(event: Event) {
+        event.isHandled = false
+        _event.postValue(event)
+    }
+
     /**
      * Convert a [Flow] to [StateFlow].
      *

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -4505,6 +4505,7 @@
 
     <string name="woo_shipping_address_validate_and_save">Validate &amp; Save</string>
     <string name="woo_shipping_address_missing_info_hint">Add missing information</string>
+    <string name="woo_shipping_labels_loading_order_error">Unable to load the order</string>
 
 
     <string name="error_user_username_instead_of_email">Please log in using your WordPress.com username instead of your email address.</string>

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/WooShippingLabelCreationViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/WooShippingLabelCreationViewModelTest.kt
@@ -33,6 +33,7 @@ import com.woocommerce.android.ui.orders.wooshippinglabels.rates.ui.ShippingSort
 import com.woocommerce.android.util.CurrencyFormatter
 import com.woocommerce.android.viewmodel.BaseUnitTest
 import com.woocommerce.android.viewmodel.MultiLiveEvent
+import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.Exit
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.test.advanceUntilIdle
@@ -49,6 +50,7 @@ import java.math.BigDecimal
 import java.util.Date
 import kotlin.test.assertEquals
 import kotlin.test.assertIs
+import kotlin.test.assertNotNull
 
 @OptIn(ExperimentalCoroutinesApi::class)
 class WooShippingLabelCreationViewModelTest : BaseUnitTest() {
@@ -280,7 +282,7 @@ class WooShippingLabelCreationViewModelTest : BaseUnitTest() {
     }
 
     @Test
-    fun `when the order is not found, then show an error`() = testBlocking {
+    fun `when the order is not found, then exit`() = testBlocking {
         val order: Order? = null
         whenever(orderDetailRepository.getOrderById(any())) doReturn order
         whenever(observeOriginAddresses()) doReturn flowOf(defaultOriginAddresses)
@@ -288,10 +290,10 @@ class WooShippingLabelCreationViewModelTest : BaseUnitTest() {
 
         createViewModel()
 
-        advanceUntilIdle()
+        var exit: Exit? = null
+        sut.event.observeForever { if (it is Exit) exit = it }
 
-        val currentViewState = sut.viewState.value
-        assert(currentViewState is WooShippingViewState.Error)
+        assertNotNull(exit)
     }
 
     @Test


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #13317

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
This handles an error when retrieving the order on the shipping label creation screen. Since the creation flow starts from the order detail screen and the order is fetched from the local database, this error is not expected to occur in the released version. However, it is handled as a precaution. If the order from the database is null, we display an “Unable to load the order” error and navigate back.

### Steps to reproduce
<!-- Step-by-step testing instructions. For new user flows, consider instead stating the goal of the workflow and see if your PR reviewer can accomplish the workflow without specific steps! -->
- To force the database return a null order, apply this patch:[_Force_the_database_to_return_a_null_order_in_the_shipping_label_creation.patch](https://github.com/user-attachments/files/18847056/_Force_the_database_to_return_a_null_order_in_the_shipping_label_creation.patch)
- Log in to a site that is eligible for shipping labels.
- Go to orders.
- Create a new order and complete the payment.
- Open the order details and tap the "Create shipping label" button.

### The tests that have been performed
<!-- To give the reviewer an idea of what could be missed in terms of testing -->
Steps above.

### Images/gif
<!-- Include before and after images or gifs when appropriate. -->
<img src="https://github.com/user-attachments/assets/79fc1762-1e95-43ab-b1c8-31f490d7c69b" width=360>

- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.

## Reviewer (or Author, in the case of optional code reviews):

Please make sure these conditions are met before approving the PR, or request changes if the PR needs improvement:

- [ ] The PR is small and has a clear, single focus, or a valid explanation is provided in the description. If needed, please request to split it into smaller PRs.
- [ ] Ensure Adequate Unit Test Coverage: The changes are reasonably covered by unit tests or an explanation is provided in the PR description.
- [ ] Manual Testing: The author listed all the tests they ran, including smoke tests when needed (e.g., for refactorings). The reviewer confirmed that the PR works as expected on big (tablet) and small (phone) in case of UI changes, and no regressions are added.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->