### PR TITLE
Address status feedback

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/ShipmentDetails.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/ShipmentDetails.kt
@@ -50,6 +50,7 @@ import com.woocommerce.android.ui.compose.animations.SkeletonView
 import com.woocommerce.android.ui.compose.theme.WooThemeWithBackground
 import com.woocommerce.android.ui.orders.wooshippinglabels.address.AddressSectionLandscape
 import com.woocommerce.android.ui.orders.wooshippinglabels.address.AddressSectionPortrait
+import com.woocommerce.android.ui.orders.wooshippinglabels.address.AddressStatus
 import com.woocommerce.android.ui.orders.wooshippinglabels.address.getShipFrom
 import com.woocommerce.android.ui.orders.wooshippinglabels.address.getShipTo
 import com.woocommerce.android.ui.orders.wooshippinglabels.models.DestinationShippingAddress
@@ -69,6 +70,7 @@ fun ShipmentDetails(
     isShipmentDetailsExpanded: Boolean = false,
     onShipmentDetailsExpandedChange: (Boolean) -> Boolean,
     onEditDestinationAddress: (DestinationShippingAddress) -> Unit,
+    destinationStatus: AddressStatus,
     markOrderComplete: Boolean = false,
     onMarkOrderCompleteChange: (Boolean) -> Unit = {},
     handlerModifier: Modifier = Modifier,
@@ -131,7 +133,8 @@ fun ShipmentDetails(
                 modifier = modifier.padding(top = dimensionResource(R.dimen.minor_100)),
                 isReadOnly = isReadOnly,
                 shipFromSelectionBottomSheetState = shipFromSelectionBottomSheetState,
-                onEditDestinationAddress = onEditDestinationAddress
+                onEditDestinationAddress = onEditDestinationAddress,
+                destinationStatus = destinationStatus
             )
         }
     }
