### PR TITLE
[Android SDK] Fix edge-to-edge support of MainActivity in API < 30

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/main/MainActivity.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/main/MainActivity.kt
@@ -266,7 +266,10 @@ class MainActivity :
                     binding.appBarDivider.isVisible = appBarStatus.hasDivider
                 }
 
-                AppBarStatus.Hidden -> hideToolbar(animate = f is TopLevelFragment)
+                AppBarStatus.Hidden -> {
+                    hideToolbar(animate = f is TopLevelFragment)
+                    binding.appBarLayout.targetElevation = 0f
+                }
             }
 
             if (f is TopLevelFragment) {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/main/MainActivityEdgeToEdgeHelper.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/main/MainActivityEdgeToEdgeHelper.kt
@@ -1,9 +1,10 @@
 package com.woocommerce.android.ui.main
 
-import android.view.View
 import androidx.core.view.ViewCompat
 import androidx.core.view.WindowInsetsCompat
+import androidx.core.view.isVisible
 import com.woocommerce.android.databinding.ActivityMainBinding
+import com.woocommerce.android.util.SystemVersionUtils
 import javax.inject.Inject
 
 class MainActivityEdgeToEdgeHelper @Inject constructor() {
@@ -13,22 +14,17 @@ class MainActivityEdgeToEdgeHelper @Inject constructor() {
                 WindowInsetsCompat.Type.systemBars() or WindowInsetsCompat.Type.displayCutout()
             )
 
-            v.setPadding(systemInsets.left, systemInsets.top, systemInsets.right, 0)
-            insets
-        }
-
-        ViewCompat.setOnApplyWindowInsetsListener(binding.snackRoot) { v, insets ->
-            val systemInsets = insets.getInsets(
-                WindowInsetsCompat.Type.systemBars() or WindowInsetsCompat.Type.displayCutout()
-            )
-
-            val isBottomNavVisible = binding.bottomNav.visibility == View.VISIBLE
-
+            val isBottomNavVisible = binding.bottomNav.isVisible
             // Apply bottom padding only if bottom nav is hidden
             // because bottom nav is already handling the padding
-            val bottomPadding = if (isBottomNavVisible) 0 else systemInsets.bottom
+            // Note: this doesn't work well on Android Q and below, so we apply it only on Android R and above
+            // TODO: Remove this when Androidx Core v1.16 is released by using
+            //  ViewGroupCompat#installCompatInsetsDispatch
+            //  see: https://developer.android.com/develop/ui/views/layout/edge-to-edge#backward-compatible-dispatching
+            val bottomPadding = if (SystemVersionUtils.isAtLeastR() && isBottomNavVisible) 0 else systemInsets.bottom
 
-            v.setPadding(0, 0, 0, bottomPadding)
+            v.setPadding(systemInsets.left, systemInsets.top, systemInsets.right, bottomPadding)
+
             insets
         }
     }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/main/MainActivityEdgeToEdgeHelper.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/main/MainActivityEdgeToEdgeHelper.kt
@@ -3,8 +3,8 @@ package com.woocommerce.android.ui.main
 import androidx.core.view.ViewCompat
 import androidx.core.view.WindowInsetsCompat
 import androidx.core.view.isVisible
+import androidx.core.view.updatePadding
 import com.woocommerce.android.databinding.ActivityMainBinding
-import com.woocommerce.android.util.SystemVersionUtils
 import javax.inject.Inject
 
 class MainActivityEdgeToEdgeHelper @Inject constructor() {
@@ -14,18 +14,21 @@ class MainActivityEdgeToEdgeHelper @Inject constructor() {
                 WindowInsetsCompat.Type.systemBars() or WindowInsetsCompat.Type.displayCutout()
             )
 
-            val isBottomNavVisible = binding.bottomNav.isVisible
-            // Apply bottom padding only if bottom nav is hidden
-            // because bottom nav is already handling the padding
-            // Note: this doesn't work well on Android Q and below, so we apply it only on Android R and above
-            // TODO: Remove this when Androidx Core v1.16 is released by using
-            //  ViewGroupCompat#installCompatInsetsDispatch
-            //  see: https://developer.android.com/develop/ui/views/layout/edge-to-edge#backward-compatible-dispatching
-            val bottomPadding = if (SystemVersionUtils.isAtLeastR() && isBottomNavVisible) 0 else systemInsets.bottom
+            binding.appBarLayout.setPadding(0, systemInsets.top, 0, 0)
 
-            v.setPadding(systemInsets.left, systemInsets.top, systemInsets.right, bottomPadding)
+            binding.root.updatePadding(left = systemInsets.left, right = systemInsets.right)
 
-            insets
+            if (binding.bottomNav.isVisible) {
+                // When the bottom navigation is visible, apply the bottom padding to it to make sure its
+                // background is drawn behind the system navigation bar
+                binding.bottomNav.updatePadding(bottom = systemInsets.bottom)
+                binding.root.updatePadding(bottom = 0)
+            } else {
+                binding.root.updatePadding(bottom = systemInsets.bottom)
+            }
+
+            // Prevent other views from consuming the insets, including the bottom navigation
+            WindowInsetsCompat.CONSUMED
         }
     }
 }

