### PR TITLE
[Woo POS] Play Cha-Ching sound on successful payment

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/WooPosHomeScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/WooPosHomeScreen.kt
@@ -1,5 +1,9 @@
 package com.woocommerce.android.ui.woopos.home
 
+import android.content.ContentResolver
+import android.content.Context
+import android.media.MediaPlayer
+import android.net.Uri
 import androidx.activity.compose.BackHandler
 import androidx.compose.animation.core.animateDpAsState
 import androidx.compose.animation.core.spring
@@ -26,6 +30,7 @@ import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
+import com.woocommerce.android.R
 import com.woocommerce.android.ui.woopos.common.composeui.WooPosPreview
 import com.woocommerce.android.ui.woopos.common.composeui.component.WooPosExitConfirmationDialog
 import com.woocommerce.android.ui.woopos.common.composeui.designsystem.WooPosSpacing
@@ -41,6 +46,7 @@ import com.woocommerce.android.ui.woopos.home.toolbar.PreviewWooPosFloatingToolb
 import com.woocommerce.android.ui.woopos.home.toolbar.WooPosFloatingToolbar
 import com.woocommerce.android.ui.woopos.home.totals.WooPosTotalsScreen
 import com.woocommerce.android.ui.woopos.home.totals.WooPosTotalsScreenPreview
+import kotlinx.coroutines.flow.collectLatest
 import org.wordpress.android.util.ToastUtils
 
 @Composable
@@ -67,10 +73,27 @@ fun WooPosHomeScreen(
         }
     }
 
+    LaunchedEffect(Unit) {
+        viewModel.playChaChingEvent.collectLatest {
+            playChaChingSound(context)
+            viewModel.clearChaChingEvent()
+        }
+    }
+
     WooPosHomeScreen(
         state = state,
         onHomeUIEvent = { viewModel.onUIEvent(it) },
     )
+}
+
+fun playChaChingSound(context: Context) {
+    val chaChingUri =
+        Uri.parse(
+            ContentResolver.SCHEME_ANDROID_RESOURCE +
+                "://" + context.packageName + "/" + R.raw.cha_ching
+        )
+    val mp = MediaPlayer.create(context, chaChingUri)
+    mp.start()
 }
 
 @Composable

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/WooPosHomeViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/WooPosHomeViewModel.kt
@@ -3,7 +3,6 @@ package com.woocommerce.android.ui.woopos.home
 import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
-import com.woocommerce.android.AppPrefsWrapper
 import com.woocommerce.android.ui.woopos.home.ChildToParentEvent.NavigationEvent
 import com.woocommerce.android.ui.woopos.home.ParentToChildrenEvent.OrderSuccessfullyPaid.PaymentMethod
 import com.woocommerce.android.ui.woopos.home.WooPosHomeState.ExitConfirmationDialog

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/WooPosHomeViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/WooPosHomeViewModel.kt
@@ -3,6 +3,7 @@ package com.woocommerce.android.ui.woopos.home
 import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import com.woocommerce.android.AppPrefsWrapper
 import com.woocommerce.android.ui.woopos.home.ChildToParentEvent.NavigationEvent
 import com.woocommerce.android.ui.woopos.home.ParentToChildrenEvent.OrderSuccessfullyPaid.PaymentMethod
 import com.woocommerce.android.ui.woopos.home.WooPosHomeState.ExitConfirmationDialog
@@ -14,6 +15,7 @@ import com.woocommerce.android.ui.woopos.util.analytics.WooPosAnalyticsEvent.Eve
 import com.woocommerce.android.ui.woopos.util.analytics.WooPosAnalyticsTracker
 import com.woocommerce.android.viewmodel.getStateFlow
 import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.SharedFlow
 import kotlinx.coroutines.flow.StateFlow
