### PR TITLE
[Login] Fix Window insets handling for the prologue carousel

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/LoginPrologueCarouselFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/LoginPrologueCarouselFragment.kt
@@ -55,26 +55,24 @@ class LoginPrologueCarouselFragment : Fragment(R.layout.fragment_login_prologue_
 
         val isTablet = DisplayUtils.isTablet(context) || DisplayUtils.isXLargeTablet(context)
         ViewCompat.setOnApplyWindowInsetsListener(binding.root) { _, windowInsets ->
-            val insets = windowInsets.getInsets(WindowInsetsCompat.Type.systemBars())
+            val insets = windowInsets.getInsets(
+                WindowInsetsCompat.Type.systemBars() or WindowInsetsCompat.Type.displayCutout()
+            )
+            val buttonHorizontalMargin = resources.getDimension(R.dimen.prologue_button_horizontal_margin)
+
             binding.buttonSkip.updateLayoutParams<MarginLayoutParams> {
                 val currentBottomMargin = resources.getDimension(R.dimen.prologue_button_skip_bottom_margin)
                 bottomMargin = currentBottomMargin.roundToInt() + insets.bottom
                 if (!isTablet) {
-                    val buttonHorizontalMargin = resources.getDimension(R.dimen.prologue_button_horizontal_margin)
                     rightMargin = buttonHorizontalMargin.roundToInt() + insets.right
                 }
             }
-            WindowInsetsCompat.CONSUMED
-        }
-        if (!isTablet) {
-            ViewCompat.setOnApplyWindowInsetsListener(binding.buttonNext) { v, windowInsets ->
-                val insets = windowInsets.getInsets(WindowInsetsCompat.Type.systemBars())
-                val buttonHorizontalMargin = resources.getDimension(R.dimen.prologue_button_horizontal_margin)
-                v.updateLayoutParams<MarginLayoutParams> {
+            if (!isTablet) {
+                binding.buttonNext.updateLayoutParams<MarginLayoutParams> {
                     leftMargin = buttonHorizontalMargin.roundToInt() + insets.left
                 }
-                WindowInsetsCompat.CONSUMED
             }
+            WindowInsetsCompat.CONSUMED
         }
 
         val adapter = LoginPrologueAdapter(this)


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

### Description
As discussed, this PR ports the fix that was added [here](https://github.com/woocommerce/woocommerce-android/pull/13599) to `trunk`, the fix is slighly different here because the extension `doOnApplyWindowInsets` is not available in `trunk`, but the logic is the same: listen to the Window Insets changes only on the root layout, then update the padding for the different buttons.

The issue before was that we listened to the inset changes on `binding.root` and then we returned `CONSUMED` in the listener, which prevents the button from getting the insets in its listener.

### Steps to reproduce
1. Enable three button navigation bar in your phone.
2. Clear the app data if needed.
3. Launch the app.
4. Rotate the phone to landscape.

### Testing information
- Confirm the carousel buttons do not overlap with the phone's navigation bar.
- Repeat on devices with before and after API 29 to confirm it works in both.

### The tests that have been performed
^

### Images/gif
| Before | After |
| --- | --- |
| ![Screenshot_20250225_183244](https://github.com/user-attachments/assets/b25552dc-6ede-4baf-8999-89bb99255bc4) | ![Screenshot_20250225_183408](https://github.com/user-attachments/assets/1b955c2c-f10c-49f7-b866-17ea3f236b5f) | 

- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.

## Reviewer (or Author, in the case of optional code reviews):

Please make sure these conditions are met before approving the PR, or request changes if the PR needs improvement:

- [x] The PR is small and has a clear, single focus, or a valid explanation is provided in the description. If needed, please request to split it into smaller PRs.
- [x] Ensure Adequate Unit Test Coverage: The changes are reasonably covered by unit tests or an explanation is provided in the PR description.
- [x] Manual Testing: The author listed all the tests they ran, including smoke tests when needed (e.g., for refactorings). The reviewer confirmed that the PR works as expected on big (tablet) and small (phone) in case of UI changes, and no regressions are added.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->