### PR TITLE
[Shipping Labels] Handle loading account settings error

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/WooShippingLabelCreationScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/WooShippingLabelCreationScreen.kt
@@ -2,6 +2,7 @@ package com.woocommerce.android.ui.orders.wooshippinglabels
 
 import android.content.res.Configuration
 import android.os.Parcelable
+import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
 import androidx.compose.foundation.border
 import androidx.compose.foundation.clickable
@@ -14,6 +15,7 @@ import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.text.BasicTextField
@@ -31,6 +33,7 @@ import androidx.compose.material.MaterialTheme
 import androidx.compose.material.ModalBottomSheetDefaults
 import androidx.compose.material.ModalBottomSheetState
 import androidx.compose.material.ModalBottomSheetValue
+import androidx.compose.material.Scaffold
 import androidx.compose.material.Surface
 import androidx.compose.material.Text
 import androidx.compose.material.TopAppBar
@@ -60,6 +63,7 @@ import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import com.woocommerce.android.R
 import com.woocommerce.android.ui.compose.component.WCColoredButton
+import com.woocommerce.android.ui.compose.component.WCTextButton
 import com.woocommerce.android.ui.compose.modifiers.dashedBorder
 import com.woocommerce.android.ui.compose.theme.WooThemeWithBackground
 import com.woocommerce.android.ui.orders.wooshippinglabels.WooShippingLabelCreationViewModel.CustomsState
@@ -115,8 +119,11 @@ fun WooShippingLabelCreationScreen(viewModel: WooShippingLabelCreationViewModel)
         }
 
         WooShippingLabelCreationViewModel.WooShippingViewState.Error -> {
-            Box(modifier = Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
-                Text("Error")
+            WooThemeWithBackground {
+                ErrorScreen(
+                    onNavigateBack = viewModel::onNavigateBack,
+                    onRetryClick = viewModel::onRetry,
+                )
             }
         }
     }
@@ -657,7 +664,6 @@ private fun PackageSelectionAvailableCard(
                         onValueChange = onCustomWeightChange,
                         keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Number),
                         textStyle = MaterialTheme.typography.body2.copy(color = MaterialTheme.colors.onSurface),
-
                     )
                     if (customWeight.isEmpty()) {
                         Text(
@@ -672,6 +678,39 @@ private fun PackageSelectionAvailableCard(
                     style = MaterialTheme.typography.body2,
                     color = colorResource(id = R.color.color_on_surface_disabled)
                 )
+            }
+        }
+    }
+}
+
+@Composable
+internal fun ErrorScreen(
+    modifier: Modifier = Modifier,
+    onNavigateBack: () -> Unit = {},
+    onRetryClick: () -> Unit = {}
+) {
+    Scaffold(topBar = { TopBar(onNavigateBack) }) { padding ->
+        Column(
+            modifier = modifier
+                .fillMaxSize()
+                .verticalScroll(rememberScrollState())
+                .background(MaterialTheme.colors.surface)
+                .padding(padding),
+            horizontalAlignment = Alignment.CenterHorizontally,
+            verticalArrangement = Arrangement.spacedBy(24.dp, Alignment.CenterVertically)
+        ) {
+            Image(
+                modifier = Modifier.size(87.dp),
+                painter = painterResource(id = R.drawable.ic_error),
+                contentDescription = stringResource(id = R.string.woopos_error_icon_content_description),
+            )
+            Text(
+                text = stringResource(R.string.woo_shipping_labels_loading_error),
+                style = MaterialTheme.typography.subtitle1,
+                color = MaterialTheme.colors.onSurface,
+            )
+            WCTextButton(onClick = onRetryClick) {
+                Text(stringResource(id = R.string.retry))
             }
         }
     }
@@ -787,3 +826,7 @@ private fun PackageSelectedPreview() {
         )
     }
 }
