### PR TITLE
Split shipment initial navigation

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/WooShippingLabelCreationFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/WooShippingLabelCreationFragment.kt
@@ -101,6 +101,12 @@ class WooShippingLabelCreationFragment : BaseFragment(), BackPressListener {
                     event.action
                 )
                 is MultiLiveEvent.Event.Exit -> findNavController().navigateUp()
+                is WooShippingLabelCreationViewModel.StartSplitShipment -> {
+                    WooShippingLabelCreationFragmentDirections
+                        .actionWooShippingLabelCreationFragmentToWooShippingSplitShipmentFragment().let {
+                            findNavController().navigateSafely(it)
+                        }
+                }
             }
         }
     }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/WooShippingLabelCreationFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/WooShippingLabelCreationFragment.kt
@@ -57,6 +57,7 @@ class WooShippingLabelCreationFragment : BaseFragment(), BackPressListener {
 
     override val activityAppBarStatus: AppBarStatus = AppBarStatus.Hidden
 
+    @Suppress("CyclomaticComplexMethod")
     private fun setupObservers() {
         viewModel.event.observe(viewLifecycleOwner) { event ->
             when (event) {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/WooShippingLabelCreationScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/WooShippingLabelCreationScreen.kt
@@ -122,7 +122,8 @@ fun WooShippingLabelCreationScreen(viewModel: WooShippingLabelCreationViewModel)
                 onEditDestinationAddress = viewModel::onEditDestinationAddress,
                 destinationStatus = viewState.destinationStatus,
                 actionSnackbar = viewModel.actionSnackbar,
-                onDismissAddressNotification = viewModel::onDismissAddressNotification
+                onDismissAddressNotification = viewModel::onDismissAddressNotification,
+                onSplitShipment = viewModel::onSplitShipment
             )
         }
 
@@ -165,7 +166,8 @@ fun WooShippingLabelCreationScreen(
     destinationStatus: AddressStatus,
     modifier: Modifier = Modifier,
     actionSnackbar: ActionSnackbar? = null,
-    onDismissAddressNotification: () -> Unit = {}
+    onDismissAddressNotification: () -> Unit = {},
+    onSplitShipment: () -> Unit = {}
 ) {
     val shipmentDetailsValue = if (uiState.isShipmentDetailsExpanded) {
         BottomSheetValue.Expanded
@@ -229,7 +231,8 @@ fun WooShippingLabelCreationScreen(
             onEditDestinationAddress = onEditDestinationAddress,
             onDismissAddressNotification = onDismissAddressNotification,
             destinationStatus = destinationStatus,
-            actionSnackbar = actionSnackbar
+            actionSnackbar = actionSnackbar,
+            onSplitShipment = onSplitShipment
         )
         val isDarkTheme = isSystemInDarkTheme()
         val isCollapsed = scaffoldState.bottomSheetState.isCollapsed
@@ -307,7 +310,8 @@ private fun LabelCreationScreenWithBottomSheet(
     destinationStatus: AddressStatus,
     modifier: Modifier = Modifier,
     onDismissAddressNotification: () -> Unit = {},
-    actionSnackbar: ActionSnackbar? = null
+    actionSnackbar: ActionSnackbar? = null,
+    onSplitShipment: () -> Unit = {}
 ) {
     val snackbarHostState = remember { SnackbarHostState() }
 
@@ -378,11 +382,38 @@ private fun LabelCreationScreenWithBottomSheet(
         ) {
             Column(modifier.verticalScroll(rememberScrollState())) {
                 val isExpanded = remember { mutableStateOf(false) }
+                Row(
+                    modifier = Modifier.padding(
+                        start = dimensionResource(R.dimen.major_100),
+                        end = dimensionResource(R.dimen.major_100),
+                        top = dimensionResource(R.dimen.major_100),
+                        bottom = dimensionResource(R.dimen.minor_100)
+                    ),
+                    verticalAlignment = Alignment.CenterVertically
+                ) {
+                    Text(
+                        text = stringResource(R.string.products),
+                        style = MaterialTheme.typography.h6,
+                        modifier = Modifier.weight(1f)
+                    )
+                    Text(
+                        text = stringResource(R.string.woo_shipping_split_shipment),
+                        color = MaterialTheme.colors.primary,
+                        modifier = Modifier
+                            .clickable { onSplitShipment() }
+                            .padding(dimensionResource(R.dimen.minor_100))
+                    )
+                }
+
                 ShippingProductsCard(
                     shippableItems = shippableItems,
                     modifier = Modifier
                         .fillMaxWidth()
-                        .padding(16.dp),
+                        .padding(
+                            start = dimensionResource(R.dimen.major_100),
+                            end = dimensionResource(R.dimen.major_100),
+                            bottom = dimensionResource(R.dimen.major_100)
+                        ),
                     isExpanded = isExpanded.value,
                     onExpand = { isExpanded.value = it }
                 )

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/WooShippingLabelCreationViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/WooShippingLabelCreationViewModel.kt
@@ -637,6 +637,8 @@ class WooShippingLabelCreationViewModel @Inject constructor(
         val orderId: Long
     ) : Event()
 
+    data object StartSplitShipment : Event()
+
     data class StartCustomsFormEdit(
         val shippableItems: List<ShippableItemModel>,
         val customData: CustomsData?

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/WooShippingLabelCreationViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/WooShippingLabelCreationViewModel.kt
@@ -554,6 +554,8 @@ class WooShippingLabelCreationViewModel @Inject constructor(
         selectedRate.update { rate }
     }
 
+    fun onSplitShipment() { triggerEvent(StartSplitShipment) }
+
     private fun sortShippingRates(
         option: ShippingSortOption,
         shippingRates: Map<CarrierUI, List<ShippingRateUI>>

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/split/WooShippingSplitShipmentFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/split/WooShippingSplitShipmentFragment.kt
@@ -1,0 +1,34 @@
+package com.woocommerce.android.ui.orders.wooshippinglabels.split
+
+import android.os.Bundle
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import androidx.compose.foundation.layout.Box
+import androidx.compose.material.Surface
+import androidx.compose.material.Text
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.platform.ComposeView
+import androidx.compose.ui.platform.ViewCompositionStrategy.DisposeOnViewTreeLifecycleDestroyed
+import com.woocommerce.android.ui.base.BaseFragment
+import com.woocommerce.android.ui.compose.theme.WooThemeWithBackground
+import com.woocommerce.android.ui.main.AppBarStatus
+
+class WooShippingSplitShipmentFragment : BaseFragment() {
+    override val activityAppBarStatus: AppBarStatus = AppBarStatus.Hidden
+
+    override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View {
+        return ComposeView(requireContext()).apply {
+            setViewCompositionStrategy(DisposeOnViewTreeLifecycleDestroyed)
+            setContent {
+                WooThemeWithBackground {
+                    Surface {
+                        Box(contentAlignment = Alignment.Center) {
+                            Text("WooShippingSplitShipmentFragment")
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/WooCommerce/src/main/res/navigation/nav_graph_orders.xml
+++ b/WooCommerce/src/main/res/navigation/nav_graph_orders.xml
@@ -713,6 +713,9 @@
         <action
             android:id="@+id/action_wooShippingLabelCreationFragment_to_wooShippingLabelCustomsFormFragment"
             app:destination="@id/wooShippingLabelCustomsFormFragment" />
+        <action
+            android:id="@+id/action_wooShippingLabelCreationFragment_to_wooShippingSplitShipmentFragment"
+            app:destination="@id/wooShippingSplitShipmentFragment" />
     </fragment>
     <fragment
         android:id="@+id/wooShippingLabelPackageCreationFragment"
@@ -768,4 +771,8 @@
             android:id="@+id/action_search_filter_fragment"
             app:destination="@id/searchFilterFragment" />
     </fragment>
+    <fragment
+        android:id="@+id/wooShippingSplitShipmentFragment"
+        android:name="com.woocommerce.android.ui.orders.wooshippinglabels.split.WooShippingSplitShipmentFragment"
+        android:label="WooShippingSplitShipmentFragment" />
 </navigation>

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -4564,4 +4564,6 @@
     <string name="error_user_username_instead_of_email">Please log in using your WordPress.com username instead of your email address.</string>
     <string name="about_automattic_x_item_title">X</string>
     <string name="default_web_client_id" a8c-src-lib="module:login">placeholder</string>
+
+    <string name="woo_shipping_split_shipment">Split shipment</string>
 </resources>


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #13698 

### Description
This PR modifies the main flow UI to include the Split shipment button and adds the initial navigation to the Split shipment screen.

### Testing information
TC1

1. Open the orders tab
2. Tap on an order eligible for shipping label creation without a shipping address
3. Tap on Create shipping label
4. Check that the Split shipment button is visible
5. Tap on Split shipment
6. Check that the app navigates to the split shipment screen

### The tests that have been performed

- Checked that the navigation works as expected

### Images/gif

https://github.com/user-attachments/assets/b1a31301-bb8e-4516-a9fb-bd31a4a9ed18


- [ ] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.

## Reviewer (or Author, in the case of optional code reviews):

Please make sure these conditions are met before approving the PR, or request changes if the PR needs improvement:

- [ ] The PR is small and has a clear, single focus, or a valid explanation is provided in the description. If needed, please request to split it into smaller PRs.
- [ ] Ensure Adequate Unit Test Coverage: The changes are reasonably covered by unit tests or an explanation is provided in the PR description.
- [ ] Manual Testing: The author listed all the tests they ran, including smoke tests when needed (e.g., for refactorings). The reviewer confirmed that the PR works as expected on big (tablet) and small (phone) in case of UI changes, and no regressions are added.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->