### PR TITLE
Improvements on the edit address flow

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/address/WooShippingEditAddressViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/address/WooShippingEditAddressViewModel.kt
@@ -282,11 +282,8 @@ class WooShippingEditAddressViewModel @Inject constructor(
                 }
                 when {
                     states.isNotEmpty() && stateCode.isNotEmpty() -> {
-                        findLocationByCode(stateCode, statesState.value)
-                            .takeIf { it != Location.EMPTY }
-                            ?.let { selectedState.value = it } ?: run {
-                            selectedState.value = states.first()
-                        }
+                        selectedState.value = findLocationByCode(stateCode, statesState.value)
+                            .takeIf { it != Location.EMPTY } ?: states.first()
                         rawState = ""
                     }
                     states.isNotEmpty() -> {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/address/WooShippingEditAddressViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/address/WooShippingEditAddressViewModel.kt
@@ -42,6 +42,7 @@ import javax.inject.Inject
 class WooShippingEditAddressViewModel @Inject constructor(
     private val addressValidator: AddressValidationHelper,
     private val getAcceptedOriginCountries: GetAcceptedOriginCountries,
+    private val getAllCountries: GetAllCountries,
     private val getStatesByCountryCode: GetStatesByCountryCode,
     private val normalizeAddress: NormalizeAddress,
     private val resourceProvider: ResourceProvider,
@@ -251,7 +252,11 @@ class WooShippingEditAddressViewModel @Inject constructor(
     }
 
     private suspend fun loadCountries() {
-        getAcceptedOriginCountries().fold(
+        val getCountries = when (navArgs.flow) {
+            is EditAddressFlow.EditDestinationAddress -> getAllCountries()
+            is EditAddressFlow.EditOriginAddress -> getAcceptedOriginCountries()
+        }
+        getCountries.fold(
             onSuccess = {
                 countriesState.value = LocationState.Loaded(it)
                 country.value = findLocationByCode(country.value.code, countriesState.value)

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/address/WooShippingEditAddressViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/address/WooShippingEditAddressViewModel.kt
@@ -232,16 +232,21 @@ class WooShippingEditAddressViewModel @Inject constructor(
         country.value = findLocationByCode(addressInformation.country.code, countriesState.value)
         address = address.copy(value = fullAddress, error = null)
         city = city.copy(value = addressInformation.city, error = null)
-        selectedState.value =
-            findLocationByCode(addressInformation.state.codeOrRaw, statesState.value)
+        findLocationByCode(addressInformation.state.codeOrRaw, statesState.value).let {
+            selectedState.value = it
+            rawState = addressInformation.state.codeOrRaw
+        }
         postalCode = postalCode.copy(value = addressInformation.postcode, error = null)
         email = email.copy(value = addressInformation.email, error = null)
         phone = phone.copy(value = addressInformation.phone, error = null)
         isCompanyExpanded.value = addressInformation.company.isNotNullOrEmpty()
     }
 
-    private fun findLocationByCode(code: String, state: LocationState): Location {
-        val default = AmbiguousLocation.Raw(code).asLocation()
+    private fun findLocationByCode(
+        code: String,
+        state: LocationState,
+        default: Location = AmbiguousLocation.Raw(code).asLocation()
+    ): Location {
         return when (val currentState = state) {
             is LocationState.Loaded -> {
                 currentState.locations.firstOrNull { it.code == code } ?: default
@@ -270,14 +275,20 @@ class WooShippingEditAddressViewModel @Inject constructor(
         country.mapLatest { country -> getStatesByCountryCode(country.code) }
             .collectLatest { states ->
                 statesState.value = LocationState.Loaded(states)
-                rawState = ""
+                val stateCode = if (country.value.code == currentAddress.value.country.code) {
+                    currentAddress.value.state.codeOrRaw
+                } else {
+                    ""
+                }
                 if (states.isNotEmpty()) {
-                    findLocationByCode(selectedState.value.code, statesState.value)
+                    findLocationByCode(stateCode, statesState.value, Location.EMPTY)
                         .takeIf { it != Location.EMPTY }
                         ?.let { selectedState.value = it } ?: run {
                         selectedState.value = states.first()
                     }
+                    rawState = ""
                 } else {
+                    rawState = stateCode
                     selectedState.value = Location.EMPTY
                 }
             }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/address/WooShippingEditAddressViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/address/WooShippingEditAddressViewModel.kt
@@ -280,16 +280,22 @@ class WooShippingEditAddressViewModel @Inject constructor(
                 } else {
                     ""
                 }
-                if (states.isNotEmpty()) {
-                    findLocationByCode(stateCode, statesState.value)
-                        .takeIf { it != Location.EMPTY }
-                        ?.let { selectedState.value = it } ?: run {
+                when {
+                    states.isNotEmpty() && stateCode.isNotEmpty() -> {
+                        findLocationByCode(stateCode, statesState.value)
+                            .takeIf { it != Location.EMPTY }
+                            ?.let { selectedState.value = it } ?: run {
+                            selectedState.value = states.first()
+                        }
+                        rawState = ""
+                    }
+                    states.isNotEmpty() -> {
                         selectedState.value = states.first()
                     }
-                    rawState = ""
-                } else {
-                    rawState = stateCode
-                    selectedState.value = Location.EMPTY
+                    else -> {
+                        rawState = stateCode
+                        selectedState.value = Location.EMPTY
+                    }
                 }
             }
     }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/address/WooShippingEditAddressViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/address/WooShippingEditAddressViewModel.kt
@@ -245,8 +245,8 @@ class WooShippingEditAddressViewModel @Inject constructor(
     private fun findLocationByCode(
         code: String,
         state: LocationState,
-        default: Location = AmbiguousLocation.Raw(code).asLocation()
     ): Location {
+        val default = AmbiguousLocation.Raw(code).asLocation()
         return when (val currentState = state) {
             is LocationState.Loaded -> {
                 currentState.locations.firstOrNull { it.code == code } ?: default
@@ -281,7 +281,7 @@ class WooShippingEditAddressViewModel @Inject constructor(
                     ""
                 }
                 if (states.isNotEmpty()) {
-                    findLocationByCode(stateCode, statesState.value, Location.EMPTY)
+                    findLocationByCode(stateCode, statesState.value)
                         .takeIf { it != Location.EMPTY }
                         ?.let { selectedState.value = it } ?: run {
                         selectedState.value = states.first()

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/networking/WooShippingLabelRestClient.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/networking/WooShippingLabelRestClient.kt
@@ -167,7 +167,7 @@ class WooShippingLabelRestClient @Inject constructor(
             site = site,
             path = url,
             body = mapOf(
-                "address" to address,
+                "address" to address.copy(isVerified = true),
                 "isVerified" to true // We always verify the address before saving it
             ),
             clazz = UpdateAddressResponseDTO::class.java,

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/address/WooShippingEditAddressViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/address/WooShippingEditAddressViewModelTest.kt
@@ -30,6 +30,7 @@ abstract class WooShippingEditAddressViewModelTest : BaseUnitTest() {
     protected val normalizeAddress: NormalizeAddress = mock()
     protected val updateOriginAddress: UpdateOriginAddress = mock()
     protected val updateDestinationAddress: UpdateDestinationAddress = mock()
+    protected val getAllCountries: GetAllCountries = mock()
 
     protected val countries = listOf(
         Location("US", "United States"),
@@ -46,6 +47,7 @@ abstract class WooShippingEditAddressViewModelTest : BaseUnitTest() {
     protected lateinit var sut: WooShippingEditAddressViewModel
 
     abstract fun createSavedStateHandle(address: Address, isVerified: Boolean = false): SavedStateHandle
+    abstract suspend fun mockCountries(countries: Result<List<Location>>)
 
     fun createViewModel(savedState: SavedStateHandle) {
         sut = WooShippingEditAddressViewModel(
@@ -56,7 +58,8 @@ abstract class WooShippingEditAddressViewModelTest : BaseUnitTest() {
             normalizeAddress = normalizeAddress,
             resourceProvider = resourceProvider,
             updateOriginAddress = updateOriginAddress,
-            updateDestinationAddress = updateDestinationAddress
+            updateDestinationAddress = updateDestinationAddress,
+            getAllCountries = getAllCountries
         )
     }
 
@@ -309,7 +312,7 @@ abstract class WooShippingEditAddressViewModelTest : BaseUnitTest() {
     fun `when get accepted countries succeed then don't display loading or error`() = testBlocking {
         val address = Address.EMPTY
         whenever(addressValidator.validateFieldRequired(any())).doReturn(null)
-        whenever(getAcceptedOriginCountries.invoke()).doReturn(Result.success(countries))
+        mockCountries(Result.success(countries))
         Snapshot.withMutableSnapshot {
             val savedState = createSavedStateHandle(address)
             createViewModel(savedState)
@@ -329,7 +332,7 @@ abstract class WooShippingEditAddressViewModelTest : BaseUnitTest() {
     fun `when get accepted countries fails then display error`() = testBlocking {
         val address = Address.EMPTY
         whenever(addressValidator.validateFieldRequired(any())).doReturn(null)
-        whenever(getAcceptedOriginCountries.invoke()).doReturn(Result.failure(Exception("error")))
+        mockCountries(Result.failure(Exception("error")))
         whenever(resourceProvider.getString(any())).doReturn("error")
         Snapshot.withMutableSnapshot {
             val savedState = createSavedStateHandle(address)
@@ -350,7 +353,7 @@ abstract class WooShippingEditAddressViewModelTest : BaseUnitTest() {
     fun `when get states is empty then use state input`() = testBlocking {
         val address = Address.EMPTY
         whenever(addressValidator.validateFieldRequired(any())).doReturn(null)
-        whenever(getAcceptedOriginCountries.invoke()).doReturn(Result.success(countries))
+        mockCountries(Result.success(countries))
         whenever(getStatesByCountryCode.invoke(any())).doReturn(emptyList())
         Snapshot.withMutableSnapshot {
             val savedState = createSavedStateHandle(address)
@@ -367,10 +370,10 @@ abstract class WooShippingEditAddressViewModelTest : BaseUnitTest() {
     }
 
     @Test
-    fun `when get states is empty then use state selection`() = testBlocking {
+    fun `when get states is NOT empty then use state selection`() = testBlocking {
         val address = Address.EMPTY
         whenever(addressValidator.validateFieldRequired(any())).doReturn(null)
-        whenever(getAcceptedOriginCountries.invoke()).doReturn(Result.success(countries))
+        mockCountries(Result.success(countries))
         whenever(getStatesByCountryCode.invoke(any())).doReturn(states)
         Snapshot.withMutableSnapshot {
             val savedState = createSavedStateHandle(address)
@@ -390,7 +393,7 @@ abstract class WooShippingEditAddressViewModelTest : BaseUnitTest() {
     fun `when the country selected has states then use the first state from the list`() = testBlocking {
         val address = Address.EMPTY
         whenever(addressValidator.validateFieldRequired(any())).doReturn(null)
-        whenever(getAcceptedOriginCountries.invoke()).doReturn(Result.success(countries))
+        mockCountries(Result.success(countries))
         whenever(getStatesByCountryCode.invoke(any())).doReturn(states)
         Snapshot.withMutableSnapshot {
             val savedState = createSavedStateHandle(address)
@@ -408,10 +411,87 @@ abstract class WooShippingEditAddressViewModelTest : BaseUnitTest() {
     }
 
     @Test
+    fun `when the country selected changes to a country with states then use the first state from the list`() = testBlocking {
+        val initialCountryCode = "AR"
+        val finalCountryCode = "US"
+        val initialStateCode = "BA"
+        val address = Address.EMPTY.copy(
+            country = AmbiguousLocation.Raw(initialCountryCode).asLocation(),
+            state = AmbiguousLocation.Raw("BA")
+        )
+        whenever(addressValidator.validateFieldRequired(any())).doReturn(null)
+        mockCountries(Result.success(countries))
+        whenever(getStatesByCountryCode.invoke(initialCountryCode)).doReturn(emptyList())
+        whenever(getStatesByCountryCode.invoke(finalCountryCode)).doReturn(states)
+        Snapshot.withMutableSnapshot {
+            val savedState = createSavedStateHandle(address)
+            createViewModel(savedState)
+        }
+
+        advanceUntilIdle()
+
+        var result = sut.viewState.value
+
+        assertThat(result.shouldUseStatesInput).isTrue
+        assertThat(result.editableAddress.state.code).isEqualTo(initialStateCode)
+
+        sut.onCountryChanged(finalCountryCode)
+
+        result = sut.viewState.value
+
+        assertThat(result.shouldUseStatesInput).isFalse()
+        assertThat(result.editableAddress.state).isEqualTo(states.first())
+    }
+
+    @Test
+    fun `when the country selected changes to initial country then use initial state`() = testBlocking {
+        val initialCountryCode = "AR"
+        val finalCountryCode = "US"
+        val initialStateCode = "BA"
+        val address = Address.EMPTY.copy(
+            country = AmbiguousLocation.Raw(initialCountryCode).asLocation(),
+            state = AmbiguousLocation.Raw("BA")
+        )
+        whenever(addressValidator.validateFieldRequired(any())).doReturn(null)
+        mockCountries(Result.success(countries))
+        whenever(getStatesByCountryCode.invoke(initialCountryCode)).doReturn(emptyList())
+        whenever(getStatesByCountryCode.invoke(finalCountryCode)).doReturn(states)
+        Snapshot.withMutableSnapshot {
+            val savedState = createSavedStateHandle(address)
+            createViewModel(savedState)
+        }
+
+        advanceUntilIdle()
+
+        var result = sut.viewState.value
+
+        assertThat(result.shouldUseStatesInput).isTrue
+        assertThat(result.editableAddress.state.code).isEqualTo(initialStateCode)
+
+        // Change country for the first time
+
+        sut.onCountryChanged(finalCountryCode)
+
+        result = sut.viewState.value
+
+        assertThat(result.shouldUseStatesInput).isFalse()
+        assertThat(result.editableAddress.state).isEqualTo(states.first())
+
+        // Reset country to the initial one
+
+        sut.onCountryChanged(initialCountryCode)
+
+        result = sut.viewState.value
+
+        assertThat(result.shouldUseStatesInput).isTrue
+        assertThat(result.editableAddress.state.code).isEqualTo(initialStateCode)
+    }
+
+    @Test
     fun `when the country selected has NO states then use the empty string`() = testBlocking {
         val address = Address.EMPTY
         whenever(addressValidator.validateFieldRequired(any())).doReturn(null)
-        whenever(getAcceptedOriginCountries.invoke()).doReturn(Result.success(countries))
+        mockCountries(Result.success(countries))
         whenever(getStatesByCountryCode.invoke(any())).doReturn(emptyList())
         Snapshot.withMutableSnapshot {
             val savedState = createSavedStateHandle(address)
@@ -444,7 +524,7 @@ abstract class WooShippingEditAddressViewModelTest : BaseUnitTest() {
             company = "",
         )
         whenever(addressValidator.validateFieldRequired(any())).doReturn(null)
-        whenever(getAcceptedOriginCountries.invoke()).doReturn(Result.success(countries))
+        mockCountries(Result.success(countries))
         whenever(getStatesByCountryCode.invoke(any())).doReturn(states)
         Snapshot.withMutableSnapshot {
             val savedState = createSavedStateHandle(address, true)
@@ -476,7 +556,7 @@ abstract class WooShippingEditAddressViewModelTest : BaseUnitTest() {
             company = ""
         )
         whenever(addressValidator.validateFieldRequired(any())).doReturn(null)
-        whenever(getAcceptedOriginCountries.invoke()).doReturn(Result.success(countries))
+        mockCountries(Result.success(countries))
         whenever(getStatesByCountryCode.invoke(any())).doReturn(states)
         Snapshot.withMutableSnapshot {
             val savedState = createSavedStateHandle(address, true)
@@ -509,7 +589,7 @@ abstract class WooShippingEditAddressViewModelTest : BaseUnitTest() {
             company = "",
         )
         whenever(addressValidator.validateFieldRequired(any())).doReturn(null)
-        whenever(getAcceptedOriginCountries.invoke()).doReturn(Result.success(countries))
+        mockCountries(Result.success(countries))
         whenever(getStatesByCountryCode.invoke(any())).doReturn(states)
         Snapshot.withMutableSnapshot {
             val savedState = createSavedStateHandle(address, true)
@@ -543,7 +623,7 @@ abstract class WooShippingEditAddressViewModelTest : BaseUnitTest() {
                 company = "",
             )
             whenever(addressValidator.validateFieldRequired(any())).doReturn(null)
-            whenever(getAcceptedOriginCountries.invoke()).doReturn(Result.success(countries))
+            mockCountries(Result.success(countries))
             whenever(getStatesByCountryCode.invoke(any())).doReturn(states)
             Snapshot.withMutableSnapshot {
                 val savedState = createSavedStateHandle(address)
@@ -575,7 +655,7 @@ abstract class WooShippingEditAddressViewModelTest : BaseUnitTest() {
             company = "",
         )
         whenever(addressValidator.validateFieldRequired(any())).doReturn("Field required")
-        whenever(getAcceptedOriginCountries.invoke()).doReturn(Result.success(countries))
+        mockCountries(Result.success(countries))
         whenever(getStatesByCountryCode.invoke(any())).doReturn(states)
         Snapshot.withMutableSnapshot {
             val savedState = createSavedStateHandle(address)
@@ -595,7 +675,7 @@ abstract class WooShippingEditAddressViewModelTest : BaseUnitTest() {
     fun `when screen is initialized then normalize address is closed`() = testBlocking {
         val address = Address.EMPTY
         whenever(addressValidator.validateFieldRequired(any())).doReturn(null)
-        whenever(getAcceptedOriginCountries.invoke()).doReturn(Result.success(countries))
+        mockCountries(Result.success(countries))
         whenever(getStatesByCountryCode.invoke(any())).doReturn(states)
         Snapshot.withMutableSnapshot {
             val savedState = createSavedStateHandle(address)
@@ -627,7 +707,7 @@ abstract class WooShippingEditAddressViewModelTest : BaseUnitTest() {
             company = "",
         )
         whenever(addressValidator.validateFieldRequired(any())).doReturn(null)
-        whenever(getAcceptedOriginCountries.invoke()).doReturn(Result.success(countries))
+        mockCountries(Result.success(countries))
         whenever(getStatesByCountryCode.invoke(any())).doReturn(states)
         whenever(normalizeAddress.invoke(any())).doReturn(Result.failure(Exception("error")))
         whenever(resourceProvider.getString(any())).doReturn("error")
@@ -660,7 +740,7 @@ abstract class WooShippingEditAddressViewModelTest : BaseUnitTest() {
         )
 
         whenever(addressValidator.validateFieldRequired(any())).doReturn(null)
-        whenever(getAcceptedOriginCountries.invoke()).doReturn(Result.success(countries))
+        mockCountries(Result.success(countries))
         whenever(getStatesByCountryCode.invoke(any())).doReturn(states)
         whenever(normalizeAddress.invoke(any())).doReturn(Result.success(normalizeAddressResponse))
         whenever(resourceProvider.getString(any())).doReturn("error")
@@ -694,7 +774,7 @@ abstract class WooShippingEditAddressViewModelTest : BaseUnitTest() {
         )
 
         whenever(addressValidator.validateFieldRequired(any())).doReturn(null)
-        whenever(getAcceptedOriginCountries.invoke()).doReturn(Result.success(countries))
+        mockCountries(Result.success(countries))
         whenever(getStatesByCountryCode.invoke(any())).doReturn(states)
         whenever(normalizeAddress.invoke(any())).doReturn(Result.success(normalizeAddressResponse))
         whenever(resourceProvider.getString(any())).doReturn("error")
@@ -727,7 +807,7 @@ abstract class WooShippingEditAddressViewModelTest : BaseUnitTest() {
         )
 
         whenever(addressValidator.validateFieldRequired(any())).doReturn(null)
-        whenever(getAcceptedOriginCountries.invoke()).doReturn(Result.success(countries))
+        mockCountries(Result.success(countries))
         whenever(getStatesByCountryCode.invoke(any())).doReturn(states)
         whenever(normalizeAddress.invoke(any())).doReturn(Result.success(normalizeAddressResponse))
         whenever(resourceProvider.getString(any())).doReturn("error")
@@ -767,7 +847,7 @@ abstract class WooShippingEditAddressViewModelTest : BaseUnitTest() {
         )
 
         whenever(addressValidator.validateFieldRequired(any())).doReturn(null)
-        whenever(getAcceptedOriginCountries.invoke()).doReturn(Result.success(countries))
+        mockCountries(Result.success(countries))
         whenever(getStatesByCountryCode.invoke(any())).doReturn(states)
         whenever(normalizeAddress.invoke(any())).doReturn(Result.success(normalizeAddressResponse))
         whenever(resourceProvider.getString(any())).doReturn("error")
@@ -806,7 +886,7 @@ abstract class WooShippingEditAddressViewModelTest : BaseUnitTest() {
         )
 
         whenever(addressValidator.validateFieldRequired(any())).doReturn(null)
-        whenever(getAcceptedOriginCountries.invoke()).doReturn(Result.success(countries))
+        mockCountries(Result.success(countries))
         whenever(getStatesByCountryCode.invoke(any())).doReturn(states)
         whenever(normalizeAddress.invoke(any())).doReturn(Result.success(normalizeAddressResponse))
         whenever(resourceProvider.getString(any())).doReturn("error")
@@ -829,7 +909,7 @@ abstract class WooShippingEditAddressViewModelTest : BaseUnitTest() {
     @Test
     fun `when the address selection is NOT expanded then allow back navigation`() = testBlocking {
         whenever(addressValidator.validateFieldRequired(any())).doReturn(null)
-        whenever(getAcceptedOriginCountries.invoke()).doReturn(Result.success(countries))
+        mockCountries(Result.success(countries))
         whenever(getStatesByCountryCode.invoke(any())).doReturn(states)
         Snapshot.withMutableSnapshot {
             val savedState = createSavedStateHandle(Address.EMPTY)

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/address/destination/WooShippingEditDestinationViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/address/destination/WooShippingEditDestinationViewModelTest.kt
@@ -4,6 +4,7 @@ import androidx.compose.runtime.snapshots.Snapshot
 import androidx.lifecycle.SavedStateHandle
 import com.woocommerce.android.model.Address
 import com.woocommerce.android.model.AmbiguousLocation
+import com.woocommerce.android.model.Location
 import com.woocommerce.android.ui.orders.wooshippinglabels.address.AddressValidationState
 import com.woocommerce.android.ui.orders.wooshippinglabels.address.EditAddressFlow
 import com.woocommerce.android.ui.orders.wooshippinglabels.address.EditableAddress
@@ -37,13 +38,17 @@ class WooShippingEditDestinationViewModelTest : WooShippingEditAddressViewModelT
         ).toSavedStateHandle()
     }
 
+    override suspend fun mockCountries(countries: Result<List<Location>>) {
+        whenever(getAllCountries.invoke()).doReturn(countries)
+    }
+
     @Test
     fun `when update address succeed then restart address state`() = testBlocking {
         val initialAddress = Address.EMPTY
         val editableAddress = EditableAddress()
 
         whenever(addressValidator.validateFieldRequired(any())).doReturn(null)
-        whenever(getAcceptedOriginCountries.invoke()).doReturn(Result.success(countries))
+        whenever(getAllCountries.invoke()).doReturn(Result.success(countries))
         whenever(getStatesByCountryCode.invoke(any())).doReturn(states)
         whenever(updateDestinationAddress.invoke(any(), any()))
             .doReturn(Result.success(DestinationShippingAddress.EMPTY))
@@ -73,7 +78,7 @@ class WooShippingEditDestinationViewModelTest : WooShippingEditAddressViewModelT
         )
 
         whenever(addressValidator.validateFieldRequired(any())).doReturn(null)
-        whenever(getAcceptedOriginCountries.invoke()).doReturn(Result.success(countries))
+        whenever(getAllCountries.invoke()).doReturn(Result.success(countries))
         whenever(getStatesByCountryCode.invoke(any())).doReturn(states)
         whenever(updateDestinationAddress.invoke(any(), any())).doReturn(Result.failure(Exception("error")))
         whenever(resourceProvider.getString(any())).doReturn("error")
@@ -120,7 +125,7 @@ class WooShippingEditDestinationViewModelTest : WooShippingEditAddressViewModelT
         )
 
         whenever(addressValidator.validateFieldRequired(any())).doReturn(null)
-        whenever(getAcceptedOriginCountries.invoke()).doReturn(Result.success(countries))
+        whenever(getAllCountries.invoke()).doReturn(Result.success(countries))
         whenever(getStatesByCountryCode.invoke(any())).doReturn(states)
         whenever(updateDestinationAddress.invoke(any(), any())).doReturn(Result.failure(Exception("error")))
         whenever(resourceProvider.getString(any())).doReturn("error")
@@ -151,7 +156,7 @@ class WooShippingEditDestinationViewModelTest : WooShippingEditAddressViewModelT
         )
 
         whenever(addressValidator.validateFieldRequired(any())).doReturn(null)
-        whenever(getAcceptedOriginCountries.invoke()).doReturn(Result.success(countries))
+        whenever(getAllCountries.invoke()).doReturn(Result.success(countries))
         whenever(getStatesByCountryCode.invoke(any())).doReturn(states)
         whenever(updateDestinationAddress.invoke(any(), any()))
             .doReturn(Result.success(DestinationShippingAddress.EMPTY))
@@ -186,7 +191,7 @@ class WooShippingEditDestinationViewModelTest : WooShippingEditAddressViewModelT
         )
 
         whenever(addressValidator.validateFieldRequired(any())).doReturn(null)
-        whenever(getAcceptedOriginCountries.invoke()).doReturn(Result.success(countries))
+        whenever(getAllCountries.invoke()).doReturn(Result.success(countries))
         whenever(getStatesByCountryCode.invoke(any())).doReturn(states)
         whenever(updateDestinationAddress.invoke(any(), any())).doReturn(Result.failure(Exception("error")))
         whenever(resourceProvider.getString(any())).doReturn("error")

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/address/origin/WooShippingEditOriginViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/address/origin/WooShippingEditOriginViewModelTest.kt
@@ -4,6 +4,7 @@ import androidx.compose.runtime.snapshots.Snapshot
 import androidx.lifecycle.SavedStateHandle
 import com.woocommerce.android.model.Address
 import com.woocommerce.android.model.AmbiguousLocation
+import com.woocommerce.android.model.Location
 import com.woocommerce.android.ui.orders.wooshippinglabels.address.AddressValidationState
 import com.woocommerce.android.ui.orders.wooshippinglabels.address.EditAddressFlow
 import com.woocommerce.android.ui.orders.wooshippinglabels.address.EditableAddress
@@ -48,6 +49,10 @@ class WooShippingEditOriginViewModelTest : WooShippingEditAddressViewModelTest()
             isVerified = isVerified
         )
         return WooShippingEditAddressFragmentArgs(EditAddressFlow.EditOriginAddress(originAddress)).toSavedStateHandle()
+    }
+
+    override suspend fun mockCountries(countries: Result<List<Location>>) {
+        whenever(getAcceptedOriginCountries.invoke()).doReturn(countries)
     }
 
     @Test


### PR DESCRIPTION
### Description
This PR introduces some fixes in the edit address flow

- This PR fixes the countries lists depending on the flow (origin/destination)
- This PR adds a minor fix to update the verified parameter when saving the destination address. 
We always let the user review the address before saving it, so we should mark it as verified.
- This PR introduces an improvement in the state selection. When the country selected changes to the same country as the initial address, we will use the state from the initial address

### Testing information

TC1
1. Go to the Orders tab.
2. Create a new order eligible for shipping label creation.
3. Tap on create shipping label
4. Tap Shipment Details.
5. Edit the destination address
6. Tap on country
7. Check that for the destination address, All countries can be selected

TC2
1. Go to the Orders tab.
2. Create a new order eligible for shipping label creation.
3. Tap on create shipping label
4. Tap Shipment Details.
5. Edit the origin address
6. Tap on country
7. Check that for origin address, only allowed countries can be selected

TC3
1. Go to the Orders tab.
2. Create a new order eligible for shipping label creation.
3. Tap on create shipping label
4. Tap Shipment Details.
5. Edit the destination address
6. Set an address in a country with a list of states (US ex)
7. Select a different country
8. Select the country from Step 6 and check that the state selected also matches the one from Step 6

### Images/gif

https://github.com/user-attachments/assets/ccaedaf6-be28-4799-81af-941ed3a52d61


- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.

## Reviewer (or Author, in the case of optional code reviews):

Please make sure these conditions are met before approving the PR, or request changes if the PR needs improvement:

- [ ] The PR is small and has a clear, single focus, or a valid explanation is provided in the description. If needed, please request to split it into smaller PRs.
- [ ] Ensure Adequate Unit Test Coverage: The changes are reasonably covered by unit tests or an explanation is provided in the PR description.
- [ ] Manual Testing: The author listed all the tests they ran, including smoke tests when needed (e.g., for refactorings). The reviewer confirmed that the PR works as expected on big (tablet) and small (phone) in case of UI changes, and no regressions are added.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->