### PR TITLE
Update missing address notification

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/WooShippingLabelCreationViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/WooShippingLabelCreationViewModel.kt
@@ -20,6 +20,7 @@ import com.woocommerce.android.ui.orders.wooshippinglabels.WooShippingLabelCreat
 import com.woocommerce.android.ui.orders.wooshippinglabels.WooShippingLabelCreationViewModel.PackageSelectionState.NotSelected
 import com.woocommerce.android.ui.orders.wooshippinglabels.address.AddressNotification
 import com.woocommerce.android.ui.orders.wooshippinglabels.address.AddressStatus
+import com.woocommerce.android.ui.orders.wooshippinglabels.address.AddressValidationHelper
 import com.woocommerce.android.ui.orders.wooshippinglabels.address.GetAddressNotification
 import com.woocommerce.android.ui.orders.wooshippinglabels.address.destination.VerifyDestinationAddress
 import com.woocommerce.android.ui.orders.wooshippinglabels.address.origin.FetchOriginAddresses
@@ -78,6 +79,7 @@ class WooShippingLabelCreationViewModel @Inject constructor(
     private val observeStoreOptions: ObserveStoreOptions,
     private val fetchAccountSettings: FetchAccountSettings,
     private val shouldRequireCustoms: ShouldRequireCustomsForm,
+    private val addressValidationHelper: AddressValidationHelper,
     private val verifyDestinationAddress: VerifyDestinationAddress,
     private val getAddressNotification: GetAddressNotification
 ) : ScopedViewModel(savedState) {
@@ -182,7 +184,7 @@ class WooShippingLabelCreationViewModel @Inject constructor(
 
             destinationAddress.value = defaultDestination
 
-            if (order.shippingAddress != Address.EMPTY) {
+            if (addressValidationHelper.isMissingDestinationAddress(order.shippingAddress)) {
                 verifyDestinationAddress(order.id).fold(
                     onSuccess = { destinationAddress.value = it },
                     onFailure = { }
@@ -376,7 +378,10 @@ class WooShippingLabelCreationViewModel @Inject constructor(
             val items = getShippableItems(order)
 
             val destinationStatus = when {
-                addresses.shipTo.address.hasInfo().not() -> AddressStatus.MISSING_ADDRESS
+                addressValidationHelper.isMissingDestinationAddress(addresses.shipTo.address) -> {
+                    AddressStatus.MISSING_ADDRESS
+                }
+
                 addresses.shipTo.isVerified -> AddressStatus.VERIFIED
                 else -> AddressStatus.UNVERIFIED
             }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/address/AddressSection.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/address/AddressSection.kt
@@ -183,22 +183,24 @@ internal fun AddressSectionPortrait(
                         bottom = dimensionResource(R.dimen.major_100)
                     )
             )
-            Text(
-                text = shippingAddresses.shipTo.address.toString(),
-                modifier = Modifier
-                    .constrainAs(shipToValue) {
-                        top.linkTo(shipToLabel.top)
-                        start.linkTo(barrier)
-                        end.linkTo(shipToEdit.start)
-                        width = Dimension.fillToConstraints
-                    }
-                    .padding(
-                        top = dimensionResource(R.dimen.major_100),
-                        bottom = dimensionResource(R.dimen.minor_100),
-                        start = dimensionResource(R.dimen.major_100),
-                        end = dimensionResource(R.dimen.minor_100)
-                    )
-            )
+            if (destinationStatus != AddressStatus.MISSING_ADDRESS) {
+                Text(
+                    text = shippingAddresses.shipTo.address.toString(),
+                    modifier = Modifier
+                        .constrainAs(shipToValue) {
+                            top.linkTo(shipToLabel.top)
+                            start.linkTo(barrier)
+                            end.linkTo(shipToEdit.start)
+                            width = Dimension.fillToConstraints
+                        }
+                        .padding(
+                            top = dimensionResource(R.dimen.major_100),
+                            bottom = dimensionResource(R.dimen.minor_100),
+                            start = dimensionResource(R.dimen.major_100),
+                            end = dimensionResource(R.dimen.minor_100)
+                        ),
+                )
+            }
             AddressStatusIndicator(
                 addressStatus = destinationStatus,
                 modifier = destinationStatusModifier

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/address/AddressSection.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/address/AddressSection.kt
@@ -86,12 +86,13 @@ internal fun AddressSectionPortrait(
             val scope = rememberCoroutineScope()
 
             val destinationStatusModifier = if (destinationStatus == AddressStatus.MISSING_ADDRESS) {
-                Modifier.constrainAs(destinationAddressStatus) {
-                    top.linkTo(divider.bottom)
-                    start.linkTo(shipToValue.start)
-                    bottom.linkTo(parent.bottom)
-                    end.linkTo(shipToEdit.start)
-                }
+                Modifier
+                    .padding(start = dimensionResource(R.dimen.major_100))
+                    .constrainAs(destinationAddressStatus) {
+                        top.linkTo(divider.bottom)
+                        start.linkTo(barrier)
+                        bottom.linkTo(parent.bottom)
+                    }
             } else {
                 Modifier
                     .padding(

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/address/AddressSection.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/address/AddressSection.kt
@@ -308,7 +308,8 @@ internal fun AddressSectionLandscape(
                             bottom = dimensionResource(R.dimen.major_100)
                         )
                     } else {
-                        Modifier.align(Alignment.CenterHorizontally)
+                        Modifier
+                            .align(Alignment.CenterHorizontally)
                             .padding(16.dp)
                             .height(IntrinsicSize.Min)
                     }
@@ -597,6 +598,7 @@ fun AddressStatusIndicator(
         )
     }
 }
+
 internal fun getShipFrom() = OriginShippingAddress(
     firstName = "first name",
     lastName = "last name",

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/address/AddressValidationHelper.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/address/AddressValidationHelper.kt
@@ -1,6 +1,7 @@
 package com.woocommerce.android.ui.orders.wooshippinglabels.address
 
 import com.woocommerce.android.R
+import com.woocommerce.android.model.Address
 import com.woocommerce.android.viewmodel.ResourceProvider
 import javax.inject.Inject
 
@@ -40,8 +41,14 @@ class AddressValidationHelper @Inject constructor(
             value.contains(Regex("\\d")).not() -> {
                 resourceProvider.getString(R.string.shipping_label_destination_address_phone_invalid)
             }
+
             else -> null
         }
+    }
+
+    fun isMissingDestinationAddress(address: Address) = with(address) {
+        (address1.isBlank() && address2.isBlank()) || city.isBlank() || postcode.isBlank() ||
+            (firstName.isBlank() && lastName.isBlank() && company.isBlank())
     }
 
     companion object {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/address/GetAddressNotification.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/address/GetAddressNotification.kt
@@ -5,7 +5,8 @@ import com.woocommerce.android.R
 import com.woocommerce.android.ui.orders.wooshippinglabels.WooShippingAddresses
 import javax.inject.Inject
 
-class GetAddressNotification @Inject constructor() {
+class GetAddressNotification @Inject constructor(private val addressValidationHelper: AddressValidationHelper) {
+
     operator fun invoke(
         addresses: WooShippingAddresses,
         previousNotification: AddressNotification? = null
@@ -19,7 +20,7 @@ class GetAddressNotification @Inject constructor() {
                 )
             }
 
-            addresses.shipTo.address.hasInfo().not() -> {
+            addressValidationHelper.isMissingDestinationAddress(addresses.shipTo.address) -> {
                 AddressNotification(
                     isSuccess = false,
                     message = R.string.woo_shipping_address_notification_destination_missing,

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/WooShippingLabelCreationViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/WooShippingLabelCreationViewModelTest.kt
@@ -237,6 +237,7 @@ class WooShippingLabelCreationViewModelTest : BaseUnitTest() {
             observeStoreOptions = observeStoreOptions,
             fetchAccountSettings = mock(),
             shouldRequireCustoms = shouldRequireCustomsForm,
+            addressValidationHelper = mock(),
             verifyDestinationAddress = verifyDestinationAddress,
             getAddressNotification = getAddressNotification,
             savedState = savedState

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/address/GetAddressNotificationTests.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/address/GetAddressNotificationTests.kt
@@ -8,11 +8,16 @@ import com.woocommerce.android.ui.orders.wooshippinglabels.models.OriginShipping
 import com.woocommerce.android.viewmodel.BaseUnitTest
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import org.assertj.core.api.Assertions.assertThat
+import org.mockito.Mockito.mock
+import org.mockito.kotlin.doReturn
+import org.mockito.kotlin.whenever
 import kotlin.test.Test
 
 @OptIn(ExperimentalCoroutinesApi::class)
 class GetAddressNotificationTests : BaseUnitTest() {
-    private val sut = GetAddressNotification()
+    private val addressValidationHelper: AddressValidationHelper = mock()
+
+    private val sut = GetAddressNotification(addressValidationHelper)
 
     private val defaultAddresses = WooShippingAddresses(
         shipFrom = OriginShippingAddress.EMPTY.copy(
@@ -98,6 +103,8 @@ class GetAddressNotificationTests : BaseUnitTest() {
     @Test
     fun `when shipTo is missing, then display destination missing`() {
         val addresses = defaultAddresses.copy(shipTo = DestinationShippingAddress.EMPTY)
+
+        whenever(addressValidationHelper.isMissingDestinationAddress(addresses.shipTo.address)) doReturn true
 
         val result = sut.invoke(addresses, null)
 


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #12441 
<!-- Id number of the GitHub issue this PR addresses. -->

<!-- 
━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
🛠 Need an AI review?  
Add a comment: `@coderabbitai review`
━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
-->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
This PR updates the logic for the missing address notification in shipping labels creation flow and also includes a small UI change. See the screenshots for details.

Before, if any information was present in the shipping address, it was treated as a non-missing address, and the verify address endpoint was called. Now, the verification step is skipped, and a missing address notification is shown if the required destination address fields are not fully filled.

### Steps to reproduce
<!-- Step-by-step testing instructions. For new user flows, consider instead stating the goal of the workflow and see if your PR reviewer can accomplish the workflow without specific steps! -->
1. Go to the Orders tab.
2. Create a new order with a missing address.
3. Go to Order Details.
4. Tap Shipment Details.

### Testing information
<!-- This is your opportunity to break out individual scenarios that need testing (when necessary) and/or include a checklist for the reviewer to go through. Consider documenting the following from your own completed testing: devices used, alternate workflows, edge cases, affected areas, critical flows, areas not tested, and any remaining unknowns. Provide feedback on this new section of the PR template through Sept 30, 2024 to Apps Quality; additional context here: p91TBi-b8z-p2#comment-12036 -->
Please test different address variations in orders to ensure everything works as expected.

### The tests that have been performed
<!-- To give the reviewer an idea of what could be missed in terms of testing -->
Cases below

### Images/gif
<!-- Include before and after images or gifs when appropriate. -->
#### When the Name field is filled, but others are empty
|Before|After|
|-|-|
|<img src="https://github.com/user-attachments/assets/533da08b-04c5-4917-90cc-76a81c4fbbcf" width=350>|<img src="https://github.com/user-attachments/assets/3b6c6acf-c08b-4633-b35f-68aca22497fa" width=350>|
|<img src="https://github.com/user-attachments/assets/6cd67110-57d4-464b-a118-e46b7b7b258b" width=350>|<img src="https://github.com/user-attachments/assets/07149271-6820-40aa-8222-ffd3224886f1" width=350>|

#### When all address fields are empty
_By aligning left, we match the Figma designs and the current iOS implementation._
|Before|After|
|-|-|
|<img src="https://github.com/user-attachments/assets/f92ea7f5-9922-484a-b8a4-48155aba6fc1" width=350>|<img src="https://github.com/user-attachments/assets/07149271-6820-40aa-8222-ffd3224886f1" width=350>|

- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.

## Reviewer (or Author, in the case of optional code reviews):

Please make sure these conditions are met before approving the PR, or request changes if the PR needs improvement:

- [ ] The PR is small and has a clear, single focus, or a valid explanation is provided in the description. If needed, please request to split it into smaller PRs.
- [ ] Ensure Adequate Unit Test Coverage: The changes are reasonably covered by unit tests or an explanation is provided in the PR description.
- [ ] Manual Testing: The author listed all the tests they ran, including smoke tests when needed (e.g., for refactorings). The reviewer confirmed that the PR works as expected on big (tablet) and small (phone) in case of UI changes, and no regressions are added.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->