### PR TITLE
Dark mode color issue for the icon on the notification permission banner

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -7,6 +7,7 @@
 - [**] Jetpack Setup: integrated the Connection API for a more seamless setup experience [https://github.com/woocommerce/woocommerce-android/issues/13628]
 - [*] [Internal] Improved the handling of Site Picker Jetpack setup to handle the case where the account is already connected to the site [https://github.com/woocommerce/woocommerce-android/pull/13693]
 - [*] POS: improved accessibility for the payments status changes [https://github.com/woocommerce/woocommerce-android/pull/13643]
+- [*] Fix the dark mode color issue with the icon on the notification permission banner [https://github.com/woocommerce/woocommerce-android/pull/13773]
 
 21.9
 -----

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/NotificationsPermissionBar.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/NotificationsPermissionBar.kt
@@ -1,6 +1,5 @@
 package com.woocommerce.android.ui.dashboard
 
-import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
@@ -8,6 +7,7 @@ import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material.Divider
+import androidx.compose.material.Icon
 import androidx.compose.material.MaterialTheme
 import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
@@ -47,9 +47,10 @@ fun NotificationsPermissionCard(viewModel: MainActivityViewModel = viewModel()) 
                     .fillMaxWidth()
                     .padding(bottom = dimensionResource(id = dimen.minor_100))
             ) {
-                Image(
+                Icon(
                     modifier = Modifier.padding(end = dimensionResource(id = dimen.minor_100)),
                     painter = painterResource(drawable.ic_megaphone),
+                    tint = colorResource(color.color_on_surface_high),
                     contentDescription = "",
                 )
                 Text(

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/NotificationsPermissionBar.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/NotificationsPermissionBar.kt
@@ -11,6 +11,7 @@ import androidx.compose.material.Icon
 import androidx.compose.material.MaterialTheme
 import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.colorResource
 import androidx.compose.ui.res.dimensionResource
@@ -45,7 +46,8 @@ fun NotificationsPermissionCard(viewModel: MainActivityViewModel = viewModel()) 
             Row(
                 modifier = Modifier
                     .fillMaxWidth()
-                    .padding(bottom = dimensionResource(id = dimen.minor_100))
+                    .padding(bottom = dimensionResource(id = dimen.minor_100)),
+                verticalAlignment = Alignment.CenterVertically
             ) {
                 Icon(
                     modifier = Modifier.padding(end = dimensionResource(id = dimen.minor_100)),

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/main/NotificationsPermissionBar.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/main/NotificationsPermissionBar.kt
@@ -9,6 +9,7 @@ import androidx.compose.material.Icon
 import androidx.compose.material.MaterialTheme
 import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.colorResource
 import androidx.compose.ui.res.dimensionResource
@@ -43,7 +44,8 @@ fun NotificationsPermissionCard(viewModel: MainActivityViewModel = viewModel()) 
             Row(
                 modifier = Modifier
                     .fillMaxWidth()
-                    .padding(bottom = dimensionResource(id = dimen.minor_100))
+                    .padding(bottom = dimensionResource(id = dimen.minor_100)),
+                verticalAlignment = Alignment.CenterVertically
             ) {
                 Icon(
                     modifier = Modifier.padding(end = dimensionResource(id = dimen.minor_100)),

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/main/NotificationsPermissionBar.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/main/NotificationsPermissionBar.kt
@@ -1,4 +1,3 @@
-import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
@@ -6,6 +5,7 @@ import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material.Divider
+import androidx.compose.material.Icon
 import androidx.compose.material.MaterialTheme
 import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
@@ -45,9 +45,10 @@ fun NotificationsPermissionCard(viewModel: MainActivityViewModel = viewModel()) 
                     .fillMaxWidth()
                     .padding(bottom = dimensionResource(id = dimen.minor_100))
             ) {
-                Image(
+                Icon(
                     modifier = Modifier.padding(end = dimensionResource(id = dimen.minor_100)),
                     painter = painterResource(drawable.ic_megaphone),
+                    tint = colorResource(color.color_on_surface_high),
                     contentDescription = "",
                 )
                 Text(


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #13687
<!-- Id number of the GitHub issue this PR addresses. -->

<!-- 
━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
🛠 Need an AI review?  
Add a comment: `@coderabbitai review`
━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
-->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
This fixes the design issues with the megaphone icon on the notification permission banner.

### Steps to reproduce
<!-- Step-by-step testing instructions. For new user flows, consider instead stating the goal of the workflow and see if your PR reviewer can accomplish the workflow without specific steps! -->
1. Make a clean install.
2. Do not allow the notification permission during login.
3. Log in.

### The tests that have been performed
<!-- To give the reviewer an idea of what could be missed in terms of testing -->

### Images/gif
<!-- Include before and after images or gifs when appropriate. -->
|Before|After|After light|
|-|-|-|
|<img src="https://github.com/user-attachments/assets/632bb754-0355-4ca8-a10c-d20c11200a2c" width=400>|<img src="https://github.com/user-attachments/assets/bcb1dca4-18cb-4d91-a499-0ac37dde440d" width=400>|<img src="https://github.com/user-attachments/assets/900fdd7c-e1f7-491f-ad79-daef0e7c76b4" width=400>|

- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.

## Reviewer (or Author, in the case of optional code reviews):

Please make sure these conditions are met before approving the PR, or request changes if the PR needs improvement:

- [ ] The PR is small and has a clear, single focus, or a valid explanation is provided in the description. If needed, please request to split it into smaller PRs.
- [ ] Ensure Adequate Unit Test Coverage: The changes are reasonably covered by unit tests or an explanation is provided in the PR description.
- [ ] Manual Testing: The author listed all the tests they ran, including smoke tests when needed (e.g., for refactorings). The reviewer confirmed that the PR works as expected on big (tablet) and small (phone) in case of UI changes, and no regressions are added.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->