### PR TITLE
[Woo POS][Design system] Center vertically the input fields in cash and receipts screens

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/cashpayment/WooPosCashPaymentScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/cashpayment/WooPosCashPaymentScreen.kt
@@ -1,9 +1,14 @@
 package com.woocommerce.android.ui.woopos.cashpayment
 
 import androidx.activity.compose.BackHandler
+import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.imePadding
+import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.runtime.Composable
@@ -13,6 +18,7 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.focus.FocusRequester
 import androidx.compose.ui.focus.focusRequester
@@ -21,8 +27,6 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
-import androidx.constraintlayout.compose.ConstraintLayout
-import androidx.constraintlayout.compose.Dimension
 import androidx.hilt.navigation.compose.hiltViewModel
 import com.woocommerce.android.R
 import com.woocommerce.android.ui.woopos.common.composeui.WooPosPreview
@@ -34,7 +38,6 @@ import com.woocommerce.android.ui.woopos.common.composeui.component.WooPosToolba
 import com.woocommerce.android.ui.woopos.common.composeui.designsystem.WooPosSpacing
 import com.woocommerce.android.ui.woopos.common.composeui.designsystem.WooPosTheme
 import com.woocommerce.android.ui.woopos.common.composeui.designsystem.WooPosTypography
-import com.woocommerce.android.ui.woopos.common.composeui.designsystem.toAdaptivePadding
 import com.woocommerce.android.ui.woopos.root.navigation.WooPosNavigationEvent
 import org.wordpress.android.fluxc.model.WCSettingsModel
 import java.math.BigDecimal
@@ -87,7 +90,6 @@ fun WooPosCashPaymentScreen(
     }
 }
 
