### PR TITLE
[Hack Week] Support exporting/importing using the Clipboard in Api Faker

### DIFF
--- a/libs/apifaker/src/main/java/com/woocommerce/android/apifaker/EndpointExportManager.kt
+++ b/libs/apifaker/src/main/java/com/woocommerce/android/apifaker/EndpointExportManager.kt
@@ -15,7 +15,8 @@ import javax.inject.Inject
 internal class EndpointExportManager @Inject constructor(
     private val gson: Gson,
     private val endpointDao: EndpointDao,
-    private val context: Context
+    private val context: Context,
+    private val clipDataFactory: ClipDataFactory
 ) {
     suspend fun exportEndpoints(endpoints: List<MockedEndpoint>, destination: ExportImportDestination): Result<Unit> {
         return when (destination) {
@@ -47,7 +48,7 @@ internal class EndpointExportManager @Inject constructor(
 
             runCatching {
                 val json = gson.toJson(endpoints.copyWithoutIds())
-                clipboardManager.setPrimaryClip(ClipData.newPlainText("API Faker Endpoints", json))
+                clipboardManager.setPrimaryClip(clipDataFactory.createClipData(json))
             }
         }
     }
@@ -97,6 +98,12 @@ internal class EndpointExportManager @Inject constructor(
                 response = it.response.copy(endpointId = 0)
             )
         }
+    }
+}
+
+internal class ClipDataFactory @Inject constructor() {
+    fun createClipData(text: String): ClipData {
+        return ClipData.newPlainText("API Faker Endpoints", text)
     }
 }
 

