### PR TITLE
Call verify address if destination is complete

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/WooShippingLabelCreationViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/WooShippingLabelCreationViewModel.kt
@@ -186,7 +186,7 @@ class WooShippingLabelCreationViewModel @Inject constructor(
 
             destinationAddress.value = defaultDestination
 
-            if (addressValidationHelper.isMissingDestinationAddress(order.shippingAddress)) {
+            if (addressValidationHelper.isMissingDestinationAddress(order.shippingAddress).not()) {
                 verifyDestinationAddress(order.id).fold(
                     onSuccess = { destinationAddress.value = it },
                     onFailure = { }


### PR DESCRIPTION
### Description
This PR fixes a slight regression with the destination address validation 

### Testing information

1. Go to the Orders tab.
2. Create a new order with a missing address.
3. Go to Order Details.
4. Tap Shipment Details.
5. Update the destination address details
6. Check that the address is marked as verified
7. Exit the purchase shipping labels flow and enter again
8. Check that the address is marked as verified


### Images/gif

https://github.com/user-attachments/assets/ecc87270-fb1c-42c8-9f14-04a1d00cc8da

- [ ] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.

## Reviewer (or Author, in the case of optional code reviews):

Please make sure these conditions are met before approving the PR, or request changes if the PR needs improvement:

- [ ] The PR is small and has a clear, single focus, or a valid explanation is provided in the description. If needed, please request to split it into smaller PRs.
- [ ] Ensure Adequate Unit Test Coverage: The changes are reasonably covered by unit tests or an explanation is provided in the PR description.
- [ ] Manual Testing: The author listed all the tests they ran, including smoke tests when needed (e.g., for refactorings). The reviewer confirmed that the PR works as expected on big (tablet) and small (phone) in case of UI changes, and no regressions are added.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->