-@Suppress("DestructuringDeclarationWithTooManyEntries")
 @Composable
 private fun Collecting(
     state: WooPosCashPaymentState.Collecting,
@@ -102,77 +104,72 @@ private fun Collecting(
         keyboardController?.show()
     }
 
-    ConstraintLayout(
+    Column(
         modifier = Modifier
             .fillMaxSize()
-            .imePadding()
+            .imePadding(),
+        verticalArrangement = Arrangement.SpaceBetween
     ) {
-        val (input, total, error, changeDue, button) = createRefs()
-        val standardMargin = WooPosSpacing.Medium.value.toAdaptivePadding()
-        val smallMargin = WooPosSpacing.Small.value.toAdaptivePadding()
-
         WooPosText(
             text = state.totalText,
             style = WooPosTypography.BodyLarge,
             modifier = Modifier
-                .constrainAs(total) {
-                    top.linkTo(parent.top, margin = WooPosSpacing.XSmall.value)
-                    start.linkTo(parent.start, margin = 64.dp)
-                }
+                .padding(
+                    top = WooPosSpacing.XSmall.value,
+                    start = 64.dp
+                )
         )
 
-        var inputText by remember { mutableStateOf(state.enteredAmount) }
+        Spacer(modifier = Modifier.weight(1f))
 
-        val marginBetweenTotalAndInput = 48.dp.toAdaptivePadding()
-        WooPosMoneyInputField(
-            modifier = Modifier
-                .focusRequester(focusRequester)
-                .constrainAs(input) {
-                    top.linkTo(total.bottom, margin = marginBetweenTotalAndInput)
-                    start.linkTo(parent.start, margin = standardMargin)
-                    end.linkTo(parent.end, margin = standardMargin)
+        Column(
+            modifier = Modifier.fillMaxWidth(),
+            horizontalAlignment = Alignment.CenterHorizontally
+        ) {
+            var inputText by remember { mutableStateOf(state.enteredAmount) }
+
+            WooPosMoneyInputField(
+                modifier = Modifier
+                    .focusRequester(focusRequester),
+                value = inputText,
+                onValueChange = {
+                    onAmountChanged(it)
+                    inputText = it
                 },
-            value = inputText,
-            onValueChange = {
-                onAmountChanged(it)
-                inputText = it
-            },
-            keyboardOptions = KeyboardOptions(
-                keyboardType = KeyboardType.Decimal
-            ),
-            textStyle = WooPosTypography.Heading,
-            textColor = MaterialTheme.colorScheme.onSurface,
-            currencySymbol = state.currencySymbol,
-            currencyPosition = state.currencyPosition,
-            decimalSeparator = state.decimalSeparator,
-            numberOfDecimals = state.numberOfDecimals,
-        )
-
-        WooPosText(
-            text = state.changeDueText,
-            style = WooPosTypography.BodySmall,
-            color = WooPosTheme.colors.onSurfaceVariantLowest,
-            modifier = Modifier
-                .constrainAs(changeDue) {
-                    top.linkTo(input.bottom, margin = smallMargin)
-                    start.linkTo(parent.start, margin = standardMargin)
-                    end.linkTo(parent.end, margin = standardMargin)
-                }
-        )
-
-        if (state.errorMessage != null) {
-            WooPosText(
-                text = state.errorMessage,
-                color = MaterialTheme.colorScheme.error,
-                style = WooPosTypography.BodySmall,
-                textAlign = TextAlign.Center,
-                modifier = Modifier.constrainAs(error) {
-                    top.linkTo(changeDue.bottom, margin = smallMargin)
-                    start.linkTo(parent.start, margin = standardMargin)
-                    end.linkTo(parent.end, margin = standardMargin)
-                }
+                keyboardOptions = KeyboardOptions(
+                    keyboardType = KeyboardType.Decimal
+                ),
+                textStyle = WooPosTypography.Heading,
+                textColor = MaterialTheme.colorScheme.onSurface,
+                currencySymbol = state.currencySymbol,
+                currencyPosition = state.currencyPosition,
+                decimalSeparator = state.decimalSeparator,
+                numberOfDecimals = state.numberOfDecimals,
             )
+
+            Spacer(modifier = Modifier.height(WooPosSpacing.Small.value))
+
+            WooPosText(
+                text = state.changeDueText,
+                style = WooPosTypography.BodySmall,
+                color = WooPosTheme.colors.onSurfaceVariantLowest,
+                modifier = Modifier.padding(horizontal = WooPosSpacing.Medium.value)
+            )
+
+            if (state.errorMessage != null) {
+                Spacer(modifier = Modifier.height(WooPosSpacing.Small.value))
+
+                WooPosText(
+                    text = state.errorMessage,
+                    color = MaterialTheme.colorScheme.error,
+                    style = WooPosTypography.BodySmall,
+                    textAlign = TextAlign.Center,
+                    modifier = Modifier.padding(horizontal = WooPosSpacing.Medium.value)
+                )
+            }
         }
+
+        Spacer(modifier = Modifier.weight(1f))
 
         WooPosButton(
             text = state.button.text,
@@ -183,12 +180,11 @@ private fun Collecting(
                 WooPosCashPaymentState.Collecting.Button.Status.LOADING -> WooPosButtonState.LOADING
             },
             modifier = Modifier
-                .constrainAs(button) {
-                    bottom.linkTo(parent.bottom, margin = WooPosSpacing.Medium.value)
-                    end.linkTo(parent.end, margin = standardMargin)
-                    start.linkTo(parent.start, margin = standardMargin)
-                    width = Dimension.fillToConstraints
-                }
+                .fillMaxWidth()
+                .padding(
+                    horizontal = WooPosSpacing.Medium.value,
+                    vertical = WooPosSpacing.Medium.value
+                )
         )
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/cashpayment/WooPosCashPaymentScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/cashpayment/WooPosCashPaymentScreen.kt
@@ -110,6 +110,7 @@ private fun Collecting(
             .imePadding(),
         verticalArrangement = Arrangement.SpaceBetween
     ) {
+        @Suppress("WooPosDesignSystemSpacingUsageRule")
         WooPosText(
             text = state.totalText,
             style = WooPosTypography.BodyLarge,

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/emailreceipt/WooPosEmailReceiptScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/emailreceipt/WooPosEmailReceiptScreen.kt
@@ -1,8 +1,12 @@
 package com.woocommerce.android.ui.woopos.emailreceipt
 
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.imePadding
+import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.runtime.Composable
@@ -17,9 +21,6 @@ import androidx.compose.ui.platform.LocalSoftwareKeyboardController
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.text.style.TextAlign
-import androidx.compose.ui.unit.dp
-import androidx.constraintlayout.compose.ConstraintLayout
-import androidx.constraintlayout.compose.Dimension
 import androidx.hilt.navigation.compose.hiltViewModel
 import com.woocommerce.android.R
 import com.woocommerce.android.ui.woopos.common.composeui.WooPosPreview
@@ -31,7 +32,6 @@ import com.woocommerce.android.ui.woopos.common.composeui.component.WooPosToolba
 import com.woocommerce.android.ui.woopos.common.composeui.designsystem.WooPosSpacing
 import com.woocommerce.android.ui.woopos.common.composeui.designsystem.WooPosTheme
 import com.woocommerce.android.ui.woopos.common.composeui.designsystem.WooPosTypography
-import com.woocommerce.android.ui.woopos.common.composeui.designsystem.toAdaptivePadding
 import com.woocommerce.android.ui.woopos.root.navigation.WooPosNavigationEvent
 
 @Composable
@@ -88,14 +88,13 @@ private fun EmailState(
         keyboardController?.show()
     }
 
-    ConstraintLayout(
+    Column(
         modifier = Modifier
             .fillMaxSize()
-            .imePadding()
+            .imePadding(),
+        horizontalAlignment = Alignment.CenterHorizontally
     ) {
-        val (email, error, button) = createRefs()
-        val standardMargin = WooPosSpacing.Medium.value.toAdaptivePadding()
-        val topMargin = 72.dp.toAdaptivePadding()
+        Spacer(modifier = Modifier.weight(1f))
 
         WooPosInputField(
             value = state.email,
@@ -109,27 +108,22 @@ private fun EmailState(
                 keyboardType = KeyboardType.Email
             ),
             modifier = Modifier
-                .constrainAs(email) {
-                    top.linkTo(parent.top, margin = topMargin)
-                    start.linkTo(parent.start)
-                    end.linkTo(parent.end)
-                }
-                .focusRequester(focusRequester),
+                .focusRequester(focusRequester)
+                .padding(horizontal = WooPosSpacing.Medium.value)
         )
 
         if (state.errorMessage != null) {
+            Spacer(modifier = Modifier.height(WooPosSpacing.Small.value))
+
             WooPosText(
                 text = state.errorMessage,
                 color = MaterialTheme.colorScheme.error,
                 style = WooPosTypography.BodyLarge,
                 textAlign = TextAlign.Center,
-                modifier = Modifier.constrainAs(error) {
-                    top.linkTo(email.bottom, margin = WooPosSpacing.Small.value)
-                    start.linkTo(parent.start)
-                    end.linkTo(parent.end)
-                }
             )
         }
+
+        Spacer(modifier = Modifier.weight(1f))
 
         WooPosButton(
             text = state.button.text,
@@ -139,12 +133,9 @@ private fun EmailState(
                 WooPosEmailReceiptState.Email.Button.Status.DISABLED -> WooPosButtonState.DISABLED
                 WooPosEmailReceiptState.Email.Button.Status.LOADING -> WooPosButtonState.LOADING
             },
-            modifier = Modifier.constrainAs(button) {
-                bottom.linkTo(parent.bottom, margin = WooPosSpacing.Medium.value)
-                start.linkTo(parent.start, margin = standardMargin)
-                end.linkTo(parent.end, margin = standardMargin)
-                width = Dimension.fillToConstraints
-            },
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(WooPosSpacing.Medium.value)
         )
     }
 }


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #13626
<!-- Id number of the GitHub issue this PR addresses. -->

<!-- 
━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
🛠 Need an AI review?  
Add a comment: `@coderabbitai review`
━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
-->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
The PR change the layouts on cash collection and email screens, making the input fields being centered between the button and the top of the screen. I tried that and it looks good

This comes from this proposal https://github.com/woocommerce/woocommerce-android/pull/13615#pullrequestreview-2643695039

### Steps to reproduce
<!-- Step-by-step testing instructions. For new user flows, consider instead stating the goal of the workflow and see if your PR reviewer can accomplish the workflow without specific steps! -->
* Open POS
* Put any product in the cart
* Start cash payment flow -> notice that the input field is centered, doesn't matter if keyboard is visible or not
* Collect the payment
* Start receipt sending flow -> notice that the input field is centered, doesn't matter if keyboard is visible or not

### The tests that have been performed
<!-- To give the reviewer an idea of what could be missed in terms of testing -->
Above

### Images/gif
<!-- Include before and after images or gifs when appropriate. -->

https://github.com/user-attachments/assets/259d1c47-cd90-4b0c-a097-273d358c547f



- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.

## Reviewer (or Author, in the case of optional code reviews):

Please make sure these conditions are met before approving the PR, or request changes if the PR needs improvement:

- [ ] The PR is small and has a clear, single focus, or a valid explanation is provided in the description. If needed, please request to split it into smaller PRs.
- [ ] Ensure Adequate Unit Test Coverage: The changes are reasonably covered by unit tests or an explanation is provided in the PR description.
- [ ] Manual Testing: The author listed all the tests they ran, including smoke tests when needed (e.g., for refactorings). The reviewer confirmed that the PR works as expected on big (tablet) and small (phone) in case of UI changes, and no regressions are added.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->