### PR TITLE
Fix window insets in login flow when keyboard is shown

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/LoginActivity.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/LoginActivity.kt
@@ -11,6 +11,7 @@ import androidx.activity.SystemBarStyle
 import androidx.activity.enableEdgeToEdge
 import androidx.appcompat.app.AppCompatActivity
 import androidx.core.view.ViewCompat
+import androidx.core.view.WindowInsetsCompat
 import androidx.core.view.updatePadding
 import androidx.fragment.app.DialogFragment
 import androidx.fragment.app.Fragment
@@ -211,7 +212,10 @@ class LoginActivity :
         enableEdgeToEdge()
 
         // Add system bar insets to the fragment's root
-        binding.snackRoot.doOnApplyWindowInsets(consumeInsets = true) { insets ->
+        binding.snackRoot.doOnApplyWindowInsets(
+            insetsMask = WindowInsetsCompat.Type.systemBars() or WindowInsetsCompat.Type.displayCutout() or WindowInsetsCompat.Type.ime(),
+            consumeInsets = true
+        ) { insets ->
             binding.snackRoot.updatePadding(insets.left, insets.top, insets.right, insets.bottom)
         }
     }


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #13795 
<!-- Id number of the GitHub issue this PR addresses. -->

<!-- 
━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
🛠 Need an AI review?  
Add a comment: `@coderabbitai review`
━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
-->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

I have a limited knowledge about Window Insets so it's possible I'm missing something obvious. However, I've update the LoginActivity to explicitly add inset for keyboard when the keyboard is shown. This has impact not just on the Enter URL screen, but all screens of the login flow - it's questionable whether this is desired or not, I personally kind of like it (for example, notice the behavior of Google SSO button).

### Steps to reproduce
<!-- Step-by-step testing instructions. For new user flows, consider instead stating the goal of the workflow and see if your PR reviewer can accomplish the workflow without specific steps! -->

1. Open the app
2. Tap on Skip
3. Notice that the continue button is hidden when the software keyboard is shown (this is fixed in this PR and the continue button is displayed above the software keyboard)

### Testing information
<!-- This is your opportunity to break out individual scenarios that need testing (when necessary) and/or include a checklist for the reviewer to go through. Consider documenting the following from your own completed testing: devices used, alternate workflows, edge cases, affected areas, critical flows, areas not tested, and any remaining unknowns. Provide feedback on this new section of the PR template through Sept 30, 2024 to Apps Quality; additional context here: p91TBi-b8z-p2#comment-12036 -->

Test various login flows - email login flow, self-hosted login flow, magic link login flow, google SSO login flow.

### The tests that have been performed
<!-- To give the reviewer an idea of what could be missed in terms of testing -->

All of the above.

### Images/gif
<!-- Include before and after images or gifs when appropriate. -->

BEFORE

https://github.com/user-attachments/assets/ed730bf0-befc-4ba9-a7be-b80ecd44afd8

AFTER

https://github.com/user-attachments/assets/65c912d2-b917-4204-b753-462a2a638da5

- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.

## Reviewer (or Author, in the case of optional code reviews):

Please make sure these conditions are met before approving the PR, or request changes if the PR needs improvement:

- [x] The PR is small and has a clear, single focus, or a valid explanation is provided in the description. If needed, please request to split it into smaller PRs.
- [x] Ensure Adequate Unit Test Coverage: The changes are reasonably covered by unit tests or an explanation is provided in the PR description.
- [x] Manual Testing: The author listed all the tests they ran, including smoke tests when needed (e.g., for refactorings). The reviewer confirmed that the PR works as expected on big (tablet) and small (phone) in case of UI changes, and no regressions are added.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->795