### PR TITLE
[IPP/POS] Automatically Cancel Payment Intents

### DIFF
--- a/libs/cardreader/src/main/java/com/woocommerce/android/cardreader/internal/payments/PaymentManager.kt
+++ b/libs/cardreader/src/main/java/com/woocommerce/android/cardreader/internal/payments/PaymentManager.kt
@@ -16,8 +16,15 @@ import com.woocommerce.android.cardreader.internal.payments.actions.ProcessPayme
 import com.woocommerce.android.cardreader.internal.payments.actions.ProcessPaymentAction.ProcessPaymentStatus
 import com.woocommerce.android.cardreader.internal.wrappers.TerminalWrapper
 import com.woocommerce.android.cardreader.payments.CardPaymentStatus
-import com.woocommerce.android.cardreader.payments.CardPaymentStatus.*
+import com.woocommerce.android.cardreader.payments.CardPaymentStatus.CapturingPayment
 import com.woocommerce.android.cardreader.payments.CardPaymentStatus.CardPaymentStatusErrorType.Generic
+import com.woocommerce.android.cardreader.payments.CardPaymentStatus.CollectingPayment
+import com.woocommerce.android.cardreader.payments.CardPaymentStatus.InitializingPayment
+import com.woocommerce.android.cardreader.payments.CardPaymentStatus.PaymentCompleted
+import com.woocommerce.android.cardreader.payments.CardPaymentStatus.PaymentFailed
+import com.woocommerce.android.cardreader.payments.CardPaymentStatus.PaymentMethodType
+import com.woocommerce.android.cardreader.payments.CardPaymentStatus.ProcessingPayment
+import com.woocommerce.android.cardreader.payments.CardPaymentStatus.ProcessingPaymentCompleted
 import com.woocommerce.android.cardreader.payments.PaymentData
 import com.woocommerce.android.cardreader.payments.PaymentInfo
 import kotlinx.coroutines.flow.Flow
@@ -43,7 +50,19 @@ internal class PaymentManager(
         if (paymentIntent?.status != PaymentIntentStatus.REQUIRES_PAYMENT_METHOD) {
             return@flow
         }
-        processPaymentIntent(paymentInfo.orderId, paymentIntent).collect { emit(it) }
+        var eligibleForRetry = false
+        try {
+            processPaymentIntent(paymentInfo.orderId, paymentIntent).collect {
+                emit(it)
+                if (it is PaymentFailed && it.paymentDataForRetry != null) {
+                    eligibleForRetry = true
+                }
+            }
+        } finally {
+            if (!eligibleForRetry) {
+                cancelOngoingPayment(paymentIntent)
+            }
+        }
     }
 
     fun retryPayment(orderId: Long, paymentData: PaymentData) =

--- a/libs/cardreader/src/main/java/com/woocommerce/android/cardreader/internal/payments/PaymentManager.kt
+++ b/libs/cardreader/src/main/java/com/woocommerce/android/cardreader/internal/payments/PaymentManager.kt
@@ -51,26 +51,11 @@ internal class PaymentManager(
             return@flow
         }
 
-        val paymentIntentReference = PaymentIntentReference(paymentIntent)
-        var eligibleForRetry = false
-        try {
-            /* Passing PI as reference is a hack so we can access the updated PI in the finally block */
-            processPaymentIntent(paymentInfo.orderId, paymentIntentReference).collect {
-                emit(it)
-                if (it is PaymentFailed && it.paymentDataForRetry != null) {
-                    eligibleForRetry = true
-                }
-            }
-        } finally {
-            if (!eligibleForRetry) {
-                cancelOngoingPayment(paymentIntentReference.value)
-            }
-        }
+        processPayment(paymentInfo.orderId, paymentIntent)
     }
 
     fun retryPayment(orderId: Long, paymentData: PaymentData) =
