### PR TITLE
Ensure the device is correctly unregistered after logout in all scenarios

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/AccountRepository.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/AccountRepository.kt
@@ -16,10 +16,12 @@ import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.launch
 import org.wordpress.android.fluxc.Dispatcher
 import org.wordpress.android.fluxc.generated.AccountActionBuilder
+import org.wordpress.android.fluxc.generated.NotificationActionBuilder
 import org.wordpress.android.fluxc.generated.SiteActionBuilder
 import org.wordpress.android.fluxc.model.AccountModel
 import org.wordpress.android.fluxc.store.AccountStore
 import org.wordpress.android.fluxc.store.AccountStore.OnAccountChanged
+import org.wordpress.android.fluxc.store.NotificationStore.OnDeviceUnregistered
 import org.wordpress.android.fluxc.store.SiteStore
 import org.wordpress.android.fluxc.store.account.CloseAccountStore
 import org.wordpress.android.fluxc.store.account.CloseAccountStore.CloseAccountErrorType
@@ -52,9 +54,14 @@ class AccountRepository @Inject constructor(
             (selectedSite.connectionType == SiteConnectionType.ApplicationPasswords)
     }
 
+    @Suppress("ReturnCount")
     suspend fun logout(): Boolean {
         if (!isUserLoggedIn()) return true
         return if (accountStore.hasAccessToken()) {
+            unregisterDevice().onFailure {
+                return false
+            }
+
             // WordPress.com account logout
             val event: OnAccountChanged = dispatcher.dispatchAndAwait(AccountActionBuilder.newSignOutAction())
             if (event.isError) {
@@ -124,6 +131,20 @@ class AccountRepository @Inject constructor(
 
         // Delete sites
         dispatcher.dispatch(SiteActionBuilder.newRemoveAllSitesAction())
+    }
+
+    private suspend fun unregisterDevice(): Result<Unit> {
+        val event: OnDeviceUnregistered = dispatcher.dispatchAndAwait(
+            NotificationActionBuilder.newUnregisterDeviceAction()
+        )
+
+        return when {
+            event.isError -> {
+                WooLog.e(LOGIN, "Error while trying to unregister device: ${event.error.message}")
+                Result.failure(OnChangedException(event.error))
+            }
+            else -> Result.success(Unit)
+        }
     }
 
     sealed class CloseAccountResult {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/AccountRepository.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/AccountRepository.kt
@@ -58,9 +58,7 @@ class AccountRepository @Inject constructor(
     suspend fun logout(): Boolean {
         if (!isUserLoggedIn()) return true
         return if (accountStore.hasAccessToken()) {
-            unregisterDevice().onFailure {
-                return false
-            }
+            unregisterDevice()
 
             // WordPress.com account logout
             val event: OnAccountChanged = dispatcher.dispatchAndAwait(AccountActionBuilder.newSignOutAction())
@@ -133,18 +131,10 @@ class AccountRepository @Inject constructor(
         dispatcher.dispatch(SiteActionBuilder.newRemoveAllSitesAction())
     }
 
-    private suspend fun unregisterDevice(): Result<Unit> {
-        val event: OnDeviceUnregistered = dispatcher.dispatchAndAwait(
+    private suspend fun unregisterDevice() {
+        dispatcher.dispatchAndAwait<Void, OnDeviceUnregistered>(
             NotificationActionBuilder.newUnregisterDeviceAction()
         )
-
-        return when {
-            event.isError -> {
-                WooLog.e(LOGIN, "Error while trying to unregister device: ${event.error.message}")
-                Result.failure(OnChangedException(event.error))
-            }
-            else -> Result.success(Unit)
-        }
     }
 
     sealed class CloseAccountResult {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/AppSettingsPresenter.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/AppSettingsPresenter.kt
@@ -3,16 +3,10 @@ package com.woocommerce.android.ui.prefs
 import com.woocommerce.android.ui.login.AccountRepository
 import com.woocommerce.android.ui.payments.cardreader.ClearCardReaderDataAction
 import kotlinx.coroutines.launch
-import org.greenrobot.eventbus.Subscribe
-import org.greenrobot.eventbus.ThreadMode
-import org.wordpress.android.fluxc.Dispatcher
-import org.wordpress.android.fluxc.generated.NotificationActionBuilder
 import org.wordpress.android.fluxc.store.NotificationStore
-import org.wordpress.android.fluxc.store.NotificationStore.OnDeviceUnregistered
 import javax.inject.Inject
 
 class AppSettingsPresenter @Inject constructor(
-    private val dispatcher: Dispatcher,
     private val accountRepository: AccountRepository,
     @Suppress("unused") // We keep it here to make sure that the store is subscribed to the event bus
     private val notificationStore: NotificationStore,
@@ -21,37 +15,27 @@ class AppSettingsPresenter @Inject constructor(
     private var appSettingsView: AppSettingsContract.View? = null
 
     override fun takeView(view: AppSettingsContract.View) {
-        dispatcher.register(this)
         appSettingsView = view
     }
 
     override fun dropView() {
-        dispatcher.unregister(this)
         appSettingsView = null
     }
 
     override fun logout() {
-        coroutineScope.launch { clearCardReaderDataAction() }
-        // First unregister the device for push notifications
-        dispatcher.dispatch(NotificationActionBuilder.newUnregisterDeviceAction())
+        coroutineScope.launch {
+            accountRepository.logout().let {
+                if (it) {
+                    clearCardReaderDataAction()
+                    appSettingsView?.finishLogout()
+                }
+            }
+        }
     }
 
     override fun userIsLoggedIn(): Boolean = accountRepository.isUserLoggedIn()
 
     override fun getAccountDisplayName(): String {
         return accountRepository.getUserAccount()?.displayName ?: ""
-    }
-
-    @Suppress("unused", "UNUSED_PARAMETER")
-    @Subscribe(threadMode = ThreadMode.MAIN)
-    fun onDeviceUnregistered(event: OnDeviceUnregistered) {
-        // Now that we've unregistered the device, we can logout
-        coroutineScope.launch {
-            accountRepository.logout().let {
-                if (it) {
-                    appSettingsView?.finishLogout()
-                }
-            }
-        }
     }
 }

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/FakeDispatcher.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/FakeDispatcher.kt
@@ -3,9 +3,11 @@ package com.woocommerce.android
 import org.greenrobot.eventbus.Subscribe
 import org.wordpress.android.fluxc.Dispatcher
 import org.wordpress.android.fluxc.annotations.action.Action
+import org.wordpress.android.fluxc.annotations.action.IAction
 
-class FakeDispatcher(private val dispatchCallback: Dispatcher.(action: Action<*>) -> Unit = {}) : Dispatcher() {
+class FakeDispatcher : Dispatcher() {
     private val listeners = mutableListOf<Any>()
+    private var actionHandlers = mutableMapOf<IAction, Dispatcher.() -> Unit>()
 
     @Synchronized
     override fun register(`object`: Any) {
@@ -32,6 +34,10 @@ class FakeDispatcher(private val dispatchCallback: Dispatcher.(action: Action<*>
     }
 
     override fun dispatch(action: Action<*>) {
-        dispatchCallback(action)
+        actionHandlers[action.type]?.invoke(this)
+    }
+
+    fun registerActionHandler(actionType: IAction, handler: Dispatcher.() -> Unit) {
+        actionHandlers[actionType] = handler
     }
 }

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/login/AccountRepositoryTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/login/AccountRepositoryTest.kt
@@ -1,0 +1,63 @@
+package com.woocommerce.android.ui.login
+
+import com.woocommerce.android.AppPrefs
+import com.woocommerce.android.FakeDispatcher
+import com.woocommerce.android.support.zendesk.ZendeskSettings
+import com.woocommerce.android.tools.SelectedSite
+import com.woocommerce.android.ui.sitepicker.sitevisibility.VisibleWooSitesDataStore
+import com.woocommerce.android.viewmodel.BaseUnitTest
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.TestScope
+import org.assertj.core.api.Assertions.assertThat
+import org.mockito.kotlin.given
+import org.mockito.kotlin.mock
+import org.wordpress.android.fluxc.action.AccountAction
+import org.wordpress.android.fluxc.action.NotificationAction
+import org.wordpress.android.fluxc.store.AccountStore
+import org.wordpress.android.fluxc.store.NotificationStore
+import org.wordpress.android.fluxc.store.SiteStore
+import org.wordpress.android.fluxc.store.account.CloseAccountStore
+import kotlin.test.Test
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class AccountRepositoryTest : BaseUnitTest() {
+    private val accountStore: AccountStore = mock()
+    private val siteStore: SiteStore = mock()
+    private val closeAccountStore: CloseAccountStore = mock()
+    private val selectedSite: SelectedSite = mock()
+    private val zendeskSettings: ZendeskSettings = mock()
+    private val appPrefs: AppPrefs = mock()
+    private val visibleWooSitesDataStore: VisibleWooSitesDataStore = mock()
+    private val dispatcher = FakeDispatcher().apply {
+        registerActionHandler(AccountAction.SIGN_OUT) {
+            emitChange(AccountStore.OnAccountChanged())
+        }
+    }
+    private val appCoroutineScope = TestScope(coroutinesTestRule.testDispatcher)
+
+    private val repository = AccountRepository(
+        accountStore = accountStore,
+        siteStore = siteStore,
+        closeAccountStore = closeAccountStore,
+        selectedSite = selectedSite,
+        dispatcher = dispatcher,
+        zendeskSettings = zendeskSettings,
+        prefs = appPrefs,
+        appCoroutineScope = appCoroutineScope,
+        siteVisibilityDataStore = visibleWooSitesDataStore
+    )
+
+    @Test
+    fun `given signed in using wordpress_com, when logout is called, then unregister device`() = testBlocking {
+        given(accountStore.hasAccessToken()).willReturn(true)
+        var deviceUnregistered = false
+        dispatcher.registerActionHandler(NotificationAction.UNREGISTER_DEVICE) {
+            deviceUnregistered = true
+            emitChange(NotificationStore.OnDeviceUnregistered())
+        }
+
+        repository.logout()
+
+        assertThat(deviceUnregistered).isTrue()
+    }
+}

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/main/ObserveProcessingOrdersCountTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/main/ObserveProcessingOrdersCountTest.kt
@@ -30,11 +30,9 @@ import org.wordpress.android.fluxc.store.WCOrderStore.OnOrderStatusOptionsChange
 
 @OptIn(ExperimentalCoroutinesApi::class)
 class ObserveProcessingOrdersCountTest : BaseUnitTest() {
-    private val dispatcher = FakeDispatcher { action ->
-        if (action.type == WCOrderAction.FETCH_ORDER_STATUS_OPTIONS) {
-            emitChange(
-                OnOrderStatusOptionsChanged(0)
-            )
+    private val dispatcher = FakeDispatcher().apply {
+        registerActionHandler(WCOrderAction.FETCH_ORDER_STATUS_OPTIONS) {
+            emitChange(OnOrderStatusOptionsChanged(0))
         }
     }
     private val site = SiteModel()

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/prefs/AppSettingsPresenterTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/prefs/AppSettingsPresenterTest.kt
@@ -9,20 +9,14 @@ import org.junit.Test
 import org.mockito.kotlin.KArgumentCaptor
 import org.mockito.kotlin.argumentCaptor
 import org.mockito.kotlin.mock
-import org.mockito.kotlin.times
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
-import org.wordpress.android.fluxc.Dispatcher
-import org.wordpress.android.fluxc.action.NotificationAction
 import org.wordpress.android.fluxc.annotations.action.Action
-import org.wordpress.android.fluxc.store.NotificationStore.OnDeviceUnregistered
-import kotlin.test.assertEquals
 
 @ExperimentalCoroutinesApi
 class AppSettingsPresenterTest : BaseUnitTest() {
     private val appSettingsContractView: AppSettingsContract.View = mock()
 
-    private val dispatcher: Dispatcher = mock()
     private val accountRepository: AccountRepository = mock()
     private val clearCardReaderDataAction: ClearCardReaderDataAction = mock()
 
@@ -33,7 +27,6 @@ class AppSettingsPresenterTest : BaseUnitTest() {
     @Before
     fun setup() {
         appSettingsPresenter = AppSettingsPresenter(
-            dispatcher,
             accountRepository,
             mock(),
             clearCardReaderDataAction
@@ -49,13 +42,6 @@ class AppSettingsPresenterTest : BaseUnitTest() {
 
         appSettingsPresenter.logout()
 
-        // Logging out should first trigger device unregistration for push notifications
-        verify(dispatcher, times(1)).dispatch(actionCaptor.capture())
-        assertEquals(NotificationAction.UNREGISTER_DEVICE, actionCaptor.firstValue.type)
-
-        // Simulate device unregistered for push notifications
-        appSettingsPresenter.onDeviceUnregistered(OnDeviceUnregistered())
-
         // Unregistration should trigger logout
         verify(accountRepository).logout()
 
@@ -66,6 +52,8 @@ class AppSettingsPresenterTest : BaseUnitTest() {
     @Test
     fun `cleanPaymentsData with initialized manager should disconnect reader`() {
         testBlocking {
+            whenever(accountRepository.logout()).thenReturn(true)
+
             appSettingsPresenter.logout()
 
             verify(clearCardReaderDataAction).invoke()


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #13611 
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
This PR fixes the linked issue by ensuring we unregister the device with our servers for each logout, we achieve this by moving the unregistration logic to the repository, which will ensure it will be called in all scenarios.

Failing to unregister the device was causing issues when the user has to change the account during the login that would prevent registering using the new account, this was because the app will believe the device is already registered.

### Steps to reproduce
1. Use two accounts: account A and account B, and a site connected only to Account A.
1. Start login and enter the site address.
1. Continue using account B.
1. In the Account Mismatch screen, tap on "Login using a different account"
1. Now enter the site address, and use account A.
1. Test push notifications.

### Testing information
- Confirm push notifications are received.
- Open the MC push notifications dashboard and confirm your device is registered with Account A.

### The tests that have been performed
^

- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.

## Reviewer (or Author, in the case of optional code reviews):

Please make sure these conditions are met before approving the PR, or request changes if the PR needs improvement:

- [x] The PR is small and has a clear, single focus, or a valid explanation is provided in the description. If needed, please request to split it into smaller PRs.
- [x] Ensure Adequate Unit Test Coverage: The changes are reasonably covered by unit tests or an explanation is provided in the PR description.
- [x] Manual Testing: The author listed all the tests they ran, including smoke tests when needed (e.g., for refactorings). The reviewer confirmed that the PR works as expected on big (tablet) and small (phone) in case of UI changes, and no regressions are added.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->