### PR TITLE
Fix Jetpack Benefits banner visibility

### DIFF
--- a/WooCommerce/src/main/res/layout/fragment_dashboard.xml
+++ b/WooCommerce/src/main/res/layout/fragment_dashboard.xml
@@ -20,7 +20,8 @@
     <androidx.compose.ui.platform.ComposeView
         android:id="@+id/dashboard_container"
         android:layout_width="match_parent"
-        android:layout_height="wrap_content" />
+        android:layout_height="0dp"
+        android:layout_weight="1" />
 
     <include
         android:id="@+id/jetpack_benefits_banner"


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #13667

### Description
While working on the Jetpack Connection API integration, I noticed that the Jetpack benefits banner is not shown anymore, I think this is related to the changed done to improve the dashboard for large screens.

### Steps to reproduce
1. Sign in using site credentials or using Jetpack CP.
2. Open the dashboard.

### Testing information
- Confirm the Jetpack benefits banner is shown.

### The tests that have been performed
^

### Screenshots
<img src=https://github.com/user-attachments/assets/4737db06-de87-4e82-9b05-a7bbc57d3d75 width=360/>

- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.

## Reviewer (or Author, in the case of optional code reviews):

Please make sure these conditions are met before approving the PR, or request changes if the PR needs improvement:

- [x] The PR is small and has a clear, single focus, or a valid explanation is provided in the description. If needed, please request to split it into smaller PRs.
- [ ] Ensure Adequate Unit Test Coverage: The changes are reasonably covered by unit tests or an explanation is provided in the PR description.
- [x] Manual Testing: The author listed all the tests they ran, including smoke tests when needed (e.g., for refactorings). The reviewer confirmed that the PR works as expected on big (tablet) and small (phone) in case of UI changes, and no regressions are added.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->