### PR TITLE
[Shipping Labels] Improve the logic of the initial loading

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/ObserveStoreOptions.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/ObserveStoreOptions.kt
@@ -1,22 +1,28 @@
 package com.woocommerce.android.ui.orders.wooshippinglabels
 
+import com.woocommerce.android.tools.SelectedSite
 import com.woocommerce.android.ui.orders.wooshippinglabels.datasource.WooShippingConfigurationDataStore
+import com.woocommerce.android.ui.orders.wooshippinglabels.models.StoreOptionsModel
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.transformLatest
+import org.wordpress.android.fluxc.store.WooCommerceStore
 import javax.inject.Inject
 
 class ObserveStoreOptions @Inject constructor(
     private val configurationDataStore: WooShippingConfigurationDataStore,
     private val fetchAccountSettings: FetchAccountSettings,
+    private val wooStore: WooCommerceStore,
+    private val site: SelectedSite,
 ) {
     private var isFirstValue = true
 
     @OptIn(ExperimentalCoroutinesApi::class)
     // We will use data store as the source of truth and after the first emission we will refresh the values async.
     operator fun invoke() = configurationDataStore.observeStoreOptions().transformLatest { options ->
+        val cachedStoreOptions = options ?: getStoreOptionsFromSiteSettings(wooStore, site)
+
         when {
-            isFirstValue && options == null -> {
-                // If there is no cached data, refresh the store options before emitting any value
+            isFirstValue && cachedStoreOptions == null -> {
                 isFirstValue = false
                 if (fetchAccountSettings().isFailure) {
                     // We will use null as not available
@@ -24,14 +30,22 @@ class ObserveStoreOptions @Inject constructor(
                 }
             }
 
-            isFirstValue && options != null -> {
+            isFirstValue -> {
                 // If there is cached data, emit cached values and refresh the store options async
                 isFirstValue = false
-                emit(options)
+                emit(cachedStoreOptions)
                 fetchAccountSettings()
             }
 
-            else -> emit(options)
+            else -> emit(cachedStoreOptions)
         }
     }
+
+    private fun getStoreOptionsFromSiteSettings(wooStore: WooCommerceStore, site: SelectedSite) =
+        wooStore.getProductSettings(site.get())?.let { productSettings ->
+            StoreOptionsModel.EMPTY.copy(
+                weightUnit = productSettings.weightUnit,
+                dimensionUnit = productSettings.dimensionUnit
+            )
+        }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/ObserveStoreOptions.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/ObserveStoreOptions.kt
@@ -28,9 +28,7 @@ class ObserveStoreOptions @Inject constructor(
                 // If there is cached data, emit cached values and refresh the store options async
                 isFirstValue = false
                 emit(options)
-                if (fetchAccountSettings().isFailure) {
-                    emit(null)
-                }
+                fetchAccountSettings()
             }
 
             else -> emit(options)

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/datasource/WooShippingConfigurationDataStore.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/datasource/WooShippingConfigurationDataStore.kt
@@ -34,6 +34,4 @@ class WooShippingConfigurationDataStore @Inject constructor(
             preferences[stringPreferencesKey(getStoreOptionsKey())] = gson.toJson(storeOptions)
         }
     }
-
-    suspend fun clearStoreOptions() = dataStore.edit { it.remove(stringPreferencesKey(getStoreOptionsKey())) }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/networking/WooShippingLabelRepository.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/networking/WooShippingLabelRepository.kt
@@ -42,7 +42,7 @@ class WooShippingLabelRepository @Inject constructor(
                 ?.takeIf { response.isError.not() }
                 ?.let {
                     configurationDataStore.saveStoreOptions(it)
-                } ?: configurationDataStore.clearStoreOptions()
+                }
         }
 
     suspend fun fetchPurchasedShippingLabels(

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/ObserveStoreOptionsTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/ObserveStoreOptionsTest.kt
@@ -1,5 +1,6 @@
 package com.woocommerce.android.ui.orders.wooshippinglabels
 
+import com.woocommerce.android.tools.SelectedSite
 import com.woocommerce.android.ui.orders.wooshippinglabels.datasource.WooShippingConfigurationDataStore
 import com.woocommerce.android.ui.orders.wooshippinglabels.models.StoreOptionsModel
 import com.woocommerce.android.viewmodel.BaseUnitTest
@@ -11,44 +12,60 @@ import org.mockito.kotlin.doReturn
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
+import org.wordpress.android.fluxc.model.SiteModel
+import org.wordpress.android.fluxc.model.WCProductSettingsModel
+import org.wordpress.android.fluxc.store.WooCommerceStore
 import kotlin.test.Test
 
 @OptIn(ExperimentalCoroutinesApi::class)
 class ObserveStoreOptionsTest : BaseUnitTest() {
     private val dataStore: WooShippingConfigurationDataStore = mock()
     private val fetchAccountSettings: FetchAccountSettings = mock()
+    private val wooStore: WooCommerceStore = mock()
     private val defaultStoreOptions = StoreOptionsModel(
         weightUnit = "kg",
         currencySymbol = "$",
         dimensionUnit = "cm",
         originCountry = "US"
     )
+    private val defaultProductSettings = WCProductSettingsModel().apply {
+        weightUnit = defaultStoreOptions.weightUnit
+        dimensionUnit = defaultStoreOptions.dimensionUnit
+    }
+    private val selectedSite: SelectedSite = mock {
+        on(it.get()).thenReturn(SiteModel())
+    }
 
     val sut = ObserveStoreOptions(
         configurationDataStore = dataStore,
-        fetchAccountSettings = fetchAccountSettings
+        fetchAccountSettings = fetchAccountSettings,
+        wooStore = wooStore,
+        site = selectedSite
     )
 
     @Test
-    fun `when there is NO cached data and fetch account settings fails then return null`() = testBlocking {
-        whenever(dataStore.observeStoreOptions()).doReturn(flowOf(null))
-        whenever(fetchAccountSettings.invoke()).doReturn(Result.failure(Exception("Random error")))
-        val result = sut.invoke().toList()
+    fun `when there is NO cached data and fetch account settings fails then return cached site settings`() =
+        testBlocking {
+            whenever(dataStore.observeStoreOptions()).doReturn(flowOf(null))
+            whenever(wooStore.getProductSettings(selectedSite.get())).doReturn(defaultProductSettings)
+            whenever(fetchAccountSettings.invoke()).doReturn(Result.failure(Exception("Random error")))
+            val result = sut.invoke().toList()
 
-        assertTrue(result.size == 1)
-        assertTrue(result.first() == null)
-    }
+            assertTrue(result.size == 1)
+            assertTrue(result.first()?.weightUnit == defaultProductSettings.weightUnit)
+            assertTrue(result.first()?.dimensionUnit == defaultProductSettings.dimensionUnit)
+        }
 
     @Test
-    fun `when there is cached data and fetch account settings fails then return null`() = testBlocking {
-        whenever(dataStore.observeStoreOptions()).doReturn(flowOf(defaultStoreOptions))
-        whenever(fetchAccountSettings.invoke()).doReturn(Result.failure(Exception("Random error")))
-        val result = sut.invoke().toList()
+    fun `when there is cached data and fetch account settings fails then return cached data`() =
+        testBlocking {
+            whenever(dataStore.observeStoreOptions()).doReturn(flowOf(defaultStoreOptions))
+            whenever(fetchAccountSettings.invoke()).doReturn(Result.failure(Exception("Random error")))
+            val result = sut.invoke().toList()
 
-        assertTrue(result.size == 2)
-        assertTrue(result.first() == defaultStoreOptions)
-        assertTrue(result.last() == null)
-    }
+            assertTrue(result.size == 1)
+            assertTrue(result.first() == defaultStoreOptions)
+        }
 
     @Test
     fun `refresh data only once`() = testBlocking {


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #13318 
<!-- Id number of the GitHub issue this PR addresses. -->

<!-- 
━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
🛠 Need an AI review?  
Add a comment: `@coderabbitai review`
━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
-->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
This PR improves the logic of the initial loading for the Shipping Label creation screen. 
**Before**
- An error screen was shown if `/wcshipping/v1/account/settings/` endpoint sends an error anytime.
- We were only checking the data from `/wcshipping/v1/account/settings/`
**After**
- The error screen is shown only when there is no cached data from `/wcshipping/v1/account/settings/` and `/settings/products/`.

### Steps to reproduce
<!-- Step-by-step testing instructions. For new user flows, consider instead stating the goal of the workflow and see if your PR reviewer can accomplish the workflow without specific steps! -->
A. To create a fake null response from `/settings/products/`, use this patch: [Return_null_from_getProductSettings.patch](https://github.com/user-attachments/files/19034399/Return_null_from_getProductSettings.patch)
B. To create fake null response from `/wcshipping/v1/account/settings/`
  - Go to Menu → Settings → Developer Options → API Faker
  - Tap + button.
  - Enter these settings: 
```
Type: WordPress REST API
HTTP Method: GET
Path: /wcshipping/v1/account/settings
Status Code: 403
```

#### null `/settings/products/` and `/wcshipping/v1/account/settings/`
1. Perform a clean install.
2. Apply A and B.
3. Use a site that is eligible for shipping labels.
4. Go to orders.
5. Create a new order and complete the payment.
6. Open the order details and tap the "Create shipping label" button.
7. Verify that the error screen appears.
8. Disable the API faker by tapping the red bottom banner.
9. Tap the Retry button.
10. Verify that the error disappears.

#### null `/wcshipping/v1/account/settings/`
1. Perform a clean install.
2. Apply B.
3. Use a site that is eligible for shipping labels.
4. Go to orders.
5. Create a new order and complete the payment.
6. Open the order details and tap the "Create shipping label" button.
7. Verify that the error screen does not appear. I sometimes noticed site settings data is also null at this step. It's updated in app initialization. If you encounter that restart the app and try again.

#### Happy case
1. Perform a clean install.
2. Use a site that is eligible for shipping labels.
3. Go to orders.
4. Create a new order and complete the payment.
5. Open the order details and tap the "Create shipping label" button.
6. Verify that there is no error.

### The tests that have been performed
<!-- To give the reviewer an idea of what could be missed in terms of testing -->
Steps above.

### Images/gif
<!-- Include before and after images or gifs when appropriate. -->

- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.

## Reviewer (or Author, in the case of optional code reviews):

Please make sure these conditions are met before approving the PR, or request changes if the PR needs improvement:

- [ ] The PR is small and has a clear, single focus, or a valid explanation is provided in the description. If needed, please request to split it into smaller PRs.
- [ ] Ensure Adequate Unit Test Coverage: The changes are reasonably covered by unit tests or an explanation is provided in the PR description.
- [ ] Manual Testing: The author listed all the tests they ran, including smoke tests when needed (e.g., for refactorings). The reviewer confirmed that the PR works as expected on big (tablet) and small (phone) in case of UI changes, and no regressions are added.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->