### PR TITLE
Issue/13826 fix missing toolbar on tablets in receipt preview

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -5,6 +5,9 @@
 -----
 
 
+22.0.1
+-----
+- [**] Fixed a missing toolbar on tablets on the Receipt Preview screen [https://github.com/woocommerce/woocommerce-android/pull/13830]
 22.0
 -----
 - [*] Payments: display specific error for the cases when a reader with low battery level attempted to connect [https://github.com/woocommerce/woocommerce-android/pull/13642]

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/receipt/preview/ReceiptPreviewFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/receipt/preview/ReceiptPreviewFragment.kt
@@ -1,21 +1,20 @@
 package com.woocommerce.android.ui.payments.receipt.preview
 
 import android.os.Bundle
-import android.view.Menu
-import android.view.MenuInflater
 import android.view.MenuItem
 import android.view.View
 import android.webkit.WebResourceRequest
 import android.webkit.WebResourceResponse
 import android.webkit.WebView
 import android.webkit.WebViewClient
-import androidx.core.view.MenuProvider
 import androidx.fragment.app.viewModels
+import androidx.navigation.fragment.findNavController
 import com.woocommerce.android.R
 import com.woocommerce.android.analytics.AnalyticsTracker
 import com.woocommerce.android.databinding.FragmentReceiptPreviewBinding
 import com.woocommerce.android.ui.base.BaseFragment
 import com.woocommerce.android.ui.base.UIMessageResolver
+import com.woocommerce.android.ui.main.AppBarStatus
 import com.woocommerce.android.util.PrintHtmlHelper
 import com.woocommerce.android.util.UiHelpers
 import com.woocommerce.android.util.WooLog
@@ -27,7 +26,7 @@ import java.net.URL
 import javax.inject.Inject
 
 @AndroidEntryPoint
-class ReceiptPreviewFragment : BaseFragment(R.layout.fragment_receipt_preview), MenuProvider {
+class ReceiptPreviewFragment : BaseFragment(R.layout.fragment_receipt_preview) {
     val viewModel: ReceiptPreviewViewModel by viewModels()
 
     @Inject lateinit var printHtmlHelper: PrintHtmlHelper
@@ -39,23 +38,36 @@ class ReceiptPreviewFragment : BaseFragment(R.layout.fragment_receipt_preview), 
     private var _binding: FragmentReceiptPreviewBinding? = null
     private val binding get() = _binding!!
 
+    override val activityAppBarStatus: AppBarStatus
+        get() = AppBarStatus.Hidden
+
     private var urlToLoad: String? = null
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
 
-        requireActivity().addMenuProvider(this, viewLifecycleOwner)
-
         _binding = FragmentReceiptPreviewBinding.bind(view)
+        setupToolbar(binding)
         initViews(binding, savedInstanceState)
         initObservers(binding)
     }
 
-    override fun onCreateMenu(menu: Menu, inflater: MenuInflater) {
-        inflater.inflate(R.menu.menu_receipt_preview, menu)
+    private fun setupToolbar(binding: FragmentReceiptPreviewBinding) {
+        binding.toolbar.title = getString(R.string.receipt_preview_toolbar_title)
+        binding.toolbar.setOnMenuItemClickListener { menuItem ->
+            onMenuItemSelected(menuItem)
+        }
+        binding.toolbar.setNavigationOnClickListener {
+            findNavController().navigateUp()
+        }
+        setupToolbarMenu()
     }
 
-    override fun onMenuItemSelected(item: MenuItem): Boolean {
+    private fun setupToolbarMenu() {
+        binding.toolbar.inflateMenu(R.menu.menu_receipt_preview)
+    }
+
+    private fun onMenuItemSelected(item: MenuItem): Boolean {
         return when (item.itemId) {
             R.id.menu_print -> {
                 viewModel.onPrintClicked()

--- a/WooCommerce/src/main/res/layout/fragment_receipt_preview.xml
+++ b/WooCommerce/src/main/res/layout/fragment_receipt_preview.xml
@@ -1,16 +1,45 @@
 <?xml version="1.0" encoding="utf-8"?>
-<FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="match_parent">
+
+    <com.google.android.material.appbar.MaterialToolbar
+        android:id="@+id/toolbar"
+        style="@style/Widget.Woo.Toolbar"
+        android:layout_width="match_parent"
+        android:layout_height="@dimen/toolbar_height"
+        android:elevation="@dimen/minor_50"
+        app:layout_collapseMode="pin"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent"
+        tools:title="@string/app_name" />
+
+    <View
+        android:id="@+id/app_bar_divider"
+        style="@style/Woo.Divider"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@id/toolbar" />
 
     <ProgressBar
         android:id="@+id/receipt_preview_progress_bar"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:layout_gravity="center" />
+        android:layout_gravity="center"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@id/app_bar_divider" />
 
     <WebView
         android:id="@+id/receipt_preview_preview_webview"
         android:layout_width="match_parent"
-        android:layout_height="match_parent" />
-</FrameLayout>
+        android:layout_height="match_parent"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@id/app_bar_divider" />
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -1018,6 +1018,7 @@
     <string name="orderdetail_shipping_label_notice">Learn more about creating labels with your mobile device</string>
     <string name="orderdetail_custom_fields">Custom fields</string>
     <string name="orderdetail_ai_create_thank_you_note_button">✨Create thank-you note</string>
+    <string name="receipt_preview_toolbar_title">Receipt Preview</string>
     <string name="receipt_preview_print_menu_item">Print</string>
     <string name="receipt_preview_send_menu_item">Send</string>
     <string name="order_mark_complete">Mark order complete</string>


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #13826
<!-- Id number of the GitHub issue this PR addresses. -->

<!-- 
━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
🛠 Need an AI review?  
Add a comment: `@coderabbitai review`
━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
-->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

**Beta Fix -** This PR removes activity toolbar and adds a fragment specific toolbar to the Receipt Preview screen. Using the activity owned toolbar doesn't work on tablets in two pane mode as no-toolbar is displayed on the preview screen on these devices.

### Steps to reproduce
<!-- Step-by-step testing instructions. For new user flows, consider instead stating the goal of the workflow and see if your PR reviewer can accomplish the workflow without specific steps! -->

1. Open a completed order on a device in two-pane mode.
2. Tap on See Receipt.
3. Notice the toolbar is missing.

### Testing information
<!-- This is your opportunity to break out individual scenarios that need testing (when necessary) and/or include a checklist for the reviewer to go through. Consider documenting the following from your own completed testing: devices used, alternate workflows, edge cases, affected areas, critical flows, areas not tested, and any remaining unknowns. Provide feedback on this new section of the PR template through Sept 30, 2024 to Apps Quality; additional context here: p91TBi-b8z-p2#comment-12036 -->

- Check that toolbar is present and buttons are working on a device in two-pane mode.
- Check that toolbar is present and buttons are working on a device in one-pane mode.

### The tests that have been performed
<!-- To give the reviewer an idea of what could be missed in terms of testing -->

- I've checked it works as expected on both phones and tablets.
- I've also double-checked the progress bar indicator is positioned in the center of the screen.

### Images/gif
<!-- Include before and after images or gifs when appropriate. -->

| Before | After |
|--|--|
| ![Screenshot_20250324_121141](https://github.com/user-attachments/assets/cb7c171d-1032-4fd0-98d4-a7ca246e360a) | ![Screenshot_20250324_115727](https://github.com/user-attachments/assets/b5c00eca-da50-4471-9bdc-84779631148e) |



- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.

## Reviewer (or Author, in the case of optional code reviews):

Please make sure these conditions are met before approving the PR, or request changes if the PR needs improvement:

- [ ] The PR is small and has a clear, single focus, or a valid explanation is provided in the description. If needed, please request to split it into smaller PRs.
- [ ] Ensure Adequate Unit Test Coverage: The changes are reasonably covered by unit tests or an explanation is provided in the PR description.
- [ ] Manual Testing: The author listed all the tests they ran, including smoke tests when needed (e.g., for refactorings). The reviewer confirmed that the PR works as expected on big (tablet) and small (phone) in case of UI changes, and no regressions are added.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->