@@ -147,6 +150,7 @@ private fun ShipmentDetailsPortrait(
     shippingRateSummary: ShippingRateSummaryUI?,
     shipFromSelectionBottomSheetState: ModalBottomSheetState,
     onEditDestinationAddress: (DestinationShippingAddress) -> Unit,
+    destinationStatus: AddressStatus,
     modifier: Modifier = Modifier,
     isReadOnly: Boolean = false
 ) {
@@ -165,7 +169,8 @@ private fun ShipmentDetailsPortrait(
                 shippingLines = shippingLines,
                 isReadOnly = isReadOnly,
                 shipFromSelectionBottomSheetState = shipFromSelectionBottomSheetState,
-                onEditDestinationAddress = onEditDestinationAddress
+                onEditDestinationAddress = onEditDestinationAddress,
+                destinationStatus = destinationStatus
             )
             Divider(modifier = Modifier.padding(horizontal = dimensionResource(R.dimen.major_100)))
             ShipmentCostSection(
@@ -261,6 +266,7 @@ private fun OrderDetailsSection(
     shippingLines: List<ShippingLineSummaryUI>,
     shipFromSelectionBottomSheetState: ModalBottomSheetState,
     onEditDestinationAddress: (DestinationShippingAddress) -> Unit,
+    destinationStatus: AddressStatus,
     modifier: Modifier = Modifier,
     isReadOnly: Boolean = false
 ) {
@@ -275,7 +281,8 @@ private fun OrderDetailsSection(
             modifier = Modifier.padding(horizontal = dimensionResource(R.dimen.major_100)),
             isReadOnly = isReadOnly,
             shipFromSelectionBottomSheetState = shipFromSelectionBottomSheetState,
-            onEditDestinationAddress = onEditDestinationAddress
+            onEditDestinationAddress = onEditDestinationAddress,
+            destinationStatus = destinationStatus
         )
         TotalCard(
             totalItems = totalItems,

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/ShipmentDetails.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/ShipmentDetails.kt
@@ -120,7 +120,8 @@ fun ShipmentDetails(
                 modifier = modifier.padding(top = dimensionResource(R.dimen.major_100)),
                 isReadOnly = isReadOnly,
                 shipFromSelectionBottomSheetState = shipFromSelectionBottomSheetState,
-                onEditDestinationAddress = onEditDestinationAddress
+                onEditDestinationAddress = onEditDestinationAddress,
+                destinationStatus = destinationStatus
             )
         } else {
             ShipmentDetailsPortrait(
@@ -196,6 +197,7 @@ private fun ShipmentDetailsLandscape(
     shippingRateSummary: ShippingRateSummaryUI?,
     shipFromSelectionBottomSheetState: ModalBottomSheetState,
     onEditDestinationAddress: (DestinationShippingAddress) -> Unit,
+    destinationStatus: AddressStatus,
     modifier: Modifier = Modifier,
     isReadOnly: Boolean = false
 ) {
@@ -212,7 +214,8 @@ private fun ShipmentDetailsLandscape(
                 modifier = Modifier.padding(horizontal = dimensionResource(R.dimen.major_100)),
                 isReadOnly = isReadOnly,
                 shipFromSelectionBottomSheetState = shipFromSelectionBottomSheetState,
-                onEditDestinationAddress = onEditDestinationAddress
+                onEditDestinationAddress = onEditDestinationAddress,
+                destinationStatus = destinationStatus
             )
             Row(
                 modifier = Modifier
@@ -336,7 +339,8 @@ fun ShipmentDetailsLandscapePreview() {
                 ),
                 shippingRateSummary = null,
                 shipFromSelectionBottomSheetState = rememberModalBottomSheetState(ModalBottomSheetValue.Hidden),
-                onEditDestinationAddress = {}
+                onEditDestinationAddress = {},
+                destinationStatus = AddressStatus.VERIFIED
             )
         }
     }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/WooShippingLabelCreationScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/WooShippingLabelCreationScreen.kt
@@ -73,6 +73,7 @@ import com.woocommerce.android.ui.orders.wooshippinglabels.WooShippingLabelCreat
 import com.woocommerce.android.ui.orders.wooshippinglabels.WooShippingLabelCreationViewModel.PackageSelectionState.DataAvailable
 import com.woocommerce.android.ui.orders.wooshippinglabels.WooShippingLabelCreationViewModel.PackageSelectionState.NotSelected
 import com.woocommerce.android.ui.orders.wooshippinglabels.address.AddressSelection
+import com.woocommerce.android.ui.orders.wooshippinglabels.address.AddressStatus
 import com.woocommerce.android.ui.orders.wooshippinglabels.address.getShipFrom
 import com.woocommerce.android.ui.orders.wooshippinglabels.address.getShipTo
 import com.woocommerce.android.ui.orders.wooshippinglabels.models.DestinationShippingAddress
@@ -114,7 +115,8 @@ fun WooShippingLabelCreationScreen(viewModel: WooShippingLabelCreationViewModel)
                 onShipmentDetailsExpandedChange = viewModel::onShipmentDetailsExpandedChange,
                 onSelectAddressExpandedChange = viewModel::onSelectAddressExpandedChange,
                 onEditCustomsClick = viewModel::onEditCustomsClick,
-                onEditDestinationAddress = viewModel::onEditDestinationAddress
+                onEditDestinationAddress = viewModel::onEditDestinationAddress,
+                destinationStatus = viewState.destinationStatus
             )
         }
 
@@ -154,6 +156,7 @@ fun WooShippingLabelCreationScreen(
     onEditCustomsClick: () -> Unit,
     onNavigateBack: () -> Unit,
     onEditDestinationAddress: (DestinationShippingAddress) -> Unit,
+    destinationStatus: AddressStatus,
     modifier: Modifier = Modifier
 ) {
     val shipmentDetailsValue = if (uiState.isShipmentDetailsExpanded) {
@@ -215,7 +218,8 @@ fun WooShippingLabelCreationScreen(
             shipFromSelectionBottomSheetState = shipFromSelectionBottomSheetState,
             onShipmentDetailsExpandedChange = onShipmentDetailsExpandedChange,
             onEditCustomsClick = onEditCustomsClick,
-            onEditDestinationAddress = onEditDestinationAddress
+            onEditDestinationAddress = onEditDestinationAddress,
+            destinationStatus = destinationStatus
         )
         val isDarkTheme = isSystemInDarkTheme()
         val isCollapsed = scaffoldState.bottomSheetState.isCollapsed
@@ -290,6 +294,7 @@ private fun LabelCreationScreenWithBottomSheet(
     onShipmentDetailsExpandedChange: (Boolean) -> Boolean,
     onEditCustomsClick: () -> Unit,
     onEditDestinationAddress: (DestinationShippingAddress) -> Unit,
+    destinationStatus: AddressStatus,
     modifier: Modifier = Modifier
 ) {
     val isPurchaseButtonDisplayed = shippingRatesState is WooShippingLabelCreationViewModel.ShippingRatesState.DataState
@@ -319,7 +324,8 @@ private fun LabelCreationScreenWithBottomSheet(
                     isShipmentDetailsExpanded = uiState.isShipmentDetailsExpanded,
                     markOrderComplete = uiState.markOrderComplete,
                     onShipmentDetailsExpandedChange = onShipmentDetailsExpandedChange,
-                    onEditDestinationAddress = onEditDestinationAddress
+                    onEditDestinationAddress = onEditDestinationAddress,
+                    destinationStatus = destinationStatus
                 )
             }
         },
@@ -797,7 +803,8 @@ private fun WooShippingLabelCreationScreenPreview() {
             onShipmentDetailsExpandedChange = { true },
             onSelectAddressExpandedChange = { true },
             onEditCustomsClick = {},
-            onEditDestinationAddress = {}
+            onEditDestinationAddress = {},
+            destinationStatus = AddressStatus.VERIFIED
         )
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/WooShippingLabelCreationViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/WooShippingLabelCreationViewModel.kt
@@ -17,6 +17,7 @@ import com.woocommerce.android.ui.orders.wooshippinglabels.WooShippingLabelCreat
 import com.woocommerce.android.ui.orders.wooshippinglabels.WooShippingLabelCreationViewModel.CustomsState.Unavailable
 import com.woocommerce.android.ui.orders.wooshippinglabels.WooShippingLabelCreationViewModel.PackageSelectionState.DataAvailable
 import com.woocommerce.android.ui.orders.wooshippinglabels.WooShippingLabelCreationViewModel.PackageSelectionState.NotSelected
+import com.woocommerce.android.ui.orders.wooshippinglabels.address.AddressStatus
 import com.woocommerce.android.ui.orders.wooshippinglabels.address.destination.VerifyDestinationAddress
 import com.woocommerce.android.ui.orders.wooshippinglabels.address.origin.FetchOriginAddresses
 import com.woocommerce.android.ui.orders.wooshippinglabels.address.origin.ObserveOriginAddresses
@@ -321,6 +322,13 @@ class WooShippingLabelCreationViewModel @Inject constructor(
             }
 
             val items = getShippableItems(order)
+
+            val destinationStatus = when {
+                addresses.shipTo.address.hasInfo().not() -> AddressStatus.MISSING_ADDRESS
+                addresses.shipTo.isVerified -> AddressStatus.VERIFIED
+                else -> AddressStatus.UNVERIFIED
+            }
+
             shippableItems.value = items
 
             val shippableItemsUI = items.map { item -> item.toUIModel(currencyFormatter, storeOptions) }
@@ -341,7 +349,8 @@ class WooShippingLabelCreationViewModel @Inject constructor(
                 packageSelection = packageSelection,
                 uiState = uiState,
                 purchaseState = purchaseState,
-                customsState = customsState
+                customsState = customsState,
+                destinationStatus = destinationStatus
             )
         }.collectLatest {
             viewState.value = it
@@ -577,7 +586,8 @@ class WooShippingLabelCreationViewModel @Inject constructor(
             val packageSelection: PackageSelectionState,
             val uiState: UIControlsState,
             val purchaseState: PurchaseState,
-            val customsState: CustomsState
+            val customsState: CustomsState,
+            val destinationStatus: AddressStatus
         ) : WooShippingViewState()
     }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/address/AddressSection.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/address/AddressSection.kt
@@ -65,6 +65,7 @@ internal fun AddressSectionPortrait(
     shippingAddresses: WooShippingAddresses,
     shipFromSelectionBottomSheetState: ModalBottomSheetState,
     onEditDestinationAddress: (DestinationShippingAddress) -> Unit,
+    destinationStatus: AddressStatus,
     modifier: Modifier = Modifier,
     isReadOnly: Boolean = false
 ) {
@@ -84,12 +85,6 @@ internal fun AddressSectionPortrait(
             val barrier = createEndBarrier(shipFromLabel, shipToLabel)
             val endBarrier = createStartBarrier(shipFromSelect)
             val scope = rememberCoroutineScope()
-
-            val destinationStatus = when {
-                shippingAddresses.shipTo.address.hasInfo().not() -> AddressStatus.MISSING_ADDRESS
-                shippingAddresses.shipTo.isVerified -> AddressStatus.VERIFIED
-                else -> AddressStatus.UNVERIFIED
-            }
 
             val destinationStatusModifier = if (destinationStatus == AddressStatus.MISSING_ADDRESS) {
                 Modifier.constrainAs(destinationAddressStatus) {
@@ -243,7 +238,8 @@ private fun AddressSectionPortraitPreview() {
                 ),
                 onEditDestinationAddress = {},
                 shipFromSelectionBottomSheetState = rememberModalBottomSheetState(ModalBottomSheetValue.Hidden),
-                isReadOnly = false
+                isReadOnly = false,
+                destinationStatus = AddressStatus.VERIFIED
             )
         }
     }
@@ -262,7 +258,8 @@ private fun AddressSectionPortraitMissingAddressPreview() {
                 ),
                 onEditDestinationAddress = {},
                 shipFromSelectionBottomSheetState = rememberModalBottomSheetState(ModalBottomSheetValue.Hidden),
-                isReadOnly = false
+                isReadOnly = false,
+                destinationStatus = AddressStatus.VERIFIED
             )
         }
     }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/address/AddressSection.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/address/AddressSection.kt
