### PR TITLE
[WOOMOB-252][Woo POS][Product search] Home state mismatch after search

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/common/composeui/component/WooPosSearchInput.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/common/composeui/component/WooPosSearchInput.kt
@@ -110,6 +110,7 @@ fun SearchButton(onEvent: (WooPosSearchUIEvent) -> Unit) {
         )
     }
 }
+
 @SuppressLint("UnusedBoxWithConstraintsScope")
 @Composable
 private fun AnimatedSearchInput(

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/common/composeui/component/WooPosSearchInput.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/common/composeui/component/WooPosSearchInput.kt
@@ -110,7 +110,6 @@ fun SearchButton(onEvent: (WooPosSearchUIEvent) -> Unit) {
         )
     }
 }
-
 @SuppressLint("UnusedBoxWithConstraintsScope")
 @Composable
 private fun AnimatedSearchInput(
@@ -123,9 +122,9 @@ private fun AnimatedSearchInput(
     ) {
         val maxWidthPx = maxWidth
         val focusRequester = remember { FocusRequester() }
-        var isExpanded by remember { mutableStateOf(false) }
+        var isExpanded by remember { mutableStateOf(state.hasAnimationPlayed) }
         var isClosing by remember { mutableStateOf(false) }
-        var isAnimationComplete by remember { mutableStateOf(false) }
+        var isAnimationComplete by remember { mutableStateOf(state.hasAnimationPlayed) }
 
         val transition = updateTransition(
             targetState = if (isClosing) false else isExpanded,
@@ -218,10 +217,16 @@ private fun AnimatedSearchInput(
         )
 
         LaunchedEffect(Unit) {
-            isExpanded = true
-            delay(ANIMATION_TIME)
-            isAnimationComplete = true
-            focusRequester.requestFocus()
+            if (!state.hasAnimationPlayed) {
+                isExpanded = true
+                delay(ANIMATION_TIME)
+                isAnimationComplete = true
+                focusRequester.requestFocus()
+                onEvent(WooPosSearchUIEvent.AnimationComplete)
+            } else if (!isAnimationComplete) {
+                isExpanded = true
+                isAnimationComplete = true
+            }
         }
 
         LaunchedEffect(isClosing) {
@@ -308,7 +313,8 @@ private fun animateIconAlpha(
 sealed class WooPosSearchInputState {
     data class Open(
         val input: Input,
-        val isLoading: Boolean
+        val isLoading: Boolean,
+        val hasAnimationPlayed: Boolean = false,
     ) : WooPosSearchInputState() {
         sealed class Input(val text: String) {
             data class Query(val query: String) : Input(query)
@@ -322,6 +328,7 @@ sealed class WooPosSearchUIEvent {
     object Clear : WooPosSearchUIEvent()
     data class Search(val query: String) : WooPosSearchUIEvent()
     object Close : WooPosSearchUIEvent()
+    object AnimationComplete : WooPosSearchUIEvent()
 }
 
 @WooPosPreview

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/common/composeui/component/WooPosSearchInput.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/common/composeui/component/WooPosSearchInput.kt
@@ -123,9 +123,9 @@ private fun AnimatedSearchInput(
     ) {
         val maxWidthPx = maxWidth
         val focusRequester = remember { FocusRequester() }
+
         var isExpanded by remember { mutableStateOf(state.hasAnimationPlayed) }
         var isClosing by remember { mutableStateOf(false) }
-        var isAnimationComplete by remember { mutableStateOf(state.hasAnimationPlayed) }
 
         val transition = updateTransition(
             targetState = if (isClosing) false else isExpanded,
@@ -144,9 +144,7 @@ private fun AnimatedSearchInput(
         OutlinedTextField(
             value = query,
             onValueChange = {
-                if (isAnimationComplete) {
-                    onEvent(WooPosSearchUIEvent.Search(it))
-                }
+                onEvent(WooPosSearchUIEvent.Search(it))
             },
             modifier = Modifier
                 .width(width)
@@ -164,9 +162,7 @@ private fun AnimatedSearchInput(
             shape = RoundedCornerShape(cornerRadius),
             keyboardActions = KeyboardActions(
                 onSearch = {
-                    if (isAnimationComplete) {
-                        onEvent(WooPosSearchUIEvent.Search(query))
-                    }
+                    onEvent(WooPosSearchUIEvent.Search(query))
                 }
             ),
             colors = OutlinedTextFieldDefaults.colors(
@@ -198,11 +194,7 @@ private fun AnimatedSearchInput(
                     }
                     query.isNotEmpty() -> {
                         IconButton(
-                            onClick = {
-                                if (isAnimationComplete) {
-                                    onEvent(WooPosSearchUIEvent.Clear)
-                                }
-                            },
+                            onClick = { onEvent(WooPosSearchUIEvent.Clear) },
                             modifier = Modifier.alpha(iconAlpha)
                         ) {
                             Icon(
@@ -221,18 +213,13 @@ private fun AnimatedSearchInput(
             if (!state.hasAnimationPlayed) {
                 isExpanded = true
                 delay(ANIMATION_TIME)
-                isAnimationComplete = true
                 focusRequester.requestFocus()
                 onEvent(WooPosSearchUIEvent.AnimationComplete)
-            } else if (!isAnimationComplete) {
-                isExpanded = true
-                isAnimationComplete = true
             }
         }
 
         LaunchedEffect(isClosing) {
             if (isClosing) {
-                isAnimationComplete = false
                 delay(ANIMATION_TIME)
                 onEvent(WooPosSearchUIEvent.Close)
             }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/items/WooPosItemsScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/items/WooPosItemsScreen.kt
@@ -104,6 +104,9 @@ private fun WooPosItemsScreen(
                 WooPosSearchUIEvent.Clear -> onUIEvent(WooPosItemsUIEvent.ClearSearchClicked)
                 WooPosSearchUIEvent.Close -> onUIEvent(WooPosItemsUIEvent.CloseSearchClicked)
                 is WooPosSearchUIEvent.Search -> onUIEvent(SearchChanged(it.query))
+                is WooPosSearchUIEvent.AnimationComplete -> {
+                    onUIEvent(WooPosItemsUIEvent.SearchAnimationComplete)
+                }
             }
         },
         onCouponsButtonClicked = { onUIEvent(WooPosItemsUIEvent.CouponsButtonClicked) },

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/items/WooPosItemsSearchHelper.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/items/WooPosItemsSearchHelper.kt
@@ -63,12 +63,14 @@ class WooPosItemsSearchHelper @Inject constructor(
         if (newQuery.isEmpty()) {
             updateToInitialOpenState()
         } else {
+            val currentOpenState = getCurrentSearchOpenState() ?: return
             updateSearchState(
                 currentState.copy(
                     search = WooPosItemsViewState.Content.SearchState.Visible(
                         state = WooPosSearchInputState.Open(
                             input = WooPosSearchInputState.Open.Input.Query(newQuery),
                             isLoading = false,
+                            hasAnimationPlayed = currentOpenState.hasAnimationPlayed
                         )
                     )
                 )
@@ -96,6 +98,22 @@ class WooPosItemsSearchHelper @Inject constructor(
         updateToInitialOpenState()
     }
 
+    fun onAnimationComplete() {
+        val currentState = getCurrentContentState() ?: return
+        val searchState = getCurrentSearchVisibleState() ?: return
+        val openState = getCurrentSearchOpenState() ?: return
+
+        updateSearchState(
+            currentState.copy(
+                search = searchState.copy(
+                    state = openState.copy(
+                        hasAnimationPlayed = true
+                    )
+                )
+            )
+        )
+    }
+
     fun isSearchOpen(): Boolean {
         val searchState = getCurrentSearchVisibleState() ?: return false
         return searchState.state is WooPosSearchInputState.Open
@@ -111,6 +129,7 @@ class WooPosItemsSearchHelper @Inject constructor(
                             resourceProvider.getString(R.string.woopos_search_products)
                         ),
                         isLoading = false,
+                        hasAnimationPlayed = false
                     )
                 )
             )
@@ -137,7 +156,7 @@ class WooPosItemsSearchHelper @Inject constructor(
             currentState.copy(
                 search = searchState.copy(
                     state = searchStateValue.copy(
-                        isLoading = isLoading,
+                        isLoading = isLoading
                     )
                 )
             )

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/items/WooPosItemsSearchHelper.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/items/WooPosItemsSearchHelper.kt
@@ -98,6 +98,7 @@ class WooPosItemsSearchHelper @Inject constructor(
         updateToInitialOpenState()
     }
 
+    @Suppress("ReturnCount")
     fun onAnimationComplete() {
         val currentState = getCurrentContentState() ?: return
         val searchState = getCurrentSearchVisibleState() ?: return

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/items/WooPosItemsSearchHelper.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/items/WooPosItemsSearchHelper.kt
@@ -40,10 +40,12 @@ class WooPosItemsSearchHelper @Inject constructor(
                     ParentToChildrenEvent.SearchEvent.Finished -> {
                         updateLoadingState(isLoading = false)
                     }
+                    is ParentToChildrenEvent.OrderSuccessfullyPaid -> {
+                        onCloseSearchClicked()
+                    }
 
                     is ParentToChildrenEvent.BackFromCheckoutToCartClicked -> Unit
                     is ParentToChildrenEvent.ItemClickedInProductSelector -> Unit
-                    is ParentToChildrenEvent.OrderSuccessfullyPaid -> Unit
                     is ParentToChildrenEvent.CheckoutClicked -> Unit
                     is ParentToChildrenEvent.SearchEvent.ChangedQuery -> Unit
                 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/items/WooPosItemsUIEvent.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/items/WooPosItemsUIEvent.kt
@@ -14,4 +14,5 @@ sealed class WooPosItemsUIEvent {
     data object ClearSearchClicked : WooPosItemsUIEvent()
     data class SearchChanged(val query: String) : WooPosItemsUIEvent()
     data object CloseSearchClicked : WooPosItemsUIEvent()
+    object SearchAnimationComplete : WooPosItemsUIEvent()
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/items/WooPosItemsViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/items/WooPosItemsViewModel.kt
@@ -114,6 +114,7 @@ class WooPosItemsViewModel @Inject constructor(
             WooPosItemsUIEvent.ClearSearchClicked -> searchHelper.onClearSearchClicked()
             WooPosItemsUIEvent.CloseSearchClicked -> searchHelper.onCloseSearchClicked()
             is WooPosItemsUIEvent.SearchChanged -> searchHelper.onSearchChanged(event.query)
+            WooPosItemsUIEvent.SearchAnimationComplete -> searchHelper.onAnimationComplete()
 
             WooPosItemsUIEvent.CouponsButtonClicked -> {
                 sendEventToParent(

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/home/items/WooPosItemsSearchHelperTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/home/items/WooPosItemsSearchHelperTest.kt
@@ -140,20 +140,21 @@ class WooPosItemsSearchHelperTest {
     }
 
     @Test
-    fun `given search with query, when onClearSearchClicked called, then resets to initial open state with hint`() = runTest {
-        // GIVEN
-        searchHelper.initialize(this, viewStateFlow)
-        searchHelper.onSearchChanged("initial query")
+    fun `given search with query, when onClearSearchClicked called, then resets to initial open state with hint`() =
+        runTest {
+            // GIVEN
+            searchHelper.initialize(this, viewStateFlow)
+            searchHelper.onSearchChanged("initial query")
 
-        // WHEN
-        searchHelper.onClearSearchClicked()
+            // WHEN
+            searchHelper.onClearSearchClicked()
 
-        // THEN
-        val currentState = viewStateFlow.value as WooPosItemsViewState.Content
-        val searchState = currentState.search as WooPosItemsViewState.Content.SearchState.Visible
-        val openState = searchState.state as WooPosSearchInputState.Open
-        assertThat(openState.input).isInstanceOf(WooPosSearchInputState.Open.Input.Hint::class.java)
-    }
+            // THEN
+            val currentState = viewStateFlow.value as WooPosItemsViewState.Content
+            val searchState = currentState.search as WooPosItemsViewState.Content.SearchState.Visible
+            val openState = searchState.state as WooPosSearchInputState.Open
+            assertThat(openState.input).isInstanceOf(WooPosSearchInputState.Open.Input.Hint::class.java)
+        }
 
     @Test
     fun `given search event started, when received, then updates loading state to true`() = runTest {
@@ -251,5 +252,80 @@ class WooPosItemsSearchHelperTest {
         // THEN
         val currentState = viewStateFlow.value as WooPosItemsViewState.Content
         assertThat(currentState.pullToRefreshState).isEqualTo(WooPosPullToRefreshState.Enabled)
+    }
+
+    @Test
+    fun `when animation completes, then hasAnimationPlayed flag is set to true`() = runTest {
+        // GIVEN
+        searchHelper.initialize(this, viewStateFlow)
+
+        // WHEN
+        searchHelper.onAnimationComplete()
+
+        // THEN
+        val currentState = viewStateFlow.value as WooPosItemsViewState.Content
+        val searchState = currentState.search as WooPosItemsViewState.Content.SearchState.Visible
+        val openState = searchState.state as WooPosSearchInputState.Open
+        assertThat(openState.hasAnimationPlayed).isTrue
+    }
+
+    @Test
+    fun `given animation completed, when search changed, then hasAnimationPlayed is preserved`() = runTest {
+        // GIVEN
+        searchHelper.initialize(this, viewStateFlow)
+        searchHelper.onAnimationComplete()
+
+        // WHEN
+
+        searchHelper.onSearchChanged("test")
+        advanceUntilIdle()
+
+        // THEN
+        val afterReopenState = viewStateFlow.value as WooPosItemsViewState.Content
+        val afterReopenSearchState = afterReopenState.search as WooPosItemsViewState.Content.SearchState.Visible
+        assertThat(afterReopenSearchState.state).isInstanceOf(WooPosSearchInputState.Open::class.java)
+
+        val openState = afterReopenSearchState.state as WooPosSearchInputState.Open
+        assertThat(openState.hasAnimationPlayed).isTrue
+    }
+
+    @Test
+    fun `given animation has played, when onClearSearchClicked, then hasAnimationPlayed is false`() = runTest {
+        // GIVEN
+        searchHelper.initialize(this, viewStateFlow)
+
+        searchHelper.onAnimationComplete()
+
+        // WHEN
+        searchHelper.onClearSearchClicked()
+
+        // THEN
+        val currentState = viewStateFlow.value as WooPosItemsViewState.Content
+        val searchState = currentState.search as WooPosItemsViewState.Content.SearchState.Visible
+        val openState = searchState.state as WooPosSearchInputState.Open
+        assertThat(openState.hasAnimationPlayed).isFalse
+    }
+
+    @Test
+    fun `given animation complete, when order successful paid, then state is closed`() = runTest {
+        // GIVEN
+        searchHelper.initialize(this, viewStateFlow)
+        searchHelper.onAnimationComplete()
+
+        // WHEN
+        whenever(mockParentToChildrenEventReceiver.events).thenReturn(
+            flowOf(
+                ParentToChildrenEvent.OrderSuccessfullyPaid(
+                    ParentToChildrenEvent.OrderSuccessfullyPaid.PaymentMethod.CARD
+                )
+            )
+        )
+        searchHelper.initialize(this, viewStateFlow)
+        advanceUntilIdle()
+
+        // THEN
+        val currentState = viewStateFlow.value as WooPosItemsViewState.Content
+        val searchState = currentState.search as WooPosItemsViewState.Content.SearchState.Visible
+        assertThat(searchState.state).isInstanceOf(WooPosSearchInputState.Closed::class.java)
     }
 }


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: WOOMOB-252
<!-- Id number of the GitHub issue this PR addresses. -->

<!-- 
━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
🛠 Need an AI review?  
Add a comment: `@coderabbitai review`
━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
-->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
The PR:
* Hides search when order has been paid
* Fixes issue with animation being played everytime we are coming from another screen or composable, for instance from Variations

### Steps to reproduce
<!-- Step-by-step testing instructions. For new user flows, consider instead stating the goal of the workflow and see if your PR reviewer can accomplish the workflow without specific steps! -->
* Open POS + Search
* Find variation + open it
* Go back and notice search animation played again 
* The same with "new order" after an order being paid

### The tests that have been performed
<!-- To give the reviewer an idea of what could be missed in terms of testing -->
Above

### Images/gif
<!-- Include before and after images or gifs when appropriate. -->

https://github.com/user-attachments/assets/5f55f542-010e-407e-89b5-a76360dbcdaf


- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.

## Reviewer (or Author, in the case of optional code reviews):

Please make sure these conditions are met before approving the PR, or request changes if the PR needs improvement:

- [x] The PR is small and has a clear, single focus, or a valid explanation is provided in the description. If needed, please request to split it into smaller PRs.
- [x] Ensure Adequate Unit Test Coverage: The changes are reasonably covered by unit tests or an explanation is provided in the PR description.
- [x] Manual Testing: The author listed all the tests they ran, including smoke tests when needed (e.g., for refactorings). The reviewer confirmed that the PR works as expected on big (tablet) and small (phone) in case of UI changes, and no regressions are added.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->