### PR TITLE
[Login] Improvements to Application Passwords login to work with some Captcha plugins

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -7,6 +7,7 @@
 - [**] Jetpack Setup: integrated the Connection API for a more seamless setup experience [https://github.com/woocommerce/woocommerce-android/issues/13628]
 - [*] [Internal] Improved the handling of Site Picker Jetpack setup to handle the case where the account is already connected to the site [https://github.com/woocommerce/woocommerce-android/pull/13693]
 - [*] POS: improved accessibility for the payments status changes [https://github.com/woocommerce/woocommerce-android/pull/13643]
+- [*] [Internal] Application Passwords: improve error handling when using some captcha plugins [https://github.com/woocommerce/woocommerce-android/pull/13776]
 
 21.9
 -----

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/WPApiSiteRepository.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/WPApiSiteRepository.kt
@@ -193,7 +193,7 @@ class WPApiSiteRepository @Inject constructor(
             }?.let { HTTP_SUCCESS }
 
     private fun Error.mapToUiString() = when (type) {
-        INVALID_CREDENTIALS -> UiStringRes(string.login_invalid_credentials_message)
+        INVALID_CREDENTIALS -> message?.let { UiStringText(it) } ?: UiStringRes(string.login_invalid_credentials_message)
         INVALID_RESPONSE -> UiStringRes(string.login_site_credentials_invalid_response)
         CUSTOM_LOGIN_URL -> UiStringRes(string.login_site_credentials_custom_login_url)
         CUSTOM_ADMIN_URL -> UiStringRes(string.login_site_credentials_custom_admin_url)

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/WPApiSiteRepository.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/WPApiSiteRepository.kt
@@ -26,7 +26,6 @@ import org.wordpress.android.fluxc.network.rest.wpapi.Nonce.CookieNonceErrorType
 import org.wordpress.android.fluxc.network.rest.wpapi.Nonce.CookieNonceErrorType.CUSTOM_LOGIN_URL
 import org.wordpress.android.fluxc.network.rest.wpapi.Nonce.CookieNonceErrorType.INVALID_CREDENTIALS
 import org.wordpress.android.fluxc.network.rest.wpapi.Nonce.CookieNonceErrorType.INVALID_RESPONSE
-import org.wordpress.android.fluxc.network.rest.wpapi.Nonce.CookieNonceErrorType.NOT_AUTHENTICATED
 import org.wordpress.android.fluxc.network.rest.wpapi.applicationpasswords.ApplicationPasswordCredentials
 import org.wordpress.android.fluxc.network.rest.wpapi.applicationpasswords.ApplicationPasswordsStore
 import org.wordpress.android.fluxc.store.SiteStore
@@ -184,17 +183,16 @@ class WPApiSiteRepository @Inject constructor(
     }
 
     /**
-     * If we don't have a network status code, and the error is either NOT_AUTHENTICATED or
+     * If we don't have a network status code, and the error is either INVALID_CREDENTIALS or
      * INVALID_RESPONSE, we can assume the response was 200
      */
     private fun Error.extractNetworkStatusCode() =
         networkError?.volleyError?.networkResponse?.statusCode
             ?: takeIf {
-                type == NOT_AUTHENTICATED || type == INVALID_RESPONSE
+                type == INVALID_CREDENTIALS || type == INVALID_RESPONSE
             }?.let { HTTP_SUCCESS }
 
     private fun Error.mapToUiString() = when (type) {
-        NOT_AUTHENTICATED -> message?.let { UiStringText(it) } ?: UiStringRes(string.username_or_password_incorrect)
         INVALID_CREDENTIALS -> UiStringRes(string.login_invalid_credentials_message)
         INVALID_RESPONSE -> UiStringRes(string.login_site_credentials_invalid_response)
         CUSTOM_LOGIN_URL -> UiStringRes(string.login_site_credentials_custom_login_url)

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/sitecredentials/LoginSiteCredentialsScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/sitecredentials/LoginSiteCredentialsScreen.kt
@@ -48,7 +48,8 @@ fun LoginSiteCredentialsScreen(viewModel: LoginSiteCredentialsViewModel) {
             onResetPasswordClick = viewModel::onResetPasswordClick,
             onBackClick = viewModel::onBackClick,
             onHelpButtonClick = viewModel::onHelpButtonClick,
-            onErrorDialogDismissed = viewModel::onErrorDialogDismissed
+            onErrorDialogDismissed = viewModel::onErrorDialogDismissed,
+            onStartWebAuthorizationClick = viewModel::onStartWebAuthorizationClick
         )
     }
 }
@@ -63,6 +64,7 @@ fun LoginSiteCredentialsScreen(
     onBackClick: () -> Unit,
     onHelpButtonClick: () -> Unit,
     onErrorDialogDismissed: () -> Unit,
+    onStartWebAuthorizationClick: () -> Unit
 ) {
     Scaffold(
         topBar = {
@@ -156,6 +158,11 @@ fun LoginSiteCredentialsScreen(
                                 textAlign = TextAlign.End
                             )
                         }
+                        WCTextButton(
+                            onClick = onStartWebAuthorizationClick
+                        ) {
+                            Text(text = stringResource(id = R.string.login_site_credentials_use_web_authorization))
+                        }
                     }
                 }
             )
@@ -181,7 +188,8 @@ private fun LoginSiteCredentialsScreenPreview() {
             onResetPasswordClick = {},
             onBackClick = {},
             onHelpButtonClick = {},
-            onErrorDialogDismissed = {}
+            onErrorDialogDismissed = {},
+            onStartWebAuthorizationClick = {}
         )
     }
 }
@@ -201,7 +209,8 @@ private fun LoginSiteCredentialsScreenWithErrorPreview() {
             onResetPasswordClick = {},
             onBackClick = {},
             onHelpButtonClick = {},
-            onErrorDialogDismissed = {}
+            onErrorDialogDismissed = {},
+            onStartWebAuthorizationClick = {}
         )
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/sitecredentials/LoginSiteCredentialsViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/sitecredentials/LoginSiteCredentialsViewModel.kt
@@ -144,6 +144,7 @@ class LoginSiteCredentialsViewModel @Inject constructor(
 
     fun onStartWebAuthorizationClick() {
         launch {
+            errorDialogMessage.value = null
             fetchSiteForTutorial()
         }
     }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/sitecredentials/LoginSiteCredentialsViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/sitecredentials/LoginSiteCredentialsViewModel.kt
@@ -142,6 +142,12 @@ class LoginSiteCredentialsViewModel @Inject constructor(
         triggerEvent(ShowResetPasswordScreen(siteAddress))
     }
 
+    fun onStartWebAuthorizationClick() {
+        launch {
+            fetchSiteForTutorial()
+        }
+    }
+
     fun onPasswordTutorialAborted() {
         fetchedSiteId.value = -1
     }

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -356,7 +356,7 @@
     <string name="login_jetpack_installation_enter_wpcom_password">Enter the password of your WordPress.com account to install Jetpack</string>
     <string name="login_jetpack_installation_continue_magic_link">Or continue using Magic Link</string>
     <string name="login_jetpack_installation_magic_link_failure">An error occurred while fetching your website, please retry!</string>
-    <string name="login_site_credentials_invalid_response">Login failed with an unexpected response from your site. We are working on fixing this issue.</string>
+    <string name="login_site_credentials_invalid_response">Login failed with an unexpected response from your site.</string>
     <string name="login_site_credentials_custom_login_url">Unable to login because we cannot identify your store\'s login URL</string>
     <string name="login_site_credentials_custom_admin_url">Unable to login because we cannot identify your store\'s admin URL</string>
     <string name="login_site_credentials_http_error">Login failed with status code %1$s</string>

--- a/libs/fluxc-tests/src/test/java/org/wordpress/android/fluxc/network/rest/wpapi/NonceRestClientTest.kt
+++ b/libs/fluxc-tests/src/test/java/org/wordpress/android/fluxc/network/rest/wpapi/NonceRestClientTest.kt
@@ -76,6 +76,7 @@ class NonceRestClientTest {
         val loginResponse = WPAPIResponse.Success(
             """
             <html>
+              <scrip>${NonceRestClient.INVALID_CREDENTIAL_HTML_PATTERN}</scrip>
               <head>
                     <div id="login_error">
                         <strong>Error:</strong> The password you entered for the username <strong>demo</strong> is incorrect. <a href="link/">Lost your password?</a><br>
@@ -89,8 +90,30 @@ class NonceRestClientTest {
         val actual = subject.requestNonce(site)
 
         assertIs<Nonce.FailedRequest>(actual)
-        assertEquals(Nonce.CookieNonceErrorType.NOT_AUTHENTICATED, actual.type)
+        assertEquals(Nonce.CookieNonceErrorType.INVALID_CREDENTIALS, actual.type)
         assertEquals("Error: The password you entered for the username demo is incorrect.", actual.errorMessage)
+    }
+
+    @Test
+    fun `when error message mentions captcha, treat error as invalid response`() = test {
+        @Suppress("MaxLineLength")
+        val loginResponse = WPAPIResponse.Success(
+            """
+            <html>
+              <scrip>${NonceRestClient.INVALID_CREDENTIAL_HTML_PATTERN}</scrip>
+              <head>
+                    <div id="login_error">Please enter the captcha to continue</div>
+              </head>
+            </html>
+        """.trimIndent()
+        )
+        givenLoginResponse(loginResponse)
+
+        val actual = subject.requestNonce(site)
+
+        assertIs<Nonce.FailedRequest>(actual)
+        assertEquals(Nonce.CookieNonceErrorType.INVALID_RESPONSE, actual.type)
+        assertEquals("Please enter the captcha to continue", actual.errorMessage)
     }
 
     @Test

--- a/libs/fluxc-tests/src/test/java/org/wordpress/android/fluxc/network/rest/wpapi/NonceRestClientTest.kt
+++ b/libs/fluxc-tests/src/test/java/org/wordpress/android/fluxc/network/rest/wpapi/NonceRestClientTest.kt
@@ -76,7 +76,7 @@ class NonceRestClientTest {
         val loginResponse = WPAPIResponse.Success(
             """
             <html>
-              <scrip>${NonceRestClient.INVALID_CREDENTIAL_HTML_PATTERN}</scrip>
+              <script>${NonceRestClient.INVALID_CREDENTIAL_HTML_PATTERN}</script>
               <head>
                     <div id="login_error">
                         <strong>Error:</strong> The password you entered for the username <strong>demo</strong> is incorrect. <a href="link/">Lost your password?</a><br>
@@ -100,7 +100,7 @@ class NonceRestClientTest {
         val loginResponse = WPAPIResponse.Success(
             """
             <html>
-              <scrip>${NonceRestClient.INVALID_CREDENTIAL_HTML_PATTERN}</scrip>
+              <script>${NonceRestClient.INVALID_CREDENTIAL_HTML_PATTERN}</script>
               <head>
                     <div id="login_error">Please enter the captcha to continue</div>
               </head>

--- a/libs/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpapi/Nonce.kt
+++ b/libs/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpapi/Nonce.kt
@@ -17,7 +17,6 @@ sealed interface Nonce {
     data class Unknown(override val username: String?) : Nonce
 
     enum class CookieNonceErrorType {
-        NOT_AUTHENTICATED,
         INVALID_RESPONSE,
         INVALID_CREDENTIALS,
         CUSTOM_LOGIN_URL,

--- a/libs/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpapi/NonceRestClient.kt
+++ b/libs/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpapi/NonceRestClient.kt
@@ -69,7 +69,9 @@ class NonceRestClient @Inject constructor(
                 // that it's an authentication issue, otherwise we'll assume it's an invalid response
                 val errorMessage = extractErrorMessage(response.data.orEmpty())
 
-                val errorType = if (hasInvalidCredentialsPattern(response.data.orEmpty())) {
+                val errorType = if (hasInvalidCredentialsPattern(response.data.orEmpty()) &&
+                    errorMessage?.contains("captcha", ignoreCase = true) != true
+                ) {
                     Nonce.CookieNonceErrorType.INVALID_CREDENTIALS
                 } else {
                     Nonce.CookieNonceErrorType.INVALID_RESPONSE

--- a/libs/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpapi/NonceRestClient.kt
+++ b/libs/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpapi/NonceRestClient.kt
@@ -71,8 +71,6 @@ class NonceRestClient @Inject constructor(
 
                 val errorType = if (hasInvalidCredentialsPattern(response.data.orEmpty())) {
                     Nonce.CookieNonceErrorType.INVALID_CREDENTIALS
-                } else if (errorMessage != null) {
-                    Nonce.CookieNonceErrorType.NOT_AUTHENTICATED
                 } else {
                     Nonce.CookieNonceErrorType.INVALID_RESPONSE
                 }


### PR DESCRIPTION
Closes: #13769 
<!-- Id number of the GitHub issue this PR addresses. -->

<!-- 
━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
🛠 Need an AI review?  
Add a comment: `@coderabbitai review`
━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
-->

### Description
This PR has two main changes:

- It starts web authorization when detecting the word `captcha` in the error message.
- It shows a button to start the web authorization manually for the INVALID_CREDENTIALS error type.

Regarding the second point, we had this button initially, and it was removed during the better error messages project, but this issue that we are fixing here shows that some plugins will use the same error slot for their own error messages, meaning that we can't be sure the issue is always about invalid credentials. To allow the users who might get stuck on these situations, I added back the button to start the web authorization manually.

### Steps to reproduce
**TC 1:**
1. Install this [plugin](https://wordpress.org/plugins/wp-advanced-math-captcha/).
2. Open the app.
3. Sign in using site credentials.

**TC2:**
1. Uninstall the captcha plugin.
2. Open the app.
3. Enter some wrong site credentials.

### Testing information
- For TC1: confirm that the app starts the web authorization flow automatically.
- For TC2: confirm the presence of the button "Try again with WP Admin page"

### The tests that have been performed
^

### Recording
| Before | After |
| --- | --- |
| <video src=https://github.com/user-attachments/assets/95476386-36eb-44a6-badb-9e254e025a4b/> |  <video src=https://github.com/user-attachments/assets/60fb99b3-3016-42c6-9605-4cdf507cdc94/> |

- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.

## Reviewer (or Author, in the case of optional code reviews):

Please make sure these conditions are met before approving the PR, or request changes if the PR needs improvement:

- [x] The PR is small and has a clear, single focus, or a valid explanation is provided in the description. If needed, please request to split it into smaller PRs.
- [x] Ensure Adequate Unit Test Coverage: The changes are reasonably covered by unit tests or an explanation is provided in the PR description.
- [x] Manual Testing: The author listed all the tests they ran, including smoke tests when needed (e.g., for refactorings). The reviewer confirmed that the PR works as expected on big (tablet) and small (phone) in case of UI changes, and no regressions are added.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->