### PR TITLE
[Woo POS] Fix minor design issues

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/common/composeui/component/WooPosErrorScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/common/composeui/component/WooPosErrorScreen.kt
@@ -68,6 +68,7 @@ fun WooPosErrorScreen(
                 text = reason,
                 style = WooPosTypography.BodyLarge,
             )
+            @Suppress("WooPosDesignSystemSpacingUsageRule")
             Spacer(modifier = Modifier.height(40.dp.toAdaptivePadding()))
             primaryButton?.let {
                 WooPosButton(

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/common/composeui/component/WooPosErrorScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/common/composeui/component/WooPosErrorScreen.kt
@@ -34,8 +34,7 @@ fun WooPosErrorScreen(
     message: String,
     reason: String,
     primaryButton: Button? = null,
-    secondaryButton: Button? = null,
-    adaptToScreenHeight: Boolean = false,
+    secondaryButton: Button? = null
 ) {
     Column(
         modifier = modifier.fillMaxSize()
@@ -45,7 +44,6 @@ fun WooPosErrorScreen(
         verticalArrangement = Arrangement.Center,
     ) {
         Column(
-            modifier = Modifier.let { if (adaptToScreenHeight) it.weight(1f) else it },
             horizontalAlignment = Alignment.CenterHorizontally,
             verticalArrangement = Arrangement.Center,
         ) {
@@ -71,23 +69,12 @@ fun WooPosErrorScreen(
                 style = WooPosTypography.BodyLarge,
             )
             Spacer(modifier = Modifier.height(WooPosSpacing.XLarge.value.toAdaptivePadding()))
-        }
-        Column(
-            horizontalAlignment = Alignment.CenterHorizontally,
-            modifier = Modifier
-                .fillMaxWidth()
-                .padding(
-                    top = WooPosSpacing.Medium.value,
-                    end = WooPosSpacing.Medium.value,
-                    start = WooPosSpacing.Medium.value
-                )
-        ) {
             primaryButton?.let {
                 WooPosButton(
                     text = it.text,
                     onClick = it.click,
                     modifier = Modifier
-                        .fillMaxWidth()
+                        .fillMaxWidth(.5f)
                         .height(80.dp)
                 )
             }
@@ -97,7 +84,7 @@ fun WooPosErrorScreen(
                     text = it.text,
                     onClick = it.click,
                     modifier = Modifier
-                        .fillMaxWidth()
+                        .fillMaxWidth(.5f)
                         .height(80.dp)
                 )
             }
@@ -141,42 +128,6 @@ fun WooPosErrorStateSingleButtonPreview() {
                 text = stringResource(R.string.retry),
                 click = { }
             ),
-        )
-    }
-}
-
-@Composable
-@WooPosPreview
-fun WooPosErrorStateSingleButtonAdaptToScreenHeightPreview() {
-    WooPosTheme {
-        WooPosErrorScreen(
-            message = stringResource(R.string.woopos_totals_main_error_label),
-            reason = "Reason",
-            primaryButton = Button(
-                text = stringResource(R.string.retry),
-                click = { }
-            ),
-            adaptToScreenHeight = true,
-        )
-    }
-}
-
-@Composable
-@WooPosPreview
-fun WooPosErrorStateAdaptToScreenHeightPreview() {
-    WooPosTheme {
-        WooPosErrorScreen(
-            message = stringResource(R.string.woopos_totals_main_error_label),
-            reason = "Reason",
-            primaryButton = Button(
-                text = stringResource(R.string.retry),
-                click = { }
-            ),
-            secondaryButton = Button(
-                text = stringResource(R.string.cancel),
-                click = { }
-            ),
-            adaptToScreenHeight = true,
         )
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/common/composeui/component/WooPosErrorScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/common/composeui/component/WooPosErrorScreen.kt
@@ -68,7 +68,7 @@ fun WooPosErrorScreen(
                 text = reason,
                 style = WooPosTypography.BodyLarge,
             )
-            Spacer(modifier = Modifier.height(WooPosSpacing.XLarge.value.toAdaptivePadding()))
+            Spacer(modifier = Modifier.height(40.dp.toAdaptivePadding()))
             primaryButton?.let {
                 WooPosButton(
                     text = it.text,

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/WooPosHomeProductInfoDialog.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/WooPosHomeProductInfoDialog.kt
@@ -19,12 +19,10 @@ import androidx.compose.ui.semantics.contentDescription
 import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
-import androidx.compose.ui.unit.dp
 import androidx.constraintlayout.compose.ConstraintLayout
 import androidx.constraintlayout.compose.Dimension
 import com.woocommerce.android.R
 import com.woocommerce.android.ui.woopos.common.composeui.WooPosPreview
-import com.woocommerce.android.ui.woopos.common.composeui.component.WooPosButton
 import com.woocommerce.android.ui.woopos.common.composeui.component.WooPosDialogWrapper
 import com.woocommerce.android.ui.woopos.common.composeui.component.WooPosOutlinedButton
 import com.woocommerce.android.ui.woopos.common.composeui.component.WooPosText
@@ -107,10 +105,14 @@ fun WooPosProductInfoDialog(
                     Box(
                         Modifier
                             .clip(RoundedCornerShape(WooPosCornerRadius.Medium.value))
+                            .padding(vertical = WooPosSpacing.XLarge.value.toAdaptivePadding())
                             .background(
                                 color = MaterialTheme.colorScheme.surfaceDim
                             )
-                            .padding(24.dp.toAdaptivePadding()),
+                            .padding(
+                                vertical = WooPosSpacing.XLarge.value.toAdaptivePadding(),
+                                horizontal = WooPosSpacing.Medium.value.toAdaptivePadding()
+                            ),
                         contentAlignment = Alignment.Center,
                     ) {
                         Column(

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/WooPosHomeProductInfoDialog.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/WooPosHomeProductInfoDialog.kt
@@ -19,6 +19,7 @@ import androidx.compose.ui.semantics.contentDescription
 import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.dp
 import androidx.constraintlayout.compose.ConstraintLayout
 import androidx.constraintlayout.compose.Dimension
 import com.woocommerce.android.R
@@ -102,10 +103,10 @@ fun WooPosProductInfoDialog(
                         textAlign = TextAlign.Center,
                         modifier = Modifier.padding(bottom = WooPosSpacing.Medium.value.toAdaptivePadding())
                     )
+                    Spacer(Modifier.height(40.dp.toAdaptivePadding()))
                     Box(
                         Modifier
                             .clip(RoundedCornerShape(WooPosCornerRadius.Medium.value))
-                            .padding(vertical = WooPosSpacing.XLarge.value.toAdaptivePadding())
                             .background(
                                 color = MaterialTheme.colorScheme.surfaceDim
                             )

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/WooPosHomeProductInfoDialog.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/WooPosHomeProductInfoDialog.kt
@@ -26,6 +26,7 @@ import com.woocommerce.android.R
 import com.woocommerce.android.ui.woopos.common.composeui.WooPosPreview
 import com.woocommerce.android.ui.woopos.common.composeui.component.WooPosButton
 import com.woocommerce.android.ui.woopos.common.composeui.component.WooPosDialogWrapper
+import com.woocommerce.android.ui.woopos.common.composeui.component.WooPosOutlinedButton
 import com.woocommerce.android.ui.woopos.common.composeui.component.WooPosText
 import com.woocommerce.android.ui.woopos.common.composeui.designsystem.WooPosCornerRadius
 import com.woocommerce.android.ui.woopos.common.composeui.designsystem.WooPosSpacing
@@ -124,7 +125,7 @@ fun WooPosProductInfoDialog(
                         }
                     }
                     Spacer(modifier = Modifier.height(WooPosSpacing.XLarge.value.toAdaptivePadding()))
-                    WooPosButton(
+                    WooPosOutlinedButton(
                         onClick = { onDismissRequest() },
                         text = stringResource(id = state.primaryButton.label),
                         modifier = Modifier

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/WooPosHomeProductInfoDialog.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/WooPosHomeProductInfoDialog.kt
@@ -103,6 +103,7 @@ fun WooPosProductInfoDialog(
                         textAlign = TextAlign.Center,
                         modifier = Modifier.padding(bottom = WooPosSpacing.Medium.value.toAdaptivePadding())
                     )
+                    @Suppress("WooPosDesignSystemSpacingUsageRule")
                     Spacer(Modifier.height(40.dp.toAdaptivePadding()))
                     Box(
                         Modifier

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/cart/WooPosCartScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/cart/WooPosCartScreen.kt
@@ -179,13 +179,13 @@ fun CartBodyEmpty(modifier: Modifier = Modifier) {
         Image(
             imageVector = ImageVector.vectorResource(R.drawable.ic_woo_pos_empty_cart),
             contentDescription = stringResource(R.string.woopos_cart_empty_content_description),
-            modifier = Modifier.size(104.dp)
+            modifier = Modifier.size(88.dp)
         )
         Spacer(modifier = Modifier.height(WooPosSpacing.XLarge.value.toAdaptivePadding()))
         WooPosText(
             text = stringResource(R.string.woopos_cart_empty_subtitle),
             style = WooPosTypography.BodyLarge,
-            color = MaterialTheme.colorScheme.onSurface,
+            color = WooPosTheme.colors.onSurfaceVariantLowest,
             textAlign = TextAlign.Center
         )
     }
@@ -423,7 +423,7 @@ private fun ProductItem(
                 Spacer(modifier = Modifier.height(WooPosSpacing.XSmall.value.toAdaptivePadding()))
                 if (item.description.isNotNullOrEmpty()) {
                     WooPosText(
-                        text = item.description!!,
+                        text = item.description,
                         style = WooPosTypography.BodySmall,
                         color = WooPosTheme.colors.onSurfaceVariantHighest,
                         maxLines = 1,

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/items/WooPosItemsScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/items/WooPosItemsScreen.kt
@@ -13,7 +13,6 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
-import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.lazy.LazyListState
 import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.material.ExperimentalMaterialApi
@@ -271,7 +270,6 @@ fun ProductsError(onRetryClicked: () -> Unit) {
         contentAlignment = Alignment.Center,
     ) {
         WooPosErrorScreen(
-            modifier = Modifier.width(640.dp),
             message = stringResource(id = R.string.woopos_products_loading_error_title),
             reason = stringResource(id = R.string.woopos_products_loading_error_message),
             primaryButton = Button(

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/totals/WooPosTotalsScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/totals/WooPosTotalsScreen.kt
@@ -411,8 +411,7 @@ private fun TotalsErrorScreen(
         primaryButton = Button(
             text = stringResource(R.string.retry),
             click = { onUIEvent(WooPosTotalsUIEvent.RetryOrderCreationClicked) }
-        ),
-        adaptToScreenHeight = true,
+        )
     )
 }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/totals/payment/success/WooPosTotalsPaymentSuccessScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/totals/payment/success/WooPosTotalsPaymentSuccessScreen.kt
@@ -78,7 +78,7 @@ private fun WooPosPaymentSuccessScreen(
     Box(
         modifier = Modifier
             .fillMaxSize()
-            .background(MaterialTheme.colorScheme.surfaceContainerLowest),
+            .background(MaterialTheme.colorScheme.surfaceBright),
         contentAlignment = Alignment.Center
     ) {
         val marginBetweenButtonAndText by animateDpAsState(


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #13591 
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
This PR fixes three minor design issues:
- Empty cart font has incorrect color and illustration is too large
- Supported products dialog has incorrect button type and small vertical margins
- Couldn't load totals error has incorrect button width and position
- Background color on the success screen

### Steps to reproduce
<!-- Step-by-step testing instructions. For new user flows, consider instead stating the goal of the workflow and see if your PR reviewer can accomplish the workflow without specific steps! -->
1. Enter POS and observe the empty cart design
2. Tap on `i` icon and observe the dialog design
3. Go back, add a product to the cart
4. Turn on airplane mode
5. Tap on checkout and observe the error screen designs
6. Turn off airplande mode
7. Collect a payment
8. Observer background color on the success screen

### Testing information
<!-- This is your opportunity to break out individual scenarios that need testing (when necessary) and/or include a checklist for the reviewer to go through. Consider documenting the following from your own completed testing: devices used, alternate workflows, edge cases, affected areas, critical flows, areas not tested, and any remaining unknowns. Provide feedback on this new section of the PR template through Sept 30, 2024 to Apps Quality; additional context here: p91TBi-b8z-p2#comment-12036 -->

I went through the above steps in both light and dark mode. I also tested empty variations screen and error loading variations screen.

### The tests that have been performed
<!-- To give the reviewer an idea of what could be missed in terms of testing -->

### Images/gif
<!-- Include before and after images or gifs when appropriate. -->

| Before | After | Designs |
|--|--|--|
| <img width="400" alt="Screenshot 2025-02-19 at 14 40 56" src="https://github.com/user-attachments/assets/977e9603-12b3-4853-a349-7c1d67f9f199" /> | <img width="400" alt="Screenshot 2025-02-19 at 14 40 56" src="https://github.com/user-attachments/assets/862cb1e2-99f3-41fa-87e8-bda11b80f830" /> | <img width="400" alt="Screenshot 2025-02-19 at 14 40 56" src="https://github.com/user-attachments/assets/dca24546-ac59-41ba-a89c-9b97b93c4289" /> |
| <img width="400" src="https://github.com/user-attachments/assets/b14ae978-a617-4984-be78-6e9ed5581440" /> | <img width="400" src="https://github.com/user-attachments/assets/43d0eaf5-9de2-4839-a2f6-ce8b09efc181" /> | <img width="455" alt="Screenshot 2025-02-19 at 14 44 01" src="https://github.com/user-attachments/assets/52bb66bc-f2be-423b-a2c4-6110cc121fa1" /> |
| <img width="400" src="https://github.com/user-attachments/assets/b1393ca7-d309-4db9-8543-cf0f2f4edc4e" /> | <img width="400" src="https://github.com/user-attachments/assets/c6469aff-c15a-4265-8168-8d0c15bf1b8f" /> | <img width="453" alt="Screenshot 2025-02-19 at 14 45 16" src="https://github.com/user-attachments/assets/17533013-d296-4b5a-b5e5-fed46440f8b6" /> |
| <img width="400" alt="Screenshot 2025-02-19 at 16 24 28" src="https://github.com/user-attachments/assets/943c700e-d390-4863-80ad-5c59309363ea" /> | <img width="400" src="https://github.com/user-attachments/assets/c45ee986-9893-4294-8130-e5c02f4599a3" > | <img width="400" alt="Screenshot 2025-02-19 at 16 24 33" src="https://github.com/user-attachments/assets/7a3a0669-ea81-492d-8500-9b56ee053e58" /> |



- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.

## Reviewer (or Author, in the case of optional code reviews):

Please make sure these conditions are met before approving the PR, or request changes if the PR needs improvement:

- [x] The PR is small and has a clear, single focus, or a valid explanation is provided in the description. If needed, please request to split it into smaller PRs.
- [x] Ensure Adequate Unit Test Coverage: The changes are reasonably covered by unit tests or an explanation is provided in the PR description.
- [x] Manual Testing: The author listed all the tests they ran, including smoke tests when needed (e.g., for refactorings). The reviewer confirmed that the PR works as expected on big (tablet) and small (phone) in case of UI changes, and no regressions are added.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->