### PR TITLE
[Jetpack Setup] Handle the case where wp-admin account is already connected to Jetpack

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -4,6 +4,7 @@
 22.0
 -----
 - [*] Payments: display specific error for the cases when a reader with low battery level attempted to connect [https://github.com/woocommerce/woocommerce-android/pull/13642]
+- [*] [Internal] Improved the handling of Site Picker Jetpack setup to handle the case where the account is already connected to the site [https://github.com/woocommerce/woocommerce-android/pull/13693]
 
 21.9
 -----

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/jetpack/sitecredentials/JetpackActivationSiteCredentialsFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/jetpack/sitecredentials/JetpackActivationSiteCredentialsFragment.kt
@@ -1,5 +1,6 @@
 package com.woocommerce.android.ui.login.jetpack.sitecredentials
 
+import android.content.Intent
 import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
@@ -12,7 +13,9 @@ import com.woocommerce.android.extensions.navigateSafely
 import com.woocommerce.android.ui.base.BaseFragment
 import com.woocommerce.android.ui.base.UIMessageResolver
 import com.woocommerce.android.ui.compose.theme.WooThemeWithBackground
+import com.woocommerce.android.ui.login.LoginActivity
 import com.woocommerce.android.ui.login.jetpack.sitecredentials.JetpackActivationSiteCredentialsViewModel.NavigateToJetpackActivationSteps
+import com.woocommerce.android.ui.login.jetpack.sitecredentials.JetpackActivationSiteCredentialsViewModel.OpenWordPressComLogin
 import com.woocommerce.android.ui.login.jetpack.sitecredentials.JetpackActivationSiteCredentialsViewModel.ResetPassword
 import com.woocommerce.android.ui.main.AppBarStatus
 import com.woocommerce.android.util.ChromeCustomTabUtils
@@ -20,6 +23,7 @@ import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.Exit
 import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.ShowSnackbar
 import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.ShowUiStringSnackbar
 import dagger.hilt.android.AndroidEntryPoint
+import org.wordpress.android.login.LoginMode
 import javax.inject.Inject
 
 @AndroidEntryPoint
@@ -52,6 +56,7 @@ class JetpackActivationSiteCredentialsFragment : BaseFragment() {
         viewModel.event.observe(viewLifecycleOwner) { event ->
             when (event) {
                 is NavigateToJetpackActivationSteps -> navigateToJetpackActivationSteps(event)
+                is OpenWordPressComLogin -> openWordPressComLogin(event.email)
                 is ResetPassword -> showResetPasswordWebPage(event.siteUrl)
                 Exit -> findNavController().navigateUp()
                 is ShowSnackbar -> uiMessageResolver.showSnack(event.message)
@@ -69,6 +74,16 @@ class JetpackActivationSiteCredentialsFragment : BaseFragment() {
                     siteUrl = event.siteUrl
                 )
         )
+    }
+
+    private fun openWordPressComLogin(email: String) {
+        val intent = Intent(requireActivity(), LoginActivity::class.java).apply {
+            addFlags(Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_CLEAR_TASK)
+            action = LoginActivity.LOGIN_WITH_WPCOM_EMAIL_ACTION
+            putExtra(LoginActivity.EMAIL_PARAMETER, email)
+            LoginMode.WOO_LOGIN_MODE.putInto(this)
+        }
+        startActivity(intent)
     }
 
     private fun showResetPasswordWebPage(siteUrl: String) {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/jetpack/sitecredentials/JetpackActivationSiteCredentialsScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/jetpack/sitecredentials/JetpackActivationSiteCredentialsScreen.kt
@@ -25,6 +25,7 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.input.ImeAction
 import androidx.compose.ui.tooling.preview.Preview
 import com.woocommerce.android.R
+import com.woocommerce.android.ui.compose.Render
 import com.woocommerce.android.ui.compose.annotatedStringResLegacy
 import com.woocommerce.android.ui.compose.component.ProgressDialog
 import com.woocommerce.android.ui.compose.component.Toolbar
@@ -49,6 +50,8 @@ fun JetpackActivationSiteCredentialsScreen(viewModel: JetpackActivationSiteCrede
             onCloseClick = viewModel::onCloseClick
         )
     }
+
+    viewModel.dialogState.observeAsState().value?.Render()
 }
 
 @Composable

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/jetpack/sitecredentials/JetpackActivationSiteCredentialsViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/jetpack/sitecredentials/JetpackActivationSiteCredentialsViewModel.kt
@@ -13,6 +13,7 @@ import com.woocommerce.android.model.JetpackSiteRegistrationStatus
 import com.woocommerce.android.model.JetpackStatus
 import com.woocommerce.android.model.UiString
 import com.woocommerce.android.model.UiString.UiStringRes
+import com.woocommerce.android.ui.compose.DialogState
 import com.woocommerce.android.ui.jetpack.FetchJetpackStatus
 import com.woocommerce.android.ui.jetpack.FetchJetpackStatus.JetpackStatusFetchResponse
 import com.woocommerce.android.ui.login.WPApiSiteRepository
@@ -24,6 +25,7 @@ import com.woocommerce.android.viewmodel.ScopedViewModel
 import com.woocommerce.android.viewmodel.getStateFlow
 import com.woocommerce.android.viewmodel.navArgs
 import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 import kotlinx.parcelize.IgnoredOnParcel
@@ -42,6 +44,12 @@ class JetpackActivationSiteCredentialsViewModel @Inject constructor(
 ) : ScopedViewModel(savedStateHandle) {
     private val navArgs: JetpackActivationSiteCredentialsFragmentArgs by savedStateHandle.navArgs()
 
+    private var isShowingAccountConnectionDialog = savedStateHandle.getStateFlow(
+        scope = viewModelScope,
+        initialValue = false,
+        key = "is-showing-account-connection-dialog"
+    )
+
     private val _viewState = savedStateHandle.getStateFlow(
         scope = viewModelScope,
         initialValue = JetpackActivationSiteCredentialsViewState(
@@ -50,6 +58,30 @@ class JetpackActivationSiteCredentialsViewModel @Inject constructor(
         )
     )
     val viewState = _viewState.asLiveData()
+
+    val dialogState = isShowingAccountConnectionDialog.map {
+        when (it) {
+            true -> DialogState(
+                title = R.string.login_jetpack_user_already_connected_dialog_title,
+                message = R.string.login_jetpack_user_already_connected_dialog_message,
+                positiveButton = DialogState.DialogButton(
+                    text = R.string.yes,
+                    onClick = { TODO() }
+                ),
+                negativeButton = DialogState.DialogButton(
+                    text = R.string.no,
+                    onClick = {
+                        _viewState.update {
+                            it.copy(username = "", password = "")
+                        }
+                        isShowingAccountConnectionDialog.value = false
+                    }
+                )
+            )
+
+            false -> null
+        }
+    }.asLiveData()
 
     init {
         analyticsTrackerWrapper.track(AnalyticsEvent.LOGIN_JETPACK_SITE_CREDENTIAL_SCREEN_VIEWED)
@@ -129,7 +161,14 @@ class JetpackActivationSiteCredentialsViewModel @Inject constructor(
         ).fold(
             onSuccess = {
                 val jetpackStatus = when (it) {
-                    is JetpackStatusFetchResponse.Success -> it.status
+                    is JetpackStatusFetchResponse.Success -> {
+                        if (it.status.jetpackConnectionStatus is JetpackConnectionStatus.AccountConnected) {
+                            isShowingAccountConnectionDialog.value = true
+                            return@fold
+                        }
+                        it.status
+                    }
+
                     is JetpackStatusFetchResponse.ConnectionForbidden -> {
                         // When we can't fetch the connection data, we know that the site is not registered with Jetpack
                         // The user won't be to connect to Jetpack, and the next screen will show the error message

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/jetpack/sitecredentials/JetpackActivationSiteCredentialsViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/jetpack/sitecredentials/JetpackActivationSiteCredentialsViewModel.kt
@@ -4,6 +4,7 @@ import android.os.Parcelable
 import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.asLiveData
 import androidx.lifecycle.viewModelScope
+import com.woocommerce.android.AppPrefsWrapper
 import com.woocommerce.android.OnChangedException
 import com.woocommerce.android.R
 import com.woocommerce.android.analytics.AnalyticsEvent
@@ -40,7 +41,8 @@ class JetpackActivationSiteCredentialsViewModel @Inject constructor(
     savedStateHandle: SavedStateHandle,
     private val wpApiSiteRepository: WPApiSiteRepository,
     private val analyticsTrackerWrapper: AnalyticsTrackerWrapper,
-    private val fetchJetpackStatus: FetchJetpackStatus
+    private val fetchJetpackStatus: FetchJetpackStatus,
+    private val appPrefs: AppPrefsWrapper
 ) : ScopedViewModel(savedStateHandle) {
     private val navArgs: JetpackActivationSiteCredentialsFragmentArgs by savedStateHandle.navArgs()
 
@@ -49,6 +51,9 @@ class JetpackActivationSiteCredentialsViewModel @Inject constructor(
         initialValue = false,
         key = "is-showing-account-connection-dialog"
     )
+    private var connectedWPComEmail: String?
+        get() = savedState["connected-wpcom-email"]
+        set(value) = savedState.set("connected-wpcom-email", value)
 
     private val _viewState = savedStateHandle.getStateFlow(
         scope = viewModelScope,
@@ -66,7 +71,7 @@ class JetpackActivationSiteCredentialsViewModel @Inject constructor(
                 message = R.string.login_jetpack_user_already_connected_dialog_message,
                 positiveButton = DialogState.DialogButton(
                     text = R.string.yes,
-                    onClick = { TODO() }
+                    onClick = ::signInUsingConnectedWPComAccount
                 ),
                 negativeButton = DialogState.DialogButton(
                     text = R.string.no,
@@ -163,6 +168,7 @@ class JetpackActivationSiteCredentialsViewModel @Inject constructor(
                 val jetpackStatus = when (it) {
                     is JetpackStatusFetchResponse.Success -> {
                         if (it.status.jetpackConnectionStatus is JetpackConnectionStatus.AccountConnected) {
+                            connectedWPComEmail = it.status.jetpackConnectionStatus.wpComEmail
                             isShowingAccountConnectionDialog.value = true
                             return@fold
                         }
@@ -190,6 +196,14 @@ class JetpackActivationSiteCredentialsViewModel @Inject constructor(
         )
     }
 
+    private fun signInUsingConnectedWPComAccount() {
+        connectedWPComEmail?.let {
+            // Save the address of the site the user is trying to connect to to be used later in the login screen
+            appPrefs.setLoginSiteAddress(navArgs.siteUrl)
+            triggerEvent(OpenWordPressComLogin(it))
+        }
+    }
+
     @Parcelize
     data class JetpackActivationSiteCredentialsViewState(
         val isJetpackInstalled: Boolean,
@@ -207,6 +221,8 @@ class JetpackActivationSiteCredentialsViewModel @Inject constructor(
         val siteUrl: String,
         val jetpackStatus: JetpackStatus
     ) : MultiLiveEvent.Event()
+
+    data class OpenWordPressComLogin(val email: String) : MultiLiveEvent.Event()
 
     data class ResetPassword(val siteUrl: String) : MultiLiveEvent.Event()
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/jetpack/sitecredentials/JetpackActivationSiteCredentialsViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/jetpack/sitecredentials/JetpackActivationSiteCredentialsViewModel.kt
@@ -70,11 +70,11 @@ class JetpackActivationSiteCredentialsViewModel @Inject constructor(
                 title = R.string.login_jetpack_user_already_connected_dialog_title,
                 message = R.string.login_jetpack_user_already_connected_dialog_message,
                 positiveButton = DialogState.DialogButton(
-                    text = R.string.yes,
+                    text = R.string.login_jetpack_user_already_connected_dialog_proceed_button,
                     onClick = ::signInUsingConnectedWPComAccount
                 ),
                 negativeButton = DialogState.DialogButton(
-                    text = R.string.no,
+                    text = R.string.login_jetpack_user_already_connected_dialog_cancel_button,
                     onClick = {
                         _viewState.update {
                             it.copy(username = "", password = "")

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -311,7 +311,9 @@
     <string name="login_jetpack_installation_enter_site_credentials">Log in to &lt;b&gt;%1$s&lt;/b&gt; with your store credentials to install Jetpack.</string>
     <string name="login_jetpack_connection_enter_site_credentials">Log in to &lt;b&gt;%1$s&lt;/b&gt; with your store credentials to connect Jetpack.</string>
     <string name="login_jetpack_user_already_connected_dialog_title">Account already connected</string>
-    <string name="login_jetpack_user_already_connected_dialog_message">The selected account is already connected to a different WordPress.com account. Signing in with that account will log you out of your current account.\nWould you like to proceed?</string>
+    <string name="login_jetpack_user_already_connected_dialog_message">This WordPress admin account is already connected to a different WordPress.com account.\nContinuing with that account will log you out of your current account.</string>
+    <string name="login_jetpack_user_already_connected_dialog_proceed_button">Proceed</string>
+    <string name="login_jetpack_user_already_connected_dialog_cancel_button">Cancel</string>
     <string name="login_jetpack_steps_installing">Installing Jetpack</string>
     <string name="login_jetpack_steps_activating">Activating</string>
     <string name="login_jetpack_steps_authorizing">Connect store to Jetpack</string>

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -49,6 +49,7 @@
     <string name="untitled">Untitled</string>
     <string name="dialog_ok">OK</string>
     <string name="cancel">Cancel</string>
+    <string name="yes">Yes</string>
     <string name="no">No</string>
     <string name="cancel_anyway">Cancel anyway</string>
     <string name="keep_editing">Keep editing</string>
@@ -309,6 +310,8 @@
     <string name="login_jetpack_connect">Connect Jetpack</string>
     <string name="login_jetpack_installation_enter_site_credentials">Log in to &lt;b&gt;%1$s&lt;/b&gt; with your store credentials to install Jetpack.</string>
     <string name="login_jetpack_connection_enter_site_credentials">Log in to &lt;b&gt;%1$s&lt;/b&gt; with your store credentials to connect Jetpack.</string>
+    <string name="login_jetpack_user_already_connected_dialog_title">Account already connected</string>
+    <string name="login_jetpack_user_already_connected_dialog_message">The selected account is already connected to a different WordPress.com account. Signing in with that account will log you out of your current account.\nWould you like to proceed?</string>
     <string name="login_jetpack_steps_installing">Installing Jetpack</string>
     <string name="login_jetpack_steps_activating">Activating</string>
     <string name="login_jetpack_steps_authorizing">Connect store to Jetpack</string>

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/login/jetpack/sitecredentials/JetpackActivationSiteCredentialsViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/login/jetpack/sitecredentials/JetpackActivationSiteCredentialsViewModelTest.kt
@@ -164,8 +164,8 @@ class JetpackActivationSiteCredentialsViewModelTest : BaseUnitTest() {
         assertThat(dialogState).matches {
             it?.title == UiStringRes(R.string.login_jetpack_user_already_connected_dialog_title) &&
                 it.message == UiStringRes(R.string.login_jetpack_user_already_connected_dialog_message) &&
-                it.positiveButton?.text == UiStringRes(R.string.yes) &&
-                it.negativeButton?.text == UiStringRes(R.string.no)
+                it.positiveButton?.text == UiStringRes(R.string.login_jetpack_user_already_connected_dialog_proceed_button) &&
+                it.negativeButton?.text == UiStringRes(R.string.login_jetpack_user_already_connected_dialog_cancel_button)
         }
     }
 

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/login/jetpack/sitecredentials/JetpackActivationSiteCredentialsViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/login/jetpack/sitecredentials/JetpackActivationSiteCredentialsViewModelTest.kt
@@ -1,5 +1,6 @@
 package com.woocommerce.android.ui.login.jetpack.sitecredentials
 
+import com.woocommerce.android.AppPrefsWrapper
 import com.woocommerce.android.R
 import com.woocommerce.android.analytics.AnalyticsTrackerWrapper
 import com.woocommerce.android.model.JetpackConnectionStatus
@@ -8,6 +9,7 @@ import com.woocommerce.android.model.JetpackStatus
 import com.woocommerce.android.model.UiString.UiStringRes
 import com.woocommerce.android.ui.jetpack.FetchJetpackStatus
 import com.woocommerce.android.ui.login.WPApiSiteRepository
+import com.woocommerce.android.util.getOrAwaitValue
 import com.woocommerce.android.util.runAndCaptureValues
 import com.woocommerce.android.viewmodel.BaseUnitTest
 import com.woocommerce.android.viewmodel.MultiLiveEvent
@@ -17,6 +19,7 @@ import org.junit.Test
 import org.mockito.Mockito.mock
 import org.mockito.kotlin.any
 import org.mockito.kotlin.given
+import org.mockito.kotlin.verify
 import org.wordpress.android.fluxc.model.SiteModel
 
 @OptIn(ExperimentalCoroutinesApi::class)
@@ -25,6 +28,7 @@ class JetpackActivationSiteCredentialsViewModelTest : BaseUnitTest() {
     private val wpApiSiteRepository: WPApiSiteRepository = mock()
     private val analyticsTrackerWrapper: AnalyticsTrackerWrapper = mock()
     private val fetchJetpackStatus: FetchJetpackStatus = mock()
+    private val appPrefs: AppPrefsWrapper = mock()
 
     private lateinit var viewModel: JetpackActivationSiteCredentialsViewModel
 
@@ -43,7 +47,8 @@ class JetpackActivationSiteCredentialsViewModelTest : BaseUnitTest() {
             ).toSavedStateHandle(),
             wpApiSiteRepository,
             analyticsTrackerWrapper,
-            fetchJetpackStatus
+            fetchJetpackStatus,
+            appPrefs
         )
     }
 
@@ -130,6 +135,107 @@ class JetpackActivationSiteCredentialsViewModelTest : BaseUnitTest() {
                     )
                 )
             )
+        }
+
+    @Test
+    fun `given successful login, when Jetpack is already connected, then show an alert`() = testBlocking {
+        val isJetpackInstalled = true
+        setUp(isJetpackInstalled = isJetpackInstalled) {
+            givenLoginResult(Result.success(SiteModel()))
+
+            givenJetpackFetchResult(
+                Result.success(
+                    FetchJetpackStatus.JetpackStatusFetchResponse.Success(
+                        JetpackStatus(
+                            isJetpackInstalled = isJetpackInstalled,
+                            jetpackConnectionStatus = JetpackConnectionStatus.AccountConnected("email")
+                        )
+                    )
+                )
+            )
+        }
+
+        val dialogState = viewModel.dialogState.runAndCaptureValues {
+            viewModel.onUsernameChanged("username")
+            viewModel.onPasswordChanged("password")
+            viewModel.onContinueClick()
+        }.last()
+
+        assertThat(dialogState).matches {
+            it?.title == UiStringRes(R.string.login_jetpack_user_already_connected_dialog_title) &&
+                it.message == UiStringRes(R.string.login_jetpack_user_already_connected_dialog_message) &&
+                it.positiveButton?.text == UiStringRes(R.string.yes) &&
+                it.negativeButton?.text == UiStringRes(R.string.no)
+        }
+    }
+
+    @Test
+    fun `given account connection alert is shown, when user confirms, then proceed to the WordPress_com login`() =
+        testBlocking {
+            val isJetpackInstalled = true
+            setUp(isJetpackInstalled = isJetpackInstalled) {
+                givenLoginResult(Result.success(SiteModel()))
+
+                givenJetpackFetchResult(
+                    Result.success(
+                        FetchJetpackStatus.JetpackStatusFetchResponse.Success(
+                            JetpackStatus(
+                                isJetpackInstalled = isJetpackInstalled,
+                                jetpackConnectionStatus = JetpackConnectionStatus.AccountConnected("email")
+                            )
+                        )
+                    )
+                )
+            }
+
+            val dialogState = viewModel.dialogState.runAndCaptureValues {
+                viewModel.onUsernameChanged("username")
+                viewModel.onPasswordChanged("password")
+                viewModel.onContinueClick()
+            }.last()
+
+            val event = viewModel.event.runAndCaptureValues {
+                dialogState?.positiveButton?.onClick?.invoke()
+            }.last()
+
+            assertThat(event).isEqualTo(
+                JetpackActivationSiteCredentialsViewModel.OpenWordPressComLogin("email")
+            )
+            verify(appPrefs).setLoginSiteAddress(siteUrl)
+        }
+
+    @Test
+    fun `given account connection alert is shown, when user cancels, then clear the username and password`() =
+        testBlocking {
+            val isJetpackInstalled = true
+            setUp(isJetpackInstalled = isJetpackInstalled) {
+                givenLoginResult(Result.success(SiteModel()))
+
+                givenJetpackFetchResult(
+                    Result.success(
+                        FetchJetpackStatus.JetpackStatusFetchResponse.Success(
+                            JetpackStatus(
+                                isJetpackInstalled = isJetpackInstalled,
+                                jetpackConnectionStatus = JetpackConnectionStatus.AccountConnected("email")
+                            )
+                        )
+                    )
+                )
+            }
+
+            val dialogState = viewModel.dialogState.runAndCaptureValues {
+                viewModel.onUsernameChanged("username")
+                viewModel.onPasswordChanged("password")
+                viewModel.onContinueClick()
+            }.last()
+
+            val viewState = viewModel.viewState.runAndCaptureValues {
+                dialogState?.negativeButton?.onClick?.invoke()
+            }.last()
+
+            assertThat(viewState.username).isEmpty()
+            assertThat(viewState.password).isEmpty()
+            assertThat(viewModel.dialogState.getOrAwaitValue()).isNull()
         }
 
     private suspend fun givenLoginResult(result: Result<SiteModel>) {


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #13681 
<!-- Id number of the GitHub issue this PR addresses. -->

<!-- 
━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
🛠 Need an AI review?  
Add a comment: `@coderabbitai review`
━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
-->

### Description
This PR handles one edge case that we were missing for a long time: when connecting a new site from the site picker, we didn't check whether the used `wp-admin` account is already connected to Jetpack or not.

This PR now shows a dialog to warn the user that the account is already connected, and allows them to continue signing in using the account.

**Note:** I know the dialog could be confusing to the users, I hope this will be OK given this is an edge case. And if you have any suggestions to make the wording clearer please let me know.

### Steps to reproduce
1. Have two WPCom accounts: `WPComA` and `WPComB`.
2. Connect one of your sites to `WPComB`.
3. Open the app, and sign in using `WPComA`.
4. Open the site picker.
5. Tap on "Connect an existing store"
6. Enter the site address of the site from step 2.
7. Enter the site credentials of the same account used to connect `WPComB`

### Testing information
- Confirm the app warns you about the connected account.
- Tap on "No" and confirm it clears the entered credentials and allow you to enter other credentials.
- Tap on "Yes" and confirm this allows you to sign in to the app using `WPComB`.

### The tests that have been performed
^

### Images/gif
https://github.com/user-attachments/assets/1798f779-447c-4a6e-a1b2-b5f9ecbd04d0


- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.

## Reviewer (or Author, in the case of optional code reviews):

Please make sure these conditions are met before approving the PR, or request changes if the PR needs improvement:

- [ ] The PR is small and has a clear, single focus, or a valid explanation is provided in the description. If needed, please request to split it into smaller PRs.
- [ ] Ensure Adequate Unit Test Coverage: The changes are reasonably covered by unit tests or an explanation is provided in the PR description.
- [ ] Manual Testing: The author listed all the tests they ran, including smoke tests when needed (e.g., for refactorings). The reviewer confirmed that the PR works as expected on big (tablet) and small (phone) in case of UI changes, and no regressions are added.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->