### PR TITLE
Issue/add store id and url to surveys

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/feedback/FeedbackSurveyFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/feedback/FeedbackSurveyFragment.kt
@@ -29,7 +29,6 @@ import com.woocommerce.android.databinding.FragmentFeedbackSurveyBinding
 import com.woocommerce.android.extensions.navigateSafely
 import com.woocommerce.android.tools.SelectedSite
 import com.woocommerce.android.ui.base.BaseFragment
-import com.woocommerce.android.ui.dashboard.DashboardStatsUsageTracksEventEmitter
 import com.woocommerce.android.ui.main.AppBarStatus
 import com.woocommerce.android.widgets.CustomProgressDialog
 import dagger.hilt.android.AndroidEntryPoint

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/feedback/FeedbackSurveyFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/feedback/FeedbackSurveyFragment.kt
@@ -45,6 +45,7 @@ class FeedbackSurveyFragment : BaseFragment(R.layout.fragment_feedback_survey) {
 
     @Inject
     lateinit var selectedSite: SelectedSite
+
     @Inject
     lateinit var appPrefsWrapper: AppPrefsWrapper
 
@@ -93,16 +94,18 @@ class FeedbackSurveyFragment : BaseFragment(R.layout.fragment_feedback_survey) {
 
     private fun getSurveyUrlFromArguments(): String = arguments.customUrl ?: arguments.surveyType.url
 
-private fun addCrowdSignalTagsTo(url: String): String {
-    val storeId = appPrefsWrapper.getWCStoreID(selectedSite.getOrNull()?.siteId ?: 0L)
-    val storeUrl = selectedSite.getOrNull()?.url
+    private fun addCrowdSignalTagsTo(url: String): String {
+        val siteId = selectedSite.getOrNull()?.siteId
+        val storeId = appPrefsWrapper.getWCStoreID(siteId ?: 0L)
+        val storeUrl = selectedSite.getOrNull()?.url
 
-    return buildString {
-        append(url)
-        if (!storeId.isNullOrBlank()) append("&store-id=$storeId")
-        if (!storeUrl.isNullOrBlank()) append("&store-url=$storeUrl")
+        return buildString {
+            append(url)
+            if (siteId != null) append("&site-id=$siteId")
+            if (!storeId.isNullOrBlank()) append("&store-id=$storeId")
+            if (!storeUrl.isNullOrBlank()) append("&store-url=$storeUrl")
+        }
     }
-}
 
     override fun onDestroyView() {
         super.onDestroyView()

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/feedback/FeedbackSurveyFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/feedback/FeedbackSurveyFragment.kt
@@ -11,6 +11,7 @@ import androidx.appcompat.app.AppCompatActivity
 import androidx.navigation.fragment.findNavController
 import androidx.navigation.fragment.navArgs
 import com.google.android.material.appbar.MaterialToolbar
+import com.woocommerce.android.AppPrefsWrapper
 import com.woocommerce.android.R
 import com.woocommerce.android.analytics.AnalyticsEvent.SURVEY_SCREEN
 import com.woocommerce.android.analytics.AnalyticsTracker
@@ -26,16 +27,26 @@ import com.woocommerce.android.analytics.AnalyticsTracker.Companion.VALUE_ORDER_
 import com.woocommerce.android.analytics.AnalyticsTracker.Companion.VALUE_PRODUCT_ADDONS_FEEDBACK
 import com.woocommerce.android.databinding.FragmentFeedbackSurveyBinding
 import com.woocommerce.android.extensions.navigateSafely
+import com.woocommerce.android.tools.SelectedSite
 import com.woocommerce.android.ui.base.BaseFragment
+import com.woocommerce.android.ui.dashboard.DashboardStatsUsageTracksEventEmitter
 import com.woocommerce.android.ui.main.AppBarStatus
 import com.woocommerce.android.widgets.CustomProgressDialog
+import dagger.hilt.android.AndroidEntryPoint
+import javax.inject.Inject
 
+@AndroidEntryPoint
 class FeedbackSurveyFragment : BaseFragment(R.layout.fragment_feedback_survey) {
     companion object {
         const val TAG = "feedback_survey"
         private const val QUERY_PARAMETER_MESSAGE = "msg"
         private const val SURVEY_DONE_QUERY_MESSAGE = "done"
     }
+
+    @Inject
+    lateinit var selectedSite: SelectedSite
+    @Inject
+    lateinit var appPrefsWrapper: AppPrefsWrapper
 
     override val activityAppBarStatus: AppBarStatus
         get() = AppBarStatus.Hidden
@@ -66,7 +77,7 @@ class FeedbackSurveyFragment : BaseFragment(R.layout.fragment_feedback_survey) {
         configureWebView()
         savedInstanceState?.let {
             binding.webView.restoreState(it)
-        } ?: binding.webView.loadUrl(getSurveyUrlFromArguments())
+        } ?: binding.webView.loadUrl(addCrowdSignalTagsTo(getSurveyUrlFromArguments()))
     }
 
     private fun setupToolbar(toolbar: MaterialToolbar) {
@@ -81,6 +92,17 @@ class FeedbackSurveyFragment : BaseFragment(R.layout.fragment_feedback_survey) {
     }
 
     private fun getSurveyUrlFromArguments(): String = arguments.customUrl ?: arguments.surveyType.url
+
+private fun addCrowdSignalTagsTo(url: String): String {
+    val storeId = appPrefsWrapper.getWCStoreID(selectedSite.getOrNull()?.siteId ?: 0L)
+    val storeUrl = selectedSite.getOrNull()?.url
+
+    return buildString {
+        append(url)
+        if (!storeId.isNullOrBlank()) append("&store-id=$storeId")
+        if (!storeUrl.isNullOrBlank()) append("&store-url=$storeUrl")
+    }
+}
 
     override fun onDestroyView() {
         super.onDestroyView()

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/feedback/SurveyType.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/feedback/SurveyType.kt
@@ -27,10 +27,4 @@ enum class SurveyType(
     private val appVersionTag = "&app-version=${BuildConfig.VERSION_NAME}"
 
     private val platformTag = "woo-mobile-platform=android"
-
-//    private val storeUrlTag
-//        get() = when {
-//            storeUrl.isNullOrBlank() -> ""
-//            else -> "&store-url=$storeUrl"
-//        }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/feedback/SurveyType.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/feedback/SurveyType.kt
@@ -4,10 +4,7 @@ import com.woocommerce.android.AppUrls
 import com.woocommerce.android.BuildConfig
 
 @Suppress("MagicNumber")
-enum class SurveyType(
-    private val untaggedUrl: String,
-    private val milestone: Int? = null,
-) {
+enum class SurveyType(private val untaggedUrl: String, private val milestone: Int? = null) {
     PRODUCT(AppUrls.CROWDSIGNAL_PRODUCT_SURVEY, 4),
     MAIN(AppUrls.CROWDSIGNAL_MAIN_SURVEY),
     ADDONS(AppUrls.ADDONS_SURVEY),

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/feedback/SurveyType.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/feedback/SurveyType.kt
@@ -4,7 +4,10 @@ import com.woocommerce.android.AppUrls
 import com.woocommerce.android.BuildConfig
 
 @Suppress("MagicNumber")
-enum class SurveyType(private val untaggedUrl: String, private val milestone: Int? = null) {
+enum class SurveyType(
+    private val untaggedUrl: String,
+    private val milestone: Int? = null,
+) {
     PRODUCT(AppUrls.CROWDSIGNAL_PRODUCT_SURVEY, 4),
     MAIN(AppUrls.CROWDSIGNAL_MAIN_SURVEY),
     ADDONS(AppUrls.ADDONS_SURVEY),
@@ -24,4 +27,10 @@ enum class SurveyType(private val untaggedUrl: String, private val milestone: In
     private val appVersionTag = "&app-version=${BuildConfig.VERSION_NAME}"
 
     private val platformTag = "woo-mobile-platform=android"
+
+//    private val storeUrlTag
+//        get() = when {
+//            storeUrl.isNullOrBlank() -> ""
+//            else -> "&store-url=$storeUrl"
+//        }
 }


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

<!-- 
━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
🛠 Need an AI review?  
Add a comment: `@coderabbitai review`
━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
-->

### Description
Appends `store_id`, `blog_id`, and `store_url` to all the crowdsignal urls. Those values are added as [custom tags](https://crowdsignal.com/support/using-custom-tags-to-track-survey-responses/), just as we currently do with `appVersionTag` and `platformTag`. 

### Testing information
<!-- This is your opportunity to break out individual scenarios that need testing (when necessary) and/or include a checklist for the reviewer to go through. Consider documenting the following from your own completed testing: devices used, alternate workflows, edge cases, affected areas, critical flows, areas not tested, and any remaining unknowns. Provide feedback on this new section of the PR template through Sept 30, 2024 to Apps Quality; additional context here: p91TBi-b8z-p2#comment-12036 -->
The easiest way to test this is by checking the url that the webview is loading when navigating to Settings > Send feedback. 
By setting a breakpoint inside the `loadUrl()` function call from `binding.webView.loadUrl` in `FeedbackSurveyFragment`, you should see a URL with the following format: 
```url
https://automattic.survey.fm/woo-app-general-feedback-user-survey?woo-mobile-platform=android&app-version=21.8-rc-2&site-id=205513046&store-id=447ba549-ae10-4d08-9437-c6b2bcbbdd01&store-url=https://ipptesting.mystagingwebsite.com
```

You can also open crowdsignal `Woo app - General feedback` results and check that the new tags are shown.


![Screenshot 2025-03-06 at 18 06 14](https://github.com/user-attachments/assets/d061387c-a6fe-42cc-a4d8-d21027d06576)


### The tests that have been performed
<!-- To give the reviewer an idea of what could be missed in terms of testing -->
The above

### Images/gif
<!-- Include before and after images or gifs when appropriate. -->

- [ ] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.

## Reviewer (or Author, in the case of optional code reviews):

Please make sure these conditions are met before approving the PR, or request changes if the PR needs improvement:

- [ ] The PR is small and has a clear, single focus, or a valid explanation is provided in the description. If needed, please request to split it into smaller PRs.
- [ ] Ensure Adequate Unit Test Coverage: The changes are reasonably covered by unit tests or an explanation is provided in the PR description.
- [ ] Manual Testing: The author listed all the tests they ran, including smoke tests when needed (e.g., for refactorings). The reviewer confirmed that the PR works as expected on big (tablet) and small (phone) in case of UI changes, and no regressions are added.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->