### PR TITLE
[Woo POS] Prevent cancellation in `ProcessingPayment`, `PaymentCapturing` states

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/totals/WooPosTotalsViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/totals/WooPosTotalsViewModel.kt
@@ -227,6 +227,10 @@ class WooPosTotalsViewModel @Inject constructor(
         viewModelScope.launch {
             when (state.value) {
                 is PaymentFailed, is PaymentInProgress -> {
+                    val paymentState = cardReaderPaymentController?.paymentState?.value
+                    if (paymentState is CardReaderPaymentState.ProcessingPayment ||
+                        paymentState is CardReaderPaymentState.PaymentCapturing) return@launch
+
                     childrenToParentEventSender.sendToParent(ChildToParentEvent.ReturnedFromCardReaderPaymentToCheckout)
                     retryPaymentCollectionFromScratch()
                 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/totals/WooPosTotalsViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/totals/WooPosTotalsViewModel.kt
@@ -229,7 +229,10 @@ class WooPosTotalsViewModel @Inject constructor(
                 is PaymentFailed, is PaymentInProgress -> {
                     val paymentState = cardReaderPaymentController?.paymentState?.value
                     if (paymentState is CardReaderPaymentState.ProcessingPayment ||
-                        paymentState is CardReaderPaymentState.PaymentCapturing) return@launch
+                        paymentState is CardReaderPaymentState.PaymentCapturing
+                    ) {
+                        return@launch
+                    }
 
                     childrenToParentEventSender.sendToParent(ChildToParentEvent.ReturnedFromCardReaderPaymentToCheckout)
                     retryPaymentCollectionFromScratch()

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/home/totals/WooPosTotalsViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/home/totals/WooPosTotalsViewModelTest.kt
@@ -1234,7 +1234,6 @@ class WooPosTotalsViewModelTest {
             assertFalse(checkout.isFreeOrder)
         }
 
-
     @Test
     fun `given payment processing state, when OnBackClicked, then should ignore OnBackClicked`() = runTest {
         // GIVEN

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/home/totals/WooPosTotalsViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/home/totals/WooPosTotalsViewModelTest.kt
@@ -873,16 +873,7 @@ class WooPosTotalsViewModelTest {
     fun `given payment failed with retry action, when retry clicked, then should retry previous payment action`() =
         runTest {
             // GIVEN
-            whenever(resourceProvider.getString(R.string.woopos_success_totals_payment_processing_title))
-                .thenReturn("Processing payment")
-            whenever(resourceProvider.getString(R.string.woopos_success_totals_payment_processing_subtitle))
-                .thenReturn("Please wait…")
-            whenever(resourceProvider.getString(R.string.woopos_success_totals_payment_failed_title))
-                .thenReturn("Payment failed")
-            whenever(uiStringParser.asString(any())).thenReturn("Unfortunately, this payment has been declined.")
-            whenever(resourceProvider.getString(R.string.woo_pos_payment_failed_try_again))
-                .thenReturn("Try payment again")
-
+            mockPaymentFailedTexts()
             givenCardReaderConnectedAndNetworkAvailable()
             val mockCardReaderPaymentController: CardReaderPaymentController = mock()
             val factory: WooPosCardReaderPaymentControllerFactory = mock()
@@ -1318,6 +1309,46 @@ class WooPosTotalsViewModelTest {
         // THEN
         verify(mockCardReaderPaymentController, never()).onBackPressed()
         verify(childrenToParentEventSender).sendToParent(BackFromCheckoutToCartClicked)
+    }
+
+    @Test
+    fun `given payment failed state, when OnBackClicked, then should not ignore OnBackClicked`() = runTest {
+        // GIVEN
+        mockPaymentFailedTexts()
+        givenCardReaderConnectedAndNetworkAvailable()
+        val mockCardReaderPaymentController: CardReaderPaymentController = mock()
+        val factory: WooPosCardReaderPaymentControllerFactory = mock()
+        whenever(factory.create(any(), any(), any())).thenReturn(mockCardReaderPaymentController)
+        val paymentState =
+            MutableStateFlow<CardReaderPaymentOrRefundState>(
+                CardReaderPaymentState.CollectingPayment.ExternalReaderCollectPaymentState("") {}
+            )
+        whenever(mockCardReaderPaymentController.paymentState).thenReturn(paymentState)
+
+        // WHEN
+        val vm = createViewModelAndSetupForSuccessfulOrderCreation(controllerFactory = factory)
+        paymentState.value = CardReaderPaymentState.ProcessingPayment.ExternalReaderProcessingPayment("") {}
+        paymentState.value = CardReaderPaymentState.PaymentFailed.ExternalReaderFailedPayment.NonCancelable(
+            errorType = PaymentFlowError.NoNetwork, {}
+        )
+        advanceUntilIdle()
+
+        vm.onUIEvent(OnBackClicked)
+
+        // THEN
+        verify(childrenToParentEventSender).sendToParent(ReturnedFromCardReaderPaymentToCheckout)
+    }
+
+    private fun mockPaymentFailedTexts() {
+        whenever(resourceProvider.getString(R.string.woopos_success_totals_payment_processing_title))
+            .thenReturn("Processing payment")
+        whenever(resourceProvider.getString(R.string.woopos_success_totals_payment_processing_subtitle))
+            .thenReturn("Please wait…")
+        whenever(resourceProvider.getString(R.string.woopos_success_totals_payment_failed_title))
+            .thenReturn("Payment failed")
+        whenever(uiStringParser.asString(any())).thenReturn("Unfortunately, this payment has been declined.")
+        whenever(resourceProvider.getString(R.string.woo_pos_payment_failed_try_again))
+            .thenReturn("Try payment again")
     }
 
     private fun givenCardReaderConnectedAndNetworkAvailable() {

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/home/totals/WooPosTotalsViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/home/totals/WooPosTotalsViewModelTest.kt
@@ -33,11 +33,14 @@ import com.woocommerce.android.ui.woopos.cardreader.WooPosCardReaderFacade
 import com.woocommerce.android.ui.woopos.emailreceipt.WooPosEmailReceiptIsSendingSupported
 import com.woocommerce.android.ui.woopos.emailreceipt.WooPosEmailReceiptIsSendingSupported.Companion.WC_VERSION_SUPPORTS_SENDING_RECEIPTS_BY_EMAIL
 import com.woocommerce.android.ui.woopos.home.ChildToParentEvent
+import com.woocommerce.android.ui.woopos.home.ChildToParentEvent.BackFromCheckoutToCartClicked
+import com.woocommerce.android.ui.woopos.home.ChildToParentEvent.ReturnedFromCardReaderPaymentToCheckout
 import com.woocommerce.android.ui.woopos.home.ParentToChildrenEvent
 import com.woocommerce.android.ui.woopos.home.ParentToChildrenEvent.OrderSuccessfullyPaid.PaymentMethod
 import com.woocommerce.android.ui.woopos.home.WooPosChildrenToParentEventSender
 import com.woocommerce.android.ui.woopos.home.WooPosParentToChildrenEventReceiver
 import com.woocommerce.android.ui.woopos.home.items.WooPosItemsViewModel
+import com.woocommerce.android.ui.woopos.home.totals.WooPosTotalsUIEvent.OnBackClicked
 import com.woocommerce.android.ui.woopos.util.WooPosCoroutineTestRule
 import com.woocommerce.android.ui.woopos.util.WooPosNetworkStatus
 import com.woocommerce.android.ui.woopos.util.analytics.WooPosAnalyticsEvent
@@ -747,9 +750,7 @@ class WooPosTotalsViewModelTest {
                     R.string.woopos_success_totals_payment_processing_subtitle
                 )
             ).thenReturn("Please wait…")
-            whenever(networkStatus.isConnected()).thenReturn(true)
-            val readerStatus = MutableStateFlow<CardReaderStatus>(CardReaderStatus.Connected(mock()))
-            whenever(cardReaderFacade.readerStatus).thenReturn(readerStatus)
+            givenCardReaderConnectedAndNetworkAvailable()
             val mockCardReaderPaymentController: CardReaderPaymentController = mock()
             val factory: WooPosCardReaderPaymentControllerFactory = mock()
             whenever(factory.create(any(), any(), any())).thenReturn(mockCardReaderPaymentController)
@@ -782,9 +783,7 @@ class WooPosTotalsViewModelTest {
                     R.string.woopos_success_totals_payment_processing_subtitle
                 )
             ).thenReturn("Please wait…")
-            whenever(networkStatus.isConnected()).thenReturn(true)
-            val readerStatus = MutableStateFlow<CardReaderStatus>(CardReaderStatus.Connected(mock()))
-            whenever(cardReaderFacade.readerStatus).thenReturn(readerStatus)
+            givenCardReaderConnectedAndNetworkAvailable()
             val mockCardReaderPaymentController: CardReaderPaymentController = mock()
             val factory: WooPosCardReaderPaymentControllerFactory = mock()
             whenever(factory.create(any(), any(), any())).thenReturn(mockCardReaderPaymentController)
@@ -818,9 +817,7 @@ class WooPosTotalsViewModelTest {
                     R.string.woopos_success_totals_payment_processing_subtitle
                 )
             ).thenReturn("Please wait…")
-            whenever(networkStatus.isConnected()).thenReturn(true)
-            val readerStatus = MutableStateFlow<CardReaderStatus>(CardReaderStatus.Connected(mock()))
-            whenever(cardReaderFacade.readerStatus).thenReturn(readerStatus)
+            givenCardReaderConnectedAndNetworkAvailable()
             val mockCardReaderPaymentController: CardReaderPaymentController = mock()
             val factory: WooPosCardReaderPaymentControllerFactory = mock()
             whenever(factory.create(any(), any(), any())).thenReturn(mockCardReaderPaymentController)
@@ -848,9 +845,7 @@ class WooPosTotalsViewModelTest {
     fun `given order draft created and reader connected, when payment is processed, should show processing state`() =
         runTest {
             // GIVEN
-            whenever(networkStatus.isConnected()).thenReturn(true)
-            val readerStatus = MutableStateFlow<CardReaderStatus>(CardReaderStatus.Connected(mock()))
-            whenever(cardReaderFacade.readerStatus).thenReturn(readerStatus)
+            givenCardReaderConnectedAndNetworkAvailable()
             val mockCardReaderPaymentController: CardReaderPaymentController = mock()
             val factory: WooPosCardReaderPaymentControllerFactory = mock()
             whenever(factory.create(any(), any(), any())).thenReturn(mockCardReaderPaymentController)
@@ -888,9 +883,7 @@ class WooPosTotalsViewModelTest {
             whenever(resourceProvider.getString(R.string.woo_pos_payment_failed_try_again))
                 .thenReturn("Try payment again")
 
-            whenever(networkStatus.isConnected()).thenReturn(true)
-            val readerStatus = MutableStateFlow<CardReaderStatus>(CardReaderStatus.Connected(mock()))
-            whenever(cardReaderFacade.readerStatus).thenReturn(readerStatus)
+            givenCardReaderConnectedAndNetworkAvailable()
             val mockCardReaderPaymentController: CardReaderPaymentController = mock()
             val factory: WooPosCardReaderPaymentControllerFactory = mock()
             whenever(factory.create(any(), any(), any())).thenReturn(mockCardReaderPaymentController)
@@ -931,9 +924,7 @@ class WooPosTotalsViewModelTest {
             whenever(uiStringParser.asString(any())).thenReturn("Unfortunately, this payment has been declined.")
             whenever(resourceProvider.getString(R.string.woo_pos_payment_failed_try_another_payment_method))
                 .thenReturn("Try another payment method")
-            whenever(networkStatus.isConnected()).thenReturn(true)
-            val readerStatus = MutableStateFlow<CardReaderStatus>(CardReaderStatus.Connected(mock()))
-            whenever(cardReaderFacade.readerStatus).thenReturn(readerStatus)
+            givenCardReaderConnectedAndNetworkAvailable()
             val mockCardReaderPaymentController: CardReaderPaymentController = mock()
             val factory: WooPosCardReaderPaymentControllerFactory = mock()
             whenever(factory.create(any(), any(), any())).thenReturn(mockCardReaderPaymentController)
@@ -975,9 +966,7 @@ class WooPosTotalsViewModelTest {
             .thenReturn("Try another payment method")
         whenever(uiStringParser.asString(any())).thenReturn("Unfortunately, this payment has been declined.")
 
-        whenever(networkStatus.isConnected()).thenReturn(true)
-        val readerStatus = MutableStateFlow<CardReaderStatus>(CardReaderStatus.Connected(mock()))
-        whenever(cardReaderFacade.readerStatus).thenReturn(readerStatus)
+        givenCardReaderConnectedAndNetworkAvailable()
         val mockCardReaderPaymentController: CardReaderPaymentController = mock()
         val factory: WooPosCardReaderPaymentControllerFactory = mock()
         whenever(factory.create(any(), any(), any())).thenReturn(mockCardReaderPaymentController)
@@ -1016,9 +1005,7 @@ class WooPosTotalsViewModelTest {
                 .thenReturn("Try payment again")
             whenever(uiStringParser.asString(any())).thenReturn("Unfortunately, this payment has been declined.")
 
-            whenever(networkStatus.isConnected()).thenReturn(true)
-            val readerStatus = MutableStateFlow<CardReaderStatus>(CardReaderStatus.Connected(mock()))
-            whenever(cardReaderFacade.readerStatus).thenReturn(readerStatus)
+            givenCardReaderConnectedAndNetworkAvailable()
             val mockCardReaderPaymentController: CardReaderPaymentController = mock()
             val factory: WooPosCardReaderPaymentControllerFactory = mock()
             whenever(factory.create(any(), any(), any())).thenReturn(mockCardReaderPaymentController)
@@ -1255,6 +1242,89 @@ class WooPosTotalsViewModelTest {
             val checkout = viewModel.state.value as WooPosTotalsViewState.Checkout
             assertFalse(checkout.isFreeOrder)
         }
+
+
+    @Test
+    fun `given payment processing state, when OnBackClicked, then should ignore OnBackClicked`() = runTest {
+        // GIVEN
+        givenCardReaderConnectedAndNetworkAvailable()
+        val mockCardReaderPaymentController: CardReaderPaymentController = mock()
+        val factory: WooPosCardReaderPaymentControllerFactory = mock()
+        whenever(factory.create(any(), any(), any())).thenReturn(mockCardReaderPaymentController)
+        val paymentState =
+            MutableStateFlow<CardReaderPaymentOrRefundState>(
+                CardReaderPaymentState.CollectingPayment.ExternalReaderCollectPaymentState("") {}
+            )
+        whenever(mockCardReaderPaymentController.paymentState).thenReturn(paymentState)
+
+        // WHEN
+        val vm = createViewModelAndSetupForSuccessfulOrderCreation(controllerFactory = factory)
+        paymentState.value = CardReaderPaymentState.ProcessingPayment.ExternalReaderProcessingPayment("") {}
+        advanceUntilIdle()
+
+        vm.onUIEvent(OnBackClicked)
+
+        // THEN
+        verify(mockCardReaderPaymentController, never()).onBackPressed()
+        verify(childrenToParentEventSender, never()).sendToParent(BackFromCheckoutToCartClicked)
+        verify(childrenToParentEventSender, never()).sendToParent(ReturnedFromCardReaderPaymentToCheckout)
+    }
+
+    @Test
+    fun `given payment capturing state, when OnBackClicked, then should ignore OnBackClicked`() = runTest {
+        // GIVEN
+        givenCardReaderConnectedAndNetworkAvailable()
+        val mockCardReaderPaymentController: CardReaderPaymentController = mock()
+        val factory: WooPosCardReaderPaymentControllerFactory = mock()
+        whenever(factory.create(any(), any(), any())).thenReturn(mockCardReaderPaymentController)
+        val paymentState =
+            MutableStateFlow<CardReaderPaymentOrRefundState>(
+                CardReaderPaymentState.CollectingPayment.ExternalReaderCollectPaymentState("") {}
+            )
+        whenever(mockCardReaderPaymentController.paymentState).thenReturn(paymentState)
+
+        // WHEN
+        val vm = createViewModelAndSetupForSuccessfulOrderCreation(controllerFactory = factory)
+        paymentState.value = CardReaderPaymentState.PaymentCapturing.ExternalReaderPaymentCapturing("")
+        advanceUntilIdle()
+
+        vm.onUIEvent(OnBackClicked)
+
+        // THEN
+        verify(mockCardReaderPaymentController, never()).onBackPressed()
+        verify(childrenToParentEventSender, never()).sendToParent(BackFromCheckoutToCartClicked)
+        verify(childrenToParentEventSender, never()).sendToParent(ReturnedFromCardReaderPaymentToCheckout)
+    }
+
+    @Test
+    fun `given payment collecting state, when OnBackClicked, then should not ignore OnBackClicked`() = runTest {
+        // GIVEN
+        givenCardReaderConnectedAndNetworkAvailable()
+        val mockCardReaderPaymentController: CardReaderPaymentController = mock()
+        val factory: WooPosCardReaderPaymentControllerFactory = mock()
+        whenever(factory.create(any(), any(), any())).thenReturn(mockCardReaderPaymentController)
+        val paymentState =
+            MutableStateFlow<CardReaderPaymentOrRefundState>(
+                CardReaderPaymentState.CollectingPayment.ExternalReaderCollectPaymentState("") {}
+            )
+        whenever(mockCardReaderPaymentController.paymentState).thenReturn(paymentState)
+
+        // WHEN
+        val vm = createViewModelAndSetupForSuccessfulOrderCreation(controllerFactory = factory)
+        advanceUntilIdle()
+
+        vm.onUIEvent(OnBackClicked)
+
+        // THEN
+        verify(mockCardReaderPaymentController, never()).onBackPressed()
+        verify(childrenToParentEventSender).sendToParent(BackFromCheckoutToCartClicked)
+    }
+
+    private fun givenCardReaderConnectedAndNetworkAvailable() {
+        whenever(networkStatus.isConnected()).thenReturn(true)
+        val readerStatus = MutableStateFlow<CardReaderStatus>(CardReaderStatus.Connected(mock()))
+        whenever(cardReaderFacade.readerStatus).thenReturn(readerStatus)
+    }
 
     private fun createNonEmptyOrder() = Order.getEmptyOrder(
         dateCreated = Date(),


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
This PR disallows canceling the payment flow in POS during payment processing and payment capturing states.

This partially addresses https://github.com/woocommerce/woocommerce-android/issues/13593.

### Steps to reproduce
<!-- Step-by-step testing instructions. For new user flows, consider instead stating the goal of the workflow and see if your PR reviewer can accomplish the workflow without specific steps! -->
Go to POS (More menu -> Point Of Sale), and try to reproduce the following scenarios:
<img width="722" alt="414813753-7c634560-aa66-411b-a06b-a55a0737c7e0" src="https://github.com/user-attachments/assets/9bc86c93-6ad9-4939-a854-3050f12a1808" />

### Testing information
<!-- This is your opportunity to break out individual scenarios that need testing (when necessary) and/or include a checklist for the reviewer to go through. Consider documenting the following from your own completed testing: devices used, alternate workflows, edge cases, affected areas, critical flows, areas not tested, and any remaining unknowns. Provide feedback on this new section of the PR template through Sept 30, 2024 to Apps Quality; additional context here: p91TBi-b8z-p2#comment-12036 -->
- [x] Verify it's impossible to cancel the flow in the processing and capturing states (essentially after the card is tapped to the reader)

### The tests that have been performed
<!-- To give the reviewer an idea of what could be missed in terms of testing -->
I verified that canceling the flow in the processing and capturing states is impossible.

### Images/gif
<!-- Include before and after images or gifs when appropriate. -->
—

- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.

## Reviewer (or Author, in the case of optional code reviews):

Please make sure these conditions are met before approving the PR, or request changes if the PR needs improvement:

- [x] The PR is small and has a clear, single focus, or a valid explanation is provided in the description. If needed, please request to split it into smaller PRs.
- [x] Ensure Adequate Unit Test Coverage: The changes are reasonably covered by unit tests or an explanation is provided in the PR description.
- [x] Manual Testing: The author listed all the tests they ran, including smoke tests when needed (e.g., for refactorings). The reviewer confirmed that the PR works as expected on big (tablet) and small (phone) in case of UI changes, and no regressions are added.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->