### PR TITLE
Add title to the shipping labels sub-screens

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/customs/WooShippingCustomsFormFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/customs/WooShippingCustomsFormFragment.kt
@@ -30,6 +30,8 @@ import dagger.hilt.android.AndroidEntryPoint
 class WooShippingCustomsFormFragment : BaseFragment() {
     private val viewModel: WooShippingCustomsFormViewModel by viewModels()
 
+    override fun getFragmentTitle() = getString(R.string.shipping_label_create_customs)
+
     override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View? {
         return ComposeView(requireContext()).apply {
             setViewCompositionStrategy(DisposeOnViewTreeLifecycleDestroyed)

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/hazmat/WooShippingLabelHazmatFormFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/hazmat/WooShippingLabelHazmatFormFragment.kt
@@ -30,6 +30,8 @@ import dagger.hilt.android.AndroidEntryPoint
 class WooShippingLabelHazmatFormFragment : BaseFragment(), BackPressListener {
     private val viewModel: WooShippingLabelHazmatFormViewModel by viewModels()
 
+    override fun getFragmentTitle() = ""
+
     override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View? {
         return ComposeView(requireContext()).apply {
             setViewCompositionStrategy(ViewCompositionStrategy.DisposeOnViewTreeLifecycleDestroyed)

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/packages/WooShippingLabelPackageCreationFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/packages/WooShippingLabelPackageCreationFragment.kt
@@ -29,6 +29,8 @@ class WooShippingLabelPackageCreationFragment : BaseFragment() {
 
     private var progressDialog: CustomProgressDialog? = null
 
+    override fun getFragmentTitle() = getString(R.string.shipping_label_package_title)
+
     override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View? {
         return ComposeView(requireContext()).apply {
             setViewCompositionStrategy(DisposeOnViewTreeLifecycleDestroyed)

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -1282,6 +1282,7 @@
     <string name="shipping_label_package_details_items_weight_price">%1$s  ·  %2$s</string>
     <string name="shipping_label_package_details_items_expand_content_description">Collapse/expand items card</string>
     <string name="shipping_label_hazmat_title">Are you shipping dangerous goods or hazardous materials?</string>
+    <string name="shipping_label_package_title">Select a Package</string>
     <string name="shipping_label_select_package_button">Select a Package</string>
     <string name="shipping_label_select_package_title">Select a package to get shipping rates</string>
     <string name="shipping_label_package_default_name">Custom Package</string>


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

<!-- 
━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
🛠 Need an AI review?  
Add a comment: `@coderabbitai review`
━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
-->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
This adds a proper title to the Customs, Package, and Hazmat screens. Previously, the default title was shown as “Order #1234” and changed to “Woo” when the orientation changed. I set an empty title for the Hazmat screen since no title was in the Figma file.

### Steps to reproduce
<!-- Step-by-step testing instructions. For new user flows, consider instead stating the goal of the workflow and see if your PR reviewer can accomplish the workflow without specific steps! -->
1. Open an order where the total product cost exceeds the 2,500 USD.
2. Open the Shipping Labels Creation form.
3. Tap the Hazmat field.
4. Tap the edit button in the Customs section.
5. Tap the "Select a Package" button.

### The tests that have been performed
<!-- To give the reviewer an idea of what could be missed in terms of testing -->
Steps above

### Images/gif
<!-- Include before and after images or gifs when appropriate. -->
|Before|After|
|-|-|
|<img src="https://github.com/user-attachments/assets/17ce1042-d7b8-4d91-abad-8a251361a9e7" width=400>|<img src="https://github.com/user-attachments/assets/ef12609f-8fce-4a62-b4a9-77c0f8cee1e2" width=400>|
|<img src="https://github.com/user-attachments/assets/3a6385a5-205e-4e9e-a9e9-b659294e8176" width=400>|<img src="https://github.com/user-attachments/assets/cafe408a-7442-41a9-b2d6-9decfb64cf35" width=400>|
|<img src="https://github.com/user-attachments/assets/d98bb23f-ddcc-4aae-ab30-b87667de0a0a" width=400>|<img src="https://github.com/user-attachments/assets/7544f22a-c9b7-4520-ab09-c117bea40c5b" width=400>|
|<img src="https://github.com/user-attachments/assets/a988bee9-b4b5-4798-99bf-ea3dc33cb349" width=400>|<img src="https://github.com/user-attachments/assets/b2bcf7fc-c44a-4e5a-b191-4877c1aea85e" width=400>|

- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.

## Reviewer (or Author, in the case of optional code reviews):

Please make sure these conditions are met before approving the PR, or request changes if the PR needs improvement:

- [ ] The PR is small and has a clear, single focus, or a valid explanation is provided in the description. If needed, please request to split it into smaller PRs.
- [ ] Ensure Adequate Unit Test Coverage: The changes are reasonably covered by unit tests or an explanation is provided in the PR description.
- [ ] Manual Testing: The author listed all the tests they ran, including smoke tests when needed (e.g., for refactorings). The reviewer confirmed that the PR works as expected on big (tablet) and small (phone) in case of UI changes, and no regressions are added.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->