### PR TITLE
[Shipping Labels Revamp] Add Customs Shippable product details validation

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/customs/WooShippingCustomsFormFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/customs/WooShippingCustomsFormFragment.kt
@@ -12,12 +12,15 @@ import androidx.navigation.fragment.findNavController
 import com.woocommerce.android.R
 import com.woocommerce.android.extensions.handleDialogResult
 import com.woocommerce.android.extensions.navigateSafely
+import com.woocommerce.android.model.Location
 import com.woocommerce.android.ui.base.BaseFragment
 import com.woocommerce.android.ui.compose.theme.WooThemeWithBackground
 import com.woocommerce.android.ui.orders.wooshippinglabels.customs.WooShippingCustomsFormViewModel.ContentType
 import com.woocommerce.android.ui.orders.wooshippinglabels.customs.WooShippingCustomsFormViewModel.RestrictionType
 import com.woocommerce.android.ui.orders.wooshippinglabels.customs.WooShippingCustomsFormViewModel.ShowContentTypeDialog
+import com.woocommerce.android.ui.orders.wooshippinglabels.customs.WooShippingCustomsFormViewModel.ShowCountrySelector
 import com.woocommerce.android.ui.orders.wooshippinglabels.customs.WooShippingCustomsFormViewModel.ShowRestrictionTypeDialog
+import com.woocommerce.android.ui.searchfilter.SearchFilterItem
 import dagger.hilt.android.AndroidEntryPoint
 
 @AndroidEntryPoint
@@ -67,6 +70,8 @@ class WooShippingCustomsFormFragment : BaseFragment() {
                             .toTypedArray()
                     )
                 }
+
+                is ShowCountrySelector -> showCountrySearchScreen(event.countries)
             }
         }
     }
@@ -106,8 +111,26 @@ class WooShippingCustomsFormFragment : BaseFragment() {
             ).let { findNavController().navigateSafely(it) }
     }
 
+
+
+    private fun showCountrySearchScreen(countries: List<Location>) {
+        val action = WooShippingCustomsFormFragmentDirections.actionSearchFilterFragment(
+            items = countries.map {
+                SearchFilterItem(
+                    name = it.name,
+                    value = it.code
+                )
+            }.toTypedArray(),
+            hint = getString(R.string.shipping_label_edit_address_country_search_hint),
+            requestKey = SELECT_COUNTRY_REQUEST,
+            title = getString(R.string.shipping_label_edit_address_country)
+        )
+        findNavController().navigateSafely(action)
+    }
+
     companion object {
         const val SELECTOR_CONTENT_REQUEST_KEY = "label_customs_content_selector"
         const val SELECTOR_RESTRICTION_REQUEST_KEY = "label_customs_restriction_selector"
+        const val SELECT_COUNTRY_REQUEST = "select_address_country_request"
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/customs/WooShippingCustomsFormFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/customs/WooShippingCustomsFormFragment.kt
@@ -11,6 +11,7 @@ import androidx.fragment.app.viewModels
 import androidx.navigation.fragment.findNavController
 import com.woocommerce.android.R
 import com.woocommerce.android.extensions.handleDialogResult
+import com.woocommerce.android.extensions.handleResult
 import com.woocommerce.android.extensions.navigateSafely
 import com.woocommerce.android.model.Location
 import com.woocommerce.android.ui.base.BaseFragment
@@ -93,6 +94,10 @@ class WooShippingCustomsFormFragment : BaseFragment() {
             RestrictionType.entries
                 .firstOrNull { it.toString() == result }
                 ?.let { viewModel.onRestrictionTypeSelected(it) }
+        }
+
+        handleResult<String>(SELECT_COUNTRY_REQUEST) { countryCode ->
+            viewModel.onShippableProductOriginCountryChanged(countryCode)
         }
     }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/customs/WooShippingCustomsFormFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/customs/WooShippingCustomsFormFragment.kt
@@ -111,8 +111,6 @@ class WooShippingCustomsFormFragment : BaseFragment() {
             ).let { findNavController().navigateSafely(it) }
     }
 
-
-
     private fun showCountrySearchScreen(countries: List<Location>) {
         val action = WooShippingCustomsFormFragmentDirections.actionSearchFilterFragment(
             items = countries.map {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/customs/WooShippingCustomsFormScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/customs/WooShippingCustomsFormScreen.kt
@@ -59,6 +59,7 @@ fun WooShippingCustomsFormScreen(viewModel: WooShippingCustomsFormViewModel) {
         onTariffChanged = viewModel::onShippableProductTariffNumberChanged,
         onValuePerUnitChanged = viewModel::onShippableProductValuePerUnitChanged,
         onWeightPerUnitChanged = viewModel::onShippableProductWeightPerUnitChanged,
+        onCountrySelectorClick = viewModel::onCountrySelectorClick,
         onAddCustomsDataClick = viewModel::onAddCustomsDataClick
     )
 }
@@ -87,6 +88,7 @@ fun WooShippingCustomsFormScreen(
     onTariffChanged: (position: Int, tariff: String) -> Unit,
     onValuePerUnitChanged: (position: Int, valuePerUnit: String) -> Unit,
     onWeightPerUnitChanged: (position: Int, weightPerUnit: String) -> Unit,
+    onCountrySelectorClick: (position: Int) -> Unit,
     onAddCustomsDataClick: () -> Unit
 
 ) {
@@ -190,7 +192,8 @@ fun WooShippingCustomsFormScreen(
                     onDescriptionChanged = { onDescriptionChanged(index, it) },
                     onTariffChanged = { onTariffChanged(index, it) },
                     onValuePerUnitChanged = { onValuePerUnitChanged(index, it) },
-                    onWeightPerUnitChanged = { onWeightPerUnitChanged(index, it) }
+                    onWeightPerUnitChanged = { onWeightPerUnitChanged(index, it) },
+                    onCountrySelectorClick = { onCountrySelectorClick(index) }
                 )
             }
         }
@@ -250,6 +253,7 @@ fun PreviewWooShippingCustomsFormScreen() {
             onTariffChanged = { _, _ -> },
             onValuePerUnitChanged = { _, _ -> },
             onWeightPerUnitChanged = { _, _ -> },
+            onCountrySelectorClick = { }
         )
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/customs/WooShippingCustomsFormScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/customs/WooShippingCustomsFormScreen.kt
@@ -10,7 +10,6 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.foundation.verticalScroll
-import androidx.compose.material3.Button
 import androidx.compose.material3.Checkbox
 import androidx.compose.material3.CheckboxDefaults
 import androidx.compose.material3.MaterialTheme

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/customs/WooShippingCustomsFormScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/customs/WooShippingCustomsFormScreen.kt
@@ -25,6 +25,7 @@ import androidx.compose.ui.text.input.ImeAction
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import com.woocommerce.android.R
+import com.woocommerce.android.ui.compose.component.WCColoredButton
 import com.woocommerce.android.ui.compose.component.WCOutlinedSpinner
 import com.woocommerce.android.ui.compose.component.WCOutlinedTextField
 import com.woocommerce.android.ui.compose.theme.WooThemeWithBackground
@@ -197,13 +198,12 @@ fun WooShippingCustomsFormScreen(
                 )
             }
         }
-        Button(
+        WCColoredButton(
             modifier = modifier.fillMaxWidth(),
             enabled = isAddCustomsButtonEnabled,
-            onClick = onAddCustomsDataClick
-        ) {
-            Text(stringResource(id = R.string.woo_shipping_labels_customs_add_missing_information))
-        }
+            onClick = onAddCustomsDataClick,
+            text = stringResource(id = R.string.woo_shipping_labels_customs_add_missing_information)
+        )
     }
 }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/customs/WooShippingCustomsFormScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/customs/WooShippingCustomsFormScreen.kt
@@ -229,6 +229,7 @@ fun PreviewWooShippingCustomsFormScreen() {
                     valuePerUnit = InputValue.Data("10.00"),
                     weightPerUnit = InputValue.Data("1.00"),
                     originCountry = "US",
+                    quantity = 1F,
                     isExpanded = false
                 ),
                 WooShippingCustomsProductUIModel(
@@ -238,6 +239,7 @@ fun PreviewWooShippingCustomsFormScreen() {
                     valuePerUnit = InputValue.Data("10.00"),
                     weightPerUnit = InputValue.Data("1.00"),
                     originCountry = "US",
+                    quantity = 1F,
                     isExpanded = true
                 )
             ),

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/customs/WooShippingCustomsFormScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/customs/WooShippingCustomsFormScreen.kt
@@ -54,7 +54,11 @@ fun WooShippingCustomsFormScreen(viewModel: WooShippingCustomsFormViewModel) {
         onOtherContentDetailsInputChanged = viewModel::onOtherContentInputChanged,
         onOtherRestrictionDetailsInputChanged = viewModel::onRestrictionDetailsInputChanged,
         onReturnToSenderChanged = viewModel::onReturnToSenderChanged,
-        onProductExpanded = viewModel::onProductExpanded,
+        onProductExpanded = viewModel::onShippableProductExpanded,
+        onDescriptionChanged = viewModel::onShippableProductDescriptionChanged,
+        onTariffChanged = viewModel::onShippableProductTariffNumberChanged,
+        onValuePerUnitChanged = viewModel::onShippableProductValuePerUnitChanged,
+        onWeightPerUnitChanged = viewModel::onShippableProductWeightPerUnitChanged,
         onAddCustomsDataClick = viewModel::onAddCustomsDataClick
     )
 }
