### PR TITLE
[Shipping labels] Add undo message to the split shipment screen

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/WooShippingLabelCreationScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/WooShippingLabelCreationScreen.kt
@@ -41,7 +41,6 @@ import androidx.compose.material.icons.filled.Edit
 import androidx.compose.material.icons.filled.Star
 import androidx.compose.material.icons.outlined.Star
 import androidx.compose.material.rememberBottomSheetScaffoldState
-import androidx.compose.material3.SnackbarDuration
 import androidx.compose.material3.SnackbarHostState
 import androidx.compose.material3.SnackbarResult
 import androidx.compose.runtime.Composable
@@ -67,7 +66,6 @@ import com.woocommerce.android.ui.compose.component.WCColoredButton
 import com.woocommerce.android.ui.compose.modifiers.dashedBorder
 import com.woocommerce.android.ui.compose.theme.WooThemeWithBackground
 import com.woocommerce.android.ui.orders.shippinglabels.creation.ShippingLabelHazmatCategory
-import com.woocommerce.android.ui.orders.wooshippinglabels.WooShippingLabelCreationViewModel.ActionSnackbar
 import com.woocommerce.android.ui.orders.wooshippinglabels.WooShippingLabelCreationViewModel.CustomsState
 import com.woocommerce.android.ui.orders.wooshippinglabels.WooShippingLabelCreationViewModel.CustomsState.ItnMissing
 import com.woocommerce.android.ui.orders.wooshippinglabels.WooShippingLabelCreationViewModel.CustomsState.NotRequired
@@ -81,6 +79,7 @@ import com.woocommerce.android.ui.orders.wooshippinglabels.address.AddressSelect
 import com.woocommerce.android.ui.orders.wooshippinglabels.address.AddressStatus
 import com.woocommerce.android.ui.orders.wooshippinglabels.address.getShipFrom
 import com.woocommerce.android.ui.orders.wooshippinglabels.address.getShipTo
+import com.woocommerce.android.ui.orders.wooshippinglabels.components.ActionSnackbar
 import com.woocommerce.android.ui.orders.wooshippinglabels.components.SuccessSnackbarHost
 import com.woocommerce.android.ui.orders.wooshippinglabels.hazmat.HazmatCard
 import com.woocommerce.android.ui.orders.wooshippinglabels.models.DestinationShippingAddress
@@ -465,11 +464,11 @@ private fun LabelCreationScreenWithBottomSheet(
                     val result = snackbarHostState.showSnackbar(
                         message = actionSnackbarMessage ?: "",
                         actionLabel = actionSnackbarActionLabel,
-                        duration = SnackbarDuration.Short,
+                        duration = actionSnackbar.duration,
                     )
                     when (result) {
                         SnackbarResult.ActionPerformed -> actionSnackbar.action()
-                        SnackbarResult.Dismissed -> actionSnackbar.onDismissed()
+                        SnackbarResult.Dismissed -> actionSnackbar.dismissAction()
                     }
                 } ?: snackbarHostState.currentSnackbarData?.dismiss()
             }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/WooShippingLabelCreationScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/WooShippingLabelCreationScreen.kt
@@ -79,7 +79,7 @@ import com.woocommerce.android.ui.orders.wooshippinglabels.address.AddressSelect
 import com.woocommerce.android.ui.orders.wooshippinglabels.address.AddressStatus
 import com.woocommerce.android.ui.orders.wooshippinglabels.address.getShipFrom
 import com.woocommerce.android.ui.orders.wooshippinglabels.address.getShipTo
-import com.woocommerce.android.ui.orders.wooshippinglabels.components.ActionSnackbar
+import com.woocommerce.android.ui.orders.wooshippinglabels.components.ShippingLabelsSnackbarData
 import com.woocommerce.android.ui.orders.wooshippinglabels.components.SuccessSnackbarHost
 import com.woocommerce.android.ui.orders.wooshippinglabels.hazmat.HazmatCard
 import com.woocommerce.android.ui.orders.wooshippinglabels.models.DestinationShippingAddress
@@ -125,7 +125,7 @@ fun WooShippingLabelCreationScreen(viewModel: WooShippingLabelCreationViewModel)
                 onEditCustomsClick = viewModel::onEditCustomsClick,
                 onEditDestinationAddress = viewModel::onEditDestinationAddress,
                 destinationStatus = viewState.destinationStatus,
-                actionSnackbar = viewModel.actionSnackbar,
+                snackbarData = viewModel.snackbarData,
                 onSplitShipment = viewModel::onSplitShipment,
                 onHazmatNoticeClick = viewModel::onHazmatNoticeClick,
             )
