### PR TITLE
Refactor edit address

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/WooShippingLabelCreationFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/WooShippingLabelCreationFragment.kt
@@ -18,6 +18,7 @@ import com.woocommerce.android.ui.main.AppBarStatus
 import com.woocommerce.android.ui.main.MainActivity.Companion.BackPressListener
 import com.woocommerce.android.ui.orders.wooshippinglabels.WooShippingLabelCreationViewModel.StartCustomsFormEdit
 import com.woocommerce.android.ui.orders.wooshippinglabels.WooShippingLabelCreationViewModel.StartPackageSelection
+import com.woocommerce.android.ui.orders.wooshippinglabels.address.EditAddressFlow
 import com.woocommerce.android.ui.orders.wooshippinglabels.packages.WooShippingLabelPackageCreationFragment.Companion.PACKAGE_SELECTION_RESULT
 import com.woocommerce.android.ui.orders.wooshippinglabels.packages.ui.PackageData
 import com.woocommerce.android.viewmodel.MultiLiveEvent
@@ -70,7 +71,7 @@ class WooShippingLabelCreationFragment : BaseFragment(), BackPressListener {
                 is WooShippingLabelCreationViewModel.StartOriginAddressEdit ->
                     WooShippingLabelCreationFragmentDirections
                         .actionWooShippingLabelCreationFragmentToWooShippingEditOriginAddressFragment(
-                            originAddress = event.originAddress
+                            flow = EditAddressFlow.EditOriginAddress(event.originAddress)
                         ).let { findNavController().navigateSafely(it) }
 
                 is StartCustomsFormEdit -> {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/WooShippingLabelCreationViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/WooShippingLabelCreationViewModel.kt
@@ -17,8 +17,8 @@ import com.woocommerce.android.ui.orders.wooshippinglabels.WooShippingLabelCreat
 import com.woocommerce.android.ui.orders.wooshippinglabels.WooShippingLabelCreationViewModel.CustomsState.Unavailable
 import com.woocommerce.android.ui.orders.wooshippinglabels.WooShippingLabelCreationViewModel.PackageSelectionState.DataAvailable
 import com.woocommerce.android.ui.orders.wooshippinglabels.WooShippingLabelCreationViewModel.PackageSelectionState.NotSelected
-import com.woocommerce.android.ui.orders.wooshippinglabels.address.FetchOriginAddresses
-import com.woocommerce.android.ui.orders.wooshippinglabels.address.ObserveOriginAddresses
+import com.woocommerce.android.ui.orders.wooshippinglabels.address.origin.FetchOriginAddresses
+import com.woocommerce.android.ui.orders.wooshippinglabels.address.origin.ObserveOriginAddresses
 import com.woocommerce.android.ui.orders.wooshippinglabels.customs.ShouldRequireCustomsForm
 import com.woocommerce.android.ui.orders.wooshippinglabels.models.OriginShippingAddress
 import com.woocommerce.android.ui.orders.wooshippinglabels.models.ShippableItemModel

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/address/NormalizeAddress.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/address/NormalizeAddress.kt
@@ -1,4 +1,4 @@
-package com.woocommerce.android.ui.orders.wooshippinglabels.address.origin
+package com.woocommerce.android.ui.orders.wooshippinglabels.address
 
 import com.woocommerce.android.model.Address
 import com.woocommerce.android.tools.SelectedSite

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/address/WooShippingEditAddressFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/address/WooShippingEditAddressFragment.kt
@@ -1,4 +1,4 @@
-package com.woocommerce.android.ui.orders.wooshippinglabels.address.origin
+package com.woocommerce.android.ui.orders.wooshippinglabels.address
 
 import android.os.Bundle
 import android.view.LayoutInflater
@@ -18,21 +18,18 @@ import com.woocommerce.android.ui.compose.theme.WooThemeWithBackground
 import com.woocommerce.android.ui.main.AppBarStatus
 import com.woocommerce.android.ui.main.MainActivity.Companion.BackPressListener
 import com.woocommerce.android.ui.orders.details.editing.address.LocationCode
-import com.woocommerce.android.ui.orders.wooshippinglabels.address.WooShippingEditAddressScreen
-import com.woocommerce.android.ui.orders.wooshippinglabels.address.origin.WooShippingEditOriginViewModel.ShowCountrySelector
-import com.woocommerce.android.ui.orders.wooshippinglabels.address.origin.WooShippingEditOriginViewModel.ShowStateSelector
 import com.woocommerce.android.ui.searchfilter.SearchFilterItem
 import com.woocommerce.android.viewmodel.MultiLiveEvent
 import dagger.hilt.android.AndroidEntryPoint
 
 @AndroidEntryPoint
-class WooShippingEditOriginAddressFragment : BaseFragment(), BackPressListener {
+class WooShippingEditAddressFragment : BaseFragment(), BackPressListener {
     private companion object {
         const val SELECT_COUNTRY_REQUEST = "select_address_country_request"
         const val SELECT_STATE_REQUEST = "select_address_state_request"
     }
 
-    private val viewModel: WooShippingEditOriginViewModel by viewModels()
+    private val viewModel: WooShippingEditAddressViewModel by viewModels()
 
     override val activityAppBarStatus: AppBarStatus = AppBarStatus.Hidden
 
@@ -58,8 +55,8 @@ class WooShippingEditOriginAddressFragment : BaseFragment(), BackPressListener {
     private fun observeEvents() {
         viewModel.event.observe(viewLifecycleOwner) { event ->
             when (event) {
-                is ShowCountrySelector -> showCountrySearchScreen(event.countries)
-                is ShowStateSelector -> showStatesSearchScreen(event.states)
+                is WooShippingEditAddressViewModel.ShowCountrySelector -> showCountrySearchScreen(event.countries)
+                is WooShippingEditAddressViewModel.ShowStateSelector -> showStatesSearchScreen(event.states)
                 is MultiLiveEvent.Event.Exit -> findNavController().navigateUp()
             }
         }
@@ -75,7 +72,7 @@ class WooShippingEditOriginAddressFragment : BaseFragment(), BackPressListener {
     }
 
     private fun showCountrySearchScreen(countries: List<Location>) {
-        val action = WooShippingEditOriginAddressFragmentDirections.actionSearchFilterFragment(
+        val action = WooShippingEditAddressFragmentDirections.Companion.actionSearchFilterFragment(
             items = countries.map {
                 SearchFilterItem(
                     name = it.name,
@@ -90,7 +87,7 @@ class WooShippingEditOriginAddressFragment : BaseFragment(), BackPressListener {
     }
 
     private fun showStatesSearchScreen(states: List<Location>) {
-        val action = WooShippingEditOriginAddressFragmentDirections.actionSearchFilterFragment(
+        val action = WooShippingEditAddressFragmentDirections.Companion.actionSearchFilterFragment(
             items = states.map {
                 SearchFilterItem(
                     name = it.name,

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/address/WooShippingEditAddressScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/address/WooShippingEditAddressScreen.kt
@@ -87,17 +87,13 @@ import com.woocommerce.android.ui.compose.component.dismissWCModalBottomSheet
 import com.woocommerce.android.ui.compose.theme.WooThemeWithBackground
 import com.woocommerce.android.ui.orders.wooshippinglabels.RoundedCornerBoxWithBorder
 import com.woocommerce.android.ui.orders.wooshippinglabels.ShipmentDetailsSectionTitle
-import com.woocommerce.android.ui.orders.wooshippinglabels.address.origin.AddressStatus
-import com.woocommerce.android.ui.orders.wooshippinglabels.address.origin.AddressValidationState
-import com.woocommerce.android.ui.orders.wooshippinglabels.address.origin.EditableAddress
-import com.woocommerce.android.ui.orders.wooshippinglabels.address.origin.WooShippingEditOriginViewModel
 import com.woocommerce.android.ui.orders.wooshippinglabels.purchased.successColor
 import com.woocommerce.android.ui.orders.wooshippinglabels.rates.ui.shippingSelectedBackgroundColor
 import kotlinx.coroutines.launch
 
 @Composable
 fun WooShippingEditAddressScreen(
-    viewModel: WooShippingEditOriginViewModel,
+    viewModel: WooShippingEditAddressViewModel,
     modifier: Modifier = Modifier
 ) {
     val viewState = viewModel.viewState.collectAsState().value
@@ -123,7 +119,7 @@ fun WooShippingEditAddressScreen(
         onRawStateChange = viewModel::onRawStateChange,
         onStateChange = viewModel::onStateChange,
         onNormalizeAddress = viewModel::onNormalizeAddress,
-        onUpdateOriginAddress = viewModel::onUpdateOriginAddress,
+        onUpdateAddress = viewModel::onUpdateAddress,
         onUpdateNormalizedOriginAddress = viewModel::onUpdateNormalizedOriginAddress,
         onNavigateBack = viewModel::onNavigateBack,
         modifier = modifier
@@ -134,8 +130,8 @@ fun WooShippingEditAddressScreen(
 @Composable
 fun WooShippingEditAddressScreen(
     editableAddress: EditableAddress,
-    loading: WooShippingEditOriginViewModel.LoadingState,
-    error: WooShippingEditOriginViewModel.EditAddressError?,
+    loading: WooShippingEditAddressViewModel.LoadingState,
+    error: WooShippingEditAddressViewModel.EditAddressError?,
     shouldUseStatesInput: Boolean,
     isCompanyExpanded: Boolean,
     addressStatus: AddressStatus,
@@ -154,7 +150,7 @@ fun WooShippingEditAddressScreen(
     onRawStateChange: (String) -> Unit,
     onStateChange: () -> Unit,
     onNormalizeAddress: (editableAddress: EditableAddress) -> Unit,
-    onUpdateOriginAddress: (editableAddress: EditableAddress) -> Unit,
+    onUpdateAddress: (editableAddress: EditableAddress) -> Unit,
     onUpdateNormalizedOriginAddress: (selection: AddressValidationState.AddressSelection) -> Unit,
     onNavigateBack: () -> Unit,
     modifier: Modifier = Modifier
@@ -365,7 +361,7 @@ fun WooShippingEditAddressScreen(
                     editableAddress = editableAddress,
                     addressStatus = addressStatus,
                     onNormalizeAddress = onNormalizeAddress,
-                    onUpdateOriginAddress = onUpdateOriginAddress,
+                    onUpdateAddress = onUpdateAddress,
                     onClose = onNavigateBack,
                     modifier = Modifier
                         .fillMaxWidth()
@@ -435,7 +431,7 @@ fun WooShippingEditAddressScreen(
             }
         }
     }
-    if (loading is WooShippingEditOriginViewModel.LoadingState.DisplayLoading) {
+    if (loading is WooShippingEditAddressViewModel.LoadingState.DisplayLoading) {
         LoadingModal(
             title = loading.title,
             description = loading.message
@@ -449,7 +445,7 @@ internal fun AddressStatusSection(
     editableAddress: EditableAddress,
     addressStatus: AddressStatus,
     onNormalizeAddress: (editableAddress: EditableAddress) -> Unit,
-    onUpdateOriginAddress: (editableAddress: EditableAddress) -> Unit,
+    onUpdateAddress: (editableAddress: EditableAddress) -> Unit,
     onClose: () -> Unit,
     modifier: Modifier = Modifier
 ) {
@@ -492,7 +488,7 @@ internal fun AddressStatusSection(
                 {}
             }
             AddressStatus.SAVE_CHANGES -> {
-                { onUpdateOriginAddress(editableAddress) }
+                { onUpdateAddress(editableAddress) }
             }
         }
 
@@ -714,7 +710,7 @@ private fun SelectAddressWithCustomSnackBar(
     onAddressSelectionChange: (AddressValidationState.AddressSelection) -> Unit,
     onUpdateNormalizedOriginAddress: (selection: AddressValidationState.AddressSelection) -> Unit,
     onCloseAddressSelection: () -> Unit,
-    error: WooShippingEditOriginViewModel.EditAddressError?,
+    error: WooShippingEditAddressViewModel.EditAddressError?,
     isBottomSheetSnackBarVisible: Boolean,
     modalSheetState: SheetState,
     modifier: Modifier = Modifier

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/address/WooShippingEditAddressViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/address/WooShippingEditAddressViewModel.kt
@@ -652,3 +652,9 @@ data class InputValue(
         val EMPTY = InputValue("")
     }
 }
+
+@Parcelize
+data class DestinationShippingAddress(
+    val address: Address,
+    val isVerified: Boolean
+) : Parcelable

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/address/WooShippingEditAddressViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/address/WooShippingEditAddressViewModel.kt
@@ -1,5 +1,6 @@
-package com.woocommerce.android.ui.orders.wooshippinglabels.address.origin
+package com.woocommerce.android.ui.orders.wooshippinglabels.address
 
+import android.os.Parcelable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.setValue
@@ -12,12 +13,11 @@ import com.woocommerce.android.model.Address
 import com.woocommerce.android.model.AmbiguousLocation
 import com.woocommerce.android.model.Location
 import com.woocommerce.android.ui.orders.details.editing.address.LocationCode
-import com.woocommerce.android.ui.orders.wooshippinglabels.address.AddressValidationHelper
-import com.woocommerce.android.ui.orders.wooshippinglabels.address.GetStatesByCountryCode
+import com.woocommerce.android.ui.orders.wooshippinglabels.address.origin.GetAcceptedOriginCountries
+import com.woocommerce.android.ui.orders.wooshippinglabels.address.origin.UpdateOriginAddress
 import com.woocommerce.android.ui.orders.wooshippinglabels.models.AddressNormalizationModel
 import com.woocommerce.android.ui.orders.wooshippinglabels.models.OriginShippingAddress
 import com.woocommerce.android.util.StringUtils.combineStrings
-import com.woocommerce.android.viewmodel.MultiLiveEvent
 import com.woocommerce.android.viewmodel.MultiLiveEvent.Event
 import com.woocommerce.android.viewmodel.ResourceProvider
 import com.woocommerce.android.viewmodel.ScopedViewModel
@@ -32,11 +32,12 @@ import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.mapLatest
 import kotlinx.coroutines.flow.transformLatest
 import kotlinx.coroutines.launch
+import kotlinx.parcelize.Parcelize
 import javax.inject.Inject
 
 @HiltViewModel
 @Suppress("TooManyFunctions")
-class WooShippingEditOriginViewModel @Inject constructor(
+class WooShippingEditAddressViewModel @Inject constructor(
     private val addressValidator: AddressValidationHelper,
     private val getAcceptedOriginCountries: GetAcceptedOriginCountries,
     private val getStatesByCountryCode: GetStatesByCountryCode,
@@ -71,9 +72,19 @@ class WooShippingEditOriginViewModel @Inject constructor(
     private val addressValidationState =
         MutableStateFlow<AddressValidationState>(AddressValidationState.NotStarted)
 
-    private val navArgs: WooShippingEditOriginAddressFragmentArgs by savedState.navArgs()
+    private val navArgs: WooShippingEditAddressFragmentArgs by savedState.navArgs()
 
-    private val currentAddress = MutableStateFlow(navArgs.originAddress)
+    private val currentAddress = when (val currentFlow = navArgs.flow) {
+        is EditAddressFlow.EditDestinationAddress -> currentFlow.address.address
+        is EditAddressFlow.EditOriginAddress -> currentFlow.address.toAddress()
+    }.let { MutableStateFlow(it) }
+
+    private val isVerified = when (val currentFlow = navArgs.flow) {
+        is EditAddressFlow.EditDestinationAddress -> currentFlow.address.isVerified
+        is EditAddressFlow.EditOriginAddress -> currentFlow.address.isVerified
+    }.let { MutableStateFlow(it) }
+
+    private val addressId = (navArgs.flow as? EditAddressFlow.EditOriginAddress)?.address?.id
 
     private val nameValidatedFlow = snapshotFlow { name }
         .combine(snapshotFlow { company }) { name, company ->
@@ -172,25 +183,25 @@ class WooShippingEditOriginViewModel @Inject constructor(
         }
     }
 
-    private fun fillAddressForm(originAddress: OriginShippingAddress) {
+    private fun fillAddressForm(addressInformation: Address) {
         val fullName = combineStrings(
-            originAddress.firstName.orEmpty(),
-            originAddress.lastName.orEmpty()
+            addressInformation.firstName,
+            addressInformation.lastName
         )
         val fullAddress = combineStrings(
-            originAddress.address1.orEmpty(),
-            originAddress.address2.orEmpty()
+            addressInformation.address1,
+            addressInformation.address2
         )
         name = InputValue(fullName)
-        company = InputValue(originAddress.company.orEmpty())
-        country.value = findLocationByCode(originAddress.country, countriesState.value)
+        company = InputValue(addressInformation.company)
+        country.value = findLocationByCode(addressInformation.country.code, countriesState.value)
         address = InputValue(fullAddress)
-        city = InputValue(originAddress.city.orEmpty())
-        selectedState.value = findLocationByCode(originAddress.state.orEmpty(), statesState.value)
-        postalCode = InputValue(originAddress.postcode)
-        email = InputValue(originAddress.email.orEmpty())
-        phone = InputValue(originAddress.phone.orEmpty())
-        isCompanyExpanded.value = originAddress.company.isNotNullOrEmpty()
+        city = InputValue(addressInformation.city)
+        selectedState.value = findLocationByCode(addressInformation.state.codeOrRaw, statesState.value)
+        postalCode = InputValue(addressInformation.postcode)
+        email = InputValue(addressInformation.email)
+        phone = InputValue(addressInformation.phone)
+        isCompanyExpanded.value = addressInformation.company.isNotNullOrEmpty()
     }
 
     private fun findLocationByCode(code: String, state: LocationState): Location {
@@ -267,7 +278,7 @@ class WooShippingEditOriginViewModel @Inject constructor(
             val addressStatus = when {
                 hasIncorrectOrMissingData(address) -> AddressStatus.MISSING_INFO
                 hasOnlyNoAddressChanges(address, currentAddress) -> AddressStatus.SAVE_CHANGES
-                isSameAddress(address, currentAddress) && currentAddress.isVerified -> AddressStatus.VERIFIED
+                isSameAddress(address, currentAddress) && isVerified.value -> AddressStatus.VERIFIED
                 else -> AddressStatus.UNVERIFIED
             }
 
@@ -316,7 +327,7 @@ class WooShippingEditOriginViewModel @Inject constructor(
                     EditAddressError(
                         resourceProvider.getString(R.string.woo_shipping_updating_address_failed)
                     ) {
-                        onUpdateOriginAddress(addressSelection.editableAddress)
+                        onUpdateAddress(addressSelection.editableAddress)
                     }
                 } else {
                     addressValidationState.value = AddressValidationState.NotStarted
@@ -367,25 +378,25 @@ class WooShippingEditOriginViewModel @Inject constructor(
         }
     }
 
-    private fun isSameAddress(newAddress: EditableAddress, currentAddress: OriginShippingAddress): Boolean {
+    private fun isSameAddress(newAddress: EditableAddress, currentAddress: Address): Boolean {
         val originalFullAddress = combineStrings(
-            currentAddress.address1.orEmpty(),
-            currentAddress.address2.orEmpty()
+            currentAddress.address1,
+            currentAddress.address2
         )
 
         val isSameAddress = originalFullAddress == newAddress.address.value
         val isSameCity = currentAddress.city == newAddress.city.value
-        val isSameState = currentAddress.state == newAddress.state.code
-        val isSameCountry = currentAddress.country == newAddress.country.code
+        val isSameState = currentAddress.state.codeOrRaw == newAddress.state.code
+        val isSameCountry = currentAddress.country.code == newAddress.country.code
         val isSamePostalCode = currentAddress.postcode == newAddress.postalCode.value
 
         return isSameAddress && isSameCity && isSameState && isSameCountry && isSamePostalCode
     }
 
-    private fun hasOnlyNoAddressChanges(newAddress: EditableAddress, currentAddress: OriginShippingAddress): Boolean {
+    private fun hasOnlyNoAddressChanges(newAddress: EditableAddress, currentAddress: Address): Boolean {
         val originalFullName = combineStrings(
-            currentAddress.firstName.orEmpty(),
-            currentAddress.lastName.orEmpty()
+            currentAddress.firstName,
+            currentAddress.lastName
         )
         val isDifferentName = newAddress.name.value != originalFullName
         val isDifferentCompany = newAddress.company.value != currentAddress.company
@@ -505,11 +516,13 @@ class WooShippingEditOriginViewModel @Inject constructor(
     fun onUpdateNormalizedOriginAddress(selection: AddressValidationState.AddressSelection) {
         addressValidationState.value = AddressValidationState.UpdatingAddress
         launch {
-            updateOriginAddress(selection.selectedAddress, currentAddress.value.id).fold(
+            updateOriginAddress(selection.selectedAddress, addressId).fold(
                 onSuccess = {
-                    fillAddressForm(it)
+                    val address = it.toAddress()
+                    fillAddressForm(address)
                     addressValidationState.value = AddressValidationState.NotStarted
-                    currentAddress.value = it
+                    currentAddress.value = address
+                    isVerified.value = it.isVerified
                 },
                 onFailure = {
                     addressValidationState.value = AddressValidationState.NormalizedAddressUpdateFailed(selection)
@@ -518,15 +531,29 @@ class WooShippingEditOriginViewModel @Inject constructor(
         }
     }
 
-    fun onUpdateOriginAddress(editableAddress: EditableAddress) {
+    fun onUpdateAddress(editableAddress: EditableAddress) {
+        when (navArgs.flow) {
+            is EditAddressFlow.EditDestinationAddress -> onUpdateDestinationAddress(editableAddress)
+            is EditAddressFlow.EditOriginAddress -> onUpdateOriginAddress(editableAddress)
+        }
+    }
+
+    @Suppress("UnusedParameter")
+    private fun onUpdateDestinationAddress(editableAddress: EditableAddress) {
+        // To be created
+    }
+
+    private fun onUpdateOriginAddress(editableAddress: EditableAddress) {
         addressValidationState.value = AddressValidationState.UpdatingAddress
         launch {
             val address = editableAddress.toAddress()
-            updateOriginAddress(address, currentAddress.value.id).fold(
+            updateOriginAddress(address, addressId).fold(
                 onSuccess = {
-                    fillAddressForm(it)
+                    val address = it.toAddress()
+                    fillAddressForm(address)
                     addressValidationState.value = AddressValidationState.NotStarted
-                    currentAddress.value = it
+                    currentAddress.value = address
+                    isVerified.value = it.isVerified
                 },
                 onFailure = {
                     addressValidationState.value = AddressValidationState.AddressUpdateFailed(editableAddress)
@@ -567,11 +594,11 @@ class WooShippingEditOriginViewModel @Inject constructor(
 
     data class ShowCountrySelector(
         val countries: List<Location>
-    ) : MultiLiveEvent.Event()
+    ) : Event()
 
     data class ShowStateSelector(
         val states: List<Location>
-    ) : MultiLiveEvent.Event()
+    ) : Event()
 
     companion object {
         private const val DELAY_TIME_MILLIS = 500L

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/address/WooShippingEditAddressViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/address/WooShippingEditAddressViewModel.kt
@@ -616,6 +616,22 @@ fun EditableAddress.toAddress(): Address {
     )
 }
 
+fun OriginShippingAddress.toAddress(): Address {
+    return Address(
+        firstName = firstName.orEmpty(),
+        lastName = lastName.orEmpty(),
+        company = company.orEmpty(),
+        address1 = address1.orEmpty(),
+        address2 = address2.orEmpty(),
+        city = city.orEmpty(),
+        state = AmbiguousLocation.Raw(state.orEmpty()),
+        postcode = postcode,
+        country = AmbiguousLocation.Raw(country).asLocation(),
+        email = email.orEmpty(),
+        phone = phone.orEmpty()
+    )
+}
+
 sealed class AddressValidationState {
     data object NotStarted : AddressValidationState()
     data object VerifyingAddress : AddressValidationState()

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/address/WooShippingEditAddressViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/address/WooShippingEditAddressViewModel.kt
@@ -637,6 +637,12 @@ sealed class AddressValidationState {
     ) : AddressValidationState()
 }
 
+@Parcelize
+sealed class EditAddressFlow : Parcelable {
+    data class EditOriginAddress(val address: OriginShippingAddress) : EditAddressFlow()
+    data class EditDestinationAddress(val address: DestinationShippingAddress) : EditAddressFlow()
+}
+
 enum class AddressStatus {
     VERIFIED,
     UNVERIFIED,

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/address/origin/FetchOriginAddresses.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/address/origin/FetchOriginAddresses.kt
@@ -1,4 +1,4 @@
-package com.woocommerce.android.ui.orders.wooshippinglabels.address
+package com.woocommerce.android.ui.orders.wooshippinglabels.address.origin
 
 import com.woocommerce.android.tools.SelectedSite
 import com.woocommerce.android.ui.orders.wooshippinglabels.models.OriginShippingAddress

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/address/origin/ObserveOriginAddresses.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/address/origin/ObserveOriginAddresses.kt
@@ -1,4 +1,4 @@
-package com.woocommerce.android.ui.orders.wooshippinglabels.address
+package com.woocommerce.android.ui.orders.wooshippinglabels.address.origin
 
 import com.woocommerce.android.ui.orders.wooshippinglabels.datasource.WooShippingAddressDataStore
 import kotlinx.coroutines.ExperimentalCoroutinesApi

--- a/WooCommerce/src/main/res/navigation/nav_graph_orders.xml
+++ b/WooCommerce/src/main/res/navigation/nav_graph_orders.xml
@@ -738,11 +738,11 @@
     </fragment>
     <fragment
         android:id="@+id/wooShippingEditOriginAddressFragment"
-        android:name="com.woocommerce.android.ui.orders.wooshippinglabels.address.origin.WooShippingEditOriginAddressFragment"
+        android:name="com.woocommerce.android.ui.orders.wooshippinglabels.address.WooShippingEditAddressFragment"
         android:label="WooShippingEditOriginAddressFragment" >
         <argument
-            android:name="originAddress"
-            app:argType="com.woocommerce.android.ui.orders.wooshippinglabels.models.OriginShippingAddress" />
+            android:name="flow"
+            app:argType="com.woocommerce.android.ui.orders.wooshippinglabels.address.EditAddressFlow" />
         <action
             android:id="@+id/action_search_filter_fragment"
             app:destination="@id/searchFilterFragment" />

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/WooShippingLabelCreationViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/WooShippingLabelCreationViewModelTest.kt
@@ -12,7 +12,7 @@ import com.woocommerce.android.ui.orders.wooshippinglabels.WooShippingLabelCreat
 import com.woocommerce.android.ui.orders.wooshippinglabels.WooShippingLabelCreationViewModel.PurchaseState
 import com.woocommerce.android.ui.orders.wooshippinglabels.WooShippingLabelCreationViewModel.WooShippingViewState
 import com.woocommerce.android.ui.orders.wooshippinglabels.WooShippingLabelCreationViewModel.WooShippingViewState.DataState
-import com.woocommerce.android.ui.orders.wooshippinglabels.address.ObserveOriginAddresses
+import com.woocommerce.android.ui.orders.wooshippinglabels.address.origin.ObserveOriginAddresses
 import com.woocommerce.android.ui.orders.wooshippinglabels.customs.ShouldRequireCustomsForm
 import com.woocommerce.android.ui.orders.wooshippinglabels.models.OriginShippingAddress
 import com.woocommerce.android.ui.orders.wooshippinglabels.models.PurchasedLabelData

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/address/FetchOriginAddressesTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/address/FetchOriginAddressesTest.kt
@@ -1,6 +1,7 @@
 package com.woocommerce.android.ui.orders.wooshippinglabels.address
 
 import com.woocommerce.android.tools.SelectedSite
+import com.woocommerce.android.ui.orders.wooshippinglabels.address.origin.FetchOriginAddresses
 import com.woocommerce.android.ui.orders.wooshippinglabels.models.OriginShippingAddress
 import com.woocommerce.android.ui.orders.wooshippinglabels.networking.WooShippingLabelRepository
 import com.woocommerce.android.viewmodel.BaseUnitTest

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/address/ObserveOriginAddressesTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/address/ObserveOriginAddressesTest.kt
@@ -1,5 +1,7 @@
 package com.woocommerce.android.ui.orders.wooshippinglabels.address
 
+import com.woocommerce.android.ui.orders.wooshippinglabels.address.origin.FetchOriginAddresses
+import com.woocommerce.android.ui.orders.wooshippinglabels.address.origin.ObserveOriginAddresses
 import com.woocommerce.android.ui.orders.wooshippinglabels.datasource.WooShippingAddressDataStore
 import com.woocommerce.android.ui.orders.wooshippinglabels.models.OriginShippingAddress
 import com.woocommerce.android.viewmodel.BaseUnitTest

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/address/origin/NormalizeAddressTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/address/origin/NormalizeAddressTest.kt
@@ -2,6 +2,7 @@ package com.woocommerce.android.ui.orders.wooshippinglabels.address.origin
 
 import com.woocommerce.android.model.Address
 import com.woocommerce.android.tools.SelectedSite
+import com.woocommerce.android.ui.orders.wooshippinglabels.address.NormalizeAddress
 import com.woocommerce.android.ui.orders.wooshippinglabels.models.AddressNormalizationModel
 import com.woocommerce.android.ui.orders.wooshippinglabels.networking.WooShippingLabelRepository
 import com.woocommerce.android.viewmodel.BaseUnitTest

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/address/origin/WooShippingEditOriginViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/address/origin/WooShippingEditOriginViewModelTest.kt
@@ -3,8 +3,15 @@ package com.woocommerce.android.ui.orders.wooshippinglabels.address.origin
 import androidx.compose.runtime.snapshots.Snapshot
 import com.woocommerce.android.model.Address
 import com.woocommerce.android.model.Location
+import com.woocommerce.android.ui.orders.wooshippinglabels.address.AddressStatus
 import com.woocommerce.android.ui.orders.wooshippinglabels.address.AddressValidationHelper
+import com.woocommerce.android.ui.orders.wooshippinglabels.address.AddressValidationState
+import com.woocommerce.android.ui.orders.wooshippinglabels.address.EditableAddress
 import com.woocommerce.android.ui.orders.wooshippinglabels.address.GetStatesByCountryCode
+import com.woocommerce.android.ui.orders.wooshippinglabels.address.InputValue
+import com.woocommerce.android.ui.orders.wooshippinglabels.address.NormalizeAddress
+import com.woocommerce.android.ui.orders.wooshippinglabels.address.WooShippingEditAddressViewModel
+import com.woocommerce.android.ui.orders.wooshippinglabels.address.toAddress
 import com.woocommerce.android.ui.orders.wooshippinglabels.models.AddressNormalizationModel
 import com.woocommerce.android.ui.orders.wooshippinglabels.models.OriginShippingAddress
 import com.woocommerce.android.viewmodel.BaseUnitTest
@@ -40,10 +47,10 @@ class WooShippingEditOriginViewModelTest : BaseUnitTest() {
         Location("CA", "California"),
     )
 
-    private lateinit var sut: WooShippingEditOriginViewModel
+    private lateinit var sut: WooShippingEditAddressViewModel
 
     fun createViewModel(originAddress: OriginShippingAddress) {
-        sut = WooShippingEditOriginViewModel(
+        sut = WooShippingEditAddressViewModel(
             addressValidator = addressValidator,
             savedState = WooShippingEditOriginAddressFragmentArgs(originAddress).toSavedStateHandle(),
             getAcceptedOriginCountries = getAcceptedOriginCountries,
@@ -71,7 +78,7 @@ class WooShippingEditOriginViewModelTest : BaseUnitTest() {
 
         val result = sut.viewState.value
 
-        assertThat(result).isInstanceOf(WooShippingEditOriginViewModel.ViewState::class.java)
+        assertThat(result).isInstanceOf(WooShippingEditAddressViewModel.ViewState::class.java)
 
         assertThat(result.editableAddress.name.error).isNull()
         assertThat(result.editableAddress.company.error).isNull()
@@ -94,7 +101,7 @@ class WooShippingEditOriginViewModelTest : BaseUnitTest() {
 
         val result = sut.viewState.value
 
-        assertThat(result).isInstanceOf(WooShippingEditOriginViewModel.ViewState::class.java)
+        assertThat(result).isInstanceOf(WooShippingEditAddressViewModel.ViewState::class.java)
 
         assertThat(result.editableAddress.name.error).isNull()
         assertThat(result.editableAddress.company.error).isNull()
@@ -118,7 +125,7 @@ class WooShippingEditOriginViewModelTest : BaseUnitTest() {
 
         val result = sut.viewState.value
 
-        assertThat(result).isInstanceOf(WooShippingEditOriginViewModel.ViewState::class.java)
+        assertThat(result).isInstanceOf(WooShippingEditAddressViewModel.ViewState::class.java)
 
         assertThat(result.editableAddress.name.error).isNotEmpty()
         assertThat(result.editableAddress.company.error).isNull()
@@ -137,7 +144,7 @@ class WooShippingEditOriginViewModelTest : BaseUnitTest() {
 
         val result = sut.viewState.value
 
-        assertThat(result).isInstanceOf(WooShippingEditOriginViewModel.ViewState::class.java)
+        assertThat(result).isInstanceOf(WooShippingEditAddressViewModel.ViewState::class.java)
 
         assertThat(result.editableAddress.address.error).isNotEmpty()
     }
@@ -155,7 +162,7 @@ class WooShippingEditOriginViewModelTest : BaseUnitTest() {
 
         val result = sut.viewState.value
 
-        assertThat(result).isInstanceOf(WooShippingEditOriginViewModel.ViewState::class.java)
+        assertThat(result).isInstanceOf(WooShippingEditAddressViewModel.ViewState::class.java)
 
         assertThat(result.editableAddress.address.error).isNull()
     }
@@ -173,7 +180,7 @@ class WooShippingEditOriginViewModelTest : BaseUnitTest() {
 
         val result = sut.viewState.value
 
-        assertThat(result).isInstanceOf(WooShippingEditOriginViewModel.ViewState::class.java)
+        assertThat(result).isInstanceOf(WooShippingEditAddressViewModel.ViewState::class.java)
 
         assertThat(result.editableAddress.city.error).isNotEmpty()
     }
@@ -191,7 +198,7 @@ class WooShippingEditOriginViewModelTest : BaseUnitTest() {
 
         val result = sut.viewState.value
 
-        assertThat(result).isInstanceOf(WooShippingEditOriginViewModel.ViewState::class.java)
+        assertThat(result).isInstanceOf(WooShippingEditAddressViewModel.ViewState::class.java)
 
         assertThat(result.editableAddress.city.error).isNull()
     }
@@ -209,7 +216,7 @@ class WooShippingEditOriginViewModelTest : BaseUnitTest() {
 
         val result = sut.viewState.value
 
-        assertThat(result).isInstanceOf(WooShippingEditOriginViewModel.ViewState::class.java)
+        assertThat(result).isInstanceOf(WooShippingEditAddressViewModel.ViewState::class.java)
 
         assertThat(result.editableAddress.postalCode.error).isNotEmpty()
     }
@@ -227,7 +234,7 @@ class WooShippingEditOriginViewModelTest : BaseUnitTest() {
 
         val result = sut.viewState.value
 
-        assertThat(result).isInstanceOf(WooShippingEditOriginViewModel.ViewState::class.java)
+        assertThat(result).isInstanceOf(WooShippingEditAddressViewModel.ViewState::class.java)
 
         assertThat(result.editableAddress.postalCode.error).isNull()
     }
@@ -245,7 +252,7 @@ class WooShippingEditOriginViewModelTest : BaseUnitTest() {
 
         val result = sut.viewState.value
 
-        assertThat(result).isInstanceOf(WooShippingEditOriginViewModel.ViewState::class.java)
+        assertThat(result).isInstanceOf(WooShippingEditAddressViewModel.ViewState::class.java)
 
         assertThat(result.editableAddress.email.error).isNotEmpty()
     }
@@ -263,7 +270,7 @@ class WooShippingEditOriginViewModelTest : BaseUnitTest() {
 
         val result = sut.viewState.value
 
-        assertThat(result).isInstanceOf(WooShippingEditOriginViewModel.ViewState::class.java)
+        assertThat(result).isInstanceOf(WooShippingEditAddressViewModel.ViewState::class.java)
 
         assertThat(result.editableAddress.email.error).isNull()
     }
@@ -282,7 +289,7 @@ class WooShippingEditOriginViewModelTest : BaseUnitTest() {
 
         val result = sut.viewState.value
 
-        assertThat(result).isInstanceOf(WooShippingEditOriginViewModel.ViewState::class.java)
+        assertThat(result).isInstanceOf(WooShippingEditAddressViewModel.ViewState::class.java)
 
         assertThat(result.editableAddress.phone.error).isNotEmpty()
     }
@@ -301,7 +308,7 @@ class WooShippingEditOriginViewModelTest : BaseUnitTest() {
 
         val result = sut.viewState.value
 
-        assertThat(result).isInstanceOf(WooShippingEditOriginViewModel.ViewState::class.java)
+        assertThat(result).isInstanceOf(WooShippingEditAddressViewModel.ViewState::class.java)
 
         assertThat(result.editableAddress.phone.error).isNotEmpty()
     }
@@ -320,7 +327,7 @@ class WooShippingEditOriginViewModelTest : BaseUnitTest() {
 
         val result = sut.viewState.value
 
-        assertThat(result).isInstanceOf(WooShippingEditOriginViewModel.ViewState::class.java)
+        assertThat(result).isInstanceOf(WooShippingEditAddressViewModel.ViewState::class.java)
 
         assertThat(result.editableAddress.phone.error).isNull()
     }
@@ -340,7 +347,7 @@ class WooShippingEditOriginViewModelTest : BaseUnitTest() {
 
         val result = sut.viewState.value
 
-        assertThat(result).isInstanceOf(WooShippingEditOriginViewModel.ViewState::class.java)
+        assertThat(result).isInstanceOf(WooShippingEditAddressViewModel.ViewState::class.java)
 
         assertThat(result.isCompanyExpanded).isTrue()
     }
@@ -357,7 +364,7 @@ class WooShippingEditOriginViewModelTest : BaseUnitTest() {
 
         val result = sut.viewState.value
 
-        assertThat(result).isInstanceOf(WooShippingEditOriginViewModel.ViewState::class.java)
+        assertThat(result).isInstanceOf(WooShippingEditAddressViewModel.ViewState::class.java)
 
         assertThat(result.isCompanyExpanded).isFalse()
     }
@@ -375,9 +382,9 @@ class WooShippingEditOriginViewModelTest : BaseUnitTest() {
 
         val result = sut.viewState.value
 
-        assertThat(result).isInstanceOf(WooShippingEditOriginViewModel.ViewState::class.java)
+        assertThat(result).isInstanceOf(WooShippingEditAddressViewModel.ViewState::class.java)
 
-        assertThat(result.loading).isInstanceOf(WooShippingEditOriginViewModel.LoadingState.Hidden::class.java)
+        assertThat(result.loading).isInstanceOf(WooShippingEditAddressViewModel.LoadingState.Hidden::class.java)
         assertThat(result.error).isNull()
     }
 
@@ -395,9 +402,9 @@ class WooShippingEditOriginViewModelTest : BaseUnitTest() {
 
         val result = sut.viewState.value
 
-        assertThat(result).isInstanceOf(WooShippingEditOriginViewModel.ViewState::class.java)
+        assertThat(result).isInstanceOf(WooShippingEditAddressViewModel.ViewState::class.java)
 
-        assertThat(result.loading).isInstanceOf(WooShippingEditOriginViewModel.LoadingState.Hidden::class.java)
+        assertThat(result.loading).isInstanceOf(WooShippingEditAddressViewModel.LoadingState.Hidden::class.java)
         assertThat(result.error).isNotNull
     }
 
@@ -415,7 +422,7 @@ class WooShippingEditOriginViewModelTest : BaseUnitTest() {
 
         val result = sut.viewState.value
 
-        assertThat(result).isInstanceOf(WooShippingEditOriginViewModel.ViewState::class.java)
+        assertThat(result).isInstanceOf(WooShippingEditAddressViewModel.ViewState::class.java)
 
         assertThat(result.shouldUseStatesInput).isTrue()
     }
@@ -434,7 +441,7 @@ class WooShippingEditOriginViewModelTest : BaseUnitTest() {
 
         val result = sut.viewState.value
 
-        assertThat(result).isInstanceOf(WooShippingEditOriginViewModel.ViewState::class.java)
+        assertThat(result).isInstanceOf(WooShippingEditAddressViewModel.ViewState::class.java)
 
         assertThat(result.shouldUseStatesInput).isFalse()
     }
@@ -453,7 +460,7 @@ class WooShippingEditOriginViewModelTest : BaseUnitTest() {
 
         val result = sut.viewState.value
 
-        assertThat(result).isInstanceOf(WooShippingEditOriginViewModel.ViewState::class.java)
+        assertThat(result).isInstanceOf(WooShippingEditAddressViewModel.ViewState::class.java)
 
         assertThat(result.shouldUseStatesInput).isFalse()
         assertThat(result.editableAddress.state).isEqualTo(states.first())
@@ -473,7 +480,7 @@ class WooShippingEditOriginViewModelTest : BaseUnitTest() {
 
         val result = sut.viewState.value
 
-        assertThat(result).isInstanceOf(WooShippingEditOriginViewModel.ViewState::class.java)
+        assertThat(result).isInstanceOf(WooShippingEditAddressViewModel.ViewState::class.java)
 
         assertThat(result.shouldUseStatesInput).isTrue()
         assertThat(result.editableAddress.state.name).isEqualTo("")
@@ -508,7 +515,7 @@ class WooShippingEditOriginViewModelTest : BaseUnitTest() {
 
         val result = sut.viewState.value
 
-        assertThat(result).isInstanceOf(WooShippingEditOriginViewModel.ViewState::class.java)
+        assertThat(result).isInstanceOf(WooShippingEditAddressViewModel.ViewState::class.java)
 
         assertThat(result.addressStatus).isEqualTo(AddressStatus.VERIFIED)
     }
@@ -543,7 +550,7 @@ class WooShippingEditOriginViewModelTest : BaseUnitTest() {
 
         val result = sut.viewState.value
 
-        assertThat(result).isInstanceOf(WooShippingEditOriginViewModel.ViewState::class.java)
+        assertThat(result).isInstanceOf(WooShippingEditAddressViewModel.ViewState::class.java)
 
         assertThat(result.addressStatus).isEqualTo(AddressStatus.UNVERIFIED)
     }
@@ -578,7 +585,7 @@ class WooShippingEditOriginViewModelTest : BaseUnitTest() {
 
         val result = sut.viewState.value
 
-        assertThat(result).isInstanceOf(WooShippingEditOriginViewModel.ViewState::class.java)
+        assertThat(result).isInstanceOf(WooShippingEditAddressViewModel.ViewState::class.java)
 
         assertThat(result.addressStatus).isEqualTo(AddressStatus.SAVE_CHANGES)
     }
@@ -613,7 +620,7 @@ class WooShippingEditOriginViewModelTest : BaseUnitTest() {
 
             val result = sut.viewState.value
 
-            assertThat(result).isInstanceOf(WooShippingEditOriginViewModel.ViewState::class.java)
+            assertThat(result).isInstanceOf(WooShippingEditAddressViewModel.ViewState::class.java)
 
             assertThat(result.addressStatus).isEqualTo(AddressStatus.UNVERIFIED)
         }
@@ -647,7 +654,7 @@ class WooShippingEditOriginViewModelTest : BaseUnitTest() {
 
         val result = sut.viewState.value
 
-        assertThat(result).isInstanceOf(WooShippingEditOriginViewModel.ViewState::class.java)
+        assertThat(result).isInstanceOf(WooShippingEditAddressViewModel.ViewState::class.java)
 
         assertThat(result.addressStatus).isEqualTo(AddressStatus.MISSING_INFO)
     }
@@ -666,7 +673,7 @@ class WooShippingEditOriginViewModelTest : BaseUnitTest() {
 
         val result = sut.viewState.value
 
-        assertThat(result).isInstanceOf(WooShippingEditOriginViewModel.ViewState::class.java)
+        assertThat(result).isInstanceOf(WooShippingEditAddressViewModel.ViewState::class.java)
 
         assertThat(result.addressValidationState).isEqualTo(AddressValidationState.NotStarted)
     }
@@ -715,7 +722,7 @@ class WooShippingEditOriginViewModelTest : BaseUnitTest() {
 
         val result = sut.viewState.value
 
-        assertThat(result).isInstanceOf(WooShippingEditOriginViewModel.ViewState::class.java)
+        assertThat(result).isInstanceOf(WooShippingEditAddressViewModel.ViewState::class.java)
 
         assertThat(result.addressValidationState).isInstanceOf(AddressValidationState.VerificationFailed::class.java)
 
@@ -747,7 +754,7 @@ class WooShippingEditOriginViewModelTest : BaseUnitTest() {
 
         val result = sut.viewState.value
 
-        assertThat(result).isInstanceOf(WooShippingEditOriginViewModel.ViewState::class.java)
+        assertThat(result).isInstanceOf(WooShippingEditAddressViewModel.ViewState::class.java)
 
         assertThat(result.addressValidationState).isInstanceOf(AddressValidationState.AddressSelection::class.java)
     }
@@ -779,7 +786,7 @@ class WooShippingEditOriginViewModelTest : BaseUnitTest() {
         sut.onNormalizeAddress(updatedAddress)
 
         val result = sut.viewState.value
-        assertThat(result).isInstanceOf(WooShippingEditOriginViewModel.ViewState::class.java)
+        assertThat(result).isInstanceOf(WooShippingEditAddressViewModel.ViewState::class.java)
         val addressSelection = result.addressValidationState as AddressValidationState.AddressSelection
         assertThat(addressSelection.selectedAddress).isEqualTo(suggestedAddress)
     }
@@ -811,14 +818,14 @@ class WooShippingEditOriginViewModelTest : BaseUnitTest() {
         sut.onNormalizeAddress(updatedAddress)
 
         var result = sut.viewState.value
-        assertThat(result).isInstanceOf(WooShippingEditOriginViewModel.ViewState::class.java)
+        assertThat(result).isInstanceOf(WooShippingEditAddressViewModel.ViewState::class.java)
         var addressSelection = result.addressValidationState as AddressValidationState.AddressSelection
         assertThat(addressSelection.selectedAddress).isEqualTo(suggestedAddress)
 
         sut.onAddressSelectionChange(addressSelection.copy(selectedAddress = enteredAddress))
 
         result = sut.viewState.value
-        assertThat(result).isInstanceOf(WooShippingEditOriginViewModel.ViewState::class.java)
+        assertThat(result).isInstanceOf(WooShippingEditAddressViewModel.ViewState::class.java)
         addressSelection = result.addressValidationState as AddressValidationState.AddressSelection
         assertThat(addressSelection.selectedAddress).isEqualTo(enteredAddress)
     }
@@ -850,14 +857,14 @@ class WooShippingEditOriginViewModelTest : BaseUnitTest() {
         sut.onNormalizeAddress(updatedAddress)
 
         var result = sut.viewState.value
-        assertThat(result).isInstanceOf(WooShippingEditOriginViewModel.ViewState::class.java)
+        assertThat(result).isInstanceOf(WooShippingEditAddressViewModel.ViewState::class.java)
         val addressSelection = result.addressValidationState as AddressValidationState.AddressSelection
         assertThat(addressSelection.selectedAddress).isEqualTo(suggestedAddress)
 
         sut.onCloseAddressSelection()
 
         result = sut.viewState.value
-        assertThat(result).isInstanceOf(WooShippingEditOriginViewModel.ViewState::class.java)
+        assertThat(result).isInstanceOf(WooShippingEditAddressViewModel.ViewState::class.java)
         assertThat(result.addressValidationState).isEqualTo(AddressValidationState.NotStarted)
     }
 

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/address/origin/WooShippingEditOriginViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/address/origin/WooShippingEditOriginViewModelTest.kt
@@ -6,10 +6,12 @@ import com.woocommerce.android.model.Location
 import com.woocommerce.android.ui.orders.wooshippinglabels.address.AddressStatus
 import com.woocommerce.android.ui.orders.wooshippinglabels.address.AddressValidationHelper
 import com.woocommerce.android.ui.orders.wooshippinglabels.address.AddressValidationState
+import com.woocommerce.android.ui.orders.wooshippinglabels.address.EditAddressFlow
 import com.woocommerce.android.ui.orders.wooshippinglabels.address.EditableAddress
 import com.woocommerce.android.ui.orders.wooshippinglabels.address.GetStatesByCountryCode
 import com.woocommerce.android.ui.orders.wooshippinglabels.address.InputValue
 import com.woocommerce.android.ui.orders.wooshippinglabels.address.NormalizeAddress
+import com.woocommerce.android.ui.orders.wooshippinglabels.address.WooShippingEditAddressFragmentArgs
 import com.woocommerce.android.ui.orders.wooshippinglabels.address.WooShippingEditAddressViewModel
 import com.woocommerce.android.ui.orders.wooshippinglabels.address.toAddress
 import com.woocommerce.android.ui.orders.wooshippinglabels.models.AddressNormalizationModel
@@ -52,7 +54,8 @@ class WooShippingEditOriginViewModelTest : BaseUnitTest() {
     fun createViewModel(originAddress: OriginShippingAddress) {
         sut = WooShippingEditAddressViewModel(
             addressValidator = addressValidator,
-            savedState = WooShippingEditOriginAddressFragmentArgs(originAddress).toSavedStateHandle(),
+            savedState =
+            WooShippingEditAddressFragmentArgs(EditAddressFlow.EditOriginAddress(originAddress)).toSavedStateHandle(),
             getAcceptedOriginCountries = getAcceptedOriginCountries,
             getStatesByCountryCode = getStatesByCountryCode,
             normalizeAddress = normalizeAddress,
@@ -883,7 +886,7 @@ class WooShippingEditOriginViewModelTest : BaseUnitTest() {
 
         advanceUntilIdle()
 
-        sut.onUpdateOriginAddress(editableAddress)
+        sut.onUpdateAddress(editableAddress)
 
         val result = sut.viewState.value
         assertThat(result.addressValidationState).isEqualTo(AddressValidationState.NotStarted)
@@ -930,7 +933,7 @@ class WooShippingEditOriginViewModelTest : BaseUnitTest() {
 
         advanceUntilIdle()
 
-        sut.onUpdateOriginAddress(editableAddress)
+        sut.onUpdateAddress(editableAddress)
 
         val result = sut.viewState.value
         assertThat(result.addressValidationState).isInstanceOf(AddressValidationState.AddressUpdateFailed::class.java)


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Part of: #12440
<!-- Id number of the GitHub issue this PR addresses. -->

<!-- 
━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
🛠 Need an AI review?  
Add a comment: `@coderabbitai review`
━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
-->

### Description
This PR refactors the edit origin address classes to add support for destination addresses. The changes introduced here include:
- Reorganize address classes (origin-specific classes under the origin package and the classes used for both flows under the address package)
- Update the navigation parameter to include the edit address flow
- Update the logic under the `WooShippingEditAddressViewModel` to use Address instead of `OriginShippingAddress`
- Fix unit tests

In the next PR, I'll be working on the destination address networking and connecting the data with the UI. I will also update the view model unit tests to include tests about the flow


### Testing information
Checking that updating the origin address keeps working as expected.

TC1

1. Open the orders tab
2. Tap on an order eligible for shipping label creation
3. Expand the shipment details section
4. Expand the origin address selection (3 dots)
5. Tap on the pencil
6. Update the postal code to make the address unverified
7. Tap on Validate & Save
8. Check that the address selection bottom sheet is expanded
9. Select an address and tap on the bottom button
10. Exit the screen
11. Check that the address is updated with the changes from step 6

TC2

1. Open the orders tab
2. Tap on an order eligible for shipping label creation
3. Expand the shipment details section
4. Expand the origin address selection (3 dots)
5. Tap on the pencil
6. Update the email to make the address status as unsaved changes
7. Tap on Save changes
8. Exit the screen
9. Check that the address is updated with the changes from step 6

### The tests that have been performed
- Checked that the UI 

### Images/gif
https://github.com/user-attachments/assets/a83f3d06-406e-4160-be43-66471f943029

- [ ] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.

## Reviewer (or Author, in the case of optional code reviews):

Please make sure these conditions are met before approving the PR, or request changes if the PR needs improvement:

- [ ] The PR is small and has a clear, single focus, or a valid explanation is provided in the description. If needed, please request to split it into smaller PRs.
- [ ] Ensure Adequate Unit Test Coverage: The changes are reasonably covered by unit tests or an explanation is provided in the PR description.
- [ ] Manual Testing: The author listed all the tests they ran, including smoke tests when needed (e.g., for refactorings). The reviewer confirmed that the PR works as expected on big (tablet) and small (phone) in case of UI changes, and no regressions are added.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->