### PR TITLE
[Woo POS] Larger bottom padding for the cash and receipts screens to avoid overlaping with gesture navigation bar 

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/cashpayment/WooPosCashPaymentScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/cashpayment/WooPosCashPaymentScreen.kt
@@ -182,11 +182,10 @@ private fun Collecting(
             },
             modifier = Modifier
                 .fillMaxWidth()
-                .padding(
-                    horizontal = WooPosSpacing.Medium.value,
-                    vertical = WooPosSpacing.Medium.value
-                )
+                .padding(WooPosSpacing.Medium.value)
         )
+
+        Spacer(modifier = Modifier.height(WooPosSpacing.Small.value))
     }
 }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/emailreceipt/WooPosEmailReceiptScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/emailreceipt/WooPosEmailReceiptScreen.kt
@@ -137,6 +137,8 @@ private fun EmailState(
                 .fillMaxWidth()
                 .padding(WooPosSpacing.Medium.value)
         )
+
+        Spacer(modifier = Modifier.height(WooPosSpacing.Small.value))
     }
 }
 


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Part: #13794 
<!-- Id number of the GitHub issue this PR addresses. -->

<!-- 
━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
🛠 Need an AI review?  
Add a comment: `@coderabbitai review`
━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
-->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
I accidentally merged the PR before pushing the commit - https://github.com/woocommerce/woocommerce-android/pull/13806

Therefore a seprate PR here. It adds larger bottom padding to the buttons on email and receipts screen, so they are not covered by overlay of the gesture navigation bar on the devices with this overlay

### Steps to reproduce
<!-- Step-by-step testing instructions. For new user flows, consider instead stating the goal of the workflow and see if your PR reviewer can accomplish the workflow without specific steps! -->
* Open cash and receipt screens
* Validate that the buttons there above the gesture navigation bar

### The tests that have been performed
<!-- To give the reviewer an idea of what could be missed in terms of testing -->
above

### Images/gif
<!-- Include before and after images or gifs when appropriate. -->
![image](https://github.com/user-attachments/assets/fedbf328-df9d-4fc7-975e-2958d6664710)
![image](https://github.com/user-attachments/assets/3f8fe91b-a47a-4e5c-9ea3-2867cbe27393)


- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.

## Reviewer (or Author, in the case of optional code reviews):

Please make sure these conditions are met before approving the PR, or request changes if the PR needs improvement:

- [x] The PR is small and has a clear, single focus, or a valid explanation is provided in the description. If needed, please request to split it into smaller PRs.
- [x] Ensure Adequate Unit Test Coverage: The changes are reasonably covered by unit tests or an explanation is provided in the PR description.
- [x] Manual Testing: The author listed all the tests they ran, including smoke tests when needed (e.g., for refactorings). The reviewer confirmed that the PR works as expected on big (tablet) and small (phone) in case of UI changes, and no regressions are added.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->