### PR TITLE
[Woo POS] Analytics - part 2

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -3,7 +3,7 @@
 *** For entries which are touching the Android Wear app's, start entry with `[WEAR]` too.
 21.9
 -----
-
+- [*][Internal] Added Analytics events in POS [https://github.com/woocommerce/woocommerce-android/pull/13622]
 
 21.8
 -----

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/di/AppModePaymentsFlowTrackingModule.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/di/AppModePaymentsFlowTrackingModule.kt
@@ -9,6 +9,7 @@ import com.woocommerce.android.ui.payments.tracking.CardReaderTrackingInfoProvid
 import com.woocommerce.android.ui.payments.tracking.PaymentsFlowTracker
 import com.woocommerce.android.ui.payments.tracking.PaymentsFlowTrackerEventProvider
 import com.woocommerce.android.ui.payments.tracking.StoreManagementPaymentsFlowTrackerEventProvider
+import com.woocommerce.android.ui.woopos.util.analytics.WooPosAnalyticsTrackingDataKeeper
 import com.woocommerce.android.ui.woopos.util.analytics.WooPosPaymentsFlowTrackerEventProvider
 import dagger.Module
 import dagger.Provides
@@ -26,8 +27,10 @@ class AppModePaymentsFlowTrackingModule {
 
     @Provides
     @PointOfSaleMode
-    fun providePointOfSaleModePaymentsFlowTrackerEventProvider(): PaymentsFlowTrackerEventProvider =
-        WooPosPaymentsFlowTrackerEventProvider()
+    fun providePointOfSaleModePaymentsFlowTrackerEventProvider(
+        analyticsTrackingDataKeeper: WooPosAnalyticsTrackingDataKeeper
+    ): PaymentsFlowTrackerEventProvider =
+        WooPosPaymentsFlowTrackerEventProvider(analyticsTrackingDataKeeper)
 
     @Provides
     @StoreManagementMode

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/tracking/PaymentsFlowTracker.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/tracking/PaymentsFlowTracker.kt
@@ -28,6 +28,7 @@ import com.woocommerce.android.ui.payments.hub.PaymentsHubViewModel.CashOnDelive
 import com.woocommerce.android.ui.payments.receipt.PaymentReceiptHelper
 import com.woocommerce.android.ui.payments.receipt.PaymentReceiptShare
 import com.woocommerce.android.ui.payments.taptopay.TapToPayAvailabilityStatus.Result.NotAvailable
+import com.woocommerce.android.ui.woopos.util.analytics.WooPosAnalyticsEvent
 import javax.inject.Inject
 
 class PaymentsFlowTracker @Inject constructor(
@@ -45,6 +46,9 @@ class PaymentsFlowTracker @Inject constructor(
         errorType: String? = null,
         errorDescription: String? = null,
     ) {
+        if (stat is WooPosAnalyticsEvent) {
+            properties.putAll(stat.properties)
+        }
         addPreferredPluginSlugProperty(properties)
         addStoreCountryCodeProperty(properties)
         addCurrencyProperty(properties)

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/cashpayment/WooPosCashPaymentViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/cashpayment/WooPosCashPaymentViewModel.kt
@@ -132,17 +132,12 @@ class WooPosCashPaymentViewModel @Inject constructor(
     }
 
     private suspend fun trackPaymentSuccess() {
-        val interactionWithCustomerStartedTimestamp = analyticsData.interactionWithCustomerStartedTimestamp
-        val millisSinceCustomerInteractionStarted =
-            System.currentTimeMillis() - interactionWithCustomerStartedTimestamp
-        val event = CashCollectPaymentSuccess.apply {
-            addProperties(
-                mapOf(
-                    "milliseconds_since_customer_interaction_started" to "$millisSinceCustomerInteractionStarted",
-                    "checkout_tap_count" to "${analyticsData.checkoutButtonTapsCount}"
-                )
-            )
+        val props = mutableMapOf<String, String>()
+        analyticsData.interactionWithCustomerStartedTimestamp?.let {
+            val timeElapsed = System.currentTimeMillis() - it
+            props["milliseconds_since_customer_interaction_started"] = "$timeElapsed"
         }
+        val event = CashCollectPaymentSuccess.apply { addProperties(props) }
         analyticsTracker.track(event)
     }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/cashpayment/WooPosCashPaymentViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/cashpayment/WooPosCashPaymentViewModel.kt
@@ -5,6 +5,7 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.woocommerce.android.R
 import com.woocommerce.android.ui.woopos.util.analytics.WooPosAnalyticsEvent.Event.CashCollectPaymentSuccess
+import com.woocommerce.android.ui.woopos.util.analytics.WooPosAnalyticsEvent.Event.CashPaymentFailed
 import com.woocommerce.android.ui.woopos.util.analytics.WooPosAnalyticsEvent.Event.CashPaymentTapped
 import com.woocommerce.android.ui.woopos.util.analytics.WooPosAnalyticsTracker
 import com.woocommerce.android.ui.woopos.util.format.WooPosFormatPrice
@@ -122,6 +123,7 @@ class WooPosCashPaymentViewModel @Inject constructor(
                         status = WooPosCashPaymentState.Collecting.Button.Status.ENABLED
                     )
                 )
+                analyticsTracker.track(CashPaymentFailed)
             }
         }
     }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/cashpayment/WooPosCashPaymentViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/cashpayment/WooPosCashPaymentViewModel.kt
@@ -15,7 +15,6 @@ import com.woocommerce.android.viewmodel.getStateFlow
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.launch
-import org.wordpress.android.fluxc.network.utils.toMap
 import java.math.BigDecimal
 import javax.inject.Inject
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/cashpayment/WooPosCashPaymentViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/cashpayment/WooPosCashPaymentViewModel.kt
@@ -136,7 +136,12 @@ class WooPosCashPaymentViewModel @Inject constructor(
         val millisSinceCustomerInteractionStarted =
             System.currentTimeMillis() - interactionWithCustomerStartedTimestamp
         val event = CashCollectPaymentSuccess.apply {
-            addProperties(mapOf("milliseconds_since_customer_interaction_started" to "$millisSinceCustomerInteractionStarted"))
+            addProperties(
+                mapOf(
+                    "milliseconds_since_customer_interaction_started" to "$millisSinceCustomerInteractionStarted",
+                    "checkout_tap_count" to "${analyticsData.checkoutButtonTapsCount}"
+                )
+            )
         }
         analyticsTracker.track(event)
     }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/cashpayment/WooPosCashPaymentViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/cashpayment/WooPosCashPaymentViewModel.kt
@@ -8,12 +8,14 @@ import com.woocommerce.android.ui.woopos.util.analytics.WooPosAnalyticsEvent.Eve
 import com.woocommerce.android.ui.woopos.util.analytics.WooPosAnalyticsEvent.Event.CashPaymentFailed
 import com.woocommerce.android.ui.woopos.util.analytics.WooPosAnalyticsEvent.Event.CashPaymentTapped
 import com.woocommerce.android.ui.woopos.util.analytics.WooPosAnalyticsTracker
+import com.woocommerce.android.ui.woopos.util.analytics.WooPosAnalyticsTrackingDataKeeper
 import com.woocommerce.android.ui.woopos.util.format.WooPosFormatPrice
 import com.woocommerce.android.viewmodel.ResourceProvider
 import com.woocommerce.android.viewmodel.getStateFlow
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.launch
+import org.wordpress.android.fluxc.network.utils.toMap
 import java.math.BigDecimal
 import javax.inject.Inject
 
@@ -23,6 +25,7 @@ class WooPosCashPaymentViewModel @Inject constructor(
     private val priceFormat: WooPosFormatPrice,
     private val resourceProvider: ResourceProvider,
     private val analyticsTracker: WooPosAnalyticsTracker,
+    private val analyticsData: WooPosAnalyticsTrackingDataKeeper,
     savedState: SavedStateHandle,
 ) : ViewModel() {
     private val orderId = savedState.get<Long>(CASH_ROUTE_ORDER_ID_KEY)!!
@@ -113,7 +116,7 @@ class WooPosCashPaymentViewModel @Inject constructor(
 
             val result = repository.completeOrder(orderId)
             if (result.isSuccess) {
-                analyticsTracker.track(CashCollectPaymentSuccess)
+                trackPaymentSuccess()
                 _state.value = WooPosCashPaymentState.Complete
             } else {
                 val currentState = _state.value as? WooPosCashPaymentState.Collecting ?: return@launch
@@ -126,6 +129,16 @@ class WooPosCashPaymentViewModel @Inject constructor(
                 analyticsTracker.track(CashPaymentFailed)
             }
         }
+    }
+
+    private suspend fun trackPaymentSuccess() {
+        val interactionWithCustomerStartedTimestamp = analyticsData.interactionWithCustomerStartedTimestamp
+        val millisSinceCustomerInteractionStarted =
+            System.currentTimeMillis() - interactionWithCustomerStartedTimestamp
+        val event = CashCollectPaymentSuccess.apply {
+            addProperties(mapOf("milliseconds_since_customer_interaction_started" to "$millisSinceCustomerInteractionStarted"))
+        }
+        analyticsTracker.track(event)
     }
 
     private companion object {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/cashpayment/WooPosCashPaymentViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/cashpayment/WooPosCashPaymentViewModel.kt
@@ -5,6 +5,7 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.woocommerce.android.R
 import com.woocommerce.android.ui.woopos.util.analytics.WooPosAnalyticsEvent.Event.CashCollectPaymentSuccess
+import com.woocommerce.android.ui.woopos.util.analytics.WooPosAnalyticsEvent.Event.CashPaymentTapped
 import com.woocommerce.android.ui.woopos.util.analytics.WooPosAnalyticsTracker
 import com.woocommerce.android.ui.woopos.util.format.WooPosFormatPrice
 import com.woocommerce.android.viewmodel.ResourceProvider
@@ -100,6 +101,8 @@ class WooPosCashPaymentViewModel @Inject constructor(
 
     private fun handleOrderCompletion() {
         viewModelScope.launch {
+            analyticsTracker.track(CashPaymentTapped)
+
             val stateBeforeCompleting = _state.value as WooPosCashPaymentState.Collecting
             _state.value = stateBeforeCompleting.copy(
                 button = stateBeforeCompleting.button.copy(

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/WooPosHomeViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/WooPosHomeViewModel.kt
@@ -9,6 +9,7 @@ import com.woocommerce.android.ui.woopos.home.WooPosHomeState.ExitConfirmationDi
 import com.woocommerce.android.ui.woopos.home.WooPosHomeState.ProductsInfoDialog
 import com.woocommerce.android.ui.woopos.home.WooPosHomeState.ScreenPositionState
 import com.woocommerce.android.ui.woopos.home.items.navigation.WooPosItemsNavigator
+import com.woocommerce.android.ui.woopos.util.analytics.WooPosAnalyticsEvent
 import com.woocommerce.android.ui.woopos.util.analytics.WooPosAnalyticsEvent.Event.BackToCartTapped
 import com.woocommerce.android.ui.woopos.util.analytics.WooPosAnalyticsTracker
 import com.woocommerce.android.viewmodel.getStateFlow
@@ -94,6 +95,7 @@ class WooPosHomeViewModel @Inject constructor(
             WooPosHomeUIEvent.ExitPosClicked -> {
                 viewModelScope.launch {
                     _navigationEvent.emit(NavigationEvent.ExitPos)
+                    analyticsTracker.track(WooPosAnalyticsEvent.Event.ExitConfirmed)
                 }
             }
         }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/cart/WooPosCartViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/cart/WooPosCartViewModel.kt
@@ -28,6 +28,7 @@ import com.woocommerce.android.ui.woopos.util.analytics.WooPosAnalyticsEvent.Eve
 import com.woocommerce.android.ui.woopos.util.analytics.WooPosAnalyticsEvent.Event.ItemRemovedFromCart
 import com.woocommerce.android.ui.woopos.util.analytics.WooPosAnalyticsEventConstant
 import com.woocommerce.android.ui.woopos.util.analytics.WooPosAnalyticsTracker
+import com.woocommerce.android.ui.woopos.util.analytics.WooPosAnalyticsTrackingDataKeeper
 import com.woocommerce.android.ui.woopos.util.format.WooPosFormatPrice
 import com.woocommerce.android.viewmodel.ResourceProvider
 import com.woocommerce.android.viewmodel.getStateFlow
@@ -45,6 +46,7 @@ class WooPosCartViewModel @Inject constructor(
     private val resourceProvider: ResourceProvider,
     private val formatPrice: WooPosFormatPrice,
     private val analyticsTracker: WooPosAnalyticsTracker,
+    private val analyticsTrackingDataKeeper: WooPosAnalyticsTrackingDataKeeper,
     savedState: SavedStateHandle,
 ) : ViewModel() {
     private val _state = savedState.getStateFlow(
@@ -55,7 +57,7 @@ class WooPosCartViewModel @Inject constructor(
 
     val state: LiveData<WooPosCartState> = _state
         .asLiveData()
-        .map { updateCartStatusDependingOnItems(it) }
+        .map { updateCartStatusDependingOnItems(it).also { newState -> updateAnalyticsData(newState) } }
         .map { updateToolbarState(it) }
         .map { updateStateDependingOnCartStatus(it) }
 
@@ -264,6 +266,13 @@ class WooPosCartViewModel @Inject constructor(
     private fun sendEventToParent(event: ChildToParentEvent) {
         viewModelScope.launch {
             childrenToParentEventSender.sendToParent(event)
+        }
+    }
+
+    private fun updateAnalyticsData(newState: WooPosCartState) {
+        if (newState.body == WooPosCartState.Body.Empty) {
+            analyticsTrackingDataKeeper.reset()
+            analyticsTrackingDataKeeper.interactionWithCustomerStartedTimestamp = System.currentTimeMillis()
         }
     }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/totals/WooPosTotalsAnalyticsTracker.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/totals/WooPosTotalsAnalyticsTracker.kt
@@ -1,0 +1,97 @@
+package com.woocommerce.android.ui.woopos.home.totals
+
+import com.woocommerce.android.ui.payments.cardreader.payment.controller.CardReaderPaymentOrRefundState
+import com.woocommerce.android.ui.payments.cardreader.payment.controller.CardReaderPaymentOrRefundState.CardReaderPaymentState
+import com.woocommerce.android.ui.woopos.util.analytics.WooPosAnalyticsEvent
+import com.woocommerce.android.ui.woopos.util.analytics.WooPosAnalyticsEvent.Event.CreateNewOrderTapped
+import com.woocommerce.android.ui.woopos.util.analytics.WooPosAnalyticsEvent.Event.EmailReceiptTapped
+import com.woocommerce.android.ui.woopos.util.analytics.WooPosAnalyticsEvent.Event.ReaderReadyForCardPayment
+import com.woocommerce.android.ui.woopos.util.analytics.WooPosAnalyticsTracker
+import com.woocommerce.android.ui.woopos.util.analytics.WooPosAnalyticsTrackingDataKeeper
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.distinctUntilChanged
+import javax.inject.Inject
+
+class WooPosTotalsAnalyticsTracker @Inject constructor(
+    private val analyticsTracker: WooPosAnalyticsTracker,
+    private val analyticsData: WooPosAnalyticsTrackingDataKeeper,
+) {
+    suspend fun trackPaymentStates(paymentState: StateFlow<CardReaderPaymentOrRefundState>?) {
+        paymentState?.distinctUntilChanged { old, new -> old::class == new::class }?.collect {
+            when (it) {
+                is CardReaderPaymentState.CollectingPayment -> {
+                    analyticsData.readerReadyForPaymentTimestamp = System.currentTimeMillis()
+                    trackReaderReadyForPayment()
+                }
+
+                is CardReaderPaymentState.ProcessingPayment -> {
+                    analyticsData.cardTappedTimestamp = System.currentTimeMillis()
+                }
+
+                is CardReaderPaymentOrRefundState.CardReaderInteracRefundState.CollectingInteracRefund,
+                is CardReaderPaymentOrRefundState.CardReaderInteracRefundState.InteracRefundFailure.Cancelable,
+                is CardReaderPaymentOrRefundState.CardReaderInteracRefundState.InteracRefundFailure.NonCancelable,
+                is CardReaderPaymentOrRefundState.CardReaderInteracRefundState.InteracRefundSuccessful,
+                is CardReaderPaymentOrRefundState.CardReaderInteracRefundState.LoadingData,
+                is CardReaderPaymentOrRefundState.CardReaderInteracRefundState.ProcessingInteracRefund,
+                is CardReaderPaymentState.LoadingData,
+                is CardReaderPaymentState.PaymentCapturing.BuiltInReaderPaymentCapturing,
+                is CardReaderPaymentState.PaymentCapturing.ExternalReaderPaymentCapturing,
+                is CardReaderPaymentState.PaymentFailed.BuiltInReaderFailedPayment.Cancelable,
+                is CardReaderPaymentState.PaymentFailed.BuiltInReaderFailedPayment.NonCancelable,
+                is CardReaderPaymentState.PaymentFailed.ExternalReaderFailedPayment.Cancelable,
+                is CardReaderPaymentState.PaymentFailed.ExternalReaderFailedPayment.NonCancelable,
+                is CardReaderPaymentState.PaymentSuccessful.BuiltInReaderPaymentSuccessful,
+                is CardReaderPaymentState.PaymentSuccessful.BuiltInReaderPaymentSuccessfulReceiptSentAutomatically,
+                is CardReaderPaymentState.PaymentSuccessful.ExternalReaderPaymentSuccessful,
+                is CardReaderPaymentState.PaymentSuccessful.ExternalReaderPaymentSuccessfulReceiptSentAutomatically,
+                is CardReaderPaymentState.PrintingReceipt,
+                CardReaderPaymentState.ReFetchingOrder,
+                CardReaderPaymentState.SharingReceipt -> Unit
+            }
+        }
+    }
+
+    private suspend fun trackReaderReadyForPayment() {
+        analyticsTracker.track(
+            ReaderReadyForCardPayment.apply {
+                val props = mutableMapOf<String, String>()
+                val readerReadyForPaymentTimestamp = analyticsData.readerReadyForPaymentTimestamp
+                val orderSyncTimestamp = analyticsData.orderSyncSuccessTimestamp
+                if (readerReadyForPaymentTimestamp != null && orderSyncTimestamp != null) {
+                    @Suppress("MagicNumber")
+                    val waitingTimeSeconds = (readerReadyForPaymentTimestamp - orderSyncTimestamp) / 1000
+                    props["waiting_time"] = "$waitingTimeSeconds"
+                }
+                addProperties(props)
+            }
+        )
+    }
+
+    fun incrementCheckoutButtonTaps() {
+        analyticsData.checkoutButtonTapsCount = analyticsData.checkoutButtonTapsCount + 1
+    }
+
+    suspend fun trackOrderCreationSuccess() {
+        analyticsTracker.track(WooPosAnalyticsEvent.Event.OrderCreationSuccess)
+        analyticsData.orderSyncSuccessTimestamp = System.currentTimeMillis()
+    }
+
+    suspend fun trackOrderCreationFailed(error: Throwable) {
+        analyticsTracker.track(
+            WooPosAnalyticsEvent.Error.OrderCreationError(
+                errorContext = WooPosTotalsViewModel::class,
+                errorType = error::class.simpleName,
+                errorDescription = error.message
+            )
+        )
+    }
+
+    suspend fun trackEmailReceiptTapped() {
+        analyticsTracker.track(EmailReceiptTapped)
+    }
+
+    suspend fun trackCreateNewOrderTapped() {
+        analyticsTracker.track(CreateNewOrderTapped)
+    }
+}

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/totals/WooPosTotalsViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/totals/WooPosTotalsViewModel.kt
@@ -362,7 +362,17 @@ class WooPosTotalsViewModel @Inject constructor(
             uiState.value = buildWooPosTotalsViewState(order)
             childrenToParentEventSender.sendToParent(ChildToParentEvent.PaymentCollecting)
         }
-        analyticsTracker.track(ReaderReadyForCardPayment)
+        analyticsData.readerReadyForPaymentTimestamp = System.currentTimeMillis()
+        analyticsTracker.track(ReaderReadyForCardPayment.apply {
+            val props = mutableMapOf<String, String>()
+            val readerReadyForPaymentTimestamp = analyticsData.readerReadyForPaymentTimestamp
+            val orderSyncTimestamp = analyticsData.orderSyncSuccessTimestamp
+            if (readerReadyForPaymentTimestamp != null && orderSyncTimestamp != null) {
+                props["milliseconds_since_reader_ready_to_collect_payment"] =
+                    "${readerReadyForPaymentTimestamp - orderSyncTimestamp}"
+            }
+            addProperties(props)
+        })
     }
 
     private suspend fun handleReaderLoadingPaymentState() {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/totals/WooPosTotalsViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/totals/WooPosTotalsViewModel.kt
@@ -368,8 +368,8 @@ class WooPosTotalsViewModel @Inject constructor(
             val readerReadyForPaymentTimestamp = analyticsData.readerReadyForPaymentTimestamp
             val orderSyncTimestamp = analyticsData.orderSyncSuccessTimestamp
             if (readerReadyForPaymentTimestamp != null && orderSyncTimestamp != null) {
-                props["milliseconds_since_reader_ready_to_collect_payment"] =
-                    "${readerReadyForPaymentTimestamp - orderSyncTimestamp}"
+                val waitingTimeSeconds = (readerReadyForPaymentTimestamp - orderSyncTimestamp) / 1000
+                props["waiting_time"] = "$waitingTimeSeconds"
             }
             addProperties(props)
         })

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/totals/WooPosTotalsViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/totals/WooPosTotalsViewModel.kt
@@ -47,6 +47,7 @@ import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.launch
 import kotlinx.parcelize.Parcelize
 import java.math.BigDecimal
@@ -299,11 +300,8 @@ class WooPosTotalsViewModel @Inject constructor(
 
                     is CardReaderPaymentState.LoadingData -> handleReaderLoadingPaymentState()
 
+                    is CardReaderPaymentState.PaymentCapturing,
                     is CardReaderPaymentState.ProcessingPayment -> {
-                        analyticsData.cardTappedTimestamp = System.currentTimeMillis()
-                        handleProcessingOrCapturingPaymentState()
-                    }
-                    is CardReaderPaymentState.PaymentCapturing -> {
                         handleProcessingOrCapturingPaymentState()
                     }
 
@@ -327,6 +325,45 @@ class WooPosTotalsViewModel @Inject constructor(
                 }
             }
         }
+        viewModelScope.launch { trackPaymentStates() }
+    }
+
+    private suspend fun trackPaymentStates() {
+        cardReaderPaymentController?.paymentState?.distinctUntilChanged { old, new -> old::class == new::class }
+            ?.collect {
+                when (it) {
+                    is CardReaderPaymentState.CollectingPayment -> {
+                        analyticsData.readerReadyForPaymentTimestamp = System.currentTimeMillis()
+                        trackReaderReadyForPayment()
+                    }
+
+                    is CardReaderPaymentState.ProcessingPayment -> {
+                        analyticsData.cardTappedTimestamp = System.currentTimeMillis()
+                        handleProcessingOrCapturingPaymentState()
+                    }
+
+                    is CardReaderPaymentOrRefundState.CardReaderInteracRefundState.CollectingInteracRefund,
+                    is CardReaderPaymentOrRefundState.CardReaderInteracRefundState.InteracRefundFailure.Cancelable,
+                    is CardReaderPaymentOrRefundState.CardReaderInteracRefundState.InteracRefundFailure.NonCancelable,
+                    is CardReaderPaymentOrRefundState.CardReaderInteracRefundState.InteracRefundSuccessful,
+                    is CardReaderPaymentOrRefundState.CardReaderInteracRefundState.LoadingData,
+                    is CardReaderPaymentOrRefundState.CardReaderInteracRefundState.ProcessingInteracRefund,
+                    is CardReaderPaymentState.LoadingData,
+                    is CardReaderPaymentState.PaymentCapturing.BuiltInReaderPaymentCapturing,
+                    is CardReaderPaymentState.PaymentCapturing.ExternalReaderPaymentCapturing,
+                    is CardReaderPaymentState.PaymentFailed.BuiltInReaderFailedPayment.Cancelable,
+                    is CardReaderPaymentState.PaymentFailed.BuiltInReaderFailedPayment.NonCancelable,
+                    is CardReaderPaymentState.PaymentFailed.ExternalReaderFailedPayment.Cancelable,
+                    is CardReaderPaymentState.PaymentFailed.ExternalReaderFailedPayment.NonCancelable,
+                    is CardReaderPaymentState.PaymentSuccessful.BuiltInReaderPaymentSuccessful,
+                    is CardReaderPaymentState.PaymentSuccessful.BuiltInReaderPaymentSuccessfulReceiptSentAutomatically,
+                    is CardReaderPaymentState.PaymentSuccessful.ExternalReaderPaymentSuccessful,
+                    is CardReaderPaymentState.PaymentSuccessful.ExternalReaderPaymentSuccessfulReceiptSentAutomatically,
+                    is CardReaderPaymentState.PrintingReceipt,
+                    CardReaderPaymentState.ReFetchingOrder,
+                    CardReaderPaymentState.SharingReceipt -> Unit
+                }
+            }
     }
 
     private suspend fun handleProcessingOrCapturingPaymentState() {
@@ -362,8 +399,6 @@ class WooPosTotalsViewModel @Inject constructor(
             uiState.value = buildWooPosTotalsViewState(order)
             childrenToParentEventSender.sendToParent(ChildToParentEvent.PaymentCollecting)
         }
-        analyticsData.readerReadyForPaymentTimestamp = System.currentTimeMillis()
-        trackReaderReadyForPayment()
     }
 
     private suspend fun trackReaderReadyForPayment() {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/totals/WooPosTotalsViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/totals/WooPosTotalsViewModel.kt
@@ -299,21 +299,12 @@ class WooPosTotalsViewModel @Inject constructor(
 
                     is CardReaderPaymentState.LoadingData -> handleReaderLoadingPaymentState()
 
-                    is CardReaderPaymentState.ProcessingPayment,
+                    is CardReaderPaymentState.ProcessingPayment -> {
+                        analyticsData.cardTappedTimestamp = System.currentTimeMillis()
+                        handleProcessingOrCapturingPaymentState()
+                    }
                     is CardReaderPaymentState.PaymentCapturing -> {
-                        val state = uiState.value
-                        if (state is WooPosTotalsViewState.Checkout) {
-                            uiState.value = state.copy(totals = Totals.Hidden)
-                            // allow the UI to show "shrinking" exit animation of totals grid before showing
-                            // the "payment in progress" state.
-                            @Suppress("MagicNumber")
-                            delay(384)
-                        }
-                        uiState.value = buildPaymentInProgressState()
-                        childrenToParentEventSender.sendToParent(ChildToParentEvent.PaymentInProgress)
-                        childrenToParentEventSender.sendToParent(
-                            NavigationEvent.ReturnHomeFromCashWhenCardPaymentStarted
-                        )
+                        handleProcessingOrCapturingPaymentState()
                     }
 
                     is CardReaderPaymentState.PaymentSuccessful -> {
@@ -336,6 +327,22 @@ class WooPosTotalsViewModel @Inject constructor(
                 }
             }
         }
+    }
+
+    private suspend fun handleProcessingOrCapturingPaymentState() {
+        val state = uiState.value
+        if (state is WooPosTotalsViewState.Checkout) {
+            uiState.value = state.copy(totals = Totals.Hidden)
+            // allow the UI to show "shrinking" exit animation of totals grid before showing
+            // the "payment in progress" state.
+            @Suppress("MagicNumber")
+            delay(384)
+        }
+        uiState.value = buildPaymentInProgressState()
+        childrenToParentEventSender.sendToParent(ChildToParentEvent.PaymentInProgress)
+        childrenToParentEventSender.sendToParent(
+            NavigationEvent.ReturnHomeFromCashWhenCardPaymentStarted
+        )
     }
 
     private suspend fun handleCollectingPaymentState(paymentState: CardReaderPaymentState.CollectingPayment) {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/totals/WooPosTotalsViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/totals/WooPosTotalsViewModel.kt
@@ -421,6 +421,7 @@ class WooPosTotalsViewModel @Inject constructor(
                         )
                         uiState.value = buildWooPosTotalsViewState(order)
                         analyticsTracker.track(WooPosAnalyticsEvent.Event.OrderCreationSuccess)
+                        analyticsData.orderSyncSuccessTimestamp = System.currentTimeMillis()
                         collectPayment()
                     },
                     onFailure = { error ->

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/totals/WooPosTotalsViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/totals/WooPosTotalsViewModel.kt
@@ -30,12 +30,6 @@ import com.woocommerce.android.ui.woopos.home.totals.WooPosTotalsViewState.Payme
 import com.woocommerce.android.ui.woopos.home.totals.WooPosTotalsViewState.PaymentInProgress
 import com.woocommerce.android.ui.woopos.home.totals.WooPosTotalsViewState.Totals
 import com.woocommerce.android.ui.woopos.util.WooPosNetworkStatus
-import com.woocommerce.android.ui.woopos.util.analytics.WooPosAnalyticsEvent
-import com.woocommerce.android.ui.woopos.util.analytics.WooPosAnalyticsEvent.Event.CreateNewOrderTapped
-import com.woocommerce.android.ui.woopos.util.analytics.WooPosAnalyticsEvent.Event.EmailReceiptTapped
-import com.woocommerce.android.ui.woopos.util.analytics.WooPosAnalyticsEvent.Event.ReaderReadyForCardPayment
-import com.woocommerce.android.ui.woopos.util.analytics.WooPosAnalyticsTracker
-import com.woocommerce.android.ui.woopos.util.analytics.WooPosAnalyticsTrackingDataKeeper
 import com.woocommerce.android.ui.woopos.util.format.WooPosFormatPrice
 import com.woocommerce.android.util.UiStringParser
 import com.woocommerce.android.util.WooLog
@@ -47,7 +41,6 @@ import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.combine
-import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.launch
 import kotlinx.parcelize.Parcelize
 import java.math.BigDecimal
@@ -61,11 +54,10 @@ class WooPosTotalsViewModel @Inject constructor(
     private val cardReaderFacade: WooPosCardReaderFacade,
     private val totalsRepository: WooPosTotalsRepository,
     private val priceFormat: WooPosFormatPrice,
-    private val analyticsTracker: WooPosAnalyticsTracker,
     private val networkStatus: WooPosNetworkStatus,
     private val cardReaderPaymentControllerFactory: WooPosCardReaderPaymentControllerFactory,
     private val uiStringParser: UiStringParser,
-    private val analyticsData: WooPosAnalyticsTrackingDataKeeper,
+    private val totalsAnalyticsTracker: WooPosTotalsAnalyticsTracker,
     savedState: SavedStateHandle,
 ) : ViewModel() {
 
@@ -147,7 +139,7 @@ class WooPosTotalsViewModel @Inject constructor(
         when (event) {
             is WooPosTotalsUIEvent.OnNewTransactionClicked -> viewModelScope.launch {
                 childrenToParentEventSender.sendToParent(NewTransactionClicked)
-                analyticsTracker.track(CreateNewOrderTapped)
+                totalsAnalyticsTracker.trackCreateNewOrderTapped()
             }
 
             is WooPosTotalsUIEvent.RetryOrderCreationClicked -> {
@@ -170,7 +162,7 @@ class WooPosTotalsViewModel @Inject constructor(
 
     private fun handleEmailReceiptClicked() {
         viewModelScope.launch {
-            analyticsTracker.track(EmailReceiptTapped)
+            totalsAnalyticsTracker.trackEmailReceiptTapped()
             childrenToParentEventSender.sendToParent(
                 ToEmailReceipt(dataState.value.orderId)
             )
@@ -270,7 +262,7 @@ class WooPosTotalsViewModel @Inject constructor(
                     is ParentToChildrenEvent.CheckoutClicked -> {
                         dataState.value = dataState.value.copy(itemClickedDataList = event.itemClickedDataList)
                         createOrderDraft(dataState.value.itemClickedDataList)
-                        analyticsData.checkoutButtonTapsCount = analyticsData.checkoutButtonTapsCount + 1
+                        totalsAnalyticsTracker.incrementCheckoutButtonTaps()
                     }
 
                     is ParentToChildrenEvent.BackFromCheckoutToCartClicked -> {
@@ -325,44 +317,7 @@ class WooPosTotalsViewModel @Inject constructor(
                 }
             }
         }
-        viewModelScope.launch { trackPaymentStates() }
-    }
-
-    private suspend fun trackPaymentStates() {
-        cardReaderPaymentController?.paymentState?.distinctUntilChanged { old, new -> old::class == new::class }
-            ?.collect {
-                when (it) {
-                    is CardReaderPaymentState.CollectingPayment -> {
-                        analyticsData.readerReadyForPaymentTimestamp = System.currentTimeMillis()
-                        trackReaderReadyForPayment()
-                    }
-
-                    is CardReaderPaymentState.ProcessingPayment -> {
-                        analyticsData.cardTappedTimestamp = System.currentTimeMillis()
-                    }
-
-                    is CardReaderPaymentOrRefundState.CardReaderInteracRefundState.CollectingInteracRefund,
-                    is CardReaderPaymentOrRefundState.CardReaderInteracRefundState.InteracRefundFailure.Cancelable,
-                    is CardReaderPaymentOrRefundState.CardReaderInteracRefundState.InteracRefundFailure.NonCancelable,
-                    is CardReaderPaymentOrRefundState.CardReaderInteracRefundState.InteracRefundSuccessful,
-                    is CardReaderPaymentOrRefundState.CardReaderInteracRefundState.LoadingData,
-                    is CardReaderPaymentOrRefundState.CardReaderInteracRefundState.ProcessingInteracRefund,
-                    is CardReaderPaymentState.LoadingData,
-                    is CardReaderPaymentState.PaymentCapturing.BuiltInReaderPaymentCapturing,
-                    is CardReaderPaymentState.PaymentCapturing.ExternalReaderPaymentCapturing,
-                    is CardReaderPaymentState.PaymentFailed.BuiltInReaderFailedPayment.Cancelable,
-                    is CardReaderPaymentState.PaymentFailed.BuiltInReaderFailedPayment.NonCancelable,
-                    is CardReaderPaymentState.PaymentFailed.ExternalReaderFailedPayment.Cancelable,
-                    is CardReaderPaymentState.PaymentFailed.ExternalReaderFailedPayment.NonCancelable,
-                    is CardReaderPaymentState.PaymentSuccessful.BuiltInReaderPaymentSuccessful,
-                    is CardReaderPaymentState.PaymentSuccessful.BuiltInReaderPaymentSuccessfulReceiptSentAutomatically,
-                    is CardReaderPaymentState.PaymentSuccessful.ExternalReaderPaymentSuccessful,
-                    is CardReaderPaymentState.PaymentSuccessful.ExternalReaderPaymentSuccessfulReceiptSentAutomatically,
-                    is CardReaderPaymentState.PrintingReceipt,
-                    CardReaderPaymentState.ReFetchingOrder,
-                    CardReaderPaymentState.SharingReceipt -> Unit
-                }
-            }
+        viewModelScope.launch { totalsAnalyticsTracker.trackPaymentStates(cardReaderPaymentController?.paymentState) }
     }
 
     private suspend fun handleProcessingOrCapturingPaymentState() {
@@ -398,22 +353,6 @@ class WooPosTotalsViewModel @Inject constructor(
             uiState.value = buildWooPosTotalsViewState(order)
             childrenToParentEventSender.sendToParent(ChildToParentEvent.PaymentCollecting)
         }
-    }
-
-    private suspend fun trackReaderReadyForPayment() {
-        analyticsTracker.track(
-            ReaderReadyForCardPayment.apply {
-                val props = mutableMapOf<String, String>()
-                val readerReadyForPaymentTimestamp = analyticsData.readerReadyForPaymentTimestamp
-                val orderSyncTimestamp = analyticsData.orderSyncSuccessTimestamp
-                if (readerReadyForPaymentTimestamp != null && orderSyncTimestamp != null) {
-                    @Suppress("MagicNumber")
-                    val waitingTimeSeconds = (readerReadyForPaymentTimestamp - orderSyncTimestamp) / 1000
-                    props["waiting_time"] = "$waitingTimeSeconds"
-                }
-                addProperties(props)
-            }
-        )
     }
 
     private suspend fun handleReaderLoadingPaymentState() {
@@ -478,8 +417,7 @@ class WooPosTotalsViewModel @Inject constructor(
                             orderTotal = order.total
                         )
                         uiState.value = buildWooPosTotalsViewState(order)
-                        analyticsTracker.track(WooPosAnalyticsEvent.Event.OrderCreationSuccess)
-                        analyticsData.orderSyncSuccessTimestamp = System.currentTimeMillis()
+                        totalsAnalyticsTracker.trackOrderCreationSuccess()
                         collectPayment()
                     },
                     onFailure = { error ->
@@ -487,13 +425,7 @@ class WooPosTotalsViewModel @Inject constructor(
                         uiState.value = WooPosTotalsViewState.Error(
                             resourceProvider.getString(R.string.woopos_totals_order_creation_error)
                         )
-                        analyticsTracker.track(
-                            WooPosAnalyticsEvent.Error.OrderCreationError(
-                                errorContext = WooPosTotalsViewModel::class,
-                                errorType = error::class.simpleName,
-                                errorDescription = error.message
-                            )
-                        )
+                        totalsAnalyticsTracker.trackOrderCreationFailed(error)
                     }
                 )
         }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/totals/WooPosTotalsViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/totals/WooPosTotalsViewModel.kt
@@ -363,6 +363,10 @@ class WooPosTotalsViewModel @Inject constructor(
             childrenToParentEventSender.sendToParent(ChildToParentEvent.PaymentCollecting)
         }
         analyticsData.readerReadyForPaymentTimestamp = System.currentTimeMillis()
+        trackReaderReadyForPayment()
+    }
+
+    private suspend fun trackReaderReadyForPayment() {
         analyticsTracker.track(ReaderReadyForCardPayment.apply {
             val props = mutableMapOf<String, String>()
             val readerReadyForPaymentTimestamp = analyticsData.readerReadyForPaymentTimestamp

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/totals/WooPosTotalsViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/totals/WooPosTotalsViewModel.kt
@@ -367,16 +367,19 @@ class WooPosTotalsViewModel @Inject constructor(
     }
 
     private suspend fun trackReaderReadyForPayment() {
-        analyticsTracker.track(ReaderReadyForCardPayment.apply {
-            val props = mutableMapOf<String, String>()
-            val readerReadyForPaymentTimestamp = analyticsData.readerReadyForPaymentTimestamp
-            val orderSyncTimestamp = analyticsData.orderSyncSuccessTimestamp
-            if (readerReadyForPaymentTimestamp != null && orderSyncTimestamp != null) {
-                val waitingTimeSeconds = (readerReadyForPaymentTimestamp - orderSyncTimestamp) / 1000
-                props["waiting_time"] = "$waitingTimeSeconds"
+        analyticsTracker.track(
+            ReaderReadyForCardPayment.apply {
+                val props = mutableMapOf<String, String>()
+                val readerReadyForPaymentTimestamp = analyticsData.readerReadyForPaymentTimestamp
+                val orderSyncTimestamp = analyticsData.orderSyncSuccessTimestamp
+                if (readerReadyForPaymentTimestamp != null && orderSyncTimestamp != null) {
+                    @Suppress("MagicNumber")
+                    val waitingTimeSeconds = (readerReadyForPaymentTimestamp - orderSyncTimestamp) / 1000
+                    props["waiting_time"] = "$waitingTimeSeconds"
+                }
+                addProperties(props)
             }
-            addProperties(props)
-        })
+        )
     }
 
     private suspend fun handleReaderLoadingPaymentState() {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/totals/WooPosTotalsViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/totals/WooPosTotalsViewModel.kt
@@ -35,6 +35,7 @@ import com.woocommerce.android.ui.woopos.util.analytics.WooPosAnalyticsEvent.Eve
 import com.woocommerce.android.ui.woopos.util.analytics.WooPosAnalyticsEvent.Event.EmailReceiptTapped
 import com.woocommerce.android.ui.woopos.util.analytics.WooPosAnalyticsEvent.Event.ReaderReadyForCardPayment
 import com.woocommerce.android.ui.woopos.util.analytics.WooPosAnalyticsTracker
+import com.woocommerce.android.ui.woopos.util.analytics.WooPosAnalyticsTrackingDataKeeper
 import com.woocommerce.android.ui.woopos.util.format.WooPosFormatPrice
 import com.woocommerce.android.util.UiStringParser
 import com.woocommerce.android.util.WooLog
@@ -63,6 +64,7 @@ class WooPosTotalsViewModel @Inject constructor(
     private val networkStatus: WooPosNetworkStatus,
     private val cardReaderPaymentControllerFactory: WooPosCardReaderPaymentControllerFactory,
     private val uiStringParser: UiStringParser,
+    private val analyticsData: WooPosAnalyticsTrackingDataKeeper,
     savedState: SavedStateHandle,
 ) : ViewModel() {
 
@@ -267,6 +269,7 @@ class WooPosTotalsViewModel @Inject constructor(
                     is ParentToChildrenEvent.CheckoutClicked -> {
                         dataState.value = dataState.value.copy(itemClickedDataList = event.itemClickedDataList)
                         createOrderDraft(dataState.value.itemClickedDataList)
+                        analyticsData.checkoutButtonTapsCount = analyticsData.checkoutButtonTapsCount + 1
                     }
 
                     is ParentToChildrenEvent.BackFromCheckoutToCartClicked -> {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/totals/WooPosTotalsViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/totals/WooPosTotalsViewModel.kt
@@ -339,7 +339,6 @@ class WooPosTotalsViewModel @Inject constructor(
 
                     is CardReaderPaymentState.ProcessingPayment -> {
                         analyticsData.cardTappedTimestamp = System.currentTimeMillis()
-                        handleProcessingOrCapturingPaymentState()
                     }
 
                     is CardReaderPaymentOrRefundState.CardReaderInteracRefundState.CollectingInteracRefund,

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/util/analytics/WooPosAnalyticsDataKeeper.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/util/analytics/WooPosAnalyticsDataKeeper.kt
@@ -1,0 +1,25 @@
+package com.woocommerce.android.ui.woopos.util.analytics
+
+import javax.inject.Singleton
+
+@Singleton
+class WooPosAnalyticsTrackingDataKeeper(
+    var interactionWithCustomerStartedTimestamp: Long = EMPTY_TIMESTAMP,
+    var orderSyncSuccessTimestamp: Long = EMPTY_TIMESTAMP,
+    var readerReadyForPaymentTimestamp: Long = EMPTY_TIMESTAMP,
+    var cardTappedTimestamp: Long = EMPTY_TIMESTAMP,
+    var checkoutButtonTapsCount: Int = 0,
+) {
+
+    fun reset() {
+        interactionWithCustomerStartedTimestamp = EMPTY_TIMESTAMP
+        orderSyncSuccessTimestamp = EMPTY_TIMESTAMP
+        readerReadyForPaymentTimestamp = EMPTY_TIMESTAMP
+        cardTappedTimestamp = EMPTY_TIMESTAMP
+        checkoutButtonTapsCount = 0
+    }
+
+    private companion object  {
+        private const val EMPTY_TIMESTAMP = -1L
+    }
+}

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/util/analytics/WooPosAnalyticsDataKeeper.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/util/analytics/WooPosAnalyticsDataKeeper.kt
@@ -1,25 +1,22 @@
 package com.woocommerce.android.ui.woopos.util.analytics
 
+import javax.inject.Inject
 import javax.inject.Singleton
 
 @Singleton
-class WooPosAnalyticsTrackingDataKeeper(
-    var interactionWithCustomerStartedTimestamp: Long = EMPTY_TIMESTAMP,
-    var orderSyncSuccessTimestamp: Long = EMPTY_TIMESTAMP,
-    var readerReadyForPaymentTimestamp: Long = EMPTY_TIMESTAMP,
-    var cardTappedTimestamp: Long = EMPTY_TIMESTAMP,
-    var checkoutButtonTapsCount: Int = 0,
-) {
+class WooPosAnalyticsTrackingDataKeeper @Inject constructor() {
+    var interactionWithCustomerStartedTimestamp: Long? = null
+    var orderSyncSuccessTimestamp: Long? = null
+    var readerReadyForPaymentTimestamp: Long? = null
+    var cardTappedTimestamp: Long? = null
+    var checkoutButtonTapsCount: Int = 0
+
 
     fun reset() {
-        interactionWithCustomerStartedTimestamp = EMPTY_TIMESTAMP
-        orderSyncSuccessTimestamp = EMPTY_TIMESTAMP
-        readerReadyForPaymentTimestamp = EMPTY_TIMESTAMP
-        cardTappedTimestamp = EMPTY_TIMESTAMP
+        interactionWithCustomerStartedTimestamp = null
+        orderSyncSuccessTimestamp = null
+        readerReadyForPaymentTimestamp = null
+        cardTappedTimestamp = null
         checkoutButtonTapsCount = 0
-    }
-
-    private companion object  {
-        private const val EMPTY_TIMESTAMP = -1L
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/util/analytics/WooPosAnalyticsEvent.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/util/analytics/WooPosAnalyticsEvent.kt
@@ -38,6 +38,9 @@ sealed class WooPosAnalyticsEvent : IAnalyticsEvent {
         data object CashCollectPaymentSuccess : Event() {
             override val name: String = "cash_collect_payment_success"
         }
+        data object CashPaymentTapped : Event() {
+            override val name: String = "cash_payment_tapped"
+        }
         data object CheckoutTapped : Event() {
             override val name: String = "checkout_tapped"
         }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/util/analytics/WooPosAnalyticsEvent.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/util/analytics/WooPosAnalyticsEvent.kt
@@ -62,6 +62,9 @@ sealed class WooPosAnalyticsEvent : IAnalyticsEvent {
         data object ExitTapped : Event() {
             override val name: String = "exit_menu_item_tapped"
         }
+        data object ExitConfirmed: Event() {
+            override val name: String = "exit_confirmed"
+        }
         data object GetSupportTapped : Event() {
             override val name: String = "get_support_tapped"
         }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/util/analytics/WooPosAnalyticsEvent.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/util/analytics/WooPosAnalyticsEvent.kt
@@ -68,7 +68,7 @@ sealed class WooPosAnalyticsEvent : IAnalyticsEvent {
         data object ExitTapped : Event() {
             override val name: String = "exit_menu_item_tapped"
         }
-        data object ExitConfirmed: Event() {
+        data object ExitConfirmed : Event() {
             override val name: String = "exit_confirmed"
         }
         data object GetSupportTapped : Event() {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/util/analytics/WooPosAnalyticsEvent.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/util/analytics/WooPosAnalyticsEvent.kt
@@ -41,6 +41,9 @@ sealed class WooPosAnalyticsEvent : IAnalyticsEvent {
         data object CashPaymentTapped : Event() {
             override val name: String = "cash_payment_tapped"
         }
+        data object CashPaymentFailed : Event() {
+            override val name: String = "cash_payment_failed"
+        }
         data object CheckoutTapped : Event() {
             override val name: String = "checkout_tapped"
         }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/util/analytics/WooPosAnalyticsTrackingDataKeeper.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/util/analytics/WooPosAnalyticsTrackingDataKeeper.kt
@@ -11,7 +11,6 @@ class WooPosAnalyticsTrackingDataKeeper @Inject constructor() {
     var cardTappedTimestamp: Long? = null
     var checkoutButtonTapsCount: Int = 0
 
-
     fun reset() {
         interactionWithCustomerStartedTimestamp = null
         orderSyncSuccessTimestamp = null

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/util/analytics/WooPosPaymentsFlowTrackerEventProvider.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/util/analytics/WooPosPaymentsFlowTrackerEventProvider.kt
@@ -4,7 +4,9 @@ import com.woocommerce.android.analytics.IAnalyticsEvent
 import com.woocommerce.android.ui.payments.tracking.PaymentsFlowTrackerEventProvider
 import com.woocommerce.android.ui.woopos.util.analytics.WooPosAnalyticsEvent.PaymentFlowTrackerEvent
 
-class WooPosPaymentsFlowTrackerEventProvider : PaymentsFlowTrackerEventProvider {
+class WooPosPaymentsFlowTrackerEventProvider(
+    private val analyticsTrackingDataKeeper: WooPosAnalyticsTrackingDataKeeper,
+) : PaymentsFlowTrackerEventProvider {
     override val CARD_PRESENT_ONBOARDING_LEARN_MORE_TAPPED: IAnalyticsEvent
         get() = PaymentFlowTrackerEvent.CardPresentOnboardingLearnMoreTapped
 
@@ -93,7 +95,23 @@ class WooPosPaymentsFlowTrackerEventProvider : PaymentsFlowTrackerEventProvider 
         get() = PaymentFlowTrackerEvent.CardPresentCollectPaymentFailed
 
     override val CARD_PRESENT_COLLECT_PAYMENT_SUCCESS: IAnalyticsEvent
-        get() = PaymentFlowTrackerEvent.CardPresentCollectPaymentSuccess
+        get() = PaymentFlowTrackerEvent.CardPresentCollectPaymentSuccess.apply {
+            val props = mutableMapOf<String, String>()
+            analyticsTrackingDataKeeper.interactionWithCustomerStartedTimestamp?.let {
+                props["milliseconds_since_customer_interaction_started"] = "$it"
+            }
+            analyticsTrackingDataKeeper.orderSyncSuccessTimestamp?.let {
+                props["milliseconds_since_order_sync_success"] = "$it"
+            }
+            analyticsTrackingDataKeeper.readerReadyForPaymentTimestamp?.let {
+                props["milliseconds_since_reader_ready_to_collect_payment"] = "$it"
+            }
+            analyticsTrackingDataKeeper.cardTappedTimestamp?.let {
+                props["milliseconds_since_card_tapped"] = "$it"
+            }
+            props["checkout_tap_count"] = "${analyticsTrackingDataKeeper.checkoutButtonTapsCount}"
+            addProperties(props)
+        }
 
     override val CARD_PRESENT_COLLECT_INTERAC_PAYMENT_SUCCESS: IAnalyticsEvent
         get() = PaymentFlowTrackerEvent.CardPresentCollectInteracPaymentSuccess

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/util/analytics/WooPosPaymentsFlowTrackerEventProvider.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/util/analytics/WooPosPaymentsFlowTrackerEventProvider.kt
@@ -98,16 +98,16 @@ class WooPosPaymentsFlowTrackerEventProvider(
         get() = PaymentFlowTrackerEvent.CardPresentCollectPaymentSuccess.apply {
             val props = mutableMapOf<String, String>()
             analyticsTrackingDataKeeper.interactionWithCustomerStartedTimestamp?.let {
-                props["milliseconds_since_customer_interaction_started"] = "$it"
+                props["milliseconds_since_customer_interaction_started"] = "${System.currentTimeMillis() - it}"
             }
             analyticsTrackingDataKeeper.orderSyncSuccessTimestamp?.let {
-                props["milliseconds_since_order_sync_success"] = "$it"
+                props["milliseconds_since_order_sync_success"] = "${System.currentTimeMillis() - it}"
             }
             analyticsTrackingDataKeeper.readerReadyForPaymentTimestamp?.let {
-                props["milliseconds_since_reader_ready_to_collect_payment"] = "$it"
+                props["milliseconds_since_reader_ready_to_collect_payment"] = "${System.currentTimeMillis() - it}"
             }
             analyticsTrackingDataKeeper.cardTappedTimestamp?.let {
-                props["milliseconds_since_card_tapped"] = "$it"
+                props["milliseconds_since_card_tapped"] = "${System.currentTimeMillis() - it}"
             }
             props["checkout_tap_count"] = "${analyticsTrackingDataKeeper.checkoutButtonTapsCount}"
             addProperties(props)

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/cashpayment/WooPosCashPaymentViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/cashpayment/WooPosCashPaymentViewModelTest.kt
@@ -6,6 +6,7 @@ import com.woocommerce.android.R
 import com.woocommerce.android.model.Order
 import com.woocommerce.android.ui.woopos.util.WooPosCoroutineTestRule
 import com.woocommerce.android.ui.woopos.util.analytics.WooPosAnalyticsEvent.Event.CashCollectPaymentSuccess
+import com.woocommerce.android.ui.woopos.util.analytics.WooPosAnalyticsEvent.Event.CashPaymentTapped
 import com.woocommerce.android.ui.woopos.util.analytics.WooPosAnalyticsTracker
 import com.woocommerce.android.ui.woopos.util.format.WooPosFormatPrice
 import com.woocommerce.android.viewmodel.ResourceProvider
@@ -160,6 +161,18 @@ class WooPosCashPaymentViewModelTest {
         assertThat(collectingState.errorMessage).isEqualTo(errorMessage)
         assertThat(collectingState.button.status).isEqualTo(WooPosCashPaymentState.Collecting.Button.Status.ENABLED)
         verify(repository).completeOrder(any())
+    }
+
+    @Test
+    fun `when Complete button tapped, then should track event`() = runTest {
+        // GIVEN
+        whenever(repository.completeOrder(any())).thenReturn(Result.success(Unit))
+
+        // WHEN
+        viewModel.onUIEvent(WooPosCashPaymentUIEvent.CompleteOrderClicked)
+
+        // THEN
+        verify(tracker).track(CashPaymentTapped)
     }
 
     @Test

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/cashpayment/WooPosCashPaymentViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/cashpayment/WooPosCashPaymentViewModelTest.kt
@@ -9,6 +9,7 @@ import com.woocommerce.android.ui.woopos.util.analytics.WooPosAnalyticsEvent.Eve
 import com.woocommerce.android.ui.woopos.util.analytics.WooPosAnalyticsEvent.Event.CashPaymentFailed
 import com.woocommerce.android.ui.woopos.util.analytics.WooPosAnalyticsEvent.Event.CashPaymentTapped
 import com.woocommerce.android.ui.woopos.util.analytics.WooPosAnalyticsTracker
+import com.woocommerce.android.ui.woopos.util.analytics.WooPosAnalyticsTrackingDataKeeper
 import com.woocommerce.android.ui.woopos.util.format.WooPosFormatPrice
 import com.woocommerce.android.viewmodel.ResourceProvider
 import kotlinx.coroutines.ExperimentalCoroutinesApi
@@ -39,6 +40,7 @@ class WooPosCashPaymentViewModelTest {
     private val priceFormat: WooPosFormatPrice = mock()
     private val resourceProvider: ResourceProvider = mock()
     private val tracker: WooPosAnalyticsTracker = mock()
+    private val trackerData: WooPosAnalyticsTrackingDataKeeper = WooPosAnalyticsTrackingDataKeeper()
 
     private lateinit var viewModel: WooPosCashPaymentViewModel
 
@@ -70,7 +72,8 @@ class WooPosCashPaymentViewModelTest {
             priceFormat = priceFormat,
             resourceProvider = resourceProvider,
             analyticsTracker = tracker,
-            savedState = savedStateHandle
+            analyticsData = trackerData,
+            savedState = savedStateHandle,
         )
     }
 

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/cashpayment/WooPosCashPaymentViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/cashpayment/WooPosCashPaymentViewModelTest.kt
@@ -6,6 +6,7 @@ import com.woocommerce.android.R
 import com.woocommerce.android.model.Order
 import com.woocommerce.android.ui.woopos.util.WooPosCoroutineTestRule
 import com.woocommerce.android.ui.woopos.util.analytics.WooPosAnalyticsEvent.Event.CashCollectPaymentSuccess
+import com.woocommerce.android.ui.woopos.util.analytics.WooPosAnalyticsEvent.Event.CashPaymentFailed
 import com.woocommerce.android.ui.woopos.util.analytics.WooPosAnalyticsEvent.Event.CashPaymentTapped
 import com.woocommerce.android.ui.woopos.util.analytics.WooPosAnalyticsTracker
 import com.woocommerce.android.ui.woopos.util.format.WooPosFormatPrice
@@ -146,10 +147,7 @@ class WooPosCashPaymentViewModelTest {
     @Test
     fun `given repository fails to complete order, when onUIEvent CompleteOrderClicked, then error message is set and button is enabled`() = runTest {
         // GIVEN
-        val errorMessage = "Something went wrong"
-        whenever(repository.completeOrder(any())).thenReturn(Result.failure(Exception()))
-        whenever(resourceProvider.getString(R.string.woopos_cash_payment_error_message))
-            .thenReturn(errorMessage)
+        val errorMessage = givenRepoFailsToCompleteOrder()
 
         // WHEN
         viewModel.onUIEvent(WooPosCashPaymentUIEvent.CompleteOrderClicked)
@@ -161,6 +159,18 @@ class WooPosCashPaymentViewModelTest {
         assertThat(collectingState.errorMessage).isEqualTo(errorMessage)
         assertThat(collectingState.button.status).isEqualTo(WooPosCashPaymentState.Collecting.Button.Status.ENABLED)
         verify(repository).completeOrder(any())
+    }
+
+    @Test
+    fun `given repository fails to complete order, when onUIEvent CompleteOrderClicked, then event is tracked`() = runTest {
+        // GIVEN
+        givenRepoFailsToCompleteOrder()
+
+        // WHEN
+        viewModel.onUIEvent(WooPosCashPaymentUIEvent.CompleteOrderClicked)
+
+        // THEN
+        verify(tracker).track(CashPaymentFailed)
     }
 
     @Test
@@ -187,5 +197,13 @@ class WooPosCashPaymentViewModelTest {
         // THEN
         assertThat(state).isEqualTo(WooPosCashPaymentState.Complete)
         verify(tracker).track(CashCollectPaymentSuccess)
+    }
+
+    private suspend fun givenRepoFailsToCompleteOrder(): String {
+        val errorMessage = "Something went wrong"
+        whenever(repository.completeOrder(any())).thenReturn(Result.failure(Exception()))
+        whenever(resourceProvider.getString(R.string.woopos_cash_payment_error_message))
+            .thenReturn(errorMessage)
+        return errorMessage
     }
 }

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/home/WooPosHomeViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/home/WooPosHomeViewModelTest.kt
@@ -4,11 +4,13 @@ import androidx.arch.core.executor.testing.InstantTaskExecutorRule
 import androidx.lifecycle.SavedStateHandle
 import com.woocommerce.android.R
 import com.woocommerce.android.ui.woopos.home.ParentToChildrenEvent.OrderSuccessfullyPaid.PaymentMethod
+import com.woocommerce.android.ui.woopos.home.WooPosHomeUIEvent.ExitPosClicked
 import com.woocommerce.android.ui.woopos.home.WooPosHomeUIEvent.SystemBackClicked
 import com.woocommerce.android.ui.woopos.home.items.WooPosItemsViewModel.ItemClickedData
 import com.woocommerce.android.ui.woopos.home.items.navigation.WooPosItemsNavigator
 import com.woocommerce.android.ui.woopos.util.WooPosCoroutineTestRule
 import com.woocommerce.android.ui.woopos.util.analytics.WooPosAnalyticsEvent.Event.BackToCartTapped
+import com.woocommerce.android.ui.woopos.util.analytics.WooPosAnalyticsEvent.Event.ExitConfirmed
 import com.woocommerce.android.ui.woopos.util.analytics.WooPosAnalyticsTracker
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.MutableSharedFlow
@@ -112,7 +114,7 @@ class WooPosHomeViewModelTest {
         }
 
     @Test
-    fun `given state is Cart Empty, when ExitPosClicked passed, then exit confirmation dialog should be shown`() =
+    fun `when ExitPos confirmed in exit confirmation dialog, then should track event`() =
         runTest {
             // GIVEN
             val eventsFlow = MutableSharedFlow<ChildToParentEvent>()
@@ -120,15 +122,10 @@ class WooPosHomeViewModelTest {
             val viewModel = createViewModel()
 
             // WHEN
-            eventsFlow.emit(ChildToParentEvent.ExitPosClicked)
+            viewModel.onUIEvent(ExitPosClicked)
 
             // THEN
-            assertThat(viewModel.state.value.exitConfirmationDialog)
-                .isEqualTo(
-                    WooPosHomeState.ExitConfirmationDialog(
-                        isVisible = true
-                    )
-                )
+            verify(analyticsTracker).track(ExitConfirmed)
         }
 
     @Test

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/home/cart/WooPosCartViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/home/cart/WooPosCartViewModelTest.kt
@@ -18,6 +18,7 @@ import com.woocommerce.android.ui.woopos.util.analytics.WooPosAnalyticsEvent.Eve
 import com.woocommerce.android.ui.woopos.util.analytics.WooPosAnalyticsEvent.Event.InteractionWithCustomerStarted
 import com.woocommerce.android.ui.woopos.util.analytics.WooPosAnalyticsEventConstant
 import com.woocommerce.android.ui.woopos.util.analytics.WooPosAnalyticsTracker
+import com.woocommerce.android.ui.woopos.util.analytics.WooPosAnalyticsTrackingDataKeeper
 import com.woocommerce.android.ui.woopos.util.format.WooPosFormatPrice
 import com.woocommerce.android.util.captureValues
 import com.woocommerce.android.viewmodel.ResourceProvider
@@ -68,6 +69,7 @@ class WooPosCartViewModelTest {
     private val analyticsTracker: WooPosAnalyticsTracker = mock()
 
     private val savedState: SavedStateHandle = SavedStateHandle()
+    private val trackerData: WooPosAnalyticsTrackingDataKeeper = WooPosAnalyticsTrackingDataKeeper()
 
     @Test
     fun `given empty cart, when product clicked in product selector, then should add product to cart`() = runTest {
@@ -668,6 +670,7 @@ class WooPosCartViewModelTest {
             resourceProvider,
             formatPrice,
             analyticsTracker,
+            trackerData,
             savedState
         )
     }

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/home/cart/WooPosCartViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/home/cart/WooPosCartViewModelTest.kt
@@ -230,7 +230,7 @@ class WooPosCartViewModelTest {
     }
 
     @Test
-    fun `given items in cart, when checkout tapped, then should track envent`() = runTest {
+    fun `given items in cart, when checkout tapped, then should track event`() = runTest {
         // GIVEN
         val (sut, states) = createSutWithItemsInCart()
         assertThat(states.last().body).isInstanceOf(WooPosCartState.Body.WithItems::class.java)

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/home/totals/WooPosTotalsViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/home/totals/WooPosTotalsViewModelTest.kt
@@ -1485,11 +1485,13 @@ class WooPosTotalsViewModelTest {
         cardReaderFacade = cardReaderFacade,
         totalsRepository = totalsRepository,
         priceFormat = priceFormat,
-        analyticsTracker = analyticsTracker,
         networkStatus = networkStatus,
         cardReaderPaymentControllerFactory = cardReaderPaymentControllerFactory,
         uiStringParser = uiStringParser,
         savedState = savedState,
-        analyticsData = WooPosAnalyticsTrackingDataKeeper()
+        totalsAnalyticsTracker = WooPosTotalsAnalyticsTracker(
+            analyticsTracker = analyticsTracker,
+            analyticsData = WooPosAnalyticsTrackingDataKeeper()
+        ),
     )
 }

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/home/totals/WooPosTotalsViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/home/totals/WooPosTotalsViewModelTest.kt
@@ -45,6 +45,7 @@ import com.woocommerce.android.ui.woopos.util.analytics.WooPosAnalyticsEvent
 import com.woocommerce.android.ui.woopos.util.analytics.WooPosAnalyticsEvent.Event.CreateNewOrderTapped
 import com.woocommerce.android.ui.woopos.util.analytics.WooPosAnalyticsEvent.Event.EmailReceiptTapped
 import com.woocommerce.android.ui.woopos.util.analytics.WooPosAnalyticsTracker
+import com.woocommerce.android.ui.woopos.util.analytics.WooPosAnalyticsTrackingDataKeeper
 import com.woocommerce.android.ui.woopos.util.format.WooPosFormatPrice
 import com.woocommerce.android.util.CurrencyFormatter
 import com.woocommerce.android.util.UiStringParser
@@ -1486,5 +1487,6 @@ class WooPosTotalsViewModelTest {
         cardReaderPaymentControllerFactory = cardReaderPaymentControllerFactory,
         uiStringParser = uiStringParser,
         savedState = savedState,
+        analyticsData = WooPosAnalyticsTrackingDataKeeper()
     )
 }


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->
### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
### This is part 2 of POS Analytics event implementation.
Part 1 of POS Analytics is [merged](https://github.com/woocommerce/woocommerce-android/pull/13560).

This PR adds the following changes:
* Tracking `ExitConfirmed` event
* Tracking `CashPaymentTapped` event
* Tracking `CashPaymentFailed` event
* Adding `milliseconds_since_customer_interaction_started` property to `CashCollectPaymentSuccess` event
* Adding `checkout_tap_count` property to `CashCollectPaymentSuccess` event
* Adding properties to the `CardPresentCollectPaymentSuccess` event: `milliseconds_since_customer_interaction_started`, `milliseconds_since_order_sync_success`, `milliseconds_since_reader_ready_to_collect_payment`, `milliseconds_since_card_tapped`, and `checkout_tap_count`

Full list of events and props is available here: pdfdoF-6hn-p2#comment-7545

### Steps to reproduce
<!-- Step-by-step testing instructions. For new user flows, consider instead stating the goal of the workflow and see if your PR reviewer can accomplish the workflow without specific steps! -->

### Testing information
<!-- This is your opportunity to break out individual scenarios that need testing (when necessary) and/or include a checklist for the reviewer to go through. Consider documenting the following from your own completed testing: devices used, alternate workflows, edge cases, affected areas, critical flows, areas not tested, and any remaining unknowns. Provide feedback on this new section of the PR template through Sept 30, 2024 to Apps Quality; additional context here: p91TBi-b8z-p2#comment-12036 -->

Android Studio's Logcat can be used to test if the above events and properties are tracked correctly.

### The tests that have been performed
<!-- To give the reviewer an idea of what could be missed in terms of testing -->
As above.

### Images/gif
<!-- Include before and after images or gifs when appropriate. -->
—

- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.

## Reviewer (or Author, in the case of optional code reviews):

Please make sure these conditions are met before approving the PR, or request changes if the PR needs improvement:

- [ ] The PR is small and has a clear, single focus, or a valid explanation is provided in the description. If needed, please request to split it into smaller PRs.
- [ ] Ensure Adequate Unit Test Coverage: The changes are reasonably covered by unit tests or an explanation is provided in the PR description.
- [ ] Manual Testing: The author listed all the tests they ran, including smoke tests when needed (e.g., for refactorings). The reviewer confirmed that the PR works as expected on big (tablet) and small (phone) in case of UI changes, and no regressions are added.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->