### PR TITLE
Issue/13729 add dummy coupon to cart

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/cart/WooPosCartScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/cart/WooPosCartScreen.kt
@@ -236,6 +236,13 @@ private fun CartBodyWithItems(
                     canRemoveItems = areItemsRemovable,
                     onUIEvent = onUIEvent,
                 )
+
+                is WooPosCartItemViewState.Coupon -> CouponItem(
+                    modifier = Modifier.animateItem(),
+                    item = item,
+                    canRemoveItems = areItemsRemovable,
+                    onUIEvent = onUIEvent,
+                )
             }
         }
         item {
@@ -375,7 +382,7 @@ private fun ProductItem(
     onUIEvent: (WooPosCartUIEvent) -> Unit,
 ) {
     val itemContentDescription = stringResource(
-        id = R.string.woopos_cart_item_content_description,
+        id = R.string.woopos_cart_item_product_content_description,
         item.name,
         item.price
     )
@@ -474,6 +481,85 @@ private fun ProductItem(
 }
 
 @Composable
+private fun CouponItem(
+    modifier: Modifier = Modifier,
+    item: WooPosCartItemViewState.Coupon,
+    canRemoveItems: Boolean,
+    onUIEvent: (WooPosCartUIEvent) -> Unit,
+) {
+    val itemContentDescription = stringResource(
+        id = R.string.woopos_cart_item_coupon_content_description,
+        item.name
+    )
+
+    WooPosCard(
+        modifier = modifier
+            .height(96.dp)
+            .semantics { contentDescription = itemContentDescription },
+        backgroundColor = MaterialTheme.colorScheme.surfaceContainerLowest,
+        elevation = WooPosElevation.Medium,
+        shadowType = ShadowType.Soft,
+        shape = RoundedCornerShape(WooPosCornerRadius.Medium.value),
+    ) {
+        Row(
+            horizontalArrangement = Arrangement.SpaceBetween,
+            verticalAlignment = Alignment.CenterVertically
+        ) {
+            Box(
+                modifier = Modifier
+                    .background(MaterialTheme.colorScheme.surfaceDim),
+                contentAlignment = Alignment.Center
+            ) {
+                Image(
+                    painter = painterResource(R.drawable.ic_more_menu_coupons),
+                    contentDescription = null,
+                    colorFilter = ColorFilter.tint(WooPosTheme.colors.onSurfaceVariantLowest),
+                    modifier = Modifier.size(38.dp, 32.dp)
+                )
+            }
+
+            Spacer(modifier = Modifier.width(WooPosSpacing.Medium.value.toAdaptivePadding()))
+
+            Column(
+                modifier = Modifier.weight(1f)
+            ) {
+                WooPosText(
+                    text = item.name,
+                    maxLines = 1,
+                    style = WooPosTypography.BodyLarge,
+                    fontWeight = FontWeight.Bold,
+                    overflow = TextOverflow.Ellipsis,
+                    modifier = Modifier.clearAndSetSemantics { }
+                )
+                Spacer(modifier = Modifier.height(WooPosSpacing.XSmall.value.toAdaptivePadding()))
+            }
+
+            if (canRemoveItems) {
+                Spacer(modifier = Modifier.width(WooPosSpacing.Medium.value.toAdaptivePadding()))
+
+                val removeButtonContentDescription = stringResource(
+                    id = R.string.woopos_remove_item_button_from_cart_content_description,
+                    item.name
+                )
+                IconButton(
+                    onClick = { onUIEvent(WooPosCartUIEvent.ItemRemovedFromCart(item)) },
+                    modifier = Modifier
+                        .size(32.dp)
+                        .semantics { contentDescription = removeButtonContentDescription }
+                ) {
+                    Icon(
+                        painter = painterResource(id = R.drawable.ic_pos_remove_cart_item),
+                        tint = WooPosTheme.colors.onSurfaceVariantLowest,
+                        contentDescription = null,
+                    )
+                }
+            }
+            Spacer(modifier = Modifier.width(WooPosSpacing.Medium.value.toAdaptivePadding()))
+        }
+    }
+}
+
+@Composable
 @WooPosPreview
 fun WooPosCartScreenProductsPreview(modifier: Modifier = Modifier) {
     WooPosTheme {
@@ -487,8 +573,13 @@ fun WooPosCartScreenProductsPreview(modifier: Modifier = Modifier) {
                 ),
                 body = WooPosCartState.Body.WithItems(
                     itemsInCart = listOf(
-                        WooPosCartItemViewState.Product.Simple(
+                        WooPosCartItemViewState.Coupon(
                             itemNumber = 1,
+                            name = "Test Coupon",
+                            id = 1L
+                        ),
+                        WooPosCartItemViewState.Product.Simple(
+                            itemNumber = 2,
                             id = 1L,
                             imageUrl = "",
                             name = "VW California, VW California VW California, VW California VW California, " +
@@ -497,7 +588,7 @@ fun WooPosCartScreenProductsPreview(modifier: Modifier = Modifier) {
                             price = "€50,000",
                         ),
                         WooPosCartItemViewState.Product.Simple(
-                            itemNumber = 2,
+                            itemNumber = 3,
                             id = 2L,
                             imageUrl = "",
                             name = "VW California",
@@ -506,7 +597,7 @@ fun WooPosCartScreenProductsPreview(modifier: Modifier = Modifier) {
                             price = "$150,000",
                         ),
                         WooPosCartItemViewState.Product.Simple(
-                            itemNumber = 3,
+                            itemNumber = 4,
                             id = 3L,
                             imageUrl = "",
                             name = "VW California",
@@ -536,8 +627,13 @@ fun WooPosCartScreenCheckoutPreview(modifier: Modifier = Modifier) {
                 ),
                 body = WooPosCartState.Body.WithItems(
                     itemsInCart = listOf(
-                        WooPosCartItemViewState.Product.Simple(
+                        WooPosCartItemViewState.Coupon(
                             itemNumber = 1,
+                            name = "Test Coupon",
+                            id = 1L
+                        ),
+                        WooPosCartItemViewState.Product.Simple(
+                            itemNumber = 2,
                             id = 1L,
                             imageUrl = "",
                             name = "VW California",
@@ -545,7 +641,7 @@ fun WooPosCartScreenCheckoutPreview(modifier: Modifier = Modifier) {
                             price = "€50,000",
                         ),
                         WooPosCartItemViewState.Product.Simple(
-                            itemNumber = 2,
+                            itemNumber = 3,
                             id = 2L,
                             imageUrl = "",
                             name = "VW California",
@@ -553,7 +649,7 @@ fun WooPosCartScreenCheckoutPreview(modifier: Modifier = Modifier) {
                             price = "$150,000",
                         ),
                         WooPosCartItemViewState.Product.Simple(
-                            itemNumber = 3,
+                            itemNumber = 4,
                             id = 3L,
                             imageUrl = "",
                             name = "VW California",

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/cart/WooPosCartState.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/cart/WooPosCartState.kt
@@ -72,4 +72,11 @@ sealed class WooPosCartItemViewState(open val itemNumber: Int, open val name: St
             override val imageUrl: String?,
         ) : Product(itemNumber, id, name, price, description, imageUrl), Parcelable
     }
+
+    @Parcelize
+    data class Coupon(
+        override val itemNumber: Int,
+        override val name: String,
+        val id: Long,
+    ) : WooPosCartItemViewState(itemNumber, name), Parcelable
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/cart/WooPosCartViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/cart/WooPosCartViewModel.kt
@@ -15,6 +15,7 @@ import com.woocommerce.android.ui.woopos.home.ChildToParentEvent
 import com.woocommerce.android.ui.woopos.home.ParentToChildrenEvent
 import com.woocommerce.android.ui.woopos.home.WooPosChildrenToParentEventSender
 import com.woocommerce.android.ui.woopos.home.WooPosParentToChildrenEventReceiver
+
 import com.woocommerce.android.ui.woopos.home.cart.WooPosCartState.Body.WithItems
 import com.woocommerce.android.ui.woopos.home.cart.WooPosCartStatus.CHECKOUT
 import com.woocommerce.android.ui.woopos.home.cart.WooPosCartStatus.EDITABLE
@@ -158,28 +159,16 @@ class WooPosCartViewModel @Inject constructor(
     private fun handleItemClickedInItemsSelector(event: ParentToChildrenEvent.ItemClickedInProductSelector) {
         viewModelScope.launch {
             val itemClicked = async {
-                val product = getProductById(
-                    when (event.itemData) {
-                        is WooPosItemsViewModel.ItemClickedData.SimpleProduct -> event.itemData.id
-                        is WooPosItemsViewModel.ItemClickedData.Variation -> event.itemData.productId
-                        is WooPosItemsViewModel.ItemClickedData.Coupon ->
-                            throw NotImplementedError("Coupons are not supported yet")
-                    }
-                )!!
                 when (event.itemData) {
-                    is WooPosItemsViewModel.ItemClickedData.SimpleProduct -> {
-                        val itemNumber = getItemNumber()
-                        product.toCartListItem(itemNumber)
-                    }
-                    is WooPosItemsViewModel.ItemClickedData.Variation -> {
-                        val itemNumber = getItemNumber()
-                        val productVariation = getVariationsById(event.itemData.productId, event.itemData.id)!!
-                        productVariation.toCartListItem(itemNumber, product)
-                    }
+                    is WooPosItemsViewModel.ItemClickedData.SimpleProduct ->
+                        handleSimpleProductClicked(event.itemData.id)
+                    is WooPosItemsViewModel.ItemClickedData.Variation ->
+                        handleVariationClicked(event.itemData.productId, event.itemData.id)
                     is WooPosItemsViewModel.ItemClickedData.Coupon ->
-                        throw NotImplementedError("Coupons are not supported yet")
+                        handleCouponClicked(event.itemData.id, event.itemData.couponCode)
                 }
             }
+
             if (_state.value.body == WooPosCartState.Body.Empty) {
                 analyticsTracker.track(InteractionWithCustomerStarted)
             }
@@ -191,6 +180,23 @@ class WooPosCartViewModel @Inject constructor(
             )
             analyticsTracker.track(WooPosAnalyticsEvent.Event.ItemAddedToCart)
         }
+    }
+
+    private suspend fun handleSimpleProductClicked(productId: Long): WooPosCartItemViewState {
+        val product = getProductById(productId)!!
+        val itemNumber = getItemNumber()
+        return product.toCartListItem(itemNumber)
+    }
+
+    private suspend fun handleVariationClicked(productId: Long, variationId: Long): WooPosCartItemViewState {
+        val product = getProductById(productId)!!
+        val itemNumber = getItemNumber()
+        val productVariation = getVariationsById(productId, variationId)!!
+        return productVariation.toCartListItem(itemNumber, product)
+    }
+
+    private suspend fun handleCouponClicked(couponId: Long, couponCode: String): WooPosCartItemViewState {
+        TODO("Not yet implemented")
     }
 
     private fun clearCart() {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/cart/WooPosCartViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/cart/WooPosCartViewModel.kt
@@ -15,8 +15,6 @@ import com.woocommerce.android.ui.woopos.home.ChildToParentEvent
 import com.woocommerce.android.ui.woopos.home.ParentToChildrenEvent
 import com.woocommerce.android.ui.woopos.home.WooPosChildrenToParentEventSender
 import com.woocommerce.android.ui.woopos.home.WooPosParentToChildrenEventReceiver
-
-import com.woocommerce.android.ui.woopos.home.cart.WooPosCartState.Body.WithItems
 import com.woocommerce.android.ui.woopos.home.cart.WooPosCartStatus.CHECKOUT
 import com.woocommerce.android.ui.woopos.home.cart.WooPosCartStatus.EDITABLE
 import com.woocommerce.android.ui.woopos.home.cart.WooPosCartStatus.EMPTY
@@ -123,6 +121,7 @@ class WooPosCartViewModel @Inject constructor(
                     productId = it.id,
                     id = it.variationId
                 )
+                is WooPosCartItemViewState.Coupon -> WooPosItemsViewModel.ItemClickedData.Coupon(it.id, it.name)
             }
         }
         sendEventToParent(ChildToParentEvent.CheckoutClicked(itemClickedDataList))
@@ -195,8 +194,12 @@ class WooPosCartViewModel @Inject constructor(
         return productVariation.toCartListItem(itemNumber, product)
     }
 
-    private suspend fun handleCouponClicked(couponId: Long, couponCode: String): WooPosCartItemViewState {
-        TODO("Not yet implemented")
+    private fun handleCouponClicked(couponId: Long, couponCode: String): WooPosCartItemViewState {
+        return WooPosCartItemViewState.Coupon(
+            itemNumber = getItemNumber(),
+            id = couponId,
+            name = couponCode
+        )
     }
 
     private fun clearCart() {
@@ -314,8 +317,8 @@ class WooPosCartViewModel @Inject constructor(
             imageUrl = image?.source,
         )
 
-    private fun getInitialValueOrHighestUsedItemNumberAfterProcessDeath() = (_state.value.body as? WithItems)
-        ?.itemsInCart?.maxOfOrNull { it.itemNumber } ?: 1
+    private fun getInitialValueOrHighestUsedItemNumberAfterProcessDeath() =
+        (_state.value.body as? WooPosCartState.Body.WithItems)?.itemsInCart?.maxOfOrNull { it.itemNumber } ?: 1
 }
 
 private fun WooPosItemsViewModel.ItemClickedData.posItemNameForAnalytics(): String {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/cart/WooPosCartViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/cart/WooPosCartViewModel.kt
@@ -116,8 +116,8 @@ class WooPosCartViewModel @Inject constructor(
     private fun goToTotals() {
         val itemClickedDataList = (_state.value.body as WooPosCartState.Body.WithItems).itemsInCart.map {
             when (it) {
-                is WooPosCartItemViewState.Product.Simple -> WooPosItemsViewModel.ItemClickedData.SimpleProduct(it.id)
-                is WooPosCartItemViewState.Product.Variation -> WooPosItemsViewModel.ItemClickedData.Variation(
+                is WooPosCartItemViewState.Product.Simple -> WooPosItemsViewModel.ItemClickedData.Product.Simple(it.id)
+                is WooPosCartItemViewState.Product.Variation -> WooPosItemsViewModel.ItemClickedData.Product.Variation(
                     productId = it.id,
                     id = it.variationId
                 )
@@ -159,9 +159,9 @@ class WooPosCartViewModel @Inject constructor(
         viewModelScope.launch {
             val itemClicked = async {
                 when (event.itemData) {
-                    is WooPosItemsViewModel.ItemClickedData.SimpleProduct ->
+                    is WooPosItemsViewModel.ItemClickedData.Product.Simple ->
                         handleSimpleProductClicked(event.itemData.id)
-                    is WooPosItemsViewModel.ItemClickedData.Variation ->
+                    is WooPosItemsViewModel.ItemClickedData.Product.Variation ->
                         handleVariationClicked(event.itemData.productId, event.itemData.id)
                     is WooPosItemsViewModel.ItemClickedData.Coupon ->
                         handleCouponClicked(event.itemData.id, event.itemData.couponCode)
@@ -323,8 +323,8 @@ class WooPosCartViewModel @Inject constructor(
 
 private fun WooPosItemsViewModel.ItemClickedData.posItemNameForAnalytics(): String {
     return when (this) {
-        is WooPosItemsViewModel.ItemClickedData.SimpleProduct -> "simple"
-        is WooPosItemsViewModel.ItemClickedData.Variation -> "variation"
+        is WooPosItemsViewModel.ItemClickedData.Product.Simple -> "simple"
+        is WooPosItemsViewModel.ItemClickedData.Product.Variation -> "variation"
         is WooPosItemsViewModel.ItemClickedData.Coupon -> "coupon"
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/items/WooPosItemsViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/items/WooPosItemsViewModel.kt
@@ -255,7 +255,7 @@ class WooPosItemsViewModel @Inject constructor(
         when (event.item) {
             is WooPosItemSelectionViewState.Product.Simple -> {
                 onItemClicked(
-                    ItemClickedData.SimpleProduct(
+                    ItemClickedData.Product.Simple(
                         id = event.item.id
                     )
                 )
@@ -455,8 +455,16 @@ class WooPosItemsViewModel @Inject constructor(
 
     @Parcelize
     sealed class ItemClickedData(open val id: Long) : Parcelable {
-        data class SimpleProduct(override val id: Long) : ItemClickedData(id)
-        data class Variation(val productId: Long, override val id: Long) : ItemClickedData(id)
-        data class Coupon(override val id: Long, val couponCode: String) : ItemClickedData(id)
+        @Parcelize
+        sealed class Product(override val id: Long) : ItemClickedData(id), Parcelable {
+            @Parcelize
+            data class Simple(override val id: Long) : Product(id), Parcelable
+
+            @Parcelize
+            data class Variation(val productId: Long, override val id: Long) : Product(id), Parcelable
+        }
+
+        @Parcelize
+        data class Coupon(override val id: Long, val couponCode: String) : ItemClickedData(id), Parcelable
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/items/variations/WooPosVariationsViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/items/variations/WooPosVariationsViewModel.kt
@@ -201,7 +201,7 @@ class WooPosVariationsViewModel @Inject constructor(
     private fun onVariationClicked(productId: Long, variationId: Long) {
         sendEventToParent(
             ChildToParentEvent.ItemClickedInProductSelector(
-                WooPosItemsViewModel.ItemClickedData.Variation(productId, variationId)
+                WooPosItemsViewModel.ItemClickedData.Product.Variation(productId, variationId)
             )
         )
     }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/totals/WooPosTotalsRepository.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/totals/WooPosTotalsRepository.kt
@@ -66,11 +66,11 @@ class WooPosTotalsRepository @Inject constructor(
             .map { (id, quantity) ->
                 val itemData = itemClickedDataList.find { it.id == id }!!
                 when (itemData) {
-                    is WooPosItemsViewModel.ItemClickedData.SimpleProduct -> createSimpleProductOrderItem(
+                    is WooPosItemsViewModel.ItemClickedData.Product.Simple -> createSimpleProductOrderItem(
                         quantity,
                         itemData
                     )
-                    is WooPosItemsViewModel.ItemClickedData.Variation -> createVariationOrderItem(
+                    is WooPosItemsViewModel.ItemClickedData.Product.Variation -> createVariationOrderItem(
                         quantity,
                         itemData
                     )
@@ -83,7 +83,7 @@ class WooPosTotalsRepository @Inject constructor(
 
     private suspend fun createSimpleProductOrderItem(
         quantity: Int,
-        itemData: WooPosItemsViewModel.ItemClickedData.SimpleProduct
+        itemData: WooPosItemsViewModel.ItemClickedData.Product.Simple
     ): Order.Item {
         val productResult = getProductById(itemData.id)!!
         return Order.Item.EMPTY.copy(
@@ -100,7 +100,7 @@ class WooPosTotalsRepository @Inject constructor(
 
     private suspend fun createVariationOrderItem(
         quantity: Int,
-        itemData: WooPosItemsViewModel.ItemClickedData.Variation
+        itemData: WooPosItemsViewModel.ItemClickedData.Product.Variation
     ): Order.Item {
         val productResult = getProductById(itemData.productId)!!
         val variationResult = getVariationById(

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/totals/WooPosTotalsRepository.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/totals/WooPosTotalsRepository.kt
@@ -48,17 +48,20 @@ class WooPosTotalsRepository @Inject constructor(
     }
 
     private suspend fun createOrder(itemClickedDataList: List<WooPosItemsViewModel.ItemClickedData>): Order {
+        val products = itemClickedDataList.filterIsInstance<WooPosItemsViewModel.ItemClickedData.Product>()
+        val coupons = itemClickedDataList.filterIsInstance<WooPosItemsViewModel.ItemClickedData.Coupon>()
         return Order.getEmptyOrder(
             dateCreated = dateUtils.getCurrentDateInSiteTimeZone() ?: Date(),
             dateModified = dateUtils.getCurrentDateInSiteTimeZone() ?: Date()
         ).copy(
             status = Order.Status.Custom(Order.Status.AUTO_DRAFT),
-            items = createOrderItems(itemClickedDataList)
+            items = createProductItems(products),
+            couponLines = createCouponLines(coupons),
         )
     }
 
-    private suspend fun createOrderItems(
-        itemClickedDataList: List<WooPosItemsViewModel.ItemClickedData>
+    private suspend fun createProductItems(
+        itemClickedDataList: List<WooPosItemsViewModel.ItemClickedData.Product>
     ): List<Order.Item> {
         return itemClickedDataList
             .groupingBy { it.id }
@@ -74,11 +77,17 @@ class WooPosTotalsRepository @Inject constructor(
                         quantity,
                         itemData
                     )
-                    is WooPosItemsViewModel.ItemClickedData.Coupon -> throw IllegalArgumentException(
-                        "Coupons are not supported"
-                    )
                 }
             }
+    }
+
+    private fun createCouponLines(coupons: List<WooPosItemsViewModel.ItemClickedData.Coupon>): List<Order.CouponLine> {
+        return coupons.map {
+            Order.CouponLine(
+                code = it.couponCode,
+                id = it.id,
+            )
+        }
     }
 
     private suspend fun createSimpleProductOrderItem(

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/totals/WooPosTotalsRepository.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/totals/WooPosTotalsRepository.kt
@@ -38,18 +38,12 @@ class WooPosTotalsRepository @Inject constructor(
         orderCreationJob?.cancel()
 
         return withContext(IO) {
-            validateProductIds(itemClickedDataList)
+            check(itemClickedDataList.all { it.id >= 0 }) { "Invalid item ID" }
             orderCreationJob = async {
                 val order = createOrder(itemClickedDataList)
                 orderCreateEditRepository.createOrUpdateOrder(order)
             }
             orderCreationJob!!.await()
-        }
-    }
-
-    private fun validateProductIds(itemClickedDataList: List<WooPosItemsViewModel.ItemClickedData>) {
-        itemClickedDataList.map { it.id }.forEach { productId ->
-            require(productId >= 0) { "Invalid product ID: $productId" }
         }
     }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/totals/WooPosTotalsRepository.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/totals/WooPosTotalsRepository.kt
@@ -30,7 +30,7 @@ class WooPosTotalsRepository @Inject constructor(
 ) {
     private var orderCreationJob: Deferred<Result<Order>>? = null
 
-    suspend fun createOrderWithProducts(
+    suspend fun createOrderFromCartItems(
         itemClickedDataList: List<WooPosItemsViewModel.ItemClickedData>
     ): Result<Order> {
         check(itemClickedDataList.map { it.id }.isNotEmpty()) { "List of IDs is empty" }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/totals/WooPosTotalsViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/totals/WooPosTotalsViewModel.kt
@@ -409,7 +409,7 @@ class WooPosTotalsViewModel @Inject constructor(
         viewModelScope.launch {
             uiState.value = WooPosTotalsViewState.Loading
 
-            totalsRepository.createOrderWithProducts(itemClickedDataList = itemClickedDataList)
+            totalsRepository.createOrderFromCartItems(itemClickedDataList = itemClickedDataList)
                 .fold(
                     onSuccess = { order ->
                         dataState.value = dataState.value.copy(

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/util/FeatureFlag.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/util/FeatureFlag.kt
@@ -29,6 +29,7 @@ enum class FeatureFlag {
             BETTER_CUSTOMER_SEARCH_M2,
             ORDER_CREATION_AUTO_TAX_RATE,
             POS_PRODUCTS_SEARCH,
+            POS_COUPONS,
             REVAMP_WOO_SHIPPING -> PackageUtils.isDebugBuild()
 
             NEW_SHIPPING_SUPPORT,
@@ -36,7 +37,6 @@ enum class FeatureFlag {
             OBJECTIVE_SECTION,
             BULK_UPDATE_ORDERS_STATUS,
             HIDE_SITES_FROM_SITE_PICKER -> true
-            POS_COUPONS -> false
         }
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/util/FeatureFlag.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/util/FeatureFlag.kt
@@ -27,7 +27,6 @@ enum class FeatureFlag {
 
             WC_SHIPPING_BANNER,
             BETTER_CUSTOMER_SEARCH_M2,
-            POS_COUPONS,
             ORDER_CREATION_AUTO_TAX_RATE,
             POS_PRODUCTS_SEARCH,
             REVAMP_WOO_SHIPPING -> PackageUtils.isDebugBuild()
@@ -37,6 +36,7 @@ enum class FeatureFlag {
             OBJECTIVE_SECTION,
             BULK_UPDATE_ORDERS_STATUS,
             HIDE_SITES_FROM_SITE_PICKER -> true
+            POS_COUPONS -> false
         }
     }
 }

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -4277,7 +4277,8 @@
     <string name="woopos_product_item_content_description">Product %s, Price %s</string>
     <string name="woopos_variable_product_item_content_description">Variable Product %s, Price %s</string>
     <string name="woopos_variation_item_content_description">Variation %s, Price %s</string>
-    <string name="woopos_cart_item_content_description">Product in cart %s, Price %s</string>
+    <string name="woopos_cart_item_product_content_description">Product in cart %s, Price %s</string>
+    <string name="woopos_cart_item_coupon_content_description">Coupon in cart %s</string>
     <string name="woopos_cart_title">Cart</string>
     <string name="woopos_clear_cart_button">Clear</string>
 

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/home/WooPosHomeViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/home/WooPosHomeViewModelTest.kt
@@ -272,7 +272,7 @@ class WooPosHomeViewModelTest {
     @Test
     fun `given home screen is at checkout, when products are updated, then should not modify screen position`() {
         val itemClickedData = listOf(
-            ItemClickedData.SimpleProduct(
+            ItemClickedData.Product.Simple(
                 id = 1L
             )
         )
@@ -294,7 +294,7 @@ class WooPosHomeViewModelTest {
         whenever(childrenToParentEventReceiver.events).thenReturn(events)
 
         val viewModel: WooPosHomeViewModel = createViewModel()
-        events.emit(ChildToParentEvent.CheckoutClicked(listOf(ItemClickedData.SimpleProduct(1))))
+        events.emit(ChildToParentEvent.CheckoutClicked(listOf(ItemClickedData.Product.Simple(1))))
         assertThat(
             viewModel.state.value.screenPositionState
         ).isEqualTo(WooPosHomeState.ScreenPositionState.Checkout.CartWithTotals)
@@ -315,7 +315,7 @@ class WooPosHomeViewModelTest {
         whenever(childrenToParentEventReceiver.events).thenReturn(events)
 
         val viewModel: WooPosHomeViewModel = createViewModel()
-        events.emit(ChildToParentEvent.CheckoutClicked(listOf(ItemClickedData.SimpleProduct(1))))
+        events.emit(ChildToParentEvent.CheckoutClicked(listOf(ItemClickedData.Product.Simple(1))))
         assertThat(
             viewModel.state.value.screenPositionState
         ).isEqualTo(WooPosHomeState.ScreenPositionState.Checkout.CartWithTotals)
@@ -336,7 +336,7 @@ class WooPosHomeViewModelTest {
         whenever(childrenToParentEventReceiver.events).thenReturn(events)
 
         val viewModel: WooPosHomeViewModel = createViewModel()
-        events.emit(ChildToParentEvent.CheckoutClicked(listOf(ItemClickedData.SimpleProduct(1))))
+        events.emit(ChildToParentEvent.CheckoutClicked(listOf(ItemClickedData.Product.Simple(1))))
         assertThat(
             viewModel.state.value.screenPositionState
         ).isEqualTo(WooPosHomeState.ScreenPositionState.Checkout.CartWithTotals)
@@ -361,7 +361,7 @@ class WooPosHomeViewModelTest {
         whenever(childrenToParentEventReceiver.events).thenReturn(events)
 
         val viewModel: WooPosHomeViewModel = createViewModel()
-        events.emit(ChildToParentEvent.CheckoutClicked(listOf(ItemClickedData.SimpleProduct(1))))
+        events.emit(ChildToParentEvent.CheckoutClicked(listOf(ItemClickedData.Product.Simple(1))))
         assertThat(
             viewModel.state.value.screenPositionState
         ).isEqualTo(WooPosHomeState.ScreenPositionState.Checkout.CartWithTotals)
@@ -442,7 +442,7 @@ class WooPosHomeViewModelTest {
         whenever(childrenToParentEventReceiver.events).thenReturn(events)
 
         val viewModel: WooPosHomeViewModel = createViewModel()
-        events.emit(ChildToParentEvent.CheckoutClicked(listOf(ItemClickedData.SimpleProduct(1))))
+        events.emit(ChildToParentEvent.CheckoutClicked(listOf(ItemClickedData.Product.Simple(1))))
         assertThat(
             viewModel.state.value.screenPositionState
         ).isEqualTo(WooPosHomeState.ScreenPositionState.Checkout.CartWithTotals)

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/home/cart/WooPosCartViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/home/cart/WooPosCartViewModelTest.kt
@@ -89,7 +89,7 @@ class WooPosCartViewModelTest {
         // WHEN
         parentToChildrenEventsMutableFlow.emit(
             ParentToChildrenEvent.ItemClickedInProductSelector(
-                WooPosItemsViewModel.ItemClickedData.SimpleProduct(
+                WooPosItemsViewModel.ItemClickedData.Product.Simple(
                     id = product.remoteId
                 )
             )
@@ -127,7 +127,7 @@ class WooPosCartViewModelTest {
         // WHEN
         parentToChildrenEventsMutableFlow.emit(
             ParentToChildrenEvent.ItemClickedInProductSelector(
-                WooPosItemsViewModel.ItemClickedData.Variation(
+                WooPosItemsViewModel.ItemClickedData.Product.Variation(
                     id = variation.remoteVariationId,
                     productId = variation.remoteProductId
                 )
@@ -158,7 +158,7 @@ class WooPosCartViewModelTest {
 
         parentToChildrenEventsMutableFlow.emit(
             ParentToChildrenEvent.ItemClickedInProductSelector(
-                WooPosItemsViewModel.ItemClickedData.SimpleProduct(
+                WooPosItemsViewModel.ItemClickedData.Product.Simple(
                     id = product.remoteId
                 )
             )
@@ -200,7 +200,7 @@ class WooPosCartViewModelTest {
 
         parentToChildrenEventsMutableFlow.emit(
             ParentToChildrenEvent.ItemClickedInProductSelector(
-                WooPosItemsViewModel.ItemClickedData.SimpleProduct(
+                WooPosItemsViewModel.ItemClickedData.Product.Simple(
                     id = product.remoteId
                 )
             )
@@ -290,7 +290,7 @@ class WooPosCartViewModelTest {
 
             parentToChildrenEventsMutableFlow.emit(
                 ParentToChildrenEvent.ItemClickedInProductSelector(
-                    WooPosItemsViewModel.ItemClickedData.SimpleProduct(
+                    WooPosItemsViewModel.ItemClickedData.Product.Simple(
                         id = product.remoteId
                     )
                 )
@@ -351,14 +351,14 @@ class WooPosCartViewModelTest {
             // WHEN
             parentToChildrenEventsMutableFlow.emit(
                 ParentToChildrenEvent.ItemClickedInProductSelector(
-                    WooPosItemsViewModel.ItemClickedData.SimpleProduct(
+                    WooPosItemsViewModel.ItemClickedData.Product.Simple(
                         id = product1.remoteId
                     )
                 )
             )
             parentToChildrenEventsMutableFlow.emit(
                 ParentToChildrenEvent.ItemClickedInProductSelector(
-                    WooPosItemsViewModel.ItemClickedData.SimpleProduct(
+                    WooPosItemsViewModel.ItemClickedData.Product.Simple(
                         id = product2.remoteId
                     )
                 )
@@ -379,7 +379,7 @@ class WooPosCartViewModelTest {
 
             parentToChildrenEventsMutableFlow.emit(
                 ParentToChildrenEvent.ItemClickedInProductSelector(
-                    WooPosItemsViewModel.ItemClickedData.SimpleProduct(
+                    WooPosItemsViewModel.ItemClickedData.Product.Simple(
                         id = product3.remoteId
                     )
                 )
@@ -421,7 +421,7 @@ class WooPosCartViewModelTest {
         // WHEN
         parentToChildrenEventsMutableFlow.emit(
             ParentToChildrenEvent.ItemClickedInProductSelector(
-                WooPosItemsViewModel.ItemClickedData.SimpleProduct(
+                WooPosItemsViewModel.ItemClickedData.Product.Simple(
                     id = product.remoteId
                 )
             )
@@ -475,7 +475,7 @@ class WooPosCartViewModelTest {
 
         parentToChildrenEventsMutableFlow.emit(
             ParentToChildrenEvent.ItemClickedInProductSelector(
-                WooPosItemsViewModel.ItemClickedData.SimpleProduct(
+                WooPosItemsViewModel.ItemClickedData.Product.Simple(
                     id = product.remoteId
                 )
             )
@@ -536,7 +536,7 @@ class WooPosCartViewModelTest {
         // WHEN
         parentToChildrenEventsMutableFlow.emit(
             ParentToChildrenEvent.ItemClickedInProductSelector(
-                WooPosItemsViewModel.ItemClickedData.SimpleProduct(
+                WooPosItemsViewModel.ItemClickedData.Product.Simple(
                     id = product.remoteId
                 )
             )
@@ -564,7 +564,7 @@ class WooPosCartViewModelTest {
         // WHEN
         parentToChildrenEventsMutableFlow.emit(
             ParentToChildrenEvent.ItemClickedInProductSelector(
-                WooPosItemsViewModel.ItemClickedData.SimpleProduct(
+                WooPosItemsViewModel.ItemClickedData.Product.Simple(
                     id = product.remoteId
                 )
             )
@@ -606,7 +606,7 @@ class WooPosCartViewModelTest {
         // WHEN
         parentToChildrenEventsMutableFlow.emit(
             ParentToChildrenEvent.ItemClickedInProductSelector(
-                WooPosItemsViewModel.ItemClickedData.Variation(
+                WooPosItemsViewModel.ItemClickedData.Product.Variation(
                     id = variation.remoteProductId,
                     productId = variation.remoteProductId
                 )
@@ -638,7 +638,7 @@ class WooPosCartViewModelTest {
         val states = sut.state.captureValues()
         parentToChildrenEventsMutableFlow.emit(
             ParentToChildrenEvent.ItemClickedInProductSelector(
-                WooPosItemsViewModel.ItemClickedData.SimpleProduct(
+                WooPosItemsViewModel.ItemClickedData.Product.Simple(
                     id = product.remoteId
                 )
             )

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/home/cart/WooPosCartViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/home/cart/WooPosCartViewModelTest.kt
@@ -167,46 +167,46 @@ class WooPosCartViewModelTest {
     @Test
     fun `given product in cart, when product remove button clicked in cart, then should remove product from cart`() =
         runTest {
-        // GIVEN
-        val product = ProductTestUtils.generateProduct(
-            productId = 23L,
-            productName = "title",
-            amount = "10.0"
-        ).copy(firstImageUrl = "url")
+            // GIVEN
+            val product = ProductTestUtils.generateProduct(
+                productId = 23L,
+                productName = "title",
+                amount = "10.0"
+            ).copy(firstImageUrl = "url")
 
-        val parentToChildrenEventsMutableFlow = MutableSharedFlow<ParentToChildrenEvent>()
-        whenever(parentToChildrenEventReceiver.events).thenReturn(parentToChildrenEventsMutableFlow)
-        whenever(getProductById(eq(product.remoteId))).thenReturn(product)
-        val sut = createSut()
-        val states = sut.state.captureValues()
+            val parentToChildrenEventsMutableFlow = MutableSharedFlow<ParentToChildrenEvent>()
+            whenever(parentToChildrenEventReceiver.events).thenReturn(parentToChildrenEventsMutableFlow)
+            whenever(getProductById(eq(product.remoteId))).thenReturn(product)
+            val sut = createSut()
+            val states = sut.state.captureValues()
 
-        parentToChildrenEventsMutableFlow.emit(
-            ParentToChildrenEvent.ItemClickedInProductSelector(
-                WooPosItemsViewModel.ItemClickedData.Product.Simple(
-                    id = product.remoteId
+            parentToChildrenEventsMutableFlow.emit(
+                ParentToChildrenEvent.ItemClickedInProductSelector(
+                    WooPosItemsViewModel.ItemClickedData.Product.Simple(
+                        id = product.remoteId
+                    )
                 )
             )
-        )
 
-        // WHEN
-        sut.onUIEvent(
-            WooPosCartUIEvent.ItemRemovedFromCart(
-                WooPosCartItemViewState.Product.Simple(
-                    itemNumber = 1,
-                    id = product.remoteId,
-                    name = product.name,
-                    price = "10.0$",
-                    imageUrl = product.firstImageUrl,
-                    description = null,
+            // WHEN
+            sut.onUIEvent(
+                WooPosCartUIEvent.ItemRemovedFromCart(
+                    WooPosCartItemViewState.Product.Simple(
+                        itemNumber = 1,
+                        id = product.remoteId,
+                        name = product.name,
+                        price = "10.0$",
+                        imageUrl = product.firstImageUrl,
+                        description = null,
+                    )
                 )
             )
-        )
 
-        // THEN
-        val itemsInCartAfterRemoveClicked =
-            (states.last().body as? WooPosCartState.Body.WithItems)?.itemsInCart ?: emptyList()
-        assertThat(itemsInCartAfterRemoveClicked).isEmpty()
-    }
+            // THEN
+            val itemsInCartAfterRemoveClicked =
+                (states.last().body as? WooPosCartState.Body.WithItems)?.itemsInCart ?: emptyList()
+            assertThat(itemsInCartAfterRemoveClicked).isEmpty()
+        }
 
     @Test
     fun `given coupon in cart, when coupon remove button clicked in cart, then should remove coupon from cart`() =

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/home/cart/WooPosCartViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/home/cart/WooPosCartViewModelTest.kt
@@ -142,7 +142,31 @@ class WooPosCartViewModelTest {
     }
 
     @Test
-    fun `given items in cart, when item remove button clicked in cart, then should remove item from cart`() = runTest {
+    fun `given empty cart, when coupon clicked, then should add coupon to cart`() = runTest {
+        // GIVEN
+        val parentToChildrenEventsMutableFlow = MutableSharedFlow<ParentToChildrenEvent>()
+        whenever(parentToChildrenEventReceiver.events).thenReturn(parentToChildrenEventsMutableFlow)
+        val sut = createSut()
+        val states = sut.state.captureValues()
+
+        // WHEN
+        parentToChildrenEventsMutableFlow.emit(
+            ParentToChildrenEvent.ItemClickedInProductSelector(
+                WooPosItemsViewModel.ItemClickedData.Coupon(
+                    id = 1L,
+                    couponCode = "coupon_code"
+                )
+            )
+        )
+
+        // THEN
+        val itemsInCart = (states.last().body as WooPosCartState.Body.WithItems).itemsInCart
+        assertThat(itemsInCart).hasSize(1)
+    }
+
+    @Test
+    fun `given product in cart, when product remove button clicked in cart, then should remove product from cart`() =
+        runTest {
         // GIVEN
         val product = ProductTestUtils.generateProduct(
             productId = 23L,
@@ -183,6 +207,41 @@ class WooPosCartViewModelTest {
             (states.last().body as? WooPosCartState.Body.WithItems)?.itemsInCart ?: emptyList()
         assertThat(itemsInCartAfterRemoveClicked).isEmpty()
     }
+
+    @Test
+    fun `given coupon in cart, when coupon remove button clicked in cart, then should remove coupon from cart`() =
+        runTest {
+            // GIVEN
+            val parentToChildrenEventsMutableFlow = MutableSharedFlow<ParentToChildrenEvent>()
+            whenever(parentToChildrenEventReceiver.events).thenReturn(parentToChildrenEventsMutableFlow)
+            val sut = createSut()
+            val states = sut.state.captureValues()
+
+            parentToChildrenEventsMutableFlow.emit(
+                ParentToChildrenEvent.ItemClickedInProductSelector(
+                    WooPosItemsViewModel.ItemClickedData.Coupon(
+                        id = 1L,
+                        couponCode = "coupon_code"
+                    )
+                )
+            )
+
+            // WHEN
+            sut.onUIEvent(
+                WooPosCartUIEvent.ItemRemovedFromCart(
+                    WooPosCartItemViewState.Coupon(
+                        id = 1L,
+                        itemNumber = 1,
+                        name = "coupon_code"
+                    )
+                )
+            )
+
+            // THEN
+            val itemsInCartAfterRemoveClicked =
+                (states.last().body as? WooPosCartState.Body.WithItems)?.itemsInCart ?: emptyList()
+            assertThat(itemsInCartAfterRemoveClicked).isEmpty()
+        }
 
     @Test
     fun `given items in cart, when item remove button clicked in cart, then should track envent`() = runTest {
@@ -432,6 +491,27 @@ class WooPosCartViewModelTest {
     }
 
     @Test
+    fun `given empty cart, when coupon tapped, then should track start of customer interaction event`() = runTest {
+        // GIVEN
+        val parentToChildrenEventsMutableFlow = MutableSharedFlow<ParentToChildrenEvent>()
+        whenever(parentToChildrenEventReceiver.events).thenReturn(parentToChildrenEventsMutableFlow)
+        createSut()
+
+        // WHEN
+        parentToChildrenEventsMutableFlow.emit(
+            ParentToChildrenEvent.ItemClickedInProductSelector(
+                WooPosItemsViewModel.ItemClickedData.Coupon(
+                    id = 1L,
+                    couponCode = "coupon_code"
+                )
+            )
+        )
+
+        // THEN
+        verify(analyticsTracker).track(InteractionWithCustomerStarted)
+    }
+
+    @Test
     fun `given non-empty cart, when all items removed, then state should be empty`() = runTest {
         // GIVEN
         val (sut, states) = createSutWithItemsInCart()
@@ -547,6 +627,28 @@ class WooPosCartViewModelTest {
     }
 
     @Test
+    fun `when coupon added to cart, then should track analytics event`() = runTest {
+        // GIVEN
+        val parentToChildrenEventsMutableFlow = MutableSharedFlow<ParentToChildrenEvent>()
+        whenever(parentToChildrenEventReceiver.events).thenReturn(parentToChildrenEventsMutableFlow)
+        val sut = createSut()
+        sut.state.captureValues()
+
+        // WHEN
+        parentToChildrenEventsMutableFlow.emit(
+            ParentToChildrenEvent.ItemClickedInProductSelector(
+                WooPosItemsViewModel.ItemClickedData.Coupon(
+                    id = 1L,
+                    couponCode = "coupon_code"
+                )
+            )
+        )
+
+        // THEN
+        verify(analyticsTracker).track(WooPosAnalyticsEvent.Event.ItemAddedToCart)
+    }
+
+    @Test
     fun `when simple product added to cart, then should track analytics event with product type simple`() = runTest {
         // GIVEN
         val product = ProductTestUtils.generateProduct(
@@ -620,6 +722,35 @@ class WooPosCartViewModelTest {
                     (
                         this as WooPosAnalyticsEvent.Event.ItemAddedToCart
                         ).properties[WooPosAnalyticsEventConstant.PRODUCT_TYPE] == "variation"
+            }
+        )
+    }
+
+    @Test
+    fun `when coupon added to cart, then should track analytics event with item type coupon`() = runTest {
+        // GIVEN
+        val parentToChildrenEventsMutableFlow = MutableSharedFlow<ParentToChildrenEvent>()
+        whenever(parentToChildrenEventReceiver.events).thenReturn(parentToChildrenEventsMutableFlow)
+        val sut = createSut()
+        sut.state.captureValues()
+
+        // WHEN
+        parentToChildrenEventsMutableFlow.emit(
+            ParentToChildrenEvent.ItemClickedInProductSelector(
+                WooPosItemsViewModel.ItemClickedData.Coupon(
+                    id = 1L,
+                    couponCode = "coupon_code"
+                )
+            )
+        )
+
+        // THEN
+        verify(analyticsTracker).track(
+            argThat {
+                this == WooPosAnalyticsEvent.Event.ItemAddedToCart &&
+                    (
+                        this as WooPosAnalyticsEvent.Event.ItemAddedToCart
+                        ).properties[WooPosAnalyticsEventConstant.PRODUCT_TYPE] == "coupon"
             }
         )
     }

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/home/items/WooPosItemsViewModelTestSelectionViewState.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/home/items/WooPosItemsViewModelTestSelectionViewState.kt
@@ -195,7 +195,7 @@ class WooPosItemsViewModelTestSelectionViewState {
     }
 
     @Test
-    fun `when item clicked, then send event to parent`() = runTest {
+    fun `when product clicked, then send event to parent`() = runTest {
         // GIVEN
         val product = Product.Simple(id = 1, name = "", price = "", imageUrl = null)
         val viewModel = createViewModel()

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/home/items/WooPosItemsViewModelTestSelectionViewState.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/home/items/WooPosItemsViewModelTestSelectionViewState.kt
@@ -207,7 +207,7 @@ class WooPosItemsViewModelTestSelectionViewState {
         viewModel.viewState.test {
             verify(fromChildToParentEventSender).sendToParent(
                 ChildToParentEvent.ItemClickedInProductSelector(
-                    WooPosItemsViewModel.ItemClickedData.SimpleProduct(
+                    WooPosItemsViewModel.ItemClickedData.Product.Simple(
                         id = product.id
                     )
                 )

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/home/totals/WooPosTotalsRepositoryTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/home/totals/WooPosTotalsRepositoryTest.kt
@@ -180,8 +180,8 @@ class WooPosTotalsRepositoryTest {
 
         // THEN
         assertThat(result.isFailure).isTrue()
-        assertThat(result.exceptionOrNull()).isInstanceOf(IllegalArgumentException::class.java)
-        assertThat(result.exceptionOrNull()?.message).isEqualTo("Invalid product ID: -1")
+        assertThat(result.exceptionOrNull()).isInstanceOf(IllegalStateException::class.java)
+        assertThat(result.exceptionOrNull()?.message).isEqualTo("Invalid item ID")
         verify(orderCreateEditRepository, never()).createOrUpdateOrder(any(), eq(""))
     }
 

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/home/totals/WooPosTotalsRepositoryTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/home/totals/WooPosTotalsRepositoryTest.kt
@@ -41,20 +41,20 @@ class WooPosTotalsRepositoryTest {
     ).copy(remoteId = 1L)
 
     @Test
-    fun `given empty product list, when createOrderWithProducts called, then return error`() = runTest {
+    fun `given empty product list, when createOrderFromCartItems called, then return error`() = runTest {
         // GIVEN
         repository = createRepository()
         val itemClickedData = emptyList<WooPosItemsViewModel.ItemClickedData>()
 
         // WHEN
-        val result = runCatching { repository.createOrderWithProducts(itemClickedData) }
+        val result = runCatching { repository.createOrderFromCartItems(itemClickedData) }
 
         // THEN
         assertThat(result.exceptionOrNull()).isInstanceOf(IllegalStateException::class.java)
     }
 
     @Test
-    fun `given product ids without duplicates, when createOrderWithProducts, then items all quantity one`() = runTest {
+    fun `given product ids without duplicates, when createOrderFromCartItems, then items all quantity one`() = runTest {
         // GIVEN
         repository = createRepository()
         val itemClickedData = listOf(
@@ -74,7 +74,7 @@ class WooPosTotalsRepositoryTest {
         whenever(getProductById(3L)).thenReturn(product1)
 
         // WHEN
-        repository.createOrderWithProducts(itemClickedData)
+        repository.createOrderFromCartItems(itemClickedData)
 
         // THEN
         val orderCapture = argumentCaptor<Order>()
@@ -89,7 +89,7 @@ class WooPosTotalsRepositoryTest {
     }
 
     @Test
-    fun `given product id, when createOrderWithProducts, then item name matches original product`() = runTest {
+    fun `given product id, when createOrderFromCartItems, then item name matches original product`() = runTest {
         // GIVEN
         repository = createRepository()
         val itemClickedData = listOf(
@@ -101,7 +101,7 @@ class WooPosTotalsRepositoryTest {
         whenever(getProductById(1L)).thenReturn(product1)
 
         // WHEN
-        repository.createOrderWithProducts(itemClickedData)
+        repository.createOrderFromCartItems(itemClickedData)
 
         // THEN
         val orderCapture = argumentCaptor<Order>()
@@ -115,7 +115,7 @@ class WooPosTotalsRepositoryTest {
     }
 
     @Test
-    fun `given product ids with duplicates, when createOrderWithProducts, then items quantity is correct`() = runTest {
+    fun `given product ids with duplicates, when createOrderFromCartItems, then items quantity is correct`() = runTest {
         // GIVEN
         repository = createRepository()
         val itemClickedData = listOf(
@@ -144,7 +144,7 @@ class WooPosTotalsRepositoryTest {
         whenever(getProductById(3L)).thenReturn(product1)
 
         // WHEN
-        repository.createOrderWithProducts(itemClickedData)
+        repository.createOrderFromCartItems(itemClickedData)
 
         // THEN
         val orderCapture = argumentCaptor<Order>()
@@ -176,7 +176,7 @@ class WooPosTotalsRepositoryTest {
         whenever(orderCreateEditRepository.createOrUpdateOrder(any(), eq(""))).thenReturn(Result.success(mockOrder))
 
         // WHEN
-        val result = runCatching { repository.createOrderWithProducts(itemClickedData) }
+        val result = runCatching { repository.createOrderFromCartItems(itemClickedData) }
 
         // THEN
         assertThat(result.isFailure).isTrue()

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/home/totals/WooPosTotalsRepositoryTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/home/totals/WooPosTotalsRepositoryTest.kt
@@ -58,13 +58,13 @@ class WooPosTotalsRepositoryTest {
         // GIVEN
         repository = createRepository()
         val itemClickedData = listOf(
-            WooPosItemsViewModel.ItemClickedData.SimpleProduct(
+            WooPosItemsViewModel.ItemClickedData.Product.Simple(
                 id = 1L
             ),
-            WooPosItemsViewModel.ItemClickedData.SimpleProduct(
+            WooPosItemsViewModel.ItemClickedData.Product.Simple(
                 id = 2L
             ),
-            WooPosItemsViewModel.ItemClickedData.SimpleProduct(
+            WooPosItemsViewModel.ItemClickedData.Product.Simple(
                 id = 3L
             )
         )
@@ -93,7 +93,7 @@ class WooPosTotalsRepositoryTest {
         // GIVEN
         repository = createRepository()
         val itemClickedData = listOf(
-            WooPosItemsViewModel.ItemClickedData.SimpleProduct(
+            WooPosItemsViewModel.ItemClickedData.Product.Simple(
                 id = 1L
             )
         )
@@ -119,22 +119,22 @@ class WooPosTotalsRepositoryTest {
         // GIVEN
         repository = createRepository()
         val itemClickedData = listOf(
-            WooPosItemsViewModel.ItemClickedData.SimpleProduct(
+            WooPosItemsViewModel.ItemClickedData.Product.Simple(
                 id = 1L
             ),
-            WooPosItemsViewModel.ItemClickedData.SimpleProduct(
+            WooPosItemsViewModel.ItemClickedData.Product.Simple(
                 id = 1L
             ),
-            WooPosItemsViewModel.ItemClickedData.SimpleProduct(
+            WooPosItemsViewModel.ItemClickedData.Product.Simple(
                 id = 2L
             ),
-            WooPosItemsViewModel.ItemClickedData.SimpleProduct(
+            WooPosItemsViewModel.ItemClickedData.Product.Simple(
                 id = 3L
             ),
-            WooPosItemsViewModel.ItemClickedData.SimpleProduct(
+            WooPosItemsViewModel.ItemClickedData.Product.Simple(
                 id = 3L
             ),
-            WooPosItemsViewModel.ItemClickedData.SimpleProduct(
+            WooPosItemsViewModel.ItemClickedData.Product.Simple(
                 id = 3L
             )
         )
@@ -162,13 +162,13 @@ class WooPosTotalsRepositoryTest {
         // GIVEN
         repository = createRepository()
         val itemClickedData = listOf(
-            WooPosItemsViewModel.ItemClickedData.SimpleProduct(
+            WooPosItemsViewModel.ItemClickedData.Product.Simple(
                 id = 1L
             ),
-            WooPosItemsViewModel.ItemClickedData.SimpleProduct(
+            WooPosItemsViewModel.ItemClickedData.Product.Simple(
                 id = -1L
             ),
-            WooPosItemsViewModel.ItemClickedData.SimpleProduct(
+            WooPosItemsViewModel.ItemClickedData.Product.Simple(
                 id = 3L
             )
         )

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/home/totals/WooPosTotalsRepositoryTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/home/totals/WooPosTotalsRepositoryTest.kt
@@ -185,6 +185,30 @@ class WooPosTotalsRepositoryTest {
         verify(orderCreateEditRepository, never()).createOrUpdateOrder(any(), eq(""))
     }
 
+    @Test
+    fun `given item list contains coupon, when createOrderFromCartItems, then coupon lines present`() = runTest {
+        // GIVEN
+        repository = createRepository()
+        val itemClickedData = listOf(
+            WooPosItemsViewModel.ItemClickedData.Coupon(
+                id = 1L,
+                couponCode = "coupon"
+            )
+        )
+
+        // WHEN
+        repository.createOrderFromCartItems(itemClickedData)
+
+        // THEN
+        val orderCapture = argumentCaptor<Order>()
+        verify(orderCreateEditRepository).createOrUpdateOrder(
+            orderCapture.capture(),
+            eq("")
+        )
+
+        assertThat(orderCapture.lastValue.couponLines.size).isEqualTo(1)
+    }
+
     private fun createRepository() = WooPosTotalsRepository(
         orderCreateEditRepository,
         dateUtils,

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/home/totals/WooPosTotalsViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/home/totals/WooPosTotalsViewModelTest.kt
@@ -192,7 +192,7 @@ class WooPosTotalsViewModelTest {
             .thenReturn("No internet")
 
         val itemClickedData = listOf(
-            WooPosItemsViewModel.ItemClickedData.SimpleProduct(
+            WooPosItemsViewModel.ItemClickedData.Product.Simple(
                 id = 1L
             )
         )
@@ -261,7 +261,7 @@ class WooPosTotalsViewModelTest {
             whenever(resourceProvider.getString(R.string.woopos_no_internet_message))
                 .thenReturn("No internet")
             val itemClickedData = listOf(
-                WooPosItemsViewModel.ItemClickedData.SimpleProduct(id = 1L)
+                WooPosItemsViewModel.ItemClickedData.Product.Simple(id = 1L)
             )
             val parentToChildrenEventFlow = MutableStateFlow(ParentToChildrenEvent.CheckoutClicked(itemClickedData))
             val parentToChildrenEventReceiver: WooPosParentToChildrenEventReceiver = mock {
@@ -365,7 +365,7 @@ class WooPosTotalsViewModelTest {
         whenever(resourceProvider.getString(R.string.woopos_totals_reader_checking_order))
             .thenReturn("Checking order")
         val itemClickedData = listOf(
-            WooPosItemsViewModel.ItemClickedData.SimpleProduct(id = 1L)
+            WooPosItemsViewModel.ItemClickedData.Product.Simple(id = 1L)
         )
         val parentToChildrenEventFlow = MutableStateFlow(ParentToChildrenEvent.CheckoutClicked(itemClickedData))
         val parentToChildrenEventReceiver: WooPosParentToChildrenEventReceiver = mock {
@@ -403,7 +403,7 @@ class WooPosTotalsViewModelTest {
     fun `when RetryClicked event is triggered, should retry creating order and show loading state`() = runTest {
         // GIVEN
         val itemClickedData = listOf(
-            WooPosItemsViewModel.ItemClickedData.SimpleProduct(id = 1L)
+            WooPosItemsViewModel.ItemClickedData.Product.Simple(id = 1L)
         )
         val parentToChildrenEventFlow = MutableStateFlow(ParentToChildrenEvent.CheckoutClicked(itemClickedData))
         val parentToChildrenEventReceiver: WooPosParentToChildrenEventReceiver = mock {
@@ -482,7 +482,7 @@ class WooPosTotalsViewModelTest {
         whenever(resourceProvider.getString(R.string.woopos_no_internet_message))
             .thenReturn("No internet")
         val itemClickedData = listOf(
-            WooPosItemsViewModel.ItemClickedData.SimpleProduct(id = 1L)
+            WooPosItemsViewModel.ItemClickedData.Product.Simple(id = 1L)
         )
         val parentToChildrenEventFlow = MutableStateFlow(ParentToChildrenEvent.CheckoutClicked(itemClickedData))
         val parentToChildrenEventReceiver: WooPosParentToChildrenEventReceiver = mock {
@@ -539,7 +539,7 @@ class WooPosTotalsViewModelTest {
     @Test
     fun `when fails to create order, then should track order creation failure`() = runTest {
         val itemClickedData = listOf(
-            WooPosItemsViewModel.ItemClickedData.SimpleProduct(id = 1L)
+            WooPosItemsViewModel.ItemClickedData.Product.Simple(id = 1L)
         )
         val parentToChildrenEventFlow = MutableStateFlow(ParentToChildrenEvent.CheckoutClicked(itemClickedData))
         val parentToChildrenEventReceiver: WooPosParentToChildrenEventReceiver = mock {
@@ -617,7 +617,7 @@ class WooPosTotalsViewModelTest {
         whenever(resourceProvider.getString(R.string.woopos_no_internet_message)).thenReturn("No internet")
         whenever(networkStatus.isConnected()).thenReturn(false)
         val itemClickedData = listOf(
-            WooPosItemsViewModel.ItemClickedData.SimpleProduct(
+            WooPosItemsViewModel.ItemClickedData.Product.Simple(
                 id = 1L
             )
         )
@@ -1067,13 +1067,13 @@ class WooPosTotalsViewModelTest {
             val parentToChildrenEventFlow = MutableStateFlow<ParentToChildrenEvent>(
                 ParentToChildrenEvent.CheckoutClicked(
                     listOf(
-                        WooPosItemsViewModel.ItemClickedData.SimpleProduct(
+                        WooPosItemsViewModel.ItemClickedData.Product.Simple(
                             id = 1L
                         ),
-                        WooPosItemsViewModel.ItemClickedData.SimpleProduct(
+                        WooPosItemsViewModel.ItemClickedData.Product.Simple(
                             id = 2L
                         ),
-                        WooPosItemsViewModel.ItemClickedData.SimpleProduct(
+                        WooPosItemsViewModel.ItemClickedData.Product.Simple(
                             id = 3L
                         ),
                     )
@@ -1100,13 +1100,13 @@ class WooPosTotalsViewModelTest {
             val parentToChildrenEventFlow = MutableStateFlow<ParentToChildrenEvent>(
                 ParentToChildrenEvent.CheckoutClicked(
                     listOf(
-                        WooPosItemsViewModel.ItemClickedData.SimpleProduct(
+                        WooPosItemsViewModel.ItemClickedData.Product.Simple(
                             id = 1L
                         ),
-                        WooPosItemsViewModel.ItemClickedData.SimpleProduct(
+                        WooPosItemsViewModel.ItemClickedData.Product.Simple(
                             id = 2L
                         ),
-                        WooPosItemsViewModel.ItemClickedData.SimpleProduct(
+                        WooPosItemsViewModel.ItemClickedData.Product.Simple(
                             id = 3L
                         ),
                     )
@@ -1135,7 +1135,7 @@ class WooPosTotalsViewModelTest {
             whenever(resourceProvider.getString(R.string.woopos_no_internet_message))
                 .thenReturn("No internet")
             val itemClickedData = listOf(
-                WooPosItemsViewModel.ItemClickedData.SimpleProduct(id = 1L)
+                WooPosItemsViewModel.ItemClickedData.Product.Simple(id = 1L)
             )
             val parentToChildrenEventFlow = MutableStateFlow(ParentToChildrenEvent.CheckoutClicked(itemClickedData))
             val parentToChildrenEventReceiver: WooPosParentToChildrenEventReceiver = mock {
@@ -1194,7 +1194,7 @@ class WooPosTotalsViewModelTest {
             whenever(resourceProvider.getString(R.string.woopos_no_internet_message))
                 .thenReturn("No internet")
             val itemClickedData = listOf(
-                WooPosItemsViewModel.ItemClickedData.SimpleProduct(id = 1L)
+                WooPosItemsViewModel.ItemClickedData.Product.Simple(id = 1L)
             )
             val parentToChildrenEventFlow = MutableStateFlow(ParentToChildrenEvent.CheckoutClicked(itemClickedData))
             val parentToChildrenEventReceiver: WooPosParentToChildrenEventReceiver = mock {
@@ -1388,13 +1388,13 @@ class WooPosTotalsViewModelTest {
     private suspend fun createViewModelAndSetupForSuccessfulOrderCreation(
         controllerFactory: WooPosCardReaderPaymentControllerFactory = paymentControllerFactory,
         itemClickedData: List<WooPosItemsViewModel.ItemClickedData> = listOf(
-            WooPosItemsViewModel.ItemClickedData.SimpleProduct(
+            WooPosItemsViewModel.ItemClickedData.Product.Simple(
                 id = 1L
             ),
-            WooPosItemsViewModel.ItemClickedData.SimpleProduct(
+            WooPosItemsViewModel.ItemClickedData.Product.Simple(
                 id = 2L
             ),
-            WooPosItemsViewModel.ItemClickedData.SimpleProduct(
+            WooPosItemsViewModel.ItemClickedData.Product.Simple(
                 id = 3L
             ),
         ),

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/home/totals/WooPosTotalsViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/home/totals/WooPosTotalsViewModelTest.kt
@@ -223,7 +223,7 @@ class WooPosTotalsViewModelTest {
         )
 
         val totalsRepository: WooPosTotalsRepository = mock {
-            onBlocking { createOrderWithProducts(itemClickedData) }.thenReturn(Result.success(order))
+            onBlocking { createOrderFromCartItems(itemClickedData) }.thenReturn(Result.success(order))
         }
 
         val priceFormat: WooPosFormatPrice = mock {
@@ -247,7 +247,7 @@ class WooPosTotalsViewModelTest {
         assertThat(castedTotals.orderTotalText).isEqualTo("$5.00")
         assertThat(castedTotals.orderTaxText).isEqualTo("$2.00")
         assertThat(castedTotals.orderSubtotalText).isEqualTo("$3.00")
-        verify(totalsRepository).createOrderWithProducts(itemClickedData)
+        verify(totalsRepository).createOrderFromCartItems(itemClickedData)
     }
 
     @Test
@@ -287,7 +287,7 @@ class WooPosTotalsViewModelTest {
                 productsTotal = BigDecimal("3.00"),
             )
             val totalsRepository: WooPosTotalsRepository = mock {
-                onBlocking { createOrderWithProducts(itemClickedData) }.thenReturn(
+                onBlocking { createOrderFromCartItems(itemClickedData) }.thenReturn(
                     Result.success(order)
                 )
             }
@@ -373,7 +373,7 @@ class WooPosTotalsViewModelTest {
         }
         val errorMessage = "Order creation failed"
         val totalsRepository: WooPosTotalsRepository = mock {
-            onBlocking { createOrderWithProducts(itemClickedData) }.thenReturn(
+            onBlocking { createOrderFromCartItems(itemClickedData) }.thenReturn(
                 Result.failure(Exception(errorMessage))
             )
         }
@@ -411,7 +411,7 @@ class WooPosTotalsViewModelTest {
         }
         val errorMessage = "Order creation failed"
         val totalsRepository: WooPosTotalsRepository = mock {
-            onBlocking { createOrderWithProducts(itemClickedData) }.thenReturn(
+            onBlocking { createOrderFromCartItems(itemClickedData) }.thenReturn(
                 Result.failure(Exception(errorMessage))
             )
         }
@@ -457,7 +457,7 @@ class WooPosTotalsViewModelTest {
             productsTotal = BigDecimal("3.00"),
         )
 
-        whenever(totalsRepository.createOrderWithProducts(itemClickedData)).thenReturn(
+        whenever(totalsRepository.createOrderFromCartItems(itemClickedData)).thenReturn(
             Result.success(order)
         )
 
@@ -511,7 +511,7 @@ class WooPosTotalsViewModelTest {
         )
 
         val totalsRepository: WooPosTotalsRepository = mock {
-            onBlocking { createOrderWithProducts(itemClickedData) }.thenReturn(Result.success(order))
+            onBlocking { createOrderFromCartItems(itemClickedData) }.thenReturn(Result.success(order))
         }
 
         val priceFormat: WooPosFormatPrice = mock {
@@ -533,7 +533,7 @@ class WooPosTotalsViewModelTest {
         assertThat(castedTotals.orderSubtotalText).isEqualTo("3.00$")
         assertThat(castedTotals.orderTaxText).isEqualTo("2.00$")
         assertThat(castedTotals.orderTotalText).isEqualTo("5.00$")
-        verify(totalsRepository).createOrderWithProducts(itemClickedData)
+        verify(totalsRepository).createOrderFromCartItems(itemClickedData)
     }
 
     @Test
@@ -547,7 +547,7 @@ class WooPosTotalsViewModelTest {
         }
         val errorMessage = "Order creation failed"
         val totalsRepository: WooPosTotalsRepository = mock {
-            onBlocking { createOrderWithProducts(itemClickedData) }.thenReturn(
+            onBlocking { createOrderFromCartItems(itemClickedData) }.thenReturn(
                 Result.failure(Exception(errorMessage))
             )
         }
@@ -627,7 +627,7 @@ class WooPosTotalsViewModelTest {
         }
         val order = createNonEmptyOrder()
         val totalsRepository: WooPosTotalsRepository = mock {
-            onBlocking { createOrderWithProducts(itemClickedData) }.thenReturn(
+            onBlocking { createOrderFromCartItems(itemClickedData) }.thenReturn(
                 Result.success(order)
             )
         }
@@ -1161,7 +1161,7 @@ class WooPosTotalsViewModelTest {
                 productsTotal = BigDecimal("0.00"),
             )
             val totalsRepository: WooPosTotalsRepository = mock {
-                onBlocking { createOrderWithProducts(itemClickedData) }.thenReturn(
+                onBlocking { createOrderFromCartItems(itemClickedData) }.thenReturn(
                     Result.success(order)
                 )
             }
@@ -1220,7 +1220,7 @@ class WooPosTotalsViewModelTest {
                 productsTotal = BigDecimal("3.00"),
             )
             val totalsRepository: WooPosTotalsRepository = mock {
-                onBlocking { createOrderWithProducts(itemClickedData) }.thenReturn(
+                onBlocking { createOrderFromCartItems(itemClickedData) }.thenReturn(
                     Result.success(order)
                 )
             }
@@ -1448,7 +1448,7 @@ class WooPosTotalsViewModelTest {
         )
         val totalsRepository: WooPosTotalsRepository = mock {
             onBlocking {
-                createOrderWithProducts(itemClickedData)
+                createOrderFromCartItems(itemClickedData)
             }.thenReturn(Result.success(order))
         }
         val priceFormat: WooPosFormatPrice = mock {

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/home/variations/WooPosVariationsViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/home/variations/WooPosVariationsViewModelTest.kt
@@ -345,7 +345,7 @@ class WooPosVariationsViewModelTest {
         // THEN
         verify(fromChildToParentEventSender).sendToParent(
             ChildToParentEvent.ItemClickedInProductSelector(
-                WooPosItemsViewModel.ItemClickedData.Variation(123L, 1L)
+                WooPosItemsViewModel.ItemClickedData.Product.Variation(123L, 1L)
             )
         )
     }


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #13729 #13733 #13730 #13732
<!-- Id number of the GitHub issue this PR addresses. -->

<!-- 
━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
🛠 Need an AI review?  
Add a comment: `@coderabbitai review`
━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
-->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

This PR focuses on the happy path:
- adds a dummy coupon to the cart upon tapping on the coupons icon
- displays the coupon with dummy UI in the cart
- updates couponLines in the order creation request with the provided coupon

📓 Error handling for multiple coupons and invalid coupons is NOT part of this PR - focus especially on product/variationID handling. This is relevant in this PR and I forgot to explicitly mention it in the previous PRs. I might have accidentally swap productId with variationId.

### Testing information
<!-- This is your opportunity to break out individual scenarios that need testing (when necessary) and/or include a checklist for the reviewer to go through. Consider documenting the following from your own completed testing: devices used, alternate workflows, edge cases, affected areas, critical flows, areas not tested, and any remaining unknowns. Provide feedback on this new section of the PR template through Sept 30, 2024 to Apps Quality; additional context here: p91TBi-b8z-p2#comment-12036 -->

1. Go to WPAdmin -> Marketing -> Coupons and create a coupon with `dummycoupon` code. Eg. add $20 discount to the order.
2. Go to the POS
3. Tap on the coupon icon - verify a coupon is displayed in the cart.
4. Tap on the remove icon on the coupon - verify it is removed.
5. Tap on the coupon icon - verify a coupon is displayed in the cart.
6. Add a product to the cart.
7. Tap on checkout - notice the total price reflects the correct amount with the discount. 

_**The most important test is to verify that nothing is changed with the coupons FF off. Focus on verifying that productId and variationId work as expected. I forgot to explicitly call this out in the previous PR and it's the most probably source of a bug - I might have accidentally swapped them.**_

### The tests that have been performed
<!-- To give the reviewer an idea of what could be missed in terms of testing -->

- I've tested the above. I also tested that removing the coupon from the cart actually removes it from the request.



### Images/gif
<!-- Include before and after images or gifs when appropriate. -->


https://github.com/user-attachments/assets/7e5aa0b2-3410-45d2-bf69-7fe74ba73dc2


- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.

## Reviewer (or Author, in the case of optional code reviews):

Please make sure these conditions are met before approving the PR, or request changes if the PR needs improvement:

- [x] The PR is small and has a clear, single focus, or a valid explanation is provided in the description. If needed, please request to split it into smaller PRs.
- [x] Ensure Adequate Unit Test Coverage: The changes are reasonably covered by unit tests or an explanation is provided in the PR description.
- [x] Manual Testing: The author listed all the tests they ran, including smoke tests when needed (e.g., for refactorings). The reviewer confirmed that the PR works as expected on big (tablet) and small (phone) in case of UI changes, and no regressions are added.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->