### PR TITLE
[Jetpack Performance Experiment] Introduce new network class for the experiment

### DIFF
--- a/libs/fluxc-plugin/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/WooExperimentalNetwork.kt
+++ b/libs/fluxc-plugin/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/WooExperimentalNetwork.kt
@@ -1,0 +1,146 @@
+package org.wordpress.android.fluxc.network.rest.wpcom.wc
+
+import org.wordpress.android.fluxc.model.SiteModel
+import org.wordpress.android.fluxc.network.rest.wpapi.WPAPINetwork
+import org.wordpress.android.fluxc.network.rest.wpapi.WPAPIResponse
+import org.wordpress.android.fluxc.network.rest.wpapi.applicationpasswords.ApplicationPasswordsNetwork
+import org.wordpress.android.fluxc.network.rest.wpcom.JetpackTunnelWPAPINetwork
+import org.wordpress.android.util.AppLog
+import javax.inject.Inject
+import javax.inject.Singleton
+
+/**
+ * An experimental network class for WooCommerce that allows using Application Passwords for Jetpack sites too,
+ * it will allow us to confirm if the Jetpack Tunnel is causing performance issues.
+ *
+ * Depending on the results of this experiment, we will either move the logic to the existing WooNetwork class or
+ * drop the experiment.
+ */
+@Singleton
+class WooExperimentalNetwork @Inject constructor(
+    private val applicationPasswordsNetwork: ApplicationPasswordsNetwork,
+    private val jetpackTunnelWPAPINetwork: JetpackTunnelWPAPINetwork,
+) : WPAPINetwork {
+    override suspend fun <T : Any> executeGetGsonRequest(
+        site: SiteModel,
+        path: String,
+        clazz: Class<T>,
+        params: Map<String, String>,
+        enableCaching: Boolean,
+        cacheTimeToLive: Int,
+        forced: Boolean,
+        requestTimeout: Int,
+        retries: Int
+    ): WPAPIResponse<T> = handleRequest(site) {
+        executeGetGsonRequest(
+            site = site,
+            path = path,
+            clazz = clazz,
+            params = params,
+            enableCaching = enableCaching,
+            cacheTimeToLive = cacheTimeToLive,
+            forced = forced,
+            requestTimeout = requestTimeout,
+            retries = retries
+        )
+    }
+
+    override suspend fun <T : Any> executePostGsonRequest(
+        site: SiteModel,
+        path: String,
+        clazz: Class<T>,
+        body: Map<String, Any>
+    ): WPAPIResponse<T> = handleRequest(site) {
+        executePostGsonRequest(
+            site = site,
+            path = path,
+            clazz = clazz,
+            body = body
+        )
+    }
+
+    override suspend fun <T : Any> executePutGsonRequest(
+        site: SiteModel,
+        path: String,
+        clazz: Class<T>,
+        body: Map<String, Any>
+    ): WPAPIResponse<T> = handleRequest(site) {
+        executePutGsonRequest(
+            site = site,
+            path = path,
+            clazz = clazz,
+            body = body
+        )
+    }
+
+    override suspend fun <T : Any> executeDeleteGsonRequest(
+        site: SiteModel,
+        path: String,
+        clazz: Class<T>,
+        params: Map<String, String>
+    ): WPAPIResponse<T> = handleRequest(site) {
+        executeDeleteGsonRequest(
+            site = site,
+            path = path,
+            clazz = clazz,
+            params = params
+        )
+    }
+
+    private suspend fun <T : Any> handleRequest(
+        site: SiteModel,
+        request: suspend WPAPINetwork.() -> WPAPIResponse<T>
+    ): WPAPIResponse<T> {
+        return when (site.origin) {
+            SiteModel.ORIGIN_WPAPI, SiteModel.ORIGIN_XMLRPC -> {
+                applicationPasswordsNetwork.request()
+            }
+
+            SiteModel.ORIGIN_WPCOM_REST -> {
+                handleRequestForJetpackSites(site) {
+                    request()
+                }
+            }
+
+            else -> {
+                throw IllegalArgumentException("Unsupported site origin: ${site.origin}")
+            }
+        }
+    }
+
+    private suspend fun <T : Any> handleRequestForJetpackSites(
+        site: SiteModel,
+        request: suspend WPAPINetwork.() -> WPAPIResponse<T>
+    ): WPAPIResponse<T> {
+        if (!site.isApplicationPasswordsSupported) {
+            AppLog.v(
+                AppLog.T.API,
+                "Application Passwords not supported for site: ${site.url}, use Jetpack Tunnel"
+            )
+            return jetpackTunnelWPAPINetwork.request()
+        }
+
+        return when (val appPasswordsResponse = applicationPasswordsNetwork.request()) {
+            is WPAPIResponse.Success<*> -> {
+                AppLog.v(
+                    AppLog.T.API,
+                    "Request successful for site: ${site.url}, using Application Passwords"
+                )
+                appPasswordsResponse
+            }
+
+            is WPAPIResponse.Error<*> -> {
+                AppLog.w(
+                    AppLog.T.API,
+                    "Request failed for site: ${site.url} using Application Passwords, falling back to Jetpack Tunnel"
+                )
+                if (appPasswordsResponse.error.errorCode ==
+                    ApplicationPasswordsNetwork.APPLICATION_PASSWORDS_NOT_SUPPORT_ERROR_CODE
+                ) {
+                    // TODO flag the site as not supported
+                }
+                jetpackTunnelWPAPINetwork.request()
+            }
+        }
+    }
+}

