### PR TITLE
[AndroidManifest] Reveal Manifest Changes in PR (`V2`)

### DIFF
--- a/.buildkite/commands/diff-merged-manifest.sh
+++ b/.buildkite/commands/diff-merged-manifest.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+
+set -euo pipefail
+
+"$(dirname "${BASH_SOURCE[0]}")/restore-cache.sh"
+
+BUILD_VARIANT=$1
+
+echo "--- :rubygems: Setting up Gems"
+install_gems
+
+echo "--- :closed_lock_with_key: Installing Secrets"
+bundle exec fastlane run configure_apply
+
+echo "--- 💾 Diff Merged Manifest (Module: WooCommerce, Build Variant: ${BUILD_VARIANT})"
+comment_with_manifest_diff "WooCommerce" ${BUILD_VARIANT}
+
+echo "--- 💾 Diff Merged Manifest (Module: WooCommerce-Wear, Build Variant: ${BUILD_VARIANT})"
+comment_with_manifest_diff "WooCommerce-Wear" ${BUILD_VARIANT}

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -53,6 +53,13 @@ steps:
         artifact_paths:
           - "**/build/reports/diff/*"
 
+      - label: "Merged Manifest Diff"
+        command: ".buildkite/commands/diff-merged-manifest.sh vanillaRelease"
+        if: build.pull_request.id != null
+        plugins: [$CI_TOOLKIT]
+        artifact_paths:
+          - "**/build/reports/diff_manifest/**/**/*"
+
   ########################################
   - group: "🛠 Prototype Builds"
     steps:

--- a/.buildkite/shared-pipeline-vars
+++ b/.buildkite/shared-pipeline-vars
@@ -3,5 +3,5 @@
 # This file is `source`'d before calling `buildkite-agent pipeline upload`, and can be used
 # to set up some variables that will be interpolated in the `.yml` pipeline before uploading it.
 
-export CI_TOOLKIT="automattic/a8c-ci-toolkit#5.1.1"
+export CI_TOOLKIT="automattic/a8c-ci-toolkit#5.1.2"
 export TEST_COLLECTOR="test-collector#v1.10.1"

--- a/.buildkite/shared-pipeline-vars
+++ b/.buildkite/shared-pipeline-vars
@@ -3,5 +3,5 @@
 # This file is `source`'d before calling `buildkite-agent pipeline upload`, and can be used
 # to set up some variables that will be interpolated in the `.yml` pipeline before uploading it.
 
-export CI_TOOLKIT="automattic/a8c-ci-toolkit#69d45ffb216b9f7f3c24747fd2889ec84218f27b"
+export CI_TOOLKIT="automattic/a8c-ci-toolkit#5.1.1"
 export TEST_COLLECTOR="test-collector#v1.10.1"

--- a/.buildkite/shared-pipeline-vars
+++ b/.buildkite/shared-pipeline-vars
@@ -3,5 +3,5 @@
 # This file is `source`'d before calling `buildkite-agent pipeline upload`, and can be used
 # to set up some variables that will be interpolated in the `.yml` pipeline before uploading it.
 
