### PR TITLE
[Shipping Labels] Simplify and improve tab animation when changing pages in packages screen

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/packages/WooShippingLabelPackageCreationScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/packages/WooShippingLabelPackageCreationScreen.kt
@@ -1,6 +1,5 @@
 package com.woocommerce.android.ui.orders.wooshippinglabels.packages
 
-import androidx.compose.foundation.ExperimentalFoundationApi
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
@@ -48,7 +47,6 @@ fun WooShippingLabelPackageCreationScreen(
     )
 }
 
-@OptIn(ExperimentalFoundationApi::class)
 @Composable
 fun WooShippingLabelPackageCreationScreen(
     modifier: Modifier = Modifier,
@@ -62,10 +60,8 @@ fun WooShippingLabelPackageCreationScreen(
     LaunchedEffect(tabIndex) {
         pagerState.animateScrollToPage(tabIndex)
     }
-    LaunchedEffect(pagerState.currentPage, pagerState.isScrollInProgress) {
-        if (!pagerState.isScrollInProgress) {
-            tabIndex = pagerState.currentPage
-        }
+    LaunchedEffect(pagerState.targetPage) {
+        tabIndex = pagerState.targetPage
     }
 
     fun findIndex(type: PageType) = tabs.indexOfFirst { it.type == type }


### PR DESCRIPTION
### Description
While reviewing the PR #13887, I noticed a big delay between the tabs scrolling after swiping pages, given this was a minor fix, I'm creating this small PR to improve it.

### Steps to reproduce
1. Using a store eligible for shipping labels creation.
2. Open order details and start shipping labels creation.
3. Tap on Select a package.
4. Swipe between the different pages.

### Testing information
- Confirm the scrolling works better.

### The tests that have been performed
^

### Images/gif
| Before | After |
| --- | --- |
| <video src=https://github.com/user-attachments/assets/3dcc3911-c82a-4eed-83db-a6f6ccb7d393/> | <video src=https://github.com/user-attachments/assets/c3a39321-1bbf-4b78-9183-64dc57bb049d/> |

- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.

## Reviewer (or Author, in the case of optional code reviews):

Please make sure these conditions are met before approving the PR, or request changes if the PR needs improvement:

- [x] The PR is small and has a clear, single focus, or a valid explanation is provided in the description. If needed, please request to split it into smaller PRs.
- [x] Ensure Adequate Unit Test Coverage: The changes are reasonably covered by unit tests or an explanation is provided in the PR description.
- [x] Manual Testing: The author listed all the tests they ran, including smoke tests when needed (e.g., for refactorings). The reviewer confirmed that the PR works as expected on big (tablet) and small (phone) in case of UI changes, and no regressions are added.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->