### PR TITLE
[Custom Amounts] Fix: Use currency code instead of symbol in Custom Amounts screen 

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -7,6 +7,7 @@
 - [*] Fix rare crash in the POS upon adding an item to the cart [https://github.com/woocommerce/woocommerce-android/pull/13838]
 - [**] Fixed a crash in the custom amount dialog on Android version 12 and older.
 - [*] Updated the Woo upgrade dialog to resolve layout issues and align it with the current app design [https://github.com/woocommerce/woocommerce-android/pull/13851]
+- [*] Fix: Use currency code instead of symbol in Custom Amounts screen [https://github.com/woocommerce/woocommerce-android/pull/13875]
 
 22.0.2
 -----

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/common/CurrencyCode.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/common/CurrencyCode.kt
@@ -1,0 +1,4 @@
+package com.woocommerce.android.ui.common
+
+@JvmInline
+value class CurrencyCode(val value: String)

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/common/CurrencySymbol.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/common/CurrencySymbol.kt
@@ -1,0 +1,4 @@
+package com.woocommerce.android.ui.common
+
+@JvmInline
+value class CurrencySymbol(val value: String)

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/CustomAmountUIModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/CustomAmountUIModel.kt
@@ -1,16 +1,18 @@
 package com.woocommerce.android.ui.orders
 
 import android.os.Parcelable
+import com.woocommerce.android.ui.common.CurrencyCode
 import com.woocommerce.android.ui.payments.customamounts.CustomAmountsViewModel.CustomAmountType
 import com.woocommerce.android.ui.payments.customamounts.CustomAmountsViewModel.TaxStatus
 import kotlinx.parcelize.Parcelize
+import kotlinx.parcelize.RawValue
 import java.math.BigDecimal
 
 @Parcelize
 data class CustomAmountUIModel(
     val id: Long,
     val amount: BigDecimal,
-    val currency: String? = null,
+    val currencyCode: @RawValue CurrencyCode? = null,
     val name: String,
     val taxStatus: TaxStatus = TaxStatus(),
     val type: CustomAmountType,

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/MapFeeLineToCustomAmountUiModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/MapFeeLineToCustomAmountUiModel.kt
@@ -1,6 +1,7 @@
 package com.woocommerce.android.ui.orders.creation
 
 import com.woocommerce.android.model.Order
+import com.woocommerce.android.ui.common.CurrencyCode
 import com.woocommerce.android.ui.orders.CustomAmountUIModel
 import com.woocommerce.android.ui.payments.customamounts.CustomAmountsFragment.Companion.CUSTOM_AMOUNT
 import com.woocommerce.android.ui.payments.customamounts.CustomAmountsViewModel
@@ -20,7 +21,7 @@ class MapFeeLineToCustomAmountUiModel @Inject constructor() {
                 Order.FeeLine.FeeLineTaxStatus.UNKNOWN -> TaxStatus(isTaxable = false)
             },
             type = CustomAmountsViewModel.CustomAmountType.FIXED_CUSTOM_AMOUNT,
-            currency = orderCurrency
+            currencyCode = CurrencyCode(orderCurrency)
         )
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/OrderCreateEditCustomAmountAdapter.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/OrderCreateEditCustomAmountAdapter.kt
@@ -42,10 +42,10 @@ class OrderCreateEditCustomAmountAdapter(
 
         fun bind(customAmountUIModel: CustomAmountUIModel) {
             binding.customAmountLayout.customAmountName.text = customAmountUIModel.name
-            binding.customAmountLayout.customAmountAmount.text = customAmountUIModel.currency?.let {
+            binding.customAmountLayout.customAmountAmount.text = customAmountUIModel.currencyCode?.let {
                 currencyFormatter.formatCurrency(
                     customAmountUIModel.amount.toString(),
-                    currencyCode = it
+                    currencyCode = it.value
                 )
             } ?: run {
                 currencyFormatter.formatCurrency(customAmountUIModel.amount.toString())

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/OrderCreateEditFormFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/OrderCreateEditFormFragment.kt
@@ -51,7 +51,6 @@ import com.woocommerce.android.model.Order
 import com.woocommerce.android.ui.barcodescanner.BarcodeScanningFragment
 import com.woocommerce.android.ui.base.BaseFragment
 import com.woocommerce.android.ui.base.UIMessageResolver
-import com.woocommerce.android.ui.common.CurrencyCode
 import com.woocommerce.android.ui.compose.component.FeedbackDialog
 import com.woocommerce.android.ui.compose.theme.WooTheme
 import com.woocommerce.android.ui.compose.theme.WooThemeWithBackground
@@ -91,7 +90,6 @@ import com.woocommerce.android.ui.orders.creation.views.OrderCreateEditSectionVi
 import com.woocommerce.android.ui.orders.creation.views.OrderCreateEditSectionView.AddButton
 import com.woocommerce.android.ui.orders.details.OrderStatusSelectorDialog.Companion.KEY_ORDER_STATUS_RESULT
 import com.woocommerce.android.ui.orders.details.views.OrderDetailOrderStatusView
-import com.woocommerce.android.ui.payments.customamounts.CustomAmountsViewModel.CustomAmountType.FIXED_CUSTOM_AMOUNT
 import com.woocommerce.android.ui.products.selector.ProductSelectorFragment
 import com.woocommerce.android.ui.products.selector.ProductSelectorFragmentArgs
 import com.woocommerce.android.ui.products.selector.ProductSelectorSharedViewModel
@@ -653,7 +651,7 @@ class OrderCreateEditFormFragment :
         binding.customAmountsSection.setCustomAmountsSectionButtons(
             addCustomAmountsButton = AddButton(
                 text = getString(R.string.order_creation_add_custom_amounts),
-                onClickListener = { navigateToCustomAmountsDialog() }
+                onClickListener = { viewModel.onCustomAmountTapped() }
             )
         )
         binding.customAmountsSection.isEachAddButtonEnabled = isEditable
@@ -703,7 +701,7 @@ class OrderCreateEditFormFragment :
                 addCustomAmountsButton = AddButton(
                     text = getString(R.string.order_creation_add_custom_amounts),
                     onClickListener = {
-                        navigateToCustomAmountsDialog()
+                        viewModel.onCustomAmountTapped()
                     }
                 )
             )
@@ -716,7 +714,7 @@ class OrderCreateEditFormFragment :
                 addCustomAmountsButton = AddButton(
                     text = getString(R.string.order_creation_add_custom_amounts),
                     onClickListener = {
-                        navigateToCustomAmountsDialog()
+                        viewModel.onCustomAmountTapped()
                     }
                 )
             )
@@ -724,24 +722,16 @@ class OrderCreateEditFormFragment :
     }
 
     private fun navigateToCustomAmountsDialog(
-        customAmountUIModel: CustomAmountUIModel = CustomAmountUIModel.EMPTY,
-        orderTotal: String = viewModel.orderDraft.value?.total.toString(),
+        customAmountUIModel: CustomAmountUIModel,
+        orderTotal: String,
     ) {
-        if (viewModel.orderContainsProductsOrCustomAmounts()) {
-            displayCustomAmountTypeBottomSheet()
-        } else {
-            val currencyCode = viewModel.currencyCodeLiveData.value?.value?.let { CurrencyCode(it) }
-            OrderCreateEditNavigator.navigate(
-                this,
-                OrderCreateEditNavigationTarget.CustomAmountDialog(
-                    customAmountUIModel.copy(
-                        type = FIXED_CUSTOM_AMOUNT,
-                        currencyCode = currencyCode
-                    ),
-                    orderTotal
-                )
+        OrderCreateEditNavigator.navigate(
+            this,
+            OrderCreateEditNavigationTarget.CustomAmountDialog(
+                customAmountUIModel,
+                orderTotal
             )
-        }
+        )
     }
 
     private fun displayCustomAmountTypeBottomSheet() {
@@ -861,9 +851,7 @@ class OrderCreateEditFormFragment :
                         currencyFormatter,
                         onCustomAmountClick = {
                             viewModel.selectCustomAmount(it)
-                            navigateToCustomAmountsDialog(
-                                customAmountUIModel = it,
-                            )
+                            viewModel.onCustomAmountTapped(it)
                         }
                     )
                     itemAnimator = animator
@@ -874,7 +862,7 @@ class OrderCreateEditFormFragment :
                 submitList(customAmounts)
             }
             customAmountsSection.addIcon.setOnClickListener {
-                navigateToCustomAmountsDialog()
+                viewModel.onCustomAmountTapped()
             }
         }
     }
@@ -1184,9 +1172,10 @@ class OrderCreateEditFormFragment :
             is OpenBarcodeScanningFragment -> navigateToBarcodeScanning()
             is VMKilledWhenScanningInProgress -> ToastUtils.showToast(context, event.message)
             is OnCouponRejectedByBackend -> uiMessageResolver.getSnack(stringResId = event.message).show()
-            is OnCustomAmountTypeSelected -> handleCustomAmountSelection(event)
             is OnTotalsSectionHeightChanged -> updateScrollViewPadding(binding, event.newHeight)
             is OnSelectedProductsSyncRequested -> syncSelectedProducts()
+            is ShowCustomAmountBottomSheet -> displayCustomAmountTypeBottomSheet()
+            is ShowCustomAmountDialog -> navigateToCustomAmountsDialog(event.customAmountUIModel, event.orderTotal)
             is Exit -> findNavController().navigateUp()
             is ShippingLinesFeedback -> sendShippingLinesFeedback()
         }
@@ -1216,23 +1205,6 @@ class OrderCreateEditFormFragment :
     private fun navigateToBarcodeScanning() {
         findNavController().navigateSafely(
             OrderCreateEditFormFragmentDirections.actionOrderCreationFragmentToBarcodeScanningFragment()
-        )
-    }
-
-    private fun handleCustomAmountSelection(event: OnCustomAmountTypeSelected) {
-        val currencyCode = viewModel.currencyCodeLiveData.value?.value?.let { CurrencyCode(it) }
-        OrderCreateEditNavigator.navigate(
-            this,
-            OrderCreateEditNavigationTarget.CustomAmountDialog(
-                customAmountUIModel = viewModel.selectedCustomAmount.value?.copy(
-                    type = event.type,
-                    currencyCode = currencyCode
-                ) ?: CustomAmountUIModel.EMPTY.copy(
-                    type = event.type,
-                    currencyCode = currencyCode
-                ),
-                orderTotal = viewModel.orderDraft.value?.total.toString(),
-            )
         )
     }
 
@@ -1282,7 +1254,7 @@ class OrderCreateEditFormFragment :
      * that to delay navigation to the dialog. As marker that we can navigate is the view is created
      */
     private fun navigateToCustomAmountDialogWhenViewIsCreated(root: View) {
-        root.post { navigateToCustomAmountsDialog() }
+        root.post { viewModel.onCustomAmountTapped() }
     }
 
     private fun hideProgressDialog() {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/OrderCreateEditFormFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/OrderCreateEditFormFragment.kt
@@ -734,7 +734,7 @@ class OrderCreateEditFormFragment :
                 OrderCreateEditNavigationTarget.CustomAmountDialog(
                     customAmountUIModel.copy(
                         type = FIXED_CUSTOM_AMOUNT,
-                        currency = viewModel.getCurrencySymbol()
+                        currency = viewModel.orderDraft.value?.currency
                     ),
                     orderTotal
                 )
@@ -1223,10 +1223,10 @@ class OrderCreateEditFormFragment :
             OrderCreateEditNavigationTarget.CustomAmountDialog(
                 customAmountUIModel = viewModel.selectedCustomAmount.value?.copy(
                     type = event.type,
-                    currency = viewModel.getCurrencySymbol()
+                    currency = viewModel.orderDraft.value?.currency
                 ) ?: CustomAmountUIModel.EMPTY.copy(
                     type = event.type,
-                    currency = viewModel.getCurrencySymbol()
+                    currency = viewModel.orderDraft.value?.currency
                 ),
                 orderTotal = viewModel.orderDraft.value?.total.toString(),
             )

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/OrderCreateEditFormFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/OrderCreateEditFormFragment.kt
@@ -51,6 +51,7 @@ import com.woocommerce.android.model.Order
 import com.woocommerce.android.ui.barcodescanner.BarcodeScanningFragment
 import com.woocommerce.android.ui.base.BaseFragment
 import com.woocommerce.android.ui.base.UIMessageResolver
+import com.woocommerce.android.ui.common.CurrencyCode
 import com.woocommerce.android.ui.compose.component.FeedbackDialog
 import com.woocommerce.android.ui.compose.theme.WooTheme
 import com.woocommerce.android.ui.compose.theme.WooThemeWithBackground
@@ -729,12 +730,13 @@ class OrderCreateEditFormFragment :
         if (viewModel.orderContainsProductsOrCustomAmounts()) {
             displayCustomAmountTypeBottomSheet()
         } else {
+            val currencyCode = viewModel.currencyCodeLiveData.value?.value?.let { CurrencyCode(it) }
             OrderCreateEditNavigator.navigate(
                 this,
                 OrderCreateEditNavigationTarget.CustomAmountDialog(
                     customAmountUIModel.copy(
                         type = FIXED_CUSTOM_AMOUNT,
-                        currency = viewModel.orderDraft.value?.currency
+                        currencyCode = currencyCode
                     ),
                     orderTotal
                 )
@@ -1218,15 +1220,16 @@ class OrderCreateEditFormFragment :
     }
 
     private fun handleCustomAmountSelection(event: OnCustomAmountTypeSelected) {
+        val currencyCode = viewModel.currencyCodeLiveData.value?.value?.let { CurrencyCode(it) }
         OrderCreateEditNavigator.navigate(
             this,
             OrderCreateEditNavigationTarget.CustomAmountDialog(
                 customAmountUIModel = viewModel.selectedCustomAmount.value?.copy(
                     type = event.type,
-                    currency = viewModel.orderDraft.value?.currency
+                    currencyCode = currencyCode
                 ) ?: CustomAmountUIModel.EMPTY.copy(
                     type = event.type,
-                    currency = viewModel.orderDraft.value?.currency
+                    currencyCode = currencyCode
                 ),
                 orderTotal = viewModel.orderDraft.value?.total.toString(),
             )

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/OrderCreateEditViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/OrderCreateEditViewModel.kt
@@ -91,6 +91,7 @@ import com.woocommerce.android.model.Order.ShippingLine
 import com.woocommerce.android.model.WooPlugin
 import com.woocommerce.android.tracker.OrderDurationRecorder
 import com.woocommerce.android.ui.barcodescanner.BarcodeScanningTracker
+import com.woocommerce.android.ui.common.CurrencyCode
 import com.woocommerce.android.ui.feedback.FeedbackRepository
 import com.woocommerce.android.ui.orders.CustomAmountUIModel
 import com.woocommerce.android.ui.orders.OrderNavigationTarget.ViewOrderStatusSelector
@@ -315,6 +316,9 @@ class OrderCreateEditViewModel @Inject constructor(
 
     val selectedItems: StateFlow<List<SelectedItem>> =
         _orderDraft.map { order -> order.selectedItems() }.toStateFlow(emptyList())
+
+    val currencyCodeLiveData: LiveData<CurrencyCode?> =
+        _orderDraft.map { CurrencyCode(it.currency) }.asLiveData()
 
     fun Order.selectedItems(): List<SelectedItem> = items.map { item ->
         if (item.isVariation) {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/OrderCreateEditViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/OrderCreateEditViewModel.kt
@@ -317,9 +317,6 @@ class OrderCreateEditViewModel @Inject constructor(
     val selectedItems: StateFlow<List<SelectedItem>> =
         _orderDraft.map { order -> order.selectedItems() }.toStateFlow(emptyList())
 
-    val currencyCodeLiveData: LiveData<CurrencyCode?> =
-        _orderDraft.map { CurrencyCode(it.currency) }.asLiveData()
-
     fun Order.selectedItems(): List<SelectedItem> = items.map { item ->
         if (item.isVariation) {
             SelectedItem.ProductVariation(item.productId, item.variationId)

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/OrderCreateEditViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/OrderCreateEditViewModel.kt
@@ -332,9 +332,11 @@ class OrderCreateEditViewModel @Inject constructor(
     val pendingSelectedItems: StateFlow<List<SelectedItem>> = _pendingSelectedItems
 
     val customAmounts: LiveData<List<CustomAmountUIModel>> = _orderDraft
-        .map { order -> order.feesLines }
-        .map { feeLines ->
-            feeLines.map { feeLine -> mapFeeLineToCustomAmountUiModel(feeLine, getCurrencySymbol()) }
+        .map { order ->
+            val currency = order.currency
+            order.feesLines.map { feeLine ->
+                mapFeeLineToCustomAmountUiModel(feeLine, currency)
+            }
         }
         .asLiveData()
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/OrderCreateEditViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/OrderCreateEditViewModel.kt
@@ -511,10 +511,6 @@ class OrderCreateEditViewModel @Inject constructor(
         _selectedCustomAmount.value = null
     }
 
-    fun onCustomAmountTypeSelected(type: CustomAmountType) {
-        triggerEvent(OnCustomAmountTypeSelected(type = type))
-    }
-
     private suspend fun updateAutoTaxRateSettingState() {
         val rate = getAutoTaxRateSetting()
         viewState = if (rate != null) {
@@ -2011,6 +2007,38 @@ class OrderCreateEditViewModel @Inject constructor(
         )
     }
 
+    fun onCustomAmountTapped(customAmountUIModel: CustomAmountUIModel = CustomAmountUIModel.EMPTY) {
+        val orderTotal = _orderDraft.value.total.toString()
+        val currencyCode = _orderDraft.value.currency.let { CurrencyCode(it) }
+
+        if (orderContainsProductsOrCustomAmounts()) {
+            triggerEvent(ShowCustomAmountBottomSheet)
+        } else {
+            triggerEvent(
+                ShowCustomAmountDialog(
+                    customAmountUIModel.copy(
+                        type = CustomAmountType.FIXED_CUSTOM_AMOUNT,
+                        currencyCode = currencyCode
+                    ),
+                    orderTotal = orderTotal
+                )
+            )
+        }
+    }
+
+    fun onCustomAmountTypeSelected(type: CustomAmountType) {
+        val selected = selectedCustomAmount.value ?: CustomAmountUIModel.EMPTY
+        val currencyCode = _orderDraft.value.currency.let { CurrencyCode(it) }
+        val orderTotal = _orderDraft.value.total.toString()
+
+        triggerEvent(
+            ShowCustomAmountDialog(
+                customAmountUIModel = selected.copy(type = type, currencyCode = currencyCode),
+                orderTotal = orderTotal
+            )
+        )
+    }
+
     @Parcelize
     data class ViewState(
         val isProgressDialogShown: Boolean = false,
@@ -2099,9 +2127,12 @@ data class OnTotalsSectionHeightChanged(
     val newHeight: Int
 ) : Event()
 
-data class OnCustomAmountTypeSelected(
-    val type: CustomAmountType
+data class ShowCustomAmountDialog(
+    val customAmountUIModel: CustomAmountUIModel,
+    val orderTotal: String
 ) : Event()
+
+object ShowCustomAmountBottomSheet : Event()
 
 object OnSelectedProductsSyncRequested : Event()
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/customamounts/CustomAmountsFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/customamounts/CustomAmountsFragment.kt
@@ -209,12 +209,6 @@ class CustomAmountsFragment : BaseFragment(R.layout.dialog_custom_amounts) {
         observePercentageView(binding)
         observeCustomAmountNameView(binding)
 
-        if (arguments.customAmountUIModel.type == FIXED_CUSTOM_AMOUNT) {
-            viewModel.currencySymbolLiveData.observe(viewLifecycleOwner) { symbol ->
-                binding.editPrice.orderCurrency = symbol?.value
-            }
-        }
-
         viewModel.viewStateLiveData.observe(viewLifecycleOwner) { old, new ->
             new.isDoneButtonEnabled.takeIfNotEqualTo(old?.isDoneButtonEnabled) { isEnabled ->
                 binding.buttonDone.isEnabled = isEnabled
@@ -240,6 +234,11 @@ class CustomAmountsFragment : BaseFragment(R.layout.dialog_custom_amounts) {
                     PERCENTAGE_CUSTOM_AMOUNT -> {
                         binding.updatedAmount.text = viewModel.currentPrice.toString()
                     }
+                }
+            }
+            if (arguments.customAmountUIModel.type == FIXED_CUSTOM_AMOUNT) {
+                new.currencySymbol?.let { symbol ->
+                    binding.editPrice.orderCurrency = symbol.value
                 }
             }
         }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/customamounts/CustomAmountsFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/customamounts/CustomAmountsFragment.kt
@@ -69,9 +69,6 @@ class CustomAmountsFragment : BaseFragment(R.layout.dialog_custom_amounts) {
     ) {
         when (arguments.customAmountUIModel.type) {
             FIXED_CUSTOM_AMOUNT -> {
-                binding.editPrice.orderCurrency = viewModel.getCurrencySymbol(
-                    arguments.customAmountUIModel.currency,
-                )
                 if (!isLandscape && binding.editPrice.editText.requestFocus()) {
                     binding.editPrice.postDelayed(
                         {
@@ -211,6 +208,12 @@ class CustomAmountsFragment : BaseFragment(R.layout.dialog_custom_amounts) {
     private fun setupObservers(binding: DialogCustomAmountsBinding) {
         observePercentageView(binding)
         observeCustomAmountNameView(binding)
+
+        if (arguments.customAmountUIModel.type == FIXED_CUSTOM_AMOUNT) {
+            viewModel.currencySymbolLiveData.observe(viewLifecycleOwner) { symbol ->
+                binding.editPrice.orderCurrency = symbol?.value
+            }
+        }
 
         viewModel.viewStateLiveData.observe(viewLifecycleOwner) { old, new ->
             new.isDoneButtonEnabled.takeIfNotEqualTo(old?.isDoneButtonEnabled) { isEnabled ->

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/customamounts/CustomAmountsFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/customamounts/CustomAmountsFragment.kt
@@ -69,7 +69,9 @@ class CustomAmountsFragment : BaseFragment(R.layout.dialog_custom_amounts) {
     ) {
         when (arguments.customAmountUIModel.type) {
             FIXED_CUSTOM_AMOUNT -> {
-                binding.editPrice.orderCurrency = arguments.customAmountUIModel.currency
+                binding.editPrice.orderCurrency = viewModel.getCurrencySymbol(
+                    arguments.customAmountUIModel.currency,
+                )
                 if (!isLandscape && binding.editPrice.editText.requestFocus()) {
                     binding.editPrice.postDelayed(
                         {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/customamounts/CustomAmountsViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/customamounts/CustomAmountsViewModel.kt
@@ -107,7 +107,6 @@ class CustomAmountsViewModel @Inject constructor(
     private val args: CustomAmountsFragmentArgs by savedState.navArgs()
 
     init {
-        setCurrencySymbol()
         if (isInCreateMode()) {
             tracker.track(ORDER_CREATION_ADD_CUSTOM_AMOUNT_TAPPED)
         } else {
@@ -115,27 +114,22 @@ class CustomAmountsViewModel @Inject constructor(
             populateUIWithExistingData()
             tracker.track(ORDER_CREATION_EDIT_CUSTOM_AMOUNT_TAPPED)
         }
-        updateCustomAmountType()
+        updateCustomAmountTypeAndSetCurrencySymbol()
     }
 
-    private fun setCurrencySymbol() {
+    private fun updateCustomAmountTypeAndSetCurrencySymbol() {
         viewModelScope.launch {
             val code = args.customAmountUIModel.currencyCode?.value
                 ?: store.getSiteSettings(selectedSite.get())?.currencyCode
 
             val symbol = code?.let { currencySymbolFinder.findCurrencySymbol(it) }
             viewState = viewState.copy(
+                customAmountUIModel = viewState.customAmountUIModel.copy(
+                    type = args.customAmountUIModel.type
+                ),
                 currencySymbol = symbol?.let { CurrencySymbol(it) }
             )
         }
-    }
-
-    private fun updateCustomAmountType() {
-        viewState = viewState.copy(
-            customAmountUIModel = viewState.customAmountUIModel.copy(
-                type = args.customAmountUIModel.type
-            )
-        )
     }
 
     private fun populateUIWithExistingData() {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/customamounts/CustomAmountsViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/customamounts/CustomAmountsViewModel.kt
@@ -114,11 +114,11 @@ class CustomAmountsViewModel @Inject constructor(
     }
 
     fun getCurrencySymbol(currencyCode: String?): String? {
-        currencyCode?.let { code ->
-            return currencySymbolFinder.findCurrencySymbol(code)
-        } ?: run {
-            return store.getSiteSettings(selectedSite.get())?.currencyCode
-        }
+        val code = currencyCode
+            ?: store.getSiteSettings(selectedSite.get())?.currencyCode
+            ?: return null
+
+        return currencySymbolFinder.findCurrencySymbol(code)
     }
 
     private fun updateCustomAmountType() {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/customamounts/CustomAmountsViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/customamounts/CustomAmountsViewModel.kt
@@ -1,13 +1,16 @@
 package com.woocommerce.android.ui.payments.customamounts
 
 import android.os.Parcelable
+import androidx.lifecycle.LiveData
 import androidx.lifecycle.SavedStateHandle
+import androidx.lifecycle.liveData
 import com.woocommerce.android.R
 import com.woocommerce.android.analytics.AnalyticsEvent.ORDER_CREATION_ADD_CUSTOM_AMOUNT_TAPPED
 import com.woocommerce.android.analytics.AnalyticsEvent.ORDER_CREATION_EDIT_CUSTOM_AMOUNT_TAPPED
 import com.woocommerce.android.analytics.AnalyticsTrackerWrapper
 import com.woocommerce.android.model.Order
 import com.woocommerce.android.tools.SelectedSite
+import com.woocommerce.android.ui.common.CurrencySymbol
 import com.woocommerce.android.ui.orders.CustomAmountUIModel
 import com.woocommerce.android.ui.orders.creation.product.discount.CurrencySymbolFinder
 import com.woocommerce.android.viewmodel.LiveDataDelegate
@@ -100,6 +103,14 @@ class CustomAmountsViewModel @Inject constructor(
             )
         }
 
+    val currencySymbolLiveData: LiveData<CurrencySymbol?> = liveData {
+        val code = args.customAmountUIModel.currencyCode?.value
+            ?: store.getSiteSettings(selectedSite.get())?.currencyCode
+
+        val symbol = code?.let { currencySymbolFinder.findCurrencySymbol(it) }
+        emit(symbol?.let { CurrencySymbol(it) })
+    }
+
     private val args: CustomAmountsFragmentArgs by savedState.navArgs()
 
     init {
@@ -111,14 +122,6 @@ class CustomAmountsViewModel @Inject constructor(
             tracker.track(ORDER_CREATION_EDIT_CUSTOM_AMOUNT_TAPPED)
         }
         updateCustomAmountType()
-    }
-
-    fun getCurrencySymbol(currencyCode: String?): String? {
-        val code = currencyCode
-            ?: store.getSiteSettings(selectedSite.get())?.currencyCode
-            ?: return null
-
-        return currencySymbolFinder.findCurrencySymbol(code)
     }
 
     private fun updateCustomAmountType() {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/customamounts/CustomAmountsViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/customamounts/CustomAmountsViewModel.kt
@@ -7,13 +7,16 @@ import com.woocommerce.android.analytics.AnalyticsEvent.ORDER_CREATION_ADD_CUSTO
 import com.woocommerce.android.analytics.AnalyticsEvent.ORDER_CREATION_EDIT_CUSTOM_AMOUNT_TAPPED
 import com.woocommerce.android.analytics.AnalyticsTrackerWrapper
 import com.woocommerce.android.model.Order
+import com.woocommerce.android.tools.SelectedSite
 import com.woocommerce.android.ui.orders.CustomAmountUIModel
+import com.woocommerce.android.ui.orders.creation.product.discount.CurrencySymbolFinder
 import com.woocommerce.android.viewmodel.LiveDataDelegate
 import com.woocommerce.android.viewmodel.MultiLiveEvent.Event
 import com.woocommerce.android.viewmodel.ScopedViewModel
 import com.woocommerce.android.viewmodel.navArgs
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.parcelize.Parcelize
+import org.wordpress.android.fluxc.store.WooCommerceStore
 import java.math.BigDecimal
 import java.math.RoundingMode
 import javax.inject.Inject
@@ -23,6 +26,9 @@ import kotlin.math.roundToInt
 class CustomAmountsViewModel @Inject constructor(
     savedState: SavedStateHandle,
     tracker: AnalyticsTrackerWrapper,
+    private val currencySymbolFinder: CurrencySymbolFinder,
+    private val store: WooCommerceStore,
+    private val selectedSite: SelectedSite,
 ) : ScopedViewModel(savedState) {
     /**
      * Saving more data than necessary into the SavedState has associated risks which were not known at the time this
@@ -105,6 +111,14 @@ class CustomAmountsViewModel @Inject constructor(
             tracker.track(ORDER_CREATION_EDIT_CUSTOM_AMOUNT_TAPPED)
         }
         updateCustomAmountType()
+    }
+
+    fun getCurrencySymbol(currencyCode: String?): String? {
+        currencyCode?.let { code ->
+            return currencySymbolFinder.findCurrencySymbol(code)
+        } ?: run {
+            return store.getSiteSettings(selectedSite.get())?.currencyCode
+        }
     }
 
     private fun updateCustomAmountType() {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/customamounts/CustomAmountsViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/customamounts/CustomAmountsViewModel.kt
@@ -1,9 +1,8 @@
 package com.woocommerce.android.ui.payments.customamounts
 
 import android.os.Parcelable
-import androidx.lifecycle.LiveData
 import androidx.lifecycle.SavedStateHandle
-import androidx.lifecycle.liveData
+import androidx.lifecycle.viewModelScope
 import com.woocommerce.android.R
 import com.woocommerce.android.analytics.AnalyticsEvent.ORDER_CREATION_ADD_CUSTOM_AMOUNT_TAPPED
 import com.woocommerce.android.analytics.AnalyticsEvent.ORDER_CREATION_EDIT_CUSTOM_AMOUNT_TAPPED
@@ -18,7 +17,9 @@ import com.woocommerce.android.viewmodel.MultiLiveEvent.Event
 import com.woocommerce.android.viewmodel.ScopedViewModel
 import com.woocommerce.android.viewmodel.navArgs
 import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.launch
 import kotlinx.parcelize.Parcelize
+import kotlinx.parcelize.RawValue
 import org.wordpress.android.fluxc.store.WooCommerceStore
 import java.math.BigDecimal
 import java.math.RoundingMode
@@ -103,17 +104,10 @@ class CustomAmountsViewModel @Inject constructor(
             )
         }
 
-    val currencySymbolLiveData: LiveData<CurrencySymbol?> = liveData {
-        val code = args.customAmountUIModel.currencyCode?.value
-            ?: store.getSiteSettings(selectedSite.get())?.currencyCode
-
-        val symbol = code?.let { currencySymbolFinder.findCurrencySymbol(it) }
-        emit(symbol?.let { CurrencySymbol(it) })
-    }
-
     private val args: CustomAmountsFragmentArgs by savedState.navArgs()
 
     init {
+        setCurrencySymbol()
         if (isInCreateMode()) {
             tracker.track(ORDER_CREATION_ADD_CUSTOM_AMOUNT_TAPPED)
         } else {
@@ -122,6 +116,18 @@ class CustomAmountsViewModel @Inject constructor(
             tracker.track(ORDER_CREATION_EDIT_CUSTOM_AMOUNT_TAPPED)
         }
         updateCustomAmountType()
+    }
+
+    private fun setCurrencySymbol() {
+        viewModelScope.launch {
+            val code = args.customAmountUIModel.currencyCode?.value
+                ?: store.getSiteSettings(selectedSite.get())?.currencyCode
+
+            val symbol = code?.let { currencySymbolFinder.findCurrencySymbol(it) }
+            viewState = viewState.copy(
+                currencySymbol = symbol?.let { CurrencySymbol(it) }
+            )
+        }
     }
 
     private fun updateCustomAmountType() {
@@ -170,6 +176,7 @@ class CustomAmountsViewModel @Inject constructor(
     @Parcelize
     data class ViewState(
         val customAmountUIModel: CustomAmountUIState = CustomAmountUIState(),
+        val currencySymbol: @RawValue CurrencySymbol? = null,
         val isDoneButtonEnabled: Boolean = false,
         val isProgressShowing: Boolean = false,
         val createdOrder: Order? = null,

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/creation/MapFeeLineToCustomAmountUIModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/creation/MapFeeLineToCustomAmountUIModelTest.kt
@@ -1,6 +1,7 @@
 package com.woocommerce.android.ui.orders.creation
 
 import com.woocommerce.android.model.Order
+import com.woocommerce.android.ui.common.CurrencyCode
 import com.woocommerce.android.ui.orders.CustomAmountUIModel
 import com.woocommerce.android.ui.payments.customamounts.CustomAmountsViewModel
 import com.woocommerce.android.viewmodel.BaseUnitTest
@@ -27,7 +28,7 @@ class MapFeeLineToCustomAmountUIModelTest : BaseUnitTest() {
             name = "Test Amount",
             taxStatus = CustomAmountsViewModel.TaxStatus(isTaxable = false),
             type = CustomAmountsViewModel.CustomAmountType.FIXED_CUSTOM_AMOUNT,
-            currency = "USD"
+            currencyCode = CurrencyCode("USD")
         )
 
         val mapperResult = MapFeeLineToCustomAmountUiModel().invoke(feeLine, "USD")
@@ -50,7 +51,7 @@ class MapFeeLineToCustomAmountUIModelTest : BaseUnitTest() {
             name = "Test Amount",
             taxStatus = CustomAmountsViewModel.TaxStatus(isTaxable = false),
             type = CustomAmountsViewModel.CustomAmountType.FIXED_CUSTOM_AMOUNT,
-            currency = "USD"
+            currencyCode = CurrencyCode("USD")
         )
 
         val mapperResult = MapFeeLineToCustomAmountUiModel().invoke(feeLine, "USD")
@@ -73,7 +74,7 @@ class MapFeeLineToCustomAmountUIModelTest : BaseUnitTest() {
             name = "Test Amount",
             taxStatus = CustomAmountsViewModel.TaxStatus(isTaxable = true),
             type = CustomAmountsViewModel.CustomAmountType.FIXED_CUSTOM_AMOUNT,
-            currency = "USD"
+            currencyCode = CurrencyCode("USD")
         )
 
         val mapperResult = MapFeeLineToCustomAmountUiModel().invoke(feeLine, "USD")

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/payments/customamounts/CustomAmountsFragmentViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/payments/customamounts/CustomAmountsFragmentViewModelTest.kt
@@ -3,7 +3,9 @@ package com.woocommerce.android.ui.payments.customamounts
 import com.woocommerce.android.analytics.AnalyticsEvent.ORDER_CREATION_ADD_CUSTOM_AMOUNT_TAPPED
 import com.woocommerce.android.analytics.AnalyticsEvent.ORDER_CREATION_EDIT_CUSTOM_AMOUNT_TAPPED
 import com.woocommerce.android.analytics.AnalyticsTrackerWrapper
+import com.woocommerce.android.tools.SelectedSite
 import com.woocommerce.android.ui.orders.CustomAmountUIModel
+import com.woocommerce.android.ui.orders.creation.product.discount.CurrencySymbolFinder
 import com.woocommerce.android.ui.payments.customamounts.CustomAmountsViewModel.CustomAmountType.FIXED_CUSTOM_AMOUNT
 import com.woocommerce.android.ui.payments.customamounts.CustomAmountsViewModel.CustomAmountType.PERCENTAGE_CUSTOM_AMOUNT
 import com.woocommerce.android.viewmodel.BaseUnitTest
@@ -13,6 +15,7 @@ import org.junit.Before
 import org.junit.Test
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.verify
+import org.wordpress.android.fluxc.store.WooCommerceStore
 import java.math.BigDecimal
 import kotlin.test.assertFalse
 import kotlin.test.assertTrue
@@ -21,6 +24,9 @@ import kotlin.test.assertTrue
 class CustomAmountsFragmentViewModelTest : BaseUnitTest() {
 
     private val tracker: AnalyticsTrackerWrapper = mock()
+    private val currencySymbolFinder: CurrencySymbolFinder = mock()
+    private val store: WooCommerceStore = mock()
+    private val selectedSite: SelectedSite = mock()
     private lateinit var viewModel: CustomAmountsViewModel
 
     @Before
@@ -30,7 +36,10 @@ class CustomAmountsFragmentViewModelTest : BaseUnitTest() {
                 customAmountUIModel = CustomAmountUIModel.EMPTY,
                 orderTotal = null,
             ).toSavedStateHandle(),
-            tracker
+            tracker,
+            currencySymbolFinder,
+            store,
+            selectedSite
         )
     }
 
@@ -70,7 +79,10 @@ class CustomAmountsFragmentViewModelTest : BaseUnitTest() {
                 ),
                 orderTotal = null
             ).toSavedStateHandle(),
-            tracker
+            tracker,
+            currencySymbolFinder,
+            store,
+            selectedSite
         )
 
         verify(tracker).track(ORDER_CREATION_EDIT_CUSTOM_AMOUNT_TAPPED)
@@ -95,7 +107,9 @@ class CustomAmountsFragmentViewModelTest : BaseUnitTest() {
             ),
             orderTotal = "100"
         )
-        viewModel = CustomAmountsViewModel(args.toSavedStateHandle(), tracker)
+        viewModel = CustomAmountsViewModel(
+            args.toSavedStateHandle(), tracker, currencySymbolFinder, store, selectedSite
+        )
         viewModel.currentPercentage = BigDecimal.TEN
 
         assertTrue(viewModel.viewState.isDoneButtonEnabled)
@@ -113,7 +127,10 @@ class CustomAmountsFragmentViewModelTest : BaseUnitTest() {
                 ),
                 orderTotal = "200"
             ).toSavedStateHandle(),
-            tracker
+            tracker,
+            currencySymbolFinder,
+            store,
+            selectedSite
         )
 
         assertThat(viewModel.currentPercentage).isEqualTo(BigDecimal("5.00"))
@@ -131,7 +148,10 @@ class CustomAmountsFragmentViewModelTest : BaseUnitTest() {
                 ),
                 orderTotal = "200"
             ).toSavedStateHandle(),
-            tracker
+            tracker,
+            currencySymbolFinder,
+            store,
+            selectedSite
         )
         viewModel.currentPercentage = BigDecimal("20")
 
@@ -150,7 +170,10 @@ class CustomAmountsFragmentViewModelTest : BaseUnitTest() {
                 ),
                 orderTotal = "200"
             ).toSavedStateHandle(),
-            tracker
+            tracker,
+            currencySymbolFinder,
+            store,
+            selectedSite
         )
         assertThat(viewModel.viewState.customAmountUIModel.type).isEqualTo(FIXED_CUSTOM_AMOUNT)
     }
@@ -167,7 +190,10 @@ class CustomAmountsFragmentViewModelTest : BaseUnitTest() {
                 ),
                 orderTotal = "200"
             ).toSavedStateHandle(),
-            tracker
+            tracker,
+            currencySymbolFinder,
+            store,
+            selectedSite
         )
         assertThat(viewModel.viewState.customAmountUIModel.type).isEqualTo(PERCENTAGE_CUSTOM_AMOUNT)
     }
@@ -185,7 +211,10 @@ class CustomAmountsFragmentViewModelTest : BaseUnitTest() {
         )
         viewModel = CustomAmountsViewModel(
             customAmountUIModel.toSavedStateHandle(),
-            tracker
+            tracker,
+            currencySymbolFinder,
+            store,
+            selectedSite
         )
         assertThat(viewModel.viewState.customAmountUIModel.id).isEqualTo(
             customAmountUIModel.customAmountUIModel.id
@@ -216,7 +245,10 @@ class CustomAmountsFragmentViewModelTest : BaseUnitTest() {
                 ),
                 orderTotal = "0"
             ).toSavedStateHandle(),
-            tracker
+            tracker,
+            currencySymbolFinder,
+            store,
+            selectedSite
         )
 
         assertThat(viewModel.currentPercentage).isEqualTo(BigDecimal.ZERO)
@@ -234,10 +266,36 @@ class CustomAmountsFragmentViewModelTest : BaseUnitTest() {
                 ),
                 orderTotal = null
             ).toSavedStateHandle(),
-            tracker
+            tracker,
+            currencySymbolFinder,
+            store,
+            selectedSite
         )
 
         assertThat(viewModel.currentPercentage).isEqualTo(BigDecimal.ZERO)
+    }
+
+    @Test
+    fun `when currency code is not null, then return order currency symbol`() {
+        viewModel = CustomAmountsViewModel(
+            CustomAmountsFragmentArgs(
+                customAmountUIModel = CustomAmountUIModel(
+                    id = 0L,
+                    amount = BigDecimal.TEN,
+                    name = "",
+                    type = PERCENTAGE_CUSTOM_AMOUNT
+                ),
+                orderTotal = null
+            ).toSavedStateHandle(),
+            tracker,
+            currencySymbolFinder,
+            store,
+            selectedSite
+        )
+
+        viewModel.getCurrencySymbol("USD")
+
+        verify(currencySymbolFinder).findCurrencySymbol("USD")
     }
     //endregion
 }

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/payments/customamounts/CustomAmountsFragmentViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/payments/customamounts/CustomAmountsFragmentViewModelTest.kt
@@ -13,7 +13,6 @@ import kotlinx.coroutines.ExperimentalCoroutinesApi
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.Before
 import org.junit.Test
-import org.mockito.kotlin.any
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/payments/customamounts/CustomAmountsFragmentViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/payments/customamounts/CustomAmountsFragmentViewModelTest.kt
@@ -13,8 +13,11 @@ import kotlinx.coroutines.ExperimentalCoroutinesApi
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.Before
 import org.junit.Test
+import org.mockito.kotlin.any
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
+import org.wordpress.android.fluxc.model.SiteModel
 import org.wordpress.android.fluxc.store.WooCommerceStore
 import java.math.BigDecimal
 import kotlin.test.assertFalse
@@ -296,6 +299,31 @@ class CustomAmountsFragmentViewModelTest : BaseUnitTest() {
         viewModel.getCurrencySymbol("USD")
 
         verify(currencySymbolFinder).findCurrencySymbol("USD")
+    }
+
+    @Test
+    fun `when currency code is null, then return site currency symbol`() {
+        viewModel = CustomAmountsViewModel(
+            CustomAmountsFragmentArgs(
+                customAmountUIModel = CustomAmountUIModel(
+                    id = 0L,
+                    amount = BigDecimal.TEN,
+                    name = "",
+                    type = PERCENTAGE_CUSTOM_AMOUNT
+                ),
+                orderTotal = null
+            ).toSavedStateHandle(),
+            tracker,
+            currencySymbolFinder,
+            store,
+            selectedSite
+        )
+        val siteModel = SiteModel()
+        whenever(selectedSite.get()).thenReturn(siteModel)
+
+        viewModel.getCurrencySymbol(null)
+
+        verify(store).getSiteSettings(siteModel)
     }
     //endregion
 }

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/payments/customamounts/CustomAmountsFragmentViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/payments/customamounts/CustomAmountsFragmentViewModelTest.kt
@@ -1,12 +1,10 @@
 package com.woocommerce.android.ui.payments.customamounts
 
-import androidx.lifecycle.Observer
 import com.woocommerce.android.analytics.AnalyticsEvent.ORDER_CREATION_ADD_CUSTOM_AMOUNT_TAPPED
 import com.woocommerce.android.analytics.AnalyticsEvent.ORDER_CREATION_EDIT_CUSTOM_AMOUNT_TAPPED
 import com.woocommerce.android.analytics.AnalyticsTrackerWrapper
 import com.woocommerce.android.tools.SelectedSite
 import com.woocommerce.android.ui.common.CurrencyCode
-import com.woocommerce.android.ui.common.CurrencySymbol
 import com.woocommerce.android.ui.orders.CustomAmountUIModel
 import com.woocommerce.android.ui.orders.creation.product.discount.CurrencySymbolFinder
 import com.woocommerce.android.ui.payments.customamounts.CustomAmountsViewModel.CustomAmountType.FIXED_CUSTOM_AMOUNT
@@ -20,6 +18,7 @@ import org.mockito.kotlin.mock
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
 import org.wordpress.android.fluxc.model.SiteModel
+import org.wordpress.android.fluxc.model.WCSettingsModel
 import org.wordpress.android.fluxc.store.WooCommerceStore
 import java.math.BigDecimal
 import kotlin.test.assertFalse
@@ -32,6 +31,7 @@ class CustomAmountsFragmentViewModelTest : BaseUnitTest() {
     private val currencySymbolFinder: CurrencySymbolFinder = mock()
     private val store: WooCommerceStore = mock()
     private val selectedSite: SelectedSite = mock()
+    private val siteSettings: WCSettingsModel = mock()
     private lateinit var viewModel: CustomAmountsViewModel
 
     @Before
@@ -283,7 +283,6 @@ class CustomAmountsFragmentViewModelTest : BaseUnitTest() {
     @Test
     fun `when currency code is not null, then return order currency symbol`() {
         whenever(currencySymbolFinder.findCurrencySymbol("USD")).thenReturn("$")
-        val observer = mock<Observer<CurrencySymbol?>>()
 
         viewModel = CustomAmountsViewModel(
             CustomAmountsFragmentArgs(
@@ -301,16 +300,16 @@ class CustomAmountsFragmentViewModelTest : BaseUnitTest() {
             store,
             selectedSite
         )
-        viewModel.currencySymbolLiveData.observeForever(observer)
-
-        verify(observer).onChanged(CurrencySymbol("$"))
+        assertThat(viewModel.viewState.currencySymbol?.value).isEqualTo("$")
     }
 
     @Test
     fun `when currency code is null, then return site currency symbol`() {
-        val siteModel = SiteModel()
-        whenever(selectedSite.get()).thenReturn(siteModel)
-        val observer = mock<Observer<CurrencySymbol?>>()
+        val site: SiteModel = mock()
+        whenever(selectedSite.get()).thenReturn(site)
+        whenever(store.getSiteSettings(site)).thenReturn(siteSettings)
+        whenever(siteSettings.currencyCode).thenReturn("INR")
+        whenever(currencySymbolFinder.findCurrencySymbol("INR")).thenReturn("₹")
 
         viewModel = CustomAmountsViewModel(
             CustomAmountsFragmentArgs(
@@ -327,9 +326,8 @@ class CustomAmountsFragmentViewModelTest : BaseUnitTest() {
             store,
             selectedSite
         )
-        viewModel.currencySymbolLiveData.observeForever(observer)
 
-        verify(store).getSiteSettings(siteModel)
+        assertThat(viewModel.viewState.currencySymbol?.value).isEqualTo("₹")
     }
     //endregion
 }

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/payments/customamounts/CustomAmountsFragmentViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/payments/customamounts/CustomAmountsFragmentViewModelTest.kt
@@ -1,9 +1,12 @@
 package com.woocommerce.android.ui.payments.customamounts
 
+import androidx.lifecycle.Observer
 import com.woocommerce.android.analytics.AnalyticsEvent.ORDER_CREATION_ADD_CUSTOM_AMOUNT_TAPPED
 import com.woocommerce.android.analytics.AnalyticsEvent.ORDER_CREATION_EDIT_CUSTOM_AMOUNT_TAPPED
 import com.woocommerce.android.analytics.AnalyticsTrackerWrapper
 import com.woocommerce.android.tools.SelectedSite
+import com.woocommerce.android.ui.common.CurrencyCode
+import com.woocommerce.android.ui.common.CurrencySymbol
 import com.woocommerce.android.ui.orders.CustomAmountUIModel
 import com.woocommerce.android.ui.orders.creation.product.discount.CurrencySymbolFinder
 import com.woocommerce.android.ui.payments.customamounts.CustomAmountsViewModel.CustomAmountType.FIXED_CUSTOM_AMOUNT
@@ -279,13 +282,17 @@ class CustomAmountsFragmentViewModelTest : BaseUnitTest() {
 
     @Test
     fun `when currency code is not null, then return order currency symbol`() {
+        whenever(currencySymbolFinder.findCurrencySymbol("USD")).thenReturn("$")
+        val observer = mock<Observer<CurrencySymbol?>>()
+
         viewModel = CustomAmountsViewModel(
             CustomAmountsFragmentArgs(
                 customAmountUIModel = CustomAmountUIModel(
                     id = 0L,
                     amount = BigDecimal.TEN,
                     name = "",
-                    type = PERCENTAGE_CUSTOM_AMOUNT
+                    type = PERCENTAGE_CUSTOM_AMOUNT,
+                    currencyCode = CurrencyCode("USD")
                 ),
                 orderTotal = null
             ).toSavedStateHandle(),
@@ -294,21 +301,24 @@ class CustomAmountsFragmentViewModelTest : BaseUnitTest() {
             store,
             selectedSite
         )
+        viewModel.currencySymbolLiveData.observeForever(observer)
 
-        viewModel.getCurrencySymbol("USD")
-
-        verify(currencySymbolFinder).findCurrencySymbol("USD")
+        verify(observer).onChanged(CurrencySymbol("$"))
     }
 
     @Test
     fun `when currency code is null, then return site currency symbol`() {
+        val siteModel = SiteModel()
+        whenever(selectedSite.get()).thenReturn(siteModel)
+        val observer = mock<Observer<CurrencySymbol?>>()
+
         viewModel = CustomAmountsViewModel(
             CustomAmountsFragmentArgs(
                 customAmountUIModel = CustomAmountUIModel(
                     id = 0L,
                     amount = BigDecimal.TEN,
                     name = "",
-                    type = PERCENTAGE_CUSTOM_AMOUNT
+                    type = PERCENTAGE_CUSTOM_AMOUNT,
                 ),
                 orderTotal = null
             ).toSavedStateHandle(),
@@ -317,10 +327,7 @@ class CustomAmountsFragmentViewModelTest : BaseUnitTest() {
             store,
             selectedSite
         )
-        val siteModel = SiteModel()
-        whenever(selectedSite.get()).thenReturn(siteModel)
-
-        viewModel.getCurrencySymbol(null)
+        viewModel.currencySymbolLiveData.observeForever(observer)
 
         verify(store).getSiteSettings(siteModel)
     }


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #13839 
<!-- Id number of the GitHub issue this PR addresses. -->

<!-- 
━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
🛠 Need an AI review?  
Add a comment: `@coderabbitai review`
━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
-->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
This PR fixes a bug where the Custom Amounts screen was using the currency symbol (e.g., "₹", "$") instead of the currency code (e.g., "INR", "USD") when handling currency values. 

### Steps to reproduce
<!-- Step-by-step testing instructions. For new user flows, consider instead stating the goal of the workflow and see if your PR reviewer can accomplish the workflow without specific steps! -->
1. Navigate to Orders tab
2. Tap on "+" button to create a new order
3. Click on "Add custom amount" button
4. Enter custom amount and click on "Add custom amount" CTA
5. In the logs, ensure you see the stack trace that complains invalid currency code
6. After this PR, ensure you don't see the stack trace anymore when adding custom amounts



### The tests that have been performed
<!-- To give the reviewer an idea of what could be missed in terms of testing -->
Tested adding, deleting custom amounts


- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.

## Reviewer (or Author, in the case of optional code reviews):

Please make sure these conditions are met before approving the PR, or request changes if the PR needs improvement:

- [ ] The PR is small and has a clear, single focus, or a valid explanation is provided in the description. If needed, please request to split it into smaller PRs.
- [ ] Ensure Adequate Unit Test Coverage: The changes are reasonably covered by unit tests or an explanation is provided in the PR description.
- [ ] Manual Testing: The author listed all the tests they ran, including smoke tests when needed (e.g., for refactorings). The reviewer confirmed that the PR works as expected on big (tablet) and small (phone) in case of UI changes, and no regressions are added.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->