### PR TITLE
[Jetpack Setup] Tracking updates for the Connection API

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/AppPrefs.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/AppPrefs.kt
@@ -113,7 +113,6 @@ object AppPrefs {
         UPDATE_SIMULATED_READER_OPTION,
         ENABLE_SIMULATED_INTERAC,
         CUSTOM_DOMAINS_SOURCE,
-        JETPACK_INSTALLATION_FROM_BANNER,
         NOTIFICATIONS_PERMISSION_BAR,
         IS_EU_SHIPPING_NOTICE_DISMISSED,
         HAS_SAVED_PRIVACY_SETTINGS,
@@ -903,12 +902,6 @@ object AppPrefs {
     }
 
     fun getCustomDomainsSource() = getString(DeletablePrefKey.CUSTOM_DOMAINS_SOURCE, DomainFlowSource.SETTINGS.name)
-
-    fun setJetpackInstallationIsFromBanner(isFromBanner: Boolean) {
-        setBoolean(DeletablePrefKey.JETPACK_INSTALLATION_FROM_BANNER, isFromBanner)
-    }
-
-    fun getJetpackInstallationIsFromBanner() = getBoolean(DeletablePrefKey.JETPACK_INSTALLATION_FROM_BANNER, false)
 
     fun setWasNotificationsPermissionBarDismissed(source: Boolean) {
         setBoolean(DeletablePrefKey.NOTIFICATIONS_PERMISSION_BAR, source)

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/AppPrefsWrapper.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/AppPrefsWrapper.kt
@@ -237,12 +237,6 @@ class AppPrefsWrapper @Inject constructor() {
     fun getCustomDomainsSource(): DomainFlowSource = enumValueOf(AppPrefs.getCustomDomainsSource())
     fun getCustomDomainsSourceAsString(): String = AppPrefs.getCustomDomainsSource().lowercase()
 
-    fun setJetpackInstallationIsFromBanner(isFromBanner: Boolean) {
-        AppPrefs.setJetpackInstallationIsFromBanner(isFromBanner)
-    }
-
-    fun getJetpackInstallationIsFromBanner() = AppPrefs.getJetpackInstallationIsFromBanner()
-
     /**
      * Card Reader Upsell
      */

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/analytics/AnalyticsTracker.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/analytics/AnalyticsTracker.kt
@@ -531,6 +531,9 @@ class AnalyticsTracker private constructor(
         const val VALUE_JETPACK_SETUP_TAP_GO_TO_STORE = "go_to_store"
         const val VALUE_JETPACK_SETUP_TAP_SUPPORT = "support"
         const val VALUE_JETPACK_SETUP_TAP_TRY_AGAIN = "try_again"
+        const val KEY_CONNECTION_TYPE = "connection_type"
+        const val VALUE_CONNECTION_TYPE_NATIVE = "native"
+        const val VALUE_CONNECTION_TYPE_WEB = "web"
 
         // -- Upsell banner
         const val KEY_BANNER_SOURCE = "source"

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/DashboardFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/DashboardFragment.kt
@@ -246,14 +246,12 @@ class DashboardFragment :
     }
 
     private fun prepareJetpackBenefitsBanner() {
-        appPrefsWrapper.setJetpackInstallationIsFromBanner(false)
         binding.jetpackBenefitsBanner.root.isVisible = false
         binding.jetpackBenefitsBanner.root.setOnClickListener {
             AnalyticsTracker.track(
                 stat = AnalyticsEvent.FEATURE_JETPACK_BENEFITS_BANNER,
                 properties = mapOf(AnalyticsTracker.KEY_JETPACK_BENEFITS_BANNER_ACTION to "tapped")
             )
-            appPrefsWrapper.setJetpackInstallationIsFromBanner(true)
             findNavController().navigateSafely(DashboardFragmentDirections.actionDashboardToJetpackBenefitsDialog())
         }
         // For the banner to be above the bottom navigation view when the toolbar is expanded

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/jetpack/main/JetpackActivationMainViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/jetpack/main/JetpackActivationMainViewModel.kt
@@ -263,6 +263,10 @@ class JetpackActivationMainViewModel @Inject constructor(
                 val stepType = step.type
                 WooLog.d(WooLog.T.LOGIN, "Jetpack Activation: handle step: $stepType")
 
+                if (useApplicationPasswords) {
+                    trackSetupFlow()
+                }
+
                 when (stepType) {
                     StepType.Installation -> {
                         startJetpackInstallation()

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/jetpack/main/JetpackActivationMainViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/jetpack/main/JetpackActivationMainViewModel.kt
@@ -144,10 +144,8 @@ class JetpackActivationMainViewModel @Inject constructor(
         }
     }.asLiveData()
 
-    private val isFromBanner = appPrefsWrapper.getJetpackInstallationIsFromBanner()
-
     init {
-        if (!isFromBanner) {
+        if (!useApplicationPasswords) {
             analyticsTrackerWrapper.track(AnalyticsEvent.LOGIN_JETPACK_SETUP_SCREEN_VIEWED)
         }
 
@@ -157,7 +155,7 @@ class JetpackActivationMainViewModel @Inject constructor(
     }
 
     fun onCloseClick() {
-        if (isFromBanner) {
+        if (useApplicationPasswords) {
             trackSetupFlow(tap = AnalyticsTracker.VALUE_DISMISS)
         } else {
             analyticsTrackerWrapper.track(
@@ -172,7 +170,7 @@ class JetpackActivationMainViewModel @Inject constructor(
     }
 
     fun onContinueClick() = launch {
-        if (isFromBanner) {
+        if (useApplicationPasswords) {
             trackSetupFlow(tap = AnalyticsTracker.VALUE_JETPACK_SETUP_TAP_GO_TO_STORE)
         } else {
             analyticsTrackerWrapper.track(stat = AnalyticsEvent.LOGIN_JETPACK_SETUP_GO_TO_STORE_BUTTON_TAPPED)
@@ -186,7 +184,7 @@ class JetpackActivationMainViewModel @Inject constructor(
                 jetpackActivationRepository.setSelectedSiteAndCleanOldSites(site)
                 triggerEvent(GoToStore)
 
-                if (isFromBanner) {
+                if (useApplicationPasswords) {
                     analyticsTrackerWrapper.track(stat = AnalyticsEvent.JETPACK_SETUP_SYNCHRONIZATION_COMPLETED)
                 }
             } else {
@@ -212,7 +210,7 @@ class JetpackActivationMainViewModel @Inject constructor(
     }
 
     fun onRetryClick() {
-        if (isFromBanner) {
+        if (useApplicationPasswords) {
             trackSetupFlow(tap = AnalyticsTracker.VALUE_JETPACK_SETUP_TAP_TRY_AGAIN)
         } else {
             analyticsTrackerWrapper.track(
@@ -227,7 +225,7 @@ class JetpackActivationMainViewModel @Inject constructor(
     }
 
     fun onGetHelpClick() {
-        if (isFromBanner) {
+        if (useApplicationPasswords) {
             trackSetupFlow(tap = AnalyticsTracker.VALUE_JETPACK_SETUP_TAP_SUPPORT)
         } else {
             analyticsTrackerWrapper.track(
@@ -292,7 +290,7 @@ class JetpackActivationMainViewModel @Inject constructor(
                     }
 
                     StepType.Done -> {
-                        if (isFromBanner) {
+                        if (useApplicationPasswords) {
                             analyticsTrackerWrapper.track(stat = AnalyticsEvent.JETPACK_SETUP_COMPLETED)
                         } else {
                             analyticsTrackerWrapper.track(
@@ -333,7 +331,7 @@ class JetpackActivationMainViewModel @Inject constructor(
         ).collect { status ->
             when (status) {
                 is PluginInstalled -> {
-                    if (!isFromBanner) {
+                    if (!useApplicationPasswords) {
                         analyticsTrackerWrapper.track(AnalyticsEvent.LOGIN_JETPACK_SETUP_INSTALL_SUCCESSFUL)
                     }
                     currentStep.value = Step(type = StepType.Activation, state = StepState.Ongoing)
@@ -345,7 +343,7 @@ class JetpackActivationMainViewModel @Inject constructor(
                 }
 
                 is PluginActivated -> {
-                    if (!isFromBanner) {
+                    if (!useApplicationPasswords) {
                         analyticsTrackerWrapper.track(AnalyticsEvent.LOGIN_JETPACK_SETUP_ACTIVATION_SUCCESSFUL)
                     }
                     currentStep.value = Step(type = StepType.Connection, state = StepState.Ongoing)
@@ -360,7 +358,7 @@ class JetpackActivationMainViewModel @Inject constructor(
     }
 
     private fun trackPluginActivationError(status: PluginActivationFailed) {
-        if (isFromBanner) {
+        if (useApplicationPasswords) {
             trackSetupFlow(failure =  "Jetpack activation failed: $status")
         } else {
             analyticsTrackerWrapper.track(
@@ -374,7 +372,7 @@ class JetpackActivationMainViewModel @Inject constructor(
     }
 
     private fun trackPluginInstallationError(status: PluginInstallFailed) {
-        if (isFromBanner) {
+        if (useApplicationPasswords) {
             trackSetupFlow(failure =  "Jetpack installation failed: $status")
         } else {
             analyticsTrackerWrapper.track(
@@ -392,7 +390,7 @@ class JetpackActivationMainViewModel @Inject constructor(
         val onFailure: (Throwable) -> Unit = {
             val error = (it as? OnChangedException)?.error as? JetpackStore.JetpackError
 
-            if (isFromBanner) {
+            if (useApplicationPasswords) {
                 trackSetupFlow(failure = "Jetpack connection failed: ${it.message}")
             } else {
                 analyticsTrackerWrapper.track(
@@ -434,7 +432,7 @@ class JetpackActivationMainViewModel @Inject constructor(
         val currentSite = site.await()
         jetpackActivationRepository.fetchJetpackConnectionUrl(currentSite, useApplicationPasswords).fold(
             onSuccess = { connectionUrl ->
-                if (!isFromBanner) {
+                if (!useApplicationPasswords) {
                     analyticsTrackerWrapper.track(
                         stat = AnalyticsEvent.LOGIN_JETPACK_SETUP_FETCH_JETPACK_CONNECTION_URL_SUCCESSFUL
                     )
@@ -491,7 +489,7 @@ class JetpackActivationMainViewModel @Inject constructor(
             onSuccess = { email ->
                 jetpackConnectedEmail = email
                 if (accountRepository.getUserAccount()?.email != email) {
-                    if (!isFromBanner) {
+                    if (!useApplicationPasswords) {
                         analyticsTrackerWrapper.track(
                             stat = AnalyticsEvent.LOGIN_JETPACK_SETUP_AUTHORIZED_USING_DIFFERENT_WPCOM_ACCOUNT
                         )
@@ -508,7 +506,7 @@ class JetpackActivationMainViewModel @Inject constructor(
             onFailure = {
                 val error = (it as? OnChangedException)?.error as? JetpackStore.JetpackError
 
-                if (isFromBanner) {
+                if (useApplicationPasswords) {
                     trackSetupFlow(failure = "Jetpack connection validation failed: ${it.message}")
                 } else {
                     analyticsTrackerWrapper.track(
@@ -536,7 +534,7 @@ class JetpackActivationMainViewModel @Inject constructor(
                 connectionStep.value = ConnectionStep.Approved
             },
             onFailure = {
-                if (isFromBanner) {
+                if (useApplicationPasswords) {
                     trackSetupFlow(failure = "Site connection confirmation failed: ${it.message}")
                 } else {
                     analyticsTrackerWrapper.track(

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/jetpack/main/JetpackActivationMainViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/jetpack/main/JetpackActivationMainViewModel.kt
@@ -565,6 +565,10 @@ class JetpackActivationMainViewModel @Inject constructor(
                 AnalyticsTracker.KEY_STEP to currentStep.value.type.analyticsName,
                 AnalyticsTracker.KEY_TAP to tap,
                 AnalyticsTracker.KEY_FAILURE to failure,
+                AnalyticsTracker.KEY_CONNECTION_TYPE to when {
+                    supportNativeConnectionAPI -> AnalyticsTracker.VALUE_CONNECTION_TYPE_NATIVE
+                    else -> AnalyticsTracker.VALUE_CONNECTION_TYPE_WEB
+                }
             ).filterNotNull()
         )
     }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/jetpack/main/JetpackActivationMainViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/jetpack/main/JetpackActivationMainViewModel.kt
@@ -8,11 +8,9 @@ import androidx.lifecycle.viewModelScope
 import com.woocommerce.android.AppPrefsWrapper
 import com.woocommerce.android.OnChangedException
 import com.woocommerce.android.analytics.AnalyticsEvent
-import com.woocommerce.android.analytics.AnalyticsEvent.JETPACK_SETUP_FLOW
-import com.woocommerce.android.analytics.AnalyticsEvent.LOGIN_JETPACK_SETUP_ACTIVATION_FAILED
-import com.woocommerce.android.analytics.AnalyticsEvent.LOGIN_JETPACK_SETUP_INSTALL_FAILED
 import com.woocommerce.android.analytics.AnalyticsTracker
 import com.woocommerce.android.analytics.AnalyticsTrackerWrapper
+import com.woocommerce.android.extensions.filterNotNull
 import com.woocommerce.android.extensions.isNotNullOrEmpty
 import com.woocommerce.android.model.JetpackConnectionStatus
 import com.woocommerce.android.support.help.HelpOrigin.JETPACK_INSTALLATION
@@ -160,13 +158,7 @@ class JetpackActivationMainViewModel @Inject constructor(
 
     fun onCloseClick() {
         if (isFromBanner) {
-            analyticsTrackerWrapper.track(
-                stat = JETPACK_SETUP_FLOW,
-                properties = mapOf(
-                    AnalyticsTracker.KEY_STEP to currentStep.value.type.analyticsName,
-                    AnalyticsTracker.KEY_TAP to AnalyticsTracker.VALUE_DISMISS
-                )
-            )
+            trackSetupFlow(tap = AnalyticsTracker.VALUE_DISMISS)
         } else {
             analyticsTrackerWrapper.track(
                 stat = AnalyticsEvent.LOGIN_JETPACK_SETUP_SCREEN_DISMISSED,
@@ -181,13 +173,7 @@ class JetpackActivationMainViewModel @Inject constructor(
 
     fun onContinueClick() = launch {
         if (isFromBanner) {
-            analyticsTrackerWrapper.track(
-                stat = JETPACK_SETUP_FLOW,
-                properties = mapOf(
-                    AnalyticsTracker.KEY_STEP to currentStep.value.type.analyticsName,
-                    AnalyticsTracker.KEY_TAP to AnalyticsTracker.VALUE_JETPACK_SETUP_TAP_GO_TO_STORE
-                )
-            )
+            trackSetupFlow(tap = AnalyticsTracker.VALUE_JETPACK_SETUP_TAP_GO_TO_STORE)
         } else {
             analyticsTrackerWrapper.track(stat = AnalyticsEvent.LOGIN_JETPACK_SETUP_GO_TO_STORE_BUTTON_TAPPED)
         }
@@ -227,13 +213,7 @@ class JetpackActivationMainViewModel @Inject constructor(
 
     fun onRetryClick() {
         if (isFromBanner) {
-            analyticsTrackerWrapper.track(
-                stat = JETPACK_SETUP_FLOW,
-                properties = mapOf(
-                    AnalyticsTracker.KEY_STEP to currentStep.value.type.analyticsName,
-                    AnalyticsTracker.KEY_TAP to AnalyticsTracker.VALUE_JETPACK_SETUP_TAP_TRY_AGAIN
-                )
-            )
+            trackSetupFlow(tap = AnalyticsTracker.VALUE_JETPACK_SETUP_TAP_TRY_AGAIN)
         } else {
             analyticsTrackerWrapper.track(
                 stat = AnalyticsEvent.LOGIN_JETPACK_SETUP_TRY_AGAIN_BUTTON_TAPPED,
@@ -248,13 +228,7 @@ class JetpackActivationMainViewModel @Inject constructor(
 
     fun onGetHelpClick() {
         if (isFromBanner) {
-            analyticsTrackerWrapper.track(
-                stat = JETPACK_SETUP_FLOW,
-                properties = mapOf(
-                    AnalyticsTracker.KEY_STEP to currentStep.value.type.analyticsName,
-                    AnalyticsTracker.KEY_TAP to AnalyticsTracker.VALUE_JETPACK_SETUP_TAP_SUPPORT
-                )
-            )
+            trackSetupFlow(tap = AnalyticsTracker.VALUE_JETPACK_SETUP_TAP_SUPPORT)
         } else {
             analyticsTrackerWrapper.track(
                 stat = AnalyticsEvent.LOGIN_JETPACK_SETUP_GET_SUPPORT_BUTTON_TAPPED,
@@ -387,16 +361,10 @@ class JetpackActivationMainViewModel @Inject constructor(
 
     private fun trackPluginActivationError(status: PluginActivationFailed) {
         if (isFromBanner) {
-            analyticsTrackerWrapper.track(
-                stat = JETPACK_SETUP_FLOW,
-                properties = mapOf(
-                    AnalyticsTracker.KEY_STEP to currentStep.value.type.analyticsName,
-                    AnalyticsTracker.KEY_FAILURE to "Jetpack activation failed: $status",
-                )
-            )
+            trackSetupFlow(failure =  "Jetpack activation failed: $status")
         } else {
             analyticsTrackerWrapper.track(
-                stat = LOGIN_JETPACK_SETUP_ACTIVATION_FAILED,
+                stat = AnalyticsEvent.LOGIN_JETPACK_SETUP_ACTIVATION_FAILED,
                 properties = mapOf(AnalyticsTracker.KEY_ERROR_CODE to status.errorCode.toString()),
                 errorContext = this@JetpackActivationMainViewModel::class.simpleName,
                 errorType = status.errorType,
@@ -407,16 +375,10 @@ class JetpackActivationMainViewModel @Inject constructor(
 
     private fun trackPluginInstallationError(status: PluginInstallFailed) {
         if (isFromBanner) {
-            analyticsTrackerWrapper.track(
-                stat = JETPACK_SETUP_FLOW,
-                properties = mapOf(
-                    AnalyticsTracker.KEY_STEP to currentStep.value.type.analyticsName,
-                    AnalyticsTracker.KEY_FAILURE to "Jetpack installation failed: $status",
-                )
-            )
+            trackSetupFlow(failure =  "Jetpack installation failed: $status")
         } else {
             analyticsTrackerWrapper.track(
-                stat = LOGIN_JETPACK_SETUP_INSTALL_FAILED,
+                stat = AnalyticsEvent.LOGIN_JETPACK_SETUP_INSTALL_FAILED,
                 properties = mapOf(AnalyticsTracker.KEY_ERROR_CODE to status.errorCode.toString()),
                 errorContext = this@JetpackActivationMainViewModel::class.simpleName,
                 errorType = status.errorType,
@@ -431,13 +393,7 @@ class JetpackActivationMainViewModel @Inject constructor(
             val error = (it as? OnChangedException)?.error as? JetpackStore.JetpackError
 
             if (isFromBanner) {
-                analyticsTrackerWrapper.track(
-                    stat = JETPACK_SETUP_FLOW,
-                    properties = mapOf(
-                        AnalyticsTracker.KEY_STEP to currentStep.value.type.analyticsName,
-                        AnalyticsTracker.KEY_FAILURE to "Jetpack connection failed: ${it.message}",
-                    )
-                )
+                trackSetupFlow(failure = "Jetpack connection failed: ${it.message}")
             } else {
                 analyticsTrackerWrapper.track(
                     stat = AnalyticsEvent.LOGIN_JETPACK_SETUP_FETCH_JETPACK_CONNECTION_URL_FAILED,
@@ -553,13 +509,7 @@ class JetpackActivationMainViewModel @Inject constructor(
                 val error = (it as? OnChangedException)?.error as? JetpackStore.JetpackError
 
                 if (isFromBanner) {
-                    analyticsTrackerWrapper.track(
-                        stat = JETPACK_SETUP_FLOW,
-                        properties = mapOf(
-                            AnalyticsTracker.KEY_STEP to currentStep.value.type.analyticsName,
-                            AnalyticsTracker.KEY_FAILURE to "Jetpack connection validation failed: ${it.message}",
-                        )
-                    )
+                    trackSetupFlow(failure = "Jetpack connection validation failed: ${it.message}")
                 } else {
                     analyticsTrackerWrapper.track(
                         stat = AnalyticsEvent.LOGIN_JETPACK_SETUP_ERROR_CHECKING_JETPACK_CONNECTION,
@@ -587,13 +537,7 @@ class JetpackActivationMainViewModel @Inject constructor(
             },
             onFailure = {
                 if (isFromBanner) {
-                    analyticsTrackerWrapper.track(
-                        stat = JETPACK_SETUP_FLOW,
-                        properties = mapOf(
-                            AnalyticsTracker.KEY_STEP to currentStep.value.type.analyticsName,
-                            AnalyticsTracker.KEY_FAILURE to "Site connection confirmation failed: ${it.message}",
-                        )
-                    )
+                    trackSetupFlow(failure = "Site connection confirmation failed: ${it.message}")
                 } else {
                     analyticsTrackerWrapper.track(
                         stat = AnalyticsEvent.LOGIN_JETPACK_FETCHING_WPCOM_SITES_FAILED,
@@ -610,6 +554,20 @@ class JetpackActivationMainViewModel @Inject constructor(
     private fun stepsForInstallation() = StepType.entries
 
     private fun stepsForConnection() = listOf(StepType.Connection, StepType.Done)
+
+    private fun trackSetupFlow(
+        tap: String? = null,
+        failure: String? = null
+    ) {
+        analyticsTrackerWrapper.track(
+            stat = AnalyticsEvent.JETPACK_SETUP_FLOW,
+            properties = mapOf(
+                AnalyticsTracker.KEY_STEP to currentStep.value.type.analyticsName,
+                AnalyticsTracker.KEY_TAP to tap,
+                AnalyticsTracker.KEY_FAILURE to failure,
+            ).filterNotNull()
+        )
+    }
 
     sealed interface ViewState {
         data class ProgressViewState(


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #13656 
<!-- Id number of the GitHub issue this PR addresses. -->

<!-- 
━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
🛠 Need an AI review?  
Add a comment: `@coderabbitai review`
━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
-->

### Description
This PR updates tracking for the Jetpack Setup as suggested in p91TBi-d1G-p2, the changes are:

- Introduce a new property `connection_type` with a value of either `native` or `web` depending on whether Connection API is supported or not.
- Track the `jetpack_setup_flow` event for all intermediate steps, this matches what iOS does, and would make creating advanced funnels to detect drop points easier.

The PR also fixes an issue where we were using the wrong tracks if the setup was launched from the settings, more about this in the comment section.

### Steps to reproduce
- Start Jetpack Setup.
- Check the logcat for the `Tracked` entries.

### Testing information
- Confirm that the event `jetpack_setup_flow` includes a new property `connection_type` with the correct value.
- Confirm that the event `jetpack_setup_flow` is tracked whenever the flow moves from one step to another.

### The tests that have been performed
^

- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.

## Reviewer (or Author, in the case of optional code reviews):

Please make sure these conditions are met before approving the PR, or request changes if the PR needs improvement:

- [x] The PR is small and has a clear, single focus, or a valid explanation is provided in the description. If needed, please request to split it into smaller PRs.
- [x] Ensure Adequate Unit Test Coverage: The changes are reasonably covered by unit tests or an explanation is provided in the PR description.
- [x] Manual Testing: The author listed all the tests they ran, including smoke tests when needed (e.g., for refactorings). The reviewer confirmed that the PR works as expected on big (tablet) and small (phone) in case of UI changes, and no regressions are added.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->