### PR TITLE
Add feature flag for POS coupons

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/featureflags/WooPosIsCouponsEnabled.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/featureflags/WooPosIsCouponsEnabled.kt
@@ -1,0 +1,10 @@
+package com.woocommerce.android.ui.woopos.featureflags
+
+import com.woocommerce.android.util.FeatureFlag
+import javax.inject.Inject
+
+class WooPosIsCouponsEnabled @Inject constructor() {
+    operator fun invoke(): Boolean {
+        return FeatureFlag.POS_COUPONS.isEnabled()
+    }
+}

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/util/FeatureFlag.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/util/FeatureFlag.kt
@@ -14,6 +14,7 @@ enum class FeatureFlag {
     ENDLESS_CAMPAIGNS_SUPPORT,
     REVAMP_WOO_SHIPPING,
     OBJECTIVE_SECTION,
+    POS_COUPONS,
     BULK_UPDATE_ORDERS_STATUS,
     HIDE_SITES_FROM_SITE_PICKER;
 
@@ -25,6 +26,7 @@ enum class FeatureFlag {
 
             WC_SHIPPING_BANNER,
             BETTER_CUSTOMER_SEARCH_M2,
+            POS_COUPONS,
             ORDER_CREATION_AUTO_TAX_RATE,
             REVAMP_WOO_SHIPPING -> PackageUtils.isDebugBuild()
 


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #13712
<!-- Id number of the GitHub issue this PR addresses. -->

<!-- 
━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
🛠 Need an AI review?  
Add a comment: `@coderabbitai review`
━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
-->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

This PR introduced a feature flag that we plan to use for the Coupons for POS feature. It is not currently used anywhere, but we plan to introduce a button on the POS home screen that will be visible when this FF is enabled.

Unit-Test-Exemption - nothing to test here.

### Steps to reproduce
<!-- Step-by-step testing instructions. For new user flows, consider instead stating the goal of the workflow and see if your PR reviewer can accomplish the workflow without specific steps! -->

N/A

### Testing information
<!-- This is your opportunity to break out individual scenarios that need testing (when necessary) and/or include a checklist for the reviewer to go through. Consider documenting the following from your own completed testing: devices used, alternate workflows, edge cases, affected areas, critical flows, areas not tested, and any remaining unknowns. Provide feedback on this new section of the PR template through Sept 30, 2024 to Apps Quality; additional context here: p91TBi-b8z-p2#comment-12036 -->

Nothing to test

### The tests that have been performed
<!-- To give the reviewer an idea of what could be missed in terms of testing -->

I just ran detektAll

### Images/gif
<!-- Include before and after images or gifs when appropriate. -->

- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.

## Reviewer (or Author, in the case of optional code reviews):

Please make sure these conditions are met before approving the PR, or request changes if the PR needs improvement:

- [x] The PR is small and has a clear, single focus, or a valid explanation is provided in the description. If needed, please request to split it into smaller PRs.
- [x] Ensure Adequate Unit Test Coverage: The changes are reasonably covered by unit tests or an explanation is provided in the PR description.
- [x] Manual Testing: The author listed all the tests they ran, including smoke tests when needed (e.g., for refactorings). The reviewer confirmed that the PR works as expected on big (tablet) and small (phone) in case of UI changes, and no regressions are added.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->