### PR TITLE
[Crash][WOOMOB-264] Crash when order currency is not correct

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -3,6 +3,7 @@
 *** For entries which are touching the Android Wear app's, start entry with `[WEAR]` too.
 22.2
 -----
+- [*] Fixed rear crash related to currency formatting [https://github.com/woocommerce/woocommerce-android/pull/13899]
 
 
 22.1

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/cardreader/CardReaderPaymentsUtilsModule.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/cardreader/CardReaderPaymentsUtilsModule.kt
@@ -1,5 +1,6 @@
 package com.woocommerce.android.ui.payments.cardreader
 
+import com.woocommerce.android.cardreader.LogWrapper
 import com.woocommerce.android.cardreader.internal.payments.PaymentUtils
 import dagger.Module
 import dagger.Provides
@@ -10,5 +11,5 @@ import dagger.hilt.components.SingletonComponent
 @Module
 class CardReaderPaymentsUtilsModule {
     @Provides
-    fun providePaymentsUtils() = PaymentUtils
+    fun providePaymentsUtils(logWrapper: LogWrapper) = PaymentUtils(logWrapper)
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/util/SiteIndependentCurrencyFormatter.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/util/SiteIndependentCurrencyFormatter.kt
@@ -1,5 +1,6 @@
 package com.woocommerce.android.util
 
+import com.automattic.android.tracks.crashlogging.CrashLogging
 import com.woocommerce.android.util.locale.LocaleProvider
 import java.text.NumberFormat
 import java.util.Currency
@@ -8,6 +9,7 @@ import javax.inject.Inject
 
 class SiteIndependentCurrencyFormatter @Inject constructor(
     private val localeProvider: LocaleProvider,
+    private val crashLogging: CrashLogging,
 ) {
     /**
      * Returns formatted amount with currency symbol - eg. $113.5 for EN/USD or 113,5€ for FR/EUR.
@@ -15,10 +17,19 @@ class SiteIndependentCurrencyFormatter @Inject constructor(
     fun formatAmountWithCurrency(amount: Double, currencyCode: String): String {
         val locale = localeProvider.provideLocale() ?: Locale.getDefault()
         val formatter = NumberFormat.getCurrencyInstance(locale)
-        formatter.currency = if (currencyCode.isEmpty()) {
+
+        formatter.currency = try {
+            if (currencyCode.isEmpty()) {
+                Currency.getInstance(locale)
+            } else {
+                Currency.getInstance(currencyCode)
+            }
+        } catch (e: IllegalArgumentException) {
+            crashLogging.sendReport(
+                exception = e,
+                message = "Invalid currency code: $currencyCode"
+            )
             Currency.getInstance(locale)
-        } else {
-            Currency.getInstance(currencyCode)
         }
         return formatter.format(amount)
     }

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/util/DefaultCurrencyFormatterTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/util/DefaultCurrencyFormatterTest.kt
@@ -1,5 +1,6 @@
 package com.woocommerce.android.util
 
+import com.automattic.android.tracks.crashlogging.CrashLogging
 import com.woocommerce.android.tools.SelectedSite
 import com.woocommerce.android.util.locale.LocaleProvider
 import com.woocommerce.android.viewmodel.BaseUnitTest
@@ -29,8 +30,9 @@ class DefaultCurrencyFormatterTest : BaseUnitTest() {
     private val localeProvider: LocaleProvider = mock()
     private val wcStore: WooCommerceStore = mock()
     private val selectedSite: SelectedSite = mock()
+    private val crashLogging: CrashLogging = mock()
     private val siteIndependentCurrencyFormatter: SiteIndependentCurrencyFormatter =
-        SiteIndependentCurrencyFormatter(localeProvider)
+        SiteIndependentCurrencyFormatter(localeProvider, crashLogging)
 
     @Test
     fun `when the selected site changes the default currency code updates`() =

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/util/SiteIndependentCurrencyFormatterTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/util/SiteIndependentCurrencyFormatterTest.kt
@@ -1,5 +1,6 @@
 package com.woocommerce.android.util
 
+import com.automattic.android.tracks.crashlogging.CrashLogging
 import com.woocommerce.android.util.locale.LocaleProvider
 import com.woocommerce.android.viewmodel.BaseUnitTest
 import kotlinx.coroutines.ExperimentalCoroutinesApi
@@ -12,9 +13,11 @@ import java.util.Locale
 @ExperimentalCoroutinesApi
 class SiteIndependentCurrencyFormatterTest : BaseUnitTest() {
     private val localeProvider: LocaleProvider = mock()
+    private val crashLogging: CrashLogging = mock()
 
     private val currencyFormatter: SiteIndependentCurrencyFormatter = SiteIndependentCurrencyFormatter(
-        localeProvider
+        localeProvider,
+        crashLogging
     )
 
     @Test

--- a/libs/cardreader/src/main/java/com/woocommerce/android/cardreader/CardReaderManagerFactory.kt
+++ b/libs/cardreader/src/main/java/com/woocommerce/android/cardreader/CardReaderManagerFactory.kt
@@ -41,6 +41,7 @@ object CardReaderManagerFactory {
         )
         val terminalListener = TerminalListenerImpl(logWrapper)
         val cardReaderConfigFactory = CardReaderConfigFactory()
+        val paymentUtils = PaymentUtils(logWrapper)
 
         return CardReaderManagerImpl(
             application,
@@ -55,12 +56,12 @@ object CardReaderManagerFactory {
                     terminal,
                     logWrapper,
                     cardReaderConfigFactory,
-                    PaymentUtils
+                    paymentUtils,
                 ),
                 CollectPaymentAction(terminal, logWrapper),
                 ProcessPaymentAction(terminal, logWrapper),
                 CancelPaymentAction(terminal),
-                PaymentUtils,
+                paymentUtils,
                 PaymentErrorMapper(),
                 cardReaderConfigFactory
             ),
@@ -68,7 +69,7 @@ object CardReaderManagerFactory {
                 CollectInteracRefundAction(terminal),
                 ProcessInteracRefundAction(terminal),
                 RefundErrorMapper(),
-                PaymentUtils
+                paymentUtils,
             ),
             ConnectionManager(
                 terminal,

--- a/libs/cardreader/src/main/java/com/woocommerce/android/cardreader/internal/payments/PaymentUtils.kt
+++ b/libs/cardreader/src/main/java/com/woocommerce/android/cardreader/internal/payments/PaymentUtils.kt
@@ -1,11 +1,13 @@
 package com.woocommerce.android.cardreader.internal.payments
 
+import com.woocommerce.android.cardreader.LogWrapper
 import com.woocommerce.android.cardreader.config.CardReaderConfigForSupportedCountry
+import com.woocommerce.android.cardreader.internal.LOG_TAG
 import java.math.BigDecimal
 import java.math.RoundingMode
 import java.util.Currency
 
-object PaymentUtils {
+class PaymentUtils(private val logWrapper: LogWrapper) {
     fun isSupportedCurrency(
         currency: String,
         cardReaderConfigFor: CardReaderConfigForSupportedCountry
@@ -15,8 +17,19 @@ object PaymentUtils {
     )
 
     fun convertToSmallestCurrencyUnit(value: BigDecimal, currencyCode: String): Long {
-        val currencyObj = Currency.getInstance(currencyCode)
-        val smallestCurrencyUnit = BigDecimal.TEN.pow(currencyObj.defaultFractionDigits)
-        return value.multiply(smallestCurrencyUnit).setScale(0, RoundingMode.HALF_UP).toLong()
+        return try {
+            val currencyObj = Currency.getInstance(currencyCode)
+            val smallestCurrencyUnit = BigDecimal.TEN.pow(currencyObj.defaultFractionDigits)
+            value.multiply(smallestCurrencyUnit).setScale(0, RoundingMode.HALF_UP).toLong()
+        } catch (e: IllegalArgumentException) {
+            logWrapper.e(
+                LOG_TAG,
+                "Failed to convert to smallest currency unit for currency code: $currencyCode. " +
+                    "value: $value. Exception: ${e.message}"
+            )
+            val fallbackScale = 2
+            val fallbackSmallestUnit = BigDecimal.TEN.pow(fallbackScale)
+            value.multiply(fallbackSmallestUnit).setScale(0, RoundingMode.HALF_UP).toLong()
+        }
     }
 }

--- a/libs/cardreader/src/test/java/com/woocommerce/android/cardreader/internal/payments/PaymentUtilsTest.kt
+++ b/libs/cardreader/src/test/java/com/woocommerce/android/cardreader/internal/payments/PaymentUtilsTest.kt
@@ -1,11 +1,16 @@
 package com.woocommerce.android.cardreader.internal.payments
 
+import com.woocommerce.android.cardreader.LogWrapper
 import com.woocommerce.android.cardreader.config.CardReaderConfigForCanada
+import com.woocommerce.android.cardreader.config.CardReaderConfigForSupportedCountry
 import com.woocommerce.android.cardreader.config.CardReaderConfigForUSA
 import com.woocommerce.android.cardreader.internal.CardReaderBaseUnitTest
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import org.assertj.core.api.Assertions.assertThat
+import org.junit.Before
 import org.junit.Test
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.whenever
 import java.math.BigDecimal
 
 private const val NONE_USD_CURRENCY = "CZK"
@@ -13,7 +18,14 @@ private const val USD_CURRENCY = "USD"
 
 @ExperimentalCoroutinesApi
 class PaymentUtilsTest : CardReaderBaseUnitTest() {
-    private val paymentUtils = PaymentUtils
+    private lateinit var paymentUtils: PaymentUtils
+    private lateinit var mockLogWrapper: LogWrapper
+
+    @Before
+    fun setup() {
+        mockLogWrapper = mock()
+        paymentUtils = PaymentUtils(mockLogWrapper)
+    }
 
     @Test
     fun `given two decimal currency, given supported country, when not supported currency invoked, then false returned`() =
@@ -29,6 +41,28 @@ class PaymentUtilsTest : CardReaderBaseUnitTest() {
             val result = paymentUtils.isSupportedCurrency(USD_CURRENCY, CardReaderConfigForUSA)
 
             assertThat(result).isTrue()
+        }
+
+    @Test
+    fun `given case difference, when is currency supported invoked, then true returned`() =
+        testBlocking {
+            val mockConfig = mock<CardReaderConfigForSupportedCountry>()
+            whenever(mockConfig.currency).thenReturn("USD")
+
+            val result = paymentUtils.isSupportedCurrency("usd", mockConfig)
+
+            assertThat(result).isTrue()
+        }
+
+    @Test
+    fun `given empty currency, when is currency supported invoked, then false returned`() =
+        testBlocking {
+            val mockConfig = mock<CardReaderConfigForSupportedCountry>()
+            whenever(mockConfig.currency).thenReturn("USD")
+
+            val result = paymentUtils.isSupportedCurrency("", mockConfig)
+
+            assertThat(result).isFalse()
         }
 
     @Test
@@ -139,6 +173,58 @@ class PaymentUtilsTest : CardReaderBaseUnitTest() {
         )
 
         assertThat(result).isEqualTo(100000)
+    }
+
+    @Test
+    fun `given negative amount, when converting to smallest unit, then correct negative value returned`() {
+        val result = paymentUtils.convertToSmallestCurrencyUnit(
+            BigDecimal("-10.50"),
+            TWO_DECIMAL_CURRENCY_CODE,
+        )
+
+        assertThat(result).isEqualTo(-1050)
+    }
+
+    @Test
+    fun `given zero amount, when converting to smallest unit, then zero returned`() {
+        val result = paymentUtils.convertToSmallestCurrencyUnit(
+            BigDecimal.ZERO,
+            TWO_DECIMAL_CURRENCY_CODE,
+        )
+
+        assertThat(result).isEqualTo(0)
+    }
+
+    @Test
+    fun `given very small amount, when converting to smallest unit, then correct value returned`() {
+        val result = paymentUtils.convertToSmallestCurrencyUnit(
+            BigDecimal("0.01"),
+            TWO_DECIMAL_CURRENCY_CODE,
+        )
+
+        assertThat(result).isEqualTo(1)
+    }
+
+    @Test
+    fun `given large amount, when converting to smallest unit, then correct value returned`() {
+        val result = paymentUtils.convertToSmallestCurrencyUnit(
+            BigDecimal("9999.99"),
+            TWO_DECIMAL_CURRENCY_CODE,
+        )
+
+        assertThat(result).isEqualTo(999999)
+    }
+
+    @Test
+    fun `given invalid currency code, when converting to smallest unit, then fallback mechanism used`() {
+        val invalidCurrencyCode = "INVALID"
+
+        val result = paymentUtils.convertToSmallestCurrencyUnit(
+            BigDecimal("10.50"),
+            invalidCurrencyCode
+        )
+
+        assertThat(result).isEqualTo(1050)
     }
 
     private companion object {


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: WOOMOB-264
<!-- Id number of the GitHub issue this PR addresses. -->

<!-- 
━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
🛠 Need an AI review?  
Add a comment: `@coderabbitai review`
━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
-->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
The PR addresses crashes in Sentry related to currency formatting. We can not reproduce this issue, but the assumption is that the backend, in some cases, returns something other than the formatted country code. The approach is not to crash in this case by providing a sensible default and logging the incident.

peaMlT-1bn-p2#comment-3009

### Testing information
<!-- This is your opportunity to break out individual scenarios that need testing (when necessary) and/or include a checklist for the reviewer to go through. Consider documenting the following from your own completed testing: devices used, alternate workflows, edge cases, affected areas, critical flows, areas not tested, and any remaining unknowns. Provide feedback on this new section of the PR template through Sept 30, 2024 to Apps Quality; additional context here: p91TBi-b8z-p2#comment-12036 -->
I don't know how to reproduce this, so I just put break point on the changed methods and made them to be invoked to be sure that there is no regression

### Images/gif
<!-- Include before and after images or gifs when appropriate. -->

- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.

## Reviewer (or Author, in the case of optional code reviews):

Please make sure these conditions are met before approving the PR, or request changes if the PR needs improvement:

- [x] The PR is small and has a clear, single focus, or a valid explanation is provided in the description. If needed, please request to split it into smaller PRs.
- [x] Ensure Adequate Unit Test Coverage: The changes are reasonably covered by unit tests or an explanation is provided in the PR description.
- [x] Manual Testing: The author listed all the tests they ran, including smoke tests when needed (e.g., for refactorings). The reviewer confirmed that the PR works as expected on big (tablet) and small (phone) in case of UI changes, and no regressions are added.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->