### PR TITLE
Edge to edge in media picker

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -101,7 +101,7 @@ wiremock = '2.26.3'
 wordpress-aztec = 'v2.1.4'
 wordpress-libaddressinput = '0.0.2'
 wordpress-lint = "2.1.0"
-wordpress-mediapicker = '87-eded3410d253bc6dd5a2ade4f8599c87ce733d69'
+wordpress-mediapicker = 'trunk-0e275be05341678996dc1b9abfc8608f331d2540'
 wordpress-utils = '3.15.0'
 zendesk = '5.0.8'
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -101,7 +101,7 @@ wiremock = '2.26.3'
 wordpress-aztec = 'v2.1.4'
 wordpress-libaddressinput = '0.0.2'
 wordpress-lint = "2.1.0"
-wordpress-mediapicker = '87-30b12e0996ec61f82039cd72c70506fd89e088e8'
+wordpress-mediapicker = '87-eded3410d253bc6dd5a2ade4f8599c87ce733d69'
 wordpress-utils = '3.15.0'
 zendesk = '5.0.8'
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -101,7 +101,7 @@ wiremock = '2.26.3'
 wordpress-aztec = 'v2.1.4'
 wordpress-libaddressinput = '0.0.2'
 wordpress-lint = "2.1.0"
-wordpress-mediapicker = '0.3.3'
+wordpress-mediapicker = '87-30b12e0996ec61f82039cd72c70506fd89e088e8'
 wordpress-utils = '3.15.0'
 zendesk = '5.0.8'
 


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

⚠️  This PR depends on [this PR](https://github.com/wordpress-mobile/WordPress-MediaPicker-Android/pull/87)

Closes: #13396 

<!-- 
━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
🛠 Need an AI review?  
Add a comment: `@coderabbitai review`
━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
-->

### Description
This PR fixes the edge-to-edge support for the `MediaPickerActivity`. The PR just updates the media picker library

### Testing information
TC1

1. Navigate to the products tab
2. Open a product
3. Tap on add new image
4. Select WordPress media library
5. Check that the app bar padding is displayed as expected

TC2

1. Navigate to the products tab
2. Open a product
3. Tap on add new image
4. Tap on Take a photo
5. Check that the permission screen bar  is displayed as expected


### The tests that have been performed
Checking the Media Picker UI is displayed as expected

### Images/gif

| Before | After |
| ------------- | ------------- |
|  <img width="300" src="https://github.com/user-attachments/assets/6494e46a-2f25-4987-a87e-3e78487d1e08" /> |  <img width="300" src="https://github.com/user-attachments/assets/c4a53dc5-f62e-4492-b99b-97af3a1a4430" /> |
|  <img width="300" src="https://github.com/user-attachments/assets/819a2040-3ac7-4e37-a59d-0470ed857c44" /> |  <img width="300" src="https://github.com/user-attachments/assets/f21ed26d-92bf-40c8-8453-3eb39c8511c7" /> |


- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.

## Reviewer (or Author, in the case of optional code reviews):

Please make sure these conditions are met before approving the PR, or request changes if the PR needs improvement:

- [x] The PR is small and has a clear, single focus, or a valid explanation is provided in the description. If needed, please request to split it into smaller PRs.
- [x] Ensure Adequate Unit Test Coverage: The changes are reasonably covered by unit tests or an explanation is provided in the PR description.
- [x] Manual Testing: The author listed all the tests they ran, including smoke tests when needed (e.g., for refactorings). The reviewer confirmed that the PR works as expected on big (tablet) and small (phone) in case of UI changes, and no regressions are added.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->