### PR TITLE
[Woo POS][Products search] Move search to the toolbar

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/common/composeui/component/WooPosSearchInput.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/common/composeui/component/WooPosSearchInput.kt
@@ -8,7 +8,6 @@ import androidx.compose.animation.core.animateDp
 import androidx.compose.animation.core.animateFloat
 import androidx.compose.animation.core.tween
 import androidx.compose.animation.core.updateTransition
-import androidx.compose.foundation.BorderStroke
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.BoxWithConstraints
@@ -18,7 +17,6 @@ import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
-import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.text.KeyboardActions
 import androidx.compose.foundation.text.KeyboardOptions
@@ -30,7 +28,6 @@ import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.IconButtonDefaults
 import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.OutlinedIconButton
 import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.OutlinedTextFieldDefaults
 import androidx.compose.runtime.Composable
@@ -57,7 +54,8 @@ import com.woocommerce.android.ui.woopos.common.composeui.designsystem.WooPosThe
 import com.woocommerce.android.ui.woopos.common.composeui.designsystem.WooPosTypography
 import kotlinx.coroutines.delay
 
-private val BUTTON_SIZE = 48.dp
+private val BUTTON_SIZE = 40.dp
+private val INPUT_FIELD_HEIGHT = 56.dp
 private const val ANIMATION_TIME = 300L
 
 @Composable
