### PR TITLE
[Woo POS][Products search] It's possible to pull to refresh when search is visible. Search is hidden when products arrive

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/common/composeui/component/WooPosPaginationErrorIndicator.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/common/composeui/component/WooPosPaginationErrorIndicator.kt
@@ -149,7 +149,7 @@ fun WooPosPaginationErrorScreenPreview() {
                 ),
             ),
             paginationState = PaginationState.Error,
-            pullToRefreshState = WooPosPullToRefreshState.Enabled(isRefreshing = true),
+            pullToRefreshState = WooPosPullToRefreshState.Refreshing,
             bannerState = WooPosItemsViewState.Content.BannerState(
                 isBannerHiddenByUser = true,
                 title = R.string.woopos_banner_simple_products_only_title,

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/common/composeui/component/WooPosPaginationErrorIndicator.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/common/composeui/component/WooPosPaginationErrorIndicator.kt
@@ -29,10 +29,10 @@ import com.woocommerce.android.ui.woopos.common.composeui.designsystem.WooPosSpa
 import com.woocommerce.android.ui.woopos.common.composeui.designsystem.WooPosTheme
 import com.woocommerce.android.ui.woopos.common.composeui.designsystem.WooPosTypography
 import com.woocommerce.android.ui.woopos.common.composeui.designsystem.toAdaptivePadding
-import com.woocommerce.android.ui.woopos.home.items.WooPosPaginationState
 import com.woocommerce.android.ui.woopos.home.items.WooPosItemList
 import com.woocommerce.android.ui.woopos.home.items.WooPosItemSelectionViewState.Product
 import com.woocommerce.android.ui.woopos.home.items.WooPosItemsViewState
+import com.woocommerce.android.ui.woopos.home.items.WooPosPaginationState
 import com.woocommerce.android.ui.woopos.home.items.WooPosPullToRefreshState
 
 @Composable

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/common/composeui/component/WooPosPaginationErrorIndicator.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/common/composeui/component/WooPosPaginationErrorIndicator.kt
@@ -29,7 +29,7 @@ import com.woocommerce.android.ui.woopos.common.composeui.designsystem.WooPosSpa
 import com.woocommerce.android.ui.woopos.common.composeui.designsystem.WooPosTheme
 import com.woocommerce.android.ui.woopos.common.composeui.designsystem.WooPosTypography
 import com.woocommerce.android.ui.woopos.common.composeui.designsystem.toAdaptivePadding
-import com.woocommerce.android.ui.woopos.home.items.PaginationState
+import com.woocommerce.android.ui.woopos.home.items.WooPosPaginationState
 import com.woocommerce.android.ui.woopos.home.items.WooPosItemList
 import com.woocommerce.android.ui.woopos.home.items.WooPosItemSelectionViewState.Product
 import com.woocommerce.android.ui.woopos.home.items.WooPosItemsViewState
@@ -148,7 +148,7 @@ fun WooPosPaginationErrorScreenPreview() {
                     variationIds = listOf()
                 ),
             ),
