### PR TITLE
[Woo POS] Add accessibility announcements in WooPosTotalsScreen

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -4,6 +4,7 @@
 21.9
 -----
 - [*] Fixed an issue that can cause a crash when adding a new payment card in Blaze campaign form [https://github.com/woocommerce/woocommerce-android/pull/13624]
+- [*] POS: improved accessibility for the payments status changes [https://github.com/woocommerce/woocommerce-android/pull/13643]
 
 21.8
 -----

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/totals/WooPosTotalsScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/totals/WooPosTotalsScreen.kt
@@ -30,6 +30,7 @@ import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
@@ -58,6 +59,7 @@ import com.woocommerce.android.ui.woopos.home.totals.WooPosTotalsViewState.Total
 import com.woocommerce.android.ui.woopos.home.totals.payment.failed.WooPosPaymentFailedScreen
 import com.woocommerce.android.ui.woopos.home.totals.payment.inprogress.WooPosPaymentInProgressScreen
 import com.woocommerce.android.ui.woopos.home.totals.payment.success.WooPosPaymentSuccessScreen
+import com.woocommerce.android.ui.woopos.util.ext.announceForAccessibility
 
 @Composable
 fun WooPosTotalsScreen(modifier: Modifier = Modifier) {
@@ -88,6 +90,7 @@ private fun WooPosTotalsScreen(
 
         StateChangeAnimated(visible = state is WooPosTotalsViewState.PaymentSuccess) {
             if (state is WooPosTotalsViewState.PaymentSuccess) {
+                LocalContext.current.announceForAccessibility(stringResource(R.string.woopos_payment_successful_label))
                 WooPosPaymentSuccessScreen(
                     state,
                     onReceiptClicked = { onUIEvent(WooPosTotalsUIEvent.OnStartReceiptFlowClicked) },
@@ -104,6 +107,7 @@ private fun WooPosTotalsScreen(
 
         StateChangeAnimated(visible = state is WooPosTotalsViewState.Error) {
             if (state is WooPosTotalsViewState.Error) {
+                LocalContext.current.announceForAccessibility(state.message)
                 TotalsErrorScreen(
                     errorMessage = state.message,
                     onUIEvent = onUIEvent
@@ -113,12 +117,14 @@ private fun WooPosTotalsScreen(
 
         StateChangeAnimated(visible = state is WooPosTotalsViewState.PaymentInProgress) {
             if (state is WooPosTotalsViewState.PaymentInProgress) {
+                LocalContext.current.announceForAccessibility(state.title)
                 WooPosPaymentInProgressScreen(state, onUIEvent)
             }
         }
 
         StateChangeAnimated(visible = state is WooPosTotalsViewState.PaymentFailed) {
             if (state is WooPosTotalsViewState.PaymentFailed) {
+                LocalContext.current.announceForAccessibility(state.title)
                 WooPosPaymentFailedScreen(
                     state = state,
                     onUIEvent = onUIEvent,
@@ -164,6 +170,7 @@ private fun TotalsLoaded(
             when (val readerStatus = state.readerStatus) {
                 is WooPosTotalsViewState.ReaderStatus.Disconnected -> {
                     ReaderDisconnected(modifier = Modifier, status = readerStatus, onUIEvent = onUIEvent)
+                    LocalContext.current.announceForAccessibility(readerStatus.title)
                 }
 
                 is WooPosTotalsViewState.ReaderStatus.Preparing -> {
@@ -171,16 +178,19 @@ private fun TotalsLoaded(
                         title = readerStatus.title,
                         subtitle = readerStatus.subtitle
                     )
+                    LocalContext.current.announceForAccessibility(readerStatus.title)
                 }
                 is WooPosTotalsViewState.ReaderStatus.CheckingOrder -> {
                     PreparingReader(
                         title = readerStatus.title,
                         subtitle = readerStatus.subtitle
                     )
+                    LocalContext.current.announceForAccessibility(readerStatus.title)
                 }
 
                 is WooPosTotalsViewState.ReaderStatus.ReadyForPayment -> {
                     ReaderReadyForPayment(readerStatus)
+                    LocalContext.current.announceForAccessibility(readerStatus.title)
                 }
 
                 is WooPosTotalsViewState.ReaderStatus.Unavailable -> {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/util/ext/WooPosContextExt.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/util/ext/WooPosContextExt.kt
@@ -1,6 +1,9 @@
 package com.woocommerce.android.ui.woopos.util.ext
 
 import android.content.Context
+import android.os.Build
+import android.view.accessibility.AccessibilityEvent
+import android.view.accessibility.AccessibilityManager
 import androidx.compose.ui.unit.dp
 import androidx.datastore.core.DataStore
 import androidx.datastore.preferences.core.Preferences
@@ -19,3 +22,18 @@ fun Context.getScreenHeightDp(): Int {
 }
 
 fun Context.getLongestScreenSideDp() = maxOf(getScreenWidthDp(), getScreenHeightDp()).dp
+
+fun Context.announceForAccessibility(text: String) {
+    val manager = getSystemService(Context.ACCESSIBILITY_SERVICE) as AccessibilityManager
+    if (manager.isEnabled) {
+        val event = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
+            AccessibilityEvent()
+        } else {
+            @Suppress("DEPRECATION")
+            AccessibilityEvent.obtain()
+        }
+        event.eventType = AccessibilityEvent.TYPE_ANNOUNCEMENT
+        event.text.add(text)
+        manager.sendAccessibilityEvent(event)
+    }
+}


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #13547 
<!-- Id number of the GitHub issue this PR addresses. -->

<!-- 
━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
🛠 Need an AI review?  
Add a comment: `@coderabbitai review`
━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
-->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
The PR adds talkback annoncement to the changes to the payment state 

### Testing information
<!-- This is your opportunity to break out individual scenarios that need testing (when necessary) and/or include a checklist for the reviewer to go through. Consider documenting the following from your own completed testing: devices used, alternate workflows, edge cases, affected areas, critical flows, areas not tested, and any remaining unknowns. Provide feedback on this new section of the PR template through Sept 30, 2024 to Apps Quality; additional context here: p91TBi-b8z-p2#comment-12036 -->
* Enable talkback
* Open POS and start collecting payment
* Notice that statuses are announced now

### The tests that have been performed
<!-- To give the reviewer an idea of what could be missed in terms of testing -->
Above


- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.

## Reviewer (or Author, in the case of optional code reviews):

Please make sure these conditions are met before approving the PR, or request changes if the PR needs improvement:

- [x] The PR is small and has a clear, single focus, or a valid explanation is provided in the description. If needed, please request to split it into smaller PRs.
- [x] Ensure Adequate Unit Test Coverage: The changes are reasonably covered by unit tests or an explanation is provided in the PR description.
- [x] Manual Testing: The author listed all the tests they ran, including smoke tests when needed (e.g., for refactorings). The reviewer confirmed that the PR works as expected on big (tablet) and small (phone) in case of UI changes, and no regressions are added.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->