### PR TITLE
[Deps] Group Kotlin & KSP Dependabot Updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,6 +9,14 @@ updates:
       - "bot: dependencies update"
     reviewers:
       - "woocommerce/android-developers"
+    groups:
+      kotlin-ksp:
+        applies-to: version-updates
+        patterns:
+          - "org.jetbrains.kotlin*"
+          - "com.google.devtools.ksp*"
+        exclude-patterns:
+          - "org.jetbrains.kotlinx*"
     ignore:
       # Bumping 2.26.3 to 2.27.2 will break the mocks. For more details, see
       # https://github.com/wiremock/wiremock/issues/1345#issuecomment-656060968


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

<!-- 
━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
🛠 Need an AI review?  
Add a comment: `@coderabbitai review`
━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
-->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

With this configuration Dependabot (:dependabot:) should update both, the `Kotlin` and `KSP` related dependencies in one go, on a single Dependabot related PR.

FYI: Using the `applies-to key` is optional. If the `applies-to key` is absent from a set of grouping rules, it defaults to `version-updates` for backwards compatibility. I chose to use `applies-to` in order to be explicit about this and avoid any confusion related to the defaults.

For more info see: [Configuration options for the dependabot.yml file -> groups](https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file#groups)

---

### Testing information
<!-- This is your opportunity to break out individual scenarios that need testing (when necessary) and/or include a checklist for the reviewer to go through. Consider documenting the following from your own completed testing: devices used, alternate workflows, edge cases, affected areas, critical flows, areas not tested, and any remaining unknowns. Provide feedback on this new section of the PR template through Sept 30, 2024 to Apps Quality; additional context here: p91TBi-b8z-p2#comment-12036 -->

FYI: The very same configuration was already tested on [JP/WPAndroid](https://github.com/wordpress-mobile/WordPress-Android) and works as expected ([Config PR](https://github.com/wordpress-mobile/WordPress-Android/pull/21514) -> [Dependabot PR](https://github.com/wordpress-mobile/WordPress-Android/pull/21723)).

---

- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.

## Reviewer (or Author, in the case of optional code reviews):

Please make sure these conditions are met before approving the PR, or request changes if the PR needs improvement:

- [x] The PR is small and has a clear, single focus, or a valid explanation is provided in the description. If needed, please request to split it into smaller PRs.
- [x] Ensure Adequate Unit Test Coverage: The changes are reasonably covered by unit tests or an explanation is provided in the PR description.
- [x] Manual Testing: The author listed all the tests they ran, including smoke tests when needed (e.g., for refactorings). The reviewer confirmed that the PR works as expected on big (tablet) and small (phone) in case of UI changes, and no regressions are added.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->