-            paginationState = PaginationState.Error,
+            paginationState = WooPosPaginationState.Error,
             pullToRefreshState = WooPosPullToRefreshState.Refreshing,
             bannerState = WooPosItemsViewState.Content.BannerState(
                 isBannerHiddenByUser = true,

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/common/composeui/component/WooPosPaginationErrorIndicator.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/common/composeui/component/WooPosPaginationErrorIndicator.kt
@@ -33,6 +33,7 @@ import com.woocommerce.android.ui.woopos.home.items.PaginationState
 import com.woocommerce.android.ui.woopos.home.items.WooPosItemList
 import com.woocommerce.android.ui.woopos.home.items.WooPosItemSelectionViewState.Product
 import com.woocommerce.android.ui.woopos.home.items.WooPosItemsViewState
+import com.woocommerce.android.ui.woopos.home.items.WooPosPullToRefreshState
 
 @Composable
 fun WooPosPaginationErrorIndicator(
@@ -148,7 +149,7 @@ fun WooPosPaginationErrorScreenPreview() {
                 ),
             ),
             paginationState = PaginationState.Error,
-            reloadingWithPullToRefresh = true,
+            pullToRefreshState = WooPosPullToRefreshState.Enabled(isRefreshing = true),
             bannerState = WooPosItemsViewState.Content.BannerState(
                 isBannerHiddenByUser = true,
                 title = R.string.woopos_banner_simple_products_only_title,

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/items/WooPosBaseViewState.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/items/WooPosBaseViewState.kt
@@ -7,13 +7,13 @@ sealed class WooPosBaseViewState(
 interface ContentViewState {
     val items: List<WooPosItemSelectionViewState>
     val pullToRefreshState: WooPosPullToRefreshState
-    val paginationState: PaginationState
+    val paginationState: WooPosPaginationState
 }
 
-sealed class PaginationState {
-    data object None : PaginationState()
-    data object Loading : PaginationState()
-    data object Error : PaginationState()
+sealed class WooPosPaginationState {
+    data object None : WooPosPaginationState()
+    data object Loading : WooPosPaginationState()
+    data object Error : WooPosPaginationState()
 }
 
 enum class WooPosPullToRefreshState {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/items/WooPosBaseViewState.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/items/WooPosBaseViewState.kt
@@ -4,7 +4,7 @@ sealed class WooPosBaseViewState(
     open val pullToRefreshState: WooPosPullToRefreshState
 )
 
-interface ContentViewState {
+interface WooPosContentViewState {
     val items: List<WooPosItemSelectionViewState>
     val pullToRefreshState: WooPosPullToRefreshState
     val paginationState: WooPosPaginationState

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/items/WooPosBaseViewState.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/items/WooPosBaseViewState.kt
@@ -16,7 +16,6 @@ sealed class PaginationState {
     data object Error : PaginationState()
 }
 
-sealed class WooPosPullToRefreshState {
-    object Disabled : WooPosPullToRefreshState()
-    data class Enabled(val isRefreshing: Boolean = false) : WooPosPullToRefreshState()
+enum class WooPosPullToRefreshState {
+    Disabled, Enabled, Refreshing,
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/items/WooPosBaseViewState.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/items/WooPosBaseViewState.kt
@@ -1,12 +1,12 @@
 package com.woocommerce.android.ui.woopos.home.items
 
 sealed class WooPosBaseViewState(
-    open val reloadingWithPullToRefresh: Boolean
+    open val pullToRefreshState: WooPosPullToRefreshState
 )
 
 interface ContentViewState {
     val items: List<WooPosItemSelectionViewState>
-    val reloadingWithPullToRefresh: Boolean
+    val pullToRefreshState: WooPosPullToRefreshState
     val paginationState: PaginationState
 }
 
@@ -14,4 +14,9 @@ sealed class PaginationState {
     data object None : PaginationState()
     data object Loading : PaginationState()
     data object Error : PaginationState()
+}
+
+sealed class WooPosPullToRefreshState {
+    object Disabled : WooPosPullToRefreshState()
+    data class Enabled(val isRefreshing: Boolean = false) : WooPosPullToRefreshState()
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/items/WooPosItemsList.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/items/WooPosItemsList.kt
@@ -68,7 +68,7 @@ import kotlinx.coroutines.flow.filter
 @OptIn(ExperimentalFoundationApi::class)
 @Composable
 fun WooPosItemList(
-    state: ContentViewState,
+    state: WooPosContentViewState,
     listState: LazyListState,
     onItemClicked: (item: WooPosItemSelectionViewState) -> Unit,
     onEndOfProductsListReached: () -> Unit,
@@ -408,7 +408,7 @@ fun WooPosItemsEmptyList(
 @Composable
 private fun InfiniteListHandler(
     listState: LazyListState,
-    state: ContentViewState,
+    state: WooPosContentViewState,
     onEndOfProductsListReached: () -> Unit
 ) {
     val buffer = 5

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/items/WooPosItemsList.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/items/WooPosItemsList.kt
@@ -111,19 +111,19 @@ fun WooPosItemList(
         }
 
         when (state.paginationState) {
-            PaginationState.Error -> {
+            WooPosPaginationState.Error -> {
                 item {
                     onErrorWhilePaginating()
                 }
             }
 
-            PaginationState.Loading -> {
+            WooPosPaginationState.Loading -> {
                 item {
                     ItemsLoadingItem()
                 }
             }
 
-            PaginationState.None -> {
+            WooPosPaginationState.None -> {
             }
         }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/items/WooPosItemsList.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/items/WooPosItemsList.kt
@@ -422,7 +422,7 @@ private fun InfiniteListHandler(
         }
     }
 
-    LaunchedEffect(state.reloadingWithPullToRefresh) {
+    LaunchedEffect(state.pullToRefreshState) {
         snapshotFlow { loadMore.value }
             .distinctUntilChanged()
             .filter { it }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/items/WooPosItemsScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/items/WooPosItemsScreen.kt
@@ -129,7 +129,7 @@ private fun MainItemsList(
 ) {
     val pullToRefreshState = rememberPullRefreshState(
         refreshing = state.value.pullToRefreshState == WooPosPullToRefreshState.Enabled(true),
-        onRefresh = { onPullToRefreshTriggered },
+        onRefresh = onPullToRefreshTriggered,
     )
 
     Box(

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/items/WooPosItemsScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/items/WooPosItemsScreen.kt
@@ -17,7 +17,6 @@ import androidx.compose.foundation.lazy.LazyListState
 import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.material.ExperimentalMaterialApi
 import androidx.compose.material.pullrefresh.PullRefreshIndicator
-import androidx.compose.material.pullrefresh.PullRefreshState
 import androidx.compose.material.pullrefresh.pullRefresh
 import androidx.compose.material.pullrefresh.rememberPullRefreshState
 import androidx.compose.material3.Icon
@@ -81,14 +80,9 @@ private fun WooPosItemsScreen(
     onUIEvent: (WooPosItemsUIEvent) -> Unit,
 ) {
     val state = itemsStateFlow.collectAsState()
-    val pullToRefreshState = rememberPullRefreshState(
-        state.value.reloadingWithPullToRefresh,
-        onRefresh = { onUIEvent(PullToRefreshTriggered) },
-    )
 
     MainItemsList(
         modifier = modifier,
-        pullToRefreshState = pullToRefreshState,
         state = state,
         listState = listState,
         onToolbarInfoIconClicked = {
@@ -113,6 +107,7 @@ private fun WooPosItemsScreen(
             }
         },
         onCouponsButtonClicked = { onUIEvent(WooPosItemsUIEvent.CouponsButtonClicked) },
+        onPullToRefreshTriggered = { onUIEvent(PullToRefreshTriggered) },
     )
 }
 
@@ -120,7 +115,6 @@ private fun WooPosItemsScreen(
 @Composable
 private fun MainItemsList(
     modifier: Modifier,
-    pullToRefreshState: PullRefreshState,
     state: State<WooPosItemsViewState>,
     listState: LazyListState,
     onToolbarInfoIconClicked: () -> Unit,
@@ -131,11 +125,20 @@ private fun MainItemsList(
     onRetryClicked: () -> Unit,
     onSearchEvent: (WooPosSearchUIEvent) -> Unit,
     onCouponsButtonClicked: () -> Unit,
+    onPullToRefreshTriggered: () -> Unit,
 ) {
+    val pullToRefreshState = rememberPullRefreshState(
+        refreshing = state.value.pullToRefreshState == WooPosPullToRefreshState.Enabled(true),
+        onRefresh = { onPullToRefreshTriggered },
+    )
+
     Box(
         modifier = modifier
             .fillMaxSize()
-            .pullRefresh(pullToRefreshState)
+            .pullRefresh(
+                state = pullToRefreshState,
+                enabled = state.value.pullToRefreshState is WooPosPullToRefreshState.Enabled,
+            )
             .padding(
                 start = WooPosSpacing.Medium.value.toAdaptivePadding(),
                 end = WooPosSpacing.Medium.value.toAdaptivePadding(),
@@ -222,7 +225,7 @@ private fun MainItemsList(
         }
         PullRefreshIndicator(
             modifier = Modifier.align(Alignment.TopCenter),
-            refreshing = state.value.reloadingWithPullToRefresh,
+            refreshing = state.value.pullToRefreshState == WooPosPullToRefreshState.Enabled(true),
             state = pullToRefreshState
         )
     }
@@ -380,7 +383,7 @@ fun WooPosItemsScreenPreview(modifier: Modifier = Modifier) {
                 ),
             ),
             paginationState = PaginationState.Loading,
-            reloadingWithPullToRefresh = true,
+            pullToRefreshState = WooPosPullToRefreshState.Enabled(isRefreshing = true),
             bannerState = WooPosItemsViewState.Content.BannerState(
                 isBannerHiddenByUser = true,
                 title = R.string.woopos_banner_simple_products_only_title,
@@ -436,7 +439,7 @@ fun WooPosItemsScreenPaginationErrorPreview(modifier: Modifier = Modifier) {
                 ),
             ),
             paginationState = PaginationState.Error,
-            reloadingWithPullToRefresh = true,
+            pullToRefreshState = WooPosPullToRefreshState.Enabled(isRefreshing = true),
             bannerState = WooPosItemsViewState.Content.BannerState(
                 isBannerHiddenByUser = true,
                 title = R.string.woopos_banner_simple_products_only_title,
@@ -462,7 +465,7 @@ fun WooPosItemsScreenPaginationErrorPreview(modifier: Modifier = Modifier) {
 fun WooPosItemsScreenLoadingPreview() {
     val productState = MutableStateFlow(
         WooPosItemsViewState.Loading(
-            reloadingWithPullToRefresh = true,
+            pullToRefreshState = WooPosPullToRefreshState.Enabled(isRefreshing = true),
             withCart = false
         )
     )
@@ -479,7 +482,11 @@ fun WooPosItemsScreenLoadingPreview() {
 @Composable
 @WooPosPreview
 fun WooPosProductsScreenEmptyListPreview() {
-    val productState = MutableStateFlow(WooPosItemsViewState.Empty(true))
+    val productState = MutableStateFlow(
+        WooPosItemsViewState.Empty(
+            WooPosPullToRefreshState.Enabled(isRefreshing = true)
+        )
+    )
     WooPosTheme {
         WooPosItemsScreen(
             itemsStateFlow = productState,
@@ -531,7 +538,7 @@ fun WooPosHomeScreenItemsWithSimpleProductsOnlyBannerPreview() {
                     imageUrl = null,
                 ),
             ),
-            reloadingWithPullToRefresh = true,
+            pullToRefreshState = WooPosPullToRefreshState.Enabled(isRefreshing = true),
             bannerState = WooPosItemsViewState.Content.BannerState(
                 isBannerHiddenByUser = false,
                 title = R.string.woopos_banner_simple_products_only_title,
@@ -583,7 +590,7 @@ fun WooPosHomeScreenItemsWithInfoIconInToolbarPreview() {
                     imageUrl = null,
                 ),
             ),
-            reloadingWithPullToRefresh = false,
+            pullToRefreshState = WooPosPullToRefreshState.Disabled,
             bannerState = WooPosItemsViewState.Content.BannerState(
                 isBannerHiddenByUser = true,
                 title = R.string.woopos_banner_simple_products_only_title,

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/items/WooPosItemsScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/items/WooPosItemsScreen.kt
@@ -137,7 +137,7 @@ private fun MainItemsList(
             .fillMaxSize()
             .pullRefresh(
                 state = pullToRefreshState,
-                enabled = state.value.pullToRefreshState ==  WooPosPullToRefreshState.Enabled,
+                enabled = state.value.pullToRefreshState == WooPosPullToRefreshState.Enabled,
             )
             .padding(
                 start = WooPosSpacing.Medium.value.toAdaptivePadding(),

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/items/WooPosItemsScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/items/WooPosItemsScreen.kt
@@ -128,7 +128,7 @@ private fun MainItemsList(
     onPullToRefreshTriggered: () -> Unit,
 ) {
     val pullToRefreshState = rememberPullRefreshState(
-        refreshing = state.value.pullToRefreshState == WooPosPullToRefreshState.Enabled(true),
+        refreshing = state.value.pullToRefreshState == WooPosPullToRefreshState.Refreshing,
         onRefresh = onPullToRefreshTriggered,
     )
 
@@ -137,7 +137,7 @@ private fun MainItemsList(
             .fillMaxSize()
             .pullRefresh(
                 state = pullToRefreshState,
-                enabled = state.value.pullToRefreshState is WooPosPullToRefreshState.Enabled,
+                enabled = state.value.pullToRefreshState ==  WooPosPullToRefreshState.Enabled,
             )
             .padding(
                 start = WooPosSpacing.Medium.value.toAdaptivePadding(),
@@ -225,7 +225,7 @@ private fun MainItemsList(
         }
         PullRefreshIndicator(
             modifier = Modifier.align(Alignment.TopCenter),
-            refreshing = state.value.pullToRefreshState == WooPosPullToRefreshState.Enabled(true),
+            refreshing = state.value.pullToRefreshState == WooPosPullToRefreshState.Refreshing,
             state = pullToRefreshState
         )
     }
@@ -383,7 +383,7 @@ fun WooPosItemsScreenPreview(modifier: Modifier = Modifier) {
                 ),
             ),
             paginationState = PaginationState.Loading,
-            pullToRefreshState = WooPosPullToRefreshState.Enabled(isRefreshing = true),
+            pullToRefreshState = WooPosPullToRefreshState.Refreshing,
             bannerState = WooPosItemsViewState.Content.BannerState(
                 isBannerHiddenByUser = true,
                 title = R.string.woopos_banner_simple_products_only_title,
@@ -439,7 +439,7 @@ fun WooPosItemsScreenPaginationErrorPreview(modifier: Modifier = Modifier) {
                 ),
             ),
             paginationState = PaginationState.Error,
-            pullToRefreshState = WooPosPullToRefreshState.Enabled(isRefreshing = true),
+            pullToRefreshState = WooPosPullToRefreshState.Refreshing,
             bannerState = WooPosItemsViewState.Content.BannerState(
                 isBannerHiddenByUser = true,
                 title = R.string.woopos_banner_simple_products_only_title,
@@ -465,7 +465,7 @@ fun WooPosItemsScreenPaginationErrorPreview(modifier: Modifier = Modifier) {
 fun WooPosItemsScreenLoadingPreview() {
     val productState = MutableStateFlow(
         WooPosItemsViewState.Loading(
-            pullToRefreshState = WooPosPullToRefreshState.Enabled(isRefreshing = true),
+            pullToRefreshState = WooPosPullToRefreshState.Refreshing,
             withCart = false
         )
     )
@@ -484,7 +484,7 @@ fun WooPosItemsScreenLoadingPreview() {
 fun WooPosProductsScreenEmptyListPreview() {
     val productState = MutableStateFlow(
         WooPosItemsViewState.Empty(
-            WooPosPullToRefreshState.Enabled(isRefreshing = true)
+            WooPosPullToRefreshState.Refreshing,
         )
     )
     WooPosTheme {
@@ -538,7 +538,7 @@ fun WooPosHomeScreenItemsWithSimpleProductsOnlyBannerPreview() {
                     imageUrl = null,
                 ),
             ),
-            pullToRefreshState = WooPosPullToRefreshState.Enabled(isRefreshing = true),
+            pullToRefreshState = WooPosPullToRefreshState.Refreshing,
             bannerState = WooPosItemsViewState.Content.BannerState(
                 isBannerHiddenByUser = false,
                 title = R.string.woopos_banner_simple_products_only_title,

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/items/WooPosItemsScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/items/WooPosItemsScreen.kt
@@ -382,7 +382,7 @@ fun WooPosItemsScreenPreview(modifier: Modifier = Modifier) {
                     imageUrl = null,
                 ),
             ),
-            paginationState = PaginationState.Loading,
+            paginationState = WooPosPaginationState.Loading,
             pullToRefreshState = WooPosPullToRefreshState.Refreshing,
             bannerState = WooPosItemsViewState.Content.BannerState(
                 isBannerHiddenByUser = true,
@@ -438,7 +438,7 @@ fun WooPosItemsScreenPaginationErrorPreview(modifier: Modifier = Modifier) {
                     variationIds = listOf()
                 ),
             ),
-            paginationState = PaginationState.Error,
+            paginationState = WooPosPaginationState.Error,
             pullToRefreshState = WooPosPullToRefreshState.Refreshing,
             bannerState = WooPosItemsViewState.Content.BannerState(
                 isBannerHiddenByUser = true,

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/items/WooPosItemsSearchHelper.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/items/WooPosItemsSearchHelper.kt
@@ -145,7 +145,22 @@ class WooPosItemsSearchHelper @Inject constructor(
     }
 
     private fun updateSearchState(newState: WooPosItemsViewState.Content) {
-        viewStateFlow.value = newState
+        var pullToRefreshState = when (val searchState = newState.search) {
+            WooPosItemsViewState.Content.SearchState.Hidden -> WooPosPullToRefreshState.Enabled(
+                isRefreshing = false
+            )
+
+            is WooPosItemsViewState.Content.SearchState.Visible -> {
+                when (searchState.state) {
+                    WooPosSearchInputState.Closed -> WooPosPullToRefreshState.Enabled(
+                        isRefreshing = false
+                    )
+
+                    is WooPosSearchInputState.Open -> WooPosPullToRefreshState.Disabled
+                }
+            }
+        }
+        viewStateFlow.value = newState.copy(pullToRefreshState = pullToRefreshState)
     }
 
     private fun getCurrentContentState(): WooPosItemsViewState.Content? {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/items/WooPosItemsSearchHelper.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/items/WooPosItemsSearchHelper.kt
@@ -146,15 +146,11 @@ class WooPosItemsSearchHelper @Inject constructor(
 
     private fun updateSearchState(newState: WooPosItemsViewState.Content) {
         var pullToRefreshState = when (val searchState = newState.search) {
-            WooPosItemsViewState.Content.SearchState.Hidden -> WooPosPullToRefreshState.Enabled(
-                isRefreshing = false
-            )
+            WooPosItemsViewState.Content.SearchState.Hidden -> WooPosPullToRefreshState.Enabled
 
             is WooPosItemsViewState.Content.SearchState.Visible -> {
                 when (searchState.state) {
-                    WooPosSearchInputState.Closed -> WooPosPullToRefreshState.Enabled(
-                        isRefreshing = false
-                    )
+                    WooPosSearchInputState.Closed -> WooPosPullToRefreshState.Enabled
 
                     is WooPosSearchInputState.Open -> WooPosPullToRefreshState.Disabled
                 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/items/WooPosItemsSearchHelper.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/items/WooPosItemsSearchHelper.kt
@@ -96,6 +96,11 @@ class WooPosItemsSearchHelper @Inject constructor(
         updateToInitialOpenState()
     }
 
+    fun isSearchOpen(): Boolean {
+        val searchState = getCurrentSearchVisibleState() ?: return false
+        return searchState.state is WooPosSearchInputState.Open
+    }
+
     private fun updateToInitialOpenState() {
         val currentState = getCurrentContentState() ?: return
         updateSearchState(

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/items/WooPosItemsViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/items/WooPosItemsViewModel.kt
@@ -220,7 +220,11 @@ class WooPosItemsViewModel @Inject constructor(
                                         currentState.copy(
                                             items = products.map { it.toItemSelectionViewState() },
                                             paginationState = paginationState,
-                                            reloadingWithPullToRefresh = false
+                                            pullToRefreshState = if (searchHelper.isSearchOpen()) {
+                                                WooPosPullToRefreshState.Disabled
+                                            } else {
+                                                WooPosPullToRefreshState.Enabled()
+                                            },
                                         )
                                     } else {
                                         products.toContentState(
@@ -241,10 +245,18 @@ class WooPosItemsViewModel @Inject constructor(
 
     private fun buildProductsReloadingState() =
         when (val state = viewState.value) {
-            is WooPosItemsViewState.Content -> state.copy(reloadingWithPullToRefresh = true)
-            is WooPosItemsViewState.Loading -> state.copy(reloadingWithPullToRefresh = true)
-            is WooPosItemsViewState.Error -> state.copy(reloadingWithPullToRefresh = true)
-            is WooPosItemsViewState.Empty -> state.copy(reloadingWithPullToRefresh = true)
+            is WooPosItemsViewState.Content -> state.copy(
+                pullToRefreshState = WooPosPullToRefreshState.Enabled(isRefreshing = true)
+            )
+            is WooPosItemsViewState.Loading -> state.copy(
+                pullToRefreshState = WooPosPullToRefreshState.Enabled(isRefreshing = true)
+            )
+            is WooPosItemsViewState.Error -> state.copy(
+                pullToRefreshState = WooPosPullToRefreshState.Enabled(isRefreshing = true)
+            )
+            is WooPosItemsViewState.Empty -> state.copy(
+                pullToRefreshState = WooPosPullToRefreshState.Enabled(isRefreshing = true)
+            )
         }
 
     private suspend fun List<Product>.toContentState(
@@ -252,7 +264,7 @@ class WooPosItemsViewModel @Inject constructor(
     ) = WooPosItemsViewState.Content(
         items = map { it.toItemSelectionViewState() },
         paginationState = paginationState,
-        reloadingWithPullToRefresh = false,
+        pullToRefreshState = WooPosPullToRefreshState.Enabled(),
         couponsEnabled = isCouponsEnabled.invoke(),
         bannerState = WooPosItemsViewState.Content.BannerState(
             isBannerHiddenByUser = isBannerHiddenByUser(),

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/items/WooPosItemsViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/items/WooPosItemsViewModel.kt
@@ -211,23 +211,20 @@ class WooPosItemsViewModel @Inject constructor(
                                 val products = result.productsResult.getOrThrow()
                                 if (products.isNotEmpty()) {
                                     val currentState = _viewState.value
+                                    var paginationState = if (loadMoreProductsJob?.isActive == true) {
+                                        PaginationState.Loading
+                                    } else {
+                                        PaginationState.None
+                                    }
                                     if (currentState is WooPosItemsViewState.Content) {
                                         currentState.copy(
                                             items = products.map { it.toItemSelectionViewState() },
-                                            paginationState = if (loadMoreProductsJob?.isActive == true) {
-                                                PaginationState.Loading
-                                            } else {
-                                                PaginationState.None
-                                            },
+                                            paginationState = paginationState,
                                             reloadingWithPullToRefresh = false
                                         )
                                     } else {
                                         products.toContentState(
-                                            paginationState = if (loadMoreProductsJob?.isActive == true) {
-                                                PaginationState.Loading
-                                            } else {
-                                                PaginationState.None
-                                            }
+                                            paginationState = paginationState
                                         )
                                     }
                                 } else {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/items/WooPosItemsViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/items/WooPosItemsViewModel.kt
@@ -210,18 +210,30 @@ class WooPosItemsViewModel @Inject constructor(
                             result.productsResult.isSuccess -> {
                                 val products = result.productsResult.getOrThrow()
                                 if (products.isNotEmpty()) {
-                                    products.toContentState(
-                                        paginationState = if (loadMoreProductsJob?.isActive == true) {
-                                            PaginationState.Loading
-                                        } else {
-                                            PaginationState.None
-                                        }
-                                    )
+                                    val currentState = _viewState.value
+                                    if (currentState is WooPosItemsViewState.Content) {
+                                        currentState.copy(
+                                            items = products.map { it.toItemSelectionViewState() },
+                                            paginationState = if (loadMoreProductsJob?.isActive == true) {
+                                                PaginationState.Loading
+                                            } else {
+                                                PaginationState.None
+                                            },
+                                            reloadingWithPullToRefresh = false
+                                        )
+                                    } else {
+                                        products.toContentState(
+                                            paginationState = if (loadMoreProductsJob?.isActive == true) {
+                                                PaginationState.Loading
+                                            } else {
+                                                PaginationState.None
+                                            }
+                                        )
+                                    }
                                 } else {
                                     WooPosItemsViewState.Empty()
                                 }
                             }
-
                             else -> WooPosItemsViewState.Error()
                         }
                     }
@@ -229,6 +241,7 @@ class WooPosItemsViewModel @Inject constructor(
             }
         }
     }
+
 
     private fun buildProductsReloadingState() =
         when (val state = viewState.value) {
@@ -241,25 +254,7 @@ class WooPosItemsViewModel @Inject constructor(
     private suspend fun List<Product>.toContentState(
         paginationState: PaginationState = PaginationState.None
     ) = WooPosItemsViewState.Content(
-        items = map { product ->
-            if (product.isVariable()) {
-                WooPosItemSelectionViewState.Product.Variable(
-                    id = product.remoteId,
-                    name = product.name,
-                    price = priceFormat(product.price),
-                    imageUrl = product.firstImageUrl,
-                    numOfVariations = product.numVariations,
-                    variationIds = product.variationIds
-                )
-            } else {
-                WooPosItemSelectionViewState.Product.Simple(
-                    id = product.remoteId,
-                    name = product.name,
-                    price = priceFormat(product.price),
-                    imageUrl = product.firstImageUrl,
-                )
-            }
-        },
+        items = map { it.toItemSelectionViewState() },
         paginationState = paginationState,
         reloadingWithPullToRefresh = false,
         couponsEnabled = isCouponsEnabled.invoke(),
@@ -271,6 +266,26 @@ class WooPosItemsViewModel @Inject constructor(
         ),
         search = searchHelper.getInitialSearchState(isProductsSearchEnabled())
     )
+
+    private suspend fun Product.toItemSelectionViewState(): WooPosItemSelectionViewState {
+        return if (this.isVariable()) {
+            WooPosItemSelectionViewState.Product.Variable(
+                id = this.remoteId,
+                name = this.name,
+                price = priceFormat(this.price),
+                imageUrl = this.firstImageUrl,
+                numOfVariations = this.numVariations,
+                variationIds = this.variationIds
+            )
+        } else {
+            WooPosItemSelectionViewState.Product.Simple(
+                id = this.remoteId,
+                name = this.name,
+                price = priceFormat(this.price),
+                imageUrl = this.firstImageUrl,
+            )
+        }
+    }
 
     private fun onEndOfProductsListReached() {
         val currentState = _viewState.value

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/items/WooPosItemsViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/items/WooPosItemsViewModel.kt
@@ -223,7 +223,7 @@ class WooPosItemsViewModel @Inject constructor(
                                             pullToRefreshState = if (searchHelper.isSearchOpen()) {
                                                 WooPosPullToRefreshState.Disabled
                                             } else {
-                                                WooPosPullToRefreshState.Enabled()
+                                                WooPosPullToRefreshState.Enabled
                                             },
                                         )
                                     } else {
@@ -245,18 +245,10 @@ class WooPosItemsViewModel @Inject constructor(
 
     private fun buildProductsReloadingState() =
         when (val state = viewState.value) {
-            is WooPosItemsViewState.Content -> state.copy(
-                pullToRefreshState = WooPosPullToRefreshState.Enabled(isRefreshing = true)
-            )
-            is WooPosItemsViewState.Loading -> state.copy(
-                pullToRefreshState = WooPosPullToRefreshState.Enabled(isRefreshing = true)
-            )
-            is WooPosItemsViewState.Error -> state.copy(
-                pullToRefreshState = WooPosPullToRefreshState.Enabled(isRefreshing = true)
-            )
-            is WooPosItemsViewState.Empty -> state.copy(
-                pullToRefreshState = WooPosPullToRefreshState.Enabled(isRefreshing = true)
-            )
+            is WooPosItemsViewState.Content -> state.copy(pullToRefreshState = WooPosPullToRefreshState.Refreshing)
+            is WooPosItemsViewState.Loading -> state.copy(pullToRefreshState = WooPosPullToRefreshState.Refreshing)
+            is WooPosItemsViewState.Error -> state.copy(pullToRefreshState = WooPosPullToRefreshState.Refreshing)
+            is WooPosItemsViewState.Empty -> state.copy(pullToRefreshState = WooPosPullToRefreshState.Refreshing)
         }
 
     private suspend fun List<Product>.toContentState(
@@ -264,7 +256,7 @@ class WooPosItemsViewModel @Inject constructor(
     ) = WooPosItemsViewState.Content(
         items = map { it.toItemSelectionViewState() },
         paginationState = paginationState,
-        pullToRefreshState = WooPosPullToRefreshState.Enabled(),
+        pullToRefreshState = WooPosPullToRefreshState.Enabled,
         couponsEnabled = isCouponsEnabled.invoke(),
         bannerState = WooPosItemsViewState.Content.BannerState(
             isBannerHiddenByUser = isBannerHiddenByUser(),

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/items/WooPosItemsViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/items/WooPosItemsViewModel.kt
@@ -212,9 +212,9 @@ class WooPosItemsViewModel @Inject constructor(
                                 if (products.isNotEmpty()) {
                                     val currentState = _viewState.value
                                     var paginationState = if (loadMoreProductsJob?.isActive == true) {
-                                        PaginationState.Loading
+                                        WooPosPaginationState.Loading
                                     } else {
-                                        PaginationState.None
+                                        WooPosPaginationState.None
                                     }
                                     if (currentState is WooPosItemsViewState.Content) {
                                         currentState.copy(
@@ -252,7 +252,7 @@ class WooPosItemsViewModel @Inject constructor(
         }
 
     private suspend fun List<Product>.toContentState(
-        paginationState: PaginationState = PaginationState.None
+        paginationState: WooPosPaginationState = WooPosPaginationState.None
     ) = WooPosItemsViewState.Content(
         items = map { it.toItemSelectionViewState() },
         paginationState = paginationState,
@@ -297,7 +297,7 @@ class WooPosItemsViewModel @Inject constructor(
             return
         }
 
-        _viewState.value = currentState.copy(paginationState = PaginationState.Loading)
+        _viewState.value = currentState.copy(paginationState = WooPosPaginationState.Loading)
 
         loadMoreProductsJob?.cancel()
         loadMoreProductsJob = viewModelScope.launch {
@@ -305,7 +305,7 @@ class WooPosItemsViewModel @Inject constructor(
             _viewState.value = if (result.isSuccess) {
                 result.getOrThrow().toContentState()
             } else {
-                currentState.copy(paginationState = PaginationState.Error)
+                currentState.copy(paginationState = WooPosPaginationState.Error)
             }
         }
     }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/items/WooPosItemsViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/items/WooPosItemsViewModel.kt
@@ -239,7 +239,6 @@ class WooPosItemsViewModel @Inject constructor(
         }
     }
 
-
     private fun buildProductsReloadingState() =
         when (val state = viewState.value) {
             is WooPosItemsViewState.Content -> state.copy(reloadingWithPullToRefresh = true)

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/items/WooPosItemsViewState.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/items/WooPosItemsViewState.kt
@@ -14,7 +14,7 @@ sealed class WooPosItemsViewState(
         override val paginationState: WooPosPaginationState = WooPosPaginationState.None,
         override val pullToRefreshState: WooPosPullToRefreshState = WooPosPullToRefreshState.Enabled,
         val couponsEnabled: Boolean = false,
-    ) : WooPosItemsViewState(pullToRefreshState), ContentViewState {
+    ) : WooPosItemsViewState(pullToRefreshState), WooPosContentViewState {
         data class BannerState(
             val isBannerHiddenByUser: Boolean,
             @StringRes val title: Int,

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/items/WooPosItemsViewState.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/items/WooPosItemsViewState.kt
@@ -5,16 +5,18 @@ import androidx.annotation.StringRes
 import com.woocommerce.android.ui.woopos.common.composeui.component.WooPosSearchInputState
 
 sealed class WooPosItemsViewState(
-    override val reloadingWithPullToRefresh: Boolean,
-) : WooPosBaseViewState(reloadingWithPullToRefresh) {
+    override val pullToRefreshState: WooPosPullToRefreshState,
+) : WooPosBaseViewState(pullToRefreshState) {
     data class Content(
         val search: SearchState,
         override val items: List<WooPosItemSelectionViewState>,
         val bannerState: BannerState,
         override val paginationState: PaginationState = PaginationState.None,
-        override val reloadingWithPullToRefresh: Boolean = false,
+        override val pullToRefreshState: WooPosPullToRefreshState = WooPosPullToRefreshState.Enabled(
+            isRefreshing = false
+        ),
         val couponsEnabled: Boolean = false,
-    ) : WooPosItemsViewState(reloadingWithPullToRefresh), ContentViewState {
+    ) : WooPosItemsViewState(pullToRefreshState), ContentViewState {
         data class BannerState(
             val isBannerHiddenByUser: Boolean,
             @StringRes val title: Int,
@@ -29,15 +31,20 @@ sealed class WooPosItemsViewState(
     }
 
     data class Loading(
-        override val reloadingWithPullToRefresh: Boolean = false,
-        val withCart: Boolean
-    ) : WooPosItemsViewState(reloadingWithPullToRefresh)
+        override val pullToRefreshState: WooPosPullToRefreshState = WooPosPullToRefreshState.Enabled(
+            isRefreshing = false
+        ), val withCart: Boolean
+    ) : WooPosItemsViewState(pullToRefreshState)
 
     data class Error(
-        override val reloadingWithPullToRefresh: Boolean = false
-    ) : WooPosItemsViewState(reloadingWithPullToRefresh)
+        override val pullToRefreshState: WooPosPullToRefreshState = WooPosPullToRefreshState.Enabled(
+            isRefreshing = false
+        ),
+    ) : WooPosItemsViewState(pullToRefreshState)
 
     data class Empty(
-        override val reloadingWithPullToRefresh: Boolean = false
-    ) : WooPosItemsViewState(reloadingWithPullToRefresh)
+        override val pullToRefreshState: WooPosPullToRefreshState = WooPosPullToRefreshState.Enabled(
+            isRefreshing = false
+        ),
+    ) : WooPosItemsViewState(pullToRefreshState)
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/items/WooPosItemsViewState.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/items/WooPosItemsViewState.kt
@@ -33,7 +33,8 @@ sealed class WooPosItemsViewState(
     data class Loading(
         override val pullToRefreshState: WooPosPullToRefreshState = WooPosPullToRefreshState.Enabled(
             isRefreshing = false
-        ), val withCart: Boolean
+        ),
+        val withCart: Boolean
     ) : WooPosItemsViewState(pullToRefreshState)
 
     data class Error(

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/items/WooPosItemsViewState.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/items/WooPosItemsViewState.kt
@@ -12,9 +12,7 @@ sealed class WooPosItemsViewState(
         override val items: List<WooPosItemSelectionViewState>,
         val bannerState: BannerState,
         override val paginationState: PaginationState = PaginationState.None,
-        override val pullToRefreshState: WooPosPullToRefreshState = WooPosPullToRefreshState.Enabled(
-            isRefreshing = false
-        ),
+        override val pullToRefreshState: WooPosPullToRefreshState = WooPosPullToRefreshState.Enabled,
         val couponsEnabled: Boolean = false,
     ) : WooPosItemsViewState(pullToRefreshState), ContentViewState {
         data class BannerState(
@@ -31,21 +29,15 @@ sealed class WooPosItemsViewState(
     }
 
     data class Loading(
-        override val pullToRefreshState: WooPosPullToRefreshState = WooPosPullToRefreshState.Enabled(
-            isRefreshing = false
-        ),
+        override val pullToRefreshState: WooPosPullToRefreshState = WooPosPullToRefreshState.Enabled,
         val withCart: Boolean
     ) : WooPosItemsViewState(pullToRefreshState)
 
     data class Error(
-        override val pullToRefreshState: WooPosPullToRefreshState = WooPosPullToRefreshState.Enabled(
-            isRefreshing = false
-        ),
+        override val pullToRefreshState: WooPosPullToRefreshState = WooPosPullToRefreshState.Enabled,
     ) : WooPosItemsViewState(pullToRefreshState)
 
     data class Empty(
-        override val pullToRefreshState: WooPosPullToRefreshState = WooPosPullToRefreshState.Enabled(
-            isRefreshing = false
-        ),
+        override val pullToRefreshState: WooPosPullToRefreshState = WooPosPullToRefreshState.Enabled,
     ) : WooPosItemsViewState(pullToRefreshState)
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/items/WooPosItemsViewState.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/items/WooPosItemsViewState.kt
@@ -11,7 +11,7 @@ sealed class WooPosItemsViewState(
         val search: SearchState,
         override val items: List<WooPosItemSelectionViewState>,
         val bannerState: BannerState,
-        override val paginationState: PaginationState = PaginationState.None,
+        override val paginationState: WooPosPaginationState = WooPosPaginationState.None,
         override val pullToRefreshState: WooPosPullToRefreshState = WooPosPullToRefreshState.Enabled,
         val couponsEnabled: Boolean = false,
     ) : WooPosItemsViewState(pullToRefreshState), ContentViewState {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/items/WooPosVariationsViewState.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/items/WooPosVariationsViewState.kt
@@ -1,25 +1,33 @@
 package com.woocommerce.android.ui.woopos.home.items
 
 sealed class WooPosVariationsViewState(
-    override val reloadingWithPullToRefresh: Boolean
-) : WooPosBaseViewState(reloadingWithPullToRefresh) {
+    override val pullToRefreshState: WooPosPullToRefreshState
+) : WooPosBaseViewState(pullToRefreshState) {
 
     data class Content(
         override val items: List<WooPosItemSelectionViewState.Variation>,
-        override val reloadingWithPullToRefresh: Boolean = false,
+        override val pullToRefreshState: WooPosPullToRefreshState = WooPosPullToRefreshState.Enabled(
+            isRefreshing = false
+        ),
         override val paginationState: PaginationState = PaginationState.None,
-    ) : WooPosVariationsViewState(reloadingWithPullToRefresh), ContentViewState
+    ) : WooPosVariationsViewState(pullToRefreshState), ContentViewState
 
     data class Loading(
-        override val reloadingWithPullToRefresh: Boolean = false,
+        override val pullToRefreshState: WooPosPullToRefreshState = WooPosPullToRefreshState.Enabled(
+            isRefreshing = false
+        ),
         val withCart: Boolean
-    ) : WooPosVariationsViewState(reloadingWithPullToRefresh)
+    ) : WooPosVariationsViewState(pullToRefreshState)
 
     data class Error(
-        override val reloadingWithPullToRefresh: Boolean = false
-    ) : WooPosVariationsViewState(reloadingWithPullToRefresh)
+        override val pullToRefreshState: WooPosPullToRefreshState = WooPosPullToRefreshState.Enabled(
+            isRefreshing = false
+        ),
+    ) : WooPosVariationsViewState(pullToRefreshState)
 
     data class Empty(
-        override val reloadingWithPullToRefresh: Boolean = false
-    ) : WooPosVariationsViewState(reloadingWithPullToRefresh)
+        override val pullToRefreshState: WooPosPullToRefreshState = WooPosPullToRefreshState.Enabled(
+            isRefreshing = false
+        ),
+    ) : WooPosVariationsViewState(pullToRefreshState)
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/items/WooPosVariationsViewState.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/items/WooPosVariationsViewState.kt
@@ -8,7 +8,7 @@ sealed class WooPosVariationsViewState(
         override val items: List<WooPosItemSelectionViewState.Variation>,
         override val pullToRefreshState: WooPosPullToRefreshState = WooPosPullToRefreshState.Enabled,
         override val paginationState: WooPosPaginationState = WooPosPaginationState.None,
-    ) : WooPosVariationsViewState(pullToRefreshState), ContentViewState
+    ) : WooPosVariationsViewState(pullToRefreshState), WooPosContentViewState
 
     data class Loading(
         override val pullToRefreshState: WooPosPullToRefreshState = WooPosPullToRefreshState.Enabled,

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/items/WooPosVariationsViewState.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/items/WooPosVariationsViewState.kt
@@ -6,28 +6,20 @@ sealed class WooPosVariationsViewState(
 
     data class Content(
         override val items: List<WooPosItemSelectionViewState.Variation>,
-        override val pullToRefreshState: WooPosPullToRefreshState = WooPosPullToRefreshState.Enabled(
-            isRefreshing = false
-        ),
+        override val pullToRefreshState: WooPosPullToRefreshState = WooPosPullToRefreshState.Enabled,
         override val paginationState: PaginationState = PaginationState.None,
     ) : WooPosVariationsViewState(pullToRefreshState), ContentViewState
 
     data class Loading(
-        override val pullToRefreshState: WooPosPullToRefreshState = WooPosPullToRefreshState.Enabled(
-            isRefreshing = false
-        ),
+        override val pullToRefreshState: WooPosPullToRefreshState = WooPosPullToRefreshState.Enabled,
         val withCart: Boolean
     ) : WooPosVariationsViewState(pullToRefreshState)
 
     data class Error(
-        override val pullToRefreshState: WooPosPullToRefreshState = WooPosPullToRefreshState.Enabled(
-            isRefreshing = false
-        ),
+        override val pullToRefreshState: WooPosPullToRefreshState = WooPosPullToRefreshState.Enabled,
     ) : WooPosVariationsViewState(pullToRefreshState)
 
     data class Empty(
-        override val pullToRefreshState: WooPosPullToRefreshState = WooPosPullToRefreshState.Enabled(
-            isRefreshing = false
-        ),
+        override val pullToRefreshState: WooPosPullToRefreshState = WooPosPullToRefreshState.Enabled,
     ) : WooPosVariationsViewState(pullToRefreshState)
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/items/WooPosVariationsViewState.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/items/WooPosVariationsViewState.kt
@@ -7,7 +7,7 @@ sealed class WooPosVariationsViewState(
     data class Content(
         override val items: List<WooPosItemSelectionViewState.Variation>,
         override val pullToRefreshState: WooPosPullToRefreshState = WooPosPullToRefreshState.Enabled,
-        override val paginationState: PaginationState = PaginationState.None,
+        override val paginationState: WooPosPaginationState = WooPosPaginationState.None,
     ) : WooPosVariationsViewState(pullToRefreshState), ContentViewState
 
     data class Loading(

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/items/search/WooPosItemsSearchScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/items/search/WooPosItemsSearchScreen.kt
@@ -16,11 +16,11 @@ import com.woocommerce.android.ui.woopos.common.composeui.component.WooPosErrorS
 import com.woocommerce.android.ui.woopos.common.composeui.component.WooPosPaginationErrorIndicator
 import com.woocommerce.android.ui.woopos.common.composeui.designsystem.WooPosSpacing
 import com.woocommerce.android.ui.woopos.common.composeui.designsystem.WooPosTheme
-import com.woocommerce.android.ui.woopos.home.items.WooPosPaginationState
 import com.woocommerce.android.ui.woopos.home.items.WooPosItemList
 import com.woocommerce.android.ui.woopos.home.items.WooPosItemSelectionViewState
 import com.woocommerce.android.ui.woopos.home.items.WooPosItemsEmptyList
 import com.woocommerce.android.ui.woopos.home.items.WooPosItemsLoadingIndicator
+import com.woocommerce.android.ui.woopos.home.items.WooPosPaginationState
 import com.woocommerce.android.ui.woopos.home.items.WooPosPullToRefreshState
 
 @Composable

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/items/search/WooPosItemsSearchScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/items/search/WooPosItemsSearchScreen.kt
@@ -21,6 +21,7 @@ import com.woocommerce.android.ui.woopos.home.items.WooPosItemList
 import com.woocommerce.android.ui.woopos.home.items.WooPosItemSelectionViewState
 import com.woocommerce.android.ui.woopos.home.items.WooPosItemsEmptyList
 import com.woocommerce.android.ui.woopos.home.items.WooPosItemsLoadingIndicator
+import com.woocommerce.android.ui.woopos.home.items.WooPosPullToRefreshState
 
 @Composable
 fun WooPosItemsSearchScreen(
@@ -159,7 +160,7 @@ fun WooPosItemsSearchContentPreview() {
                             imageUrl = "https://example.com/image2.jpg",
                         ),
                     ),
-                    reloadingWithPullToRefresh = false,
+                    pullToRefreshState = WooPosPullToRefreshState.Enabled(false),
                     paginationState = PaginationState.None
                 ),
                 onUIEvent = {}

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/items/search/WooPosItemsSearchScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/items/search/WooPosItemsSearchScreen.kt
@@ -16,7 +16,7 @@ import com.woocommerce.android.ui.woopos.common.composeui.component.WooPosErrorS
 import com.woocommerce.android.ui.woopos.common.composeui.component.WooPosPaginationErrorIndicator
 import com.woocommerce.android.ui.woopos.common.composeui.designsystem.WooPosSpacing
 import com.woocommerce.android.ui.woopos.common.composeui.designsystem.WooPosTheme
-import com.woocommerce.android.ui.woopos.home.items.PaginationState
+import com.woocommerce.android.ui.woopos.home.items.WooPosPaginationState
 import com.woocommerce.android.ui.woopos.home.items.WooPosItemList
 import com.woocommerce.android.ui.woopos.home.items.WooPosItemSelectionViewState
 import com.woocommerce.android.ui.woopos.home.items.WooPosItemsEmptyList
@@ -161,7 +161,7 @@ fun WooPosItemsSearchContentPreview() {
                         ),
                     ),
                     pullToRefreshState = WooPosPullToRefreshState.Enabled,
-                    paginationState = PaginationState.None
+                    paginationState = WooPosPaginationState.None
                 ),
                 onUIEvent = {}
             )

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/items/search/WooPosItemsSearchScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/items/search/WooPosItemsSearchScreen.kt
@@ -160,7 +160,7 @@ fun WooPosItemsSearchContentPreview() {
                             imageUrl = "https://example.com/image2.jpg",
                         ),
                     ),
-                    pullToRefreshState = WooPosPullToRefreshState.Enabled(false),
+                    pullToRefreshState = WooPosPullToRefreshState.Enabled,
                     paginationState = PaginationState.None
                 ),
                 onUIEvent = {}

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/items/search/WooPosItemsSearchViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/items/search/WooPosItemsSearchViewModel.kt
@@ -8,7 +8,7 @@ import com.woocommerce.android.ui.woopos.home.ChildToParentEvent
 import com.woocommerce.android.ui.woopos.home.ParentToChildrenEvent
 import com.woocommerce.android.ui.woopos.home.WooPosChildrenToParentEventSender
 import com.woocommerce.android.ui.woopos.home.WooPosParentToChildrenEventReceiver
-import com.woocommerce.android.ui.woopos.home.items.PaginationState
+import com.woocommerce.android.ui.woopos.home.items.WooPosPaginationState
 import com.woocommerce.android.ui.woopos.home.items.WooPosItemNavigationData.VariableProductData
 import com.woocommerce.android.ui.woopos.home.items.WooPosItemSelectionViewState
 import com.woocommerce.android.ui.woopos.home.items.WooPosItemsViewModel.ItemClickedData
@@ -144,7 +144,7 @@ class WooPosItemsSearchViewModel @Inject constructor(
             return
         }
 
-        _viewState.value = currentState.copy(paginationState = PaginationState.Loading)
+        _viewState.value = currentState.copy(paginationState = WooPosPaginationState.Loading)
 
         loadMoreJob?.cancel()
         loadMoreJob = viewModelScope.launch {
@@ -154,7 +154,7 @@ class WooPosItemsSearchViewModel @Inject constructor(
                     searchQuery = currentState.searchQuery,
                 )
             } else {
-                currentState.copy(paginationState = PaginationState.Error)
+                currentState.copy(paginationState = WooPosPaginationState.Error)
             }
         }
     }
@@ -193,7 +193,7 @@ class WooPosItemsSearchViewModel @Inject constructor(
 
     private suspend fun List<Product>.toContentState(
         searchQuery: String,
-        paginationState: PaginationState = PaginationState.None,
+        paginationState: WooPosPaginationState = WooPosPaginationState.None,
     ) = WooPosItemsSearchViewState.Content(
         items = map { product ->
             if (product.productType == ProductType.VARIABLE) {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/items/search/WooPosItemsSearchViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/items/search/WooPosItemsSearchViewModel.kt
@@ -8,10 +8,10 @@ import com.woocommerce.android.ui.woopos.home.ChildToParentEvent
 import com.woocommerce.android.ui.woopos.home.ParentToChildrenEvent
 import com.woocommerce.android.ui.woopos.home.WooPosChildrenToParentEventSender
 import com.woocommerce.android.ui.woopos.home.WooPosParentToChildrenEventReceiver
-import com.woocommerce.android.ui.woopos.home.items.WooPosPaginationState
 import com.woocommerce.android.ui.woopos.home.items.WooPosItemNavigationData.VariableProductData
 import com.woocommerce.android.ui.woopos.home.items.WooPosItemSelectionViewState
 import com.woocommerce.android.ui.woopos.home.items.WooPosItemsViewModel.ItemClickedData
+import com.woocommerce.android.ui.woopos.home.items.WooPosPaginationState
 import com.woocommerce.android.ui.woopos.home.items.navigation.WooPosItemsNavigator
 import com.woocommerce.android.ui.woopos.home.items.navigation.WooPosItemsNavigator.WooPosItemsScreenNavigationEvent.NavigateToVariationsScreen
 import com.woocommerce.android.ui.woopos.util.format.WooPosFormatPrice

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/items/search/WooPosItemsSearchViewState.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/items/search/WooPosItemsSearchViewState.kt
@@ -14,9 +14,7 @@ sealed class WooPosItemsSearchViewState {
     data class Content(
         val searchQuery: String,
         override val items: List<WooPosItemSelectionViewState>,
-        override val pullToRefreshState: WooPosPullToRefreshState = WooPosPullToRefreshState.Enabled(
-            isRefreshing = false
-        ),
+        override val pullToRefreshState: WooPosPullToRefreshState = WooPosPullToRefreshState.Enabled,
         override val paginationState: PaginationState = PaginationState.None,
     ) : WooPosItemsSearchViewState(), ContentViewState
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/items/search/WooPosItemsSearchViewState.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/items/search/WooPosItemsSearchViewState.kt
@@ -1,8 +1,8 @@
 package com.woocommerce.android.ui.woopos.home.items.search
 
 import com.woocommerce.android.ui.woopos.home.items.WooPosContentViewState
-import com.woocommerce.android.ui.woopos.home.items.WooPosPaginationState
 import com.woocommerce.android.ui.woopos.home.items.WooPosItemSelectionViewState
+import com.woocommerce.android.ui.woopos.home.items.WooPosPaginationState
 import com.woocommerce.android.ui.woopos.home.items.WooPosPullToRefreshState
 
 sealed class WooPosItemsSearchViewState {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/items/search/WooPosItemsSearchViewState.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/items/search/WooPosItemsSearchViewState.kt
@@ -1,7 +1,7 @@
 package com.woocommerce.android.ui.woopos.home.items.search
 
 import com.woocommerce.android.ui.woopos.home.items.ContentViewState
-import com.woocommerce.android.ui.woopos.home.items.PaginationState
+import com.woocommerce.android.ui.woopos.home.items.WooPosPaginationState
 import com.woocommerce.android.ui.woopos.home.items.WooPosItemSelectionViewState
 import com.woocommerce.android.ui.woopos.home.items.WooPosPullToRefreshState
 
@@ -15,7 +15,7 @@ sealed class WooPosItemsSearchViewState {
         val searchQuery: String,
         override val items: List<WooPosItemSelectionViewState>,
         override val pullToRefreshState: WooPosPullToRefreshState = WooPosPullToRefreshState.Enabled,
-        override val paginationState: PaginationState = PaginationState.None,
+        override val paginationState: WooPosPaginationState = WooPosPaginationState.None,
     ) : WooPosItemsSearchViewState(), ContentViewState
 
     data object Empty : WooPosItemsSearchViewState()

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/items/search/WooPosItemsSearchViewState.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/items/search/WooPosItemsSearchViewState.kt
@@ -3,6 +3,7 @@ package com.woocommerce.android.ui.woopos.home.items.search
 import com.woocommerce.android.ui.woopos.home.items.ContentViewState
 import com.woocommerce.android.ui.woopos.home.items.PaginationState
 import com.woocommerce.android.ui.woopos.home.items.WooPosItemSelectionViewState
+import com.woocommerce.android.ui.woopos.home.items.WooPosPullToRefreshState
 
 sealed class WooPosItemsSearchViewState {
     data class EmptySearchQuery(
@@ -13,7 +14,9 @@ sealed class WooPosItemsSearchViewState {
     data class Content(
         val searchQuery: String,
         override val items: List<WooPosItemSelectionViewState>,
-        override val reloadingWithPullToRefresh: Boolean = false,
+        override val pullToRefreshState: WooPosPullToRefreshState = WooPosPullToRefreshState.Enabled(
+            isRefreshing = false
+        ),
         override val paginationState: PaginationState = PaginationState.None,
     ) : WooPosItemsSearchViewState(), ContentViewState
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/items/search/WooPosItemsSearchViewState.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/items/search/WooPosItemsSearchViewState.kt
@@ -1,6 +1,6 @@
 package com.woocommerce.android.ui.woopos.home.items.search
 
-import com.woocommerce.android.ui.woopos.home.items.ContentViewState
+import com.woocommerce.android.ui.woopos.home.items.WooPosContentViewState
 import com.woocommerce.android.ui.woopos.home.items.WooPosPaginationState
 import com.woocommerce.android.ui.woopos.home.items.WooPosItemSelectionViewState
 import com.woocommerce.android.ui.woopos.home.items.WooPosPullToRefreshState
@@ -16,7 +16,7 @@ sealed class WooPosItemsSearchViewState {
         override val items: List<WooPosItemSelectionViewState>,
         override val pullToRefreshState: WooPosPullToRefreshState = WooPosPullToRefreshState.Enabled,
         override val paginationState: WooPosPaginationState = WooPosPaginationState.None,
-    ) : WooPosItemsSearchViewState(), ContentViewState
+    ) : WooPosItemsSearchViewState(), WooPosContentViewState
 
     data object Empty : WooPosItemsSearchViewState()
     data class Error(val searchQuery: String) : WooPosItemsSearchViewState()

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/items/variations/WooPosVariationsScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/items/variations/WooPosVariationsScreen.kt
@@ -106,7 +106,7 @@ private fun WooPosVariationsScreens(
 ) {
     val itemState = state.collectAsState()
     val pullToRefreshState = rememberPullRefreshState(
-        refreshing = itemState.value.pullToRefreshState == WooPosPullToRefreshState.Enabled(true),
+        refreshing = itemState.value.pullToRefreshState == WooPosPullToRefreshState.Refreshing,
         onRefresh = onPullToRefresh
     )
     val listState = rememberLazyListState()
@@ -115,7 +115,7 @@ private fun WooPosVariationsScreens(
             .fillMaxSize()
             .pullRefresh(
                 state = pullToRefreshState,
-                enabled = itemState.value.pullToRefreshState is WooPosPullToRefreshState.Enabled
+                enabled = itemState.value.pullToRefreshState == WooPosPullToRefreshState.Enabled
             )
             .padding(
                 start = WooPosSpacing.Medium.value.toAdaptivePadding(),
@@ -177,7 +177,7 @@ private fun WooPosVariationsScreens(
         }
         PullRefreshIndicator(
             modifier = Modifier.align(Alignment.TopCenter),
-            refreshing = itemState.value.pullToRefreshState == WooPosPullToRefreshState.Enabled(true),
+            refreshing = itemState.value.pullToRefreshState == WooPosPullToRefreshState.Enabled,
             state = pullToRefreshState
         )
     }
@@ -282,7 +282,7 @@ fun WooPosVariationsScreenPreview() {
                     imageUrl = null,
                 ),
             ),
-            pullToRefreshState = WooPosPullToRefreshState.Enabled(true),
+            pullToRefreshState = WooPosPullToRefreshState.Refreshing,
         )
     )
     WooPosTheme {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/items/variations/WooPosVariationsScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/items/variations/WooPosVariationsScreen.kt
@@ -177,7 +177,7 @@ private fun WooPosVariationsScreens(
         }
         PullRefreshIndicator(
             modifier = Modifier.align(Alignment.TopCenter),
-            refreshing = itemState.value.pullToRefreshState == WooPosPullToRefreshState.Enabled,
+            refreshing = itemState.value.pullToRefreshState == WooPosPullToRefreshState.Refreshing,
             state = pullToRefreshState
         )
     }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/items/variations/WooPosVariationsScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/items/variations/WooPosVariationsScreen.kt
@@ -46,6 +46,7 @@ import com.woocommerce.android.ui.woopos.home.items.WooPosItemNavigationData.Var
 import com.woocommerce.android.ui.woopos.home.items.WooPosItemSelectionViewState
 import com.woocommerce.android.ui.woopos.home.items.WooPosItemsEmptyList
 import com.woocommerce.android.ui.woopos.home.items.WooPosItemsLoadingIndicator
+import com.woocommerce.android.ui.woopos.home.items.WooPosPullToRefreshState
 import com.woocommerce.android.ui.woopos.home.items.WooPosVariationsViewState
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
@@ -105,14 +106,17 @@ private fun WooPosVariationsScreens(
 ) {
     val itemState = state.collectAsState()
     val pullToRefreshState = rememberPullRefreshState(
-        itemState.value.reloadingWithPullToRefresh,
-        onPullToRefresh
+        refreshing = itemState.value.pullToRefreshState == WooPosPullToRefreshState.Enabled(true),
+        onRefresh = onPullToRefresh
     )
     val listState = rememberLazyListState()
     Box(
         modifier = modifier
             .fillMaxSize()
-            .pullRefresh(pullToRefreshState)
+            .pullRefresh(
+                state = pullToRefreshState,
+                enabled = itemState.value.pullToRefreshState is WooPosPullToRefreshState.Enabled
+            )
             .padding(
                 start = WooPosSpacing.Medium.value.toAdaptivePadding(),
                 end = WooPosSpacing.Medium.value.toAdaptivePadding(),
@@ -173,7 +177,7 @@ private fun WooPosVariationsScreens(
         }
         PullRefreshIndicator(
             modifier = Modifier.align(Alignment.TopCenter),
-            refreshing = itemState.value.reloadingWithPullToRefresh,
+            refreshing = itemState.value.pullToRefreshState == WooPosPullToRefreshState.Enabled(true),
             state = pullToRefreshState
         )
     }
@@ -278,7 +282,7 @@ fun WooPosVariationsScreenPreview() {
                     imageUrl = null,
                 ),
             ),
-            reloadingWithPullToRefresh = true,
+            pullToRefreshState = WooPosPullToRefreshState.Enabled(true),
         )
     )
     WooPosTheme {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/items/variations/WooPosVariationsViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/items/variations/WooPosVariationsViewModel.kt
@@ -140,16 +140,16 @@ class WooPosVariationsViewModel @Inject constructor(
     private fun buildProductsReloadingState() =
         when (val state = viewState.value) {
             is WooPosVariationsViewState.Content -> state.copy(
-                pullToRefreshState = WooPosPullToRefreshState.Enabled(true),
+                pullToRefreshState = WooPosPullToRefreshState.Refreshing
             )
             is WooPosVariationsViewState.Loading -> state.copy(
-                pullToRefreshState = WooPosPullToRefreshState.Enabled(true),
+                pullToRefreshState = WooPosPullToRefreshState.Refreshing
             )
             is WooPosVariationsViewState.Error -> state.copy(
-                pullToRefreshState = WooPosPullToRefreshState.Enabled(true),
+                pullToRefreshState = WooPosPullToRefreshState.Refreshing,
             )
             is WooPosVariationsViewState.Empty -> state.copy(
-                pullToRefreshState = WooPosPullToRefreshState.Enabled(true),
+                pullToRefreshState = WooPosPullToRefreshState.Refreshing,
             )
         }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/items/variations/WooPosVariationsViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/items/variations/WooPosVariationsViewModel.kt
@@ -12,6 +12,7 @@ import com.woocommerce.android.ui.woopos.home.WooPosChildrenToParentEventSender
 import com.woocommerce.android.ui.woopos.home.items.PaginationState
 import com.woocommerce.android.ui.woopos.home.items.WooPosItemSelectionViewState
 import com.woocommerce.android.ui.woopos.home.items.WooPosItemsViewModel
+import com.woocommerce.android.ui.woopos.home.items.WooPosPullToRefreshState
 import com.woocommerce.android.ui.woopos.home.items.WooPosVariationsViewState
 import com.woocommerce.android.ui.woopos.util.analytics.WooPosAnalyticsEvent.Event.VariationsPullToRefreshTriggered
 import com.woocommerce.android.ui.woopos.util.analytics.WooPosAnalyticsTracker
@@ -138,10 +139,18 @@ class WooPosVariationsViewModel @Inject constructor(
 
     private fun buildProductsReloadingState() =
         when (val state = viewState.value) {
-            is WooPosVariationsViewState.Content -> state.copy(reloadingWithPullToRefresh = true)
-            is WooPosVariationsViewState.Loading -> state.copy(reloadingWithPullToRefresh = true)
-            is WooPosVariationsViewState.Error -> state.copy(reloadingWithPullToRefresh = true)
-            is WooPosVariationsViewState.Empty -> state.copy(reloadingWithPullToRefresh = true)
+            is WooPosVariationsViewState.Content -> state.copy(
+                pullToRefreshState = WooPosPullToRefreshState.Enabled(true),
+            )
+            is WooPosVariationsViewState.Loading -> state.copy(
+                pullToRefreshState = WooPosPullToRefreshState.Enabled(true),
+            )
+            is WooPosVariationsViewState.Error -> state.copy(
+                pullToRefreshState = WooPosPullToRefreshState.Enabled(true),
+            )
+            is WooPosVariationsViewState.Empty -> state.copy(
+                pullToRefreshState = WooPosPullToRefreshState.Enabled(true),
+            )
         }
 
     private fun loadMore(productId: Long, numOfVariations: Int) {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/items/variations/WooPosVariationsViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/items/variations/WooPosVariationsViewModel.kt
@@ -9,9 +9,9 @@ import com.woocommerce.android.model.ProductVariation
 import com.woocommerce.android.ui.woopos.common.data.WooPosGetProductById
 import com.woocommerce.android.ui.woopos.home.ChildToParentEvent
 import com.woocommerce.android.ui.woopos.home.WooPosChildrenToParentEventSender
-import com.woocommerce.android.ui.woopos.home.items.WooPosPaginationState
 import com.woocommerce.android.ui.woopos.home.items.WooPosItemSelectionViewState
 import com.woocommerce.android.ui.woopos.home.items.WooPosItemsViewModel
+import com.woocommerce.android.ui.woopos.home.items.WooPosPaginationState
 import com.woocommerce.android.ui.woopos.home.items.WooPosPullToRefreshState
 import com.woocommerce.android.ui.woopos.home.items.WooPosVariationsViewState
 import com.woocommerce.android.ui.woopos.util.analytics.WooPosAnalyticsEvent.Event.VariationsPullToRefreshTriggered

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/items/variations/WooPosVariationsViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/items/variations/WooPosVariationsViewModel.kt
@@ -9,7 +9,7 @@ import com.woocommerce.android.model.ProductVariation
 import com.woocommerce.android.ui.woopos.common.data.WooPosGetProductById
 import com.woocommerce.android.ui.woopos.home.ChildToParentEvent
 import com.woocommerce.android.ui.woopos.home.WooPosChildrenToParentEventSender
-import com.woocommerce.android.ui.woopos.home.items.PaginationState
+import com.woocommerce.android.ui.woopos.home.items.WooPosPaginationState
 import com.woocommerce.android.ui.woopos.home.items.WooPosItemSelectionViewState
 import com.woocommerce.android.ui.woopos.home.items.WooPosItemsViewModel
 import com.woocommerce.android.ui.woopos.home.items.WooPosPullToRefreshState
@@ -101,9 +101,9 @@ class WooPosVariationsViewModel @Inject constructor(
                                             )
                                         },
                                         paginationState = if (loadMoreJob?.isActive == true) {
-                                            PaginationState.Loading
+                                            WooPosPaginationState.Loading
                                         } else {
-                                            PaginationState.None
+                                            WooPosPaginationState.None
                                         }
                                     )
                                 } else {
@@ -163,7 +163,7 @@ class WooPosVariationsViewModel @Inject constructor(
             return
         }
 
-        _viewState.value = currentState.copy(paginationState = PaginationState.Loading)
+        _viewState.value = currentState.copy(paginationState = WooPosPaginationState.Loading)
 
         loadMoreJob?.cancel()
         loadMoreJob = viewModelScope.launch {
@@ -181,7 +181,7 @@ class WooPosVariationsViewModel @Inject constructor(
                     }
                 )
             } else {
-                currentState.copy(paginationState = PaginationState.Error)
+                currentState.copy(paginationState = WooPosPaginationState.Error)
             }
         }
     }

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/home/items/WooPosItemsSearchHelperTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/home/items/WooPosItemsSearchHelperTest.kt
@@ -206,7 +206,7 @@ class WooPosItemsSearchHelperTest {
                 icon = R.drawable.ic_woo
             ),
             paginationState = PaginationState.None,
-            reloadingWithPullToRefresh = false,
+            pullToRefreshState = false,
             couponsEnabled = false
         )
     }

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/home/items/WooPosItemsSearchHelperTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/home/items/WooPosItemsSearchHelperTest.kt
@@ -206,7 +206,7 @@ class WooPosItemsSearchHelperTest {
                 icon = R.drawable.ic_woo
             ),
             paginationState = WooPosPaginationState.None,
-            pullToRefreshState = false,
+            pullToRefreshState = WooPosPullToRefreshState.Enabled,
             couponsEnabled = false
         )
     }

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/home/items/WooPosItemsSearchHelperTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/home/items/WooPosItemsSearchHelperTest.kt
@@ -210,4 +210,46 @@ class WooPosItemsSearchHelperTest {
             couponsEnabled = false
         )
     }
+
+    @Test
+    fun `when closed search, then pull to refresh is enabled`() = runTest {
+        // GIVEN
+        searchHelper.initialize(this, viewStateFlow)
+
+        // WHEN
+        searchHelper.onCloseSearchClicked()
+
+        // THEN
+        val currentState = viewStateFlow.value as WooPosItemsViewState.Content
+        assertThat(currentState.pullToRefreshState).isEqualTo(WooPosPullToRefreshState.Enabled)
+    }
+
+    @Test
+    fun `when search changed, then pull to refresh is disabled`() = runTest {
+        // GIVEN
+        searchHelper.initialize(this, viewStateFlow)
+
+        // WHEN
+        searchHelper.onSearchChanged("test query")
+
+        // THEN
+        val currentState = viewStateFlow.value as WooPosItemsViewState.Content
+        assertThat(currentState.pullToRefreshState).isEqualTo(WooPosPullToRefreshState.Disabled)
+    }
+
+    @Test
+    fun `when hidden search state, then pull to refresh is enabled`() = runTest {
+        // GIVEN
+        searchHelper.initialize(this, viewStateFlow)
+        val contentState = createContentState().copy(
+            search = WooPosItemsViewState.Content.SearchState.Hidden
+        )
+
+        // WHEN
+        viewStateFlow.value = contentState
+
+        // THEN
+        val currentState = viewStateFlow.value as WooPosItemsViewState.Content
+        assertThat(currentState.pullToRefreshState).isEqualTo(WooPosPullToRefreshState.Enabled)
+    }
 }

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/home/items/WooPosItemsSearchHelperTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/home/items/WooPosItemsSearchHelperTest.kt
@@ -205,7 +205,7 @@ class WooPosItemsSearchHelperTest {
                 message = R.string.app_name,
                 icon = R.drawable.ic_woo
             ),
-            paginationState = PaginationState.None,
+            paginationState = WooPosPaginationState.None,
             pullToRefreshState = false,
             couponsEnabled = false
         )

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/home/items/WooPosItemsViewModelTestSelectionViewState.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/home/items/WooPosItemsViewModelTestSelectionViewState.kt
@@ -269,7 +269,7 @@ class WooPosItemsViewModelTestSelectionViewState {
 
         // THEN
         viewModel.viewState.test {
-            val value = awaitItem() as ContentViewState
+            val value = awaitItem() as WooPosContentViewState
             assertThat(value.paginationState).isInstanceOf(WooPosPaginationState.Error::class.java)
         }
     }

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/home/items/WooPosItemsViewModelTestSelectionViewState.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/home/items/WooPosItemsViewModelTestSelectionViewState.kt
@@ -194,7 +194,7 @@ class WooPosItemsViewModelTestSelectionViewState {
         // THEN
         viewModel.viewState.test {
             val value = awaitItem() as WooPosItemsViewState.Content
-            assertThat(value.paginationState).isEqualTo(PaginationState.None)
+            assertThat(value.paginationState).isEqualTo(WooPosPaginationState.None)
         }
     }
 
@@ -232,7 +232,7 @@ class WooPosItemsViewModelTestSelectionViewState {
             // THEN
             viewModel.viewState.test {
                 val value = awaitItem() as WooPosItemsViewState.Content
-                assertThat(value.paginationState).isEqualTo(PaginationState.None)
+                assertThat(value.paginationState).isEqualTo(WooPosPaginationState.None)
             }
         }
 
@@ -270,7 +270,7 @@ class WooPosItemsViewModelTestSelectionViewState {
         // THEN
         viewModel.viewState.test {
             val value = awaitItem() as ContentViewState
-            assertThat(value.paginationState).isInstanceOf(PaginationState.Error::class.java)
+            assertThat(value.paginationState).isInstanceOf(WooPosPaginationState.Error::class.java)
         }
     }
 

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/home/items/search/WooPosItemsSearchViewModelTestSelectionViewState.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/home/items/search/WooPosItemsSearchViewModelTestSelectionViewState.kt
@@ -6,7 +6,7 @@ import com.woocommerce.android.ui.woopos.home.ChildToParentEvent
 import com.woocommerce.android.ui.woopos.home.ParentToChildrenEvent
 import com.woocommerce.android.ui.woopos.home.WooPosChildrenToParentEventSender
 import com.woocommerce.android.ui.woopos.home.WooPosParentToChildrenEventReceiver
-import com.woocommerce.android.ui.woopos.home.items.PaginationState
+import com.woocommerce.android.ui.woopos.home.items.WooPosPaginationState
 import com.woocommerce.android.ui.woopos.home.items.WooPosItemNavigationData.VariableProductData
 import com.woocommerce.android.ui.woopos.home.items.WooPosItemSelectionViewState
 import com.woocommerce.android.ui.woopos.home.items.WooPosItemSelectionViewState.Product
@@ -340,11 +340,11 @@ class WooPosItemsSearchViewModelTestSelectionViewState {
             viewModel.onUIEvent(WooPosItemsSearchUiEvent.OnNextPageRequested)
 
             val loadingState = awaitItem() as WooPosItemsSearchViewState.Content
-            assertThat(loadingState.paginationState).isEqualTo(PaginationState.Loading)
+            assertThat(loadingState.paginationState).isEqualTo(WooPosPaginationState.Loading)
 
             val finalState = awaitItem() as WooPosItemsSearchViewState.Content
             assertThat(finalState.items).hasSize(1)
-            assertThat(finalState.paginationState).isEqualTo(PaginationState.None)
+            assertThat(finalState.paginationState).isEqualTo(WooPosPaginationState.None)
         }
     }
 
@@ -365,10 +365,10 @@ class WooPosItemsSearchViewModelTestSelectionViewState {
             viewModel.onUIEvent(WooPosItemsSearchUiEvent.OnNextPageRequested)
 
             val loadingState = awaitItem() as WooPosItemsSearchViewState.Content
-            assertThat(loadingState.paginationState).isEqualTo(PaginationState.Loading)
+            assertThat(loadingState.paginationState).isEqualTo(WooPosPaginationState.Loading)
 
             val errorState = awaitItem() as WooPosItemsSearchViewState.Content
-            assertThat(errorState.paginationState).isEqualTo(PaginationState.Error)
+            assertThat(errorState.paginationState).isEqualTo(WooPosPaginationState.Error)
         }
     }
 

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/home/items/search/WooPosItemsSearchViewModelTestSelectionViewState.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/home/items/search/WooPosItemsSearchViewModelTestSelectionViewState.kt
@@ -6,11 +6,11 @@ import com.woocommerce.android.ui.woopos.home.ChildToParentEvent
 import com.woocommerce.android.ui.woopos.home.ParentToChildrenEvent
 import com.woocommerce.android.ui.woopos.home.WooPosChildrenToParentEventSender
 import com.woocommerce.android.ui.woopos.home.WooPosParentToChildrenEventReceiver
-import com.woocommerce.android.ui.woopos.home.items.WooPosPaginationState
 import com.woocommerce.android.ui.woopos.home.items.WooPosItemNavigationData.VariableProductData
 import com.woocommerce.android.ui.woopos.home.items.WooPosItemSelectionViewState
 import com.woocommerce.android.ui.woopos.home.items.WooPosItemSelectionViewState.Product
 import com.woocommerce.android.ui.woopos.home.items.WooPosItemsViewModel.ItemClickedData
+import com.woocommerce.android.ui.woopos.home.items.WooPosPaginationState
 import com.woocommerce.android.ui.woopos.home.items.navigation.WooPosItemsNavigator
 import com.woocommerce.android.ui.woopos.home.items.navigation.WooPosItemsNavigator.WooPosItemsScreenNavigationEvent.NavigateToVariationsScreen
 import com.woocommerce.android.ui.woopos.util.WooPosCoroutineTestRule

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/home/variations/WooPosVariationsViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/home/variations/WooPosVariationsViewModelTest.kt
@@ -6,8 +6,8 @@ import com.woocommerce.android.ui.products.ProductTestUtils
 import com.woocommerce.android.ui.woopos.common.data.WooPosGetProductById
 import com.woocommerce.android.ui.woopos.home.ChildToParentEvent
 import com.woocommerce.android.ui.woopos.home.WooPosChildrenToParentEventSender
-import com.woocommerce.android.ui.woopos.home.items.WooPosPaginationState
 import com.woocommerce.android.ui.woopos.home.items.WooPosItemsViewModel
+import com.woocommerce.android.ui.woopos.home.items.WooPosPaginationState
 import com.woocommerce.android.ui.woopos.home.items.WooPosVariationsViewState
 import com.woocommerce.android.ui.woopos.home.items.variations.FetchResult
 import com.woocommerce.android.ui.woopos.home.items.variations.WooPosVariationsDataSource

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/home/variations/WooPosVariationsViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/home/variations/WooPosVariationsViewModelTest.kt
@@ -6,7 +6,7 @@ import com.woocommerce.android.ui.products.ProductTestUtils
 import com.woocommerce.android.ui.woopos.common.data.WooPosGetProductById
 import com.woocommerce.android.ui.woopos.home.ChildToParentEvent
 import com.woocommerce.android.ui.woopos.home.WooPosChildrenToParentEventSender
-import com.woocommerce.android.ui.woopos.home.items.PaginationState
+import com.woocommerce.android.ui.woopos.home.items.WooPosPaginationState
 import com.woocommerce.android.ui.woopos.home.items.WooPosItemsViewModel
 import com.woocommerce.android.ui.woopos.home.items.WooPosVariationsViewState
 import com.woocommerce.android.ui.woopos.home.items.variations.FetchResult
@@ -213,7 +213,7 @@ class WooPosVariationsViewModelTest {
         // THEN
         viewModel.viewState.test {
             val state = awaitItem() as WooPosVariationsViewState.Content
-            assertThat(state.paginationState).isEqualTo(PaginationState.None)
+            assertThat(state.paginationState).isEqualTo(WooPosPaginationState.None)
         }
     }
 
@@ -281,7 +281,7 @@ class WooPosVariationsViewModelTest {
         // THEN
         viewModel.viewState.test {
             val state = awaitItem() as WooPosVariationsViewState.Content
-            assertThat(state.paginationState).isEqualTo(PaginationState.Error)
+            assertThat(state.paginationState).isEqualTo(WooPosPaginationState.Error)
         }
     }
 
@@ -307,7 +307,7 @@ class WooPosVariationsViewModelTest {
             viewModel.viewState.test {
                 // THEN
                 val state = awaitItem() as WooPosVariationsViewState.Content
-                assertThat(state.paginationState).isEqualTo(PaginationState.Loading)
+                assertThat(state.paginationState).isEqualTo(WooPosPaginationState.Loading)
             }
         }
 
@@ -330,7 +330,7 @@ class WooPosVariationsViewModelTest {
             viewModel.viewState.test {
                 // THEN
                 val state = awaitItem() as WooPosVariationsViewState.Content
-                assertThat(state.paginationState).isEqualTo(PaginationState.None)
+                assertThat(state.paginationState).isEqualTo(WooPosPaginationState.None)
             }
         }
 


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #13771
Closes: #13870
<!-- Id number of the GitHub issue this PR addresses. -->

<!-- 
━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
🛠 Need an AI review?  
Add a comment: `@coderabbitai review`
━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
-->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
The PR:
* Fixed a bug when if the new products set coming the search state is hidden
* That pull to refresh was available on the searching state
* I renamed wrongly named high-level classes `PaginationState` and `ContentViewState`

### Steps to reproduce
<!-- Step-by-step testing instructions. For new user flows, consider instead stating the goal of the workflow and see if your PR reviewer can accomplish the workflow without specific steps! -->
* Open the POS and right-open open search
* Notice that after a second, it's hidden
---
* Try to do pull to refresh on the search state
* Notice that products are shown

### Testing information
<!-- This is your opportunity to break out individual scenarios that need testing (when necessary) and/or include a checklist for the reviewer to go through. Consider documenting the following from your own completed testing: devices used, alternate workflows, edge cases, affected areas, critical flows, areas not tested, and any remaining unknowns. Provide feedback on this new section of the PR template through Sept 30, 2024 to Apps Quality; additional context here: p91TBi-b8z-p2#comment-12036 -->

Make sure that there is no regression regarding PTR, including variations

### The tests that have been performed
<!-- To give the reviewer an idea of what could be missed in terms of testing -->
above

### Images/gif
<!-- Include before and after images or gifs when appropriate. -->


https://github.com/user-attachments/assets/216f135b-1134-4d5e-8945-4b47daa7f102


- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.

## Reviewer (or Author, in the case of optional code reviews):

Please make sure these conditions are met before approving the PR, or request changes if the PR needs improvement:

- [ ] The PR is small and has a clear, single focus, or a valid explanation is provided in the description. If needed, please request to split it into smaller PRs.
- [ ] Ensure Adequate Unit Test Coverage: The changes are reasonably covered by unit tests or an explanation is provided in the PR description.
- [ ] Manual Testing: The author listed all the tests they ran, including smoke tests when needed (e.g., for refactorings). The reviewer confirmed that the PR works as expected on big (tablet) and small (phone) in case of UI changes, and no regressions are added.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->