-        // TODO Make sure we are cancelling even in this code path
-        processPaymentIntent(orderId, PaymentIntentReference((paymentData as PaymentDataImpl).paymentIntent))
+        processPayment(orderId, (paymentData as PaymentDataImpl).paymentIntent)
 
     fun cancelPayment(paymentData: PaymentData) {
         val paymentIntent = (paymentData as PaymentDataImpl).paymentIntent
@@ -85,6 +70,24 @@ internal class PaymentManager(
             paymentIntent.status != PaymentIntentStatus.REQUIRES_CAPTURE
         ) {
             cancelPaymentAction.cancelPayment(paymentIntent)
+        }
+    }
+
+    private fun processPayment(orderId: Long, paymentIntent: PaymentIntent) = flow {
+        val paymentIntentReference = PaymentIntentReference(paymentIntent)
+        var eligibleForRetry = false
+        try {
+            /* Passing PI as reference is a hack so we can access the updated PI in the finally block */
+            processPaymentIntent(orderId, paymentIntentReference).collect {
+                emit(it)
+                if (it is PaymentFailed && it.paymentDataForRetry != null) {
+                    eligibleForRetry = true
+                }
+            }
+        } finally {
+            if (!eligibleForRetry) {
+                cancelOngoingPayment(paymentIntentReference.value)
+            }
         }
     }
 

