### PR TITLE
[Jetpack Setup] Fix WebView connection when using older Jetpack versions

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/AppPrefs.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/AppPrefs.kt
@@ -113,7 +113,6 @@ object AppPrefs {
         UPDATE_SIMULATED_READER_OPTION,
         ENABLE_SIMULATED_INTERAC,
         CUSTOM_DOMAINS_SOURCE,
-        JETPACK_INSTALLATION_FROM_BANNER,
         NOTIFICATIONS_PERMISSION_BAR,
         IS_EU_SHIPPING_NOTICE_DISMISSED,
         HAS_SAVED_PRIVACY_SETTINGS,
@@ -903,12 +902,6 @@ object AppPrefs {
     }
 
     fun getCustomDomainsSource() = getString(DeletablePrefKey.CUSTOM_DOMAINS_SOURCE, DomainFlowSource.SETTINGS.name)
-
-    fun setJetpackInstallationIsFromBanner(isFromBanner: Boolean) {
-        setBoolean(DeletablePrefKey.JETPACK_INSTALLATION_FROM_BANNER, isFromBanner)
-    }
-
-    fun getJetpackInstallationIsFromBanner() = getBoolean(DeletablePrefKey.JETPACK_INSTALLATION_FROM_BANNER, false)
 
     fun setWasNotificationsPermissionBarDismissed(source: Boolean) {
         setBoolean(DeletablePrefKey.NOTIFICATIONS_PERMISSION_BAR, source)

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/AppPrefsWrapper.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/AppPrefsWrapper.kt
@@ -237,12 +237,6 @@ class AppPrefsWrapper @Inject constructor() {
     fun getCustomDomainsSource(): DomainFlowSource = enumValueOf(AppPrefs.getCustomDomainsSource())
     fun getCustomDomainsSourceAsString(): String = AppPrefs.getCustomDomainsSource().lowercase()
 
-    fun setJetpackInstallationIsFromBanner(isFromBanner: Boolean) {
-        AppPrefs.setJetpackInstallationIsFromBanner(isFromBanner)
-    }
-
-    fun getJetpackInstallationIsFromBanner() = AppPrefs.getJetpackInstallationIsFromBanner()
-
     /**
      * Card Reader Upsell
      */

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/analytics/AnalyticsTracker.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/analytics/AnalyticsTracker.kt
@@ -531,6 +531,9 @@ class AnalyticsTracker private constructor(
         const val VALUE_JETPACK_SETUP_TAP_GO_TO_STORE = "go_to_store"
         const val VALUE_JETPACK_SETUP_TAP_SUPPORT = "support"
         const val VALUE_JETPACK_SETUP_TAP_TRY_AGAIN = "try_again"
+        const val KEY_CONNECTION_TYPE = "connection_type"
+        const val VALUE_CONNECTION_TYPE_NATIVE = "native"
+        const val VALUE_CONNECTION_TYPE_WEB = "web"
 
         // -- Upsell banner
         const val KEY_BANNER_SOURCE = "source"

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/common/webview/WebViewAuthenticationFlowResolver.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/common/webview/WebViewAuthenticationFlowResolver.kt
@@ -22,27 +22,22 @@ class WebViewAuthenticationFlowResolver @Inject constructor(
         val isWPComAuthenticated = accountStore.accessToken.isNotNullOrEmpty() &&
             accountStore.account.userName.isNotNullOrEmpty()
 
-        return if (isWPComAuthenticated) {
-            when {
-                wpComAuthAcceptedDomains.any { it == urlDomain } -> {
-                    WebViewAuthenticationFlow.WPCom
-                }
-
-                currentSite?.supportsJetpackSSO() == true && url.isPartOf(currentSite) -> {
-                    WebViewAuthenticationFlow.JetpackSSO
-                }
-
-                else -> {
-                    WebViewAuthenticationFlow.None
-                }
+        return when {
+            isWPComAuthenticated && wpComAuthAcceptedDomains.any { it == urlDomain } -> {
+                WebViewAuthenticationFlow.WPCom
             }
-        } else if (currentSite?.username.isNotNullOrEmpty() &&
-            currentSite.password.isNotNullOrEmpty() &&
-            url.isPartOf(currentSite)
-        ) {
-            WebViewAuthenticationFlow.SiteCredentials
-        } else {
-            WebViewAuthenticationFlow.None
+
+            isWPComAuthenticated && currentSite?.supportsJetpackSSO() == true && url.isPartOf(currentSite) -> {
+                WebViewAuthenticationFlow.JetpackSSO
+            }
+
+            currentSite?.hasCredentials() == true && url.isPartOf(currentSite) -> {
+                WebViewAuthenticationFlow.SiteCredentials
+            }
+
+            else -> {
+                WebViewAuthenticationFlow.None
+            }
         }
     }
 
@@ -57,6 +52,10 @@ class WebViewAuthenticationFlowResolver @Inject constructor(
 
     private fun SiteModel.supportsJetpackSSO(): Boolean {
         return jetpackModules?.contains("sso") == true
+    }
+
+    private fun SiteModel.hasCredentials(): Boolean {
+        return username.isNotNullOrEmpty() && password.isNotNullOrEmpty()
     }
 
     enum class WebViewAuthenticationFlow {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/DashboardFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/DashboardFragment.kt
@@ -246,14 +246,12 @@ class DashboardFragment :
     }
 
     private fun prepareJetpackBenefitsBanner() {
-        appPrefsWrapper.setJetpackInstallationIsFromBanner(false)
         binding.jetpackBenefitsBanner.root.isVisible = false
         binding.jetpackBenefitsBanner.root.setOnClickListener {
             AnalyticsTracker.track(
                 stat = AnalyticsEvent.FEATURE_JETPACK_BENEFITS_BANNER,
                 properties = mapOf(AnalyticsTracker.KEY_JETPACK_BENEFITS_BANNER_ACTION to "tapped")
             )
-            appPrefsWrapper.setJetpackInstallationIsFromBanner(true)
             findNavController().navigateSafely(DashboardFragmentDirections.actionDashboardToJetpackBenefitsDialog())
         }
         // For the banner to be above the bottom navigation view when the toolbar is expanded

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/jetpack/connection/JetpackActivationWebViewViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/jetpack/connection/JetpackActivationWebViewViewModel.kt
@@ -1,7 +1,9 @@
 package com.woocommerce.android.ui.login.jetpack.connection
 
 import android.os.Parcelable
-import androidx.annotation.VisibleForTesting
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.setValue
 import androidx.lifecycle.SavedStateHandle
 import com.woocommerce.android.viewmodel.MultiLiveEvent.Event
 import com.woocommerce.android.viewmodel.ScopedViewModel
@@ -15,20 +17,27 @@ class JetpackActivationWebViewViewModel @Inject constructor(
     savedStateHandle: SavedStateHandle
 ) : ScopedViewModel(savedStateHandle) {
     companion object {
-        @VisibleForTesting
-        const val JETPACK_PLANS_URL = "https://wordpress.com/jetpack/connect/plans"
-
-        @VisibleForTesting
-        const val MOBILE_REDIRECT = "woocommerce://jetpack-connected"
+        private const val JETPACK_PLANS_URL = "https://wordpress.com/jetpack/connect/plans"
+        private const val MOBILE_REDIRECT = "woocommerce://jetpack-connected"
+        private const val JETPACK_AUTHORIZE_URL = "jetpack.wordpress.com/jetpack.authorize"
     }
 
     private val navArgs: JetpackActivationWebViewFragmentArgs by savedStateHandle.navArgs()
     private var isExiting = false
 
-    val urlToLoad = navArgs.urlToLoad
+    var urlToLoad by mutableStateOf(navArgs.urlToLoad)
+        private set
 
     fun onUrlLoaded(url: String) {
-        if (!isExiting && url.startsWith(JETPACK_PLANS_URL) || url.startsWith(MOBILE_REDIRECT)) {
+        if (isExiting) return
+
+        if (url.contains(JETPACK_AUTHORIZE_URL) && !navArgs.urlToLoad.contains(JETPACK_AUTHORIZE_URL)) {
+            // The initial URL was not the authorize URL, which happens when we need to handle the site registration
+            // and this means the user is not authenticated to WordPress.com yet.
+            // By updating the URL to the authorize URL, we will then use the WebViewAuthenticator and will be able to
+            // handle the authentication process.
+            urlToLoad = url
+        } else if (url.startsWith(JETPACK_PLANS_URL) || url.startsWith(MOBILE_REDIRECT)) {
             triggerEvent(ConnectionResult.Success)
             isExiting = true
         }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/jetpack/main/JetpackActivationMainViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/jetpack/main/JetpackActivationMainViewModel.kt
@@ -56,6 +56,7 @@ import kotlinx.coroutines.withContext
 import kotlinx.parcelize.Parcelize
 import org.wordpress.android.fluxc.model.SiteModel
 import org.wordpress.android.fluxc.store.JetpackStore
+import org.wordpress.android.fluxc.utils.extensions.slashJoin
 import org.wordpress.android.util.UrlUtils
 import javax.inject.Inject
 
@@ -78,9 +79,6 @@ class JetpackActivationMainViewModel @Inject constructor(
 
         @VisibleForTesting
         const val JETPACK_SITE_CONNECTED_AUTH_URL_PREFIX = "https://jetpack.wordpress.com/jetpack.authorize"
-
-        @VisibleForTesting
-        const val MOBILE_REDIRECT = "woocommerce://jetpack-connected"
     }
 
     private val navArgs: JetpackActivationMainFragmentArgs by savedStateHandle.navArgs()
@@ -488,27 +486,22 @@ class JetpackActivationMainViewModel @Inject constructor(
 
                 if (useApplicationPasswords) {
                     // Depending on the site's connection status, we should provide different URLs to the webview.
-                    // If the site already has a Jetpack site-connection, we can use the API-given URL as-is. We
+                    // If the site is already registered with WordPress.com, we can use the API-given URL as-is. We
                     // know this is the case if the URL starts with JETPACK_SITE_CONNECTED_AUTH_URL_PREFIX.
 
                     // If the site lacks a connection, the API-provided URL will be in the format of
                     // https://{site_url}/wp-admin/admin.php?page=jetpack&action=register&_wpnonce={nonce}.
-                    // For application password login, where we don't want to use cookie-nonce authentication, the URL
+                    // For application password login, where we can't use cookie-nonce authentication, the URL
                     // above cannot be used to connect the site to Jetpack.
                     // See: https://github.com/woocommerce/woocommerce-android/issues/7525
 
-                    // As a workaround, we use a special URL that enables site connection without the app needing
-                    // cookie-nonce authentication. The format looks like below:
-                    // https://wordpress.com/jetpack/connect?url=<site_url>
-                    //  &mobile_redirect=woocommerce://jetpack-connected&from=mobile
-                    // See: pe5sF9-1le-p2#comment-1942
+                    // As a workaround, we load the site's wp-admin Jetpack page, which will allow the user to
+                    // connect the site to Jetpack using their WordPress.com account.
 
                     val chosenUrl = if (connectionUrl.startsWith(JETPACK_SITE_CONNECTED_AUTH_URL_PREFIX)) {
                         connectionUrl
                     } else {
-                        "https://wordpress.com/jetpack/connect?url=" + navArgs.siteUrl +
-                            "&mobile_redirect=" + MOBILE_REDIRECT +
-                            "&from=mobile"
+                        navArgs.siteUrl.slashJoin("wp-admin/admin.php?page=jetpack")
                     }
 
                     triggerEvent(

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/jetpack/main/JetpackActivationMainViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/jetpack/main/JetpackActivationMainViewModel.kt
@@ -263,6 +263,10 @@ class JetpackActivationMainViewModel @Inject constructor(
                 val stepType = step.type
                 WooLog.d(WooLog.T.LOGIN, "Jetpack Activation: handle step: $stepType")
 
+                if (useApplicationPasswords) {
+                    trackSetupFlow()
+                }
+
                 when (stepType) {
                     StepType.Installation -> {
                         startJetpackInstallation()

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/jetpack/main/JetpackActivationMainViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/jetpack/main/JetpackActivationMainViewModel.kt
@@ -144,10 +144,8 @@ class JetpackActivationMainViewModel @Inject constructor(
         }
     }.asLiveData()
 
-    private val isFromBanner = appPrefsWrapper.getJetpackInstallationIsFromBanner()
-
     init {
-        if (!isFromBanner) {
+        if (!useApplicationPasswords) {
             analyticsTrackerWrapper.track(AnalyticsEvent.LOGIN_JETPACK_SETUP_SCREEN_VIEWED)
         }
 
@@ -157,7 +155,7 @@ class JetpackActivationMainViewModel @Inject constructor(
     }
 
     fun onCloseClick() {
-        if (isFromBanner) {
+        if (useApplicationPasswords) {
             trackSetupFlow(tap = AnalyticsTracker.VALUE_DISMISS)
         } else {
             analyticsTrackerWrapper.track(
@@ -172,7 +170,7 @@ class JetpackActivationMainViewModel @Inject constructor(
     }
 
     fun onContinueClick() = launch {
-        if (isFromBanner) {
+        if (useApplicationPasswords) {
             trackSetupFlow(tap = AnalyticsTracker.VALUE_JETPACK_SETUP_TAP_GO_TO_STORE)
         } else {
             analyticsTrackerWrapper.track(stat = AnalyticsEvent.LOGIN_JETPACK_SETUP_GO_TO_STORE_BUTTON_TAPPED)
@@ -186,7 +184,7 @@ class JetpackActivationMainViewModel @Inject constructor(
                 jetpackActivationRepository.setSelectedSiteAndCleanOldSites(site)
                 triggerEvent(GoToStore)
 
-                if (isFromBanner) {
+                if (useApplicationPasswords) {
                     analyticsTrackerWrapper.track(stat = AnalyticsEvent.JETPACK_SETUP_SYNCHRONIZATION_COMPLETED)
                 }
             } else {
@@ -212,7 +210,7 @@ class JetpackActivationMainViewModel @Inject constructor(
     }
 
     fun onRetryClick() {
-        if (isFromBanner) {
+        if (useApplicationPasswords) {
             trackSetupFlow(tap = AnalyticsTracker.VALUE_JETPACK_SETUP_TAP_TRY_AGAIN)
         } else {
             analyticsTrackerWrapper.track(
@@ -227,7 +225,7 @@ class JetpackActivationMainViewModel @Inject constructor(
     }
 
     fun onGetHelpClick() {
-        if (isFromBanner) {
+        if (useApplicationPasswords) {
             trackSetupFlow(tap = AnalyticsTracker.VALUE_JETPACK_SETUP_TAP_SUPPORT)
         } else {
             analyticsTrackerWrapper.track(
@@ -292,7 +290,7 @@ class JetpackActivationMainViewModel @Inject constructor(
                     }
 
                     StepType.Done -> {
-                        if (isFromBanner) {
+                        if (useApplicationPasswords) {
                             analyticsTrackerWrapper.track(stat = AnalyticsEvent.JETPACK_SETUP_COMPLETED)
                         } else {
                             analyticsTrackerWrapper.track(
@@ -333,7 +331,7 @@ class JetpackActivationMainViewModel @Inject constructor(
         ).collect { status ->
             when (status) {
                 is PluginInstalled -> {
-                    if (!isFromBanner) {
+                    if (!useApplicationPasswords) {
                         analyticsTrackerWrapper.track(AnalyticsEvent.LOGIN_JETPACK_SETUP_INSTALL_SUCCESSFUL)
                     }
                     currentStep.value = Step(type = StepType.Activation, state = StepState.Ongoing)
@@ -345,7 +343,7 @@ class JetpackActivationMainViewModel @Inject constructor(
                 }
 
                 is PluginActivated -> {
-                    if (!isFromBanner) {
+                    if (!useApplicationPasswords) {
                         analyticsTrackerWrapper.track(AnalyticsEvent.LOGIN_JETPACK_SETUP_ACTIVATION_SUCCESSFUL)
                     }
                     currentStep.value = Step(type = StepType.Connection, state = StepState.Ongoing)
@@ -360,7 +358,7 @@ class JetpackActivationMainViewModel @Inject constructor(
     }
 
     private fun trackPluginActivationError(status: PluginActivationFailed) {
-        if (isFromBanner) {
+        if (useApplicationPasswords) {
             trackSetupFlow(failure =  "Jetpack activation failed: $status")
         } else {
             analyticsTrackerWrapper.track(
@@ -374,7 +372,7 @@ class JetpackActivationMainViewModel @Inject constructor(
     }
 
     private fun trackPluginInstallationError(status: PluginInstallFailed) {
-        if (isFromBanner) {
+        if (useApplicationPasswords) {
             trackSetupFlow(failure =  "Jetpack installation failed: $status")
         } else {
             analyticsTrackerWrapper.track(
@@ -392,7 +390,7 @@ class JetpackActivationMainViewModel @Inject constructor(
         val onFailure: (Throwable) -> Unit = {
             val error = (it as? OnChangedException)?.error as? JetpackStore.JetpackError
 
-            if (isFromBanner) {
+            if (useApplicationPasswords) {
                 trackSetupFlow(failure = "Jetpack connection failed: ${it.message}")
             } else {
                 analyticsTrackerWrapper.track(
@@ -434,7 +432,7 @@ class JetpackActivationMainViewModel @Inject constructor(
         val currentSite = site.await()
         jetpackActivationRepository.fetchJetpackConnectionUrl(currentSite, useApplicationPasswords).fold(
             onSuccess = { connectionUrl ->
-                if (!isFromBanner) {
+                if (!useApplicationPasswords) {
                     analyticsTrackerWrapper.track(
                         stat = AnalyticsEvent.LOGIN_JETPACK_SETUP_FETCH_JETPACK_CONNECTION_URL_SUCCESSFUL
                     )
@@ -491,7 +489,7 @@ class JetpackActivationMainViewModel @Inject constructor(
             onSuccess = { email ->
                 jetpackConnectedEmail = email
                 if (accountRepository.getUserAccount()?.email != email) {
-                    if (!isFromBanner) {
+                    if (!useApplicationPasswords) {
                         analyticsTrackerWrapper.track(
                             stat = AnalyticsEvent.LOGIN_JETPACK_SETUP_AUTHORIZED_USING_DIFFERENT_WPCOM_ACCOUNT
                         )
@@ -508,7 +506,7 @@ class JetpackActivationMainViewModel @Inject constructor(
             onFailure = {
                 val error = (it as? OnChangedException)?.error as? JetpackStore.JetpackError
 
-                if (isFromBanner) {
+                if (useApplicationPasswords) {
                     trackSetupFlow(failure = "Jetpack connection validation failed: ${it.message}")
                 } else {
                     analyticsTrackerWrapper.track(
@@ -536,7 +534,7 @@ class JetpackActivationMainViewModel @Inject constructor(
                 connectionStep.value = ConnectionStep.Approved
             },
             onFailure = {
-                if (isFromBanner) {
+                if (useApplicationPasswords) {
                     trackSetupFlow(failure = "Site connection confirmation failed: ${it.message}")
                 } else {
                     analyticsTrackerWrapper.track(

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/jetpack/main/JetpackActivationMainViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/jetpack/main/JetpackActivationMainViewModel.kt
@@ -565,6 +565,10 @@ class JetpackActivationMainViewModel @Inject constructor(
                 AnalyticsTracker.KEY_STEP to currentStep.value.type.analyticsName,
                 AnalyticsTracker.KEY_TAP to tap,
                 AnalyticsTracker.KEY_FAILURE to failure,
+                AnalyticsTracker.KEY_CONNECTION_TYPE to when {
+                    supportNativeConnectionAPI -> AnalyticsTracker.VALUE_CONNECTION_TYPE_NATIVE
+                    else -> AnalyticsTracker.VALUE_CONNECTION_TYPE_WEB
+                }
             ).filterNotNull()
         )
     }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/jetpack/main/JetpackActivationMainViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/jetpack/main/JetpackActivationMainViewModel.kt
@@ -8,11 +8,9 @@ import androidx.lifecycle.viewModelScope
 import com.woocommerce.android.AppPrefsWrapper
 import com.woocommerce.android.OnChangedException
 import com.woocommerce.android.analytics.AnalyticsEvent
-import com.woocommerce.android.analytics.AnalyticsEvent.JETPACK_SETUP_FLOW
-import com.woocommerce.android.analytics.AnalyticsEvent.LOGIN_JETPACK_SETUP_ACTIVATION_FAILED
-import com.woocommerce.android.analytics.AnalyticsEvent.LOGIN_JETPACK_SETUP_INSTALL_FAILED
 import com.woocommerce.android.analytics.AnalyticsTracker
 import com.woocommerce.android.analytics.AnalyticsTrackerWrapper
+import com.woocommerce.android.extensions.filterNotNull
 import com.woocommerce.android.extensions.isNotNullOrEmpty
 import com.woocommerce.android.model.JetpackConnectionStatus
 import com.woocommerce.android.support.help.HelpOrigin.JETPACK_INSTALLATION
@@ -160,13 +158,7 @@ class JetpackActivationMainViewModel @Inject constructor(
 
     fun onCloseClick() {
         if (isFromBanner) {
-            analyticsTrackerWrapper.track(
-                stat = JETPACK_SETUP_FLOW,
-                properties = mapOf(
-                    AnalyticsTracker.KEY_STEP to currentStep.value.type.analyticsName,
-                    AnalyticsTracker.KEY_TAP to AnalyticsTracker.VALUE_DISMISS
-                )
-            )
+            trackSetupFlow(tap = AnalyticsTracker.VALUE_DISMISS)
         } else {
             analyticsTrackerWrapper.track(
                 stat = AnalyticsEvent.LOGIN_JETPACK_SETUP_SCREEN_DISMISSED,
@@ -181,13 +173,7 @@ class JetpackActivationMainViewModel @Inject constructor(
 
     fun onContinueClick() = launch {
         if (isFromBanner) {
-            analyticsTrackerWrapper.track(
-                stat = JETPACK_SETUP_FLOW,
-                properties = mapOf(
-                    AnalyticsTracker.KEY_STEP to currentStep.value.type.analyticsName,
-                    AnalyticsTracker.KEY_TAP to AnalyticsTracker.VALUE_JETPACK_SETUP_TAP_GO_TO_STORE
-                )
-            )
+            trackSetupFlow(tap = AnalyticsTracker.VALUE_JETPACK_SETUP_TAP_GO_TO_STORE)
         } else {
             analyticsTrackerWrapper.track(stat = AnalyticsEvent.LOGIN_JETPACK_SETUP_GO_TO_STORE_BUTTON_TAPPED)
         }
@@ -227,13 +213,7 @@ class JetpackActivationMainViewModel @Inject constructor(
 
     fun onRetryClick() {
         if (isFromBanner) {
-            analyticsTrackerWrapper.track(
-                stat = JETPACK_SETUP_FLOW,
-                properties = mapOf(
-                    AnalyticsTracker.KEY_STEP to currentStep.value.type.analyticsName,
-                    AnalyticsTracker.KEY_TAP to AnalyticsTracker.VALUE_JETPACK_SETUP_TAP_TRY_AGAIN
-                )
-            )
+            trackSetupFlow(tap = AnalyticsTracker.VALUE_JETPACK_SETUP_TAP_TRY_AGAIN)
         } else {
             analyticsTrackerWrapper.track(
                 stat = AnalyticsEvent.LOGIN_JETPACK_SETUP_TRY_AGAIN_BUTTON_TAPPED,
@@ -248,13 +228,7 @@ class JetpackActivationMainViewModel @Inject constructor(
 
     fun onGetHelpClick() {
         if (isFromBanner) {
-            analyticsTrackerWrapper.track(
-                stat = JETPACK_SETUP_FLOW,
-                properties = mapOf(
-                    AnalyticsTracker.KEY_STEP to currentStep.value.type.analyticsName,
-                    AnalyticsTracker.KEY_TAP to AnalyticsTracker.VALUE_JETPACK_SETUP_TAP_SUPPORT
-                )
-            )
+            trackSetupFlow(tap = AnalyticsTracker.VALUE_JETPACK_SETUP_TAP_SUPPORT)
         } else {
             analyticsTrackerWrapper.track(
                 stat = AnalyticsEvent.LOGIN_JETPACK_SETUP_GET_SUPPORT_BUTTON_TAPPED,
@@ -387,16 +361,10 @@ class JetpackActivationMainViewModel @Inject constructor(
 
     private fun trackPluginActivationError(status: PluginActivationFailed) {
         if (isFromBanner) {
-            analyticsTrackerWrapper.track(
-                stat = JETPACK_SETUP_FLOW,
-                properties = mapOf(
-                    AnalyticsTracker.KEY_STEP to currentStep.value.type.analyticsName,
-                    AnalyticsTracker.KEY_FAILURE to "Jetpack activation failed: $status",
-                )
-            )
+            trackSetupFlow(failure =  "Jetpack activation failed: $status")
         } else {
             analyticsTrackerWrapper.track(
-                stat = LOGIN_JETPACK_SETUP_ACTIVATION_FAILED,
+                stat = AnalyticsEvent.LOGIN_JETPACK_SETUP_ACTIVATION_FAILED,
                 properties = mapOf(AnalyticsTracker.KEY_ERROR_CODE to status.errorCode.toString()),
                 errorContext = this@JetpackActivationMainViewModel::class.simpleName,
                 errorType = status.errorType,
@@ -407,16 +375,10 @@ class JetpackActivationMainViewModel @Inject constructor(
 
     private fun trackPluginInstallationError(status: PluginInstallFailed) {
         if (isFromBanner) {
-            analyticsTrackerWrapper.track(
-                stat = JETPACK_SETUP_FLOW,
-                properties = mapOf(
-                    AnalyticsTracker.KEY_STEP to currentStep.value.type.analyticsName,
-                    AnalyticsTracker.KEY_FAILURE to "Jetpack installation failed: $status",
-                )
-            )
+            trackSetupFlow(failure =  "Jetpack installation failed: $status")
         } else {
             analyticsTrackerWrapper.track(
-                stat = LOGIN_JETPACK_SETUP_INSTALL_FAILED,
+                stat = AnalyticsEvent.LOGIN_JETPACK_SETUP_INSTALL_FAILED,
                 properties = mapOf(AnalyticsTracker.KEY_ERROR_CODE to status.errorCode.toString()),
                 errorContext = this@JetpackActivationMainViewModel::class.simpleName,
                 errorType = status.errorType,
@@ -431,13 +393,7 @@ class JetpackActivationMainViewModel @Inject constructor(
             val error = (it as? OnChangedException)?.error as? JetpackStore.JetpackError
 
             if (isFromBanner) {
-                analyticsTrackerWrapper.track(
-                    stat = JETPACK_SETUP_FLOW,
-                    properties = mapOf(
-                        AnalyticsTracker.KEY_STEP to currentStep.value.type.analyticsName,
-                        AnalyticsTracker.KEY_FAILURE to "Jetpack connection failed: ${it.message}",
-                    )
-                )
+                trackSetupFlow(failure = "Jetpack connection failed: ${it.message}")
             } else {
                 analyticsTrackerWrapper.track(
                     stat = AnalyticsEvent.LOGIN_JETPACK_SETUP_FETCH_JETPACK_CONNECTION_URL_FAILED,
@@ -553,13 +509,7 @@ class JetpackActivationMainViewModel @Inject constructor(
                 val error = (it as? OnChangedException)?.error as? JetpackStore.JetpackError
 
                 if (isFromBanner) {
-                    analyticsTrackerWrapper.track(
-                        stat = JETPACK_SETUP_FLOW,
-                        properties = mapOf(
-                            AnalyticsTracker.KEY_STEP to currentStep.value.type.analyticsName,
-                            AnalyticsTracker.KEY_FAILURE to "Jetpack connection validation failed: ${it.message}",
-                        )
-                    )
+                    trackSetupFlow(failure = "Jetpack connection validation failed: ${it.message}")
                 } else {
                     analyticsTrackerWrapper.track(
                         stat = AnalyticsEvent.LOGIN_JETPACK_SETUP_ERROR_CHECKING_JETPACK_CONNECTION,
@@ -587,13 +537,7 @@ class JetpackActivationMainViewModel @Inject constructor(
             },
             onFailure = {
                 if (isFromBanner) {
-                    analyticsTrackerWrapper.track(
-                        stat = JETPACK_SETUP_FLOW,
-                        properties = mapOf(
-                            AnalyticsTracker.KEY_STEP to currentStep.value.type.analyticsName,
-                            AnalyticsTracker.KEY_FAILURE to "Site connection confirmation failed: ${it.message}",
-                        )
-                    )
+                    trackSetupFlow(failure = "Site connection confirmation failed: ${it.message}")
                 } else {
                     analyticsTrackerWrapper.track(
                         stat = AnalyticsEvent.LOGIN_JETPACK_FETCHING_WPCOM_SITES_FAILED,
@@ -610,6 +554,20 @@ class JetpackActivationMainViewModel @Inject constructor(
     private fun stepsForInstallation() = StepType.entries
 
     private fun stepsForConnection() = listOf(StepType.Connection, StepType.Done)
+
+    private fun trackSetupFlow(
+        tap: String? = null,
+        failure: String? = null
+    ) {
+        analyticsTrackerWrapper.track(
+            stat = AnalyticsEvent.JETPACK_SETUP_FLOW,
+            properties = mapOf(
+                AnalyticsTracker.KEY_STEP to currentStep.value.type.analyticsName,
+                AnalyticsTracker.KEY_TAP to tap,
+                AnalyticsTracker.KEY_FAILURE to failure,
+            ).filterNotNull()
+        )
+    }
 
     sealed interface ViewState {
         data class ProgressViewState(

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/login/jetpack/main/JetpackActivationMainViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/login/jetpack/main/JetpackActivationMainViewModelTest.kt
@@ -164,8 +164,7 @@ class JetpackActivationMainViewModelTest : BaseUnitTest() {
 
             assertThat(event).isEqualTo(
                 ShowJetpackConnectionWebView(
-                    url = "https://wordpress.com/jetpack/connect?url=example.com" +
-                        "&mobile_redirect=${JetpackActivationMainViewModel.MOBILE_REDIRECT}&from=mobile"
+                    url = "$siteUrl/wp-admin/admin.php?page=jetpack"
                 )
             )
         }


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Part of: #13628 

### Description
As pointed in the previous PR #13655, the WebView connection is broken with the new logic. The cause for this is that the page we currently use (`https://wordpress.com/jetpack/connect`) doesn't work well when the site already had Jetpack but it's an older version, it tries to update it, but it fails, and the user will be stuck.

This PR updates the URL for an alternative one: Using `wp-admin` directly, and the experience is not bad, especially considering that this is just a temporary solution until the last version of Jetpack is more broadly used.

### Steps to reproduce
Perform the TC7 of the testing plan pe5sF9-42S-p2

### Testing information
- Confirm the WebView connection works correctly.

### The tests that have been performed
^

### Images/gif
| Before | After |
| --- | --- |
| <video src=https://github.com/user-attachments/assets/c1b35723-59e9-47ef-8454-fda29ad81e1b/> | <video src=https://github.com/user-attachments/assets/1f53f9a1-ceb4-4d94-a28c-8aa7ae168374/> |

- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.

## Reviewer (or Author, in the case of optional code reviews):

Please make sure these conditions are met before approving the PR, or request changes if the PR needs improvement:

- [x] The PR is small and has a clear, single focus, or a valid explanation is provided in the description. If needed, please request to split it into smaller PRs.
- [x] Ensure Adequate Unit Test Coverage: The changes are reasonably covered by unit tests or an explanation is provided in the PR description.
- [x] Manual Testing: The author listed all the tests they ran, including smoke tests when needed (e.g., for refactorings). The reviewer confirmed that the PR works as expected on big (tablet) and small (phone) in case of UI changes, and no regressions are added.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->