### PR TITLE
[Login] Track the site URL when detecting that Application Passwords are disabled

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/analytics/AnalyticsTracker.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/analytics/AnalyticsTracker.kt
@@ -168,7 +168,7 @@ class AnalyticsTracker private constructor(
         private const val TRACKS_ANON_ID = "nosara_tracks_anon_id"
         private const val EVENTS_PREFIX = "woocommerceandroid_"
         private const val POS_EVENTS_PREFIX = "woocommerceandroid_pos_"
-        private const val KEY_SITE_URL = "site_url"
+        const val KEY_SITE_URL = "site_url"
 
         const val IS_DEBUG = "is_debug"
         const val KEY_ALREADY_READ = "already_read"

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/applicationpasswords/ApplicationPasswordsNotifier.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/applicationpasswords/ApplicationPasswordsNotifier.kt
@@ -33,7 +33,10 @@ class ApplicationPasswordsNotifier @Inject constructor(
     override fun onFeatureUnavailable(siteModel: SiteModel, networkError: WPAPINetworkError) {
         trackGenerationFailure(
             cause = GenerationFailureCause.FEATURE_DISABLED,
-            networkError = networkError
+            networkError = networkError,
+            additionalProperties = mapOf(
+                AnalyticsTracker.KEY_SITE_URL to siteModel.url
+            )
         )
         _featureUnavailableEvents.tryEmit(networkError)
     }
@@ -65,7 +68,8 @@ class ApplicationPasswordsNotifier @Inject constructor(
 
     private fun trackGenerationFailure(
         cause: GenerationFailureCause,
-        networkError: WPAPINetworkError
+        networkError: WPAPINetworkError,
+        additionalProperties: Map<String, String> = emptyMap()
     ) {
         val scenario = if (selectedSite.exists()) {
             GenerationFailureScenario.REGENERATION
@@ -78,7 +82,7 @@ class ApplicationPasswordsNotifier @Inject constructor(
             properties = mapOf(
                 AnalyticsTracker.KEY_SCENARIO to scenario.name.lowercase(),
                 AnalyticsTracker.KEY_CAUSE to cause.name.lowercase()
-            ),
+            ) + additionalProperties,
             errorContext = networkError.javaClass.simpleName,
             errorType = networkError.type.name,
             errorDescription = networkError.message

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/sitecredentials/LoginSiteCredentialsViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/sitecredentials/LoginSiteCredentialsViewModel.kt
@@ -245,7 +245,12 @@ class LoginSiteCredentialsViewModel @Inject constructor(
                             )
                         )
                     } else {
-                        analyticsTracker.track(AnalyticsEvent.APPLICATION_PASSWORDS_AUTHORIZATION_URL_NOT_AVAILABLE)
+                        analyticsTracker.track(
+                            AnalyticsEvent.APPLICATION_PASSWORDS_AUTHORIZATION_URL_NOT_AVAILABLE,
+                            properties = mapOf(
+                                AnalyticsTracker.KEY_SITE_URL to siteAddress
+                            )
+                        )
                         triggerEvent(ShowApplicationPasswordsUnavailableScreen(siteAddress, site.isJetpackConnected))
                     }
                 } else {


### PR DESCRIPTION
### Description
This PR just adds logic to track the site URL when detecting that the Application Passwords are disabled, the URL will be tracked using the same property we use for the other events `site_url`.

### Steps to reproduce
Just code review should be enough, but you can also test this using the following steps:
- Install the plugin ["Disable Application Passwords"](https://wordpress.org/plugins/disable-application-passwords/)
- Launch the app
- Test signing using site credentials.
- Check for the `Tracked: woocommerceandroid_application_passwords_generation_failed` and confirm it includes the `site_url` property.

- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.

## Reviewer (or Author, in the case of optional code reviews):

Please make sure these conditions are met before approving the PR, or request changes if the PR needs improvement:

- [x] The PR is small and has a clear, single focus, or a valid explanation is provided in the description. If needed, please request to split it into smaller PRs.
- [x] Ensure Adequate Unit Test Coverage: The changes are reasonably covered by unit tests or an explanation is provided in the PR description.
- [x] Manual Testing: The author listed all the tests they ran, including smoke tests when needed (e.g., for refactorings). The reviewer confirmed that the PR works as expected on big (tablet) and small (phone) in case of UI changes, and no regressions are added.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced analytics tracking now captures additional site context during error events.
	- Improved event reporting provides more detailed data for faster issue resolution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->