--- a/libs/apifaker/src/main/java/com/woocommerce/android/apifaker/EndpointExportManager.kt
+++ b/libs/apifaker/src/main/java/com/woocommerce/android/apifaker/EndpointExportManager.kt
@@ -14,7 +14,7 @@ internal class EndpointExportManager @Inject constructor(
     private val endpointDao: EndpointDao,
     private val context: Context
 ) {
-    suspend fun exportEndpoints(
+    suspend fun exportEndpointsToFile(
         endpoints: List<MockedEndpoint>,
         uri: Uri
     ): Result<Unit> {
@@ -37,7 +37,7 @@ internal class EndpointExportManager @Inject constructor(
         }
     }
 
-    suspend fun importEndpoints(uri: Uri): Result<Unit> {
+    suspend fun importEndpointsFromFile(uri: Uri): Result<Unit> {
         return withContext(Dispatchers.IO) {
             val inputStream = context.contentResolver.openInputStream(uri)
                 ?: return@withContext Result.failure(IllegalStateException("Could not open input stream for uri: $uri"))

--- a/libs/apifaker/src/main/java/com/woocommerce/android/apifaker/EndpointExportManager.kt
+++ b/libs/apifaker/src/main/java/com/woocommerce/android/apifaker/EndpointExportManager.kt
@@ -7,13 +7,14 @@ import android.net.Uri
 import androidx.core.content.getSystemService
 import com.google.gson.Gson
 import com.woocommerce.android.apifaker.db.EndpointDao
+import com.woocommerce.android.apifaker.di.ApiFakerGson
 import com.woocommerce.android.apifaker.models.MockedEndpoint
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 import javax.inject.Inject
 
 internal class EndpointExportManager @Inject constructor(
-    private val gson: Gson,
+    @ApiFakerGson private val gson: Gson,
     private val endpointDao: EndpointDao,
     private val context: Context,
     private val clipDataFactory: ClipDataFactory

--- a/libs/apifaker/src/main/java/com/woocommerce/android/apifaker/EndpointExportManager.kt
+++ b/libs/apifaker/src/main/java/com/woocommerce/android/apifaker/EndpointExportManager.kt
@@ -1,7 +1,10 @@
 package com.woocommerce.android.apifaker
 
+import android.content.ClipData
+import android.content.ClipboardManager
 import android.content.Context
 import android.net.Uri
+import androidx.core.content.getSystemService
 import com.google.gson.Gson
 import com.woocommerce.android.apifaker.db.EndpointDao
 import com.woocommerce.android.apifaker.models.MockedEndpoint
@@ -14,7 +17,14 @@ internal class EndpointExportManager @Inject constructor(
     private val endpointDao: EndpointDao,
     private val context: Context
 ) {
-    suspend fun exportEndpointsToFile(
+    suspend fun exportEndpoints(endpoints: List<MockedEndpoint>, destination: ExportImportDestination): Result<Unit> {
+        return when (destination) {
+            is ExportImportDestination.File -> exportEndpointsToFile(endpoints, destination.uri)
+            ExportImportDestination.Clipboard -> exportEndpointsToClipboard(endpoints)
+        }
+    }
+
+    private suspend fun exportEndpointsToFile(
         endpoints: List<MockedEndpoint>,
         uri: Uri
     ): Result<Unit> {
@@ -22,22 +32,34 @@ internal class EndpointExportManager @Inject constructor(
             val outputStream = context.contentResolver.openOutputStream(uri)
                 ?: return@withContext Result.failure(IllegalStateException("Could not open output stream for: $uri"))
 
-            val endpointsExcludingIds = endpoints.map {
-                it.copy(
-                    request = it.request.copy(id = 0),
-                    response = it.response.copy(endpointId = 0)
-                )
-            }
-
             runCatching {
                 outputStream.bufferedWriter().use { writer ->
-                    gson.toJson(endpointsExcludingIds, writer)
+                    gson.toJson(endpoints.copyWithoutIds(), writer)
                 }
             }
         }
     }
 
-    suspend fun importEndpointsFromFile(uri: Uri): Result<Unit> {
+    private suspend fun exportEndpointsToClipboard(endpoints: List<MockedEndpoint>): Result<Unit> {
+        return withContext(Dispatchers.IO) {
+            val clipboardManager = context.getSystemService<ClipboardManager>()
+                ?: return@withContext Result.failure(IllegalStateException("Could not get clipboard manager"))
+
+            runCatching {
+                val json = gson.toJson(endpoints.copyWithoutIds())
+                clipboardManager.setPrimaryClip(ClipData.newPlainText("API Faker Endpoints", json))
+            }
+        }
+    }
+
+    suspend fun importEndpoints(destination: ExportImportDestination): Result<Unit> {
+        return when (destination) {
+            is ExportImportDestination.File -> importEndpointsFromFile(destination.uri)
+            ExportImportDestination.Clipboard -> importEndpointsFromClipboard()
+        }
+    }
+
+    private suspend fun importEndpointsFromFile(uri: Uri): Result<Unit> {
         return withContext(Dispatchers.IO) {
             val inputStream = context.contentResolver.openInputStream(uri)
                 ?: return@withContext Result.failure(IllegalStateException("Could not open input stream for uri: $uri"))
@@ -51,4 +73,34 @@ internal class EndpointExportManager @Inject constructor(
             }
         }
     }
+
+    private suspend fun importEndpointsFromClipboard(): Result<Unit> {
+        return withContext(Dispatchers.IO) {
+            val clipboardManager = context.getSystemService<ClipboardManager>()
+                ?: return@withContext Result.failure(IllegalStateException("Could not get clipboard manager"))
+
+            val clipData = clipboardManager.primaryClip
+                ?: return@withContext Result.failure(IllegalStateException("Clipboard is empty"))
+
+            runCatching {
+                val json = clipData.getItemAt(0).text.toString()
+                val endpoints = gson.fromJson(json, Array<MockedEndpoint>::class.java).toList()
+                endpointDao.insertEndpoints(endpoints)
+            }
+        }
+    }
+
+    private fun List<MockedEndpoint>.copyWithoutIds(): List<MockedEndpoint> {
+        return map {
+            it.copy(
+                request = it.request.copy(id = 0),
+                response = it.response.copy(endpointId = 0)
+            )
+        }
+    }
+}
+
+sealed interface ExportImportDestination {
+    data class File(val uri: Uri) : ExportImportDestination
+    object Clipboard : ExportImportDestination
 }

--- a/libs/apifaker/src/main/java/com/woocommerce/android/apifaker/di/ApiFakerModule.kt
+++ b/libs/apifaker/src/main/java/com/woocommerce/android/apifaker/di/ApiFakerModule.kt
@@ -2,6 +2,7 @@ package com.woocommerce.android.apifaker.di
 
 import android.content.Context
 import androidx.compose.material.SnackbarHostState
+import com.google.gson.GsonBuilder
 import com.woocommerce.android.apifaker.ApiFakerConfig
 import com.woocommerce.android.apifaker.ApiFakerInterceptor
 import com.woocommerce.android.apifaker.EndpointProcessor
@@ -13,7 +14,9 @@ import dagger.hilt.components.SingletonComponent
 import dagger.multibindings.IntoSet
 import okhttp3.Interceptor
 import javax.inject.Named
+import javax.inject.Qualifier
 import javax.inject.Singleton
+import kotlin.annotation.AnnotationRetention.RUNTIME
 
 @Module
 @InstallIn(SingletonComponent::class)
@@ -36,4 +39,14 @@ object ApiFakerModule {
     @Provides
     @Singleton
     internal fun providesSnackbarHostState() = SnackbarHostState()
+
+    @Provides
+    @Singleton
+    @ApiFakerGson
+    internal fun providesGson() = GsonBuilder().setPrettyPrinting().create()
 }
+
+@Qualifier
+@MustBeDocumented
+@Retention(RUNTIME)
+internal annotation class ApiFakerGson

--- a/libs/apifaker/src/main/java/com/woocommerce/android/apifaker/ui/home/HomeScreen.kt
+++ b/libs/apifaker/src/main/java/com/woocommerce/android/apifaker/ui/home/HomeScreen.kt
@@ -1,6 +1,5 @@
 package com.woocommerce.android.apifaker.ui.home
 
-import android.net.Uri
 import androidx.activity.compose.rememberLauncherForActivityResult
 import androidx.activity.result.contract.ActivityResultContracts
 import androidx.compose.foundation.background
@@ -9,6 +8,7 @@ import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.defaultMinSize
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
@@ -29,6 +29,7 @@ import androidx.compose.material.SnackbarHostState
 import androidx.compose.material.SwipeToDismiss
 import androidx.compose.material.Switch
 import androidx.compose.material.Text
+import androidx.compose.material.TextButton
 import androidx.compose.material.TopAppBar
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
@@ -49,9 +50,11 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
+import androidx.compose.ui.window.Dialog
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.navigation.NavController
 import androidx.navigation.compose.rememberNavController
+import com.woocommerce.android.apifaker.ExportImportDestination
 import com.woocommerce.android.apifaker.models.ApiType
 import com.woocommerce.android.apifaker.models.HttpMethod
 import com.woocommerce.android.apifaker.models.MockedEndpoint
@@ -87,8 +90,8 @@ private fun HomeScreen(
     snackbarHostState: SnackbarHostState,
     onRemoveRequest: (Request) -> Unit,
     onMockingToggleChanged: (Boolean) -> Unit,
-    onExportEndpoints: (Uri) -> Unit,
-    onImportEndpoints: (Uri) -> Unit,
+    onExportEndpoints: (ExportImportDestination) -> Unit,
+    onImportEndpoints: (ExportImportDestination) -> Unit,
     onExit: () -> Unit
 ) {
     Scaffold(
@@ -156,34 +159,10 @@ private fun HomeScreen(
 @Composable
 private fun TopMenu(
     hasEndpoints: Boolean,
-    onExportEndpoints: (Uri) -> Unit,
-    onImportEndpoints: (Uri) -> Unit
+    onExportEndpoints: (ExportImportDestination) -> Unit,
+    onImportEndpoints: (ExportImportDestination) -> Unit
 ) {
     var expanded by rememberSaveable { mutableStateOf(false) }
-
-    @Composable
-    fun ExportButton() {
-        val launcher = rememberLauncherForActivityResult(ActivityResultContracts.CreateDocument("application/json")) {
-            expanded = false
-            it?.let { onExportEndpoints(it) }
-        }
-
-        DropdownMenuItem(onClick = { launcher.launch("endpoints.json") }) {
-            Text("Export")
-        }
-    }
-
-    @Composable
-    fun ImportButton() {
-        val launcher = rememberLauncherForActivityResult(ActivityResultContracts.OpenDocument()) {
-            expanded = false
-            it?.let { onImportEndpoints(it) }
-        }
-
-        DropdownMenuItem(onClick = { launcher.launch(arrayOf("application/json")) }) {
-            Text("Import")
-        }
-    }
 
     IconButton(onClick = { expanded = !expanded }) {
         Icon(
@@ -197,9 +176,111 @@ private fun TopMenu(
         onDismissRequest = { expanded = false }
     ) {
         if (hasEndpoints) {
-            ExportButton()
+            ExportMenuButton(
+                onDismiss = { expanded = false },
+                onExportEndpoints = {
+                    expanded = false
+                    onExportEndpoints(it)
+                }
+            )
         }
-        ImportButton()
+        ImportMenuButton(
+            onDismiss = { expanded = false },
+            onImportEndpoints = {
+                expanded = false
+                onImportEndpoints(it)
+            }
+        )
+    }
+}
+
+@Composable
+fun ExportMenuButton(
+    onDismiss: () -> Unit,
+    onExportEndpoints: (ExportImportDestination) -> Unit
+) {
+    val launcher = rememberLauncherForActivityResult(ActivityResultContracts.CreateDocument("application/json")) {
+        it?.let { onExportEndpoints(ExportImportDestination.File(it)) }
+    }
+
+    var showDialog by rememberSaveable { mutableStateOf(false) }
+
+    DropdownMenuItem(onClick = { showDialog = true }) {
+        Text("Export")
+    }
+
+    if (showDialog) {
+        Dialog({
+            showDialog = false
+            onDismiss()
+        }) {
+            Column(
+                horizontalAlignment = Alignment.CenterHorizontally,
+                modifier = Modifier
+                    .background(MaterialTheme.colors.surface, MaterialTheme.shapes.medium)
+                    .padding(16.dp)
+                    .defaultMinSize(minWidth = 200.dp)
+            ) {
+                Text("Export to:", Modifier.align(Alignment.Start))
+                TextButton(onClick = {
+                    showDialog = false
+                    launcher.launch("endpoints.json")
+                }) {
+                    Text("File")
+                }
+                TextButton(onClick = {
+                    showDialog = false
+                    onExportEndpoints(ExportImportDestination.Clipboard)
+                }) {
+                    Text("Clipboard")
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun ImportMenuButton(
+    onDismiss: () -> Unit,
+    onImportEndpoints: (ExportImportDestination) -> Unit
+) {
+    val launcher = rememberLauncherForActivityResult(ActivityResultContracts.OpenDocument()) {
+        it?.let { onImportEndpoints(ExportImportDestination.File(it)) }
+    }
+
+    var showDialog by rememberSaveable { mutableStateOf(false) }
+
+    DropdownMenuItem(onClick = { showDialog = true }) {
+        Text("Import")
+    }
+
+    if (showDialog) {
+        Dialog({
+            showDialog = false
+            onDismiss()
+        }) {
+            Column(
+                horizontalAlignment = Alignment.CenterHorizontally,
+                modifier = Modifier
+                    .background(MaterialTheme.colors.surface, MaterialTheme.shapes.medium)
+                    .padding(16.dp)
+                    .defaultMinSize(minWidth = 200.dp)
+            ) {
+                Text("Import from:", Modifier.align(Alignment.Start))
+                TextButton(onClick = {
+                    showDialog = false
+                    launcher.launch(arrayOf("application/json"))
+                }) {
+                    Text("File")
+                }
+                TextButton(onClick = {
+                    showDialog = false
+                    onImportEndpoints(ExportImportDestination.Clipboard)
+                }) {
+                    Text("Clipboard")
+                }
+            }
+        }
     }
 }
 

--- a/libs/apifaker/src/main/java/com/woocommerce/android/apifaker/ui/home/HomeViewModel.kt
+++ b/libs/apifaker/src/main/java/com/woocommerce/android/apifaker/ui/home/HomeViewModel.kt
@@ -1,12 +1,12 @@
 package com.woocommerce.android.apifaker.ui.home
 
-import android.net.Uri
 import android.util.Log
 import androidx.compose.material.SnackbarHostState
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.woocommerce.android.apifaker.ApiFakerConfig
 import com.woocommerce.android.apifaker.EndpointExportManager
+import com.woocommerce.android.apifaker.ExportImportDestination
 import com.woocommerce.android.apifaker.LOG_TAG
 import com.woocommerce.android.apifaker.db.EndpointDao
 import com.woocommerce.android.apifaker.models.Request
@@ -41,9 +41,9 @@ internal class HomeViewModel @Inject constructor(
         }
     }
 
-    fun onExportEndpoints(uri: Uri) {
+    fun onExportEndpoints(destination: ExportImportDestination) {
         viewModelScope.launch {
-            endpointExportManager.exportEndpointsToFile(endpoints.value, uri).fold(
+            endpointExportManager.exportEndpoints(endpoints.value, destination).fold(
                 onSuccess = {
                     snackbarHostState.showSnackbar("Endpoints exported successfully")
                 },
@@ -55,16 +55,20 @@ internal class HomeViewModel @Inject constructor(
         }
     }
 
-    fun onImportEndpoints(uri: Uri) {
+    fun onImportEndpoints(destination: ExportImportDestination) {
         viewModelScope.launch {
-            endpointExportManager.importEndpointsFromFile(uri).fold(
+            endpointExportManager.importEndpoints(destination).fold(
                 onSuccess = {
                     snackbarHostState.showSnackbar("Endpoints imported successfully")
                 },
                 onFailure = {
-                    snackbarHostState.showSnackbar(
-                        "Failed to import endpoints, please ensure the file was exported from the same app version"
-                    )
+                    val message = when (destination) {
+                        is ExportImportDestination.File ->
+                            "Failed to import endpoints, please ensure the file was exported from the same app version"
+                        ExportImportDestination.Clipboard ->
+                            "Failed to import endpoints, please ensure the clipboard contains valid JSON"
+                    }
+                    snackbarHostState.showSnackbar(message)
                     Log.e(LOG_TAG, "Failed to import endpoints", it)
                 }
             )

--- a/libs/apifaker/src/main/java/com/woocommerce/android/apifaker/ui/home/HomeViewModel.kt
+++ b/libs/apifaker/src/main/java/com/woocommerce/android/apifaker/ui/home/HomeViewModel.kt
@@ -43,7 +43,7 @@ internal class HomeViewModel @Inject constructor(
 
     fun onExportEndpoints(uri: Uri) {
         viewModelScope.launch {
-            endpointExportManager.exportEndpoints(endpoints.value, uri).fold(
+            endpointExportManager.exportEndpointsToFile(endpoints.value, uri).fold(
                 onSuccess = {
                     snackbarHostState.showSnackbar("Endpoints exported successfully")
                 },
@@ -57,7 +57,7 @@ internal class HomeViewModel @Inject constructor(
 
     fun onImportEndpoints(uri: Uri) {
         viewModelScope.launch {
-            endpointExportManager.importEndpoints(uri).fold(
+            endpointExportManager.importEndpointsFromFile(uri).fold(
                 onSuccess = {
                     snackbarHostState.showSnackbar("Endpoints imported successfully")
                 },

--- a/libs/apifaker/src/test/java/com/woocommerce/android/apifaker/EndpointExportManagerTest.kt
+++ b/libs/apifaker/src/test/java/com/woocommerce/android/apifaker/EndpointExportManagerTest.kt
@@ -48,11 +48,11 @@ class EndpointExportManagerTest {
     )
 
     @Test
-    fun `when exportEndpoints is called, it should export the endpoints to the given uri`() = runTest {
+    fun `when exportEndpointsToFile is called, it should export the endpoints to the given uri`() = runTest {
         val stream = ByteArrayOutputStream()
         given(contentResolver.openOutputStream(any())).willReturn(stream)
 
-        val result = sut.exportEndpoints(mockedEndpoints, mock())
+        val result = sut.exportEndpointsToFile(mockedEndpoints, mock())
         val exportedEndpoints = gson.fromJson(stream.toString(), Array<MockedEndpoint>::class.java).toList()
 
         assertTrue(result.isSuccess)
@@ -66,11 +66,11 @@ class EndpointExportManagerTest {
     }
 
     @Test
-    fun `when importEndpoints is called, it should import the endpoints from the given uri`() = runTest {
+    fun `when importEndpointsFromFile is called, it should import the endpoints from the given uri`() = runTest {
         val stream = gson.toJson(mockedEndpoints).byteInputStream()
         given(contentResolver.openInputStream(any())).willReturn(stream)
 
-        val result = sut.importEndpoints(mock())
+        val result = sut.importEndpointsFromFile(mock())
 
         assertTrue(result.isSuccess)
         verify(endpointDao).insertEndpoints(mockedEndpoints)

--- a/libs/apifaker/src/test/java/com/woocommerce/android/apifaker/EndpointExportManagerTest.kt
+++ b/libs/apifaker/src/test/java/com/woocommerce/android/apifaker/EndpointExportManagerTest.kt
@@ -1,5 +1,6 @@
 package com.woocommerce.android.apifaker
 
+import android.content.ClipboardManager
 import android.content.ContentResolver
 import android.content.Context
 import com.google.gson.Gson
@@ -40,39 +41,79 @@ class EndpointExportManagerTest {
         on { contentResolver } doReturn contentResolver
     }
     private val endpointDao = mock<EndpointDao>()
+    private val clipDataFactory = mock<ClipDataFactory> {
+        on { createClipData(any()) } doReturn mock()
+    }
 
     private val sut = EndpointExportManager(
         gson = gson,
         endpointDao = endpointDao,
-        context = context
+        context = context,
+        clipDataFactory = clipDataFactory
     )
 
     @Test
-    fun `when exportEndpointsToFile is called, it should export the endpoints to the given uri`() = runTest {
-        val stream = ByteArrayOutputStream()
-        given(contentResolver.openOutputStream(any())).willReturn(stream)
+    fun `when exportEndpoints is called with file destination, it should export the endpoints to the given uri`() =
+        runTest {
+            val stream = ByteArrayOutputStream()
+            given(contentResolver.openOutputStream(any())).willReturn(stream)
 
-        val result = sut.exportEndpointsToFile(mockedEndpoints, mock())
-        val exportedEndpoints = gson.fromJson(stream.toString(), Array<MockedEndpoint>::class.java).toList()
+            val result = sut.exportEndpoints(mockedEndpoints, ExportImportDestination.File(mock()))
+            val exportedEndpoints = gson.fromJson(stream.toString(), Array<MockedEndpoint>::class.java).toList()
 
-        assertTrue(result.isSuccess)
-        val expectedEndpoints = mockedEndpoints.map {
-            it.copy(
-                request = it.request.copy(id = 0),
-                response = it.response.copy(endpointId = 0)
-            )
+            assertTrue(result.isSuccess)
+            val expectedEndpoints = mockedEndpoints.map {
+                it.copy(
+                    request = it.request.copy(id = 0),
+                    response = it.response.copy(endpointId = 0)
+                )
+            }
+            assertEquals(expectedEndpoints, exportedEndpoints)
         }
-        assertEquals(expectedEndpoints, exportedEndpoints)
-    }
 
     @Test
-    fun `when importEndpointsFromFile is called, it should import the endpoints from the given uri`() = runTest {
-        val stream = gson.toJson(mockedEndpoints).byteInputStream()
-        given(contentResolver.openInputStream(any())).willReturn(stream)
+    fun `when importEndpoints is called with file destination, it should import the endpoints from the given uri`() =
+        runTest {
+            val stream = gson.toJson(mockedEndpoints).byteInputStream()
+            given(contentResolver.openInputStream(any())).willReturn(stream)
 
-        val result = sut.importEndpointsFromFile(mock())
+            val result = sut.importEndpoints(ExportImportDestination.File(mock()))
 
-        assertTrue(result.isSuccess)
-        verify(endpointDao).insertEndpoints(mockedEndpoints)
-    }
+            assertTrue(result.isSuccess)
+            verify(endpointDao).insertEndpoints(mockedEndpoints)
+        }
+
+    @Test
+    fun `when exportEndpoints is called with clipboard destination, it should export the endpoints to the clipboard`() =
+        runTest {
+            val clipboardManager = mock<ClipboardManager>()
+            given(context.getSystemService(Context.CLIPBOARD_SERVICE)).willReturn(clipboardManager)
+
+            val result = sut.exportEndpoints(mockedEndpoints, ExportImportDestination.Clipboard)
+
+            assertTrue(result.isSuccess)
+            verify(clipboardManager).setPrimaryClip(any())
+        }
+
+    @Test
+    fun `when importEndpoints is called with clipboard destination, it should import the endpoints from the clipboard`() =
+        runTest {
+            val json = gson.toJson(mockedEndpoints)
+            val clipItem = mock<android.content.ClipData.Item> {
+                on { text } doReturn json
+            }
+            val clipData = mock<android.content.ClipData> {
+                on { itemCount } doReturn 1
+                on { getItemAt(0) } doReturn clipItem
+            }
+            val clipboardManager = mock<ClipboardManager> {
+                on { primaryClip } doReturn clipData
+            }
+            given(context.getSystemService(Context.CLIPBOARD_SERVICE)).willReturn(clipboardManager)
+
+            val result = sut.importEndpoints(ExportImportDestination.Clipboard)
+
+            assertTrue(result.isSuccess)
+            verify(endpointDao).insertEndpoints(mockedEndpoints)
+        }
 }


### PR DESCRIPTION
### Description
During the review of the previous PR #13802, @JorgeMucientes suggested a great idea to make this work with the clipboard as well, this PR implements this, it updates the export/import flow to give the user the option to select the destination, whether it's a file or the clipboard.

### Steps to reproduce
1. Open the app and sign in if needed.
2. Open the settings.
3. Tap on Developer Options.
4. Tap on Api Faker.

### Testing information
- Test exporting to the clipboard.
- Test importing from the clipboard.

### The tests that have been performed
^

### Images/gif

https://github.com/user-attachments/assets/057850b9-205e-408d-81d0-87df65cc122c



- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.

## Reviewer (or Author, in the case of optional code reviews):

Please make sure these conditions are met before approving the PR, or request changes if the PR needs improvement:

- [ ] The PR is small and has a clear, single focus, or a valid explanation is provided in the description. If needed, please request to split it into smaller PRs.
- [ ] Ensure Adequate Unit Test Coverage: The changes are reasonably covered by unit tests or an explanation is provided in the PR description.
- [ ] Manual Testing: The author listed all the tests they ran, including smoke tests when needed (e.g., for refactorings). The reviewer confirmed that the PR works as expected on big (tablet) and small (phone) in case of UI changes, and no regressions are added.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->