### PR TITLE
Fix crash in Custom Amount Flow on Android 8-12

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -4,6 +4,10 @@
 22.1
 -----
 
+22.0.3
+-----
+- [**] Fixed a crash in the custom amount dialog on Android version 12 and older.
+
 22.0.2
 -----
 - [**] Fixed crash during order creation when currency symbol instead of currency code provided in an order [https://github.com/woocommerce/woocommerce-android/pull/13844]

--- a/WooCommerce/src/main/res/layout/dialog_custom_amounts.xml
+++ b/WooCommerce/src/main/res/layout/dialog_custom_amounts.xml
@@ -5,8 +5,7 @@
     android:layout_width="match_parent"
     android:layout_height="match_parent"
     android:background="@color/color_surface"
-    android:paddingVertical="@dimen/major_100"
-    tools:context="com.woocommerce.android.ui.payments.simplepayments.SimplePaymentsDialog">
+    android:paddingVertical="@dimen/major_100">
 
     <ScrollView
         android:id="@+id/scrollView"
@@ -72,7 +71,7 @@
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
                     android:gravity="start"
-                    android:imeOptions="flagNoFullscreen"
+                    android:imeOptions="flagNoFullscreen|actionDone"
                     android:textSize="@dimen/line_height_major_100"
                     android:visibility="gone"
                     app:layout_constraintTop_toTopOf="parent"
@@ -96,7 +95,7 @@
                     android:layout_height="wrap_content"
                     android:maxWidth="@dimen/edit_percentage_max_width"
                     android:gravity="start"
-                    android:imeOptions="flagNoFullscreen"
+                    android:imeOptions="flagNoFullscreen|actionDone"
                     android:textSize="@dimen/line_height_major_100"
                     android:inputType="numberDecimal"
                     android:hint="@string/custom_amounts_percentage_hint"


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #13812 
<!-- Id number of the GitHub issue this PR addresses. -->

<!-- 
━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
🛠 Need an AI review?  
Add a comment: `@coderabbitai review`
━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
-->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

The app crashes on Android 8-12 when you enter a custom amount and press the `Next` button on the software keyboard.

### Steps to reproduce
<!-- Step-by-step testing instructions. For new user flows, consider instead stating the goal of the workflow and see if your PR reviewer can accomplish the workflow without specific steps! -->

1. Start the app on Android 12.
2. Tap on order list.
3. Tap on create order.
4. Tap on Enter custom amount.
5. Tap on the `Next` button on the software keyboard.

### Testing information
<!-- This is your opportunity to break out individual scenarios that need testing (when necessary) and/or include a checklist for the reviewer to go through. Consider documenting the following from your own completed testing: devices used, alternate workflows, edge cases, affected areas, critical flows, areas not tested, and any remaining unknowns. Provide feedback on this new section of the PR template through Sept 30, 2024 to Apps Quality; additional context here: p91TBi-b8z-p2#comment-12036 -->

1. Start the app on Android 12.
2. Tap on order list.
3. Tap on create order.
4. Tap on Enter custom amount.
5. Notice the sw keyboard has `done` instead of `next` button and pressing it hides the keyboard.

### The tests that have been performed
<!-- To give the reviewer an idea of what could be missed in terms of testing -->

I've tested the above for a fixed custom amount as well as percentage custom amount.


- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.

## Reviewer (or Author, in the case of optional code reviews):

Please make sure these conditions are met before approving the PR, or request changes if the PR needs improvement:

- [ ] The PR is small and has a clear, single focus, or a valid explanation is provided in the description. If needed, please request to split it into smaller PRs.
- [ ] Ensure Adequate Unit Test Coverage: The changes are reasonably covered by unit tests or an explanation is provided in the PR description.
- [ ] Manual Testing: The author listed all the tests they ran, including smoke tests when needed (e.g., for refactorings). The reviewer confirmed that the PR works as expected on big (tablet) and small (phone) in case of UI changes, and no regressions are added.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->