### PR TITLE
Fix crashes related to calling `onBackPressed` directly

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -12,6 +12,7 @@
 - [*] [Internal] Removal animation of the items from the cart [https://github.com/woocommerce/woocommerce-android/pull/13442]
 - [*] Updated bottom sheet in Scan to update inventory to Material 3 component [https://github.com/woocommerce/woocommerce-android/pull/13554]
 - [*] Improved the Authenticated WebView implementation, and it will now handle opening the Analytics reports directly from the app without requiring additional authentication [https://github.com/woocommerce/woocommerce-android/pull/13487]
+- [*] Fixed a crash that occurred when the app was backgrounded during bulk variations update [https://github.com/woocommerce/woocommerce-android/pull/13584]
 
 21.7
 -----

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/BaseProductFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/BaseProductFragment.kt
@@ -11,7 +11,6 @@ import com.woocommerce.android.ui.dialog.WooDialog
 import com.woocommerce.android.ui.main.AppBarStatus
 import com.woocommerce.android.ui.main.MainActivity.Companion.BackPressListener
 import com.woocommerce.android.ui.products.details.ProductDetailViewModel
-import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.Exit
 import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.ShowDialog
 import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.ShowSnackbar
 import com.woocommerce.android.viewmodel.fixedHiltNavGraphViewModels
@@ -46,7 +45,6 @@ abstract class BaseProductFragment : BaseFragment, BackPressListener {
         viewModel.event.observe(viewLifecycleOwner) { event ->
             when (event) {
                 is ShowSnackbar -> uiMessageResolver.showSnack(event.message)
-                is Exit -> requireActivity().onBackPressedDispatcher.onBackPressed()
                 is ShowDialog -> WooDialog.showDialog(
                     requireActivity(),
                     event.positiveBtnAction,

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/categories/AddProductCategoryFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/categories/AddProductCategoryFragment.kt
@@ -181,7 +181,7 @@ class AddProductCategoryFragment :
         viewModel.event.observe(viewLifecycleOwner) { event ->
             when (event) {
                 is ShowSnackbar -> uiMessageResolver.showSnack(event.message)
-                is Exit -> requireActivity().onBackPressedDispatcher.onBackPressed()
+                is Exit -> findNavController().navigateUp()
                 is ShowDialog -> event.showDialog()
                 is ExitWithResult<*> -> navigateBackWithResult(ARG_CATEGORY_UPDATE_RESULT, event.data)
                 else -> event.isHandled = false

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/variations/VariationDetailFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/variations/VariationDetailFragment.kt
@@ -113,9 +113,7 @@ class VariationDetailFragment :
             onMenuItemSelected = ::onMenuItemSelected,
             onCreateMenu = { toolbar ->
                 toolbar.setNavigationOnClickListener {
-                    if (onRequestAllowBackPress()) {
-                        findNavController().navigateUp()
-                    }
+                    viewModel.onExit()
                 }
                 onCreateMenu(toolbar)
             }
@@ -432,11 +430,7 @@ class VariationDetailFragment :
     }
 
     override fun onRequestAllowBackPress(): Boolean {
-        return if (viewModel.event.value == Exit) {
-            true
-        } else {
-            viewModel.onExit()
-            false
-        }
+        viewModel.onExit()
+        return false
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/variations/VariationDetailFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/variations/VariationDetailFragment.kt
@@ -320,12 +320,7 @@ class VariationDetailFragment :
                 is ShowDialog -> event.showDialog()
                 is ShowDialogFragment -> event.showIn(parentFragmentManager, this)
                 is VariationDetailViewModel.ShowUpdateVariationError -> showUpdateVariationError(event.message)
-                is Exit -> {
-                    // Ensure subsequent Exit events are ignored to avoid IllegalStateException
-                    viewModel.event.removeObservers(viewLifecycleOwner)
-                    requireActivity().onBackPressedDispatcher.onBackPressed()
-                }
-
+                is Exit -> findNavController().navigateUp()
                 else -> event.isHandled = false
             }
         }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/variations/VariationsBulkUpdateBaseFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/variations/VariationsBulkUpdateBaseFragment.kt
@@ -1,18 +1,17 @@
 package com.woocommerce.android.ui.products.variations
 
 import android.os.Bundle
-import android.view.Menu
-import android.view.MenuInflater
 import android.view.MenuItem
 import android.view.View
 import androidx.annotation.CallSuper
 import androidx.annotation.LayoutRes
 import androidx.annotation.StringRes
-import androidx.core.view.MenuProvider
 import androidx.navigation.fragment.findNavController
 import com.woocommerce.android.R
 import com.woocommerce.android.ui.base.BaseFragment
 import com.woocommerce.android.ui.base.UIMessageResolver
+import com.woocommerce.android.ui.main.AppBarStatus
+import com.woocommerce.android.util.setupTabletSecondPaneToolbar
 import com.woocommerce.android.viewmodel.MultiLiveEvent
 import com.woocommerce.android.widgets.CustomProgressDialog
 import dagger.hilt.android.AndroidEntryPoint
@@ -27,6 +26,9 @@ abstract class VariationsBulkUpdateBaseFragment(@LayoutRes layoutId: Int) : Base
     @Inject
     lateinit var uiMessageResolver: UIMessageResolver
 
+    override val activityAppBarStatus: AppBarStatus
+        get() = AppBarStatus.Hidden
+
     private var doneMenuItem: MenuItem? = null
     private var progressDialog: CustomProgressDialog? = null
 
@@ -37,31 +39,16 @@ abstract class VariationsBulkUpdateBaseFragment(@LayoutRes layoutId: Int) : Base
 
     @CallSuper
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
-        setupMenu()
-        observeEvents()
-    }
-
-    private fun setupMenu() {
-        requireActivity().addMenuProvider(
-            object : MenuProvider {
-                override fun onCreateMenu(menu: Menu, menuInflater: MenuInflater) {
-                    menuInflater.inflate(R.menu.menu_variations_bulk_update, menu)
-                    doneMenuItem = menu.findItem(R.id.done)
-                }
-
-                override fun onMenuItemSelected(item: MenuItem): Boolean {
-                    return when (item.itemId) {
-                        R.id.done -> {
-                            viewModel.onDoneClicked()
-                            true
-                        }
-
-                        else -> false
-                    }
-                }
-            },
-            viewLifecycleOwner
+        setupTabletSecondPaneToolbar(
+            title = getFragmentTitle(),
+            onMenuItemSelected = ::onMenuItemSelected,
+            onCreateMenu = { toolbar ->
+                toolbar.inflateMenu(R.menu.menu_variations_bulk_update)
+                doneMenuItem = toolbar.menu.findItem(R.id.done)
+            }
         )
+
+        observeEvents()
     }
 
     private fun observeEvents() {
@@ -74,6 +61,17 @@ abstract class VariationsBulkUpdateBaseFragment(@LayoutRes layoutId: Int) : Base
 
                 is MultiLiveEvent.Event.Exit -> findNavController().navigateUp()
             }
+        }
+    }
+
+    private fun onMenuItemSelected(item: MenuItem): Boolean {
+        return when (item.itemId) {
+            R.id.done -> {
+                viewModel.onDoneClicked()
+                true
+            }
+
+            else -> false
         }
     }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/variations/VariationsBulkUpdateBaseFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/variations/VariationsBulkUpdateBaseFragment.kt
@@ -9,6 +9,7 @@ import androidx.annotation.CallSuper
 import androidx.annotation.LayoutRes
 import androidx.annotation.StringRes
 import androidx.core.view.MenuProvider
+import androidx.navigation.fragment.findNavController
 import com.woocommerce.android.R
 import com.woocommerce.android.ui.base.BaseFragment
 import com.woocommerce.android.ui.base.UIMessageResolver
@@ -23,7 +24,8 @@ import javax.inject.Inject
  */
 @AndroidEntryPoint
 abstract class VariationsBulkUpdateBaseFragment(@LayoutRes layoutId: Int) : BaseFragment(layoutId) {
-    @Inject lateinit var uiMessageResolver: UIMessageResolver
+    @Inject
+    lateinit var uiMessageResolver: UIMessageResolver
 
     private var doneMenuItem: MenuItem? = null
     private var progressDialog: CustomProgressDialog? = null
@@ -70,11 +72,7 @@ abstract class VariationsBulkUpdateBaseFragment(@LayoutRes layoutId: Int) : Base
                     uiMessageResolver.showSnack(event.message)
                 }
 
-                is MultiLiveEvent.Event.Exit -> {
-                    // Ensure subsequent Exit events are ignored to avoid IllegalStateException
-                    viewModel.event.removeObservers(viewLifecycleOwner)
-                    requireActivity().onBackPressedDispatcher.onBackPressed()
-                }
+                is MultiLiveEvent.Event.Exit -> findNavController().navigateUp()
             }
         }
     }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/variations/VariationsBulkUpdatePriceFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/variations/VariationsBulkUpdatePriceFragment.kt
@@ -45,7 +45,7 @@ class VariationsBulkUpdatePriceFragment :
     private fun observeViewStateChanges() {
         viewModel.viewStateData.observe(viewLifecycleOwner) { old, new ->
             new.priceType.takeIfNotEqualTo(old?.priceType) {
-                requireActivity().title = when (new.priceType) {
+                binding.toolbar.title = when (new.priceType) {
                     Regular -> getString(R.string.variations_bulk_update_regular_price)
                     Sale -> getString(R.string.variations_bulk_update_sale_price)
                 }

--- a/WooCommerce/src/main/res/layout/fragment_variations_bulk_update_inventory.xml
+++ b/WooCommerce/src/main/res/layout/fragment_variations_bulk_update_inventory.xml
@@ -5,6 +5,14 @@
     android:layout_height="match_parent"
     android:orientation="vertical">
 
+    <com.google.android.material.appbar.MaterialToolbar
+        android:id="@+id/toolbar"
+        style="@style/Widget.Woo.Toolbar"
+        android:layout_width="match_parent"
+        android:layout_height="@dimen/toolbar_height"
+        android:elevation="@dimen/minor_50"
+        tools:title="@string/app_name" />
+
     <com.google.android.material.card.MaterialCardView
         style="@style/Woo.Card"
         android:layout_width="match_parent"

--- a/WooCommerce/src/main/res/layout/fragment_variations_bulk_update_price.xml
+++ b/WooCommerce/src/main/res/layout/fragment_variations_bulk_update_price.xml
@@ -5,6 +5,14 @@
     android:layout_height="match_parent"
     android:orientation="vertical">
 
+    <com.google.android.material.appbar.MaterialToolbar
+        android:id="@+id/toolbar"
+        style="@style/Widget.Woo.Toolbar"
+        android:layout_width="match_parent"
+        android:layout_height="@dimen/toolbar_height"
+        android:elevation="@dimen/minor_50"
+        tools:title="@string/app_name" />
+
     <com.google.android.material.card.MaterialCardView
         style="@style/Woo.Card"
         android:layout_width="match_parent"


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #13289 
Closes: #13226 
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
This PR is a second attempt to fix the above two crashes, the attempt we did last time didn't work.

This time, I spend some trying to find the root cause, and I think it comes down to using `onBackPressed` directly instead of using `findNavController().navigateUp()`, the `onBackPressed()` callback doesn't work well when we have multiple concurrent navigation events, which can occur in some cases:
1. In the `VariationDetailFragment`: if the loading fails, the `viewModel` will trigger the `Exit` event, so if this happens at the same time with another navigation event, it will cause a crash.
2. In `VariationsBulkUpdateBaseFragment`: Same but here the `Exit` event is triggered when saving the changes finishes.

The easiest approach to reproduce the crash in both cases is to send the app to background during the loading, and then resume it after it's done, this will cause two navigation events (or multiple): handling the `Exit` event + restoring the fragments. I'll post below the exact steps.

The last [commit](https://github.com/woocommerce/woocommerce-android/pull/13584/commits/e70d1651f00d351443752b53f0d341fb69722882) of the PR fixes an issue with Toolbar visibility in the variation bulk update screens, it was broken in tablets when the two-pane layout was used.

### Steps to reproduce
**TC1**: Confirm the fix
1. Open a variable product.
2. Open the variations list.
3. Tap on the menu, and choose "Bulk Update"
4. Choose the Price option.
5. Enter a new price, then tap "Done"
6. Send the app to background.
7. Wait a little bit for the request to finish, then open the app.
8. Confirm the app crashes in `trunk` and not in this branch.

**TC2**: Non-regression (using a **tablet**)
Just to confirm that `navigateUp` works without issue in the two-pane layout:
- Test navigation back in `VariationDetailFragment `
- Test opening an `AddProductCategoryFragment`, then make some edits and navigate back, then discard the changes.

### Testing information
- Confirm the fix works as expected.
- Confirm there is no regression with the changes in the two-pane layout.

### The tests that have been performed
^

- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.

## Reviewer (or Author, in the case of optional code reviews):

Please make sure these conditions are met before approving the PR, or request changes if the PR needs improvement:

- [x] The PR is small and has a clear, single focus, or a valid explanation is provided in the description. If needed, please request to split it into smaller PRs.
- [ ] Ensure Adequate Unit Test Coverage: The changes are reasonably covered by unit tests or an explanation is provided in the PR description.
- [x] Manual Testing: The author listed all the tests they ran, including smoke tests when needed (e.g., for refactorings). The reviewer confirmed that the PR works as expected on big (tablet) and small (phone) in case of UI changes, and no regressions are added.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->