+
+@Preview
+@Composable
+private fun EmptyScreenPreview() = WooThemeWithBackground { ErrorScreen() }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/WooShippingLabelCreationScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/WooShippingLabelCreationScreen.kt
@@ -86,9 +86,7 @@ import kotlinx.parcelize.Parcelize
 fun WooShippingLabelCreationScreen(viewModel: WooShippingLabelCreationViewModel) {
     when (val viewState = viewModel.viewState.collectAsState().value) {
         WooShippingLabelCreationViewModel.WooShippingViewState.Loading -> {
-            Box(modifier = Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
-                CircularProgressIndicator()
-            }
+            LoadingScreen(onNavigateBack = viewModel::onNavigateBack)
         }
 
         is WooShippingLabelCreationViewModel.WooShippingViewState.DataState -> {
@@ -679,6 +677,23 @@ private fun PackageSelectionAvailableCard(
                     color = colorResource(id = R.color.color_on_surface_disabled)
                 )
             }
+        }
+    }
+}
+
+@Composable
+internal fun LoadingScreen(
+    modifier: Modifier = Modifier,
+    onNavigateBack: () -> Unit = {},
+) {
+    Scaffold(topBar = { TopBar(onNavigateBack) }) { padding ->
+        Box(
+            modifier = modifier
+                .fillMaxSize()
+                .padding(padding),
+            contentAlignment = Alignment.Center
+        ) {
+            CircularProgressIndicator()
         }
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/WooShippingLabelCreationScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/WooShippingLabelCreationScreen.kt
@@ -315,19 +315,7 @@ private fun LabelCreationScreenWithBottomSheet(
         sheetPeekHeight = bottomSheetPeekHeight,
         scaffoldState = scaffoldState,
         topBar = {
-            TopAppBar(
-                title = { Text(stringResource(id = R.string.shipping_label_create_title)) },
-                navigationIcon = {
-                    IconButton(onNavigateBack) {
-                        Icon(
-                            imageVector = Icons.AutoMirrored.Filled.ArrowBack,
-                            contentDescription = stringResource(id = R.string.back)
-                        )
-                    }
-                },
-                backgroundColor = colorResource(id = R.color.color_toolbar),
-                elevation = 0.dp,
-            )
+            TopBar(onNavigateBack)
         },
     ) { innerPadding ->
         Surface(
@@ -374,6 +362,21 @@ private fun LabelCreationScreenWithBottomSheet(
         }
     }
 }
+
+@Composable
+private fun TopBar(onNavigateBack: () -> Unit) = TopAppBar(
+    title = { Text(stringResource(id = R.string.shipping_label_create_title)) },
+    navigationIcon = {
+        IconButton(onNavigateBack) {
+            Icon(
+                imageVector = Icons.AutoMirrored.Filled.ArrowBack,
+                contentDescription = stringResource(id = R.string.back)
+            )
+        }
+    },
+    backgroundColor = colorResource(id = R.color.color_toolbar),
+    elevation = 0.dp,
+)
 
 @Composable
 internal fun HazmatCard(

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/WooShippingLabelCreationViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/WooShippingLabelCreationViewModel.kt
@@ -57,6 +57,7 @@ class WooShippingLabelCreationViewModel @Inject constructor(
     private val getShippingRates: GetShippingRates,
     private val purchaseShippingLabel: PurchaseShippingLabel,
     private val observeStoreOptions: ObserveStoreOptions,
+    private val fetchAccountSettings: FetchAccountSettings,
     private val shouldRequireCustoms: ShouldRequireCustomsForm
 ) : ScopedViewModel(savedState) {
     private val navArgs: WooShippingLabelCreationFragmentArgs by savedState.navArgs()
@@ -503,7 +504,13 @@ class WooShippingLabelCreationViewModel @Inject constructor(
 
     fun onRetry() {
         // Retry loading data that may have previously resulted in errors.
+        viewState.value = WooShippingViewState.Loading
         launch { getOrderInformation() }
+        launch {
+            val result = fetchAccountSettings().getOrNull()
+            storeOptions.value = StoreOptionsModel.EMPTY
+            storeOptions.value = result
+        }
     }
 
     data object StartPackageSelection : Event()

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/WooShippingLabelCreationViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/WooShippingLabelCreationViewModel.kt
@@ -501,6 +501,11 @@ class WooShippingLabelCreationViewModel @Inject constructor(
         if (allowBackNavigation()) triggerEvent(Event.Exit)
     }
 
+    fun onRetry() {
+        // Retry loading data that may have previously resulted in errors.
+        launch { getOrderInformation() }
+    }
+
     data object StartPackageSelection : Event()
     data class LabelPurchased(val purchaseData: PurchasedShippingLabelData) : Event()
     data class StartOriginAddressEdit(val originAddress: OriginShippingAddress) : Event()

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/datasource/WooShippingConfigurationDataStore.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/datasource/WooShippingConfigurationDataStore.kt
@@ -34,4 +34,6 @@ class WooShippingConfigurationDataStore @Inject constructor(
             preferences[stringPreferencesKey(getStoreOptionsKey())] = gson.toJson(storeOptions)
         }
     }
+
+    suspend fun clearStoreOptions() = dataStore.edit { it.remove(stringPreferencesKey(getStoreOptionsKey())) }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/networking/WooShippingLabelRepository.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/networking/WooShippingLabelRepository.kt
@@ -39,7 +39,7 @@ class WooShippingLabelRepository @Inject constructor(
                 ?.takeIf { response.isError.not() }
                 ?.let {
                     configurationDataStore.saveStoreOptions(it)
-                }
+                } ?: configurationDataStore.clearStoreOptions()
         }
 
     suspend fun fetchPurchasedShippingLabels(

--- a/WooCommerce/src/main/res/drawable-night/ic_error.xml
+++ b/WooCommerce/src/main/res/drawable-night/ic_error.xml
@@ -1,0 +1,15 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+    <group>
+        <clip-path android:pathData="M0.035,0.541h23v23h-23z" />
+        <path
+            android:fillColor="#646970"
+            android:pathData="M11.535,23.541c6.35,0 11.5,-5.149 11.5,-11.5s-5.15,-11.5 -11.5,-11.5c-6.352,0 -11.5,5.149 -11.5,11.5s5.148,11.5 11.5,11.5Z" />
+        <path
+            android:fillColor="#3C434A"
+            android:pathData="M11.535,20.019a2.032,2.032 0,1 0,0 -4.063,2.032 2.032,0 0,0 0,4.063ZM11.948,4.06h-0.826c-1.606,0 -2.408,0.8 -2.11,2.502 0.347,1.961 1.102,6.5 1.305,7.622l1.218,0.009 1.218,-0.008c0.202,-1.12 0.958,-5.662 1.305,-7.623 0.301,-1.701 -0.5,-2.502 -2.11,-2.502Z" />
+    </group>
+</vector>

--- a/WooCommerce/src/main/res/drawable/ic_error.xml
+++ b/WooCommerce/src/main/res/drawable/ic_error.xml
@@ -1,0 +1,15 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+    <group>
+        <clip-path android:pathData="M0.91,0.541h23v23h-23z" />
+        <path
+            android:fillColor="#F0F0F0"
+            android:pathData="M12.41,23.541c6.351,0 11.5,-5.149 11.5,-11.5S18.761,0.541 12.41,0.541 0.91,5.69 0.91,12.041s5.149,11.5 11.5,11.5Z" />
+        <path
+            android:fillColor="#E0E0E0"
+            android:pathData="M12.41,20.02a2.032,2.032 0,1 0,0 -4.064,2.032 2.032,0 0,0 0,4.063ZM12.823,4.059h-0.826c-1.606,0 -2.407,0.8 -2.11,2.502 0.347,1.961 1.103,6.5 1.305,7.623l1.218,0.008 1.218,-0.008c0.203,-1.12 0.958,-5.662 1.305,-7.623 0.302,-1.701 -0.5,-2.502 -2.11,-2.502Z" />
+    </group>
+</vector>

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -4507,6 +4507,7 @@
     <string name="woo_shipping_address_validate_and_save">Validate &amp; Save</string>
     <string name="woo_shipping_address_missing_info_hint">Add missing information</string>
     <string name="woo_shipping_labels_loading_order_error">Unable to load the order</string>
+    <string name="woo_shipping_labels_loading_error">Unable to load data</string>
 
     <string name="woo_shipping_address_validate_title">Validating</string>
     <string name="woo_shipping_address_validate_message">Validating entered address</string>

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/WooShippingLabelCreationViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/WooShippingLabelCreationViewModelTest.kt
@@ -227,6 +227,7 @@ class WooShippingLabelCreationViewModelTest : BaseUnitTest() {
             getShippingRates = getShippingRates,
             purchaseShippingLabel = purchaseShippingLabel,
             observeStoreOptions = observeStoreOptions,
+            fetchAccountSettings = mock(),
             shouldRequireCustoms = shouldRequireCustomsForm,
             savedState = savedState
         )

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/WooShippingLabelCreationViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/WooShippingLabelCreationViewModelTest.kt
@@ -215,6 +215,7 @@ class WooShippingLabelCreationViewModelTest : BaseUnitTest() {
     private val getShippingRates: GetShippingRates = mock()
     private val purchaseShippingLabel: PurchaseShippingLabel = mock()
     private val observeStoreOptions: ObserveStoreOptions = mock()
+    private val fetchAccountSettings: FetchAccountSettings = mock()
 
     private lateinit var sut: WooShippingLabelCreationViewModel
 
@@ -227,7 +228,7 @@ class WooShippingLabelCreationViewModelTest : BaseUnitTest() {
             getShippingRates = getShippingRates,
             purchaseShippingLabel = purchaseShippingLabel,
             observeStoreOptions = observeStoreOptions,
-            fetchAccountSettings = mock(),
+            fetchAccountSettings = fetchAccountSettings,
             shouldRequireCustoms = shouldRequireCustomsForm,
             savedState = savedState
         )
@@ -720,12 +721,14 @@ class WooShippingLabelCreationViewModelTest : BaseUnitTest() {
         }
 
     @Test
-    fun `when there is no cached store options and API request fails then display error`() = testBlocking {
+    fun `when there is no cached store options and API request fails then display error with retry`() = testBlocking {
         val order = OrderTestUtils.generateTestOrder(orderId = orderId)
 
         whenever(orderDetailRepository.getOrderById(any())) doReturn order
         whenever(observeOriginAddresses()) doReturn flowOf(defaultOriginAddresses)
         whenever(observeStoreOptions()) doReturn flowOf(null)
+        whenever(getShippableItems(any())) doReturn defaultShippableItems
+        whenever(fetchAccountSettings()) doReturn Result.success(defaultStoreOptions)
 
         createViewModel()
 
@@ -733,6 +736,11 @@ class WooShippingLabelCreationViewModelTest : BaseUnitTest() {
 
         val currentViewState = sut.viewState.value
         assertThat(currentViewState).isInstanceOf(WooShippingViewState.Error::class.java)
+
+        sut.onRetry()
+
+        val newViewState = sut.viewState.value
+        assertThat(newViewState).isInstanceOf(DataState::class.java)
     }
 
     @Test


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #13318 
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
This introduces a new error screen to the shipping labels creation screen. If fetching account settings fails, this error screen will appear. Currently, the Retry button is non-functional and will be addressed in #13598.
Reference for the error screen design: bsLNrhmi2xQZB4C0TzjmHB-fi-3374_21712 (I’m aware that this design is from a WIP/M4 version. We can update the screen later if the design changes.)

This also adds a top bar to loading screen.

### Steps to reproduce
<!-- Step-by-step testing instructions. For new user flows, consider instead stating the goal of the workflow and see if your PR reviewer can accomplish the workflow without specific steps! -->
#### To create fake error response from the endpoint
1. Go to Menu → Settings → Developer Options → API Faker
2. Tap + button.
3. Enter these settings:
```
Type: WordPress REST API
HTTP Method: GET
Path: /wcshipping/v1/account/settings
Status Code: 403
```
4. Tap Save.
5. Enable API Faker.

#### To display the error screen
1. Log in to a site that is eligible for shipping labels.
2. Go to orders.
3. Create a new order and complete the payment.
4. Open the order details and tap the "Create shipping label" button.

### Testing information
<!-- This is your opportunity to break out individual scenarios that need testing (when necessary) and/or include a checklist for the reviewer to go through. Consider documenting the following from your own completed testing: devices used, alternate workflows, edge cases, affected areas, critical flows, areas not tested, and any remaining unknowns. Provide feedback on this new section of the PR template through Sept 30, 2024 to Apps Quality; additional context here: p91TBi-b8z-p2#comment-12036 -->
Please also test dark mode, light mode, large font, and vertical orientation.

### The tests that have been performed
<!-- To give the reviewer an idea of what could be missed in terms of testing -->
Steps above.

### Images/gif
<!-- Include before and after images or gifs when appropriate. -->
<img src="https://github.com/user-attachments/assets/6182f8fa-ed1a-4c8a-8d27-344234cb112f" width=360><img src="https://github.com/user-attachments/assets/3f4b6858-8332-43ec-b714-31dddf32cfe5" width=360>

<details>
  <summary>Loading screen - First launch and second launch</summary>
  
[Screen_recording_20250220_150216.webm](https://github.com/user-attachments/assets/e9710869-39e7-4956-a124-7dcbe6b0f999)
  
</details>

- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.

## Reviewer (or Author, in the case of optional code reviews):

Please make sure these conditions are met before approving the PR, or request changes if the PR needs improvement:

- [ ] The PR is small and has a clear, single focus, or a valid explanation is provided in the description. If needed, please request to split it into smaller PRs.
- [ ] Ensure Adequate Unit Test Coverage: The changes are reasonably covered by unit tests or an explanation is provided in the PR description.
- [ ] Manual Testing: The author listed all the tests they ran, including smoke tests when needed (e.g., for refactorings). The reviewer confirmed that the PR works as expected on big (tablet) and small (phone) in case of UI changes, and no regressions are added.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->