### PR TITLE
[Hack Week] Api Faker auto-completion

### DIFF
--- a/libs/apifaker/build.gradle
+++ b/libs/apifaker/build.gradle
@@ -44,6 +44,7 @@ dependencies {
     implementation(libs.google.gson)
 
     implementation(project(":libs:fluxc"))
+    implementation(project(":libs:fluxc-plugin"))
 
     implementation(libs.androidx.room.runtime)
     implementation(libs.androidx.room.ktx)

--- a/libs/apifaker/src/main/java/com/woocommerce/android/apifaker/AutoCompleteProvider.kt
+++ b/libs/apifaker/src/main/java/com/woocommerce/android/apifaker/AutoCompleteProvider.kt
@@ -10,8 +10,9 @@ import org.wordpress.android.fluxc.generated.endpoint.JPAPI
 import org.wordpress.android.fluxc.generated.endpoint.WOOCOMMERCE
 import org.wordpress.android.fluxc.generated.endpoint.WPAPI
 import java.lang.reflect.Modifier
+import javax.inject.Inject
 
-internal class AutoCompleteProvider {
+internal class AutoCompleteProvider @Inject constructor() {
     private val wpApiEndpointsList by lazy {
         getEndpointsFromClass(WPAPI::class.java, WPAPIEndpoint::class.java) { "/$urlV2" }
             .map { AutoCompleteSuggestion(it) } +
@@ -26,9 +27,11 @@ internal class AutoCompleteProvider {
         query: String
     ): List<AutoCompleteSuggestion> = withContext(Dispatchers.Default) {
         when (endpointType) {
-            ApiType.WPApi -> wpApiEndpointsList.filter { it.endpoint.contains(query) }
+            ApiType.WPApi -> wpApiEndpointsList
             else -> error("Not supported yet")
         }
+            .filter { it.endpoint.contains(query) && it.endpoint != query }
+            .take(10)
     }
 
     private inline fun <reified T : Any> getEndpointsFromClass(

--- a/libs/apifaker/src/main/java/com/woocommerce/android/apifaker/AutoCompleteProvider.kt
+++ b/libs/apifaker/src/main/java/com/woocommerce/android/apifaker/AutoCompleteProvider.kt
@@ -103,10 +103,14 @@ internal class AutoCompleteProvider @Inject constructor() {
             endpoint.startsWith(WOOCOMMERCE.reports.endpoint) -> pathV4Analytics
 
         endpoint.startsWith(WOOCOMMERCE.product_add_ons.endpoint) -> pathV1Addons
+
         endpoint.startsWith(WOOCOMMERCE.options.endpoint) ||
             endpoint.startsWith(WOOCOMMERCE.onboarding.endpoint) -> pathWcAdmin
 
         endpoint.startsWith(WOOCOMMERCE.tracker.endpoint) -> pathWcTelemetry
+
+        endpoint.startsWith(WOOCOMMERCE.connect.endpoint) -> pathV1
+
         else -> pathV3
     }
 

--- a/libs/apifaker/src/main/java/com/woocommerce/android/apifaker/AutoCompleteProvider.kt
+++ b/libs/apifaker/src/main/java/com/woocommerce/android/apifaker/AutoCompleteProvider.kt
@@ -6,9 +6,13 @@ import kotlinx.coroutines.withContext
 import org.wordpress.android.fluxc.annotations.endpoint.JPAPIEndpoint
 import org.wordpress.android.fluxc.annotations.endpoint.WCWPAPIEndpoint
 import org.wordpress.android.fluxc.annotations.endpoint.WPAPIEndpoint
+import org.wordpress.android.fluxc.annotations.endpoint.WPComEndpoint
+import org.wordpress.android.fluxc.annotations.endpoint.WPComV2Endpoint
 import org.wordpress.android.fluxc.generated.endpoint.JPAPI
 import org.wordpress.android.fluxc.generated.endpoint.WOOCOMMERCE
 import org.wordpress.android.fluxc.generated.endpoint.WPAPI
+import org.wordpress.android.fluxc.generated.endpoint.WPCOMREST
+import org.wordpress.android.fluxc.generated.endpoint.WPCOMV2
 import java.lang.reflect.Modifier
 import javax.inject.Inject
 
@@ -22,13 +26,23 @@ internal class AutoCompleteProvider @Inject constructor() {
                 .map { AutoCompleteSuggestion(it) }
     }
 
+    private val wpComEndpointsList by lazy {
+        fun String.excludingWPComPrefix() = replace(WPCOM_PREFIX, "")
+
+        getEndpointsFromClass(WPCOMREST::class.java, WPComEndpoint::class.java) { urlV1_1.excludingWPComPrefix() }
+            .map { AutoCompleteSuggestion(it, isNameSpaceConfirmed = false) } +
+            getEndpointsFromClass(WPCOMV2::class.java, WPComV2Endpoint::class.java) { url.excludingWPComPrefix() }
+                .map { AutoCompleteSuggestion(it) }
+    }
+
     suspend fun provideAutoCompleteSuggestions(
         endpointType: ApiType,
         query: String
     ): List<AutoCompleteSuggestion> = withContext(Dispatchers.Default) {
         when (endpointType) {
             ApiType.WPApi -> wpApiEndpointsList
-            else -> error("Not supported yet")
+            ApiType.WPCom -> wpComEndpointsList
+            else -> emptyList()
         }
             .filter { it.endpoint.contains(query) && it.endpoint != query }
             .take(10)
@@ -99,6 +113,7 @@ internal class AutoCompleteProvider @Inject constructor() {
     companion object {
         private const val STRING_PLACEHOLDER = "string"
         private const val INT_PLACEHOLDER = 999
+        private const val WPCOM_PREFIX = "https://public-api.wordpress.com"
     }
 }
 

--- a/libs/apifaker/src/main/java/com/woocommerce/android/apifaker/AutoCompleteProvider.kt
+++ b/libs/apifaker/src/main/java/com/woocommerce/android/apifaker/AutoCompleteProvider.kt
@@ -45,7 +45,7 @@ internal class AutoCompleteProvider @Inject constructor() {
             else -> emptyList()
         }
             .filter { it.endpoint.contains(query) && it.endpoint != query }
-            .take(10)
+            .take(SUGGESTIONS_LIMIT)
     }
 
     private inline fun <reified T : Any> getEndpointsFromClass(
@@ -64,7 +64,7 @@ internal class AutoCompleteProvider @Inject constructor() {
             .map { it.replace(STRING_PLACEHOLDER, "%").replace("$INT_PLACEHOLDER", "%") }
     }
 
-    @Suppress("UNCHECKED_CAST")
+    @Suppress("UNCHECKED_CAST", "SpreadOperator")
     private fun <T : Any> T.getNestedEndpoints(
         endpointTypeClass: Class<T>,
         currentClass: Class<*>
@@ -111,6 +111,7 @@ internal class AutoCompleteProvider @Inject constructor() {
     }
 
     companion object {
+        private const val SUGGESTIONS_LIMIT = 10
         private const val STRING_PLACEHOLDER = "string"
         private const val INT_PLACEHOLDER = 999
         private const val WPCOM_PREFIX = "https://public-api.wordpress.com"

--- a/libs/apifaker/src/main/java/com/woocommerce/android/apifaker/AutoCompleteProvider.kt
+++ b/libs/apifaker/src/main/java/com/woocommerce/android/apifaker/AutoCompleteProvider.kt
@@ -1,0 +1,105 @@
+package com.woocommerce.android.apifaker
+
+import com.woocommerce.android.apifaker.models.ApiType
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+import org.wordpress.android.fluxc.annotations.endpoint.JPAPIEndpoint
+import org.wordpress.android.fluxc.annotations.endpoint.WCWPAPIEndpoint
+import org.wordpress.android.fluxc.annotations.endpoint.WPAPIEndpoint
+import org.wordpress.android.fluxc.generated.endpoint.JPAPI
+import org.wordpress.android.fluxc.generated.endpoint.WOOCOMMERCE
+import org.wordpress.android.fluxc.generated.endpoint.WPAPI
+import java.lang.reflect.Modifier
+
+internal class AutoCompleteProvider {
+    private val wpApiEndpointsList by lazy {
+        getEndpointsFromClass(WPAPI::class.java, WPAPIEndpoint::class.java) { "/$urlV2" }
+            .map { AutoCompleteSuggestion(it) } +
+            getEndpointsFromClass(WOOCOMMERCE::class.java, WCWPAPIEndpoint::class.java) { findBestUrl() }
+                .map { AutoCompleteSuggestion(it, isNameSpaceConfirmed = false) } +
+            getEndpointsFromClass(JPAPI::class.java, JPAPIEndpoint::class.java) { pathV4 }
+                .map { AutoCompleteSuggestion(it) }
+    }
+
+    suspend fun provideAutoCompleteSuggestions(
+        endpointType: ApiType,
+        query: String
+    ): List<AutoCompleteSuggestion> = withContext(Dispatchers.Default) {
+        when (endpointType) {
+            ApiType.WPApi -> wpApiEndpointsList.filter { it.endpoint.contains(query) }
+            else -> error("Not supported yet")
+        }
+    }
+
+    private inline fun <reified T : Any> getEndpointsFromClass(
+        clazz: Class<*>,
+        fieldClazz: Class<T>,
+        noinline urlGetter: T.() -> String
+    ): List<String> {
+        val endpoints = clazz.declaredFields
+            .filter {
+                Modifier.isStatic(it.modifiers) && fieldClazz.isAssignableFrom(it.type)
+            }
+            .map { Pair(it.get(null), it.type) }
+            .flatMap { (field, type) -> (field as T).getNestedEndpoints(T::class.java, type) + field }
+
+        return endpoints.map { it.urlGetter() }
+            .map { it.replace(STRING_PLACEHOLDER, "%").replace("$INT_PLACEHOLDER", "%") }
+    }
+
+    @Suppress("UNCHECKED_CAST")
+    private fun <T : Any> T.getNestedEndpoints(
+        endpointTypeClass: Class<T>,
+        currentClass: Class<*>
+    ): List<T> {
+        val fieldEndpoints = currentClass.declaredFields
+            .filter { endpointTypeClass.isAssignableFrom(it.type) }
+            .map { it.get(this) as T }
+
+        val methodEndpoints = currentClass.declaredMethods
+            .filter { endpointTypeClass.isAssignableFrom(it.returnType) }
+            .map {
+                val args = it.parameters.map { param ->
+                    when (param.type) {
+                        String::class.java -> STRING_PLACEHOLDER
+                        Int::class.java, Long::class.java -> INT_PLACEHOLDER
+                        else -> error("Unsupported type: ${param.type}")
+                    }
+                } as List<Any>
+
+                it.invoke(this, *args.toTypedArray()) as T
+            }
+
+        return fieldEndpoints + methodEndpoints +
+            fieldEndpoints.flatMap { it.getNestedEndpoints(endpointTypeClass, it::class.java) } +
+            methodEndpoints.flatMap { it.getNestedEndpoints(endpointTypeClass, it::class.java) }
+    }
+
+    /**
+     * Try to find the best namespace for the given endpoint.
+     *
+     * This is not perfect, but it should offer better suggestions than just using pathV3 by default.
+     */
+    private fun WCWPAPIEndpoint.findBestUrl(): String = when {
+        endpoint.startsWith(WOOCOMMERCE.leaderboards.endpoint) ||
+            endpoint.startsWith(WOOCOMMERCE.admin.endpoint) ||
+            endpoint.startsWith(WOOCOMMERCE.reports.endpoint) -> pathV4Analytics
+
+        endpoint.startsWith(WOOCOMMERCE.product_add_ons.endpoint) -> pathV1Addons
+        endpoint.startsWith(WOOCOMMERCE.options.endpoint) ||
+            endpoint.startsWith(WOOCOMMERCE.onboarding.endpoint) -> pathWcAdmin
+
+        endpoint.startsWith(WOOCOMMERCE.tracker.endpoint) -> pathWcTelemetry
+        else -> pathV3
+    }
+
+    companion object {
+        private const val STRING_PLACEHOLDER = "string"
+        private const val INT_PLACEHOLDER = 999
+    }
+}
+
+data class AutoCompleteSuggestion(
+    val endpoint: String,
+    val isNameSpaceConfirmed: Boolean = true
+)

--- a/libs/apifaker/src/main/java/com/woocommerce/android/apifaker/EndpointProcessor.kt
+++ b/libs/apifaker/src/main/java/com/woocommerce/android/apifaker/EndpointProcessor.kt
@@ -75,7 +75,7 @@ internal class EndpointProcessor @Inject constructor(
             EndpointData(
                 apiType = ApiType.WPCom,
                 httpMethod = httpMethod,
-                path = url.encodedPath.substringAfter("/rest"),
+                path = url.encodedPath,
                 body = originalBody
             )
         }

--- a/libs/apifaker/src/main/java/com/woocommerce/android/apifaker/di/ApiFakerModule.kt
+++ b/libs/apifaker/src/main/java/com/woocommerce/android/apifaker/di/ApiFakerModule.kt
@@ -1,6 +1,7 @@
 package com.woocommerce.android.apifaker.di
 
 import android.content.Context
+import androidx.compose.material.SnackbarHostState
 import com.woocommerce.android.apifaker.ApiFakerConfig
 import com.woocommerce.android.apifaker.ApiFakerInterceptor
 import com.woocommerce.android.apifaker.EndpointProcessor
@@ -31,4 +32,8 @@ object ApiFakerModule {
         apiFakerConfig: ApiFakerConfig,
         endpointProcessor: EndpointProcessor
     ): Interceptor = ApiFakerInterceptor(apiFakerConfig, endpointProcessor)
+
+    @Provides
+    @Singleton
+    internal fun providesSnackbarHostState() = SnackbarHostState()
 }

--- a/libs/apifaker/src/main/java/com/woocommerce/android/apifaker/ui/ApiFakerNavHost.kt
+++ b/libs/apifaker/src/main/java/com/woocommerce/android/apifaker/ui/ApiFakerNavHost.kt
@@ -1,6 +1,8 @@
 package com.woocommerce.android.apifaker.ui
 
+import androidx.compose.material.SnackbarHostState
 import androidx.compose.runtime.Composable
+import androidx.compose.ui.platform.LocalContext
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.navigation.NavType
 import androidx.navigation.compose.NavHost
@@ -10,19 +12,29 @@ import androidx.navigation.navArgument
 import com.woocommerce.android.apifaker.ui.details.EndpointDetailsScreen
 import com.woocommerce.android.apifaker.ui.details.MISSING_ENDPOINT_ID
 import com.woocommerce.android.apifaker.ui.home.HomeScreen
+import dagger.hilt.EntryPoint
+import dagger.hilt.InstallIn
+import dagger.hilt.android.EntryPointAccessors
+import dagger.hilt.components.SingletonComponent
 
 @Composable
 fun ApiFakerNavHost(
     onExit: () -> Unit
 ) {
     val navController = rememberNavController()
+    val snackbarHostStateEntryPoint = SnackbarHostStateEntryPoint.create()
 
     NavHost(
         navController = navController,
         startDestination = Screen.Home.route()
     ) {
         composable(Screen.Home.route()) {
-            HomeScreen(viewModel = hiltViewModel(), navController = navController, onExit = onExit)
+            HomeScreen(
+                viewModel = hiltViewModel(),
+                navController = navController,
+                snackbarHostState = snackbarHostStateEntryPoint.snackbarHostState(),
+                onExit = onExit
+            )
         }
         composable(
             Screen.EndpointDetails.routeTemplate,
@@ -33,7 +45,29 @@ fun ApiFakerNavHost(
                 }
             )
         ) {
-            EndpointDetailsScreen(hiltViewModel(), navController)
+            EndpointDetailsScreen(
+                viewModel = hiltViewModel(),
+                navController = navController,
+                snackbarHostState = snackbarHostStateEntryPoint.snackbarHostState()
+            )
+        }
+    }
+}
+
+@EntryPoint
+@InstallIn(SingletonComponent::class)
+interface SnackbarHostStateEntryPoint {
+    fun snackbarHostState(): SnackbarHostState
+
+    companion object {
+        @Composable
+        fun create(): SnackbarHostStateEntryPoint {
+            val appContext = LocalContext.current.applicationContext ?: error("No context found")
+
+            return EntryPointAccessors.fromApplication(
+                appContext,
+                SnackbarHostStateEntryPoint::class.java
+            )
         }
     }
 }

--- a/libs/apifaker/src/main/java/com/woocommerce/android/apifaker/ui/details/EndpointDetailsScreen.kt
+++ b/libs/apifaker/src/main/java/com/woocommerce/android/apifaker/ui/details/EndpointDetailsScreen.kt
@@ -87,6 +87,7 @@ internal fun EndpointDetailsScreen(
         onApiTypeChanged = viewModel::onApiTypeChanged,
         onRequestHttpMethodChanged = viewModel::onRequestHttpMethodChanged,
         onRequestPathChanged = viewModel::onRequestPathChanged,
+        onSuggestionSelected = viewModel::onSuggestionSelected,
         onQueryParameterAdded = viewModel::onQueryParameterAdded,
         onQueryParameterDeleted = viewModel::onQueryParameterDeleted,
         onRequestBodyChanged = viewModel::onRequestBodyChanged,
@@ -104,6 +105,7 @@ private fun EndpointDetailsScreen(
     onApiTypeChanged: (ApiType) -> Unit = {},
     onRequestHttpMethodChanged: (HttpMethod?) -> Unit = {},
     onRequestPathChanged: (String) -> Unit = {},
+    onSuggestionSelected: (AutoCompleteSuggestion) -> Unit = {},
     onQueryParameterAdded: (String, String) -> Unit = { _, _ -> },
     onQueryParameterDeleted: (QueryParameter) -> Unit = {},
     onRequestBodyChanged: (String) -> Unit = {},
@@ -150,6 +152,7 @@ private fun EndpointDetailsScreen(
                 onApiTypeChanged = onApiTypeChanged,
                 onHttpMethodChanged = onRequestHttpMethodChanged,
                 onPathChanged = onRequestPathChanged,
+                onSuggestionSelected = onSuggestionSelected,
                 onQueryParameterAdded = onQueryParameterAdded,
                 onQueryParameterDeleted = onQueryParameterDeleted,
                 onBodyChanged = onRequestBodyChanged,
@@ -181,6 +184,7 @@ private fun RequestDefinitionSection(
     onApiTypeChanged: (ApiType) -> Unit,
     onHttpMethodChanged: (HttpMethod?) -> Unit,
     onPathChanged: (String) -> Unit,
+    onSuggestionSelected: (AutoCompleteSuggestion) -> Unit,
     onQueryParameterAdded: (String, String) -> Unit,
     onQueryParameterDeleted: (QueryParameter) -> Unit,
     onBodyChanged: (String) -> Unit,
@@ -211,6 +215,7 @@ private fun RequestDefinitionSection(
             apiType = request.type,
             autoCompleteSuggestions = autoCompleteSuggestions,
             onPathChanged = onPathChanged,
+            onSuggestionSelected = onSuggestionSelected,
             modifier = Modifier.fillMaxWidth()
         )
 
@@ -310,6 +315,7 @@ private fun PathField(
     apiType: ApiType,
     autoCompleteSuggestions: List<AutoCompleteSuggestion>,
     onPathChanged: (String) -> Unit,
+    onSuggestionSelected: (AutoCompleteSuggestion) -> Unit,
     modifier: Modifier = Modifier
 ) {
     Column(
@@ -327,7 +333,8 @@ private fun PathField(
                     onPathChanged(it)
                     expanded = true
                 },
-                modifier = Modifier.fillMaxWidth()
+                modifier = Modifier
+                    .fillMaxWidth()
                     .onGloballyPositioned {
                         fieldWidth = it.size.width
                     }
@@ -343,9 +350,12 @@ private fun PathField(
                     .width(with(LocalDensity.current) { fieldWidth.toDp() })
                     .heightIn(max = 200.dp)
             ) {
-                autoCompleteSuggestions.forEach {
-                    DropdownMenuItem(onClick = { TODO() }) {
-                        Text(text = it.endpoint)
+                autoCompleteSuggestions.forEach { suggestion ->
+                    DropdownMenuItem(onClick = {
+                        onSuggestionSelected(suggestion)
+                        expanded = false
+                    }) {
+                        Text(text = suggestion.endpoint)
                     }
                 }
             }

--- a/libs/apifaker/src/main/java/com/woocommerce/android/apifaker/ui/details/EndpointDetailsScreen.kt
+++ b/libs/apifaker/src/main/java/com/woocommerce/android/apifaker/ui/details/EndpointDetailsScreen.kt
@@ -30,6 +30,8 @@ import androidx.compose.material.LocalTextStyle
 import androidx.compose.material.MaterialTheme
 import androidx.compose.material.OutlinedTextField
 import androidx.compose.material.Scaffold
+import androidx.compose.material.SnackbarHost
+import androidx.compose.material.SnackbarHostState
 import androidx.compose.material.Surface
 import androidx.compose.material.Text
 import androidx.compose.material.TextButton
@@ -75,7 +77,8 @@ import kotlin.math.min
 @Composable
 internal fun EndpointDetailsScreen(
     viewModel: EndpointDetailsViewModel,
-    navController: NavController
+    navController: NavController,
+    snackbarHostState: SnackbarHostState
 ) {
     if (viewModel.state.isEndpointSaved) {
         navController.navigateUp()
@@ -85,6 +88,7 @@ internal fun EndpointDetailsScreen(
         state = viewModel.state,
         autoCompleteSuggestions = viewModel.autoCompleteSuggestions,
         navController = navController,
+        snackbarHostState = snackbarHostState,
         onSaveClicked = viewModel::onSaveClicked,
         onApiTypeChanged = viewModel::onApiTypeChanged,
         onRequestHttpMethodChanged = viewModel::onRequestHttpMethodChanged,
@@ -103,6 +107,7 @@ private fun EndpointDetailsScreen(
     state: EndpointDetailsViewModel.UiState,
     autoCompleteSuggestions: List<AutoCompleteSuggestion>,
     navController: NavController,
+    snackbarHostState: SnackbarHostState,
     onSaveClicked: () -> Unit = {},
     onApiTypeChanged: (ApiType) -> Unit = {},
     onRequestHttpMethodChanged: (HttpMethod?) -> Unit = {},
@@ -140,6 +145,9 @@ private fun EndpointDetailsScreen(
                 backgroundColor = MaterialTheme.colors.surface,
                 elevation = 4.dp
             )
+        },
+        snackbarHost = {
+            SnackbarHost(snackbarHostState)
         },
         backgroundColor = MaterialTheme.colors.surface
     ) { paddingValues ->
@@ -698,7 +706,8 @@ private fun EndpointDetailsScreenPreview() {
                 )
             ),
             autoCompleteSuggestions = emptyList(),
-            navController = rememberNavController()
+            navController = rememberNavController(),
+            snackbarHostState = SnackbarHostState()
         )
     }
 }

--- a/libs/apifaker/src/main/java/com/woocommerce/android/apifaker/ui/details/EndpointDetailsScreen.kt
+++ b/libs/apifaker/src/main/java/com/woocommerce/android/apifaker/ui/details/EndpointDetailsScreen.kt
@@ -51,9 +51,11 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.layout.onGloballyPositioned
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.text.SpanStyle
+import androidx.compose.ui.text.TextRange
 import androidx.compose.ui.text.buildAnnotatedString
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.input.KeyboardType
+import androidx.compose.ui.text.input.TextFieldValue
 import androidx.compose.ui.text.withStyle
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
@@ -325,12 +327,17 @@ private fun PathField(
         Box {
             var expanded by remember { mutableStateOf(true) }
             var fieldWidth by remember { mutableIntStateOf(0) }
+            var textFieldValue by remember { mutableStateOf(TextFieldValue(path, TextRange(path.length))) }
+
+            // Update the field value with the last path
+            textFieldValue = textFieldValue.copy(text = path)
 
             OutlinedTextField(
                 label = { Text(text = "Path") },
-                value = path,
+                value = textFieldValue,
                 onValueChange = {
-                    onPathChanged(it)
+                    textFieldValue = it
+                    onPathChanged(it.text)
                     expanded = true
                 },
                 modifier = Modifier
@@ -353,6 +360,10 @@ private fun PathField(
                 autoCompleteSuggestions.forEach { suggestion ->
                     DropdownMenuItem(onClick = {
                         onSuggestionSelected(suggestion)
+                        textFieldValue = textFieldValue.copy(
+                            text = suggestion.endpoint,
+                            selection = TextRange(suggestion.endpoint.length)
+                        )
                         expanded = false
                     }) {
                         Text(text = suggestion.endpoint)

--- a/libs/apifaker/src/main/java/com/woocommerce/android/apifaker/ui/details/EndpointDetailsScreen.kt
+++ b/libs/apifaker/src/main/java/com/woocommerce/android/apifaker/ui/details/EndpointDetailsScreen.kt
@@ -374,15 +374,15 @@ private fun PathField(
 
         val prefix = when (apiType) {
             ApiType.WPApi -> "/wp-json"
-            ApiType.WPCom -> "/rest"
+            ApiType.WPCom -> "public-api.wordpress.com"
             is ApiType.Custom -> "host"
         }
         val caption = buildAnnotatedString {
-            append("Enter the path after the")
+            append("Enter the path after")
             withStyle(style = SpanStyle(fontWeight = FontWeight.Bold)) {
                 append(" $prefix ")
             }
-            append("part, without the query arguments")
+            append(", without the query arguments")
             append("\n")
             append("Use")
             withStyle(style = SpanStyle(fontWeight = FontWeight.Bold)) {

--- a/libs/apifaker/src/main/java/com/woocommerce/android/apifaker/ui/details/EndpointDetailsScreen.kt
+++ b/libs/apifaker/src/main/java/com/woocommerce/android/apifaker/ui/details/EndpointDetailsScreen.kt
@@ -2,12 +2,14 @@ package com.woocommerce.android.apifaker.ui.details
 
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.defaultMinSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.heightIn
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
@@ -19,6 +21,8 @@ import androidx.compose.material.ButtonDefaults
 import androidx.compose.material.Chip
 import androidx.compose.material.ChipDefaults
 import androidx.compose.material.Divider
+import androidx.compose.material.DropdownMenu
+import androidx.compose.material.DropdownMenuItem
 import androidx.compose.material.ExperimentalMaterialApi
 import androidx.compose.material.Icon
 import androidx.compose.material.IconButton
@@ -37,12 +41,15 @@ import androidx.compose.material.icons.filled.Add
 import androidx.compose.material.icons.filled.Delete
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableIntStateOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.layout.onGloballyPositioned
+import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.text.SpanStyle
 import androidx.compose.ui.text.buildAnnotatedString
 import androidx.compose.ui.text.font.FontWeight
@@ -51,8 +58,10 @@ import androidx.compose.ui.text.withStyle
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.window.Dialog
+import androidx.compose.ui.window.PopupProperties
 import androidx.navigation.NavController
 import androidx.navigation.compose.rememberNavController
+import com.woocommerce.android.apifaker.AutoCompleteSuggestion
 import com.woocommerce.android.apifaker.models.ApiType
 import com.woocommerce.android.apifaker.models.HttpMethod
 import com.woocommerce.android.apifaker.models.QueryParameter
@@ -72,6 +81,7 @@ internal fun EndpointDetailsScreen(
 
     EndpointDetailsScreen(
         state = viewModel.state,
+        autoCompleteSuggestions = viewModel.autoCompleteSuggestions,
         navController = navController,
         onSaveClicked = viewModel::onSaveClicked,
         onApiTypeChanged = viewModel::onApiTypeChanged,
@@ -88,6 +98,7 @@ internal fun EndpointDetailsScreen(
 @Composable
 private fun EndpointDetailsScreen(
     state: EndpointDetailsViewModel.UiState,
+    autoCompleteSuggestions: List<AutoCompleteSuggestion>,
     navController: NavController,
     onSaveClicked: () -> Unit = {},
     onApiTypeChanged: (ApiType) -> Unit = {},
@@ -135,6 +146,7 @@ private fun EndpointDetailsScreen(
         ) {
             RequestDefinitionSection(
                 request = state.request,
+                autoCompleteSuggestions = autoCompleteSuggestions,
                 onApiTypeChanged = onApiTypeChanged,
                 onHttpMethodChanged = onRequestHttpMethodChanged,
                 onPathChanged = onRequestPathChanged,
@@ -165,6 +177,7 @@ private fun EndpointDetailsScreen(
 @Composable
 private fun RequestDefinitionSection(
     request: Request,
+    autoCompleteSuggestions: List<AutoCompleteSuggestion>,
     onApiTypeChanged: (ApiType) -> Unit,
     onHttpMethodChanged: (HttpMethod?) -> Unit,
     onPathChanged: (String) -> Unit,
@@ -196,6 +209,7 @@ private fun RequestDefinitionSection(
         PathField(
             path = request.path,
             apiType = request.type,
+            autoCompleteSuggestions = autoCompleteSuggestions,
             onPathChanged = onPathChanged,
             modifier = Modifier.fillMaxWidth()
         )
@@ -289,10 +303,12 @@ private fun HttpMethodField(
     )
 }
 
+@OptIn(ExperimentalMaterialApi::class)
 @Composable
 private fun PathField(
     path: String,
     apiType: ApiType,
+    autoCompleteSuggestions: List<AutoCompleteSuggestion>,
     onPathChanged: (String) -> Unit,
     modifier: Modifier = Modifier
 ) {
@@ -300,12 +316,41 @@ private fun PathField(
         verticalArrangement = Arrangement.spacedBy(8.dp),
         modifier = modifier
     ) {
-        OutlinedTextField(
-            label = { Text(text = "Path") },
-            value = path,
-            onValueChange = onPathChanged,
-            modifier = Modifier.fillMaxWidth()
-        )
+        Box {
+            var expanded by remember { mutableStateOf(true) }
+            var fieldWidth by remember { mutableIntStateOf(0) }
+
+            OutlinedTextField(
+                label = { Text(text = "Path") },
+                value = path,
+                onValueChange = {
+                    onPathChanged(it)
+                    expanded = true
+                },
+                modifier = Modifier.fillMaxWidth()
+                    .onGloballyPositioned {
+                        fieldWidth = it.size.width
+                    }
+            )
+
+            DropdownMenu(
+                expanded = autoCompleteSuggestions.isNotEmpty() && expanded,
+                onDismissRequest = { expanded = false },
+                properties = PopupProperties(
+                    focusable = false
+                ),
+                modifier = Modifier
+                    .width(with(LocalDensity.current) { fieldWidth.toDp() })
+                    .heightIn(max = 200.dp)
+            ) {
+                autoCompleteSuggestions.forEach {
+                    DropdownMenuItem(onClick = { TODO() }) {
+                        Text(text = it.endpoint)
+                    }
+                }
+            }
+        }
+
         val prefix = when (apiType) {
             ApiType.WPApi -> "/wp-json"
             ApiType.WPCom -> "/rest"
@@ -631,6 +676,7 @@ private fun EndpointDetailsScreenPreview() {
                     body = ""
                 )
             ),
+            autoCompleteSuggestions = emptyList(),
             navController = rememberNavController()
         )
     }

--- a/libs/apifaker/src/main/java/com/woocommerce/android/apifaker/ui/details/EndpointDetailsViewModel.kt
+++ b/libs/apifaker/src/main/java/com/woocommerce/android/apifaker/ui/details/EndpointDetailsViewModel.kt
@@ -21,7 +21,6 @@ import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.FlowPreview
 import kotlinx.coroutines.flow.debounce
 import kotlinx.coroutines.flow.drop
-import kotlinx.coroutines.flow.filter
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.launch
 import javax.inject.Inject
@@ -58,9 +57,14 @@ internal class EndpointDetailsViewModel @Inject constructor(
     private suspend fun handleAutoCompleteSuggestions() {
         snapshotFlow { state.request.path }
             .drop(1)
-            .filter { it.length > 2 }
             .debounce(300.milliseconds)
-            .map { autoCompleteProvider.provideAutoCompleteSuggestions(state.request.type, it) }
+            .map { path ->
+                if (path.length > 2) {
+                    autoCompleteProvider.provideAutoCompleteSuggestions(state.request.type, path)
+                } else {
+                    emptyList()
+                }
+            }
             .collect { autoCompleteSuggestions = it }
     }
 

--- a/libs/apifaker/src/main/java/com/woocommerce/android/apifaker/ui/details/EndpointDetailsViewModel.kt
+++ b/libs/apifaker/src/main/java/com/woocommerce/android/apifaker/ui/details/EndpointDetailsViewModel.kt
@@ -3,7 +3,6 @@ package com.woocommerce.android.apifaker.ui.details
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.setValue
-import androidx.compose.runtime.snapshots.Snapshot.Companion.withMutableSnapshot
 import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
@@ -37,60 +36,44 @@ internal class EndpointDetailsViewModel @Inject constructor(
     }
 
     fun onApiTypeChanged(apiType: ApiType) {
-        withMutableSnapshot {
-            state = state.copy(request = state.request.copy(type = apiType))
-        }
+        state = state.copy(request = state.request.copy(type = apiType))
     }
 
     fun onRequestHttpMethodChanged(httpMethod: HttpMethod?) {
-        withMutableSnapshot {
-            state = state.copy(request = state.request.copy(httpMethod = httpMethod))
-        }
+        state = state.copy(request = state.request.copy(httpMethod = httpMethod))
     }
 
     fun onRequestPathChanged(path: String) {
-        withMutableSnapshot {
-            state = state.copy(request = state.request.copy(path = path))
-        }
+        state = state.copy(request = state.request.copy(path = path))
     }
 
     fun onQueryParameterAdded(name: String, value: String) {
         val queryParameter = QueryParameter(name, value)
-        withMutableSnapshot {
-            state = state.copy(
-                request = state.request.copy(
-                    queryParameters = state.request.queryParameters + queryParameter
-                )
+        state = state.copy(
+            request = state.request.copy(
+                queryParameters = state.request.queryParameters + queryParameter
             )
-        }
+        )
     }
 
     fun onQueryParameterDeleted(queryParameter: QueryParameter) {
-        withMutableSnapshot {
-            state = state.copy(
-                request = state.request.copy(
-                    queryParameters = state.request.queryParameters - queryParameter
-                )
+        state = state.copy(
+            request = state.request.copy(
+                queryParameters = state.request.queryParameters - queryParameter
             )
-        }
+        )
     }
 
     fun onRequestBodyChanged(body: String) {
-        withMutableSnapshot {
-            state = state.copy(request = state.request.copy(body = body.ifEmpty { null }))
-        }
+        state = state.copy(request = state.request.copy(body = body.ifEmpty { null }))
     }
 
     fun onResponseStatusCodeChanged(statusCode: Int) {
-        withMutableSnapshot {
-            state = state.copy(response = state.response.copy(statusCode = statusCode))
-        }
+        state = state.copy(response = state.response.copy(statusCode = statusCode))
     }
 
     fun onResponseBodyChanged(body: String) {
-        withMutableSnapshot {
-            state = state.copy(response = state.response.copy(body = body))
-        }
+        state = state.copy(response = state.response.copy(body = body))
     }
 
     fun onSaveClicked() {

--- a/libs/apifaker/src/main/java/com/woocommerce/android/apifaker/ui/details/EndpointDetailsViewModel.kt
+++ b/libs/apifaker/src/main/java/com/woocommerce/android/apifaker/ui/details/EndpointDetailsViewModel.kt
@@ -3,9 +3,12 @@ package com.woocommerce.android.apifaker.ui.details
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.setValue
+import androidx.compose.runtime.snapshotFlow
 import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import com.woocommerce.android.apifaker.AutoCompleteProvider
+import com.woocommerce.android.apifaker.AutoCompleteSuggestion
 import com.woocommerce.android.apifaker.db.EndpointDao
 import com.woocommerce.android.apifaker.models.ApiType
 import com.woocommerce.android.apifaker.models.HttpMethod
@@ -14,25 +17,51 @@ import com.woocommerce.android.apifaker.models.Request
 import com.woocommerce.android.apifaker.models.Response
 import com.woocommerce.android.apifaker.ui.Screen
 import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.FlowPreview
+import kotlinx.coroutines.flow.debounce
+import kotlinx.coroutines.flow.drop
+import kotlinx.coroutines.flow.filter
+import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.launch
 import javax.inject.Inject
+import kotlin.time.Duration.Companion.milliseconds
 
 const val MISSING_ENDPOINT_ID = 0L
 
 @HiltViewModel
 internal class EndpointDetailsViewModel @Inject constructor(
     savedStateHandle: SavedStateHandle,
-    private val endpointDao: EndpointDao
+    private val endpointDao: EndpointDao,
+    private val autoCompleteProvider: AutoCompleteProvider
 ) : ViewModel() {
     private val id = checkNotNull(savedStateHandle.get<Long>(Screen.EndpointDetails.endpointIdArgumentName))
 
     var state: UiState by mutableStateOf(defaultEndpoint())
         private set
 
+    var autoCompleteSuggestions by mutableStateOf(emptyList<AutoCompleteSuggestion>())
+        private set
+
+    private var isLastSuggestionApplied: Boolean = false
+
     init {
-        if (id != MISSING_ENDPOINT_ID && state.request.id == MISSING_ENDPOINT_ID) {
-            loadEndpoint()
+        viewModelScope.launch {
+            if (id != MISSING_ENDPOINT_ID && state.request.id == MISSING_ENDPOINT_ID) {
+                loadEndpoint()
+            }
+
+            handleAutoCompleteSuggestions()
         }
+    }
+
+    @OptIn(FlowPreview::class)
+    private suspend fun handleAutoCompleteSuggestions() {
+        snapshotFlow { state.request.path }
+            .drop(1)
+            .filter { !isLastSuggestionApplied && it.length > 2 }
+            .debounce(300.milliseconds)
+            .map { autoCompleteProvider.provideAutoCompleteSuggestions(state.request.type, it) }
+            .collect { autoCompleteSuggestions = it }
     }
 
     fun onApiTypeChanged(apiType: ApiType) {
@@ -44,6 +73,8 @@ internal class EndpointDetailsViewModel @Inject constructor(
     }
 
     fun onRequestPathChanged(path: String) {
+        // Reset the flag when the path is changed by the user
+        isLastSuggestionApplied = false
         state = state.copy(request = state.request.copy(path = path))
     }
 
@@ -83,7 +114,7 @@ internal class EndpointDetailsViewModel @Inject constructor(
         }
     }
 
-    private fun loadEndpoint() = viewModelScope.launch {
+    private suspend fun loadEndpoint() {
         state = endpointDao.getEndpoint(id)!!.let {
             UiState(
                 it.request,

--- a/libs/apifaker/src/main/java/com/woocommerce/android/apifaker/ui/details/EndpointDetailsViewModel.kt
+++ b/libs/apifaker/src/main/java/com/woocommerce/android/apifaker/ui/details/EndpointDetailsViewModel.kt
@@ -42,8 +42,6 @@ internal class EndpointDetailsViewModel @Inject constructor(
     var autoCompleteSuggestions by mutableStateOf(emptyList<AutoCompleteSuggestion>())
         private set
 
-    private var isLastSuggestionApplied: Boolean = false
-
     init {
         viewModelScope.launch {
             if (id != MISSING_ENDPOINT_ID && state.request.id == MISSING_ENDPOINT_ID) {
@@ -58,7 +56,7 @@ internal class EndpointDetailsViewModel @Inject constructor(
     private suspend fun handleAutoCompleteSuggestions() {
         snapshotFlow { state.request.path }
             .drop(1)
-            .filter { !isLastSuggestionApplied && it.length > 2 }
+            .filter { it.length > 2 }
             .debounce(300.milliseconds)
             .map { autoCompleteProvider.provideAutoCompleteSuggestions(state.request.type, it) }
             .collect { autoCompleteSuggestions = it }
@@ -73,9 +71,13 @@ internal class EndpointDetailsViewModel @Inject constructor(
     }
 
     fun onRequestPathChanged(path: String) {
-        // Reset the flag when the path is changed by the user
-        isLastSuggestionApplied = false
         state = state.copy(request = state.request.copy(path = path))
+    }
+
+    fun onSuggestionSelected(suggestion: AutoCompleteSuggestion) {
+        state = state.copy(request = state.request.copy(path = suggestion.endpoint))
+
+        // TODO handle the isNameSpaceConfirmed flag
     }
 
     fun onQueryParameterAdded(name: String, value: String) {

--- a/libs/apifaker/src/main/java/com/woocommerce/android/apifaker/ui/details/EndpointDetailsViewModel.kt
+++ b/libs/apifaker/src/main/java/com/woocommerce/android/apifaker/ui/details/EndpointDetailsViewModel.kt
@@ -1,5 +1,6 @@
 package com.woocommerce.android.apifaker.ui.details
 
+import androidx.compose.material.SnackbarHostState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.setValue
@@ -32,7 +33,8 @@ const val MISSING_ENDPOINT_ID = 0L
 internal class EndpointDetailsViewModel @Inject constructor(
     savedStateHandle: SavedStateHandle,
     private val endpointDao: EndpointDao,
-    private val autoCompleteProvider: AutoCompleteProvider
+    private val autoCompleteProvider: AutoCompleteProvider,
+    private val snackbarHostState: SnackbarHostState
 ) : ViewModel() {
     private val id = checkNotNull(savedStateHandle.get<Long>(Screen.EndpointDetails.endpointIdArgumentName))
 

--- a/libs/apifaker/src/main/java/com/woocommerce/android/apifaker/ui/details/EndpointDetailsViewModel.kt
+++ b/libs/apifaker/src/main/java/com/woocommerce/android/apifaker/ui/details/EndpointDetailsViewModel.kt
@@ -79,7 +79,11 @@ internal class EndpointDetailsViewModel @Inject constructor(
     fun onSuggestionSelected(suggestion: AutoCompleteSuggestion) {
         state = state.copy(request = state.request.copy(path = suggestion.endpoint))
 
-        // TODO handle the isNameSpaceConfirmed flag
+        if (!suggestion.isNameSpaceConfirmed) {
+            viewModelScope.launch {
+                snackbarHostState.showSnackbar("Please verify and confirm that the suggested namespace is correct")
+            }
+        }
     }
 
     fun onQueryParameterAdded(name: String, value: String) {

--- a/libs/apifaker/src/main/java/com/woocommerce/android/apifaker/ui/home/HomeScreen.kt
+++ b/libs/apifaker/src/main/java/com/woocommerce/android/apifaker/ui/home/HomeScreen.kt
@@ -63,13 +63,14 @@ import com.woocommerce.android.apifaker.ui.Screen
 internal fun HomeScreen(
     viewModel: HomeViewModel,
     navController: NavController,
+    snackbarHostState: SnackbarHostState,
     onExit: () -> Unit
 ) {
     HomeScreen(
         endpoints = viewModel.endpoints.collectAsStateWithLifecycle().value,
         isEnabled = viewModel.isEnabled.collectAsState(initial = false).value,
         navController = navController,
-        snackbarHostState = viewModel.snackbarHostState,
+        snackbarHostState = snackbarHostState,
         onRemoveRequest = viewModel::onRemoveRequest,
         onMockingToggleChanged = viewModel::onMockingToggleChanged,
         onExportEndpoints = viewModel::onExportEndpoints,

--- a/libs/apifaker/src/main/java/com/woocommerce/android/apifaker/ui/home/HomeViewModel.kt
+++ b/libs/apifaker/src/main/java/com/woocommerce/android/apifaker/ui/home/HomeViewModel.kt
@@ -20,15 +20,14 @@ import javax.inject.Inject
 internal class HomeViewModel @Inject constructor(
     private val endpointDao: EndpointDao,
     private val config: ApiFakerConfig,
-    private val endpointExportManager: EndpointExportManager
+    private val endpointExportManager: EndpointExportManager,
+    private val snackbarHostState: SnackbarHostState
 ) : ViewModel() {
     @Suppress("MagicNumber")
     val endpoints = endpointDao.observeEndpoints()
         .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5000), emptyList())
 
     val isEnabled = config.enabled
-
-    val snackbarHostState = SnackbarHostState()
 
     fun onMockingToggleChanged(enabled: Boolean) {
         viewModelScope.launch {

--- a/libs/apifaker/src/test/java/com/woocommerce/android/apifaker/AutoCompleteProviderTest.kt
+++ b/libs/apifaker/src/test/java/com/woocommerce/android/apifaker/AutoCompleteProviderTest.kt
@@ -1,0 +1,47 @@
+package com.woocommerce.android.apifaker
+
+import com.woocommerce.android.apifaker.models.ApiType
+import kotlinx.coroutines.test.runTest
+import org.junit.Test
+
+class AutoCompleteProviderTest {
+    @Test
+    fun `when looking for a suggestion, then return correct results`() = runTest {
+        val provider = AutoCompleteProvider()
+
+        val result = provider.provideAutoCompleteSuggestions(ApiType.WPApi, "products")
+
+        assert(result.isNotEmpty())
+        assert(result.all { it.endpoint.contains("products") })
+    }
+
+    @Test
+    fun `when getting WooCommerce suggestion, then mark namespace as not confirmed`() = runTest {
+        val provider = AutoCompleteProvider()
+
+        val result = provider.provideAutoCompleteSuggestions(ApiType.WPApi, "/wc/v3/")
+
+        assert(result.isNotEmpty())
+        assert(result.all { !it.isNameSpaceConfirmed })
+    }
+
+    @Test
+    fun `when getting WordPress suggestion, then mark namespace as confirmed`() = runTest {
+        val provider = AutoCompleteProvider()
+
+        val result = provider.provideAutoCompleteSuggestions(ApiType.WPApi, "/wp/v2/")
+
+        assert(result.isNotEmpty())
+        assert(result.all { it.isNameSpaceConfirmed })
+    }
+
+    @Test
+    fun `when getting Jetpack suggestion, then mark namespace as confirmed`() = runTest {
+        val provider = AutoCompleteProvider()
+
+        val result = provider.provideAutoCompleteSuggestions(ApiType.WPApi, "/jetpack/v4/")
+
+        assert(result.isNotEmpty())
+        assert(result.all { it.isNameSpaceConfirmed })
+    }
+}

--- a/libs/apifaker/src/test/java/com/woocommerce/android/apifaker/EndpointProcessorTest.kt
+++ b/libs/apifaker/src/test/java/com/woocommerce/android/apifaker/EndpointProcessorTest.kt
@@ -37,7 +37,7 @@ class EndpointProcessorTest {
         verify(endpointDaoMock).queryEndpoint(
             type = ApiType.WPCom,
             httpMethod = HttpMethod.GET,
-            path = "/v1.1/me",
+            path = "/rest/v1.1/me",
             body = ""
         )
     }
@@ -55,7 +55,7 @@ class EndpointProcessorTest {
         verify(endpointDaoMock).queryEndpoint(
             type = ApiType.WPCom,
             httpMethod = HttpMethod.POST,
-            path = "/v1.1/me",
+            path = "/rest/v1.1/me",
             body = body
         )
     }


### PR DESCRIPTION
### Description
This PR adds a basic auto-completion feature to the Api Faker tool, the suggestions are provided by parsing the endpoint definitions of `FluxC`.

**Important:** While working on this I noticed that the current implementation of the Api Faker doesn't allow faking WordPress.com's `wpcom/v2` endpoints, this is because I wrongly assumed all WPCom endpoints start with the `/rest` prefix, while it's not the case. This is not is fixed with the commit 410352a5a05715cc4e827b5fe1354a8e36087a90.
This means that any WPCom saved endpoints will stop working, as they need to be updated to include the `/rest` prefix. I don't think it's a big issue given this is a dev tool, let me know what you think.

### Steps to reproduce
1. Open the app and sign in if needed.
2. Open the settings.
3. Tap on Developer Options.
4. Tap on Api Faker.
5. Add a new endpoint.

### Testing information
- Start typing in the path field and confirm that a dropdown list is shown with suggestions matching the entered text.
- Repeat using different API types.
- Notice the Snackbar about confirming the namespace when tapping on a WooCommerce suggestion

### The tests that have been performed
<!-- To give the reviewer an idea of what could be missed in terms of testing -->

### Images/gif
https://github.com/user-attachments/assets/494cff35-c453-4f3c-8a8d-e52c26f0c305


- [ ] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.

## Reviewer (or Author, in the case of optional code reviews):

Please make sure these conditions are met before approving the PR, or request changes if the PR needs improvement:

- [ ] The PR is small and has a clear, single focus, or a valid explanation is provided in the description. If needed, please request to split it into smaller PRs.
- [ ] Ensure Adequate Unit Test Coverage: The changes are reasonably covered by unit tests or an explanation is provided in the PR description.
- [ ] Manual Testing: The author listed all the tests they ran, including smoke tests when needed (e.g., for refactorings). The reviewer confirmed that the PR works as expected on big (tablet) and small (phone) in case of UI changes, and no regressions are added.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->