### PR TITLE
[Woo POS] Add setting option to enable/disable Cha-Ching sound in POS

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/AppPrefs.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/AppPrefs.kt
@@ -132,7 +132,8 @@ object AppPrefs {
         CUSTOM_FIELDS_TOP_BANNER_DISMISSED,
         BLAZE_CAMPAIGN_SELECTED_OBJECTIVE,
         BLAZE_CAMPAIGN_OBJECTIVE_SWITCH_CHECKED,
-        IS_SITE_WPCOM_SUSPENDED
+        IS_SITE_WPCOM_SUSPENDED,
+        WOO_POS_PAYMENT_SOUND_ENABLED,
     }
 
     /**
@@ -286,6 +287,10 @@ object AppPrefs {
     var isSiteWPComSuspended: Boolean
         get() = getBoolean(DeletablePrefKey.IS_SITE_WPCOM_SUSPENDED, false)
         set(value) = setBoolean(DeletablePrefKey.IS_SITE_WPCOM_SUSPENDED, value)
+
+    var isWooPosPaymentSoundEnabled: Boolean
+        get() = getBoolean(DeletablePrefKey.WOO_POS_PAYMENT_SOUND_ENABLED, true)
+        set(value) = setBoolean(DeletablePrefKey.WOO_POS_PAYMENT_SOUND_ENABLED, value)
 
     fun getProductSortingChoice(currentSiteId: Int) = getString(getProductSortingKey(currentSiteId)).orNullIfEmpty()
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/AppPrefsWrapper.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/AppPrefsWrapper.kt
@@ -39,6 +39,8 @@ class AppPrefsWrapper @Inject constructor() {
 
     var isSiteWPComSuspended by AppPrefs::isSiteWPComSuspended
 
+    var isWooPosPaymentSoundEnabled by AppPrefs::isWooPosPaymentSoundEnabled
+
     fun getAppInstallationDate() = AppPrefs.installationDate
 
     fun getReceiptUrl(localSiteId: Int, remoteSiteId: Long, selfHostedSiteId: Long, orderId: Long) =

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/WooPosHomeViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/WooPosHomeViewModel.kt
@@ -28,6 +28,7 @@ class WooPosHomeViewModel @Inject constructor(
     private val parentToChildrenEventSender: WooPosParentToChildrenEventSender,
     private val wooPosItemsNavigator: WooPosItemsNavigator,
     private val analyticsTracker: WooPosAnalyticsTracker,
+    private val appPrefsWrapper: AppPrefsWrapper,
     savedStateHandle: SavedStateHandle,
 ) : ViewModel() {
     private val _state = savedStateHandle.getStateFlow(
@@ -219,7 +220,9 @@ class WooPosHomeViewModel @Inject constructor(
             wooPosItemsNavigator.sendNavigationEvent(
                 WooPosItemsNavigator.WooPosItemsScreenNavigationEvent.NavigateBackToItemListScreen
             )
-            _playChaChingEvent.emit("Cha-Ching")
+            if (appPrefsWrapper.isWooPosPaymentSoundEnabled) {
+                _playChaChingEvent.emit("Cha-Ching")
+            }
         }
         _state.value = _state.value.copy(
             screenPositionState = ScreenPositionState.Checkout.FullScreenTotals

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/toolbar/WooPosToolbar.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/toolbar/WooPosToolbar.kt
@@ -26,7 +26,6 @@ import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Switch
-import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
@@ -340,7 +339,6 @@ fun ToggleSwitch(
         )
     }
 }
-
 
 @Composable
 private fun CardReaderStatusButton(

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/toolbar/WooPosToolbar.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/toolbar/WooPosToolbar.kt
@@ -11,8 +11,10 @@ import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.IntrinsicSize
 import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
@@ -23,6 +25,8 @@ import androidx.compose.material3.ButtonDefaults
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
+import androidx.compose.material3.Switch
+import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
@@ -32,6 +36,7 @@ import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
@@ -274,6 +279,9 @@ private fun PopUpMenuItem(
     menuItem: Menu.MenuItem,
     onClick: (Menu.MenuItem) -> Unit
 ) {
+    var isChaChingEnabled by remember {
+        mutableStateOf(menuItem is Menu.MenuItem.Toggleable && menuItem.isToggled)
+    }
     TextButton(onClick = { onClick(menuItem) }) {
         Spacer(modifier = Modifier.width(WooPosSpacing.Medium.value.toAdaptivePadding()))
         Icon(
@@ -293,9 +301,46 @@ private fun PopUpMenuItem(
             maxLines = 1,
             overflow = TextOverflow.Ellipsis,
         )
+        if (menuItem is Menu.MenuItem.Toggleable) {
+            ToggleSwitch(
+                isChecked = isChaChingEnabled,
+                onToggleChange = {
+                    isChaChingEnabled = it
+                    onClick(menuItem.copy(isToggled = !menuItem.isToggled))
+                }
+            )
+        }
         Spacer(modifier = Modifier.width(WooPosSpacing.Medium.value.toAdaptivePadding()))
     }
 }
+
+@Composable
+fun ToggleSwitch(
+    isChecked: Boolean,
+    onToggleChange: (Boolean) -> Unit
+) {
+    Row(
+        modifier = Modifier
+            .fillMaxWidth(),
+        verticalAlignment = Alignment.CenterVertically
+    ) {
+        WooPosText(
+            modifier = Modifier
+                .padding(vertical = WooPosSpacing.Small.value.toAdaptivePadding())
+                .weight(1f),
+            text = stringResource(id = R.string.woopos_payment_success_sound_setting_title),
+            style = WooPosTypography.BodyMedium,
+            color = MaterialTheme.colorScheme.onSurface,
+            maxLines = 1,
+            overflow = TextOverflow.Ellipsis,
+        )
+        Switch(
+            checked = isChecked,
+            onCheckedChange = onToggleChange
+        )
+    }
+}
+
 
 @Composable
 private fun CardReaderStatusButton(
@@ -484,15 +529,20 @@ fun PreviewWooPosFloatingToolbarStatusConnectedWithMenu() {
                 cardReaderStatus = WooPosCardReaderStatus.Connected,
                 menu = Menu.Visible(
                     listOf(
-                        Menu.MenuItem(
+                        Menu.MenuItem.Toggleable(
+                            title = R.string.woopos_cart_title,
+                            icon = R.drawable.woo_pos_info_ic,
+                            isToggled = true
+                        ),
+                        Menu.MenuItem.Standard(
                             title = R.string.woopos_documentation_title,
                             icon = R.drawable.woo_pos_info_ic
                         ),
-                        Menu.MenuItem(
+                        Menu.MenuItem.Standard(
                             title = R.string.woopos_exit_confirmation_title,
                             icon = R.drawable.ic_woo_pos_exit,
                         ),
-                        Menu.MenuItem(
+                        Menu.MenuItem.Standard(
                             title = R.string.woopos_get_support_title,
                             icon = R.drawable.woopos_ic_get_support,
                         ),

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/toolbar/WooPosToolbarState.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/toolbar/WooPosToolbarState.kt
@@ -17,9 +17,20 @@ data class WooPosToolbarState(
         data object Hidden : Menu()
         data class Visible(val items: List<MenuItem>) : Menu()
 
-        data class MenuItem(
-            @StringRes val title: Int,
-            @DrawableRes val icon: Int,
-        )
+        sealed class MenuItem(
+            @StringRes open val title: Int,
+            @DrawableRes open val icon: Int
+        ) {
+            data class Standard(
+                @StringRes override val title: Int,
+                @DrawableRes override val icon: Int
+            ) : MenuItem(title, icon)
+
+            data class Toggleable(
+                @StringRes override val title: Int,
+                @DrawableRes override val icon: Int,
+                val isToggled: Boolean
+            ) : MenuItem(title, icon)
+        }
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/toolbar/WooPosToolbarViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/toolbar/WooPosToolbarViewModel.kt
@@ -2,6 +2,7 @@ package com.woocommerce.android.ui.woopos.home.toolbar
 
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import com.woocommerce.android.AppPrefsWrapper
 import com.woocommerce.android.AppUrls.WOO_POS_DOCUMENTATION_URL
 import com.woocommerce.android.R
 import com.woocommerce.android.cardreader.connection.CardReaderStatus
@@ -39,6 +40,7 @@ class WooPosToolbarViewModel @Inject constructor(
     private val networkStatus: WooPosNetworkStatus,
     private val resourceProvider: ResourceProvider,
     private val analyticsTracker: WooPosAnalyticsTracker,
+    private val appPrefsWrapper: AppPrefsWrapper,
 ) : ViewModel() {
     private val _state = MutableStateFlow(
         WooPosToolbarState(
@@ -70,8 +72,15 @@ class WooPosToolbarViewModel @Inject constructor(
 
         when (event) {
             is OnToolbarMenuClicked -> {
+                val updatedToolBarMenuItems = toolbarMenuItems.map {
+                    if (it is WooPosToolbarState.Menu.MenuItem.Toggleable) {
+                        it.copy(isToggled = appPrefsWrapper.isWooPosPaymentSoundEnabled)
+                    } else {
+                        it
+                    }
+                }
                 _state.value = currentState.copy(
-                    menu = WooPosToolbarState.Menu.Visible(toolbarMenuItems)
+                    menu = WooPosToolbarState.Menu.Visible(updatedToolBarMenuItems)
                 )
             }
 
@@ -86,7 +95,9 @@ class WooPosToolbarViewModel @Inject constructor(
     }
 
     private fun handleMenuItemClicked(event: MenuItemClicked) {
-        hideMenu()
+        if (event.menuItem !is WooPosToolbarState.Menu.MenuItem.Toggleable) {
+            hideMenu()
+        }
 
         when (event.menuItem.title) {
             R.string.woopos_get_support_title -> {
@@ -95,15 +106,23 @@ class WooPosToolbarViewModel @Inject constructor(
                     analyticsTracker.track(GetSupportTapped)
                 }
             }
+
             R.string.woopos_exit_confirmation_title ->
                 viewModelScope.launch {
                     childrenToParentEventSender.sendToParent(ChildToParentEvent.ExitPosClicked)
                     analyticsTracker.track(ExitTapped)
                 }
+
             R.string.woopos_documentation_title -> {
                 viewModelScope.launch {
                     _openUrlEvent.emit(WOO_POS_DOCUMENTATION_URL)
                     analyticsTracker.track(ViewDocsTapped)
+                }
+            }
+
+            R.string.woopos_payment_success_sound_setting_title -> {
+                viewModelScope.launch {
+                    appPrefsWrapper.isWooPosPaymentSoundEnabled = !appPrefsWrapper.isWooPosPaymentSoundEnabled
                 }
             }
         }
@@ -120,6 +139,7 @@ class WooPosToolbarViewModel @Inject constructor(
                     cardReaderFacade.disconnectFromReader()
                 }
             }
+
             WooPosToolbarState.WooPosCardReaderStatus.NotConnected -> {
                 if (!networkStatus.isConnected()) {
                     viewModelScope.launch {
@@ -143,20 +163,23 @@ class WooPosToolbarViewModel @Inject constructor(
         }
     }
 
-    private companion object {
-        val toolbarMenuItems = listOf(
-            WooPosToolbarState.Menu.MenuItem(
-                title = R.string.woopos_documentation_title,
-                icon = R.drawable.woo_pos_info_ic,
-            ),
-            WooPosToolbarState.Menu.MenuItem(
-                title = R.string.woopos_get_support_title,
-                icon = R.drawable.woopos_ic_get_support,
-            ),
-            WooPosToolbarState.Menu.MenuItem(
-                title = R.string.woopos_exit_confirmation_title,
-                icon = R.drawable.ic_woo_pos_exit,
-            ),
-        )
-    }
+    private val toolbarMenuItems = listOf(
+        WooPosToolbarState.Menu.MenuItem.Toggleable(
+            title = R.string.woopos_payment_success_sound_setting_title,
+            icon = R.drawable.woo_pos_info_ic,
+            isToggled = appPrefsWrapper.isWooPosPaymentSoundEnabled
+        ),
+        WooPosToolbarState.Menu.MenuItem.Standard(
+            title = R.string.woopos_documentation_title,
+            icon = R.drawable.woo_pos_info_ic,
+        ),
+        WooPosToolbarState.Menu.MenuItem.Standard(
+            title = R.string.woopos_get_support_title,
+            icon = R.drawable.woopos_ic_get_support,
+        ),
+        WooPosToolbarState.Menu.MenuItem.Standard(
+            title = R.string.woopos_exit_confirmation_title,
+            icon = R.drawable.ic_woo_pos_exit,
+        ),
+    )
 }

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -4279,6 +4279,7 @@
     <string name="woopos_cart_item_content_description">Product in cart %s, Price %s</string>
     <string name="woopos_cart_title">Cart</string>
     <string name="woopos_clear_cart_button">Clear</string>
+    <string name="woopos_payment_success_sound_setting_title">Cha-Ching Sound</string>
 
     <string name="woopos_banner_simple_products_only_title">Showing simple, variable and virtual products only</string>
     <string name="woopos_banner_simple_products_only_message">Only simple physical, variable and virtual products are compatible with POS right now. Other product types will become available in future updates. </string>

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/home/WooPosHomeViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/home/WooPosHomeViewModelTest.kt
@@ -2,6 +2,7 @@ package com.woocommerce.android.ui.woopos.home
 
 import androidx.arch.core.executor.testing.InstantTaskExecutorRule
 import androidx.lifecycle.SavedStateHandle
+import com.woocommerce.android.AppPrefsWrapper
 import com.woocommerce.android.R
 import com.woocommerce.android.ui.woopos.home.ParentToChildrenEvent.OrderSuccessfullyPaid.PaymentMethod
 import com.woocommerce.android.ui.woopos.home.WooPosHomeUIEvent.ExitPosClicked
@@ -38,6 +39,7 @@ class WooPosHomeViewModelTest {
     private val parentToChildrenEventSender: WooPosParentToChildrenEventSender = mock()
     private val wooPosItemsNavigator: WooPosItemsNavigator = mock()
     private val analyticsTracker: WooPosAnalyticsTracker = mock()
+    private val appPrefsWrapper: AppPrefsWrapper = mock()
 
     @Test
     fun `given state checkout, when SystemBackClicked passed, then BackFromCheckoutToCartClicked event should be sent`() =
@@ -459,6 +461,7 @@ class WooPosHomeViewModelTest {
         parentToChildrenEventSender,
         wooPosItemsNavigator,
         analyticsTracker,
+        appPrefsWrapper = appPrefsWrapper,
         SavedStateHandle()
     )
 }

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/home/toolbar/WooPosToolbarViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/home/toolbar/WooPosToolbarViewModelTest.kt
@@ -1,6 +1,7 @@
 package com.woocommerce.android.ui.woopos.home.toolbar
 
 import app.cash.turbine.test
+import com.woocommerce.android.AppPrefsWrapper
 import com.woocommerce.android.AppUrls.WOO_POS_DOCUMENTATION_URL
 import com.woocommerce.android.R
 import com.woocommerce.android.cardreader.connection.CardReaderStatus
@@ -40,6 +41,7 @@ class WooPosToolbarViewModelTest {
     private val networkStatus: WooPosNetworkStatus = mock()
     private val resourceProvider: ResourceProvider = mock()
     private val analyticsTracker: WooPosAnalyticsTracker = mock()
+    private val appPrefsWrapper: AppPrefsWrapper = mock()
 
     @Test
     fun `given card reader status is NotConnected, when initialized, then state should be NotConnected`() = runTest {
@@ -87,15 +89,20 @@ class WooPosToolbarViewModelTest {
             .isEqualTo(
                 WooPosToolbarState.Menu.Visible(
                     listOf(
-                        WooPosToolbarState.Menu.MenuItem(
+                        WooPosToolbarState.Menu.MenuItem.Toggleable(
+                            title = R.string.woopos_payment_success_sound_setting_title,
+                            icon = R.drawable.woo_pos_info_ic,
+                            isToggled = false
+                        ),
+                        WooPosToolbarState.Menu.MenuItem.Standard(
                             title = R.string.woopos_documentation_title,
                             icon = R.drawable.woo_pos_info_ic,
                         ),
-                        WooPosToolbarState.Menu.MenuItem(
+                        WooPosToolbarState.Menu.MenuItem.Standard(
                             title = R.string.woopos_get_support_title,
                             icon = R.drawable.woopos_ic_get_support,
                         ),
-                        WooPosToolbarState.Menu.MenuItem(
+                        WooPosToolbarState.Menu.MenuItem.Standard(
                             title = R.string.woopos_exit_confirmation_title,
                             icon = R.drawable.ic_woo_pos_exit,
                         ),
@@ -136,7 +143,7 @@ class WooPosToolbarViewModelTest {
     fun `when MenuItemClicked with ExitPosClicked, then ExitPosClicked event should be sent`() = runTest {
         // GIVEN
         val viewModel = createViewModel()
-        val menuItem = WooPosToolbarState.Menu.MenuItem(
+        val menuItem = WooPosToolbarState.Menu.MenuItem.Standard(
             title = R.string.woopos_exit_confirmation_title,
             icon = R.drawable.ic_woo_pos_exit
         )
@@ -184,7 +191,7 @@ class WooPosToolbarViewModelTest {
 
         viewModel.onUiEvent(
             WooPosToolbarUIEvent.MenuItemClicked(
-                WooPosToolbarState.Menu.MenuItem(
+                WooPosToolbarState.Menu.MenuItem.Standard(
                     title = R.string.woopos_get_support_title,
                     icon = R.drawable.woopos_ic_get_support,
                 )
@@ -232,7 +239,7 @@ class WooPosToolbarViewModelTest {
     fun `when Documentation MenuItemClicked, then openUrlEvent should be emitted with proper url`() = runTest {
         // GIVEN
         val viewModel = createViewModel()
-        val menuItem = WooPosToolbarState.Menu.MenuItem(
+        val menuItem = WooPosToolbarState.Menu.MenuItem.Standard(
             title = R.string.woopos_documentation_title,
             icon = R.drawable.ic_help_24dp
         )
@@ -252,7 +259,7 @@ class WooPosToolbarViewModelTest {
     @Test
     fun `when get Support is clicked, then should track analytics event`() = runTest {
         val viewModel = createViewModel()
-        val menuItem = WooPosToolbarState.Menu.MenuItem(
+        val menuItem = WooPosToolbarState.Menu.MenuItem.Standard(
             title = R.string.woopos_get_support_title,
             icon = R.drawable.ic_help_24dp
         )
@@ -264,7 +271,7 @@ class WooPosToolbarViewModelTest {
     @Test
     fun `when View Documentation is clicked, then should track analytics event`() = runTest {
         val viewModel = createViewModel()
-        val menuItem = WooPosToolbarState.Menu.MenuItem(
+        val menuItem = WooPosToolbarState.Menu.MenuItem.Standard(
             title = R.string.woopos_documentation_title,
             icon = R.drawable.ic_info_outline_20dp
         )
@@ -276,7 +283,7 @@ class WooPosToolbarViewModelTest {
     @Test
     fun `when Exit menu item is clicked, then should track analytics event`() = runTest {
         val viewModel = createViewModel()
-        val menuItem = WooPosToolbarState.Menu.MenuItem(
+        val menuItem = WooPosToolbarState.Menu.MenuItem.Standard(
             title = R.string.woopos_exit_confirmation_title,
             icon = R.drawable.ic_woo_pos_exit
         )
@@ -292,5 +299,6 @@ class WooPosToolbarViewModelTest {
         networkStatus,
         resourceProvider,
         analyticsTracker,
+        appPrefsWrapper = appPrefsWrapper
     )
 }


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #13804 
<!-- Id number of the GitHub issue this PR addresses. -->

<!-- 
━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
🛠 Need an AI review?  
Add a comment: `@coderabbitai review`
━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
-->

**NOTE:** This PR depends on another parent PR. Please merge only after the parent PR has been merged.

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
This PR gives merchants an ability to enable/disable the Cha-Ching sound on successful payment. The option is preserved in shared preference and hence it is remembered until the user signs out or uninstalls the app. 

**NOTE:** Please note that the design and the placement of the setting is not optimal and needs design consideration before merging the code. I worked on this as a part of HACK week to demonstrate the feature. This can be merged only after we finalise the placement of the setting and designs.

### Steps to reproduce
<!-- Step-by-step testing instructions. For new user flows, consider instead stating the goal of the workflow and see if your PR reviewer can accomplish the workflow without specific steps! -->
1. Navigate to POS mode (more menu -> POS)
2. Ensure you see an option to enable/disable Cha-Ching sound from the popup menu 
3. Enable the setting and make sure you hear Cha-Ching sound on successful payment
4. Disable the setting and make sure you do not hear Cha-Ching sound on successful payment


### The tests that have been performed
<!-- To give the reviewer an idea of what could be missed in terms of testing -->
Tested above steps on both emulator and on tablet device

### Images/gif
<!-- Include before and after images or gifs when appropriate. -->

https://github.com/user-attachments/assets/7165c20c-66ea-4b0f-9f36-feba152bcd0c



- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.

## Reviewer (or Author, in the case of optional code reviews):

Please make sure these conditions are met before approving the PR, or request changes if the PR needs improvement:

- [ ] The PR is small and has a clear, single focus, or a valid explanation is provided in the description. If needed, please request to split it into smaller PRs.
- [ ] Ensure Adequate Unit Test Coverage: The changes are reasonably covered by unit tests or an explanation is provided in the PR description.
- [ ] Manual Testing: The author listed all the tests they ran, including smoke tests when needed (e.g., for refactorings). The reviewer confirmed that the PR works as expected on big (tablet) and small (phone) in case of UI changes, and no regressions are added.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->