@@ -69,8 +67,7 @@ fun WooPosSearchInput(
     Row(
         modifier = modifier
             .fillMaxWidth()
-            .padding(vertical = WooPosSpacing.XSmall.value)
-            .height(BUTTON_SIZE + WooPosSpacing.XSmall.value * 2),
+            .height(INPUT_FIELD_HEIGHT),
         verticalAlignment = Alignment.CenterVertically,
         horizontalArrangement = Arrangement.End,
     ) {
@@ -91,11 +88,9 @@ fun WooPosSearchInput(
 
 @Composable
 fun SearchButton(onEvent: (WooPosSearchUIEvent) -> Unit) {
-    OutlinedIconButton(
-        onClick = { onEvent(WooPosSearchUIEvent.Search("")) },
-        border = BorderStroke(2.dp, MaterialTheme.colorScheme.onSurface),
+    IconButton(
         modifier = Modifier.size(BUTTON_SIZE),
-        shape = CircleShape,
+        onClick = { onEvent(WooPosSearchUIEvent.Search("")) },
         colors = IconButtonDefaults.outlinedIconButtonColors(
             containerColor = WooPosTheme.colors.transparent,
             contentColor = MaterialTheme.colorScheme.onSurface
@@ -106,7 +101,7 @@ fun SearchButton(onEvent: (WooPosSearchUIEvent) -> Unit) {
             contentDescription = stringResource(
                 R.string.woopos_search_products
             ),
-            modifier = Modifier.size(32.dp),
+            modifier = Modifier.size(36.dp),
         )
     }
 }
@@ -264,7 +259,7 @@ private fun animateSearchHeight(transition: Transition<Boolean>): Dp {
             )
         }
     ) { expanded ->
-        if (expanded) 56.dp else BUTTON_SIZE
+        if (expanded) INPUT_FIELD_HEIGHT else BUTTON_SIZE
     }
     return height
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/common/composeui/component/WooPosSearchInput.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/common/composeui/component/WooPosSearchInput.kt
@@ -101,6 +101,7 @@ fun SearchButton(onEvent: (WooPosSearchUIEvent) -> Unit) {
             contentDescription = stringResource(
                 R.string.woopos_search_products
             ),
+            tint = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.87f),
             modifier = Modifier.size(32.dp)
         )
     }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/common/composeui/component/WooPosSearchInput.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/common/composeui/component/WooPosSearchInput.kt
@@ -101,7 +101,7 @@ fun SearchButton(onEvent: (WooPosSearchUIEvent) -> Unit) {
             contentDescription = stringResource(
                 R.string.woopos_search_products
             ),
-            modifier = Modifier.size(36.dp),
+            modifier = Modifier.size(32.dp)
         )
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/common/composeui/component/WooPosToolbar.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/common/composeui/component/WooPosToolbar.kt
@@ -4,6 +4,7 @@ import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.offset
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.material3.Icon
@@ -33,7 +34,7 @@ fun WooPosToolbar(
         modifier = Modifier
             .fillMaxWidth()
             .padding(top = WooPosSpacing.XLarge.value.toAdaptivePadding())
-            .height(40.dp)
+            .height(48.dp),
     ) {
         val (backButton, title) = createRefs()
         IconButton(
@@ -41,8 +42,7 @@ fun WooPosToolbar(
             modifier = Modifier
                 .constrainAs(backButton) {
                     start.linkTo(parent.start)
-                    top.linkTo(parent.top)
-                    centerVerticallyTo(parent)
+                    bottom.linkTo(parent.bottom)
                 }
                 .padding(start = WooPosSpacing.Small.value.toAdaptivePadding())
         ) {
@@ -50,7 +50,9 @@ fun WooPosToolbar(
                 imageVector = ImageVector.vectorResource(R.drawable.ic_back_24dp),
                 contentDescription = stringResource(R.string.woopos_toolbar_icon_content_description),
                 tint = MaterialTheme.colorScheme.onBackground,
-                modifier = Modifier.size(28.dp)
+                modifier = Modifier
+                    .size(28.dp)
+                    .offset(y = 2.dp)
             )
         }
 
@@ -63,9 +65,8 @@ fun WooPosToolbar(
             maxLines = 1,
             modifier = Modifier
                 .constrainAs(title) {
-                    top.linkTo(backButton.top)
                     start.linkTo(backButton.end, margin = iconTitlePadding)
-                    centerVerticallyTo(parent)
+                    bottom.linkTo(parent.bottom)
                 }
         )
     }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/cart/WooPosCartScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/cart/WooPosCartScreen.kt
@@ -18,6 +18,7 @@ import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.offset
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
@@ -285,7 +286,7 @@ private fun CartToolbar(
     ConstraintLayout(
         modifier = modifier
             .fillMaxWidth()
-            .height(40.dp)
+            .height(56.dp)
     ) {
         val (backButton, title, spacer, itemsCount, clearAllButton) = createRefs()
 
@@ -307,7 +308,9 @@ private fun CartToolbar(
                     imageVector = ImageVector.vectorResource(R.drawable.ic_back_24dp),
                     contentDescription = stringResource(R.string.woopos_cart_back_content_description),
                     tint = MaterialTheme.colorScheme.onBackground,
-                    modifier = Modifier.size(iconSize)
+                    modifier = Modifier
+                        .size(iconSize)
+                        .offset(y = 4.dp)
                 )
             }
         }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/items/WooPosItemsScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/items/WooPosItemsScreen.kt
@@ -21,8 +21,8 @@ import androidx.compose.foundation.lazy.LazyListState
 import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.material.ExperimentalMaterialApi
 import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.outlined.Discount
 import androidx.compose.material.icons.outlined.Info
+import androidx.compose.material.icons.outlined.LocalOffer
 import androidx.compose.material.pullrefresh.PullRefreshIndicator
 import androidx.compose.material.pullrefresh.PullRefreshState
 import androidx.compose.material.pullrefresh.pullRefresh
@@ -304,7 +304,7 @@ private fun ItemsToolbar(
                             }
                         ) {
                             Icon(
-                                imageVector = Icons.Outlined.Discount,
+                                imageVector = Icons.Outlined.LocalOffer,
                                 contentDescription = stringResource(
                                     id = R.string.coupons
                                 ),

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/items/WooPosItemsScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/items/WooPosItemsScreen.kt
@@ -13,6 +13,7 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.lazy.LazyListState
 import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.material.ExperimentalMaterialApi
@@ -153,7 +154,13 @@ private fun MainItemsList(
 
                 is WooPosItemsViewState.Content -> MaterialTheme.colorScheme.onSurface
             }
-            ItemsToolbar(state.value, titleColor, onToolbarInfoIconClicked, onCouponsButtonClicked)
+            ItemsToolbar(
+                state = state.value,
+                titleColor = titleColor,
+                onToolbarInfoIconClicked = onToolbarInfoIconClicked,
+                onCouponsButtonClicked = onCouponsButtonClicked,
+                onSearchEvent = onSearchEvent,
+            )
 
             Spacer(modifier = Modifier.height(WooPosSpacing.Large.value))
 
@@ -168,10 +175,6 @@ private fun MainItemsList(
 
                         when (itemsState.search) {
                             is WooPosItemsViewState.Content.SearchState.Visible -> {
-                                WooPosSearchInput(
-                                    state = itemsState.search.state,
-                                    onEvent = onSearchEvent,
-                                )
                                 when (itemsState.search.state) {
                                     WooPosSearchInputState.Closed -> {
                                         WooPosItemList(
@@ -227,20 +230,20 @@ private fun MainItemsList(
         )
     }
 }
-
 @Composable
 private fun ItemsToolbar(
-    productViewState: WooPosItemsViewState,
+    state: WooPosItemsViewState,
     titleColor: Color,
     onToolbarInfoIconClicked: () -> Unit,
     onCouponsButtonClicked: () -> Unit,
+    onSearchEvent: (WooPosSearchUIEvent) -> Unit,
 ) {
     Row(
         modifier = Modifier
             .fillMaxWidth()
             .height(40.dp),
-        horizontalArrangement = Arrangement.SpaceBetween,
         verticalAlignment = Alignment.Top,
+        horizontalArrangement = Arrangement.SpaceBetween,
     ) {
         WooPosText(
             text = stringResource(id = R.string.woopos_products_screen_title),
@@ -248,43 +251,64 @@ private fun ItemsToolbar(
             fontWeight = FontWeight.Bold,
             color = titleColor,
         )
-        when (productViewState) {
-            is WooPosItemsViewState.Content -> {
-                if (productViewState.couponsEnabled) {
-                    Spacer(modifier = Modifier.weight(1f))
-                    IconButton(
-                        modifier = Modifier.size(40.dp),
-                        onClick = {
-                            onCouponsButtonClicked()
+
+        Row(
+            horizontalArrangement = Arrangement.End,
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+            when (state) {
+                is WooPosItemsViewState.Content -> {
+                    when (val searchState = state.search) {
+                        WooPosItemsViewState.Content.SearchState.Hidden -> Unit
+                        is WooPosItemsViewState.Content.SearchState.Visible -> {
+                            WooPosSearchInput(
+                                state = searchState.state,
+                                onEvent = onSearchEvent,
+                                modifier = Modifier.weight(1f)
+                            )
                         }
-                    ) {
-                        Icon(
-                            painterResource(id = R.drawable.ic_more_menu_coupons),
-                            contentDescription = stringResource(
-                                id = R.string.coupons
-                            ),
-                            tint = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.87f),
-                        )
+                    }
+
+                    if (state.couponsEnabled) {
+                        Spacer(modifier = Modifier.width(WooPosSpacing.Small.value))
+                        IconButton(
+                            modifier = Modifier.size(40.dp),
+                            onClick = {
+                                onCouponsButtonClicked()
+                            }
+                        ) {
+                            Icon(
+                                painterResource(id = R.drawable.ic_more_menu_coupons),
+                                contentDescription = stringResource(
+                                    id = R.string.coupons
+                                ),
+                                tint = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.87f),
+                            )
+                        }
+                    }
+
+                    if (state.bannerState.isBannerHiddenByUser) {
+                        Spacer(modifier = Modifier.width(WooPosSpacing.Small.value))
+                        IconButton(
+                            modifier = Modifier.size(40.dp),
+                            onClick = {
+                                onToolbarInfoIconClicked()
+                            }
+                        ) {
+                            Icon(
+                                painterResource(id = R.drawable.info),
+                                contentDescription = stringResource(
+                                    id = R.string.woopos_banner_simple_products_info_content_description
+                                ),
+                                tint = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.87f),
+                            )
+                        }
                     }
                 }
-                if (productViewState.bannerState.isBannerHiddenByUser) {
-                    IconButton(
-                        modifier = Modifier.size(40.dp),
-                        onClick = {
-                            onToolbarInfoIconClicked()
-                        }
-                    ) {
-                        Icon(
-                            painterResource(id = R.drawable.info),
-                            contentDescription = stringResource(
-                                id = R.string.woopos_banner_simple_products_info_content_description
-                            ),
-                            tint = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.87f),
-                        )
-                    }
-                }
-            }
-            else -> {
+
+                is WooPosItemsViewState.Empty,
+                is WooPosItemsViewState.Error,
+                is WooPosItemsViewState.Loading -> Unit
             }
         }
     }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/items/WooPosItemsScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/items/WooPosItemsScreen.kt
@@ -1,6 +1,9 @@
 package com.woocommerce.android.ui.woopos.home.items
 
 import androidx.compose.animation.AnimatedVisibility
+import androidx.compose.animation.core.tween
+import androidx.compose.animation.fadeIn
+import androidx.compose.animation.fadeOut
 import androidx.compose.animation.shrinkVertically
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
@@ -190,6 +193,7 @@ private fun MainItemsList(
                                             )
                                         }
                                     }
+
                                     is WooPosSearchInputState.Open -> WooPosItemsSearchScreen()
                                 }
                             }
@@ -230,6 +234,7 @@ private fun MainItemsList(
         )
     }
 }
+
 @Composable
 private fun ItemsToolbar(
     state: WooPosItemsViewState,
@@ -245,12 +250,22 @@ private fun ItemsToolbar(
         verticalAlignment = Alignment.Top,
         horizontalArrangement = Arrangement.SpaceBetween,
     ) {
-        WooPosText(
-            text = stringResource(id = R.string.woopos_products_screen_title),
-            style = WooPosTypography.Heading,
-            fontWeight = FontWeight.Bold,
-            color = titleColor,
-        )
+        val isSearchExpanded = state is WooPosItemsViewState.Content &&
+            state.search is WooPosItemsViewState.Content.SearchState.Visible &&
+            state.search.state is WooPosSearchInputState.Open
+
+        AnimatedVisibility(
+            visible = !isSearchExpanded,
+            enter = fadeIn(animationSpec = tween(150)),
+            exit = fadeOut(animationSpec = tween(150)),
+        ) {
+            WooPosText(
+                text = stringResource(id = R.string.woopos_products_screen_title),
+                style = WooPosTypography.Heading,
+                fontWeight = FontWeight.Bold,
+                color = titleColor,
+            )
+        }
 
         Row(
             horizontalArrangement = Arrangement.End,

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/items/WooPosItemsScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/items/WooPosItemsScreen.kt
@@ -1,7 +1,6 @@
 package com.woocommerce.android.ui.woopos.home.items
 
 import androidx.compose.animation.AnimatedVisibility
-import androidx.compose.animation.core.animateDpAsState
 import androidx.compose.animation.core.tween
 import androidx.compose.animation.fadeIn
 import androidx.compose.animation.fadeOut
@@ -21,6 +20,9 @@ import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.lazy.LazyListState
 import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.material.ExperimentalMaterialApi
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.outlined.Discount
+import androidx.compose.material.icons.outlined.Info
 import androidx.compose.material.pullrefresh.PullRefreshIndicator
 import androidx.compose.material.pullrefresh.PullRefreshState
 import androidx.compose.material.pullrefresh.pullRefresh
@@ -28,14 +30,13 @@ import androidx.compose.material.pullrefresh.rememberPullRefreshState
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.VerticalDivider
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.State
 import androidx.compose.runtime.collectAsState
-import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
@@ -249,22 +250,17 @@ private fun ItemsToolbar(
         state.search is WooPosItemsViewState.Content.SearchState.Visible &&
         state.search.state is WooPosSearchInputState.Open
 
-    val toolbarHeight by animateDpAsState(
-        targetValue = if (isSearchExpanded) 64.dp else 40.dp,
-        animationSpec = tween(150),
-        label = "toolbarHeight"
-    )
     Row(
         modifier = Modifier
             .fillMaxWidth()
-            .height(toolbarHeight),
+            .height(56.dp),
         verticalAlignment = Alignment.Top,
         horizontalArrangement = Arrangement.SpaceBetween,
     ) {
         AnimatedVisibility(
             visible = !isSearchExpanded,
-            enter = fadeIn(animationSpec = tween(150)),
-            exit = fadeOut(animationSpec = tween(150)),
+            enter = fadeIn(animationSpec = tween(200)),
+            exit = fadeOut(animationSpec = tween(200)),
         ) {
             WooPosText(
                 text = stringResource(id = R.string.woopos_products_screen_title),
@@ -276,7 +272,7 @@ private fun ItemsToolbar(
 
         Row(
             horizontalArrangement = Arrangement.End,
-            verticalAlignment = Alignment.CenterVertically,
+            verticalAlignment = Alignment.Top,
         ) {
             when (state) {
                 is WooPosItemsViewState.Content -> {
@@ -288,11 +284,19 @@ private fun ItemsToolbar(
                                 onEvent = onSearchEvent,
                                 modifier = Modifier.weight(1f)
                             )
+
+                            Spacer(modifier = Modifier.width(WooPosSpacing.Small.value))
+
+                            VerticalDivider(
+                                modifier = Modifier.padding(vertical = WooPosSpacing.Medium.value),
+                                thickness = 2.dp,
+                            )
+
+                            Spacer(modifier = Modifier.width(WooPosSpacing.Small.value))
                         }
                     }
 
                     if (state.couponsEnabled) {
-                        Spacer(modifier = Modifier.width(WooPosSpacing.Small.value))
                         IconButton(
                             modifier = Modifier.size(40.dp),
                             onClick = {
@@ -300,17 +304,18 @@ private fun ItemsToolbar(
                             }
                         ) {
                             Icon(
-                                painterResource(id = R.drawable.ic_more_menu_coupons),
+                                imageVector = Icons.Outlined.Discount,
                                 contentDescription = stringResource(
                                     id = R.string.coupons
                                 ),
                                 tint = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.87f),
+                                modifier = Modifier.size(32.dp)
                             )
                         }
+                        Spacer(modifier = Modifier.width(WooPosSpacing.Small.value))
                     }
 
                     if (state.bannerState.isBannerHiddenByUser) {
-                        Spacer(modifier = Modifier.width(WooPosSpacing.Small.value))
                         IconButton(
                             modifier = Modifier.size(40.dp),
                             onClick = {
@@ -318,11 +323,12 @@ private fun ItemsToolbar(
                             }
                         ) {
                             Icon(
-                                painterResource(id = R.drawable.info),
+                                imageVector = Icons.Outlined.Info,
                                 contentDescription = stringResource(
                                     id = R.string.woopos_banner_simple_products_info_content_description
                                 ),
                                 tint = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.87f),
+                                modifier = Modifier.size(32.dp)
                             )
                         }
                     }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/items/WooPosItemsScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/items/WooPosItemsScreen.kt
@@ -254,7 +254,7 @@ private fun ItemsToolbar(
         modifier = Modifier
             .fillMaxWidth()
             .height(56.dp),
-        verticalAlignment = Alignment.Top,
+        verticalAlignment = Alignment.CenterVertically,
         horizontalArrangement = Arrangement.SpaceBetween,
     ) {
         AnimatedVisibility(
@@ -272,7 +272,7 @@ private fun ItemsToolbar(
 
         Row(
             horizontalArrangement = Arrangement.End,
-            verticalAlignment = Alignment.Top,
+            verticalAlignment = Alignment.CenterVertically,
         ) {
             when (state) {
                 is WooPosItemsViewState.Content -> {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/items/WooPosItemsScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/items/WooPosItemsScreen.kt
@@ -288,8 +288,8 @@ private fun ItemsToolbar(
                             Spacer(modifier = Modifier.width(WooPosSpacing.Small.value))
 
                             VerticalDivider(
-                                modifier = Modifier.padding(vertical = WooPosSpacing.Medium.value),
-                                thickness = 2.dp,
+                                modifier = Modifier.padding(vertical = WooPosSpacing.Small.value),
+                                thickness = 1.dp,
                             )
 
                             Spacer(modifier = Modifier.width(WooPosSpacing.Small.value))
@@ -312,6 +312,13 @@ private fun ItemsToolbar(
                                 modifier = Modifier.size(32.dp)
                             )
                         }
+                        Spacer(modifier = Modifier.width(WooPosSpacing.Small.value))
+
+                        VerticalDivider(
+                            modifier = Modifier.padding(vertical = WooPosSpacing.Small.value),
+                            thickness = 1.dp,
+                        )
+
                         Spacer(modifier = Modifier.width(WooPosSpacing.Small.value))
                     }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/items/WooPosItemsScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/items/WooPosItemsScreen.kt
@@ -1,6 +1,7 @@
 package com.woocommerce.android.ui.woopos.home.items
 
 import androidx.compose.animation.AnimatedVisibility
+import androidx.compose.animation.core.animateDpAsState
 import androidx.compose.animation.core.tween
 import androidx.compose.animation.fadeIn
 import androidx.compose.animation.fadeOut
@@ -30,6 +31,7 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.State
 import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
@@ -243,17 +245,22 @@ private fun ItemsToolbar(
     onCouponsButtonClicked: () -> Unit,
     onSearchEvent: (WooPosSearchUIEvent) -> Unit,
 ) {
+    val isSearchExpanded = state is WooPosItemsViewState.Content &&
+        state.search is WooPosItemsViewState.Content.SearchState.Visible &&
+        state.search.state is WooPosSearchInputState.Open
+
+    val toolbarHeight by animateDpAsState(
+        targetValue = if (isSearchExpanded) 64.dp else 40.dp,
+        animationSpec = tween(150),
+        label = "toolbarHeight"
+    )
     Row(
         modifier = Modifier
             .fillMaxWidth()
-            .height(40.dp),
+            .height(toolbarHeight),
         verticalAlignment = Alignment.Top,
         horizontalArrangement = Arrangement.SpaceBetween,
     ) {
-        val isSearchExpanded = state is WooPosItemsViewState.Content &&
-            state.search is WooPosItemsViewState.Content.SearchState.Visible &&
-            state.search.state is WooPosSearchInputState.Open
-
         AnimatedVisibility(
             visible = !isSearchExpanded,
             enter = fadeIn(animationSpec = tween(150)),

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/items/search/WooPosItemsEmptySearchQueryState.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/items/search/WooPosItemsEmptySearchQueryState.kt
@@ -50,12 +50,7 @@ fun WooPosItemsEmptySearchQueryState(state: WooPosItemsSearchViewState.EmptySear
         Modifier
             .fillMaxHeight()
             .verticalScroll(scrollState)
-            .padding(
-                start = WooPosSpacing.None.value.toAdaptivePadding(),
-                end = WooPosSpacing.None.value.toAdaptivePadding(),
-                top = WooPosSpacing.Small.value.toAdaptivePadding(),
-                bottom = WooPosSpacing.None.value.toAdaptivePadding(),
-            )
+            .padding(WooPosSpacing.None.value.toAdaptivePadding())
     ) {
         if (state.popularItems.isNotEmpty() || state.recentSearches.isNotEmpty()) {
             Row(


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #13772
<!-- Id number of the GitHub issue this PR addresses. -->

<!-- 
━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
🛠 Need an AI review?  
Add a comment: `@coderabbitai review`
━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
-->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
The PR:
* Moves search to the toolbar to have more vertical space
* Change the icon of the coupons to use the standard one. Standard size and style
* I had to increase the height of the toolbar; otherwise, the input text does not fit. It makes all aligned I had to increase this in the cart, cash and emails

### Testing information
<!-- This is your opportunity to break out individual scenarios that need testing (when necessary) and/or include a checklist for the reviewer to go through. Consider documenting the following from your own completed testing: devices used, alternate workflows, edge cases, affected areas, critical flows, areas not tested, and any remaining unknowns. Provide feedback on this new section of the PR template through Sept 30, 2024 to Apps Quality; additional context here: p91TBi-b8z-p2#comment-12036 -->
**Important: validate that no changes done when SEARCH and COUPONS FFs are off.**

The only change is that the toolbars are bigger on 16 dp  no. Please let me know if it looks ok to you

With feature flags ON, validate that search, coupons and info banner works fine

### The tests that have been performed
<!-- To give the reviewer an idea of what could be missed in terms of testing -->
Above
### Images/gif
<!-- Include before and after images or gifs when appropriate. -->

https://github.com/user-attachments/assets/984354a0-4d12-4834-851f-a67ca51cb149

https://github.com/user-attachments/assets/57f4f5fd-d9fc-477c-bae3-a75f1e5d748b



- [ ] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.

## Reviewer (or Author, in the case of optional code reviews):

Please make sure these conditions are met before approving the PR, or request changes if the PR needs improvement:

- [x] The PR is small and has a clear, single focus, or a valid explanation is provided in the description. If needed, please request to split it into smaller PRs.
- [x] Ensure Adequate Unit Test Coverage: The changes are reasonably covered by unit tests or an explanation is provided in the PR description.
- [x] Manual Testing: The author listed all the tests they ran, including smoke tests when needed (e.g., for refactorings). The reviewer confirmed that the PR works as expected on big (tablet) and small (phone) in case of UI changes, and no regressions are added.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->