### PR TITLE
[Android SDK] Support request page toolbar overlaps with status bar

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/support/requests/SupportRequestFormActivity.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/support/requests/SupportRequestFormActivity.kt
@@ -13,7 +13,7 @@ import com.woocommerce.android.analytics.AnalyticsEvent
 import com.woocommerce.android.analytics.AnalyticsTracker
 import com.woocommerce.android.databinding.ActivitySupportRequestFormBinding
 import com.woocommerce.android.extensions.adjustActivityTransition
-import com.woocommerce.android.extensions.edgeToEdgeHandlingForNavigationBar
+import com.woocommerce.android.extensions.edgeToEdgeHandlingForNavigationAndStatusBar
 import com.woocommerce.android.extensions.serializable
 import com.woocommerce.android.support.SupportHelper
 import com.woocommerce.android.support.help.HelpOrigin
@@ -51,7 +51,7 @@ class SupportRequestFormActivity : AppCompatActivity() {
         zendeskSettings.setup(context = this)
 
         ActivitySupportRequestFormBinding.inflate(layoutInflater).apply {
-            this.root.edgeToEdgeHandlingForNavigationBar()
+            this.root.edgeToEdgeHandlingForNavigationAndStatusBar(appBarLayout)
             setContentView(root)
             setupActionBar()
             observeViewEvents(this)

--- a/WooCommerce/src/main/res/layout/activity_support_request_form.xml
+++ b/WooCommerce/src/main/res/layout/activity_support_request_form.xml
@@ -199,8 +199,7 @@
 
     <androidx.appcompat.widget.LinearLayoutCompat
         android:layout_width="match_parent"
-        android:layout_height="0dp"
-        android:layout_weight="0.15"
+        android:layout_height="wrap_content"
         android:background="@color/color_surface"
         android:orientation="vertical">
 


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #13793
<!-- Id number of the GitHub issue this PR addresses. -->

<!-- 
━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
🛠 Need an AI review?  
Add a comment: `@coderabbitai review`
━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
-->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
Fixes on support request screen:
* The overlap with status bar
* Bottom button is cut of in landscape

### Steps to reproduce
<!-- Step-by-step testing instructions. For new user flows, consider instead stating the goal of the workflow and see if your PR reviewer can accomplish the workflow without specific steps! -->
* More -> Settings -> Contact support
* Notice toolbar overlaps with status bar
* In landscape notice the bottom button is cut off 

### The tests that have been performed
<!-- To give the reviewer an idea of what could be missed in terms of testing -->
Visually checked the fix

### Images/gif
<!-- Include before and after images or gifs when appropriate. -->

https://github.com/user-attachments/assets/02f8b85b-b361-4334-a240-bed22123d6d6


- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.

## Reviewer (or Author, in the case of optional code reviews):

Please make sure these conditions are met before approving the PR, or request changes if the PR needs improvement:

- [x] The PR is small and has a clear, single focus, or a valid explanation is provided in the description. If needed, please request to split it into smaller PRs.
- [x] Ensure Adequate Unit Test Coverage: The changes are reasonably covered by unit tests or an explanation is provided in the PR description.
- [x] Manual Testing: The author listed all the tests they ran, including smoke tests when needed (e.g., for refactorings). The reviewer confirmed that the PR works as expected on big (tablet) and small (phone) in case of UI changes, and no regressions are added.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->