### PR TITLE
[Woo POS][Product Search][WOOMOB-230] Handle back press when search is active

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/common/composeui/component/WooPosSearchInput.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/common/composeui/component/WooPosSearchInput.kt
@@ -1,6 +1,7 @@
 package com.woocommerce.android.ui.woopos.common.composeui.component
 
 import android.annotation.SuppressLint
+import androidx.activity.compose.BackHandler
 import androidx.compose.animation.core.CubicBezierEasing
 import androidx.compose.animation.core.FastOutSlowInEasing
 import androidx.compose.animation.core.Transition
@@ -66,6 +67,11 @@ fun WooPosSearchInput(
     state: WooPosSearchInputState = WooPosSearchInputState.Closed,
     onEvent: (WooPosSearchUIEvent) -> Unit = {},
 ) {
+    BackHandler(
+        enabled = state is WooPosSearchInputState.Open,
+        onBack = { onEvent(WooPosSearchUIEvent.Close) }
+    )
+
     Row(
         modifier = modifier
             .fillMaxWidth()
@@ -196,6 +202,7 @@ private fun AnimatedSearchInput(
                                 .alpha(iconAlpha)
                         )
                     }
+
                     query.isNotEmpty() -> {
                         IconButton(
                             onClick = {
@@ -315,6 +322,7 @@ sealed class WooPosSearchInputState {
             data class Hint(val hint: String) : Input(hint)
         }
     }
+
     object Closed : WooPosSearchInputState()
 }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/items/navigation/WooPosItemsScreens.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/items/navigation/WooPosItemsScreens.kt
@@ -46,4 +46,3 @@ fun WooPosItemsScreens(
         }
     }
 }
-

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/items/navigation/WooPosItemsScreens.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/items/navigation/WooPosItemsScreens.kt
@@ -8,7 +8,6 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
 import androidx.compose.ui.Modifier
 import androidx.hilt.navigation.compose.hiltViewModel
-import com.woocommerce.android.ui.woopos.home.items.WooPosItemNavigationData.VariableProductData
 import com.woocommerce.android.ui.woopos.home.items.WooPosItemsScreen
 import com.woocommerce.android.ui.woopos.home.items.variations.WooPosVariationsScreen
 import kotlinx.coroutines.flow.StateFlow
@@ -37,9 +36,9 @@ fun WooPosItemsScreens(
                 }
 
                 is WooPosItemsScreenViewModel.ItemsScreens.VariationsScreen -> {
-                    NavigateToVariationsScreen(
-                        variableProductData = navigationState.product,
+                    WooPosVariationsScreen(
                         modifier = modifier,
+                        variableProductData = navigationState.product,
                         onBackClicked = { onNavigateToItemsListScreen() }
                     )
                 }
@@ -48,15 +47,3 @@ fun WooPosItemsScreens(
     }
 }
 
-@Composable
-private fun NavigateToVariationsScreen(
-    variableProductData: VariableProductData,
-    modifier: Modifier,
-    onBackClicked: () -> Unit,
-) {
-    WooPosVariationsScreen(
-        modifier,
-        variableProductData,
-        onBackClicked = onBackClicked
-    )
-}


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: WOOMOB-230
<!-- Id number of the GitHub issue this PR addresses. -->

<!-- 
━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
🛠 Need an AI review?  
Add a comment: `@coderabbitai review`
━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
-->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
The PR adds system back handling when search is open. It'll close the search first

### Steps to reproduce
<!-- Step-by-step testing instructions. For new user flows, consider instead stating the goal of the workflow and see if your PR reviewer can accomplish the workflow without specific steps! -->
* Open POS
* Open Search
* Use system back

### The tests that have been performed
<!-- To give the reviewer an idea of what could be missed in terms of testing -->
Aboce

### Images/gif
<!-- Include before and after images or gifs when appropriate. -->

https://github.com/user-attachments/assets/89c221b1-2d8b-473a-a944-7016d55db878

- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.

## Reviewer (or Author, in the case of optional code reviews):

Please make sure these conditions are met before approving the PR, or request changes if the PR needs improvement:

- [x] The PR is small and has a clear, single focus, or a valid explanation is provided in the description. If needed, please request to split it into smaller PRs.
- [x] Ensure Adequate Unit Test Coverage: The changes are reasonably covered by unit tests or an explanation is provided in the PR description.
- [x] Manual Testing: The author listed all the tests they ran, including smoke tests when needed (e.g., for refactorings). The reviewer confirmed that the PR works as expected on big (tablet) and small (phone) in case of UI changes, and no regressions are added.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->