@@ -170,7 +170,7 @@ fun WooShippingLabelCreationScreen(
     onEditDestinationAddress: (DestinationShippingAddress) -> Unit,
     destinationStatus: AddressStatus,
     modifier: Modifier = Modifier,
-    actionSnackbar: ActionSnackbar? = null,
+    snackbarData: ShippingLabelsSnackbarData? = null,
     onSplitShipment: () -> Unit = {},
     onHazmatNoticeClick: () -> Unit = {}
 ) {
@@ -236,7 +236,7 @@ fun WooShippingLabelCreationScreen(
             onEditCustomsClick = onEditCustomsClick,
             onEditDestinationAddress = onEditDestinationAddress,
             destinationStatus = destinationStatus,
-            actionSnackbar = actionSnackbar,
+            snackbarData = snackbarData,
             onSplitShipment = onSplitShipment,
             onHazmatNoticeClick = onHazmatNoticeClick
         )
@@ -317,7 +317,7 @@ private fun LabelCreationScreenWithBottomSheet(
     onEditDestinationAddress: (DestinationShippingAddress) -> Unit,
     destinationStatus: AddressStatus,
     modifier: Modifier = Modifier,
-    actionSnackbar: ActionSnackbar? = null,
+    snackbarData: ShippingLabelsSnackbarData? = null,
     onSplitShipment: () -> Unit = {},
     onHazmatNoticeClick: () -> Unit = {}
 ) {
@@ -456,19 +456,19 @@ private fun LabelCreationScreenWithBottomSheet(
                 )
             }
 
-            val actionSnackbarMessage = actionSnackbar?.let { stringResource(it.message) }
-            val actionSnackbarActionLabel = actionSnackbar?.let { stringResource(it.actionLabel) }
+            val actionSnackbarMessage = snackbarData?.let { stringResource(it.message) }
+            val actionSnackbarActionLabel = snackbarData?.let { stringResource(it.actionLabel) }
 
-            LaunchedEffect(actionSnackbar) {
-                actionSnackbar?.let {
+            LaunchedEffect(snackbarData) {
+                snackbarData?.let {
                     val result = snackbarHostState.showSnackbar(
                         message = actionSnackbarMessage ?: "",
                         actionLabel = actionSnackbarActionLabel,
-                        duration = actionSnackbar.duration,
+                        duration = snackbarData.duration,
                     )
                     when (result) {
-                        SnackbarResult.ActionPerformed -> actionSnackbar.action()
-                        SnackbarResult.Dismissed -> actionSnackbar.dismissAction()
+                        SnackbarResult.ActionPerformed -> snackbarData.action()
+                        SnackbarResult.Dismissed -> snackbarData.dismissAction()
                     }
                 } ?: snackbarHostState.currentSnackbarData?.dismiss()
             }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/WooShippingLabelCreationViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/WooShippingLabelCreationViewModel.kt
@@ -487,10 +487,6 @@ class WooShippingLabelCreationViewModel @Inject constructor(
         return true
     }
 
-    fun onDismissItnNotice() {
-        customsState.value = Unavailable
-    }
-
     fun onSelectPackageClicked() {
         triggerEvent(StartPackageSelection)
     }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/WooShippingLabelCreationViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/WooShippingLabelCreationViewModel.kt
@@ -27,9 +27,9 @@ import com.woocommerce.android.ui.orders.wooshippinglabels.address.ObserveShippi
 import com.woocommerce.android.ui.orders.wooshippinglabels.address.destination.VerifyDestinationAddress
 import com.woocommerce.android.ui.orders.wooshippinglabels.address.origin.FetchOriginAddresses
 import com.woocommerce.android.ui.orders.wooshippinglabels.address.origin.ObserveOriginAddresses
-import com.woocommerce.android.ui.orders.wooshippinglabels.components.ShippingLabelsSnackbarData
 import com.woocommerce.android.ui.orders.wooshippinglabels.components.NoticeBannerUiState
 import com.woocommerce.android.ui.orders.wooshippinglabels.components.NoticeType
+import com.woocommerce.android.ui.orders.wooshippinglabels.components.ShippingLabelsSnackbarData
 import com.woocommerce.android.ui.orders.wooshippinglabels.customs.CustomsData
 import com.woocommerce.android.ui.orders.wooshippinglabels.customs.domain.ShouldRequireCustomsForm
 import com.woocommerce.android.ui.orders.wooshippinglabels.customs.domain.ShouldRequireITN

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/WooShippingLabelCreationViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/WooShippingLabelCreationViewModel.kt
@@ -27,6 +27,7 @@ import com.woocommerce.android.ui.orders.wooshippinglabels.address.ObserveShippi
 import com.woocommerce.android.ui.orders.wooshippinglabels.address.destination.VerifyDestinationAddress
 import com.woocommerce.android.ui.orders.wooshippinglabels.address.origin.FetchOriginAddresses
 import com.woocommerce.android.ui.orders.wooshippinglabels.address.origin.ObserveOriginAddresses
+import com.woocommerce.android.ui.orders.wooshippinglabels.components.ActionSnackbar
 import com.woocommerce.android.ui.orders.wooshippinglabels.components.NoticeBannerUiState
 import com.woocommerce.android.ui.orders.wooshippinglabels.components.NoticeType
 import com.woocommerce.android.ui.orders.wooshippinglabels.customs.CustomsData
@@ -532,8 +533,8 @@ class WooShippingLabelCreationViewModel @Inject constructor(
             } else {
                 purchaseState.value = backupPurchaseState
                 actionSnackbar = ActionSnackbar(
-                    R.string.woo_shipping_labels_purchase_error,
-                    R.string.retry,
+                    message = R.string.woo_shipping_labels_purchase_error,
+                    actionLabel = R.string.retry,
                 ) { onPurchaseShippingLabel() }
             }
         }
@@ -658,7 +659,7 @@ class WooShippingLabelCreationViewModel @Inject constructor(
         actionSnackbar = ActionSnackbar(
             message = snackbarMessage,
             actionLabel = R.string.undo,
-            onDismissed = { actionSnackbar = null }
+            dismissAction = { actionSnackbar = null }
         ) {
             hazmatState.value = previousState
         }
@@ -757,13 +758,6 @@ class WooShippingLabelCreationViewModel @Inject constructor(
             val destinationStatus: AddressStatus
         ) : WooShippingViewState()
     }
-
-    data class ActionSnackbar(
-        val message: Int,
-        val actionLabel: Int,
-        val onDismissed: () -> Unit = {},
-        val action: () -> Unit
-    )
 
     sealed class ShippingRatesState {
         data object NoAvailable : ShippingRatesState()

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/WooShippingLabelCreationViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/WooShippingLabelCreationViewModel.kt
@@ -27,7 +27,7 @@ import com.woocommerce.android.ui.orders.wooshippinglabels.address.ObserveShippi
 import com.woocommerce.android.ui.orders.wooshippinglabels.address.destination.VerifyDestinationAddress
 import com.woocommerce.android.ui.orders.wooshippinglabels.address.origin.FetchOriginAddresses
 import com.woocommerce.android.ui.orders.wooshippinglabels.address.origin.ObserveOriginAddresses
-import com.woocommerce.android.ui.orders.wooshippinglabels.components.ActionSnackbar
+import com.woocommerce.android.ui.orders.wooshippinglabels.components.ShippingLabelsSnackbarData
 import com.woocommerce.android.ui.orders.wooshippinglabels.components.NoticeBannerUiState
 import com.woocommerce.android.ui.orders.wooshippinglabels.components.NoticeType
 import com.woocommerce.android.ui.orders.wooshippinglabels.customs.CustomsData
@@ -88,7 +88,7 @@ class WooShippingLabelCreationViewModel @Inject constructor(
 ) : ScopedViewModel(savedState) {
     private val navArgs: WooShippingLabelCreationFragmentArgs by savedState.navArgs()
 
-    var actionSnackbar by mutableStateOf<ActionSnackbar?>(null)
+    var snackbarData by mutableStateOf<ShippingLabelsSnackbarData?>(null)
 
     private val emptyOrder = Order.getEmptyOrder(Date(), Date())
     private val order = MutableStateFlow<Order>(emptyOrder)
@@ -528,7 +528,7 @@ class WooShippingLabelCreationViewModel @Inject constructor(
                 handlePurchaseSuccess(result)
             } else {
                 purchaseState.value = backupPurchaseState
-                actionSnackbar = ActionSnackbar(
+                snackbarData = ShippingLabelsSnackbarData(
                     message = R.string.woo_shipping_labels_purchase_error,
                     actionLabel = R.string.retry,
                 ) { onPurchaseShippingLabel() }
@@ -632,7 +632,7 @@ class WooShippingLabelCreationViewModel @Inject constructor(
 
         // Disables the current Snackbar before navigation
         // to avoid presentation conflict with the Hazmat selection result
-        actionSnackbar = null
+        snackbarData = null
         triggerEvent(StartHazmatFormEdit(selectedCategory))
     }
 
@@ -652,10 +652,10 @@ class WooShippingLabelCreationViewModel @Inject constructor(
             R.string.woo_shipping_labels_hazmat_selection_removed
         }
 
-        actionSnackbar = ActionSnackbar(
+        snackbarData = ShippingLabelsSnackbarData(
             message = snackbarMessage,
             actionLabel = R.string.undo,
-            dismissAction = { actionSnackbar = null }
+            dismissAction = { snackbarData = null }
         ) {
             hazmatState.value = previousState
         }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/components/ActionSnackbar.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/components/ActionSnackbar.kt
@@ -1,0 +1,12 @@
+package com.woocommerce.android.ui.orders.wooshippinglabels.components
+
+import androidx.annotation.StringRes
+import androidx.compose.material3.SnackbarDuration
+
+data class ActionSnackbar(
+    @StringRes val message: Int,
+    val duration: SnackbarDuration = SnackbarDuration.Short,
+    val actionLabel: Int,
+    val dismissAction: () -> Unit = {},
+    val action: () -> Unit
+)

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/components/ActionSnackbar.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/components/ActionSnackbar.kt
@@ -5,6 +5,7 @@ import androidx.compose.material3.SnackbarDuration
 
 data class ActionSnackbar(
     @StringRes val message: Int,
+    val messageParameters: List<Int> = emptyList(),
     val duration: SnackbarDuration = SnackbarDuration.Short,
     val actionLabel: Int,
     val dismissAction: () -> Unit = {},

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/components/ShippingLabelsSnackbarData.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/components/ShippingLabelsSnackbarData.kt
@@ -3,7 +3,7 @@ package com.woocommerce.android.ui.orders.wooshippinglabels.components
 import androidx.annotation.StringRes
 import androidx.compose.material3.SnackbarDuration
 
-data class ActionSnackbar(
+data class ShippingLabelsSnackbarData(
     @StringRes val message: Int,
     val messageParameters: List<Int> = emptyList(),
     val duration: SnackbarDuration = SnackbarDuration.Short,

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/split/WooShippingSplitShipmentScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/split/WooShippingSplitShipmentScreen.kt
@@ -195,7 +195,7 @@ fun WooShippingSplitShipmentScreen(
     val context = LocalContext.current
     LaunchedEffect(viewState.splitMessage) {
         if (viewState.splitMessage is SplitShipmentMessage.Success) {
-            val snackbarData = viewState.splitMessage.actionSnackbar
+            val snackbarData = viewState.splitMessage.snackbarData
 
             @Suppress("SpreadOperator")
             val result = snackbarHostState.showSnackbar(

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/split/WooShippingSplitShipmentScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/split/WooShippingSplitShipmentScreen.kt
@@ -147,18 +147,13 @@ fun WooShippingSplitShipmentScreen(
                         modifier
                     )
 
-                    val pagerState = rememberPagerState { shipments.size }
-                    val scope = rememberCoroutineScope()
-
                     val onUpdateShipmentAndChangeSelection: (splitMovement: SplitMovement) -> Unit = { splitMovement ->
                         if (splitMovement.isRemoveMovement) {
-                            scope.launch {
-                                val nextPage = shipments.indexOfFirst { it == splitMovement.updatedShipment }
-                                    .takeIf { it != -1 && it < shipments.lastIndex }
-                                    ?: shipments.first { it != splitMovement.currentShipment }
-                                pagerState.animateScrollToPage(nextPage)
-                                onUpdateShipment(splitMovement)
-                            }
+                            val nextPage = shipments.indexOfFirst { it == splitMovement.updatedShipment }
+                                .takeIf { it != -1 && it < shipments.lastIndex }
+                                ?: shipments.first { it != splitMovement.currentShipment }
+                            onUpdateSelectedShipment(shipments[nextPage])
+                            onUpdateShipment(splitMovement)
                         } else {
                             onUpdateShipment(splitMovement)
                         }
@@ -233,13 +228,20 @@ private fun MultipleShipments(
     val scope = rememberCoroutineScope()
 
     Column {
-        LaunchedEffect(pagerState.currentPage) {
-            onUpdateSelectedShipment(shipments[pagerState.currentPage])
+        LaunchedEffect(pagerState.targetPage) {
+            onUpdateSelectedShipment(shipments[pagerState.targetPage])
+        }
+
+        LaunchedEffect(viewState.shipmentSelected) {
+            val viewStateCurrentPage = shipments.indexOf(viewState.shipmentSelected)
+            if (pagerState.currentPage != viewStateCurrentPage) {
+                pagerState.animateScrollToPage(viewStateCurrentPage)
+            }
         }
 
         Row(modifier = modifier.fillMaxWidth()) {
             ScrollableTabRow(
-                selectedTabIndex = pagerState.currentPage,
+                selectedTabIndex = if (pagerState.currentPage < pagerState.pageCount) pagerState.currentPage else 0,
                 backgroundColor = MaterialTheme.colors.surface,
                 contentColor = MaterialTheme.colors.primary,
                 divider = {},

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/split/WooShippingSplitShipmentScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/split/WooShippingSplitShipmentScreen.kt
@@ -131,78 +131,17 @@ fun WooShippingSplitShipmentScreen(
                 val shipments = viewState.selectableItems.keys.toList()
 
                 if (shipments.size > 1) {
+                    MultipleShipments(
+                        viewState,
+                        shipments,
+                        productsExtraPadding,
+                        onUpdateSelectedShipment,
+                        onUpdateSelection,
+                        modifier
+                    )
+
                     val pagerState = rememberPagerState { shipments.size }
                     val scope = rememberCoroutineScope()
-
-                    Column {
-                        LaunchedEffect(pagerState.currentPage) {
-                            onUpdateSelectedShipment(shipments[pagerState.currentPage])
-                        }
-
-                        Row(modifier = modifier.fillMaxWidth()) {
-                            ScrollableTabRow(
-                                selectedTabIndex = pagerState.currentPage,
-                                backgroundColor = MaterialTheme.colors.surface,
-                                contentColor = MaterialTheme.colors.primary,
-                                divider = {},
-                                edgePadding = 0.dp,
-                                modifier = modifier
-                                    .weight(1f)
-                                    .padding(top = 8.dp)
-                            ) {
-                                shipments.forEachIndexed { index, _ ->
-                                    val textColor = if (index == pagerState.currentPage) {
-                                        MaterialTheme.colors.primary
-                                    } else {
-                                        colorResource(id = R.color.color_on_surface_medium)
-                                    }
-                                    Tab(
-                                        text = {
-                                            Text(
-                                                text = stringResource(
-                                                    R.string.woo_shipping_split_shipment_shipment_name,
-                                                    index + 1 // Use 1-based indexing for the shipments
-                                                ),
-                                                color = textColor,
-                                                style = MaterialTheme.typography.subtitle1,
-                                                fontWeight = FontWeight.SemiBold
-                                            )
-                                        },
-                                        selected = pagerState.currentPage == index,
-                                        onClick = {
-                                            scope.launch {
-                                                pagerState.animateScrollToPage(index)
-                                            }
-                                        }
-                                    )
-                                }
-                            }
-                            IconButton(onClick = {}, modifier = modifier.align(Alignment.CenterVertically)) {
-                                Icon(
-                                    imageVector = Icons.Filled.MoreHoriz,
-                                    contentDescription = null,
-                                    tint = MaterialTheme.colors.primary
-                                )
-                            }
-                        }
-
-                        HorizontalPager(
-                            state = pagerState,
-                            modifier = modifier.fillMaxSize(),
-                            verticalAlignment = Alignment.Top,
-                            pageSpacing = 16.dp
-                        ) { page ->
-                            viewState.selectableItems.getValue(shipments[page]).let {
-                                SelectableProductsSection(
-                                    shipmentKey = shipments[page],
-                                    shipment = it,
-                                    onUpdateSelection = onUpdateSelection,
-                                    modifier = modifier.padding(top = 16.dp, start = 16.dp, end = 16.dp),
-                                    extraBottomPadding = productsExtraPadding
-                                )
-                            }
-                        }
-                    }
 
                     val onUpdateShipmentAndChangeSelection: (splitMovement: SplitMovement) -> Unit = { splitMovement ->
                         if (splitMovement.isRemoveMovement) {
@@ -268,6 +207,89 @@ fun WooShippingSplitShipmentScreen(
             when (result) {
                 SnackbarResult.ActionPerformed -> snackbarData.action()
                 SnackbarResult.Dismissed -> snackbarData.dismissAction()
+            }
+        }
+    }
+}
+
+@Composable
+private fun MultipleShipments(
+    viewState: SplitShipmentViewState,
+    shipments: List<Int>,
+    productsExtraPadding: Dp,
+    onUpdateSelectedShipment: (shipmentKey: Int) -> Unit,
+    onUpdateSelection: (shipmentKey: Int, index: Int, selectedIndexes: Set<Int>?) -> Unit,
+    modifier: Modifier
+) {
+    val pagerState = rememberPagerState { shipments.size }
+    val scope = rememberCoroutineScope()
+
+    Column {
+        LaunchedEffect(pagerState.currentPage) {
+            onUpdateSelectedShipment(shipments[pagerState.currentPage])
+        }
+
+        Row(modifier = modifier.fillMaxWidth()) {
+            ScrollableTabRow(
+                selectedTabIndex = pagerState.currentPage,
+                backgroundColor = MaterialTheme.colors.surface,
+                contentColor = MaterialTheme.colors.primary,
+                divider = {},
+                edgePadding = 0.dp,
+                modifier = modifier
+                    .weight(1f)
+                    .padding(top = 8.dp)
+            ) {
+                shipments.forEachIndexed { index, _ ->
+                    val textColor = if (index == pagerState.currentPage) {
+                        MaterialTheme.colors.primary
+                    } else {
+                        colorResource(id = R.color.color_on_surface_medium)
+                    }
+                    Tab(
+                        text = {
+                            Text(
+                                text = stringResource(
+                                    R.string.woo_shipping_split_shipment_shipment_name,
+                                    index + 1 // Use 1-based indexing for the shipments
+                                ),
+                                color = textColor,
+                                style = MaterialTheme.typography.subtitle1,
+                                fontWeight = FontWeight.SemiBold
+                            )
+                        },
+                        selected = pagerState.currentPage == index,
+                        onClick = {
+                            scope.launch {
+                                pagerState.animateScrollToPage(index)
+                            }
+                        }
+                    )
+                }
+            }
+            IconButton(onClick = {}, modifier = modifier.align(Alignment.CenterVertically)) {
+                Icon(
+                    imageVector = Icons.Filled.MoreHoriz,
+                    contentDescription = null,
+                    tint = MaterialTheme.colors.primary
+                )
+            }
+        }
+
+        HorizontalPager(
+            state = pagerState,
+            modifier = modifier.fillMaxSize(),
+            verticalAlignment = Alignment.Top,
+            pageSpacing = 16.dp
+        ) { page ->
+            viewState.selectableItems.getValue(shipments[page]).let {
+                SelectableProductsSection(
+                    shipmentKey = shipments[page],
+                    shipment = it,
+                    onUpdateSelection = onUpdateSelection,
+                    modifier = modifier.padding(top = 16.dp, start = 16.dp, end = 16.dp),
+                    extraBottomPadding = productsExtraPadding
+                )
             }
         }
     }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/split/WooShippingSplitShipmentScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/split/WooShippingSplitShipmentScreen.kt
@@ -33,6 +33,8 @@ import androidx.compose.material.icons.filled.ArrowDropDown
 import androidx.compose.material.icons.filled.Close
 import androidx.compose.material.icons.filled.MoreHoriz
 import androidx.compose.material3.Scaffold
+import androidx.compose.material3.SnackbarHostState
+import androidx.compose.material3.SnackbarResult
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
@@ -43,6 +45,7 @@ import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.colorResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.AnnotatedString
@@ -55,6 +58,7 @@ import com.woocommerce.android.ui.compose.component.WCTextButton
 import com.woocommerce.android.ui.orders.wooshippinglabels.ExpandableSelectableShippingProduct
 import com.woocommerce.android.ui.orders.wooshippinglabels.ProductsSummary
 import com.woocommerce.android.ui.orders.wooshippinglabels.SelectableShippingProduct
+import com.woocommerce.android.ui.orders.wooshippinglabels.components.SuccessSnackbarHost
 import com.woocommerce.android.ui.orders.wooshippinglabels.split.WooShippingSplitShipmentViewModel.SplitShipmentViewState
 import kotlinx.coroutines.launch
 
@@ -86,6 +90,8 @@ fun WooShippingSplitShipmentScreen(
     onUpdateSelectedShipment: (shipmentKey: Int) -> Unit,
     modifier: Modifier = Modifier
 ) {
+    val snackbarHostState = remember { SnackbarHostState() }
+
     Scaffold(
         topBar = {
             TopAppBar(
@@ -106,7 +112,8 @@ fun WooShippingSplitShipmentScreen(
                     )
                 }
             )
-        }
+        },
+        snackbarHost = { SuccessSnackbarHost(snackbarHostState) }
     ) { padding ->
         Surface(
             modifier = modifier
@@ -243,6 +250,27 @@ fun WooShippingSplitShipmentScreen(
             }
         }
     }
+
+    val context = LocalContext.current
+    LaunchedEffect(viewState.splitMessage) {
+        if (viewState.splitMessage is SplitShipmentMessage.Success) {
+            val snackbarData = viewState.splitMessage.actionSnackbar
+
+            @Suppress("SpreadOperator")
+            val result = snackbarHostState.showSnackbar(
+                message = context.getString(
+                    snackbarData.message,
+                    *snackbarData.messageParameters.toTypedArray()
+                ),
+                actionLabel = context.getString(R.string.undo),
+                duration = snackbarData.duration
+            )
+            when (result) {
+                SnackbarResult.ActionPerformed -> snackbarData.action()
+                SnackbarResult.Dismissed -> snackbarData.dismissAction()
+            }
+        }
+    }
 }
 
 @Composable
@@ -260,16 +288,11 @@ private fun SplitMessagesSection(
             label = "message_transition",
             enter = slideInVertically(initialOffsetY = { it })
         ) {
-            when (splitMessage) {
-                is SplitShipmentMessage.Instructions -> {
-                    InstructionsMessage(
-                        message = annotatedStringRes(R.string.woo_shipping_split_shipment_instructions),
-                        onClose = onDismissInstructions
-                    )
-                }
-
-                is SplitShipmentMessage.Success -> TODO()
-                null -> {}
+            if (splitMessage is SplitShipmentMessage.Instructions) {
+                InstructionsMessage(
+                    message = annotatedStringRes(R.string.woo_shipping_split_shipment_instructions),
+                    onClose = onDismissInstructions
+                )
             }
         }
         AnimatedVisibility(

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/split/WooShippingSplitShipmentViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/split/WooShippingSplitShipmentViewModel.kt
@@ -38,7 +38,7 @@ class WooShippingSplitShipmentViewModel @Inject constructor(
 
     init {
         launch {
-            delay(NOTIFICATIONS_DELAY)
+            delay(TOOLTIP_DELAY)
             splitMessage.value = SplitShipmentMessage.Instructions
         }
         launch {
@@ -158,7 +158,7 @@ class WooShippingSplitShipmentViewModel @Inject constructor(
     )
 
     companion object {
-        const val NOTIFICATIONS_DELAY = 500L
+        private const val TOOLTIP_DELAY = 800L
     }
 }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/split/WooShippingSplitShipmentViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/split/WooShippingSplitShipmentViewModel.kt
@@ -3,6 +3,7 @@ package com.woocommerce.android.ui.orders.wooshippinglabels.split
 import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.asLiveData
 import com.woocommerce.android.ui.orders.wooshippinglabels.ShippableItemUI
+import com.woocommerce.android.ui.orders.wooshippinglabels.components.ActionSnackbar
 import com.woocommerce.android.ui.orders.wooshippinglabels.models.ShippableItemModel
 import com.woocommerce.android.ui.orders.wooshippinglabels.toSelectableUIModel
 import com.woocommerce.android.util.CurrencyFormatter
@@ -164,10 +165,7 @@ sealed class SelectableShippableItemUI {
 
 sealed class SplitShipmentMessage {
     data object Instructions : SplitShipmentMessage()
-    data class Success(
-        val message: String,
-        val action: () -> Unit
-    ) : SplitShipmentMessage()
+    data class Success(val actionSnackbar: ActionSnackbar) : SplitShipmentMessage()
 }
 
 fun List<ShippableItemModel>.combine(other: List<ShippableItemModel>): List<ShippableItemModel> {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/split/WooShippingSplitShipmentViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/split/WooShippingSplitShipmentViewModel.kt
@@ -2,6 +2,7 @@ package com.woocommerce.android.ui.orders.wooshippinglabels.split
 
 import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.asLiveData
+import com.woocommerce.android.R
 import com.woocommerce.android.ui.orders.wooshippinglabels.ShippableItemUI
 import com.woocommerce.android.ui.orders.wooshippinglabels.components.ActionSnackbar
 import com.woocommerce.android.ui.orders.wooshippinglabels.models.ShippableItemModel
@@ -19,8 +20,6 @@ import kotlinx.coroutines.flow.filterNotNull
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 import javax.inject.Inject
-import kotlin.collections.mapValues
-import kotlin.getValue
 
 @HiltViewModel
 class WooShippingSplitShipmentViewModel @Inject constructor(
@@ -126,6 +125,22 @@ class WooShippingSplitShipmentViewModel @Inject constructor(
                 ?: splitMovement.updatedShipmentItems
             shipments
         }
+    private fun showUndoSnackbar(splitMovement: SplitMovement, undoAction: () -> Unit) {
+        val snackbarMessage = if (splitMovement.totalItemsToMove > 1) {
+            R.string.woo_shipping_split_shipment_moved_notice_plural
+        } else {
+            R.string.woo_shipping_split_shipment_moved_notice_one
+        }
+
+        splitMessage.value = SplitShipmentMessage.Success(
+            ActionSnackbar(
+                message = snackbarMessage,
+                messageParameters = listOf(splitMovement.totalItemsToMove, splitMovement.updatedShipment + 1),
+                actionLabel = R.string.undo,
+                dismissAction = { splitMessage.value = null },
+                action = undoAction
+            )
+        )
     }
 
     data class SplitShipmentViewState(

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/split/WooShippingSplitShipmentViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/split/WooShippingSplitShipmentViewModel.kt
@@ -83,7 +83,7 @@ class WooShippingSplitShipmentViewModel @Inject constructor(
     }
 
     fun onUpdateSelectedShipment(shipmentKey: Int) {
-        shipmentSelected.value = shipmentKey
+        shipmentSelected.update { shipmentKey }
     }
 
     fun onRemoveShipment(shipmentKey: Int) {
@@ -134,7 +134,14 @@ class WooShippingSplitShipmentViewModel @Inject constructor(
             shipments
         }
 
-        val undoAction = { currentShipments.update { currentShipmentBackup } }
+        val undoAction = {
+            currentShipments.update {
+                if (!currentShipmentBackup.keys.contains(shipmentSelected.value)) {
+                    onUpdateSelectedShipment(currentShipmentBackup.keys.first())
+                }
+                currentShipmentBackup
+            }
+        }
 
         showUndoSnackbar(splitMovement, undoAction)
     }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/split/WooShippingSplitShipmentViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/split/WooShippingSplitShipmentViewModel.kt
@@ -112,6 +112,7 @@ class WooShippingSplitShipmentViewModel @Inject constructor(
     }
 
     fun onUpdateShipment(splitMovement: SplitMovement) {
+        val currentShipmentBackup = currentShipments.value
         currentShipments.update {
             val shipments = it.toMutableMap()
             if (splitMovement.updatedCurrentShipmentItems.isEmpty()) {
@@ -125,6 +126,12 @@ class WooShippingSplitShipmentViewModel @Inject constructor(
                 ?: splitMovement.updatedShipmentItems
             shipments
         }
+
+        val undoAction = { currentShipments.update { currentShipmentBackup } }
+
+        showUndoSnackbar(splitMovement, undoAction)
+    }
+
     private fun showUndoSnackbar(splitMovement: SplitMovement, undoAction: () -> Unit) {
         val snackbarMessage = if (splitMovement.totalItemsToMove > 1) {
             R.string.woo_shipping_split_shipment_moved_notice_plural

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/split/WooShippingSplitShipmentViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/split/WooShippingSplitShipmentViewModel.kt
@@ -4,7 +4,7 @@ import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.asLiveData
 import com.woocommerce.android.R
 import com.woocommerce.android.ui.orders.wooshippinglabels.ShippableItemUI
-import com.woocommerce.android.ui.orders.wooshippinglabels.components.ActionSnackbar
+import com.woocommerce.android.ui.orders.wooshippinglabels.components.ShippingLabelsSnackbarData
 import com.woocommerce.android.ui.orders.wooshippinglabels.models.ShippableItemModel
 import com.woocommerce.android.ui.orders.wooshippinglabels.toSelectableUIModel
 import com.woocommerce.android.util.CurrencyFormatter
@@ -154,7 +154,7 @@ class WooShippingSplitShipmentViewModel @Inject constructor(
         }
 
         splitMessage.value = SplitShipmentMessage.Success(
-            ActionSnackbar(
+            ShippingLabelsSnackbarData(
                 message = snackbarMessage,
                 messageParameters = listOf(splitMovement.totalItemsToMove, splitMovement.updatedShipment + 1),
                 actionLabel = R.string.undo,
@@ -202,7 +202,7 @@ sealed class SelectableShippableItemUI {
 
 sealed class SplitShipmentMessage {
     data object Instructions : SplitShipmentMessage()
-    data class Success(val actionSnackbar: ActionSnackbar) : SplitShipmentMessage()
+    data class Success(val snackbarData: ShippingLabelsSnackbarData) : SplitShipmentMessage()
 }
 
 fun List<ShippableItemModel>.combine(other: List<ShippableItemModel>): List<ShippableItemModel> {

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -4592,6 +4592,8 @@
 
     <string name="woo_shipping_split_shipment">Split shipment</string>
     <string name="woo_shipping_split_shipment_instructions"><![CDATA[To split, select the items, and tap <b>move to new shipment</b> when the toolbar appears.]]></string>
+    <string name="woo_shipping_split_shipment_moved_notice_one">Moved %1$d item to Shipment %2$d</string>
+    <string name="woo_shipping_split_shipment_moved_notice_plural">Moved %1$d items to Shipment %2$d</string>
     <string name="woo_shipping_split_move_to_new">Move to new shipment</string>
     <string name="woo_shipping_split_move_to">Move to</string>
     <string name="woo_shipping_split_shipment_shipment_name">Shipment %s</string>

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/WooShippingLabelCreationViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/WooShippingLabelCreationViewModelTest.kt
@@ -822,7 +822,7 @@ class WooShippingLabelCreationViewModelTest : BaseUnitTest() {
 
         sut.onPurchaseShippingLabel()
 
-        assertThat(sut.actionSnackbar).matches { it?.message == R.string.woo_shipping_labels_purchase_error }
+        assertThat(sut.snackbarData).matches { it?.message == R.string.woo_shipping_labels_purchase_error }
     }
 
     @Test

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/split/WooShippingSplitShipmentViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/split/WooShippingSplitShipmentViewModelTest.kt
@@ -1,5 +1,6 @@
 package com.woocommerce.android.ui.orders.wooshippinglabels.split
 
+import com.woocommerce.android.R
 import com.woocommerce.android.ui.orders.wooshippinglabels.WooShippingLabelCreationViewModel.SplitShipmentArgs
 import com.woocommerce.android.ui.orders.wooshippinglabels.models.ShippableItemModel
 import com.woocommerce.android.ui.orders.wooshippinglabels.models.StoreOptionsModel
@@ -231,6 +232,70 @@ class WooShippingSplitShipmentViewModelTest : BaseUnitTest() {
             // Assert that quantity is combined 3f + 3f
             assertThat(item.shippableItem.quantity).isEqualTo(6f)
         }
+
+    @Test
+    fun `when moving a shippable item to new shipment, then show singular snackbar`() = testBlocking {
+        val shipmentArgs = SplitShipmentArgs(
+            orderId = 1L,
+            storeOptions = StoreOptionsModel.EMPTY,
+            shipments = defaultShipment
+        )
+        val updatedCurrentShipmentItems = defaultShipment.getValue(1).subList(fromIndex = 1, toIndex = 3)
+        val updatedShipmentItems = defaultShipment.getValue(1).subList(fromIndex = 0, toIndex = 1)
+
+        val movement = SplitMovement(
+            currentShipment = 0,
+            updatedCurrentShipmentItems = updatedCurrentShipmentItems,
+            updatedShipment = 1,
+            updatedShipmentItems = updatedShipmentItems
+        )
+
+        createViewModel(shipmentArgs)
+
+        sut.onUpdateShipment(movement)
+
+        sut.viewState.observeForTesting { }
+
+        val state = sut.viewState.value!!
+
+        val splitMessage = state.splitMessage
+        assertThat(splitMessage).isInstanceOf(SplitShipmentMessage.Success::class.java)
+        val snackbarData = (splitMessage as SplitShipmentMessage.Success).actionSnackbar
+        assertThat(snackbarData.message).isEqualTo(R.string.woo_shipping_split_shipment_moved_notice_one)
+        assertThat(snackbarData.messageParameters).isEqualTo(listOf(1, 2))
+    }
+
+    @Test
+    fun `when moving shippable items to new shipment, then show plural snackbar`() = testBlocking {
+        val shipmentArgs = SplitShipmentArgs(
+            orderId = 1L,
+            storeOptions = StoreOptionsModel.EMPTY,
+            shipments = defaultShipment
+        )
+        val updatedCurrentShipmentItems = defaultShipment.getValue(1).subList(fromIndex = 0, toIndex = 1)
+        val updatedShipmentItems = defaultShipment.getValue(1).subList(fromIndex = 1, toIndex = 2)
+
+        val movement = SplitMovement(
+            currentShipment = 0,
+            updatedCurrentShipmentItems = updatedCurrentShipmentItems,
+            updatedShipment = 1,
+            updatedShipmentItems = updatedShipmentItems
+        )
+
+        createViewModel(shipmentArgs)
+
+        sut.onUpdateShipment(movement)
+
+        sut.viewState.observeForTesting { }
+
+        val state = sut.viewState.value!!
+
+        val splitMessage = state.splitMessage
+        assertThat(splitMessage).isInstanceOf(SplitShipmentMessage.Success::class.java)
+        val snackbarData = (splitMessage as SplitShipmentMessage.Success).actionSnackbar
+        assertThat(snackbarData.message).isEqualTo(R.string.woo_shipping_split_shipment_moved_notice_plural)
+        assertThat(snackbarData.messageParameters).isEqualTo(listOf(5, 2))
+    }
 
     private val defaultShipment = mapOf(
         1 to listOf(

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/split/WooShippingSplitShipmentViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/split/WooShippingSplitShipmentViewModelTest.kt
@@ -260,7 +260,7 @@ class WooShippingSplitShipmentViewModelTest : BaseUnitTest() {
 
         val splitMessage = state.splitMessage
         assertThat(splitMessage).isInstanceOf(SplitShipmentMessage.Success::class.java)
-        val snackbarData = (splitMessage as SplitShipmentMessage.Success).actionSnackbar
+        val snackbarData = (splitMessage as SplitShipmentMessage.Success).snackbarData
         assertThat(snackbarData.message).isEqualTo(R.string.woo_shipping_split_shipment_moved_notice_one)
         assertThat(snackbarData.messageParameters).isEqualTo(listOf(1, 2))
     }
@@ -292,7 +292,7 @@ class WooShippingSplitShipmentViewModelTest : BaseUnitTest() {
 
         val splitMessage = state.splitMessage
         assertThat(splitMessage).isInstanceOf(SplitShipmentMessage.Success::class.java)
-        val snackbarData = (splitMessage as SplitShipmentMessage.Success).actionSnackbar
+        val snackbarData = (splitMessage as SplitShipmentMessage.Success).snackbarData
         assertThat(snackbarData.message).isEqualTo(R.string.woo_shipping_split_shipment_moved_notice_plural)
         assertThat(snackbarData.messageParameters).isEqualTo(listOf(5, 2))
     }


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: WOOMOB-282
<!-- Id number of the GitHub issue this PR addresses. -->

<!-- 
━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
🛠 Need an AI review?  
Add a comment: `@coderabbitai review`
━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
-->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
This PR adds an Undo snackbar message that appears after moving items on the Split Shipment screen.
It focuses solely on the undo action bar, but feel free to report any other issues you encounter.

Design: bsLNrhmi2xQZB4C0TzjmHB-fi-985_69395

### Steps to reproduce
<!-- Step-by-step testing instructions. For new user flows, consider instead stating the goal of the workflow and see if your PR reviewer can accomplish the workflow without specific steps! -->
1. Open the orders tab
2. Tap on an order eligible for shipping label creation
3. Tap on Create shipping label
4. Tap on Split shipment
5. Select items and move them.

### Testing information
<!-- This is your opportunity to break out individual scenarios that need testing (when necessary) and/or include a checklist for the reviewer to go through. Consider documenting the following from your own completed testing: devices used, alternate workflows, edge cases, affected areas, critical flows, areas not tested, and any remaining unknowns. Provide feedback on this new section of the PR template through Sept 30, 2024 to Apps Quality; additional context here: p91TBi-b8z-p2#comment-12036 -->
- [ ] Test changing the orientation and ensure the snackbar does not reappear after being dismissed.

### The tests that have been performed
<!-- To give the reviewer an idea of what could be missed in terms of testing -->
Steps above

### Images/gif
<!-- Include before and after images or gifs when appropriate. -->
<img src="https://github.com/user-attachments/assets/7d5e396c-2bdc-439c-ab3f-016fc1630e6f" width=400>

- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.

## Reviewer (or Author, in the case of optional code reviews):

Please make sure these conditions are met before approving the PR, or request changes if the PR needs improvement:

- [ ] The PR is small and has a clear, single focus, or a valid explanation is provided in the description. If needed, please request to split it into smaller PRs.
- [ ] Ensure Adequate Unit Test Coverage: The changes are reasonably covered by unit tests or an explanation is provided in the PR description.
- [ ] Manual Testing: The author listed all the tests they ran, including smoke tests when needed (e.g., for refactorings). The reviewer confirmed that the PR works as expected on big (tablet) and small (phone) in case of UI changes, and no regressions are added.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->