--- a/libs/fluxc-plugin/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/WooExperimentalNetwork.kt
+++ b/libs/fluxc-plugin/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/WooExperimentalNetwork.kt
@@ -1,5 +1,7 @@
 package org.wordpress.android.fluxc.network.rest.wpcom.wc
 
+import org.wordpress.android.fluxc.Dispatcher
+import org.wordpress.android.fluxc.generated.SiteActionBuilder
 import org.wordpress.android.fluxc.model.SiteModel
 import org.wordpress.android.fluxc.network.rest.wpapi.WPAPINetwork
 import org.wordpress.android.fluxc.network.rest.wpapi.WPAPIResponse
@@ -20,6 +22,7 @@ import javax.inject.Singleton
 class WooExperimentalNetwork @Inject constructor(
     private val applicationPasswordsNetwork: ApplicationPasswordsNetwork,
     private val jetpackTunnelWPAPINetwork: JetpackTunnelWPAPINetwork,
+    private val dispatcher: Dispatcher
 ) : WPAPINetwork {
     override suspend fun <T : Any> executeGetGsonRequest(
         site: SiteModel,
@@ -137,7 +140,8 @@ class WooExperimentalNetwork @Inject constructor(
                 if (appPasswordsResponse.error.errorCode ==
                     ApplicationPasswordsNetwork.APPLICATION_PASSWORDS_NOT_SUPPORT_ERROR_CODE
                 ) {
-                    // TODO flag the site as not supported
+                    site.applicationPasswordsAuthorizeUrl = null
+                    dispatcher.dispatch(SiteActionBuilder.newUpdateSiteAction(site))
                 }
                 jetpackTunnelWPAPINetwork.request()
             }

--- a/libs/fluxc-plugin/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/WooNetwork.kt
+++ b/libs/fluxc-plugin/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/WooNetwork.kt
@@ -1,14 +1,10 @@
 package org.wordpress.android.fluxc.network.rest.wpcom.wc
 
 import org.wordpress.android.fluxc.model.SiteModel
-import org.wordpress.android.fluxc.network.BaseRequest
-import org.wordpress.android.fluxc.network.rest.wpapi.WPAPINetworkError
+import org.wordpress.android.fluxc.network.rest.wpapi.WPAPINetwork
 import org.wordpress.android.fluxc.network.rest.wpapi.WPAPIResponse
 import org.wordpress.android.fluxc.network.rest.wpapi.applicationpasswords.ApplicationPasswordsNetwork
 import org.wordpress.android.fluxc.network.rest.wpcom.JetpackTunnelWPAPINetwork
-import org.wordpress.android.fluxc.network.rest.wpcom.jetpacktunnel.JetpackTunnelGsonRequestBuilder.JetpackResponse
-import org.wordpress.android.fluxc.network.rest.wpcom.jetpacktunnel.JetpackTunnelGsonRequestBuilder.JetpackResponse.JetpackError
-import org.wordpress.android.fluxc.network.rest.wpcom.jetpacktunnel.JetpackTunnelGsonRequestBuilder.JetpackResponse.JetpackSuccess
 import javax.inject.Inject
 import javax.inject.Singleton
 
@@ -24,81 +20,72 @@ import javax.inject.Singleton
 class WooNetwork @Inject constructor(
     private val jetpackTunnelWPAPINetwork: JetpackTunnelWPAPINetwork,
     private val applicationPasswordsNetwork: ApplicationPasswordsNetwork
-) {
-    suspend fun <T : Any> executeGetGsonRequest(
+) : WPAPINetwork {
+    override suspend fun <T : Any> executeGetGsonRequest(
         site: SiteModel,
         path: String,
         clazz: Class<T>,
-        params: Map<String, String> = emptyMap(),
-        enableCaching: Boolean = false,
-        cacheTimeToLive: Int = BaseRequest.DEFAULT_CACHE_LIFETIME,
-        forced: Boolean = false,
-        requestTimeout: Int = BaseRequest.DEFAULT_REQUEST_TIMEOUT,
-        retries: Int = BaseRequest.DEFAULT_MAX_RETRIES
-    ): WPAPIResponse<T> {
-        return when (site.origin) {
-            SiteModel.ORIGIN_WPCOM_REST -> jetpackTunnelWPAPINetwork.executeGetGsonRequest(
-                site, path, clazz, params, enableCaching, cacheTimeToLive, forced, requestTimeout, retries
-            ).toWPAPIResponse()
-            SiteModel.ORIGIN_XMLRPC, SiteModel.ORIGIN_WPAPI -> applicationPasswordsNetwork.executeGetGsonRequest(
-                site, path, clazz, params, enableCaching, cacheTimeToLive, forced, requestTimeout, retries
-            )
-            else -> error("Site with unsupported origin")
-        }
-    }
+        params: Map<String, String>,
+        enableCaching: Boolean,
+        cacheTimeToLive: Int,
+        forced: Boolean,
+        requestTimeout: Int,
+        retries: Int
+    ): WPAPIResponse<T> = site.getDelegate()
+        .executeGetGsonRequest(
+            site = site,
+            path = path,
+            clazz = clazz,
+            params = params,
+            enableCaching = enableCaching,
+            cacheTimeToLive = cacheTimeToLive,
+            forced = forced,
+            requestTimeout = requestTimeout,
+            retries = retries
+        )
 
-    suspend fun <T : Any> executePostGsonRequest(
+    override suspend fun <T : Any> executePostGsonRequest(
         site: SiteModel,
         path: String,
         clazz: Class<T>,
-        body: Map<String, Any> = emptyMap()
-    ): WPAPIResponse<T> {
-        return when (site.origin) {
-            SiteModel.ORIGIN_WPCOM_REST -> jetpackTunnelWPAPINetwork.executePostGsonRequest(site, path, clazz, body)
-                .toWPAPIResponse()
-            SiteModel.ORIGIN_XMLRPC, SiteModel.ORIGIN_WPAPI -> applicationPasswordsNetwork.executePostGsonRequest(
-                site, path, clazz, body
-            )
-            else -> error("Site with unsupported origin")
-        }
-    }
+        body: Map<String, Any>
+    ): WPAPIResponse<T> = site.getDelegate()
+        .executePostGsonRequest(
+            site = site,
+            path = path,
+            clazz = clazz,
+            body = body
+        )
 
-    suspend fun <T : Any> executePutGsonRequest(
+    override suspend fun <T : Any> executePutGsonRequest(
         site: SiteModel,
         path: String,
         clazz: Class<T>,
-        body: Map<String, Any> = emptyMap()
-    ): WPAPIResponse<T> {
-        return when (site.origin) {
-            SiteModel.ORIGIN_WPCOM_REST -> jetpackTunnelWPAPINetwork.executePutGsonRequest(site, path, clazz, body)
-                .toWPAPIResponse()
-            SiteModel.ORIGIN_XMLRPC, SiteModel.ORIGIN_WPAPI -> applicationPasswordsNetwork.executePutGsonRequest(
-                site, path, clazz, body
-            )
-            else -> error("Site with unsupported origin")
-        }
-    }
+        body: Map<String, Any>
+    ): WPAPIResponse<T> = site.getDelegate()
+        .executePutGsonRequest(
+            site = site,
+            path = path,
+            clazz = clazz,
+            body = body
+        )
 
-    suspend fun <T : Any> executeDeleteGsonRequest(
+    override suspend fun <T : Any> executeDeleteGsonRequest(
         site: SiteModel,
         path: String,
         clazz: Class<T>,
-        params: Map<String, String> = emptyMap()
-    ): WPAPIResponse<T> {
-        return when (site.origin) {
-            SiteModel.ORIGIN_WPCOM_REST -> jetpackTunnelWPAPINetwork.executeDeleteGsonRequest(site, path, clazz, params)
-                .toWPAPIResponse()
-            SiteModel.ORIGIN_XMLRPC, SiteModel.ORIGIN_WPAPI -> applicationPasswordsNetwork.executeDeleteGsonRequest(
-                site, path, clazz, params
-            )
-            else -> error("Site with unsupported origin")
-        }
-    }
-}
+        params: Map<String, String>
+    ): WPAPIResponse<T> = site.getDelegate()
+        .executeDeleteGsonRequest(
+            site = site,
+            path = path,
+            clazz = clazz,
+            params = params
+        )
 
-private fun <T> JetpackResponse<T>.toWPAPIResponse(): WPAPIResponse<T> {
-    return when (this) {
-        is JetpackSuccess -> WPAPIResponse.Success(data)
-        is JetpackError -> WPAPIResponse.Error(WPAPINetworkError(error, errorCode = error.apiError))
+    private fun SiteModel.getDelegate() = when (origin) {
+        SiteModel.ORIGIN_WPCOM_REST -> jetpackTunnelWPAPINetwork
+        SiteModel.ORIGIN_XMLRPC, SiteModel.ORIGIN_WPAPI -> applicationPasswordsNetwork
+        else -> error("Site with unsupported origin")
     }
 }

--- a/libs/fluxc-tests/src/test/java/org/wordpress/android/fluxc/network/rest/wpcom/wc/WooExperimentalNetworkTest.kt
+++ b/libs/fluxc-tests/src/test/java/org/wordpress/android/fluxc/network/rest/wpcom/wc/WooExperimentalNetworkTest.kt
@@ -1,0 +1,141 @@
+package org.wordpress.android.fluxc.network.rest.wpcom.wc
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.mockito.kotlin.argThat
+import org.mockito.kotlin.given
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.never
+import org.mockito.kotlin.verify
+import org.robolectric.RobolectricTestRunner
+import org.wordpress.android.fluxc.Dispatcher
+import org.wordpress.android.fluxc.action.SiteAction
+import org.wordpress.android.fluxc.model.SiteModel
+import org.wordpress.android.fluxc.network.rest.wpapi.WPAPINetworkError
+import org.wordpress.android.fluxc.network.rest.wpapi.WPAPIResponse
+import org.wordpress.android.fluxc.network.rest.wpapi.applicationpasswords.ApplicationPasswordsNetwork
+import org.wordpress.android.fluxc.network.rest.wpcom.JetpackTunnelWPAPINetwork
+import org.wordpress.android.fluxc.test
+
+@RunWith(RobolectricTestRunner::class)
+class WooExperimentalNetworkTest {
+    private val testSite = SiteModel()
+    private val testPath = "path"
+    private val applicationPasswordsNetwork: ApplicationPasswordsNetwork = mock()
+    private val jetpackTunnelWPAPINetwork: JetpackTunnelWPAPINetwork = mock()
+    private val dispatcher: Dispatcher = mock()
+
+    private val sut = WooExperimentalNetwork(
+        applicationPasswordsNetwork = applicationPasswordsNetwork,
+        jetpackTunnelWPAPINetwork = jetpackTunnelWPAPINetwork,
+        dispatcher = dispatcher
+    )
+
+    @Test
+    fun `given Jetpack site supports app passwords, when making request, then use app passwords network`() = test {
+        testSite.origin = SiteModel.ORIGIN_WPCOM_REST
+        testSite.applicationPasswordsAuthorizeUrl = "authorize_url"
+        val sampleResponse = SampleResponse("value")
+        givenAppPasswordsResponse(WPAPIResponse.Success(SampleResponse("value")))
+
+        val response = sut.executeGetGsonRequest(
+            site = testSite,
+            path = testPath,
+            clazz = SampleResponse::class.java
+        )
+
+        assertThat((response as WPAPIResponse.Success).data).isEqualTo(sampleResponse)
+        verify(jetpackTunnelWPAPINetwork, never()).executeGetGsonRequest(
+            site = testSite,
+            path = testPath,
+            clazz = SampleResponse::class.java
+        )
+    }
+
+    @Test
+    fun `given jetpack site that supports app passwords, when request fails, then fall back to jetpack tunnel`() =
+        test {
+            testSite.origin = SiteModel.ORIGIN_WPCOM_REST
+            testSite.applicationPasswordsAuthorizeUrl = "authorize_url"
+            givenAppPasswordsResponse(WPAPIResponse.Error(WPAPINetworkError(mock(), "error")))
+            val sampleResponse = SampleResponse("value")
+            givenJetpackTunnelResponse(WPAPIResponse.Success(sampleResponse))
+
+            val response = sut.executeGetGsonRequest(
+                site = testSite,
+                path = testPath,
+                clazz = SampleResponse::class.java
+            )
+
+            assertThat((response as WPAPIResponse.Success).data).isEqualTo(sampleResponse)
+        }
+
+    @Test
+    fun `given jetpack site that does not support app passwords, when making request, then use jetpack tunnel`() =
+        test {
+            testSite.origin = SiteModel.ORIGIN_WPCOM_REST
+            testSite.applicationPasswordsAuthorizeUrl = null
+            val sampleResponse = SampleResponse("value")
+            givenJetpackTunnelResponse(WPAPIResponse.Success(sampleResponse))
+
+            val response = sut.executeGetGsonRequest(
+                site = testSite,
+                path = testPath,
+                clazz = SampleResponse::class.java
+            )
+
+            assertThat((response as WPAPIResponse.Success).data).isEqualTo(sampleResponse)
+        }
+
+    @Test
+    fun `when detecting that a site doesn't support app passwords, then update cached site with correct status`() =
+        test {
+            testSite.origin = SiteModel.ORIGIN_WPCOM_REST
+            testSite.applicationPasswordsAuthorizeUrl = "authorize_url"
+            givenAppPasswordsResponse(
+                WPAPIResponse.Error(
+                    WPAPINetworkError(
+                        mock(),
+                        errorCode = ApplicationPasswordsNetwork.APPLICATION_PASSWORDS_NOT_SUPPORT_ERROR_CODE
+                    )
+                )
+            )
+
+            sut.executeGetGsonRequest(
+                site = testSite,
+                path = testPath,
+                clazz = SampleResponse::class.java
+            )
+
+            val expectedSite = testSite.apply {
+                applicationPasswordsAuthorizeUrl = null
+            }
+            verify(dispatcher).dispatch(argThat {
+                this.type == SiteAction.UPDATE_SITE &&
+                    this.payload == expectedSite
+            })
+        }
+
+    private suspend fun givenAppPasswordsResponse(response: WPAPIResponse<SampleResponse>) {
+        given(
+            applicationPasswordsNetwork.executeGetGsonRequest(
+                testSite,
+                testPath,
+                SampleResponse::class.java
+            )
+        ).willReturn(response)
+    }
+
+    private suspend fun givenJetpackTunnelResponse(response: WPAPIResponse<SampleResponse>) {
+        given(
+            jetpackTunnelWPAPINetwork.executeGetGsonRequest(
+                testSite,
+                testPath,
+                SampleResponse::class.java
+            )
+        ).willReturn(response)
+    }
+
+    private data class SampleResponse(val value: String)
+}

--- a/libs/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpapi/WPAPINetwork.kt
+++ b/libs/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpapi/WPAPINetwork.kt
@@ -1,0 +1,39 @@
+package org.wordpress.android.fluxc.network.rest.wpapi
+
+import org.wordpress.android.fluxc.model.SiteModel
+import org.wordpress.android.fluxc.network.BaseRequest
+
+interface WPAPINetwork {
+    suspend fun <T : Any> executeGetGsonRequest(
+        site: SiteModel,
+        path: String,
+        clazz: Class<T>,
+        params: Map<String, String> = emptyMap(),
+        enableCaching: Boolean = false,
+        cacheTimeToLive: Int = BaseRequest.DEFAULT_CACHE_LIFETIME,
+        forced: Boolean = false,
+        requestTimeout: Int = BaseRequest.DEFAULT_REQUEST_TIMEOUT,
+        retries: Int = BaseRequest.DEFAULT_MAX_RETRIES
+    ): WPAPIResponse<T>
+
+    suspend fun <T : Any> executePostGsonRequest(
+        site: SiteModel,
+        path: String,
+        clazz: Class<T>,
+        body: Map<String, Any> = emptyMap()
+    ): WPAPIResponse<T>
+
+    suspend fun <T : Any> executePutGsonRequest(
+        site: SiteModel,
+        path: String,
+        clazz: Class<T>,
+        body: Map<String, Any> = emptyMap()
+    ): WPAPIResponse<T>
+
+    suspend fun <T : Any> executeDeleteGsonRequest(
+        site: SiteModel,
+        path: String,
+        clazz: Class<T>,
+        params: Map<String, String> = emptyMap()
+    ): WPAPIResponse<T>
+}

--- a/libs/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpapi/applicationpasswords/ApplicationPasswordsNetwork.kt
+++ b/libs/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpapi/applicationpasswords/ApplicationPasswordsNetwork.kt
@@ -10,6 +10,7 @@ import org.wordpress.android.fluxc.network.BaseRequest.BaseNetworkError
 import org.wordpress.android.fluxc.network.HttpMethod
 import org.wordpress.android.fluxc.network.UserAgent
 import org.wordpress.android.fluxc.network.rest.wpapi.WPAPIGsonRequest
+import org.wordpress.android.fluxc.network.rest.wpapi.WPAPINetwork
 import org.wordpress.android.fluxc.network.rest.wpapi.WPAPINetworkError
 import org.wordpress.android.fluxc.network.rest.wpapi.WPAPIResponse
 import org.wordpress.android.fluxc.network.rest.wpcom.WPComGsonRequest.WPComGsonNetworkError
@@ -31,12 +32,13 @@ class ApplicationPasswordsNetwork @Inject constructor(
     @Named("no-cookies") private val requestQueue: RequestQueue,
     private val userAgent: UserAgent,
     private val listener: Optional<ApplicationPasswordsListener>
-) {
+) : WPAPINetwork {
     // We can't use construction injection for this variable, as its class is internal
-    @Inject internal lateinit var mApplicationPasswordsManager: ApplicationPasswordsManager
+    @Inject
+    internal lateinit var mApplicationPasswordsManager: ApplicationPasswordsManager
 
     @Suppress("ReturnCount", "ComplexMethod")
-    suspend fun <T> executeGsonRequest(
+    private suspend fun <T> executeGsonRequest(
         site: SiteModel,
         method: HttpMethod,
         path: String,
@@ -92,12 +94,14 @@ class ApplicationPasswordsNetwork @Inject constructor(
                 }
                 credentialsResult.credentials
             }
+
             is ApplicationPasswordCreationResult.Failure -> {
                 if (listener.isPresent) {
                     listener.get().onPasswordGenerationFailed(credentialsResult.error.toWPAPINetworkError())
                 }
                 return WPAPIResponse.Error(credentialsResult.error.toWPAPINetworkError())
             }
+
             is ApplicationPasswordCreationResult.NotSupported -> {
                 if (listener.isPresent) {
                     listener.get().onFeatureUnavailable(site, credentialsResult.originalError.toWPAPINetworkError())
@@ -113,7 +117,7 @@ class ApplicationPasswordsNetwork @Inject constructor(
 
         val authorizationHeader = Credentials.basic(credentials.userName, credentials.password)
 
-        val response = suspendCancellableCoroutine<WPAPIResponse<T>> { continuation ->
+        val response = suspendCancellableCoroutine { continuation ->
             val request = buildRequest(continuation, authorizationHeader)
             requestQueue.add(request)
 
@@ -138,16 +142,16 @@ class ApplicationPasswordsNetwork @Inject constructor(
         }
     }
 
-    suspend fun <T> executeGetGsonRequest(
+    override suspend fun <T : Any> executeGetGsonRequest(
         site: SiteModel,
         path: String,
         clazz: Class<T>,
-        params: Map<String, String> = emptyMap(),
-        enableCaching: Boolean = false,
-        cacheTimeToLive: Int = BaseRequest.DEFAULT_CACHE_LIFETIME,
-        forced: Boolean = false,
-        requestTimeout: Int = BaseRequest.DEFAULT_REQUEST_TIMEOUT,
-        retries: Int = BaseRequest.DEFAULT_MAX_RETRIES
+        params: Map<String, String>,
+        enableCaching: Boolean,
+        cacheTimeToLive: Int,
+        forced: Boolean,
+        requestTimeout: Int,
+        retries: Int
     ) = executeGsonRequest(
         site = site,
         method = HttpMethod.GET,
@@ -161,29 +165,26 @@ class ApplicationPasswordsNetwork @Inject constructor(
         retries = retries
     )
 
-    suspend fun <T> executePostGsonRequest(
+    override suspend fun <T : Any> executePostGsonRequest(
         site: SiteModel,
         path: String,
         clazz: Class<T>,
-        body: Map<String, Any> = emptyMap(),
-        params: Map<String, String> = emptyMap()
-    ) = executeGsonRequest(site, HttpMethod.POST, path, clazz, params, body)
+        body: Map<String, Any>
+    ) = executeGsonRequest(site, HttpMethod.POST, path, clazz, body = body)
 
-    suspend fun <T> executePutGsonRequest(
+    override suspend fun <T : Any> executePutGsonRequest(
         site: SiteModel,
         path: String,
         clazz: Class<T>,
-        body: Map<String, Any> = emptyMap(),
-        params: Map<String, String> = emptyMap()
-    ) = executeGsonRequest(site, HttpMethod.PUT, path, clazz, params, body)
+        body: Map<String, Any>,
+    ) = executeGsonRequest(site, HttpMethod.PUT, path, clazz, body = body)
 
-    suspend fun <T> executeDeleteGsonRequest(
+    override suspend fun <T : Any> executeDeleteGsonRequest(
         site: SiteModel,
         path: String,
         clazz: Class<T>,
-        params: Map<String, String> = emptyMap(),
-        body: Map<String, Any> = emptyMap()
-    ) = executeGsonRequest(site, HttpMethod.DELETE, path, clazz, params, body)
+        params: Map<String, String>
+    ) = executeGsonRequest(site, HttpMethod.DELETE, path, clazz, params)
 
     companion object {
         const val APPLICATION_PASSWORDS_NOT_SUPPORT_ERROR_CODE = "application_passwords_not_supported"
@@ -197,6 +198,7 @@ private fun BaseNetworkError.toWPAPINetworkError(): WPAPINetworkError {
             baseError = this,
             errorCode = this.apiError
         )
+
         else -> WPAPINetworkError(this)
     }
 }

--- a/libs/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpapi/applicationpasswords/ApplicationPasswordsNetwork.kt
+++ b/libs/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpapi/applicationpasswords/ApplicationPasswordsNetwork.kt
@@ -99,11 +99,15 @@ class ApplicationPasswordsNetwork @Inject constructor(
                 return WPAPIResponse.Error(credentialsResult.error.toWPAPINetworkError())
             }
             is ApplicationPasswordCreationResult.NotSupported -> {
-                val networkError = credentialsResult.originalError.toWPAPINetworkError()
                 if (listener.isPresent) {
-                    listener.get().onFeatureUnavailable(site, networkError)
+                    listener.get().onFeatureUnavailable(site, credentialsResult.originalError.toWPAPINetworkError())
                 }
-                return WPAPIResponse.Error(networkError)
+                return WPAPIResponse.Error(
+                    WPAPINetworkError(
+                        baseError = credentialsResult.originalError.toWPAPINetworkError(),
+                        errorCode = APPLICATION_PASSWORDS_NOT_SUPPORT_ERROR_CODE
+                    )
+                )
             }
         }
 
@@ -180,6 +184,10 @@ class ApplicationPasswordsNetwork @Inject constructor(
         params: Map<String, String> = emptyMap(),
         body: Map<String, Any> = emptyMap()
     ) = executeGsonRequest(site, HttpMethod.DELETE, path, clazz, params, body)
+
+    companion object {
+        const val APPLICATION_PASSWORDS_NOT_SUPPORT_ERROR_CODE = "application_passwords_not_supported"
+    }
 }
 
 private fun BaseNetworkError.toWPAPINetworkError(): WPAPINetworkError {

--- a/libs/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpapi/jetpack/JetpackWPAPIRestClient.kt
+++ b/libs/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpapi/jetpack/JetpackWPAPIRestClient.kt
@@ -104,7 +104,7 @@ class JetpackWPAPIRestClient @Inject constructor(
 
         return when (response) {
             is Success<JetpackConnectionDataResponse> -> JetpackWPAPIPayload(
-                    response.data?.toDomainModel()
+                response.data?.toDomainModel()
             )
 
             is Error -> JetpackWPAPIPayload(response.error)
@@ -193,7 +193,7 @@ class JetpackWPAPIRestClient @Inject constructor(
         }
     }
 
-    private suspend inline fun <reified T> makeGetWPAPIRequest(
+    private suspend inline fun <reified T : Any> makeGetWPAPIRequest(
         site: SiteModel,
         path: String,
         useApplicationPasswords: Boolean
@@ -217,7 +217,7 @@ class JetpackWPAPIRestClient @Inject constructor(
         }
     }
 
-    private suspend inline fun <reified T> makePostWPAPIRequest(
+    private suspend inline fun <reified T : Any> makePostWPAPIRequest(
         site: SiteModel,
         path: String,
         body: Map<String, String>,

--- a/libs/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/JetpackTunnelWPAPINetwork.kt
+++ b/libs/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/JetpackTunnelWPAPINetwork.kt
@@ -5,11 +5,15 @@ import com.android.volley.DefaultRetryPolicy
 import com.android.volley.RequestQueue
 import org.wordpress.android.fluxc.Dispatcher
 import org.wordpress.android.fluxc.model.SiteModel
-import org.wordpress.android.fluxc.network.BaseRequest
 import org.wordpress.android.fluxc.network.UserAgent
+import org.wordpress.android.fluxc.network.rest.wpapi.WPAPINetwork
+import org.wordpress.android.fluxc.network.rest.wpapi.WPAPINetworkError
+import org.wordpress.android.fluxc.network.rest.wpapi.WPAPIResponse
 import org.wordpress.android.fluxc.network.rest.wpcom.auth.AccessToken
 import org.wordpress.android.fluxc.network.rest.wpcom.jetpacktunnel.JetpackTunnelGsonRequestBuilder
 import org.wordpress.android.fluxc.network.rest.wpcom.jetpacktunnel.JetpackTunnelGsonRequestBuilder.JetpackResponse
+import org.wordpress.android.fluxc.network.rest.wpcom.jetpacktunnel.JetpackTunnelGsonRequestBuilder.JetpackResponse.JetpackError
+import org.wordpress.android.fluxc.network.rest.wpcom.jetpacktunnel.JetpackTunnelGsonRequestBuilder.JetpackResponse.JetpackSuccess
 import javax.inject.Inject
 import javax.inject.Named
 import javax.inject.Singleton
@@ -28,18 +32,18 @@ class JetpackTunnelWPAPINetwork @Inject constructor(
     accessToken: AccessToken,
     userAgent: UserAgent,
     private val jetpackTunnelGsonRequestBuilder: JetpackTunnelGsonRequestBuilder
-) : BaseWPComRestClient(appContext, dispatcher, requestQueue, accessToken, userAgent) {
-    suspend fun <T : Any> executeGetGsonRequest(
+) : BaseWPComRestClient(appContext, dispatcher, requestQueue, accessToken, userAgent), WPAPINetwork {
+    override suspend fun <T : Any> executeGetGsonRequest(
         site: SiteModel,
         path: String,
         clazz: Class<T>,
-        params: Map<String, String> = emptyMap(),
-        enableCaching: Boolean = false,
-        cacheTimeToLive: Int = BaseRequest.DEFAULT_CACHE_LIFETIME,
-        forced: Boolean = false,
-        requestTimeout: Int = BaseRequest.DEFAULT_REQUEST_TIMEOUT,
-        retries: Int = BaseRequest.DEFAULT_MAX_RETRIES
-    ): JetpackResponse<T> {
+        params: Map<String, String>,
+        enableCaching: Boolean,
+        cacheTimeToLive: Int,
+        forced: Boolean,
+        requestTimeout: Int,
+        retries: Int
+    ): WPAPIResponse<T> {
         return jetpackTunnelGsonRequestBuilder.syncGetRequest(
             restClient = this,
             site = site,
@@ -54,51 +58,58 @@ class JetpackTunnelWPAPINetwork @Inject constructor(
                 retries,
                 DefaultRetryPolicy.DEFAULT_BACKOFF_MULT
             )
-        )
+        ).toWPAPIResponse()
     }
 
-    suspend fun <T : Any> executePostGsonRequest(
+    override suspend fun <T : Any> executePostGsonRequest(
         site: SiteModel,
         path: String,
         clazz: Class<T>,
-        body: Map<String, Any> = emptyMap(),
-    ): JetpackResponse<T> {
+        body: Map<String, Any>
+    ): WPAPIResponse<T> {
         return jetpackTunnelGsonRequestBuilder.syncPostRequest(
             restClient = this,
             site = site,
             url = path,
             clazz = clazz,
             body = body
-        )
+        ).toWPAPIResponse()
     }
 
-    suspend fun <T : Any> executePutGsonRequest(
+    override suspend fun <T : Any> executePutGsonRequest(
         site: SiteModel,
         path: String,
         clazz: Class<T>,
-        body: Map<String, Any> = emptyMap()
-    ): JetpackResponse<T> {
+        body: Map<String, Any>
+    ): WPAPIResponse<T> {
         return jetpackTunnelGsonRequestBuilder.syncPutRequest(
             restClient = this,
             site = site,
             url = path,
             clazz = clazz,
             body = body
-        )
+        ).toWPAPIResponse()
     }
 
-    suspend fun <T : Any> executeDeleteGsonRequest(
+    override suspend fun <T : Any> executeDeleteGsonRequest(
         site: SiteModel,
         path: String,
         clazz: Class<T>,
-        params: Map<String, String> = emptyMap()
-    ): JetpackResponse<T> {
+        params: Map<String, String>
+    ): WPAPIResponse<T> {
         return jetpackTunnelGsonRequestBuilder.syncDeleteRequest(
             restClient = this,
             site = site,
             url = path,
             clazz = clazz,
             params = params
-        )
+        ).toWPAPIResponse()
+    }
+
+    private fun <T> JetpackResponse<T>.toWPAPIResponse(): WPAPIResponse<T> {
+        return when (this) {
+            is JetpackSuccess -> WPAPIResponse.Success(data)
+            is JetpackError -> WPAPIResponse.Error(WPAPINetworkError(error, errorCode = error.apiError))
+        }
     }
 }

--- a/libs/fluxc/src/test/java/org/wordpress/android/fluxc/network/rest/wpapi/applicationpasswords/ApplicationPasswordsNetworkTests.kt
+++ b/libs/fluxc/src/test/java/org/wordpress/android/fluxc/network/rest/wpapi/applicationpasswords/ApplicationPasswordsNetworkTests.kt
@@ -18,7 +18,6 @@ import org.mockito.kotlin.whenever
 import org.robolectric.RobolectricTestRunner
 import org.wordpress.android.fluxc.model.SiteModel
 import org.wordpress.android.fluxc.network.BaseRequest.BaseNetworkError
-import org.wordpress.android.fluxc.network.HttpMethod
 import org.wordpress.android.fluxc.network.UserAgent
 import org.wordpress.android.fluxc.network.rest.wpapi.WPAPIGsonRequest
 import org.wordpress.android.fluxc.network.rest.wpapi.WPAPIResponse
@@ -61,7 +60,7 @@ class ApplicationPasswordsNetworkTests {
         whenever(mApplicationPasswordsManager.getApplicationCredentials(testSite))
             .thenReturn(ApplicationPasswordCreationResult.Created(testCredentials))
 
-        network.executeGsonRequest(testSite, HttpMethod.GET, "path", TestResponse::class.java)
+        network.executeGetGsonRequest(testSite, "path", TestResponse::class.java)
 
         verify(mApplicationPasswordsManager).getApplicationCredentials(testSite)
     }
@@ -74,7 +73,7 @@ class ApplicationPasswordsNetworkTests {
         val networkError = VolleyError(NetworkResponse(401, byteArrayOf(), true, 0, emptyList()))
         givenErrorResponse(networkError)
 
-        network.executeGsonRequest(testSite, HttpMethod.GET, "path", TestResponse::class.java)
+        network.executeGetGsonRequest(testSite, "path", TestResponse::class.java)
 
         verify(mApplicationPasswordsManager).deleteLocalApplicationPassword(testSite)
         verify(mApplicationPasswordsManager, times(2)).getApplicationCredentials(testSite)
@@ -87,7 +86,7 @@ class ApplicationPasswordsNetworkTests {
         whenever(mApplicationPasswordsManager.getApplicationCredentials(testSite))
             .thenReturn(ApplicationPasswordCreationResult.Existing(testCredentials))
 
-        val response = network.executeGsonRequest(testSite, HttpMethod.GET, "path", TestResponse::class.java)
+        val response = network.executeGetGsonRequest(testSite, "path", TestResponse::class.java)
 
         assertIs<WPAPIResponse.Success<TestResponse>>(response)
         assertEquals(expectedResponse, response.data)
@@ -100,7 +99,7 @@ class ApplicationPasswordsNetworkTests {
         whenever(mApplicationPasswordsManager.getApplicationCredentials(testSite))
             .thenReturn(ApplicationPasswordCreationResult.Existing(testCredentials))
 
-        val response = network.executeGsonRequest(testSite, HttpMethod.GET, "path", TestResponse::class.java)
+        val response = network.executeGetGsonRequest(testSite, "path", TestResponse::class.java)
 
         assertIs<WPAPIResponse.Error<TestResponse>>(response)
         assertEquals(networkError, response.error.volleyError)
@@ -113,7 +112,7 @@ class ApplicationPasswordsNetworkTests {
             whenever(mApplicationPasswordsManager.getApplicationCredentials(testSite))
                 .thenReturn(ApplicationPasswordCreationResult.NotSupported(BaseNetworkError(networkError)))
 
-            network.executeGsonRequest(testSite, HttpMethod.GET, "path", TestResponse::class.java)
+            network.executeGetGsonRequest(testSite, "path", TestResponse::class.java)
 
             verify(listener).onFeatureUnavailable(eq(testSite), any())
         }
@@ -125,7 +124,7 @@ class ApplicationPasswordsNetworkTests {
             whenever(mApplicationPasswordsManager.getApplicationCredentials(testSite))
                 .thenReturn(ApplicationPasswordCreationResult.Created(testCredentials))
 
-            network.executeGsonRequest(testSite, HttpMethod.GET, "path", TestResponse::class.java)
+            network.executeGetGsonRequest(testSite, "path", TestResponse::class.java)
 
             verify(listener).onNewPasswordCreated(isPasswordRegenerated = false)
         }
@@ -139,7 +138,7 @@ class ApplicationPasswordsNetworkTests {
             val networkError = VolleyError(NetworkResponse(401, byteArrayOf(), true, 0, emptyList()))
             givenErrorResponse(networkError)
 
-            network.executeGsonRequest(testSite, HttpMethod.GET, "path", TestResponse::class.java)
+            network.executeGetGsonRequest(testSite, "path", TestResponse::class.java)
 
             verify(listener).onNewPasswordCreated(isPasswordRegenerated = true)
         }


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: WOOMOB-276
Closes: WOOMOB-279
<!-- Id number of the GitHub issue this PR addresses. -->

<!-- 
━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
🛠 Need an AI review?  
Add a comment: `@coderabbitai review`
━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
-->

### Description
This PR adds a new `Network` implementation that allows using Application Passwords with Jetpack sites when possible, for not it's not used, so all you need is just code review, and check the unit tests.

I took this PR as a chance to introduce an interface for the different `Network` implementations that work with the WordPress REST API: `WPAPINetwork`, this makes delegating work to other implementations more convenient. This change in the commit 0d7c216 and it would be better to review it individually.

The experimental network follows this algorithm:
```mermaid
flowchart TD
    A[Consumer] -->|Request| B
    B(Network) --> C
    C{Supports App Passwords?} -->|Yes| D[Use Application Passwords]
    C --> |No| E[Use Jetpack Proxy]
    D --> S{Success?}
    S --> |Yes| Done
    S --> |No| EType{Error Type}
    EType --> |General Error| E
    EType --> |Application Passwords Disabled| Flag[Flag Site]
    Flag --> E
 ```

### Steps to reproduce
Just code review.

### Testing information
Just code review.

### The tests that have been performed
NA

- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.

## Reviewer (or Author, in the case of optional code reviews):

Please make sure these conditions are met before approving the PR, or request changes if the PR needs improvement:

- [ ] The PR is small and has a clear, single focus, or a valid explanation is provided in the description. If needed, please request to split it into smaller PRs.
- [ ] Ensure Adequate Unit Test Coverage: The changes are reasonably covered by unit tests or an explanation is provided in the PR description.
- [ ] Manual Testing: The author listed all the tests they ran, including smoke tests when needed (e.g., for refactorings). The reviewer confirmed that the PR works as expected on big (tablet) and small (phone) in case of UI changes, and no regressions are added.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->