### PR TITLE
Fix purchase shipping label errors

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/networking/DTOs.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/networking/DTOs.kt
@@ -60,21 +60,21 @@ data class PurchasedShippingLabelResponseDTO(
 data class ShippingRatePurchaseDTO(val rate: ShippingRatePurchaseResponseDTO)
 
 data class ShippingRatePurchaseResponseDTO(
-    val rateId: String,
-    val serviceId: String,
-    val carrierId: String?,
+    @SerializedName("rate_id") val rateId: String,
+    @SerializedName("service_id") val serviceId: String,
+    @SerializedName("carrier_id") val carrierId: String?,
     val title: String,
     val rate: BigDecimal,
-    val retailRate: BigDecimal? = null,
-    val listRate: BigDecimal? = null,
-    val isSelected: Boolean,
+    @SerializedName("retail_rate") val retailRate: BigDecimal? = null,
+    @SerializedName("list_rate") val listRate: BigDecimal? = null,
+    @SerializedName("is_selected") val isSelected: Boolean,
     val tracking: Boolean = false,
     val insurance: String?,
-    val freePickup: Boolean,
-    val shipmentId: String?,
-    val deliveryDays: Int,
-    val deliveryDateGuaranteed: Boolean,
-    val deliveryDate: String?
+    @SerializedName("free_pickup") val freePickup: Boolean,
+    @SerializedName("shipment_id") val shipmentId: String?,
+    @SerializedName("delivery_days") val deliveryDays: Int,
+    @SerializedName("delivery_date_guaranteed") val deliveryDateGuaranteed: Boolean,
+    @SerializedName("delivery_date") val deliveryDate: String?
 )
 
 data class AddressDTO(

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/networking/WooShippingLabelRestClient.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/networking/WooShippingLabelRestClient.kt
@@ -74,7 +74,7 @@ class WooShippingLabelRestClient @Inject constructor(
         return result.toWooPayload()
     }
 
-    @Suppress("LongParameterList")
+    @Suppress("LongParameterList", "ForbiddenComment")
     suspend fun purchaseShippingLabel(
         orderId: Long,
         site: SiteModel,
@@ -100,6 +100,8 @@ class WooShippingLabelRestClient @Inject constructor(
                         "parent" to null
                     )
                 ),
+                // TODO: `selected_rate_options` will be updated while adding UPS support PaJDVv-2Gf-p2
+                "selected_rate_options" to "",
                 "hazmat" to mapOf(selectedPackage.boxId to hazmat),
                 "customs" to emptyMap<String, String>(),
                 "user_meta" to mapOf("last_order_completed" to markOrderComplete)


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #13664

<!-- 
━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
🛠 Need an AI review?  
Add a comment: `@coderabbitai review`
━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
-->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
This adds an empty `selected_rate_options` field to the purchase label endpoint. It will be filled later. (More context: p1740749891615239/1740733221.593429-slack-C03L1NF1EA3)
This also adds JSON property names to enable successful response parsing. Before, it was crashing.

### Steps to reproduce
<!-- Step-by-step testing instructions. For new user flows, consider instead stating the goal of the workflow and see if your PR reviewer can accomplish the workflow without specific steps! -->
1. Open the app
2. Navigate to the Orders section
3. Open an order eligible for shipping label creation
4. Tap on create shipping label
5. Tap on select a package
6. Select any package
7. Tap on a shipping rate
9. Tap on the purchase label
11. Check that the app navigates to the final screen when the purchase completes

### The tests that have been performed
<!-- To give the reviewer an idea of what could be missed in terms of testing -->

### Images/gif
<!-- Include before and after images or gifs when appropriate. -->

- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.

## Reviewer (or Author, in the case of optional code reviews):

Please make sure these conditions are met before approving the PR, or request changes if the PR needs improvement:

- [ ] The PR is small and has a clear, single focus, or a valid explanation is provided in the description. If needed, please request to split it into smaller PRs.
- [ ] Ensure Adequate Unit Test Coverage: The changes are reasonably covered by unit tests or an explanation is provided in the PR description.
- [ ] Manual Testing: The author listed all the tests they ran, including smoke tests when needed (e.g., for refactorings). The reviewer confirmed that the PR works as expected on big (tablet) and small (phone) in case of UI changes, and no regressions are added.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->