### PR TITLE
[Shipping labels] Error handling for load shipping rates fails

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/packages/components/ErrorMessageWithButton.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/packages/components/ErrorMessageWithButton.kt
@@ -14,6 +14,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import com.woocommerce.android.R
@@ -41,6 +42,7 @@ fun ErrorMessageWithButton(
         Text(
             text = stringResource(message),
             style = MaterialTheme.typography.subtitle1,
+            textAlign = TextAlign.Center,
             color = MaterialTheme.colors.onSurface,
         )
         WCTextButton(onClick = onRetryClick) {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/packages/components/ErrorMessageWithButton.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/packages/components/ErrorMessageWithButton.kt
@@ -7,8 +7,6 @@ import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.size
-import androidx.compose.foundation.rememberScrollState
-import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.MaterialTheme
 import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
@@ -31,7 +29,6 @@ fun ErrorMessageWithButton(
     Column(
         modifier = modifier
             .fillMaxSize()
-            .verticalScroll(rememberScrollState())
             .background(MaterialTheme.colors.surface),
         horizontalAlignment = Alignment.CenterHorizontally,
         verticalArrangement = Arrangement.spacedBy(24.dp, Alignment.CenterVertically)

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/rates/ui/ShippingRatesSection.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/rates/ui/ShippingRatesSection.kt
@@ -1,16 +1,13 @@
 package com.woocommerce.android.ui.orders.wooshippinglabels.rates.ui
 
-import androidx.compose.foundation.layout.Arrangement
-import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.sizeIn
-import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
-import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
-import com.woocommerce.android.ui.compose.component.WCColoredButton
+import com.woocommerce.android.R
 import com.woocommerce.android.ui.orders.wooshippinglabels.WooShippingLabelCreationViewModel
+import com.woocommerce.android.ui.orders.wooshippinglabels.packages.components.ErrorMessageWithButton
 
 @Composable
 internal fun ShippingRatesSection(
@@ -31,20 +28,11 @@ internal fun ShippingRatesSection(
             )
         }
 
-        WooShippingLabelCreationViewModel.ShippingRatesState.Error -> {
-            Column(
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .sizeIn(minHeight = 300.dp),
-                horizontalAlignment = Alignment.CenterHorizontally,
-                verticalArrangement = Arrangement.Center
-            ) {
-                Text(text = "Error")
-                WCColoredButton(onClick = { onRefreshShippingRates() }) {
-                    Text(text = "Retry")
-                }
-            }
-        }
+        WooShippingLabelCreationViewModel.ShippingRatesState.Error -> ErrorMessageWithButton(
+            message = R.string.woo_shipping_labels_package_creation_shipping_rates_loading_error,
+            modifier = Modifier.sizeIn(minHeight = 300.dp),
+            onRetryClick = { onRefreshShippingRates() }
+        )
 
         is WooShippingLabelCreationViewModel.ShippingRatesState.Loading -> {
             ShippingRatesLoading(

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -4459,6 +4459,7 @@
     <string name="woo_shipping_labels_package_creation_error">Failed to load the package data</string>
     <string name="woo_shipping_labels_package_creation_carrier_loading_error">We are unable to load carrier packages.</string>
     <string name="woo_shipping_labels_package_creation_saved_loading_error">We are unable to load saved packages.</string>
+    <string name="woo_shipping_labels_package_creation_shipping_rates_loading_error">We are unable to load shipping rates.</string>
     <string name="woo_shipping_labels_package_creation_box_type">Box</string>
     <string name="woo_shipping_labels_package_creation_envelope_type">Envelope</string>
     <string name="woo_shipping_labels_package_creation_error_title">We couldn\'t save the package as template</string>


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #13327 
<!-- Id number of the GitHub issue this PR addresses. -->

<!-- 
━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
🛠 Need an AI review?  
Add a comment: `@coderabbitai review`
━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
-->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
This updates the error view for load shipping rates. 

### Steps to reproduce
<!-- Step-by-step testing instructions. For new user flows, consider instead stating the goal of the workflow and see if your PR reviewer can accomplish the workflow without specific steps! -->
#### To create fake error for loading shipping rates
1. Go to Menu → Settings → Developer Options → API Faker
2. Tap + button.
3. Enter these settings:
```
Type: WordPress REST API
HTTP Method: GET
Path: /wcshipping/v1/label/rate
Status Code: 500
```

#### Error view
1. Use a site that is eligible for shipping labels.
2. Go to orders.
3. Create a new order and complete the payment.
4. Open the order details and tap the "Create shipping label" button.
5. Tap the "Select a package button"
6. Add a package.
7. Verify that the error screen appears.
8. Tap "APIFaker Enabled" banner and disable APIFaker.
9. Tap the Retry button.
10. Verify that the error screen disappears.

### The tests that have been performed
<!-- To give the reviewer an idea of what could be missed in terms of testing -->
Steps above

### Images/gif
<!-- Include before and after images or gifs when appropriate. -->
|Network error|No internet|Large text|
|-|-|-|
|<img src="https://github.com/user-attachments/assets/bd3a582b-4afe-49d2-bcea-06771d1fcecc" width=360>|<img src="https://github.com/user-attachments/assets/fcadd3f0-3b81-48a1-beed-9aa9f36e287f" width=360>|<img src="https://github.com/user-attachments/assets/cbf96d4e-97eb-42c4-b103-dad09bb96134" width=360>|

- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.

## Reviewer (or Author, in the case of optional code reviews):

Please make sure these conditions are met before approving the PR, or request changes if the PR needs improvement:

- [ ] The PR is small and has a clear, single focus, or a valid explanation is provided in the description. If needed, please request to split it into smaller PRs.
- [ ] Ensure Adequate Unit Test Coverage: The changes are reasonably covered by unit tests or an explanation is provided in the PR description.
- [ ] Manual Testing: The author listed all the tests they ran, including smoke tests when needed (e.g., for refactorings). The reviewer confirmed that the PR works as expected on big (tablet) and small (phone) in case of UI changes, and no regressions are added.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->