### PR TITLE
Edit order navigation

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/address/WooShippingEditAddressScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/address/WooShippingEditAddressScreen.kt
@@ -125,6 +125,7 @@ fun WooShippingEditAddressScreen(
         onNormalizeAddress = viewModel::onNormalizeAddress,
         onUpdateOriginAddress = viewModel::onUpdateOriginAddress,
         onUpdateNormalizedOriginAddress = viewModel::onUpdateNormalizedOriginAddress,
+        onNavigateBack = viewModel::onNavigateBack,
         modifier = modifier
     )
 }
@@ -155,6 +156,7 @@ fun WooShippingEditAddressScreen(
     onNormalizeAddress: (editableAddress: EditableAddress) -> Unit,
     onUpdateOriginAddress: (editableAddress: EditableAddress) -> Unit,
     onUpdateNormalizedOriginAddress: (selection: AddressValidationState.AddressSelection) -> Unit,
+    onNavigateBack: () -> Unit,
     modifier: Modifier = Modifier
 ) {
     val snackbarHostState = remember { SnackbarHostState() }
@@ -170,7 +172,7 @@ fun WooShippingEditAddressScreen(
         topBar = {
             Toolbar(
                 title = stringResource(id = R.string.woo_shipping_edit_origin_address_title),
-                onNavigationButtonClick = {},
+                onNavigationButtonClick = onNavigateBack,
                 navigationIcon = Icons.AutoMirrored.Filled.ArrowBack
             )
         },

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/address/WooShippingEditAddressScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/address/WooShippingEditAddressScreen.kt
@@ -366,6 +366,7 @@ fun WooShippingEditAddressScreen(
                     addressStatus = addressStatus,
                     onNormalizeAddress = onNormalizeAddress,
                     onUpdateOriginAddress = onUpdateOriginAddress,
+                    onClose = onNavigateBack,
                     modifier = Modifier
                         .fillMaxWidth()
                         .padding(16.dp)
@@ -449,6 +450,7 @@ internal fun AddressStatusSection(
     addressStatus: AddressStatus,
     onNormalizeAddress: (editableAddress: EditableAddress) -> Unit,
     onUpdateOriginAddress: (editableAddress: EditableAddress) -> Unit,
+    onClose: () -> Unit,
     modifier: Modifier = Modifier
 ) {
     Column(
@@ -481,7 +483,7 @@ internal fun AddressStatusSection(
 
         val buttonAction: () -> Unit = when (addressStatus) {
             AddressStatus.VERIFIED -> {
-                {}
+                { onClose() }
             }
             AddressStatus.UNVERIFIED -> {
                 { onNormalizeAddress(editableAddress) }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/address/origin/WooShippingEditOriginAddressFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/address/origin/WooShippingEditOriginAddressFragment.kt
@@ -16,15 +16,17 @@ import com.woocommerce.android.model.Location
 import com.woocommerce.android.ui.base.BaseFragment
 import com.woocommerce.android.ui.compose.theme.WooThemeWithBackground
 import com.woocommerce.android.ui.main.AppBarStatus
+import com.woocommerce.android.ui.main.MainActivity.Companion.BackPressListener
 import com.woocommerce.android.ui.orders.details.editing.address.LocationCode
 import com.woocommerce.android.ui.orders.wooshippinglabels.address.WooShippingEditAddressScreen
 import com.woocommerce.android.ui.orders.wooshippinglabels.address.origin.WooShippingEditOriginViewModel.ShowCountrySelector
 import com.woocommerce.android.ui.orders.wooshippinglabels.address.origin.WooShippingEditOriginViewModel.ShowStateSelector
 import com.woocommerce.android.ui.searchfilter.SearchFilterItem
+import com.woocommerce.android.viewmodel.MultiLiveEvent
 import dagger.hilt.android.AndroidEntryPoint
 
 @AndroidEntryPoint
-class WooShippingEditOriginAddressFragment : BaseFragment() {
+class WooShippingEditOriginAddressFragment : BaseFragment(), BackPressListener {
     private companion object {
         const val SELECT_COUNTRY_REQUEST = "select_address_country_request"
         const val SELECT_STATE_REQUEST = "select_address_state_request"
@@ -58,6 +60,7 @@ class WooShippingEditOriginAddressFragment : BaseFragment() {
             when (event) {
                 is ShowCountrySelector -> showCountrySearchScreen(event.countries)
                 is ShowStateSelector -> showStatesSearchScreen(event.states)
+                is MultiLiveEvent.Event.Exit -> findNavController().navigateUp()
             }
         }
     }
@@ -100,4 +103,6 @@ class WooShippingEditOriginAddressFragment : BaseFragment() {
         )
         findNavController().navigateSafely(action)
     }
+
+    override fun onRequestAllowBackPress(): Boolean = viewModel.allowBackNavigation()
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/address/origin/WooShippingEditOriginViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/address/origin/WooShippingEditOriginViewModel.kt
@@ -18,6 +18,7 @@ import com.woocommerce.android.ui.orders.wooshippinglabels.models.AddressNormali
 import com.woocommerce.android.ui.orders.wooshippinglabels.models.OriginShippingAddress
 import com.woocommerce.android.util.StringUtils.combineStrings
 import com.woocommerce.android.viewmodel.MultiLiveEvent
+import com.woocommerce.android.viewmodel.MultiLiveEvent.Event
 import com.woocommerce.android.viewmodel.ResourceProvider
 import com.woocommerce.android.viewmodel.ScopedViewModel
 import com.woocommerce.android.viewmodel.navArgs
@@ -229,6 +230,21 @@ class WooShippingEditOriginViewModel @Inject constructor(
                     selectedState.value = Location.EMPTY
                 }
             }
+    }
+
+    fun allowBackNavigation(): Boolean {
+        return when (viewState.value.addressValidationState) {
+            is AddressValidationState.AddressSelection,
+            is AddressValidationState.NormalizedAddressUpdateFailed -> {
+                onCloseAddressSelection()
+                return false
+            }
+            else -> true
+        }
+    }
+
+    fun onNavigateBack() {
+        if (allowBackNavigation()) triggerEvent(Event.Exit)
     }
 
     fun onExpandCompany() {

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/address/origin/WooShippingEditOriginViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/address/origin/WooShippingEditOriginViewModelTest.kt
@@ -997,4 +997,95 @@ class WooShippingEditOriginViewModelTest : BaseUnitTest() {
 
         assertThat(result.error).isNotNull()
     }
+
+    @Test
+    fun `when the address selection is expanded then prevent back navigation`() = testBlocking {
+        val initialAddress = OriginShippingAddress.EMPTY
+        val updatedAddress = EditableAddress(postalCode = InputValue("12345"))
+        val enteredAddress = EditableAddress(postalCode = InputValue("12345")).toAddress()
+        val suggestedAddress = enteredAddress.copy(postcode = "12345-1000")
+
+        val normalizeAddressResponse = AddressNormalizationModel(
+            address = enteredAddress,
+            normalizedAddress = suggestedAddress,
+            isTrivial = false
+        )
+
+        whenever(addressValidator.validateFieldRequired(any())).doReturn(null)
+        whenever(getAcceptedOriginCountries.invoke()).doReturn(Result.success(countries))
+        whenever(getStatesByCountryCode.invoke(any())).doReturn(states)
+        whenever(normalizeAddress.invoke(any())).doReturn(Result.success(normalizeAddressResponse))
+        whenever(resourceProvider.getString(any())).doReturn("error")
+        Snapshot.withMutableSnapshot {
+            createViewModel(initialAddress)
+        }
+
+        advanceUntilIdle()
+
+        sut.onNormalizeAddress(updatedAddress)
+
+        var result = sut.viewState.value
+        assertThat(result.addressValidationState).isInstanceOf(AddressValidationState.AddressSelection::class.java)
+
+        val shouldNavigateBack = sut.allowBackNavigation()
+        assertThat(shouldNavigateBack).isFalse()
+    }
+
+    @Test
+    fun `when the address selection is expanded with an error then prevent back navigation`() = testBlocking {
+        val initialAddress = OriginShippingAddress.EMPTY
+        val enteredAddress = EditableAddress(postalCode = InputValue("12345")).toAddress()
+        val suggestedAddress = enteredAddress.copy(postcode = "12345-1000")
+        val normalizeAddressResponse = AddressNormalizationModel(
+            address = enteredAddress,
+            normalizedAddress = suggestedAddress,
+            isTrivial = false
+        )
+
+        whenever(addressValidator.validateFieldRequired(any())).doReturn(null)
+        whenever(getAcceptedOriginCountries.invoke()).doReturn(Result.success(countries))
+        whenever(getStatesByCountryCode.invoke(any())).doReturn(states)
+        whenever(updateOriginAddress.invoke(any(), any())).doReturn(Result.failure(Exception("error")))
+        whenever(resourceProvider.getString(any())).doReturn("error")
+        Snapshot.withMutableSnapshot {
+            createViewModel(initialAddress)
+        }
+
+        advanceUntilIdle()
+
+        sut.onUpdateNormalizedOriginAddress(
+            AddressValidationState.AddressSelection(
+                addressNormalization = normalizeAddressResponse,
+                selectedAddress = suggestedAddress
+            )
+        )
+
+        val result = sut.viewState.value
+        assertThat(result.addressValidationState)
+            .isInstanceOf(AddressValidationState.NormalizedAddressUpdateFailed::class.java)
+
+        assertThat(result.error).isNotNull()
+
+        val shouldNavigateBack = sut.allowBackNavigation()
+        assertThat(shouldNavigateBack).isFalse()
+    }
+
+    @Test
+    fun `when the address selection is NOT expanded then allow back navigation`() = testBlocking {
+        whenever(addressValidator.validateFieldRequired(any())).doReturn(null)
+        whenever(getAcceptedOriginCountries.invoke()).doReturn(Result.success(countries))
+        whenever(getStatesByCountryCode.invoke(any())).doReturn(states)
+        Snapshot.withMutableSnapshot {
+            createViewModel(OriginShippingAddress.EMPTY)
+        }
+
+        advanceUntilIdle()
+
+        val result = sut.viewState.value
+
+        assertThat(result.addressValidationState).isInstanceOf(AddressValidationState.NotStarted::class.java)
+
+        val shouldNavigateBack = sut.allowBackNavigation()
+        assertThat(shouldNavigateBack).isTrue()
+    }
 }


### PR DESCRIPTION
Closes: #12439

### Description
This PR fixes the edit origin address navigation. The changes introduced here add the Top bar navigation, the Close button navigation, and update the gesture navigation. I included a special case when using the gesture navigation: if the select address bottom sheet is expanded, then the back gesture navigation will close the bottom sheet; otherwise, it will navigate to the previous screen.

### Testing information
TC1
1. Open the orders tab
2. Tap on an order eligible for shipping label creation
3. Expand the shipment details section
4. Expand the origin address selection (3 dots)
5. Tap on the pencil
6. Tap on the back arrow in the ToolBar
7. Check that the app navigates to the previous screen

TC2
1. Open the orders tab
2. Tap on an order eligible for shipping label creation
3. Expand the shipment details section
4. Expand the origin address selection (3 dots)
5. Tap on the pencil on a verified address
6. Tap on the Close button
7. Check that the app navigates to the previous screen

TC3
1. Open the orders tab
2. Tap on an order eligible for shipping label creation
3. Expand the shipment details section
4. Expand the origin address selection (3 dots)
5. Tap on the pencil
6. Update the postal code to make the address unverified
7. Tap on validate and save
8. Check that the address selection bottom sheet is expanded
9. Use the back gesture/back navigation button
10. Check that the address selection bottom sheet is collapsed
11. Use the back gesture/back navigation button again to exit the screen (If an edit text field is focused, using the back button will first remove the focus and then navigate back)


### The tests that have been performed
- The tests described above 

### Images/gif

https://github.com/user-attachments/assets/a83f3d06-406e-4160-be43-66471f943029



- [ ] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.

## Reviewer (or Author, in the case of optional code reviews):

Please make sure these conditions are met before approving the PR, or request changes if the PR needs improvement:

- [x] The PR is small and has a clear, single focus, or a valid explanation is provided in the description. If needed, please request to split it into smaller PRs.
- [x] Ensure Adequate Unit Test Coverage: The changes are reasonably covered by unit tests or an explanation is provided in the PR description.
- [x] Manual Testing: The author listed all the tests they ran, including smoke tests when needed (e.g., for refactorings). The reviewer confirmed that the PR works as expected on big (tablet) and small (phone) in case of UI changes, and no regressions are added.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->