### PR TITLE
Disable `review_status` in CodeRabbit config

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -9,7 +9,7 @@ reviews:
   request_changes_workflow: false
   high_level_summary: false
   poem: false
-  review_status: true
+  review_status: false
   commit_status: false
   sequence_diagrams: true
   changed_files_summary: true


### PR DESCRIPTION
To disable following comment that is posted on every new PR:

<img width="932" alt="image" src="https://github.com/user-attachments/assets/00d2963e-8e14-4f5e-a817-175ea015c919" />

https://github.com/woocommerce/woocommerce-android/pull/13619#issuecomment-2682889071