### PR TITLE
[Shipping Labels Revamp] Add HAZMAT undo support with Snackbar

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/WooShippingLabelCreationScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/WooShippingLabelCreationScreen.kt
@@ -83,6 +83,7 @@ import com.woocommerce.android.ui.orders.wooshippinglabels.address.AddressSelect
 import com.woocommerce.android.ui.orders.wooshippinglabels.address.AddressStatus
 import com.woocommerce.android.ui.orders.wooshippinglabels.address.getShipFrom
 import com.woocommerce.android.ui.orders.wooshippinglabels.address.getShipTo
+import com.woocommerce.android.ui.orders.wooshippinglabels.components.SuccessSnackbarHost
 import com.woocommerce.android.ui.orders.wooshippinglabels.hazmat.HazmatSelectionCard
 import com.woocommerce.android.ui.orders.wooshippinglabels.models.DestinationShippingAddress
 import com.woocommerce.android.ui.orders.wooshippinglabels.models.OriginShippingAddress
@@ -347,7 +348,7 @@ private fun LabelCreationScreenWithBottomSheet(
 
     BottomSheetScaffold(
         snackbarHost = {
-            SnackbarHost(
+            SuccessSnackbarHost(
                 snackbarHostState,
                 modifier = Modifier.padding(bottom = snackbarPaddingBottom)
             )

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/WooShippingLabelCreationScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/WooShippingLabelCreationScreen.kt
@@ -465,14 +465,15 @@ private fun LabelCreationScreenWithBottomSheet(
 
             LaunchedEffect(actionSnackbar) {
                 if (actionSnackbar != null) {
-                    val snackBarResult = snackbarHostState.showSnackbar(
+                    snackbarHostState.showSnackbar(
                         message = actionSnackbarMessage ?: "",
                         actionLabel = actionSnackbarActionLabel,
                         duration = SnackbarDuration.Short
-                    )
-                    if (snackBarResult == ActionPerformed) {
+                    ).takeIf { it == ActionPerformed }?.let {
                         actionSnackbar.action()
                     }
+                } else {
+                    snackbarHostState.currentSnackbarData?.dismiss()
                 }
             }
         }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/WooShippingLabelCreationScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/WooShippingLabelCreationScreen.kt
@@ -42,7 +42,6 @@ import androidx.compose.material.icons.filled.Star
 import androidx.compose.material.icons.outlined.Star
 import androidx.compose.material.rememberBottomSheetScaffoldState
 import androidx.compose.material3.SnackbarDuration
-import androidx.compose.material3.SnackbarHost
 import androidx.compose.material3.SnackbarHostState
 import androidx.compose.material3.SnackbarResult.ActionPerformed
 import androidx.compose.runtime.Composable

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/WooShippingLabelCreationScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/WooShippingLabelCreationScreen.kt
@@ -43,7 +43,7 @@ import androidx.compose.material.icons.outlined.Star
 import androidx.compose.material.rememberBottomSheetScaffoldState
 import androidx.compose.material3.SnackbarDuration
 import androidx.compose.material3.SnackbarHostState
-import androidx.compose.material3.SnackbarResult.ActionPerformed
+import androidx.compose.material3.SnackbarResult
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
@@ -464,17 +464,17 @@ private fun LabelCreationScreenWithBottomSheet(
             val actionSnackbarActionLabel = actionSnackbar?.let { stringResource(it.actionLabel) }
 
             LaunchedEffect(actionSnackbar) {
-                if (actionSnackbar != null) {
-                    snackbarHostState.showSnackbar(
+                actionSnackbar?.let {
+                    val result = snackbarHostState.showSnackbar(
                         message = actionSnackbarMessage ?: "",
                         actionLabel = actionSnackbarActionLabel,
-                        duration = SnackbarDuration.Short
-                    ).takeIf { it == ActionPerformed }?.let {
-                        actionSnackbar.action()
+                        duration = SnackbarDuration.Short,
+                    )
+                    when (result) {
+                        SnackbarResult.ActionPerformed -> actionSnackbar.action()
+                        SnackbarResult.Dismissed -> actionSnackbar.onDismissed()
                     }
-                } else {
-                    snackbarHostState.currentSnackbarData?.dismiss()
-                }
+                } ?: snackbarHostState.currentSnackbarData?.dismiss()
             }
         }
     }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/WooShippingLabelCreationViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/WooShippingLabelCreationViewModel.kt
@@ -631,6 +631,9 @@ class WooShippingLabelCreationViewModel @Inject constructor(
             .run { this as? Declared }
             ?.hazmatCategory
 
+        // Disables the current Snackbar before navigation
+        // to avoid presentation conflict with the Hazmat selection result
+        actionSnackbar = null
         triggerEvent(StartHazmatFormEdit(selectedCategory))
     }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/WooShippingLabelCreationViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/WooShippingLabelCreationViewModel.kt
@@ -568,7 +568,7 @@ class WooShippingLabelCreationViewModel @Inject constructor(
                 purchaseState.value = backupPurchaseState
                 actionSnackbar = ActionSnackbar(
                     R.string.woo_shipping_labels_purchase_error,
-                    R.string.retry
+                    R.string.retry,
                 ) { onPurchaseShippingLabel() }
             }
         }
@@ -653,7 +653,11 @@ class WooShippingLabelCreationViewModel @Inject constructor(
             R.string.woo_shipping_labels_hazmat_selection_removed
         }
 
-        actionSnackbar = ActionSnackbar(snackbarMessage, R.string.undo) {
+        actionSnackbar = ActionSnackbar(
+            message = snackbarMessage,
+            actionLabel = R.string.undo,
+            onDismissed = { actionSnackbar = null }
+        ) {
             hazmatState.value = previousState
         }
     }
@@ -748,6 +752,7 @@ class WooShippingLabelCreationViewModel @Inject constructor(
     data class ActionSnackbar(
         val message: Int,
         val actionLabel: Int,
+        val onDismissed: () -> Unit = {},
         val action: () -> Unit
     )
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/WooShippingLabelCreationViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/WooShippingLabelCreationViewModel.kt
@@ -635,12 +635,14 @@ class WooShippingLabelCreationViewModel @Inject constructor(
     }
 
     fun onHazmatCategorySelected(selectedCategory: ShippingLabelHazmatCategory?) {
-        val previousSelection = hazmatState.value
+        val previousState = hazmatState.value
+        val newState = when (selectedCategory) {
+            null -> NoSelection
+            else -> Declared(selectedCategory)
+        }
+        if (newState == previousState) return
 
-        when {
-            selectedCategory != null -> Declared(selectedCategory)
-            else -> NoSelection
-        }.let { hazmatState.value = it }
+        hazmatState.value = newState
 
         val snackbarMessage = if (selectedCategory != null) {
             R.string.woo_shipping_labels_hazmat_selection_set
@@ -649,7 +651,7 @@ class WooShippingLabelCreationViewModel @Inject constructor(
         }
 
         actionSnackbar = ActionSnackbar(snackbarMessage, R.string.undo) {
-            hazmatState.value = previousSelection
+            hazmatState.value = previousState
         }
     }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/WooShippingLabelCreationViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/WooShippingLabelCreationViewModel.kt
@@ -635,6 +635,8 @@ class WooShippingLabelCreationViewModel @Inject constructor(
     }
 
     fun onHazmatCategorySelected(selectedCategory: ShippingLabelHazmatCategory?) {
+        val previousSelection = hazmatState.value
+
         when {
             selectedCategory != null -> Declared(selectedCategory)
             else -> NoSelection
@@ -646,7 +648,9 @@ class WooShippingLabelCreationViewModel @Inject constructor(
             R.string.woo_shipping_labels_hazmat_selection_removed
         }
 
-        actionSnackbar = ActionSnackbar(snackbarMessage, R.string.undo) {}
+        actionSnackbar = ActionSnackbar(snackbarMessage, R.string.undo) {
+            hazmatState.value = previousSelection
+        }
     }
 
     fun allowBackNavigation(): Boolean {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/WooShippingLabelCreationViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/WooShippingLabelCreationViewModel.kt
@@ -639,6 +639,14 @@ class WooShippingLabelCreationViewModel @Inject constructor(
             selectedCategory != null -> Declared(selectedCategory)
             else -> NoSelection
         }.let { hazmatState.value = it }
+
+        val snackbarMessage = if (selectedCategory != null) {
+            R.string.woo_shipping_labels_hazmat_selection_set
+        } else {
+            R.string.woo_shipping_labels_hazmat_selection_removed
+        }
+
+        actionSnackbar = ActionSnackbar(snackbarMessage, R.string.undo) {}
     }
 
     fun allowBackNavigation(): Boolean {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/components/CustomSnackbarHost.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/components/CustomSnackbarHost.kt
@@ -1,0 +1,72 @@
+package com.woocommerce.android.ui.orders.wooshippinglabels.components
+
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.CheckCircle
+import androidx.compose.material3.ButtonDefaults
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.SnackbarDuration
+import androidx.compose.material3.SnackbarHost
+import androidx.compose.material3.SnackbarHostState
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+
+@Composable
+fun CustomSnackbarHost(
+    hostState: SnackbarHostState,
+    modifier: Modifier = Modifier,
+    snackbarPadding: PaddingValues = PaddingValues(0.dp)
+) {
+    SnackbarHost(
+        hostState = hostState,
+        modifier = modifier,
+        snackbar = { snackbarData ->
+            val actionLabel = snackbarData.visuals.actionLabel
+
+            Surface(
+                color = MaterialTheme.colorScheme.surfaceVariant,
+                shape = RoundedCornerShape(4.dp),
+                modifier = Modifier.padding(snackbarPadding)
+            ) {
+                Row(
+                    modifier = Modifier.padding(16.dp),
+                    verticalAlignment = Alignment.CenterVertically
+                ) {
+                    Icon(
+                        imageVector = Icons.Filled.CheckCircle,
+                        contentDescription = null,
+                        tint = MaterialTheme.colorScheme.primary,
+                        modifier = Modifier.padding(end = 16.dp)
+                    )
+
+                    Text(
+                        text = snackbarData.visuals.message,
+                        modifier = Modifier.weight(1f),
+                        style = MaterialTheme.typography.bodyMedium,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant
+                    )
+
+                    if (actionLabel != null) {
+                        TextButton(
+                            onClick = { snackbarData.performAction() },
+                            colors = ButtonDefaults.textButtonColors(
+                                contentColor = MaterialTheme.colorScheme.primary
+                            )
+                        ) {
+                            Text(text = actionLabel)
+                        }
+                    }
+                }
+            }
+        }
+    )
+}

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/components/SuccessSnackbarHost.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/components/SuccessSnackbarHost.kt
@@ -1,8 +1,8 @@
 package com.woocommerce.android.ui.orders.wooshippinglabels.components
 
+import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.CheckCircle
 import androidx.compose.material3.ButtonDefaults
@@ -50,35 +50,35 @@ private fun SuccessSnackbar(
 ) {
     Surface(
         color = SnackbarDefaults.color,
-        shape = RoundedCornerShape(4.dp),
-        modifier = Modifier.padding(12.dp)
+        shape = SnackbarDefaults.shape,
+        modifier = Modifier.padding(16.dp)
     ) {
         Row(
-            modifier = Modifier.padding(horizontal = 12.dp),
-            verticalAlignment = Alignment.CenterVertically
+            modifier = Modifier.padding(horizontal = 16.dp),
+            verticalAlignment = Alignment.CenterVertically,
+            horizontalArrangement = Arrangement.spacedBy(8.dp)
         ) {
             Icon(
                 imageVector = Icons.Filled.CheckCircle,
                 contentDescription = null,
                 tint = colorResource(R.color.woo_green_20),
-                modifier = Modifier.padding(end = 16.dp)
             )
 
             Text(
                 text = content,
-                modifier = Modifier.weight(1f),
-                style = MaterialTheme.typography.bodyMedium,
+                modifier = Modifier
+                    .weight(1f)
+                    .padding(vertical = 16.dp),
+                style = MaterialTheme.typography.titleMedium,
                 color = SnackbarDefaults.contentColor
             )
 
-            if (actionLabel != null) {
+            actionLabel?.let { label ->
                 TextButton(
                     onClick = action,
-                    colors = ButtonDefaults.textButtonColors(
-                        contentColor = SnackbarDefaults.actionContentColor
-                    )
+                    colors = ButtonDefaults.textButtonColors(contentColor = SnackbarDefaults.actionContentColor)
                 ) {
-                    Text(text = actionLabel)
+                    Text(text = label)
                 }
             }
         }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/components/SuccessSnackbarHost.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/components/SuccessSnackbarHost.kt
@@ -9,7 +9,6 @@ import androidx.compose.material.icons.filled.CheckCircle
 import androidx.compose.material3.ButtonDefaults
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.SnackbarDuration
 import androidx.compose.material3.SnackbarHost
 import androidx.compose.material3.SnackbarHostState
 import androidx.compose.material3.Surface
@@ -21,7 +20,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
 
 @Composable
-fun CustomSnackbarHost(
+fun SuccessSnackbarHost(
     hostState: SnackbarHostState,
     modifier: Modifier = Modifier,
     snackbarPadding: PaddingValues = PaddingValues(0.dp)

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/components/SuccessSnackbarHost.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/components/SuccessSnackbarHost.kt
@@ -54,7 +54,7 @@ private fun SuccessSnackbar(
         modifier = Modifier.padding(12.dp)
     ) {
         Row(
-            modifier = Modifier.padding(12.dp),
+            modifier = Modifier.padding(horizontal = 12.dp),
             verticalAlignment = Alignment.CenterVertically
         ) {
             Icon(

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/components/SuccessSnackbarHost.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/components/SuccessSnackbarHost.kt
@@ -1,6 +1,5 @@
 package com.woocommerce.android.ui.orders.wooshippinglabels.components
 
-import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.shape.RoundedCornerShape
@@ -19,6 +18,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.colorResource
+import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import com.woocommerce.android.R
 
@@ -33,41 +33,64 @@ fun SuccessSnackbarHost(
         snackbar = { snackbarData ->
             val actionLabel = snackbarData.visuals.actionLabel
 
-            Surface(
-                color = SnackbarDefaults.color,
-                shape = RoundedCornerShape(4.dp),
-                modifier = Modifier.padding(12.dp)
-            ) {
-                Row(
-                    modifier = Modifier.padding(12.dp),
-                    verticalAlignment = Alignment.CenterVertically
+            SuccessSnackbar(
+                content = snackbarData.visuals.message,
+                actionLabel = actionLabel,
+                action =  { snackbarData.performAction() }
+            )
+        }
+    )
+}
+
+@Composable
+private fun SuccessSnackbar(
+    content: String,
+    actionLabel: String?,
+    action: () -> Unit
+) {
+    Surface(
+        color = SnackbarDefaults.color,
+        shape = RoundedCornerShape(4.dp),
+        modifier = Modifier.padding(12.dp)
+    ) {
+        Row(
+            modifier = Modifier.padding(12.dp),
+            verticalAlignment = Alignment.CenterVertically
+        ) {
+            Icon(
+                imageVector = Icons.Filled.CheckCircle,
+                contentDescription = null,
+                tint = colorResource(R.color.woo_green_20),
+                modifier = Modifier.padding(end = 16.dp)
+            )
+
+            Text(
+                text = content,
+                modifier = Modifier.weight(1f),
+                style = MaterialTheme.typography.bodyMedium,
+                color = SnackbarDefaults.contentColor
+            )
+
+            if (actionLabel != null) {
+                TextButton(
+                    onClick = action,
+                    colors = ButtonDefaults.textButtonColors(
+                        contentColor = SnackbarDefaults.actionContentColor
+                    )
                 ) {
-                    Icon(
-                        imageVector = Icons.Filled.CheckCircle,
-                        contentDescription = null,
-                        tint = colorResource(R.color.woo_green_20),
-                        modifier = Modifier.padding(end = 16.dp)
-                    )
-
-                    Text(
-                        text = snackbarData.visuals.message,
-                        modifier = Modifier.weight(1f),
-                        style = MaterialTheme.typography.bodyMedium,
-                        color = SnackbarDefaults.contentColor
-                    )
-
-                    if (actionLabel != null) {
-                        TextButton(
-                            onClick = { snackbarData.performAction() },
-                            colors = ButtonDefaults.textButtonColors(
-                                contentColor = SnackbarDefaults.actionContentColor
-                            )
-                        ) {
-                            Text(text = actionLabel)
-                        }
-                    }
+                    Text(text = actionLabel)
                 }
             }
         }
+    }
+}
+
+@Preview
+@Composable
+fun SuccessSnackbarHostPreview() {
+    SuccessSnackbar(
+        content = "Shipping label created successfully",
+        actionLabel = "View",
+        action = {}
     )
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/components/SuccessSnackbarHost.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/components/SuccessSnackbarHost.kt
@@ -36,7 +36,7 @@ fun SuccessSnackbarHost(
             SuccessSnackbar(
                 content = snackbarData.visuals.message,
                 actionLabel = actionLabel,
-                action =  { snackbarData.performAction() }
+                action = { snackbarData.performAction() }
             )
         }
     )

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/components/SuccessSnackbarHost.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/components/SuccessSnackbarHost.kt
@@ -9,6 +9,7 @@ import androidx.compose.material.icons.filled.CheckCircle
 import androidx.compose.material3.ButtonDefaults
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.SnackbarDefaults
 import androidx.compose.material3.SnackbarHost
 import androidx.compose.material3.SnackbarHostState
 import androidx.compose.material3.Surface
@@ -17,13 +18,14 @@ import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.colorResource
 import androidx.compose.ui.unit.dp
+import com.woocommerce.android.R
 
 @Composable
 fun SuccessSnackbarHost(
     hostState: SnackbarHostState,
-    modifier: Modifier = Modifier,
-    snackbarPadding: PaddingValues = PaddingValues(0.dp)
+    modifier: Modifier = Modifier
 ) {
     SnackbarHost(
         hostState = hostState,
@@ -32,18 +34,18 @@ fun SuccessSnackbarHost(
             val actionLabel = snackbarData.visuals.actionLabel
 
             Surface(
-                color = MaterialTheme.colorScheme.surfaceVariant,
+                color = SnackbarDefaults.color,
                 shape = RoundedCornerShape(4.dp),
-                modifier = Modifier.padding(snackbarPadding)
+                modifier = Modifier.padding(12.dp)
             ) {
                 Row(
-                    modifier = Modifier.padding(16.dp),
+                    modifier = Modifier.padding(12.dp),
                     verticalAlignment = Alignment.CenterVertically
                 ) {
                     Icon(
                         imageVector = Icons.Filled.CheckCircle,
                         contentDescription = null,
-                        tint = MaterialTheme.colorScheme.primary,
+                        tint = colorResource(R.color.woo_green_20),
                         modifier = Modifier.padding(end = 16.dp)
                     )
 
@@ -51,14 +53,14 @@ fun SuccessSnackbarHost(
                         text = snackbarData.visuals.message,
                         modifier = Modifier.weight(1f),
                         style = MaterialTheme.typography.bodyMedium,
-                        color = MaterialTheme.colorScheme.onSurfaceVariant
+                        color = SnackbarDefaults.contentColor
                     )
 
                     if (actionLabel != null) {
                         TextButton(
                             onClick = { snackbarData.performAction() },
                             colors = ButtonDefaults.textButtonColors(
-                                contentColor = MaterialTheme.colorScheme.primary
+                                contentColor = SnackbarDefaults.actionContentColor
                             )
                         ) {
                             Text(text = actionLabel)

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/components/SuccessSnackbarHost.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/components/SuccessSnackbarHost.kt
@@ -85,11 +85,21 @@ private fun SuccessSnackbar(
     }
 }
 
-@Preview
+@Preview(name = "Standard snackbar")
 @Composable
 fun SuccessSnackbarHostPreview() {
     SuccessSnackbar(
         content = "Shipping label created successfully",
+        actionLabel = "View",
+        action = {}
+    )
+}
+
+@Preview(name = "Snackbar with long message")
+@Composable
+fun SuccessSnackbarHostWithLongMessagePreview() {
+    SuccessSnackbar(
+        content = "Shipping label created successfully in a long long long long long message",
         actionLabel = "View",
         action = {}
     )

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -4526,6 +4526,8 @@
     <string name="woo_shipping_labels_hazmat_info_tooltip_2">WooCommerce Shipping does not currently support HAZMAT shipments through &lt;a href=\'dhl-hazmat\'&gt;&lt;u&gt;DHL Express&lt;/u&gt;&lt;/a&gt;.</string>
     <string name="woo_shipping_labels_hazmat_info_select_category">Select Category</string>
     <string name="woo_shipping_labels_hazmat_search_hint">Search a Category</string>
+    <string name="woo_shipping_labels_hazmat_selection_set">Hazardous materials category set</string>
+    <string name="woo_shipping_labels_hazmat_selection_removed">Removed hazardous materials category</string>
 
 
     <string name="email_not_registered_wpcom">Hmm, we can\'t find a WordPress.com account connected to this email address.</string>


### PR DESCRIPTION
Summary
==========
This improves issues #13711 and #13709 by applying the same ActionSnackbar, which is available inside the Label Creation screen, as an actionable notification when the HAZMAT selection is changed.

I've noticed that Figma details the Snackbar used around the Shipping Labels feature with a green confirmation icon, but it seems that our usage of the SnackbarHostState from the Compose framework doesn't support that, so I introduced a Custom SnackbarHost to override the default UI and introduce one with the expected icon.

Screen Capture
==========
https://github.com/user-attachments/assets/54322817-7578-43cb-a03e-eccf0e315fc7

How to Test
==========
1. Start a Shipping Label Creation flow
2. Start to select and remove Hazmat selections in the form
3. Verify a Snackbar confirming the removal/selection of the Hazmat is displayed correctly
4. Verify that the `undo` button works as expected

Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

## Reviewer (or Author, in the case of optional code reviews):

Please make sure these conditions are met before approving the PR, or request changes if the PR needs improvement:

- [ ] The PR is small and has a clear, single focus, or a valid explanation is provided in the description. If needed, please request to split it into smaller PRs.
- [ ] Ensure Adequate Unit Test Coverage: The changes are reasonably covered by unit tests or an explanation is provided in the PR description.
- [ ] Manual Testing: The author listed all the tests they ran, including smoke tests when needed (e.g., for refactorings). The reviewer confirmed that the PR works as expected on big (tablet) and small (phone) in case of UI changes, and no regressions are added.
