### PR TITLE
[Shipping Labels Revamp] Update Customs form UI to properly support Dark theme

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/components/RoundedBorderDropdownWithLabel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/components/RoundedBorderDropdownWithLabel.kt
@@ -14,8 +14,10 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.colorResource
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
+import com.woocommerce.android.R
 import com.woocommerce.android.ui.orders.wooshippinglabels.RoundedCornerBoxWithBorder
 
 @Composable
@@ -29,6 +31,7 @@ fun RoundedBorderDropDownWithLabel(
         Text(
             text = label,
             style = MaterialTheme.typography.bodyMedium,
+            color = colorResource(id = R.color.color_on_surface),
             modifier = Modifier.padding(vertical = 8.dp)
         )
         RoundedCornerBoxWithBorder(innerModifier = Modifier.clickable { onClick() }) {
@@ -41,12 +44,13 @@ fun RoundedBorderDropDownWithLabel(
                 Text(
                     text = text,
                     style = MaterialTheme.typography.bodyMedium,
+                    color = colorResource(id = R.color.color_on_surface),
                     modifier = Modifier.weight(1f)
                 )
                 Icon(
                     imageVector = Icons.Filled.ArrowDropDown,
                     contentDescription = null,
-                    tint = MaterialTheme.colorScheme.onSurface
+                    tint = colorResource(id = R.color.color_on_surface)
                 )
             }
         }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/customs/WooShippingCustomsFormScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/customs/WooShippingCustomsFormScreen.kt
@@ -185,7 +185,8 @@ fun WooShippingCustomsFormScreen(
 
             Text(
                 text = stringResource(R.string.woo_shipping_labels_customs_product_details_title),
-                style = MaterialTheme.typography.titleMedium,
+                color = colorResource(id = R.color.color_on_surface),
+                style = MaterialTheme.typography.titleMedium
             )
 
             shippingProducts.forEachIndexed { index, product ->

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/customs/WooShippingCustomsFormScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/customs/WooShippingCustomsFormScreen.kt
@@ -21,6 +21,7 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.livedata.observeAsState
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.colorResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.input.ImeAction
 import androidx.compose.ui.tooling.preview.Preview
@@ -167,6 +168,7 @@ fun WooShippingCustomsFormScreen(
             ) {
                 Text(
                     text = stringResource(id = R.string.woo_shipping_labels_customs_return_to_sender_label),
+                    color = colorResource(id = R.color.color_on_surface),
                     modifier = modifier
                         .align(Alignment.CenterVertically)
                         .weight(1f)
@@ -176,7 +178,7 @@ fun WooShippingCustomsFormScreen(
                     onCheckedChange = onReturnToSenderChanged,
                     colors = CheckboxDefaults.colors(
                         checkedColor = MaterialTheme.colorScheme.primary,
-                        uncheckedColor = MaterialTheme.colorScheme.onSurface
+                        uncheckedColor = colorResource(id = R.color.color_on_surface_disabled),
                     )
                 )
             }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/customs/WooShippingCustomsFormScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/customs/WooShippingCustomsFormScreen.kt
@@ -1,5 +1,6 @@
 package com.woocommerce.android.ui.orders.wooshippinglabels.customs
 
+import android.content.res.Configuration.UI_MODE_NIGHT_YES
 import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
@@ -10,6 +11,7 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.foundation.verticalScroll
+import androidx.compose.material.Surface
 import androidx.compose.material3.Checkbox
 import androidx.compose.material3.CheckboxDefaults
 import androidx.compose.material3.MaterialTheme
@@ -207,58 +209,61 @@ fun WooShippingCustomsFormScreen(
 }
 
 @Preview
+@Preview(uiMode = UI_MODE_NIGHT_YES)
 @Composable
 fun PreviewWooShippingCustomsFormScreen() {
     WooThemeWithBackground {
-        WooShippingCustomsFormScreen(
-            contentType = ContentType.MERCHANDISE,
-            restrictionType = RestrictionType.NONE,
-            itnValue = InputValue.Data("123456"),
-            otherContentDetailsInput = InputValue.Data("Important Stuff"),
-            otherRestrictionDetailsInput = InputValue.Data("Restricted Stuff"),
-            returnToSenderChecked = false,
-            isAddCustomsButtonEnabled = true,
-            shouldDisplayContentTypeInput = true,
-            shouldDisplayRestrictionTypeInput = false,
-            shippingProducts = listOf(
-                WooShippingCustomsProductUIModel(
-                    productId = 0,
-                    name = "Little Nap Brazil 250g",
-                    description = InputValue.Data("Product Description"),
-                    tariffNumber = InputValue.Data("123456"),
-                    valuePerUnit = InputValue.Data("10.00"),
-                    weightPerUnit = InputValue.Data("1.00"),
-                    originCountry = "United Stats of America",
-                    originCountryCode = "US",
-                    quantity = 1F,
-                    isExpanded = false
+        Surface {
+            WooShippingCustomsFormScreen(
+                contentType = ContentType.MERCHANDISE,
+                restrictionType = RestrictionType.NONE,
+                itnValue = InputValue.Data("123456"),
+                otherContentDetailsInput = InputValue.Data("Important Stuff"),
+                otherRestrictionDetailsInput = InputValue.Data("Restricted Stuff"),
+                returnToSenderChecked = false,
+                isAddCustomsButtonEnabled = true,
+                shouldDisplayContentTypeInput = true,
+                shouldDisplayRestrictionTypeInput = false,
+                shippingProducts = listOf(
+                    WooShippingCustomsProductUIModel(
+                        productId = 0,
+                        name = "Little Nap Brazil 250g",
+                        description = InputValue.Data("Product Description"),
+                        tariffNumber = InputValue.Data("123456"),
+                        valuePerUnit = InputValue.Data("10.00"),
+                        weightPerUnit = InputValue.Data("1.00"),
+                        originCountry = "United Stats of America",
+                        originCountryCode = "US",
+                        quantity = 1F,
+                        isExpanded = false
+                    ),
+                    WooShippingCustomsProductUIModel(
+                        productId = 0,
+                        name = "Little Nap Brazil 250g",
+                        description = InputValue.Data("Product Description"),
+                        tariffNumber = InputValue.Data("123456"),
+                        valuePerUnit = InputValue.Data("10.00"),
+                        weightPerUnit = InputValue.Data("1.00"),
+                        originCountry = "United Stats of America",
+                        originCountryCode = "US",
+                        quantity = 1F,
+                        isExpanded = true
+                    )
                 ),
-                WooShippingCustomsProductUIModel(
-                    productId = 0,
-                    name = "Little Nap Brazil 250g",
-                    description = InputValue.Data("Product Description"),
-                    tariffNumber = InputValue.Data("123456"),
-                    valuePerUnit = InputValue.Data("10.00"),
-                    weightPerUnit = InputValue.Data("1.00"),
-                    originCountry = "United Stats of America",
-                    originCountryCode = "US",
-                    quantity = 1F,
-                    isExpanded = true
-                )
-            ),
-            onContentTypeClick = {},
-            onRestrictionTypeClick = {},
-            onItnChanged = {},
-            onReturnToSenderChanged = {},
-            onOtherContentDetailsInputChanged = {},
-            onOtherRestrictionDetailsInputChanged = {},
-            onProductExpanded = { _, _ -> },
-            onAddCustomsDataClick = {},
-            onDescriptionChanged = { _, _ -> },
-            onTariffChanged = { _, _ -> },
-            onValuePerUnitChanged = { _, _ -> },
-            onWeightPerUnitChanged = { _, _ -> },
-            onCountrySelectorClick = { }
-        )
+                onContentTypeClick = {},
+                onRestrictionTypeClick = {},
+                onItnChanged = {},
+                onReturnToSenderChanged = {},
+                onOtherContentDetailsInputChanged = {},
+                onOtherRestrictionDetailsInputChanged = {},
+                onProductExpanded = { _, _ -> },
+                onAddCustomsDataClick = {},
+                onDescriptionChanged = { _, _ -> },
+                onTariffChanged = { _, _ -> },
+                onValuePerUnitChanged = { _, _ -> },
+                onWeightPerUnitChanged = { _, _ -> },
+                onCountrySelectorClick = { }
+            )
+        }
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/customs/products/WooShippingCustomsProductListItem.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/customs/products/WooShippingCustomsProductListItem.kt
@@ -1,5 +1,6 @@
 package com.woocommerce.android.ui.orders.wooshippinglabels.customs.products
 
+import android.content.res.Configuration.UI_MODE_NIGHT_YES
 import androidx.compose.animation.animateContentSize
 import androidx.compose.animation.core.animateFloatAsState
 import androidx.compose.foundation.background
@@ -250,6 +251,7 @@ fun WooShippingCustomsProductExpandedListItem(
 }
 
 @Preview
+@Preview(uiMode = UI_MODE_NIGHT_YES)
 @Composable
 fun WooShippingCustomsProductListCollapsedItemPreview() {
     WooThemeWithBackground {
@@ -279,6 +281,7 @@ fun WooShippingCustomsProductListCollapsedItemPreview() {
 }
 
 @Preview
+@Preview(uiMode = UI_MODE_NIGHT_YES)
 @Composable
 fun WooShippingCustomsProductListCollapsedItemErrorPreview() {
     WooThemeWithBackground {
@@ -308,6 +311,7 @@ fun WooShippingCustomsProductListCollapsedItemErrorPreview() {
 }
 
 @Preview
+@Preview(uiMode = UI_MODE_NIGHT_YES)
 @Composable
 fun WooShippingCustomsProductListExpandedItemPreview() {
     WooThemeWithBackground {
@@ -337,6 +341,7 @@ fun WooShippingCustomsProductListExpandedItemPreview() {
 }
 
 @Preview
+@Preview(uiMode = UI_MODE_NIGHT_YES)
 @Composable
 fun WooShippingCustomsProductListExpandedItemErrorPreview() {
     WooThemeWithBackground {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/customs/products/WooShippingCustomsProductListItem.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/customs/products/WooShippingCustomsProductListItem.kt
@@ -57,7 +57,7 @@ fun WooShippingCustomsProductListItem(
         .let { animateFloatAsState(targetValue = it, label = "rotationAnimation") }
 
     val borderColor = when {
-        itemData.isExpanded -> colorResource(R.color.woo_black)
+        itemData.isExpanded -> colorResource(R.color.color_on_surface)
         itemData.isValid.not() -> colorResource(R.color.color_error)
         else -> colorResource(R.color.divider_color)
     }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/customs/products/WooShippingCustomsProductListItem.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/customs/products/WooShippingCustomsProductListItem.kt
@@ -67,7 +67,7 @@ fun WooShippingCustomsProductListItem(
             .fillMaxWidth()
             .animateContentSize()
             .background(
-                color = MaterialTheme.colorScheme.onPrimary,
+                color = colorResource(R.color.color_surface),
                 shape = RoundedCornerShape(dimensionResource(R.dimen.corner_radius_large))
             )
             .border(
@@ -83,6 +83,7 @@ fun WooShippingCustomsProductListItem(
                 text = itemData.name,
                 style = MaterialTheme.typography.titleMedium,
                 fontWeight = FontWeight.Bold,
+                color = colorResource(id = R.color.color_on_surface),
                 modifier = modifier.weight(1f)
             )
 
@@ -141,12 +142,14 @@ fun WooShippingCustomsProductCollapsedListItem(
             Text(
                 style = MaterialTheme.typography.bodySmall,
                 modifier = modifier.weight(1f),
+                color = colorResource(id = R.color.color_on_surface),
                 text = itemData.description.currentInput
                     .takeIf { it.isNotBlank() }
                     ?: stringResource(id = R.string.woo_shipping_labels_customs_product_details_description_missing)
             )
             Text(
                 style = MaterialTheme.typography.bodySmall,
+                color = colorResource(id = R.color.color_on_surface),
                 text = itemData.tariffNumber.currentInput
                     .takeIf { it.isNotBlank() }
                     ?: stringResource(id = R.string.woo_shipping_labels_customs_product_details_tariff_missing)
@@ -156,12 +159,14 @@ fun WooShippingCustomsProductCollapsedListItem(
             Text(
                 style = MaterialTheme.typography.bodySmall,
                 modifier = modifier.weight(1f),
+                color = colorResource(id = R.color.color_on_surface),
                 text = itemData.originCountry
                     .takeIf { it.isNotBlank() }
                     ?: stringResource(id = R.string.woo_shipping_labels_customs_product_details_origin_country_missing)
             )
             Text(
                 text = itemData.valueAndWeightForDisplay,
+                color = colorResource(id = R.color.color_on_surface),
                 style = MaterialTheme.typography.bodySmall,
             )
         }


### PR DESCRIPTION
Summary
==========
Updates the Customs form UI to correctly support the Android's dark theme colors.

Screen Capture
==========
https://github.com/user-attachments/assets/e21edce4-20bc-46d7-9779-6f7c1f82dc53

How to Test
==========
1. Access the Customs form UI with the Dark theme active and ensure the entire screen follows the colors requirements.

Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

## Reviewer (or Author, in the case of optional code reviews):

Please make sure these conditions are met before approving the PR, or request changes if the PR needs improvement:

- [ ] The PR is small and has a clear, single focus, or a valid explanation is provided in the description. If needed, please request to split it into smaller PRs.
- [ ] Ensure Adequate Unit Test Coverage: The changes are reasonably covered by unit tests or an explanation is provided in the PR description.
- [ ] Manual Testing: The author listed all the tests they ran, including smoke tests when needed (e.g., for refactorings). The reviewer confirmed that the PR works as expected on big (tablet) and small (phone) in case of UI changes, and no regressions are added.
