### PR TITLE
Rename WooPosItem to WooPosItemSelectionViewState

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/common/composeui/component/WooPosPaginationErrorIndicator.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/common/composeui/component/WooPosPaginationErrorIndicator.kt
@@ -30,8 +30,8 @@ import com.woocommerce.android.ui.woopos.common.composeui.designsystem.WooPosThe
 import com.woocommerce.android.ui.woopos.common.composeui.designsystem.WooPosTypography
 import com.woocommerce.android.ui.woopos.common.composeui.designsystem.toAdaptivePadding
 import com.woocommerce.android.ui.woopos.home.items.PaginationState
-import com.woocommerce.android.ui.woopos.home.items.WooPosItem.Product
 import com.woocommerce.android.ui.woopos.home.items.WooPosItemList
+import com.woocommerce.android.ui.woopos.home.items.WooPosItemSelectionViewState.Product
 import com.woocommerce.android.ui.woopos.home.items.WooPosItemsViewState
 
 @Composable

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/items/WooPosBaseViewState.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/items/WooPosBaseViewState.kt
@@ -5,7 +5,7 @@ sealed class WooPosBaseViewState(
 )
 
 interface ContentViewState {
-    val items: List<WooPosItem>
+    val items: List<WooPosItemSelectionViewState>
     val reloadingProductsWithPullToRefresh: Boolean
     val paginationState: PaginationState
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/items/WooPosItemSelectionViewState.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/items/WooPosItemSelectionViewState.kt
@@ -1,6 +1,6 @@
 package com.woocommerce.android.ui.woopos.home.items
 
-sealed class WooPosItem(
+sealed class WooPosItemSelectionViewState(
     open val id: Long,
     open val name: String
 ) {
@@ -8,7 +8,7 @@ sealed class WooPosItem(
         override val id: Long,
         override val name: String,
         open val price: String,
-    ) : WooPosItem(id, name) {
+    ) : WooPosItemSelectionViewState(id, name) {
         data class Simple(
             override val id: Long,
             override val name: String,
@@ -32,5 +32,5 @@ sealed class WooPosItem(
         val productId: Long,
         val price: String,
         val imageUrl: String?,
-    ) : WooPosItem(id, name)
+    ) : WooPosItemSelectionViewState(id, name)
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/items/WooPosItemsList.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/items/WooPosItemsList.kt
@@ -59,8 +59,8 @@ import com.woocommerce.android.ui.woopos.common.composeui.designsystem.WooPosSpa
 import com.woocommerce.android.ui.woopos.common.composeui.designsystem.WooPosTheme
 import com.woocommerce.android.ui.woopos.common.composeui.designsystem.WooPosTypography
 import com.woocommerce.android.ui.woopos.common.composeui.designsystem.toAdaptivePadding
-import com.woocommerce.android.ui.woopos.home.items.WooPosItem.Product
-import com.woocommerce.android.ui.woopos.home.items.WooPosItem.Variation
+import com.woocommerce.android.ui.woopos.home.items.WooPosItemSelectionViewState.Product
+import com.woocommerce.android.ui.woopos.home.items.WooPosItemSelectionViewState.Variation
 import com.woocommerce.android.ui.woopos.home.items.WooPosItemsViewState.Content.BannerState
 import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.filter
@@ -70,7 +70,7 @@ import kotlinx.coroutines.flow.filter
 fun WooPosItemList(
     state: ContentViewState,
     listState: LazyListState,
-    onItemClicked: (item: WooPosItem) -> Unit,
+    onItemClicked: (item: WooPosItemSelectionViewState) -> Unit,
     onEndOfProductsListReached: () -> Unit,
     onErrorWhilePaginating: @Composable () -> Unit,
 ) {
@@ -141,7 +141,7 @@ fun WooPosItemList(
 private fun ProductItem(
     modifier: Modifier = Modifier,
     item: Product.Simple,
-    onItemClicked: (item: WooPosItem) -> Unit
+    onItemClicked: (item: WooPosItemSelectionViewState) -> Unit
 ) {
     val itemContentDescription = stringResource(
         id = R.string.woopos_product_item_content_description,
@@ -155,7 +155,7 @@ private fun ProductItem(
 private fun VariableProductItem(
     modifier: Modifier = Modifier,
     item: Product.Variable,
-    onItemClicked: (item: WooPosItem) -> Unit
+    onItemClicked: (item: WooPosItemSelectionViewState) -> Unit
 ) {
     val itemContentDescription = stringResource(
         id = R.string.woopos_variable_product_item_content_description,
@@ -169,7 +169,7 @@ private fun VariableProductItem(
 private fun VariationItem(
     modifier: Modifier = Modifier,
     item: Variation,
-    onItemClicked: (item: WooPosItem) -> Unit
+    onItemClicked: (item: WooPosItemSelectionViewState) -> Unit
 ) {
     val itemContentDescription = stringResource(
         id = R.string.woopos_variation_item_content_description,
@@ -183,8 +183,8 @@ private fun VariationItem(
 fun WooPosItemCard(
     modifier: Modifier,
     itemContentDescription: String,
-    onItemClicked: (item: WooPosItem) -> Unit,
-    item: WooPosItem
+    onItemClicked: (item: WooPosItemSelectionViewState) -> Unit,
+    item: WooPosItemSelectionViewState
 ) {
     WooPosCard(
         modifier = modifier
@@ -211,7 +211,7 @@ fun WooPosItemCard(
 }
 
 @Composable
-private fun ProductInfo(item: WooPosItem) {
+private fun ProductInfo(item: WooPosItemSelectionViewState) {
     Column(
         modifier = Modifier
             .fillMaxHeight()
@@ -239,7 +239,7 @@ private fun ProductInfo(item: WooPosItem) {
 }
 
 @Composable
-private fun ProductImage(item: WooPosItem) {
+private fun ProductImage(item: WooPosItemSelectionViewState) {
     val imageUrl = when (item) {
         is Product.Simple -> item.imageUrl
         is Product.Variable -> item.imageUrl

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/items/WooPosItemsScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/items/WooPosItemsScreen.kt
@@ -47,7 +47,7 @@ import com.woocommerce.android.ui.woopos.common.composeui.designsystem.WooPosSpa
 import com.woocommerce.android.ui.woopos.common.composeui.designsystem.WooPosTheme
 import com.woocommerce.android.ui.woopos.common.composeui.designsystem.WooPosTypography
 import com.woocommerce.android.ui.woopos.common.composeui.designsystem.toAdaptivePadding
-import com.woocommerce.android.ui.woopos.home.items.WooPosItem.Product
+import com.woocommerce.android.ui.woopos.home.items.WooPosItemSelectionViewState.Product
 import com.woocommerce.android.ui.woopos.home.items.WooPosItemsUIEvent.EndOfItemsListReached
 import com.woocommerce.android.ui.woopos.home.items.WooPosItemsUIEvent.ProductsLoadingErrorRetryButtonClicked
 import com.woocommerce.android.ui.woopos.home.items.WooPosItemsUIEvent.PullToRefreshTriggered
@@ -128,7 +128,7 @@ private fun MainItemsList(
     onToolbarInfoIconClicked: () -> Unit,
     onSimpleProductsBannerLearnMoreClicked: () -> Unit,
     onSimpleProductsBannerClosed: () -> Unit,
-    onItemClicked: (item: WooPosItem) -> Unit,
+    onItemClicked: (item: WooPosItemSelectionViewState) -> Unit,
     onEndOfItemListReached: () -> Unit,
     onRetryClicked: () -> Unit,
     onSearchEvent: (WooPosSearchUIEvent) -> Unit,

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/items/WooPosItemsUIEvent.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/items/WooPosItemsUIEvent.kt
@@ -1,7 +1,7 @@
 package com.woocommerce.android.ui.woopos.home.items
 
 sealed class WooPosItemsUIEvent {
-    data class ItemClicked(val item: WooPosItem) : WooPosItemsUIEvent()
+    data class ItemClicked(val item: WooPosItemSelectionViewState) : WooPosItemsUIEvent()
     data object EndOfItemsListReached : WooPosItemsUIEvent()
     data object PullToRefreshTriggered : WooPosItemsUIEvent()
     data object ProductsLoadingErrorRetryButtonClicked : WooPosItemsUIEvent()

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/items/WooPosItemsViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/items/WooPosItemsViewModel.kt
@@ -253,7 +253,7 @@ class WooPosItemsViewModel @Inject constructor(
 
     private fun handleItemClick(event: WooPosItemsUIEvent.ItemClicked) {
         when (event.item) {
-            is WooPosItem.Product.Simple -> {
+            is WooPosItemSelectionViewState.Product.Simple -> {
                 onItemClicked(
                     ItemClickedData.SimpleProduct(
                         id = event.item.id
@@ -261,7 +261,7 @@ class WooPosItemsViewModel @Inject constructor(
                 )
             }
 
-            is WooPosItem.Product.Variable -> {
+            is WooPosItemSelectionViewState.Product.Variable -> {
                 viewModelScope.launch {
                     navigator.sendNavigationEvent(
                         NavigateToVariationsScreen(
@@ -275,7 +275,7 @@ class WooPosItemsViewModel @Inject constructor(
                 }
             }
 
-            is WooPosItem.Variation -> {
+            is WooPosItemSelectionViewState.Variation -> {
             }
         }
     }
@@ -360,7 +360,7 @@ class WooPosItemsViewModel @Inject constructor(
     ) = WooPosItemsViewState.Content(
         items = map { product ->
             if (product.isVariable()) {
-                WooPosItem.Product.Variable(
+                WooPosItemSelectionViewState.Product.Variable(
                     id = product.remoteId,
                     name = product.name,
                     price = priceFormat(product.price),
@@ -369,7 +369,7 @@ class WooPosItemsViewModel @Inject constructor(
                     variationIds = product.variationIds
                 )
             } else {
-                WooPosItem.Product.Simple(
+                WooPosItemSelectionViewState.Product.Simple(
                     id = product.remoteId,
                     name = product.name,
                     price = priceFormat(product.price),

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/items/WooPosItemsViewState.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/items/WooPosItemsViewState.kt
@@ -9,7 +9,7 @@ sealed class WooPosItemsViewState(
 ) : WooPosBaseViewState(reloadingProductsWithPullToRefresh) {
     data class Content(
         val search: SearchState,
-        override val items: List<WooPosItem>,
+        override val items: List<WooPosItemSelectionViewState>,
         val bannerState: BannerState,
         override val paginationState: PaginationState = PaginationState.None,
         override val reloadingProductsWithPullToRefresh: Boolean = false,

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/items/WooPosVariationsViewState.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/items/WooPosVariationsViewState.kt
@@ -5,7 +5,7 @@ sealed class WooPosVariationsViewState(
 ) : WooPosBaseViewState(reloadingProductsWithPullToRefresh) {
 
     data class Content(
-        override val items: List<WooPosItem.Variation>,
+        override val items: List<WooPosItemSelectionViewState.Variation>,
         override val reloadingProductsWithPullToRefresh: Boolean = false,
         override val paginationState: PaginationState = PaginationState.None,
     ) : WooPosVariationsViewState(reloadingProductsWithPullToRefresh), ContentViewState

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/items/search/WooPosItemsEmptySearchQueryState.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/items/search/WooPosItemsEmptySearchQueryState.kt
@@ -40,8 +40,8 @@ import com.woocommerce.android.ui.woopos.common.composeui.designsystem.WooPosSpa
 import com.woocommerce.android.ui.woopos.common.composeui.designsystem.WooPosTheme
 import com.woocommerce.android.ui.woopos.common.composeui.designsystem.WooPosTypography
 import com.woocommerce.android.ui.woopos.common.composeui.designsystem.toAdaptivePadding
-import com.woocommerce.android.ui.woopos.home.items.WooPosItem
 import com.woocommerce.android.ui.woopos.home.items.WooPosItemCard
+import com.woocommerce.android.ui.woopos.home.items.WooPosItemSelectionViewState
 
 @Composable
 fun WooPosItemsEmptySearchQueryState(state: WooPosItemsSearchViewState.EmptySearchQuery) {
@@ -89,7 +89,7 @@ fun WooPosItemsEmptySearchQueryState(state: WooPosItemsSearchViewState.EmptySear
 }
 
 @Composable
-private fun PopularItemsSection(popularItems: List<WooPosItem.Product>) {
+private fun PopularItemsSection(popularItems: List<WooPosItemSelectionViewState.Product>) {
     SectionHeader(
         icon = Icons.AutoMirrored.Outlined.TrendingUp,
         title = stringResource(R.string.woopos_search_popular_items_title)
@@ -209,20 +209,20 @@ fun WooPosItemsEmptySearchQueryStatePreview() {
         ) {
             WooPosItemsEmptySearchQueryState(
                 state = WooPosItemsSearchViewState.EmptySearchQuery(
-                    popularItems = listOf<WooPosItem.Product>(
-                        WooPosItem.Product.Simple(
+                    popularItems = listOf(
+                        WooPosItemSelectionViewState.Product.Simple(
                             id = 1,
                             name = "Popular Item 1",
                             price = "10.0$",
                             imageUrl = "https://example.com/image1.jpg",
                         ),
-                        WooPosItem.Product.Simple(
+                        WooPosItemSelectionViewState.Product.Simple(
                             id = 2,
                             name = "Popular Item 2",
                             price = "20.0$",
                             imageUrl = "https://example.com/image2.jpg",
                         ),
-                        WooPosItem.Product.Variable(
+                        WooPosItemSelectionViewState.Product.Variable(
                             id = 3,
                             name = "Popular Item 3",
                             price = "30.0$",
@@ -249,20 +249,20 @@ fun WooPosItemsEmptySearchQueryStateOnyItemsPreview() {
         ) {
             WooPosItemsEmptySearchQueryState(
                 state = WooPosItemsSearchViewState.EmptySearchQuery(
-                    popularItems = listOf<WooPosItem.Product>(
-                        WooPosItem.Product.Simple(
+                    popularItems = listOf(
+                        WooPosItemSelectionViewState.Product.Simple(
                             id = 1,
                             name = "Popular Item 1",
                             price = "10.0$",
                             imageUrl = "https://example.com/image1.jpg",
                         ),
-                        WooPosItem.Product.Simple(
+                        WooPosItemSelectionViewState.Product.Simple(
                             id = 2,
                             name = "Popular Item 2",
                             price = "20.0$",
                             imageUrl = "https://example.com/image2.jpg",
                         ),
-                        WooPosItem.Product.Variable(
+                        WooPosItemSelectionViewState.Product.Variable(
                             id = 3,
                             name = "Popular Item 3",
                             price = "30.0$",

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/items/search/WooPosItemsSearchEmptyStateProvider.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/items/search/WooPosItemsSearchEmptyStateProvider.kt
@@ -1,27 +1,27 @@
 package com.woocommerce.android.ui.woopos.home.items.search
 
-import com.woocommerce.android.ui.woopos.home.items.WooPosItem
+import com.woocommerce.android.ui.woopos.home.items.WooPosItemSelectionViewState
 import kotlinx.coroutines.delay
 import javax.inject.Inject
 
 @Suppress("MagicNumber")
 class WooPosItemsSearchEmptyStateProvider @Inject constructor() {
-    suspend fun getPopularItems(): List<WooPosItem.Product> {
+    suspend fun getPopularItems(): List<WooPosItemSelectionViewState.Product> {
         delay(50)
-        return listOf<WooPosItem.Product>(
-            WooPosItem.Product.Simple(
+        return listOf(
+            WooPosItemSelectionViewState.Product.Simple(
                 id = 1,
                 name = "Popular Item 1",
                 price = "10.0$",
                 imageUrl = "https://example.com/image1.jpg",
             ),
-            WooPosItem.Product.Simple(
+            WooPosItemSelectionViewState.Product.Simple(
                 id = 2,
                 name = "Popular Item 2",
                 price = "20.0$",
                 imageUrl = "https://example.com/image2.jpg",
             ),
-            WooPosItem.Product.Variable(
+            WooPosItemSelectionViewState.Product.Variable(
                 id = 3,
                 name = "Popular Item 3",
                 price = "30.0$",

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/items/search/WooPosItemsSearchScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/items/search/WooPosItemsSearchScreen.kt
@@ -10,7 +10,7 @@ import androidx.hilt.navigation.compose.hiltViewModel
 import com.woocommerce.android.ui.woopos.common.composeui.WooPosPreview
 import com.woocommerce.android.ui.woopos.common.composeui.designsystem.WooPosSpacing
 import com.woocommerce.android.ui.woopos.common.composeui.designsystem.WooPosTheme
-import com.woocommerce.android.ui.woopos.home.items.WooPosItem
+import com.woocommerce.android.ui.woopos.home.items.WooPosItemSelectionViewState
 
 @Composable
 fun WooPosItemsSearchScreen(
@@ -57,8 +57,8 @@ fun WooPosItemsSearchScreenPreview() {
         ) {
             WooPosItemsEmptySearchQueryState(
                 state = WooPosItemsSearchViewState.EmptySearchQuery(
-                    popularItems = listOf<WooPosItem.Product>(
-                        WooPosItem.Product.Simple(
+                    popularItems = listOf<WooPosItemSelectionViewState.Product>(
+                        WooPosItemSelectionViewState.Product.Simple(
                             id = 1,
                             name = "Popular Item 1",
                             price = "10.0$",

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/items/search/WooPosItemsSearchViewState.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/items/search/WooPosItemsSearchViewState.kt
@@ -1,10 +1,10 @@
 package com.woocommerce.android.ui.woopos.home.items.search
 
-import com.woocommerce.android.ui.woopos.home.items.WooPosItem
+import com.woocommerce.android.ui.woopos.home.items.WooPosItemSelectionViewState
 
 sealed class WooPosItemsSearchViewState {
     data class EmptySearchQuery(
-        val popularItems: List<WooPosItem.Product>,
+        val popularItems: List<WooPosItemSelectionViewState.Product>,
         val recentSearches: List<String>,
     ) : WooPosItemsSearchViewState()
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/items/variations/WooPosVariationsScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/items/variations/WooPosVariationsScreen.kt
@@ -43,9 +43,9 @@ import com.woocommerce.android.ui.woopos.common.composeui.designsystem.WooPosTyp
 import com.woocommerce.android.ui.woopos.common.composeui.designsystem.toAdaptivePadding
 import com.woocommerce.android.ui.woopos.home.items.ItemsEmptyList
 import com.woocommerce.android.ui.woopos.home.items.ItemsLoadingIndicator
-import com.woocommerce.android.ui.woopos.home.items.WooPosItem
 import com.woocommerce.android.ui.woopos.home.items.WooPosItemList
 import com.woocommerce.android.ui.woopos.home.items.WooPosItemNavigationData.VariableProductData
+import com.woocommerce.android.ui.woopos.home.items.WooPosItemSelectionViewState
 import com.woocommerce.android.ui.woopos.home.items.WooPosVariationsViewState
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
@@ -136,7 +136,7 @@ private fun WooPosVariationsScreens(
                         listState = listState,
                         onItemClicked = {
                             onItemClicked(
-                                (it as WooPosItem.Variation).productId,
+                                (it as WooPosItemSelectionViewState.Variation).productId,
                                 it.id
                             )
                         },
@@ -254,7 +254,7 @@ fun WooPosVariationsScreenPreview() {
     val productState = MutableStateFlow(
         WooPosVariationsViewState.Content(
             items = listOf(
-                WooPosItem.Variation(
+                WooPosItemSelectionViewState.Variation(
                     1,
                     name = "Product 1, Product 1, Product 1, " +
                         "Product 1, Product 1, Product 1, Product 1, Product 1" +
@@ -263,14 +263,14 @@ fun WooPosVariationsScreenPreview() {
                     price = "10.0$",
                     imageUrl = null,
                 ),
-                WooPosItem.Variation(
+                WooPosItemSelectionViewState.Variation(
                     2,
                     name = "Product 2",
                     productId = 1,
                     price = "2000.00$",
                     imageUrl = null,
                 ),
-                WooPosItem.Variation(
+                WooPosItemSelectionViewState.Variation(
                     3,
                     name = "Product 3",
                     productId = 1,

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/items/variations/WooPosVariationsViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/items/variations/WooPosVariationsViewModel.kt
@@ -10,7 +10,7 @@ import com.woocommerce.android.ui.woopos.common.data.WooPosGetProductById
 import com.woocommerce.android.ui.woopos.home.ChildToParentEvent
 import com.woocommerce.android.ui.woopos.home.WooPosChildrenToParentEventSender
 import com.woocommerce.android.ui.woopos.home.items.PaginationState
-import com.woocommerce.android.ui.woopos.home.items.WooPosItem
+import com.woocommerce.android.ui.woopos.home.items.WooPosItemSelectionViewState
 import com.woocommerce.android.ui.woopos.home.items.WooPosItemsViewModel
 import com.woocommerce.android.ui.woopos.home.items.WooPosVariationsViewState
 import com.woocommerce.android.ui.woopos.util.analytics.WooPosAnalyticsEvent.Event.VariationsPullToRefreshTriggered
@@ -91,7 +91,7 @@ class WooPosVariationsViewModel @Inject constructor(
                                 if (variations.isNotEmpty()) {
                                     WooPosVariationsViewState.Content(
                                         items = variations.map {
-                                            WooPosItem.Variation(
+                                            WooPosItemSelectionViewState.Variation(
                                                 id = it.remoteVariationId,
                                                 name = it.getNameForPOS(getProductById(productId), resourceProvider),
                                                 productId = it.remoteProductId,
@@ -124,7 +124,7 @@ class WooPosVariationsViewModel @Inject constructor(
         } else {
             _viewState.value = WooPosVariationsViewState.Content(
                 items = variations.map {
-                    WooPosItem.Variation(
+                    WooPosItemSelectionViewState.Variation(
                         id = it.remoteVariationId,
                         name = it.getNameForPOS(getProductById(productId), resourceProvider),
                         productId = it.remoteProductId,
@@ -162,7 +162,7 @@ class WooPosVariationsViewModel @Inject constructor(
             _viewState.value = if (result.isSuccess) {
                 WooPosVariationsViewState.Content(
                     items = result.getOrThrow().map {
-                        WooPosItem.Variation(
+                        WooPosItemSelectionViewState.Variation(
                             id = it.remoteVariationId,
                             name = it.getNameForPOS(getProductById(productId), resourceProvider),
                             productId = it.remoteProductId,

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/home/items/WooPosItemsViewModelTestSelectionViewState.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/home/items/WooPosItemsViewModelTestSelectionViewState.kt
@@ -31,7 +31,7 @@ import kotlin.test.Test
 import kotlin.test.assertTrue
 
 @ExperimentalCoroutinesApi
-class WooPosItemsViewModelTest {
+class WooPosItemsViewModelTestSelectionViewState {
 
     @Rule
     @JvmField
@@ -109,7 +109,7 @@ class WooPosItemsViewModelTest {
             val value = awaitItem() as WooPosItemsViewState.Content
 
             @Suppress("UNCHECKED_CAST")
-            val items = value.items as List<WooPosItem.Product.Simple>
+            val items = value.items as List<WooPosItemSelectionViewState.Product.Simple>
             assertThat(items).hasSize(2)
             assertThat(items[0].id).isEqualTo(1)
             assertThat(items[0].name).isEqualTo("Product 1")
@@ -196,7 +196,7 @@ class WooPosItemsViewModelTest {
     @Test
     fun `when item clicked, then send event to parent`() = runTest {
         // GIVEN
-        val product = WooPosItem.Product.Simple(id = 1, name = "", price = "", imageUrl = null)
+        val product = WooPosItemSelectionViewState.Product.Simple(id = 1, name = "", price = "", imageUrl = null)
         val viewModel = createViewModel()
 
         // WHEN
@@ -515,7 +515,7 @@ class WooPosItemsViewModelTest {
         // WHEN
         viewModel.onUIEvent(
             WooPosItemsUIEvent.ItemClicked(
-                WooPosItem.Product.Variable(
+                WooPosItemSelectionViewState.Product.Variable(
                     id = 1L,
                     name = "Product 1",
                     numOfVariations = 10,
@@ -601,7 +601,7 @@ class WooPosItemsViewModelTest {
                 // THEN
                 val value = awaitItem() as WooPosItemsViewState.Content
 
-                assertThat(value.items.filterIsInstance<WooPosItem.Product.Variable>().size).isEqualTo(1)
+                assertThat(value.items.filterIsInstance<WooPosItemSelectionViewState.Product.Variable>().size).isEqualTo(1)
             }
         }
 

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/home/items/WooPosItemsViewModelTestSelectionViewState.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/home/items/WooPosItemsViewModelTestSelectionViewState.kt
@@ -8,6 +8,7 @@ import com.woocommerce.android.ui.woopos.featureflags.WooPosIsCouponsEnabled
 import com.woocommerce.android.ui.woopos.featureflags.WooPosIsProductsSearchEnabled
 import com.woocommerce.android.ui.woopos.home.ChildToParentEvent
 import com.woocommerce.android.ui.woopos.home.WooPosChildrenToParentEventSender
+import com.woocommerce.android.ui.woopos.home.items.WooPosItemSelectionViewState.Product
 import com.woocommerce.android.ui.woopos.home.items.navigation.WooPosItemsNavigator
 import com.woocommerce.android.ui.woopos.home.items.products.WooPosProductsDataSource
 import com.woocommerce.android.ui.woopos.util.WooPosCoroutineTestRule
@@ -109,7 +110,7 @@ class WooPosItemsViewModelTestSelectionViewState {
             val value = awaitItem() as WooPosItemsViewState.Content
 
             @Suppress("UNCHECKED_CAST")
-            val items = value.items as List<WooPosItemSelectionViewState.Product.Simple>
+            val items = value.items as List<Product.Simple>
             assertThat(items).hasSize(2)
             assertThat(items[0].id).isEqualTo(1)
             assertThat(items[0].name).isEqualTo("Product 1")
@@ -196,7 +197,7 @@ class WooPosItemsViewModelTestSelectionViewState {
     @Test
     fun `when item clicked, then send event to parent`() = runTest {
         // GIVEN
-        val product = WooPosItemSelectionViewState.Product.Simple(id = 1, name = "", price = "", imageUrl = null)
+        val product = Product.Simple(id = 1, name = "", price = "", imageUrl = null)
         val viewModel = createViewModel()
 
         // WHEN
@@ -515,7 +516,7 @@ class WooPosItemsViewModelTestSelectionViewState {
         // WHEN
         viewModel.onUIEvent(
             WooPosItemsUIEvent.ItemClicked(
-                WooPosItemSelectionViewState.Product.Variable(
+                Product.Variable(
                     id = 1L,
                     name = "Product 1",
                     numOfVariations = 10,
@@ -601,7 +602,7 @@ class WooPosItemsViewModelTestSelectionViewState {
                 // THEN
                 val value = awaitItem() as WooPosItemsViewState.Content
 
-                assertThat(value.items.filterIsInstance<WooPosItemSelectionViewState.Product.Variable>().size).isEqualTo(1)
+                assertThat(value.items.filterIsInstance<Product.Variable>().size).isEqualTo(1)
             }
         }
 

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/home/items/search/WooPosItemsSearchViewModelTestSelectionViewState.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/home/items/search/WooPosItemsSearchViewModelTestSelectionViewState.kt
@@ -1,7 +1,7 @@
 package com.woocommerce.android.ui.woopos.home.items.search
 
 import app.cash.turbine.test
-import com.woocommerce.android.ui.woopos.home.items.WooPosItem
+import com.woocommerce.android.ui.woopos.home.items.WooPosItemSelectionViewState
 import com.woocommerce.android.ui.woopos.util.WooPosCoroutineTestRule
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.runTest
@@ -12,7 +12,7 @@ import org.mockito.kotlin.mock
 import org.mockito.kotlin.whenever
 
 @ExperimentalCoroutinesApi
-class WooPosItemsSearchViewModelTest {
+class WooPosItemsSearchViewModelTestSelectionViewState {
 
     @Rule
     @JvmField
@@ -25,8 +25,8 @@ class WooPosItemsSearchViewModelTest {
             val mockEmptyStateProvider: WooPosItemsSearchEmptyStateProvider = mock()
 
             val popularItems = listOf(
-                WooPosItem.Product.Simple(id = 1, name = "Popular Item 1", price = "$10.0", imageUrl = null),
-                WooPosItem.Product.Simple(id = 2, name = "Popular Item 2", price = "$15.0", imageUrl = null)
+                WooPosItemSelectionViewState.Product.Simple(id = 1, name = "Popular Item 1", price = "$10.0", imageUrl = null),
+                WooPosItemSelectionViewState.Product.Simple(id = 2, name = "Popular Item 2", price = "$15.0", imageUrl = null)
             )
             val recentSearches = listOf(
                 "Recent Search 1"
@@ -76,7 +76,7 @@ class WooPosItemsSearchViewModelTest {
         // GIVEN
         val mockEmptyStateProvider: WooPosItemsSearchEmptyStateProvider = mock()
         whenever(mockEmptyStateProvider.getPopularItems()).thenAnswer {
-            emptyList<WooPosItem>()
+            emptyList<WooPosItemSelectionViewState>()
         }
         whenever(mockEmptyStateProvider.getLastSearches()).thenAnswer {
             emptyList<String>()
@@ -94,10 +94,10 @@ class WooPosItemsSearchViewModelTest {
         // GIVEN
         val mockEmptyStateProvider: WooPosItemsSearchEmptyStateProvider = mock()
         val popularItems = listOf(
-            WooPosItem.Product.Simple(id = 1, name = "Popular Item 1", price = "$10.0", imageUrl = null),
-            WooPosItem.Product.Simple(id = 2, name = "Popular Item 2", price = "$15.0", imageUrl = null),
-            WooPosItem.Product.Simple(id = 3, name = "Popular Item 3", price = "$20.0", imageUrl = null),
-            WooPosItem.Product.Simple(id = 4, name = "Popular Item 4", price = "$25.0", imageUrl = null)
+            WooPosItemSelectionViewState.Product.Simple(id = 1, name = "Popular Item 1", price = "$10.0", imageUrl = null),
+            WooPosItemSelectionViewState.Product.Simple(id = 2, name = "Popular Item 2", price = "$15.0", imageUrl = null),
+            WooPosItemSelectionViewState.Product.Simple(id = 3, name = "Popular Item 3", price = "$20.0", imageUrl = null),
+            WooPosItemSelectionViewState.Product.Simple(id = 4, name = "Popular Item 4", price = "$25.0", imageUrl = null)
         )
         val recentSearches = listOf(
             "Recent Search 1",

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/home/items/search/WooPosItemsSearchViewModelTestSelectionViewState.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/home/items/search/WooPosItemsSearchViewModelTestSelectionViewState.kt
@@ -2,6 +2,7 @@ package com.woocommerce.android.ui.woopos.home.items.search
 
 import app.cash.turbine.test
 import com.woocommerce.android.ui.woopos.home.items.WooPosItemSelectionViewState
+import com.woocommerce.android.ui.woopos.home.items.WooPosItemSelectionViewState.Product
 import com.woocommerce.android.ui.woopos.util.WooPosCoroutineTestRule
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.runTest
@@ -25,8 +26,8 @@ class WooPosItemsSearchViewModelTestSelectionViewState {
             val mockEmptyStateProvider: WooPosItemsSearchEmptyStateProvider = mock()
 
             val popularItems = listOf(
-                WooPosItemSelectionViewState.Product.Simple(id = 1, name = "Popular Item 1", price = "$10.0", imageUrl = null),
-                WooPosItemSelectionViewState.Product.Simple(id = 2, name = "Popular Item 2", price = "$15.0", imageUrl = null)
+                Product.Simple(id = 1, name = "Popular Item 1", price = "$10.0", imageUrl = null),
+                Product.Simple(id = 2, name = "Popular Item 2", price = "$15.0", imageUrl = null)
             )
             val recentSearches = listOf(
                 "Recent Search 1"
@@ -94,10 +95,10 @@ class WooPosItemsSearchViewModelTestSelectionViewState {
         // GIVEN
         val mockEmptyStateProvider: WooPosItemsSearchEmptyStateProvider = mock()
         val popularItems = listOf(
-            WooPosItemSelectionViewState.Product.Simple(id = 1, name = "Popular Item 1", price = "$10.0", imageUrl = null),
-            WooPosItemSelectionViewState.Product.Simple(id = 2, name = "Popular Item 2", price = "$15.0", imageUrl = null),
-            WooPosItemSelectionViewState.Product.Simple(id = 3, name = "Popular Item 3", price = "$20.0", imageUrl = null),
-            WooPosItemSelectionViewState.Product.Simple(id = 4, name = "Popular Item 4", price = "$25.0", imageUrl = null)
+            Product.Simple(id = 1, name = "Popular Item 1", price = "$10.0", imageUrl = null),
+            Product.Simple(id = 2, name = "Popular Item 2", price = "$15.0", imageUrl = null),
+            Product.Simple(id = 3, name = "Popular Item 3", price = "$20.0", imageUrl = null),
+            Product.Simple(id = 4, name = "Popular Item 4", price = "$25.0", imageUrl = null)
         )
         val recentSearches = listOf(
             "Recent Search 1",


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->


### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

This is a very simple PR which renames WooPosItem to WooPosItemSelectionViewState to clearly indicate that it's a view state, not a model that should be re-used across components (eg. in the cart view or the checkout). 

### Testing information
<!-- This is your opportunity to break out individual scenarios that need testing (when necessary) and/or include a checklist for the reviewer to go through. Consider documenting the following from your own completed testing: devices used, alternate workflows, edge cases, affected areas, critical flows, areas not tested, and any remaining unknowns. Provide feedback on this new section of the PR template through Sept 30, 2024 to Apps Quality; additional context here: p91TBi-b8z-p2#comment-12036 -->

Green CI should be enough - all the changes were done by the AS refactoring tool.

### The tests that have been performed
<!-- To give the reviewer an idea of what could be missed in terms of testing -->

I've smoke tested the POS.

- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.

## Reviewer (or Author, in the case of optional code reviews):

Please make sure these conditions are met before approving the PR, or request changes if the PR needs improvement:

- [x] The PR is small and has a clear, single focus, or a valid explanation is provided in the description. If needed, please request to split it into smaller PRs.
- [x] Ensure Adequate Unit Test Coverage: The changes are reasonably covered by unit tests or an explanation is provided in the PR description.
- [x] Manual Testing: The author listed all the tests they ran, including smoke tests when needed (e.g., for refactorings). The reviewer confirmed that the PR works as expected on big (tablet) and small (phone) in case of UI changes, and no regressions are added.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->