### PR TITLE
[Konsist] Integration & Custom Tests

### DIFF
--- a/.buildkite/commands/run-unit-tests.sh
+++ b/.buildkite/commands/run-unit-tests.sh
@@ -10,7 +10,7 @@ bundle exec fastlane run configure_apply
 
 echo "--- 🧪 Testing"
 set +e
-./gradlew testJalapenoDebugUnitTest testDebugUnitTest
+./gradlew testJalapenoDebugUnitTest testDebugUnitTest -x libs:konsist-test:testDebugUnitTest
 TESTS_EXIT_STATUS=$?
 set -e
 

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -34,6 +34,13 @@ steps:
         agents:
           queue: "linter"
 
+      - label: "konsist"
+        command: ./gradlew konsist
+        plugins: [$CI_TOOLKIT]
+        artifact_paths:
+          - "**/build/reports/tests/**/*"
+          - "**/build/test-results/*/*.xml"
+
       - label: "detekt"
         command: ./gradlew detektAll
         plugins: [$CI_TOOLKIT]

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/cart/WooPosCartScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/cart/WooPosCartScreen.kt
@@ -25,9 +25,11 @@ import androidx.compose.foundation.lazy.LazyListState
 import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.Button
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
@@ -60,7 +62,6 @@ import com.woocommerce.android.R
 import com.woocommerce.android.extensions.isNotNullOrEmpty
 import com.woocommerce.android.ui.woopos.common.composeui.WooPosPreview
 import com.woocommerce.android.ui.woopos.common.composeui.component.ShadowType
-import com.woocommerce.android.ui.woopos.common.composeui.component.WooPosButton
 import com.woocommerce.android.ui.woopos.common.composeui.component.WooPosCard
 import com.woocommerce.android.ui.woopos.common.composeui.component.WooPosLazyColumn
 import com.woocommerce.android.ui.woopos.common.composeui.component.WooPosOutlinedButtonSmall
@@ -162,10 +163,13 @@ private fun WooPosCartScreen(
                     end.linkTo(parent.end)
                 }
         ) {
-            WooPosButton(
-                text = stringResource(R.string.woopos_checkout_button),
+            Button(
                 onClick = { onUIEvent(WooPosCartUIEvent.CheckoutClicked) }
-            )
+            ) {
+                Text(
+                    text = stringResource(R.string.woopos_checkout_button)
+                )
+            }
         }
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/cart/WooPosCartScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/cart/WooPosCartScreen.kt
@@ -74,9 +74,10 @@ import com.woocommerce.android.ui.woopos.common.composeui.designsystem.WooPosTyp
 import com.woocommerce.android.ui.woopos.common.composeui.designsystem.toAdaptivePadding
 
 @Composable
