### PR TITLE
Issue/13743 display total discount in checkout

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/totals/WooPosTotalsScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/totals/WooPosTotalsScreen.kt
@@ -60,7 +60,6 @@ import com.woocommerce.android.ui.woopos.home.totals.payment.failed.WooPosPaymen
 import com.woocommerce.android.ui.woopos.home.totals.payment.inprogress.WooPosPaymentInProgressScreen
 import com.woocommerce.android.ui.woopos.home.totals.payment.success.WooPosPaymentSuccessScreen
 import com.woocommerce.android.ui.woopos.util.ext.announceForAccessibility
-import com.woocommerce.android.util.FeatureFlag
 
 @Composable
 fun WooPosTotalsScreen(modifier: Modifier = Modifier) {
@@ -325,7 +324,7 @@ private fun TotalsGrid(totals: Totals.Visible) {
         horizontalAlignment = Alignment.CenterHorizontally,
         verticalArrangement = Arrangement.Center,
     ) {
-        if (FeatureFlag.POS_COUPONS.isEnabled() && totals.orderDiscountText != null) {
+        totals.orderDiscountText?.let {
             TotalsGridRow(
                 textOne = stringResource(R.string.woopos_payment_discount_label),
                 textTwo = totals.orderDiscountText,

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/totals/WooPosTotalsScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/totals/WooPosTotalsScreen.kt
@@ -60,6 +60,7 @@ import com.woocommerce.android.ui.woopos.home.totals.payment.failed.WooPosPaymen
 import com.woocommerce.android.ui.woopos.home.totals.payment.inprogress.WooPosPaymentInProgressScreen
 import com.woocommerce.android.ui.woopos.home.totals.payment.success.WooPosPaymentSuccessScreen
 import com.woocommerce.android.ui.woopos.util.ext.announceForAccessibility
+import com.woocommerce.android.util.FeatureFlag
 
 @Composable
 fun WooPosTotalsScreen(modifier: Modifier = Modifier) {
@@ -324,6 +325,15 @@ private fun TotalsGrid(totals: Totals.Visible) {
         horizontalAlignment = Alignment.CenterHorizontally,
         verticalArrangement = Arrangement.Center,
     ) {
+        if (FeatureFlag.POS_COUPONS.isEnabled() && totals.orderDiscountText != null) {
+            TotalsGridRow(
+                textOne = stringResource(R.string.woopos_payment_discount_label),
+                textTwo = totals.orderDiscountText,
+            )
+
+            Spacer(modifier = Modifier.height(WooPosSpacing.Medium.value.toAdaptivePadding()))
+        }
+
         TotalsGridRow(
             textOne = stringResource(R.string.woopos_payment_subtotal_label),
             textTwo = totals.orderSubtotalText,
@@ -445,6 +455,7 @@ fun WooPosTotalsScreenPreview(modifier: Modifier = Modifier) {
                     orderSubtotalText = "$420.00",
                     orderTotalText = "$462.00",
                     orderTaxText = "$42.00",
+                    orderDiscountText = "$20.00",
                 ),
                 readerStatus = WooPosTotalsViewState.ReaderStatus.ReadyForPayment(
                     title = "Ready for payment",
@@ -467,6 +478,7 @@ fun WooPosTotalsScreenPreviewReaderNotConnected(modifier: Modifier = Modifier) {
                     orderSubtotalText = "$420.00",
                     orderTotalText = "$462.00",
                     orderTaxText = "$42.00",
+                    orderDiscountText = "$20.00",
                 ),
                 readerStatus = WooPosTotalsViewState.ReaderStatus.Disconnected(
                     title = "Reader not connected",
@@ -490,6 +502,7 @@ fun WooPosTotalsScreenPreviewWithCashPaymentAvailable() {
                     orderSubtotalText = "$420.00",
                     orderTotalText = "$462.00",
                     orderTaxText = "$42.00",
+                    orderDiscountText = null,
                 ),
                 readerStatus = WooPosTotalsViewState.ReaderStatus.Disconnected(
                     title = "Reader not connected",
@@ -513,6 +526,7 @@ fun WooPosTotalsScreenPreviewForFreeOrders() {
                     orderSubtotalText = "$420.00",
                     orderTotalText = "$462.00",
                     orderTaxText = "$42.00",
+                    orderDiscountText = "$20.00",
                 ),
                 readerStatus = WooPosTotalsViewState.ReaderStatus.Unavailable,
             ),

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/totals/WooPosTotalsViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/totals/WooPosTotalsViewModel.kt
@@ -453,6 +453,7 @@ class WooPosTotalsViewModel @Inject constructor(
     }
 
     private suspend fun buildWooPosTotalsViewState(order: Order): WooPosTotalsViewState.Checkout {
+        val discountAmount = order.discountTotal
         val subtotalAmount = order.productsTotal
         val taxAmount = order.totalTax
         val totalAmount = order.total
@@ -466,6 +467,7 @@ class WooPosTotalsViewModel @Inject constructor(
         }
         return WooPosTotalsViewState.Checkout(
             totals = Totals.Visible(
+                orderDiscountText = if(discountAmount > BigDecimal.ZERO) priceFormat(discountAmount) else null,
                 orderSubtotalText = priceFormat(subtotalAmount),
                 orderTaxText = priceFormat(taxAmount),
                 orderTotalText = priceFormat(totalAmount),

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/totals/WooPosTotalsViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/totals/WooPosTotalsViewModel.kt
@@ -14,6 +14,7 @@ import com.woocommerce.android.ui.payments.cardreader.payment.controller.CardRea
 import com.woocommerce.android.ui.payments.cardreader.payment.controller.CardReaderPaymentOrRefundState
 import com.woocommerce.android.ui.payments.cardreader.payment.controller.CardReaderPaymentOrRefundState.CardReaderPaymentState
 import com.woocommerce.android.ui.woopos.cardreader.WooPosCardReaderFacade
+import com.woocommerce.android.ui.woopos.featureflags.WooPosIsCouponsEnabled
 import com.woocommerce.android.ui.woopos.home.ChildToParentEvent
 import com.woocommerce.android.ui.woopos.home.ChildToParentEvent.NavigationEvent
 import com.woocommerce.android.ui.woopos.home.ChildToParentEvent.NavigationEvent.ToCashPayment
@@ -57,6 +58,7 @@ class WooPosTotalsViewModel @Inject constructor(
     private val networkStatus: WooPosNetworkStatus,
     private val cardReaderPaymentControllerFactory: WooPosCardReaderPaymentControllerFactory,
     private val uiStringParser: UiStringParser,
+    private val isCouponsEnabled: WooPosIsCouponsEnabled,
     private val totalsAnalyticsTracker: WooPosTotalsAnalyticsTracker,
     savedState: SavedStateHandle,
 ) : ViewModel() {
@@ -467,7 +469,8 @@ class WooPosTotalsViewModel @Inject constructor(
         }
         return WooPosTotalsViewState.Checkout(
             totals = Totals.Visible(
-                orderDiscountText = if (discountAmount > BigDecimal.ZERO) priceFormat(discountAmount) else null,
+                orderDiscountText =
+                if (isCouponsEnabled() && discountAmount > BigDecimal.ZERO) priceFormat(discountAmount) else null,
                 orderSubtotalText = priceFormat(subtotalAmount),
                 orderTaxText = priceFormat(taxAmount),
                 orderTotalText = priceFormat(totalAmount),

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/totals/WooPosTotalsViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/totals/WooPosTotalsViewModel.kt
@@ -467,7 +467,7 @@ class WooPosTotalsViewModel @Inject constructor(
         }
         return WooPosTotalsViewState.Checkout(
             totals = Totals.Visible(
-                orderDiscountText = if(discountAmount > BigDecimal.ZERO) priceFormat(discountAmount) else null,
+                orderDiscountText = if (discountAmount > BigDecimal.ZERO) priceFormat(discountAmount) else null,
                 orderSubtotalText = priceFormat(subtotalAmount),
                 orderTaxText = priceFormat(taxAmount),
                 orderTotalText = priceFormat(totalAmount),

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/totals/WooPosTotalsViewState.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/totals/WooPosTotalsViewState.kt
@@ -18,6 +18,7 @@ sealed class WooPosTotalsViewState : Parcelable {
 
         @Parcelize
         data class Visible(
+            val orderDiscountText: String?,
             val orderSubtotalText: String,
             val orderTaxText: String,
             val orderTotalText: String,

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -4320,6 +4320,7 @@
     <string name="woopos_payment_successful_checkmark_icon_content_description">Payment successful checkmark icon</string>
     <string name="woopos_new_order_button">New order</string>
     <string name="woopos_receipt_button">Email receipt</string>
+    <string name="woopos_payment_discount_label">Discount</string>
     <string name="woopos_payment_subtotal_label">Subtotal</string>
     <string name="woopos_payment_tax_label">Taxes</string>
     <string name="woopos_payment_total_label">Total</string>

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/home/totals/WooPosTotalsViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/home/totals/WooPosTotalsViewModelTest.kt
@@ -898,7 +898,8 @@ class WooPosTotalsViewModelTest {
             val vm = createViewModelAndSetupForSuccessfulOrderCreation(discountTotal = discountTotal)
 
             // THEN
-            assertThat(((vm.state.value as WooPosTotalsViewState.Checkout).totals as Visible).orderDiscountText).isNotNull()
+            assertThat(((vm.state.value as WooPosTotalsViewState.Checkout).totals as Visible).orderDiscountText)
+                .isNotNull()
         }
 
     @Test

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/home/totals/WooPosTotalsViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/home/totals/WooPosTotalsViewModelTest.kt
@@ -30,6 +30,7 @@ import com.woocommerce.android.ui.payments.receipt.PaymentReceiptShare
 import com.woocommerce.android.ui.payments.tracking.CardReaderTrackingInfoKeeper
 import com.woocommerce.android.ui.payments.tracking.PaymentsFlowTracker
 import com.woocommerce.android.ui.woopos.cardreader.WooPosCardReaderFacade
+import com.woocommerce.android.ui.woopos.featureflags.WooPosIsCouponsEnabled
 import com.woocommerce.android.ui.woopos.home.ChildToParentEvent
 import com.woocommerce.android.ui.woopos.home.ChildToParentEvent.BackFromCheckoutToCartClicked
 import com.woocommerce.android.ui.woopos.home.ChildToParentEvent.ReturnedFromCardReaderPaymentToCheckout
@@ -107,6 +108,7 @@ class WooPosTotalsViewModelTest {
     private val cardReaderOnboardingChecker: CardReaderOnboardingChecker = mock()
     private val paymentReceiptShare: PaymentReceiptShare = mock()
     private val uiStringParser: UiStringParser = mock()
+    private val isCouponsEnabled: WooPosIsCouponsEnabled = mock()
     private val paymentControllerFactory = WooPosCardReaderPaymentControllerFactory(
         cardReaderManager = cardReaderManager,
         orderRepository = orderRepository,
@@ -159,6 +161,7 @@ class WooPosTotalsViewModelTest {
             flow<BluetoothCardReaderMessages> {}
         }
         whenever(cardReaderFacade.readerStatus).thenAnswer { cardReaderManager.readerStatus }
+        whenever(isCouponsEnabled()).thenAnswer { false }
     }
 
     @Test
@@ -889,10 +892,11 @@ class WooPosTotalsViewModelTest {
         }
 
     @Test
-    fun `given order contains discount, when order draft created, should propagate discount to UI`() =
+    fun `given FF enabled and order contains discount, when order draft created, should propagate discount`() =
         runTest {
             // GIVEN
             val discountTotal = BigDecimal("1.00")
+            whenever(isCouponsEnabled()).thenReturn(true)
 
             // WHEN
             val vm = createViewModelAndSetupForSuccessfulOrderCreation(discountTotal = discountTotal)
@@ -900,6 +904,21 @@ class WooPosTotalsViewModelTest {
             // THEN
             assertThat(((vm.state.value as WooPosTotalsViewState.Checkout).totals as Visible).orderDiscountText)
                 .isNotNull()
+        }
+
+    @Test
+    fun `given FF disabled and order contains discount, when order draft created, should not propagate discount`() =
+        runTest {
+            // GIVEN
+            val discountTotal = BigDecimal("1.00")
+            whenever(isCouponsEnabled()).thenReturn(false)
+
+            // WHEN
+            val vm = createViewModelAndSetupForSuccessfulOrderCreation(discountTotal = discountTotal)
+
+            // THEN
+            assertThat(((vm.state.value as WooPosTotalsViewState.Checkout).totals as Visible).orderDiscountText)
+                .isNull()
         }
 
     @Test
@@ -1509,5 +1528,6 @@ class WooPosTotalsViewModelTest {
             analyticsTracker = analyticsTracker,
             analyticsData = WooPosAnalyticsTrackingDataKeeper()
         ),
+        isCouponsEnabled = isCouponsEnabled,
     )
 }

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/home/totals/WooPosTotalsViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/home/totals/WooPosTotalsViewModelTest.kt
@@ -39,6 +39,7 @@ import com.woocommerce.android.ui.woopos.home.WooPosChildrenToParentEventSender
 import com.woocommerce.android.ui.woopos.home.WooPosParentToChildrenEventReceiver
 import com.woocommerce.android.ui.woopos.home.items.WooPosItemsViewModel
 import com.woocommerce.android.ui.woopos.home.totals.WooPosTotalsUIEvent.OnBackClicked
+import com.woocommerce.android.ui.woopos.home.totals.WooPosTotalsViewState.Totals.Visible
 import com.woocommerce.android.ui.woopos.util.WooPosCoroutineTestRule
 import com.woocommerce.android.ui.woopos.util.WooPosNetworkStatus
 import com.woocommerce.android.ui.woopos.util.analytics.WooPosAnalyticsEvent
@@ -888,6 +889,19 @@ class WooPosTotalsViewModelTest {
         }
 
     @Test
+    fun `given order contains discount, when order draft created, should propagate discount to UI`() =
+        runTest {
+            // GIVEN
+            val discountTotal = BigDecimal("1.00")
+
+            // WHEN
+            val vm = createViewModelAndSetupForSuccessfulOrderCreation(discountTotal = discountTotal)
+
+            // THEN
+            assertThat(((vm.state.value as WooPosTotalsViewState.Checkout).totals as Visible).orderDiscountText).isNotNull()
+        }
+
+    @Test
     fun `given payment failed with retry action, when retry clicked, then should retry previous payment action`() =
         runTest {
             // GIVEN
@@ -1369,6 +1383,7 @@ class WooPosTotalsViewModelTest {
         dateModified = Date()
     ).copy(
         totalTax = BigDecimal("2.00"),
+        discountTotal = BigDecimal("1.00"),
         items = listOf(
             Order.Item.EMPTY.copy(
                 subtotal = BigDecimal("1.00"),
@@ -1400,6 +1415,7 @@ class WooPosTotalsViewModelTest {
         ),
         parentToChildrenEventFlow: MutableStateFlow<ParentToChildrenEvent> =
             MutableStateFlow(ParentToChildrenEvent.CheckoutClicked(itemClickedData)),
+        discountTotal: BigDecimal = BigDecimal.ZERO,
     ): WooPosTotalsViewModel {
         whenever(resourceProvider.getString(R.string.woopos_success_totals_error_reader_not_connected_title))
             .thenReturn("Reader not connected")
@@ -1444,6 +1460,7 @@ class WooPosTotalsViewModelTest {
                 )
             ),
             productsTotal = BigDecimal("3.00"),
+            discountTotal = discountTotal,
             total = BigDecimal("5.00"),
         )
         val totalsRepository: WooPosTotalsRepository = mock {
@@ -1452,6 +1469,7 @@ class WooPosTotalsViewModelTest {
             }.thenReturn(Result.success(order))
         }
         val priceFormat: WooPosFormatPrice = mock {
+            onBlocking { invoke(BigDecimal("1.00")) }.thenReturn("1.00$")
             onBlocking { invoke(BigDecimal("2.00")) }.thenReturn("2.00$")
             onBlocking { invoke(BigDecimal("3.00")) }.thenReturn("3.00$")
             onBlocking { invoke(BigDecimal("5.00")) }.thenReturn("5.00$")


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #13743 
<!-- Id number of the GitHub issue this PR addresses. -->

<!-- 
━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
🛠 Need an AI review?  
Add a comment: `@coderabbitai review`
━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
-->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

Display total discount on the checkout summary screen in the POS. The discount is shown only when Coupons feature flag is enabled.

The position of the discount row is random at the moment and doesn't contain `-` character since implementation of these will depend on the final designs from a designer.


### Testing information
<!-- This is your opportunity to break out individual scenarios that need testing (when necessary) and/or include a checklist for the reviewer to go through. Consider documenting the following from your own completed testing: devices used, alternate workflows, edge cases, affected areas, critical flows, areas not tested, and any remaining unknowns. Provide feedback on this new section of the PR template through Sept 30, 2024 to Apps Quality; additional context here: p91TBi-b8z-p2#comment-12036 -->

- Verify the total discount is displayed when the discount is non-zero.
- Verify the total discount is not displayed when the discount is zero.
- Verify the total discount is not displayed when FF is disabled.

### The tests that have been performed
<!-- To give the reviewer an idea of what could be missed in terms of testing -->

I've performed the above tests. I haven't tested any edge cases since currently the coupons feature supports only the most happy path with dummy implementation of coupon selection.

### Images/gif
<!-- Include before and after images or gifs when appropriate. -->
![Screenshot_1743084689](https://github.com/user-attachments/assets/21d3caab-c48b-41dc-8e52-3f0fe02a66f5)


- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.

## Reviewer (or Author, in the case of optional code reviews):

Please make sure these conditions are met before approving the PR, or request changes if the PR needs improvement:

- [ ] The PR is small and has a clear, single focus, or a valid explanation is provided in the description. If needed, please request to split it into smaller PRs.
- [ ] Ensure Adequate Unit Test Coverage: The changes are reasonably covered by unit tests or an explanation is provided in the PR description.
- [ ] Manual Testing: The author listed all the tests they ran, including smoke tests when needed (e.g., for refactorings). The reviewer confirmed that the PR works as expected on big (tablet) and small (phone) in case of UI changes, and no regressions are added.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->