### PR TITLE
[Dynamic Dashboard] Fix padding + fix JITM announcements

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -16,6 +16,7 @@
 - [*] [Internal] All non-login tracking events will now include the selected site data [https://github.com/woocommerce/woocommerce-android/pull/13575]
 - [*] Fixed a crash that occurred when the app was backgrounded during bulk variations update [https://github.com/woocommerce/woocommerce-android/pull/13584]
 - [*] Improved handling of product previews by using the Authenticated WebView in supported scenarios [https://github.com/woocommerce/woocommerce-android/pull/13494]
+- [*] [Internal] Fixed a bug that caused the app to not show JITM messages in the dashboard [https://github.com/woocommerce/woocommerce-android/pull/13604]
 
 21.7
 -----

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/DashboardContainer.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/DashboardContainer.kt
@@ -80,7 +80,7 @@ fun DashboardContainer(
                 modifier = Modifier
                     .fillMaxSize()
                     .background(MaterialTheme.colors.surface)
-                    .padding(16.dp),
+                    .padding(horizontal = 16.dp),
                 numberOfColumns = calculateColumnNumber(boxWithConstraintsScope.maxWidth, state)
             )
             PullRefreshIndicator(
@@ -111,6 +111,7 @@ private fun DashboardWidgets(
                 .verticalScroll(rememberScrollState()),
             verticalArrangement = Arrangement.spacedBy(16.dp),
         ) {
+            Spacer(modifier = Modifier)
             widgetUiModels.forEach { widget ->
                 AnimatedVisibility(widget.isVisible) {
                     DashboardWidgetCard(
@@ -122,6 +123,7 @@ private fun DashboardWidgets(
                     )
                 }
             }
+            Spacer(modifier = Modifier)
         }
     } else {
         val widgetColumns = splitWidgetsIntoColumns(
@@ -134,6 +136,7 @@ private fun DashboardWidgets(
                 .verticalScroll(rememberScrollState()),
             horizontalArrangement = Arrangement.spacedBy(16.dp)
         ) {
+            Spacer(modifier = Modifier)
             widgetColumns.forEach { columnWidgets ->
                 Column(
                     modifier = Modifier.weight(1f),
@@ -150,6 +153,7 @@ private fun DashboardWidgets(
                     }
                 }
             }
+            Spacer(modifier = Modifier)
         }
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/DashboardFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/DashboardFragment.kt
@@ -193,7 +193,9 @@ class DashboardFragment :
             // Show banners only if onboarding list is NOT displayed
             if (
                 state.widgets.none {
-                    (it as? DashboardWidgetUiModel.ConfigurableWidget)?.widget?.type == DashboardWidget.Type.ONBOARDING
+                    val configurableWidget = it as? DashboardWidgetUiModel.ConfigurableWidget
+                    configurableWidget?.widget?.type == DashboardWidget.Type.ONBOARDING &&
+                        configurableWidget.widget.isVisible
                 }
             ) {
                 initJitm()

--- a/WooCommerce/src/main/res/layout/fragment_dashboard.xml
+++ b/WooCommerce/src/main/res/layout/fragment_dashboard.xml
@@ -14,8 +14,7 @@
     <androidx.fragment.app.FragmentContainerView
         android:id="@+id/jitmFragment"
         android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:layout_marginBottom="@dimen/minor_100" />
+        android:layout_height="wrap_content" />
 
     <!-- Dynamic dashboard container -->
     <androidx.compose.ui.platform.ComposeView


### PR DESCRIPTION
Closes: #13603

### Description
Fix two issues with the Dynamic Dashboard:
1. Ensures the JITM fragment is correctly initialized when needed, the issue was caused by our changes for the dynamic dashboard. The good news is that it seems we don't have any active JITM messages (Check the JITM dashboard), so hopefully this didn't have any production impact. (07e0f193fde619cc946b4798d27f4595c6bcacac)
2. Fixes the padding in the screen to avoid having a white space when scrolling, this was reported [here](https://github.com/woocommerce/woocommerce-android/pull/13590#pullrequestreview-2630831534) (74597ac3f775fee89654277743e5a1e92c345cd0 and 70b2302584ff4c838bc10d4de742167d3a41273a)

### Steps to reproduce
1. Add the following line to your `developer.properties` file (create one if it's missing):
```
wc.jitm_testing_json_file_name = jitm_testing.json
```
2. Launch the dashboard screen.

### Testing information
- Confirm the JITM fragment is shown (the example will show an IPP banner)
- Confirm there is now white spacing around the dashboard widgets (both when the JITM banner is shown and it's dismissed)

### The tests that have been performed
^

### Images/gif
<img src=https://github.com/user-attachments/assets/090e937a-533f-4c5e-9ee8-7b931c6fd54e width=360 />

- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.

## Reviewer (or Author, in the case of optional code reviews):

Please make sure these conditions are met before approving the PR, or request changes if the PR needs improvement:

- [ ] The PR is small and has a clear, single focus, or a valid explanation is provided in the description. If needed, please request to split it into smaller PRs.
- [ ] Ensure Adequate Unit Test Coverage: The changes are reasonably covered by unit tests or an explanation is provided in the PR description.
- [ ] Manual Testing: The author listed all the tests they ran, including smoke tests when needed (e.g., for refactorings). The reviewer confirmed that the PR works as expected on big (tablet) and small (phone) in case of UI changes, and no regressions are added.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->