### PR TITLE
Fix app password creation flow when credentials are null

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -6,6 +6,7 @@
 - [*] Payments: display specific error for the cases when a reader with low battery level attempted to connect [https://github.com/woocommerce/woocommerce-android/pull/13642]
 - [**] Jetpack Setup: integrated the Connection API for a more seamless setup experience [https://github.com/woocommerce/woocommerce-android/issues/13628]
 - [*] [Internal] Improved the handling of Site Picker Jetpack setup to handle the case where the account is already connected to the site [https://github.com/woocommerce/woocommerce-android/pull/13693]
+- [*] Fixed a bug that rarely caused the app to crash when logging in on a self-hosted site.
 
 21.9
 -----

--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -6,7 +6,7 @@
 - [*] Payments: display specific error for the cases when a reader with low battery level attempted to connect [https://github.com/woocommerce/woocommerce-android/pull/13642]
 - [**] Jetpack Setup: integrated the Connection API for a more seamless setup experience [https://github.com/woocommerce/woocommerce-android/issues/13628]
 - [*] [Internal] Improved the handling of Site Picker Jetpack setup to handle the case where the account is already connected to the site [https://github.com/woocommerce/woocommerce-android/pull/13693]
-- [*] Fixed a bug that rarely caused the app to crash when logging in on a self-hosted site.
+- [*] Fixed a rare bug that caused the app to crash when logging in on a self-hosted site.
 
 21.9
 -----

--- a/libs/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpapi/applicationpasswords/ApplicationPasswordsManager.kt
+++ b/libs/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpapi/applicationpasswords/ApplicationPasswordsManager.kt
@@ -83,7 +83,7 @@ internal class ApplicationPasswordsManager @Inject constructor(
         username: String
     ): ApplicationPasswordCreationResult {
         if (!site.supportsApplicationPasswordsGeneration) {
-            ApplicationPasswordCreationResult.Failure(
+            return ApplicationPasswordCreationResult.Failure(
                 WPAPINetworkError(
                     BaseNetworkError(
                         GenericErrorType.NOT_AUTHENTICATED,


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #10481
<!-- Id number of the GitHub issue this PR addresses. -->

Do not merge label - I'm still trying to figure out how to test these changes. Having said that, feel free to start the review.

<!-- 
━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
🛠 Need an AI review?  
Add a comment: `@coderabbitai review`
━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
-->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

This PR fixes a path that results in a crash if the app is attempting to create an application password but it doesn't have a valid token/credentials.

### Steps to reproduce
<!-- Step-by-step testing instructions. For new user flows, consider instead stating the goal of the workflow and see if your PR reviewer can accomplish the workflow without specific steps! -->

1. Modify your site to trigger the Application Passwords web authorization. Personally I used this [plugin](https://wordpress.org/plugins/captcha-for-contact-form-7/) (just make sure the Captcha is enabled for WordPress Login, and use arithmetic captcha for example)
2. Login to the app using site credentials.
3. After finishing, open wp-admin, and revoke the app password.
4. Re-open the app.
5. Trigger an API call.
6. The app will crash.

### Testing information
<!-- This is your opportunity to break out individual scenarios that need testing (when necessary) and/or include a checklist for the reviewer to go through. Consider documenting the following from your own completed testing: devices used, alternate workflows, edge cases, affected areas, critical flows, areas not tested, and any remaining unknowns. Provide feedback on this new section of the PR template through Sept 30, 2024 to Apps Quality; additional context here: p91TBi-b8z-p2#comment-12036 -->

- I tested the above flow multiple times and I also verified jetpack login works as expected.

### The tests that have been performed
<!-- To give the reviewer an idea of what could be missed in terms of testing -->

None at the moment - I'm familarizing myself with these login flows.

### Images/gif
<!-- Include before and after images or gifs when appropriate. -->

- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.

## Reviewer (or Author, in the case of optional code reviews):

Please make sure these conditions are met before approving the PR, or request changes if the PR needs improvement:

- [ ] The PR is small and has a clear, single focus, or a valid explanation is provided in the description. If needed, please request to split it into smaller PRs.
- [ ] Ensure Adequate Unit Test Coverage: The changes are reasonably covered by unit tests or an explanation is provided in the PR description.
- [ ] Manual Testing: The author listed all the tests they ran, including smoke tests when needed (e.g., for refactorings). The reviewer confirmed that the PR works as expected on big (tablet) and small (phone) in case of UI changes, and no regressions are added.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->