### PR TITLE
[Shipping Labels Revamp] Connect customs form with creation form

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/WooShippingLabelCreationFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/WooShippingLabelCreationFragment.kt
@@ -18,6 +18,8 @@ import com.woocommerce.android.ui.main.AppBarStatus
 import com.woocommerce.android.ui.main.MainActivity.Companion.BackPressListener
 import com.woocommerce.android.ui.orders.wooshippinglabels.WooShippingLabelCreationViewModel.StartCustomsFormEdit
 import com.woocommerce.android.ui.orders.wooshippinglabels.WooShippingLabelCreationViewModel.StartPackageSelection
+import com.woocommerce.android.ui.orders.wooshippinglabels.customs.CustomsData
+import com.woocommerce.android.ui.orders.wooshippinglabels.customs.WooShippingCustomsFormFragment.Companion.CUSTOMS_DATA_RESULT
 import com.woocommerce.android.ui.orders.wooshippinglabels.packages.WooShippingLabelPackageCreationFragment.Companion.PACKAGE_SELECTION_RESULT
 import com.woocommerce.android.ui.orders.wooshippinglabels.packages.ui.PackageData
 import com.woocommerce.android.viewmodel.MultiLiveEvent
@@ -88,6 +90,10 @@ class WooShippingLabelCreationFragment : BaseFragment(), BackPressListener {
     private fun setupResultHandlers() {
         handleResult<PackageData>(PACKAGE_SELECTION_RESULT) {
             viewModel.onPackageSelected(it)
+        }
+
+        handleResult<CustomsData>(CUSTOMS_DATA_RESULT) {
+            viewModel.onCustomsDataAvailable(it)
         }
     }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/WooShippingLabelCreationFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/WooShippingLabelCreationFragment.kt
@@ -20,9 +20,9 @@ import com.woocommerce.android.ui.orders.wooshippinglabels.WooShippingLabelCreat
 import com.woocommerce.android.ui.orders.wooshippinglabels.WooShippingLabelCreationViewModel.StartPackageSelection
 import com.woocommerce.android.ui.orders.wooshippinglabels.address.EditAddressFlow
 import com.woocommerce.android.ui.orders.wooshippinglabels.address.WooShippingEditAddressFragment.Companion.DESTINATION_ADDRESS_UPDATE_RESULT
-import com.woocommerce.android.ui.orders.wooshippinglabels.models.DestinationShippingAddress
 import com.woocommerce.android.ui.orders.wooshippinglabels.customs.CustomsData
 import com.woocommerce.android.ui.orders.wooshippinglabels.customs.WooShippingCustomsFormFragment.Companion.CUSTOMS_DATA_RESULT
+import com.woocommerce.android.ui.orders.wooshippinglabels.models.DestinationShippingAddress
 import com.woocommerce.android.ui.orders.wooshippinglabels.packages.WooShippingLabelPackageCreationFragment.Companion.PACKAGE_SELECTION_RESULT
 import com.woocommerce.android.ui.orders.wooshippinglabels.packages.ui.PackageData
 import com.woocommerce.android.viewmodel.MultiLiveEvent

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/WooShippingLabelCreationFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/WooShippingLabelCreationFragment.kt
@@ -78,7 +78,8 @@ class WooShippingLabelCreationFragment : BaseFragment(), BackPressListener {
                 is StartCustomsFormEdit -> {
                     WooShippingLabelCreationFragmentDirections
                         .actionWooShippingLabelCreationFragmentToWooShippingLabelCustomsFormFragment(
-                            shippableItems = event.shippableItems.toTypedArray()
+                            shippableItems = event.shippableItems.toTypedArray(),
+                            customsData = event.customData
                         ).let { findNavController().navigateSafely(it) }
                 }
                 is MultiLiveEvent.Event.ShowSnackbar -> uiMessageResolver.showSnack(event.message)

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/WooShippingLabelCreationScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/WooShippingLabelCreationScreen.kt
@@ -424,9 +424,15 @@ private fun CustomsCard(
     modifier: Modifier = Modifier
 ) {
     val (backgroundColor, labelText) = if (customsState is Unavailable) {
-        Pair(colorResource(id = R.color.woo_red_20), stringResource(id = R.string.shipping_labels_customs_missing_info_badge))
+        Pair(
+            colorResource(id = R.color.woo_red_20),
+            stringResource(id = R.string.shipping_labels_customs_missing_info_badge)
+        )
     } else {
-        Pair(colorResource(id = R.color.woo_green_20), stringResource(id = R.string.shipping_labels_customs_completed_badge))
+        Pair(
+            colorResource(id = R.color.woo_green_20),
+            stringResource(id = R.string.shipping_labels_customs_completed_badge)
+        )
     }
 
     if (customsState !is NotRequired) {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/WooShippingLabelCreationScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/WooShippingLabelCreationScreen.kt
@@ -423,6 +423,12 @@ private fun CustomsCard(
     onEditCustomsClick: () -> Unit,
     modifier: Modifier = Modifier
 ) {
+    val (backgroundColor, labelText) = if (customsState is Unavailable) {
+        Pair(colorResource(id = R.color.woo_red_20), stringResource(id = R.string.shipping_labels_customs_missing_info_badge))
+    } else {
+        Pair(colorResource(id = R.color.woo_green_20), stringResource(id = R.string.shipping_labels_customs_completed_badge))
+    }
+
     if (customsState !is NotRequired) {
         Row(
             modifier = modifier
@@ -450,13 +456,13 @@ private fun CustomsCard(
             Box(
                 modifier = Modifier
                     .background(
-                        color = colorResource(id = R.color.woo_red_20),
+                        color = backgroundColor,
                         shape = RoundedCornerShape(dimensionResource(R.dimen.corner_radius_medium))
                     )
                     .align(Alignment.CenterVertically)
             ) {
                 Text(
-                    text = stringResource(id = R.string.shipping_labels_customs_missing_info_badge),
+                    text = labelText,
                     style = MaterialTheme.typography.caption,
                     color = MaterialTheme.colors.onSurface,
                     modifier = Modifier

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/WooShippingLabelCreationViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/WooShippingLabelCreationViewModel.kt
@@ -51,6 +51,8 @@ import kotlinx.coroutines.launch
 import kotlinx.parcelize.Parcelize
 import java.util.Date
 import javax.inject.Inject
+import kotlinx.coroutines.flow.filter
+import kotlinx.coroutines.flow.filterNotNull
 
 @HiltViewModel
 class WooShippingLabelCreationViewModel @Inject constructor(
@@ -250,6 +252,22 @@ class WooShippingLabelCreationViewModel @Inject constructor(
                 }
             }
             customsState.value = it
+        }
+
+        combine(
+            packageSelected.filterNotNull(),
+            customsState.filter { it is CustomsState.DataAvailable }
+        ) { packageSelected, customState ->
+            val customData = customState
+                .run { this as? CustomsState.DataAvailable }
+                ?.customsData?.copy(
+                    packageId = packageSelected.id,
+                    packageName = packageSelected.name
+                )
+
+            packageSelected.copy(customsData = customData)
+        }.collectLatest {
+            packageSelected.value = it
         }
     }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/WooShippingLabelCreationViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/WooShippingLabelCreationViewModel.kt
@@ -18,13 +18,11 @@ import com.woocommerce.android.ui.orders.wooshippinglabels.WooShippingLabelCreat
 import com.woocommerce.android.ui.orders.wooshippinglabels.WooShippingLabelCreationViewModel.CustomsState.Unavailable
 import com.woocommerce.android.ui.orders.wooshippinglabels.WooShippingLabelCreationViewModel.PackageSelectionState.DataAvailable
 import com.woocommerce.android.ui.orders.wooshippinglabels.WooShippingLabelCreationViewModel.PackageSelectionState.NotSelected
-import com.woocommerce.android.ui.orders.wooshippinglabels.address.FetchOriginAddresses
-import com.woocommerce.android.ui.orders.wooshippinglabels.address.ObserveOriginAddresses
-import com.woocommerce.android.ui.orders.wooshippinglabels.customs.CustomsData
 import com.woocommerce.android.ui.orders.wooshippinglabels.address.AddressStatus
 import com.woocommerce.android.ui.orders.wooshippinglabels.address.destination.VerifyDestinationAddress
 import com.woocommerce.android.ui.orders.wooshippinglabels.address.origin.FetchOriginAddresses
 import com.woocommerce.android.ui.orders.wooshippinglabels.address.origin.ObserveOriginAddresses
+import com.woocommerce.android.ui.orders.wooshippinglabels.customs.CustomsData
 import com.woocommerce.android.ui.orders.wooshippinglabels.customs.ShouldRequireCustomsForm
 import com.woocommerce.android.ui.orders.wooshippinglabels.models.DestinationShippingAddress
 import com.woocommerce.android.ui.orders.wooshippinglabels.models.OriginShippingAddress
@@ -602,7 +600,6 @@ class WooShippingLabelCreationViewModel @Inject constructor(
     data object StartPackageSelection : Event()
     data class LabelPurchased(val purchaseData: PurchasedShippingLabelData) : Event()
     data class StartOriginAddressEdit(val originAddress: OriginShippingAddress) : Event()
-    data class StartCustomsFormEdit(val shippableItems: List<ShippableItemModel>) : Event()
     data class StartDestinationAddressEdit(
         val destinationAddress: DestinationShippingAddress,
         val orderId: Long

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/WooShippingLabelCreationViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/WooShippingLabelCreationViewModel.kt
@@ -19,6 +19,7 @@ import com.woocommerce.android.ui.orders.wooshippinglabels.WooShippingLabelCreat
 import com.woocommerce.android.ui.orders.wooshippinglabels.WooShippingLabelCreationViewModel.PackageSelectionState.NotSelected
 import com.woocommerce.android.ui.orders.wooshippinglabels.address.FetchOriginAddresses
 import com.woocommerce.android.ui.orders.wooshippinglabels.address.ObserveOriginAddresses
+import com.woocommerce.android.ui.orders.wooshippinglabels.customs.CustomsData
 import com.woocommerce.android.ui.orders.wooshippinglabels.customs.ShouldRequireCustomsForm
 import com.woocommerce.android.ui.orders.wooshippinglabels.models.OriginShippingAddress
 import com.woocommerce.android.ui.orders.wooshippinglabels.models.ShippableItemModel
@@ -76,6 +77,7 @@ class WooShippingLabelCreationViewModel @Inject constructor(
     private val shippableItems = MutableStateFlow<List<ShippableItemModel>>(emptyList())
 
     private val packageSelected = MutableStateFlow<PackageData?>(null)
+    private val customsFormData = MutableStateFlow<CustomsData?>(null)
     private val packageWeight = MutableStateFlow<PackageWeight?>(null)
     private val packageSelection = MutableStateFlow<PackageSelectionState>(NotSelected)
     private val customsState = MutableStateFlow<CustomsState>(NotRequired)
@@ -142,10 +144,11 @@ class WooShippingLabelCreationViewModel @Inject constructor(
     private suspend fun observeShippingRates() {
         combine(
             packageSelected,
+            customsFormData,
             shippingAddresses,
             packageWeight,
             refreshShippingRates.onStart { emit(Unit) }
-        ) { selectedPackage, addresses, packageWeight, _ ->
+        ) { selectedPackage, customsData, addresses, packageWeight, _ ->
             if (
                 selectedPackage != null &&
                 addresses != null &&
@@ -154,7 +157,7 @@ class WooShippingLabelCreationViewModel @Inject constructor(
             ) {
                 ShippingRatesInfo(
                     orderId = navArgs.orderId,
-                    packageSelected = selectedPackage,
+                    packageSelected = selectedPackage.copy(customsData = customsData),
                     shipFrom = addresses.shipFrom,
                     shipTo = addresses.shipTo,
                     weight = packageWeight.totalWeight,
@@ -233,13 +236,22 @@ class WooShippingLabelCreationViewModel @Inject constructor(
     private suspend fun observeCustomsDataChanges() {
         combine(
             shippingAddresses,
+            customsFormData,
             customsState
-        ) { addresses, _ ->
+        ) { addresses, customsData, _ ->
             when {
+                customsData != null -> CustomsState.DataAvailable(customsData)
                 addresses != null && shouldRequireCustoms(addresses) -> Unavailable
                 else -> NotRequired
             }
-        }.collectLatest { customsState.value = it }
+        }.collectLatest {
+            if (it is CustomsState.DataAvailable) {
+                packageSelected.update { packageSelected ->
+                    packageSelected?.copy(customsData = it.customsData)
+                }
+            }
+            customsState.value = it
+        }
     }
 
     private suspend fun getShippingAddresses() {
@@ -609,6 +621,7 @@ class WooShippingLabelCreationViewModel @Inject constructor(
     sealed class CustomsState {
         data object NotRequired : CustomsState()
         data object Unavailable : CustomsState()
+        data class DataAvailable(val customsData: CustomsData) : CustomsState()
     }
 
     companion object {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/WooShippingLabelCreationViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/WooShippingLabelCreationViewModel.kt
@@ -518,7 +518,8 @@ class WooShippingLabelCreationViewModel @Inject constructor(
     }
 
     fun onEditCustomsClick() {
-        triggerEvent(StartCustomsFormEdit(shippableItems.value))
+        val event = StartCustomsFormEdit(shippableItems.value, customsFormData.value)
+        triggerEvent(event)
     }
 
     fun allowBackNavigation(): Boolean {
@@ -564,7 +565,10 @@ class WooShippingLabelCreationViewModel @Inject constructor(
     data object StartPackageSelection : Event()
     data class LabelPurchased(val purchaseData: PurchasedShippingLabelData) : Event()
     data class StartOriginAddressEdit(val originAddress: OriginShippingAddress) : Event()
-    data class StartCustomsFormEdit(val shippableItems: List<ShippableItemModel>) : Event()
+    data class StartCustomsFormEdit(
+        val shippableItems: List<ShippableItemModel>,
+        val customData: CustomsData?
+    ) : Event()
 
     sealed class WooShippingViewState {
         data object Error : WooShippingViewState()

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/WooShippingLabelCreationViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/WooShippingLabelCreationViewModel.kt
@@ -492,6 +492,10 @@ class WooShippingLabelCreationViewModel @Inject constructor(
         packageSelected.value = packageData
     }
 
+    fun onCustomsDataAvailable(customsData: CustomsData) {
+        customsFormData.value = customsData
+    }
+
     fun onCustomWeightChange(input: String) {
         customWeight = input
     }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/WooShippingLabelCreationViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/WooShippingLabelCreationViewModel.kt
@@ -44,6 +44,8 @@ import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.debounce
 import kotlinx.coroutines.flow.drop
+import kotlinx.coroutines.flow.filter
+import kotlinx.coroutines.flow.filterNotNull
 import kotlinx.coroutines.flow.onStart
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.joinAll
@@ -51,8 +53,6 @@ import kotlinx.coroutines.launch
 import kotlinx.parcelize.Parcelize
 import java.util.Date
 import javax.inject.Inject
-import kotlinx.coroutines.flow.filter
-import kotlinx.coroutines.flow.filterNotNull
 
 @HiltViewModel
 class WooShippingLabelCreationViewModel @Inject constructor(

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/WooShippingLabelCreationViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/WooShippingLabelCreationViewModel.kt
@@ -6,6 +6,7 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.setValue
 import androidx.compose.runtime.snapshotFlow
 import androidx.lifecycle.SavedStateHandle
+import androidx.lifecycle.viewModelScope
 import com.woocommerce.android.R
 import com.woocommerce.android.extensions.combine
 import com.woocommerce.android.extensions.formatToString
@@ -53,6 +54,8 @@ import kotlinx.coroutines.launch
 import kotlinx.parcelize.Parcelize
 import java.util.Date
 import javax.inject.Inject
+import kotlinx.coroutines.flow.launchIn
+import kotlinx.coroutines.flow.onEach
 
 @HiltViewModel
 class WooShippingLabelCreationViewModel @Inject constructor(
@@ -245,7 +248,9 @@ class WooShippingLabelCreationViewModel @Inject constructor(
                 addresses != null && shouldRequireCustoms(addresses) -> Unavailable
                 else -> NotRequired
             }
-        }.collectLatest { customsState.value = it }
+        }.onEach {
+            customsState.value = it
+        }.launchIn(viewModelScope)
 
         combine(
             packageSelected.filterNotNull(),
@@ -259,9 +264,9 @@ class WooShippingLabelCreationViewModel @Inject constructor(
                 )
 
             packageSelected.copy(customsData = customData)
-        }.collectLatest {
+        }.onEach {
             packageSelected.value = it
-        }
+        }.launchIn(viewModelScope)
     }
 
     private suspend fun getShippingAddresses() {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/WooShippingLabelCreationViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/WooShippingLabelCreationViewModel.kt
@@ -245,14 +245,7 @@ class WooShippingLabelCreationViewModel @Inject constructor(
                 addresses != null && shouldRequireCustoms(addresses) -> Unavailable
                 else -> NotRequired
             }
-        }.collectLatest {
-            if (it is CustomsState.DataAvailable) {
-                packageSelected.update { packageSelected ->
-                    packageSelected?.copy(customsData = it.customsData)
-                }
-            }
-            customsState.value = it
-        }
+        }.collectLatest { customsState.value = it }
 
         combine(
             packageSelected.filterNotNull(),

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/WooShippingLabelCreationViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/WooShippingLabelCreationViewModel.kt
@@ -144,11 +144,10 @@ class WooShippingLabelCreationViewModel @Inject constructor(
     private suspend fun observeShippingRates() {
         combine(
             packageSelected,
-            customsFormData,
             shippingAddresses,
             packageWeight,
             refreshShippingRates.onStart { emit(Unit) }
-        ) { selectedPackage, customsData, addresses, packageWeight, _ ->
+        ) { selectedPackage, addresses, packageWeight, _ ->
             if (
                 selectedPackage != null &&
                 addresses != null &&
@@ -157,7 +156,7 @@ class WooShippingLabelCreationViewModel @Inject constructor(
             ) {
                 ShippingRatesInfo(
                     orderId = navArgs.orderId,
-                    packageSelected = selectedPackage.copy(customsData = customsData),
+                    packageSelected = selectedPackage,
                     shipFrom = addresses.shipFrom,
                     shipTo = addresses.shipTo,
                     weight = packageWeight.totalWeight,

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/WooShippingLabelCreationViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/WooShippingLabelCreationViewModel.kt
@@ -47,6 +47,8 @@ import kotlinx.coroutines.flow.debounce
 import kotlinx.coroutines.flow.drop
 import kotlinx.coroutines.flow.filter
 import kotlinx.coroutines.flow.filterNotNull
+import kotlinx.coroutines.flow.launchIn
+import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.flow.onStart
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.joinAll
@@ -54,8 +56,6 @@ import kotlinx.coroutines.launch
 import kotlinx.parcelize.Parcelize
 import java.util.Date
 import javax.inject.Inject
-import kotlinx.coroutines.flow.launchIn
-import kotlinx.coroutines.flow.onEach
 
 @HiltViewModel
 class WooShippingLabelCreationViewModel @Inject constructor(

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/customs/WooShippingCustomsForm.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/customs/WooShippingCustomsForm.kt
@@ -2,6 +2,7 @@ package com.woocommerce.android.ui.orders.wooshippinglabels.customs
 
 import com.woocommerce.android.ui.orders.wooshippinglabels.customs.WooShippingCustomsFormViewModel.ContentType
 import com.woocommerce.android.ui.orders.wooshippinglabels.customs.WooShippingCustomsFormViewModel.RestrictionType
+import java.math.BigDecimal
 
 data class WooShippingCustomsForm(
     val packageId: String,
@@ -12,4 +13,15 @@ data class WooShippingCustomsForm(
     val restrictionDescription: String,
     val noDeliveryOption: Boolean,
     val itn: String,
+    val items: List<CustomsItem>
+)
+
+data class CustomsItem(
+    val productID: Long,
+    val description: String,
+    val quantity: Float,
+    val value: BigDecimal,
+    val weight: Float,
+    val hsTariffNumber: String,
+    val originCountry: String
 )

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/customs/WooShippingCustomsForm.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/customs/WooShippingCustomsForm.kt
@@ -8,7 +8,7 @@ import kotlinx.parcelize.Parcelize
 
 @Parcelize
 data class CustomsData(
-    val packageId: Long,
+    val packageId: String,
     val packageName: String,
     val contentType: ContentType,
     val contentDescription: String,

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/customs/WooShippingCustomsForm.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/customs/WooShippingCustomsForm.kt
@@ -8,7 +8,7 @@ import kotlinx.parcelize.Parcelize
 
 @Parcelize
 data class CustomsData(
-    val packageId: String,
+    val packageId: Long,
     val packageName: String,
     val contentType: ContentType,
     val contentDescription: String,

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/customs/WooShippingCustomsForm.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/customs/WooShippingCustomsForm.kt
@@ -1,0 +1,15 @@
+package com.woocommerce.android.ui.orders.wooshippinglabels.customs
+
+import com.woocommerce.android.ui.orders.wooshippinglabels.customs.WooShippingCustomsFormViewModel.ContentType
+import com.woocommerce.android.ui.orders.wooshippinglabels.customs.WooShippingCustomsFormViewModel.RestrictionType
+
+data class WooShippingCustomsForm(
+    val packageId: String,
+    val packageName: String,
+    val contentType: ContentType,
+    val contentDescription: String,
+    val restrictionType: RestrictionType,
+    val restrictionDescription: String,
+    val noDeliveryOption: Boolean,
+    val itn: String,
+)

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/customs/WooShippingCustomsForm.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/customs/WooShippingCustomsForm.kt
@@ -1,10 +1,13 @@
 package com.woocommerce.android.ui.orders.wooshippinglabels.customs
 
+import android.os.Parcelable
 import com.woocommerce.android.ui.orders.wooshippinglabels.customs.WooShippingCustomsFormViewModel.ContentType
 import com.woocommerce.android.ui.orders.wooshippinglabels.customs.WooShippingCustomsFormViewModel.RestrictionType
 import java.math.BigDecimal
+import kotlinx.parcelize.Parcelize
 
-data class WooShippingCustomsForm(
+@Parcelize
+data class CustomsData(
     val packageId: String,
     val packageName: String,
     val contentType: ContentType,
@@ -14,8 +17,9 @@ data class WooShippingCustomsForm(
     val noDeliveryOption: Boolean,
     val itn: String,
     val items: List<CustomsItem>
-)
+) : Parcelable
 
+@Parcelize
 data class CustomsItem(
     val productID: Long,
     val description: String,
@@ -24,4 +28,4 @@ data class CustomsItem(
     val weight: Float,
     val hsTariffNumber: String,
     val originCountry: String
-)
+) : Parcelable

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/customs/WooShippingCustomsForm.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/customs/WooShippingCustomsForm.kt
@@ -3,8 +3,8 @@ package com.woocommerce.android.ui.orders.wooshippinglabels.customs
 import android.os.Parcelable
 import com.woocommerce.android.ui.orders.wooshippinglabels.customs.WooShippingCustomsFormViewModel.ContentType
 import com.woocommerce.android.ui.orders.wooshippinglabels.customs.WooShippingCustomsFormViewModel.RestrictionType
-import java.math.BigDecimal
 import kotlinx.parcelize.Parcelize
+import java.math.BigDecimal
 
 @Parcelize
 data class CustomsData(

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/customs/WooShippingCustomsFormFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/customs/WooShippingCustomsFormFragment.kt
@@ -12,11 +12,13 @@ import androidx.navigation.fragment.findNavController
 import com.woocommerce.android.R
 import com.woocommerce.android.extensions.handleDialogResult
 import com.woocommerce.android.extensions.handleResult
+import com.woocommerce.android.extensions.navigateBackWithResult
 import com.woocommerce.android.extensions.navigateSafely
 import com.woocommerce.android.model.Location
 import com.woocommerce.android.ui.base.BaseFragment
 import com.woocommerce.android.ui.compose.theme.WooThemeWithBackground
 import com.woocommerce.android.ui.orders.wooshippinglabels.customs.WooShippingCustomsFormViewModel.ContentType
+import com.woocommerce.android.ui.orders.wooshippinglabels.customs.WooShippingCustomsFormViewModel.FinishCustomsForm
 import com.woocommerce.android.ui.orders.wooshippinglabels.customs.WooShippingCustomsFormViewModel.RestrictionType
 import com.woocommerce.android.ui.orders.wooshippinglabels.customs.WooShippingCustomsFormViewModel.ShowContentTypeDialog
 import com.woocommerce.android.ui.orders.wooshippinglabels.customs.WooShippingCustomsFormViewModel.ShowCountrySelector
@@ -73,6 +75,8 @@ class WooShippingCustomsFormFragment : BaseFragment() {
                 }
 
                 is ShowCountrySelector -> showCountrySearchScreen(event.countries)
+
+                is FinishCustomsForm -> navigateBackWithResult(CUSTOMS_DATA_RESULT, event.customData)
             }
         }
     }
@@ -135,5 +139,7 @@ class WooShippingCustomsFormFragment : BaseFragment() {
         const val SELECTOR_CONTENT_REQUEST_KEY = "label_customs_content_selector"
         const val SELECTOR_RESTRICTION_REQUEST_KEY = "label_customs_restriction_selector"
         const val SELECT_COUNTRY_REQUEST = "select_address_country_request"
+
+        const val CUSTOMS_DATA_RESULT = "customs_data_result"
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/customs/WooShippingCustomsFormScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/customs/WooShippingCustomsFormScreen.kt
@@ -223,6 +223,7 @@ fun PreviewWooShippingCustomsFormScreen() {
             shouldDisplayRestrictionTypeInput = false,
             shippingProducts = listOf(
                 WooShippingCustomsProductUIModel(
+                    productId = 0,
                     name = "Little Nap Brazil 250g",
                     description = InputValue.Data("Product Description"),
                     tariffNumber = InputValue.Data("123456"),
@@ -233,6 +234,7 @@ fun PreviewWooShippingCustomsFormScreen() {
                     isExpanded = false
                 ),
                 WooShippingCustomsProductUIModel(
+                    productId = 0,
                     name = "Little Nap Brazil 250g",
                     description = InputValue.Data("Product Description"),
                     tariffNumber = InputValue.Data("123456"),

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/customs/WooShippingCustomsFormViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/customs/WooShippingCustomsFormViewModel.kt
@@ -50,8 +50,12 @@ class WooShippingCustomsFormViewModel @Inject constructor(
 
     init {
         launch { loadCountries() }
-        val shippableProducts = navArgs.shippableItems.map { item -> item.toProductUIModel() }
-        _viewState.update { it.copy(shippingProducts = shippableProducts) }
+        navArgs.customsData?.let { customData ->
+            loadViewStateFromExistentCustomData(customData)
+        } ?: run {
+            val shippableProducts = navArgs.shippableItems.map { item -> item.toProductUIModel() }
+            _viewState.update { it.copy(shippingProducts = shippableProducts) }
+        }
         observeShippableItemsChanges()
     }
 
@@ -62,6 +66,32 @@ class WooShippingCustomsFormViewModel @Inject constructor(
             .onEach { (products, itnValue) ->
                 onITNChanged(itnValue.currentInput, products.isITNRequired)
             }.launchIn(viewModelScope)
+    }
+
+    private fun loadViewStateFromExistentCustomData(customData: CustomsData) {
+        _viewState.update {
+            it.copy(
+                contentType = customData.contentType,
+                otherContentInput = InputValue.Data(customData.contentDescription),
+                restrictionType = customData.restrictionType,
+                otherRestrictionInput = InputValue.Data(customData.restrictionDescription),
+                itnValue = InputValue.Data(customData.itn),
+                returnToSenderChecked = customData.noDeliveryOption,
+                shippingProducts = customData.items.map { item ->
+                    WooShippingCustomsProductUIModel(
+                        productId = item.productID,
+                        name = item.description,
+                        description = InputValue.Data(item.description),
+                        tariffNumber = InputValue.Data(item.hsTariffNumber),
+                        valuePerUnit = InputValue.Data(item.value.toString()),
+                        weightPerUnit = InputValue.Data(item.weight.toString()),
+                        originCountry = item.originCountry,
+                        quantity = item.quantity,
+                        isExpanded = false
+                    )
+                }
+            )
+        }
     }
 
     fun onContentTypeClick() {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/customs/WooShippingCustomsFormViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/customs/WooShippingCustomsFormViewModel.kt
@@ -296,7 +296,7 @@ class WooShippingCustomsFormViewModel @Inject constructor(
 
         val asCustomData: CustomsData
             get() = CustomsData(
-                packageId = 0,
+                packageId = "",
                 packageName = "",
                 contentType = contentType,
                 contentDescription = otherContentInput.currentInput,

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/customs/WooShippingCustomsFormViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/customs/WooShippingCustomsFormViewModel.kt
@@ -159,7 +159,7 @@ class WooShippingCustomsFormViewModel @Inject constructor(
                     errorMessageId = R.string.woo_shipping_labels_customs_itn_required_message
                 )
 
-            itnRegex.matches(newItnValue).not() ->
+            newItnValue.isNotBlank() && itnRegex.matches(newItnValue).not() ->
                 InputValue.Error(
                     input = newItnValue,
                     errorMessageId = R.string.woo_shipping_labels_customs_itn_error_message

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/customs/WooShippingCustomsFormViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/customs/WooShippingCustomsFormViewModel.kt
@@ -218,7 +218,7 @@ class WooShippingCustomsFormViewModel @Inject constructor(
     }
 
     fun onAddCustomsDataClick() {
-        triggerEvent(FinishCustomsForm)
+        _viewState.value.asCustomData.let { triggerEvent(FinishCustomsForm(it)) }
     }
 
     private fun updateShippingProductsAt(
@@ -243,6 +243,7 @@ class WooShippingCustomsFormViewModel @Inject constructor(
     }
 
     private fun ShippableItemModel.toProductUIModel() = WooShippingCustomsProductUIModel(
+        productId = productId,
         name = title,
         description = "".asInputValueError,
         tariffNumber = "".asInputValueError,
@@ -292,6 +293,19 @@ class WooShippingCustomsFormViewModel @Inject constructor(
                 (contentType != ContentType.OTHER || otherContentInput is InputValue.Data) &&
                 (restrictionType != RestrictionType.OTHER || otherRestrictionInput is InputValue.Data) &&
                 shippingProducts.all { it.isValid }
+
+        val asCustomData: CustomsData
+            get() = CustomsData(
+                packageId = 0,
+                packageName = "",
+                contentType = contentType,
+                contentDescription = otherContentInput.currentInput,
+                restrictionType = restrictionType,
+                restrictionDescription = otherRestrictionInput.currentInput,
+                itn = itnValue.currentInput,
+                noDeliveryOption = returnToSenderChecked,
+                items = shippingProducts.map { it.asCustomItem }
+            )
     }
 
     @Parcelize
@@ -334,7 +348,7 @@ class WooShippingCustomsFormViewModel @Inject constructor(
     data class ShowContentTypeDialog(val currentSelection: ContentType) : MultiLiveEvent.Event()
     data class ShowRestrictionTypeDialog(val currentSelection: RestrictionType) : MultiLiveEvent.Event()
     data class ShowCountrySelector(val countries: List<Location>) : MultiLiveEvent.Event()
-    object FinishCustomsForm : MultiLiveEvent.Event()
+    data class FinishCustomsForm(val customData: CustomsData) : MultiLiveEvent.Event()
 
     companion object {
         /**

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/customs/products/WooShippingCustomsProductListItem.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/customs/products/WooShippingCustomsProductListItem.kt
@@ -256,6 +256,7 @@ fun WooShippingCustomsProductListCollapsedItemPreview() {
         Box(Modifier.padding(16.dp)) {
             WooShippingCustomsProductListItem(
                 itemData = WooShippingCustomsProductUIModel(
+                    productId = 0,
                     name = "Little Nap Brazil 250g",
                     description = InputValue.Data("Coffee Beans"),
                     tariffNumber = InputValue.Data("HS 14-1"),
@@ -283,6 +284,7 @@ fun WooShippingCustomsProductListCollapsedItemErrorPreview() {
         Box(Modifier.padding(16.dp)) {
             WooShippingCustomsProductListItem(
                 itemData = WooShippingCustomsProductUIModel(
+                    productId = 0,
                     name = "Little Nap Brazil 250g",
                     description = InputValue.Error("Coffee Beans", 0),
                     tariffNumber = InputValue.Data("HS 14-1"),
@@ -310,6 +312,7 @@ fun WooShippingCustomsProductListExpandedItemPreview() {
         Box(Modifier.padding(16.dp)) {
             WooShippingCustomsProductListItem(
                 itemData = WooShippingCustomsProductUIModel(
+                    productId = 0,
                     name = "Little Nap Brazil 250g",
                     description = InputValue.Data("Coffee Beans"),
                     tariffNumber = InputValue.Data("HS 14-1"),
@@ -337,6 +340,7 @@ fun WooShippingCustomsProductListExpandedItemErrorPreview() {
         Box(Modifier.padding(16.dp)) {
             WooShippingCustomsProductListItem(
                 itemData = WooShippingCustomsProductUIModel(
+                    productId = 0,
                     name = "Little Nap Brazil 250g",
                     description = InputValue.Error("Coffee Beans", 0),
                     tariffNumber = InputValue.Error("HS 14-1", 0),

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/customs/products/WooShippingCustomsProductUIModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/customs/products/WooShippingCustomsProductUIModel.kt
@@ -1,11 +1,14 @@
 package com.woocommerce.android.ui.orders.wooshippinglabels.customs.products
 
 import android.os.Parcelable
+import com.woocommerce.android.ui.orders.wooshippinglabels.customs.CustomsItem
 import com.woocommerce.android.ui.orders.wooshippinglabels.customs.WooShippingCustomsFormViewModel.InputValue
+import java.math.BigDecimal
 import kotlinx.parcelize.Parcelize
 
 @Parcelize
 data class WooShippingCustomsProductUIModel(
+    val productId: Long,
     val name: String,
     val description: InputValue,
     val tariffNumber: InputValue,
@@ -32,4 +35,15 @@ data class WooShippingCustomsProductUIModel(
             ?.currentInput
             ?.toFloatOrNull()
             ?.let { it * quantity }
+
+    val asCustomItem: CustomsItem
+        get() = CustomsItem(
+            productID = productId,
+            description = description.currentInput,
+            hsTariffNumber = tariffNumber.currentInput,
+            value = valuePerUnit.currentInput.toBigDecimalOrNull() ?: BigDecimal.ZERO,
+            weight = weightPerUnit.currentInput.toFloatOrNull() ?: 0F,
+            originCountry = originCountry,
+            quantity = quantity
+        )
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/customs/products/WooShippingCustomsProductUIModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/customs/products/WooShippingCustomsProductUIModel.kt
@@ -3,8 +3,8 @@ package com.woocommerce.android.ui.orders.wooshippinglabels.customs.products
 import android.os.Parcelable
 import com.woocommerce.android.ui.orders.wooshippinglabels.customs.CustomsItem
 import com.woocommerce.android.ui.orders.wooshippinglabels.customs.WooShippingCustomsFormViewModel.InputValue
-import java.math.BigDecimal
 import kotlinx.parcelize.Parcelize
+import java.math.BigDecimal
 
 @Parcelize
 data class WooShippingCustomsProductUIModel(

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/packages/ui/UIModels.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/packages/ui/UIModels.kt
@@ -3,6 +3,7 @@ package com.woocommerce.android.ui.orders.wooshippinglabels.packages.ui
 import android.os.Parcelable
 import com.woocommerce.android.R
 import com.woocommerce.android.extensions.isNotNullOrEmpty
+import com.woocommerce.android.ui.orders.wooshippinglabels.customs.CustomsData
 import com.woocommerce.android.ui.orders.wooshippinglabels.packages.WooShippingLabelPackageCreationViewModel.PackageType
 import com.woocommerce.android.ui.orders.wooshippinglabels.packages.datasource.PackageDAO
 import kotlinx.parcelize.IgnoredOnParcel
@@ -19,7 +20,8 @@ data class PackageData(
     val isPredefined: Boolean = false,
     val dimensionUnit: String = "cm",
     val weightUnit: String = "kg",
-    val groupName: String? = null
+    val groupName: String? = null,
+    val customsData: CustomsData? = null
 ) : Parcelable {
     @IgnoredOnParcel
     val length: String

--- a/WooCommerce/src/main/res/navigation/nav_graph_orders.xml
+++ b/WooCommerce/src/main/res/navigation/nav_graph_orders.xml
@@ -755,6 +755,11 @@
             android:name="shippableItems"
             app:argType="com.woocommerce.android.ui.orders.wooshippinglabels.models.ShippableItemModel[]" />
 
+        <argument
+            android:name="customsData"
+            app:argType="com.woocommerce.android.ui.orders.wooshippinglabels.customs.CustomsData"
+            app:nullable="true"/>
+
         <action
             android:id="@+id/action_wooShippingLabelCustomsFormFragment_to_itemSelectorDialog"
             app:destination="@id/itemSelectorDialog" />

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/customs/WooShippingCustomsFormViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/customs/WooShippingCustomsFormViewModelTest.kt
@@ -75,7 +75,8 @@ class WooShippingCustomsFormViewModelTest : BaseUnitTest() {
 
         viewModel = WooShippingCustomsFormViewModel(
             savedState = WooShippingCustomsFormFragmentArgs(
-                shippableItems = arrayOf(testProduct, expensiveProduct)
+                shippableItems = arrayOf(testProduct, expensiveProduct),
+                customsData = null
             ).toSavedStateHandle(),
             getAcceptedOriginCountries = getAcceptedOriginCountries
         )


### PR DESCRIPTION
Summary
==========
Fix issue #13368 by connecting the Customs form with the main Creation form, making the Customs progression complete. 

⚠️ The networking part alongside the Creation form check to demand the Custom data to be available will be added in the next PR.

Screen Capture
==========
https://github.com/user-attachments/assets/fb23716e-05f2-408d-9d6a-6c94589f553e

How to Test
==========
In case you want to avoid having to fill the address data to access the Customs form, you can simply override the ShouldRequireCustomsForm use case always to return true to trigger the Customs data requirement forcefully.

1. Open the Shipping Labels Creation form
2, Click the edit button inside the Customs section
3. Once inside the Customs form, complete it until the submission button is enabled
4. Submit the Customs data, verify the Creation form is presented back again, now with the Completed label
5. Verify that clicking the edit button again moves to the Custom form, now with the data pre-filled

Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

## Reviewer (or Author, in the case of optional code reviews):

Please make sure these conditions are met before approving the PR, or request changes if the PR needs improvement:

- [ ] The PR is small and has a clear, single focus, or a valid explanation is provided in the description. If needed, please request to split it into smaller PRs.
- [ ] Ensure Adequate Unit Test Coverage: The changes are reasonably covered by unit tests or an explanation is provided in the PR description.
- [ ] Manual Testing: The author listed all the tests they ran, including smoke tests when needed (e.g., for refactorings). The reviewer confirmed that the PR works as expected on big (tablet) and small (phone) in case of UI changes, and no regressions are added.