### PR TITLE
Update destination address

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/ShipmentDetails.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/ShipmentDetails.kt
@@ -50,6 +50,7 @@ import com.woocommerce.android.ui.compose.animations.SkeletonView
 import com.woocommerce.android.ui.compose.theme.WooThemeWithBackground
 import com.woocommerce.android.ui.orders.wooshippinglabels.address.AddressSectionLandscape
 import com.woocommerce.android.ui.orders.wooshippinglabels.address.AddressSectionPortrait
+import com.woocommerce.android.ui.orders.wooshippinglabels.address.DestinationShippingAddress
 import com.woocommerce.android.ui.orders.wooshippinglabels.address.getShipFrom
 import com.woocommerce.android.ui.orders.wooshippinglabels.address.getShipTo
 import com.woocommerce.android.ui.orders.wooshippinglabels.models.OriginShippingAddress
@@ -67,6 +68,7 @@ fun ShipmentDetails(
     modifier: Modifier = Modifier,
     isShipmentDetailsExpanded: Boolean = false,
     onShipmentDetailsExpandedChange: (Boolean) -> Boolean,
+    onEditDestinationAddress: (DestinationShippingAddress) -> Unit,
     markOrderComplete: Boolean = false,
     onMarkOrderCompleteChange: (Boolean) -> Unit = {},
     handlerModifier: Modifier = Modifier,
@@ -115,7 +117,8 @@ fun ShipmentDetails(
                 shippingRateSummary = shippingRateSummary,
                 modifier = modifier.padding(top = dimensionResource(R.dimen.major_100)),
                 isReadOnly = isReadOnly,
-                shipFromSelectionBottomSheetState = shipFromSelectionBottomSheetState
+                shipFromSelectionBottomSheetState = shipFromSelectionBottomSheetState,
+                onEditDestinationAddress = onEditDestinationAddress
             )
         } else {
             ShipmentDetailsPortrait(
@@ -127,7 +130,8 @@ fun ShipmentDetails(
                 shippingRateSummary = shippingRateSummary,
                 modifier = modifier.padding(top = dimensionResource(R.dimen.minor_100)),
                 isReadOnly = isReadOnly,
-                shipFromSelectionBottomSheetState = shipFromSelectionBottomSheetState
+                shipFromSelectionBottomSheetState = shipFromSelectionBottomSheetState,
+                onEditDestinationAddress = onEditDestinationAddress
             )
         }
     }
