### PR TITLE
[Jetpack Setup] Add networking layer for the Connection API 

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/jetpack/benefits/FetchJetpackStatus.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/jetpack/benefits/FetchJetpackStatus.kt
@@ -38,7 +38,7 @@ class FetchJetpackStatus @Inject constructor(
 
     @Suppress("ReturnCount", "NestedBlockDepth")
     suspend operator fun invoke(): Result<JetpackStatusFetchResponse> {
-        return jetpackStore.fetchJetpackUser(selectedSite.get(), useApplicationPasswords = true).let { userResult ->
+        return jetpackStore.fetchJetpackConnectionData(selectedSite.get(), useApplicationPasswords = true).let { userResult ->
             when {
                 userResult.error?.errorCode == FORBIDDEN_CODE -> {
                     Result.success(JetpackStatusFetchResponse.ConnectionForbidden)
@@ -76,8 +76,8 @@ class FetchJetpackStatus @Inject constructor(
                         JetpackStatusFetchResponse.Success(
                             JetpackStatus(
                                 isJetpackInstalled = isJetpackInstalled,
-                                isJetpackConnected = userResult.data!!.isConnected,
-                                wpComEmail = userResult.data!!.wpcomEmail.orNullIfEmpty()
+                                isJetpackConnected = userResult.data!!.currentUser.isConnected,
+                                wpComEmail = userResult.data!!.currentUser.wpcomEmail.orNullIfEmpty()
                             )
                         )
                     )

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/jetpack/benefits/FetchJetpackStatus.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/jetpack/benefits/FetchJetpackStatus.kt
@@ -38,7 +38,10 @@ class FetchJetpackStatus @Inject constructor(
 
     @Suppress("ReturnCount", "NestedBlockDepth")
     suspend operator fun invoke(): Result<JetpackStatusFetchResponse> {
-        return jetpackStore.fetchJetpackConnectionData(selectedSite.get(), useApplicationPasswords = true).let { userResult ->
+        return jetpackStore.fetchJetpackConnectionData(
+            site = selectedSite.get(),
+            useApplicationPasswords = true
+        ).let { userResult ->
             when {
                 userResult.error?.errorCode == FORBIDDEN_CODE -> {
                     Result.success(JetpackStatusFetchResponse.ConnectionForbidden)
@@ -66,6 +69,7 @@ class FetchJetpackStatus @Inject constructor(
                             pluginResult.isError -> {
                                 return Result.failure(OnChangedException(pluginResult.error))
                             }
+
                             else -> {
                                 pluginResult.model!!.any { it.slug == JETPACK_SLUG && it.isActive }
                             }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/accountmismatch/AccountMismatchRepository.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/accountmismatch/AccountMismatchRepository.kt
@@ -98,11 +98,11 @@ class AccountMismatchRepository @Inject constructor(
     }
 
     private suspend fun fetchJetpackUser(site: SiteModel): Result<JetpackUser?> {
-        return jetpackStore.fetchJetpackUser(site, useApplicationPasswords = false).let {
+        return jetpackStore.fetchJetpackConnectionData(site, useApplicationPasswords = false).let {
             if (it.isError) {
                 Result.failure(OnChangedException(it.error, it.error.message))
             } else {
-                Result.success(it.data)
+                Result.success(it.data?.currentUser)
             }
         }
     }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/jetpack/JetpackActivationRepository.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/jetpack/JetpackActivationRepository.kt
@@ -69,14 +69,17 @@ class JetpackActivationRepository @Inject constructor(
         useApplicationPasswords: Boolean
     ): Result<String> = runWithRetry {
         WooLog.d(WooLog.T.LOGIN, "Fetching email of Jetpack User")
-        val result = jetpackStore.fetchJetpackUser(site = site, useApplicationPasswords = useApplicationPasswords)
+        val result = jetpackStore.fetchJetpackConnectionData(
+            site = site,
+            useApplicationPasswords = useApplicationPasswords
+        )
         return@runWithRetry when {
             result.isError -> {
                 WooLog.w(WooLog.T.LOGIN, "Fetching Jetpack User failed error: $result.error.message")
                 Result.failure(OnChangedException(result.error, result.error.message))
             }
 
-            result.data?.wpcomEmail.isNullOrEmpty() -> {
+            result.data?.currentUser?.wpcomEmail.isNullOrEmpty() -> {
                 analyticsTrackerWrapper.track(
                     stat = AnalyticsEvent.LOGIN_JETPACK_SETUP_CANNOT_FIND_WPCOM_USER
                 )
@@ -86,7 +89,7 @@ class JetpackActivationRepository @Inject constructor(
 
             else -> {
                 WooLog.d(WooLog.T.LOGIN, "Jetpack User fetched successfully")
-                Result.success(result.data!!.wpcomEmail)
+                Result.success(result.data!!.currentUser.wpcomEmail)
             }
         }
     }

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/login/accountmismatch/AccountMismatchRepositoryTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/login/accountmismatch/AccountMismatchRepositoryTest.kt
@@ -11,6 +11,7 @@ import org.mockito.kotlin.eq
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.whenever
 import org.wordpress.android.fluxc.model.SiteModel
+import org.wordpress.android.fluxc.model.jetpack.JetpackConnectionData
 import org.wordpress.android.fluxc.model.jetpack.JetpackUser
 import org.wordpress.android.fluxc.store.JetpackStore
 import org.wordpress.android.fluxc.store.SiteStore
@@ -33,8 +34,8 @@ class AccountMismatchRepositoryTest : BaseUnitTest() {
 
     @Test
     fun `given a non-connected Jetpack Account, when fetching status, then return correct status`() = testBlocking {
-        whenever(jetpackStore.fetchJetpackUser(any(), eq(false)))
-            .thenReturn(JetpackStore.JetpackResult(createJetpackUser(isConnected = false)))
+        whenever(jetpackStore.fetchJetpackConnectionData(any(), eq(false)))
+            .thenReturn(JetpackStore.JetpackResult(createJetpackConnectionData(isConnected = false)))
 
         val result = sut.checkJetpackConnection(
             siteUrl = "https://example.com",
@@ -47,7 +48,7 @@ class AccountMismatchRepositoryTest : BaseUnitTest() {
 
     @Test
     fun `given a null jetpack user, when fetching connection status, then assume non-connected`() = testBlocking {
-        whenever(jetpackStore.fetchJetpackUser(any(), eq(false)))
+        whenever(jetpackStore.fetchJetpackConnectionData(any(), eq(false)))
             .thenReturn(JetpackStore.JetpackResult(null))
 
         val result = sut.checkJetpackConnection(
@@ -61,8 +62,8 @@ class AccountMismatchRepositoryTest : BaseUnitTest() {
 
     @Test
     fun `given a connected Jetpack Account, when fetching status, then return correct status`() = testBlocking {
-        whenever(jetpackStore.fetchJetpackUser(any(), eq(false)))
-            .thenReturn(JetpackStore.JetpackResult(createJetpackUser(isConnected = true, wpcomEmail = "email")))
+        whenever(jetpackStore.fetchJetpackConnectionData(any(), eq(false)))
+            .thenReturn(JetpackStore.JetpackResult(createJetpackConnectionData(isConnected = true, wpcomEmail = "email")))
 
         val result = sut.checkJetpackConnection(
             siteUrl = "https://example.com",
@@ -76,8 +77,8 @@ class AccountMismatchRepositoryTest : BaseUnitTest() {
 
     @Test
     fun `given a correctly connected Jetpack account, when fetching email, then return it`() = testBlocking {
-        whenever(jetpackStore.fetchJetpackUser(any(), eq(false)))
-            .thenReturn(JetpackStore.JetpackResult(createJetpackUser(isConnected = true, wpcomEmail = "email")))
+        whenever(jetpackStore.fetchJetpackConnectionData(any(), eq(false)))
+            .thenReturn(JetpackStore.JetpackResult(createJetpackConnectionData(isConnected = true, wpcomEmail = "email")))
 
         val result = sut.fetchJetpackConnectedEmail(SiteModel())
 
@@ -86,23 +87,27 @@ class AccountMismatchRepositoryTest : BaseUnitTest() {
 
     @Test
     fun `given an issue with Jetpack account, when fetching email, then return error`() = testBlocking {
-        whenever(jetpackStore.fetchJetpackUser(any(), eq(false)))
-            .thenReturn(JetpackStore.JetpackResult(createJetpackUser(isConnected = true, wpcomEmail = "")))
+        whenever(jetpackStore.fetchJetpackConnectionData(any(), eq(false)))
+            .thenReturn(JetpackStore.JetpackResult(createJetpackConnectionData(isConnected = true, wpcomEmail = "")))
 
         val result = sut.fetchJetpackConnectedEmail(SiteModel())
 
         assertThat(result.isFailure).isTrue()
     }
 
-    private fun createJetpackUser(
+    private fun createJetpackConnectionData(
         isConnected: Boolean = false,
         wpcomEmail: String = ""
-    ) = JetpackUser(
-        isConnected = isConnected,
-        wpcomEmail = wpcomEmail,
-        isMaster = false,
-        username = "username",
-        wpcomId = 1L,
-        wpcomUsername = "wpcomUsername"
+    ) = JetpackConnectionData(
+        currentUser = JetpackUser(
+            isConnected = isConnected,
+            wpcomEmail = wpcomEmail,
+            isMaster = false,
+            username = "username",
+            wpcomId = 1L,
+            wpcomUsername = "wpcomUsername"
+        ),
+        isSiteRegistered = null,
+        blogId = 1L
     )
 }

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/login/accountmismatch/AccountMismatchRepositoryTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/login/accountmismatch/AccountMismatchRepositoryTest.kt
@@ -108,6 +108,7 @@ class AccountMismatchRepositoryTest : BaseUnitTest() {
             wpcomUsername = "wpcomUsername"
         ),
         isSiteRegistered = null,
-        blogId = 1L
+        blogId = 1L,
+        connectionOwner = null
     )
 }

--- a/libs/fluxc-processor/src/main/resources/jp-api-endpoints.txt
+++ b/libs/fluxc-processor/src/main/resources/jp-api-endpoints.txt
@@ -1,4 +1,5 @@
 /module/stats/active
 /connection/url
 /connection/data
+/connection/register
 /jitm

--- a/libs/fluxc-processor/src/main/resources/jp-api-endpoints.txt
+++ b/libs/fluxc-processor/src/main/resources/jp-api-endpoints.txt
@@ -2,4 +2,5 @@
 /connection/url
 /connection/data
 /connection/register
+/remote_provision
 /jitm

--- a/libs/fluxc-processor/src/main/resources/wp-com-v2-endpoints.txt
+++ b/libs/fluxc-processor/src/main/resources/wp-com-v2-endpoints.txt
@@ -79,3 +79,5 @@
 /jetpack-ai-transcription
 /jetpack-ai-query
 /sites/$site/jetpack-ai/ai-assistant-feature
+
+/sites/$site/jetpack-remote-connect-user

--- a/libs/fluxc-tests/src/test/java/org/wordpress/android/fluxc/store/JetpackStoreTest.kt
+++ b/libs/fluxc-tests/src/test/java/org/wordpress/android/fluxc/store/JetpackStoreTest.kt
@@ -1,13 +1,19 @@
 package org.wordpress.android.fluxc.store
 
-import org.junit.Ignore
+import kotlinx.coroutines.runBlocking
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.runner.RunWith
 import org.mockito.Mockito.mock
+import org.mockito.junit.MockitoJUnitRunner
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
 import org.wordpress.android.fluxc.model.SiteModel
+import org.wordpress.android.fluxc.network.rest.wpapi.jetpack.JetpackConnectionProvisionResponse
 import org.wordpress.android.fluxc.network.rest.wpapi.jetpack.JetpackWPAPIRestClient
 import org.wordpress.android.fluxc.tools.initCoroutineEngine
 import kotlin.test.Test
 
-@Suppress("unused")
+@RunWith(MockitoJUnitRunner::class)
 class JetpackStoreTest {
     private val jetpackWPAPIRestClient: JetpackWPAPIRestClient = mock()
     private val site: SiteModel = SiteModel()
@@ -18,9 +24,37 @@ class JetpackStoreTest {
     )
 
     @Test
-    @Ignore("Empty test to keep JUnit happy, we'll add real tests later")
-    @Suppress("EmptyFunctionBlock")
-    fun `empty test to keep JUnit happy`() {
+    fun `when registerSite is called, then call jetpackWPAPIRestClient`() {
+        runBlocking {
+            whenever(jetpackWPAPIRestClient.registerSite(site, useApplicationPasswords = true))
+                .thenReturn(JetpackWPAPIRestClient.JetpackWPAPIPayload(1L))
 
+            val result = jetpackStore.registerSite(site, useApplicationPasswords = true)
+
+            verify(jetpackWPAPIRestClient).registerSite(site, useApplicationPasswords = true)
+            assertThat(result).isEqualTo(JetpackStore.JetpackResult(1L))
+        }
+    }
+
+    @Test
+    fun `when connectJetpackAccount is called, then call jetpackWPAPIRestClient`() {
+        runBlocking {
+            val blogId = 1L
+            val provisionResponse = JetpackConnectionProvisionResponse(
+                userId = 1L,
+                secret = "secret",
+                scope = "scope"
+            )
+            whenever(jetpackWPAPIRestClient.provisionConnection(site, useApplicationPasswords = true))
+                .thenReturn(JetpackWPAPIRestClient.JetpackWPAPIPayload(provisionResponse))
+            whenever(jetpackWPAPIRestClient.connectJetpackAccount(site, blogId, provisionResponse))
+                .thenReturn(JetpackWPAPIRestClient.JetpackWPAPIPayload(Unit))
+
+            val result = jetpackStore.connectJetpackAccount(site, blogId = blogId, useApplicationPasswords = true)
+
+            verify(jetpackWPAPIRestClient).provisionConnection(site, useApplicationPasswords = true)
+            verify(jetpackWPAPIRestClient).connectJetpackAccount(site, blogId, provisionResponse)
+            assertThat(result).isEqualTo(JetpackStore.JetpackResult(Unit))
+        }
     }
 }

--- a/libs/fluxc/src/main/java/org/wordpress/android/fluxc/model/jetpack/JetpackConnectionData.kt
+++ b/libs/fluxc/src/main/java/org/wordpress/android/fluxc/model/jetpack/JetpackConnectionData.kt
@@ -5,6 +5,7 @@ data class JetpackConnectionData(
     val currentUser: JetpackUser,
     val blogId: Long?,
     val isSiteRegistered: Boolean?,
+    val connectionOwner: String?
 )
 
 data class JetpackUser(

--- a/libs/fluxc/src/main/java/org/wordpress/android/fluxc/model/jetpack/JetpackConnectionData.kt
+++ b/libs/fluxc/src/main/java/org/wordpress/android/fluxc/model/jetpack/JetpackConnectionData.kt
@@ -1,5 +1,12 @@
 package org.wordpress.android.fluxc.model.jetpack
 
+
+data class JetpackConnectionData(
+    val currentUser: JetpackUser,
+    val blogId: Long?,
+    val isSiteRegistered: Boolean?,
+)
+
 data class JetpackUser(
     val isConnected: Boolean,
     val isMaster: Boolean,

--- a/libs/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpapi/jetpack/JetpackConnectionApiResponses.kt
+++ b/libs/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpapi/jetpack/JetpackConnectionApiResponses.kt
@@ -29,3 +29,8 @@ data class WpcomUser(
 data class JetpackConnectionRegisterResponse(
     val authorizeUrl: String
 )
+
+data class JetpackConnectionProvisionResponse(
+    val scope: String,
+    val secret: String,
+)

--- a/libs/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpapi/jetpack/JetpackConnectionApiResponses.kt
+++ b/libs/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpapi/jetpack/JetpackConnectionApiResponses.kt
@@ -25,3 +25,7 @@ data class WpcomUser(
     @SerializedName("jetpack_connect") val jetpackConnect: String?,
     @SerializedName("avatar") val avatar: String?
 )
+
+data class JetpackConnectionRegisterResponse(
+    val authorizeUrl: String
+)

--- a/libs/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpapi/jetpack/JetpackConnectionApiResponses.kt
+++ b/libs/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpapi/jetpack/JetpackConnectionApiResponses.kt
@@ -1,15 +1,18 @@
 package org.wordpress.android.fluxc.network.rest.wpapi.jetpack
 
+import com.google.gson.JsonPrimitive
 import com.google.gson.annotations.SerializedName
 
 data class JetpackConnectionDataResponse(
-    val currentUser: CurrentUser
+    @SerializedName("isRegistered") val isRegistered: Boolean?,
+    @SerializedName("currentUser") val currentUser: CurrentUser
 )
 
 data class CurrentUser(
     @SerializedName("isConnected") val isConnected: Boolean?,
     @SerializedName("isMaster") val isMaster: Boolean?,
     @SerializedName("username") val username: String?,
+    @SerializedName("blogId") val blogId: JsonPrimitive?,
     @SerializedName("wpcomUser") val wpcomUser: WpcomUser?,
     @SerializedName("gravatar") val gravatar: String?,
     @SerializedName("permissions") val permissions: Map<String, Boolean>?

--- a/libs/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpapi/jetpack/JetpackConnectionApiResponses.kt
+++ b/libs/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpapi/jetpack/JetpackConnectionApiResponses.kt
@@ -31,6 +31,7 @@ data class JetpackConnectionRegisterResponse(
 )
 
 data class JetpackConnectionProvisionResponse(
+    @SerializedName("user_id") val userId: Long,
     val scope: String,
     val secret: String,
 )

--- a/libs/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpapi/jetpack/JetpackConnectionApiResponses.kt
+++ b/libs/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpapi/jetpack/JetpackConnectionApiResponses.kt
@@ -5,7 +5,8 @@ import com.google.gson.annotations.SerializedName
 
 data class JetpackConnectionDataResponse(
     @SerializedName("isRegistered") val isRegistered: Boolean?,
-    @SerializedName("currentUser") val currentUser: CurrentUser
+    @SerializedName("currentUser") val currentUser: CurrentUser,
+    @SerializedName("connectionOwner") val connectionOwner: String?
 )
 
 data class CurrentUser(

--- a/libs/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpapi/jetpack/JetpackWPAPIRestClient.kt
+++ b/libs/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpapi/jetpack/JetpackWPAPIRestClient.kt
@@ -9,6 +9,7 @@ import org.wordpress.android.fluxc.Payload
 import org.wordpress.android.fluxc.generated.endpoint.JPAPI
 import org.wordpress.android.fluxc.generated.endpoint.WPCOMV2
 import org.wordpress.android.fluxc.model.SiteModel
+import org.wordpress.android.fluxc.model.jetpack.JetpackConnectionData
 import org.wordpress.android.fluxc.model.jetpack.JetpackUser
 import org.wordpress.android.fluxc.network.BaseRequest
 import org.wordpress.android.fluxc.network.BaseRequest.BaseNetworkError
@@ -91,10 +92,10 @@ class JetpackWPAPIRestClient @Inject constructor(
         }
     }
 
-    suspend fun fetchJetpackUser(
+    suspend fun fetchJetpackConnectionData(
         site: SiteModel,
         useApplicationPasswords: Boolean = false
-    ): JetpackWPAPIPayload<JetpackUser> {
+    ): JetpackWPAPIPayload<JetpackConnectionData> {
         val response = makeGetWPAPIRequest<JetpackConnectionDataResponse>(
             site = site,
             path = JPAPI.connection.data.pathV4,
@@ -103,7 +104,7 @@ class JetpackWPAPIRestClient @Inject constructor(
 
         return when (response) {
             is Success<JetpackConnectionDataResponse> -> JetpackWPAPIPayload(
-                response.data?.toJetpackUser()
+                    response.data?.toDomainModel()
             )
 
             is Error -> JetpackWPAPIPayload(response.error)
@@ -243,14 +244,18 @@ class JetpackWPAPIRestClient @Inject constructor(
         }
     }
 
-    private fun JetpackConnectionDataResponse.toJetpackUser(): JetpackUser {
-        return JetpackUser(
-            isConnected = currentUser.isConnected ?: false,
-            isMaster = currentUser.isMaster ?: false,
-            username = currentUser.username.orEmpty(),
-            wpcomEmail = currentUser.wpcomUser?.email.orEmpty(),
-            wpcomId = currentUser.wpcomUser?.id ?: 0L,
-            wpcomUsername = currentUser.wpcomUser?.login.orEmpty()
+    private fun JetpackConnectionDataResponse.toDomainModel(): JetpackConnectionData {
+        return JetpackConnectionData(
+            isSiteRegistered = isRegistered,
+            blogId = currentUser.blogId?.let { if (it.isNumber) it.asLong else null },
+            currentUser = JetpackUser(
+                isConnected = currentUser.isConnected ?: false,
+                isMaster = currentUser.isMaster ?: false,
+                username = currentUser.username.orEmpty(),
+                wpcomEmail = currentUser.wpcomUser?.email.orEmpty(),
+                wpcomId = currentUser.wpcomUser?.id ?: 0L,
+                wpcomUsername = currentUser.wpcomUser?.login.orEmpty()
+            )
         )
     }
 

--- a/libs/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpapi/jetpack/JetpackWPAPIRestClient.kt
+++ b/libs/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpapi/jetpack/JetpackWPAPIRestClient.kt
@@ -99,7 +99,7 @@ class JetpackWPAPIRestClient @Inject constructor(
 
         return when (response) {
             is Success<JetpackConnectionDataResponse> -> JetpackWPAPIPayload(
-                    response.data?.toJetpackUser()
+                response.data?.toJetpackUser()
             )
 
             is Error -> JetpackWPAPIPayload(response.error)
@@ -111,7 +111,10 @@ class JetpackWPAPIRestClient @Inject constructor(
      *
      * @return a [JetpackWPAPIPayload] with the blog_id of the site
      */
-    suspend fun registerSite(site: SiteModel, useApplicationPasswords: Boolean): JetpackWPAPIPayload<Long> {
+    suspend fun registerSite(
+        site: SiteModel,
+        useApplicationPasswords: Boolean
+    ): JetpackWPAPIPayload<Long> {
         val response = makePostWPAPIRequest<JetpackConnectionRegisterResponse>(
             site = site,
             path = JPAPI.connection.register.pathV4,
@@ -124,7 +127,8 @@ class JetpackWPAPIRestClient @Inject constructor(
 
         return when (response) {
             is Success<JetpackConnectionRegisterResponse> -> {
-                val blogId = response.data?.authorizeUrl?.toHttpUrl()?.queryParameter("client_id")?.toLong()
+                val blogId =
+                    response.data?.authorizeUrl?.toHttpUrl()?.queryParameter("client_id")?.toLong()
 
                 if (blogId == null) {
                     JetpackWPAPIPayload(
@@ -136,6 +140,26 @@ class JetpackWPAPIRestClient @Inject constructor(
                 } else {
                     JetpackWPAPIPayload(blogId)
                 }
+            }
+
+            is Error -> JetpackWPAPIPayload(response.error)
+        }
+    }
+
+    suspend fun provisionConnection(
+        site: SiteModel,
+        useApplicationPasswords: Boolean
+    ): JetpackWPAPIPayload<JetpackConnectionProvisionResponse> {
+        val response = makePostWPAPIRequest<JetpackConnectionProvisionResponse>(
+            site = site,
+            path = JPAPI.remote_provision.pathV4,
+            body = emptyMap(),
+            useApplicationPasswords = useApplicationPasswords
+        )
+
+        return when (response) {
+            is Success<JetpackConnectionProvisionResponse> -> {
+                JetpackWPAPIPayload(response.data)
             }
 
             is Error -> JetpackWPAPIPayload(response.error)

--- a/libs/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpapi/jetpack/JetpackWPAPIRestClient.kt
+++ b/libs/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpapi/jetpack/JetpackWPAPIRestClient.kt
@@ -7,6 +7,7 @@ import okhttp3.HttpUrl.Companion.toHttpUrl
 import org.wordpress.android.fluxc.Dispatcher
 import org.wordpress.android.fluxc.Payload
 import org.wordpress.android.fluxc.generated.endpoint.JPAPI
+import org.wordpress.android.fluxc.generated.endpoint.WPCOMV2
 import org.wordpress.android.fluxc.model.SiteModel
 import org.wordpress.android.fluxc.model.jetpack.JetpackUser
 import org.wordpress.android.fluxc.network.BaseRequest
@@ -20,6 +21,8 @@ import org.wordpress.android.fluxc.network.rest.wpapi.WPAPIResponse
 import org.wordpress.android.fluxc.network.rest.wpapi.WPAPIResponse.Error
 import org.wordpress.android.fluxc.network.rest.wpapi.WPAPIResponse.Success
 import org.wordpress.android.fluxc.network.rest.wpapi.applicationpasswords.ApplicationPasswordsNetwork
+import org.wordpress.android.fluxc.network.rest.wpcom.WPComGsonRequestBuilder
+import org.wordpress.android.fluxc.network.rest.wpcom.WPComNetwork
 import javax.inject.Inject
 import javax.inject.Named
 import javax.inject.Singleton
@@ -30,6 +33,7 @@ class JetpackWPAPIRestClient @Inject constructor(
     private val wpApiGsonRequestBuilder: WPAPIGsonRequestBuilder,
     private val cookieNonceAuthenticator: CookieNonceAuthenticator,
     private val applicationPasswordsNetwork: ApplicationPasswordsNetwork,
+    private val wpComNetwork: WPComNetwork,
     dispatcher: Dispatcher,
     @Named("custom-ssl") requestQueue: RequestQueue,
     @Named("no-redirects") private val noRedirectsRequestQueue: RequestQueue,
@@ -163,6 +167,28 @@ class JetpackWPAPIRestClient @Inject constructor(
             }
 
             is Error -> JetpackWPAPIPayload(response.error)
+        }
+    }
+
+    suspend fun connectJetpackAccount(
+        site: SiteModel,
+        blogId: Long,
+        provisioningParams: JetpackConnectionProvisionResponse
+    ): JetpackWPAPIPayload<Unit> {
+        val response = wpComNetwork.executePostGsonRequest(
+            url = WPCOMV2.sites.site(blogId).jetpack_remote_connect_user.url,
+            body = mapOf(
+                "redirect_uri" to site.url,
+                "secret" to provisioningParams.secret,
+                "scope" to provisioningParams.scope,
+                "external_user_id" to provisioningParams.userId
+            ),
+            clazz = Unit::class.java
+        )
+
+        return when (response) {
+            is WPComGsonRequestBuilder.Response.Success<Unit> -> JetpackWPAPIPayload(Unit)
+            is WPComGsonRequestBuilder.Response.Error -> JetpackWPAPIPayload(response.error)
         }
     }
 

--- a/libs/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpapi/jetpack/JetpackWPAPIRestClient.kt
+++ b/libs/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpapi/jetpack/JetpackWPAPIRestClient.kt
@@ -3,11 +3,13 @@ package org.wordpress.android.fluxc.network.rest.wpapi.jetpack
 import com.android.volley.Request
 import com.android.volley.RequestQueue
 import kotlinx.coroutines.suspendCancellableCoroutine
+import okhttp3.HttpUrl.Companion.toHttpUrl
 import org.wordpress.android.fluxc.Dispatcher
 import org.wordpress.android.fluxc.Payload
 import org.wordpress.android.fluxc.generated.endpoint.JPAPI
 import org.wordpress.android.fluxc.model.SiteModel
 import org.wordpress.android.fluxc.model.jetpack.JetpackUser
+import org.wordpress.android.fluxc.network.BaseRequest
 import org.wordpress.android.fluxc.network.BaseRequest.BaseNetworkError
 import org.wordpress.android.fluxc.network.RawRequest
 import org.wordpress.android.fluxc.network.UserAgent
@@ -37,7 +39,7 @@ class JetpackWPAPIRestClient @Inject constructor(
         site: SiteModel,
         useApplicationPasswords: Boolean = false
     ): JetpackWPAPIPayload<String> {
-        val response = makeWPAPIRequest<String>(
+        val response = makeGetWPAPIRequest<String>(
             site = site,
             path = JPAPI.connection.url.pathV4,
             useApplicationPasswords = useApplicationPasswords
@@ -89,7 +91,7 @@ class JetpackWPAPIRestClient @Inject constructor(
         site: SiteModel,
         useApplicationPasswords: Boolean = false
     ): JetpackWPAPIPayload<JetpackUser> {
-        val response = makeWPAPIRequest<JetpackConnectionDataResponse>(
+        val response = makeGetWPAPIRequest<JetpackConnectionDataResponse>(
             site = site,
             path = JPAPI.connection.data.pathV4,
             useApplicationPasswords = useApplicationPasswords
@@ -104,7 +106,43 @@ class JetpackWPAPIRestClient @Inject constructor(
         }
     }
 
-    private suspend inline fun <reified T> makeWPAPIRequest(
+    /**
+     * Establishes a site-level connection between the site and WordPress.com using Jetpack.
+     *
+     * @return a [JetpackWPAPIPayload] with the blog_id of the site
+     */
+    suspend fun registerSite(site: SiteModel, useApplicationPasswords: Boolean): JetpackWPAPIPayload<Long> {
+        val response = makePostWPAPIRequest<JetpackConnectionRegisterResponse>(
+            site = site,
+            path = JPAPI.connection.register.pathV4,
+            body = mapOf(
+                "from" to "woocommerce_android",
+                "plugin_slug" to "jetpack"
+            ),
+            useApplicationPasswords = useApplicationPasswords
+        )
+
+        return when (response) {
+            is Success<JetpackConnectionRegisterResponse> -> {
+                val blogId = response.data?.authorizeUrl?.toHttpUrl()?.queryParameter("client_id")?.toLong()
+
+                if (blogId == null) {
+                    JetpackWPAPIPayload(
+                        BaseNetworkError(
+                            BaseRequest.GenericErrorType.INVALID_RESPONSE,
+                            "Invalid blog_id"
+                        )
+                    )
+                } else {
+                    JetpackWPAPIPayload(blogId)
+                }
+            }
+
+            is Error -> JetpackWPAPIPayload(response.error)
+        }
+    }
+
+    private suspend inline fun <reified T> makeGetWPAPIRequest(
         site: SiteModel,
         path: String,
         useApplicationPasswords: Boolean
@@ -122,6 +160,33 @@ class JetpackWPAPIRestClient @Inject constructor(
                     restClient = this,
                     url = url,
                     nonce = nonce.value,
+                    clazz = T::class.java
+                )
+            }
+        }
+    }
+
+    private suspend inline fun <reified T> makePostWPAPIRequest(
+        site: SiteModel,
+        path: String,
+        body: Map<String, String>,
+        useApplicationPasswords: Boolean
+    ): WPAPIResponse<T> {
+        return if (useApplicationPasswords) {
+            applicationPasswordsNetwork.executePostGsonRequest(
+                site = site,
+                path = path,
+                body = body,
+                clazz = T::class.java
+            )
+        } else {
+            val url = site.buildUrl(path)
+            cookieNonceAuthenticator.makeAuthenticatedWPAPIRequest(site) { nonce ->
+                wpApiGsonRequestBuilder.syncPostRequest(
+                    restClient = this,
+                    url = url,
+                    nonce = nonce.value,
+                    body = body,
                     clazz = T::class.java
                 )
             }

--- a/libs/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpapi/jetpack/JetpackWPAPIRestClient.kt
+++ b/libs/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpapi/jetpack/JetpackWPAPIRestClient.kt
@@ -182,7 +182,7 @@ class JetpackWPAPIRestClient @Inject constructor(
                 "redirect_uri" to site.url,
                 "secret" to provisioningParams.secret,
                 "scope" to provisioningParams.scope,
-                "external_user_id" to provisioningParams.userId
+                "external_user_id" to provisioningParams.userId.toString()
             ),
             clazz = Unit::class.java
         )

--- a/libs/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpapi/jetpack/JetpackWPAPIRestClient.kt
+++ b/libs/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpapi/jetpack/JetpackWPAPIRestClient.kt
@@ -255,7 +255,8 @@ class JetpackWPAPIRestClient @Inject constructor(
                 wpcomEmail = currentUser.wpcomUser?.email.orEmpty(),
                 wpcomId = currentUser.wpcomUser?.id ?: 0L,
                 wpcomUsername = currentUser.wpcomUser?.login.orEmpty()
-            )
+            ),
+            connectionOwner = connectionOwner
         )
     }
 

--- a/libs/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpapi/jetpack/JetpackWPAPIRestClient.kt
+++ b/libs/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpapi/jetpack/JetpackWPAPIRestClient.kt
@@ -49,7 +49,7 @@ class JetpackWPAPIRestClient @Inject constructor(
         }
     }
 
-    suspend fun registerJetpackSite(registrationUrl: String): Result<String> {
+    suspend fun registerJetpackSiteUsingCookies(registrationUrl: String): Result<String> {
         @Suppress("MagicNumber")
         fun Int.isRedirect(): Boolean = this in 300..399
         return suspendCancellableCoroutine { cont ->

--- a/libs/fluxc/src/main/java/org/wordpress/android/fluxc/store/JetpackStore.kt
+++ b/libs/fluxc/src/main/java/org/wordpress/android/fluxc/store/JetpackStore.kt
@@ -67,6 +67,50 @@ class JetpackStore @Inject constructor(
         }
     }
 
+    /**
+     * Register a site with Jetpack
+     *
+     * @return the blog ID of the registered site
+     */
+    suspend fun registerSite(
+        site: SiteModel,
+        useApplicationPasswords: Boolean
+    ): JetpackResult<Long> {
+        if (site.isUsingWpComRestApi) error("This function is not implemented yet for Jetpack tunnel")
+        return coroutineEngine.withDefaultContext(T.API, this, "registerSite") {
+            val result = jetpackWPAPIRestClient.registerSite(site, useApplicationPasswords)
+
+            result.toJetpackResult { result ->
+                JetpackResult(result)
+            }
+        }
+    }
+
+    suspend fun connectJetpackAccount(
+        site: SiteModel,
+        blogId: Long,
+        useApplicationPasswords: Boolean
+    ): JetpackResult<Unit> {
+        return coroutineEngine.withDefaultContext(T.API, this, "connectJetpackAccount") {
+            val provision = jetpackWPAPIRestClient.provisionConnection(site, useApplicationPasswords).also {
+                if (it.isError) return@withDefaultContext JetpackResult<Unit>(
+                    JetpackError(
+                        it.error?.message,
+                        it.error?.volleyError?.networkResponse?.statusCode
+                    )
+                )
+            }
+
+            val result = jetpackWPAPIRestClient.connectJetpackAccount(
+                site = site,
+                blogId = blogId,
+                provisioningParams = provision.result!!
+            )
+
+            result.toJetpackResult { JetpackResult(Unit) }
+        }
+    }
+
     data class JetpackResult<T>(
         val data: T?
     ) : Payload<JetpackError>() {

--- a/libs/fluxc/src/main/java/org/wordpress/android/fluxc/store/JetpackStore.kt
+++ b/libs/fluxc/src/main/java/org/wordpress/android/fluxc/store/JetpackStore.kt
@@ -58,7 +58,7 @@ class JetpackStore @Inject constructor(
         useApplicationPasswords: Boolean
     ): JetpackResult<JetpackConnectionData> {
         if (site.isUsingWpComRestApi) error("This function is not implemented yet for Jetpack tunnel")
-        return coroutineEngine.withDefaultContext(T.API, this, "fetchJetpackUser") {
+        return coroutineEngine.withDefaultContext(T.API, this, "fetchJetpackConnectionData") {
             val result = jetpackWPAPIRestClient.fetchJetpackConnectionData(site, useApplicationPasswords)
 
             result.toJetpackResult { result ->

--- a/libs/fluxc/src/main/java/org/wordpress/android/fluxc/store/JetpackStore.kt
+++ b/libs/fluxc/src/main/java/org/wordpress/android/fluxc/store/JetpackStore.kt
@@ -3,7 +3,7 @@ package org.wordpress.android.fluxc.store
 import com.android.volley.VolleyError
 import org.wordpress.android.fluxc.Payload
 import org.wordpress.android.fluxc.model.SiteModel
-import org.wordpress.android.fluxc.model.jetpack.JetpackUser
+import org.wordpress.android.fluxc.model.jetpack.JetpackConnectionData
 import org.wordpress.android.fluxc.network.rest.wpapi.jetpack.JetpackWPAPIRestClient
 import org.wordpress.android.fluxc.store.Store.OnChangedError
 import org.wordpress.android.fluxc.tools.CoroutineEngine
@@ -53,16 +53,16 @@ class JetpackStore @Inject constructor(
         }
     }
 
-    suspend fun fetchJetpackUser(
+    suspend fun fetchJetpackConnectionData(
         site: SiteModel,
         useApplicationPasswords: Boolean
-    ): JetpackResult<JetpackUser> {
+    ): JetpackResult<JetpackConnectionData> {
         if (site.isUsingWpComRestApi) error("This function is not implemented yet for Jetpack tunnel")
         return coroutineEngine.withDefaultContext(T.API, this, "fetchJetpackUser") {
             val result = jetpackWPAPIRestClient.fetchJetpackConnectionData(site, useApplicationPasswords)
 
             result.toJetpackResult { result ->
-                JetpackResult(result.currentUser)
+                JetpackResult(result)
             }
         }
     }

--- a/libs/fluxc/src/main/java/org/wordpress/android/fluxc/store/JetpackStore.kt
+++ b/libs/fluxc/src/main/java/org/wordpress/android/fluxc/store/JetpackStore.kt
@@ -59,10 +59,10 @@ class JetpackStore @Inject constructor(
     ): JetpackResult<JetpackUser> {
         if (site.isUsingWpComRestApi) error("This function is not implemented yet for Jetpack tunnel")
         return coroutineEngine.withDefaultContext(T.API, this, "fetchJetpackUser") {
-            val result = jetpackWPAPIRestClient.fetchJetpackUser(site, useApplicationPasswords)
+            val result = jetpackWPAPIRestClient.fetchJetpackConnectionData(site, useApplicationPasswords)
 
             result.toJetpackResult { result ->
-                JetpackResult(result)
+                JetpackResult(result.currentUser)
             }
         }
     }

--- a/libs/fluxc/src/main/java/org/wordpress/android/fluxc/store/JetpackStore.kt
+++ b/libs/fluxc/src/main/java/org/wordpress/android/fluxc/store/JetpackStore.kt
@@ -34,7 +34,7 @@ class JetpackStore @Inject constructor(
                 if (!autoRegisterSiteIfNeeded || connectionUri.host == JETPACK_DOMAIN || useApplicationPasswords) {
                     JetpackResult(url)
                 } else {
-                    registerJetpackSite(url).fold(
+                    jetpackWPAPIRestClient.registerJetpackSiteUsingCookies(url).fold(
                         onSuccess = {
                             JetpackResult(it)
                         },
@@ -52,9 +52,6 @@ class JetpackStore @Inject constructor(
             }
         }
     }
-
-    private suspend fun registerJetpackSite(registrationUrl: String): Result<String> =
-        jetpackWPAPIRestClient.registerJetpackSite(registrationUrl)
 
     suspend fun fetchJetpackUser(
         site: SiteModel,


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #13629
<!-- Id number of the GitHub issue this PR addresses. -->

> [!NOTE]
> Depends on https://github.com/woocommerce/woocommerce-android/pull/13645 

### Description
This PR adds the networking integration with the Jetpack Connection API.

### Steps to reproduce
Code review should be enough, the integration will be tested in the next PR.

- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.

## Reviewer (or Author, in the case of optional code reviews):

Please make sure these conditions are met before approving the PR, or request changes if the PR needs improvement:

- [ ] The PR is small and has a clear, single focus, or a valid explanation is provided in the description. If needed, please request to split it into smaller PRs.
- [ ] Ensure Adequate Unit Test Coverage: The changes are reasonably covered by unit tests or an explanation is provided in the PR description.
- [ ] Manual Testing: The author listed all the tests they ran, including smoke tests when needed (e.g., for refactorings). The reviewer confirmed that the PR works as expected on big (tablet) and small (phone) in case of UI changes, and no regressions are added.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->