### PR TITLE
Issue/13787 fix printing instructions

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/OrderDetailFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/OrderDetailFragment.kt
@@ -379,7 +379,7 @@ class OrderDetailFragment :
     private fun setupObservers(viewModel: OrderDetailViewModel) {
         viewModel.viewStateData.observe(viewLifecycleOwner) { old, new ->
             new.orderInfo?.takeIfNotEqualTo(old?.orderInfo) {
-                showOrderDetail(it.order!!, it.isPaymentCollectableWithCardReader, it.receiptButtonStatus)
+                showOrderDetail(it.order!!, it.receiptButtonStatus)
                 if (requireContext().isTwoPanesShouldBeUsed) {
                     orderEditingViewModel.setOrderId(it.order.id)
                 }
@@ -625,7 +625,6 @@ class OrderDetailFragment :
 
     private fun showOrderDetail(
         order: Order,
-        isPaymentCollectableWithCardReader: Boolean,
         receiptButtonStatus: OrderDetailViewState.ReceiptButtonStatus
     ) {
         binding.orderDetailOrderStatus.updateOrder(order)
@@ -636,7 +635,6 @@ class OrderDetailFragment :
         )
         binding.orderDetailPaymentInfo.updatePaymentInfo(
             order = order,
-            isPaymentCollectableWithCardReader = isPaymentCollectableWithCardReader,
             receiptButtonStatus = receiptButtonStatus,
             formatCurrencyForDisplay = currencyFormatter.buildBigDecimalFormatter(order.currency),
             onIssueRefundClickListener = { viewModel.onIssueOrderRefundClicked() },

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/OrderDetailViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/OrderDetailViewModel.kt
@@ -738,7 +738,8 @@ class OrderDetailViewModel @Inject constructor(
         )
     }
 
-    private suspend fun isPaymentCollectableWithCardReader(order: Order) = cardPaymentCollectibilityChecker.isCollectable(order)
+    private suspend fun isPaymentCollectableWithCardReader(order: Order) =
+        cardPaymentCollectibilityChecker.isCollectable(order)
 
     private fun loadOrderNotes() {
         launch {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/OrderDetailViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/OrderDetailViewModel.kt
@@ -104,7 +104,7 @@ class OrderDetailViewModel @Inject constructor(
     private val addonsRepository: AddonRepository,
     private val selectedSite: SelectedSite,
     private val productImageMap: ProductImageMap,
-    private val paymentCollectibilityChecker: CardReaderPaymentCollectibilityChecker,
+    private val cardPaymentCollectibilityChecker: CardReaderPaymentCollectibilityChecker,
     private val paymentsFlowTracker: PaymentsFlowTracker,
     private val tracker: OrderDetailTracker,
     private val shippingLabelOnboardingRepository: ShippingLabelOnboardingRepository,
@@ -720,12 +720,11 @@ class OrderDetailViewModel @Inject constructor(
 
     private suspend fun updateOrderState() {
         val order = awaitOrder()
-        val isPaymentCollectable = isPaymentCollectable(order)
         val orderStatus = orderDetailRepository.getOrderStatus(order.status.value)
         viewState = viewState.copy(
             orderInfo = OrderDetailViewState.OrderInfo(
                 order = order,
-                isPaymentCollectableWithCardReader = isPaymentCollectable,
+                isPaymentCollectableWithCardReader = isPaymentCollectableWithCardReader(order),
                 receiptButtonStatus = if (paymentReceiptHelper.isReceiptAvailable(order.id) && order.isOrderPaid) {
                     OrderDetailViewState.ReceiptButtonStatus.Visible
                 } else {
@@ -739,7 +738,7 @@ class OrderDetailViewModel @Inject constructor(
         )
     }
 
-    private suspend fun isPaymentCollectable(order: Order) = paymentCollectibilityChecker.isCollectable(order)
+    private suspend fun isPaymentCollectableWithCardReader(order: Order) = cardPaymentCollectibilityChecker.isCollectable(order)
 
     private fun loadOrderNotes() {
         launch {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/views/OrderDetailPaymentInfoView.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/views/OrderDetailPaymentInfoView.kt
@@ -38,7 +38,6 @@ class OrderDetailPaymentInfoView @JvmOverloads constructor(
     fun updatePaymentInfo(
         order: Order,
         receiptButtonStatus: OrderDetailViewState.ReceiptButtonStatus,
-        isPaymentCollectableWithCardReader: Boolean,
         formatCurrencyForDisplay: (BigDecimal) -> String,
         onSeeReceiptClickListener: (view: View) -> Unit,
         onIssueRefundClickListener: (view: View) -> Unit,
@@ -92,7 +91,7 @@ class OrderDetailPaymentInfoView @JvmOverloads constructor(
         updateRefundSection(order, formatCurrencyForDisplay, onIssueRefundClickListener)
         updateCollectPaymentSection(order, onCollectPaymentClickListener)
         updateSeeReceiptSection(receiptButtonStatus, onSeeReceiptClickListener)
-        updatePrintingInstructionSection(isPaymentCollectableWithCardReader, onPrintingInstructionsClickListener)
+        updatePrintingInstructionSection(onPrintingInstructionsClickListener)
     }
 
     private fun showPaymentSubDetails() {
@@ -220,17 +219,12 @@ class OrderDetailPaymentInfoView @JvmOverloads constructor(
     }
 
     private fun updatePrintingInstructionSection(
-        isPaymentCollectableWithCardReader: Boolean,
         onPrintingInstructionsClickListener: (view: View) -> Unit
     ) {
-        if (isPaymentCollectableWithCardReader) {
-            binding.paymentInfoPrintingInstructions.visibility = VISIBLE
-            binding.paymentInfoPrintingInstructions.setOnClickListener(
-                onPrintingInstructionsClickListener
+        binding.paymentInfoPrintingInstructions.visibility = VISIBLE
+        binding.paymentInfoPrintingInstructions.setOnClickListener(
+            onPrintingInstructionsClickListener
             )
-        } else {
-            binding.paymentInfoPrintingInstructions.visibility = GONE
-        }
     }
 
     fun showRefunds(

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/views/OrderDetailPaymentInfoView.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/views/OrderDetailPaymentInfoView.kt
@@ -224,7 +224,7 @@ class OrderDetailPaymentInfoView @JvmOverloads constructor(
         binding.paymentInfoPrintingInstructions.visibility = VISIBLE
         binding.paymentInfoPrintingInstructions.setOnClickListener(
             onPrintingInstructionsClickListener
-            )
+        )
     }
 
     fun showRefunds(


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #13787 
<!-- Id number of the GitHub issue this PR addresses. -->

<!-- 
━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
🛠 Need an AI review?  
Add a comment: `@coderabbitai review`
━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
-->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

After merging https://github.com/woocommerce/woocommerce-android/pull/13780 I realized the behavior of the printing instructions is off and doesn't reflect the recent changes to the receipts endpoint which now supports receipts for all types of payments, not just IPP payments. 

Moreover, the printing instructions are visible only before a payment is taken even though the app allows users to print receipts even on paid orders. I believe it should be visible at all times.

### Steps to reproduce
<!-- Step-by-step testing instructions. For new user flows, consider instead stating the goal of the workflow and see if your PR reviewer can accomplish the workflow without specific steps! -->

1. Create an order that isn't collectible with IPP - eg. amount is < $0.5 or it contains a subscription product.
1. Open Order Detail
1. Notice the printing instructions are not visible.
----------
1. Create any order - even an order collectible with a card reader
1. Open Order Detail
1. Collect payment for the order
1. Notice the printing instructions are not visible

### Testing information
<!-- This is your opportunity to break out individual scenarios that need testing (when necessary) and/or include a checklist for the reviewer to go through. Consider documenting the following from your own completed testing: devices used, alternate workflows, edge cases, affected areas, critical flows, areas not tested, and any remaining unknowns. Provide feedback on this new section of the PR template through Sept 30, 2024 to Apps Quality; additional context here: p91TBi-b8z-p2#comment-12036 -->

Repeat the above steps and make sure the row is visible.

### The tests that have been performed
<!-- To give the reviewer an idea of what could be missed in terms of testing -->

I've tested the above steps.


https://github.com/user-attachments/assets/db22523c-3b47-4bb1-af20-356fc88703f6


- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.

## Reviewer (or Author, in the case of optional code reviews):

Please make sure these conditions are met before approving the PR, or request changes if the PR needs improvement:

- [x] The PR is small and has a clear, single focus, or a valid explanation is provided in the description. If needed, please request to split it into smaller PRs.
- [x] Ensure Adequate Unit Test Coverage: The changes are reasonably covered by unit tests or an explanation is provided in the PR description.
- [x] Manual Testing: The author listed all the tests they ran, including smoke tests when needed (e.g., for refactorings). The reviewer confirmed that the PR works as expected on big (tablet) and small (phone) in case of UI changes, and no regressions are added.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->