### PR TITLE
Fix failing file uploads to products

### DIFF
--- a/libs/fluxc-tests/src/test/java/org/wordpress/android/fluxc/network/rest/wpcom/media/wpv2/WPComV2MediaRestClientTest.kt
+++ b/libs/fluxc-tests/src/test/java/org/wordpress/android/fluxc/network/rest/wpcom/media/wpv2/WPComV2MediaRestClientTest.kt
@@ -1,5 +1,6 @@
 package org.wordpress.android.fluxc.network.rest.wpcom.media.wpv2
 
+import com.google.gson.Gson
 import okhttp3.Call
 import okhttp3.Callback
 import okhttp3.MediaType.Companion.toMediaType
@@ -24,6 +25,7 @@ import org.wordpress.android.fluxc.action.UploadAction.UPLOADED_MEDIA
 import org.wordpress.android.fluxc.annotations.action.Action
 import org.wordpress.android.fluxc.media.MediaTestUtils
 import org.wordpress.android.fluxc.model.SiteModel
+import org.wordpress.android.fluxc.network.rest.wpapi.media.MediaWPRESTResponse
 import org.wordpress.android.fluxc.network.rest.wpcom.WPComNetwork
 import org.wordpress.android.fluxc.network.rest.wpcom.auth.AccessToken
 import org.wordpress.android.fluxc.store.MediaStore.ProgressPayload