@@ -78,7 +82,11 @@ fun WooShippingCustomsFormScreen(
     onReturnToSenderChanged: (Boolean) -> Unit,
     onOtherContentDetailsInputChanged: (String) -> Unit,
     onOtherRestrictionDetailsInputChanged: (String) -> Unit,
-    onProductExpanded: (WooShippingCustomsProductUIModel, Boolean) -> Unit,
+    onProductExpanded: (position: Int, isExpanded: Boolean) -> Unit,
+    onDescriptionChanged: (position: Int, description: String) -> Unit,
+    onTariffChanged: (position: Int, tariff: String) -> Unit,
+    onValuePerUnitChanged: (position: Int, valuePerUnit: String) -> Unit,
+    onWeightPerUnitChanged: (position: Int, weightPerUnit: String) -> Unit,
     onAddCustomsDataClick: () -> Unit
 
 ) {
@@ -174,11 +182,15 @@ fun WooShippingCustomsFormScreen(
                 style = MaterialTheme.typography.titleMedium,
             )
 
-            shippingProducts.forEach { product ->
+            shippingProducts.forEachIndexed { index, product ->
                 WooShippingCustomsProductListItem(
                     modifier = modifier.fillMaxWidth(),
                     itemData = product,
-                    onExpand = { onProductExpanded(product, it) }
+                    onExpand = { onProductExpanded(index, it) },
+                    onDescriptionChanged = { onDescriptionChanged(index, it) },
+                    onTariffChanged = { onTariffChanged(index, it) },
+                    onValuePerUnitChanged = { onValuePerUnitChanged(index, it) },
+                    onWeightPerUnitChanged = { onWeightPerUnitChanged(index, it) }
                 )
             }
         }
@@ -233,7 +245,11 @@ fun PreviewWooShippingCustomsFormScreen() {
             onOtherContentDetailsInputChanged = {},
             onOtherRestrictionDetailsInputChanged = {},
             onProductExpanded = { _, _ -> },
-            onAddCustomsDataClick = {}
+            onAddCustomsDataClick = {},
+            onDescriptionChanged = { _, _ -> },
+            onTariffChanged = { _, _ -> },
+            onValuePerUnitChanged = { _, _ -> },
+            onWeightPerUnitChanged = { _, _ -> },
         )
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/customs/WooShippingCustomsFormViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/customs/WooShippingCustomsFormViewModel.kt
@@ -15,7 +15,6 @@ import com.woocommerce.android.viewmodel.ScopedViewModel
 import com.woocommerce.android.viewmodel.getStateFlow
 import com.woocommerce.android.viewmodel.navArgs
 import dagger.hilt.android.lifecycle.HiltViewModel
-import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 import kotlinx.parcelize.Parcelize
@@ -36,7 +35,7 @@ class WooShippingCustomsFormViewModel @Inject constructor(
     )
     val viewState = _viewState.asLiveData()
 
-    private val countriesState = MutableStateFlow<LocationState>(LocationState.Loading)
+    private var possibleLocations: List<Location>? = null
     private var itemIndexUnderCountrySelection: Int? = null
 
     private val isITNRequired: Boolean
@@ -188,24 +187,16 @@ class WooShippingCustomsFormViewModel @Inject constructor(
     fun onCountrySelectorClick(itemIndex: Int) {
         itemIndexUnderCountrySelection = itemIndex
 
-        countriesState.value
-            .run { this as? LocationState.Loaded }
-            ?.let { triggerEvent(ShowCountrySelector(it.locations)) }
+        possibleLocations?.let { triggerEvent(ShowCountrySelector(it)) }
     }
 
     fun onShippableProductOriginCountryChanged(newValue: String) {
         val itemIndex = itemIndexUnderCountrySelection ?: return
         itemIndexUnderCountrySelection = null
 
-        val possibleSelections = countriesState.value
-        val defaultLocation = AmbiguousLocation.Raw(newValue).asLocation()
-        val selectedLocation = when (possibleSelections) {
-            is LocationState.Loaded ->
-                possibleSelections
-                    .locations.firstOrNull { it.code == newValue } ?: defaultLocation
-
-            else -> defaultLocation
-        }
+        val selectedLocation = possibleLocations
+            ?.firstOrNull { it.code == newValue }
+            ?: AmbiguousLocation.Raw(newValue).asLocation()
 
         _viewState.update { state ->
             val updatedItem = state.shippingProducts[itemIndex]
@@ -237,8 +228,8 @@ class WooShippingCustomsFormViewModel @Inject constructor(
 
     private suspend fun loadCountries() {
         getAcceptedOriginCountries().fold(
-            onSuccess = { countriesState.value = LocationState.Loaded(it) },
-            onFailure = { countriesState.value = LocationState.Error }
+            onSuccess = { possibleLocations = it },
+            onFailure = { possibleLocations = null }
         )
     }
 
@@ -294,12 +285,6 @@ class WooShippingCustomsFormViewModel @Inject constructor(
 
         val errorMessageOrNull: Int?
             get() = run { this as? Error }?.errorMessageId
-    }
-
-    sealed class LocationState {
-        data object Loading : LocationState()
-        data object Error : LocationState()
-        data class Loaded(val locations: List<Location>) : LocationState()
     }
 
     enum class ContentType(val resourceId: Int) {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/customs/WooShippingCustomsFormViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/customs/WooShippingCustomsFormViewModel.kt
@@ -57,10 +57,10 @@ class WooShippingCustomsFormViewModel @Inject constructor(
 
     private fun observeShippableItemsChanges() {
         _viewState
-            .map { it.shippingProducts }
+            .map { Pair(it.shippingProducts, it.itnValue) }
             .distinctUntilChanged()
-            .onEach {
-                onITNChanged(_viewState.value.itnValue.currentInput, it.isITNRequired)
+            .onEach { (products, itnValue) ->
+                onITNChanged(itnValue.currentInput, products.isITNRequired)
             }.launchIn(viewModelScope)
     }
 
@@ -128,8 +128,6 @@ class WooShippingCustomsFormViewModel @Inject constructor(
                     input = newItnValue,
                     errorMessageId = R.string.woo_shipping_labels_customs_itn_required_message
                 )
-
-            newItnValue.isBlank() -> InputValue.Empty
 
             itnRegex.matches(newItnValue).not() ->
                 InputValue.Error(

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/customs/WooShippingCustomsFormViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/customs/WooShippingCustomsFormViewModel.kt
@@ -15,15 +15,15 @@ import com.woocommerce.android.viewmodel.ScopedViewModel
 import com.woocommerce.android.viewmodel.getStateFlow
 import com.woocommerce.android.viewmodel.navArgs
 import dagger.hilt.android.lifecycle.HiltViewModel
-import java.math.BigDecimal
-import kotlinx.coroutines.flow.update
-import kotlinx.coroutines.launch
-import kotlinx.parcelize.Parcelize
-import javax.inject.Inject
 import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.onEach
+import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.launch
+import kotlinx.parcelize.Parcelize
+import java.math.BigDecimal
+import javax.inject.Inject
 
 @HiltViewModel
 class WooShippingCustomsFormViewModel @Inject constructor(

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/customs/WooShippingCustomsFormViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/customs/WooShippingCustomsFormViewModel.kt
@@ -200,8 +200,9 @@ class WooShippingCustomsFormViewModel @Inject constructor(
         val possibleSelections = countriesState.value
         val defaultLocation = AmbiguousLocation.Raw(newValue).asLocation()
         val selectedLocation = when (possibleSelections) {
-            is LocationState.Loaded -> possibleSelections
-                .locations.firstOrNull { it.code == newValue } ?: defaultLocation
+            is LocationState.Loaded ->
+                possibleSelections
+                    .locations.firstOrNull { it.code == newValue } ?: defaultLocation
 
             else -> defaultLocation
         }
@@ -297,7 +298,6 @@ class WooShippingCustomsFormViewModel @Inject constructor(
 
     sealed class LocationState {
         data object Loading : LocationState()
-        data object DisplayLoading : LocationState()
         data object Error : LocationState()
         data class Loaded(val locations: List<Location>) : LocationState()
     }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/customs/WooShippingCustomsFormViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/customs/WooShippingCustomsFormViewModel.kt
@@ -129,7 +129,7 @@ class WooShippingCustomsFormViewModel @Inject constructor(
                     errorMessageId = R.string.woo_shipping_labels_customs_itn_required_message
                 )
 
-            itnRegex.matches(newItnValue).not() ->
+            newItnValue.isNotBlank() && itnRegex.matches(newItnValue).not() ->
                 InputValue.Error(
                     input = newItnValue,
                     errorMessageId = R.string.woo_shipping_labels_customs_itn_error_message

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/customs/WooShippingCustomsFormViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/customs/WooShippingCustomsFormViewModel.kt
@@ -38,7 +38,7 @@ class WooShippingCustomsFormViewModel @Inject constructor(
     val viewState = _viewState.asLiveData()
 
     private val countriesState = MutableStateFlow<LocationState>(LocationState.Loading)
-    private val itemIndexUnderCountrySelection = MutableStateFlow<Int?>(null)
+    private var itemIndexUnderCountrySelection: Int? = null
 
     init {
         launch { loadCountries() }
@@ -170,13 +170,14 @@ class WooShippingCustomsFormViewModel @Inject constructor(
     }
 
     fun onCountrySelectorClick(itemIndex: Int) {
-        itemIndexUnderCountrySelection.update { itemIndex }
+        itemIndexUnderCountrySelection = itemIndex
         val currentCountry = _viewState.value.shippingProducts[itemIndex].originCountry
         triggerEvent(ShowCountrySelector(emptyList()))
     }
 
     fun onShippableProductOriginCountryChanged(newValue: String) {
-        val itemIndex = itemIndexUnderCountrySelection.value ?: return
+        val itemIndex = itemIndexUnderCountrySelection ?: return
+        itemIndexUnderCountrySelection = null
 
         _viewState.update { state ->
             val updatedItem = state.shippingProducts[itemIndex]

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/customs/WooShippingCustomsFormViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/customs/WooShippingCustomsFormViewModel.kt
@@ -102,14 +102,13 @@ class WooShippingCustomsFormViewModel @Inject constructor(
         _viewState.update { it.copy(itnValue = input) }
     }
 
-    fun onProductExpanded(itemData: WooShippingCustomsProductUIModel, isExpanded: Boolean) {
+    fun onProductExpanded(itemIndex: Int, isExpanded: Boolean) {
         _viewState.update { state ->
-            state.shippingProducts.map { product ->
-                if (product == itemData) {
-                    product.copy(isExpanded = isExpanded)
-                } else {
-                    product
-                }
+            val updatedItem = state.shippingProducts[itemIndex]
+                .copy(isExpanded = isExpanded)
+
+            state.shippingProducts.toMutableList().apply {
+                set(itemIndex, updatedItem)
             }.let { state.copy(shippingProducts = it) }
         }
     }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/customs/WooShippingCustomsFormViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/customs/WooShippingCustomsFormViewModel.kt
@@ -292,7 +292,8 @@ class WooShippingCustomsFormViewModel @Inject constructor(
         val isAddCustomsButtonEnabled: Boolean
             get() = itnValue is InputValue.Data &&
                 (contentType != ContentType.OTHER || otherContentInput is InputValue.Data) &&
-                (restrictionType != RestrictionType.OTHER || otherRestrictionInput is InputValue.Data)
+                (restrictionType != RestrictionType.OTHER || otherRestrictionInput is InputValue.Data) &&
+                shippingProducts.all { it.isValid }
     }
 
     @Parcelize

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/customs/WooShippingCustomsFormViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/customs/WooShippingCustomsFormViewModel.kt
@@ -19,6 +19,11 @@ import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 import kotlinx.parcelize.Parcelize
 import javax.inject.Inject
+import kotlinx.coroutines.flow.distinctUntilChanged
+import kotlinx.coroutines.flow.filter
+import kotlinx.coroutines.flow.launchIn
+import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.onEach
 
 @HiltViewModel
 class WooShippingCustomsFormViewModel @Inject constructor(
@@ -38,9 +43,8 @@ class WooShippingCustomsFormViewModel @Inject constructor(
     private var possibleLocations: List<Location>? = null
     private var itemIndexUnderCountrySelection: Int? = null
 
-    private val isITNRequired: Boolean
-        get() = _viewState.value.shippingProducts
-            .mapNotNull { it.shippingTotalValue }
+    private val List<WooShippingCustomsProductUIModel>.isITNRequired: Boolean
+        get() = mapNotNull { it.shippingTotalValue }
             .reduce { acc, current -> acc + current }
             .let { it >= MAX_SHIPPING_ITEM_VALUE_FOR_CUSTOMS }
 
@@ -48,6 +52,16 @@ class WooShippingCustomsFormViewModel @Inject constructor(
         launch { loadCountries() }
         val shippableProducts = navArgs.shippableItems.map { item -> item.toProductUIModel() }
         _viewState.update { it.copy(shippingProducts = shippableProducts) }
+        observeShippableItemsChanges()
+    }
+
+    private fun observeShippableItemsChanges() {
+        _viewState
+            .map { it.shippingProducts }
+            .distinctUntilChanged()
+            .onEach {
+                onITNChanged(_viewState.value.itnValue.currentInput, it.isITNRequired)
+            }.launchIn(viewModelScope)
     }
 
     fun onContentTypeClick() {
@@ -104,9 +118,12 @@ class WooShippingCustomsFormViewModel @Inject constructor(
         }
     }
 
-    fun onITNChanged(newItnValue: String) {
+    fun onITNChanged(
+        newItnValue: String,
+        shouldRequireITN: Boolean = false
+    ) {
         val input = when {
-            newItnValue.isBlank() && isITNRequired ->
+            newItnValue.isBlank() && shouldRequireITN ->
                 InputValue.Error(
                     input = newItnValue,
                     errorMessageId = R.string.woo_shipping_labels_customs_itn_required_message

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/customs/WooShippingCustomsFormViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/customs/WooShippingCustomsFormViewModel.kt
@@ -126,25 +126,49 @@ class WooShippingCustomsFormViewModel @Inject constructor(
 
     fun onShippableProductDescriptionChanged(itemIndex: Int, newValue: String) {
         updateShippingProductsAt(itemIndex) { item ->
-            item.copy(description = InputValue.Data(newValue))
+            when (newValue.isBlank()) {
+                false -> InputValue.Data(newValue)
+                true -> InputValue.Error(
+                    input = newValue,
+                    errorMessageId = R.string.woo_shipping_labels_customs_other_error_message
+                )
+            }.let { item.copy(description = it) }
         }
     }
 
     fun onShippableProductTariffNumberChanged(itemIndex: Int, newValue: String) {
         updateShippingProductsAt(itemIndex) { item ->
-            item.copy(tariffNumber = InputValue.Data(newValue))
+            when (newValue.isBlank()) {
+                false -> InputValue.Data(newValue)
+                true -> InputValue.Error(
+                    input = newValue,
+                    errorMessageId = R.string.woo_shipping_labels_customs_other_error_message
+                )
+            }.let { item.copy(tariffNumber = it) }
         }
     }
 
     fun onShippableProductValuePerUnitChanged(itemIndex: Int, newValue: String) {
         updateShippingProductsAt(itemIndex) { item ->
-            item.copy(valuePerUnit = InputValue.Data(newValue))
+            when (newValue.isBlank()) {
+                false -> InputValue.Data(newValue)
+                true -> InputValue.Error(
+                    input = newValue,
+                    errorMessageId = R.string.woo_shipping_labels_customs_other_error_message
+                )
+            }.let { item.copy(valuePerUnit = it) }
         }
     }
 
     fun onShippableProductWeightPerUnitChanged(itemIndex: Int, newValue: String) {
         updateShippingProductsAt(itemIndex) { item ->
-            item.copy(weightPerUnit = InputValue.Data(newValue))
+            when (newValue.isBlank()) {
+                false -> InputValue.Data(newValue)
+                true -> InputValue.Error(
+                    input = newValue,
+                    errorMessageId = R.string.woo_shipping_labels_customs_other_error_message
+                )
+            }.let { item.copy(weightPerUnit = it) }
         }
     }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/customs/WooShippingCustomsFormViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/customs/WooShippingCustomsFormViewModel.kt
@@ -5,6 +5,8 @@ import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.asLiveData
 import androidx.lifecycle.viewModelScope
 import com.woocommerce.android.R
+import com.woocommerce.android.model.Location
+import com.woocommerce.android.ui.orders.wooshippinglabels.address.origin.GetAcceptedOriginCountries
 import com.woocommerce.android.ui.orders.wooshippinglabels.customs.products.WooShippingCustomsProductUIModel
 import com.woocommerce.android.ui.orders.wooshippinglabels.models.ShippableItemModel
 import com.woocommerce.android.viewmodel.MultiLiveEvent
@@ -15,9 +17,12 @@ import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.update
 import kotlinx.parcelize.Parcelize
 import javax.inject.Inject
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.launch
 
 @HiltViewModel
 class WooShippingCustomsFormViewModel @Inject constructor(
+    private val getAcceptedOriginCountries: GetAcceptedOriginCountries,
     savedState: SavedStateHandle
 ) : ScopedViewModel(savedState) {
     private val itnRegex by lazy { ITN_REGEX_STRING.toRegex() }
@@ -30,9 +35,13 @@ class WooShippingCustomsFormViewModel @Inject constructor(
     )
     val viewState = _viewState.asLiveData()
 
+    private val countriesState = MutableStateFlow<LocationState>(LocationState.Loading)
+
     init {
+        launch { loadCountries() }
         val shippableProducts = navArgs.shippableItems.map { item -> item.toProductUIModel() }
         _viewState.update { it.copy(shippingProducts = shippableProducts) }
+
     }
 
     fun onContentTypeClick() {
@@ -174,6 +183,13 @@ class WooShippingCustomsFormViewModel @Inject constructor(
         triggerEvent(FinishCustomsForm)
     }
 
+    private suspend fun loadCountries() {
+        getAcceptedOriginCountries().fold(
+            onSuccess = { countriesState.value = LocationState.Loaded(it) },
+            onFailure = { countriesState.value = LocationState.Error }
+        )
+    }
+
     private fun ShippableItemModel.toProductUIModel() = WooShippingCustomsProductUIModel(
         name = title,
         description = InputValue.Empty,
@@ -225,6 +241,13 @@ class WooShippingCustomsFormViewModel @Inject constructor(
 
         val errorMessageOrNull: Int?
             get() = run { this as? Error }?.errorMessageId
+    }
+
+    sealed class LocationState {
+        data object Loading : LocationState()
+        data object DisplayLoading : LocationState()
+        data object Error : LocationState()
+        data class Loaded(val locations: List<Location>) : LocationState()
     }
 
     enum class ContentType(val resourceId: Int) {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/customs/WooShippingCustomsFormViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/customs/WooShippingCustomsFormViewModel.kt
@@ -169,11 +169,16 @@ class WooShippingCustomsFormViewModel @Inject constructor(
     }
 
     fun onCountrySelectorClick(itemIndex: Int) {
+        _viewState.update { it.copy(itemIndexUnderCountrySelection = itemIndex) }
         val currentCountry = _viewState.value.shippingProducts[itemIndex].originCountry
         triggerEvent(ShowCountrySelector(emptyList()))
     }
 
-    fun onShippableProductOriginCountryChanged(itemIndex: Int, newValue: String) {
+    fun onShippableProductOriginCountryChanged(newValue: String) {
+        val itemIndex = _viewState.value
+            .itemIndexUnderCountrySelection
+            ?: return
+
         _viewState.update { state ->
             val updatedItem = state.shippingProducts[itemIndex]
                 .copy(originCountry = newValue)
@@ -213,7 +218,8 @@ class WooShippingCustomsFormViewModel @Inject constructor(
         val otherRestrictionInput: InputValue = InputValue.Empty,
         val itnValue: InputValue = InputValue.Empty,
         val returnToSenderChecked: Boolean = false,
-        val shippingProducts: List<WooShippingCustomsProductUIModel> = emptyList()
+        val shippingProducts: List<WooShippingCustomsProductUIModel> = emptyList(),
+        val itemIndexUnderCountrySelection: Int? = null
     ) : Parcelable {
         val shouldDisplayContentTypeInput: Boolean
             get() = contentType == ContentType.OTHER

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/customs/WooShippingCustomsFormViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/customs/WooShippingCustomsFormViewModel.kt
@@ -15,6 +15,7 @@ import com.woocommerce.android.viewmodel.ScopedViewModel
 import com.woocommerce.android.viewmodel.getStateFlow
 import com.woocommerce.android.viewmodel.navArgs
 import dagger.hilt.android.lifecycle.HiltViewModel
+import java.math.BigDecimal
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 import kotlinx.parcelize.Parcelize
@@ -247,11 +248,23 @@ class WooShippingCustomsFormViewModel @Inject constructor(
         name = title,
         description = "".asInputValueError,
         tariffNumber = "".asInputValueError,
-        valuePerUnit = InputValue.Data(price.toString()),
-        weightPerUnit = InputValue.Data(weight.toString()),
         quantity = quantity,
         originCountry = "",
-        isExpanded = false
+        isExpanded = false,
+        valuePerUnit = when {
+            price == BigDecimal.ZERO -> InputValue.Error(
+                input = "",
+                errorMessageId = R.string.woo_shipping_labels_customs_product_details_value_required
+            )
+            else -> InputValue.Data(price.toString())
+        },
+        weightPerUnit = when {
+            weight == 0f -> InputValue.Error(
+                input = "",
+                errorMessageId = R.string.woo_shipping_labels_customs_product_details_value_required
+            )
+            else -> InputValue.Data(weight.toString())
+        }
     )
 
     private val String.asInputValueError

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/customs/WooShippingCustomsFormViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/customs/WooShippingCustomsFormViewModel.kt
@@ -40,9 +40,9 @@ class WooShippingCustomsFormViewModel @Inject constructor(
 
     private val isITNRequired: Boolean
         get() = _viewState.value.shippingProducts
-            .asSequence()
             .mapNotNull { it.shippingTotalValue }
-            .any { it >= MAX_SHIPPING_ITEM_VALUE_FOR_CUSTOMS }
+            .reduce { acc, current -> acc + current }
+            .let { it >= MAX_SHIPPING_ITEM_VALUE_FOR_CUSTOMS }
 
     init {
         launch { loadCountries() }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/customs/WooShippingCustomsFormViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/customs/WooShippingCustomsFormViewModel.kt
@@ -97,12 +97,13 @@ class WooShippingCustomsFormViewModel @Inject constructor(
                     input = newItnValue,
                     errorMessageId = R.string.woo_shipping_labels_customs_itn_error_message
                 )
+
             else -> InputValue.Data(newItnValue)
         }
         _viewState.update { it.copy(itnValue = input) }
     }
 
-    fun onProductExpanded(itemIndex: Int, isExpanded: Boolean) {
+    fun onShippableProductExpanded(itemIndex: Int, isExpanded: Boolean) {
         _viewState.update { state ->
             val updatedItem = state.shippingProducts[itemIndex]
                 .copy(isExpanded = isExpanded)
@@ -112,6 +113,62 @@ class WooShippingCustomsFormViewModel @Inject constructor(
             }.let { state.copy(shippingProducts = it) }
         }
     }
+
+    fun onShippableProductDescriptionChanged(itemIndex: Int, newValue: String) {
+        _viewState.update { state ->
+            val updatedItem = state.shippingProducts[itemIndex]
+                .copy(description = InputValue.Data(newValue))
+
+            state.shippingProducts.toMutableList().apply {
+                set(itemIndex, updatedItem)
+            }.let { state.copy(shippingProducts = it) }
+        }
+    }
+
+    fun onShippableProductTariffNumberChanged(itemIndex: Int, newValue: String) {
+        _viewState.update { state ->
+            val updatedItem = state.shippingProducts[itemIndex]
+                .copy(tariffNumber = InputValue.Data(newValue))
+
+            state.shippingProducts.toMutableList().apply {
+                set(itemIndex, updatedItem)
+            }.let { state.copy(shippingProducts = it) }
+        }
+    }
+
+    fun onShippableProductValuePerUnitChanged(itemIndex: Int, newValue: String) {
+        _viewState.update { state ->
+            val updatedItem = state.shippingProducts[itemIndex]
+                .copy(valuePerUnit = InputValue.Data(newValue))
+
+            state.shippingProducts.toMutableList().apply {
+                set(itemIndex, updatedItem)
+            }.let { state.copy(shippingProducts = it) }
+        }
+    }
+
+    fun onShippableProductWeightPerUnitChanged(itemIndex: Int, newValue: String) {
+        _viewState.update { state ->
+            val updatedItem = state.shippingProducts[itemIndex]
+                .copy(weightPerUnit = InputValue.Data(newValue))
+
+            state.shippingProducts.toMutableList().apply {
+                set(itemIndex, updatedItem)
+            }.let { state.copy(shippingProducts = it) }
+        }
+    }
+
+    fun onShippableProductOriginCountryChanged(itemIndex: Int, newValue: String) {
+        _viewState.update { state ->
+            val updatedItem = state.shippingProducts[itemIndex]
+                .copy(originCountry = newValue)
+
+            state.shippingProducts.toMutableList().apply {
+                set(itemIndex, updatedItem)
+            }.let { state.copy(shippingProducts = it) }
+        }
+    }
+
 
     fun onAddCustomsDataClick() {
         triggerEvent(FinishCustomsForm)
@@ -156,6 +213,7 @@ class WooShippingCustomsFormViewModel @Inject constructor(
             val input: String,
             val errorMessageId: Int
         ) : InputValue()
+
         data object Empty : InputValue()
 
         val currentInput

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/customs/WooShippingCustomsFormViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/customs/WooShippingCustomsFormViewModel.kt
@@ -125,46 +125,26 @@ class WooShippingCustomsFormViewModel @Inject constructor(
     }
 
     fun onShippableProductDescriptionChanged(itemIndex: Int, newValue: String) {
-        _viewState.update { state ->
-            val updatedItem = state.shippingProducts[itemIndex]
-                .copy(description = InputValue.Data(newValue))
-
-            state.shippingProducts.toMutableList().apply {
-                set(itemIndex, updatedItem)
-            }.let { state.copy(shippingProducts = it) }
+        updateShippingProductsAt(itemIndex) { item ->
+            item.copy(description = InputValue.Data(newValue))
         }
     }
 
     fun onShippableProductTariffNumberChanged(itemIndex: Int, newValue: String) {
-        _viewState.update { state ->
-            val updatedItem = state.shippingProducts[itemIndex]
-                .copy(tariffNumber = InputValue.Data(newValue))
-
-            state.shippingProducts.toMutableList().apply {
-                set(itemIndex, updatedItem)
-            }.let { state.copy(shippingProducts = it) }
+        updateShippingProductsAt(itemIndex) { item ->
+            item.copy(tariffNumber = InputValue.Data(newValue))
         }
     }
 
     fun onShippableProductValuePerUnitChanged(itemIndex: Int, newValue: String) {
-        _viewState.update { state ->
-            val updatedItem = state.shippingProducts[itemIndex]
-                .copy(valuePerUnit = InputValue.Data(newValue))
-
-            state.shippingProducts.toMutableList().apply {
-                set(itemIndex, updatedItem)
-            }.let { state.copy(shippingProducts = it) }
+        updateShippingProductsAt(itemIndex) { item ->
+            item.copy(valuePerUnit = InputValue.Data(newValue))
         }
     }
 
     fun onShippableProductWeightPerUnitChanged(itemIndex: Int, newValue: String) {
-        _viewState.update { state ->
-            val updatedItem = state.shippingProducts[itemIndex]
-                .copy(weightPerUnit = InputValue.Data(newValue))
-
-            state.shippingProducts.toMutableList().apply {
-                set(itemIndex, updatedItem)
-            }.let { state.copy(shippingProducts = it) }
+        updateShippingProductsAt(itemIndex) { item ->
+            item.copy(weightPerUnit = InputValue.Data(newValue))
         }
     }
 
@@ -200,6 +180,20 @@ class WooShippingCustomsFormViewModel @Inject constructor(
 
     fun onAddCustomsDataClick() {
         triggerEvent(FinishCustomsForm)
+    }
+
+    private fun updateShippingProductsAt(
+        itemIndex: Int,
+        generateUpdatedItem: (WooShippingCustomsProductUIModel) -> WooShippingCustomsProductUIModel
+    ) {
+        _viewState.update { state ->
+            val updatedItem = state.shippingProducts[itemIndex]
+                .let(generateUpdatedItem)
+
+            state.shippingProducts.toMutableList().apply {
+                set(itemIndex, updatedItem)
+            }.let { state.copy(shippingProducts = it) }
+        }
     }
 
     private suspend fun loadCountries() {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/customs/WooShippingCustomsFormViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/customs/WooShippingCustomsFormViewModel.kt
@@ -5,8 +5,8 @@ import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.asLiveData
 import androidx.lifecycle.viewModelScope
 import com.woocommerce.android.R
+import com.woocommerce.android.model.AmbiguousLocation
 import com.woocommerce.android.model.Location
-import com.woocommerce.android.ui.orders.wooshippinglabels.address.GetStatesByCountryCode
 import com.woocommerce.android.ui.orders.wooshippinglabels.address.origin.GetAcceptedOriginCountries
 import com.woocommerce.android.ui.orders.wooshippinglabels.customs.products.WooShippingCustomsProductUIModel
 import com.woocommerce.android.ui.orders.wooshippinglabels.models.ShippableItemModel
@@ -24,7 +24,6 @@ import javax.inject.Inject
 @HiltViewModel
 class WooShippingCustomsFormViewModel @Inject constructor(
     private val getAcceptedOriginCountries: GetAcceptedOriginCountries,
-    private val getStatesByCountryCode: GetStatesByCountryCode,
     savedState: SavedStateHandle
 ) : ScopedViewModel(savedState) {
     private val itnRegex by lazy { ITN_REGEX_STRING.toRegex() }
@@ -171,17 +170,27 @@ class WooShippingCustomsFormViewModel @Inject constructor(
 
     fun onCountrySelectorClick(itemIndex: Int) {
         itemIndexUnderCountrySelection = itemIndex
-        val currentCountry = _viewState.value.shippingProducts[itemIndex].originCountry
-        triggerEvent(ShowCountrySelector(emptyList()))
+
+        countriesState.value
+            .run { this as? LocationState.Loaded }
+            ?.let { triggerEvent(ShowCountrySelector(it.locations)) }
     }
 
     fun onShippableProductOriginCountryChanged(newValue: String) {
         val itemIndex = itemIndexUnderCountrySelection ?: return
         itemIndexUnderCountrySelection = null
 
+        val possibleSelections = countriesState.value
+        val defaultLocation = AmbiguousLocation.Raw(newValue).asLocation()
+        val selectedLocation = when (possibleSelections) {
+            is LocationState.Loaded -> possibleSelections
+                .locations.firstOrNull { it.code == newValue } ?: defaultLocation
+            else -> defaultLocation
+        }
+
         _viewState.update { state ->
             val updatedItem = state.shippingProducts[itemIndex]
-                .copy(originCountry = newValue)
+                .copy(originCountry = selectedLocation.name)
 
             state.shippingProducts.toMutableList().apply {
                 set(itemIndex, updatedItem)

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/customs/WooShippingCustomsFormViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/customs/WooShippingCustomsFormViewModel.kt
@@ -183,7 +183,7 @@ class WooShippingCustomsFormViewModel @Inject constructor(
                 false -> InputValue.Data(newValue)
                 true -> InputValue.Error(
                     input = newValue,
-                    errorMessageId = R.string.woo_shipping_labels_customs_product_details_value_per_unit
+                    errorMessageId = R.string.woo_shipping_labels_customs_product_details_value_required
                 )
             }.let { item.copy(valuePerUnit = it) }
         }
@@ -195,7 +195,7 @@ class WooShippingCustomsFormViewModel @Inject constructor(
                 false -> InputValue.Data(newValue)
                 true -> InputValue.Error(
                     input = newValue,
-                    errorMessageId = R.string.woo_shipping_labels_customs_product_details_weight_per_unit
+                    errorMessageId = R.string.woo_shipping_labels_customs_product_details_value_required
                 )
             }.let { item.copy(weightPerUnit = it) }
         }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/customs/WooShippingCustomsFormViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/customs/WooShippingCustomsFormViewModel.kt
@@ -233,6 +233,7 @@ class WooShippingCustomsFormViewModel @Inject constructor(
         tariffNumber = InputValue.Empty,
         valuePerUnit = InputValue.Data(price.toString()),
         weightPerUnit = InputValue.Data(weight.toString()),
+        quantity = quantity,
         originCountry = "",
         isExpanded = false
     )

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/customs/WooShippingCustomsFormViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/customs/WooShippingCustomsFormViewModel.kt
@@ -130,7 +130,7 @@ class WooShippingCustomsFormViewModel @Inject constructor(
                 false -> InputValue.Data(newValue)
                 true -> InputValue.Error(
                     input = newValue,
-                    errorMessageId = R.string.woo_shipping_labels_customs_other_error_message
+                    errorMessageId = R.string.woo_shipping_labels_customs_product_details_description_missing
                 )
             }.let { item.copy(description = it) }
         }
@@ -142,7 +142,7 @@ class WooShippingCustomsFormViewModel @Inject constructor(
                 false -> InputValue.Data(newValue)
                 true -> InputValue.Error(
                     input = newValue,
-                    errorMessageId = R.string.woo_shipping_labels_customs_other_error_message
+                    errorMessageId = R.string.woo_shipping_labels_customs_product_details_tariff_missing
                 )
             }.let { item.copy(tariffNumber = it) }
         }
@@ -154,7 +154,7 @@ class WooShippingCustomsFormViewModel @Inject constructor(
                 false -> InputValue.Data(newValue)
                 true -> InputValue.Error(
                     input = newValue,
-                    errorMessageId = R.string.woo_shipping_labels_customs_other_error_message
+                    errorMessageId = R.string.woo_shipping_labels_customs_product_details_value_per_unit
                 )
             }.let { item.copy(valuePerUnit = it) }
         }
@@ -166,7 +166,7 @@ class WooShippingCustomsFormViewModel @Inject constructor(
                 false -> InputValue.Data(newValue)
                 true -> InputValue.Error(
                     input = newValue,
-                    errorMessageId = R.string.woo_shipping_labels_customs_other_error_message
+                    errorMessageId = R.string.woo_shipping_labels_customs_product_details_weight_per_unit
                 )
             }.let { item.copy(weightPerUnit = it) }
         }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/customs/WooShippingCustomsFormViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/customs/WooShippingCustomsFormViewModel.kt
@@ -20,7 +20,6 @@ import kotlinx.coroutines.launch
 import kotlinx.parcelize.Parcelize
 import javax.inject.Inject
 import kotlinx.coroutines.flow.distinctUntilChanged
-import kotlinx.coroutines.flow.filter
 import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.onEach
@@ -181,10 +180,7 @@ class WooShippingCustomsFormViewModel @Inject constructor(
         updateShippingProductsAt(itemIndex) { item ->
             when (newValue.isBlank()) {
                 false -> InputValue.Data(newValue)
-                true -> InputValue.Error(
-                    input = newValue,
-                    errorMessageId = R.string.woo_shipping_labels_customs_product_details_value_required
-                )
+                true -> newValue.asInputValueError
             }.let { item.copy(valuePerUnit = it) }
         }
     }
@@ -193,10 +189,7 @@ class WooShippingCustomsFormViewModel @Inject constructor(
         updateShippingProductsAt(itemIndex) { item ->
             when (newValue.isBlank()) {
                 false -> InputValue.Data(newValue)
-                true -> InputValue.Error(
-                    input = newValue,
-                    errorMessageId = R.string.woo_shipping_labels_customs_product_details_value_required
-                )
+                true -> newValue.asInputValueError
             }.let { item.copy(weightPerUnit = it) }
         }
     }
@@ -252,14 +245,20 @@ class WooShippingCustomsFormViewModel @Inject constructor(
 
     private fun ShippableItemModel.toProductUIModel() = WooShippingCustomsProductUIModel(
         name = title,
-        description = InputValue.Empty,
-        tariffNumber = InputValue.Empty,
+        description = "".asInputValueError,
+        tariffNumber = "".asInputValueError,
         valuePerUnit = InputValue.Data(price.toString()),
         weightPerUnit = InputValue.Data(weight.toString()),
         quantity = quantity,
         originCountry = "",
         isExpanded = false
     )
+
+    private val String.asInputValueError
+        get() = InputValue.Error(
+            input = this,
+            errorMessageId = R.string.woo_shipping_labels_customs_product_details_value_required
+        )
 
     @Parcelize
     data class ViewState(

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/customs/WooShippingCustomsFormViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/customs/WooShippingCustomsFormViewModel.kt
@@ -38,6 +38,7 @@ class WooShippingCustomsFormViewModel @Inject constructor(
     val viewState = _viewState.asLiveData()
 
     private val countriesState = MutableStateFlow<LocationState>(LocationState.Loading)
+    private val itemIndexUnderCountrySelection = MutableStateFlow<Int?>(null)
 
     init {
         launch { loadCountries() }
@@ -169,15 +170,13 @@ class WooShippingCustomsFormViewModel @Inject constructor(
     }
 
     fun onCountrySelectorClick(itemIndex: Int) {
-        _viewState.update { it.copy(itemIndexUnderCountrySelection = itemIndex) }
+        itemIndexUnderCountrySelection.update { itemIndex }
         val currentCountry = _viewState.value.shippingProducts[itemIndex].originCountry
         triggerEvent(ShowCountrySelector(emptyList()))
     }
 
     fun onShippableProductOriginCountryChanged(newValue: String) {
-        val itemIndex = _viewState.value
-            .itemIndexUnderCountrySelection
-            ?: return
+        val itemIndex = itemIndexUnderCountrySelection.value ?: return
 
         _viewState.update { state ->
             val updatedItem = state.shippingProducts[itemIndex]
@@ -218,8 +217,7 @@ class WooShippingCustomsFormViewModel @Inject constructor(
         val otherRestrictionInput: InputValue = InputValue.Empty,
         val itnValue: InputValue = InputValue.Empty,
         val returnToSenderChecked: Boolean = false,
-        val shippingProducts: List<WooShippingCustomsProductUIModel> = emptyList(),
-        val itemIndexUnderCountrySelection: Int? = null
+        val shippingProducts: List<WooShippingCustomsProductUIModel> = emptyList()
     ) : Parcelable {
         val shouldDisplayContentTypeInput: Boolean
             get() = contentType == ContentType.OTHER

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/customs/WooShippingCustomsFormViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/customs/WooShippingCustomsFormViewModel.kt
@@ -15,11 +15,11 @@ import com.woocommerce.android.viewmodel.ScopedViewModel
 import com.woocommerce.android.viewmodel.getStateFlow
 import com.woocommerce.android.viewmodel.navArgs
 import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.launch
 import kotlinx.parcelize.Parcelize
 import javax.inject.Inject
-import kotlinx.coroutines.flow.MutableStateFlow
-import kotlinx.coroutines.launch
 
 @HiltViewModel
 class WooShippingCustomsFormViewModel @Inject constructor(
@@ -43,7 +43,6 @@ class WooShippingCustomsFormViewModel @Inject constructor(
         launch { loadCountries() }
         val shippableProducts = navArgs.shippableItems.map { item -> item.toProductUIModel() }
         _viewState.update { it.copy(shippingProducts = shippableProducts) }
-
     }
 
     fun onContentTypeClick() {
@@ -184,7 +183,6 @@ class WooShippingCustomsFormViewModel @Inject constructor(
             }.let { state.copy(shippingProducts = it) }
         }
     }
-
 
     fun onAddCustomsDataClick() {
         triggerEvent(FinishCustomsForm)

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/customs/WooShippingCustomsFormViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/customs/WooShippingCustomsFormViewModel.kt
@@ -6,6 +6,7 @@ import androidx.lifecycle.asLiveData
 import androidx.lifecycle.viewModelScope
 import com.woocommerce.android.R
 import com.woocommerce.android.model.Location
+import com.woocommerce.android.ui.orders.wooshippinglabels.address.GetStatesByCountryCode
 import com.woocommerce.android.ui.orders.wooshippinglabels.address.origin.GetAcceptedOriginCountries
 import com.woocommerce.android.ui.orders.wooshippinglabels.customs.products.WooShippingCustomsProductUIModel
 import com.woocommerce.android.ui.orders.wooshippinglabels.models.ShippableItemModel
@@ -23,6 +24,7 @@ import kotlinx.coroutines.launch
 @HiltViewModel
 class WooShippingCustomsFormViewModel @Inject constructor(
     private val getAcceptedOriginCountries: GetAcceptedOriginCountries,
+    private val getStatesByCountryCode: GetStatesByCountryCode,
     savedState: SavedStateHandle
 ) : ScopedViewModel(savedState) {
     private val itnRegex by lazy { ITN_REGEX_STRING.toRegex() }
@@ -167,6 +169,11 @@ class WooShippingCustomsFormViewModel @Inject constructor(
         }
     }
 
+    fun onCountrySelectorClick(itemIndex: Int) {
+        val currentCountry = _viewState.value.shippingProducts[itemIndex].originCountry
+        triggerEvent(ShowCountrySelector(emptyList()))
+    }
+
     fun onShippableProductOriginCountryChanged(itemIndex: Int, newValue: String) {
         _viewState.update { state ->
             val updatedItem = state.shippingProducts[itemIndex]
@@ -268,6 +275,7 @@ class WooShippingCustomsFormViewModel @Inject constructor(
 
     data class ShowContentTypeDialog(val currentSelection: ContentType) : MultiLiveEvent.Event()
     data class ShowRestrictionTypeDialog(val currentSelection: RestrictionType) : MultiLiveEvent.Event()
+    data class ShowCountrySelector(val countries: List<Location>) : MultiLiveEvent.Event()
     object FinishCustomsForm : MultiLiveEvent.Event()
 
     companion object {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/customs/WooShippingCustomsFormViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/customs/WooShippingCustomsFormViewModel.kt
@@ -39,6 +39,12 @@ class WooShippingCustomsFormViewModel @Inject constructor(
     private val countriesState = MutableStateFlow<LocationState>(LocationState.Loading)
     private var itemIndexUnderCountrySelection: Int? = null
 
+    private val isITNRequired: Boolean
+        get() = _viewState.value.shippingProducts
+            .asSequence()
+            .mapNotNull { it.shippingTotalValue }
+            .any { it >= MAX_SHIPPING_ITEM_VALUE_FOR_CUSTOMS }
+
     init {
         launch { loadCountries() }
         val shippableProducts = navArgs.shippableItems.map { item -> item.toProductUIModel() }
@@ -101,7 +107,14 @@ class WooShippingCustomsFormViewModel @Inject constructor(
 
     fun onITNChanged(newItnValue: String) {
         val input = when {
+            newItnValue.isBlank() && isITNRequired ->
+                InputValue.Error(
+                    input = newItnValue,
+                    errorMessageId = R.string.woo_shipping_labels_customs_itn_required_message
+                )
+
             newItnValue.isBlank() -> InputValue.Empty
+
             itnRegex.matches(newItnValue).not() ->
                 InputValue.Error(
                     input = newItnValue,
@@ -189,6 +202,7 @@ class WooShippingCustomsFormViewModel @Inject constructor(
         val selectedLocation = when (possibleSelections) {
             is LocationState.Loaded -> possibleSelections
                 .locations.firstOrNull { it.code == newValue } ?: defaultLocation
+
             else -> defaultLocation
         }
 
@@ -316,5 +330,7 @@ class WooShippingCustomsFormViewModel @Inject constructor(
          */
         private const val ITN_REGEX_STRING =
             """^(?:(?:AES X\d{14})|(?:NOEEI 30\.\d{1,2}(?:\([a-z]\)(?:\(\d\))?)?))${'$'}"""
+
+        private const val MAX_SHIPPING_ITEM_VALUE_FOR_CUSTOMS = 2500
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/customs/products/WooShippingCustomsProductListItem.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/customs/products/WooShippingCustomsProductListItem.kt
@@ -243,6 +243,7 @@ fun WooShippingCustomsProductListCollapsedItemPreview() {
                     valuePerUnit = InputValue.Data("$20.00"),
                     weightPerUnit = InputValue.Data("0.3kg"),
                     originCountry = "Japan",
+                    quantity = 1F,
                     isExpanded = false
                 ),
                 onExpand = { },
@@ -269,6 +270,7 @@ fun WooShippingCustomsProductListExpandedItemPreview() {
                     valuePerUnit = InputValue.Data("$20.00"),
                     weightPerUnit = InputValue.Data("0.3kg"),
                     originCountry = "Japan",
+                    quantity = 1F,
                     isExpanded = true
                 ),
                 onExpand = { },

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/customs/products/WooShippingCustomsProductListItem.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/customs/products/WooShippingCustomsProductListItem.kt
@@ -271,6 +271,33 @@ fun WooShippingCustomsProductListCollapsedItemPreview() {
 
 @Preview
 @Composable
+fun WooShippingCustomsProductListCollapsedItemErrorPreview() {
+    WooThemeWithBackground {
+        Box(Modifier.padding(16.dp)) {
+            WooShippingCustomsProductListItem(
+                itemData = WooShippingCustomsProductUIModel(
+                    name = "Little Nap Brazil 250g",
+                    description = InputValue.Error("Coffee Beans", 0),
+                    tariffNumber = InputValue.Data("HS 14-1"),
+                    valuePerUnit = InputValue.Data("$20.00"),
+                    weightPerUnit = InputValue.Data("0.3kg"),
+                    originCountry = "Japan",
+                    quantity = 1F,
+                    isExpanded = false
+                ),
+                onExpand = { },
+                onDescriptionChanged = { },
+                onTariffChanged = { },
+                onValuePerUnitChanged = { },
+                onWeightPerUnitChanged = { },
+                onCountrySelectorClick = { }
+            )
+        }
+    }
+}
+
+@Preview
+@Composable
 fun WooShippingCustomsProductListExpandedItemPreview() {
     WooThemeWithBackground {
         Box(Modifier.padding(16.dp)) {
@@ -279,6 +306,33 @@ fun WooShippingCustomsProductListExpandedItemPreview() {
                     name = "Little Nap Brazil 250g",
                     description = InputValue.Data("Coffee Beans"),
                     tariffNumber = InputValue.Data("HS 14-1"),
+                    valuePerUnit = InputValue.Data("$20.00"),
+                    weightPerUnit = InputValue.Data("0.3kg"),
+                    originCountry = "Japan",
+                    quantity = 1F,
+                    isExpanded = true
+                ),
+                onExpand = { },
+                onDescriptionChanged = { },
+                onTariffChanged = { },
+                onValuePerUnitChanged = { },
+                onWeightPerUnitChanged = { },
+                onCountrySelectorClick = { }
+            )
+        }
+    }
+}
+
+@Preview
+@Composable
+fun WooShippingCustomsProductListExpandedItemErrorPreview() {
+    WooThemeWithBackground {
+        Box(Modifier.padding(16.dp)) {
+            WooShippingCustomsProductListItem(
+                itemData = WooShippingCustomsProductUIModel(
+                    name = "Little Nap Brazil 250g",
+                    description = InputValue.Error("Coffee Beans", 0),
+                    tariffNumber = InputValue.Error("HS 14-1", 0),
                     valuePerUnit = InputValue.Data("$20.00"),
                     weightPerUnit = InputValue.Data("0.3kg"),
                     originCountry = "Japan",

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/customs/products/WooShippingCustomsProductListItem.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/customs/products/WooShippingCustomsProductListItem.kt
@@ -84,15 +84,15 @@ fun WooShippingCustomsProductListItem(
                 modifier = modifier.weight(1f)
             )
 
-            if(itemData.isValid.not()) {
-            Icon(
-                imageVector = Icons.Outlined.Error,
-                tint = MaterialTheme.colorScheme.error,
-                contentDescription = stringResource(
-                    id = R.string.shipping_label_package_details_items_expand_content_description
+            if (itemData.isValid.not()) {
+                Icon(
+                    imageVector = Icons.Outlined.Error,
+                    tint = MaterialTheme.colorScheme.error,
+                    contentDescription = stringResource(
+                        id = R.string.shipping_label_package_details_items_expand_content_description
+                    )
                 )
-            )
-                }
+            }
             Icon(
                 painter = painterResource(R.drawable.ic_arrow_down),
                 tint = MaterialTheme.colorScheme.primary,

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/customs/products/WooShippingCustomsProductListItem.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/customs/products/WooShippingCustomsProductListItem.kt
@@ -15,6 +15,8 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.text.KeyboardOptions
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.outlined.Error
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
@@ -52,10 +54,10 @@ fun WooShippingCustomsProductListItem(
         .let { if (it) 180f else 0f }
         .let { animateFloatAsState(targetValue = it, label = "rotationAnimation") }
 
-    val borderColor = if (itemData.isExpanded) {
-        colorResource(R.color.woo_black)
-    } else {
-        colorResource(R.color.divider_color)
+    val borderColor = when {
+        itemData.isExpanded -> colorResource(R.color.woo_black)
+        itemData.isValid.not() -> colorResource(R.color.color_error)
+        else -> colorResource(R.color.divider_color)
     }
 
     Column(
@@ -81,6 +83,16 @@ fun WooShippingCustomsProductListItem(
                 fontWeight = FontWeight.Bold,
                 modifier = modifier.weight(1f)
             )
+
+            if(itemData.isValid.not()) {
+            Icon(
+                imageVector = Icons.Outlined.Error,
+                tint = MaterialTheme.colorScheme.error,
+                contentDescription = stringResource(
+                    id = R.string.shipping_label_package_details_items_expand_content_description
+                )
+            )
+                }
             Icon(
                 painter = painterResource(R.drawable.ic_arrow_down),
                 tint = MaterialTheme.colorScheme.primary,

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/customs/products/WooShippingCustomsProductListItem.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/customs/products/WooShippingCustomsProductListItem.kt
@@ -45,6 +45,7 @@ fun WooShippingCustomsProductListItem(
     onTariffChanged: (String) -> Unit,
     onValuePerUnitChanged: (String) -> Unit,
     onWeightPerUnitChanged: (String) -> Unit,
+    onCountrySelectorClick: () -> Unit,
     modifier: Modifier = Modifier
 ) {
     val rotationAnimation = itemData.isExpanded
@@ -100,6 +101,7 @@ fun WooShippingCustomsProductListItem(
                 onTariffChanged = onTariffChanged,
                 onValuePerUnitChanged = onValuePerUnitChanged,
                 onWeightPerUnitChanged = onWeightPerUnitChanged,
+                onCountrySelectorClick = onCountrySelectorClick,
                 modifier = modifier
             )
         } else {
@@ -159,7 +161,8 @@ fun WooShippingCustomsProductExpandedListItem(
     onDescriptionChanged: (String) -> Unit,
     onTariffChanged: (String) -> Unit,
     onValuePerUnitChanged: (String) -> Unit,
-    onWeightPerUnitChanged: (String) -> Unit
+    onWeightPerUnitChanged: (String) -> Unit,
+    onCountrySelectorClick: () -> Unit
 ) {
     Column(modifier = modifier.fillMaxWidth()) {
         HorizontalDivider(modifier.padding(vertical = 8.dp))
@@ -217,7 +220,7 @@ fun WooShippingCustomsProductExpandedListItem(
 
             RoundedBorderDropDownWithLabel(
                 label = stringResource(id = R.string.woo_shipping_labels_customs_product_details_origin_country),
-                onClick = { },
+                onClick = onCountrySelectorClick,
                 modifier = modifier.fillMaxWidth(),
                 text = itemData.originCountry
                     .takeIf { it.isNotBlank() }
@@ -246,7 +249,8 @@ fun WooShippingCustomsProductListCollapsedItemPreview() {
                 onDescriptionChanged = { },
                 onTariffChanged = { },
                 onValuePerUnitChanged = { },
-                onWeightPerUnitChanged = { }
+                onWeightPerUnitChanged = { },
+                onCountrySelectorClick = { }
             )
         }
     }
@@ -271,7 +275,8 @@ fun WooShippingCustomsProductListExpandedItemPreview() {
                 onDescriptionChanged = { },
                 onTariffChanged = { },
                 onValuePerUnitChanged = { },
-                onWeightPerUnitChanged = { }
+                onWeightPerUnitChanged = { },
+                onCountrySelectorClick = { }
             )
         }
     }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/customs/products/WooShippingCustomsProductListItem.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/customs/products/WooShippingCustomsProductListItem.kt
@@ -31,6 +31,7 @@ import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.input.ImeAction
+import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import com.woocommerce.android.R
@@ -198,7 +199,10 @@ fun WooShippingCustomsProductExpandedListItem(
                 label = stringResource(id = R.string.woo_shipping_labels_customs_product_details_tariff),
                 singleLine = true,
                 isError = itemData.tariffNumber is InputValue.Error,
-                keyboardOptions = KeyboardOptions(imeAction = ImeAction.Next),
+                keyboardOptions = KeyboardOptions(
+                    imeAction = ImeAction.Next,
+                    keyboardType = KeyboardType.Number
+                ),
                 modifier = modifier.fillMaxWidth(),
                 helperText = itemData.tariffNumber.errorMessageOrNull
                     ?.let { stringResource(it) }
@@ -211,7 +215,10 @@ fun WooShippingCustomsProductExpandedListItem(
                     label = stringResource(id = R.string.woo_shipping_labels_customs_product_details_value_per_unit),
                     singleLine = true,
                     isError = itemData.valuePerUnit is InputValue.Error,
-                    keyboardOptions = KeyboardOptions(imeAction = ImeAction.Next),
+                    keyboardOptions = KeyboardOptions(
+                        imeAction = ImeAction.Next,
+                        keyboardType = KeyboardType.Number
+                    ),
                     modifier = modifier.weight(1f),
                     helperText = itemData.valuePerUnit.errorMessageOrNull
                         ?.let { stringResource(it) }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/customs/products/WooShippingCustomsProductListItem.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/customs/products/WooShippingCustomsProductListItem.kt
@@ -41,6 +41,10 @@ import com.woocommerce.android.ui.orders.wooshippinglabels.customs.WooShippingCu
 fun WooShippingCustomsProductListItem(
     itemData: WooShippingCustomsProductUIModel,
     onExpand: (isExtended: Boolean) -> Unit,
+    onDescriptionChanged: (String) -> Unit,
+    onTariffChanged: (String) -> Unit,
+    onValuePerUnitChanged: (String) -> Unit,
+    onWeightPerUnitChanged: (String) -> Unit,
     modifier: Modifier = Modifier
 ) {
     val rotationAnimation = itemData.isExpanded
@@ -92,10 +96,10 @@ fun WooShippingCustomsProductListItem(
         if (itemData.isExpanded) {
             WooShippingCustomsProductExpandedListItem(
                 itemData = itemData,
-                onDescriptionChanged = { },
-                onTariffChanged = { },
-                onValuePerUnitChanged = { },
-                onWeightPerUnitChanged = { },
+                onDescriptionChanged = onDescriptionChanged,
+                onTariffChanged = onTariffChanged,
+                onValuePerUnitChanged = onValuePerUnitChanged,
+                onWeightPerUnitChanged = onWeightPerUnitChanged,
                 modifier = modifier
             )
         } else {
@@ -238,7 +242,11 @@ fun WooShippingCustomsProductListCollapsedItemPreview() {
                     originCountry = "Japan",
                     isExpanded = false
                 ),
-                onExpand = { }
+                onExpand = { },
+                onDescriptionChanged = { },
+                onTariffChanged = { },
+                onValuePerUnitChanged = { },
+                onWeightPerUnitChanged = { }
             )
         }
     }
@@ -259,7 +267,11 @@ fun WooShippingCustomsProductListExpandedItemPreview() {
                     originCountry = "Japan",
                     isExpanded = true
                 ),
-                onExpand = { }
+                onExpand = { },
+                onDescriptionChanged = { },
+                onTariffChanged = { },
+                onValuePerUnitChanged = { },
+                onWeightPerUnitChanged = { }
             )
         }
     }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/customs/products/WooShippingCustomsProductUIModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/customs/products/WooShippingCustomsProductUIModel.kt
@@ -16,4 +16,10 @@ data class WooShippingCustomsProductUIModel(
 ) : Parcelable {
     val valueAndWeightForDisplay: String
         get() = "${valuePerUnit.currentInput} • ${weightPerUnit.currentInput}"
+
+    val isValid: Boolean
+        get() = description is InputValue.Data &&
+            tariffNumber is InputValue.Data &&
+            valuePerUnit is InputValue.Data &&
+            weightPerUnit is InputValue.Data
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/customs/products/WooShippingCustomsProductUIModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/customs/products/WooShippingCustomsProductUIModel.kt
@@ -23,4 +23,12 @@ data class WooShippingCustomsProductUIModel(
             tariffNumber is InputValue.Data &&
             valuePerUnit is InputValue.Data &&
             weightPerUnit is InputValue.Data
+
+    val shippingTotalValue: Float?
+        get() = valuePerUnit
+            .takeIf { valuePerUnit is InputValue.Data && quantity > 0 }
+            ?.run { this as? InputValue.Data }
+            ?.currentInput
+            ?.toFloatOrNull()
+            ?.let { it * quantity }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/customs/products/WooShippingCustomsProductUIModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/customs/products/WooShippingCustomsProductUIModel.kt
@@ -22,7 +22,8 @@ data class WooShippingCustomsProductUIModel(
         get() = description is InputValue.Data &&
             tariffNumber is InputValue.Data &&
             valuePerUnit is InputValue.Data &&
-            weightPerUnit is InputValue.Data
+            weightPerUnit is InputValue.Data &&
+            originCountry.isNotBlank()
 
     val shippingTotalValue: Float?
         get() = valuePerUnit

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/customs/products/WooShippingCustomsProductUIModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/customs/products/WooShippingCustomsProductUIModel.kt
@@ -12,6 +12,7 @@ data class WooShippingCustomsProductUIModel(
     val valuePerUnit: InputValue,
     val weightPerUnit: InputValue,
     val originCountry: String,
+    val quantity: Float,
     val isExpanded: Boolean
 ) : Parcelable {
     val valueAndWeightForDisplay: String

--- a/WooCommerce/src/main/res/navigation/nav_graph_orders.xml
+++ b/WooCommerce/src/main/res/navigation/nav_graph_orders.xml
@@ -758,5 +758,9 @@
         <action
             android:id="@+id/action_wooShippingLabelCustomsFormFragment_to_itemSelectorDialog"
             app:destination="@id/itemSelectorDialog" />
+
+        <action
+            android:id="@+id/action_search_filter_fragment"
+            app:destination="@id/searchFilterFragment" />
     </fragment>
 </navigation>

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -4484,6 +4484,7 @@
     <string name="woo_shipping_labels_customs_restriction_other">Other</string>
     <string name="woo_shipping_labels_customs_other_error_message">Type must not be empty</string>
     <string name="woo_shipping_labels_customs_itn_error_message">Invalid ITN format</string>
+    <string name="woo_shipping_labels_customs_itn_required_message">ITN must not be empty</string>
     <string name="woo_shipping_labels_customs_product_details_title">Product Details</string>
     <string name="woo_shipping_labels_customs_product_details_description">Description</string>
     <string name="woo_shipping_labels_customs_product_details_description_missing">Missing Description</string>

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -4492,6 +4492,7 @@
     <string name="woo_shipping_labels_customs_product_details_tariff_missing">Missing tariff number</string>
     <string name="woo_shipping_labels_customs_product_details_value_per_unit">Value per unit</string>
     <string name="woo_shipping_labels_customs_product_details_weight_per_unit">Weight per unit</string>
+    <string name="woo_shipping_labels_customs_product_details_value_required">Value required</string>
     <string name="woo_shipping_labels_customs_product_details_origin_country">Origin country</string>
     <string name="woo_shipping_labels_customs_product_details_origin_country_missing">Missing country</string>
     <string name="woo_shipping_labels_customs_product_details_origin_country_selection">Select a country</string>

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/customs/WooShippingCustomsFormViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/customs/WooShippingCustomsFormViewModelTest.kt
@@ -13,13 +13,13 @@ import com.woocommerce.android.ui.orders.wooshippinglabels.models.ShippableItemM
 import com.woocommerce.android.viewmodel.BaseUnitTest
 import com.woocommerce.android.viewmodel.MultiLiveEvent
 import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.advanceUntilIdle
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.Before
 import org.junit.Test
-import java.math.BigDecimal
-import kotlinx.coroutines.test.advanceUntilIdle
 import org.mockito.kotlin.doReturn
 import org.mockito.kotlin.mock
+import java.math.BigDecimal
 
 @ExperimentalCoroutinesApi
 class WooShippingCustomsFormViewModelTest : BaseUnitTest() {

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/customs/WooShippingCustomsFormViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/customs/WooShippingCustomsFormViewModelTest.kt
@@ -1,10 +1,12 @@
 package com.woocommerce.android.ui.orders.wooshippinglabels.customs
 
+import com.woocommerce.android.model.Location
 import com.woocommerce.android.ui.orders.wooshippinglabels.address.origin.GetAcceptedOriginCountries
 import com.woocommerce.android.ui.orders.wooshippinglabels.customs.WooShippingCustomsFormViewModel.ContentType
 import com.woocommerce.android.ui.orders.wooshippinglabels.customs.WooShippingCustomsFormViewModel.InputValue
 import com.woocommerce.android.ui.orders.wooshippinglabels.customs.WooShippingCustomsFormViewModel.RestrictionType
 import com.woocommerce.android.ui.orders.wooshippinglabels.customs.WooShippingCustomsFormViewModel.ShowContentTypeDialog
+import com.woocommerce.android.ui.orders.wooshippinglabels.customs.WooShippingCustomsFormViewModel.ShowCountrySelector
 import com.woocommerce.android.ui.orders.wooshippinglabels.customs.WooShippingCustomsFormViewModel.ShowRestrictionTypeDialog
 import com.woocommerce.android.ui.orders.wooshippinglabels.customs.WooShippingCustomsFormViewModel.ViewState
 import com.woocommerce.android.ui.orders.wooshippinglabels.models.ShippableItemModel
@@ -15,37 +17,65 @@ import org.assertj.core.api.Assertions.assertThat
 import org.junit.Before
 import org.junit.Test
 import java.math.BigDecimal
+import kotlinx.coroutines.test.advanceUntilIdle
 import org.mockito.kotlin.doReturn
 import org.mockito.kotlin.mock
 
 @ExperimentalCoroutinesApi
 class WooShippingCustomsFormViewModelTest : BaseUnitTest() {
     private lateinit var viewModel: WooShippingCustomsFormViewModel
-
-    private val getAcceptedOriginCountries = mock<GetAcceptedOriginCountries> {
-        onBlocking { invoke() } doReturn Result.success(emptyList())
-    }
+    private lateinit var getAcceptedOriginCountries: GetAcceptedOriginCountries
 
     @Before
     fun setup() {
+        // Create mock locations for the tests
+        val mockLocations = listOf(
+            mock<Location> {
+                on { code } doReturn "US"
+                on { name } doReturn "United States"
+            },
+            mock<Location> {
+                on { code } doReturn "CA"
+                on { name } doReturn "Canada"
+            }
+        )
 
+        // Configure the mock to return our test locations
+        getAcceptedOriginCountries = mock {
+            onBlocking { invoke() } doReturn Result.success(mockLocations)
+        }
+
+        // Create a test product with high value for ITN tests
+        val testProduct = ShippableItemModel(
+            itemId = 1,
+            productId = 1,
+            title = "Test Product",
+            price = BigDecimal.ONE,
+            quantity = 1f,
+            currency = "USD",
+            length = 1f,
+            width = 1f,
+            height = 1f,
+            weight = 1f
+        )
+
+        // Create expensive product for ITN required tests
+        val expensiveProduct = ShippableItemModel(
+            itemId = 2,
+            productId = 2,
+            title = "Expensive Product",
+            price = BigDecimal.valueOf(2600),
+            quantity = 1f,
+            currency = "USD",
+            length = 1f,
+            width = 1f,
+            height = 1f,
+            weight = 1f
+        )
 
         viewModel = WooShippingCustomsFormViewModel(
             savedState = WooShippingCustomsFormFragmentArgs(
-                shippableItems = arrayOf(
-                    ShippableItemModel(
-                        itemId = 1,
-                        productId = 1,
-                        title = "Test Product",
-                        price = BigDecimal.ONE,
-                        quantity = 1f,
-                        currency = "USD",
-                        length = 1f,
-                        width = 1f,
-                        height = 1f,
-                        weight = 1f
-                    )
-                )
+                shippableItems = arrayOf(testProduct, expensiveProduct)
             ).toSavedStateHandle(),
             getAcceptedOriginCountries = getAcceptedOriginCountries
         )
@@ -172,5 +202,240 @@ class WooShippingCustomsFormViewModelTest : BaseUnitTest() {
         assertThat(
             capturedViewState?.otherRestrictionInput
         ).isInstanceOf(InputValue.Error::class.java)
+    }
+
+    @Test
+    fun `onShippableProductExpanded should update isExpanded state for specific product`() = testBlocking {
+        // Given
+        val itemIndex = 0
+        val isExpanded = true
+        var capturedViewState: ViewState? = null
+        viewModel.viewState.observeForever {
+            capturedViewState = it
+        }
+
+        // When
+        viewModel.onShippableProductExpanded(itemIndex, isExpanded)
+
+        // Then
+        assertThat(capturedViewState?.shippingProducts?.get(itemIndex)?.isExpanded).isEqualTo(isExpanded)
+    }
+
+    @Test
+    fun `onShippableProductDescriptionChanged should update description with valid input`() = testBlocking {
+        // Given
+        val itemIndex = 0
+        val newDescription = "Test description"
+        var capturedViewState: ViewState? = null
+        viewModel.viewState.observeForever {
+            capturedViewState = it
+        }
+
+        // When
+        viewModel.onShippableProductDescriptionChanged(itemIndex, newDescription)
+
+        // Then
+        assertThat(capturedViewState?.shippingProducts?.get(itemIndex)?.description)
+            .isEqualTo(InputValue.Data(newDescription))
+    }
+
+    @Test
+    fun `onShippableProductDescriptionChanged should update description with error for blank input`() =
+        testBlocking {
+            // Given
+            val itemIndex = 0
+            val blankDescription = ""
+            var capturedViewState: ViewState? = null
+            viewModel.viewState.observeForever {
+                capturedViewState = it
+            }
+
+            // When
+            viewModel.onShippableProductDescriptionChanged(itemIndex, blankDescription)
+
+            // Then
+            assertThat(capturedViewState?.shippingProducts?.get(itemIndex)?.description)
+                .isInstanceOf(InputValue.Error::class.java)
+        }
+
+    @Test
+    fun `onShippableProductTariffNumberChanged should update tariffNumber with valid input`() = testBlocking {
+        // Given
+        val itemIndex = 0
+        val newTariff = "HS 12345"
+        var capturedViewState: ViewState? = null
+        viewModel.viewState.observeForever {
+            capturedViewState = it
+        }
+
+        // When
+        viewModel.onShippableProductTariffNumberChanged(itemIndex, newTariff)
+
+        // Then
+        assertThat(capturedViewState?.shippingProducts?.get(itemIndex)?.tariffNumber)
+            .isEqualTo(InputValue.Data(newTariff))
+    }
+
+    @Test
+    fun `onShippableProductTariffNumberChanged should update tariffNumber with error for blank input`() =
+        testBlocking {
+            // Given
+            val itemIndex = 0
+            val blankTariff = ""
+            var capturedViewState: ViewState? = null
+            viewModel.viewState.observeForever {
+                capturedViewState = it
+            }
+
+            // When
+            viewModel.onShippableProductTariffNumberChanged(itemIndex, blankTariff)
+
+            // Then
+            assertThat(capturedViewState?.shippingProducts?.get(itemIndex)?.tariffNumber)
+                .isInstanceOf(InputValue.Error::class.java)
+        }
+
+    @Test
+    fun `onShippableProductValuePerUnitChanged should update valuePerUnit with valid input`() = testBlocking {
+        // Given
+        val itemIndex = 0
+        val newValue = "10.00"
+        var capturedViewState: ViewState? = null
+        viewModel.viewState.observeForever {
+            capturedViewState = it
+        }
+
+        // When
+        viewModel.onShippableProductValuePerUnitChanged(itemIndex, newValue)
+
+        // Then
+        assertThat(capturedViewState?.shippingProducts?.get(itemIndex)?.valuePerUnit)
+            .isEqualTo(InputValue.Data(newValue))
+    }
+
+    @Test
+    fun `onShippableProductValuePerUnitChanged should update valuePerUnit with error for blank input`() =
+        testBlocking {
+            // Given
+            val itemIndex = 0
+            val blankValue = ""
+            var capturedViewState: ViewState? = null
+            viewModel.viewState.observeForever {
+                capturedViewState = it
+            }
+
+            // When
+            viewModel.onShippableProductValuePerUnitChanged(itemIndex, blankValue)
+
+            // Then
+            assertThat(capturedViewState?.shippingProducts?.get(itemIndex)?.valuePerUnit)
+                .isInstanceOf(InputValue.Error::class.java)
+        }
+
+    @Test
+    fun `onShippableProductWeightPerUnitChanged should update weightPerUnit with valid input`() = testBlocking {
+        // Given
+        val itemIndex = 0
+        val newWeight = "5.00"
+        var capturedViewState: ViewState? = null
+        viewModel.viewState.observeForever {
+            capturedViewState = it
+        }
+
+        // When
+        viewModel.onShippableProductWeightPerUnitChanged(itemIndex, newWeight)
+
+        // Then
+        assertThat(capturedViewState?.shippingProducts?.get(itemIndex)?.weightPerUnit)
+            .isEqualTo(InputValue.Data(newWeight))
+    }
+
+    @Test
+    fun `onShippableProductWeightPerUnitChanged should update weightPerUnit with error for blank input`() =
+        testBlocking {
+            // Given
+            val itemIndex = 0
+            val blankWeight = ""
+            var capturedViewState: ViewState? = null
+            viewModel.viewState.observeForever {
+                capturedViewState = it
+            }
+
+            // When
+            viewModel.onShippableProductWeightPerUnitChanged(itemIndex, blankWeight)
+
+            // Then
+            assertThat(capturedViewState?.shippingProducts?.get(itemIndex)?.weightPerUnit)
+                .isInstanceOf(InputValue.Error::class.java)
+        }
+
+    @Test
+    fun `onCountrySelectorClick should trigger ShowCountrySelector event with possible locations`() = testBlocking {
+        // Given
+        val itemIndex = 0
+
+        // Let the viewModel initialize to load countries
+        advanceUntilIdle()
+
+        var latestEvent: MultiLiveEvent.Event? = null
+        viewModel.event.observeForever {
+            latestEvent = it
+        }
+
+        // When
+        viewModel.onCountrySelectorClick(itemIndex)
+
+        // Then
+        assertThat(latestEvent).isInstanceOf(ShowCountrySelector::class.java)
+        val countries = (latestEvent as ShowCountrySelector).countries
+        assertThat(countries.size).isEqualTo(2)
+        assertThat(countries[0].code).isEqualTo("US")
+        assertThat(countries[0].name).isEqualTo("United States")
+        assertThat(countries[1].code).isEqualTo("CA")
+        assertThat(countries[1].name).isEqualTo("Canada")
+    }
+
+    @Test
+    fun `onShippableProductOriginCountryChanged should update originCountry for selected product`() = testBlocking {
+        // Given
+        val itemIndex = 0
+        val countryCode = "US"
+
+        // Let the viewModel initialize to load countries
+        advanceUntilIdle()
+
+        // First set the item for country selection
+        viewModel.onCountrySelectorClick(itemIndex)
+
+        var capturedViewState: ViewState? = null
+        viewModel.viewState.observeForever {
+            capturedViewState = it
+        }
+
+        // When
+        viewModel.onShippableProductOriginCountryChanged(countryCode)
+
+        // Then
+        assertThat(capturedViewState?.shippingProducts?.get(itemIndex)?.originCountry).isEqualTo("United States")
+    }
+
+    @Test
+    fun `onITNChanged with blank value should set error when ITN is required`() = testBlocking {
+        // Given
+        val blankItn = ""
+
+        // The second product in our setup is the expensive one,
+        // so expanding the second product will make the ITN required
+        var capturedViewState: ViewState? = null
+        viewModel.viewState.observeForever {
+            capturedViewState = it
+        }
+
+        // When
+        viewModel.onShippableProductValuePerUnitChanged(1, "2600")
+        viewModel.onITNChanged(blankItn)
+
+        // Then
+        assertThat(capturedViewState?.itnValue).isInstanceOf(InputValue.Error::class.java)
     }
 }

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/customs/WooShippingCustomsFormViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/customs/WooShippingCustomsFormViewModelTest.kt
@@ -1,5 +1,6 @@
 package com.woocommerce.android.ui.orders.wooshippinglabels.customs
 
+import com.woocommerce.android.ui.orders.wooshippinglabels.address.origin.GetAcceptedOriginCountries
 import com.woocommerce.android.ui.orders.wooshippinglabels.customs.WooShippingCustomsFormViewModel.ContentType
 import com.woocommerce.android.ui.orders.wooshippinglabels.customs.WooShippingCustomsFormViewModel.InputValue
 import com.woocommerce.android.ui.orders.wooshippinglabels.customs.WooShippingCustomsFormViewModel.RestrictionType
@@ -14,13 +15,21 @@ import org.assertj.core.api.Assertions.assertThat
 import org.junit.Before
 import org.junit.Test
 import java.math.BigDecimal
+import org.mockito.kotlin.doReturn
+import org.mockito.kotlin.mock
 
 @ExperimentalCoroutinesApi
 class WooShippingCustomsFormViewModelTest : BaseUnitTest() {
     private lateinit var viewModel: WooShippingCustomsFormViewModel
 
+    private val getAcceptedOriginCountries = mock<GetAcceptedOriginCountries> {
+        onBlocking { invoke() } doReturn Result.success(emptyList())
+    }
+
     @Before
     fun setup() {
+
+
         viewModel = WooShippingCustomsFormViewModel(
             savedState = WooShippingCustomsFormFragmentArgs(
                 shippableItems = arrayOf(
@@ -37,7 +46,8 @@ class WooShippingCustomsFormViewModelTest : BaseUnitTest() {
                         weight = 1f
                     )
                 )
-            ).toSavedStateHandle()
+            ).toSavedStateHandle(),
+            getAcceptedOriginCountries = getAcceptedOriginCountries
         )
     }
 


### PR DESCRIPTION
Why
==========
Finalize issue #13367 by adding the data validation and error states for the Shippable Products section of the Customs form.

How
==========
Extends the WooShippingCustomsFormViewModel to support all contained fields changes and their respective validation. Also, it adds the ITN check when the total shippable items' values exceed the amount of 2500 USD.

Screen Capture
==========
https://github.com/user-attachments/assets/bf489086-5de0-4162-bb83-818691b815bc

How to Test
==========
In case you want to avoid having to fill the address data to access the Customs form, you can simply override the ShouldRequireCustomsForm use case always to return true to trigger the Customs data requirement forcefully.

### Scenario 1 - All Products are interactable and can be updated as expected

1. Open the Shipping Labels Creation form, verify the Shippable Items declared in the form
2. Click the edit button inside the Customs section
3. Once inside the Customs form, check the Product Details reflects exactly the Shippable Items
4. Click on each Item and verify they expand and collapse as expected
5. Verify that each Product Details is requiring the unavailable data
6. Verify that the Product Country selection works as expected

### Scenario 2 - ITN is required only when the Products total value sum is higher than 2500.

1. Open the Shipping Labels Creation form, verify the Shippable Items declared in the form
2. Click the edit button inside the Customs section
3. Once inside the Customs form, check the Product Details reflects exactly the Shippable Items
4. Edit the Products values in a way that their sum of all Products are above 2500.
5. Verify that the ITN number is being required.

### Scenario 3 - Button submission is only available when the form is validated
1. Open the Shipping Labels Creation form, verify the Shippable Items declared in the form
2. Click the edit button inside the Customs section
3. Ensure the Customs form submission button is only available when the entire form is valid.

Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

## Reviewer (or Author, in the case of optional code reviews):

Please make sure these conditions are met before approving the PR, or request changes if the PR needs improvement:

- [ ] The PR is small and has a clear, single focus, or a valid explanation is provided in the description. If needed, please request to split it into smaller PRs.
- [ ] Ensure Adequate Unit Test Coverage: The changes are reasonably covered by unit tests or an explanation is provided in the PR description.
- [ ] Manual Testing: The author listed all the tests they ran, including smoke tests when needed (e.g., for refactorings). The reviewer confirmed that the PR works as expected on big (tablet) and small (phone) in case of UI changes, and no regressions are added.