-export CI_TOOLKIT="automattic/a8c-ci-toolkit#3.10.1"
+export CI_TOOLKIT="automattic/a8c-ci-toolkit#69d45ffb216b9f7f3c24747fd2889ec84218f27b"
 export TEST_COLLECTOR="test-collector#v1.10.1"


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Project Thread: paaHJt-7Tl-p2
Depends On: [a8c-ci-toolkit#164](https://github.com/Automattic/a8c-ci-toolkit-buildkite-plugin/pull/164)
Related: #13582 (`previous workflow`)
Tested By: #13644

<!-- 
━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
🛠 Need an AI review?  
Add a comment: `@coderabbitai review`
━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
-->

---

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

This PR introduces the `Merged Manifest Diff` CI job that is aiming to help revealing merged manifest changes a PR might introduce.

The main problem this script is trying to address is the fact that:
1. Although explicit `AndroidManifest.xml` changes are visible on a PR review, just by looking at the `Files changed` tab for that specific change, this doesn't necessarily mean that the actual, auto-generated, merged `AndroidManifest.xml` file should have the same amount of changes.
2. Sometimes, implicit `AndroidManifest.xml` changes can occur (think new/updated dependency). Those changes are actually invisible for both, to the author and reviewer of that specific PR.

For more info on the technical/workflow side of things see: p1740739725150069/1740493471.859349-slack-C030U03RC8Y

---

### Review

@malinajirka I am adding you as an additional reviewer to @wzieba just so that at least one product engineer is aware of this new CI workflow and CI check. I hope this will, through you, give a decent heads-up to other product engineers as well.

FYI: At a later point of time a formal announcement will be posted.

---

### Testing information
<!-- This is your opportunity to break out individual scenarios that need testing (when necessary) and/or include a checklist for the reviewer to go through. Consider documenting the following from your own completed testing: devices used, alternate workflows, edge cases, affected areas, critical flows, areas not tested, and any remaining unknowns. Provide feedback on this new section of the PR template through Sept 30, 2024 to Apps Quality; additional context here: p91TBi-b8z-p2#comment-12036 -->

You could check the associated test PR (#13644) and see when and how such comments might appear ([here](https://github.com/woocommerce/woocommerce-android/pull/13644#issuecomment-2690635509) and [here](https://github.com/woocommerce/woocommerce-android/pull/13644#issuecomment-2690636426)):

![image](https://github.com/user-attachments/assets/f5137241-e111-47c4-8d23-45f0d6d888dd)

FYI: The above test comment appeared due to an implicit `AndroidManifest.xml` change, adding the [singular](https://support.singular.net/hc/en-us/articles/360037581952-Android-SDK-Integration-Guide) dependency to the project. It would have been impossible for an engineer to know how the merged `AndroidManifest.xml` file got updated without doing such a check manually.

---

### Merge Instructions

- [x] Wait for [a8c-ci-toolkit#164](https://github.com/Automattic/a8c-ci-toolkit-buildkite-plugin/pull/164) to be reviewed, approved and merged.
- [x] Create a new [a8c-ci-toolkit release](https://github.com/Automattic/a8c-ci-toolkit-buildkite-plugin/releases) ([3.10.1](https://github.com/Automattic/a8c-ci-toolkit-buildkite-plugin/releases/tag/3.10.1) [current] -> [5.1.0](https://github.com/Automattic/a8c-ci-toolkit-buildkite-plugin/releases/tag/5.1.0) [merge manifest diff] -> [5.1.2](https://github.com/Automattic/a8c-ci-toolkit-buildkite-plugin/releases/tag/5.1.2) [latest]).
- [x] Update [CI_TOOLKIT](https://github.com/woocommerce/woocommerce-android/blob/trunk/.buildkite/shared-pipeline-vars#L6) to point to this newly created [a8c-ci-toolkit release](https://github.com/Automattic/a8c-ci-toolkit-buildkite-plugin/releases) (5cd93fe9d7a8f655239896c322d2eee6d02b6437).
- [x] Remove `status: do not merge` label.
- [x] Merge this PR.
- [x] Close #13644 and #13662 test-only PRs.

---

- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.

## Reviewer (or Author, in the case of optional code reviews):

Please make sure these conditions are met before approving the PR, or request changes if the PR needs improvement:

- [x] The PR is small and has a clear, single focus, or a valid explanation is provided in the description. If needed, please request to split it into smaller PRs.
- [x] Ensure Adequate Unit Test Coverage: The changes are reasonably covered by unit tests or an explanation is provided in the PR description.
- [x] Manual Testing: The author listed all the tests they ran, including smoke tests when needed (e.g., for refactorings). The reviewer confirmed that the PR works as expected on big (tablet) and small (phone) in case of UI changes, and no regressions are added.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->