### PR TITLE
[Jetpack Setup] Jetpack Connection API using Cookies+Nonce authentication

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/jetpack/FetchJetpackStatus.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/jetpack/FetchJetpackStatus.kt
@@ -5,7 +5,6 @@ import com.woocommerce.android.extensions.isNotNullOrEmpty
 import com.woocommerce.android.model.JetpackConnectionStatus
 import com.woocommerce.android.model.JetpackSiteRegistrationStatus
 import com.woocommerce.android.model.JetpackStatus
-import com.woocommerce.android.tools.SelectedSite
 import org.wordpress.android.fluxc.model.SiteModel
 import org.wordpress.android.fluxc.model.jetpack.JetpackConnectionData
 import org.wordpress.android.fluxc.store.JetpackStore
@@ -26,7 +25,6 @@ import javax.inject.Inject
  */
 class FetchJetpackStatus @Inject constructor(
     private val jetpackStore: JetpackStore,
-    private val selectedSite: SelectedSite,
     private val wooCommerceStore: WooCommerceStore
 ) {
     companion object {
@@ -42,12 +40,13 @@ class FetchJetpackStatus @Inject constructor(
 
     @Suppress("ReturnCount", "NestedBlockDepth")
     suspend operator fun invoke(
-        site: SiteModel = selectedSite.get(),
+        site: SiteModel,
+        useApplicationPasswords: Boolean,
         isJetpackInstalled: Boolean? = null
     ): Result<JetpackStatusFetchResponse> {
         return jetpackStore.fetchJetpackConnectionData(
             site = site,
-            useApplicationPasswords = true
+            useApplicationPasswords = useApplicationPasswords
         ).let { userResult ->
             when {
                 userResult.error?.errorCode == FORBIDDEN_CODE -> {
@@ -73,7 +72,7 @@ class FetchJetpackStatus @Inject constructor(
                 }
 
                 else -> {
-                    val isJetpackInstalled = isJetpackInstalled ?: checkIfJetpackIsInstalled().getOrElse {
+                    val isJetpackInstalled = isJetpackInstalled ?: checkIfJetpackIsInstalled(site).getOrElse {
                         return Result.failure(it)
                     }
 
@@ -92,8 +91,8 @@ class FetchJetpackStatus @Inject constructor(
         }
     }
 
-    private suspend fun checkIfJetpackIsInstalled(): Result<Boolean> {
-        return wooCommerceStore.fetchSitePlugins(selectedSite.get())
+    private suspend fun checkIfJetpackIsInstalled(site: SiteModel): Result<Boolean> {
+        return wooCommerceStore.fetchSitePlugins(site)
             .let { pluginResult ->
                 when {
                     pluginResult.isError -> {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/jetpack/FetchJetpackStatus.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/jetpack/FetchJetpackStatus.kt
@@ -1,4 +1,4 @@
-package com.woocommerce.android.ui.jetpack.benefits
+package com.woocommerce.android.ui.jetpack
 
 import com.woocommerce.android.OnChangedException
 import com.woocommerce.android.extensions.isNotNullOrEmpty

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/jetpack/JetpackActivationEligibilityErrorViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/jetpack/JetpackActivationEligibilityErrorViewModel.kt
@@ -55,7 +55,10 @@ class JetpackActivationEligibilityErrorViewModel @Inject constructor(
 
     fun onRetryButtonClicked() = launch {
         isRetrying.value = true
-        val jetpackStatusResult = fetchJetpackStatus()
+        val jetpackStatusResult = fetchJetpackStatus(
+            site = selectedSite.get(),
+            useApplicationPasswords = true
+        )
         handleJetpackStatusResult(jetpackStatusResult)
         isRetrying.value = false
     }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/jetpack/JetpackActivationEligibilityErrorViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/jetpack/JetpackActivationEligibilityErrorViewModel.kt
@@ -10,8 +10,7 @@ import com.woocommerce.android.model.UserRole
 import com.woocommerce.android.support.help.HelpOrigin
 import com.woocommerce.android.tools.SelectedSite
 import com.woocommerce.android.ui.common.UserEligibilityFetcher
-import com.woocommerce.android.ui.jetpack.benefits.FetchJetpackStatus
-import com.woocommerce.android.ui.jetpack.benefits.FetchJetpackStatus.JetpackStatusFetchResponse
+import com.woocommerce.android.ui.jetpack.FetchJetpackStatus.JetpackStatusFetchResponse
 import com.woocommerce.android.viewmodel.MultiLiveEvent.Event
 import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.Exit
 import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.NavigateToHelpScreen

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/jetpack/benefits/FetchJetpackStatus.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/jetpack/benefits/FetchJetpackStatus.kt
@@ -41,7 +41,10 @@ class FetchJetpackStatus @Inject constructor(
     }
 
     @Suppress("ReturnCount", "NestedBlockDepth")
-    suspend operator fun invoke(site: SiteModel = selectedSite.get()): Result<JetpackStatusFetchResponse> {
+    suspend operator fun invoke(
+        site: SiteModel = selectedSite.get(),
+        isJetpackInstalled: Boolean? = null
+    ): Result<JetpackStatusFetchResponse> {
         return jetpackStore.fetchJetpackConnectionData(
             site = site,
             useApplicationPasswords = true
@@ -70,7 +73,7 @@ class FetchJetpackStatus @Inject constructor(
                 }
 
                 else -> {
-                    val isJetpackInstalled = checkIfJetpackIsInstalled().getOrElse {
+                    val isJetpackInstalled = isJetpackInstalled ?: checkIfJetpackIsInstalled().getOrElse {
                         return Result.failure(it)
                     }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/jetpack/benefits/FetchJetpackStatus.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/jetpack/benefits/FetchJetpackStatus.kt
@@ -6,6 +6,7 @@ import com.woocommerce.android.model.JetpackConnectionStatus
 import com.woocommerce.android.model.JetpackSiteRegistrationStatus
 import com.woocommerce.android.model.JetpackStatus
 import com.woocommerce.android.tools.SelectedSite
+import org.wordpress.android.fluxc.model.SiteModel
 import org.wordpress.android.fluxc.model.jetpack.JetpackConnectionData
 import org.wordpress.android.fluxc.store.JetpackStore
 import org.wordpress.android.fluxc.store.WooCommerceStore
@@ -40,9 +41,9 @@ class FetchJetpackStatus @Inject constructor(
     }
 
     @Suppress("ReturnCount", "NestedBlockDepth")
-    suspend operator fun invoke(): Result<JetpackStatusFetchResponse> {
+    suspend operator fun invoke(site: SiteModel = selectedSite.get()): Result<JetpackStatusFetchResponse> {
         return jetpackStore.fetchJetpackConnectionData(
-            site = selectedSite.get(),
+            site = site,
             useApplicationPasswords = true
         ).let { userResult ->
             when {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/jetpack/benefits/JetpackBenefitsViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/jetpack/benefits/JetpackBenefitsViewModel.kt
@@ -15,7 +15,8 @@ import com.woocommerce.android.model.UserRole
 import com.woocommerce.android.tools.SelectedSite
 import com.woocommerce.android.tools.SiteConnectionType
 import com.woocommerce.android.ui.common.UserEligibilityFetcher
-import com.woocommerce.android.ui.jetpack.benefits.FetchJetpackStatus.JetpackStatusFetchResponse
+import com.woocommerce.android.ui.jetpack.FetchJetpackStatus
+import com.woocommerce.android.ui.jetpack.FetchJetpackStatus.JetpackStatusFetchResponse
 import com.woocommerce.android.viewmodel.MultiLiveEvent.Event
 import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.Exit
 import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.ShowSnackbar

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/jetpack/benefits/JetpackBenefitsViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/jetpack/benefits/JetpackBenefitsViewModel.kt
@@ -63,12 +63,16 @@ class JetpackBenefitsViewModel @Inject constructor(
 
                 triggerEvent(StartJetpackActivationForJetpackCP)
             }
+
             SiteConnectionType.ApplicationPasswords -> {
                 AnalyticsTracker.track(stat = JETPACK_BENEFITS_LOGIN_BUTTON_TAPPED)
 
                 _viewState.update { it.copy(isLoadingDialogShown = true) }
 
-                val jetpackStatusResult = fetchJetpackStatus()
+                val jetpackStatusResult = fetchJetpackStatus(
+                    site = selectedSite.get(),
+                    useApplicationPasswords = true
+                )
                 handleJetpackStatusResult(jetpackStatusResult)
 
                 _viewState.update { it.copy(isLoadingDialogShown = false) }
@@ -110,6 +114,7 @@ class JetpackBenefitsViewModel @Inject constructor(
                             hasInstallCapability && statusCode == ERROR_CODE_NOT_FOUND && jetpackStatus != null -> {
                                 startJetpackActivation(jetpackStatus)
                             }
+
                             else -> {
                                 triggerEvent(OpenJetpackEligibilityError(user.username, user.roles.first().value))
 
@@ -139,6 +144,7 @@ class JetpackBenefitsViewModel @Inject constructor(
                             handleUserEligibility(ERROR_CODE_NOT_FOUND, fetchResponse.status)
                         }
                     }
+
                     JetpackStatusFetchResponse.ConnectionForbidden -> handleUserEligibility(ERROR_CODE_FORBIDDEN)
                 }
             },
@@ -185,6 +191,7 @@ class JetpackBenefitsViewModel @Inject constructor(
         val siteUrl: String,
         val jetpackStatus: JetpackStatus
     ) : Event()
+
     data class OpenWpAdminJetpackActivation(val activationUrl: String) : Event()
     data class OpenJetpackEligibilityError(val username: String, val role: String) : Event()
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/jetpack/sitecredentials/JetpackActivationSiteCredentialsViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/jetpack/sitecredentials/JetpackActivationSiteCredentialsViewModel.kt
@@ -8,9 +8,13 @@ import com.woocommerce.android.OnChangedException
 import com.woocommerce.android.R
 import com.woocommerce.android.analytics.AnalyticsEvent
 import com.woocommerce.android.analytics.AnalyticsTrackerWrapper
+import com.woocommerce.android.model.JetpackConnectionStatus
+import com.woocommerce.android.model.JetpackSiteRegistrationStatus
 import com.woocommerce.android.model.JetpackStatus
 import com.woocommerce.android.model.UiString
 import com.woocommerce.android.model.UiString.UiStringRes
+import com.woocommerce.android.ui.jetpack.benefits.FetchJetpackStatus
+import com.woocommerce.android.ui.jetpack.benefits.FetchJetpackStatus.JetpackStatusFetchResponse
 import com.woocommerce.android.ui.login.WPApiSiteRepository
 import com.woocommerce.android.ui.login.WPApiSiteRepository.CookieNonceAuthenticationException
 import com.woocommerce.android.viewmodel.MultiLiveEvent
@@ -24,6 +28,7 @@ import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 import kotlinx.parcelize.IgnoredOnParcel
 import kotlinx.parcelize.Parcelize
+import org.wordpress.android.fluxc.model.SiteModel
 import org.wordpress.android.fluxc.store.SiteStore.SiteError
 import org.wordpress.android.util.UrlUtils
 import javax.inject.Inject
@@ -32,7 +37,8 @@ import javax.inject.Inject
 class JetpackActivationSiteCredentialsViewModel @Inject constructor(
     savedStateHandle: SavedStateHandle,
     private val wpApiSiteRepository: WPApiSiteRepository,
-    private val analyticsTrackerWrapper: AnalyticsTrackerWrapper
+    private val analyticsTrackerWrapper: AnalyticsTrackerWrapper,
+    private val fetchJetpackStatus: FetchJetpackStatus
 ) : ScopedViewModel(savedStateHandle) {
     private val navArgs: JetpackActivationSiteCredentialsFragmentArgs by savedStateHandle.navArgs()
 
@@ -89,12 +95,7 @@ class JetpackActivationSiteCredentialsViewModel @Inject constructor(
         ).fold(
             onSuccess = {
                 analyticsTrackerWrapper.track(AnalyticsEvent.LOGIN_JETPACK_SITE_CREDENTIAL_DID_FINISH_LOGIN)
-                triggerEvent(
-                    NavigateToJetpackActivationSteps(
-                        siteUrl = navArgs.siteUrl,
-                        jetpackStatus = navArgs.jetpackStatus
-                    )
-                )
+                fetchJetpackStatusAndContinue(it)
             },
             onFailure = { exception ->
                 val authenticationError = exception as? CookieNonceAuthenticationException
@@ -118,6 +119,31 @@ class JetpackActivationSiteCredentialsViewModel @Inject constructor(
         )
 
         _viewState.update { it.copy(isLoading = false) }
+    }
+
+    private suspend fun fetchJetpackStatusAndContinue(site: SiteModel) {
+        fetchJetpackStatus(site = site, isJetpackInstalled = navArgs.jetpackStatus.isJetpackInstalled).fold(
+            onSuccess = {
+                val jetpackStatus = when (it) {is JetpackStatusFetchResponse.Success -> it.status
+                    is JetpackStatusFetchResponse.ConnectionForbidden -> {
+                        // When we can't fetch the connection data, we know that the site is not registered with Jetpack
+                        // The user won't be to connect to Jetpack, and the next screen will show the error message
+                        // So we can just proceed with default values
+                        JetpackStatus(
+                            isJetpackInstalled = navArgs.jetpackStatus.isJetpackInstalled,
+                            jetpackConnectionStatus = JetpackConnectionStatus.AccountNotConnected(
+                                siteRegistrationStatus = JetpackSiteRegistrationStatus.NOT_REGISTERED,
+                                blogId = null
+                            )
+                        )
+                    }
+                }
+                triggerEvent(NavigateToJetpackActivationSteps(navArgs.siteUrl, jetpackStatus))
+            },
+            onFailure = {
+                triggerEvent(ShowUiStringSnackbar(UiStringRes(R.string.error_generic)))
+            }
+        )
     }
 
     @Parcelize

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/jetpack/sitecredentials/JetpackActivationSiteCredentialsViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/jetpack/sitecredentials/JetpackActivationSiteCredentialsViewModel.kt
@@ -13,8 +13,8 @@ import com.woocommerce.android.model.JetpackSiteRegistrationStatus
 import com.woocommerce.android.model.JetpackStatus
 import com.woocommerce.android.model.UiString
 import com.woocommerce.android.model.UiString.UiStringRes
-import com.woocommerce.android.ui.jetpack.benefits.FetchJetpackStatus
-import com.woocommerce.android.ui.jetpack.benefits.FetchJetpackStatus.JetpackStatusFetchResponse
+import com.woocommerce.android.ui.jetpack.FetchJetpackStatus
+import com.woocommerce.android.ui.jetpack.FetchJetpackStatus.JetpackStatusFetchResponse
 import com.woocommerce.android.ui.login.WPApiSiteRepository
 import com.woocommerce.android.ui.login.WPApiSiteRepository.CookieNonceAuthenticationException
 import com.woocommerce.android.viewmodel.MultiLiveEvent

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/jetpack/sitecredentials/JetpackActivationSiteCredentialsViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/jetpack/sitecredentials/JetpackActivationSiteCredentialsViewModel.kt
@@ -122,9 +122,14 @@ class JetpackActivationSiteCredentialsViewModel @Inject constructor(
     }
 
     private suspend fun fetchJetpackStatusAndContinue(site: SiteModel) {
-        fetchJetpackStatus(site = site, isJetpackInstalled = navArgs.jetpackStatus.isJetpackInstalled).fold(
+        fetchJetpackStatus(
+            site = site,
+            useApplicationPasswords = false,
+            isJetpackInstalled = navArgs.jetpackStatus.isJetpackInstalled
+        ).fold(
             onSuccess = {
-                val jetpackStatus = when (it) {is JetpackStatusFetchResponse.Success -> it.status
+                val jetpackStatus = when (it) {
+                    is JetpackStatusFetchResponse.Success -> it.status
                     is JetpackStatusFetchResponse.ConnectionForbidden -> {
                         // When we can't fetch the connection data, we know that the site is not registered with Jetpack
                         // The user won't be to connect to Jetpack, and the next screen will show the error message

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/sitepicker/sitediscovery/SitePickerSiteDiscoveryFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/sitepicker/sitediscovery/SitePickerSiteDiscoveryFragment.kt
@@ -78,6 +78,8 @@ class SitePickerSiteDiscoveryFragment : BaseFragment() {
                     siteUrl = event.siteAddress,
                     jetpackStatus = JetpackStatus(
                         isJetpackInstalled = event.isJetpackInstalled,
+                        // Pass a default value, we'll update it later after the user signs in
+                        // See JetpackActivationSiteCredentialsViewModel
                         jetpackConnectionStatus = JetpackConnectionStatus.AccountNotConnected(
                             siteRegistrationStatus = JetpackSiteRegistrationStatus.UNKNOWN,
                             blogId = null

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/sitepicker/sitediscovery/SitePickerSiteDiscoveryFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/sitepicker/sitediscovery/SitePickerSiteDiscoveryFragment.kt
@@ -10,9 +10,6 @@ import androidx.compose.ui.platform.ComposeView
 import androidx.compose.ui.platform.ViewCompositionStrategy
 import androidx.fragment.app.viewModels
 import androidx.navigation.fragment.findNavController
-import com.woocommerce.android.NavGraphMainDirections
-import com.woocommerce.android.R
-import com.woocommerce.android.extensions.handleNotice
 import com.woocommerce.android.extensions.navigateBackWithResult
 import com.woocommerce.android.extensions.navigateToHelpScreen
 import com.woocommerce.android.model.JetpackConnectionStatus
@@ -21,15 +18,11 @@ import com.woocommerce.android.model.JetpackStatus
 import com.woocommerce.android.support.help.HelpOrigin
 import com.woocommerce.android.support.requests.SupportRequestFormActivity
 import com.woocommerce.android.ui.base.BaseFragment
-import com.woocommerce.android.ui.common.webview.AuthenticatedWebViewFragment
-import com.woocommerce.android.ui.common.webview.AuthenticatedWebViewViewModel
 import com.woocommerce.android.ui.compose.theme.WooThemeWithBackground
 import com.woocommerce.android.ui.login.LoginActivity
-import com.woocommerce.android.ui.login.accountmismatch.AccountMismatchErrorFragment
 import com.woocommerce.android.ui.main.AppBarStatus
 import com.woocommerce.android.ui.sitepicker.sitediscovery.SitePickerSiteDiscoveryViewModel.CreateZendeskTicket
-import com.woocommerce.android.ui.sitepicker.sitediscovery.SitePickerSiteDiscoveryViewModel.StartNativeJetpackActivation
-import com.woocommerce.android.ui.sitepicker.sitediscovery.SitePickerSiteDiscoveryViewModel.StartWebBasedJetpackInstallation
+import com.woocommerce.android.ui.sitepicker.sitediscovery.SitePickerSiteDiscoveryViewModel.StartJetpackActivation
 import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.Exit
 import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.ExitWithResult
 import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.Logout
@@ -41,8 +34,6 @@ import org.wordpress.android.login.LoginMode
 class SitePickerSiteDiscoveryFragment : BaseFragment() {
     companion object {
         const val SITE_PICKER_SITE_ADDRESS_RESULT = "site-url"
-        private const val JETPACK_CONNECT_URL = "https://wordpress.com/jetpack/connect"
-        private const val JETPACK_CONNECTED_REDIRECT_URL = "woocommerce://jetpack-connected"
     }
 
     private val viewModel: SitePickerSiteDiscoveryViewModel by viewModels()
@@ -65,7 +56,6 @@ class SitePickerSiteDiscoveryFragment : BaseFragment() {
         super.onViewCreated(view, savedInstanceState)
 
         setupObservers()
-        setupResultHandlers()
     }
 
     private fun setupObservers() {
@@ -73,8 +63,7 @@ class SitePickerSiteDiscoveryFragment : BaseFragment() {
             when (event) {
                 is CreateZendeskTicket -> startSupportRequestForm()
                 is NavigateToHelpScreen -> navigateToHelpScreen(event.origin)
-                is StartWebBasedJetpackInstallation -> startWebBasedJetpackInstallation(event.siteAddress)
-                is StartNativeJetpackActivation -> startNativeJetpackActivation(event)
+                is StartJetpackActivation -> startJetpackActivation(event)
                 is Logout -> onLogout()
                 is ExitWithResult<*> -> navigateBackWithResult(SITE_PICKER_SITE_ADDRESS_RESULT, event.data)
                 is Exit -> findNavController().navigateUp()
@@ -82,32 +71,7 @@ class SitePickerSiteDiscoveryFragment : BaseFragment() {
         }
     }
 
-    private fun setupResultHandlers() {
-        handleNotice(AuthenticatedWebViewFragment.WEBVIEW_RESULT) {
-            viewModel.onJetpackInstalled()
-        }
-        handleNotice(AccountMismatchErrorFragment.JETPACK_CONNECTED_NOTICE) {
-            viewModel.onJetpackConnected()
-        }
-    }
-
-    private fun startWebBasedJetpackInstallation(siteAddress: String) {
-        val url = "$JETPACK_CONNECT_URL?" +
-            "url=$siteAddress" +
-            "&mobile_redirect=$JETPACK_CONNECTED_REDIRECT_URL" +
-            "&from=mobile"
-
-        findNavController().navigate(
-            NavGraphMainDirections.actionGlobalAuthenticatedWebViewFragment(
-                urlToLoad = url,
-                urlsToTriggerExit = arrayOf(JETPACK_CONNECTED_REDIRECT_URL),
-                urlComparisonMode = AuthenticatedWebViewViewModel.UrlComparisonMode.EQUALITY,
-                title = getString(R.string.login_jetpack_install)
-            )
-        )
-    }
-
-    private fun startNativeJetpackActivation(event: StartNativeJetpackActivation) {
+    private fun startJetpackActivation(event: StartJetpackActivation) {
         findNavController().navigate(
             SitePickerSiteDiscoveryFragmentDirections
                 .actionSitePickerSiteDiscoveryFragmentToJetpackActivation(

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/sitepicker/sitediscovery/SitePickerSiteDiscoveryViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/sitepicker/sitediscovery/SitePickerSiteDiscoveryViewModel.kt
@@ -183,7 +183,7 @@ class SitePickerSiteDiscoveryViewModel @Inject constructor(
                     !it.isWordPress -> stepFlow.value = Step.NotWordpress
                     !it.isWPCom -> {
                         triggerEvent(
-                            StartNativeJetpackActivation(
+                            StartJetpackActivation(
                                 siteAddress = siteAddress,
                                 isJetpackInstalled = it.isJetpackActive
                             )
@@ -204,14 +204,6 @@ class SitePickerSiteDiscoveryViewModel @Inject constructor(
 
     fun onHelpButtonClick() {
         triggerEvent(NavigateToHelpScreen(LOGIN_SITE_ADDRESS))
-    }
-
-    fun onJetpackInstalled() {
-        navigateBackToSitePicker()
-    }
-
-    fun onJetpackConnected() {
-        navigateBackToSitePicker()
     }
 
     private fun navigateBackToSitePicker() {
@@ -263,8 +255,7 @@ class SitePickerSiteDiscoveryViewModel @Inject constructor(
     }
 
     object CreateZendeskTicket : MultiLiveEvent.Event()
-    data class StartWebBasedJetpackInstallation(val siteAddress: String) : MultiLiveEvent.Event()
-    data class StartNativeJetpackActivation(
+    data class StartJetpackActivation(
         val siteAddress: String,
         val isJetpackInstalled: Boolean
     ) : MultiLiveEvent.Event()

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -338,7 +338,7 @@
     <string name="login_jetpack_installation_retry_activating">Try activating again</string>
     <string name="login_jetpack_installation_retry_authorizing">Try authorising again</string>
     <string name="login_jetpack_installation_cancel">Cancel installation</string>
-    <string name="login_jetpack_installation_error_forbidden_suggestion">Please contact your shop manager or administrator for help.</string>
+    <string name="login_jetpack_installation_error_forbidden_suggestion">Please contact your administrator for help.</string>
     <string name="login_jetpack_installation_error_connection_permission_message">You don’t have permission to connect to Jetpack on this store</string>
     <string name="login_jetpack_installation_connection_dismissed">Jetpack is installed, but not connected.</string>
     <string name="login_jetpack_installation_connection_dismissed_explanation">Try connecting again to access your store.</string>

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/jetpack/benefits/JetpackBenefitsViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/jetpack/benefits/JetpackBenefitsViewModelTest.kt
@@ -184,7 +184,7 @@ class JetpackBenefitsViewModelTest : BaseUnitTest() {
         jetpackStatusFetchResponse: FetchJetpackStatus.JetpackStatusFetchResponse
     ) = testBlocking {
         val result = Result.success(jetpackStatusFetchResponse)
-        whenever(fetchJetpackStatus.invoke()).thenReturn(result)
+        whenever(fetchJetpackStatus.invoke(site = siteModelMock, useApplicationPasswords = true)).thenReturn(result)
     }
 
     private fun givenUserEligibility(user: User, role: UserRole) = testBlocking {

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/jetpack/benefits/JetpackBenefitsViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/jetpack/benefits/JetpackBenefitsViewModelTest.kt
@@ -10,6 +10,7 @@ import com.woocommerce.android.model.UserRole
 import com.woocommerce.android.tools.SelectedSite
 import com.woocommerce.android.tools.SiteConnectionType
 import com.woocommerce.android.ui.common.UserEligibilityFetcher
+import com.woocommerce.android.ui.jetpack.FetchJetpackStatus
 import com.woocommerce.android.viewmodel.BaseUnitTest
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import org.assertj.core.api.Assertions.assertThat

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/login/jetpack/sitecredentials/JetpackActivationSiteCredentialsViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/login/jetpack/sitecredentials/JetpackActivationSiteCredentialsViewModelTest.kt
@@ -139,6 +139,6 @@ class JetpackActivationSiteCredentialsViewModelTest : BaseUnitTest() {
     private suspend fun givenJetpackFetchResult(
         result: Result<FetchJetpackStatus.JetpackStatusFetchResponse>
     ) {
-        given(fetchJetpackStatus.invoke(any(), any())).willReturn(result)
+        given(fetchJetpackStatus.invoke(any(), any(), any())).willReturn(result)
     }
 }

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/login/jetpack/sitecredentials/JetpackActivationSiteCredentialsViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/login/jetpack/sitecredentials/JetpackActivationSiteCredentialsViewModelTest.kt
@@ -34,7 +34,12 @@ class JetpackActivationSiteCredentialsViewModelTest : BaseUnitTest() {
         viewModel = JetpackActivationSiteCredentialsViewModel(
             JetpackActivationSiteCredentialsFragmentArgs(
                 siteUrl = siteUrl,
-                jetpackStatus = JetpackStatus(isJetpackInstalled, null)
+                jetpackStatus = JetpackStatus(
+                    isJetpackInstalled, JetpackConnectionStatus.AccountNotConnected(
+                        siteRegistrationStatus = JetpackSiteRegistrationStatus.UNKNOWN,
+                        blogId = null
+                    )
+                )
             ).toSavedStateHandle(),
             wpApiSiteRepository,
             analyticsTrackerWrapper,

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/login/jetpack/sitecredentials/JetpackActivationSiteCredentialsViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/login/jetpack/sitecredentials/JetpackActivationSiteCredentialsViewModelTest.kt
@@ -1,0 +1,139 @@
+package com.woocommerce.android.ui.login.jetpack.sitecredentials
+
+import com.woocommerce.android.R
+import com.woocommerce.android.analytics.AnalyticsTrackerWrapper
+import com.woocommerce.android.model.JetpackConnectionStatus
+import com.woocommerce.android.model.JetpackSiteRegistrationStatus
+import com.woocommerce.android.model.JetpackStatus
+import com.woocommerce.android.model.UiString.UiStringRes
+import com.woocommerce.android.ui.jetpack.benefits.FetchJetpackStatus
+import com.woocommerce.android.ui.login.WPApiSiteRepository
+import com.woocommerce.android.util.runAndCaptureValues
+import com.woocommerce.android.viewmodel.BaseUnitTest
+import com.woocommerce.android.viewmodel.MultiLiveEvent
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.Test
+import org.mockito.Mockito.mock
+import org.mockito.kotlin.any
+import org.mockito.kotlin.given
+import org.wordpress.android.fluxc.model.SiteModel
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class JetpackActivationSiteCredentialsViewModelTest : BaseUnitTest() {
+    private val siteUrl = "https://woocommerce.com/"
+    private val wpApiSiteRepository: WPApiSiteRepository = mock()
+    private val analyticsTrackerWrapper: AnalyticsTrackerWrapper = mock()
+    private val fetchJetpackStatus: FetchJetpackStatus = mock()
+
+    private lateinit var viewModel: JetpackActivationSiteCredentialsViewModel
+
+    suspend fun setUp(isJetpackInstalled: Boolean, prepareMocks: suspend () -> Unit = {}) {
+        prepareMocks()
+
+        viewModel = JetpackActivationSiteCredentialsViewModel(
+            JetpackActivationSiteCredentialsFragmentArgs(
+                siteUrl = siteUrl,
+                jetpackStatus = JetpackStatus(isJetpackInstalled, null)
+            ).toSavedStateHandle(),
+            wpApiSiteRepository,
+            analyticsTrackerWrapper,
+            fetchJetpackStatus
+        )
+    }
+
+    @Test
+    fun `given successfull login, when Jetpack Status fetching succeeds, then start Jetpack Activation`() =
+        testBlocking {
+            val isJetpackInstalled = true
+            val jetpackStatus = JetpackStatus(
+                isJetpackInstalled = isJetpackInstalled,
+                jetpackConnectionStatus = JetpackConnectionStatus.AccountNotConnected(
+                    siteRegistrationStatus = JetpackSiteRegistrationStatus.NOT_REGISTERED,
+                    blogId = null
+                )
+            )
+            setUp(isJetpackInstalled = isJetpackInstalled) {
+                givenLoginResult(Result.success(SiteModel()))
+
+                givenJetpackFetchResult(
+                    Result.success(FetchJetpackStatus.JetpackStatusFetchResponse.Success(jetpackStatus))
+                )
+            }
+
+            val event = viewModel.event.runAndCaptureValues {
+                viewModel.onUsernameChanged("username")
+                viewModel.onPasswordChanged("password")
+                viewModel.onContinueClick()
+            }.last()
+
+            assertThat(event).isEqualTo(
+                JetpackActivationSiteCredentialsViewModel.NavigateToJetpackActivationSteps(
+                    siteUrl,
+                    jetpackStatus
+                )
+            )
+        }
+
+    @Test
+    fun `given successfull login, when Jetpack Status fetching fails, then show error message`() =
+        testBlocking {
+            val isJetpackInstalled = true
+            setUp(isJetpackInstalled = isJetpackInstalled) {
+                givenLoginResult(Result.success(SiteModel()))
+
+                givenJetpackFetchResult(Result.failure(Exception()))
+            }
+
+            val event = viewModel.event.runAndCaptureValues {
+                viewModel.onUsernameChanged("username")
+                viewModel.onPasswordChanged("password")
+                viewModel.onContinueClick()
+            }.last()
+
+            assertThat(event)
+                .isEqualTo(MultiLiveEvent.Event.ShowUiStringSnackbar(UiStringRes(R.string.error_generic)))
+        }
+
+    @Test
+    fun `given successful login, when Jetpack Status fetching fails with forbidden, then continue with default value`() =
+        testBlocking {
+            val isJetpackInstalled = true
+            setUp(isJetpackInstalled = isJetpackInstalled) {
+                givenLoginResult(Result.success(SiteModel()))
+
+                givenJetpackFetchResult(
+                    Result.success(FetchJetpackStatus.JetpackStatusFetchResponse.ConnectionForbidden)
+                )
+            }
+
+            val event = viewModel.event.runAndCaptureValues {
+                viewModel.onUsernameChanged("username")
+                viewModel.onPasswordChanged("password")
+                viewModel.onContinueClick()
+            }.last()
+
+            assertThat(event).isEqualTo(
+                JetpackActivationSiteCredentialsViewModel.NavigateToJetpackActivationSteps(
+                    siteUrl,
+                    JetpackStatus(
+                        isJetpackInstalled = isJetpackInstalled,
+                        jetpackConnectionStatus = JetpackConnectionStatus.AccountNotConnected(
+                            siteRegistrationStatus = JetpackSiteRegistrationStatus.NOT_REGISTERED,
+                            blogId = null
+                        )
+                    )
+                )
+            )
+        }
+
+    private suspend fun givenLoginResult(result: Result<SiteModel>) {
+        given(wpApiSiteRepository.loginAndFetchSite(any(), any(), any())).willReturn(result)
+    }
+
+    private suspend fun givenJetpackFetchResult(
+        result: Result<FetchJetpackStatus.JetpackStatusFetchResponse>
+    ) {
+        given(fetchJetpackStatus.invoke(any(), any())).willReturn(result)
+    }
+}

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/login/jetpack/sitecredentials/JetpackActivationSiteCredentialsViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/login/jetpack/sitecredentials/JetpackActivationSiteCredentialsViewModelTest.kt
@@ -6,7 +6,7 @@ import com.woocommerce.android.model.JetpackConnectionStatus
 import com.woocommerce.android.model.JetpackSiteRegistrationStatus
 import com.woocommerce.android.model.JetpackStatus
 import com.woocommerce.android.model.UiString.UiStringRes
-import com.woocommerce.android.ui.jetpack.benefits.FetchJetpackStatus
+import com.woocommerce.android.ui.jetpack.FetchJetpackStatus
 import com.woocommerce.android.ui.login.WPApiSiteRepository
 import com.woocommerce.android.util.runAndCaptureValues
 import com.woocommerce.android.viewmodel.BaseUnitTest


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #13665 
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
This PR adds logic to integrate the Jetpack Connection API when connecting a new site to Jetpack from the site picker, in this scenario we use the Cookies+nonce authentication, and we need to ensure we fetch the Jetpack Status using it.

### Steps to reproduce
Go over the test cases in pe5sF9-42S-p2 (section: Cookies+Nonce)

### Testing information
- Confirm the tests work as expected.

### The tests that have been performed
^

- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.

## Reviewer (or Author, in the case of optional code reviews):

Please make sure these conditions are met before approving the PR, or request changes if the PR needs improvement:

- [ ] The PR is small and has a clear, single focus, or a valid explanation is provided in the description. If needed, please request to split it into smaller PRs.
- [ ] Ensure Adequate Unit Test Coverage: The changes are reasonably covered by unit tests or an explanation is provided in the PR description.
- [ ] Manual Testing: The author listed all the tests they ran, including smoke tests when needed (e.g., for refactorings). The reviewer confirmed that the PR works as expected on big (tablet) and small (phone) in case of UI changes, and no regressions are added.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->