### PR TITLE
Add retry to flaky e2eRealApiOrderDetails test

### DIFF
--- a/WooCommerce/src/androidTest/kotlin/com/woocommerce/android/e2e/tests/ui/OrdersRealAPI.kt
+++ b/WooCommerce/src/androidTest/kotlin/com/woocommerce/android/e2e/tests/ui/OrdersRealAPI.kt
@@ -117,6 +117,7 @@ class OrdersRealAPI : TestBase() {
             .assertOrdersCount(2)
     }
 
+    @Retry(numberOfTimes = 1)
     @Test
     fun e2eRealApiOrderDetails() {
         try {


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

<!-- 
━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
🛠 Need an AI review?  
Add a comment: `@coderabbitai review`
━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
-->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
Reported in: p1741682285823039/1741682231.647289-slack-CGPNUU63E
This PR adds the `Retry` annotation to the flaky `e2eRealApiOrderDetails` UI test. Before, this test was flaky and ignored. I enabled this test in #13066 and removed `Retry(numberOfTimes = 1)` since it did not appear flaky in my IDE tests. Still, I couldn’t confirm its flakiness when running it from the IDE. I added the retry annotation back to prevent flaky tests in the CI environment.

If the flakiness persists, we can investigate further.

### Steps to reproduce
<!-- Step-by-step testing instructions. For new user flows, consider instead stating the goal of the workflow and see if your PR reviewer can accomplish the workflow without specific steps! -->
Run `OrdersRealAPI.e2eRealApiOrderDetails()`

- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.

## Reviewer (or Author, in the case of optional code reviews):

Please make sure these conditions are met before approving the PR, or request changes if the PR needs improvement:

- [ ] The PR is small and has a clear, single focus, or a valid explanation is provided in the description. If needed, please request to split it into smaller PRs.
- [ ] Ensure Adequate Unit Test Coverage: The changes are reasonably covered by unit tests or an explanation is provided in the PR description.
- [ ] Manual Testing: The author listed all the tests they ran, including smoke tests when needed (e.g., for refactorings). The reviewer confirmed that the PR works as expected on big (tablet) and small (phone) in case of UI changes, and no regressions are added.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->