### PR TITLE
[Woo POS] Custom detekt rules work on the code outside of woopos package

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/common/composeui/component/WooPosButtons.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/common/composeui/component/WooPosButtons.kt
@@ -1,3 +1,5 @@
+@file:Suppress("WooPosDesignSystemButtonUsageRule")
+
 package com.woocommerce.android.ui.woopos.common.composeui.component
 
 import androidx.compose.foundation.BorderStroke

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/common/composeui/component/WooPosTexts.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/common/composeui/component/WooPosTexts.kt
@@ -1,3 +1,5 @@
+@file:Suppress("WooPosDesignSystemTextUsageRule")
+
 package com.woocommerce.android.ui.woopos.common.composeui.component
 
 import androidx.compose.material3.Text

--- a/libs/detektrules/src/main/kotlin/com/woocommerce/android/detektrules/woopos/WooPosBaseDetektRule.kt
+++ b/libs/detektrules/src/main/kotlin/com/woocommerce/android/detektrules/woopos/WooPosBaseDetektRule.kt
@@ -1,0 +1,15 @@
+package com.woocommerce.android.detektrules.woopos
+
+import io.gitlab.arturbosch.detekt.api.Config
+import io.gitlab.arturbosch.detekt.api.Rule
+import org.jetbrains.kotlin.psi.KtFile
+
+abstract class WooPosBaseDetektRule(config: Config) : Rule(config) {
+    private val targetPackagePrefix = "com.woocommerce.android.ui.woopos"
+
+    override fun visitKtFile(file: KtFile) {
+        if (file.packageFqName.asString().startsWith(targetPackagePrefix)) {
+            super.visitKtFile(file)
+        }
+    }
+}

--- a/libs/detektrules/src/main/kotlin/com/woocommerce/android/detektrules/woopos/WooPosDesignSystemButtonUsageRule.kt
+++ b/libs/detektrules/src/main/kotlin/com/woocommerce/android/detektrules/woopos/WooPosDesignSystemButtonUsageRule.kt
@@ -5,16 +5,12 @@ import io.gitlab.arturbosch.detekt.api.Config
 import io.gitlab.arturbosch.detekt.api.Debt
 import io.gitlab.arturbosch.detekt.api.Entity
 import io.gitlab.arturbosch.detekt.api.Issue
-import io.gitlab.arturbosch.detekt.api.Rule
 import io.gitlab.arturbosch.detekt.api.Severity
 import org.jetbrains.kotlin.psi.KtCallExpression
 import org.jetbrains.kotlin.psi.KtDotQualifiedExpression
-import org.jetbrains.kotlin.psi.KtFile
 import org.jetbrains.kotlin.psi.KtNameReferenceExpression
 
