### PR TITLE
[Jetpack Performance Experiment] Check whether Jetpack sites support application passwords after login

### DIFF
--- a/libs/fluxc-plugin/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/WooCommerceRestClient.kt
+++ b/libs/fluxc-plugin/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/WooCommerceRestClient.kt
@@ -22,11 +22,10 @@ class WooCommerceRestClient @Inject constructor(private val wooNetwork: WooNetwo
 
     /**
      * Makes a GET call to the root wp-json endpoint (`/`) via the Jetpack tunnel (see [JetpackTunnelGsonRequest])
-     * for the given [SiteModel], and parses through the `namespaces` field in the result for supported versions
-     * of the Woo API.
+     * for the given [SiteModel]
      *
      */
-    suspend fun fetchSupportedWooApiVersion(
+    suspend fun fetchSiteRootAPIEndpoint(
         site: SiteModel,
         overrideRetryPolicy: Boolean = false
     ): WooPayload<RootWPAPIRestResponse> {

--- a/libs/fluxc-plugin/src/main/kotlin/org/wordpress/android/fluxc/store/WooCommerceStore.kt
+++ b/libs/fluxc-plugin/src/main/kotlin/org/wordpress/android/fluxc/store/WooCommerceStore.kt
@@ -373,6 +373,11 @@ open class WooCommerceStore @Inject constructor(
                 }
 
                 response.result != null -> {
+                    // Persist the Application Passwords auhtorization URL
+                    site.applicationPasswordsAuthorizeUrl = response.result.authentication
+                        ?.applicationPasswords?.endpoints?.authorization
+                    siteSqlUtils.insertOrUpdateSite(site)
+
                     val namespaces = response.result.namespaces
                     val maxWooApiVersion = namespaces?.run {
                         find { it == WOO_API_NAMESPACE_V3 }

--- a/libs/fluxc-plugin/src/main/kotlin/org/wordpress/android/fluxc/store/WooCommerceStore.kt
+++ b/libs/fluxc-plugin/src/main/kotlin/org/wordpress/android/fluxc/store/WooCommerceStore.kt
@@ -362,7 +362,7 @@ open class WooCommerceStore @Inject constructor(
         overrideRetryPolicy: Boolean = false
     ): WooResult<WCApiVersionResponse> {
         return coroutineEngine.withDefaultContext(T.API, this, "fetchSupportedWooApiVersion") {
-            val response = wcCoreRestClient.fetchSupportedWooApiVersion(site, overrideRetryPolicy)
+            val response = wcCoreRestClient.fetchSiteRootAPIEndpoint(site, overrideRetryPolicy)
             return@withDefaultContext when {
                 response.isError -> {
                     AppLog.w(

--- a/libs/fluxc-plugin/src/main/kotlin/org/wordpress/android/fluxc/store/WooCommerceStore.kt
+++ b/libs/fluxc-plugin/src/main/kotlin/org/wordpress/android/fluxc/store/WooCommerceStore.kt
@@ -39,6 +39,7 @@ import org.wordpress.android.fluxc.persistence.dao.TaxBasedOnDao
 import org.wordpress.android.fluxc.store.SiteStore.FetchSitesPayload
 import org.wordpress.android.fluxc.store.SiteStore.OnSiteChanged
 import org.wordpress.android.fluxc.tools.CoroutineEngine
+import org.wordpress.android.fluxc.utils.PreferenceUtils
 import org.wordpress.android.fluxc.utils.WCCurrencyUtils
 import org.wordpress.android.util.AppLog
 import org.wordpress.android.util.AppLog.T
@@ -132,6 +133,23 @@ open class WooCommerceStore @Inject constructor(
 
     @Suppress("ReturnCount")
     suspend fun fetchWooCommerceSite(site: SiteModel): WooResult<SiteModel> {
+        // Check if the site supports application passwords or not
+        // TODO remove this check after finishing the application passwords experiment
+        suspend fun fetchAppPasswordsSupportIfNeeded(site: SiteModel) {
+            val sharedPrefs = PreferenceUtils.getFluxCPreferences(appContext)
+            val sharedPrefKey = "application_passwords_check_done"
+            val checkDone = sharedPrefs.getBoolean(sharedPrefKey, false)
+            if (site.applicationPasswordsAuthorizeUrl != null || checkDone) return
+
+            fetchSupportedApiVersion(site, false).let {
+                if (!it.isError) {
+                    sharedPrefs.edit()
+                        .putBoolean(sharedPrefKey, true)
+                        .apply()
+                }
+            }
+        }
+
         if (!site.isJetpackCPConnected) {
             // The endpoint used by siteStore to fetch a single site is broken for Jetpack CP sites, so skip it for them
             siteStore.fetchSite(site).let {
@@ -168,6 +186,8 @@ open class WooCommerceStore @Inject constructor(
         if (isSiteUpdated) {
             emitChange(OnSiteChanged(1, listOf(updatedSite)))
         }
+
+        fetchAppPasswordsSupportIfNeeded(updatedSite)
 
         return WooResult(updatedSite)
     }

--- a/libs/fluxc-tests/src/test/java/org/wordpress/android/fluxc/store/SiteStoreTest.kt
+++ b/libs/fluxc-tests/src/test/java/org/wordpress/android/fluxc/store/SiteStoreTest.kt
@@ -8,6 +8,7 @@ import org.junit.Test
 import org.junit.runner.RunWith
 import org.mockito.Mock
 import org.mockito.junit.MockitoJUnitRunner
+import org.mockito.kotlin.any
 import org.mockito.kotlin.argWhere
 import org.mockito.kotlin.inOrder
 import org.mockito.kotlin.never
@@ -518,5 +519,26 @@ class SiteStoreTest {
 
         val expectedErrorType = AllDomainsError(AllDomainsErrorType.GENERIC_ERROR, null).type
         assertThat(onAllDomainsFetched.error.type).isEqualTo(expectedErrorType)
+    }
+
+    @Test
+    fun `when updating site from WPCom REST API, then preserve existing app passwords authorize URL`() = test {
+        val siteId = 1234L
+        val authorizationUrl = "https://example.com/authorize"
+        whenever(siteSqlUtils.getSitesWithRemoteId(siteId)).thenReturn(listOf(SiteModel().apply {
+            this.siteId = siteId
+            applicationPasswordsAuthorizeUrl = authorizationUrl
+        }))
+        val fetchedSite = SiteModel().apply {
+            this.origin = SiteModel.ORIGIN_WPCOM_REST
+            this.siteId = siteId
+        }
+        whenever(siteRestClient.fetchSite(any())).thenReturn(fetchedSite)
+
+        siteStore.fetchSite(fetchedSite)
+
+        verify(siteSqlUtils).insertOrUpdateSite(argWhere { site ->
+            site.applicationPasswordsAuthorizeUrl == authorizationUrl
+        })
     }
 }

--- a/libs/fluxc-tests/src/test/java/org/wordpress/android/fluxc/wc/WooCommerceStoreTest.kt
+++ b/libs/fluxc-tests/src/test/java/org/wordpress/android/fluxc/wc/WooCommerceStoreTest.kt
@@ -30,6 +30,7 @@ import org.wordpress.android.fluxc.model.settings.WCSettingsMapper
 import org.wordpress.android.fluxc.model.taxes.TaxBasedOnSettingEntity
 import org.wordpress.android.fluxc.network.BaseRequest.GenericErrorType.NETWORK_ERROR
 import org.wordpress.android.fluxc.network.discovery.RootWPAPIRestResponse
+import org.wordpress.android.fluxc.network.discovery.RootWPAPIRestResponse.Authentication
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.WooCommerceRestClient
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.WooError
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.WooErrorType.INVALID_RESPONSE
@@ -306,6 +307,30 @@ class WooCommerceStoreTest {
             assertThat(result.model).isNotNull
             assertThat(result.model?.apiVersion).isEqualTo(SUPPORTED_API_VERSION)
             assertThat(result.model?.siteModel).isEqualTo(site)
+        }
+    }
+
+    @Test
+    fun `when fetching api version succeeds, then update application passwords authorization URL`() {
+        runBlocking {
+            // Sanity check
+            assertThat(site.applicationPasswordsAuthorizeUrl).isNull()
+
+            val authorizationUrl = "https://example.com/authorization-url"
+            TestSiteSqlUtils.siteSqlUtils.insertOrUpdateSite(site)
+
+            fetchSupportedWooApiVersion(
+                response = RootWPAPIRestResponse(
+                    authentication = Authentication(
+                        applicationPasswords = Authentication.ApplicationPasswords(
+                            endpoints = Authentication.ApplicationPasswords.Endpoints(authorizationUrl)
+                        )
+                    )
+                )
+            )
+
+            val updateSite = TestSiteSqlUtils.siteSqlUtils.getSiteWithLocalId(site.localId())
+            assertThat(updateSite!!.applicationPasswordsAuthorizeUrl).isEqualTo(authorizationUrl)
         }
     }
 

--- a/libs/fluxc-tests/src/test/java/org/wordpress/android/fluxc/wc/WooCommerceStoreTest.kt
+++ b/libs/fluxc-tests/src/test/java/org/wordpress/android/fluxc/wc/WooCommerceStoreTest.kt
@@ -489,9 +489,9 @@ class WooCommerceStoreTest {
     ): WooResult<WCApiVersionResponse> {
         val payload = WooPayload(response)
         if (isError) {
-            whenever(wcrestClient.fetchSupportedWooApiVersion(any(), any())).thenReturn(WooPayload(error))
+            whenever(wcrestClient.fetchSiteRootAPIEndpoint(any(), any())).thenReturn(WooPayload(error))
         } else {
-            whenever(wcrestClient.fetchSupportedWooApiVersion(any(), any())).thenReturn(payload)
+            whenever(wcrestClient.fetchSiteRootAPIEndpoint(any(), any())).thenReturn(payload)
         }
         return wooCommerceStore.fetchSupportedApiVersion(site)
     }

--- a/libs/fluxc-tests/src/test/java/org/wordpress/android/fluxc/wc/WooCommerceStoreTest.kt
+++ b/libs/fluxc-tests/src/test/java/org/wordpress/android/fluxc/wc/WooCommerceStoreTest.kt
@@ -445,6 +445,7 @@ class WooCommerceStoreTest {
             whenever(siteStore.sites).thenReturn(listOf(site))
             whenever(siteStore.getSiteByLocalId(any())).thenReturn(site)
             whenever(restClient.checkIfWooCommerceIsAvailable(site)).thenReturn(WooPayload(true))
+            fetchSupportedWooApiVersion(response = RootWPAPIRestResponse())
 
             wooCommerceStore.fetchWooCommerceSite(site)
 
@@ -462,6 +463,7 @@ class WooCommerceStoreTest {
             whenever(siteStore.sites).thenReturn(listOf(site))
             whenever(siteStore.getSiteByLocalId(any())).thenReturn(site)
             whenever(restClient.checkIfWooCommerceIsAvailable(site)).thenReturn(WooPayload(true))
+            fetchSupportedWooApiVersion(response = RootWPAPIRestResponse())
 
             wooCommerceStore.fetchWooCommerceSite(site)
 

--- a/libs/fluxc/src/main/java/org/wordpress/android/fluxc/store/SiteStore.kt
+++ b/libs/fluxc/src/main/java/org/wordpress/android/fluxc/store/SiteStore.kt
@@ -1574,14 +1574,16 @@ open class SiteStore @Inject constructor(
 
     private fun createOrUpdateSite(site: SiteModel): Int {
         val freshSiteFromDB = getSiteBySiteId(site.siteId)
-        // Update the site with existing values from the DB that are not returned by the WPCom REST API
+        // Update the site with existing values from the DB that are not returned by the REST API
         if (freshSiteFromDB != null) {
             // The REST API doesn't return info about the editor(s).
             site.mobileEditor = freshSiteFromDB.mobileEditor
             site.webEditor = freshSiteFromDB.webEditor
 
-            // The REST API doesn't return info about the application passwords authorize URL.
-            site.applicationPasswordsAuthorizeUrl = freshSiteFromDB.applicationPasswordsAuthorizeUrl
+            // The WPCom REST API doesn't return info about the application passwords authorize URL.
+            if (site.origin == SiteModel.ORIGIN_WPCOM_REST) {
+                site.applicationPasswordsAuthorizeUrl = freshSiteFromDB.applicationPasswordsAuthorizeUrl
+            }
         }
 
         return siteSqlUtils.insertOrUpdateSite(site)

--- a/libs/fluxc/src/main/java/org/wordpress/android/fluxc/store/SiteStore.kt
+++ b/libs/fluxc/src/main/java/org/wordpress/android/fluxc/store/SiteStore.kt
@@ -1510,15 +1510,7 @@ open class SiteStore @Inject constructor(
             OnSiteChanged(SiteErrorUtils.genericToSiteError(siteModel.error))
         } else {
             try {
-                // The REST API doesn't return info about the editor(s). Make sure to copy current values
-                // available on the DB. Otherwise the apps will receive an update site without editor prefs set.
-                // The apps will dispatch the action to update editor(s) when necessary.
-                val freshSiteFromDB = getSiteByLocalId(siteModel.id)
-                if (freshSiteFromDB != null) {
-                    siteModel.mobileEditor = freshSiteFromDB.mobileEditor
-                    siteModel.webEditor = freshSiteFromDB.webEditor
-                }
-                OnSiteChanged(siteSqlUtils.insertOrUpdateSite(siteModel))
+                OnSiteChanged(createOrUpdateSite(siteModel))
             } catch (e: DuplicateSiteException) {
                 OnSiteChanged(SiteError(DUPLICATE_SITE))
             }
@@ -1568,15 +1560,7 @@ open class SiteStore @Inject constructor(
         val updatedSites = mutableListOf<SiteModel>()
         for (site in sites.sites) {
             try {
-                // The REST API doesn't return info about the editor(s). Make sure to copy current values
-                // available on the DB. Otherwise the apps will receive an update site without editor prefs set.
-                // The apps will dispatch the action to update editor(s) when necessary.
-                val siteFromDB = getSiteBySiteId(site.siteId)
-                if (siteFromDB != null) {
-                    site.mobileEditor = siteFromDB.mobileEditor
-                    site.webEditor = siteFromDB.webEditor
-                }
-                val isUpdated = (siteSqlUtils.insertOrUpdateSite(site) == 1)
+                val isUpdated = (createOrUpdateSite(site) == 1)
                 if (isUpdated) {
                     rowsAffected++
                     updatedSites.add(site)
@@ -1586,6 +1570,21 @@ open class SiteStore @Inject constructor(
             }
         }
         return UpdateSitesResult(rowsAffected, updatedSites, duplicateSiteFound)
+    }
+
+    private fun createOrUpdateSite(site: SiteModel): Int {
+        val freshSiteFromDB = getSiteBySiteId(site.siteId)
+        // Update the site with existing values from the DB that are not returned by the WPCom REST API
+        if (freshSiteFromDB != null) {
+            // The REST API doesn't return info about the editor(s).
+            site.mobileEditor = freshSiteFromDB.mobileEditor
+            site.webEditor = freshSiteFromDB.webEditor
+
+            // The REST API doesn't return info about the application passwords authorize URL.
+            site.applicationPasswordsAuthorizeUrl = freshSiteFromDB.applicationPasswordsAuthorizeUrl
+        }
+
+        return siteSqlUtils.insertOrUpdateSite(site)
     }
 
     // Insert Jetpack CP connected sites, with updated local id info if they are also in the fetched sites list


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: WOOMOB-275
<!-- Id number of the GitHub issue this PR addresses. -->

<!-- 
━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
🛠 Need an AI review?  
Add a comment: `@coderabbitai review`
━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
-->

### Description
This PR adds logic to check whether websites support application passwords or not after login (or after selecting a new website), the check uses the existing fetch of the root API endpoint that we already do, and just saves the Application Passwords authorization URL to the database.

For more context: pe5sF9-4aN-p2

### Steps to reproduce
1. Open the app.
2. Sign in if needed.
3. Switch sites.

### Testing information
- Open the DB inspector in Android Studio, and check the table `SiteModel`, and confirm the `APPLICATION_PASSWORDS_AUTHORIZE_URL` is correctly filled for the selected site.
- Confirm that after re-opening the app, the column is not overridden.

### The tests that have been performed
^

- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.

## Reviewer (or Author, in the case of optional code reviews):

Please make sure these conditions are met before approving the PR, or request changes if the PR needs improvement:

- [x] The PR is small and has a clear, single focus, or a valid explanation is provided in the description. If needed, please request to split it into smaller PRs.
- [x] Ensure Adequate Unit Test Coverage: The changes are reasonably covered by unit tests or an explanation is provided in the PR description.
- [x] Manual Testing: The author listed all the tests they ran, including smoke tests when needed (e.g., for refactorings). The reviewer confirmed that the PR works as expected on big (tablet) and small (phone) in case of UI changes, and no regressions are added.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->