@@ -142,6 +146,7 @@ private fun ShipmentDetailsPortrait(
     onMarkOrderCompleteChange: (Boolean) -> Unit,
     shippingRateSummary: ShippingRateSummaryUI?,
     shipFromSelectionBottomSheetState: ModalBottomSheetState,
+    onEditDestinationAddress: (DestinationShippingAddress) -> Unit,
     modifier: Modifier = Modifier,
     isReadOnly: Boolean = false
 ) {
@@ -159,7 +164,8 @@ private fun ShipmentDetailsPortrait(
                 totalItemsCost = shippableItems.formattedTotalPrice,
                 shippingLines = shippingLines,
                 isReadOnly = isReadOnly,
-                shipFromSelectionBottomSheetState = shipFromSelectionBottomSheetState
+                shipFromSelectionBottomSheetState = shipFromSelectionBottomSheetState,
+                onEditDestinationAddress = onEditDestinationAddress
             )
             Divider(modifier = Modifier.padding(horizontal = dimensionResource(R.dimen.major_100)))
             ShipmentCostSection(
@@ -184,6 +190,7 @@ private fun ShipmentDetailsLandscape(
     shippingAddresses: WooShippingAddresses,
     shippingRateSummary: ShippingRateSummaryUI?,
     shipFromSelectionBottomSheetState: ModalBottomSheetState,
+    onEditDestinationAddress: (DestinationShippingAddress) -> Unit,
     modifier: Modifier = Modifier,
     isReadOnly: Boolean = false
 ) {
@@ -199,7 +206,8 @@ private fun ShipmentDetailsLandscape(
                 shippingAddresses = shippingAddresses,
                 modifier = Modifier.padding(horizontal = dimensionResource(R.dimen.major_100)),
                 isReadOnly = isReadOnly,
-                shipFromSelectionBottomSheetState = shipFromSelectionBottomSheetState
+                shipFromSelectionBottomSheetState = shipFromSelectionBottomSheetState,
+                onEditDestinationAddress = onEditDestinationAddress
             )
             Row(
                 modifier = Modifier
@@ -252,6 +260,7 @@ private fun OrderDetailsSection(
     totalItemsCost: String,
     shippingLines: List<ShippingLineSummaryUI>,
     shipFromSelectionBottomSheetState: ModalBottomSheetState,
+    onEditDestinationAddress: (DestinationShippingAddress) -> Unit,
     modifier: Modifier = Modifier,
     isReadOnly: Boolean = false
 ) {
@@ -265,7 +274,8 @@ private fun OrderDetailsSection(
             shippingAddresses = shippingAddresses,
             modifier = Modifier.padding(horizontal = dimensionResource(R.dimen.major_100)),
             isReadOnly = isReadOnly,
-            shipFromSelectionBottomSheetState = shipFromSelectionBottomSheetState
+            shipFromSelectionBottomSheetState = shipFromSelectionBottomSheetState,
+            onEditDestinationAddress = onEditDestinationAddress
         )
         TotalCard(
             totalItems = totalItems,
@@ -318,7 +328,8 @@ fun ShipmentDetailsLandscapePreview() {
                     originAddresses = listOf(getShipFrom())
                 ),
                 shippingRateSummary = null,
-                shipFromSelectionBottomSheetState = rememberModalBottomSheetState(ModalBottomSheetValue.Hidden)
+                shipFromSelectionBottomSheetState = rememberModalBottomSheetState(ModalBottomSheetValue.Hidden),
+                onEditDestinationAddress = {}
             )
         }
     }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/ShipmentDetails.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/ShipmentDetails.kt
@@ -50,9 +50,9 @@ import com.woocommerce.android.ui.compose.animations.SkeletonView
 import com.woocommerce.android.ui.compose.theme.WooThemeWithBackground
 import com.woocommerce.android.ui.orders.wooshippinglabels.address.AddressSectionLandscape
 import com.woocommerce.android.ui.orders.wooshippinglabels.address.AddressSectionPortrait
-import com.woocommerce.android.ui.orders.wooshippinglabels.address.DestinationShippingAddress
 import com.woocommerce.android.ui.orders.wooshippinglabels.address.getShipFrom
 import com.woocommerce.android.ui.orders.wooshippinglabels.address.getShipTo
+import com.woocommerce.android.ui.orders.wooshippinglabels.models.DestinationShippingAddress
 import com.woocommerce.android.ui.orders.wooshippinglabels.models.OriginShippingAddress
 import com.woocommerce.android.util.StringUtils
 import kotlinx.parcelize.Parcelize

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/WooShippingLabelCreationFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/WooShippingLabelCreationFragment.kt
@@ -18,7 +18,9 @@ import com.woocommerce.android.ui.main.AppBarStatus
 import com.woocommerce.android.ui.main.MainActivity.Companion.BackPressListener
 import com.woocommerce.android.ui.orders.wooshippinglabels.WooShippingLabelCreationViewModel.StartCustomsFormEdit
 import com.woocommerce.android.ui.orders.wooshippinglabels.WooShippingLabelCreationViewModel.StartPackageSelection
+import com.woocommerce.android.ui.orders.wooshippinglabels.address.DestinationShippingAddress
 import com.woocommerce.android.ui.orders.wooshippinglabels.address.EditAddressFlow
+import com.woocommerce.android.ui.orders.wooshippinglabels.address.WooShippingEditAddressFragment.Companion.DESTINATION_ADDRESS_UPDATE_RESULT
 import com.woocommerce.android.ui.orders.wooshippinglabels.packages.WooShippingLabelPackageCreationFragment.Companion.PACKAGE_SELECTION_RESULT
 import com.woocommerce.android.ui.orders.wooshippinglabels.packages.ui.PackageData
 import com.woocommerce.android.viewmodel.MultiLiveEvent
@@ -74,6 +76,15 @@ class WooShippingLabelCreationFragment : BaseFragment(), BackPressListener {
                             flow = EditAddressFlow.EditOriginAddress(event.originAddress)
                         ).let { findNavController().navigateSafely(it) }
 
+                is WooShippingLabelCreationViewModel.StartDestinationAddressEdit ->
+                    WooShippingLabelCreationFragmentDirections
+                        .actionWooShippingLabelCreationFragmentToWooShippingEditOriginAddressFragment(
+                            flow = EditAddressFlow.EditDestinationAddress(
+                                address = event.destinationAddress,
+                                orderId = event.orderId
+                            )
+                        ).let { findNavController().navigateSafely(it) }
+
                 is StartCustomsFormEdit -> {
                     WooShippingLabelCreationFragmentDirections
                         .actionWooShippingLabelCreationFragmentToWooShippingLabelCustomsFormFragment()
@@ -88,6 +99,9 @@ class WooShippingLabelCreationFragment : BaseFragment(), BackPressListener {
     private fun setupResultHandlers() {
         handleResult<PackageData>(PACKAGE_SELECTION_RESULT) {
             viewModel.onPackageSelected(it)
+        }
+        handleResult<DestinationShippingAddress>(DESTINATION_ADDRESS_UPDATE_RESULT) {
+            viewModel.onUpdateDestinationAddress(it)
         }
     }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/WooShippingLabelCreationFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/WooShippingLabelCreationFragment.kt
@@ -18,9 +18,9 @@ import com.woocommerce.android.ui.main.AppBarStatus
 import com.woocommerce.android.ui.main.MainActivity.Companion.BackPressListener
 import com.woocommerce.android.ui.orders.wooshippinglabels.WooShippingLabelCreationViewModel.StartCustomsFormEdit
 import com.woocommerce.android.ui.orders.wooshippinglabels.WooShippingLabelCreationViewModel.StartPackageSelection
-import com.woocommerce.android.ui.orders.wooshippinglabels.address.DestinationShippingAddress
 import com.woocommerce.android.ui.orders.wooshippinglabels.address.EditAddressFlow
 import com.woocommerce.android.ui.orders.wooshippinglabels.address.WooShippingEditAddressFragment.Companion.DESTINATION_ADDRESS_UPDATE_RESULT
+import com.woocommerce.android.ui.orders.wooshippinglabels.models.DestinationShippingAddress
 import com.woocommerce.android.ui.orders.wooshippinglabels.packages.WooShippingLabelPackageCreationFragment.Companion.PACKAGE_SELECTION_RESULT
 import com.woocommerce.android.ui.orders.wooshippinglabels.packages.ui.PackageData
 import com.woocommerce.android.viewmodel.MultiLiveEvent

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/WooShippingLabelCreationScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/WooShippingLabelCreationScreen.kt
@@ -73,6 +73,7 @@ import com.woocommerce.android.ui.orders.wooshippinglabels.WooShippingLabelCreat
 import com.woocommerce.android.ui.orders.wooshippinglabels.WooShippingLabelCreationViewModel.PackageSelectionState.DataAvailable
 import com.woocommerce.android.ui.orders.wooshippinglabels.WooShippingLabelCreationViewModel.PackageSelectionState.NotSelected
 import com.woocommerce.android.ui.orders.wooshippinglabels.address.AddressSelection
+import com.woocommerce.android.ui.orders.wooshippinglabels.address.DestinationShippingAddress
 import com.woocommerce.android.ui.orders.wooshippinglabels.address.getShipFrom
 import com.woocommerce.android.ui.orders.wooshippinglabels.address.getShipTo
 import com.woocommerce.android.ui.orders.wooshippinglabels.models.OriginShippingAddress
@@ -112,7 +113,8 @@ fun WooShippingLabelCreationScreen(viewModel: WooShippingLabelCreationViewModel)
                 purchaseState = viewState.purchaseState,
                 onShipmentDetailsExpandedChange = viewModel::onShipmentDetailsExpandedChange,
                 onSelectAddressExpandedChange = viewModel::onSelectAddressExpandedChange,
-                onEditCustomsClick = viewModel::onEditCustomsClick
+                onEditCustomsClick = viewModel::onEditCustomsClick,
+                onEditDestinationAddress = viewModel::onEditDestinationAddress
             )
         }
 
@@ -151,6 +153,7 @@ fun WooShippingLabelCreationScreen(
     purchaseState: WooShippingLabelCreationViewModel.PurchaseState,
     onEditCustomsClick: () -> Unit,
     onNavigateBack: () -> Unit,
+    onEditDestinationAddress: (DestinationShippingAddress) -> Unit,
     modifier: Modifier = Modifier
 ) {
     val shipmentDetailsValue = if (uiState.isShipmentDetailsExpanded) {
@@ -211,7 +214,8 @@ fun WooShippingLabelCreationScreen(
             onMarkOrderCompleteChange = onMarkOrderCompleteChange,
             shipFromSelectionBottomSheetState = shipFromSelectionBottomSheetState,
             onShipmentDetailsExpandedChange = onShipmentDetailsExpandedChange,
-            onEditCustomsClick = onEditCustomsClick
+            onEditCustomsClick = onEditCustomsClick,
+            onEditDestinationAddress = onEditDestinationAddress
         )
         val isDarkTheme = isSystemInDarkTheme()
         val isCollapsed = scaffoldState.bottomSheetState.isCollapsed
@@ -285,6 +289,7 @@ private fun LabelCreationScreenWithBottomSheet(
     onNavigateBack: () -> Unit,
     onShipmentDetailsExpandedChange: (Boolean) -> Boolean,
     onEditCustomsClick: () -> Unit,
+    onEditDestinationAddress: (DestinationShippingAddress) -> Unit,
     modifier: Modifier = Modifier
 ) {
     val isPurchaseButtonDisplayed = shippingRatesState is WooShippingLabelCreationViewModel.ShippingRatesState.DataState
@@ -313,7 +318,8 @@ private fun LabelCreationScreenWithBottomSheet(
                     scaffoldState = scaffoldState,
                     isShipmentDetailsExpanded = uiState.isShipmentDetailsExpanded,
                     markOrderComplete = uiState.markOrderComplete,
-                    onShipmentDetailsExpandedChange = onShipmentDetailsExpandedChange
+                    onShipmentDetailsExpandedChange = onShipmentDetailsExpandedChange,
+                    onEditDestinationAddress = onEditDestinationAddress
                 )
             }
         },
@@ -790,7 +796,8 @@ private fun WooShippingLabelCreationScreenPreview() {
             ),
             onShipmentDetailsExpandedChange = { true },
             onSelectAddressExpandedChange = { true },
-            onEditCustomsClick = {}
+            onEditCustomsClick = {},
+            onEditDestinationAddress = {}
         )
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/WooShippingLabelCreationScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/WooShippingLabelCreationScreen.kt
@@ -73,9 +73,9 @@ import com.woocommerce.android.ui.orders.wooshippinglabels.WooShippingLabelCreat
 import com.woocommerce.android.ui.orders.wooshippinglabels.WooShippingLabelCreationViewModel.PackageSelectionState.DataAvailable
 import com.woocommerce.android.ui.orders.wooshippinglabels.WooShippingLabelCreationViewModel.PackageSelectionState.NotSelected
 import com.woocommerce.android.ui.orders.wooshippinglabels.address.AddressSelection
-import com.woocommerce.android.ui.orders.wooshippinglabels.address.DestinationShippingAddress
 import com.woocommerce.android.ui.orders.wooshippinglabels.address.getShipFrom
 import com.woocommerce.android.ui.orders.wooshippinglabels.address.getShipTo
+import com.woocommerce.android.ui.orders.wooshippinglabels.models.DestinationShippingAddress
 import com.woocommerce.android.ui.orders.wooshippinglabels.models.OriginShippingAddress
 import com.woocommerce.android.ui.orders.wooshippinglabels.packages.ui.PackageData
 import com.woocommerce.android.ui.orders.wooshippinglabels.rates.ui.ShippingRateUI

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/WooShippingLabelCreationViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/WooShippingLabelCreationViewModel.kt
@@ -17,10 +17,10 @@ import com.woocommerce.android.ui.orders.wooshippinglabels.WooShippingLabelCreat
 import com.woocommerce.android.ui.orders.wooshippinglabels.WooShippingLabelCreationViewModel.CustomsState.Unavailable
 import com.woocommerce.android.ui.orders.wooshippinglabels.WooShippingLabelCreationViewModel.PackageSelectionState.DataAvailable
 import com.woocommerce.android.ui.orders.wooshippinglabels.WooShippingLabelCreationViewModel.PackageSelectionState.NotSelected
-import com.woocommerce.android.ui.orders.wooshippinglabels.address.DestinationShippingAddress
 import com.woocommerce.android.ui.orders.wooshippinglabels.address.origin.FetchOriginAddresses
 import com.woocommerce.android.ui.orders.wooshippinglabels.address.origin.ObserveOriginAddresses
 import com.woocommerce.android.ui.orders.wooshippinglabels.customs.ShouldRequireCustomsForm
+import com.woocommerce.android.ui.orders.wooshippinglabels.models.DestinationShippingAddress
 import com.woocommerce.android.ui.orders.wooshippinglabels.models.OriginShippingAddress
 import com.woocommerce.android.ui.orders.wooshippinglabels.models.ShippableItemModel
 import com.woocommerce.android.ui.orders.wooshippinglabels.models.StoreOptionsModel

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/WooShippingLabelCreationViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/WooShippingLabelCreationViewModel.kt
@@ -343,7 +343,16 @@ class WooShippingLabelCreationViewModel @Inject constructor(
         triggerEvent(StartOriginAddressEdit(address))
     }
 
-    fun onShippingToAddressChange(address: Address) {
+    fun onEditDestinationAddress(destinationAddress: DestinationShippingAddress) {
+        triggerEvent(
+            StartDestinationAddressEdit(
+                destinationAddress = destinationAddress,
+                orderId = navArgs.orderId
+            )
+        )
+    }
+
+    fun onUpdateDestinationAddress(destinationAddress: DestinationShippingAddress) {
         shippingAddresses.value?.let {
             shippingAddresses.value = it.copy(shipTo = address)
         }
@@ -531,6 +540,11 @@ class WooShippingLabelCreationViewModel @Inject constructor(
     data object StartPackageSelection : Event()
     data class LabelPurchased(val purchaseData: PurchasedShippingLabelData) : Event()
     data class StartOriginAddressEdit(val originAddress: OriginShippingAddress) : Event()
+    data class StartDestinationAddressEdit(
+        val destinationAddress: DestinationShippingAddress,
+        val orderId: Long
+    ) : Event()
+
     data object StartCustomsFormEdit : Event()
 
     sealed class WooShippingViewState {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/WooShippingLabelCreationViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/WooShippingLabelCreationViewModel.kt
@@ -17,6 +17,7 @@ import com.woocommerce.android.ui.orders.wooshippinglabels.WooShippingLabelCreat
 import com.woocommerce.android.ui.orders.wooshippinglabels.WooShippingLabelCreationViewModel.CustomsState.Unavailable
 import com.woocommerce.android.ui.orders.wooshippinglabels.WooShippingLabelCreationViewModel.PackageSelectionState.DataAvailable
 import com.woocommerce.android.ui.orders.wooshippinglabels.WooShippingLabelCreationViewModel.PackageSelectionState.NotSelected
+import com.woocommerce.android.ui.orders.wooshippinglabels.address.DestinationShippingAddress
 import com.woocommerce.android.ui.orders.wooshippinglabels.address.origin.FetchOriginAddresses
 import com.woocommerce.android.ui.orders.wooshippinglabels.address.origin.ObserveOriginAddresses
 import com.woocommerce.android.ui.orders.wooshippinglabels.customs.ShouldRequireCustomsForm
@@ -156,7 +157,7 @@ class WooShippingLabelCreationViewModel @Inject constructor(
                     orderId = navArgs.orderId,
                     packageSelected = selectedPackage,
                     shipFrom = addresses.shipFrom,
-                    shipTo = addresses.shipTo,
+                    shipTo = addresses.shipTo.address,
                     weight = packageWeight.totalWeight,
                     currencyCode = order.value.currency
                 )
@@ -249,7 +250,7 @@ class WooShippingLabelCreationViewModel @Inject constructor(
                 WooShippingAddresses(
                     shipFrom = selectedOriginAddress,
                     originAddresses = originAddresses,
-                    shipTo = order.shippingAddress
+                    shipTo = DestinationShippingAddress(order.shippingAddress, false)
                 )
             } else {
                 null
@@ -354,7 +355,7 @@ class WooShippingLabelCreationViewModel @Inject constructor(
 
     fun onUpdateDestinationAddress(destinationAddress: DestinationShippingAddress) {
         shippingAddresses.value?.let {
-            shippingAddresses.value = it.copy(shipTo = address)
+            shippingAddresses.value = it.copy(shipTo = destinationAddress)
         }
     }
 
@@ -426,7 +427,7 @@ class WooShippingLabelCreationViewModel @Inject constructor(
                 orderId,
                 shippableItemsIdList,
                 selectedPackage,
-                addresses.shipTo,
+                addresses.shipTo.address,
                 addresses.shipFrom,
                 shippingRate,
                 weight,
@@ -634,13 +635,13 @@ class WooShippingLabelCreationViewModel @Inject constructor(
 @Parcelize
 data class WooShippingAddresses(
     val shipFrom: OriginShippingAddress,
-    val shipTo: Address,
+    val shipTo: DestinationShippingAddress,
     val originAddresses: List<OriginShippingAddress>
 ) : Parcelable {
     companion object {
         val EMPTY = WooShippingAddresses(
             shipFrom = OriginShippingAddress.EMPTY,
-            shipTo = Address.EMPTY,
+            shipTo = DestinationShippingAddress.EMPTY,
             originAddresses = emptyList()
         )
     }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/address/AddressSection.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/address/AddressSection.kt
@@ -59,6 +59,7 @@ import kotlinx.coroutines.launch
 internal fun AddressSectionPortrait(
     shippingAddresses: WooShippingAddresses,
     shipFromSelectionBottomSheetState: ModalBottomSheetState,
+    onEditDestinationAddress: (DestinationShippingAddress) -> Unit,
     modifier: Modifier = Modifier,
     isReadOnly: Boolean = false
 ) {
@@ -157,7 +158,7 @@ internal fun AddressSectionPortrait(
                     )
             )
             Text(
-                text = shippingAddresses.shipTo.toString(),
+                text = shippingAddresses.shipTo.address.toString(),
                 modifier = Modifier
                     .constrainAs(shipToValue) {
                         top.linkTo(shipToLabel.top)
@@ -174,7 +175,7 @@ internal fun AddressSectionPortrait(
             )
             if (isReadOnly.not()) {
                 IconButton(
-                    onClick = { },
+                    onClick = { onEditDestinationAddress(shippingAddresses.shipTo) },
                     modifier = Modifier
                         .constrainAs(shipToEdit) {
                             top.linkTo(shipToLabel.top)
@@ -205,6 +206,7 @@ private fun AddressSectionPortraitPreview() {
                     shipTo = getShipTo(),
                     originAddresses = listOf(getShipFrom())
                 ),
+                onEditDestinationAddress = {},
                 shipFromSelectionBottomSheetState = rememberModalBottomSheetState(ModalBottomSheetValue.Hidden),
                 isReadOnly = false
             )
@@ -217,6 +219,7 @@ private fun AddressSectionPortraitPreview() {
 internal fun AddressSectionLandscape(
     shippingAddresses: WooShippingAddresses,
     shipFromSelectionBottomSheetState: ModalBottomSheetState,
+    onEditDestinationAddress: (DestinationShippingAddress) -> Unit,
     modifier: Modifier = Modifier,
     isReadOnly: Boolean = false
 ) {
@@ -245,7 +248,7 @@ internal fun AddressSectionLandscape(
                 )
 
                 Text(
-                    text = shippingAddresses.shipTo.toString(),
+                    text = shippingAddresses.shipTo.address.toString(),
                     modifier = Modifier
                         .padding(
                             top = dimensionResource(R.dimen.major_100),
@@ -270,7 +273,7 @@ internal fun AddressSectionLandscape(
                     }
 
                     IconButton(
-                        onClick = { },
+                        onClick = { onEditDestinationAddress(shippingAddresses.shipTo) },
                         modifier = iconModifier
                     ) {
                         Icon(
@@ -465,7 +468,8 @@ private fun AddressSectionLandscapePreview() {
                     originAddresses = listOf(getShipFrom())
                 ),
                 shipFromSelectionBottomSheetState = rememberModalBottomSheetState(ModalBottomSheetValue.Hidden),
-                isReadOnly = false
+                isReadOnly = false,
+                onEditDestinationAddress = {}
             )
         }
     }
@@ -488,18 +492,21 @@ internal fun getShipFrom() = OriginShippingAddress(
     isVerified = true
 )
 
-internal fun getShipTo() = Address(
-    firstName = "first name",
-    lastName = "last name",
-    company = "Company",
-    phone = "",
-    address1 = "Another Address",
-    address2 = "",
-    city = "City",
-    postcode = "",
-    email = "email",
-    country = Location("US", "USA"),
-    state = AmbiguousLocation.Defined(Location("CA", "California", "USA"))
+internal fun getShipTo() = DestinationShippingAddress(
+    address = Address(
+        firstName = "first name",
+        lastName = "last name",
+        company = "Company",
+        phone = "",
+        address1 = "Another Address",
+        address2 = "",
+        city = "City",
+        postcode = "",
+        email = "email",
+        country = Location("US", "USA"),
+        state = AmbiguousLocation.Defined(Location("CA", "California", "USA")),
+    ),
+    isVerified = true
 )
 
 fun OriginShippingAddress.getFormattedName(context: Context): String {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/address/AddressSection.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/address/AddressSection.kt
@@ -49,6 +49,7 @@ import com.woocommerce.android.ui.orders.wooshippinglabels.RoundedCornerBoxWithB
 import com.woocommerce.android.ui.orders.wooshippinglabels.ShipmentDetailsSectionTitle
 import com.woocommerce.android.ui.orders.wooshippinglabels.VerticalDivider
 import com.woocommerce.android.ui.orders.wooshippinglabels.WooShippingAddresses
+import com.woocommerce.android.ui.orders.wooshippinglabels.models.DestinationShippingAddress
 import com.woocommerce.android.ui.orders.wooshippinglabels.models.OriginShippingAddress
 import com.woocommerce.android.ui.orders.wooshippinglabels.rates.ui.shippingSelectedBackgroundColor
 import com.woocommerce.android.ui.orders.wooshippinglabels.toShippingFromString

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/address/WooShippingEditAddressFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/address/WooShippingEditAddressFragment.kt
@@ -11,6 +11,7 @@ import androidx.fragment.app.viewModels
 import androidx.navigation.fragment.findNavController
 import com.woocommerce.android.R
 import com.woocommerce.android.extensions.handleResult
+import com.woocommerce.android.extensions.navigateBackWithResult
 import com.woocommerce.android.extensions.navigateSafely
 import com.woocommerce.android.model.Location
 import com.woocommerce.android.ui.base.BaseFragment
@@ -24,9 +25,10 @@ import dagger.hilt.android.AndroidEntryPoint
 
 @AndroidEntryPoint
 class WooShippingEditAddressFragment : BaseFragment(), BackPressListener {
-    private companion object {
-        const val SELECT_COUNTRY_REQUEST = "select_address_country_request"
-        const val SELECT_STATE_REQUEST = "select_address_state_request"
+    companion object {
+        private const val SELECT_COUNTRY_REQUEST = "select_address_country_request"
+        private const val SELECT_STATE_REQUEST = "select_address_state_request"
+        const val DESTINATION_ADDRESS_UPDATE_RESULT = "destination_address_update_result"
     }
 
     private val viewModel: WooShippingEditAddressViewModel by viewModels()
@@ -58,6 +60,10 @@ class WooShippingEditAddressFragment : BaseFragment(), BackPressListener {
                 is WooShippingEditAddressViewModel.ShowCountrySelector -> showCountrySearchScreen(event.countries)
                 is WooShippingEditAddressViewModel.ShowStateSelector -> showStatesSearchScreen(event.states)
                 is MultiLiveEvent.Event.Exit -> findNavController().navigateUp()
+                is MultiLiveEvent.Event.ExitWithResult<*> -> navigateBackWithResult(
+                    key = DESTINATION_ADDRESS_UPDATE_RESULT,
+                    result = event.data
+                )
             }
         }
     }
@@ -101,5 +107,5 @@ class WooShippingEditAddressFragment : BaseFragment(), BackPressListener {
         findNavController().navigateSafely(action)
     }
 
-    override fun onRequestAllowBackPress(): Boolean = viewModel.allowBackNavigation()
+    override fun onRequestAllowBackPress(): Boolean = viewModel.handleBackPress()
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/address/WooShippingEditAddressScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/address/WooShippingEditAddressScreen.kt
@@ -98,6 +98,7 @@ fun WooShippingEditAddressScreen(
 ) {
     val viewState = viewModel.viewState.collectAsState().value
     WooShippingEditAddressScreen(
+        screenTitle = viewModel.screenTitle,
         editableAddress = viewState.editableAddress,
         isCompanyExpanded = viewState.isCompanyExpanded,
         loading = viewState.loading,
@@ -120,7 +121,7 @@ fun WooShippingEditAddressScreen(
         onStateChange = viewModel::onStateChange,
         onNormalizeAddress = viewModel::onNormalizeAddress,
         onUpdateAddress = viewModel::onUpdateAddress,
-        onUpdateNormalizedOriginAddress = viewModel::onUpdateNormalizedOriginAddress,
+        onUpdateNormalizedAddress = viewModel::onUpdateNormalizedAddress,
         onNavigateBack = viewModel::onNavigateBack,
         modifier = modifier
     )
@@ -129,6 +130,7 @@ fun WooShippingEditAddressScreen(
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun WooShippingEditAddressScreen(
+    screenTitle: String,
     editableAddress: EditableAddress,
     loading: WooShippingEditAddressViewModel.LoadingState,
     error: WooShippingEditAddressViewModel.EditAddressError?,
@@ -151,7 +153,7 @@ fun WooShippingEditAddressScreen(
     onStateChange: () -> Unit,
     onNormalizeAddress: (editableAddress: EditableAddress) -> Unit,
     onUpdateAddress: (editableAddress: EditableAddress) -> Unit,
-    onUpdateNormalizedOriginAddress: (selection: AddressValidationState.AddressSelection) -> Unit,
+    onUpdateNormalizedAddress: (selection: AddressValidationState.AddressSelection) -> Unit,
     onNavigateBack: () -> Unit,
     modifier: Modifier = Modifier
 ) {
@@ -167,7 +169,7 @@ fun WooShippingEditAddressScreen(
         },
         topBar = {
             Toolbar(
-                title = stringResource(id = R.string.woo_shipping_edit_origin_address_title),
+                title = screenTitle,
                 onNavigationButtonClick = onNavigateBack,
                 navigationIcon = Icons.AutoMirrored.Filled.ArrowBack
             )
@@ -406,7 +408,7 @@ fun WooShippingEditAddressScreen(
                 SelectAddressWithCustomSnackBar(
                     addressSelection = addressSelection,
                     onAddressSelectionChange = onAddressSelectionChange,
-                    onUpdateNormalizedOriginAddress = onUpdateNormalizedOriginAddress,
+                    onUpdateNormalizedAddress = onUpdateNormalizedAddress,
                     onCloseAddressSelection = onCloseAddressSelection,
                     error = error,
                     isBottomSheetSnackBarVisible = isBottomSheetSnackBarVisible,
@@ -708,7 +710,7 @@ private fun CollapsedField(
 private fun SelectAddressWithCustomSnackBar(
     addressSelection: AddressValidationState.AddressSelection,
     onAddressSelectionChange: (AddressValidationState.AddressSelection) -> Unit,
-    onUpdateNormalizedOriginAddress: (selection: AddressValidationState.AddressSelection) -> Unit,
+    onUpdateNormalizedAddress: (selection: AddressValidationState.AddressSelection) -> Unit,
     onCloseAddressSelection: () -> Unit,
     error: WooShippingEditAddressViewModel.EditAddressError?,
     isBottomSheetSnackBarVisible: Boolean,
@@ -721,7 +723,7 @@ private fun SelectAddressWithCustomSnackBar(
         SelectAddress(
             addressSelection = addressSelection,
             onAddressSelectionChange = onAddressSelectionChange,
-            onUpdateOriginAddress = onUpdateNormalizedOriginAddress,
+            onUpdateNormalizedAddress = onUpdateNormalizedAddress,
             onCloseAddressSelection = {
                 dismissWCModalBottomSheet(
                     coroutineScope = coroutineScope,
@@ -782,7 +784,7 @@ private fun SelectAddressWithCustomSnackBar(
 private fun SelectAddress(
     addressSelection: AddressValidationState.AddressSelection,
     onAddressSelectionChange: (AddressValidationState.AddressSelection) -> Unit,
-    onUpdateOriginAddress: (selection: AddressValidationState.AddressSelection) -> Unit,
+    onUpdateNormalizedAddress: (selection: AddressValidationState.AddressSelection) -> Unit,
     onCloseAddressSelection: () -> Unit,
     modifier: Modifier = Modifier
 ) {
@@ -862,7 +864,7 @@ private fun SelectAddress(
                     .windowInsetsPadding(WindowInsets.navigationBars)
             ) {
                 WCColoredButton(
-                    onClick = { onUpdateOriginAddress(addressSelection) },
+                    onClick = { onUpdateNormalizedAddress(addressSelection) },
                     text = buttonText,
                     modifier = Modifier.fillMaxWidth()
                 )

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/address/WooShippingEditAddressScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/address/WooShippingEditAddressScreen.kt
@@ -194,9 +194,10 @@ fun WooShippingEditAddressScreen(
                 val keyboardController = LocalSoftwareKeyboardController.current
 
                 RoundedBorderTextFieldWithLabel(
-                    label = "${stringResource(id = R.string.woo_shipping_label_name)} *",
+                    label = stringResource(id = R.string.woo_shipping_label_name),
                     text = editableAddress.name.value,
                     error = editableAddress.name.error,
+                    isRequired = editableAddress.name.isRequired,
                     onTextChange = onNameChange,
                     keyboardOptions = KeyboardOptions(imeAction = ImeAction.Next),
                     keyboardActions = KeyboardActions(
@@ -219,6 +220,7 @@ fun WooShippingEditAddressScreen(
                     RoundedBorderTextFieldWithLabel(
                         label = stringResource(id = R.string.woo_shipping_label_company),
                         text = editableAddress.company.value,
+                        isRequired = editableAddress.company.isRequired,
                         onTextChange = onCompanyChange,
                         keyboardOptions = KeyboardOptions(imeAction = ImeAction.Next),
                         keyboardActions = KeyboardActions(
@@ -238,9 +240,10 @@ fun WooShippingEditAddressScreen(
                     onClick = onCountryChange
                 )
                 RoundedBorderTextFieldWithLabel(
-                    label = "${stringResource(id = R.string.woo_shipping_label_address)} *",
+                    label = stringResource(id = R.string.woo_shipping_label_address),
                     text = editableAddress.address.value,
                     error = editableAddress.address.error,
+                    isRequired = editableAddress.address.isRequired,
                     onTextChange = onAddressChange,
                     keyboardOptions = KeyboardOptions(imeAction = ImeAction.Next),
                     keyboardActions = KeyboardActions(
@@ -252,9 +255,10 @@ fun WooShippingEditAddressScreen(
                     modifier = Modifier.padding(top = 8.dp)
                 )
                 RoundedBorderTextFieldWithLabel(
-                    label = "${stringResource(id = R.string.woo_shipping_label_city)} *",
+                    label = stringResource(id = R.string.woo_shipping_label_city),
                     text = editableAddress.city.value,
                     error = editableAddress.city.error,
+                    isRequired = editableAddress.city.isRequired,
                     onTextChange = onCityChange,
                     keyboardOptions = KeyboardOptions(imeAction = ImeAction.Next),
                     keyboardActions = KeyboardActions(
@@ -302,9 +306,10 @@ fun WooShippingEditAddressScreen(
                     }
                     Spacer(modifier = Modifier.size(8.dp))
                     RoundedBorderTextFieldWithLabel(
-                        label = "${stringResource(id = R.string.woo_shipping_label_post_code)} *",
+                        label = stringResource(id = R.string.woo_shipping_label_post_code),
                         text = editableAddress.postalCode.value,
                         error = editableAddress.postalCode.error,
+                        isRequired = editableAddress.postalCode.isRequired,
                         keyboardOptions = KeyboardOptions(
                             keyboardType = KeyboardType.Number,
                             imeAction = ImeAction.Next
@@ -323,9 +328,10 @@ fun WooShippingEditAddressScreen(
                 }
 
                 RoundedBorderTextFieldWithLabel(
-                    label = "${stringResource(id = R.string.woo_shipping_label_email)} *",
+                    label = stringResource(id = R.string.woo_shipping_label_email),
                     text = editableAddress.email.value,
                     error = editableAddress.email.error,
+                    isRequired = editableAddress.email.isRequired,
                     keyboardOptions = KeyboardOptions(
                         keyboardType = KeyboardType.Email,
                         imeAction = ImeAction.Next
@@ -340,9 +346,10 @@ fun WooShippingEditAddressScreen(
                     modifier = Modifier.padding(top = 32.dp)
                 )
                 RoundedBorderTextFieldWithLabel(
-                    label = "${stringResource(id = R.string.woo_shipping_label_phone)} *",
+                    label = stringResource(id = R.string.woo_shipping_label_phone),
                     text = editableAddress.phone.value,
                     error = editableAddress.phone.error,
+                    isRequired = editableAddress.phone.isRequired,
                     keyboardOptions = KeyboardOptions(
                         keyboardType = KeyboardType.Phone,
                         imeAction = ImeAction.Done
@@ -483,12 +490,15 @@ internal fun AddressStatusSection(
             AddressStatus.VERIFIED -> {
                 { onClose() }
             }
+
             AddressStatus.UNVERIFIED -> {
                 { onNormalizeAddress(editableAddress) }
             }
+
             AddressStatus.MISSING_INFO -> {
                 {}
             }
+
             AddressStatus.SAVE_CHANGES -> {
                 { onUpdateAddress(editableAddress) }
             }
@@ -522,6 +532,7 @@ internal fun RoundedBorderTextFieldWithLabel(
     text: String,
     onTextChange: (String) -> Unit,
     modifier: Modifier = Modifier,
+    isRequired: Boolean = false,
     hint: String = "",
     error: String? = null,
     keyboardOptions: KeyboardOptions = KeyboardOptions.Default,
@@ -544,9 +555,11 @@ internal fun RoundedBorderTextFieldWithLabel(
         Modifier
     }
 
+    val labelWithRequired = if (isRequired) "$label *" else label
+
     Column(modifier = modifier) {
         Text(
-            text = label,
+            text = labelWithRequired,
             style = MaterialTheme.typography.body2,
             modifier = Modifier.padding(vertical = 8.dp)
         )

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/address/WooShippingEditAddressViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/address/WooShippingEditAddressViewModel.kt
@@ -86,6 +86,13 @@ class WooShippingEditAddressViewModel @Inject constructor(
 
     private val addressId = (navArgs.flow as? EditAddressFlow.EditOriginAddress)?.address?.id
 
+    val screenTitle = when (navArgs.flow) {
+        is EditAddressFlow.EditDestinationAddress ->
+            resourceProvider.getString(R.string.woo_shipping_edit_destination_address_title)
+        is EditAddressFlow.EditOriginAddress ->
+            resourceProvider.getString(R.string.woo_shipping_edit_origin_address_title)
+    }
+
     private val nameValidatedFlow = snapshotFlow { name }
         .combine(snapshotFlow { company }) { name, company ->
             Pair(name, company)

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/address/WooShippingEditAddressViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/address/WooShippingEditAddressViewModel.kt
@@ -554,11 +554,7 @@ class WooShippingEditAddressViewModel @Inject constructor(
         launch {
             updateDestinationAddress(selection.selectedAddress, orderId).fold(
                 onSuccess = {
-                    val address = it.address
-                    fillAddressForm(address)
-                    addressValidationState.value = AddressValidationState.NotStarted
-                    currentAddress.value = address
-                    isVerified.value = it.isVerified
+                    onUpdateAddress(it.address, it.isVerified)
                 },
                 onFailure = {
                     addressValidationState.value = AddressValidationState.NormalizedAddressUpdateFailed(selection)
@@ -572,11 +568,7 @@ class WooShippingEditAddressViewModel @Inject constructor(
         launch {
             updateOriginAddress(selection.selectedAddress, addressId).fold(
                 onSuccess = {
-                    val address = it.toAddress()
-                    fillAddressForm(address)
-                    addressValidationState.value = AddressValidationState.NotStarted
-                    currentAddress.value = address
-                    isVerified.value = it.isVerified
+                    onUpdateAddress(it.toAddress(), it.isVerified)
                 },
                 onFailure = {
                     addressValidationState.value = AddressValidationState.NormalizedAddressUpdateFailed(selection)
@@ -600,11 +592,7 @@ class WooShippingEditAddressViewModel @Inject constructor(
             val address = editableAddress.toAddress()
             updateDestinationAddress(address, orderId).fold(
                 onSuccess = { result ->
-                    val updatedAddress = result.address
-                    fillAddressForm(updatedAddress)
-                    addressValidationState.value = AddressValidationState.NotStarted
-                    currentAddress.value = updatedAddress
-                    isVerified.value = result.isVerified
+                    onUpdateAddress(result.address, result.isVerified)
                 },
                 onFailure = {
                     addressValidationState.value = AddressValidationState.AddressUpdateFailed(editableAddress)
@@ -619,17 +607,20 @@ class WooShippingEditAddressViewModel @Inject constructor(
             val address = editableAddress.toAddress()
             updateOriginAddress(address, addressId).fold(
                 onSuccess = {
-                    val updatedAddress = it.toAddress()
-                    fillAddressForm(updatedAddress)
-                    addressValidationState.value = AddressValidationState.NotStarted
-                    currentAddress.value = updatedAddress
-                    isVerified.value = it.isVerified
+                    onUpdateAddress(it.toAddress(), it.isVerified)
                 },
                 onFailure = {
                     addressValidationState.value = AddressValidationState.AddressUpdateFailed(editableAddress)
                 }
             )
         }
+    }
+
+    private fun onUpdateAddress(updatedAddress: Address, updatedIsVerified: Boolean) {
+        fillAddressForm(updatedAddress)
+        addressValidationState.value = AddressValidationState.NotStarted
+        currentAddress.value = updatedAddress
+        isVerified.value = updatedIsVerified
     }
 
     data class ViewState(

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/address/WooShippingEditAddressViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/address/WooShippingEditAddressViewModel.kt
@@ -49,13 +49,25 @@ class WooShippingEditAddressViewModel @Inject constructor(
     private val updateDestinationAddress: UpdateDestinationAddress,
     savedState: SavedStateHandle
 ) : ScopedViewModel(savedState) {
-    private var name by mutableStateOf(InputValue(""))
-    private var company by mutableStateOf(InputValue(""))
-    private var address by mutableStateOf(InputValue(""))
-    private var city by mutableStateOf(InputValue(""))
-    private var postalCode by mutableStateOf(InputValue(""))
-    private var email by mutableStateOf(InputValue(""))
-    private var phone by mutableStateOf(InputValue(""))
+    private val navArgs: WooShippingEditAddressFragmentArgs by savedState.navArgs()
+
+    private var name by mutableStateOf(InputValue(value = "", isRequired = true))
+    private var company by mutableStateOf(InputValue(value = "", isRequired = false))
+    private var address by mutableStateOf(InputValue(value = "", isRequired = true))
+    private var city by mutableStateOf(InputValue(value = "", isRequired = true))
+    private var postalCode by mutableStateOf(InputValue(value = "", isRequired = true))
+    private var email by mutableStateOf(
+        InputValue(
+            value = "",
+            isRequired = navArgs.flow is EditAddressFlow.EditOriginAddress
+        )
+    )
+    private var phone by mutableStateOf(
+        InputValue(
+            value = "",
+            isRequired = navArgs.flow is EditAddressFlow.EditOriginAddress
+        )
+    )
 
     private var country = MutableStateFlow(Location.EMPTY)
 
@@ -66,7 +78,8 @@ class WooShippingEditAddressViewModel @Inject constructor(
         snapshotFlow { rawState },
         selectedState
     ) { rawState, selectedState ->
-        if (selectedState != Location.EMPTY) selectedState else AmbiguousLocation.Raw(rawState).asLocation()
+        if (selectedState != Location.EMPTY) selectedState else AmbiguousLocation.Raw(rawState)
+            .asLocation()
     }
 
     private val countriesState = MutableStateFlow<LocationState>(LocationState.Loading)
@@ -74,8 +87,6 @@ class WooShippingEditAddressViewModel @Inject constructor(
 
     private val addressValidationState =
         MutableStateFlow<AddressValidationState>(AddressValidationState.NotStarted)
-
-    private val navArgs: WooShippingEditAddressFragmentArgs by savedState.navArgs()
 
     private val currentAddress = when (val currentFlow = navArgs.flow) {
         is EditAddressFlow.EditDestinationAddress -> currentFlow.address.address
@@ -92,6 +103,7 @@ class WooShippingEditAddressViewModel @Inject constructor(
     val screenTitle = when (navArgs.flow) {
         is EditAddressFlow.EditDestinationAddress ->
             resourceProvider.getString(R.string.woo_shipping_edit_destination_address_title)
+
         is EditAddressFlow.EditOriginAddress ->
             resourceProvider.getString(R.string.woo_shipping_edit_origin_address_title)
     }
@@ -137,14 +149,22 @@ class WooShippingEditAddressViewModel @Inject constructor(
         .transformLatestWithDelay(
             delayMillis = DELAY_TIME_MILLIS,
         ) { inputValue ->
-            inputValue.copy(error = addressValidator.validateFieldRequired(inputValue.value))
+            if (inputValue.isRequired) {
+                inputValue.copy(error = addressValidator.validateFieldRequired(inputValue.value))
+            } else {
+                inputValue
+            }
         }
 
     private val phoneValidatedFlow = snapshotFlow { phone }
         .transformLatestWithDelay(
             delayMillis = DELAY_TIME_MILLIS,
         ) { inputValue ->
-            inputValue.copy(error = addressValidator.validateUSCustomsPhone(inputValue.value))
+            if (inputValue.isRequired) {
+                inputValue.copy(error = addressValidator.validateFieldRequired(inputValue.value))
+            } else {
+                inputValue
+            }
         }
 
     private val isCompanyExpanded = MutableStateFlow(false)
@@ -202,15 +222,16 @@ class WooShippingEditAddressViewModel @Inject constructor(
             addressInformation.address1,
             addressInformation.address2
         )
-        name = InputValue(fullName)
-        company = InputValue(addressInformation.company)
+        name = name.copy(value = fullName, error = null)
+        company = company.copy(value = addressInformation.company, error = null)
         country.value = findLocationByCode(addressInformation.country.code, countriesState.value)
-        address = InputValue(fullAddress)
-        city = InputValue(addressInformation.city)
-        selectedState.value = findLocationByCode(addressInformation.state.codeOrRaw, statesState.value)
-        postalCode = InputValue(addressInformation.postcode)
-        email = InputValue(addressInformation.email)
-        phone = InputValue(addressInformation.phone)
+        address = address.copy(value = fullAddress, error = null)
+        city = city.copy(value = addressInformation.city, error = null)
+        selectedState.value =
+            findLocationByCode(addressInformation.state.codeOrRaw, statesState.value)
+        postalCode = postalCode.copy(value = addressInformation.postcode, error = null)
+        email = email.copy(value = addressInformation.email, error = null)
+        phone = phone.copy(value = addressInformation.phone, error = null)
         isCompanyExpanded.value = addressInformation.company.isNotNullOrEmpty()
     }
 
@@ -254,7 +275,9 @@ class WooShippingEditAddressViewModel @Inject constructor(
     }
 
     fun handleBackPress(): Boolean {
-        if (allowBackNavigation()) { onNavigateBack() }
+        if (allowBackNavigation()) {
+            onNavigateBack()
+        }
         return false
     }
 
@@ -417,7 +440,10 @@ class WooShippingEditAddressViewModel @Inject constructor(
         return isSameAddress && isSameCity && isSameState && isSameCountry && isSamePostalCode
     }
 
-    private fun hasOnlyNoAddressChanges(newAddress: EditableAddress, currentAddress: Address): Boolean {
+    private fun hasOnlyNoAddressChanges(
+        newAddress: EditableAddress,
+        currentAddress: Address
+    ): Boolean {
         val originalFullName = combineStrings(
             currentAddress.firstName,
             currentAddress.lastName
@@ -428,46 +454,59 @@ class WooShippingEditAddressViewModel @Inject constructor(
         val isDifferentPhone = newAddress.phone.value != currentAddress.phone
         val isSameAddress = isSameAddress(newAddress, currentAddress)
         val isVerified = isVerified.value
-        val hasNoAddressChanges = isDifferentName || isDifferentCompany || isDifferentEmail || isDifferentPhone
+        val hasNoAddressChanges =
+            isDifferentName || isDifferentCompany || isDifferentEmail || isDifferentPhone
         return hasNoAddressChanges && isSameAddress && isVerified
     }
 
     private fun hasIncorrectOrMissingData(editableAddress: EditableAddress): Boolean {
         return editableAddress.address.error.isNotNullOrEmpty() ||
-            editableAddress.city.error.isNotNullOrEmpty() ||
-            editableAddress.postalCode.error.isNotNullOrEmpty() ||
-            editableAddress.email.error.isNotNullOrEmpty() ||
-            editableAddress.phone.error.isNotNullOrEmpty() ||
-            editableAddress.name.error.isNotNullOrEmpty() ||
-            editableAddress.company.error.isNotNullOrEmpty()
+                editableAddress.city.error.isNotNullOrEmpty() ||
+                editableAddress.postalCode.error.isNotNullOrEmpty() ||
+                editableAddress.email.error.isNotNullOrEmpty() ||
+                editableAddress.phone.error.isNotNullOrEmpty() ||
+                editableAddress.name.error.isNotNullOrEmpty() ||
+                editableAddress.company.error.isNotNullOrEmpty()
     }
 
     fun onNameChange(value: String) {
-        name = InputValue(value)
+        val isCompanyRequired = value.isEmpty() && company.value.isNotNullOrEmpty()
+        name = InputValue(
+            value = value,
+            isRequired = isCompanyRequired.not(),
+            error = null
+        )
+        company = company.copy(isRequired = isCompanyRequired)
     }
 
     fun onCompanyChange(value: String) {
-        company = InputValue(value)
+        val isCompanyRequired = value.isEmpty() && name.value.isNotEmpty()
+        company = InputValue(
+            value = value,
+            isRequired = isCompanyRequired,
+            error = null
+        )
+        name = name.copy(isRequired = isCompanyRequired.not())
     }
 
     fun onAddressChange(value: String) {
-        address = InputValue(value)
+        address = address.copy(value = value, error = null)
     }
 
     fun onCityChange(value: String) {
-        city = InputValue(value)
+        city = city.copy(value = value, error = null)
     }
 
     fun onPostalCodeChange(value: String) {
-        postalCode = InputValue(value)
+        postalCode = postalCode.copy(value = value, error = null)
     }
 
     fun onEmailChange(value: String) {
-        email = InputValue(value)
+        email = email.copy(value = value, error = null)
     }
 
     fun onPhoneChange(value: String) {
-        phone = InputValue(value)
+        phone = phone.copy(value = value, error = null)
     }
 
     fun onRawStateChange(value: String) {
@@ -525,7 +564,8 @@ class WooShippingEditAddressViewModel @Inject constructor(
                         AddressValidationState.AddressSelection(it, it.normalizedAddress)
                 },
                 onFailure = {
-                    addressValidationState.value = AddressValidationState.VerificationFailed(editableAddress)
+                    addressValidationState.value =
+                        AddressValidationState.VerificationFailed(editableAddress)
                 }
             )
         }
@@ -543,6 +583,7 @@ class WooShippingEditAddressViewModel @Inject constructor(
         when (val currentFlow = navArgs.flow) {
             is EditAddressFlow.EditDestinationAddress ->
                 onUpdateNormalizedDestinationAddress(selection, currentFlow.orderId)
+
             is EditAddressFlow.EditOriginAddress -> onUpdateNormalizedOriginAddress(selection)
         }
     }
@@ -558,7 +599,8 @@ class WooShippingEditAddressViewModel @Inject constructor(
                     onUpdateAddress(it.address, it.isVerified)
                 },
                 onFailure = {
-                    addressValidationState.value = AddressValidationState.NormalizedAddressUpdateFailed(selection)
+                    addressValidationState.value =
+                        AddressValidationState.NormalizedAddressUpdateFailed(selection)
                 }
             )
         }
@@ -572,7 +614,8 @@ class WooShippingEditAddressViewModel @Inject constructor(
                     onUpdateAddress(it.toAddress(), it.isVerified)
                 },
                 onFailure = {
-                    addressValidationState.value = AddressValidationState.NormalizedAddressUpdateFailed(selection)
+                    addressValidationState.value =
+                        AddressValidationState.NormalizedAddressUpdateFailed(selection)
                 }
             )
         }
@@ -596,7 +639,8 @@ class WooShippingEditAddressViewModel @Inject constructor(
                     onUpdateAddress(result.address, result.isVerified)
                 },
                 onFailure = {
-                    addressValidationState.value = AddressValidationState.AddressUpdateFailed(editableAddress)
+                    addressValidationState.value =
+                        AddressValidationState.AddressUpdateFailed(editableAddress)
                 }
             )
         }
@@ -611,7 +655,8 @@ class WooShippingEditAddressViewModel @Inject constructor(
                     onUpdateAddress(it.toAddress(), it.isVerified)
                 },
                 onFailure = {
-                    addressValidationState.value = AddressValidationState.AddressUpdateFailed(editableAddress)
+                    addressValidationState.value =
+                        AddressValidationState.AddressUpdateFailed(editableAddress)
                 }
             )
         }
@@ -761,7 +806,8 @@ enum class AddressStatus {
 
 data class InputValue(
     val value: String,
-    val error: String? = null
+    val error: String? = null,
+    val isRequired: Boolean = false
 ) {
     companion object {
         val EMPTY = InputValue("")

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/address/WooShippingEditAddressViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/address/WooShippingEditAddressViewModel.kt
@@ -250,6 +250,11 @@ class WooShippingEditAddressViewModel @Inject constructor(
             }
     }
 
+    fun handleBackPress(): Boolean {
+        if (allowBackNavigation()) { onNavigateBack() }
+        return false
+    }
+
     fun allowBackNavigation(): Boolean {
         return when (viewState.value.addressValidationState) {
             is AddressValidationState.AddressSelection,
@@ -257,12 +262,21 @@ class WooShippingEditAddressViewModel @Inject constructor(
                 onCloseAddressSelection()
                 return false
             }
+
             else -> true
         }
     }
 
     fun onNavigateBack() {
-        if (allowBackNavigation()) triggerEvent(Event.Exit)
+        when (navArgs.flow) {
+            is EditAddressFlow.EditDestinationAddress -> triggerEvent(
+                Event.ExitWithResult(
+                    DestinationShippingAddress(currentAddress.value, isVerified.value)
+                )
+            )
+
+            is EditAddressFlow.EditOriginAddress -> triggerEvent(Event.Exit)
+        }
     }
 
     fun onExpandCompany() {
@@ -690,7 +704,10 @@ sealed class AddressValidationState {
 @Parcelize
 sealed class EditAddressFlow : Parcelable {
     data class EditOriginAddress(val address: OriginShippingAddress) : EditAddressFlow()
-    data class EditDestinationAddress(val address: DestinationShippingAddress) : EditAddressFlow()
+    data class EditDestinationAddress(
+        val address: DestinationShippingAddress,
+        val orderId: Long
+    ) : EditAddressFlow()
 }
 
 enum class AddressStatus {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/address/WooShippingEditAddressViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/address/WooShippingEditAddressViewModel.kt
@@ -13,6 +13,7 @@ import com.woocommerce.android.model.Address
 import com.woocommerce.android.model.AmbiguousLocation
 import com.woocommerce.android.model.Location
 import com.woocommerce.android.ui.orders.details.editing.address.LocationCode
+import com.woocommerce.android.ui.orders.wooshippinglabels.address.destination.UpdateDestinationAddress
 import com.woocommerce.android.ui.orders.wooshippinglabels.address.origin.GetAcceptedOriginCountries
 import com.woocommerce.android.ui.orders.wooshippinglabels.address.origin.UpdateOriginAddress
 import com.woocommerce.android.ui.orders.wooshippinglabels.models.AddressNormalizationModel
@@ -44,6 +45,7 @@ class WooShippingEditAddressViewModel @Inject constructor(
     private val normalizeAddress: NormalizeAddress,
     private val resourceProvider: ResourceProvider,
     private val updateOriginAddress: UpdateOriginAddress,
+    private val updateDestinationAddress: UpdateDestinationAddress,
     savedState: SavedStateHandle
 ) : ScopedViewModel(savedState) {
     private var name by mutableStateOf(InputValue(""))
@@ -536,7 +538,36 @@ class WooShippingEditAddressViewModel @Inject constructor(
         addressValidationState.value = AddressValidationState.NotStarted
     }
 
-    fun onUpdateNormalizedOriginAddress(selection: AddressValidationState.AddressSelection) {
+    fun onUpdateNormalizedAddress(selection: AddressValidationState.AddressSelection) {
+        when (val currentFlow = navArgs.flow) {
+            is EditAddressFlow.EditDestinationAddress ->
+                onUpdateNormalizedDestinationAddress(selection, currentFlow.orderId)
+            is EditAddressFlow.EditOriginAddress -> onUpdateNormalizedOriginAddress(selection)
+        }
+    }
+
+    private fun onUpdateNormalizedDestinationAddress(
+        selection: AddressValidationState.AddressSelection,
+        orderId: Long
+    ) {
+        addressValidationState.value = AddressValidationState.UpdatingAddress
+        launch {
+            updateDestinationAddress(selection.selectedAddress, orderId).fold(
+                onSuccess = {
+                    val address = it.address
+                    fillAddressForm(address)
+                    addressValidationState.value = AddressValidationState.NotStarted
+                    currentAddress.value = address
+                    isVerified.value = it.isVerified
+                },
+                onFailure = {
+                    addressValidationState.value = AddressValidationState.NormalizedAddressUpdateFailed(selection)
+                }
+            )
+        }
+    }
+
+    private fun onUpdateNormalizedOriginAddress(selection: AddressValidationState.AddressSelection) {
         addressValidationState.value = AddressValidationState.UpdatingAddress
         launch {
             updateOriginAddress(selection.selectedAddress, addressId).fold(
@@ -555,15 +586,31 @@ class WooShippingEditAddressViewModel @Inject constructor(
     }
 
     fun onUpdateAddress(editableAddress: EditableAddress) {
-        when (navArgs.flow) {
-            is EditAddressFlow.EditDestinationAddress -> onUpdateDestinationAddress(editableAddress)
+        when (val currentFlow = navArgs.flow) {
+            is EditAddressFlow.EditDestinationAddress ->
+                onUpdateDestinationAddress(editableAddress, currentFlow.orderId)
+
             is EditAddressFlow.EditOriginAddress -> onUpdateOriginAddress(editableAddress)
         }
     }
 
-    @Suppress("UnusedParameter")
-    private fun onUpdateDestinationAddress(editableAddress: EditableAddress) {
-        // To be created
+    private fun onUpdateDestinationAddress(editableAddress: EditableAddress, orderId: Long) {
+        addressValidationState.value = AddressValidationState.UpdatingAddress
+        launch {
+            val address = editableAddress.toAddress()
+            updateDestinationAddress(address, orderId).fold(
+                onSuccess = { result ->
+                    val updatedAddress = result.address
+                    fillAddressForm(updatedAddress)
+                    addressValidationState.value = AddressValidationState.NotStarted
+                    currentAddress.value = updatedAddress
+                    isVerified.value = result.isVerified
+                },
+                onFailure = {
+                    addressValidationState.value = AddressValidationState.AddressUpdateFailed(editableAddress)
+                }
+            )
+        }
     }
 
     private fun onUpdateOriginAddress(editableAddress: EditableAddress) {
@@ -572,10 +619,10 @@ class WooShippingEditAddressViewModel @Inject constructor(
             val address = editableAddress.toAddress()
             updateOriginAddress(address, addressId).fold(
                 onSuccess = {
-                    val address = it.toAddress()
-                    fillAddressForm(address)
+                    val updatedAddress = it.toAddress()
+                    fillAddressForm(updatedAddress)
                     addressValidationState.value = AddressValidationState.NotStarted
-                    currentAddress.value = address
+                    currentAddress.value = updatedAddress
                     isVerified.value = it.isVerified
                 },
                 onFailure = {
@@ -693,6 +740,7 @@ sealed class AddressValidationState {
         val addressNormalization: AddressNormalizationModel,
         val selectedAddress: Address
     ) : AddressValidationState()
+
     data object UpdatingAddress : AddressValidationState()
     data class AddressUpdateFailed(
         val editableAddress: EditableAddress
@@ -732,4 +780,8 @@ data class InputValue(
 data class DestinationShippingAddress(
     val address: Address,
     val isVerified: Boolean
-) : Parcelable
+) : Parcelable {
+    companion object {
+        val EMPTY = DestinationShippingAddress(Address.EMPTY, false)
+    }
+}

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/address/WooShippingEditAddressViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/address/WooShippingEditAddressViewModel.kt
@@ -663,10 +663,10 @@ class WooShippingEditAddressViewModel @Inject constructor(
     }
 
     private fun onUpdateAddress(updatedAddress: Address, updatedIsVerified: Boolean) {
+        isVerified.value = updatedIsVerified
         fillAddressForm(updatedAddress)
         addressValidationState.value = AddressValidationState.NotStarted
         currentAddress.value = updatedAddress
-        isVerified.value = updatedIsVerified
     }
 
     data class ViewState(

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/address/WooShippingEditAddressViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/address/WooShippingEditAddressViewModel.kt
@@ -470,7 +470,7 @@ class WooShippingEditAddressViewModel @Inject constructor(
     }
 
     fun onNameChange(value: String) {
-        val isCompanyRequired = value.isEmpty() && company.value.isNotNullOrEmpty()
+        val isCompanyRequired = value.isEmpty() && company.value.isNotEmpty()
         name = InputValue(
             value = value,
             isRequired = isCompanyRequired.not(),
@@ -480,7 +480,7 @@ class WooShippingEditAddressViewModel @Inject constructor(
     }
 
     fun onCompanyChange(value: String) {
-        val isCompanyRequired = value.isEmpty() && name.value.isNotEmpty()
+        val isCompanyRequired = value.isNotEmpty() && name.value.isEmpty()
         company = InputValue(
             value = value,
             isRequired = isCompanyRequired,

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/address/WooShippingEditAddressViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/address/WooShippingEditAddressViewModel.kt
@@ -78,8 +78,12 @@ class WooShippingEditAddressViewModel @Inject constructor(
         snapshotFlow { rawState },
         selectedState
     ) { rawState, selectedState ->
-        if (selectedState != Location.EMPTY) selectedState else AmbiguousLocation.Raw(rawState)
-            .asLocation()
+        if (selectedState != Location.EMPTY) {
+            selectedState
+        } else {
+            AmbiguousLocation.Raw(rawState)
+                .asLocation()
+        }
     }
 
     private val countriesState = MutableStateFlow<LocationState>(LocationState.Loading)
@@ -461,12 +465,12 @@ class WooShippingEditAddressViewModel @Inject constructor(
 
     private fun hasIncorrectOrMissingData(editableAddress: EditableAddress): Boolean {
         return editableAddress.address.error.isNotNullOrEmpty() ||
-                editableAddress.city.error.isNotNullOrEmpty() ||
-                editableAddress.postalCode.error.isNotNullOrEmpty() ||
-                editableAddress.email.error.isNotNullOrEmpty() ||
-                editableAddress.phone.error.isNotNullOrEmpty() ||
-                editableAddress.name.error.isNotNullOrEmpty() ||
-                editableAddress.company.error.isNotNullOrEmpty()
+            editableAddress.city.error.isNotNullOrEmpty() ||
+            editableAddress.postalCode.error.isNotNullOrEmpty() ||
+            editableAddress.email.error.isNotNullOrEmpty() ||
+            editableAddress.phone.error.isNotNullOrEmpty() ||
+            editableAddress.name.error.isNotNullOrEmpty() ||
+            editableAddress.company.error.isNotNullOrEmpty()
     }
 
     fun onNameChange(value: String) {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/address/WooShippingEditAddressViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/address/WooShippingEditAddressViewModel.kt
@@ -17,6 +17,7 @@ import com.woocommerce.android.ui.orders.wooshippinglabels.address.destination.U
 import com.woocommerce.android.ui.orders.wooshippinglabels.address.origin.GetAcceptedOriginCountries
 import com.woocommerce.android.ui.orders.wooshippinglabels.address.origin.UpdateOriginAddress
 import com.woocommerce.android.ui.orders.wooshippinglabels.models.AddressNormalizationModel
+import com.woocommerce.android.ui.orders.wooshippinglabels.models.DestinationShippingAddress
 import com.woocommerce.android.ui.orders.wooshippinglabels.models.OriginShippingAddress
 import com.woocommerce.android.util.StringUtils.combineStrings
 import com.woocommerce.android.viewmodel.MultiLiveEvent.Event
@@ -764,15 +765,5 @@ data class InputValue(
 ) {
     companion object {
         val EMPTY = InputValue("")
-    }
-}
-
-@Parcelize
-data class DestinationShippingAddress(
-    val address: Address,
-    val isVerified: Boolean
-) : Parcelable {
-    companion object {
-        val EMPTY = DestinationShippingAddress(Address.EMPTY, false)
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/address/WooShippingEditAddressViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/address/WooShippingEditAddressViewModel.kt
@@ -424,7 +424,9 @@ class WooShippingEditAddressViewModel @Inject constructor(
         val isDifferentEmail = newAddress.email.value != currentAddress.email
         val isDifferentPhone = newAddress.phone.value != currentAddress.phone
         val isSameAddress = isSameAddress(newAddress, currentAddress)
-        return (isDifferentName || isDifferentCompany || isDifferentEmail || isDifferentPhone) && isSameAddress
+        val isVerified = isVerified.value
+        val hasNoAddressChanges = isDifferentName || isDifferentCompany || isDifferentEmail || isDifferentPhone
+        return hasNoAddressChanges && isSameAddress && isVerified
     }
 
     private fun hasIncorrectOrMissingData(editableAddress: EditableAddress): Boolean {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/address/destination/UpdateDestinationAddress.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/address/destination/UpdateDestinationAddress.kt
@@ -1,0 +1,37 @@
+package com.woocommerce.android.ui.orders.wooshippinglabels.address.destination
+
+import com.woocommerce.android.model.Address
+import com.woocommerce.android.tools.SelectedSite
+import com.woocommerce.android.ui.orders.wooshippinglabels.address.DestinationShippingAddress
+import com.woocommerce.android.ui.orders.wooshippinglabels.networking.WooShippingLabelRepository
+import com.woocommerce.android.util.CoroutineDispatchers
+import kotlinx.coroutines.withContext
+import javax.inject.Inject
+
+class UpdateDestinationAddress @Inject constructor(
+    private val shippingRepository: WooShippingLabelRepository,
+    private val selectedSite: SelectedSite,
+    private val coroutineDispatchers: CoroutineDispatchers
+) {
+    suspend operator fun invoke(
+        address: Address,
+        orderId: Long
+    ): Result<DestinationShippingAddress> {
+        return withContext(coroutineDispatchers.io) {
+            selectedSite.getOrNull()?.let {
+                val response = shippingRepository.updateDestinationAddress(it, orderId, address)
+                val result = response.model
+                when {
+                    response.isError || result == null -> {
+                        val message =
+                            response.error.message
+                                ?: if (result == null) "Empty response" else "Unknown error"
+                        Result.failure(Exception(message))
+                    }
+
+                    else -> Result.success(result)
+                }
+            } ?: Result.failure(Exception("No site selected"))
+        }
+    }
+}

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/address/destination/UpdateDestinationAddress.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/address/destination/UpdateDestinationAddress.kt
@@ -2,7 +2,7 @@ package com.woocommerce.android.ui.orders.wooshippinglabels.address.destination
 
 import com.woocommerce.android.model.Address
 import com.woocommerce.android.tools.SelectedSite
-import com.woocommerce.android.ui.orders.wooshippinglabels.address.DestinationShippingAddress
+import com.woocommerce.android.ui.orders.wooshippinglabels.models.DestinationShippingAddress
 import com.woocommerce.android.ui.orders.wooshippinglabels.networking.WooShippingLabelRepository
 import com.woocommerce.android.util.CoroutineDispatchers
 import kotlinx.coroutines.withContext

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/customs/ShouldRequireCustomsForm.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/customs/ShouldRequireCustomsForm.kt
@@ -13,15 +13,15 @@ class ShouldRequireCustomsForm @Inject constructor() {
         )
 
         val isShippingAddressMilitary = isAddressInMilitaryState(
-            addressData.shipTo.country.code,
-            addressData.shipTo.state.codeOrRaw
+            addressData.shipTo.address.country.code,
+            addressData.shipTo.address.state.codeOrRaw
         )
 
         return isOriginAddressMilitary || isShippingAddressMilitary
     }
 
     private val WooShippingAddresses.isDifferentCountryShipment
-        get() = shipFrom.country != shipTo.country.code
+        get() = shipFrom.country != shipTo.address.country.code
 
     private fun isAddressInMilitaryState(
         countryCode: String,

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/models/DestinationShippingAddress.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/models/DestinationShippingAddress.kt
@@ -1,0 +1,15 @@
+package com.woocommerce.android.ui.orders.wooshippinglabels.models
+
+import android.os.Parcelable
+import com.woocommerce.android.model.Address
+import kotlinx.parcelize.Parcelize
+
+@Parcelize
+data class DestinationShippingAddress(
+    val address: Address,
+    val isVerified: Boolean
+) : Parcelable {
+    companion object {
+        val EMPTY = DestinationShippingAddress(Address.EMPTY, false)
+    }
+}

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/networking/WooShippingLabelRepository.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/networking/WooShippingLabelRepository.kt
@@ -1,6 +1,7 @@
 package com.woocommerce.android.ui.orders.wooshippinglabels.networking
 
 import com.woocommerce.android.model.Address
+import com.woocommerce.android.ui.orders.wooshippinglabels.address.DestinationShippingAddress
 import com.woocommerce.android.ui.orders.wooshippinglabels.datasource.WooShippingAddressDataStore
 import com.woocommerce.android.ui.orders.wooshippinglabels.datasource.WooShippingConfigurationDataStore
 import com.woocommerce.android.ui.orders.wooshippinglabels.models.AddressNormalizationModel
@@ -152,6 +153,35 @@ class WooShippingLabelRepository @Inject constructor(
                             addressDataStore.updateOriginAddress(it)
                         }
                 }
+        } else {
+            WooResult(
+                WooError(
+                    type = WooErrorType.INVALID_RESPONSE,
+                    original = GenericErrorType.INVALID_RESPONSE,
+                    message = "Address update failed"
+                )
+            )
+        }
+    }
+
+    suspend fun updateDestinationAddress(
+        site: SiteModel,
+        orderId: Long,
+        address: Address,
+    ): WooResult<DestinationShippingAddress> {
+        val updatedAddress = restClient.updateDestinationAddress(
+            site = site,
+            orderId = orderId,
+            address = mapper.toAddressDTO(address, null)
+        )
+
+        return if (updatedAddress.result?.success == true) {
+            updatedAddress.asWooResult {
+                DestinationShippingAddress(
+                    address = mapper(it.address),
+                    isVerified = it.isVerified
+                )
+            }
         } else {
             WooResult(
                 WooError(

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/networking/WooShippingLabelRepository.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/networking/WooShippingLabelRepository.kt
@@ -1,10 +1,10 @@
 package com.woocommerce.android.ui.orders.wooshippinglabels.networking
 
 import com.woocommerce.android.model.Address
-import com.woocommerce.android.ui.orders.wooshippinglabels.address.DestinationShippingAddress
 import com.woocommerce.android.ui.orders.wooshippinglabels.datasource.WooShippingAddressDataStore
 import com.woocommerce.android.ui.orders.wooshippinglabels.datasource.WooShippingConfigurationDataStore
 import com.woocommerce.android.ui.orders.wooshippinglabels.models.AddressNormalizationModel
+import com.woocommerce.android.ui.orders.wooshippinglabels.models.DestinationShippingAddress
 import com.woocommerce.android.ui.orders.wooshippinglabels.models.OriginShippingAddress
 import com.woocommerce.android.ui.orders.wooshippinglabels.models.PurchasedLabelData
 import com.woocommerce.android.ui.orders.wooshippinglabels.models.ShippingLabelStatus

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/networking/WooShippingLabelRepository.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/networking/WooShippingLabelRepository.kt
@@ -172,7 +172,7 @@ class WooShippingLabelRepository @Inject constructor(
         val updatedAddress = restClient.updateDestinationAddress(
             site = site,
             orderId = orderId,
-            address = mapper.toAddressDTO(address, null)
+            address = mapper.toAddressDTO(address)
         )
 
         return if (updatedAddress.result?.success == true) {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/networking/WooShippingLabelRestClient.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/networking/WooShippingLabelRestClient.kt
@@ -153,4 +153,24 @@ class WooShippingLabelRestClient @Inject constructor(
 
         return result.toWooPayload()
     }
+
+    suspend fun updateDestinationAddress(
+        site: SiteModel,
+        orderId: Long,
+        address: AddressDTO,
+    ): WooPayload<UpdateAddressResponseDTO> {
+        val url = "/wcshipping/v1/address/$orderId/update_destination/"
+
+        val result = wooNetwork.executePostGsonRequest(
+            site = site,
+            path = url,
+            body = mapOf(
+                "address" to address,
+                "isVerified" to true // We always verify the address before saving it
+            ),
+            clazz = UpdateAddressResponseDTO::class.java,
+        )
+
+        return result.toWooPayload()
+    }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/purchased/WooShippingLabelPurchasedScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/purchased/WooShippingLabelPurchasedScreen.kt
@@ -125,7 +125,8 @@ internal fun WooShippingLabelPurchasedWithBottomSheetScreen(
                             }
                         }
                         true
-                    }
+                    },
+                    onEditDestinationAddress = {}
                 )
             }
         },

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -4489,6 +4489,7 @@
     <string name="email_not_registered_wpcom">Hmm, we can\'t find a WordPress.com account connected to this email address.</string>
 
     <string name="woo_shipping_edit_origin_address_title">Edit Origin</string>
+    <string name="woo_shipping_edit_destination_address_title">Edit Destination</string>
     <string name="woo_shipping_label_name">Name</string>
     <string name="woo_shipping_label_company">Company</string>
     <string name="woo_shipping_label_country">Country</string>

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/address/WooShippingEditAddressViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/address/WooShippingEditAddressViewModelTest.kt
@@ -1,0 +1,938 @@
+package com.woocommerce.android.ui.orders.wooshippinglabels.address
+
+import androidx.compose.runtime.snapshots.Snapshot
+import androidx.lifecycle.SavedStateHandle
+import com.woocommerce.android.model.Address
+import com.woocommerce.android.model.AmbiguousLocation
+import com.woocommerce.android.model.Location
+import com.woocommerce.android.ui.orders.wooshippinglabels.address.destination.UpdateDestinationAddress
+import com.woocommerce.android.ui.orders.wooshippinglabels.address.origin.GetAcceptedOriginCountries
+import com.woocommerce.android.ui.orders.wooshippinglabels.address.origin.UpdateOriginAddress
+import com.woocommerce.android.ui.orders.wooshippinglabels.models.AddressNormalizationModel
+import com.woocommerce.android.viewmodel.BaseUnitTest
+import com.woocommerce.android.viewmodel.ResourceProvider
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.advanceUntilIdle
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.Test
+import org.mockito.kotlin.any
+import org.mockito.kotlin.doReturn
+import org.mockito.kotlin.eq
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.whenever
+
+@OptIn(ExperimentalCoroutinesApi::class)
+abstract class WooShippingEditAddressViewModelTest: BaseUnitTest() {
+    protected val addressValidator: AddressValidationHelper = mock()
+    protected val getAcceptedOriginCountries: GetAcceptedOriginCountries = mock()
+    protected val getStatesByCountryCode: GetStatesByCountryCode = mock()
+    protected val resourceProvider: ResourceProvider = mock()
+    protected val normalizeAddress: NormalizeAddress = mock()
+    protected val updateOriginAddress: UpdateOriginAddress = mock()
+    protected val updateDestinationAddress: UpdateDestinationAddress = mock()
+
+    protected val countries = listOf(
+        Location("US", "United States"),
+        Location("UK", "United Kingdom"),
+        Location("AR", "Argentina"),
+        Location("BR", "Brazil")
+    )
+
+    protected val states = listOf(
+        Location("FL", "Florida"),
+        Location("CA", "California"),
+    )
+
+    protected lateinit var sut: WooShippingEditAddressViewModel
+
+    abstract fun createSavedStateHandle(address: Address, isVerified: Boolean = false): SavedStateHandle
+
+    fun createViewModel(savedState: SavedStateHandle) {
+        sut = WooShippingEditAddressViewModel(
+            addressValidator = addressValidator,
+            savedState = savedState,
+            getAcceptedOriginCountries = getAcceptedOriginCountries,
+            getStatesByCountryCode = getStatesByCountryCode,
+            normalizeAddress = normalizeAddress,
+            resourceProvider = resourceProvider,
+            updateOriginAddress = updateOriginAddress,
+            updateDestinationAddress = updateDestinationAddress
+        )
+    }
+
+    @Test
+    fun `when name is not empty and company is empty, then name error is null`() = testBlocking {
+        val name = "name"
+        val company = ""
+        val address = Address.EMPTY.copy(
+            firstName = name,
+            company = company
+        )
+        whenever(addressValidator.validateFieldRequired(any())).doReturn(null)
+        Snapshot.withMutableSnapshot {
+            val savedState = createSavedStateHandle(address)
+            createViewModel(savedState)
+        }
+
+        advanceUntilIdle()
+
+        val result = sut.viewState.value
+
+        assertThat(result).isInstanceOf(WooShippingEditAddressViewModel.ViewState::class.java)
+
+        assertThat(result.editableAddress.name.error).isNull()
+        assertThat(result.editableAddress.company.error).isNull()
+    }
+
+    @Test
+    fun `when name is empty and company Not is empty, then name error is null`() = testBlocking {
+        val name = ""
+        val company = "company"
+        val address = Address.EMPTY.copy(
+            firstName = name,
+            company = company
+        )
+        whenever(addressValidator.validateFieldRequired(any())).doReturn(null)
+        Snapshot.withMutableSnapshot {
+            val savedState = createSavedStateHandle(address)
+            createViewModel(savedState)
+        }
+
+        advanceUntilIdle()
+
+        val result = sut.viewState.value
+
+        assertThat(result).isInstanceOf(WooShippingEditAddressViewModel.ViewState::class.java)
+
+        assertThat(result.editableAddress.name.error).isNull()
+        assertThat(result.editableAddress.company.error).isNull()
+    }
+
+    @Test
+    fun `when name is empty and company is empty, then name error is not null`() = testBlocking {
+        val name = ""
+        val company = ""
+        val address = Address.EMPTY.copy(
+            firstName = name,
+            company = company
+        )
+        whenever(addressValidator.validateAtLeastOneOf(eq(""), eq(""))).doReturn("error")
+        whenever(addressValidator.validateFieldRequired(any())).doReturn(null)
+        Snapshot.withMutableSnapshot {
+            val savedState = createSavedStateHandle(address)
+            createViewModel(savedState)
+        }
+
+        advanceUntilIdle()
+
+        val result = sut.viewState.value
+
+        assertThat(result).isInstanceOf(WooShippingEditAddressViewModel.ViewState::class.java)
+
+        assertThat(result.editableAddress.name.error).isNotEmpty()
+        assertThat(result.editableAddress.company.error).isNull()
+    }
+
+    @Test
+    fun `when address is empty then address error is not null`() = testBlocking {
+        val address = Address.EMPTY
+        whenever(addressValidator.validateAtLeastOneOf(eq(""), eq(""))).doReturn("error")
+        whenever(addressValidator.validateFieldRequired("")).doReturn("error")
+        Snapshot.withMutableSnapshot {
+            val savedState = createSavedStateHandle(address)
+            createViewModel(savedState)
+        }
+
+        advanceUntilIdle()
+
+        val result = sut.viewState.value
+
+        assertThat(result).isInstanceOf(WooShippingEditAddressViewModel.ViewState::class.java)
+
+        assertThat(result.editableAddress.address.error).isNotEmpty()
+    }
+
+    @Test
+    fun `when address is NOT empty then address error is null`() = testBlocking {
+        val address = Address.EMPTY.copy(address1 = "This is an address")
+        whenever(addressValidator.validateAtLeastOneOf(eq(""), eq(""))).doReturn("error")
+        whenever(addressValidator.validateFieldRequired("")).doReturn("error")
+        Snapshot.withMutableSnapshot {
+            val savedState = createSavedStateHandle(address)
+            createViewModel(savedState)
+        }
+
+        advanceUntilIdle()
+
+        val result = sut.viewState.value
+
+        assertThat(result).isInstanceOf(WooShippingEditAddressViewModel.ViewState::class.java)
+
+        assertThat(result.editableAddress.address.error).isNull()
+    }
+
+    @Test
+    fun `when city is empty then address error is not null`() = testBlocking {
+        val address = Address.EMPTY
+        whenever(addressValidator.validateAtLeastOneOf(eq(""), eq(""))).doReturn("error")
+        whenever(addressValidator.validateFieldRequired("")).doReturn("error")
+        Snapshot.withMutableSnapshot {
+            val savedState = createSavedStateHandle(address)
+            createViewModel(savedState)
+        }
+
+        advanceUntilIdle()
+
+        val result = sut.viewState.value
+
+        assertThat(result).isInstanceOf(WooShippingEditAddressViewModel.ViewState::class.java)
+
+        assertThat(result.editableAddress.city.error).isNotEmpty()
+    }
+
+    @Test
+    fun `when city is NOT empty then address error is null`() = testBlocking {
+        val address = Address.EMPTY.copy(city = "This is a city")
+        whenever(addressValidator.validateAtLeastOneOf(eq(""), eq(""))).doReturn("error")
+        whenever(addressValidator.validateFieldRequired("")).doReturn("error")
+        Snapshot.withMutableSnapshot {
+            val savedState = createSavedStateHandle(address)
+            createViewModel(savedState)
+        }
+
+        advanceUntilIdle()
+
+        val result = sut.viewState.value
+
+        assertThat(result).isInstanceOf(WooShippingEditAddressViewModel.ViewState::class.java)
+
+        assertThat(result.editableAddress.city.error).isNull()
+    }
+
+    @Test
+    fun `when postal code is empty then address error is not null`() = testBlocking {
+        val address = Address.EMPTY
+        whenever(addressValidator.validateAtLeastOneOf(eq(""), eq(""))).doReturn("error")
+        whenever(addressValidator.validateFieldRequired("")).doReturn("error")
+        Snapshot.withMutableSnapshot {
+            val savedState = createSavedStateHandle(address)
+            createViewModel(savedState)
+        }
+
+        advanceUntilIdle()
+
+        val result = sut.viewState.value
+
+        assertThat(result).isInstanceOf(WooShippingEditAddressViewModel.ViewState::class.java)
+
+        assertThat(result.editableAddress.postalCode.error).isNotEmpty()
+    }
+
+    @Test
+    fun `when postal code is NOT empty then address error is null`() = testBlocking {
+        val address = Address.EMPTY.copy(postcode = "This is a post code")
+        whenever(addressValidator.validateAtLeastOneOf(eq(""), eq(""))).doReturn("error")
+        whenever(addressValidator.validateFieldRequired("")).doReturn("error")
+        Snapshot.withMutableSnapshot {
+            val savedState = createSavedStateHandle(address)
+            createViewModel(savedState)
+        }
+
+        advanceUntilIdle()
+
+        val result = sut.viewState.value
+
+        assertThat(result).isInstanceOf(WooShippingEditAddressViewModel.ViewState::class.java)
+
+        assertThat(result.editableAddress.postalCode.error).isNull()
+    }
+
+    @Test
+    fun `when email is empty then address error is not null`() = testBlocking {
+        val address = Address.EMPTY
+        whenever(addressValidator.validateAtLeastOneOf(eq(""), eq(""))).doReturn("error")
+        whenever(addressValidator.validateFieldRequired("")).doReturn("error")
+        Snapshot.withMutableSnapshot {
+            val savedState = createSavedStateHandle(address)
+            createViewModel(savedState)
+        }
+
+        advanceUntilIdle()
+
+        val result = sut.viewState.value
+
+        assertThat(result).isInstanceOf(WooShippingEditAddressViewModel.ViewState::class.java)
+
+        assertThat(result.editableAddress.email.error).isNotEmpty()
+    }
+
+    @Test
+    fun `when email is NOT empty then address error is null`() = testBlocking {
+        val address = Address.EMPTY.copy(email = "This is an email")
+        whenever(addressValidator.validateAtLeastOneOf(eq(""), eq(""))).doReturn("error")
+        whenever(addressValidator.validateFieldRequired("")).doReturn("error")
+        Snapshot.withMutableSnapshot {
+            val savedState = createSavedStateHandle(address)
+            createViewModel(savedState)
+        }
+
+        advanceUntilIdle()
+
+        val result = sut.viewState.value
+
+        assertThat(result).isInstanceOf(WooShippingEditAddressViewModel.ViewState::class.java)
+
+        assertThat(result.editableAddress.email.error).isNull()
+    }
+
+    @Test
+    fun `when phone is empty then phone error is not null`() = testBlocking {
+        val address = Address.EMPTY
+        whenever(addressValidator.validateAtLeastOneOf(eq(""), eq(""))).doReturn("error")
+        whenever(addressValidator.validateFieldRequired("")).doReturn("error")
+        whenever(addressValidator.validateUSCustomsPhone("")).doReturn("error")
+        Snapshot.withMutableSnapshot {
+            val savedState = createSavedStateHandle(address)
+            createViewModel(savedState)
+        }
+
+        advanceUntilIdle()
+
+        val result = sut.viewState.value
+
+        assertThat(result).isInstanceOf(WooShippingEditAddressViewModel.ViewState::class.java)
+
+        assertThat(result.editableAddress.phone.error).isNotEmpty()
+    }
+
+    @Test
+    fun `when phone is NOT empty and invalid then phone error is not null`() = testBlocking {
+        val address = Address.EMPTY.copy(phone = "1234567890")
+        whenever(addressValidator.validateAtLeastOneOf(eq(""), eq(""))).doReturn("error")
+        whenever(addressValidator.validateFieldRequired("")).doReturn("error")
+        whenever(addressValidator.validateUSCustomsPhone("1234567890")).doReturn("error")
+        Snapshot.withMutableSnapshot {
+            val savedState = createSavedStateHandle(address)
+            createViewModel(savedState)
+        }
+
+        advanceUntilIdle()
+
+        val result = sut.viewState.value
+
+        assertThat(result).isInstanceOf(WooShippingEditAddressViewModel.ViewState::class.java)
+
+        assertThat(result.editableAddress.phone.error).isNotEmpty()
+    }
+
+    @Test
+    fun `when phone is NOT empty and valid then phone error is null`() = testBlocking {
+        val address = Address.EMPTY.copy(phone = "1234567890")
+        whenever(addressValidator.validateAtLeastOneOf(eq(""), eq(""))).doReturn("error")
+        whenever(addressValidator.validateFieldRequired("")).doReturn("error")
+        whenever(addressValidator.validateUSCustomsPhone("1234567890")).doReturn(null)
+        Snapshot.withMutableSnapshot {
+            val savedState = createSavedStateHandle(address)
+            createViewModel(savedState)
+        }
+
+        advanceUntilIdle()
+
+        val result = sut.viewState.value
+
+        assertThat(result).isInstanceOf(WooShippingEditAddressViewModel.ViewState::class.java)
+
+        assertThat(result.editableAddress.phone.error).isNull()
+    }
+
+    @Test
+    fun `when company is NOT empty, then company control is expanded`() = testBlocking {
+        val company = "company"
+        val address = Address.EMPTY.copy(
+            company = company
+        )
+        whenever(addressValidator.validateFieldRequired(any())).doReturn(null)
+        Snapshot.withMutableSnapshot {
+            val savedState = createSavedStateHandle(address)
+            createViewModel(savedState)
+        }
+
+        advanceUntilIdle()
+
+        val result = sut.viewState.value
+
+        assertThat(result).isInstanceOf(WooShippingEditAddressViewModel.ViewState::class.java)
+
+        assertThat(result.isCompanyExpanded).isTrue()
+    }
+
+    @Test
+    fun `when company is empty, then company control is NOT expanded`() = testBlocking {
+        val address = Address.EMPTY
+        whenever(addressValidator.validateFieldRequired(any())).doReturn(null)
+        Snapshot.withMutableSnapshot {
+            val savedState = createSavedStateHandle(address)
+            createViewModel(savedState)
+        }
+
+        advanceUntilIdle()
+
+        val result = sut.viewState.value
+
+        assertThat(result).isInstanceOf(WooShippingEditAddressViewModel.ViewState::class.java)
+
+        assertThat(result.isCompanyExpanded).isFalse()
+    }
+
+    @Test
+    fun `when get accepted countries succeed then don't display loading or error`() = testBlocking {
+        val address = Address.EMPTY
+        whenever(addressValidator.validateFieldRequired(any())).doReturn(null)
+        whenever(getAcceptedOriginCountries.invoke()).doReturn(Result.success(countries))
+        Snapshot.withMutableSnapshot {
+            val savedState = createSavedStateHandle(address)
+            createViewModel(savedState)
+        }
+
+        advanceUntilIdle()
+
+        val result = sut.viewState.value
+
+        assertThat(result).isInstanceOf(WooShippingEditAddressViewModel.ViewState::class.java)
+
+        assertThat(result.loading).isInstanceOf(WooShippingEditAddressViewModel.LoadingState.Hidden::class.java)
+        assertThat(result.error).isNull()
+    }
+
+    @Test
+    fun `when get accepted countries fails then display error`() = testBlocking {
+        val address = Address.EMPTY
+        whenever(addressValidator.validateFieldRequired(any())).doReturn(null)
+        whenever(getAcceptedOriginCountries.invoke()).doReturn(Result.failure(Exception("error")))
+        whenever(resourceProvider.getString(any())).doReturn("error")
+        Snapshot.withMutableSnapshot {
+            val savedState = createSavedStateHandle(address)
+            createViewModel(savedState)
+        }
+
+        advanceUntilIdle()
+
+        val result = sut.viewState.value
+
+        assertThat(result).isInstanceOf(WooShippingEditAddressViewModel.ViewState::class.java)
+
+        assertThat(result.loading).isInstanceOf(WooShippingEditAddressViewModel.LoadingState.Hidden::class.java)
+        assertThat(result.error).isNotNull
+    }
+
+    @Test
+    fun `when get states is empty then use state input`() = testBlocking {
+        val address = Address.EMPTY
+        whenever(addressValidator.validateFieldRequired(any())).doReturn(null)
+        whenever(getAcceptedOriginCountries.invoke()).doReturn(Result.success(countries))
+        whenever(getStatesByCountryCode.invoke(any())).doReturn(emptyList())
+        Snapshot.withMutableSnapshot {
+            val savedState = createSavedStateHandle(address)
+            createViewModel(savedState)
+        }
+
+        advanceUntilIdle()
+
+        val result = sut.viewState.value
+
+        assertThat(result).isInstanceOf(WooShippingEditAddressViewModel.ViewState::class.java)
+
+        assertThat(result.shouldUseStatesInput).isTrue()
+    }
+
+    @Test
+    fun `when get states is empty then use state selection`() = testBlocking {
+        val address = Address.EMPTY
+        whenever(addressValidator.validateFieldRequired(any())).doReturn(null)
+        whenever(getAcceptedOriginCountries.invoke()).doReturn(Result.success(countries))
+        whenever(getStatesByCountryCode.invoke(any())).doReturn(states)
+        Snapshot.withMutableSnapshot {
+            val savedState = createSavedStateHandle(address)
+            createViewModel(savedState)
+        }
+
+        advanceUntilIdle()
+
+        val result = sut.viewState.value
+
+        assertThat(result).isInstanceOf(WooShippingEditAddressViewModel.ViewState::class.java)
+
+        assertThat(result.shouldUseStatesInput).isFalse()
+    }
+
+    @Test
+    fun `when the country selected has states then use the first state from the list`() = testBlocking {
+        val address = Address.EMPTY
+        whenever(addressValidator.validateFieldRequired(any())).doReturn(null)
+        whenever(getAcceptedOriginCountries.invoke()).doReturn(Result.success(countries))
+        whenever(getStatesByCountryCode.invoke(any())).doReturn(states)
+        Snapshot.withMutableSnapshot {
+            val savedState = createSavedStateHandle(address)
+            createViewModel(savedState)
+        }
+
+        advanceUntilIdle()
+
+        val result = sut.viewState.value
+
+        assertThat(result).isInstanceOf(WooShippingEditAddressViewModel.ViewState::class.java)
+
+        assertThat(result.shouldUseStatesInput).isFalse()
+        assertThat(result.editableAddress.state).isEqualTo(states.first())
+    }
+
+    @Test
+    fun `when the country selected has NO states then use the empty string`() = testBlocking {
+        val address = Address.EMPTY
+        whenever(addressValidator.validateFieldRequired(any())).doReturn(null)
+        whenever(getAcceptedOriginCountries.invoke()).doReturn(Result.success(countries))
+        whenever(getStatesByCountryCode.invoke(any())).doReturn(emptyList())
+        Snapshot.withMutableSnapshot {
+            val savedState = createSavedStateHandle(address)
+            createViewModel(savedState)
+        }
+
+        advanceUntilIdle()
+
+        val result = sut.viewState.value
+
+        assertThat(result).isInstanceOf(WooShippingEditAddressViewModel.ViewState::class.java)
+
+        assertThat(result.shouldUseStatesInput).isTrue()
+        assertThat(result.editableAddress.state.name).isEqualTo("")
+    }
+
+    @Test
+    fun `when received address is verified and displayed address has no changes, display verified`() = testBlocking {
+        val address = Address(
+            address1 = "Address",
+            address2 = "",
+            city = "Miami",
+            postcode = "",
+            email = "",
+            phone = "",
+            state = AmbiguousLocation.Raw("FL"),
+            country = AmbiguousLocation.Raw("US").asLocation(),
+            firstName = "Name",
+            lastName = "",
+            company = "",
+        )
+        whenever(addressValidator.validateFieldRequired(any())).doReturn(null)
+        whenever(getAcceptedOriginCountries.invoke()).doReturn(Result.success(countries))
+        whenever(getStatesByCountryCode.invoke(any())).doReturn(states)
+        Snapshot.withMutableSnapshot {
+            val savedState = createSavedStateHandle(address,true)
+            createViewModel(savedState)
+        }
+
+        advanceUntilIdle()
+
+        val result = sut.viewState.value
+
+        assertThat(result).isInstanceOf(WooShippingEditAddressViewModel.ViewState::class.java)
+
+        assertThat(result.addressStatus).isEqualTo(AddressStatus.VERIFIED)
+    }
+
+    @Test
+    fun `when received address is verified and displayed address has changes, display unverified`() = testBlocking {
+        val address = Address(
+            address1 = "Address",
+            address2 = "",
+            city = "Miami",
+            postcode = "",
+            email = "",
+            phone = "",
+            state = AmbiguousLocation.Raw("FL"),
+            country = AmbiguousLocation.Raw("US").asLocation(),
+            firstName = "Name",
+            lastName = "",
+            company = ""
+        )
+        whenever(addressValidator.validateFieldRequired(any())).doReturn(null)
+        whenever(getAcceptedOriginCountries.invoke()).doReturn(Result.success(countries))
+        whenever(getStatesByCountryCode.invoke(any())).doReturn(states)
+        Snapshot.withMutableSnapshot {
+            val savedState = createSavedStateHandle(address,true)
+            createViewModel(savedState)
+            sut.onAddressChange("Updated address")
+        }
+
+        advanceUntilIdle()
+
+        val result = sut.viewState.value
+
+        assertThat(result).isInstanceOf(WooShippingEditAddressViewModel.ViewState::class.java)
+
+        assertThat(result.addressStatus).isEqualTo(AddressStatus.UNVERIFIED)
+    }
+
+    @Test
+    fun `when only no address related fields has changes, display save changes`() = testBlocking {
+        val address = Address(
+            address1 = "Address",
+            address2 = "",
+            city = "Miami",
+            postcode = "",
+            email = "",
+            phone = "",
+            state = AmbiguousLocation.Raw("FL"),
+            country = AmbiguousLocation.Raw("US").asLocation(),
+            firstName = "Name",
+            lastName = "",
+            company = "",
+        )
+        whenever(addressValidator.validateFieldRequired(any())).doReturn(null)
+        whenever(getAcceptedOriginCountries.invoke()).doReturn(Result.success(countries))
+        whenever(getStatesByCountryCode.invoke(any())).doReturn(states)
+        Snapshot.withMutableSnapshot {
+            val savedState = createSavedStateHandle(address,true)
+            createViewModel(savedState)
+            sut.onEmailChange("email@test.com")
+        }
+
+        advanceUntilIdle()
+
+        val result = sut.viewState.value
+
+        assertThat(result).isInstanceOf(WooShippingEditAddressViewModel.ViewState::class.java)
+
+        assertThat(result.addressStatus).isEqualTo(AddressStatus.SAVE_CHANGES)
+    }
+
+    @Test
+    fun `when received address is not verified and displayed address has no changes, display unverified`() =
+        testBlocking {
+            val address = Address(
+                address1 = "Address",
+                address2 = "",
+                city = "Miami",
+                postcode = "",
+                email = "",
+                phone = "",
+                state = AmbiguousLocation.Raw("FL"),
+                country = AmbiguousLocation.Raw("US").asLocation(),
+                firstName = "Name",
+                lastName = "",
+                company = "",
+            )
+            whenever(addressValidator.validateFieldRequired(any())).doReturn(null)
+            whenever(getAcceptedOriginCountries.invoke()).doReturn(Result.success(countries))
+            whenever(getStatesByCountryCode.invoke(any())).doReturn(states)
+            Snapshot.withMutableSnapshot {
+                val savedState = createSavedStateHandle(address)
+                createViewModel(savedState)
+            }
+
+            advanceUntilIdle()
+
+            val result = sut.viewState.value
+
+            assertThat(result).isInstanceOf(WooShippingEditAddressViewModel.ViewState::class.java)
+
+            assertThat(result.addressStatus).isEqualTo(AddressStatus.UNVERIFIED)
+        }
+
+    @Test
+    fun `when there are errors, display missing info`() = testBlocking {
+        val address = Address(
+            address1 = "Address",
+            address2 = "",
+            city = "Miami",
+            postcode = "",
+            email = "",
+            phone = "",
+            state = AmbiguousLocation.Raw("FL"),
+            country = AmbiguousLocation.Raw("US").asLocation(),
+            firstName = "Name",
+            lastName = "",
+            company = "",
+        )
+        whenever(addressValidator.validateFieldRequired(any())).doReturn("Field required")
+        whenever(getAcceptedOriginCountries.invoke()).doReturn(Result.success(countries))
+        whenever(getStatesByCountryCode.invoke(any())).doReturn(states)
+        Snapshot.withMutableSnapshot {
+            val savedState = createSavedStateHandle(address)
+            createViewModel(savedState)
+        }
+
+        advanceUntilIdle()
+
+        val result = sut.viewState.value
+
+        assertThat(result).isInstanceOf(WooShippingEditAddressViewModel.ViewState::class.java)
+
+        assertThat(result.addressStatus).isEqualTo(AddressStatus.MISSING_INFO)
+    }
+
+    @Test
+    fun `when screen is initialized then normalize address is closed`() = testBlocking {
+        val address = Address.EMPTY
+        whenever(addressValidator.validateFieldRequired(any())).doReturn(null)
+        whenever(getAcceptedOriginCountries.invoke()).doReturn(Result.success(countries))
+        whenever(getStatesByCountryCode.invoke(any())).doReturn(states)
+        Snapshot.withMutableSnapshot {
+            val savedState = createSavedStateHandle(address)
+            createViewModel(savedState)
+        }
+
+        advanceUntilIdle()
+
+        val result = sut.viewState.value
+
+        assertThat(result).isInstanceOf(WooShippingEditAddressViewModel.ViewState::class.java)
+
+        assertThat(result.addressValidationState).isEqualTo(AddressValidationState.NotStarted)
+    }
+
+    @Test
+    fun `when normalize address fails, display error`() = testBlocking {
+        val address = Address(
+            address1 = "Address",
+            address2 = "",
+            city = "Miami",
+            postcode = "",
+            email = "",
+            phone = "",
+            state = AmbiguousLocation.Raw("FL"),
+            country = AmbiguousLocation.Raw("US").asLocation(),
+            firstName = "Name",
+            lastName = "",
+            company = "",
+        )
+        val editableAddress = EditableAddress(
+            name = InputValue(address.firstName),
+            company = InputValue(address.company),
+            country = countries.first { it.code == address.country.code },
+            address = InputValue(address.address1),
+            city = InputValue(address.city),
+            state = states.first { it.code == address.state.codeOrRaw },
+            postalCode = InputValue(address.postcode),
+            email = InputValue(address.email),
+            phone = InputValue(address.phone)
+        )
+        whenever(addressValidator.validateFieldRequired(any())).doReturn(null)
+        whenever(getAcceptedOriginCountries.invoke()).doReturn(Result.success(countries))
+        whenever(getStatesByCountryCode.invoke(any())).doReturn(states)
+        whenever(normalizeAddress.invoke(any())).doReturn(Result.failure(Exception("error")))
+        whenever(resourceProvider.getString(any())).doReturn("error")
+        Snapshot.withMutableSnapshot {
+            val savedState = createSavedStateHandle(address)
+            createViewModel(savedState)
+        }
+
+        advanceUntilIdle()
+
+        sut.onNormalizeAddress(editableAddress)
+
+        val result = sut.viewState.value
+
+        assertThat(result).isInstanceOf(WooShippingEditAddressViewModel.ViewState::class.java)
+
+        assertThat(result.addressValidationState).isInstanceOf(AddressValidationState.VerificationFailed::class.java)
+
+        assertThat(result.error).isNotNull()
+    }
+
+    @Test
+    fun `when normalize address succeed, display address selection`() = testBlocking {
+        val address = Address.EMPTY
+        val updatedAddress = EditableAddress(postalCode = InputValue("12345"))
+        val normalizeAddressResponse = AddressNormalizationModel(
+            address = Address.EMPTY,
+            normalizedAddress = Address.EMPTY,
+            isTrivial = true
+        )
+
+        whenever(addressValidator.validateFieldRequired(any())).doReturn(null)
+        whenever(getAcceptedOriginCountries.invoke()).doReturn(Result.success(countries))
+        whenever(getStatesByCountryCode.invoke(any())).doReturn(states)
+        whenever(normalizeAddress.invoke(any())).doReturn(Result.success(normalizeAddressResponse))
+        whenever(resourceProvider.getString(any())).doReturn("error")
+        Snapshot.withMutableSnapshot {
+            val savedState = createSavedStateHandle(address)
+            createViewModel(savedState)
+        }
+
+        advanceUntilIdle()
+
+        sut.onNormalizeAddress(updatedAddress)
+
+        val result = sut.viewState.value
+
+        assertThat(result).isInstanceOf(WooShippingEditAddressViewModel.ViewState::class.java)
+
+        assertThat(result.addressValidationState).isInstanceOf(AddressValidationState.AddressSelection::class.java)
+    }
+
+    @Test
+    fun `when normalize address succeed then suggested address is selected`() = testBlocking {
+        val initialAddress = Address.EMPTY
+        val updatedAddress = EditableAddress(postalCode = InputValue("12345"))
+        val enteredAddress = EditableAddress(postalCode = InputValue("12345")).toAddress()
+        val suggestedAddress = enteredAddress.copy(postcode = "12345-1000")
+
+        val normalizeAddressResponse = AddressNormalizationModel(
+            address = enteredAddress,
+            normalizedAddress = suggestedAddress,
+            isTrivial = false
+        )
+
+        whenever(addressValidator.validateFieldRequired(any())).doReturn(null)
+        whenever(getAcceptedOriginCountries.invoke()).doReturn(Result.success(countries))
+        whenever(getStatesByCountryCode.invoke(any())).doReturn(states)
+        whenever(normalizeAddress.invoke(any())).doReturn(Result.success(normalizeAddressResponse))
+        whenever(resourceProvider.getString(any())).doReturn("error")
+        Snapshot.withMutableSnapshot {
+            val savedState = createSavedStateHandle(initialAddress)
+            createViewModel(savedState)
+        }
+
+        advanceUntilIdle()
+
+        sut.onNormalizeAddress(updatedAddress)
+
+        val result = sut.viewState.value
+        assertThat(result).isInstanceOf(WooShippingEditAddressViewModel.ViewState::class.java)
+        val addressSelection = result.addressValidationState as AddressValidationState.AddressSelection
+        assertThat(addressSelection.selectedAddress).isEqualTo(suggestedAddress)
+    }
+
+    @Test
+    fun `when normalize address selection changes then address selection is updated`() = testBlocking {
+        val initialAddress = Address.EMPTY
+        val updatedAddress = EditableAddress(postalCode = InputValue("12345"))
+        val enteredAddress = EditableAddress(postalCode = InputValue("12345")).toAddress()
+        val suggestedAddress = enteredAddress.copy(postcode = "12345-1000")
+
+        val normalizeAddressResponse = AddressNormalizationModel(
+            address = enteredAddress,
+            normalizedAddress = suggestedAddress,
+            isTrivial = false
+        )
+
+        whenever(addressValidator.validateFieldRequired(any())).doReturn(null)
+        whenever(getAcceptedOriginCountries.invoke()).doReturn(Result.success(countries))
+        whenever(getStatesByCountryCode.invoke(any())).doReturn(states)
+        whenever(normalizeAddress.invoke(any())).doReturn(Result.success(normalizeAddressResponse))
+        whenever(resourceProvider.getString(any())).doReturn("error")
+        Snapshot.withMutableSnapshot {
+            val savedState = createSavedStateHandle(initialAddress)
+            createViewModel(savedState)
+        }
+
+        advanceUntilIdle()
+
+        sut.onNormalizeAddress(updatedAddress)
+
+        var result = sut.viewState.value
+        assertThat(result).isInstanceOf(WooShippingEditAddressViewModel.ViewState::class.java)
+        var addressSelection = result.addressValidationState as AddressValidationState.AddressSelection
+        assertThat(addressSelection.selectedAddress).isEqualTo(suggestedAddress)
+
+        sut.onAddressSelectionChange(addressSelection.copy(selectedAddress = enteredAddress))
+
+        result = sut.viewState.value
+        assertThat(result).isInstanceOf(WooShippingEditAddressViewModel.ViewState::class.java)
+        addressSelection = result.addressValidationState as AddressValidationState.AddressSelection
+        assertThat(addressSelection.selectedAddress).isEqualTo(enteredAddress)
+    }
+
+    @Test
+    fun `when normalize address is closed then close address selection`() = testBlocking {
+        val initialAddress = Address.EMPTY
+        val updatedAddress = EditableAddress(postalCode = InputValue("12345"))
+        val enteredAddress = EditableAddress(postalCode = InputValue("12345")).toAddress()
+        val suggestedAddress = enteredAddress.copy(postcode = "12345-1000")
+
+        val normalizeAddressResponse = AddressNormalizationModel(
+            address = enteredAddress,
+            normalizedAddress = suggestedAddress,
+            isTrivial = false
+        )
+
+        whenever(addressValidator.validateFieldRequired(any())).doReturn(null)
+        whenever(getAcceptedOriginCountries.invoke()).doReturn(Result.success(countries))
+        whenever(getStatesByCountryCode.invoke(any())).doReturn(states)
+        whenever(normalizeAddress.invoke(any())).doReturn(Result.success(normalizeAddressResponse))
+        whenever(resourceProvider.getString(any())).doReturn("error")
+        Snapshot.withMutableSnapshot {
+            val savedState = createSavedStateHandle(initialAddress)
+            createViewModel(savedState)
+        }
+
+        advanceUntilIdle()
+
+        sut.onNormalizeAddress(updatedAddress)
+
+        var result = sut.viewState.value
+        assertThat(result).isInstanceOf(WooShippingEditAddressViewModel.ViewState::class.java)
+        val addressSelection = result.addressValidationState as AddressValidationState.AddressSelection
+        assertThat(addressSelection.selectedAddress).isEqualTo(suggestedAddress)
+
+        sut.onCloseAddressSelection()
+
+        result = sut.viewState.value
+        assertThat(result).isInstanceOf(WooShippingEditAddressViewModel.ViewState::class.java)
+        assertThat(result.addressValidationState).isEqualTo(AddressValidationState.NotStarted)
+    }
+
+    @Test
+    fun `when the address selection is expanded then prevent back navigation`() = testBlocking {
+        val initialAddress = Address.EMPTY
+        val updatedAddress = EditableAddress(postalCode = InputValue("12345"))
+        val enteredAddress = EditableAddress(postalCode = InputValue("12345")).toAddress()
+        val suggestedAddress = enteredAddress.copy(postcode = "12345-1000")
+
+        val normalizeAddressResponse = AddressNormalizationModel(
+            address = enteredAddress,
+            normalizedAddress = suggestedAddress,
+            isTrivial = false
+        )
+
+        whenever(addressValidator.validateFieldRequired(any())).doReturn(null)
+        whenever(getAcceptedOriginCountries.invoke()).doReturn(Result.success(countries))
+        whenever(getStatesByCountryCode.invoke(any())).doReturn(states)
+        whenever(normalizeAddress.invoke(any())).doReturn(Result.success(normalizeAddressResponse))
+        whenever(resourceProvider.getString(any())).doReturn("error")
+        Snapshot.withMutableSnapshot {
+            val savedState = createSavedStateHandle(initialAddress)
+            createViewModel(savedState)
+        }
+
+        advanceUntilIdle()
+
+        sut.onNormalizeAddress(updatedAddress)
+
+        var result = sut.viewState.value
+        assertThat(result.addressValidationState).isInstanceOf(AddressValidationState.AddressSelection::class.java)
+
+        val shouldNavigateBack = sut.allowBackNavigation()
+        assertThat(shouldNavigateBack).isFalse()
+    }
+
+    @Test
+    fun `when the address selection is NOT expanded then allow back navigation`() = testBlocking {
+        whenever(addressValidator.validateFieldRequired(any())).doReturn(null)
+        whenever(getAcceptedOriginCountries.invoke()).doReturn(Result.success(countries))
+        whenever(getStatesByCountryCode.invoke(any())).doReturn(states)
+        Snapshot.withMutableSnapshot {
+            val savedState = createSavedStateHandle(Address.EMPTY)
+            createViewModel(savedState)
+        }
+
+        advanceUntilIdle()
+
+        val result = sut.viewState.value
+
+        assertThat(result.addressValidationState).isInstanceOf(AddressValidationState.NotStarted::class.java)
+
+        val shouldNavigateBack = sut.allowBackNavigation()
+        assertThat(shouldNavigateBack).isTrue()
+    }
+}

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/address/WooShippingEditAddressViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/address/WooShippingEditAddressViewModelTest.kt
@@ -22,7 +22,7 @@ import org.mockito.kotlin.mock
 import org.mockito.kotlin.whenever
 
 @OptIn(ExperimentalCoroutinesApi::class)
-abstract class WooShippingEditAddressViewModelTest: BaseUnitTest() {
+abstract class WooShippingEditAddressViewModelTest : BaseUnitTest() {
     protected val addressValidator: AddressValidationHelper = mock()
     protected val getAcceptedOriginCountries: GetAcceptedOriginCountries = mock()
     protected val getStatesByCountryCode: GetStatesByCountryCode = mock()
@@ -526,7 +526,7 @@ abstract class WooShippingEditAddressViewModelTest: BaseUnitTest() {
         whenever(getAcceptedOriginCountries.invoke()).doReturn(Result.success(countries))
         whenever(getStatesByCountryCode.invoke(any())).doReturn(states)
         Snapshot.withMutableSnapshot {
-            val savedState = createSavedStateHandle(address,true)
+            val savedState = createSavedStateHandle(address, true)
             createViewModel(savedState)
         }
 
@@ -558,7 +558,7 @@ abstract class WooShippingEditAddressViewModelTest: BaseUnitTest() {
         whenever(getAcceptedOriginCountries.invoke()).doReturn(Result.success(countries))
         whenever(getStatesByCountryCode.invoke(any())).doReturn(states)
         Snapshot.withMutableSnapshot {
-            val savedState = createSavedStateHandle(address,true)
+            val savedState = createSavedStateHandle(address, true)
             createViewModel(savedState)
             sut.onAddressChange("Updated address")
         }
@@ -591,7 +591,7 @@ abstract class WooShippingEditAddressViewModelTest: BaseUnitTest() {
         whenever(getAcceptedOriginCountries.invoke()).doReturn(Result.success(countries))
         whenever(getStatesByCountryCode.invoke(any())).doReturn(states)
         Snapshot.withMutableSnapshot {
-            val savedState = createSavedStateHandle(address,true)
+            val savedState = createSavedStateHandle(address, true)
             createViewModel(savedState)
             sut.onEmailChange("email@test.com")
         }

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/address/WooShippingEditAddressViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/address/WooShippingEditAddressViewModelTest.kt
@@ -248,89 +248,10 @@ abstract class WooShippingEditAddressViewModelTest : BaseUnitTest() {
     }
 
     @Test
-    fun `when email is empty then address error is not null`() = testBlocking {
-        val address = Address.EMPTY
-        whenever(addressValidator.validateAtLeastOneOf(eq(""), eq(""))).doReturn("error")
-        whenever(addressValidator.validateFieldRequired("")).doReturn("error")
-        Snapshot.withMutableSnapshot {
-            val savedState = createSavedStateHandle(address)
-            createViewModel(savedState)
-        }
-
-        advanceUntilIdle()
-
-        val result = sut.viewState.value
-
-        assertThat(result).isInstanceOf(WooShippingEditAddressViewModel.ViewState::class.java)
-
-        assertThat(result.editableAddress.email.error).isNotEmpty()
-    }
-
-    @Test
-    fun `when email is NOT empty then address error is null`() = testBlocking {
-        val address = Address.EMPTY.copy(email = "This is an email")
-        whenever(addressValidator.validateAtLeastOneOf(eq(""), eq(""))).doReturn("error")
-        whenever(addressValidator.validateFieldRequired("")).doReturn("error")
-        Snapshot.withMutableSnapshot {
-            val savedState = createSavedStateHandle(address)
-            createViewModel(savedState)
-        }
-
-        advanceUntilIdle()
-
-        val result = sut.viewState.value
-
-        assertThat(result).isInstanceOf(WooShippingEditAddressViewModel.ViewState::class.java)
-
-        assertThat(result.editableAddress.email.error).isNull()
-    }
-
-    @Test
-    fun `when phone is empty then phone error is not null`() = testBlocking {
-        val address = Address.EMPTY
-        whenever(addressValidator.validateAtLeastOneOf(eq(""), eq(""))).doReturn("error")
-        whenever(addressValidator.validateFieldRequired("")).doReturn("error")
-        whenever(addressValidator.validateUSCustomsPhone("")).doReturn("error")
-        Snapshot.withMutableSnapshot {
-            val savedState = createSavedStateHandle(address)
-            createViewModel(savedState)
-        }
-
-        advanceUntilIdle()
-
-        val result = sut.viewState.value
-
-        assertThat(result).isInstanceOf(WooShippingEditAddressViewModel.ViewState::class.java)
-
-        assertThat(result.editableAddress.phone.error).isNotEmpty()
-    }
-
-    @Test
-    fun `when phone is NOT empty and invalid then phone error is not null`() = testBlocking {
-        val address = Address.EMPTY.copy(phone = "1234567890")
-        whenever(addressValidator.validateAtLeastOneOf(eq(""), eq(""))).doReturn("error")
-        whenever(addressValidator.validateFieldRequired("")).doReturn("error")
-        whenever(addressValidator.validateUSCustomsPhone("1234567890")).doReturn("error")
-        Snapshot.withMutableSnapshot {
-            val savedState = createSavedStateHandle(address)
-            createViewModel(savedState)
-        }
-
-        advanceUntilIdle()
-
-        val result = sut.viewState.value
-
-        assertThat(result).isInstanceOf(WooShippingEditAddressViewModel.ViewState::class.java)
-
-        assertThat(result.editableAddress.phone.error).isNotEmpty()
-    }
-
-    @Test
     fun `when phone is NOT empty and valid then phone error is null`() = testBlocking {
         val address = Address.EMPTY.copy(phone = "1234567890")
         whenever(addressValidator.validateAtLeastOneOf(eq(""), eq(""))).doReturn("error")
         whenever(addressValidator.validateFieldRequired("")).doReturn("error")
-        whenever(addressValidator.validateUSCustomsPhone("1234567890")).doReturn(null)
         Snapshot.withMutableSnapshot {
             val savedState = createSavedStateHandle(address)
             createViewModel(savedState)
@@ -705,17 +626,6 @@ abstract class WooShippingEditAddressViewModelTest : BaseUnitTest() {
             lastName = "",
             company = "",
         )
-        val editableAddress = EditableAddress(
-            name = InputValue(address.firstName),
-            company = InputValue(address.company),
-            country = countries.first { it.code == address.country.code },
-            address = InputValue(address.address1),
-            city = InputValue(address.city),
-            state = states.first { it.code == address.state.codeOrRaw },
-            postalCode = InputValue(address.postcode),
-            email = InputValue(address.email),
-            phone = InputValue(address.phone)
-        )
         whenever(addressValidator.validateFieldRequired(any())).doReturn(null)
         whenever(getAcceptedOriginCountries.invoke()).doReturn(Result.success(countries))
         whenever(getStatesByCountryCode.invoke(any())).doReturn(states)
@@ -728,7 +638,7 @@ abstract class WooShippingEditAddressViewModelTest : BaseUnitTest() {
 
         advanceUntilIdle()
 
-        sut.onNormalizeAddress(editableAddress)
+        sut.onNormalizeAddress(sut.viewState.value.editableAddress)
 
         val result = sut.viewState.value
 

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/address/destination/UpdateDestinationAddressTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/address/destination/UpdateDestinationAddressTest.kt
@@ -1,0 +1,59 @@
+package com.woocommerce.android.ui.orders.wooshippinglabels.address.destination
+
+import com.woocommerce.android.model.Address
+import com.woocommerce.android.tools.SelectedSite
+import com.woocommerce.android.ui.orders.wooshippinglabels.models.DestinationShippingAddress
+import com.woocommerce.android.ui.orders.wooshippinglabels.networking.WooShippingLabelRepository
+import com.woocommerce.android.viewmodel.BaseUnitTest
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.Test
+import org.mockito.Mockito.mock
+import org.mockito.kotlin.any
+import org.mockito.kotlin.whenever
+import org.wordpress.android.fluxc.model.SiteModel
+import org.wordpress.android.fluxc.network.BaseRequest.GenericErrorType.UNKNOWN
+import org.wordpress.android.fluxc.network.rest.wpcom.wc.WooError
+import org.wordpress.android.fluxc.network.rest.wpcom.wc.WooErrorType.GENERIC_ERROR
+import org.wordpress.android.fluxc.network.rest.wpcom.wc.WooResult
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class UpdateDestinationAddressTest : BaseUnitTest() {
+    private val repository: WooShippingLabelRepository = mock()
+    private val site: SelectedSite = mock()
+
+    private val sut = UpdateDestinationAddress(repository, site, coroutinesTestRule.testDispatchers)
+
+    private val defaultAddress = Address.EMPTY
+    private val defaultOrderId = 2L
+    private val defaultAddressResponse = DestinationShippingAddress.EMPTY
+
+    @Test
+    fun `when selected site is null then return failure`() = testBlocking {
+        val result = sut.invoke(defaultAddress, defaultOrderId)
+        assert(result.isFailure)
+    }
+
+    @Test
+    fun `when normalize address fails then return failure`() = testBlocking {
+        whenever(site.getOrNull()).thenReturn(SiteModel())
+        whenever(repository.updateDestinationAddress(any(), any(), any()))
+            .thenReturn(WooResult(WooError(GENERIC_ERROR, UNKNOWN)))
+
+        val result = sut.invoke(defaultAddress, defaultOrderId)
+
+        assert(result.isFailure)
+    }
+
+    @Test
+    fun `when normalize address succeed then return expected data`() = testBlocking {
+        whenever(site.getOrNull()).thenReturn(SiteModel())
+        whenever(repository.updateDestinationAddress(any(), any(), any()))
+            .thenReturn(WooResult(defaultAddressResponse))
+
+        val result = sut.invoke(defaultAddress, defaultOrderId)
+
+        assert(result.isSuccess)
+        assertThat(result.getOrNull()).isEqualTo(defaultAddressResponse)
+    }
+}

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/address/destination/WooShippingEditDestinationViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/address/destination/WooShippingEditDestinationViewModelTest.kt
@@ -1,4 +1,4 @@
-package com.woocommerce.android.ui.orders.wooshippinglabels.address.origin
+package com.woocommerce.android.ui.orders.wooshippinglabels.address.destination
 
 import androidx.compose.runtime.snapshots.Snapshot
 import androidx.lifecycle.SavedStateHandle
@@ -12,7 +12,7 @@ import com.woocommerce.android.ui.orders.wooshippinglabels.address.WooShippingEd
 import com.woocommerce.android.ui.orders.wooshippinglabels.address.WooShippingEditAddressViewModelTest
 import com.woocommerce.android.ui.orders.wooshippinglabels.address.toAddress
 import com.woocommerce.android.ui.orders.wooshippinglabels.models.AddressNormalizationModel
-import com.woocommerce.android.ui.orders.wooshippinglabels.models.OriginShippingAddress
+import com.woocommerce.android.ui.orders.wooshippinglabels.models.DestinationShippingAddress
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.advanceUntilIdle
 import org.assertj.core.api.Assertions.assertThat
@@ -24,28 +24,15 @@ import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
 
 @OptIn(ExperimentalCoroutinesApi::class)
-class WooShippingEditOriginViewModelTest : WooShippingEditAddressViewModelTest() {
+class WooShippingEditDestinationViewModelTest : WooShippingEditAddressViewModelTest() {
     override fun createSavedStateHandle(
         address: Address,
         isVerified: Boolean
     ): SavedStateHandle {
-        val originAddress = OriginShippingAddress(
-            id = "123",
-            company = address.company,
-            firstName = address.firstName,
-            lastName = address.lastName,
-            email = address.email,
-            address1 = address.address1,
-            address2 = address.address2,
-            city = address.city,
-            state = address.state.codeOrRaw,
-            postcode = address.postcode,
-            country = address.country.code,
-            phone = address.phone,
-            isDefault = true,
-            isVerified = isVerified
-        )
-        return WooShippingEditAddressFragmentArgs(EditAddressFlow.EditOriginAddress(originAddress)).toSavedStateHandle()
+        val destination = DestinationShippingAddress(address,isVerified)
+        return WooShippingEditAddressFragmentArgs(
+            EditAddressFlow.EditDestinationAddress(destination,1L)
+        ).toSavedStateHandle()
     }
 
     @Test
@@ -56,7 +43,8 @@ class WooShippingEditOriginViewModelTest : WooShippingEditAddressViewModelTest()
         whenever(addressValidator.validateFieldRequired(any())).doReturn(null)
         whenever(getAcceptedOriginCountries.invoke()).doReturn(Result.success(countries))
         whenever(getStatesByCountryCode.invoke(any())).doReturn(states)
-        whenever(updateOriginAddress.invoke(any(), any())).doReturn(Result.success(OriginShippingAddress.EMPTY))
+        whenever(updateDestinationAddress.invoke(any(), any()))
+            .doReturn(Result.success(DestinationShippingAddress.EMPTY))
         Snapshot.withMutableSnapshot {
             val savedState = createSavedStateHandle(initialAddress)
             createViewModel(savedState)
@@ -68,7 +56,7 @@ class WooShippingEditOriginViewModelTest : WooShippingEditAddressViewModelTest()
 
         val result = sut.viewState.value
         assertThat(result.addressValidationState).isEqualTo(AddressValidationState.NotStarted)
-        verify(updateDestinationAddress, never()).invoke(any(), any())
+        verify(updateOriginAddress, never()).invoke(any(), any())
     }
 
     @Test
@@ -85,7 +73,7 @@ class WooShippingEditOriginViewModelTest : WooShippingEditAddressViewModelTest()
         whenever(addressValidator.validateFieldRequired(any())).doReturn(null)
         whenever(getAcceptedOriginCountries.invoke()).doReturn(Result.success(countries))
         whenever(getStatesByCountryCode.invoke(any())).doReturn(states)
-        whenever(updateOriginAddress.invoke(any(), any())).doReturn(Result.failure(Exception("error")))
+        whenever(updateDestinationAddress.invoke(any(), any())).doReturn(Result.failure(Exception("error")))
         whenever(resourceProvider.getString(any())).doReturn("error")
         Snapshot.withMutableSnapshot {
             val savedState = createSavedStateHandle(initialAddress)
@@ -109,9 +97,10 @@ class WooShippingEditOriginViewModelTest : WooShippingEditAddressViewModelTest()
 
         val shouldNavigateBack = sut.allowBackNavigation()
         assertThat(shouldNavigateBack).isFalse()
-        verify(updateDestinationAddress, never()).invoke(any(), any())
+        verify(updateOriginAddress, never()).invoke(any(), any())
     }
 
+    @OptIn(ExperimentalCoroutinesApi::class)
     @Test
     fun `when update address fails then address state is failure`() = testBlocking {
         val address = Address(
@@ -142,7 +131,7 @@ class WooShippingEditOriginViewModelTest : WooShippingEditAddressViewModelTest()
         whenever(addressValidator.validateFieldRequired(any())).doReturn(null)
         whenever(getAcceptedOriginCountries.invoke()).doReturn(Result.success(countries))
         whenever(getStatesByCountryCode.invoke(any())).doReturn(states)
-        whenever(updateOriginAddress.invoke(any(), any())).doReturn(Result.failure(Exception("error")))
+        whenever(updateDestinationAddress.invoke(any(), any())).doReturn(Result.failure(Exception("error")))
         whenever(resourceProvider.getString(any())).doReturn("error")
         Snapshot.withMutableSnapshot {
             val savedState = createSavedStateHandle(address)
@@ -156,7 +145,7 @@ class WooShippingEditOriginViewModelTest : WooShippingEditAddressViewModelTest()
         val result = sut.viewState.value
         assertThat(result.addressValidationState).isInstanceOf(AddressValidationState.AddressUpdateFailed::class.java)
         assertThat(result.error).isNotNull()
-        verify(updateDestinationAddress, never()).invoke(any(), any())
+        verify(updateOriginAddress, never()).invoke(any(), any())
     }
 
     @Test
@@ -173,7 +162,8 @@ class WooShippingEditOriginViewModelTest : WooShippingEditAddressViewModelTest()
         whenever(addressValidator.validateFieldRequired(any())).doReturn(null)
         whenever(getAcceptedOriginCountries.invoke()).doReturn(Result.success(countries))
         whenever(getStatesByCountryCode.invoke(any())).doReturn(states)
-        whenever(updateOriginAddress.invoke(any(), any())).doReturn(Result.success(OriginShippingAddress.EMPTY))
+        whenever(updateDestinationAddress.invoke(any(), any()))
+            .doReturn(Result.success(DestinationShippingAddress.EMPTY))
         Snapshot.withMutableSnapshot {
             val savedState = createSavedStateHandle(initialAddress)
             createViewModel(savedState)
@@ -190,7 +180,7 @@ class WooShippingEditOriginViewModelTest : WooShippingEditAddressViewModelTest()
 
         val result = sut.viewState.value
         assertThat(result.addressValidationState).isEqualTo(AddressValidationState.NotStarted)
-        verify(updateDestinationAddress, never()).invoke(any(), any())
+        verify(updateOriginAddress, never()).invoke(any(), any())
     }
 
     @Test
@@ -207,7 +197,7 @@ class WooShippingEditOriginViewModelTest : WooShippingEditAddressViewModelTest()
         whenever(addressValidator.validateFieldRequired(any())).doReturn(null)
         whenever(getAcceptedOriginCountries.invoke()).doReturn(Result.success(countries))
         whenever(getStatesByCountryCode.invoke(any())).doReturn(states)
-        whenever(updateOriginAddress.invoke(any(), any())).doReturn(Result.failure(Exception("error")))
+        whenever(updateDestinationAddress.invoke(any(), any())).doReturn(Result.failure(Exception("error")))
         whenever(resourceProvider.getString(any())).doReturn("error")
         Snapshot.withMutableSnapshot {
             val savedState = createSavedStateHandle(initialAddress)
@@ -228,6 +218,6 @@ class WooShippingEditOriginViewModelTest : WooShippingEditAddressViewModelTest()
             .isInstanceOf(AddressValidationState.NormalizedAddressUpdateFailed::class.java)
 
         assertThat(result.error).isNotNull()
-        verify(updateDestinationAddress, never()).invoke(any(), any())
+        verify(updateOriginAddress, never()).invoke(any(), any())
     }
 }

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/address/destination/WooShippingEditDestinationViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/address/destination/WooShippingEditDestinationViewModelTest.kt
@@ -9,6 +9,7 @@ import com.woocommerce.android.ui.orders.wooshippinglabels.address.EditAddressFl
 import com.woocommerce.android.ui.orders.wooshippinglabels.address.EditableAddress
 import com.woocommerce.android.ui.orders.wooshippinglabels.address.InputValue
 import com.woocommerce.android.ui.orders.wooshippinglabels.address.WooShippingEditAddressFragmentArgs
+import com.woocommerce.android.ui.orders.wooshippinglabels.address.WooShippingEditAddressViewModel
 import com.woocommerce.android.ui.orders.wooshippinglabels.address.WooShippingEditAddressViewModelTest
 import com.woocommerce.android.ui.orders.wooshippinglabels.address.toAddress
 import com.woocommerce.android.ui.orders.wooshippinglabels.models.AddressNormalizationModel
@@ -19,6 +20,7 @@ import org.assertj.core.api.Assertions.assertThat
 import org.junit.Test
 import org.mockito.kotlin.any
 import org.mockito.kotlin.doReturn
+import org.mockito.kotlin.eq
 import org.mockito.kotlin.never
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
@@ -116,17 +118,6 @@ class WooShippingEditDestinationViewModelTest : WooShippingEditAddressViewModelT
             lastName = "",
             company = ""
         )
-        val editableAddress = EditableAddress(
-            name = InputValue(address.firstName),
-            company = InputValue(address.company),
-            country = countries.first { it.code == address.country.code },
-            address = InputValue(address.address1),
-            city = InputValue(address.city),
-            state = states.first { it.code == address.state.codeOrRaw },
-            postalCode = InputValue(address.postcode),
-            email = InputValue(address.email),
-            phone = InputValue(address.phone)
-        )
 
         whenever(addressValidator.validateFieldRequired(any())).doReturn(null)
         whenever(getAcceptedOriginCountries.invoke()).doReturn(Result.success(countries))
@@ -140,7 +131,7 @@ class WooShippingEditDestinationViewModelTest : WooShippingEditAddressViewModelT
 
         advanceUntilIdle()
 
-        sut.onUpdateAddress(editableAddress)
+        sut.onUpdateAddress(sut.viewState.value.editableAddress)
 
         val result = sut.viewState.value
         assertThat(result.addressValidationState).isInstanceOf(AddressValidationState.AddressUpdateFailed::class.java)
@@ -219,5 +210,43 @@ class WooShippingEditDestinationViewModelTest : WooShippingEditAddressViewModelT
 
         assertThat(result.error).isNotNull()
         verify(updateOriginAddress, never()).invoke(any(), any())
+    }
+
+    @Test
+    fun `when phone is empty phone then error is null`() = testBlocking {
+        val address = Address.EMPTY.copy(phone = "")
+        whenever(addressValidator.validateAtLeastOneOf(eq(""), eq(""))).doReturn("error")
+        whenever(addressValidator.validateFieldRequired("")).doReturn("error")
+        Snapshot.withMutableSnapshot {
+            val savedState = createSavedStateHandle(address)
+            createViewModel(savedState)
+        }
+
+        advanceUntilIdle()
+
+        val result = sut.viewState.value
+
+        assertThat(result).isInstanceOf(WooShippingEditAddressViewModel.ViewState::class.java)
+
+        assertThat(result.editableAddress.phone.error).isNull()
+    }
+
+    @Test
+    fun `when email is empty then address error is null`() = testBlocking {
+        val address = Address.EMPTY
+        whenever(addressValidator.validateAtLeastOneOf(eq(""), eq(""))).doReturn("error")
+        whenever(addressValidator.validateFieldRequired("")).doReturn("error")
+        Snapshot.withMutableSnapshot {
+            val savedState = createSavedStateHandle(address)
+            createViewModel(savedState)
+        }
+
+        advanceUntilIdle()
+
+        val result = sut.viewState.value
+
+        assertThat(result).isInstanceOf(WooShippingEditAddressViewModel.ViewState::class.java)
+
+        assertThat(result.editableAddress.email.error).isNull()
     }
 }

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/address/destination/WooShippingEditDestinationViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/address/destination/WooShippingEditDestinationViewModelTest.kt
@@ -29,9 +29,9 @@ class WooShippingEditDestinationViewModelTest : WooShippingEditAddressViewModelT
         address: Address,
         isVerified: Boolean
     ): SavedStateHandle {
-        val destination = DestinationShippingAddress(address,isVerified)
+        val destination = DestinationShippingAddress(address, isVerified)
         return WooShippingEditAddressFragmentArgs(
-            EditAddressFlow.EditDestinationAddress(destination,1L)
+            EditAddressFlow.EditDestinationAddress(destination, 1L)
         ).toSavedStateHandle()
     }
 

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/address/origin/UpdateOriginAddressTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/address/origin/UpdateOriginAddressTest.kt
@@ -36,7 +36,7 @@ class UpdateOriginAddressTest : BaseUnitTest() {
     }
 
     @Test
-    fun `when normalize address fails then return failure`() = testBlocking {
+    fun `when update address fails then return failure`() = testBlocking {
         whenever(site.getOrNull()).thenReturn(SiteModel())
         whenever(repository.updateOriginAddress(any(), any(), any()))
             .thenReturn(WooResult(WooError(GENERIC_ERROR, UNKNOWN)))
@@ -47,7 +47,7 @@ class UpdateOriginAddressTest : BaseUnitTest() {
     }
 
     @Test
-    fun `when normalize address succeed then return expected data`() = testBlocking {
+    fun `when update address succeed then return expected data`() = testBlocking {
         whenever(site.getOrNull()).thenReturn(SiteModel())
         whenever(repository.updateOriginAddress(any(), any(), any()))
             .thenReturn(WooResult(defaultAddressResponse))

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/address/origin/WooShippingEditOriginViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/address/origin/WooShippingEditOriginViewModelTest.kt
@@ -9,6 +9,7 @@ import com.woocommerce.android.ui.orders.wooshippinglabels.address.EditAddressFl
 import com.woocommerce.android.ui.orders.wooshippinglabels.address.EditableAddress
 import com.woocommerce.android.ui.orders.wooshippinglabels.address.InputValue
 import com.woocommerce.android.ui.orders.wooshippinglabels.address.WooShippingEditAddressFragmentArgs
+import com.woocommerce.android.ui.orders.wooshippinglabels.address.WooShippingEditAddressViewModel
 import com.woocommerce.android.ui.orders.wooshippinglabels.address.WooShippingEditAddressViewModelTest
 import com.woocommerce.android.ui.orders.wooshippinglabels.address.toAddress
 import com.woocommerce.android.ui.orders.wooshippinglabels.models.AddressNormalizationModel
@@ -19,6 +20,7 @@ import org.assertj.core.api.Assertions.assertThat
 import org.junit.Test
 import org.mockito.kotlin.any
 import org.mockito.kotlin.doReturn
+import org.mockito.kotlin.eq
 import org.mockito.kotlin.never
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
@@ -127,17 +129,6 @@ class WooShippingEditOriginViewModelTest : WooShippingEditAddressViewModelTest()
             lastName = "",
             company = ""
         )
-        val editableAddress = EditableAddress(
-            name = InputValue(address.firstName),
-            company = InputValue(address.company),
-            country = countries.first { it.code == address.country.code },
-            address = InputValue(address.address1),
-            city = InputValue(address.city),
-            state = states.first { it.code == address.state.codeOrRaw },
-            postalCode = InputValue(address.postcode),
-            email = InputValue(address.email),
-            phone = InputValue(address.phone)
-        )
 
         whenever(addressValidator.validateFieldRequired(any())).doReturn(null)
         whenever(getAcceptedOriginCountries.invoke()).doReturn(Result.success(countries))
@@ -151,7 +142,7 @@ class WooShippingEditOriginViewModelTest : WooShippingEditAddressViewModelTest()
 
         advanceUntilIdle()
 
-        sut.onUpdateAddress(editableAddress)
+        sut.onUpdateAddress(sut.viewState.value.editableAddress)
 
         val result = sut.viewState.value
         assertThat(result.addressValidationState).isInstanceOf(AddressValidationState.AddressUpdateFailed::class.java)
@@ -229,5 +220,62 @@ class WooShippingEditOriginViewModelTest : WooShippingEditAddressViewModelTest()
 
         assertThat(result.error).isNotNull()
         verify(updateDestinationAddress, never()).invoke(any(), any())
+    }
+
+    @Test
+    fun `when phone is empty phone then error is NOT null`() = testBlocking {
+        val address = Address.EMPTY.copy(phone = "")
+        whenever(addressValidator.validateAtLeastOneOf(eq(""), eq(""))).doReturn("error")
+        whenever(addressValidator.validateFieldRequired("")).doReturn("error")
+        Snapshot.withMutableSnapshot {
+            val savedState = createSavedStateHandle(address)
+            createViewModel(savedState)
+        }
+
+        advanceUntilIdle()
+
+        val result = sut.viewState.value
+
+        assertThat(result).isInstanceOf(WooShippingEditAddressViewModel.ViewState::class.java)
+
+        assertThat(result.editableAddress.phone.error).isNotEmpty
+    }
+
+    @Test
+    fun `when email is empty then address error is not null`() = testBlocking {
+        val address = Address.EMPTY
+        whenever(addressValidator.validateAtLeastOneOf(eq(""), eq(""))).doReturn("error")
+        whenever(addressValidator.validateFieldRequired("")).doReturn("error")
+        Snapshot.withMutableSnapshot {
+            val savedState = createSavedStateHandle(address)
+            createViewModel(savedState)
+        }
+
+        advanceUntilIdle()
+
+        val result = sut.viewState.value
+
+        assertThat(result).isInstanceOf(WooShippingEditAddressViewModel.ViewState::class.java)
+
+        assertThat(result.editableAddress.email.error).isNotEmpty()
+    }
+
+    @Test
+    fun `when email is NOT empty then address error is null`() = testBlocking {
+        val address = Address.EMPTY.copy(email = "This is an email")
+        whenever(addressValidator.validateAtLeastOneOf(eq(""), eq(""))).doReturn("error")
+        whenever(addressValidator.validateFieldRequired("")).doReturn("error")
+        Snapshot.withMutableSnapshot {
+            val savedState = createSavedStateHandle(address)
+            createViewModel(savedState)
+        }
+
+        advanceUntilIdle()
+
+        val result = sut.viewState.value
+
+        assertThat(result).isInstanceOf(WooShippingEditAddressViewModel.ViewState::class.java)
+
+        assertThat(result.editableAddress.email.error).isNull()
     }
 }

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/address/origin/WooShippingEditOriginViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/address/origin/WooShippingEditOriginViewModelTest.kt
@@ -13,6 +13,7 @@ import com.woocommerce.android.ui.orders.wooshippinglabels.address.InputValue
 import com.woocommerce.android.ui.orders.wooshippinglabels.address.NormalizeAddress
 import com.woocommerce.android.ui.orders.wooshippinglabels.address.WooShippingEditAddressFragmentArgs
 import com.woocommerce.android.ui.orders.wooshippinglabels.address.WooShippingEditAddressViewModel
+import com.woocommerce.android.ui.orders.wooshippinglabels.address.destination.UpdateDestinationAddress
 import com.woocommerce.android.ui.orders.wooshippinglabels.address.toAddress
 import com.woocommerce.android.ui.orders.wooshippinglabels.models.AddressNormalizationModel
 import com.woocommerce.android.ui.orders.wooshippinglabels.models.OriginShippingAddress
@@ -36,6 +37,7 @@ class WooShippingEditOriginViewModelTest : BaseUnitTest() {
     private val resourceProvider: ResourceProvider = mock()
     private val normalizeAddress: NormalizeAddress = mock()
     private val updateOriginAddress: UpdateOriginAddress = mock()
+    private val updateDestinationAddress: UpdateDestinationAddress = mock()
 
     private val countries = listOf(
         Location("US", "United States"),
@@ -60,7 +62,8 @@ class WooShippingEditOriginViewModelTest : BaseUnitTest() {
             getStatesByCountryCode = getStatesByCountryCode,
             normalizeAddress = normalizeAddress,
             resourceProvider = resourceProvider,
-            updateOriginAddress = updateOriginAddress
+            updateOriginAddress = updateOriginAddress,
+            updateDestinationAddress = updateDestinationAddress
         )
     }
 
@@ -961,7 +964,7 @@ class WooShippingEditOriginViewModelTest : BaseUnitTest() {
 
         advanceUntilIdle()
 
-        sut.onUpdateNormalizedOriginAddress(
+        sut.onUpdateNormalizedAddress(
             AddressValidationState.AddressSelection(
                 addressNormalization = normalizeAddressResponse,
                 selectedAddress = suggestedAddress
@@ -994,7 +997,7 @@ class WooShippingEditOriginViewModelTest : BaseUnitTest() {
 
         advanceUntilIdle()
 
-        sut.onUpdateNormalizedOriginAddress(
+        sut.onUpdateNormalizedAddress(
             AddressValidationState.AddressSelection(
                 addressNormalization = normalizeAddressResponse,
                 selectedAddress = suggestedAddress
@@ -1063,7 +1066,7 @@ class WooShippingEditOriginViewModelTest : BaseUnitTest() {
 
         advanceUntilIdle()
 
-        sut.onUpdateNormalizedOriginAddress(
+        sut.onUpdateNormalizedAddress(
             AddressValidationState.AddressSelection(
                 addressNormalization = normalizeAddressResponse,
                 selectedAddress = suggestedAddress

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/customs/ShouldRequireCustomsFormTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/customs/ShouldRequireCustomsFormTest.kt
@@ -28,7 +28,8 @@ class ShouldRequireCustomsFormTest {
                 Address.EMPTY.copy(
                     country = Location.EMPTY.copy(code = "CA"),
                     state = AmbiguousLocation.Defined(Location.EMPTY.copy(code = "ON"))
-                ), false
+                ),
+                false
             ),
             originAddresses = emptyList()
         )
@@ -43,7 +44,8 @@ class ShouldRequireCustomsFormTest {
                 Address.EMPTY.copy(
                     country = Location.EMPTY.copy(code = "US"),
                     state = AmbiguousLocation.Defined(Location.EMPTY.copy(code = "NY"))
-                ), false
+                ),
+                false
             ),
             originAddresses = emptyList()
         )
@@ -58,7 +60,8 @@ class ShouldRequireCustomsFormTest {
                 Address.EMPTY.copy(
                     country = Location.EMPTY.copy(code = "US"),
                     state = AmbiguousLocation.Defined(Location.EMPTY.copy(code = "NY"))
-                ), false
+                ),
+                false
             ),
             originAddresses = emptyList()
         )
@@ -73,7 +76,8 @@ class ShouldRequireCustomsFormTest {
                 Address.EMPTY.copy(
                     country = Location.EMPTY.copy(code = "US"),
                     state = AmbiguousLocation.Defined(Location.EMPTY.copy(code = "AE"))
-                ), false
+                ),
+                false
             ),
             originAddresses = emptyList()
         )
@@ -88,7 +92,8 @@ class ShouldRequireCustomsFormTest {
                 Address.EMPTY.copy(
                     country = Location.EMPTY.copy(code = "US"),
                     state = AmbiguousLocation.Defined(Location.EMPTY.copy(code = "NY"))
-                ), false
+                ),
+                false
             ),
             originAddresses = emptyList()
         )

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/customs/ShouldRequireCustomsFormTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/customs/ShouldRequireCustomsFormTest.kt
@@ -4,6 +4,7 @@ import com.woocommerce.android.model.Address
 import com.woocommerce.android.model.AmbiguousLocation
 import com.woocommerce.android.model.Location
 import com.woocommerce.android.ui.orders.wooshippinglabels.WooShippingAddresses
+import com.woocommerce.android.ui.orders.wooshippinglabels.models.DestinationShippingAddress
 import com.woocommerce.android.ui.orders.wooshippinglabels.models.OriginShippingAddress
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
@@ -23,9 +24,11 @@ class ShouldRequireCustomsFormTest {
     fun `should return true for different countries`() {
         val addressData = WooShippingAddresses(
             shipFrom = OriginShippingAddress.EMPTY.copy(country = "US", state = "CA"),
-            shipTo = Address.EMPTY.copy(
-                country = Location.EMPTY.copy(code = "CA"),
-                state = AmbiguousLocation.Defined(Location.EMPTY.copy(code = "ON"))
+            shipTo = DestinationShippingAddress(
+                Address.EMPTY.copy(
+                    country = Location.EMPTY.copy(code = "CA"),
+                    state = AmbiguousLocation.Defined(Location.EMPTY.copy(code = "ON"))
+                ), false
             ),
             originAddresses = emptyList()
         )
@@ -36,9 +39,11 @@ class ShouldRequireCustomsFormTest {
     fun `should return false for same country`() {
         val addressData = WooShippingAddresses(
             shipFrom = OriginShippingAddress.EMPTY.copy(country = "US", state = "CA"),
-            shipTo = Address.EMPTY.copy(
-                country = Location.EMPTY.copy(code = "US"),
-                state = AmbiguousLocation.Defined(Location.EMPTY.copy(code = "NY"))
+            shipTo = DestinationShippingAddress(
+                Address.EMPTY.copy(
+                    country = Location.EMPTY.copy(code = "US"),
+                    state = AmbiguousLocation.Defined(Location.EMPTY.copy(code = "NY"))
+                ), false
             ),
             originAddresses = emptyList()
         )
@@ -49,9 +54,11 @@ class ShouldRequireCustomsFormTest {
     fun `should return true for military origin address`() {
         val addressData = WooShippingAddresses(
             shipFrom = OriginShippingAddress.EMPTY.copy(country = "US", state = "AA"),
-            shipTo = Address.EMPTY.copy(
-                country = Location.EMPTY.copy(code = "US"),
-                state = AmbiguousLocation.Defined(Location.EMPTY.copy(code = "NY"))
+            shipTo = DestinationShippingAddress(
+                Address.EMPTY.copy(
+                    country = Location.EMPTY.copy(code = "US"),
+                    state = AmbiguousLocation.Defined(Location.EMPTY.copy(code = "NY"))
+                ), false
             ),
             originAddresses = emptyList()
         )
@@ -62,9 +69,11 @@ class ShouldRequireCustomsFormTest {
     fun `should return true for military shipping address`() {
         val addressData = WooShippingAddresses(
             shipFrom = OriginShippingAddress.EMPTY.copy(country = "US", state = "CA"),
-            shipTo = Address.EMPTY.copy(
-                country = Location.EMPTY.copy(code = "US"),
-                state = AmbiguousLocation.Defined(Location.EMPTY.copy(code = "AE"))
+            shipTo = DestinationShippingAddress(
+                Address.EMPTY.copy(
+                    country = Location.EMPTY.copy(code = "US"),
+                    state = AmbiguousLocation.Defined(Location.EMPTY.copy(code = "AE"))
+                ), false
             ),
             originAddresses = emptyList()
         )
@@ -75,9 +84,11 @@ class ShouldRequireCustomsFormTest {
     fun `should return false for no military addresses`() {
         val addressData = WooShippingAddresses(
             shipFrom = OriginShippingAddress.EMPTY.copy(country = "US", state = "CA"),
-            shipTo = Address.EMPTY.copy(
-                country = Location.EMPTY.copy(code = "US"),
-                state = AmbiguousLocation.Defined(Location.EMPTY.copy(code = "NY"))
+            shipTo = DestinationShippingAddress(
+                Address.EMPTY.copy(
+                    country = Location.EMPTY.copy(code = "US"),
+                    state = AmbiguousLocation.Defined(Location.EMPTY.copy(code = "NY"))
+                ), false
             ),
             originAddresses = emptyList()
         )


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Part of: #12440
<!-- Id number of the GitHub issue this PR addresses. -->

<!-- 
━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
🛠 Need an AI review?  
Add a comment: `@coderabbitai review`
━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
-->

### Description
This PR adds support for editing a destination address. It includes the networking logic to update the destination address and refactor the edit origin address screen to handle both flows, edit the origin address, and edit the destination address. The changes introduced here also include the navigation changes needed to update the destination address in the main flow and some UI adjustments. 

I will work on checking if the destination address is verified and using the destination address in the main flow in the next PR.

### Testing information

TC1

1. Open the orders tab
2. Tap on an order eligible for shipping label creation
3. Expand the shipment details section
4. Tap on the pencil near the Ship to section
5. Update the postal code to make the address unverified
6. Tap on Validate & Save
7. Check that the address selection bottom sheet is expanded
8. Select an address and tap on the bottom button
9. Exit the screen
10. Check that the address is updated with the changes from step 6

TC2

1. Open the orders tab
2. Tap on an order eligible for shipping label creation
3. Expand the shipment details section
4. Tap on the pencil near the Ship to section
5. Update the email to make the address status as unsaved changes
6. Tap on Save changes
7. Exit the screen
8. Check that the address is updated with the changes from step 6

### The tests that have been performed
<!-- To give the reviewer an idea of what could be missed in terms of testing -->

### Images/gif

https://github.com/user-attachments/assets/e0108c51-3bce-4287-b5fe-052aae72b353

- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.

## Reviewer (or Author, in the case of optional code reviews):

Please make sure these conditions are met before approving the PR, or request changes if the PR needs improvement:

- [x] The PR is small and has a clear, single focus, or a valid explanation is provided in the description. If needed, please request to split it into smaller PRs.
- [x] Ensure Adequate Unit Test Coverage: The changes are reasonably covered by unit tests or an explanation is provided in the PR description.
- [x] Manual Testing: The author listed all the tests they ran, including smoke tests when needed (e.g., for refactorings). The reviewer confirmed that the PR works as expected on big (tablet) and small (phone) in case of UI changes, and no regressions are added.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md --> of