### PR TITLE
Prevent the quantity update to send a new product when removing the bundle

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/AdjustProductQuantity.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/AdjustProductQuantity.kt
@@ -29,7 +29,7 @@ class AdjustProductQuantity @Inject constructor() {
                 val newQuantity = quantity + quantityToAdd
                 val discountAmount = subtotal - total
                 val newSubtotal = pricePreDiscount.multiply(newQuantity.toBigDecimal())
-                if(newQuantity > 0) {
+                if (newQuantity > 0) {
                     items[0L] = copy(
                         itemId = 0L,
                         quantity = newQuantity,

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/AdjustProductQuantity.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/AdjustProductQuantity.kt
@@ -29,13 +29,15 @@ class AdjustProductQuantity @Inject constructor() {
                 val newQuantity = quantity + quantityToAdd
                 val discountAmount = subtotal - total
                 val newSubtotal = pricePreDiscount.multiply(newQuantity.toBigDecimal())
-                items[0L] = copy(
-                    itemId = 0L,
-                    quantity = newQuantity,
-                    subtotal = newSubtotal,
-                    total = newSubtotal - discountAmount,
-                    configuration = groupedProduct.getConfiguration()
-                )
+                if(newQuantity > 0) {
+                    items[0L] = copy(
+                        itemId = 0L,
+                        quantity = newQuantity,
+                        subtotal = newSubtotal,
+                        total = newSubtotal - discountAmount,
+                        configuration = groupedProduct.getConfiguration()
+                    )
+                }
             }
             for (child in product.children) {
                 val updatedItem = items[child.item.itemId]?.copy(quantity = 0f) ?: continue

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/creation/AdjustProductQuantityTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/creation/AdjustProductQuantityTest.kt
@@ -100,6 +100,22 @@ class AdjustProductQuantityTest : BaseUnitTest() {
     }
 
     @Test
+    fun `delete bundle product`() {
+        // To delete a bundle product we use the same quantity as the bundle item, the updated quantity should be 0
+        val quantityToDecrease = (bundleProduct.item.quantity * -1).toInt()
+        val updatedOrder = adjustProductQuantity(order, bundleProduct, quantityToDecrease)
+
+        val items = updatedOrder.items.associateBy { it.itemId }
+
+        // Assert that we remove (quantity == 0) the bundle item and its children
+        assertThat(items.getValue(bundleItemID).quantity).isEqualTo(0f)
+        assertThat(items.getValue(bundleChildItemID).quantity).isEqualTo(0f)
+
+        // Assert that NO new item is created
+        assertThat(items[notSyncedItemID]).isNull()
+    }
+
+    @Test
     fun `increase quantity for not synced product using item id`() {
         val itemId = notSyncedItemID
         val quantityToAdd = 2


### PR DESCRIPTION
Closes: #13786 

### Description
This PR resolves an issue with bundle products not being removed from the order. The current method for updating or removing bundle products is a hacky solution that creates a new product each time the bundle product quantity changes. Attempting to create a new bundle product with a quantity of `0` began to fail, which caused this bug. This PR addresses the issue by sending the updated bundle only when it is not a product removal action.

### Steps to reproduce

1. Create an order with a bundled products
2. Edit this order and try to delete the product
3. Notice an error

### Testing information

1. Create an order with a bundled products
2. Edit this order and try to delete the product
3. Check that the product is removed

### The tests that have been performed

1. Checking that a bundle product quantity can be updated
2. Checking that a bundle product can be removed from the order

### Images/gif

https://github.com/user-attachments/assets/9c740055-524b-488a-82ec-ea4245ab11c8

- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.

## Reviewer (or Author, in the case of optional code reviews):

Please make sure these conditions are met before approving the PR, or request changes if the PR needs improvement:

- [x] The PR is small and has a clear, single focus, or a valid explanation is provided in the description. If needed, please request to split it into smaller PRs.
- [x] Ensure Adequate Unit Test Coverage: The changes are reasonably covered by unit tests or an explanation is provided in the PR description.
- [x] Manual Testing: The author listed all the tests they ran, including smoke tests when needed (e.g., for refactorings). The reviewer confirmed that the PR works as expected on big (tablet) and small (phone) in case of UI changes, and no regressions are added.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->