### PR TITLE
Add coderabbit.ai configuration file

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -1,0 +1,22 @@
+# yaml-language-server: $schema=https://coderabbit.ai/integrations/schema.v2.json
+language: "en-US"
+early_access: false
+enable_free_tier: true
+reviews:
+  profile: "chill"
+  request_changes_workflow: false
+  high_level_summary: false
+  poem: false
+  review_status: true
+  commit_status: false
+  sequence_diagrams: true
+  changed_files_summary: true
+  collapse_walkthrough: true
+  auto_review:
+    enabled: true
+    drafts: false
+  finishing_touches:
+    docstrings:
+      enabled: false
+chat:
+  auto_reply: true

--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -1,9 +1,11 @@
 # yaml-language-server: $schema=https://coderabbit.ai/integrations/schema.v2.json
-language: "en-US"
+---
+
+language: en-US
 early_access: false
 enable_free_tier: true
 reviews:
-  profile: "chill"
+  profile: chill
   request_changes_workflow: false
   high_level_summary: false
   poem: false
@@ -13,7 +15,7 @@ reviews:
   changed_files_summary: true
   collapse_walkthrough: true
   auto_review:
-    enabled: true
+    enabled: false
     drafts: false
   finishing_touches:
     docstrings:

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -3,6 +3,13 @@
 Closes: #
 <!-- Id number of the GitHub issue this PR addresses. -->
 
+<!-- 
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+🛠 Need an AI review?  
+Add a comment: `@coderabbitai review`
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+-->
+
 ### Description
 <!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
 


### PR DESCRIPTION
Twin PR: https://github.com/woocommerce/woocommerce-ios/pull/15238

### Description

This PR adds configuration for Coderabbit.ai. It does not enable the tool yet.

The set of features I've enabled or disabled here is opinionated: I aimed to disable unwanted features like `finishing_touches` or `poem`. 

The walkthrough is put into "more" section, to not clutter the PR. See example PR with this config applied on my fork: https://github.com/wzieba/woocommerce-android/pull/180

Documentation: https://docs.coderabbit.ai/getting-started/configure-coderabbit