-fun WooPosCartScreen(modifier: Modifier = Modifier) {
-    val viewModel: WooPosCartViewModel = hiltViewModel()
-
+fun WooPosCartScreen(
+    modifier: Modifier = Modifier,
+    viewModel: WooPosCartViewModel = hiltViewModel()
+) {
     viewModel.state.observeAsState().value?.let {
         WooPosCartScreen(modifier, it, viewModel::onUIEvent)
     }

--- a/build.gradle
+++ b/build.gradle
@@ -82,6 +82,15 @@ dependencies {
     detektPlugins project(':libs:detektrules')
 }
 
+/* KONSIST */
+
+tasks.register("konsist") {
+    group = "verification"
+    description = "Runs Konsist static code analysis."
+
+    dependsOn(':libs:konsist-tests:testDebugUnitTest')
+}
+
 /* OTHER */
 
 tasks.register('clean', Delete) {

--- a/build.gradle
+++ b/build.gradle
@@ -57,6 +57,8 @@ allprojects {
     }
 }
 
+/* DETEKT */
+
 tasks.register("detektAll", Detekt) {
     description = "Custom DETEKT build for all modules"
     parallel = true
@@ -79,6 +81,8 @@ dependencies {
     detektPlugins(libs.detekt.formatting)
     detektPlugins project(':libs:detektrules')
 }
+
+/* OTHER */
 
 tasks.register('clean', Delete) {
     delete rootProject.layout.buildDirectory

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -81,6 +81,7 @@ jna = '5.5.0@aar'
 json-path = '2.9.0'
 junit = '4.13.2'
 lottie = '5.2.0'
+konsist = '0.17.3'
 kotlin = '2.1.10'
 kotlinx-coroutines = '1.8.1'
 ksp = '2.1.10-1.0.29'
@@ -242,6 +243,7 @@ jna = { module = "net.java.dev.jna:jna", version.ref = "jna" }
 json-path = { group = "com.jayway.jsonpath", name = "json-path", version.ref = "json-path" }
 junit = { group = "junit", name = "junit", version.ref = "junit" }
 lottie-compose = { group = "com.airbnb.android", name = "lottie-compose", version.ref = "lottie" }
+konsist = { module = "com.lemonappdev:konsist", version.ref = "konsist" }
 kotlin-test-junit = { group = "org.jetbrains.kotlin", name = "kotlin-test-junit", version.ref = "kotlin" }
 kotlinx-coroutines-android = { group = "org.jetbrains.kotlinx", name = "kotlinx-coroutines-android", version.ref = "kotlinx-coroutines" }
 kotlinx-coroutines-core = { group = "org.jetbrains.kotlinx", name = "kotlinx-coroutines-core", version.ref = "kotlinx-coroutines" }

--- a/libs/konsist-tests/build.gradle
+++ b/libs/konsist-tests/build.gradle
@@ -27,6 +27,16 @@ android {
 }
 
 dependencies {
+    implementation(libs.androidx.lifecycle.viewmodel.savedstate)
+    implementation(libs.androidx.appcompat)
+    implementation(libs.androidx.fragment.ktx)
+    implementation(libs.google.dagger.compiler)
+    implementation(libs.google.dagger.hilt.compiler)
+    implementation(libs.google.dagger.hilt.android.main)
+    implementation(libs.google.dagger.hilt.android.testing)
+    implementation(platform(libs.androidx.compose.bom))
+    implementation(libs.androidx.compose.ui.tooling.main)
+
     testImplementation(libs.junit)
     testImplementation(libs.konsist)
 }

--- a/libs/konsist-tests/build.gradle
+++ b/libs/konsist-tests/build.gradle
@@ -1,0 +1,37 @@
+import org.jetbrains.kotlin.gradle.dsl.JvmTarget
+
+plugins {
+    alias(libs.plugins.android.library)
+    alias(libs.plugins.kotlin.android)
+    alias(libs.plugins.dependency.analysis)
+}
+
+kotlin {
+    sourceCompatibility = JvmTarget.fromTarget(libs.versions.java.get()).target
+    targetCompatibility = JvmTarget.fromTarget(libs.versions.java.get()).target
+}
+
+android {
+    namespace 'com.woocommerce.android.konsist.tests'
+
+    compileOptions {
+        sourceCompatibility libs.versions.java.get()
+        targetCompatibility libs.versions.java.get()
+    }
+
+    defaultConfig {
+        minSdkVersion gradle.ext.minSdkVersion
+        targetSdkVersion gradle.ext.targetSdkVersion
+        compileSdk gradle.ext.compileSdkVersion
+    }
+}
+
+dependencies {
+    testImplementation(libs.junit)
+    testImplementation(libs.konsist)
+}
+
+// See: https://docs.konsist.lemonappdev.com/advanced/isolate-konsist-tests#solution-1-module-is-always-out-of-date
+tasks.withType(Test).configureEach {
+    outputs.upToDateWhen { false }
+}

--- a/libs/konsist-tests/src/test/java/com/woocommerce/android/konsist/test/KonsistAnnotationsTest.kt
+++ b/libs/konsist-tests/src/test/java/com/woocommerce/android/konsist/test/KonsistAnnotationsTest.kt
@@ -1,0 +1,32 @@
+package com.woocommerce.android.konsist.test
+
+import android.app.Application
+import androidx.fragment.app.Fragment
+import com.lemonappdev.konsist.api.Konsist
+import com.lemonappdev.konsist.api.ext.list.properties
+import com.lemonappdev.konsist.api.ext.list.withoutAllParentsNamed
+import com.lemonappdev.konsist.api.ext.list.withoutAllParentsOf
+import com.lemonappdev.konsist.api.ext.list.withoutAnnotationOf
+import com.lemonappdev.konsist.api.ext.list.withoutName
+import com.lemonappdev.konsist.api.ext.provider.hasAnnotationOf
+import com.lemonappdev.konsist.api.verify.assertFalse
+import dagger.hilt.android.AndroidEntryPoint
+import dagger.hilt.android.HiltAndroidApp
+import dagger.hilt.android.testing.HiltAndroidTest
+import org.junit.Test
+import javax.inject.Inject
+
+class KonsistAnnotationsTest {
+    @Test // Or suppress 'AppInitializer' class: @Suppress("konsist.no class should use field injection")
+    fun `no class should use field injection`() {
+        Konsist.scopeFromProject()
+            .classes()
+            .withoutAnnotationOf(HiltAndroidApp::class, AndroidEntryPoint::class, HiltAndroidTest::class)
+            .withoutAllParentsOf(Application::class)
+            .withoutAllParentsOf(Fragment::class)
+            .withoutAllParentsNamed("BaseFragment")
+            .withoutName("AppInitializer")
+            .properties()
+            .assertFalse { it.hasAnnotationOf<Inject>() }
+    }
+}

--- a/libs/konsist-tests/src/test/java/com/woocommerce/android/konsist/test/KonsistComposeTest.kt
+++ b/libs/konsist-tests/src/test/java/com/woocommerce/android/konsist/test/KonsistComposeTest.kt
@@ -1,0 +1,17 @@
+package com.woocommerce.android.konsist.test
+
+import androidx.compose.ui.tooling.preview.Preview
+import com.lemonappdev.konsist.api.Konsist
+import com.lemonappdev.konsist.api.ext.list.withAnnotationOf
+import com.lemonappdev.konsist.api.verify.assertTrue
+import org.junit.Test
+
+class KonsistComposeTest {
+    @Test
+    fun `all jetpack compose previews contain 'preview' in method name`() {
+        Konsist.scopeFromProject()
+            .functions()
+            .withAnnotationOf(Preview::class)
+            .assertTrue { it.hasNameContaining("Preview") }
+    }
+}

--- a/libs/konsist-tests/src/test/java/com/woocommerce/android/konsist/test/KonsistComposeTest.kt
+++ b/libs/konsist-tests/src/test/java/com/woocommerce/android/konsist/test/KonsistComposeTest.kt
@@ -1,11 +1,13 @@
 package com.woocommerce.android.konsist.test
 
+import androidx.compose.runtime.Composable
 import androidx.compose.ui.tooling.preview.Preview
 import com.lemonappdev.konsist.api.Konsist
 import com.lemonappdev.konsist.api.ext.list.withAnnotationOf
 import com.lemonappdev.konsist.api.verify.assertTrue
 import org.junit.Test
 
+@Suppress("MaxLineLength")
 class KonsistComposeTest {
     @Test
     fun `all jetpack compose previews contain 'preview' in method name`() {
@@ -13,5 +15,40 @@ class KonsistComposeTest {
             .functions()
             .withAnnotationOf(Preview::class)
             .assertTrue { it.hasNameContaining("Preview") }
+    }
+
+    /**
+     * [Composable Functions Best Practices ✅](https://github.com/woocommerce/woocommerce-android/blob/trunk/docs/compose.md#composable-functions-best-practices--)
+     *
+     * Don't acquire the viewModel inside a composable function, this will make testing harder. Inject it as a parameter
+     * and provide a default value to facilitate reusability:
+     *
+     * ❌
+     *
+     * ```
+     * @Composable
+     * fun MyComposable() {
+     * 	val viewModel by viewModel<MyViewModel>()
+     * 	...
+     * }
+     * ```
+     *
+     * ✅
+     *
+     * ```
+     * @Composable
+     * fun MyComposable(viewModel : MyViewModel = getViewModel()) {
+     * 	...
+     * }
+     * ```
+     */
+    @Test
+    fun `composable functions should not acquire view model directly`() {
+        Konsist.scopeFromProject()
+            .functions()
+            .withAnnotationOf(Composable::class)
+            .assertTrue { function ->
+                !function.text.contains("""(?i)val\s+\w*viewModel""".toRegex())
+            }
     }
 }

--- a/libs/konsist-tests/src/test/java/com/woocommerce/android/konsist/test/KonsistFieldsTest.kt
+++ b/libs/konsist-tests/src/test/java/com/woocommerce/android/konsist/test/KonsistFieldsTest.kt
@@ -1,0 +1,19 @@
+package com.woocommerce.android.konsist.test
+
+import com.lemonappdev.konsist.api.Konsist
+import com.lemonappdev.konsist.api.ext.list.properties
+import com.lemonappdev.konsist.api.verify.assertFalse
+import org.junit.Test
+
+class KonsistFieldsTest {
+    @Test
+    fun `no field should have 'm' prefix`() {
+        Konsist.scopeFromProject()
+            .classes()
+            .properties()
+            .assertFalse {
+                val secondCharacterIsUppercase = it.name.getOrNull(1)?.isUpperCase() ?: false
+                it.name.startsWith('m') && secondCharacterIsUppercase
+            }
+    }
+}

--- a/libs/konsist-tests/src/test/java/com/woocommerce/android/konsist/test/KonsistFilesTest.kt
+++ b/libs/konsist-tests/src/test/java/com/woocommerce/android/konsist/test/KonsistFilesTest.kt
@@ -1,0 +1,14 @@
+package com.woocommerce.android.konsist.test
+
+import com.lemonappdev.konsist.api.Konsist
+import com.lemonappdev.konsist.api.verify.assertFalse
+import org.junit.Test
+
+class KonsistFilesTest {
+    @Test
+    fun `no empty files allowed`() {
+        Konsist.scopeFromProject()
+            .files
+            .assertFalse { it.text.isEmpty() }
+    }
+}

--- a/libs/konsist-tests/src/test/java/com/woocommerce/android/konsist/test/KonsistFunctionsTest.kt
+++ b/libs/konsist-tests/src/test/java/com/woocommerce/android/konsist/test/KonsistFunctionsTest.kt
@@ -1,0 +1,25 @@
+package com.woocommerce.android.konsist.test
+
+import com.lemonappdev.konsist.api.Konsist
+import com.lemonappdev.konsist.api.ext.list.functions
+import com.lemonappdev.konsist.api.ext.list.returnTypes
+import com.lemonappdev.konsist.api.ext.list.withoutSourceSet
+import com.lemonappdev.konsist.api.verify.assertFalse
+import org.junit.Test
+
+class KonsistFunctionsTest {
+    @Test // Or suppress all files: @file:Suppress("konsist.return type of all functions are immutable")
+    fun `return type of all functions - expect in a test - are immutable`() {
+        Konsist.scopeFromProject()
+            .files
+            .filter { file ->
+                !file.path.contains("FlowExt.kt") &&
+                    !file.path.contains("LiveDataExt.kt") &&
+                    !file.path.contains("SavedStateFlow.kt")
+            }
+            .functions()
+            .returnTypes
+            .withoutSourceSet("test")
+            .assertFalse { it.isMutableType }
+    }
+}

--- a/libs/konsist-tests/src/test/java/com/woocommerce/android/konsist/test/KonsistGenericsTest.kt
+++ b/libs/konsist-tests/src/test/java/com/woocommerce/android/konsist/test/KonsistGenericsTest.kt
@@ -1,0 +1,21 @@
+package com.woocommerce.android.konsist.test
+
+import com.lemonappdev.konsist.api.Konsist
+import com.lemonappdev.konsist.api.ext.list.declaration.flatten
+import com.lemonappdev.konsist.api.ext.list.types
+import com.lemonappdev.konsist.api.verify.assertFalse
+import org.junit.Test
+
+class KonsistGenericsTest {
+    @Test
+    fun `property generic type does not contains star projection`() {
+        Konsist.scopeFromProduction()
+            .properties()
+            .types
+            .assertFalse { type ->
+                type.typeArguments
+                    ?.flatten()
+                    ?.any { it.isStarProjection }
+            }
+    }
+}

--- a/libs/konsist-tests/src/test/java/com/woocommerce/android/konsist/test/KonsistImportsTest.kt
+++ b/libs/konsist-tests/src/test/java/com/woocommerce/android/konsist/test/KonsistImportsTest.kt
@@ -1,0 +1,14 @@
+package com.woocommerce.android.konsist.test
+
+import com.lemonappdev.konsist.api.Konsist
+import com.lemonappdev.konsist.api.verify.assertFalse
+import org.junit.Test
+
+class KonsistImportsTest {
+    @Test // Detekt: WildcardImport (https://detekt.dev/docs/rules/style/#wildcardimport)
+    fun `no wildcard imports allowed`() {
+        Konsist.scopeFromProject()
+            .imports
+            .assertFalse { it.isWildcard }
+    }
+}

--- a/libs/konsist-tests/src/test/java/com/woocommerce/android/konsist/test/KonsistImportsTest.kt
+++ b/libs/konsist-tests/src/test/java/com/woocommerce/android/konsist/test/KonsistImportsTest.kt
@@ -1,14 +1,38 @@
 package com.woocommerce.android.konsist.test
 
 import com.lemonappdev.konsist.api.Konsist
+import com.lemonappdev.konsist.api.ext.list.imports
 import com.lemonappdev.konsist.api.verify.assertFalse
 import org.junit.Test
 
+@Suppress("MaxLineLength")
 class KonsistImportsTest {
     @Test // Detekt: WildcardImport (https://detekt.dev/docs/rules/style/#wildcardimport)
     fun `no wildcard imports allowed`() {
         Konsist.scopeFromProject()
             .imports
             .assertFalse { it.isWildcard }
+    }
+
+    @Test // Custom Detekt: WooPosDesignSystemButtonUsageRule (https://github.com/woocommerce/woocommerce-android/blob/trunk/libs/detektrules/src/main/kotlin/com/woocommerce/android/detektrules/woopos/WooPosDesignSystemButtonUsageRule.kt#L13)
+    fun `woopos package - no standard compose buttons imports allowed - use woopos button instead`() {
+        Konsist.scopeFromPackage("com.woocommerce.android.ui.woopos..")
+            .files
+            .filter { file ->
+                !file.path.contains("WooPosButtons.kt")
+            }
+            .imports
+            .assertFalse { it.hasNameMatching("""^androidx\.compose\.material3\.Button${'$'}""".toRegex()) }
+    }
+
+    @Test // Custom Detekt: WooPosDesignSystemTextUsageRule (https://github.com/woocommerce/woocommerce-android/blob/trunk/libs/detektrules/src/main/kotlin/com/woocommerce/android/detektrules/woopos/WooPosDesignSystemTextUsageRule.kt#L13)
+    fun `woopos package - no standard compose text imports allowed - use woopos text instead`() {
+        Konsist.scopeFromPackage("com.woocommerce.android.ui.woopos..")
+            .files
+            .filter { file ->
+                !file.path.contains("WooPosTexts.kt")
+            }
+            .imports
+            .assertFalse { it.hasNameMatching("""^androidx\.compose\.material3\.Text${'$'}""".toRegex()) }
     }
 }

--- a/libs/konsist-tests/src/test/java/com/woocommerce/android/konsist/test/KonsistLogsTest.kt
+++ b/libs/konsist-tests/src/test/java/com/woocommerce/android/konsist/test/KonsistLogsTest.kt
@@ -1,0 +1,26 @@
+package com.woocommerce.android.konsist.test
+
+import com.lemonappdev.konsist.api.Konsist
+import com.lemonappdev.konsist.api.ext.list.withoutSourceSet
+import com.lemonappdev.konsist.api.verify.assertFalse
+import org.junit.Test
+
+class KonsistLogsTest {
+    @Test
+    fun `no class should use java util logging`() {
+        Konsist.scopeFromProject()
+            .files
+            .assertFalse { it.hasImport { import -> import.name == "java.util.logging.." } }
+    }
+
+    @Test // Or suppress 'WooLog' file: @file:Suppress("konsist.return type of all functions are immutable")
+    fun `no class should use android util logging`() {
+        Konsist.scopeFromProject()
+            .files
+            .filter { file ->
+                !file.path.contains("WooLog.kt")
+            }
+            .withoutSourceSet("androidTest")
+            .assertFalse { it.hasImport { import -> import.name == "android.util.Log" } }
+    }
+}

--- a/libs/konsist-tests/src/test/java/com/woocommerce/android/konsist/test/KonsistNamingTest.kt
+++ b/libs/konsist-tests/src/test/java/com/woocommerce/android/konsist/test/KonsistNamingTest.kt
@@ -1,0 +1,46 @@
+package com.woocommerce.android.konsist.test
+
+import androidx.appcompat.app.AppCompatActivity
+import androidx.fragment.app.Fragment
+import androidx.lifecycle.ViewModel
+import com.lemonappdev.konsist.api.Konsist
+import com.lemonappdev.konsist.api.ext.list.withAllParentsNamed
+import com.lemonappdev.konsist.api.ext.list.withAllParentsOf
+import com.lemonappdev.konsist.api.verify.assertTrue
+import org.junit.Test
+
+class KonsistNamingTest {
+    @Test
+    fun `android activity class name ends with 'activity'`() {
+        Konsist.scopeFromProject()
+            .classes()
+            .withAllParentsOf(AppCompatActivity::class)
+            .assertTrue { it.name.endsWith("Activity") }
+    }
+
+    @Test
+    fun `android fragment class name ends with 'fragment'`() {
+        Konsist.scopeFromProject()
+            .classes()
+            .withAllParentsOf(Fragment::class)
+            .plus(
+                Konsist.scopeFromProject()
+                    .classes()
+                    .withAllParentsNamed("BaseFragment")
+            )
+            .assertTrue { it.name.endsWith("Fragment") }
+    }
+
+    @Test
+    fun `android view model class name ends with 'viewmodel'`() {
+        Konsist.scopeFromProject()
+            .classes()
+            .withAllParentsOf(ViewModel::class)
+            .plus(
+                Konsist.scopeFromProject()
+                    .classes()
+                    .withAllParentsNamed("ScopedViewModel")
+            )
+            .assertTrue { it.name.endsWith("ViewModel") }
+    }
+}

--- a/libs/konsist-tests/src/test/java/com/woocommerce/android/konsist/test/KonsistPackagesTest.kt
+++ b/libs/konsist-tests/src/test/java/com/woocommerce/android/konsist/test/KonsistPackagesTest.kt
@@ -1,0 +1,36 @@
+package com.woocommerce.android.konsist.test
+
+import com.lemonappdev.konsist.api.Konsist
+import com.lemonappdev.konsist.api.ext.list.withNameEndingWith
+import com.lemonappdev.konsist.api.ext.list.withPackage
+import com.lemonappdev.konsist.api.ext.list.withoutName
+import com.lemonappdev.konsist.api.ext.list.withoutSourceSet
+import com.lemonappdev.konsist.api.verify.assertTrue
+import org.junit.Test
+
+class KonsistPackagesTest {
+    @Test
+    fun `files in 'extensions' package must have name ending with 'ext'`() {
+        Konsist.scopeFromProject()
+            .files
+            .withPackage("..extensions..")
+            .withoutSourceSet("test")
+            .assertTrue { it.hasNameEndingWith("Ext") }
+    }
+
+    @Test // Detekt: InvalidPackageDeclaration (https://detekt.dev/docs/rules/naming/#invalidpackagedeclaration)
+    fun `package name must match file path`() {
+        Konsist.scopeFromProject()
+            .packages
+            .withoutName("org.wordpress.android.util.config")
+            .assertTrue { it.hasMatchingPath }
+    }
+
+    @Test
+    fun `classes with 'usecase' suffix should reside in 'usecases' package`() {
+        Konsist.scopeFromProject()
+            .classes()
+            .withNameEndingWith("UseCase")
+            .assertTrue { it.resideInPackage("..usecases..") }
+    }
+}

--- a/libs/konsist-tests/src/test/java/com/woocommerce/android/konsist/test/KonsistParametersTest.kt
+++ b/libs/konsist-tests/src/test/java/com/woocommerce/android/konsist/test/KonsistParametersTest.kt
@@ -1,0 +1,18 @@
+package com.woocommerce.android.konsist.test
+
+import com.lemonappdev.konsist.api.Konsist
+import com.lemonappdev.konsist.api.ext.list.modifierprovider.withValueModifier
+import com.lemonappdev.konsist.api.ext.list.primaryConstructors
+import com.lemonappdev.konsist.api.verify.assertTrue
+import org.junit.Test
+
+class KonsistParametersTest {
+    @Test
+    fun `every value class has parameter named 'value'`() {
+        Konsist.scopeFromProject()
+            .classes()
+            .withValueModifier()
+            .primaryConstructors
+            .assertTrue { it.hasParameterWithName("value") }
+    }
+}

--- a/libs/konsist-tests/src/test/java/com/woocommerce/android/konsist/test/KonsistPropertiesTest.kt
+++ b/libs/konsist-tests/src/test/java/com/woocommerce/android/konsist/test/KonsistPropertiesTest.kt
@@ -1,0 +1,38 @@
+package com.woocommerce.android.konsist.test
+
+import com.lemonappdev.konsist.api.Konsist
+import com.lemonappdev.konsist.api.declaration.KoFunctionDeclaration
+import com.lemonappdev.konsist.api.declaration.KoPropertyDeclaration
+import com.lemonappdev.konsist.api.ext.list.indexOfFirstInstance
+import com.lemonappdev.konsist.api.ext.list.indexOfLastInstance
+import com.lemonappdev.konsist.api.ext.list.withoutSourceSet
+import com.lemonappdev.konsist.api.verify.assertTrue
+import org.junit.Test
+
+class KonsistPropertiesTest {
+    @Test
+    fun `properties - expect in a test - are declared before functions`() {
+        Konsist.scopeFromProject()
+            .classes()
+            .withoutSourceSet("test")
+            .assertTrue {
+                val lastKoPropertyDeclarationIndex = it
+                    .declarations(
+                        includeNested = false,
+                        includeLocal = false,
+                    )
+                    .indexOfLastInstance<KoPropertyDeclaration>()
+                val firstKoFunctionDeclarationIndex = it
+                    .declarations(
+                        includeNested = false,
+                        includeLocal = false,
+                    )
+                    .indexOfFirstInstance<KoFunctionDeclaration>()
+                if (lastKoPropertyDeclarationIndex != -1 && firstKoFunctionDeclarationIndex != -1) {
+                    lastKoPropertyDeclarationIndex < firstKoFunctionDeclarationIndex
+                } else {
+                    true
+                }
+            }
+    }
+}

--- a/libs/konsist-tests/src/test/java/com/woocommerce/android/konsist/test/KonsistTestsTest.kt
+++ b/libs/konsist-tests/src/test/java/com/woocommerce/android/konsist/test/KonsistTestsTest.kt
@@ -1,0 +1,81 @@
+package com.woocommerce.android.konsist.test
+
+import androidx.lifecycle.ViewModel
+import com.lemonappdev.konsist.api.Konsist
+import com.lemonappdev.konsist.api.ext.list.withAllParentsNamed
+import com.lemonappdev.konsist.api.ext.list.withAllParentsOf
+import com.lemonappdev.konsist.api.ext.list.withName
+import com.lemonappdev.konsist.api.ext.list.withNameEndingWith
+import com.lemonappdev.konsist.api.ext.list.withoutName
+import com.lemonappdev.konsist.api.verify.assertTrue
+import org.junit.Test
+
+class KonsistTestsTest {
+    @Test // Or suppress 'ScopedViewModel' class: @Suppress("konsist.every view model class has test")
+    fun `every view model class has test`() {
+        Konsist.scopeFromProduction()
+            .classes()
+            .withAllParentsOf(ViewModel::class)
+            .plus(
+                Konsist.scopeFromProject()
+                    .classes()
+                    .withAllParentsNamed("ScopedViewModel")
+            )
+            .withoutName("ScopedViewModel")
+            .assertTrue { viewModelClass ->
+                Konsist.scopeFromProject()
+                    .classes()
+                    .withName("${viewModelClass.name}Test")
+                    .isNotEmpty()
+            }
+    }
+
+    @Test
+    fun `every use case class has test`() {
+        Konsist.scopeFromProduction()
+            .classes()
+            .withNameEndingWith("UseCase")
+            .assertTrue { useCaseClass ->
+                Konsist.scopeFromProject()
+                    .classes()
+                    .withName("${useCaseClass.name}Test")
+                    .isNotEmpty()
+            }
+    }
+
+    @Test
+    fun `every repository class has test`() {
+        Konsist.scopeFromProduction()
+            .classes()
+            .withNameEndingWith("Repository")
+            .assertTrue { repositoryClass ->
+                Konsist.scopeFromProject()
+                    .classes()
+                    .withName("${repositoryClass.name}Test")
+                    .isNotEmpty()
+            }
+    }
+
+    @Test
+    fun `test classes should have test subject named sut`() {
+        Konsist.scopeFromTest()
+            .classes()
+            .assertTrue {
+                val type = it.name.removeSuffix("Test")
+                val sut = it
+                    .properties()
+                    .firstOrNull { property -> property.name == "sut" }
+                sut != null && (sut.type?.name == type || sut.text.contains("$type("))
+            }
+    }
+
+    @Test
+    fun `classes with 'test' annotation should have 'test' suffix`() {
+        Konsist.scopeFromSourceSet("test")
+            .classes()
+            .filter {
+                it.functions().any { func -> func.hasAnnotationOf(Test::class) }
+            }
+            .assertTrue { it.hasNameEndingWith("Test") }
+    }
+}

--- a/libs/konsist-tests/src/test/java/com/woocommerce/android/konsist/test/KonsistUseCasesTest.kt
+++ b/libs/konsist-tests/src/test/java/com/woocommerce/android/konsist/test/KonsistUseCasesTest.kt
@@ -1,0 +1,21 @@
+package com.woocommerce.android.konsist.test
+
+import com.lemonappdev.konsist.api.Konsist
+import com.lemonappdev.konsist.api.ext.list.withNameEndingWith
+import com.lemonappdev.konsist.api.verify.assertTrue
+import org.junit.Test
+
+class KonsistUseCasesTest {
+    @Test
+    fun `classes with 'usecase' suffix should have single 'public operator' method named 'invoke'`() {
+        Konsist.scopeFromProject()
+            .classes()
+            .withNameEndingWith("UseCase")
+            .assertTrue {
+                val hasSingleInvokeOperatorMethod = it.hasFunction { function ->
+                    function.name == "invoke" && function.hasPublicOrDefaultModifier && function.hasOperatorModifier
+                }
+                hasSingleInvokeOperatorMethod && it.countFunctions { item -> item.hasPublicOrDefaultModifier } == 1
+            }
+    }
+}

--- a/settings.gradle
+++ b/settings.gradle
@@ -176,7 +176,7 @@ include ':libs:commons', ':libs:cardreader', ':libs:apifaker'
 include ':libs:fluxc', ':libs:fluxc-annotations', ':libs:fluxc-processor', ':libs:fluxc-plugin', ':libs:fluxc-tests'
 include ':libs:login'
 include ':WooCommerce', ':WooCommerce-Wear'
-include ':libs:detektrules'
+include ':libs:detektrules', ':libs:konsist-tests'
 
 gradle.ext.fluxCBinaryPath = "org.wordpress:fluxc"
 gradle.ext.fluxCWooCommercePluginBinaryPath = "org.wordpress.fluxc.plugins:woocommerce"


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

<!-- 
━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
🛠 Need an AI review?  
Add a comment: `@coderabbitai review`
━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
-->

---

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

`TODO`

---

### Testing information
<!-- This is your opportunity to break out individual scenarios that need testing (when necessary) and/or include a checklist for the reviewer to go through. Consider documenting the following from your own completed testing: devices used, alternate workflows, edge cases, affected areas, critical flows, areas not tested, and any remaining unknowns. Provide feedback on this new section of the PR template through Sept 30, 2024 to Apps Quality; additional context here: p91TBi-b8z-p2#comment-12036 -->

`TODO`

---

- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.

## Reviewer (or Author, in the case of optional code reviews):

Please make sure these conditions are met before approving the PR, or request changes if the PR needs improvement:

- [x] The PR is small and has a clear, single focus, or a valid explanation is provided in the description. If needed, please request to split it into smaller PRs.
- [x] Ensure Adequate Unit Test Coverage: The changes are reasonably covered by unit tests or an explanation is provided in the PR description.
- [x] Manual Testing: The author listed all the tests they ran, including smoke tests when needed (e.g., for refactorings). The reviewer confirmed that the PR works as expected on big (tablet) and small (phone) in case of UI changes, and no regressions are added.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->