### PR TITLE
[Authenticated WebView] Fix a crash related to using URLs without a scheme

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/common/webview/WebViewAuthenticationFlowResolver.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/common/webview/WebViewAuthenticationFlowResolver.kt
@@ -53,7 +53,10 @@ class WebViewAuthenticationFlowResolver @Inject constructor(
         return findDomain().contains(site.url.findDomain())
     }
 
-    private fun String.findDomain(): String = toHttpUrl().host.substringAfter("www.")
+    private fun String.findDomain(): String {
+        val urlWithScheme = if (contains("://")) this else "http://$this"
+        return urlWithScheme.toHttpUrl().host.substringAfter("www.")
+    }
 
     private fun SiteModel.supportsJetpackSSO(): Boolean {
         return jetpackModules?.contains("sso") == true

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/details/ProductDetailViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/details/ProductDetailViewModel.kt
@@ -347,6 +347,7 @@ class ProductDetailViewModel @Inject constructor(
             // Show "View Product" option only if the product is published or we can auto-authenticate the user
             // in a WebView.
             val showViewProductOption = !isProductUnderCreation &&
+                productDraft.permalink.isNotEmpty() &&
                 (isProductPublished || canAutoAuthenticateInWebView(productDraft.permalink))
 
             MenuButtonsState(

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/common/webview/WebViewAuthenticationFlowResolverTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/common/webview/WebViewAuthenticationFlowResolverTest.kt
@@ -124,6 +124,18 @@ class WebViewAuthenticationFlowResolverTest {
         assertThat(result).isTrue()
     }
 
+    @Test
+    fun `given a URL without scheme, when checking if the URL is part of the site, then it should return true`() {
+        val site = SiteModel().apply { url = "https://example.com" }
+        val url = "example.com/path"
+
+        val result = with(sut) {
+            url.isPartOf(site)
+        }
+
+        assertThat(result).isTrue()
+    }
+
     private fun givenWPComAuthenticated() {
         given(accountStore.accessToken).willReturn("token")
         given(accountStore.account).willReturn(AccountModel().apply { userName = "username" })

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/products/ProductTestUtils.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/products/ProductTestUtils.kt
@@ -78,6 +78,7 @@ object ProductTestUtils {
             purchasable = isPurchasable
             manageStock = isStockManaged
             combineVariationQuantities = productCombinesVariationQuantities
+            permalink = "https://example.com/product/1"
         }.toAppModel()
     }
 


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #13660 
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
This PR fixes a crash in one of the Authenticated WebView components when passing a URL without a scheme.

### Steps to reproduce
- Either check the unit test.
- Or use the ApiFaker to fake the product details response to return a `permalink` field without a scheme.

### Testing information
- Confirm the app doesn't crash in one of the two methods above.

### The tests that have been performed
- I tested just using the unit test, I think it should be enough.

- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.

## Reviewer (or Author, in the case of optional code reviews):

Please make sure these conditions are met before approving the PR, or request changes if the PR needs improvement:

- [x] The PR is small and has a clear, single focus, or a valid explanation is provided in the description. If needed, please request to split it into smaller PRs.
- [x] Ensure Adequate Unit Test Coverage: The changes are reasonably covered by unit tests or an explanation is provided in the PR description.
- [x] Manual Testing: The author listed all the tests they ran, including smoke tests when needed (e.g., for refactorings). The reviewer confirmed that the PR works as expected on big (tablet) and small (phone) in case of UI changes, and no regressions are added.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->