@@ -23,6 +23,8 @@ import androidx.compose.material.ModalBottomSheetValue
 import androidx.compose.material.Text
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.MoreHoriz
+import androidx.compose.material.icons.outlined.CheckCircleOutline
+import androidx.compose.material.icons.outlined.Info
 import androidx.compose.material.rememberModalBottomSheetState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.rememberCoroutineScope
@@ -36,6 +38,7 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
 import androidx.constraintlayout.compose.ConstraintLayout
 import androidx.constraintlayout.compose.Dimension
 import com.woocommerce.android.R
@@ -51,6 +54,7 @@ import com.woocommerce.android.ui.orders.wooshippinglabels.VerticalDivider
 import com.woocommerce.android.ui.orders.wooshippinglabels.WooShippingAddresses
 import com.woocommerce.android.ui.orders.wooshippinglabels.models.DestinationShippingAddress
 import com.woocommerce.android.ui.orders.wooshippinglabels.models.OriginShippingAddress
+import com.woocommerce.android.ui.orders.wooshippinglabels.purchased.successColor
 import com.woocommerce.android.ui.orders.wooshippinglabels.rates.ui.shippingSelectedBackgroundColor
 import com.woocommerce.android.ui.orders.wooshippinglabels.toShippingFromString
 import kotlinx.coroutines.launch
