### PR TITLE
Add retry function to shipping labels creation

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/WooShippingLabelCreationViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/WooShippingLabelCreationViewModel.kt
@@ -57,6 +57,7 @@ class WooShippingLabelCreationViewModel @Inject constructor(
     private val getShippingRates: GetShippingRates,
     private val purchaseShippingLabel: PurchaseShippingLabel,
     private val observeStoreOptions: ObserveStoreOptions,
+    private val fetchAccountSettings: FetchAccountSettings,
     private val shouldRequireCustoms: ShouldRequireCustomsForm
 ) : ScopedViewModel(savedState) {
     private val navArgs: WooShippingLabelCreationFragmentArgs by savedState.navArgs()
@@ -503,7 +504,13 @@ class WooShippingLabelCreationViewModel @Inject constructor(
 
     fun onRetry() {
         // Retry loading data that may have previously resulted in errors.
+        viewState.value = WooShippingViewState.Loading
         launch { getOrderInformation() }
+        launch {
+            val result = fetchAccountSettings().getOrNull()
+            storeOptions.value = StoreOptionsModel.EMPTY
+            storeOptions.value = result
+        }
     }
 
     data object StartPackageSelection : Event()

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/datasource/WooShippingConfigurationDataStore.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/datasource/WooShippingConfigurationDataStore.kt
@@ -34,4 +34,6 @@ class WooShippingConfigurationDataStore @Inject constructor(
             preferences[stringPreferencesKey(getStoreOptionsKey())] = gson.toJson(storeOptions)
         }
     }
+
+    suspend fun clearStoreOptions() = dataStore.edit { it.remove(stringPreferencesKey(getStoreOptionsKey())) }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/networking/WooShippingLabelRepository.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/networking/WooShippingLabelRepository.kt
@@ -39,7 +39,7 @@ class WooShippingLabelRepository @Inject constructor(
                 ?.takeIf { response.isError.not() }
                 ?.let {
                     configurationDataStore.saveStoreOptions(it)
-                }
+                } ?: configurationDataStore.clearStoreOptions()
         }
 
     suspend fun fetchPurchasedShippingLabels(

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/WooShippingLabelCreationViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/WooShippingLabelCreationViewModelTest.kt
@@ -227,6 +227,7 @@ class WooShippingLabelCreationViewModelTest : BaseUnitTest() {
             getShippingRates = getShippingRates,
             purchaseShippingLabel = purchaseShippingLabel,
             observeStoreOptions = observeStoreOptions,
+            fetchAccountSettings = mock(),
             shouldRequireCustoms = shouldRequireCustomsForm,
             savedState = savedState
         )

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/WooShippingLabelCreationViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/WooShippingLabelCreationViewModelTest.kt
@@ -215,6 +215,7 @@ class WooShippingLabelCreationViewModelTest : BaseUnitTest() {
     private val getShippingRates: GetShippingRates = mock()
     private val purchaseShippingLabel: PurchaseShippingLabel = mock()
     private val observeStoreOptions: ObserveStoreOptions = mock()
+    private val fetchAccountSettings: FetchAccountSettings = mock()
 
     private lateinit var sut: WooShippingLabelCreationViewModel
 
@@ -227,7 +228,7 @@ class WooShippingLabelCreationViewModelTest : BaseUnitTest() {
             getShippingRates = getShippingRates,
             purchaseShippingLabel = purchaseShippingLabel,
             observeStoreOptions = observeStoreOptions,
-            fetchAccountSettings = mock(),
+            fetchAccountSettings = fetchAccountSettings,
             shouldRequireCustoms = shouldRequireCustomsForm,
             savedState = savedState
         )
@@ -720,12 +721,14 @@ class WooShippingLabelCreationViewModelTest : BaseUnitTest() {
         }
 
     @Test
-    fun `when there is no cached store options and API request fails then display error`() = testBlocking {
+    fun `when there is no cached store options and API request fails then display error with retry`() = testBlocking {
         val order = OrderTestUtils.generateTestOrder(orderId = orderId)
 
         whenever(orderDetailRepository.getOrderById(any())) doReturn order
         whenever(observeOriginAddresses()) doReturn flowOf(defaultOriginAddresses)
         whenever(observeStoreOptions()) doReturn flowOf(null)
+        whenever(getShippableItems(any())) doReturn defaultShippableItems
+        whenever(fetchAccountSettings()) doReturn Result.success(defaultStoreOptions)
 
         createViewModel()
 
@@ -733,6 +736,11 @@ class WooShippingLabelCreationViewModelTest : BaseUnitTest() {
 
         val currentViewState = sut.viewState.value
         assertThat(currentViewState).isInstanceOf(WooShippingViewState.Error::class.java)
+
+        sut.onRetry()
+
+        val newViewState = sut.viewState.value
+        assertThat(newViewState).isInstanceOf(DataState::class.java)
     }
 
     @Test


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #13318
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
This adds functionality to the Retry button on the error screen of the shipping labels creation screen.

### Steps to reproduce
<!-- Step-by-step testing instructions. For new user flows, consider instead stating the goal of the workflow and see if your PR reviewer can accomplish the workflow without specific steps! -->
#### To create fake error response from the endpoint
1. Go to Menu → Settings → Developer Options → API Faker
2. Tap + button.
3. Enter these settings:
```
Type: WordPress REST API
HTTP Method: GET
Path: /wcshipping/v1/account/settings
Status Code: 403
```
4. Tap Save.
5. Enable API Faker.

#### To test the retry screen
1. Log in to a site that is eligible for shipping labels.
2. Go to orders.
3. Create a new order and complete the payment.
4. Open the order details and tap the "Create shipping label" button.
5. Verify that the error screen appears when the API faker is enabled.
6. Disable the API faker by tapping the red bottom banner.
7. Tap the Retry button.
8. Verify that the error disappears.

### The tests that have been performed
<!-- To give the reviewer an idea of what could be missed in terms of testing -->
Steps above

### Images/gif
<!-- Include before and after images or gifs when appropriate. -->
[Screen_recording_20250220_185952.webm](https://github.com/user-attachments/assets/a4798ed9-bda9-44ac-b892-31d64884f966)

- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.

## Reviewer (or Author, in the case of optional code reviews):

Please make sure these conditions are met before approving the PR, or request changes if the PR needs improvement:

- [ ] The PR is small and has a clear, single focus, or a valid explanation is provided in the description. If needed, please request to split it into smaller PRs.
- [ ] Ensure Adequate Unit Test Coverage: The changes are reasonably covered by unit tests or an explanation is provided in the PR description.
- [ ] Manual Testing: The author listed all the tests they ran, including smoke tests when needed (e.g., for refactorings). The reviewer confirmed that the PR works as expected on big (tablet) and small (phone) in case of UI changes, and no regressions are added.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->