### PR TITLE
Fix orders tracking

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/list/OrderListViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/list/OrderListViewModel.kt
@@ -624,18 +624,22 @@ class OrderListViewModel @Inject constructor(
             return
         }
 
-        launch {
-            val totalDurationInSeconds = event.duration.toDouble() / 1_000
-            val totalCompletedOrders = orderListRepository
-                .getCachedOrderStatusOptions()[CoreOrderStatus.COMPLETED.value]?.statusCount
-            AnalyticsTracker.track(
-                AnalyticsEvent.ORDERS_LIST_LOADED,
-                mapOf(
-                    AnalyticsTracker.KEY_TOTAL_DURATION to totalDurationInSeconds,
-                    AnalyticsTracker.KEY_STATUS to event.listDescriptor.statusFilter,
-                    AnalyticsTracker.KEY_TOTAL_COMPLETED_ORDERS to totalCompletedOrders
+        if (event.isError) {
+            AnalyticsTracker.track(AnalyticsEvent.ORDER_LIST_LOAD_ERROR)
+        } else {
+            launch {
+                val totalDurationInSeconds = event.duration.toDouble() / 1_000
+                val totalCompletedOrders = orderListRepository
+                    .getCachedOrderStatusOptions()[CoreOrderStatus.COMPLETED.value]?.statusCount
+                AnalyticsTracker.track(
+                    AnalyticsEvent.ORDERS_LIST_LOADED,
+                    mapOf(
+                        AnalyticsTracker.KEY_TOTAL_DURATION to totalDurationInSeconds,
+                        AnalyticsTracker.KEY_STATUS to event.listDescriptor.statusFilter,
+                        AnalyticsTracker.KEY_TOTAL_COMPLETED_ORDERS to totalCompletedOrders
+                    )
                 )
-            )
+            }
         }
     }
 

--- a/libs/fluxc-plugin/src/main/kotlin/org/wordpress/android/fluxc/store/WCOrderStore.kt
+++ b/libs/fluxc-plugin/src/main/kotlin/org/wordpress/android/fluxc/store/WCOrderStore.kt
@@ -367,8 +367,13 @@ class WCOrderStore @Inject constructor(
      */
     class OnOrderSummariesFetched(
         val listDescriptor: WCOrderListDescriptor,
-        val duration: Long
-    ) : OnChanged<OrderError>()
+        val duration: Long,
+        error: OrderError? = null
+    ) : OnChanged<OrderError>() {
+        init {
+            super.error = error
+        }
+    }
 
     class OnOrdersFetchedByIds(
         val site: SiteModel,
@@ -938,10 +943,16 @@ class WCOrderStore @Inject constructor(
 
             // Fetch outdated or missing orders
             fetchOutdatedOrMissingOrders(payload.listDescriptor.site, payload.orderSummaries)
-
-            val duration = Calendar.getInstance().timeInMillis - payload.requestStartTime.timeInMillis
-            emitChange(OnOrderSummariesFetched(listDescriptor = payload.listDescriptor, duration = duration))
         }
+
+        val duration = Calendar.getInstance().timeInMillis - payload.requestStartTime.timeInMillis
+        emitChange(
+            OnOrderSummariesFetched(
+                listDescriptor = payload.listDescriptor,
+                duration = duration,
+                error = payload.error
+            )
+        )
 
         mDispatcher.dispatch(ListActionBuilder.newFetchedListItemsAction(FetchedListItemsPayload(
             listDescriptor = payload.listDescriptor,

--- a/libs/fluxc-plugin/src/main/kotlin/org/wordpress/android/fluxc/store/WCOrderStore.kt
+++ b/libs/fluxc-plugin/src/main/kotlin/org/wordpress/android/fluxc/store/WCOrderStore.kt
@@ -15,12 +15,12 @@ import org.wordpress.android.fluxc.model.LocalOrRemoteId.LocalId
 import org.wordpress.android.fluxc.model.LocalOrRemoteId.RemoteId
 import org.wordpress.android.fluxc.model.OrderEntity
 import org.wordpress.android.fluxc.model.SiteModel
-import org.wordpress.android.fluxc.model.metadata.WCMetaData
 import org.wordpress.android.fluxc.model.WCOrderListDescriptor
 import org.wordpress.android.fluxc.model.WCOrderShipmentProviderModel
 import org.wordpress.android.fluxc.model.WCOrderShipmentTrackingModel
 import org.wordpress.android.fluxc.model.WCOrderStatusModel
 import org.wordpress.android.fluxc.model.WCOrderSummaryModel
+import org.wordpress.android.fluxc.model.metadata.WCMetaData
 import org.wordpress.android.fluxc.network.BaseRequest.BaseNetworkError
 import org.wordpress.android.fluxc.network.BaseRequest.GenericErrorType.SERVER_ERROR
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.WooError
@@ -42,6 +42,7 @@ import org.wordpress.android.fluxc.store.ListStore.OnListDataFailure
 import org.wordpress.android.fluxc.store.WCOrderStore.OrderErrorType.GENERIC_ERROR
 import org.wordpress.android.fluxc.store.WCOrderStore.OrderErrorType.PARSE_ERROR
 import org.wordpress.android.fluxc.store.WCOrderStore.OrderErrorType.TIMEOUT_ERROR
+import org.wordpress.android.fluxc.store.WCOrderStore.OrderErrorType.values
 import org.wordpress.android.fluxc.store.WCOrderStore.UpdateOrderResult.OptimisticUpdateResult
 import org.wordpress.android.fluxc.store.WCOrderStore.UpdateOrderResult.RemoteUpdateResult
 import org.wordpress.android.fluxc.store.WCOrderStore.UpdateOrdersStatusResult.FailedOrder
@@ -937,10 +938,10 @@ class WCOrderStore @Inject constructor(
 
             // Fetch outdated or missing orders
             fetchOutdatedOrMissingOrders(payload.listDescriptor.site, payload.orderSummaries)
-        }
 
-        val duration = Calendar.getInstance().timeInMillis - payload.requestStartTime.timeInMillis
-        emitChange(OnOrderSummariesFetched(listDescriptor = payload.listDescriptor, duration = duration))
+            val duration = Calendar.getInstance().timeInMillis - payload.requestStartTime.timeInMillis
+            emitChange(OnOrderSummariesFetched(listDescriptor = payload.listDescriptor, duration = duration))
+        }
 
         mDispatcher.dispatch(ListActionBuilder.newFetchedListItemsAction(FetchedListItemsPayload(
             listDescriptor = payload.listDescriptor,


### PR DESCRIPTION
### Description
While working on collecting some data about orders performance, I noticed that the `order_list_load_error` event is not  tracked correctly in Android. And looking at the code, I saw that the `orders_list_loaded` is tracked instead.

### Steps to reproduce
1. Use Api Faker to fake `/wc/v3/orders` or airplane mode.
2. Open the orders tab.
3. Pull to refresh.

### Testing information
- Confirm that `order_list_load_error` is tracked on errors.
- Confirm that `orders_list_loaded` still works when there are no errors.

### The tests that have been performed
^

- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.

## Reviewer (or Author, in the case of optional code reviews):

Please make sure these conditions are met before approving the PR, or request changes if the PR needs improvement:

- [ ] The PR is small and has a clear, single focus, or a valid explanation is provided in the description. If needed, please request to split it into smaller PRs.
- [ ] Ensure Adequate Unit Test Coverage: The changes are reasonably covered by unit tests or an explanation is provided in the PR description.
- [ ] Manual Testing: The author listed all the tests they ran, including smoke tests when needed (e.g., for refactorings). The reviewer confirmed that the PR works as expected on big (tablet) and small (phone) in case of UI changes, and no regressions are added.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->