--- a/WooCommerce/src/main/res/layout/activity_app_settings.xml
+++ b/WooCommerce/src/main/res/layout/activity_app_settings.xml
@@ -8,7 +8,6 @@
 
     <com.google.android.material.appbar.AppBarLayout
         android:id="@+id/app_bar_layout"
-        android:background="@color/color_toolbar"
         android:layout_width="match_parent"
         android:layout_height="wrap_content">
 

--- a/WooCommerce/src/main/res/values/styles_base.xml
+++ b/WooCommerce/src/main/res/values/styles_base.xml
@@ -62,6 +62,7 @@ theme across the entire app. Overridden versions should be added to the styles.x
         <item name="android:fitsSystemWindows">true</item>
         <item name="elevation">0dp</item>
         <item name="liftOnScroll">true</item>
+        <item name="android:background">@color/color_toolbar</item>
     </style>
 
     <!--


### PR DESCRIPTION
### Description
While working on some edge-to-edge tasks assigned to Kiwi team, I noticed an issue with the handling in the MainActivity, and this PR tries to fix them:
- In devices that use older APIs, the bottom navigation view overlaps with the device navigation bars, and I believe this is linked to the issue explained [here](https://developer.android.com/develop/ui/views/layout/edge-to-edge#backward-compatible-dispatching), even though we don't return `CONSUMED` ourselves, it seems some other view consumes the insets and breaks the handling. I'll explain my rationale for the fix I did in a comment below.
- This [commit](https://github.com/woocommerce/woocommerce-android/pull/13469/commits/63762cf6af58468c3b9c80c92f73cc9515656d75) caused us to show the window background below the status bar, and IMO it doesn't look good when the screen has a toolbar (which is the majority of the app's screens), I checked the discussion in the PR, and I feel like there is just some misunderstanding here, as the remark from @irfano was about the cutout handling in landscape mode, and specifically in the AppSettings Activity. @kidinov if I'm missing something here please correct me, as to my eyes, applying the top padding just to the appBarLayout looks better in all screens as shown in the below screenshots.

**Note**: @kidinov I hope you don't mind me applying the fix directly, I just thought this will be faster than creating a ticket and explaining the issues.

### Steps to reproduce
#### TC1
1. Test the app in a device that uses API lower than 30.
2. Launch the MainActivity and check few screens.

#### TC2
1. Test the app in a device that uses API higher than 30.
2. Launch the MainActivity and check few screens.

### Testing information
- Confirm that the bottom navigation view is shown correctly in all devices.
- Confirm that the insets work well on other fragments where the bottom navigation view is hidden.

### The tests that have been performed
^ + non-regression check for new APIs

### Images/gif
#### API 29
| Before | After |
| --- | --- |
| ![Screenshot_20250219_132441](https://github.com/user-attachments/assets/b840d7de-702e-4397-830f-4f542c4ab6aa) | ![Screenshot_20250219_132308](https://github.com/user-attachments/assets/767d42a3-b58e-4f24-ba2e-89fecf2f864f) |

#### API 35
| Before | After | Notes |
| --- | --- | --- |
| ![Screenshot_20250219_145637](https://github.com/user-attachments/assets/e5a5b3d0-0750-482b-b8ff-bf837a82e496) | ![Screenshot_20250219_144241](https://github.com/user-attachments/assets/73fe01a3-5632-40bd-ad7d-4719fb6567d7) | |
| ![Screenshot_20250219_145747](https://github.com/user-attachments/assets/970804d5-68d5-420b-b3f3-21768cbd473e) | ![Screenshot_20250219_144249](https://github.com/user-attachments/assets/42b3bf6e-74a4-44ad-9703-dc989b9f9297) | |
| ![Screenshot_20250219_145904](https://github.com/user-attachments/assets/0f1a2902-8544-4a0f-a257-504ca333418a) |  ![Screenshot_20250219_150100](https://github.com/user-attachments/assets/dea5712e-52a2-44b8-9752-75a5953d511c) | When scrolling, the white background looks better. So until we update our logic to not clip content, this is a better look IMO |
| ![Screenshot_20250219_145925](https://github.com/user-attachments/assets/708012ae-1e98-4640-a7b9-0098f1d3a750) | ![Screenshot_20250219_150045](https://github.com/user-attachments/assets/8d559664-98b4-42c5-9447-e59a7a0988f8) | Given we were applying the bottom padding to the `snackRoot` layout, the other views in the root layout expanded below the nav bar |
| ![Screenshot_20250219_151228](https://github.com/user-attachments/assets/13746b3e-d6dd-4704-a869-7febb875b327) | ![Screenshot_20250219_144305](https://github.com/user-attachments/assets/51c3b0b8-3640-41fe-b2ef-6659ca0f137b) | |



- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.

## Reviewer (or Author, in the case of optional code reviews):

Please make sure these conditions are met before approving the PR, or request changes if the PR needs improvement:

- [x] The PR is small and has a clear, single focus, or a valid explanation is provided in the description. If needed, please request to split it into smaller PRs.
- [x] Ensure Adequate Unit Test Coverage: The changes are reasonably covered by unit tests or an explanation is provided in the PR description.
- [x] Manual Testing: The author listed all the tests they ran, including smoke tests when needed (e.g., for refactorings). The reviewer confirmed that the PR works as expected on big (tablet) and small (phone) in case of UI changes, and no regressions are added.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
