### PR TITLE
[Hack Week] Add ability to export/import endpoints in the Api Faker

### DIFF
--- a/libs/apifaker/build.gradle
+++ b/libs/apifaker/build.gradle
@@ -55,4 +55,5 @@ dependencies {
 
     testImplementation(libs.junit)
     testImplementation(libs.mockito.kotlin)
+    testImplementation(libs.kotlinx.coroutines.test)
 }

--- a/libs/apifaker/build.gradle
+++ b/libs/apifaker/build.gradle
@@ -41,6 +41,8 @@ dependencies {
     implementation(libs.androidx.compose.material.icons.extended)
     debugImplementation(libs.androidx.compose.ui.tooling.main)
 
+    implementation(libs.google.gson)
+
     implementation(project(":libs:fluxc"))
 
     implementation(libs.androidx.room.runtime)

--- a/libs/apifaker/src/main/java/com/woocommerce/android/apifaker/EndpointExportManager.kt
+++ b/libs/apifaker/src/main/java/com/woocommerce/android/apifaker/EndpointExportManager.kt
@@ -48,10 +48,10 @@ internal class EndpointExportManager @Inject constructor(
 
             runCatching {
                 val endpoints = inputStream.bufferedReader().use { reader ->
-                    gson.fromJson(reader, Array<MockedEndpoint>::class.java)
+                    gson.fromJson(reader, Array<MockedEndpoint>::class.java).toList()
                 }
 
-                endpointDao.insertEndpoints(*endpoints)
+                endpointDao.insertEndpoints(endpoints)
             }
         }
     }

--- a/libs/apifaker/src/main/java/com/woocommerce/android/apifaker/EndpointExportManager.kt
+++ b/libs/apifaker/src/main/java/com/woocommerce/android/apifaker/EndpointExportManager.kt
@@ -1,0 +1,51 @@
+package com.woocommerce.android.apifaker
+
+import android.content.Context
+import android.net.Uri
+import com.google.gson.Gson
+import com.woocommerce.android.apifaker.db.EndpointDao
+import com.woocommerce.android.apifaker.models.MockedEndpoint
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+import javax.inject.Inject
+
+internal class EndpointExportManager @Inject constructor(
+    private val gson: Gson,
+    private val endpointDao: EndpointDao,
+    private val context: Context
+) {
+    suspend fun exportEndpoints(
+        endpoints: List<MockedEndpoint>,
+        uri: Uri
+    ): Result<Unit> {
+        return withContext(Dispatchers.IO) {
+            val outputStream = context.contentResolver.openOutputStream(uri)
+            if (outputStream == null) {
+                return@withContext Result.failure(IllegalStateException("Could not open output stream for uri: $uri"))
+            }
+
+            runCatching {
+                outputStream.bufferedWriter().use { writer ->
+                    gson.toJson(endpoints, writer)
+                }
+            }
+        }
+    }
+
+    suspend fun importEndpoints(uri: Uri): Result<Unit> {
+        return withContext(Dispatchers.IO) {
+            val inputStream = context.contentResolver.openInputStream(uri)
+            if (inputStream == null) {
+                return@withContext Result.failure(IllegalStateException("Could not open input stream for uri: $uri"))
+            }
+
+            runCatching {
+                val endpoints = inputStream.bufferedReader().use { reader ->
+                    gson.fromJson(reader, Array<MockedEndpoint>::class.java)
+                }
+
+                endpointDao.insertEndpoints(*endpoints)
+            }
+        }
+    }
+}