--- a/libs/cardreader/src/main/java/com/woocommerce/android/cardreader/internal/payments/PaymentManager.kt
+++ b/libs/cardreader/src/main/java/com/woocommerce/android/cardreader/internal/payments/PaymentManager.kt
@@ -51,10 +51,15 @@ internal class PaymentManager(
 
     fun cancelPayment(paymentData: PaymentData) {
         val paymentIntent = (paymentData as PaymentDataImpl).paymentIntent
+        cancelOngoingPayment(paymentIntent)
+    }
+
+    private fun cancelOngoingPayment(paymentIntent: PaymentIntent) {
         /* If the paymentIntent is in REQUIRES_CAPTURE state the app should not cancel the payment intent as it
         doesn't know if it was already captured or not during one of the previous attempts to capture it. */
-        if (paymentIntent.status == PaymentIntentStatus.REQUIRES_PAYMENT_METHOD ||
-            paymentIntent.status == PaymentIntentStatus.REQUIRES_CONFIRMATION
+        if (paymentIntent.status != PaymentIntentStatus.SUCCEEDED &&
+            paymentIntent.status != PaymentIntentStatus.CANCELED &&
+            paymentIntent.status != PaymentIntentStatus.REQUIRES_CAPTURE
         ) {
             cancelPaymentAction.cancelPayment(paymentIntent)
         }

--- a/libs/cardreader/src/main/java/com/woocommerce/android/cardreader/internal/payments/PaymentManager.kt
+++ b/libs/cardreader/src/main/java/com/woocommerce/android/cardreader/internal/payments/PaymentManager.kt
@@ -2,7 +2,6 @@ package com.woocommerce.android.cardreader.internal.payments
 
 import com.stripe.stripeterminal.external.models.PaymentIntent
 import com.stripe.stripeterminal.external.models.PaymentIntentStatus
-import com.stripe.stripeterminal.external.models.PaymentIntentStatus.CANCELED
 import com.woocommerce.android.cardreader.CardReaderStore
 import com.woocommerce.android.cardreader.CardReaderStore.CapturePaymentResponse
 import com.woocommerce.android.cardreader.config.CardReaderConfigFactory
@@ -63,7 +62,7 @@ internal class PaymentManager(
 
     private fun processPaymentIntent(orderId: Long, data: PaymentIntent) = flow {
         var paymentIntent = data
-        if (paymentIntent.status == null || paymentIntent.status == CANCELED) {
+        if (paymentIntent.status == null || paymentIntent.status == PaymentIntentStatus.CANCELED) {
             emit(errorMapper.mapError(errorMessage = "Cannot retry paymentIntent with status ${paymentIntent.status}"))
             return@flow
         }

--- a/libs/cardreader/src/main/java/com/woocommerce/android/cardreader/internal/payments/PaymentManager.kt
+++ b/libs/cardreader/src/main/java/com/woocommerce/android/cardreader/internal/payments/PaymentManager.kt
@@ -50,9 +50,12 @@ internal class PaymentManager(
         if (paymentIntent?.status != PaymentIntentStatus.REQUIRES_PAYMENT_METHOD) {
             return@flow
         }
+
+        val paymentIntentReference = PaymentIntentReference(paymentIntent)
         var eligibleForRetry = false
         try {
-            processPaymentIntent(paymentInfo.orderId, paymentIntent).collect {
+            /* Passing PI as reference is a hack so we can access the updated PI in the finally block */
+            processPaymentIntent(paymentInfo.orderId, paymentIntentReference).collect {
                 emit(it)
                 if (it is PaymentFailed && it.paymentDataForRetry != null) {
                     eligibleForRetry = true
@@ -60,13 +63,14 @@ internal class PaymentManager(
             }
         } finally {
             if (!eligibleForRetry) {
-                cancelOngoingPayment(paymentIntent)
+                cancelOngoingPayment(paymentIntentReference.value)
             }
         }
     }
 
     fun retryPayment(orderId: Long, paymentData: PaymentData) =
-        processPaymentIntent(orderId, (paymentData as PaymentDataImpl).paymentIntent)
+        // TODO Make sure we are cancelling even in this code path
+        processPaymentIntent(orderId, PaymentIntentReference((paymentData as PaymentDataImpl).paymentIntent))
 
     fun cancelPayment(paymentData: PaymentData) {
         val paymentIntent = (paymentData as PaymentDataImpl).paymentIntent
@@ -84,18 +88,21 @@ internal class PaymentManager(
         }
     }
 
-    private fun processPaymentIntent(orderId: Long, data: PaymentIntent) = flow {
-        var paymentIntent = data
-        if (paymentIntent.status == null || paymentIntent.status == PaymentIntentStatus.CANCELED) {
-            emit(errorMapper.mapError(errorMessage = "Cannot retry paymentIntent with status ${paymentIntent.status}"))
+    private fun processPaymentIntent(orderId: Long, paymentIntentRef: PaymentIntentReference) = flow {
+        if (paymentIntentRef.value.status == null || paymentIntentRef.value.status == PaymentIntentStatus.CANCELED) {
+            emit(
+                errorMapper.mapError(
+                    errorMessage = "Cannot retry paymentIntent with status ${paymentIntentRef.value.status}"
+                )
+            )
             return@flow
         }
 
-        if (paymentIntent.status == PaymentIntentStatus.REQUIRES_PAYMENT_METHOD) {
-            paymentIntent = collectPayment(paymentIntent)
+        if (paymentIntentRef.value.status == PaymentIntentStatus.REQUIRES_PAYMENT_METHOD) {
+            paymentIntentRef.value = collectPayment(paymentIntentRef.value)
         }
-        if (paymentIntent.status == PaymentIntentStatus.REQUIRES_CONFIRMATION) {
-            paymentIntent = processPayment(paymentIntent)
+        if (paymentIntentRef.value.status == PaymentIntentStatus.REQUIRES_CONFIRMATION) {
+            paymentIntentRef.value = processPayment(paymentIntentRef.value)
         }
 
         /*
@@ -111,9 +118,11 @@ internal class PaymentManager(
             the success/failure of the actual payment.
          */
 
-        if (paymentIntent.status == PaymentIntentStatus.REQUIRES_CAPTURE || isInteracPaymentSuccessful(paymentIntent)) {
-            retrieveReceiptUrl(paymentIntent)?.let { receiptUrl ->
-                capturePayment(receiptUrl, orderId, cardReaderStore, paymentIntent)
+        if (paymentIntentRef.value.status == PaymentIntentStatus.REQUIRES_CAPTURE ||
+            isInteracPaymentSuccessful(paymentIntentRef.value)
+        ) {
+            retrieveReceiptUrl(paymentIntentRef.value)?.let { receiptUrl ->
+                capturePayment(receiptUrl, orderId, cardReaderStore, paymentIntentRef.value)
             }
         }
     }
@@ -222,3 +231,4 @@ internal class PaymentManager(
 }
 
 internal data class PaymentDataImpl(val paymentIntent: PaymentIntent) : PaymentData
+internal data class PaymentIntentReference(var value: PaymentIntent)

--- a/libs/cardreader/src/test/java/com/woocommerce/android/cardreader/internal/payments/PaymentManagerTest.kt
+++ b/libs/cardreader/src/test/java/com/woocommerce/android/cardreader/internal/payments/PaymentManagerTest.kt
@@ -658,13 +658,13 @@ class PaymentManagerTest : CardReaderBaseUnitTest() {
     @Test
     fun `given non-retryable error, when collecting payment intent fails, then payment automatically cancelled`() =
         testBlocking {
-        whenever(collectPaymentAction.collectPayment(anyOrNull()))
-            .thenReturn(flow { emit(CollectPaymentStatus.Failure(mock())) })
+            whenever(collectPaymentAction.collectPayment(anyOrNull()))
+                .thenReturn(flow { emit(CollectPaymentStatus.Failure(mock())) })
 
-        manager.acceptPayment(createPaymentInfo()).toList()
+            manager.acceptPayment(createPaymentInfo()).toList()
 
-        verify(cancelPaymentAction).cancelPayment(any())
-    }
+            verify(cancelPaymentAction).cancelPayment(any())
+        }
 
     @Test
     fun `given retryable error, when collecting payment intent fails, then payment NOT cancelled`() =
@@ -681,14 +681,15 @@ class PaymentManagerTest : CardReaderBaseUnitTest() {
         }
 
     @Test
-    fun `given non-retryable error, when processing payment fails, then payment automatically cancelled`() = testBlocking {
-        whenever(processPaymentAction.processPayment(anyOrNull()))
-            .thenReturn(flow { emit(ProcessPaymentStatus.Failure(mock())) })
+    fun `given non-retryable error, when processing payment fails, then payment automatically cancelled`() =
+        testBlocking {
+            whenever(processPaymentAction.processPayment(anyOrNull()))
+                .thenReturn(flow { emit(ProcessPaymentStatus.Failure(mock())) })
 
-        manager.acceptPayment(createPaymentInfo()).toList()
+            manager.acceptPayment(createPaymentInfo()).toList()
 
-        verify(cancelPaymentAction).cancelPayment(any())
-    }
+            verify(cancelPaymentAction).cancelPayment(any())
+        }
 
     @Test
     fun `given retryable error, when processing payment fails, then payment NOT cancelled`() = testBlocking {

--- a/libs/cardreader/src/test/java/com/woocommerce/android/cardreader/internal/payments/PaymentManagerTest.kt
+++ b/libs/cardreader/src/test/java/com/woocommerce/android/cardreader/internal/payments/PaymentManagerTest.kt
@@ -5,6 +5,8 @@ import com.stripe.stripeterminal.external.models.Charge
 import com.stripe.stripeterminal.external.models.PaymentIntent
 import com.stripe.stripeterminal.external.models.PaymentIntentStatus
 import com.stripe.stripeterminal.external.models.PaymentIntentStatus.CANCELED
+import com.stripe.stripeterminal.external.models.PaymentIntentStatus.PROCESSING
+import com.stripe.stripeterminal.external.models.PaymentIntentStatus.REQUIRES_ACTION
 import com.stripe.stripeterminal.external.models.PaymentIntentStatus.REQUIRES_CAPTURE
 import com.stripe.stripeterminal.external.models.PaymentIntentStatus.REQUIRES_CONFIRMATION
 import com.stripe.stripeterminal.external.models.PaymentIntentStatus.REQUIRES_PAYMENT_METHOD
@@ -599,6 +601,28 @@ class PaymentManagerTest : CardReaderBaseUnitTest() {
         }
 
     @Test
+    fun `given PaymentStatus PROCESSING, when canceling payment, then payment intent canceled`() =
+        testBlocking {
+            val paymentIntent = createPaymentIntent(PROCESSING)
+            val paymentData = PaymentDataImpl(paymentIntent)
+
+            manager.cancelPayment(paymentData)
+
+            verify(cancelPaymentAction).cancelPayment(paymentIntent)
+        }
+
+    @Test
+    fun `given PaymentStatus REQUIRES_ACTION, when canceling payment, then payment intent canceled`() =
+        testBlocking {
+            val paymentIntent = createPaymentIntent(REQUIRES_ACTION)
+            val paymentData = PaymentDataImpl(paymentIntent)
+
+            manager.cancelPayment(paymentData)
+
+            verify(cancelPaymentAction).cancelPayment(paymentIntent)
+        }
+
+    @Test
     fun `given PaymentStatus REQUIRES_CAPTURE, when canceling payment, then payment intent NOT canceled`() =
         testBlocking {
             val paymentIntent = createPaymentIntent(REQUIRES_CAPTURE)
@@ -608,6 +632,76 @@ class PaymentManagerTest : CardReaderBaseUnitTest() {
 
             verify(cancelPaymentAction, never()).cancelPayment(paymentIntent)
         }
+
+    @Test
+    fun `given PaymentStatus SUCCEEDED, when canceling payment, then payment intent NOT canceled`() =
+        testBlocking {
+            val paymentIntent = createPaymentIntent(SUCCEEDED)
+            val paymentData = PaymentDataImpl(paymentIntent)
+
+            manager.cancelPayment(paymentData)
+
+            verify(cancelPaymentAction, never()).cancelPayment(paymentIntent)
+        }
+
+    @Test
+    fun `given PaymentStatus CANCELED, when canceling payment, then payment intent NOT canceled`() =
+        testBlocking {
+            val paymentIntent = createPaymentIntent(CANCELED)
+            val paymentData = PaymentDataImpl(paymentIntent)
+
+            manager.cancelPayment(paymentData)
+
+            verify(cancelPaymentAction, never()).cancelPayment(paymentIntent)
+        }
+
+    @Test
+    fun `given non-retryable error, when collecting payment intent fails, then payment automatically cancelled`() =
+        testBlocking {
+        whenever(collectPaymentAction.collectPayment(anyOrNull()))
+            .thenReturn(flow { emit(CollectPaymentStatus.Failure(mock())) })
+
+        manager.acceptPayment(createPaymentInfo()).toList()
+
+        verify(cancelPaymentAction).cancelPayment(any())
+    }
+
+    @Test
+    fun `given retryable error, when collecting payment intent fails, then payment NOT cancelled`() =
+        testBlocking {
+            whenever(collectPaymentAction.collectPayment(anyOrNull()))
+                .thenReturn(flow { emit(CollectPaymentStatus.Failure(mock())) })
+            val dataForRetry = mock<PaymentDataImpl>()
+            whenever(paymentErrorMapper.mapTerminalError(anyOrNull(), anyOrNull()))
+                .thenReturn(PaymentFailed(CardPaymentStatusErrorType.Generic, dataForRetry, ""))
+
+            manager.acceptPayment(createPaymentInfo()).toList()
+
+            verify(cancelPaymentAction, never()).cancelPayment(any())
+        }
+
+    @Test
+    fun `given non-retryable error, when processing payment fails, then payment automatically cancelled`() = testBlocking {
+        whenever(processPaymentAction.processPayment(anyOrNull()))
+            .thenReturn(flow { emit(ProcessPaymentStatus.Failure(mock())) })
+
+        manager.acceptPayment(createPaymentInfo()).toList()
+
+        verify(cancelPaymentAction).cancelPayment(any())
+    }
+
+    @Test
+    fun `given retryable error, when processing payment fails, then payment NOT cancelled`() = testBlocking {
+        whenever(processPaymentAction.processPayment(anyOrNull()))
+            .thenReturn(flow { emit(ProcessPaymentStatus.Failure(mock())) })
+        val dataForRetry = mock<PaymentDataImpl>()
+        whenever(paymentErrorMapper.mapTerminalError(anyOrNull(), anyOrNull()))
+            .thenReturn(PaymentFailed(CardPaymentStatusErrorType.Generic, dataForRetry, ""))
+
+        manager.acceptPayment(createPaymentInfo()).toList()
+
+        verify(cancelPaymentAction, never()).cancelPayment(any())
+    }
     // END - Cancel
 
     private fun createPaymentIntent(


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #13593 
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

**Note: The code complexity introduced in this PR is IMO not worth merging, especially considering it doesn't solve all the edge-cases. I'm creating the PR so we can discuss it and document the decision, however, I'd personally vote for leaving the code as is (prior this PR).** cc @kidinov @samiuelson  @AnirudhBhat in case you believe this PR is still worth merging or if you believe we should continue looking into this.

This PR adds an additional safety measure to ensure the app doesn't leave Payment Intents in an uncaptured state (on hold state) - this is not a critical issue, since the payment authorization expires after a few days and the Payment Intent gets cancelled automatically. 

We added a basic safety measure a few weeks ago in [this PR](https://github.com/woocommerce/woocommerce-android/pull/13597/files) which prevents users from leaving the payment flow by tapping on the back button. However, this solution doesn't cover edge cases and is dependent on the implementation of the client app which could potentially bite us in the future. The goal of this PR is to ensure this issue is solved even if the client app doesn't suppress the back button.

This PR doesn't completely solve the problem since we are not cancelling Payment Intents in the `Requires Capture` state, since the Stripe SDK doesn't change the status of the Payment Intent after it's successfully captured -> this is understandable, since capturing payment intent doesn't involve communication with the SDK at all, the app communicates only with the Woo site and the site communicates with Stripe's backend. We could potentially try to cancel PI in the `Requires capture` state and rely on the fact that completed payments can't be cancelled, however, this doesn't work either, since Stripe refunds the payment in such case which is likely not what we want.

Bottom line is, that I believe preventing users from pressing the back is a good enough solution and it's likely not worth further effort to try to fix this in the CardReaderModule layer.

### Steps to reproduce
<!-- Step-by-step testing instructions. For new user flows, consider instead stating the goal of the workflow and see if your PR reviewer can accomplish the workflow without specific steps! -->

Revert changes done in [this PR](https://github.com/woocommerce/woocommerce-android/pull/13597/files) to ensure you can easily reproduce the issue.

1. Enter POS
2. Add a product to the cart
3. Tap on Checkout
4. Tap your card on the reader
5. Press back during the processing payment step
6. Look at Stripe's dashboard and notice there are two records for this order - completed and incomplete/uncaptured.


### Testing information
<!-- This is your opportunity to break out individual scenarios that need testing (when necessary) and/or include a checklist for the reviewer to go through. Consider documenting the following from your own completed testing: devices used, alternate workflows, edge cases, affected areas, critical flows, areas not tested, and any remaining unknowns. Provide feedback on this new section of the PR template through Sept 30, 2024 to Apps Quality; additional context here: p91TBi-b8z-p2#comment-12036 -->

- Test all scenarios that come to mind, including re-enabling the back-button to easily test various cancellation scenarios.



### The tests that have been performed
<!-- To give the reviewer an idea of what could be missed in terms of testing -->
I have tested many different scenarios
- Tapping the back button during the processing payment step and then tapping again and letting the flow complete => the PI gets cancelled correctly and new PI completes successfully. 
- Using live card to simulate an error and then retrying using the test card => the same PI is re-used and completes successfully.
- Tapping the back button during the capturing step and then tapping again and letting the flow complete => WooPayments correctly detects that the payment is already paid and user is not double-charged.


### Images/gif
<!-- Include before and after images or gifs when appropriate. -->

- [ ] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.

## Reviewer (or Author, in the case of optional code reviews):

Please make sure these conditions are met before approving the PR, or request changes if the PR needs improvement:

- [ ] The PR is small and has a clear, single focus, or a valid explanation is provided in the description. If needed, please request to split it into smaller PRs.
- [ ] Ensure Adequate Unit Test Coverage: The changes are reasonably covered by unit tests or an explanation is provided in the PR description.
- [ ] Manual Testing: The author listed all the tests they ran, including smoke tests when needed (e.g., for refactorings). The reviewer confirmed that the PR works as expected on big (tablet) and small (phone) in case of UI changes, and no regressions are added.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->3593

