### PR TITLE
POS - Fix "Key already in use" crash

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -4,6 +4,7 @@
 22.1
 -----
 - [*] The order count badge is now fully visible for counts higher than 99 [https://github.com/woocommerce/woocommerce-android/pull/13825]
+- [*] Fix rare crash in the POS upon adding an item to the cart [https://github.com/woocommerce/woocommerce-android/pull/13838]
 
 22.0
 -----

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/cart/WooPosCartViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/cart/WooPosCartViewModel.kt
@@ -35,6 +35,7 @@ import com.woocommerce.android.viewmodel.getStateFlow
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.async
 import kotlinx.coroutines.launch
+import java.util.concurrent.atomic.AtomicInteger
 import javax.inject.Inject
 
 @HiltViewModel
@@ -60,6 +61,12 @@ class WooPosCartViewModel @Inject constructor(
         .map { updateCartStatusDependingOnItems(it).also { newState -> updateAnalyticsData(newState) } }
         .map { updateToolbarState(it) }
         .map { updateStateDependingOnCartStatus(it) }
+
+    // Set initial value to 1 or the biggest used number when VM is restored after a process death.
+    private val itemNumberProvider =
+        AtomicInteger(
+            (_state.value.body as? WooPosCartState.Body.WithItems)
+                ?.itemsInCart?.maxOfOrNull { it.itemNumber } ?: 1)
 
     init {
         listenEventsFromParent()
@@ -193,9 +200,9 @@ class WooPosCartViewModel @Inject constructor(
     }
 
     private fun getItemNumber(): Int {
-        return when (val currentState = _state.value.body) {
+        return when (_state.value.body) {
             is WooPosCartState.Body.Empty -> 1
-            is WooPosCartState.Body.WithItems -> (currentState.itemsInCart.maxOfOrNull { it.itemNumber } ?: 0) + 1
+            is WooPosCartState.Body.WithItems ->  itemNumberProvider.incrementAndGet()
         }
     }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/cart/WooPosCartViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/cart/WooPosCartViewModel.kt
@@ -15,6 +15,7 @@ import com.woocommerce.android.ui.woopos.home.ChildToParentEvent
 import com.woocommerce.android.ui.woopos.home.ParentToChildrenEvent
 import com.woocommerce.android.ui.woopos.home.WooPosChildrenToParentEventSender
 import com.woocommerce.android.ui.woopos.home.WooPosParentToChildrenEventReceiver
+import com.woocommerce.android.ui.woopos.home.cart.WooPosCartState.Body.WithItems
 import com.woocommerce.android.ui.woopos.home.cart.WooPosCartStatus.CHECKOUT
 import com.woocommerce.android.ui.woopos.home.cart.WooPosCartStatus.EDITABLE
 import com.woocommerce.android.ui.woopos.home.cart.WooPosCartStatus.EMPTY
@@ -62,12 +63,7 @@ class WooPosCartViewModel @Inject constructor(
         .map { updateToolbarState(it) }
         .map { updateStateDependingOnCartStatus(it) }
 
-    // Set initial value to 1 or the biggest used number when VM is restored after a process death.
-    private val itemNumberProvider =
-        AtomicInteger(
-            (_state.value.body as? WooPosCartState.Body.WithItems)
-                ?.itemsInCart?.maxOfOrNull { it.itemNumber } ?: 1
-        )
+    private val itemNumberProvider = AtomicInteger(getInitialValueOrHighestUsedItemNumberAfterProcessDeath())
 
     init {
         listenEventsFromParent()
@@ -311,6 +307,9 @@ class WooPosCartViewModel @Inject constructor(
             price = formatPrice(price),
             imageUrl = image?.source,
         )
+
+    private fun getInitialValueOrHighestUsedItemNumberAfterProcessDeath() = (_state.value.body as? WithItems)
+        ?.itemsInCart?.maxOfOrNull { it.itemNumber } ?: 1
 }
 
 private fun WooPosItemsViewModel.ItemClickedData.posItemNameForAnalytics(): String {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/cart/WooPosCartViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/cart/WooPosCartViewModel.kt
@@ -66,7 +66,8 @@ class WooPosCartViewModel @Inject constructor(
     private val itemNumberProvider =
         AtomicInteger(
             (_state.value.body as? WooPosCartState.Body.WithItems)
-                ?.itemsInCart?.maxOfOrNull { it.itemNumber } ?: 1)
+                ?.itemsInCart?.maxOfOrNull { it.itemNumber } ?: 1
+        )
 
     init {
         listenEventsFromParent()
@@ -203,7 +204,7 @@ class WooPosCartViewModel @Inject constructor(
     private fun getItemNumber(): Int {
         return when (_state.value.body) {
             is WooPosCartState.Body.Empty -> 1
-            is WooPosCartState.Body.WithItems ->  itemNumberProvider.incrementAndGet()
+            is WooPosCartState.Body.WithItems -> itemNumberProvider.incrementAndGet()
         }
     }
 


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #13837
<!-- Id number of the GitHub issue this PR addresses. -->

<!-- 
━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
🛠 Need an AI review?  
Add a comment: `@coderabbitai review`
━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
-->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

This PR fixes a rare crash that occurs when the user adds a product (usually many products) to the cart.

### Steps to reproduce
<!-- Step-by-step testing instructions. For new user flows, consider instead stating the goal of the workflow and see if your PR reviewer can accomplish the workflow without specific steps! -->

1. Go to More section on a tablet with US/UK store
1. Click on Point of Sale
1. Start adding as many products as fast as you can
1. Observe the app crashes at some point

### Testing information
<!-- This is your opportunity to break out individual scenarios that need testing (when necessary) and/or include a checklist for the reviewer to go through. Consider documenting the following from your own completed testing: devices used, alternate workflows, edge cases, affected areas, critical flows, areas not tested, and any remaining unknowns. Provide feedback on this new section of the PR template through Sept 30, 2024 to Apps Quality; additional context here: p91TBi-b8z-p2#comment-12036 -->

Smoke test the POS with focus on adding products to the cart. Also test the VM restoration works as expected. (P.S. I noticed the app sometime restarts from scratch, but I don't know why - doesn't seem to be related to this PR, since it was happening even before).

### The tests that have been performed
<!-- To give the reviewer an idea of what could be missed in terms of testing -->

I've tested the above with `Don't keep activities` developer settings enabled.

- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.

## Reviewer (or Author, in the case of optional code reviews):

Please make sure these conditions are met before approving the PR, or request changes if the PR needs improvement:

- [ ] The PR is small and has a clear, single focus, or a valid explanation is provided in the description. If needed, please request to split it into smaller PRs.
- [ ] Ensure Adequate Unit Test Coverage: The changes are reasonably covered by unit tests or an explanation is provided in the PR description.
- [ ] Manual Testing: The author listed all the tests they ran, including smoke tests when needed (e.g., for refactorings). The reviewer confirmed that the PR works as expected on big (tablet) and small (phone) in case of UI changes, and no regressions are added.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->