--- a/libs/apifaker/src/main/java/com/woocommerce/android/apifaker/EndpointExportManager.kt
+++ b/libs/apifaker/src/main/java/com/woocommerce/android/apifaker/EndpointExportManager.kt
@@ -20,9 +20,7 @@ internal class EndpointExportManager @Inject constructor(
     ): Result<Unit> {
         return withContext(Dispatchers.IO) {
             val outputStream = context.contentResolver.openOutputStream(uri)
-            if (outputStream == null) {
-                return@withContext Result.failure(IllegalStateException("Could not open output stream for uri: $uri"))
-            }
+                ?: return@withContext Result.failure(IllegalStateException("Could not open output stream for: $uri"))
 
             val endpointsExcludingIds = endpoints.map {
                 it.copy(
@@ -42,9 +40,8 @@ internal class EndpointExportManager @Inject constructor(
     suspend fun importEndpoints(uri: Uri): Result<Unit> {
         return withContext(Dispatchers.IO) {
             val inputStream = context.contentResolver.openInputStream(uri)
-            if (inputStream == null) {
-                return@withContext Result.failure(IllegalStateException("Could not open input stream for uri: $uri"))
-            }
+                ?: return@withContext Result.failure(IllegalStateException("Could not open input stream for uri: $uri"))
+
 
             runCatching {
                 val endpoints = inputStream.bufferedReader().use { reader ->

--- a/libs/apifaker/src/main/java/com/woocommerce/android/apifaker/EndpointExportManager.kt
+++ b/libs/apifaker/src/main/java/com/woocommerce/android/apifaker/EndpointExportManager.kt
@@ -24,9 +24,16 @@ internal class EndpointExportManager @Inject constructor(
                 return@withContext Result.failure(IllegalStateException("Could not open output stream for uri: $uri"))
             }
 
+            val endpointsExcludingIds = endpoints.map {
+                it.copy(
+                    request = it.request.copy(id = 0),
+                    response = it.response.copy(endpointId = 0)
+                )
+            }
+
             runCatching {
                 outputStream.bufferedWriter().use { writer ->
-                    gson.toJson(endpoints, writer)
+                    gson.toJson(endpointsExcludingIds, writer)
                 }
             }
         }

--- a/libs/apifaker/src/main/java/com/woocommerce/android/apifaker/EndpointExportManager.kt
+++ b/libs/apifaker/src/main/java/com/woocommerce/android/apifaker/EndpointExportManager.kt
@@ -42,7 +42,6 @@ internal class EndpointExportManager @Inject constructor(
             val inputStream = context.contentResolver.openInputStream(uri)
                 ?: return@withContext Result.failure(IllegalStateException("Could not open input stream for uri: $uri"))
 
-
             runCatching {
                 val endpoints = inputStream.bufferedReader().use { reader ->
                     gson.fromJson(reader, Array<MockedEndpoint>::class.java).toList()

--- a/libs/apifaker/src/main/java/com/woocommerce/android/apifaker/db/EndpointDao.kt
+++ b/libs/apifaker/src/main/java/com/woocommerce/android/apifaker/db/EndpointDao.kt
@@ -53,7 +53,7 @@ internal interface EndpointDao {
     }
 
     @Transaction
-    suspend fun insertEndpoints(vararg endpoints: MockedEndpoint) {
+    suspend fun insertEndpoints(endpoints: List<MockedEndpoint>) {
         endpoints.forEach {
             insertEndpoint(it.request, it.response)
         }

--- a/libs/apifaker/src/main/java/com/woocommerce/android/apifaker/db/EndpointDao.kt
+++ b/libs/apifaker/src/main/java/com/woocommerce/android/apifaker/db/EndpointDao.kt
@@ -51,4 +51,11 @@ internal interface EndpointDao {
         val id = insertRequest(request)
         insertResponse(response.copy(endpointId = id))
     }
+
+    @Transaction
+    suspend fun insertEndpoints(vararg endpoints: MockedEndpoint) {
+        endpoints.forEach {
+            insertEndpoint(it.request, it.response)
+        }
+    }
 }

--- a/libs/apifaker/src/main/java/com/woocommerce/android/apifaker/models/ApiType.kt
+++ b/libs/apifaker/src/main/java/com/woocommerce/android/apifaker/models/ApiType.kt
@@ -21,7 +21,7 @@ internal sealed interface ApiType {
     data class Custom(val host: String) : ApiType
 }
 
-internal object ApiTypeSerializer : JsonDeserializer<ApiType>, JsonSerializer<ApiType> {
+private class ApiTypeSerializer : JsonDeserializer<ApiType>, JsonSerializer<ApiType> {
     override fun serialize(
         src: ApiType?,
         typeOfSrc: Type?,

--- a/libs/apifaker/src/main/java/com/woocommerce/android/apifaker/models/ApiType.kt
+++ b/libs/apifaker/src/main/java/com/woocommerce/android/apifaker/models/ApiType.kt
@@ -1,5 +1,15 @@
 package com.woocommerce.android.apifaker.models
 
+import com.google.gson.JsonDeserializationContext
+import com.google.gson.JsonDeserializer
+import com.google.gson.JsonElement
+import com.google.gson.JsonObject
+import com.google.gson.JsonSerializationContext
+import com.google.gson.JsonSerializer
+import com.google.gson.annotations.JsonAdapter
+import java.lang.reflect.Type
+
+@JsonAdapter(ApiTypeSerializer::class)
 internal sealed interface ApiType {
     companion object {
         fun defaultValues(): List<ApiType> = listOf(WPApi, WPCom, Custom(""))
@@ -9,4 +19,47 @@ internal sealed interface ApiType {
     data object WPCom : ApiType
 
     data class Custom(val host: String) : ApiType
+}
+
+internal object ApiTypeSerializer : JsonDeserializer<ApiType>, JsonSerializer<ApiType> {
+    override fun serialize(
+        src: ApiType?,
+        typeOfSrc: Type?,
+        context: JsonSerializationContext?
+    ): JsonElement? {
+        if (src == null) return null
+
+        val jsonObject = JsonObject()
+        when (src) {
+            is ApiType.WPApi -> jsonObject.addProperty("type", "wp-api")
+            is ApiType.WPCom -> jsonObject.addProperty("type", "wp-com")
+            is ApiType.Custom -> {
+                jsonObject.addProperty("type", "custom")
+                jsonObject.addProperty("host", src.host)
+            }
+        }
+
+        return jsonObject
+    }
+
+    override fun deserialize(
+        json: JsonElement?,
+        typeOfT: Type?,
+        context: JsonDeserializationContext?
+    ): ApiType? {
+        if (json == null) return null
+
+        val jsonObject = json.asJsonObject
+        val type = jsonObject.get("type").asString
+
+        return when (type) {
+            "wp-api" -> ApiType.WPApi
+            "wp-com" -> ApiType.WPCom
+            "custom" -> {
+                val host = jsonObject.get("host").asString
+                ApiType.Custom(host)
+            }
+            else -> null
+        }
+    }
 }

--- a/libs/apifaker/src/main/java/com/woocommerce/android/apifaker/models/Request.kt
+++ b/libs/apifaker/src/main/java/com/woocommerce/android/apifaker/models/Request.kt
@@ -2,12 +2,10 @@ package com.woocommerce.android.apifaker.models
 
 import androidx.room.Entity
 import androidx.room.PrimaryKey
-import com.google.gson.annotations.Expose
 
 @Entity
 internal data class Request(
     @PrimaryKey(autoGenerate = true)
-    @Expose(serialize = false, deserialize = false)
     val id: Long = 0,
     val type: ApiType,
     val path: String,

--- a/libs/apifaker/src/main/java/com/woocommerce/android/apifaker/models/Request.kt
+++ b/libs/apifaker/src/main/java/com/woocommerce/android/apifaker/models/Request.kt
@@ -2,10 +2,13 @@ package com.woocommerce.android.apifaker.models
 
 import androidx.room.Entity
 import androidx.room.PrimaryKey
+import com.google.gson.annotations.Expose
 
 @Entity
 internal data class Request(
-    @PrimaryKey(autoGenerate = true) val id: Long = 0,
+    @PrimaryKey(autoGenerate = true)
+    @Expose(serialize = false, deserialize = false)
+    val id: Long = 0,
     val type: ApiType,
     val path: String,
     val httpMethod: HttpMethod? = null,

--- a/libs/apifaker/src/main/java/com/woocommerce/android/apifaker/models/Response.kt
+++ b/libs/apifaker/src/main/java/com/woocommerce/android/apifaker/models/Response.kt
@@ -3,7 +3,6 @@ package com.woocommerce.android.apifaker.models
 import androidx.room.Entity
 import androidx.room.ForeignKey
 import androidx.room.PrimaryKey
-import com.google.gson.annotations.Expose
 
 @Entity(
     foreignKeys = [
@@ -16,10 +15,6 @@ import com.google.gson.annotations.Expose
     ]
 )
 internal data class Response(
-    @Expose(
-        serialize = false,
-        deserialize = false
-    )
     @PrimaryKey val endpointId: Long = 0,
     val statusCode: Int,
     val body: String? = null

--- a/libs/apifaker/src/main/java/com/woocommerce/android/apifaker/models/Response.kt
+++ b/libs/apifaker/src/main/java/com/woocommerce/android/apifaker/models/Response.kt
@@ -3,6 +3,7 @@ package com.woocommerce.android.apifaker.models
 import androidx.room.Entity
 import androidx.room.ForeignKey
 import androidx.room.PrimaryKey
+import com.google.gson.annotations.Expose
 
 @Entity(
     foreignKeys = [
@@ -15,6 +16,10 @@ import androidx.room.PrimaryKey
     ]
 )
 internal data class Response(
+    @Expose(
+        serialize = false,
+        deserialize = false
+    )
     @PrimaryKey val endpointId: Long = 0,
     val statusCode: Int,
     val body: String? = null

--- a/libs/apifaker/src/main/java/com/woocommerce/android/apifaker/ui/home/HomeScreen.kt
+++ b/libs/apifaker/src/main/java/com/woocommerce/android/apifaker/ui/home/HomeScreen.kt
@@ -154,7 +154,7 @@ private fun TopMenu(
 
     @Composable
     fun ExportButton() {
-        val launcher = rememberLauncherForActivityResult(ActivityResultContracts.CreateDocument("text/plain")) {
+        val launcher = rememberLauncherForActivityResult(ActivityResultContracts.CreateDocument("application/json")) {
             expanded = false
             it?.let { onExportEndpoints(it) }
         }
@@ -171,7 +171,7 @@ private fun TopMenu(
             it?.let { onImportEndpoints(it) }
         }
 
-        DropdownMenuItem(onClick = { launcher.launch(arrayOf("text/plain")) }) {
+        DropdownMenuItem(onClick = { launcher.launch(arrayOf("application/json")) }) {
             Text("Import")
         }
     }

--- a/libs/apifaker/src/main/java/com/woocommerce/android/apifaker/ui/home/HomeScreen.kt
+++ b/libs/apifaker/src/main/java/com/woocommerce/android/apifaker/ui/home/HomeScreen.kt
@@ -153,6 +153,7 @@ private fun TopMenu(
     @Composable
     fun ExportButton() {
         val launcher = rememberLauncherForActivityResult(ActivityResultContracts.CreateDocument("text/plain")) {
+            expanded = false
             it?.let { onExportEndpoints(it) }
         }
 
@@ -164,6 +165,7 @@ private fun TopMenu(
     @Composable
     fun ImportButton() {
         val launcher = rememberLauncherForActivityResult(ActivityResultContracts.OpenDocument()) {
+            expanded = false
             it?.let { onImportEndpoints(it) }
         }
 

--- a/libs/apifaker/src/main/java/com/woocommerce/android/apifaker/ui/home/HomeScreen.kt
+++ b/libs/apifaker/src/main/java/com/woocommerce/android/apifaker/ui/home/HomeScreen.kt
@@ -24,6 +24,8 @@ import androidx.compose.material.Icon
 import androidx.compose.material.IconButton
 import androidx.compose.material.MaterialTheme
 import androidx.compose.material.Scaffold
+import androidx.compose.material.SnackbarHost
+import androidx.compose.material.SnackbarHostState
 import androidx.compose.material.SwipeToDismiss
 import androidx.compose.material.Switch
 import androidx.compose.material.Text
@@ -38,6 +40,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
 import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
@@ -66,6 +69,7 @@ internal fun HomeScreen(
         endpoints = viewModel.endpoints.collectAsStateWithLifecycle().value,
         isEnabled = viewModel.isEnabled.collectAsState(initial = false).value,
         navController = navController,
+        snackbarHostState = viewModel.snackbarHostState,
         onRemoveRequest = viewModel::onRemoveRequest,
         onMockingToggleChanged = viewModel::onMockingToggleChanged,
         onExportEndpoints = viewModel::onExportEndpoints,
@@ -79,6 +83,7 @@ private fun HomeScreen(
     endpoints: List<MockedEndpoint>,
     isEnabled: Boolean,
     navController: NavController,
+    snackbarHostState: SnackbarHostState,
     onRemoveRequest: (Request) -> Unit,
     onMockingToggleChanged: (Boolean) -> Unit,
     onExportEndpoints: (Uri) -> Unit,
@@ -109,6 +114,9 @@ private fun HomeScreen(
                 backgroundColor = MaterialTheme.colors.surface,
                 elevation = 4.dp
             )
+        },
+        snackbarHost = {
+            SnackbarHost(snackbarHostState)
         }
     ) { paddingValues ->
         Box(
@@ -295,6 +303,7 @@ private fun HomeScreenPreview() {
             )
         ),
         isEnabled = true,
+        snackbarHostState = remember { SnackbarHostState() },
         navController = rememberNavController(),
         onRemoveRequest = {},
         onMockingToggleChanged = {},

--- a/libs/apifaker/src/main/java/com/woocommerce/android/apifaker/ui/home/HomeScreen.kt
+++ b/libs/apifaker/src/main/java/com/woocommerce/android/apifaker/ui/home/HomeScreen.kt
@@ -1,5 +1,8 @@
 package com.woocommerce.android.apifaker.ui.home
 
+import android.net.Uri
+import androidx.activity.compose.rememberLauncherForActivityResult
+import androidx.activity.result.contract.ActivityResultContracts
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
@@ -13,6 +16,8 @@ import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.material.Card
 import androidx.compose.material.DismissDirection
+import androidx.compose.material.DropdownMenu
+import androidx.compose.material.DropdownMenuItem
 import androidx.compose.material.ExperimentalMaterialApi
 import androidx.compose.material.FloatingActionButton
 import androidx.compose.material.Icon
@@ -27,9 +32,14 @@ import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material.icons.filled.Add
 import androidx.compose.material.icons.filled.Delete
+import androidx.compose.material.icons.filled.MoreVert
 import androidx.compose.material.rememberDismissState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.saveable.rememberSaveable
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
@@ -58,6 +68,8 @@ internal fun HomeScreen(
         navController = navController,
         onRemoveRequest = viewModel::onRemoveRequest,
         onMockingToggleChanged = viewModel::onMockingToggleChanged,
+        onExportEndpoints = viewModel::onExportEndpoints,
+        onImportEndpoints = viewModel::onImportEndpoints,
         onExit = onExit
     )
 }
@@ -69,6 +81,8 @@ private fun HomeScreen(
     navController: NavController,
     onRemoveRequest: (Request) -> Unit,
     onMockingToggleChanged: (Boolean) -> Unit,
+    onExportEndpoints: (Uri) -> Unit,
+    onImportEndpoints: (Uri) -> Unit,
     onExit: () -> Unit
 ) {
     Scaffold(
@@ -85,6 +99,11 @@ private fun HomeScreen(
                 },
                 actions = {
                     Switch(checked = isEnabled, onCheckedChange = onMockingToggleChanged)
+
+                    TopMenu(
+                        onExportEndpoints = onExportEndpoints,
+                        onImportEndpoints = onImportEndpoints
+                    )
                 },
                 backgroundColor = MaterialTheme.colors.surface,
                 elevation = 4.dp
@@ -121,6 +140,51 @@ private fun HomeScreen(
                 Icon(imageVector = Icons.Filled.Add, contentDescription = "Add endpoint")
             }
         }
+    }
+}
+
+@Composable
+private fun TopMenu(
+    onExportEndpoints: (Uri) -> Unit,
+    onImportEndpoints: (Uri) -> Unit
+) {
+    var expanded by rememberSaveable { mutableStateOf(false) }
+
+    @Composable
+    fun ExportButton() {
+        val launcher = rememberLauncherForActivityResult(ActivityResultContracts.CreateDocument("text/plain")) {
+            it?.let { onExportEndpoints(it) }
+        }
+
+        DropdownMenuItem(onClick = { launcher.launch("endpoints.json") }) {
+            Text("Export")
+        }
+    }
+
+    @Composable
+    fun ImportButton() {
+        val launcher = rememberLauncherForActivityResult(ActivityResultContracts.OpenDocument()) {
+            it?.let { onImportEndpoints(it) }
+        }
+
+        DropdownMenuItem(onClick = { launcher.launch(arrayOf("text/plain")) }) {
+            Text("Import")
+        }
+    }
+
+    IconButton(onClick = { expanded = !expanded }) {
+        Icon(
+            Icons.Default.MoreVert,
+            contentDescription = "More"
+        )
+    }
+
+    DropdownMenu(
+        expanded = expanded,
+        onDismissRequest = { expanded = false }
+    ) {
+        ExportButton()
+        ImportButton()
     }
 }
 
@@ -228,6 +292,8 @@ private fun HomeScreenPreview() {
         navController = rememberNavController(),
         onRemoveRequest = {},
         onMockingToggleChanged = {},
+        onExportEndpoints = {},
+        onImportEndpoints = {},
         onExit = {}
     )
 }

--- a/libs/apifaker/src/main/java/com/woocommerce/android/apifaker/ui/home/HomeScreen.kt
+++ b/libs/apifaker/src/main/java/com/woocommerce/android/apifaker/ui/home/HomeScreen.kt
@@ -101,6 +101,7 @@ private fun HomeScreen(
                     Switch(checked = isEnabled, onCheckedChange = onMockingToggleChanged)
 
                     TopMenu(
+                        hasEndpoints = endpoints.isNotEmpty(),
                         onExportEndpoints = onExportEndpoints,
                         onImportEndpoints = onImportEndpoints
                     )
@@ -145,6 +146,7 @@ private fun HomeScreen(
 
 @Composable
 private fun TopMenu(
+    hasEndpoints: Boolean,
     onExportEndpoints: (Uri) -> Unit,
     onImportEndpoints: (Uri) -> Unit
 ) {
@@ -185,7 +187,9 @@ private fun TopMenu(
         expanded = expanded,
         onDismissRequest = { expanded = false }
     ) {
-        ExportButton()
+        if (hasEndpoints) {
+            ExportButton()
+        }
         ImportButton()
     }
 }

--- a/libs/apifaker/src/main/java/com/woocommerce/android/apifaker/ui/home/HomeViewModel.kt
+++ b/libs/apifaker/src/main/java/com/woocommerce/android/apifaker/ui/home/HomeViewModel.kt
@@ -4,6 +4,7 @@ import android.net.Uri
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.woocommerce.android.apifaker.ApiFakerConfig
+import com.woocommerce.android.apifaker.EndpointExportManager
 import com.woocommerce.android.apifaker.db.EndpointDao
 import com.woocommerce.android.apifaker.models.Request
 import dagger.hilt.android.lifecycle.HiltViewModel
@@ -15,7 +16,8 @@ import javax.inject.Inject
 @HiltViewModel
 internal class HomeViewModel @Inject constructor(
     private val endpointDao: EndpointDao,
-    private val config: ApiFakerConfig
+    private val config: ApiFakerConfig,
+    private val endpointExportManager: EndpointExportManager
 ) : ViewModel() {
     @Suppress("MagicNumber")
     val endpoints = endpointDao.observeEndpoints()
@@ -36,10 +38,20 @@ internal class HomeViewModel @Inject constructor(
     }
 
     fun onExportEndpoints(uri: Uri) {
-
+        viewModelScope.launch {
+            endpointExportManager.exportEndpoints(endpoints.value, uri).fold(
+                onSuccess = { /* handle success */ },
+                onFailure = { /* handle error */ }
+            )
+        }
     }
 
     fun onImportEndpoints(uri: Uri) {
-
+        viewModelScope.launch {
+            endpointExportManager.importEndpoints(uri).fold(
+                onSuccess = { /* handle success */ },
+                onFailure = { /* handle error */ }
+            )
+        }
     }
 }

--- a/libs/apifaker/src/main/java/com/woocommerce/android/apifaker/ui/home/HomeViewModel.kt
+++ b/libs/apifaker/src/main/java/com/woocommerce/android/apifaker/ui/home/HomeViewModel.kt
@@ -1,5 +1,6 @@
 package com.woocommerce.android.apifaker.ui.home
 
+import android.net.Uri
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.woocommerce.android.apifaker.ApiFakerConfig
@@ -32,5 +33,13 @@ internal class HomeViewModel @Inject constructor(
         viewModelScope.launch {
             endpointDao.deleteRequest(request)
         }
+    }
+
+    fun onExportEndpoints(uri: Uri) {
+
+    }
+
+    fun onImportEndpoints(uri: Uri) {
+
     }
 }

--- a/libs/apifaker/src/main/java/com/woocommerce/android/apifaker/ui/home/HomeViewModel.kt
+++ b/libs/apifaker/src/main/java/com/woocommerce/android/apifaker/ui/home/HomeViewModel.kt
@@ -1,10 +1,13 @@
 package com.woocommerce.android.apifaker.ui.home
 
 import android.net.Uri
+import android.util.Log
+import androidx.compose.material.SnackbarHostState
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.woocommerce.android.apifaker.ApiFakerConfig
 import com.woocommerce.android.apifaker.EndpointExportManager
+import com.woocommerce.android.apifaker.LOG_TAG
 import com.woocommerce.android.apifaker.db.EndpointDao
 import com.woocommerce.android.apifaker.models.Request
 import dagger.hilt.android.lifecycle.HiltViewModel
@@ -25,6 +28,8 @@ internal class HomeViewModel @Inject constructor(
 
     val isEnabled = config.enabled
 
+    val snackbarHostState = SnackbarHostState()
+
     fun onMockingToggleChanged(enabled: Boolean) {
         viewModelScope.launch {
             config.setStatus(enabled)
@@ -40,8 +45,13 @@ internal class HomeViewModel @Inject constructor(
     fun onExportEndpoints(uri: Uri) {
         viewModelScope.launch {
             endpointExportManager.exportEndpoints(endpoints.value, uri).fold(
-                onSuccess = { /* handle success */ },
-                onFailure = { /* handle error */ }
+                onSuccess = {
+                    snackbarHostState.showSnackbar("Endpoints exported successfully")
+                },
+                onFailure = {
+                    snackbarHostState.showSnackbar("Failed to export endpoints")
+                    Log.e(LOG_TAG, "Failed to export endpoints", it)
+                }
             )
         }
     }
@@ -49,8 +59,15 @@ internal class HomeViewModel @Inject constructor(
     fun onImportEndpoints(uri: Uri) {
         viewModelScope.launch {
             endpointExportManager.importEndpoints(uri).fold(
-                onSuccess = { /* handle success */ },
-                onFailure = { /* handle error */ }
+                onSuccess = {
+                    snackbarHostState.showSnackbar("Endpoints imported successfully")
+                },
+                onFailure = {
+                    snackbarHostState.showSnackbar(
+                        "Failed to import endpoints, please ensure the file was exported from the same app version"
+                    )
+                    Log.e(LOG_TAG, "Failed to import endpoints", it)
+                }
             )
         }
     }

--- a/libs/apifaker/src/test/java/com/woocommerce/android/apifaker/EndpointExportManagerTest.kt
+++ b/libs/apifaker/src/test/java/com/woocommerce/android/apifaker/EndpointExportManagerTest.kt
@@ -1,0 +1,78 @@
+package com.woocommerce.android.apifaker
+
+import android.content.ContentResolver
+import android.content.Context
+import com.google.gson.Gson
+import com.woocommerce.android.apifaker.db.EndpointDao
+import com.woocommerce.android.apifaker.models.ApiType
+import com.woocommerce.android.apifaker.models.MockedEndpoint
+import com.woocommerce.android.apifaker.models.Request
+import com.woocommerce.android.apifaker.models.Response
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.mockito.kotlin.any
+import org.mockito.kotlin.doReturn
+import org.mockito.kotlin.given
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.verify
+import java.io.ByteArrayOutputStream
+
+class EndpointExportManagerTest {
+    private val mockedEndpoints = listOf(
+        MockedEndpoint(
+            request = Request(
+                id = 1,
+                type = ApiType.WPApi,
+                path = "/wp/v2/posts"
+            ),
+            response = Response(
+                endpointId = 1,
+                statusCode = 200,
+                body = "[]"
+            )
+        )
+    )
+    private val gson = Gson()
+    private val contentResolver = mock<ContentResolver>()
+    private val context = mock<Context> {
+        on { contentResolver } doReturn contentResolver
+    }
+    private val endpointDao = mock<EndpointDao>()
+
+    private val sut = EndpointExportManager(
+        gson = gson,
+        endpointDao = endpointDao,
+        context = context
+    )
+
+    @Test
+    fun `when exportEndpoints is called, it should export the endpoints to the given uri`() = runTest {
+        val stream = ByteArrayOutputStream()
+        given(contentResolver.openOutputStream(any())).willReturn(stream)
+
+        val result = sut.exportEndpoints(mockedEndpoints, mock())
+        val exportedEndpoints = gson.fromJson(stream.toString(), Array<MockedEndpoint>::class.java).toList()
+
+        assertTrue(result.isSuccess)
+        val expectedEndpoints = mockedEndpoints.map {
+            it.copy(
+                request = it.request.copy(id = 0),
+                response = it.response.copy(endpointId = 0)
+            )
+        }
+        assertEquals(expectedEndpoints, exportedEndpoints)
+    }
+
+    @Test
+    fun `when importEndpoints is called, it should import the endpoints from the given uri`() = runTest {
+        val stream = gson.toJson(mockedEndpoints).byteInputStream()
+        given(contentResolver.openInputStream(any())).willReturn(stream)
+
+        val result = sut.importEndpoints(mock())
+
+        assertTrue(result.isSuccess)
+        verify(endpointDao).insertEndpoints(mockedEndpoints)
+    }
+}


### PR DESCRIPTION
### Description
This PR adds support for exporting/importing mocked endpoints in the Api Faker. The implementation is done in a simple way: using json serialization.

### Steps to reproduce
1. Open the app and sign in if needed.
2. Open the settings.
3. Tap on Developer Options.
4. Tap on Api Faker.

### Testing information
- Add some endpoints, then tap on the menu button, and tap on Export to export them.
- Test importing the endpoints and check their data.

**Important:** Importing endpoints that already exist in the database will duplicate them, I'm planning to look into this and see if it's worth improving.

### The tests that have been performed
^

### Images/gif

https://github.com/user-attachments/assets/151b0820-7f70-4284-b43d-6e013eb4eae7


- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.

## Reviewer (or Author, in the case of optional code reviews):

Please make sure these conditions are met before approving the PR, or request changes if the PR needs improvement:

- [ ] The PR is small and has a clear, single focus, or a valid explanation is provided in the description. If needed, please request to split it into smaller PRs.
- [ ] Ensure Adequate Unit Test Coverage: The changes are reasonably covered by unit tests or an explanation is provided in the PR description.
- [ ] Manual Testing: The author listed all the tests they ran, including smoke tests when needed (e.g., for refactorings). The reviewer confirmed that the PR works as expected on big (tablet) and small (phone) in case of UI changes, and no regressions are added.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->