### PR TITLE
[Crash] Currency symbol instead of currency code causes a crash

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -4,6 +4,9 @@
 22.1
 -----
 
+22.0.2
+-----
+- [**] Fixed crash during order creation when currency symbol instead of currency code provided in an order [https://github.com/woocommerce/woocommerce-android/pull/13844]
 
 22.0.1
 -----

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/product/discount/CurrencySymbolFinder.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/product/discount/CurrencySymbolFinder.kt
@@ -1,10 +1,14 @@
 package com.woocommerce.android.ui.orders.creation.product.discount
 
-import java.util.Currency
+import org.wordpress.android.fluxc.utils.WCCurrencyUtils
+import java.util.Locale
 import javax.inject.Inject
 
 class CurrencySymbolFinder @Inject constructor() {
     fun findCurrencySymbol(currencyCode: String): String {
-        return Currency.getInstance(currencyCode).symbol
+        return WCCurrencyUtils.getLocalizedCurrencySymbolForCode(
+            currencyCode,
+            Locale.getDefault()
+        )
     }
 }


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #13839 
<!-- Id number of the GitHub issue this PR addresses. -->

<!-- 
━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
🛠 Need an AI review?  
Add a comment: `@coderabbitai review`
━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
-->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
peaMlT-1bn-p2

For reasons unknown to me, some stores return the currency code in the "currency" field of an order, which causes a crash. I could not reproduce it. Looking into `WCCurrencyUtils.getLocalizedCurrencySymbolForCode` code it's been known before

### Steps to reproduce
<!-- Step-by-step testing instructions. For new user flows, consider instead stating the goal of the workflow and see if your PR reviewer can accomplish the workflow without specific steps! -->
Unknown

### The tests that have been performed
<!-- To give the reviewer an idea of what could be missed in terms of testing -->
* Order creation with custom amount
* Order editing with custom amount
* I modified the code to pass `$` instead of `USD` to validate the behavior

### Images/gif
<!-- Include before and after images or gifs when appropriate. -->

- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.

## Reviewer (or Author, in the case of optional code reviews):

Please make sure these conditions are met before approving the PR, or request changes if the PR needs improvement:

- [x] The PR is small and has a clear, single focus, or a valid explanation is provided in the description. If needed, please request to split it into smaller PRs.
- [x] Ensure Adequate Unit Test Coverage: The changes are reasonably covered by unit tests or an explanation is provided in the PR description.
- [x] Manual Testing: The author listed all the tests they ran, including smoke tests when needed (e.g., for refactorings). The reviewer confirmed that the PR works as expected on big (tablet) and small (phone) in case of UI changes, and no regressions are added.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->