### PR TITLE
Handle loading packages error

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/WooShippingLabelCreationScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/WooShippingLabelCreationScreen.kt
@@ -705,7 +705,6 @@ internal fun ErrorScreen(
     ErrorMessageWithButton(modifier = modifier.padding(padding), onRetryClick = onRetryClick)
 }
 
-
 @Parcelize
 data class ShippableItemUI(
     val itemId: Long,

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/WooShippingLabelCreationScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/WooShippingLabelCreationScreen.kt
@@ -2,7 +2,6 @@ package com.woocommerce.android.ui.orders.wooshippinglabels
 
 import android.content.res.Configuration
 import android.os.Parcelable
-import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
 import androidx.compose.foundation.border
 import androidx.compose.foundation.clickable
@@ -15,7 +14,6 @@ import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.text.BasicTextField
@@ -63,7 +61,6 @@ import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import com.woocommerce.android.R
 import com.woocommerce.android.ui.compose.component.WCColoredButton
-import com.woocommerce.android.ui.compose.component.WCTextButton
 import com.woocommerce.android.ui.compose.modifiers.dashedBorder
 import com.woocommerce.android.ui.compose.theme.WooThemeWithBackground
 import com.woocommerce.android.ui.orders.wooshippinglabels.WooShippingLabelCreationViewModel.CustomsState
@@ -76,6 +73,7 @@ import com.woocommerce.android.ui.orders.wooshippinglabels.address.AddressSelect
 import com.woocommerce.android.ui.orders.wooshippinglabels.address.getShipFrom
 import com.woocommerce.android.ui.orders.wooshippinglabels.address.getShipTo
 import com.woocommerce.android.ui.orders.wooshippinglabels.models.OriginShippingAddress
+import com.woocommerce.android.ui.orders.wooshippinglabels.packages.components.ErrorMessageWithButton
 import com.woocommerce.android.ui.orders.wooshippinglabels.packages.ui.PackageData
 import com.woocommerce.android.ui.orders.wooshippinglabels.rates.ui.ShippingRateUI
 import com.woocommerce.android.ui.orders.wooshippinglabels.rates.ui.ShippingRatesSection
@@ -703,33 +701,10 @@ internal fun ErrorScreen(
     modifier: Modifier = Modifier,
     onNavigateBack: () -> Unit = {},
     onRetryClick: () -> Unit = {}
-) {
-    Scaffold(topBar = { TopBar(onNavigateBack) }) { padding ->
-        Column(
-            modifier = modifier
-                .fillMaxSize()
-                .verticalScroll(rememberScrollState())
-                .background(MaterialTheme.colors.surface)
-                .padding(padding),
-            horizontalAlignment = Alignment.CenterHorizontally,
-            verticalArrangement = Arrangement.spacedBy(24.dp, Alignment.CenterVertically)
-        ) {
-            Image(
-                modifier = Modifier.size(87.dp),
-                painter = painterResource(id = R.drawable.ic_error),
-                contentDescription = stringResource(id = R.string.woopos_error_icon_content_description),
-            )
-            Text(
-                text = stringResource(R.string.woo_shipping_labels_loading_error),
-                style = MaterialTheme.typography.subtitle1,
-                color = MaterialTheme.colors.onSurface,
-            )
-            WCTextButton(onClick = onRetryClick) {
-                Text(stringResource(id = R.string.retry))
-            }
-        }
-    }
+) = Scaffold(topBar = { TopBar(onNavigateBack) }) { padding ->
+    ErrorMessageWithButton(modifier = modifier.padding(padding), onRetryClick = onRetryClick)
 }
+
 
 @Parcelize
 data class ShippableItemUI(
@@ -844,4 +819,4 @@ private fun PackageSelectedPreview() {
 
 @Preview
 @Composable
-private fun EmptyScreenPreview() = WooThemeWithBackground { ErrorScreen() }
+private fun ErrorScreenPreview() = WooThemeWithBackground { ErrorScreen() }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/packages/WooShippingLabelPackageCreationScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/packages/WooShippingLabelPackageCreationScreen.kt
@@ -159,8 +159,6 @@ fun WooShippingLabelsPackageCreationScreenPreview() {
                             id = "1",
                         )
                     ),
-                    isAddPackageEnabled = true,
-                    onAddPackageClick = { },
                     onSavedPackageSelected = { _, _ -> }
                 )
             },

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/packages/WooShippingLabelPackageCreationViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/packages/WooShippingLabelPackageCreationViewModel.kt
@@ -62,14 +62,15 @@ class WooShippingLabelPackageCreationViewModel @Inject constructor(
         )
 
     init {
-        launch {
-            fetchPredefinedPackages().let { response ->
-                _viewState.update { viewState ->
-                    viewState.copy(predefinedPackagesState = response)
-                }
-            }
+        loadData()
+    }
+
+    private fun loadData() = launch {
+        fetchPredefinedPackages().let { response ->
+            _viewState.update { viewState -> viewState.copy(predefinedPackagesState = response) }
         }
     }
+
 
     fun onCarrierPackageSelected(selectedPackage: PackageData, isSelected: Boolean) {
         _viewState.update { viewState ->
@@ -91,6 +92,14 @@ class WooShippingLabelPackageCreationViewModel @Inject constructor(
                 ?.safelyUpdate(selectedPackage, selectedPackage.copy(isSelected = isSelected))
                 ?.let { viewState.copy(predefinedPackagesState = predefinedPackages.copy(savedPackages = it)) }
                 ?: _viewState.value
+        }
+    }
+
+    fun onRetryClick() {
+        triggerEvent(ShowLoadingDialog(true))
+        launch {
+            loadData().join()
+            triggerEvent(ShowLoadingDialog(false))
         }
     }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/packages/WooShippingLabelPackageCreationViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/packages/WooShippingLabelPackageCreationViewModel.kt
@@ -19,6 +19,7 @@ import com.woocommerce.android.viewmodel.ResourceProvider
 import com.woocommerce.android.viewmodel.ScopedViewModel
 import com.woocommerce.android.viewmodel.getStateFlow
 import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.Job
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 import kotlinx.parcelize.Parcelize
@@ -65,12 +66,13 @@ class WooShippingLabelPackageCreationViewModel @Inject constructor(
         loadData()
     }
 
-    private fun loadData() = launch {
-        fetchPredefinedPackages().let { response ->
-            _viewState.update { viewState -> viewState.copy(predefinedPackagesState = response) }
+    private fun loadData(): Job {
+        return launch {
+            fetchPredefinedPackages().let { response ->
+                _viewState.update { viewState -> viewState.copy(predefinedPackagesState = response) }
+            }
         }
     }
-
 
     fun onCarrierPackageSelected(selectedPackage: PackageData, isSelected: Boolean) {
         _viewState.update { viewState ->

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/packages/components/ErrorMessageWithButton.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/packages/components/ErrorMessageWithButton.kt
@@ -1,0 +1,57 @@
+package com.woocommerce.android.ui.orders.wooshippinglabels.packages.components
+
+import androidx.annotation.StringRes
+import androidx.compose.foundation.Image
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material.MaterialTheme
+import androidx.compose.material.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import com.woocommerce.android.R
+import com.woocommerce.android.ui.compose.component.WCTextButton
+import com.woocommerce.android.ui.compose.theme.WooThemeWithBackground
+
+@Composable
+fun ErrorMessageWithButton(
+    modifier: Modifier = Modifier,
+    @StringRes message: Int = R.string.woo_shipping_labels_loading_error,
+    onRetryClick: () -> Unit = {}
+) {
+    Column(
+        modifier = modifier
+            .fillMaxSize()
+            .verticalScroll(rememberScrollState())
+            .background(MaterialTheme.colors.surface),
+        horizontalAlignment = Alignment.CenterHorizontally,
+        verticalArrangement = Arrangement.spacedBy(24.dp, Alignment.CenterVertically)
+    ) {
+        Image(
+            modifier = Modifier.size(87.dp),
+            painter = painterResource(id = R.drawable.ic_error),
+            contentDescription = stringResource(id = R.string.woopos_error_icon_content_description),
+        )
+        Text(
+            text = stringResource(message),
+            style = MaterialTheme.typography.subtitle1,
+            color = MaterialTheme.colors.onSurface,
+        )
+        WCTextButton(onClick = onRetryClick) {
+            Text(stringResource(id = R.string.retry))
+        }
+    }
+}
+
+@Preview
+@Composable
+private fun ErrorMessageWithButtonPreview() = WooThemeWithBackground { ErrorMessageWithButton() }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/packages/ui/WooShippingCarrierPackageScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/packages/ui/WooShippingCarrierPackageScreen.kt
@@ -3,6 +3,7 @@ package com.woocommerce.android.ui.orders.wooshippinglabels.packages.ui
 import androidx.annotation.DrawableRes
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
@@ -42,6 +43,7 @@ import com.woocommerce.android.R
 import com.woocommerce.android.ui.compose.theme.WooThemeWithBackground
 import com.woocommerce.android.ui.orders.wooshippinglabels.packages.WooShippingLabelPackageCreationViewModel
 import com.woocommerce.android.ui.orders.wooshippinglabels.packages.WooShippingLabelPackageCreationViewModel.PredefinedPackagesState
+import com.woocommerce.android.ui.orders.wooshippinglabels.packages.components.ErrorMessageWithButton
 import com.woocommerce.android.ui.orders.wooshippinglabels.packages.components.WooShippingPackageListItem
 import com.woocommerce.android.ui.orders.wooshippinglabels.packages.components.WooShippingPackageListItemSkeleton
 import kotlinx.coroutines.launch
@@ -53,7 +55,8 @@ fun WooShippingCarrierPackageScreen(viewModel: WooShippingLabelPackageCreationVi
         packageState = viewState?.predefinedPackagesState ?: PredefinedPackagesState.Waiting,
         isAddPackageEnabled = viewState?.predefinedPackagesData?.hasCarrierSelection ?: false,
         onPackageSelected = viewModel::onCarrierPackageSelected,
-        onAddPackageClick = viewModel::onAddCarrierPackageClick
+        onAddPackageClick = viewModel::onAddCarrierPackageClick,
+        onRetryClick = viewModel::onRetryClick
     )
 }
 
@@ -63,42 +66,45 @@ fun WooShippingCarrierPackageScreen(
     packageState: PredefinedPackagesState,
     onPackageSelected: (PackageData, Boolean) -> Unit,
     isAddPackageEnabled: Boolean = false,
-    onAddPackageClick: () -> Unit = {}
+    onAddPackageClick: () -> Unit = {},
+    onRetryClick: () -> Unit
 ) {
-    when (packageState) {
-        is PredefinedPackagesState.Data -> {
-            WooShippingCarrierPackageContent(
-                modifier = modifier,
-                carrierPackages = packageState.carrierPackages,
-                onPackageSelected = onPackageSelected,
-                isAddPackageEnabled = isAddPackageEnabled,
-                onAddPackageClick = onAddPackageClick
-            )
-        }
+    Column(modifier = modifier) {
+        Box(modifier = modifier.weight(1f)) {
+            when (packageState) {
+                is PredefinedPackagesState.Data -> WooShippingCarrierPackageContent(
+                    modifier = modifier,
+                    carrierPackages = packageState.carrierPackages,
+                    onPackageSelected = onPackageSelected,
+                )
 
-        is PredefinedPackagesState.Error -> {
-            Column(
-                horizontalAlignment = Alignment.CenterHorizontally,
-                modifier = modifier
-                    .fillMaxSize()
-                    .padding(16.dp)
-                    .verticalScroll(rememberScrollState())
-            ) {
-                Text(text = stringResource(id = R.string.woo_shipping_labels_package_creation_error))
+                is PredefinedPackagesState.Error -> ErrorMessageWithButton(
+                    modifier = modifier,
+                    message = R.string.woo_shipping_labels_package_creation_carrier_loading_error,
+                    onRetryClick = onRetryClick
+                )
+
+                is PredefinedPackagesState.Waiting -> Column(
+                    modifier = modifier
+                        .fillMaxSize()
+                        .padding(16.dp)
+                        .verticalScroll(rememberScrollState())
+                ) {
+                    WooShippingPackageListItemSkeleton()
+                    WooShippingPackageListItemSkeleton()
+                    WooShippingPackageListItemSkeleton()
+                }
             }
         }
-
-        is PredefinedPackagesState.Waiting -> {
-            Column(
-                modifier = modifier
-                    .fillMaxSize()
-                    .padding(16.dp)
-                    .verticalScroll(rememberScrollState())
-            ) {
-                WooShippingPackageListItemSkeleton()
-                WooShippingPackageListItemSkeleton()
-                WooShippingPackageListItemSkeleton()
-            }
+        Divider()
+        Button(
+            modifier = modifier
+                .fillMaxWidth()
+                .padding(horizontal = 16.dp, vertical = 8.dp),
+            enabled = isAddPackageEnabled,
+            onClick = onAddPackageClick
+        ) {
+            Text(stringResource(id = R.string.woo_shipping_labels_package_creation_add_package))
         }
     }
 }
@@ -108,8 +114,6 @@ fun WooShippingCarrierPackageContent(
     modifier: Modifier = Modifier,
     carrierPackages: Map<Carrier, List<CarrierPackageGroup>>,
     onPackageSelected: (PackageData, Boolean) -> Unit,
-    isAddPackageEnabled: Boolean = false,
-    onAddPackageClick: () -> Unit = {}
 ) {
     val pagerState = rememberPagerState { carrierPackages.keys.size }
     Column(
@@ -130,16 +134,6 @@ fun WooShippingCarrierPackageContent(
             carrierPackages = carrierPackages,
             onPackageSelected = onPackageSelected
         )
-        Divider()
-        Button(
-            modifier = modifier
-                .fillMaxWidth()
-                .padding(horizontal = 16.dp, vertical = 8.dp),
-            enabled = isAddPackageEnabled,
-            onClick = onAddPackageClick
-        ) {
-            Text(stringResource(id = R.string.woo_shipping_labels_package_creation_add_package))
-        }
     }
 }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/packages/ui/WooShippingSavedPackageScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/packages/ui/WooShippingSavedPackageScreen.kt
@@ -1,5 +1,6 @@
 package com.woocommerce.android.ui.orders.wooshippinglabels.packages.ui
 
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
@@ -11,7 +12,6 @@ import androidx.compose.material.Divider
 import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.livedata.observeAsState
-import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
@@ -20,6 +20,7 @@ import com.woocommerce.android.R
 import com.woocommerce.android.ui.compose.theme.WooThemeWithBackground
 import com.woocommerce.android.ui.orders.wooshippinglabels.packages.WooShippingLabelPackageCreationViewModel
 import com.woocommerce.android.ui.orders.wooshippinglabels.packages.WooShippingLabelPackageCreationViewModel.PredefinedPackagesState
+import com.woocommerce.android.ui.orders.wooshippinglabels.packages.components.ErrorMessageWithButton
 import com.woocommerce.android.ui.orders.wooshippinglabels.packages.components.WooShippingPackageListItem
 import com.woocommerce.android.ui.orders.wooshippinglabels.packages.components.WooShippingPackageListItemSkeleton
 
@@ -30,8 +31,8 @@ fun WooShippingSavedPackageScreen(viewModel: WooShippingLabelPackageCreationView
         packageState = viewState.value?.predefinedPackagesState ?: PredefinedPackagesState.Waiting,
         isAddPackageEnabled = viewState.value?.predefinedPackagesData?.hasSavedSelection ?: false,
         onAddPackageClick = viewModel::onAddSavedPackageClick,
-        onSavedPackageSelected = viewModel::onSavedPackageSelected
-
+        onSavedPackageSelected = viewModel::onSavedPackageSelected,
+        onRetryClick = viewModel::onRetryClick
     )
 }
 
@@ -41,42 +42,51 @@ fun WooShippingSavedPackageScreen(
     packageState: PredefinedPackagesState,
     isAddPackageEnabled: Boolean,
     onAddPackageClick: () -> Unit,
-    onSavedPackageSelected: (PackageData, Boolean) -> Unit
+    onSavedPackageSelected: (PackageData, Boolean) -> Unit,
+    onRetryClick: () -> Unit
 ) {
-    when (packageState) {
-        is PredefinedPackagesState.Data -> {
-            WooShippingSavedPackageContent(
-                modifier = modifier,
-                savedPackages = packageState.savedPackages,
-                isAddPackageEnabled = isAddPackageEnabled,
-                onAddPackageClick = onAddPackageClick,
-                onSavedPackageSelected = onSavedPackageSelected
-            )
-        }
+    Column(modifier = modifier) {
+        Box(modifier = modifier.weight(1f)) {
+            when (packageState) {
+                is PredefinedPackagesState.Data -> {
+                    WooShippingSavedPackageContent(
+                        modifier = modifier,
+                        savedPackages = packageState.savedPackages,
+                        onSavedPackageSelected = onSavedPackageSelected
+                    )
+                }
 
-        is PredefinedPackagesState.Error -> {
-            Column(
-                horizontalAlignment = Alignment.CenterHorizontally,
-                modifier = modifier
-                    .fillMaxSize()
-                    .padding(16.dp)
-                    .verticalScroll(rememberScrollState())
-            ) {
-                Text(text = stringResource(id = R.string.woo_shipping_labels_package_creation_error))
+                is PredefinedPackagesState.Error -> {
+                    ErrorMessageWithButton(
+                        modifier = modifier,
+                        message = R.string.woo_shipping_labels_package_creation_saved_loading_error,
+                        onRetryClick = onRetryClick
+                    )
+                }
+
+                is PredefinedPackagesState.Waiting -> {
+                    Column(
+                        modifier = modifier
+                            .fillMaxSize()
+                            .padding(16.dp)
+                            .verticalScroll(rememberScrollState())
+                    ) {
+                        WooShippingPackageListItemSkeleton()
+                        WooShippingPackageListItemSkeleton()
+                        WooShippingPackageListItemSkeleton()
+                    }
+                }
             }
         }
-
-        is PredefinedPackagesState.Waiting -> {
-            Column(
-                modifier = modifier
-                    .fillMaxSize()
-                    .padding(16.dp)
-                    .verticalScroll(rememberScrollState())
-            ) {
-                WooShippingPackageListItemSkeleton()
-                WooShippingPackageListItemSkeleton()
-                WooShippingPackageListItemSkeleton()
-            }
+        Divider()
+        Button(
+            modifier = modifier
+                .fillMaxWidth()
+                .padding(horizontal = 16.dp, vertical = 8.dp),
+            enabled = isAddPackageEnabled,
+            onClick = onAddPackageClick
+        ) {
+            Text(stringResource(id = R.string.woo_shipping_labels_package_creation_add_package))
         }
     }
 }
@@ -85,39 +95,20 @@ fun WooShippingSavedPackageScreen(
 fun WooShippingSavedPackageContent(
     modifier: Modifier = Modifier,
     savedPackages: List<PackageData>,
-    isAddPackageEnabled: Boolean,
-    onAddPackageClick: () -> Unit,
     onSavedPackageSelected: (PackageData, Boolean) -> Unit
 ) {
     Column(
         modifier = modifier
             .fillMaxSize()
+            .padding(16.dp)
+            .verticalScroll(rememberScrollState())
     ) {
-        Column(
-            modifier = modifier
-                .weight(1f)
-                .padding(16.dp)
-                .verticalScroll(rememberScrollState())
-        ) {
-            savedPackages.forEach { packageData ->
-                WooShippingPackageListItem(
-                    modifier,
-                    packageData,
-                    onSavedPackageSelected
-                )
-            }
-        }
-        Column {
-            Divider()
-            Button(
-                modifier = modifier
-                    .fillMaxWidth()
-                    .padding(horizontal = 16.dp, vertical = 8.dp),
-                enabled = isAddPackageEnabled,
-                onClick = onAddPackageClick
-            ) {
-                Text(stringResource(id = R.string.woo_shipping_labels_package_creation_add_package))
-            }
+        savedPackages.forEach { packageData ->
+            WooShippingPackageListItem(
+                modifier,
+                packageData,
+                onSavedPackageSelected
+            )
         }
     }
 }
@@ -126,36 +117,41 @@ fun WooShippingSavedPackageContent(
 @Composable
 fun WooShippingSavedPackageScreenPreview() {
     WooThemeWithBackground {
-        WooShippingSavedPackageContent(
-            savedPackages = listOf(
-                PackageData(
-                    name = "Small Flat Rate Box",
-                    dimensions = "10 x 10 x 10 cm",
-                    weight = "10",
-                    isSelected = true,
-                    isLetter = true,
-                    id = "1",
+        WooShippingSavedPackageScreen(
+            packageState = PredefinedPackagesState.Data(
+                storeOptions = StoreOptionsForPackages.DEFAULT,
+                savedPackages = listOf(
+                    PackageData(
+                        name = "Small Flat Rate Box",
+                        dimensions = "10 x 10 x 10 cm",
+                        weight = "10",
+                        isSelected = true,
+                        isLetter = true,
+                        id = "1",
+                    ),
+                    PackageData(
+                        name = "Small Flat Rate Box",
+                        dimensions = "20 x 20 x 20 cm",
+                        weight = "20",
+                        isSelected = false,
+                        isLetter = false,
+                        id = "1",
+                    ),
+                    PackageData(
+                        name = "Small Flat Rate Box",
+                        dimensions = "30 x 30 x 30 cm",
+                        weight = "30",
+                        isSelected = false,
+                        isLetter = false,
+                        id = "1",
+                    )
                 ),
-                PackageData(
-                    name = "Small Flat Rate Box",
-                    dimensions = "20 x 20 x 20 cm",
-                    weight = "20",
-                    isSelected = false,
-                    isLetter = false,
-                    id = "1",
-                ),
-                PackageData(
-                    name = "Small Flat Rate Box",
-                    dimensions = "30 x 30 x 30 cm",
-                    weight = "30",
-                    isSelected = false,
-                    isLetter = false,
-                    id = "1",
-                )
+                carrierPackages = emptyMap()
             ),
             isAddPackageEnabled = true,
             onAddPackageClick = {},
-            onSavedPackageSelected = { _, _ -> }
+            onSavedPackageSelected = { _, _ -> },
+            onRetryClick = {}
         )
     }
 }
@@ -168,7 +164,8 @@ fun WooShippingSavedPackageScreenLoadingPreview() {
             packageState = PredefinedPackagesState.Waiting,
             isAddPackageEnabled = false,
             onAddPackageClick = {},
-            onSavedPackageSelected = { _, _ -> }
+            onSavedPackageSelected = { _, _ -> },
+            onRetryClick = {}
         )
     }
 }
@@ -181,7 +178,8 @@ fun WooShippingSavedPackageScreenErrorPreview() {
             packageState = PredefinedPackagesState.Error,
             isAddPackageEnabled = false,
             onAddPackageClick = {},
-            onSavedPackageSelected = { _, _ -> }
+            onSavedPackageSelected = { _, _ -> },
+            onRetryClick = {}
         )
     }
 }

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -4457,6 +4457,7 @@
     <string name="woo_shipping_labels_package_creation_save_package_option">Save this as a new package template</string>
     <string name="woo_shipping_labels_package_creation_add_package">Add Package</string>
     <string name="woo_shipping_labels_package_creation_error">Failed to load the package data</string>
+    <string name="woo_shipping_labels_package_creation_saved_loading_error">We are unable to load saved packages.</string>
     <string name="woo_shipping_labels_package_creation_box_type">Box</string>
     <string name="woo_shipping_labels_package_creation_envelope_type">Envelope</string>
     <string name="woo_shipping_labels_package_creation_error_title">We couldn\'t save the package as template</string>

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -4457,6 +4457,7 @@
     <string name="woo_shipping_labels_package_creation_save_package_option">Save this as a new package template</string>
     <string name="woo_shipping_labels_package_creation_add_package">Add Package</string>
     <string name="woo_shipping_labels_package_creation_error">Failed to load the package data</string>
+    <string name="woo_shipping_labels_package_creation_carrier_loading_error">We are unable to load carrier packages.</string>
     <string name="woo_shipping_labels_package_creation_saved_loading_error">We are unable to load saved packages.</string>
     <string name="woo_shipping_labels_package_creation_box_type">Box</string>
     <string name="woo_shipping_labels_package_creation_envelope_type">Envelope</string>


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #13326
Closes: #13324
<!-- Id number of the GitHub issue this PR addresses. -->

<!-- 
━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
🛠 Need an AI review?  
Add a comment: `@coderabbitai review`
━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
-->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
This updates the error screen when loading a carrier and saved packages.

### Steps to reproduce
<!-- Step-by-step testing instructions. For new user flows, consider instead stating the goal of the workflow and see if your PR reviewer can accomplish the workflow without specific steps! -->
#### To create a fake error response from the endpoint
1. Go to Menu → Settings → Developer Options → API Faker
2. Tap + button.
3. Enter these settings:
```
Type: WordPress REST API
Http Method: GET
Path: /wcshipping/v1/packages
Status Code: 500
```
4. Tap Save.
5. Enable API Faker.

#### To test the retry screen
1. Log in to a site that is eligible for shipping labels.
2. Go to orders.
3. Create a new order and complete the payment.
4. Open the order details and tap the "Create shipping label" button.
5. Tap Select a package button
6. Go to the Carrier tab.
7. Disable the API faker by tapping the red bottom banner.
8. Tap the Retry button.
9. Verify that the error disappears.
10. Repeat 2-9 for the Saved tab.

### Testing information
<!-- This is your opportunity to break out individual scenarios that need testing (when necessary) and/or include a checklist for the reviewer to go through. Consider documenting the following from your own completed testing: devices used, alternate workflows, edge cases, affected areas, critical flows, areas not tested, and any remaining unknowns. Provide feedback on this new section of the PR template through Sept 30, 2024 to Apps Quality; additional context here: p91TBi-b8z-p2#comment-12036 -->
It's nice to retest #13608 as well.

### The tests that have been performed
<!-- To give the reviewer an idea of what could be missed in terms of testing -->
Streps above

### Images/gif
<!-- Include before and after images or gifs when appropriate. -->
|Before|After|
|-|-|
|<img src="https://github.com/user-attachments/assets/7cce6463-97bd-47c9-8686-221cb6439463" width=360>|<img src="https://github.com/user-attachments/assets/67c8a253-2961-4ed9-a79c-8896f239bdde" width=360>|

<details>
  <summary>After video</summary>
  
[after.webm](https://github.com/user-attachments/assets/5a7964cd-5d57-4dac-977c-3bb910e54846)
  
</details>

- [x ] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.

## Reviewer (or Author, in the case of optional code reviews):

Please make sure these conditions are met before approving the PR, or request changes if the PR needs improvement:

- [ ] The PR is small and has a clear, single focus, or a valid explanation is provided in the description. If needed, please request to split it into smaller PRs.
- [ ] Ensure Adequate Unit Test Coverage: The changes are reasonably covered by unit tests or an explanation is provided in the PR description.
- [ ] Manual Testing: The author listed all the tests they ran, including smoke tests when needed (e.g., for refactorings). The reviewer confirmed that the PR works as expected on big (tablet) and small (phone) in case of UI changes, and no regressions are added.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->