### PR TITLE
[Blaze] Fix NPE in the Blaze payments WebView

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -3,7 +3,7 @@
 *** For entries which are touching the Android Wear app's, start entry with `[WEAR]` too.
 21.9
 -----
-
+- [*] Fixed an issue that can cause a crash when adding a new payment card in Blaze campaign form [https://github.com/woocommerce/woocommerce-android/pull/13624]
 
 21.8
 -----

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/blaze/creation/payment/BlazeCampaignPaymentMethodsListViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/blaze/creation/payment/BlazeCampaignPaymentMethodsListViewModel.kt
@@ -84,7 +84,7 @@ class BlazeCampaignPaymentMethodsListViewModel @Inject constructor(
                                 triggerEvent(MultiLiveEvent.Event.ExitWithResult(newPayment.id))
                             } else {
                                 WooLog.e(WooLog.T.BLAZE, "Failed to find a new payment methods")
-                                _viewState.value = paymentMethodsListState(data.savedPaymentMethods, null)
+                                _viewState.value = paymentMethodsListState(data.savedPaymentMethods)
                             }
                         },
                         onFailure = {

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/blaze/creation/payment/BlazeCampaignPaymentMethodsListViewModelTests.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/blaze/creation/payment/BlazeCampaignPaymentMethodsListViewModelTests.kt
@@ -2,6 +2,7 @@ package com.woocommerce.android.ui.blaze.creation.payment
 
 import com.woocommerce.android.model.CreditCardType
 import com.woocommerce.android.ui.blaze.BlazeRepository
+import com.woocommerce.android.ui.blaze.creation.payment.BlazeCampaignPaymentMethodsListViewModel.ViewState
 import com.woocommerce.android.ui.login.AccountRepository
 import com.woocommerce.android.util.captureValues
 import com.woocommerce.android.util.getOrAwaitValue
@@ -51,8 +52,8 @@ class BlazeCampaignPaymentMethodsListViewModelTests : BaseUnitTest() {
         val viewState = viewModel.viewState.getOrAwaitValue()
 
         assertThat(viewState)
-            .isInstanceOf(BlazeCampaignPaymentMethodsListViewModel.ViewState.PaymentMethodsList::class.java)
-        assertThat((viewState as BlazeCampaignPaymentMethodsListViewModel.ViewState.PaymentMethodsList).paymentMethods)
+            .isInstanceOf(ViewState.PaymentMethodsList::class.java)
+        assertThat((viewState as ViewState.PaymentMethodsList).paymentMethods)
             .isEqualTo(BlazePaymentSampleData.userPaymentMethods)
         assertThat(viewState.selectedPaymentMethod)
             .isEqualTo(BlazePaymentSampleData.userPaymentMethods.first())
@@ -70,7 +71,7 @@ class BlazeCampaignPaymentMethodsListViewModelTests : BaseUnitTest() {
         val viewState = viewModel.viewState.getOrAwaitValue()
 
         assertThat(viewState)
-            .isInstanceOf(BlazeCampaignPaymentMethodsListViewModel.ViewState.AddPaymentMethodWebView::class.java)
+            .isInstanceOf(ViewState.AddPaymentMethodWebView::class.java)
     }
 
     @Test
@@ -78,7 +79,7 @@ class BlazeCampaignPaymentMethodsListViewModelTests : BaseUnitTest() {
         setup()
 
         val viewState = viewModel.viewState.getOrAwaitValue()
-            as BlazeCampaignPaymentMethodsListViewModel.ViewState.PaymentMethodsList
+            as ViewState.PaymentMethodsList
         val event = viewModel.event.runAndCaptureValues {
             viewState.onPaymentMethodClicked(viewState.paymentMethods.last())
         }.last()
@@ -91,13 +92,13 @@ class BlazeCampaignPaymentMethodsListViewModelTests : BaseUnitTest() {
         setup()
 
         val viewState = viewModel.viewState.getOrAwaitValue()
-            as BlazeCampaignPaymentMethodsListViewModel.ViewState.PaymentMethodsList
+            as ViewState.PaymentMethodsList
         val state = viewModel.viewState.runAndCaptureValues {
             viewState.onAddPaymentMethodClicked()
         }.last()
 
         assertThat(state)
-            .isInstanceOf(BlazeCampaignPaymentMethodsListViewModel.ViewState.AddPaymentMethodWebView::class.java)
+            .isInstanceOf(ViewState.AddPaymentMethodWebView::class.java)
     }
 
     @Test
@@ -124,10 +125,10 @@ class BlazeCampaignPaymentMethodsListViewModelTests : BaseUnitTest() {
 
         val viewState = viewModel.viewState.captureValues()
         val event = viewModel.event.runAndCaptureValues {
-            (viewState.first() as BlazeCampaignPaymentMethodsListViewModel.ViewState.PaymentMethodsList)
+            (viewState.first() as ViewState.PaymentMethodsList)
                 .onAddPaymentMethodClicked()
             val webViewState = viewState.last()
-                as BlazeCampaignPaymentMethodsListViewModel.ViewState.AddPaymentMethodWebView
+                as ViewState.AddPaymentMethodWebView
 
             webViewState.onUrlLoaded(urls.successUrl)
         }.last()
@@ -149,11 +150,11 @@ class BlazeCampaignPaymentMethodsListViewModelTests : BaseUnitTest() {
         }
         val urls = BlazePaymentSampleData.paymentMethodsUrls
 
-        (viewModel.viewState.getOrAwaitValue() as BlazeCampaignPaymentMethodsListViewModel.ViewState.PaymentMethodsList)
+        (viewModel.viewState.getOrAwaitValue() as ViewState.PaymentMethodsList)
             .onAddPaymentMethodClicked()
-        (viewModel.viewState.getOrAwaitValue() as BlazeCampaignPaymentMethodsListViewModel.ViewState.AddPaymentMethodWebView)
+        (viewModel.viewState.getOrAwaitValue() as ViewState.AddPaymentMethodWebView)
             .onUrlLoaded(urls.successUrl)
-        val viewState = viewModel.viewState.getOrAwaitValue() as BlazeCampaignPaymentMethodsListViewModel.ViewState.PaymentMethodsList
+        val viewState = viewModel.viewState.getOrAwaitValue() as ViewState.PaymentMethodsList
 
         assertThat(viewState.selectedPaymentMethod).isEqualTo(BlazePaymentSampleData.userPaymentMethods.first())
     }

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/blaze/creation/payment/BlazeCampaignPaymentMethodsListViewModelTests.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/blaze/creation/payment/BlazeCampaignPaymentMethodsListViewModelTests.kt
@@ -134,4 +134,27 @@ class BlazeCampaignPaymentMethodsListViewModelTests : BaseUnitTest() {
 
         assertThat(event).isEqualTo(MultiLiveEvent.Event.ExitWithResult(newPayment.id))
     }
+
+    @Test
+    fun `when payment success URL is detected and no new payment method is found, then keep old selected method`() = testBlocking {
+        setup {
+            whenever(blazeRepository.fetchPaymentMethods()).thenReturn(
+                Result.success(
+                    BlazeRepository.PaymentMethodsData(
+                        savedPaymentMethods = BlazePaymentSampleData.userPaymentMethods,
+                        addPaymentMethodUrls = BlazePaymentSampleData.paymentMethodsUrls
+                    )
+                )
+            )
+        }
+        val urls = BlazePaymentSampleData.paymentMethodsUrls
+
+        (viewModel.viewState.getOrAwaitValue() as BlazeCampaignPaymentMethodsListViewModel.ViewState.PaymentMethodsList)
+            .onAddPaymentMethodClicked()
+        (viewModel.viewState.getOrAwaitValue() as BlazeCampaignPaymentMethodsListViewModel.ViewState.AddPaymentMethodWebView)
+            .onUrlLoaded(urls.successUrl)
+        val viewState = viewModel.viewState.getOrAwaitValue() as BlazeCampaignPaymentMethodsListViewModel.ViewState.PaymentMethodsList
+
+        assertThat(viewState.selectedPaymentMethod).isEqualTo(BlazePaymentSampleData.userPaymentMethods.first())
+    }
 }


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #13623

### Description
This PR fixes a crash in the Blaze payments WebView, the issue is that when the user taps on the "back" button in the WebView, it will navigate to `me/payment-methods`, this is the same URL that the API is returning as the success URL, so when this happens we will try to fetch a new added payment method, and when we don't detect a new one, we set the selection to `null`, which was a mistake, as we need to keep the previously selected method.

### Steps to reproduce
1. Launch the Blaze campaign creation form.
2. Proceed to the creation.
3. In the Payments screen, choose "Add a new payment method"
4. Tap on the "Back" button inside the WebView.

### Testing information
- Confirm the app doesn't crash, and the previously selected method stays selected.

### The tests that have been performed
^

- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.

## Reviewer (or Author, in the case of optional code reviews):

Please make sure these conditions are met before approving the PR, or request changes if the PR needs improvement:

- [ ] The PR is small and has a clear, single focus, or a valid explanation is provided in the description. If needed, please request to split it into smaller PRs.
- [ ] Ensure Adequate Unit Test Coverage: The changes are reasonably covered by unit tests or an explanation is provided in the PR description.
- [ ] Manual Testing: The author listed all the tests they ran, including smoke tests when needed (e.g., for refactorings). The reviewer confirmed that the PR works as expected on big (tablet) and small (phone) in case of UI changes, and no regressions are added.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->