### PR TITLE
[Woo POS] Add business logic to fetch all coupons

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/coupons/CouponListHandler.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/coupons/CouponListHandler.kt
@@ -17,7 +17,7 @@ class CouponListHandler @Inject constructor(private val repository: CouponReposi
 
     private val mutex = Mutex()
     private var page = 1
-    private var canLoadMore = true
+    var canLoadMore = true
 
     private val searchQuery = MutableStateFlow<String?>(null)
     private val searchResults = MutableStateFlow(emptyList<Coupon>())

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/items/WooPosItemsViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/items/WooPosItemsViewModel.kt
@@ -13,6 +13,7 @@ import com.woocommerce.android.ui.woopos.home.WooPosChildrenToParentEventSender
 import com.woocommerce.android.ui.woopos.home.items.WooPosItemNavigationData.VariableProductData
 import com.woocommerce.android.ui.woopos.home.items.common.FetchOptions
 import com.woocommerce.android.ui.woopos.home.items.common.FetchResult
+import com.woocommerce.android.ui.woopos.home.items.coupons.WooPosCouponsDataSource
 import com.woocommerce.android.ui.woopos.home.items.navigation.WooPosItemsNavigator
 import com.woocommerce.android.ui.woopos.home.items.navigation.WooPosItemsNavigator.WooPosItemsScreenNavigationEvent
 import com.woocommerce.android.ui.woopos.home.items.navigation.WooPosItemsNavigator.WooPosItemsScreenNavigationEvent.NavigateToVariationsScreen
@@ -36,6 +37,7 @@ import javax.inject.Inject
 @HiltViewModel
 class WooPosItemsViewModel @Inject constructor(
     private val productsDataSource: WooPosProductsDataSource,
+    private val couponsDataSource: WooPosCouponsDataSource,
     private val fromChildToParentEventSender: WooPosChildrenToParentEventSender,
     private val priceFormat: WooPosFormatPrice,
     private val preferencesRepository: WooPosPreferencesRepository,

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/items/WooPosItemsViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/items/WooPosItemsViewModel.kt
@@ -37,7 +37,7 @@ import javax.inject.Inject
 @HiltViewModel
 class WooPosItemsViewModel @Inject constructor(
     private val productsDataSource: WooPosProductsDataSource,
-    private val couponsDataSource: WooPosCouponsDataSource,
+    @Suppress("UnusedPrivateProperty") private val couponsDataSource: WooPosCouponsDataSource,
     private val fromChildToParentEventSender: WooPosChildrenToParentEventSender,
     private val priceFormat: WooPosFormatPrice,
     private val preferencesRepository: WooPosPreferencesRepository,

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/items/coupons/WooPosCouponsDataSource.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/items/coupons/WooPosCouponsDataSource.kt
@@ -1,0 +1,58 @@
+
+
+
+package com.woocommerce.android.ui.woopos.home.items.coupons
+
+import com.woocommerce.android.model.Coupon
+import com.woocommerce.android.ui.coupons.CouponListHandler
+import com.woocommerce.android.ui.woopos.home.items.common.FetchOptions
+import com.woocommerce.android.ui.woopos.home.items.common.WooPosBaseDataSource
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
+import javax.inject.Inject
+import javax.inject.Singleton
+
+@Singleton
+class WooPosCouponsDataSource @Inject constructor(
+    private val handler: CouponListHandler,
+) : WooPosBaseDataSource<Coupon>() {
+    private var couponCache: List<Coupon> = emptyList()
+    private val cacheMutex = Mutex()
+
+    val hasMorePages: Boolean
+        get() = handler.canLoadMore
+
+    override suspend fun fetchFromCache(fetchOptions: FetchOptions): List<Coupon> {
+        return couponCache
+    }
+
+    override suspend fun fetchFromRemote(fetchOptions: FetchOptions): Result<List<Coupon>> {
+        val result = handler.fetchCoupons(
+            forceRefresh = true
+        )
+        return if (result.isSuccess) {
+            Result.success(handler.couponsFlow.first())
+        } else {
+            Result.failure(result.exceptionOrNull() ?: Exception("Unknown error while fetching products"))
+        }
+    }
+
+    override suspend fun updateCache(fetchOptions: FetchOptions, data: List<Coupon>) {
+        updateCouponCache(data)
+    }
+
+    private suspend fun updateCouponCache(newList: List<Coupon>) {
+        cacheMutex.withLock {
+            couponCache = newList
+        }
+    }
+
+    suspend fun loadMore(): Result<List<Coupon>> = fetchMore(
+        fetchMore = {
+            handler.loadMore()
+                .map { handler.couponsFlow.first() }
+        }
+    )
+}
+

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/items/coupons/WooPosCouponsDataSource.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/items/coupons/WooPosCouponsDataSource.kt
@@ -55,4 +55,3 @@ class WooPosCouponsDataSource @Inject constructor(
         }
     )
 }
-

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/items/products/WooPosProductsDataSource.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/items/products/WooPosProductsDataSource.kt
@@ -34,11 +34,6 @@ class WooPosProductsDataSource @Inject constructor(
         cacheMutex.withLock { productCache = newList }
     }
 
-    sealed class ProductsResult {
-        data class Cached(val products: List<Product>) : ProductsResult()
-        data class Remote(val productsResult: Result<List<Product>>) : ProductsResult()
-    }
-
     override suspend fun fetchFromCache(fetchOptions: FetchOptions): List<Product> {
         return productCache
     }

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/home/items/WooPosItemsViewModelTestSelectionViewState.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/home/items/WooPosItemsViewModelTestSelectionViewState.kt
@@ -11,6 +11,7 @@ import com.woocommerce.android.ui.woopos.home.WooPosChildrenToParentEventSender
 import com.woocommerce.android.ui.woopos.home.items.WooPosItemSelectionViewState.Product
 import com.woocommerce.android.ui.woopos.home.items.common.FetchOptions
 import com.woocommerce.android.ui.woopos.home.items.common.FetchResult
+import com.woocommerce.android.ui.woopos.home.items.coupons.WooPosCouponsDataSource
 import com.woocommerce.android.ui.woopos.home.items.navigation.WooPosItemsNavigator
 import com.woocommerce.android.ui.woopos.home.items.products.WooPosProductsDataSource
 import com.woocommerce.android.ui.woopos.util.WooPosCoroutineTestRule
@@ -40,6 +41,7 @@ class WooPosItemsViewModelTestSelectionViewState {
     val coroutinesTestRule = WooPosCoroutineTestRule()
 
     private val productsDataSource: WooPosProductsDataSource = mock()
+    private val couponsDataSource: WooPosCouponsDataSource = mock()
     private val fromChildToParentEventSender: WooPosChildrenToParentEventSender = mock()
     private val posPreferencesRepository: WooPosPreferencesRepository = mock()
     private val wooPosItemsNavigator: WooPosItemsNavigator = mock()
@@ -837,6 +839,7 @@ class WooPosItemsViewModelTestSelectionViewState {
     private fun createViewModel() =
         WooPosItemsViewModel(
             productsDataSource,
+            couponsDataSource,
             fromChildToParentEventSender,
             priceFormat,
             posPreferencesRepository,

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/home/items/coupons/WooPosCouponsDataSourceTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/home/items/coupons/WooPosCouponsDataSourceTest.kt
@@ -1,0 +1,228 @@
+package com.woocommerce.android.ui.woopos.home.items.coupons
+
+import com.woocommerce.android.model.Coupon
+import com.woocommerce.android.ui.coupons.CouponListHandler
+import com.woocommerce.android.ui.woopos.home.items.common.FetchOptions
+import com.woocommerce.android.ui.woopos.home.items.common.FetchResult
+import com.woocommerce.android.ui.woopos.util.WooPosCoroutineTestRule
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.flow.toList
+import kotlinx.coroutines.test.runTest
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Rule
+import org.junit.Test
+import org.mockito.Mockito.mock
+import org.mockito.kotlin.whenever
+import kotlin.test.BeforeTest
+
+@ExperimentalCoroutinesApi
+class WooPosCouponsDataSourceTest {
+    @Rule
+    @JvmField
+    val coroutinesTestRule = WooPosCoroutineTestRule()
+
+    private lateinit var dataSource: WooPosCouponsDataSource
+    private val handler: CouponListHandler = mock()
+
+    private val sampleCoupons = listOf(
+        Coupon(
+            id = 1,
+            code = "DISCOUNT10",
+            productIds = emptyList(),
+            categoryIds = emptyList(),
+            restrictions = Coupon.CouponRestrictions(
+                excludedProductIds = emptyList(),
+                excludedCategoryIds = emptyList(),
+                restrictedEmails = emptyList()
+            )
+        ),
+        Coupon(
+            id = 2,
+            code = "WELCOME5",
+            productIds = emptyList(),
+            categoryIds = emptyList(),
+            restrictions = Coupon.CouponRestrictions(
+                excludedProductIds = emptyList(),
+                excludedCategoryIds = emptyList(),
+                restrictedEmails = emptyList()
+            )
+        )
+    )
+
+    private val moreCoupons = listOf(
+        Coupon(
+            id = 3,
+            code = "SUMMER15",
+            productIds = emptyList(),
+            categoryIds = emptyList(),
+            restrictions = Coupon.CouponRestrictions(
+                excludedProductIds = emptyList(),
+                excludedCategoryIds = emptyList(),
+                restrictedEmails = emptyList()
+            )
+        ),
+        Coupon(
+            id = 4,
+            code = "NEWYEAR",
+            productIds = emptyList(),
+            categoryIds = emptyList(),
+            restrictions = Coupon.CouponRestrictions(
+                excludedProductIds = emptyList(),
+                excludedCategoryIds = emptyList(),
+                restrictedEmails = emptyList()
+            )
+        )
+    )
+
+    @Test
+    fun `given force refresh, when fetchFromRemote called, then should clear cache`() = runTest {
+        whenever(handler.fetchCoupons(forceRefresh = true)).thenReturn(Result.success(Unit))
+        whenever(handler.couponsFlow).thenReturn(flowOf(sampleCoupons))
+
+        val sut = WooPosCouponsDataSource(handler)
+
+        sut.fetchData(FetchOptions(forceRefresh = false)).first()
+        assertThat(sut.fetchData(FetchOptions(forceRefresh = false)).first()).isInstanceOf(FetchResult.Cached::class.java)
+
+        sut.fetchData(FetchOptions(forceRefresh = true)).first()
+
+        val result = sut.fetchData(FetchOptions(forceRefresh = false)).first()
+        assertThat(result).isInstanceOf(FetchResult.Cached::class.java)
+        val cachedResult = result as FetchResult.Cached
+        assertThat(cachedResult.data).containsExactlyElementsOf(sampleCoupons)
+    }
+
+    @Test
+    fun `given cached coupons, when fetchData called, then should emit cached coupons first`() = runTest {
+        whenever(handler.fetchCoupons(forceRefresh = true)).thenReturn(Result.success(Unit))
+        whenever(handler.couponsFlow).thenReturn(flowOf(sampleCoupons))
+
+        val sut = WooPosCouponsDataSource(handler)
+
+        sut.fetchData(FetchOptions(forceRefresh = false)).first()
+        val result = sut.fetchData(FetchOptions(forceRefresh = false)).first()
+
+        assertThat(result).isInstanceOf(FetchResult.Cached::class.java)
+        val cachedResult = result as FetchResult.Cached
+        assertThat(cachedResult.data).containsExactlyElementsOf(sampleCoupons)
+    }
+
+    @Test
+    fun `given cached and remote coupons, when fetchData called, then should emit remote coupons after cached`() = runTest {
+        whenever(handler.fetchCoupons(forceRefresh = true)).thenReturn(Result.success(Unit))
+        whenever(handler.couponsFlow).thenReturn(flowOf(sampleCoupons))
+
+        val sut = WooPosCouponsDataSource(handler)
+
+        sut.fetchData(FetchOptions(forceRefresh = false)).first()
+        val result = sut.fetchData(FetchOptions(forceRefresh = false)).toList()
+
+        val cachedResult = result[0] as FetchResult.Cached
+        val remoteResult = result[1] as FetchResult.Remote
+
+        assertThat(cachedResult.data).containsExactlyElementsOf(sampleCoupons)
+        assertThat(remoteResult.result.isSuccess).isTrue()
+        assertThat(remoteResult.result.getOrNull()).containsExactlyElementsOf(sampleCoupons)
+    }
+
+    @Test
+    fun `given remote fetch fails, when fetchData called, then emit empty cached and error`() = runTest {
+        val error = Exception("Remote fetch failed")
+        whenever(handler.fetchCoupons(forceRefresh = true)).thenReturn(Result.failure(error))
+        whenever(handler.couponsFlow).thenReturn(flowOf(emptyList()))
+
+        val sut = WooPosCouponsDataSource(handler)
+
+        val result = sut.fetchData(FetchOptions(forceRefresh = false)).toList()
+
+        val cachedResult = result[0] as FetchResult.Cached
+        val remoteResult = result[1] as FetchResult.Remote
+
+        assertThat(cachedResult.data).isEmpty()
+        assertThat(remoteResult.result.isFailure).isTrue()
+        assertThat(remoteResult.result.exceptionOrNull()).isEqualTo(error)
+    }
+
+
+    @Test
+    fun `given successful loadMore, when loadMore called, then should add coupons to cache and return them`() = runTest {
+        whenever(handler.fetchCoupons(forceRefresh = true)).thenReturn(Result.success(Unit))
+        whenever(handler.loadMore()).thenReturn(Result.success(Unit))
+        whenever(handler.couponsFlow).thenReturn(
+            flowOf(sampleCoupons),
+            flowOf(sampleCoupons + moreCoupons)
+        )
+
+        val sut = WooPosCouponsDataSource(handler)
+
+        sut.fetchData(FetchOptions(forceRefresh = false)).first()
+
+        val result = sut.loadMore()
+
+        assertThat(result.isSuccess).isTrue()
+        assertThat(result.getOrNull()).containsExactlyElementsOf(sampleCoupons + moreCoupons)
+
+        val cached = sut.fetchData(FetchOptions(forceRefresh = false)).first() as FetchResult.Cached
+        assertThat(cached.data).containsExactlyElementsOf(sampleCoupons + moreCoupons)
+    }
+
+    @Test
+    fun `given failed loadMore, when loadMore called, then return error and cache remains unchanged`() = runTest {
+        val exception = Exception("Load more failed")
+        whenever(handler.fetchCoupons(forceRefresh = true)).thenReturn(Result.success(Unit))
+        whenever(handler.loadMore()).thenReturn(Result.failure(exception))
+        whenever(handler.couponsFlow).thenReturn(flowOf(sampleCoupons))
+
+        val sut = WooPosCouponsDataSource(handler)
+
+        sut.fetchData(FetchOptions(forceRefresh = false)).first()
+
+        val result = sut.loadMore()
+
+        assertThat(result.isFailure).isTrue()
+        assertThat(result.exceptionOrNull()).isEqualTo(exception)
+
+        val cached = sut.fetchData(FetchOptions(forceRefresh = false)).first() as FetchResult.Cached
+        assertThat(cached.data).containsExactlyElementsOf(sampleCoupons)
+    }
+
+    @Test
+    fun `given no cached coupons and remote fetch fails, when fetchData called, then emit empty cache and then error`() = runTest {
+        val exception = Exception("Remote failed")
+        whenever(handler.fetchCoupons(forceRefresh = true)).thenReturn(Result.failure(exception))
+        whenever(handler.couponsFlow).thenReturn(flowOf(emptyList()))
+
+        val sut = WooPosCouponsDataSource(handler)
+
+        val result = sut.fetchData(FetchOptions(forceRefresh = false)).toList()
+
+        val cachedResult = result[0] as FetchResult.Cached
+        val remoteResult = result[1] as FetchResult.Remote
+
+        assertThat(cachedResult.data).isEmpty()
+        assertThat(remoteResult.result.isFailure).isTrue()
+        assertThat(remoteResult.result.exceptionOrNull()).isEqualTo(exception)
+    }
+
+    @Test
+    fun `given empty coupon list from handler, when fetchData called, then should emit empty cache and remote result`() = runTest {
+        whenever(handler.fetchCoupons(forceRefresh = true)).thenReturn(Result.success(Unit))
+        whenever(handler.couponsFlow).thenReturn(flowOf(emptyList()))
+
+        val sut = WooPosCouponsDataSource(handler)
+
+        val result = sut.fetchData(FetchOptions(forceRefresh = false)).toList()
+
+        val cachedResult = result[0] as FetchResult.Cached
+        val remoteResult = result[1] as FetchResult.Remote
+
+        assertThat(cachedResult.data).isEmpty()
+        assertThat(remoteResult.result.isSuccess).isTrue()
+        assertThat(remoteResult.result.getOrNull()).isEmpty()
+    }
+}

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/home/items/coupons/WooPosCouponsDataSourceTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/home/items/coupons/WooPosCouponsDataSourceTest.kt
@@ -6,19 +6,15 @@ import com.woocommerce.android.ui.woopos.home.items.common.FetchOptions
 import com.woocommerce.android.ui.woopos.home.items.common.FetchResult
 import com.woocommerce.android.ui.woopos.util.WooPosCoroutineTestRule
 import kotlinx.coroutines.ExperimentalCoroutinesApi
-import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.flow.toList
 import kotlinx.coroutines.test.runTest
 import org.assertj.core.api.Assertions.assertThat
-import org.junit.Assert.assertEquals
-import org.junit.Assert.assertTrue
 import org.junit.Rule
 import org.junit.Test
 import org.mockito.Mockito.mock
 import org.mockito.kotlin.whenever
-import kotlin.test.BeforeTest
 
 @ExperimentalCoroutinesApi
 class WooPosCouponsDataSourceTest {

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/home/items/coupons/WooPosCouponsDataSourceTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/home/items/coupons/WooPosCouponsDataSourceTest.kt
@@ -21,8 +21,6 @@ class WooPosCouponsDataSourceTest {
     @Rule
     @JvmField
     val coroutinesTestRule = WooPosCoroutineTestRule()
-
-    private lateinit var dataSource: WooPosCouponsDataSource
     private val handler: CouponListHandler = mock()
 
     private val sampleCoupons = listOf(
@@ -83,7 +81,9 @@ class WooPosCouponsDataSourceTest {
         val sut = WooPosCouponsDataSource(handler)
 
         sut.fetchData(FetchOptions(forceRefresh = false)).first()
-        assertThat(sut.fetchData(FetchOptions(forceRefresh = false)).first()).isInstanceOf(FetchResult.Cached::class.java)
+        assertThat(
+            sut.fetchData(FetchOptions(forceRefresh = false)).first()
+        ).isInstanceOf(FetchResult.Cached::class.java)
 
         sut.fetchData(FetchOptions(forceRefresh = true)).first()
 
@@ -143,7 +143,6 @@ class WooPosCouponsDataSourceTest {
         assertThat(remoteResult.result.isFailure).isTrue()
         assertThat(remoteResult.result.exceptionOrNull()).isEqualTo(error)
     }
-
 
     @Test
     fun `given successful loadMore, when loadMore called, then should add coupons to cache and return them`() = runTest {


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #13726 
<!-- Id number of the GitHub issue this PR addresses. -->

<!-- 
━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
🛠 Need an AI review?  
Add a comment: `@coderabbitai review`
━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
-->

#### Note: Please ensure the parent PR is merged before merging this PR. Please feel free to remove the "Do not merge" label when the parent PR is merged to `trunk`

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
This PR adds business logic (data source) to fetch all Coupons. The business logic class isn't hooked into the ViewModel yet and as a result, there is nothing to be seen in the UI. This class will be made use in the upcoming PRs to fetch Coupons from the ViewModel.

### Steps to reproduce
<!-- Step-by-step testing instructions. For new user flows, consider instead stating the goal of the workflow and see if your PR reviewer can accomplish the workflow without specific steps! -->

### Testing information
<!-- This is your opportunity to break out individual scenarios that need testing (when necessary) and/or include a checklist for the reviewer to go through. Consider documenting the following from your own completed testing: devices used, alternate workflows, edge cases, affected areas, critical flows, areas not tested, and any remaining unknowns. Provide feedback on this new section of the PR template through Sept 30, 2024 to Apps Quality; additional context here: p91TBi-b8z-p2#comment-12036 -->

### The tests that have been performed
<!-- To give the reviewer an idea of what could be missed in terms of testing -->

### Images/gif
<!-- Include before and after images or gifs when appropriate. -->

- [ ] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.

## Reviewer (or Author, in the case of optional code reviews):

Please make sure these conditions are met before approving the PR, or request changes if the PR needs improvement:

- [ ] The PR is small and has a clear, single focus, or a valid explanation is provided in the description. If needed, please request to split it into smaller PRs.
- [ ] Ensure Adequate Unit Test Coverage: The changes are reasonably covered by unit tests or an explanation is provided in the PR description.
- [ ] Manual Testing: The author listed all the tests they ran, including smoke tests when needed (e.g., for refactorings). The reviewer confirmed that the PR works as expected on big (tablet) and small (phone) in case of UI changes, and no regressions are added.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->