### PR TITLE
Fields required enhancement

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/address/WooShippingEditAddressScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/address/WooShippingEditAddressScreen.kt
@@ -194,9 +194,10 @@ fun WooShippingEditAddressScreen(
                 val keyboardController = LocalSoftwareKeyboardController.current
 
                 RoundedBorderTextFieldWithLabel(
-                    label = "${stringResource(id = R.string.woo_shipping_label_name)} *",
+                    label = stringResource(id = R.string.woo_shipping_label_name),
                     text = editableAddress.name.value,
                     error = editableAddress.name.error,
+                    isRequired = editableAddress.name.isRequired,
                     onTextChange = onNameChange,
                     keyboardOptions = KeyboardOptions(imeAction = ImeAction.Next),
                     keyboardActions = KeyboardActions(
@@ -219,6 +220,7 @@ fun WooShippingEditAddressScreen(
                     RoundedBorderTextFieldWithLabel(
                         label = stringResource(id = R.string.woo_shipping_label_company),
                         text = editableAddress.company.value,
+                        isRequired = editableAddress.company.isRequired,
                         onTextChange = onCompanyChange,
                         keyboardOptions = KeyboardOptions(imeAction = ImeAction.Next),
                         keyboardActions = KeyboardActions(
@@ -238,9 +240,10 @@ fun WooShippingEditAddressScreen(
                     onClick = onCountryChange
                 )
                 RoundedBorderTextFieldWithLabel(
-                    label = "${stringResource(id = R.string.woo_shipping_label_address)} *",
+                    label = stringResource(id = R.string.woo_shipping_label_address),
                     text = editableAddress.address.value,
                     error = editableAddress.address.error,
+                    isRequired = editableAddress.address.isRequired,
                     onTextChange = onAddressChange,
                     keyboardOptions = KeyboardOptions(imeAction = ImeAction.Next),
                     keyboardActions = KeyboardActions(
@@ -252,9 +255,10 @@ fun WooShippingEditAddressScreen(
                     modifier = Modifier.padding(top = 8.dp)
                 )
                 RoundedBorderTextFieldWithLabel(
-                    label = "${stringResource(id = R.string.woo_shipping_label_city)} *",
+                    label = stringResource(id = R.string.woo_shipping_label_city),
                     text = editableAddress.city.value,
                     error = editableAddress.city.error,
+                    isRequired = editableAddress.city.isRequired,
                     onTextChange = onCityChange,
                     keyboardOptions = KeyboardOptions(imeAction = ImeAction.Next),
                     keyboardActions = KeyboardActions(
@@ -302,9 +306,10 @@ fun WooShippingEditAddressScreen(
                     }
                     Spacer(modifier = Modifier.size(8.dp))
                     RoundedBorderTextFieldWithLabel(
-                        label = "${stringResource(id = R.string.woo_shipping_label_post_code)} *",
+                        label = stringResource(id = R.string.woo_shipping_label_post_code),
                         text = editableAddress.postalCode.value,
                         error = editableAddress.postalCode.error,
+                        isRequired = editableAddress.postalCode.isRequired,
                         keyboardOptions = KeyboardOptions(
                             keyboardType = KeyboardType.Number,
                             imeAction = ImeAction.Next
@@ -323,9 +328,10 @@ fun WooShippingEditAddressScreen(
                 }
 
                 RoundedBorderTextFieldWithLabel(
-                    label = "${stringResource(id = R.string.woo_shipping_label_email)} *",
+                    label = stringResource(id = R.string.woo_shipping_label_email),
                     text = editableAddress.email.value,
                     error = editableAddress.email.error,
+                    isRequired = editableAddress.email.isRequired,
                     keyboardOptions = KeyboardOptions(
                         keyboardType = KeyboardType.Email,
                         imeAction = ImeAction.Next
@@ -340,9 +346,10 @@ fun WooShippingEditAddressScreen(
                     modifier = Modifier.padding(top = 32.dp)
                 )
                 RoundedBorderTextFieldWithLabel(
-                    label = "${stringResource(id = R.string.woo_shipping_label_phone)} *",
+                    label = stringResource(id = R.string.woo_shipping_label_phone),
                     text = editableAddress.phone.value,
                     error = editableAddress.phone.error,
+                    isRequired = editableAddress.phone.isRequired,
                     keyboardOptions = KeyboardOptions(
                         keyboardType = KeyboardType.Phone,
                         imeAction = ImeAction.Done
@@ -483,12 +490,15 @@ internal fun AddressStatusSection(
             AddressStatus.VERIFIED -> {
                 { onClose() }
             }
+
             AddressStatus.UNVERIFIED -> {
                 { onNormalizeAddress(editableAddress) }
             }
+
             AddressStatus.MISSING_INFO -> {
                 {}
             }
+
             AddressStatus.SAVE_CHANGES -> {
                 { onUpdateAddress(editableAddress) }
             }
@@ -522,6 +532,7 @@ internal fun RoundedBorderTextFieldWithLabel(
     text: String,
     onTextChange: (String) -> Unit,
     modifier: Modifier = Modifier,
+    isRequired: Boolean = false,
     hint: String = "",
     error: String? = null,
     keyboardOptions: KeyboardOptions = KeyboardOptions.Default,
@@ -544,9 +555,11 @@ internal fun RoundedBorderTextFieldWithLabel(
         Modifier
     }
 
+    val labelWithRequired = if (isRequired) "$label *" else label
+
     Column(modifier = modifier) {
         Text(
-            text = label,
+            text = labelWithRequired,
             style = MaterialTheme.typography.body2,
             modifier = Modifier.padding(vertical = 8.dp)
         )

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/address/WooShippingEditAddressViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/address/WooShippingEditAddressViewModel.kt
@@ -49,13 +49,25 @@ class WooShippingEditAddressViewModel @Inject constructor(
     private val updateDestinationAddress: UpdateDestinationAddress,
     savedState: SavedStateHandle
 ) : ScopedViewModel(savedState) {
-    private var name by mutableStateOf(InputValue(""))
-    private var company by mutableStateOf(InputValue(""))
-    private var address by mutableStateOf(InputValue(""))
-    private var city by mutableStateOf(InputValue(""))
-    private var postalCode by mutableStateOf(InputValue(""))
-    private var email by mutableStateOf(InputValue(""))
-    private var phone by mutableStateOf(InputValue(""))
+    private val navArgs: WooShippingEditAddressFragmentArgs by savedState.navArgs()
+
+    private var name by mutableStateOf(InputValue(value = "", isRequired = true))
+    private var company by mutableStateOf(InputValue(value = "", isRequired = false))
+    private var address by mutableStateOf(InputValue(value = "", isRequired = true))
+    private var city by mutableStateOf(InputValue(value = "", isRequired = true))
+    private var postalCode by mutableStateOf(InputValue(value = "", isRequired = true))
+    private var email by mutableStateOf(
+        InputValue(
+            value = "",
+            isRequired = navArgs.flow is EditAddressFlow.EditOriginAddress
+        )
+    )
+    private var phone by mutableStateOf(
+        InputValue(
+            value = "",
+            isRequired = navArgs.flow is EditAddressFlow.EditOriginAddress
+        )
+    )
 
     private var country = MutableStateFlow(Location.EMPTY)
 
@@ -66,7 +78,8 @@ class WooShippingEditAddressViewModel @Inject constructor(
         snapshotFlow { rawState },
         selectedState
     ) { rawState, selectedState ->
-        if (selectedState != Location.EMPTY) selectedState else AmbiguousLocation.Raw(rawState).asLocation()
+        if (selectedState != Location.EMPTY) selectedState else AmbiguousLocation.Raw(rawState)
+            .asLocation()
     }
 
     private val countriesState = MutableStateFlow<LocationState>(LocationState.Loading)
@@ -74,8 +87,6 @@ class WooShippingEditAddressViewModel @Inject constructor(
 
     private val addressValidationState =
         MutableStateFlow<AddressValidationState>(AddressValidationState.NotStarted)
-
-    private val navArgs: WooShippingEditAddressFragmentArgs by savedState.navArgs()
 
     private val currentAddress = when (val currentFlow = navArgs.flow) {
         is EditAddressFlow.EditDestinationAddress -> currentFlow.address.address
@@ -92,6 +103,7 @@ class WooShippingEditAddressViewModel @Inject constructor(
     val screenTitle = when (navArgs.flow) {
         is EditAddressFlow.EditDestinationAddress ->
             resourceProvider.getString(R.string.woo_shipping_edit_destination_address_title)
+
         is EditAddressFlow.EditOriginAddress ->
             resourceProvider.getString(R.string.woo_shipping_edit_origin_address_title)
     }
@@ -137,14 +149,22 @@ class WooShippingEditAddressViewModel @Inject constructor(
         .transformLatestWithDelay(
             delayMillis = DELAY_TIME_MILLIS,
         ) { inputValue ->
-            inputValue.copy(error = addressValidator.validateFieldRequired(inputValue.value))
+            if (inputValue.isRequired) {
+                inputValue.copy(error = addressValidator.validateFieldRequired(inputValue.value))
+            } else {
+                inputValue
+            }
         }
 
     private val phoneValidatedFlow = snapshotFlow { phone }
         .transformLatestWithDelay(
             delayMillis = DELAY_TIME_MILLIS,
         ) { inputValue ->
-            inputValue.copy(error = addressValidator.validateUSCustomsPhone(inputValue.value))
+            if (inputValue.isRequired) {
+                inputValue.copy(error = addressValidator.validateFieldRequired(inputValue.value))
+            } else {
+                inputValue
+            }
         }
 
     private val isCompanyExpanded = MutableStateFlow(false)
@@ -202,15 +222,16 @@ class WooShippingEditAddressViewModel @Inject constructor(
             addressInformation.address1,
             addressInformation.address2
         )
-        name = InputValue(fullName)
-        company = InputValue(addressInformation.company)
+        name = name.copy(value = fullName, error = null)
+        company = company.copy(value = addressInformation.company, error = null)
         country.value = findLocationByCode(addressInformation.country.code, countriesState.value)
-        address = InputValue(fullAddress)
-        city = InputValue(addressInformation.city)
-        selectedState.value = findLocationByCode(addressInformation.state.codeOrRaw, statesState.value)
-        postalCode = InputValue(addressInformation.postcode)
-        email = InputValue(addressInformation.email)
-        phone = InputValue(addressInformation.phone)
+        address = address.copy(value = fullAddress, error = null)
+        city = city.copy(value = addressInformation.city, error = null)
+        selectedState.value =
+            findLocationByCode(addressInformation.state.codeOrRaw, statesState.value)
+        postalCode = postalCode.copy(value = addressInformation.postcode, error = null)
+        email = email.copy(value = addressInformation.email, error = null)
+        phone = phone.copy(value = addressInformation.phone, error = null)
         isCompanyExpanded.value = addressInformation.company.isNotNullOrEmpty()
     }
 
@@ -254,7 +275,9 @@ class WooShippingEditAddressViewModel @Inject constructor(
     }
 
     fun handleBackPress(): Boolean {
-        if (allowBackNavigation()) { onNavigateBack() }
+        if (allowBackNavigation()) {
+            onNavigateBack()
+        }
         return false
     }
 
@@ -417,7 +440,10 @@ class WooShippingEditAddressViewModel @Inject constructor(
         return isSameAddress && isSameCity && isSameState && isSameCountry && isSamePostalCode
     }
 
-    private fun hasOnlyNoAddressChanges(newAddress: EditableAddress, currentAddress: Address): Boolean {
+    private fun hasOnlyNoAddressChanges(
+        newAddress: EditableAddress,
+        currentAddress: Address
+    ): Boolean {
         val originalFullName = combineStrings(
             currentAddress.firstName,
             currentAddress.lastName
@@ -428,46 +454,59 @@ class WooShippingEditAddressViewModel @Inject constructor(
         val isDifferentPhone = newAddress.phone.value != currentAddress.phone
         val isSameAddress = isSameAddress(newAddress, currentAddress)
         val isVerified = isVerified.value
-        val hasNoAddressChanges = isDifferentName || isDifferentCompany || isDifferentEmail || isDifferentPhone
+        val hasNoAddressChanges =
+            isDifferentName || isDifferentCompany || isDifferentEmail || isDifferentPhone
         return hasNoAddressChanges && isSameAddress && isVerified
     }
 
     private fun hasIncorrectOrMissingData(editableAddress: EditableAddress): Boolean {
         return editableAddress.address.error.isNotNullOrEmpty() ||
-            editableAddress.city.error.isNotNullOrEmpty() ||
-            editableAddress.postalCode.error.isNotNullOrEmpty() ||
-            editableAddress.email.error.isNotNullOrEmpty() ||
-            editableAddress.phone.error.isNotNullOrEmpty() ||
-            editableAddress.name.error.isNotNullOrEmpty() ||
-            editableAddress.company.error.isNotNullOrEmpty()
+                editableAddress.city.error.isNotNullOrEmpty() ||
+                editableAddress.postalCode.error.isNotNullOrEmpty() ||
+                editableAddress.email.error.isNotNullOrEmpty() ||
+                editableAddress.phone.error.isNotNullOrEmpty() ||
+                editableAddress.name.error.isNotNullOrEmpty() ||
+                editableAddress.company.error.isNotNullOrEmpty()
     }
 
     fun onNameChange(value: String) {
-        name = InputValue(value)
+        val isCompanyRequired = value.isEmpty() && company.value.isNotNullOrEmpty()
+        name = InputValue(
+            value = value,
+            isRequired = isCompanyRequired.not(),
+            error = null
+        )
+        company = company.copy(isRequired = isCompanyRequired)
     }
 
     fun onCompanyChange(value: String) {
-        company = InputValue(value)
+        val isCompanyRequired = value.isEmpty() && name.value.isNotEmpty()
+        company = InputValue(
+            value = value,
+            isRequired = isCompanyRequired,
+            error = null
+        )
+        name = name.copy(isRequired = isCompanyRequired.not())
     }
 
     fun onAddressChange(value: String) {
-        address = InputValue(value)
+        address = address.copy(value = value, error = null)
     }
 
     fun onCityChange(value: String) {
-        city = InputValue(value)
+        city = city.copy(value = value, error = null)
     }
 
     fun onPostalCodeChange(value: String) {
-        postalCode = InputValue(value)
+        postalCode = postalCode.copy(value = value, error = null)
     }
 
     fun onEmailChange(value: String) {
-        email = InputValue(value)
+        email = email.copy(value = value, error = null)
     }
 
     fun onPhoneChange(value: String) {
-        phone = InputValue(value)
+        phone = phone.copy(value = value, error = null)
     }
 
     fun onRawStateChange(value: String) {
@@ -525,7 +564,8 @@ class WooShippingEditAddressViewModel @Inject constructor(
                         AddressValidationState.AddressSelection(it, it.normalizedAddress)
                 },
                 onFailure = {
-                    addressValidationState.value = AddressValidationState.VerificationFailed(editableAddress)
+                    addressValidationState.value =
+                        AddressValidationState.VerificationFailed(editableAddress)
                 }
             )
         }
@@ -543,6 +583,7 @@ class WooShippingEditAddressViewModel @Inject constructor(
         when (val currentFlow = navArgs.flow) {
             is EditAddressFlow.EditDestinationAddress ->
                 onUpdateNormalizedDestinationAddress(selection, currentFlow.orderId)
+
             is EditAddressFlow.EditOriginAddress -> onUpdateNormalizedOriginAddress(selection)
         }
     }
@@ -558,7 +599,8 @@ class WooShippingEditAddressViewModel @Inject constructor(
                     onUpdateAddress(it.address, it.isVerified)
                 },
                 onFailure = {
-                    addressValidationState.value = AddressValidationState.NormalizedAddressUpdateFailed(selection)
+                    addressValidationState.value =
+                        AddressValidationState.NormalizedAddressUpdateFailed(selection)
                 }
             )
         }
@@ -572,7 +614,8 @@ class WooShippingEditAddressViewModel @Inject constructor(
                     onUpdateAddress(it.toAddress(), it.isVerified)
                 },
                 onFailure = {
-                    addressValidationState.value = AddressValidationState.NormalizedAddressUpdateFailed(selection)
+                    addressValidationState.value =
+                        AddressValidationState.NormalizedAddressUpdateFailed(selection)
                 }
             )
         }
@@ -596,7 +639,8 @@ class WooShippingEditAddressViewModel @Inject constructor(
                     onUpdateAddress(result.address, result.isVerified)
                 },
                 onFailure = {
-                    addressValidationState.value = AddressValidationState.AddressUpdateFailed(editableAddress)
+                    addressValidationState.value =
+                        AddressValidationState.AddressUpdateFailed(editableAddress)
                 }
             )
         }
@@ -611,7 +655,8 @@ class WooShippingEditAddressViewModel @Inject constructor(
                     onUpdateAddress(it.toAddress(), it.isVerified)
                 },
                 onFailure = {
-                    addressValidationState.value = AddressValidationState.AddressUpdateFailed(editableAddress)
+                    addressValidationState.value =
+                        AddressValidationState.AddressUpdateFailed(editableAddress)
                 }
             )
         }
@@ -761,7 +806,8 @@ enum class AddressStatus {
 
 data class InputValue(
     val value: String,
-    val error: String? = null
+    val error: String? = null,
+    val isRequired: Boolean = false
 ) {
     companion object {
         val EMPTY = InputValue("")

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/address/WooShippingEditAddressViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/address/WooShippingEditAddressViewModel.kt
@@ -663,10 +663,10 @@ class WooShippingEditAddressViewModel @Inject constructor(
     }
 
     private fun onUpdateAddress(updatedAddress: Address, updatedIsVerified: Boolean) {
+        isVerified.value = updatedIsVerified
         fillAddressForm(updatedAddress)
         addressValidationState.value = AddressValidationState.NotStarted
         currentAddress.value = updatedAddress
-        isVerified.value = updatedIsVerified
     }
 
     data class ViewState(

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/address/WooShippingEditAddressViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/address/WooShippingEditAddressViewModel.kt
@@ -470,7 +470,7 @@ class WooShippingEditAddressViewModel @Inject constructor(
     }
 
     fun onNameChange(value: String) {
-        val isCompanyRequired = value.isEmpty() && company.value.isNotNullOrEmpty()
+        val isCompanyRequired = value.isEmpty() && company.value.isNotEmpty()
         name = InputValue(
             value = value,
             isRequired = isCompanyRequired.not(),
@@ -480,7 +480,7 @@ class WooShippingEditAddressViewModel @Inject constructor(
     }
 
     fun onCompanyChange(value: String) {
-        val isCompanyRequired = value.isEmpty() && name.value.isNotEmpty()
+        val isCompanyRequired = value.isNotEmpty() && name.value.isEmpty()
         company = InputValue(
             value = value,
             isRequired = isCompanyRequired,

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/address/WooShippingEditAddressViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/address/WooShippingEditAddressViewModel.kt
@@ -78,8 +78,12 @@ class WooShippingEditAddressViewModel @Inject constructor(
         snapshotFlow { rawState },
         selectedState
     ) { rawState, selectedState ->
-        if (selectedState != Location.EMPTY) selectedState else AmbiguousLocation.Raw(rawState)
-            .asLocation()
+        if (selectedState != Location.EMPTY) {
+            selectedState
+        } else {
+            AmbiguousLocation.Raw(rawState)
+                .asLocation()
+        }
     }
 
     private val countriesState = MutableStateFlow<LocationState>(LocationState.Loading)
@@ -461,12 +465,12 @@ class WooShippingEditAddressViewModel @Inject constructor(
 
     private fun hasIncorrectOrMissingData(editableAddress: EditableAddress): Boolean {
         return editableAddress.address.error.isNotNullOrEmpty() ||
-                editableAddress.city.error.isNotNullOrEmpty() ||
-                editableAddress.postalCode.error.isNotNullOrEmpty() ||
-                editableAddress.email.error.isNotNullOrEmpty() ||
-                editableAddress.phone.error.isNotNullOrEmpty() ||
-                editableAddress.name.error.isNotNullOrEmpty() ||
-                editableAddress.company.error.isNotNullOrEmpty()
+            editableAddress.city.error.isNotNullOrEmpty() ||
+            editableAddress.postalCode.error.isNotNullOrEmpty() ||
+            editableAddress.email.error.isNotNullOrEmpty() ||
+            editableAddress.phone.error.isNotNullOrEmpty() ||
+            editableAddress.name.error.isNotNullOrEmpty() ||
+            editableAddress.company.error.isNotNullOrEmpty()
     }
 
     fun onNameChange(value: String) {

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/address/WooShippingEditAddressViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/address/WooShippingEditAddressViewModelTest.kt
@@ -248,89 +248,10 @@ abstract class WooShippingEditAddressViewModelTest : BaseUnitTest() {
     }
 
     @Test
-    fun `when email is empty then address error is not null`() = testBlocking {
-        val address = Address.EMPTY
-        whenever(addressValidator.validateAtLeastOneOf(eq(""), eq(""))).doReturn("error")
-        whenever(addressValidator.validateFieldRequired("")).doReturn("error")
-        Snapshot.withMutableSnapshot {
-            val savedState = createSavedStateHandle(address)
-            createViewModel(savedState)
-        }
-
-        advanceUntilIdle()
-
-        val result = sut.viewState.value
-
-        assertThat(result).isInstanceOf(WooShippingEditAddressViewModel.ViewState::class.java)
-
-        assertThat(result.editableAddress.email.error).isNotEmpty()
-    }
-
-    @Test
-    fun `when email is NOT empty then address error is null`() = testBlocking {
-        val address = Address.EMPTY.copy(email = "This is an email")
-        whenever(addressValidator.validateAtLeastOneOf(eq(""), eq(""))).doReturn("error")
-        whenever(addressValidator.validateFieldRequired("")).doReturn("error")
-        Snapshot.withMutableSnapshot {
-            val savedState = createSavedStateHandle(address)
-            createViewModel(savedState)
-        }
-
-        advanceUntilIdle()
-
-        val result = sut.viewState.value
-
-        assertThat(result).isInstanceOf(WooShippingEditAddressViewModel.ViewState::class.java)
-
-        assertThat(result.editableAddress.email.error).isNull()
-    }
-
-    @Test
-    fun `when phone is empty then phone error is not null`() = testBlocking {
-        val address = Address.EMPTY
-        whenever(addressValidator.validateAtLeastOneOf(eq(""), eq(""))).doReturn("error")
-        whenever(addressValidator.validateFieldRequired("")).doReturn("error")
-        whenever(addressValidator.validateUSCustomsPhone("")).doReturn("error")
-        Snapshot.withMutableSnapshot {
-            val savedState = createSavedStateHandle(address)
-            createViewModel(savedState)
-        }
-
-        advanceUntilIdle()
-
-        val result = sut.viewState.value
-
-        assertThat(result).isInstanceOf(WooShippingEditAddressViewModel.ViewState::class.java)
-
-        assertThat(result.editableAddress.phone.error).isNotEmpty()
-    }
-
-    @Test
-    fun `when phone is NOT empty and invalid then phone error is not null`() = testBlocking {
-        val address = Address.EMPTY.copy(phone = "1234567890")
-        whenever(addressValidator.validateAtLeastOneOf(eq(""), eq(""))).doReturn("error")
-        whenever(addressValidator.validateFieldRequired("")).doReturn("error")
-        whenever(addressValidator.validateUSCustomsPhone("1234567890")).doReturn("error")
-        Snapshot.withMutableSnapshot {
-            val savedState = createSavedStateHandle(address)
-            createViewModel(savedState)
-        }
-
-        advanceUntilIdle()
-
-        val result = sut.viewState.value
-
-        assertThat(result).isInstanceOf(WooShippingEditAddressViewModel.ViewState::class.java)
-
-        assertThat(result.editableAddress.phone.error).isNotEmpty()
-    }
-
-    @Test
     fun `when phone is NOT empty and valid then phone error is null`() = testBlocking {
         val address = Address.EMPTY.copy(phone = "1234567890")
         whenever(addressValidator.validateAtLeastOneOf(eq(""), eq(""))).doReturn("error")
         whenever(addressValidator.validateFieldRequired("")).doReturn("error")
-        whenever(addressValidator.validateUSCustomsPhone("1234567890")).doReturn(null)
         Snapshot.withMutableSnapshot {
             val savedState = createSavedStateHandle(address)
             createViewModel(savedState)
@@ -705,17 +626,6 @@ abstract class WooShippingEditAddressViewModelTest : BaseUnitTest() {
             lastName = "",
             company = "",
         )
-        val editableAddress = EditableAddress(
-            name = InputValue(address.firstName),
-            company = InputValue(address.company),
-            country = countries.first { it.code == address.country.code },
-            address = InputValue(address.address1),
-            city = InputValue(address.city),
-            state = states.first { it.code == address.state.codeOrRaw },
-            postalCode = InputValue(address.postcode),
-            email = InputValue(address.email),
-            phone = InputValue(address.phone)
-        )
         whenever(addressValidator.validateFieldRequired(any())).doReturn(null)
         whenever(getAcceptedOriginCountries.invoke()).doReturn(Result.success(countries))
         whenever(getStatesByCountryCode.invoke(any())).doReturn(states)
@@ -728,7 +638,7 @@ abstract class WooShippingEditAddressViewModelTest : BaseUnitTest() {
 
         advanceUntilIdle()
 
-        sut.onNormalizeAddress(editableAddress)
+        sut.onNormalizeAddress(sut.viewState.value.editableAddress)
 
         val result = sut.viewState.value
 

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/address/destination/WooShippingEditDestinationViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/address/destination/WooShippingEditDestinationViewModelTest.kt
@@ -9,6 +9,7 @@ import com.woocommerce.android.ui.orders.wooshippinglabels.address.EditAddressFl
 import com.woocommerce.android.ui.orders.wooshippinglabels.address.EditableAddress
 import com.woocommerce.android.ui.orders.wooshippinglabels.address.InputValue
 import com.woocommerce.android.ui.orders.wooshippinglabels.address.WooShippingEditAddressFragmentArgs
+import com.woocommerce.android.ui.orders.wooshippinglabels.address.WooShippingEditAddressViewModel
 import com.woocommerce.android.ui.orders.wooshippinglabels.address.WooShippingEditAddressViewModelTest
 import com.woocommerce.android.ui.orders.wooshippinglabels.address.toAddress
 import com.woocommerce.android.ui.orders.wooshippinglabels.models.AddressNormalizationModel
@@ -19,6 +20,7 @@ import org.assertj.core.api.Assertions.assertThat
 import org.junit.Test
 import org.mockito.kotlin.any
 import org.mockito.kotlin.doReturn
+import org.mockito.kotlin.eq
 import org.mockito.kotlin.never
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
@@ -116,17 +118,6 @@ class WooShippingEditDestinationViewModelTest : WooShippingEditAddressViewModelT
             lastName = "",
             company = ""
         )
-        val editableAddress = EditableAddress(
-            name = InputValue(address.firstName),
-            company = InputValue(address.company),
-            country = countries.first { it.code == address.country.code },
-            address = InputValue(address.address1),
-            city = InputValue(address.city),
-            state = states.first { it.code == address.state.codeOrRaw },
-            postalCode = InputValue(address.postcode),
-            email = InputValue(address.email),
-            phone = InputValue(address.phone)
-        )
 
         whenever(addressValidator.validateFieldRequired(any())).doReturn(null)
         whenever(getAcceptedOriginCountries.invoke()).doReturn(Result.success(countries))
@@ -140,7 +131,7 @@ class WooShippingEditDestinationViewModelTest : WooShippingEditAddressViewModelT
 
         advanceUntilIdle()
 
-        sut.onUpdateAddress(editableAddress)
+        sut.onUpdateAddress(sut.viewState.value.editableAddress)
 
         val result = sut.viewState.value
         assertThat(result.addressValidationState).isInstanceOf(AddressValidationState.AddressUpdateFailed::class.java)
@@ -219,5 +210,43 @@ class WooShippingEditDestinationViewModelTest : WooShippingEditAddressViewModelT
 
         assertThat(result.error).isNotNull()
         verify(updateOriginAddress, never()).invoke(any(), any())
+    }
+
+    @Test
+    fun `when phone is empty phone then error is null`() = testBlocking {
+        val address = Address.EMPTY.copy(phone = "")
+        whenever(addressValidator.validateAtLeastOneOf(eq(""), eq(""))).doReturn("error")
+        whenever(addressValidator.validateFieldRequired("")).doReturn("error")
+        Snapshot.withMutableSnapshot {
+            val savedState = createSavedStateHandle(address)
+            createViewModel(savedState)
+        }
+
+        advanceUntilIdle()
+
+        val result = sut.viewState.value
+
+        assertThat(result).isInstanceOf(WooShippingEditAddressViewModel.ViewState::class.java)
+
+        assertThat(result.editableAddress.phone.error).isNull()
+    }
+
+    @Test
+    fun `when email is empty then address error is null`() = testBlocking {
+        val address = Address.EMPTY
+        whenever(addressValidator.validateAtLeastOneOf(eq(""), eq(""))).doReturn("error")
+        whenever(addressValidator.validateFieldRequired("")).doReturn("error")
+        Snapshot.withMutableSnapshot {
+            val savedState = createSavedStateHandle(address)
+            createViewModel(savedState)
+        }
+
+        advanceUntilIdle()
+
+        val result = sut.viewState.value
+
+        assertThat(result).isInstanceOf(WooShippingEditAddressViewModel.ViewState::class.java)
+
+        assertThat(result.editableAddress.email.error).isNull()
     }
 }

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/address/origin/WooShippingEditOriginViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/address/origin/WooShippingEditOriginViewModelTest.kt
@@ -9,6 +9,7 @@ import com.woocommerce.android.ui.orders.wooshippinglabels.address.EditAddressFl
 import com.woocommerce.android.ui.orders.wooshippinglabels.address.EditableAddress
 import com.woocommerce.android.ui.orders.wooshippinglabels.address.InputValue
 import com.woocommerce.android.ui.orders.wooshippinglabels.address.WooShippingEditAddressFragmentArgs
+import com.woocommerce.android.ui.orders.wooshippinglabels.address.WooShippingEditAddressViewModel
 import com.woocommerce.android.ui.orders.wooshippinglabels.address.WooShippingEditAddressViewModelTest
 import com.woocommerce.android.ui.orders.wooshippinglabels.address.toAddress
 import com.woocommerce.android.ui.orders.wooshippinglabels.models.AddressNormalizationModel
@@ -19,6 +20,7 @@ import org.assertj.core.api.Assertions.assertThat
 import org.junit.Test
 import org.mockito.kotlin.any
 import org.mockito.kotlin.doReturn
+import org.mockito.kotlin.eq
 import org.mockito.kotlin.never
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
@@ -127,17 +129,6 @@ class WooShippingEditOriginViewModelTest : WooShippingEditAddressViewModelTest()
             lastName = "",
             company = ""
         )
-        val editableAddress = EditableAddress(
-            name = InputValue(address.firstName),
-            company = InputValue(address.company),
-            country = countries.first { it.code == address.country.code },
-            address = InputValue(address.address1),
-            city = InputValue(address.city),
-            state = states.first { it.code == address.state.codeOrRaw },
-            postalCode = InputValue(address.postcode),
-            email = InputValue(address.email),
-            phone = InputValue(address.phone)
-        )
 
         whenever(addressValidator.validateFieldRequired(any())).doReturn(null)
         whenever(getAcceptedOriginCountries.invoke()).doReturn(Result.success(countries))
@@ -151,7 +142,7 @@ class WooShippingEditOriginViewModelTest : WooShippingEditAddressViewModelTest()
 
         advanceUntilIdle()
 
-        sut.onUpdateAddress(editableAddress)
+        sut.onUpdateAddress(sut.viewState.value.editableAddress)
 
         val result = sut.viewState.value
         assertThat(result.addressValidationState).isInstanceOf(AddressValidationState.AddressUpdateFailed::class.java)
@@ -229,5 +220,62 @@ class WooShippingEditOriginViewModelTest : WooShippingEditAddressViewModelTest()
 
         assertThat(result.error).isNotNull()
         verify(updateDestinationAddress, never()).invoke(any(), any())
+    }
+
+    @Test
+    fun `when phone is empty phone then error is NOT null`() = testBlocking {
+        val address = Address.EMPTY.copy(phone = "")
+        whenever(addressValidator.validateAtLeastOneOf(eq(""), eq(""))).doReturn("error")
+        whenever(addressValidator.validateFieldRequired("")).doReturn("error")
+        Snapshot.withMutableSnapshot {
+            val savedState = createSavedStateHandle(address)
+            createViewModel(savedState)
+        }
+
+        advanceUntilIdle()
+
+        val result = sut.viewState.value
+
+        assertThat(result).isInstanceOf(WooShippingEditAddressViewModel.ViewState::class.java)
+
+        assertThat(result.editableAddress.phone.error).isNotEmpty
+    }
+
+    @Test
+    fun `when email is empty then address error is not null`() = testBlocking {
+        val address = Address.EMPTY
+        whenever(addressValidator.validateAtLeastOneOf(eq(""), eq(""))).doReturn("error")
+        whenever(addressValidator.validateFieldRequired("")).doReturn("error")
+        Snapshot.withMutableSnapshot {
+            val savedState = createSavedStateHandle(address)
+            createViewModel(savedState)
+        }
+
+        advanceUntilIdle()
+
+        val result = sut.viewState.value
+
+        assertThat(result).isInstanceOf(WooShippingEditAddressViewModel.ViewState::class.java)
+
+        assertThat(result.editableAddress.email.error).isNotEmpty()
+    }
+
+    @Test
+    fun `when email is NOT empty then address error is null`() = testBlocking {
+        val address = Address.EMPTY.copy(email = "This is an email")
+        whenever(addressValidator.validateAtLeastOneOf(eq(""), eq(""))).doReturn("error")
+        whenever(addressValidator.validateFieldRequired("")).doReturn("error")
+        Snapshot.withMutableSnapshot {
+            val savedState = createSavedStateHandle(address)
+            createViewModel(savedState)
+        }
+
+        advanceUntilIdle()
+
+        val result = sut.viewState.value
+
+        assertThat(result).isInstanceOf(WooShippingEditAddressViewModel.ViewState::class.java)
+
+        assertThat(result.editableAddress.email.error).isNull()
     }
 }


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Part of: #12440 
<!-- Id number of the GitHub issue this PR addresses. -->

<!-- 
━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
🛠 Need an AI review?  
Add a comment: `@coderabbitai review`
━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
-->

### Description
This PR adds an enhancement to display is required (*) on required fields. To achieve this, I have included a `isRequired` field in the InputValue that will be used to add (*) behind the label and update the required fields based on the current flow.


### Testing information

TC1

1. Open the orders tab
2. Tap on an order eligible for shipping label creation
3. Expand the shipment details section
4. Tap on the pencil near the Ship to section
5. Check that the required fields have the (*) after the label
6. Update name and company and check that (*) and errors work as expected

TC2
1. Open the orders tab
2. Tap on an order eligible for shipping label creation
3. Expand the shipment details section
4. Expand the origin address section
5. Tap on the pencil
6. Check that the required fields have the (*) after the label
7. Update name and company and check that (*) and errors work as expected

TC3
- Check that phone and email are required when editing the origin address but not required when editing the destination address.



### The tests that have been performed
- Checking that * is displayed on required fields

### Images/gif

https://github.com/user-attachments/assets/b46bc65a-a596-43e0-9c17-fbadddd5e5ad



- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.

## Reviewer (or Author, in the case of optional code reviews):

Please make sure these conditions are met before approving the PR, or request changes if the PR needs improvement:

- [x] The PR is small and has a clear, single focus, or a valid explanation is provided in the description. If needed, please request to split it into smaller PRs.
- [x] Ensure Adequate Unit Test Coverage: The changes are reasonably covered by unit tests or an explanation is provided in the PR description.
- [x] Manual Testing: The author listed all the tests they ran, including smoke tests when needed (e.g., for refactorings). The reviewer confirmed that the PR works as expected on big (tablet) and small (phone) in case of UI changes, and no regressions are added.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->