-class WooPosDesignSystemButtonUsageRule(config: Config) : Rule(config) {
-    private val allowedPackagePrefix = "com.woocommerce.android.ui.woopos.common.composeui.component"
-
+class WooPosDesignSystemButtonUsageRule(config: Config) : WooPosBaseDetektRule(config) {
     private val disallowedButtonNames = setOf("Button")
 
     override val issue = Issue(
@@ -23,13 +19,6 @@ class WooPosDesignSystemButtonUsageRule(config: Config) : Rule(config) {
         "Standard Compose buttons should not be used. Use the WooPos button variants instead.",
         Debt.FIVE_MINS
     )
-
-    override fun visitKtFile(file: KtFile) {
-        if (file.packageFqName.asString().startsWith(allowedPackagePrefix)) {
-            return
-        }
-        super.visitKtFile(file)
-    }
 
     override fun visitCallExpression(expression: KtCallExpression) {
         super.visitCallExpression(expression)

--- a/libs/detektrules/src/main/kotlin/com/woocommerce/android/detektrules/woopos/WooPosDesignSystemColorUsageRule.kt
+++ b/libs/detektrules/src/main/kotlin/com/woocommerce/android/detektrules/woopos/WooPosDesignSystemColorUsageRule.kt
@@ -5,14 +5,11 @@ import io.gitlab.arturbosch.detekt.api.Config
 import io.gitlab.arturbosch.detekt.api.Debt
 import io.gitlab.arturbosch.detekt.api.Entity
 import io.gitlab.arturbosch.detekt.api.Issue
-import io.gitlab.arturbosch.detekt.api.Rule
 import io.gitlab.arturbosch.detekt.api.Severity
 import org.jetbrains.kotlin.com.intellij.psi.PsiElement
 import org.jetbrains.kotlin.psi.KtCallExpression
-import org.jetbrains.kotlin.psi.KtFile
 
-class WooPosDesignSystemColorUsageRule(config: Config) : Rule(config) {
-    private val targetPackagePrefix = "com.woocommerce.android.ui.woopos"
+class WooPosDesignSystemColorUsageRule(config: Config) : WooPosBaseDetektRule(config) {
     private val allowedColorSources = listOf("MaterialTheme.colorScheme", "WooPosTheme.colors")
     private val colorArguments = setOf(
         "background",
@@ -31,12 +28,6 @@ class WooPosDesignSystemColorUsageRule(config: Config) : Rule(config) {
         "Use colors from WooPosTheme.colors or MaterialTheme.colorScheme instead of hardcoded colors.",
         Debt.FIVE_MINS
     )
-
-    override fun visitKtFile(file: KtFile) {
-        if (file.packageFqName.asString().startsWith(targetPackagePrefix)) {
-            super.visitKtFile(file)
-        }
-    }
 
     override fun visitCallExpression(expression: KtCallExpression) {
         super.visitCallExpression(expression)

--- a/libs/detektrules/src/main/kotlin/com/woocommerce/android/detektrules/woopos/WooPosDesignSystemCornerRadiusUsageRule.kt
+++ b/libs/detektrules/src/main/kotlin/com/woocommerce/android/detektrules/woopos/WooPosDesignSystemCornerRadiusUsageRule.kt
@@ -5,14 +5,11 @@ import io.gitlab.arturbosch.detekt.api.Config
 import io.gitlab.arturbosch.detekt.api.Debt
 import io.gitlab.arturbosch.detekt.api.Entity
 import io.gitlab.arturbosch.detekt.api.Issue
-import io.gitlab.arturbosch.detekt.api.Rule
 import io.gitlab.arturbosch.detekt.api.Severity
 import org.jetbrains.kotlin.psi.KtCallExpression
-import org.jetbrains.kotlin.psi.KtFile
 import org.jetbrains.kotlin.psi.KtNameReferenceExpression
 
-class WooPosDesignSystemCornerRadiusUsageRule(config: Config) : Rule(config) {
-    private val targetPackagePrefix = "com.woocommerce.android.ui.woopos"
+class WooPosDesignSystemCornerRadiusUsageRule(config: Config) : WooPosBaseDetektRule(config) {
     private val cornerRadiusFile = "WooPosCornerRadius"
 
     override val issue = Issue(
@@ -21,12 +18,6 @@ class WooPosDesignSystemCornerRadiusUsageRule(config: Config) : Rule(config) {
         "Use corner radius values from $cornerRadiusFile instead of hardcoded values.",
         Debt.FIVE_MINS
     )
-
-    override fun visitKtFile(file: KtFile) {
-        if (file.packageFqName.asString().startsWith(targetPackagePrefix)) {
-            super.visitKtFile(file)
-        }
-    }
 
     override fun visitCallExpression(expression: KtCallExpression) {
         super.visitCallExpression(expression)

--- a/libs/detektrules/src/main/kotlin/com/woocommerce/android/detektrules/woopos/WooPosDesignSystemSpacingUsageRule.kt
+++ b/libs/detektrules/src/main/kotlin/com/woocommerce/android/detektrules/woopos/WooPosDesignSystemSpacingUsageRule.kt
@@ -5,14 +5,11 @@ import io.gitlab.arturbosch.detekt.api.Config
 import io.gitlab.arturbosch.detekt.api.Debt
 import io.gitlab.arturbosch.detekt.api.Entity
 import io.gitlab.arturbosch.detekt.api.Issue
-import io.gitlab.arturbosch.detekt.api.Rule
 import io.gitlab.arturbosch.detekt.api.Severity
 import org.jetbrains.kotlin.psi.KtCallExpression
-import org.jetbrains.kotlin.psi.KtFile
 import org.jetbrains.kotlin.psi.KtNameReferenceExpression
 
-class WooPosDesignSystemSpacingUsageRule(config: Config) : Rule(config) {
-    private val targetPackagePrefix = "com.woocommerce.android.ui.woopos"
+class WooPosDesignSystemSpacingUsageRule(config: Config) : WooPosBaseDetektRule(config) {
     private val dpRegex = Regex("\\d+\\.dp")
     private val dpWordRegex = Regex("\\b\\d+\\.dp\\b")
 
@@ -22,11 +19,6 @@ class WooPosDesignSystemSpacingUsageRule(config: Config) : Rule(config) {
         "Use spacing from the WooPosSpacing design system.",
         Debt.FIVE_MINS
     )
-
-    override fun visitKtFile(file: KtFile) {
-        if (!file.packageFqName.asString().startsWith(targetPackagePrefix)) return
-        super.visitKtFile(file)
-    }
 
     override fun visitCallExpression(expression: KtCallExpression) {
         super.visitCallExpression(expression)

--- a/libs/detektrules/src/main/kotlin/com/woocommerce/android/detektrules/woopos/WooPosDesignSystemTextUsageRule.kt
+++ b/libs/detektrules/src/main/kotlin/com/woocommerce/android/detektrules/woopos/WooPosDesignSystemTextUsageRule.kt
@@ -5,29 +5,18 @@ import io.gitlab.arturbosch.detekt.api.Config
 import io.gitlab.arturbosch.detekt.api.Debt
 import io.gitlab.arturbosch.detekt.api.Entity
 import io.gitlab.arturbosch.detekt.api.Issue
-import io.gitlab.arturbosch.detekt.api.Rule
 import io.gitlab.arturbosch.detekt.api.Severity
 import org.jetbrains.kotlin.psi.KtCallExpression
 import org.jetbrains.kotlin.psi.KtDotQualifiedExpression
-import org.jetbrains.kotlin.psi.KtFile
 import org.jetbrains.kotlin.psi.KtNameReferenceExpression
 
-class WooPosDesignSystemTextUsageRule(config: Config) : Rule(config) {
-    private val allowedPackagePrefix = "com.woocommerce.android.ui.woopos.common.composeui.component"
-
+class WooPosDesignSystemTextUsageRule(config: Config) : WooPosBaseDetektRule(config) {
     override val issue = Issue(
         javaClass.simpleName,
         Severity.Style,
         "Standard Compose Text should not be used. Use WooPosText instead.",
         Debt.FIVE_MINS
     )
-
-    override fun visitKtFile(file: KtFile) {
-        if (file.packageFqName.asString().startsWith(allowedPackagePrefix)) {
-            return
-        }
-        super.visitKtFile(file)
-    }
 
     override fun visitCallExpression(expression: KtCallExpression) {
         super.visitCallExpression(expression)


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #13634
<!-- Id number of the GitHub issue this PR addresses. -->

<!-- 
━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
🛠 Need an AI review?  
Add a comment: `@coderabbitai review`
━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
-->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
The PR fixes custom detekt rules to work only in the POS package

### Steps to reproduce
<!-- Step-by-step testing instructions. For new user flows, consider instead stating the goal of the workflow and see if your PR reviewer can accomplish the workflow without specific steps! -->
Use material3 text component somewhere outside of the Woo POS package and notice that detekt complains about that

### The tests that have been performed
<!-- To give the reviewer an idea of what could be missed in terms of testing -->
* Modify any compose screen to use `import androidx.compose.material3.Text`
* Run detektAll -> notice that it does not complain
* Do the same in woopos package -> notice that detekt catches it

- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.

## Reviewer (or Author, in the case of optional code reviews):

Please make sure these conditions are met before approving the PR, or request changes if the PR needs improvement:

- [ ] The PR is small and has a clear, single focus, or a valid explanation is provided in the description. If needed, please request to split it into smaller PRs.
- [ ] Ensure Adequate Unit Test Coverage: The changes are reasonably covered by unit tests or an explanation is provided in the PR description.
- [ ] Manual Testing: The author listed all the tests they ran, including smoke tests when needed (e.g., for refactorings). The reviewer confirmed that the PR works as expected on big (tablet) and small (phone) in case of UI changes, and no regressions are added.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->