@@ -41,6 +43,9 @@ class WooPosHomeViewModel @Inject constructor(
 
     private val _toastEvent = MutableSharedFlow<String>()
     val toastEvent: SharedFlow<String> = _toastEvent
+
+    private val _playChaChingEvent = MutableSharedFlow<String>(replay = 1)
+    val playChaChingEvent: SharedFlow<String> = _playChaChingEvent
 
     private val _navigationEvent = MutableSharedFlow<NavigationEvent>()
     val navigationEvent: SharedFlow<NavigationEvent> = _navigationEvent
@@ -214,10 +219,18 @@ class WooPosHomeViewModel @Inject constructor(
             wooPosItemsNavigator.sendNavigationEvent(
                 WooPosItemsNavigator.WooPosItemsScreenNavigationEvent.NavigateBackToItemListScreen
             )
+            _playChaChingEvent.emit("Cha-Ching")
         }
         _state.value = _state.value.copy(
             screenPositionState = ScreenPositionState.Checkout.FullScreenTotals
         )
         sendEventToChildren(ParentToChildrenEvent.OrderSuccessfullyPaid(paymentMethod))
+    }
+
+    @OptIn(ExperimentalCoroutinesApi::class)
+    fun clearChaChingEvent() {
+        viewModelScope.launch {
+            _playChaChingEvent.resetReplayCache()
+        }
     }
 }

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/home/WooPosHomeViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/home/WooPosHomeViewModelTest.kt
@@ -15,6 +15,9 @@ import com.woocommerce.android.ui.woopos.util.analytics.WooPosAnalyticsTracker
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.flow.toList
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.test.advanceUntilIdle
 import kotlinx.coroutines.test.runTest
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.Rule
@@ -452,6 +455,26 @@ class WooPosHomeViewModelTest {
 
         // THEN
         analyticsTracker.track(BackToCartTapped)
+    }
+
+    @Test
+    fun `given state is Checkout, when OnPaymentCompletedViaCash event passed, then cha ching event is emitted`() = runTest {
+        // GIVEN
+        val events = MutableSharedFlow<ChildToParentEvent>()
+        whenever(childrenToParentEventReceiver.events).thenReturn(events)
+        val viewModel = createViewModel()
+        val emittedValues = mutableListOf<String>()
+        val job = launch {
+            viewModel.playChaChingEvent.toList(emittedValues)
+        }
+
+        // WHEN
+        viewModel.onUIEvent(WooPosHomeUIEvent.OnPaymentCompletedViaCash)
+
+        // THEN
+        advanceUntilIdle()
+        assertTrue(emittedValues.contains("Cha-Ching"))
+        job.cancel()
     }
 
     private fun createViewModel() = WooPosHomeViewModel(

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/home/WooPosHomeViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/home/WooPosHomeViewModelTest.kt
@@ -477,6 +477,24 @@ class WooPosHomeViewModelTest {
         job.cancel()
     }
 
+    @Test
+    fun `given state is Checkout, when OrderSuccessfullyPaidByCard event passed, then cha ching event is emitted`() = runTest {
+        // GIVEN
+        whenever(childrenToParentEventReceiver.events).thenReturn(
+            flowOf(ChildToParentEvent.OrderSuccessfullyPaidByCard)
+        )
+        val viewModel = createViewModel()
+        val emittedValues = mutableListOf<String>()
+        val job = launch {
+            viewModel.playChaChingEvent.toList(emittedValues)
+        }
+
+        // THEN
+        advanceUntilIdle()
+        assertTrue(emittedValues.contains("Cha-Ching"))
+        job.cancel()
+    }
+
     private fun createViewModel() = WooPosHomeViewModel(
         childrenToParentEventReceiver,
         parentToChildrenEventSender,


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #13636 
<!-- Id number of the GitHub issue this PR addresses. -->

<!-- 
━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
🛠 Need an AI review?  
Add a comment: `@coderabbitai review`
━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
-->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
This PR adds a Cha-Ching sound on successful payment on POS mode for both card and cash payment. Right now, there is no option to turn this setting off. It will be part of another PR.

Please read the discussion [here](https://github.com/woocommerce/woocommerce-android/issues/13636) to understand more on why we think Cha-Ching sound is important


### Steps to reproduce
<!-- Step-by-step testing instructions. For new user flows, consider instead stating the goal of the workflow and see if your PR reviewer can accomplish the workflow without specific steps! -->
1. Navigate to more menu -> POS
2. Add items to cart and proceed to checkout
3. Collect payment either by card or by cash
4. Ensure you hear Cha-Ching sound on successful payment

### The tests that have been performed
<!-- To give the reviewer an idea of what could be missed in terms of testing -->
Tested the above steps on both emulator and on tablet device

### Images/gif
<!-- Include before and after images or gifs when appropriate. -->

https://github.com/user-attachments/assets/1c7b2aae-e1fe-4eba-ae64-2f034c918516



- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.

## Reviewer (or Author, in the case of optional code reviews):

Please make sure these conditions are met before approving the PR, or request changes if the PR needs improvement:

- [ ] The PR is small and has a clear, single focus, or a valid explanation is provided in the description. If needed, please request to split it into smaller PRs.
- [ ] Ensure Adequate Unit Test Coverage: The changes are reasonably covered by unit tests or an explanation is provided in the PR description.
- [ ] Manual Testing: The author listed all the tests they ran, including smoke tests when needed (e.g., for refactorings). The reviewer confirmed that the PR works as expected on big (tablet) and small (phone) in case of UI changes, and no regressions are added.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->