### PR TITLE
Verify destination address

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/WooShippingLabelCreationViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/WooShippingLabelCreationViewModel.kt
@@ -17,6 +17,7 @@ import com.woocommerce.android.ui.orders.wooshippinglabels.WooShippingLabelCreat
 import com.woocommerce.android.ui.orders.wooshippinglabels.WooShippingLabelCreationViewModel.CustomsState.Unavailable
 import com.woocommerce.android.ui.orders.wooshippinglabels.WooShippingLabelCreationViewModel.PackageSelectionState.DataAvailable
 import com.woocommerce.android.ui.orders.wooshippinglabels.WooShippingLabelCreationViewModel.PackageSelectionState.NotSelected
+import com.woocommerce.android.ui.orders.wooshippinglabels.address.destination.VerifyDestinationAddress
 import com.woocommerce.android.ui.orders.wooshippinglabels.address.origin.FetchOriginAddresses
 import com.woocommerce.android.ui.orders.wooshippinglabels.address.origin.ObserveOriginAddresses
 import com.woocommerce.android.ui.orders.wooshippinglabels.customs.ShouldRequireCustomsForm
@@ -64,12 +65,14 @@ class WooShippingLabelCreationViewModel @Inject constructor(
     private val purchaseShippingLabel: PurchaseShippingLabel,
     private val observeStoreOptions: ObserveStoreOptions,
     private val fetchAccountSettings: FetchAccountSettings,
-    private val shouldRequireCustoms: ShouldRequireCustomsForm
+    private val shouldRequireCustoms: ShouldRequireCustomsForm,
+    private val verifyDestinationAddress: VerifyDestinationAddress
 ) : ScopedViewModel(savedState) {
     private val navArgs: WooShippingLabelCreationFragmentArgs by savedState.navArgs()
 
     private val emptyOrder = Order.getEmptyOrder(Date(), Date())
     private val order = MutableStateFlow<Order>(emptyOrder)
+    private val destinationAddress = MutableStateFlow<DestinationShippingAddress>(DestinationShippingAddress.EMPTY)
     private val shippingAddresses = MutableStateFlow<WooShippingAddresses?>(WooShippingAddresses.EMPTY)
     private val loadTrigger = MutableSharedFlow<Unit>()
     private val storeOptions = MutableStateFlow<StoreOptionsModel?>(StoreOptionsModel.EMPTY)
@@ -112,6 +115,7 @@ class WooShippingLabelCreationViewModel @Inject constructor(
     init {
         launch { observeShippingLabelInformation() }
         launch { getStoreOptions() }
+        launch { getDestinationAddress() }
         launch { getShippingAddresses() }
         launch { getOrderInformation() }
         launch { observePackageWeight() }
@@ -130,10 +134,19 @@ class WooShippingLabelCreationViewModel @Inject constructor(
         }
     }
 
-    private fun getStoreOptions() {
-        launch {
-            observeStoreOptions().collectLatest { options ->
-                storeOptions.value = options
+    private suspend fun getStoreOptions() {
+        observeStoreOptions().collectLatest { options ->
+            storeOptions.value = options
+        }
+    }
+
+    private suspend fun getDestinationAddress() {
+        order.drop(1).collectLatest { order ->
+            if (order.shippingAddress != Address.EMPTY) {
+                verifyDestinationAddress(order.id).fold(
+                    onSuccess = { destinationAddress.value = it },
+                    onFailure = { }
+                )
             }
         }
     }
@@ -244,13 +257,13 @@ class WooShippingLabelCreationViewModel @Inject constructor(
     }
 
     private suspend fun getShippingAddresses() {
-        combine(order, observeOriginAddresses()) { order, originAddresses ->
+        combine(destinationAddress, observeOriginAddresses()) { destination, originAddresses ->
             if (!originAddresses.isNullOrEmpty()) {
                 val selectedOriginAddress = getSelectedOriginAddress(originAddresses)
                 WooShippingAddresses(
                     shipFrom = selectedOriginAddress,
                     originAddresses = originAddresses,
-                    shipTo = DestinationShippingAddress(order.shippingAddress, false)
+                    shipTo = destination
                 )
             } else {
                 null
@@ -353,10 +366,8 @@ class WooShippingLabelCreationViewModel @Inject constructor(
         )
     }
 
-    fun onUpdateDestinationAddress(destinationAddress: DestinationShippingAddress) {
-        shippingAddresses.value?.let {
-            shippingAddresses.value = it.copy(shipTo = destinationAddress)
-        }
+    fun onUpdateDestinationAddress(updatedDestinationAddress: DestinationShippingAddress) {
+        destinationAddress.value = updatedDestinationAddress
     }
 
     fun onRefreshShippingRates() {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/WooShippingLabelCreationViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/WooShippingLabelCreationViewModel.kt
@@ -146,13 +146,14 @@ class WooShippingLabelCreationViewModel @Inject constructor(
                 address = order.shippingAddress.copy(email = order.billingAddress.email),
                 isVerified = false
             )
+
+            destinationAddress.value = defaultDestination
+
             if (order.shippingAddress != Address.EMPTY) {
                 verifyDestinationAddress(order.id).fold(
                     onSuccess = { destinationAddress.value = it },
-                    onFailure = { destinationAddress.value = defaultDestination }
+                    onFailure = { }
                 )
-            } else {
-                destinationAddress.value = defaultDestination
             }
         }
     }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/WooShippingLabelCreationViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/WooShippingLabelCreationViewModel.kt
@@ -142,11 +142,17 @@ class WooShippingLabelCreationViewModel @Inject constructor(
 
     private suspend fun getDestinationAddress() {
         order.drop(1).collectLatest { order ->
+            val defaultDestination = DestinationShippingAddress(
+                address = order.shippingAddress.copy(email = order.billingAddress.email),
+                isVerified = false
+            )
             if (order.shippingAddress != Address.EMPTY) {
                 verifyDestinationAddress(order.id).fold(
                     onSuccess = { destinationAddress.value = it },
-                    onFailure = { }
+                    onFailure = { destinationAddress.value = defaultDestination }
                 )
+            } else {
+                destinationAddress.value = defaultDestination
             }
         }
     }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/address/WooShippingEditAddressViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/address/WooShippingEditAddressViewModel.kt
@@ -78,8 +78,12 @@ class WooShippingEditAddressViewModel @Inject constructor(
         snapshotFlow { rawState },
         selectedState
     ) { rawState, selectedState ->
-        if (selectedState != Location.EMPTY) selectedState else AmbiguousLocation.Raw(rawState)
-            .asLocation()
+        if (selectedState != Location.EMPTY) {
+            selectedState
+        } else {
+            AmbiguousLocation.Raw(rawState)
+                .asLocation()
+        }
     }
 
     private val countriesState = MutableStateFlow<LocationState>(LocationState.Loading)
@@ -461,12 +465,12 @@ class WooShippingEditAddressViewModel @Inject constructor(
 
     private fun hasIncorrectOrMissingData(editableAddress: EditableAddress): Boolean {
         return editableAddress.address.error.isNotNullOrEmpty() ||
-                editableAddress.city.error.isNotNullOrEmpty() ||
-                editableAddress.postalCode.error.isNotNullOrEmpty() ||
-                editableAddress.email.error.isNotNullOrEmpty() ||
-                editableAddress.phone.error.isNotNullOrEmpty() ||
-                editableAddress.name.error.isNotNullOrEmpty() ||
-                editableAddress.company.error.isNotNullOrEmpty()
+            editableAddress.city.error.isNotNullOrEmpty() ||
+            editableAddress.postalCode.error.isNotNullOrEmpty() ||
+            editableAddress.email.error.isNotNullOrEmpty() ||
+            editableAddress.phone.error.isNotNullOrEmpty() ||
+            editableAddress.name.error.isNotNullOrEmpty() ||
+            editableAddress.company.error.isNotNullOrEmpty()
     }
 
     fun onNameChange(value: String) {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/address/destination/VerifyDestinationAddress.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/address/destination/VerifyDestinationAddress.kt
@@ -1,0 +1,24 @@
+package com.woocommerce.android.ui.orders.wooshippinglabels.address.destination
+
+import com.woocommerce.android.tools.SelectedSite
+import com.woocommerce.android.ui.orders.wooshippinglabels.networking.WooShippingLabelRepository
+import com.woocommerce.android.util.CoroutineDispatchers
+import kotlinx.coroutines.withContext
+import javax.inject.Inject
+
+class VerifyDestinationAddress @Inject constructor(
+    private val shippingRepository: WooShippingLabelRepository,
+    private val selectedSite: SelectedSite,
+    private val coroutineDispatchers: CoroutineDispatchers
+) {
+    suspend operator fun invoke(
+        orderId: Long
+    ): Result<Boolean> {
+        return withContext(coroutineDispatchers.io) {
+            selectedSite.getOrNull()?.let {
+                val response = shippingRepository.verifyDestinationAddress(it, orderId)
+                Result.success(response.model == true)
+            } ?: Result.failure(Exception("No site selected"))
+        }
+    }
+}

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/address/destination/VerifyDestinationAddress.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/address/destination/VerifyDestinationAddress.kt
@@ -1,6 +1,7 @@
 package com.woocommerce.android.ui.orders.wooshippinglabels.address.destination
 
 import com.woocommerce.android.tools.SelectedSite
+import com.woocommerce.android.ui.orders.wooshippinglabels.models.DestinationShippingAddress
 import com.woocommerce.android.ui.orders.wooshippinglabels.networking.WooShippingLabelRepository
 import com.woocommerce.android.util.CoroutineDispatchers
 import kotlinx.coroutines.withContext
@@ -13,11 +14,21 @@ class VerifyDestinationAddress @Inject constructor(
 ) {
     suspend operator fun invoke(
         orderId: Long
-    ): Result<Boolean> {
+    ): Result<DestinationShippingAddress> {
         return withContext(coroutineDispatchers.io) {
             selectedSite.getOrNull()?.let {
                 val response = shippingRepository.verifyDestinationAddress(it, orderId)
-                Result.success(response.model == true)
+                val result = response.model
+                when {
+                    response.isError || result == null -> {
+                        val message =
+                            response.error.message
+                                ?: if (result == null) "Empty response" else "Unknown error"
+                        Result.failure(Exception(message))
+                    }
+
+                    else -> Result.success(result)
+                }
             } ?: Result.failure(Exception("No site selected"))
         }
     }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/customs/ShouldRequireCustomsForm.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/customs/ShouldRequireCustomsForm.kt
@@ -1,18 +1,19 @@
 package com.woocommerce.android.ui.orders.wooshippinglabels.customs
 
-import com.woocommerce.android.extensions.isNotNullOrEmpty
 import com.woocommerce.android.ui.orders.wooshippinglabels.WooShippingAddresses
 import javax.inject.Inject
 
 class ShouldRequireCustomsForm @Inject constructor() {
     operator fun invoke(addressData: WooShippingAddresses): Boolean {
-        if (addressData.isDifferentCountryShipment) return true
+        val isCountryEmpty = addressData.shipTo.address.country.code.isEmpty()
+        val isDifferentCountry = addressData.isDifferentCountryShipment
+
+        if (isCountryEmpty.not() && isDifferentCountry) return true
 
         val isOriginAddressMilitary = isAddressInMilitaryState(
             addressData.shipFrom.country,
             addressData.shipFrom.state.orEmpty()
         )
-
         val isShippingAddressMilitary = isAddressInMilitaryState(
             addressData.shipTo.address.country.code,
             addressData.shipTo.address.state.codeOrRaw
@@ -22,7 +23,7 @@ class ShouldRequireCustomsForm @Inject constructor() {
     }
 
     private val WooShippingAddresses.isDifferentCountryShipment
-        get() = shipTo.address.country.code.isNotNullOrEmpty() && shipFrom.country != shipTo.address.country.code
+        get() = shipFrom.country != shipTo.address.country.code
 
     private fun isAddressInMilitaryState(
         countryCode: String,

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/customs/ShouldRequireCustomsForm.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/customs/ShouldRequireCustomsForm.kt
@@ -1,5 +1,6 @@
 package com.woocommerce.android.ui.orders.wooshippinglabels.customs
 
+import com.woocommerce.android.extensions.isNotNullOrEmpty
 import com.woocommerce.android.ui.orders.wooshippinglabels.WooShippingAddresses
 import javax.inject.Inject
 
@@ -21,7 +22,7 @@ class ShouldRequireCustomsForm @Inject constructor() {
     }
 
     private val WooShippingAddresses.isDifferentCountryShipment
-        get() = shipFrom.country != shipTo.address.country.code
+        get() = shipTo.address.country.code.isNotNullOrEmpty() && shipFrom.country != shipTo.address.country.code
 
     private fun isAddressInMilitaryState(
         countryCode: String,

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/networking/DTOs.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/networking/DTOs.kt
@@ -110,6 +110,6 @@ data class UpdateAddressResponseDTO(
 
 data class VerifyDestinationAddressResponseDTO(
     val success: Boolean,
-    val address: AddressDTO,
+    val normalizedAddress: AddressDTO,
     val isVerified: Boolean
 )

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/networking/DTOs.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/networking/DTOs.kt
@@ -107,3 +107,9 @@ data class UpdateAddressResponseDTO(
     val address: AddressDTO,
     val isVerified: Boolean
 )
+
+data class VerifyDestinationAddressResponseDTO(
+    val success: Boolean,
+    val address: AddressDTO,
+    val isVerified: Boolean
+)

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/networking/WooShippingLabelRepository.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/networking/WooShippingLabelRepository.kt
@@ -196,8 +196,27 @@ class WooShippingLabelRepository @Inject constructor(
     suspend fun verifyDestinationAddress(
         site: SiteModel,
         orderId: Long,
-    ) = restClient.verifyDestinationAddress(
-        site = site,
-        orderId = orderId,
-    ).asWooResult { it.isVerified }
+    ): WooResult<DestinationShippingAddress> {
+        val verifyDestinationAddress = restClient.verifyDestinationAddress(
+            site = site,
+            orderId = orderId,
+        )
+
+        return if (verifyDestinationAddress.result?.success == true) {
+            verifyDestinationAddress.asWooResult {
+                DestinationShippingAddress(
+                    address = mapper(it.normalizedAddress),
+                    isVerified = it.isVerified
+                )
+            }
+        } else {
+            WooResult(
+                WooError(
+                    type = WooErrorType.INVALID_RESPONSE,
+                    original = GenericErrorType.INVALID_RESPONSE,
+                    message = "Address verification failed"
+                )
+            )
+        }
+    }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/networking/WooShippingLabelRepository.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/networking/WooShippingLabelRepository.kt
@@ -192,4 +192,12 @@ class WooShippingLabelRepository @Inject constructor(
             )
         }
     }
+
+    suspend fun verifyDestinationAddress(
+        site: SiteModel,
+        orderId: Long,
+    ) = restClient.verifyDestinationAddress(
+        site = site,
+        orderId = orderId,
+    ).asWooResult { it.isVerified }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/networking/WooShippingLabelRestClient.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/networking/WooShippingLabelRestClient.kt
@@ -173,4 +173,17 @@ class WooShippingLabelRestClient @Inject constructor(
 
         return result.toWooPayload()
     }
+
+    suspend fun verifyDestinationAddress(
+        site: SiteModel,
+        orderId: Long,
+    ): WooPayload<VerifyDestinationAddressResponseDTO> {
+        val url = "/wcshipping/v1/address/$orderId/verify_order/"
+
+        return wooNetwork.executeGetGsonRequest(
+            site = site,
+            path = url,
+            clazz = VerifyDestinationAddressResponseDTO::class.java,
+        ).toWooPayload()
+    }
 }

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/WooShippingLabelCreationViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/WooShippingLabelCreationViewModelTest.kt
@@ -12,6 +12,7 @@ import com.woocommerce.android.ui.orders.wooshippinglabels.WooShippingLabelCreat
 import com.woocommerce.android.ui.orders.wooshippinglabels.WooShippingLabelCreationViewModel.PurchaseState
 import com.woocommerce.android.ui.orders.wooshippinglabels.WooShippingLabelCreationViewModel.WooShippingViewState
 import com.woocommerce.android.ui.orders.wooshippinglabels.WooShippingLabelCreationViewModel.WooShippingViewState.DataState
+import com.woocommerce.android.ui.orders.wooshippinglabels.address.destination.VerifyDestinationAddress
 import com.woocommerce.android.ui.orders.wooshippinglabels.address.origin.ObserveOriginAddresses
 import com.woocommerce.android.ui.orders.wooshippinglabels.customs.ShouldRequireCustomsForm
 import com.woocommerce.android.ui.orders.wooshippinglabels.models.OriginShippingAddress
@@ -215,6 +216,7 @@ class WooShippingLabelCreationViewModelTest : BaseUnitTest() {
     private val getShippingRates: GetShippingRates = mock()
     private val purchaseShippingLabel: PurchaseShippingLabel = mock()
     private val observeStoreOptions: ObserveStoreOptions = mock()
+    private val verifyDestinationAddress: VerifyDestinationAddress = mock()
 
     private lateinit var sut: WooShippingLabelCreationViewModel
 
@@ -230,6 +232,7 @@ class WooShippingLabelCreationViewModelTest : BaseUnitTest() {
             observeStoreOptions = observeStoreOptions,
             fetchAccountSettings = mock(),
             shouldRequireCustoms = shouldRequireCustomsForm,
+            verifyDestinationAddress = verifyDestinationAddress,
             savedState = savedState
         )
     }

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/address/destination/VerifyDestinationAddressTests.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/address/destination/VerifyDestinationAddressTests.kt
@@ -1,0 +1,57 @@
+package com.woocommerce.android.ui.orders.wooshippinglabels.address.destination
+
+import com.woocommerce.android.tools.SelectedSite
+import com.woocommerce.android.ui.orders.wooshippinglabels.models.DestinationShippingAddress
+import com.woocommerce.android.ui.orders.wooshippinglabels.networking.WooShippingLabelRepository
+import com.woocommerce.android.viewmodel.BaseUnitTest
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.Test
+import org.mockito.Mockito.mock
+import org.mockito.kotlin.any
+import org.mockito.kotlin.whenever
+import org.wordpress.android.fluxc.model.SiteModel
+import org.wordpress.android.fluxc.network.BaseRequest.GenericErrorType.UNKNOWN
+import org.wordpress.android.fluxc.network.rest.wpcom.wc.WooError
+import org.wordpress.android.fluxc.network.rest.wpcom.wc.WooErrorType.GENERIC_ERROR
+import org.wordpress.android.fluxc.network.rest.wpcom.wc.WooResult
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class VerifyDestinationAddressTests : BaseUnitTest() {
+    private val repository: WooShippingLabelRepository = mock()
+    private val site: SelectedSite = mock()
+
+    private val sut = VerifyDestinationAddress(repository, site, coroutinesTestRule.testDispatchers)
+
+    private val defaultOrderId = 2L
+    private val defaultAddressResponse = DestinationShippingAddress.EMPTY
+
+    @Test
+    fun `when selected site is null then return failure`() = testBlocking {
+        val result = sut.invoke(defaultOrderId)
+        assert(result.isFailure)
+    }
+
+    @Test
+    fun `when verify address fails then return failure`() = testBlocking {
+        whenever(site.getOrNull()).thenReturn(SiteModel())
+        whenever(repository.verifyDestinationAddress(any(), any()))
+            .thenReturn(WooResult(WooError(GENERIC_ERROR, UNKNOWN)))
+
+        val result = sut.invoke(defaultOrderId)
+
+        assert(result.isFailure)
+    }
+
+    @Test
+    fun `when verify address succeed then return expected data`() = testBlocking {
+        whenever(site.getOrNull()).thenReturn(SiteModel())
+        whenever(repository.verifyDestinationAddress(any(), any()))
+            .thenReturn(WooResult(defaultAddressResponse))
+
+        val result = sut.invoke(defaultOrderId)
+
+        assert(result.isSuccess)
+        assertThat(result.getOrNull()).isEqualTo(defaultAddressResponse)
+    }
+}

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/customs/ShouldRequireCustomsFormTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/customs/ShouldRequireCustomsFormTest.kt
@@ -99,4 +99,17 @@ class ShouldRequireCustomsFormTest {
         )
         assertFalse(shouldRequireCustomsForm(addressData))
     }
+
+    @Test
+    fun `should return false for empty destination addresses`() {
+        val addressData = WooShippingAddresses(
+            shipFrom = OriginShippingAddress.EMPTY.copy(country = "US", state = "CA"),
+            shipTo = DestinationShippingAddress(
+                Address.EMPTY,
+                false
+            ),
+            originAddresses = emptyList()
+        )
+        assertFalse(shouldRequireCustomsForm(addressData))
+    }
 }


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Part of : #12440
<!-- Id number of the GitHub issue this PR addresses. -->

<!-- 
━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
🛠 Need an AI review?  
Add a comment: `@coderabbitai review`
━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
-->

### Description
This PR adds address verification support to check whether a destination address is verified. The changes introduced in this PR include networking support and introducing the request in the main flow. 

### Testing information
TC1
1. Open the orders tab
2. Tap on an order eligible for shipping label creation with an invalid/not verified shipping address
3. Expand the Shipment details section
4. Tap on the pencil near the ship to address
5. Check that the address status displays Unverified address

TC2
1. Using the order from TC1, update the destination address to make the address verified
2. Check that the address status displays: Verified address
3. Close the app and reopen the Edit Destination screen by following the steps 1-4 from TC1
4. Check that the address status displays: Verified address


### The tests that have been performed
- Checking that the address information is fetched from the API when possible

### Images/gif

https://github.com/user-attachments/assets/8726febb-4ab1-4c92-999b-e14fc5a344b7


- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.

## Reviewer (or Author, in the case of optional code reviews):

Please make sure these conditions are met before approving the PR, or request changes if the PR needs improvement:

- [x] The PR is small and has a clear, single focus, or a valid explanation is provided in the description. If needed, please request to split it into smaller PRs.
- [x] Ensure Adequate Unit Test Coverage: The changes are reasonably covered by unit tests or an explanation is provided in the PR description.
- [x] Manual Testing: The author listed all the tests they ran, including smoke tests when needed (e.g., for refactorings). The reviewer confirmed that the PR works as expected on big (tablet) and small (phone) in case of UI changes, and no regressions are added.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->