@@ -37,6 +39,7 @@ class WPComV2MediaRestClientTest {
     private val okHttpClient: OkHttpClient = mock()
     private val dispatcher: Dispatcher = mock()
     private val wpComNetwork: WPComNetwork = mock()
+    private val gson: Gson = Gson()
     private val mockedCall: Call = mock()
     private lateinit var countDownLatch: CountDownLatch
     private lateinit var restClient: WPComV2MediaRestClient
@@ -46,11 +49,12 @@ class WPComV2MediaRestClientTest {
     @Before
     fun setup() {
         restClient = WPComV2MediaRestClient(
-                dispatcher = dispatcher,
-                coroutineEngine = initCoroutineEngine(),
-                okHttpClient = okHttpClient,
-                accessToken = accessToken,
-                wpComNetwork = wpComNetwork
+            dispatcher = dispatcher,
+            coroutineEngine = initCoroutineEngine(),
+            okHttpClient = okHttpClient,
+            accessToken = accessToken,
+            wpComNetwork = wpComNetwork,
+            gson = gson
         )
         EventBus.getDefault().register(this)
     }
@@ -61,14 +65,14 @@ class WPComV2MediaRestClientTest {
             whenever(okHttpClient.newCall(any())).thenReturn(mockedCall)
             whenever(mockedCall.enqueue(any())).then {
                 (it.arguments.first() as Callback).onResponse(
-                        mockedCall,
-                        mock {
-                            on { body } doReturn UnitTestUtils.getStringFromResourceFile(
-                                    this::class.java,
-                                    "media/media-upload-wp-api-success.json"
-                            ).toResponseBody("application/json".toMediaType())
-                            on { isSuccessful } doReturn true
-                        }
+                    mockedCall,
+                    mock {
+                        on { body } doReturn UnitTestUtils.getStringFromResourceFile(
+                            this::class.java,
+                            "media/media-upload-wp-api-success.json"
+                        ).toResponseBody("application/json".toMediaType())
+                        on { isSuccessful } doReturn true
+                    }
                 )
                 countDownLatch.countDown()
             }
@@ -110,11 +114,11 @@ class WPComV2MediaRestClientTest {
             whenever(okHttpClient.newCall(any())).thenReturn(mockedCall)
             whenever(mockedCall.enqueue(any())).then {
                 (it.arguments.first() as Callback).onResponse(
-                        mockedCall,
-                        mock {
-                            on { body } doReturn "".toResponseBody("application/json".toMediaType())
-                            on { isSuccessful } doReturn true
-                        }
+                    mockedCall,
+                    mock {
+                        on { body } doReturn "".toResponseBody("application/json".toMediaType())
+                        on { isSuccessful } doReturn true
+                    }
                 )
                 countDownLatch.countDown()
             }

--- a/libs/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpapi/media/ApplicationPasswordsMediaRestClient.kt
+++ b/libs/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpapi/media/ApplicationPasswordsMediaRestClient.kt
@@ -1,5 +1,6 @@
 package org.wordpress.android.fluxc.network.rest.wpapi.media
 
+import com.google.gson.Gson
 import okhttp3.Credentials
 import okhttp3.OkHttpClient
 import org.wordpress.android.fluxc.Dispatcher
@@ -23,9 +24,11 @@ class ApplicationPasswordsMediaRestClient @Inject constructor(
     dispatcher: Dispatcher,
     coroutineEngine: CoroutineEngine,
     @Named("no-cookies") okHttpClient: OkHttpClient,
-    private val applicationPasswordsNetwork: ApplicationPasswordsNetwork
-) : BaseWPV2MediaRestClient(dispatcher, coroutineEngine, okHttpClient) {
-    @Inject internal lateinit var applicationPasswordsManager: ApplicationPasswordsManager
+    private val applicationPasswordsNetwork: ApplicationPasswordsNetwork,
+    gson: Gson
+) : BaseWPV2MediaRestClient(dispatcher, coroutineEngine, okHttpClient, gson) {
+    @Inject
+    internal lateinit var applicationPasswordsManager: ApplicationPasswordsManager
 
     override fun WPAPIEndpoint.getFullUrl(site: SiteModel): String {
         return (site.wpApiRestUrl ?: site.url.slashJoin("wp-json")).slashJoin(urlV2)

--- a/libs/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpapi/media/BaseWPV2MediaRestClient.kt
+++ b/libs/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpapi/media/BaseWPV2MediaRestClient.kt
@@ -44,10 +44,9 @@ import javax.inject.Named
 abstract class BaseWPV2MediaRestClient constructor(
     private val dispatcher: Dispatcher,
     private val coroutineEngine: CoroutineEngine,
-    @Named("regular") private val okHttpClient: OkHttpClient
+    @Named("regular") private val okHttpClient: OkHttpClient,
+    private val gson: Gson
 ) {
-    private val gson: Gson by lazy { Gson() }
-
     private val currentUploads = ConcurrentHashMap<Int, CoroutineScope>()
 
     protected abstract fun WPAPIEndpoint.getFullUrl(site: SiteModel): String

--- a/libs/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpapi/media/BaseWPV2MediaRestClient.kt
+++ b/libs/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpapi/media/BaseWPV2MediaRestClient.kt
@@ -41,7 +41,7 @@ import java.io.IOException
 import java.util.concurrent.ConcurrentHashMap
 import javax.inject.Named
 
-abstract class BaseWPV2MediaRestClient constructor(
+abstract class BaseWPV2MediaRestClient(
     private val dispatcher: Dispatcher,
     private val coroutineEngine: CoroutineEngine,
     @Named("regular") private val okHttpClient: OkHttpClient,

--- a/libs/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/media/wpv2/WPComV2MediaRestClient.kt
+++ b/libs/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/media/wpv2/WPComV2MediaRestClient.kt
@@ -1,5 +1,6 @@
 package org.wordpress.android.fluxc.network.rest.wpcom.media.wpv2
 
+import com.google.gson.Gson
 import okhttp3.OkHttpClient
 import org.wordpress.android.fluxc.Dispatcher
 import org.wordpress.android.fluxc.annotations.endpoint.WPAPIEndpoint
@@ -21,13 +22,14 @@ class WPComV2MediaRestClient @Inject constructor(
     coroutineEngine: CoroutineEngine,
     @Named("regular") okHttpClient: OkHttpClient,
     private val accessToken: AccessToken,
-    private val wpComNetwork: WPComNetwork
-) : BaseWPV2MediaRestClient(dispatcher, coroutineEngine, okHttpClient) {
+    private val wpComNetwork: WPComNetwork,
+    gson: Gson
+) : BaseWPV2MediaRestClient(dispatcher, coroutineEngine, okHttpClient, gson) {
     override fun WPAPIEndpoint.getFullUrl(site: SiteModel): String = getWPComUrl(site.siteId)
 
     override suspend fun getAuthorizationHeader(site: SiteModel): String = "Bearer ${accessToken.get()}"
 
-    override suspend fun <T:Any> executeGetGsonRequest(
+    override suspend fun <T : Any> executeGetGsonRequest(
         site: SiteModel,
         endpoint: WPAPIEndpoint,
         params: Map<String, String>,
@@ -41,7 +43,7 @@ class WPComV2MediaRestClient @Inject constructor(
             params = params,
         )
 
-        return when(response) {
+        return when (response) {
             is WPComGsonRequestBuilder.Response.Success -> WPAPIResponse.Success(response.data)
             is WPComGsonRequestBuilder.Response.Error -> WPAPIResponse.Error(
                 WPAPINetworkError(response.error, response.error.apiError)


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #13684
<!-- Id number of the GitHub issue this PR addresses. -->

<!-- 
━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
🛠 Need an AI review?  
Add a comment: `@coderabbitai review`
━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
-->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
This PR fixes failing file upload into a virtual product. 
When uploading images, the endpoint returns `sizes` object with various image resolutions. But when uploading pdf file, the endpoint returns size array. `BaseWPV2MediaRestClient` was using `Gson()` and it cannot parse `JsonObjectOrEmptyArray()`. I used injected gson, then it can use [JsonObjectOrEmptyArrayDeserializer](https://github.com/woocommerce/woocommerce-android/blob/trunk/libs/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/JsonObjectOrEmptyArrayDeserializer.java). 

### Steps to reproduce
<!-- Step-by-step testing instructions. For new user flows, consider instead stating the goal of the workflow and see if your PR reviewer can accomplish the workflow without specific steps! -->
1. Launch the app.
2. Open "Products".
3. Tap the create product button or open an existing product.
4. Change product type to "Simple virtual product"
5. Tap the ADD MORE DETAILS button
6. Tap "Downloadable files" and select "Documents and other files on device"
7. Choose a PDF file or any other file that is not an image/video from your device.
8. Verify that it's uploaded successfully.

### The tests that have been performed
<!-- To give the reviewer an idea of what could be missed in terms of testing -->
Steps above

### Images/gif
<!-- Include before and after images or gifs when appropriate. -->
|Before|After|
|-|-|
|<img src="https://github.com/user-attachments/assets/b5e77d19-a116-4e9d-80bd-9988762d452d" width=360>|<img src="https://github.com/user-attachments/assets/15def90e-8835-460e-8486-99cb1ec53346" width=360>

- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.

## Reviewer (or Author, in the case of optional code reviews):

Please make sure these conditions are met before approving the PR, or request changes if the PR needs improvement:

- [ ] The PR is small and has a clear, single focus, or a valid explanation is provided in the description. If needed, please request to split it into smaller PRs.
- [ ] Ensure Adequate Unit Test Coverage: The changes are reasonably covered by unit tests or an explanation is provided in the PR description.
- [ ] Manual Testing: The author listed all the tests they ran, including smoke tests when needed (e.g., for refactorings). The reviewer confirmed that the PR works as expected on big (tablet) and small (phone) in case of UI changes, and no regressions are added.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->