@@ -73,12 +77,38 @@ internal fun AddressSectionPortrait(
                 shipToLabel,
                 shipToValue,
                 shipToEdit,
-                divider
+                divider,
+                destinationAddressStatus
             ) = createRefs()
 
             val barrier = createEndBarrier(shipFromLabel, shipToLabel)
             val endBarrier = createStartBarrier(shipFromSelect)
             val scope = rememberCoroutineScope()
+
+            val destinationStatus = when {
+                shippingAddresses.shipTo.address.hasInfo().not() -> AddressStatus.MISSING_ADDRESS
+                shippingAddresses.shipTo.isVerified -> AddressStatus.VERIFIED
+                else -> AddressStatus.UNVERIFIED
+            }
+
+            val destinationStatusModifier = if (destinationStatus == AddressStatus.MISSING_ADDRESS) {
+                Modifier.constrainAs(destinationAddressStatus) {
+                    top.linkTo(divider.bottom)
+                    start.linkTo(shipToValue.start)
+                    bottom.linkTo(parent.bottom)
+                    end.linkTo(shipToEdit.start)
+                }
+            } else {
+                Modifier
+                    .padding(
+                        bottom = dimensionResource(R.dimen.major_100),
+                        start = dimensionResource(R.dimen.major_100)
+                    )
+                    .constrainAs(destinationAddressStatus) {
+                        top.linkTo(shipToValue.bottom)
+                        start.linkTo(shipToValue.start)
+                    }
+            }
 
             Text(
                 text = stringResource(id = R.string.orderdetail_shipping_label_item_shipfrom),
@@ -169,10 +199,14 @@ internal fun AddressSectionPortrait(
                     }
                     .padding(
                         top = dimensionResource(R.dimen.major_100),
-                        bottom = dimensionResource(R.dimen.major_100),
+                        bottom = dimensionResource(R.dimen.minor_100),
                         start = dimensionResource(R.dimen.major_100),
                         end = dimensionResource(R.dimen.minor_100)
                     )
+            )
+            AddressStatusIndicator(
+                addressStatus = destinationStatus,
+                modifier = destinationStatusModifier
             )
             if (isReadOnly.not()) {
                 IconButton(
@@ -205,6 +239,25 @@ private fun AddressSectionPortraitPreview() {
                 shippingAddresses = WooShippingAddresses(
                     shipFrom = getShipFrom(),
                     shipTo = getShipTo(),
+                    originAddresses = listOf(getShipFrom())
+                ),
+                onEditDestinationAddress = {},
+                shipFromSelectionBottomSheetState = rememberModalBottomSheetState(ModalBottomSheetValue.Hidden),
+                isReadOnly = false
+            )
+        }
+    }
+}
+
+@Preview
+@Composable
+private fun AddressSectionPortraitMissingAddressPreview() {
+    WooThemeWithBackground {
+        Box(modifier = Modifier.padding(dimensionResource(R.dimen.major_100))) {
+            AddressSectionPortrait(
+                shippingAddresses = WooShippingAddresses(
+                    shipFrom = getShipFrom(),
+                    shipTo = DestinationShippingAddress.EMPTY,
                     originAddresses = listOf(getShipFrom())
                 ),
                 onEditDestinationAddress = {},
@@ -248,34 +301,49 @@ internal fun AddressSectionLandscape(
                         )
                 )
 
-                Text(
-                    text = shippingAddresses.shipTo.address.toString(),
-                    modifier = Modifier
-                        .padding(
-                            top = dimensionResource(R.dimen.major_100),
-                            bottom = dimensionResource(R.dimen.major_100),
+                Column(modifier = Modifier.weight(1f)) {
+                    val destinationAddressStatusModifier = if (shippingAddresses.shipTo.address.hasInfo()) {
+                        Modifier.padding(
                             start = dimensionResource(R.dimen.major_100),
-                            end = dimensionResource(R.dimen.minor_100)
+                            bottom = dimensionResource(R.dimen.major_100)
                         )
-                        .weight(1f)
-                )
-
-                if (isReadOnly.not()) {
-                    val iconModifier = if (shippingAddresses.shipTo == Address.EMPTY) {
-                        Modifier
-                            .padding(end = dimensionResource(R.dimen.minor_100))
-                            .align(Alignment.CenterVertically)
                     } else {
-                        Modifier
-                            .padding(
-                                top = dimensionResource(R.dimen.minor_100),
-                                end = dimensionResource(R.dimen.minor_100)
-                            )
+                        Modifier.align(Alignment.CenterHorizontally)
+                            .padding(16.dp)
+                            .height(IntrinsicSize.Min)
                     }
 
+                    if (shippingAddresses.shipTo.address.hasInfo()) {
+                        Text(
+                            text = shippingAddresses.shipTo.address.toString(),
+                            modifier = Modifier
+                                .padding(
+                                    top = dimensionResource(R.dimen.major_100),
+                                    bottom = dimensionResource(R.dimen.minor_100),
+                                    start = dimensionResource(R.dimen.major_100),
+                                    end = dimensionResource(R.dimen.minor_100)
+                                )
+                        )
+                    }
+                    AddressStatusIndicator(
+                        addressStatus = when {
+                            shippingAddresses.shipTo.address.hasInfo().not() -> AddressStatus.MISSING_ADDRESS
+                            shippingAddresses.shipTo.isVerified -> AddressStatus.VERIFIED
+                            else -> AddressStatus.UNVERIFIED
+                        },
+                        modifier = destinationAddressStatusModifier
+                    )
+                }
+
+                if (isReadOnly.not()) {
                     IconButton(
                         onClick = { onEditDestinationAddress(shippingAddresses.shipTo) },
-                        modifier = iconModifier
+                        modifier = Modifier
+                            .padding(
+                                top = dimensionResource(R.dimen.minor_50),
+                                end = dimensionResource(R.dimen.minor_100),
+                                bottom = dimensionResource(R.dimen.minor_50)
+                            )
                     ) {
                         Icon(
                             painter = painterResource(id = R.drawable.ic_edit_pencil),
@@ -476,6 +544,61 @@ private fun AddressSectionLandscapePreview() {
     }
 }
 
+@Preview(widthDp = 750, heightDp = 100)
+@Composable
+private fun AddressSectionLandscapeMissingAddressPreview() {
+    WooThemeWithBackground {
+        Box(modifier = Modifier.padding(dimensionResource(R.dimen.major_100))) {
+            AddressSectionLandscape(
+                shippingAddresses = WooShippingAddresses(
+                    shipFrom = getShipFrom(),
+                    shipTo = DestinationShippingAddress.EMPTY,
+                    originAddresses = listOf(getShipFrom())
+                ),
+                shipFromSelectionBottomSheetState = rememberModalBottomSheetState(ModalBottomSheetValue.Hidden),
+                isReadOnly = false,
+                onEditDestinationAddress = {}
+            )
+        }
+    }
+}
+
+@Composable
+fun AddressStatusIndicator(
+    addressStatus: AddressStatus,
+    modifier: Modifier = Modifier
+) {
+    val text = when (addressStatus) {
+        AddressStatus.VERIFIED -> stringResource(id = R.string.woo_shipping_address_verified)
+        AddressStatus.UNVERIFIED -> stringResource(id = R.string.woo_shipping_address_unverified)
+        AddressStatus.MISSING_INFO -> stringResource(id = R.string.woo_shipping_address_missing_info)
+        AddressStatus.SAVE_CHANGES -> stringResource(id = R.string.woo_shipping_address_unsaved_changes)
+        AddressStatus.MISSING_ADDRESS -> stringResource(id = R.string.woo_shipping_address_missing)
+    }
+
+    val color = when (addressStatus) {
+        AddressStatus.VERIFIED -> MaterialTheme.colors.successColor
+        else -> MaterialTheme.colors.error
+    }
+
+    val icon = when (addressStatus) {
+        AddressStatus.VERIFIED -> Icons.Outlined.CheckCircleOutline
+        else -> Icons.Outlined.Info
+    }
+
+    Row(modifier) {
+        Icon(
+            imageVector = icon,
+            contentDescription = null,
+            tint = color,
+            modifier = Modifier.padding(end = 8.dp)
+        )
+        Text(
+            text = text,
+            color = color
+        )
+    }
+}
 internal fun getShipFrom() = OriginShippingAddress(
     firstName = "first name",
     lastName = "last name",

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/address/AddressSection.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/address/AddressSection.kt
@@ -271,6 +271,7 @@ internal fun AddressSectionLandscape(
     shippingAddresses: WooShippingAddresses,
     shipFromSelectionBottomSheetState: ModalBottomSheetState,
     onEditDestinationAddress: (DestinationShippingAddress) -> Unit,
+    destinationStatus: AddressStatus,
     modifier: Modifier = Modifier,
     isReadOnly: Boolean = false
 ) {
@@ -323,11 +324,7 @@ internal fun AddressSectionLandscape(
                         )
                     }
                     AddressStatusIndicator(
-                        addressStatus = when {
-                            shippingAddresses.shipTo.address.hasInfo().not() -> AddressStatus.MISSING_ADDRESS
-                            shippingAddresses.shipTo.isVerified -> AddressStatus.VERIFIED
-                            else -> AddressStatus.UNVERIFIED
-                        },
+                        addressStatus = destinationStatus,
                         modifier = destinationAddressStatusModifier
                     )
                 }
@@ -535,7 +532,8 @@ private fun AddressSectionLandscapePreview() {
                 ),
                 shipFromSelectionBottomSheetState = rememberModalBottomSheetState(ModalBottomSheetValue.Hidden),
                 isReadOnly = false,
-                onEditDestinationAddress = {}
+                onEditDestinationAddress = {},
+                destinationStatus = AddressStatus.VERIFIED
             )
         }
     }
@@ -554,7 +552,8 @@ private fun AddressSectionLandscapeMissingAddressPreview() {
                 ),
                 shipFromSelectionBottomSheetState = rememberModalBottomSheetState(ModalBottomSheetValue.Hidden),
                 isReadOnly = false,
-                onEditDestinationAddress = {}
+                onEditDestinationAddress = {},
+                destinationStatus = AddressStatus.VERIFIED
             )
         }
     }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/address/WooShippingEditAddressScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/address/WooShippingEditAddressScreen.kt
@@ -85,7 +85,6 @@ import com.woocommerce.android.ui.compose.theme.WooThemeWithBackground
 import com.woocommerce.android.ui.orders.wooshippinglabels.RoundedCornerBoxWithBorder
 import com.woocommerce.android.ui.orders.wooshippinglabels.ShipmentDetailsSectionTitle
 import com.woocommerce.android.ui.orders.wooshippinglabels.components.RoundedBorderDropDownWithLabel
-import com.woocommerce.android.ui.orders.wooshippinglabels.purchased.successColor
 import com.woocommerce.android.ui.orders.wooshippinglabels.rates.ui.shippingSelectedBackgroundColor
 import kotlinx.coroutines.launch
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/address/WooShippingEditAddressScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/address/WooShippingEditAddressScreen.kt
@@ -50,8 +50,6 @@ import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material.icons.filled.Add
 import androidx.compose.material.icons.filled.ArrowDropDown
 import androidx.compose.material.icons.filled.Close
-import androidx.compose.material.icons.outlined.CheckCircleOutline
-import androidx.compose.material.icons.outlined.Info
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.SheetState
@@ -87,7 +85,6 @@ import com.woocommerce.android.ui.compose.component.dismissWCModalBottomSheet
 import com.woocommerce.android.ui.compose.theme.WooThemeWithBackground
 import com.woocommerce.android.ui.orders.wooshippinglabels.RoundedCornerBoxWithBorder
 import com.woocommerce.android.ui.orders.wooshippinglabels.ShipmentDetailsSectionTitle
-import com.woocommerce.android.ui.orders.wooshippinglabels.purchased.successColor
 import com.woocommerce.android.ui.orders.wooshippinglabels.rates.ui.shippingSelectedBackgroundColor
 import kotlinx.coroutines.launch
 
@@ -462,28 +459,12 @@ internal fun AddressStatusSection(
         modifier = modifier,
         horizontalAlignment = Alignment.CenterHorizontally
     ) {
-        val text = when (addressStatus) {
-            AddressStatus.VERIFIED -> stringResource(id = R.string.woo_shipping_address_verified)
-            AddressStatus.UNVERIFIED -> stringResource(id = R.string.woo_shipping_address_unverified)
-            AddressStatus.MISSING_INFO -> stringResource(id = R.string.woo_shipping_address_missing_info)
-            AddressStatus.SAVE_CHANGES -> stringResource(id = R.string.woo_shipping_address_unsaved_changes)
-        }
-
-        val color = when (addressStatus) {
-            AddressStatus.VERIFIED -> MaterialTheme.colors.successColor
-            else -> MaterialTheme.colors.error
-        }
-
-        val icon = when (addressStatus) {
-            AddressStatus.VERIFIED -> Icons.Outlined.CheckCircleOutline
-            else -> Icons.Outlined.Info
-        }
-
         val buttonText = when (addressStatus) {
             AddressStatus.VERIFIED -> stringResource(id = R.string.close)
             AddressStatus.UNVERIFIED -> stringResource(id = R.string.woo_shipping_address_validate_and_save)
             AddressStatus.MISSING_INFO -> stringResource(id = R.string.woo_shipping_address_missing_info_hint)
             AddressStatus.SAVE_CHANGES -> stringResource(id = R.string.woo_shipping_address_save_changes)
+            AddressStatus.MISSING_ADDRESS -> ""
         }
 
         val buttonAction: () -> Unit = when (addressStatus) {
@@ -502,20 +483,15 @@ internal fun AddressStatusSection(
             AddressStatus.SAVE_CHANGES -> {
                 { onUpdateAddress(editableAddress) }
             }
+            AddressStatus.MISSING_ADDRESS -> {
+                {}
+            }
         }
 
-        Row(modifier = Modifier.padding(bottom = 16.dp)) {
-            Icon(
-                imageVector = icon,
-                contentDescription = null,
-                tint = color,
-                modifier = Modifier.padding(end = 8.dp)
-            )
-            Text(
-                text = text,
-                color = color
-            )
-        }
+        AddressStatusIndicator(
+            addressStatus = addressStatus,
+            modifier = Modifier.padding(bottom = 16.dp)
+        )
 
         WCColoredButton(
             onClick = buttonAction,

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/address/WooShippingEditAddressViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/address/WooShippingEditAddressViewModel.kt
@@ -804,6 +804,7 @@ sealed class EditAddressFlow : Parcelable {
 enum class AddressStatus {
     VERIFIED,
     UNVERIFIED,
+    MISSING_ADDRESS,
     MISSING_INFO,
     SAVE_CHANGES
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/purchased/WooShippingLabelPurchasedScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/purchased/WooShippingLabelPurchasedScreen.kt
@@ -58,6 +58,7 @@ import com.woocommerce.android.ui.orders.wooshippinglabels.RoundedCornerBoxWithB
 import com.woocommerce.android.ui.orders.wooshippinglabels.ShipmentDetails
 import com.woocommerce.android.ui.orders.wooshippinglabels.ShippableItemsUI
 import com.woocommerce.android.ui.orders.wooshippinglabels.ShippingProductsCard
+import com.woocommerce.android.ui.orders.wooshippinglabels.address.AddressStatus
 import com.woocommerce.android.ui.orders.wooshippinglabels.generateItems
 import kotlinx.coroutines.launch
 
@@ -126,7 +127,8 @@ internal fun WooShippingLabelPurchasedWithBottomSheetScreen(
                         }
                         true
                     },
-                    onEditDestinationAddress = {}
+                    onEditDestinationAddress = {},
+                    destinationStatus = AddressStatus.VERIFIED
                 )
             }
         },

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -4505,6 +4505,7 @@
     <string name="woo_shipping_address_verified">Address verified</string>
     <string name="woo_shipping_address_unverified">Unverified address</string>
     <string name="woo_shipping_address_missing_info">Missing information</string>
+    <string name="woo_shipping_address_missing">Missing address</string>
     <string name="woo_shipping_address_unsaved_changes">Unsaved changes</string>
     <string name="woo_shipping_verifying_address_failed">The address verification failed. Please try again.</string>
     <string name="woo_shipping_updating_address_failed">We couldn\'t update your address. Please try again.</string>


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Part of: #12440
<!-- Id number of the GitHub issue this PR addresses. -->

<!-- 
━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
🛠 Need an AI review?  
Add a comment: `@coderabbitai review`
━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
-->

### Description
This PR updates the UI to display the destination address status in the Shipment details section. The changes in this PR are focused only on UI.


### Testing information
TC1

1. Open the orders tab
2. Tap on an order eligible for shipping label creation without a shipping address
3. Tap on Create shipping label
4. Expand the Shipment details section
5. Check that the Missing address error is displayed

TC2

1. Open the orders tab
2. Tap on an order eligible for shipping label creation with an unverified shipping address
3. Tap on Create shipping label
4. Expand the Shipment details section
5. Check that the Unverified address error is displayed

TC3

1. Open the orders tab
2. Tap on an order eligible for shipping label creation with a verified shipping address
3. Tap on Create shipping label
4. Expand the Shipment details section
5. Check that the Verified address message is displayed

TC4
Check landscape

### The tests that have been performed
- The UI displays the address status

### Images/gif

https://github.com/user-attachments/assets/1c2774bf-b623-4a4b-b22b-5cd5e8807e03

- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.

## Reviewer (or Author, in the case of optional code reviews):

Please make sure these conditions are met before approving the PR, or request changes if the PR needs improvement:

- [ ] The PR is small and has a clear, single focus, or a valid explanation is provided in the description. If needed, please request to split it into smaller PRs.
- [ ] Ensure Adequate Unit Test Coverage: The changes are reasonably covered by unit tests or an explanation is provided in the PR description.
- [ ] Manual Testing: The author listed all the tests they ran, including smoke tests when needed (e.g., for refactorings). The reviewer confirmed that the PR works as expected on big (tablet) and small (phone) in case of UI changes, and no regressions are added.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->