### PR TITLE
[WOOMOB-277][Woo POS][Product Search] Remove ProductListHandler usage. Cache prepopulation on splash screen

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/common/data/WooPosGetProductById.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/common/data/WooPosGetProductById.kt
@@ -25,11 +25,11 @@ class WooPosGetProductById @Inject constructor(
                 remoteProductId = productId,
             )
 
-            if (!remoteProductResult.isError) {
+            return@withContext if (!remoteProductResult.isError) {
                 val remoteProduct = remoteProductResult.productWithMetaData.product
                 val product = remoteProduct.toAppModel()
                 cache.addAll(listOf(product))
-                return@withContext product
+                product
             } else {
                 null
             }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/common/data/WooPosGetProductById.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/common/data/WooPosGetProductById.kt
@@ -5,27 +5,36 @@ import com.woocommerce.android.model.toAppModel
 import com.woocommerce.android.tools.SelectedSite
 import kotlinx.coroutines.Dispatchers.IO
 import kotlinx.coroutines.withContext
-import org.wordpress.android.fluxc.store.WCProductStore
+import org.wordpress.android.fluxc.network.rest.wpcom.wc.product.ProductRestClient
 import javax.inject.Inject
 
 class WooPosGetProductById @Inject constructor(
     private val selectedSite: SelectedSite,
     private val cache: WooPosProductsCache,
-    private val productsStore: WCProductStore,
+    private val productRestClient: ProductRestClient,
 ) {
     suspend operator fun invoke(productId: Long): Product? = withContext(IO) {
         val cachedProduct = cache.getProductById(productId)
-        cachedProduct
-            ?: if (cache.getAll().size >= WooPosProductsCache.MAX_CACHE_SIZE) {
-                cache.getProductById(productId) ?: productsStore.getProductByRemoteId(
-                    site = selectedSite.get(),
-                    remoteProductId = productId,
-                )?.toAppModel()?.let {
-                    cache.addAll(listOf(it))
-                    it
-                }
+        if (cachedProduct != null) {
+            return@withContext cachedProduct
+        }
+
+        if (cache.getAll().size >= WooPosProductsCache.MAX_CACHE_SIZE) {
+            val remoteProductResult = productRestClient.fetchSingleProduct(
+                site = selectedSite.get(),
+                remoteProductId = productId,
+            )
+
+            if (!remoteProductResult.isError) {
+                val remoteProduct = remoteProductResult.productWithMetaData.product
+                val product = remoteProduct.toAppModel()
+                cache.addAll(listOf(product))
+                return@withContext product
             } else {
                 null
             }
+        } else {
+            null
+        }
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/common/data/WooPosGetProductById.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/common/data/WooPosGetProductById.kt
@@ -1,18 +1,14 @@
 package com.woocommerce.android.ui.woopos.common.data
 
 import com.woocommerce.android.model.Product
-import com.woocommerce.android.model.toAppModel
-import com.woocommerce.android.tools.SelectedSite
 import kotlinx.coroutines.Dispatchers.IO
 import kotlinx.coroutines.withContext
-import org.wordpress.android.fluxc.store.WCProductStore
 import javax.inject.Inject
 
 class WooPosGetProductById @Inject constructor(
-    private val store: WCProductStore,
-    private val site: SelectedSite,
+    private val cache: WooPosProductsCache,
 ) {
     suspend operator fun invoke(productId: Long): Product? = withContext(IO) {
-        return@withContext store.getProductByRemoteId(site.get(), productId)?.toAppModel()
+        cache.getProductById(productId)
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/common/data/WooPosGetProductById.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/common/data/WooPosGetProductById.kt
@@ -1,14 +1,25 @@
 package com.woocommerce.android.ui.woopos.common.data
 
 import com.woocommerce.android.model.Product
+import com.woocommerce.android.model.toAppModel
+import com.woocommerce.android.tools.SelectedSite
 import kotlinx.coroutines.Dispatchers.IO
 import kotlinx.coroutines.withContext
+import org.wordpress.android.fluxc.store.WCProductStore
 import javax.inject.Inject
 
 class WooPosGetProductById @Inject constructor(
+    private val selectedSite: SelectedSite,
     private val cache: WooPosProductsCache,
+    private val productsStore: WCProductStore,
 ) {
     suspend operator fun invoke(productId: Long): Product? = withContext(IO) {
-        cache.getProductById(productId)
+        cache.getProductById(productId) ?: productsStore.getProductByRemoteId(
+            site = selectedSite.get(),
+            remoteProductId = productId,
+        )?.toAppModel()?.let {
+            cache.addAll(listOf(it))
+            it
+        }
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/common/data/WooPosGetProductById.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/common/data/WooPosGetProductById.kt
@@ -14,12 +14,18 @@ class WooPosGetProductById @Inject constructor(
     private val productsStore: WCProductStore,
 ) {
     suspend operator fun invoke(productId: Long): Product? = withContext(IO) {
-        cache.getProductById(productId) ?: productsStore.getProductByRemoteId(
-            site = selectedSite.get(),
-            remoteProductId = productId,
-        )?.toAppModel()?.let {
-            cache.addAll(listOf(it))
-            it
-        }
+        val cachedProduct = cache.getProductById(productId)
+        cachedProduct
+            ?: if (cache.getAll().size >= WooPosProductsCache.MAX_CACHE_SIZE) {
+                cache.getProductById(productId) ?: productsStore.getProductByRemoteId(
+                    site = selectedSite.get(),
+                    remoteProductId = productId,
+                )?.toAppModel()?.let {
+                    cache.addAll(listOf(it))
+                    it
+                }
+            } else {
+                null
+            }
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/common/data/WooPosMockedPopularProductsProvider.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/common/data/WooPosMockedPopularProductsProvider.kt
@@ -1,19 +1,20 @@
 package com.woocommerce.android.ui.woopos.common.data
 
 import com.woocommerce.android.model.Product
+import com.woocommerce.android.ui.woopos.home.items.products.WooPosProductsIndex
 import javax.inject.Inject
 import javax.inject.Singleton
 
 @Singleton
 class WooPosMockedPopularProductsProvider @Inject constructor(
-    private val productsCache: WooPosProductsCache
+    private val productsIndex: WooPosProductsIndex,
 ) {
     companion object {
         private const val MAX_POPULAR_PRODUCTS = 10
     }
 
     suspend fun getPopularProducts(): List<Product> {
-        val products = productsCache.getAll()
+        val products = productsIndex.getProductList()
         return products.shuffled().take(minOf(products.size, MAX_POPULAR_PRODUCTS))
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/common/data/WooPosProductsCache.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/common/data/WooPosProductsCache.kt
@@ -3,6 +3,10 @@ package com.woocommerce.android.ui.woopos.common.data
 import com.woocommerce.android.model.Product
 
 interface WooPosProductsCache {
+    companion object {
+        const val MAX_CACHE_SIZE = 2_000
+    }
+
     suspend fun addAll(products: List<Product>)
 
     suspend fun getAll(): List<Product>

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/common/data/WooPosProductsInMemoryCache.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/common/data/WooPosProductsInMemoryCache.kt
@@ -1,6 +1,7 @@
 package com.woocommerce.android.ui.woopos.common.data
 
 import com.woocommerce.android.model.Product
+import com.woocommerce.android.ui.woopos.common.data.WooPosProductsCache.Companion.MAX_CACHE_SIZE
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
 import javax.inject.Inject
@@ -11,7 +12,6 @@ class WooPosProductsInMemoryCache @Inject constructor() : WooPosProductsCache {
     private val mutex = Mutex()
 
     companion object {
-        private const val MAX_CACHE_SIZE = 2_000
         private const val INITIAL_CAPACITY = 200
         private const val LOAD_FACTOR = 0.75f
     }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/items/WooPosItemsViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/items/WooPosItemsViewModel.kt
@@ -198,7 +198,7 @@ class WooPosItemsViewModel @Inject constructor(
                 WooPosItemsViewState.Loading(withCart = withCart)
             }
 
-            productsDataSource.loadSimpleProducts(forceRefreshProducts = forceRefreshProducts).collect { result ->
+            productsDataSource.loadProducts(forceRefreshProducts = forceRefreshProducts).collect { result ->
                 when (result) {
                     is WooPosProductsDataSource.ProductsResult.Cached -> {
                         if (result.products.isNotEmpty()) {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/items/products/WooPosProductsDataSource.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/items/products/WooPosProductsDataSource.kt
@@ -78,13 +78,13 @@ class WooPosProductsDataSource @Inject constructor(
         }
         productsIndex.clearCache()
 
-        val cachedProducts = sortProductsByName(productsCache.getAll()).take(PAGE_SIZE)
+        val cachedProducts = productsCache.getAll().sortedBy { it.name }.take(PAGE_SIZE)
         emit(ProductsResult.Cached(cachedProducts))
 
         val fetchResult = fetchProducts()
 
         if (fetchResult.isSuccess) {
-            emit(ProductsResult.Remote(Result.success(sortProductsByName(productsIndex.getProductList()))))
+            emit(ProductsResult.Remote(Result.success(fetchResult.getOrThrow())))
         } else {
             emit(ProductsResult.Remote(Result.failure(fetchResult.exceptionOrNull() ?: Exception("Unknown error"))))
         }
@@ -92,13 +92,13 @@ class WooPosProductsDataSource @Inject constructor(
 
     suspend fun loadMore(): Result<List<Product>> = withContext(Dispatchers.IO) {
         if (!canLoadMore.get()) {
-            return@withContext Result.success(sortProductsByName(productsIndex.getProductList()))
+            return@withContext Result.success(productsIndex.getProductList().sortedBy { it.name })
         }
 
         val fetchResult = fetchProducts()
 
         if (fetchResult.isSuccess) {
-            Result.success(sortProductsByName(productsIndex.getProductList()))
+            Result.success(fetchResult.getOrThrow())
         } else {
             fetchResult
         }
@@ -122,7 +122,7 @@ class WooPosProductsDataSource @Inject constructor(
 
             productsCache.addAll(products)
             productsIndex.storeProductList(products.map { it.remoteId })
-            Result.success(sortProductsByName(productsIndex.getProductList()))
+            Result.success(productsIndex.getProductList().sortedBy { it.name })
         } else {
             result.logFailure()
             Result.failure(WooException(result.error))
@@ -140,10 +140,6 @@ class WooPosProductsDataSource @Inject constructor(
         WCProductStore.IncludeType.Simple,
         WCProductStore.IncludeType.Variable
     )
-
-    private fun sortProductsByName(products: List<Product>): List<Product> {
-        return products.sortedBy { it.name }
-    }
 
     private fun WooResult<*>.logFailure() {
         val errorMessage = error?.message ?: "Unknown error"

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/items/products/WooPosProductsDataSource.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/items/products/WooPosProductsDataSource.kt
@@ -57,7 +57,6 @@ class WooPosProductsDataSource @Inject constructor(
                 val productsList = result.model ?: emptyList()
                 val products = productsList.map { it.toAppModel() }
 
-                productsIndex.storeProductList(products.map { it.remoteId })
                 productsToFetch.addAll(products)
 
                 hasMoreToFetch = products.size == PRE_POPULATION_PAGE_SIZE

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/items/products/WooPosProductsDataSource.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/items/products/WooPosProductsDataSource.kt
@@ -152,6 +152,6 @@ class WooPosProductsDataSource @Inject constructor(
     companion object {
         private const val NORMAL_PAGE_SIZE = 25
         private const val PRE_POPULATION_PAGE_SIZE = 100
-        private const val PRE_POPULATION_MAX_PAGES = 25
+        private const val PRE_POPULATION_MAX_PAGES = 2
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/items/products/WooPosProductsDataSource.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/items/products/WooPosProductsDataSource.kt
@@ -78,8 +78,8 @@ class WooPosProductsDataSource @Inject constructor(
         }
         productsIndex.clearCache()
 
-        val cachedProducts = productsIndex.getProductList().take(PAGE_SIZE)
-        emit(ProductsResult.Cached(sortProductsByName(cachedProducts)))
+        val cachedProducts = sortProductsByName(productsCache.getAll()).take(PAGE_SIZE)
+        emit(ProductsResult.Cached(cachedProducts))
 
         val fetchResult = fetchProducts()
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/items/products/WooPosProductsDataSource.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/items/products/WooPosProductsDataSource.kt
@@ -22,8 +22,6 @@ import java.util.concurrent.atomic.AtomicInteger
 import javax.inject.Inject
 import javax.inject.Singleton
 
-private const val PAGE_SIZE = 25 // Matches [ProductListHandler]'s PAGE_SIZE
-
 @Singleton
 class WooPosProductsDataSource @Inject constructor(
     private val productStore: WCProductStore,
@@ -78,7 +76,7 @@ class WooPosProductsDataSource @Inject constructor(
         }
         productsIndex.clearCache()
 
-        val cachedProducts = productsCache.getAll().sortedBy { it.name }.take(PAGE_SIZE)
+        val cachedProducts = productsCache.getAll().sortedBy { it.name }.take(NORMAL_PAGE_SIZE)
         emit(ProductsResult.Cached(cachedProducts))
 
         val fetchResult = fetchProducts()

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/items/products/WooPosProductsDataSource.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/items/products/WooPosProductsDataSource.kt
@@ -35,7 +35,7 @@ class WooPosProductsDataSource @Inject constructor(
     val hasMorePages: Boolean
         get() = canLoadMore.get()
 
-    fun loadSimpleProducts(forceRefreshProducts: Boolean): Flow<ProductsResult> = flow {
+    fun loadProducts(forceRefreshProducts: Boolean): Flow<ProductsResult> = flow {
         offset.set(0)
         if (forceRefreshProducts) {
             productsCache.clear()

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/items/products/WooPosProductsDataSource.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/items/products/WooPosProductsDataSource.kt
@@ -43,35 +43,12 @@ class WooPosProductsDataSource @Inject constructor(
         val cachedProducts = productsCache.getAll()
         emit(ProductsResult.Cached(sortProductsByName(cachedProducts)))
 
-        val filters = createProductFilters()
-        val includeTypes = listOf(WCProductStore.IncludeType.Simple, WCProductStore.IncludeType.Variable)
+        val fetchResult = fetchProducts()
 
-        val result = productStore.fetchProducts(
-            site = selectedSite.get(),
-            offset = offset.get(),
-            pageSize = pageSize,
-            filterOptions = filters,
-            includeTypes = includeTypes
-        )
-
-        if (!result.isError) {
-            val productsList = result.model ?: emptyList()
-            val remoteProducts = productsList.map { it.toAppModel() }
-
-            canLoadMore.set(productsList.size == pageSize)
-            offset.addAndGet(pageSize)
-
-            productsCache.addAll(remoteProducts)
+        if (fetchResult.isSuccess) {
             emit(ProductsResult.Remote(Result.success(sortProductsByName(productsCache.getAll()))))
         } else {
-            result.logFailure()
-            emit(
-                ProductsResult.Remote(
-                    Result.failure(
-                        WooException(result.error)
-                    )
-                )
-            )
+            emit(ProductsResult.Remote(Result.failure(fetchResult.exceptionOrNull() ?: Exception("Unknown error"))))
         }
     }.flowOn(Dispatchers.IO).take(2)
 
@@ -80,25 +57,32 @@ class WooPosProductsDataSource @Inject constructor(
             return@withContext Result.success(sortProductsByName(productsCache.getAll()))
         }
 
-        val filters = createProductFilters()
-        val includeTypes = listOf(WCProductStore.IncludeType.Simple, WCProductStore.IncludeType.Variable)
+        val fetchResult = fetchProducts()
 
+        if (fetchResult.isSuccess) {
+            Result.success(sortProductsByName(productsCache.getAll()))
+        } else {
+            fetchResult
+        }
+    }
+
+    private suspend fun fetchProducts(): Result<List<Product>> {
         val result = productStore.fetchProducts(
             site = selectedSite.get(),
             offset = offset.get(),
             pageSize = pageSize,
-            filterOptions = filters,
-            includeTypes = includeTypes
+            filterOptions = createProductFilters(),
+            includeTypes = listOf(WCProductStore.IncludeType.Simple, WCProductStore.IncludeType.Variable),
         )
 
-        if (!result.isError) {
+        return if (!result.isError) {
             val productsList = result.model ?: emptyList()
-            val moreProducts = productsList.map { it.toAppModel() }
+            val products = productsList.map { it.toAppModel() }
 
             canLoadMore.set(productsList.size == pageSize)
             offset.addAndGet(pageSize)
 
-            productsCache.addAll(moreProducts)
+            productsCache.addAll(products)
             Result.success(sortProductsByName(productsCache.getAll()))
         } else {
             result.logFailure()

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/items/products/WooPosProductsDataSource.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/items/products/WooPosProductsDataSource.kt
@@ -92,13 +92,13 @@ class WooPosProductsDataSource @Inject constructor(
 
     suspend fun loadMore(): Result<List<Product>> = withContext(Dispatchers.IO) {
         if (!canLoadMore.get()) {
-            return@withContext Result.success(sortProductsByName(productsCache.getAll()))
+            return@withContext Result.success(sortProductsByName(productsIndex.getProductList()))
         }
 
         val fetchResult = fetchProducts()
 
         if (fetchResult.isSuccess) {
-            Result.success(sortProductsByName(productsCache.getAll()))
+            Result.success(sortProductsByName(productsIndex.getProductList()))
         } else {
             fetchResult
         }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/items/products/WooPosProductsDataSource.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/items/products/WooPosProductsDataSource.kt
@@ -1,49 +1,66 @@
 package com.woocommerce.android.ui.woopos.home.items.products
 
+import com.woocommerce.android.WooException
 import com.woocommerce.android.model.Product
+import com.woocommerce.android.model.toAppModel
+import com.woocommerce.android.tools.SelectedSite
 import com.woocommerce.android.ui.products.ProductStatus
-import com.woocommerce.android.ui.products.selector.ProductListHandler
 import com.woocommerce.android.ui.woopos.common.data.WooPosProductsCache
 import com.woocommerce.android.util.WooLog
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.Flow
-import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.flow.flowOn
 import kotlinx.coroutines.flow.take
 import kotlinx.coroutines.withContext
+import org.wordpress.android.fluxc.network.rest.wpcom.wc.WooResult
 import org.wordpress.android.fluxc.store.WCProductStore
+import org.wordpress.android.fluxc.store.WCProductStore.DownloadableOptions
+import org.wordpress.android.fluxc.store.WCProductStore.ProductFilterOption
+import java.util.concurrent.atomic.AtomicBoolean
+import java.util.concurrent.atomic.AtomicInteger
 import javax.inject.Inject
 import javax.inject.Singleton
 
 @Singleton
 class WooPosProductsDataSource @Inject constructor(
-    private val handler: ProductListHandler,
+    private val productStore: WCProductStore,
+    private val selectedSite: SelectedSite,
     private val productsCache: WooPosProductsCache
 ) {
+    private val canLoadMore = AtomicBoolean(false)
+    private val offset = AtomicInteger(0)
+    private val pageSize = 25
+
     val hasMorePages: Boolean
-        get() = handler.canLoadMore.get()
+        get() = canLoadMore.get()
 
     fun loadSimpleProducts(forceRefreshProducts: Boolean): Flow<ProductsResult> = flow {
+        offset.set(0)
         if (forceRefreshProducts) {
             productsCache.clear()
         }
-
         val cachedProducts = productsCache.getAll()
         emit(ProductsResult.Cached(sortProductsByName(cachedProducts)))
 
-        val result = handler.loadFromCacheAndFetch(
-            forceRefresh = forceRefreshProducts,
-            searchType = ProductListHandler.SearchType.DEFAULT,
-            includeType = listOf(WCProductStore.IncludeType.Simple, WCProductStore.IncludeType.Variable),
-            filters = mapOf(
-                WCProductStore.ProductFilterOption.STATUS to ProductStatus.PUBLISH.value,
-                WCProductStore.ProductFilterOption.DOWNLOADABLE to WCProductStore.DownloadableOptions.FALSE.toString(),
-            )
+        val filters = createProductFilters()
+        val includeTypes = listOf(WCProductStore.IncludeType.Simple, WCProductStore.IncludeType.Variable)
+
+        val result = productStore.fetchProducts(
+            site = selectedSite.get(),
+            offset = offset.get(),
+            pageSize = pageSize,
+            filterOptions = filters,
+            includeTypes = includeTypes
         )
 
-        if (result.isSuccess) {
-            val remoteProducts = handler.productsFlow.first()
+        if (!result.isError) {
+            val productsList = result.model ?: emptyList()
+            val remoteProducts = productsList.map { it.toAppModel() }
+
+            canLoadMore.set(productsList.size == pageSize)
+            offset.addAndGet(pageSize)
+
             productsCache.addAll(remoteProducts)
             emit(ProductsResult.Remote(Result.success(sortProductsByName(productsCache.getAll()))))
         } else {
@@ -51,7 +68,7 @@ class WooPosProductsDataSource @Inject constructor(
             emit(
                 ProductsResult.Remote(
                     Result.failure(
-                        result.exceptionOrNull() ?: Exception("Unknown error")
+                        WooException(result.error)
                     )
                 )
             )
@@ -59,27 +76,50 @@ class WooPosProductsDataSource @Inject constructor(
     }.flowOn(Dispatchers.IO).take(2)
 
     suspend fun loadMore(): Result<List<Product>> = withContext(Dispatchers.IO) {
-        val result = handler.loadMore(
-            includeTypes = listOf(WCProductStore.IncludeType.Simple, WCProductStore.IncludeType.Variable),
+        if (!canLoadMore.get()) {
+            return@withContext Result.success(sortProductsByName(productsCache.getAll()))
+        }
+
+        val filters = createProductFilters()
+        val includeTypes = listOf(WCProductStore.IncludeType.Simple, WCProductStore.IncludeType.Variable)
+
+        val result = productStore.fetchProducts(
+            site = selectedSite.get(),
+            offset = offset.get(),
+            pageSize = pageSize,
+            filterOptions = filters,
+            includeTypes = includeTypes
         )
-        if (result.isSuccess) {
-            val moreProducts = handler.productsFlow.first()
+
+        if (!result.isError) {
+            val productsList = result.model ?: emptyList()
+            val moreProducts = productsList.map { it.toAppModel() }
+
+            canLoadMore.set(productsList.size == pageSize)
+            offset.addAndGet(pageSize)
+
             productsCache.addAll(moreProducts)
             Result.success(sortProductsByName(productsCache.getAll()))
         } else {
             result.logFailure()
-            Result.failure(result.exceptionOrNull() ?: Exception("Unknown error"))
+            Result.failure(WooException(result.error))
         }
+    }
+
+    private fun createProductFilters(): Map<ProductFilterOption, String> {
+        return mapOf(
+            ProductFilterOption.STATUS to ProductStatus.PUBLISH.value,
+            ProductFilterOption.DOWNLOADABLE to DownloadableOptions.FALSE.toString()
+        )
     }
 
     private fun sortProductsByName(products: List<Product>): List<Product> {
         return products.sortedBy { it.name }
     }
 
-    private fun Result<Unit>.logFailure() {
-        val error = exceptionOrNull()
+    private fun WooResult<*>.logFailure() {
         val errorMessage = error?.message ?: "Unknown error"
-        WooLog.e(WooLog.T.POS, "Loading products failed - $errorMessage", error)
+        WooLog.e(WooLog.T.POS, "Loading products failed - $errorMessage")
     }
 
     sealed class ProductsResult {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/items/products/WooPosProductsDataSource.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/items/products/WooPosProductsDataSource.kt
@@ -30,10 +30,43 @@ class WooPosProductsDataSource @Inject constructor(
 ) {
     private val canLoadMore = AtomicBoolean(false)
     private val offset = AtomicInteger(0)
-    private val pageSize = 25
 
     val hasMorePages: Boolean
         get() = canLoadMore.get()
+
+    suspend fun prepopulateProductsCache(): Result<Unit> {
+        productsCache.clear()
+
+        var currentPage = 0
+        val productsToFetch = mutableListOf<Product>()
+        var hasMoreToFetch = true
+
+        while (hasMoreToFetch && currentPage < PRE_POPULATION_MAX_PAGES) {
+            val result = productStore.fetchProducts(
+                site = selectedSite.get(),
+                offset = currentPage * PRE_POPULATION_PAGE_SIZE,
+                pageSize = PRE_POPULATION_PAGE_SIZE,
+                filterOptions = createProductFilters(),
+                includeTypes = createIncludedTypes(),
+            )
+
+            if (!result.isError) {
+                val productsList = result.model ?: emptyList()
+                val products = productsList.map { it.toAppModel() }
+
+                productsToFetch.addAll(products)
+
+                hasMoreToFetch = products.size == PRE_POPULATION_PAGE_SIZE
+                currentPage++
+            } else {
+                result.logFailure()
+                return Result.failure(WooException(result.error))
+            }
+        }
+
+        productsCache.addAll(productsToFetch)
+        return Result.success(Unit)
+    }
 
     fun loadProducts(forceRefreshProducts: Boolean): Flow<ProductsResult> = flow {
         offset.set(0)
@@ -70,17 +103,17 @@ class WooPosProductsDataSource @Inject constructor(
         val result = productStore.fetchProducts(
             site = selectedSite.get(),
             offset = offset.get(),
-            pageSize = pageSize,
+            pageSize = NORMAL_PAGE_SIZE,
             filterOptions = createProductFilters(),
-            includeTypes = listOf(WCProductStore.IncludeType.Simple, WCProductStore.IncludeType.Variable),
+            includeTypes = createIncludedTypes(),
         )
 
         return if (!result.isError) {
             val productsList = result.model ?: emptyList()
             val products = productsList.map { it.toAppModel() }
 
-            canLoadMore.set(productsList.size == pageSize)
-            offset.addAndGet(pageSize)
+            canLoadMore.set(productsList.size == NORMAL_PAGE_SIZE)
+            offset.addAndGet(NORMAL_PAGE_SIZE)
 
             productsCache.addAll(products)
             Result.success(sortProductsByName(productsCache.getAll()))
@@ -97,6 +130,11 @@ class WooPosProductsDataSource @Inject constructor(
         )
     }
 
+    private fun createIncludedTypes() = listOf(
+        WCProductStore.IncludeType.Simple,
+        WCProductStore.IncludeType.Variable
+    )
+
     private fun sortProductsByName(products: List<Product>): List<Product> {
         return products.sortedBy { it.name }
     }
@@ -109,5 +147,11 @@ class WooPosProductsDataSource @Inject constructor(
     sealed class ProductsResult {
         data class Cached(val products: List<Product>) : ProductsResult()
         data class Remote(val productsResult: Result<List<Product>>) : ProductsResult()
+    }
+
+    companion object {
+        private const val NORMAL_PAGE_SIZE = 25
+        private const val PRE_POPULATION_PAGE_SIZE = 100
+        private const val PRE_POPULATION_MAX_PAGES = 25
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/items/products/WooPosProductsDataSource.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/items/products/WooPosProductsDataSource.kt
@@ -57,6 +57,7 @@ class WooPosProductsDataSource @Inject constructor(
                 val productsList = result.model ?: emptyList()
                 val products = productsList.map { it.toAppModel() }
 
+                productsIndex.storeProductList(products.map { it.remoteId })
                 productsToFetch.addAll(products)
 
                 hasMoreToFetch = products.size == PRE_POPULATION_PAGE_SIZE

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/items/products/WooPosProductsDataSource.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/items/products/WooPosProductsDataSource.kt
@@ -76,7 +76,7 @@ class WooPosProductsDataSource @Inject constructor(
         if (forceRefreshProducts) {
             productsCache.clear()
         }
-productsIndex.clearCache()
+        productsIndex.clearCache()
 
         val cachedProducts = productsIndex.getProductList().take(PAGE_SIZE)
         emit(ProductsResult.Cached(sortProductsByName(cachedProducts)))
@@ -84,7 +84,6 @@ productsIndex.clearCache()
         val fetchResult = fetchProducts()
 
         if (fetchResult.isSuccess) {
-            productsIndex.storeProductList(remoteProducts.map { it.remoteId })
             emit(ProductsResult.Remote(Result.success(sortProductsByName(productsIndex.getProductList()))))
         } else {
             emit(ProductsResult.Remote(Result.failure(fetchResult.exceptionOrNull() ?: Exception("Unknown error"))))
@@ -122,7 +121,7 @@ productsIndex.clearCache()
             offset.addAndGet(NORMAL_PAGE_SIZE)
 
             productsCache.addAll(products)
-            productsIndex.storeProductList(moreProducts.map { it.remoteId })
+            productsIndex.storeProductList(products.map { it.remoteId })
             Result.success(sortProductsByName(productsIndex.getProductList()))
         } else {
             result.logFailure()

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/items/search/WooPosSearchProductsDataSource.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/items/search/WooPosSearchProductsDataSource.kt
@@ -103,7 +103,8 @@ class WooPosSearchProductsDataSource @Inject constructor(
                 )
 
                 val searchResults = SearchResult(
-                    products = searchResultsIndex.getSearchResults(searchQuery),
+                    products = searchResultsIndex.getSearchResults(searchQuery)
+                        .sortedBy { it.name },
                     canLoadMore = searchResult.canLoadMore
                 )
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/items/search/WooPosSearchProductsDataSource.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/items/search/WooPosSearchProductsDataSource.kt
@@ -51,9 +51,6 @@ class WooPosSearchProductsDataSource @Inject constructor(
             val remoteResults = remoteSearchDeferred.await()
             remoteResults.fold(
                 onSuccess = { result ->
-                    canLoadMore.set(result.canLoadMore)
-                    productsCache.addAll(result.products)
-                    searchResultsIndex.storeSearchResults(query, result.products.map { it.remoteId })
                     emit(ProductsResult.Remote(Result.success(result.products)))
                 },
                 onFailure = { error ->
@@ -73,9 +70,6 @@ class WooPosSearchProductsDataSource @Inject constructor(
 
         return remoteSearch(query, offset).fold(
             onSuccess = { result ->
-                canLoadMore.set(result.canLoadMore)
-                productsCache.addAll(result.products)
-                searchResultsIndex.storeSearchResults(query, result.products.map { it.remoteId })
                 Result.success(searchResultsIndex.getSearchResults(query).sortedBy { it.name })
             },
             onFailure = { error ->
@@ -102,12 +96,17 @@ class WooPosSearchProductsDataSource @Inject constructor(
                 Result.failure(WooException(result.error))
             } else {
                 val searchResult = result.model!!
-                Result.success(
-                    SearchResult(
-                        products = searchResult.products.map { product -> product.toAppModel() },
-                        canLoadMore = searchResult.canLoadMore
-                    )
+                val products = searchResult.products.map { product -> product.toAppModel() }
+                val searchResults = SearchResult(
+                    products = products,
+                    canLoadMore = searchResult.canLoadMore
                 )
+
+                canLoadMore.set(searchResults.canLoadMore)
+                productsCache.addAll(searchResults.products)
+                searchResultsIndex.storeSearchResults(searchQuery, searchResults.products.map { it.remoteId })
+
+                Result.success(searchResults)
             }
         }
     }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/items/search/WooPosSearchProductsDataSource.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/items/search/WooPosSearchProductsDataSource.kt
@@ -43,10 +43,7 @@ class WooPosSearchProductsDataSource @Inject constructor(
             }
             val remoteSearchDeferred = async { remoteSearch(query) }
 
-            val localResults = localSearchDeferred.await()
-            if (localResults.isNotEmpty()) {
-                emit(ProductsResult.Cached(localResults))
-            }
+            emit(ProductsResult.Cached(localSearchDeferred.await()))
 
             val remoteResults = remoteSearchDeferred.await()
             remoteResults.fold(

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/items/search/WooPosSearchProductsDataSource.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/items/search/WooPosSearchProductsDataSource.kt
@@ -67,7 +67,7 @@ class WooPosSearchProductsDataSource @Inject constructor(
 
         return remoteSearch(query, offset).fold(
             onSuccess = { result ->
-                Result.success(searchResultsIndex.getSearchResults(query).sortedBy { it.name })
+                Result.success(result.products)
             },
             onFailure = { error ->
                 Result.failure(error)
@@ -94,14 +94,18 @@ class WooPosSearchProductsDataSource @Inject constructor(
             } else {
                 val searchResult = result.model!!
                 val products = searchResult.products.map { product -> product.toAppModel() }
-                val searchResults = SearchResult(
-                    products = products,
-                    canLoadMore = searchResult.canLoadMore
+
+                canLoadMore.set(searchResult.canLoadMore)
+                productsCache.addAll(products)
+                searchResultsIndex.storeSearchResults(
+                    searchQuery,
+                    products.map { it.remoteId }
                 )
 
-                canLoadMore.set(searchResults.canLoadMore)
-                productsCache.addAll(searchResults.products)
-                searchResultsIndex.storeSearchResults(searchQuery, searchResults.products.map { it.remoteId })
+                val searchResults = SearchResult(
+                    products = searchResultsIndex.getSearchResults(searchQuery),
+                    canLoadMore = searchResult.canLoadMore
+                )
 
                 Result.success(searchResults)
             }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/items/search/WooPosSearchProductsDataSource.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/items/search/WooPosSearchProductsDataSource.kt
@@ -39,7 +39,7 @@ class WooPosSearchProductsDataSource @Inject constructor(
             searchResultsIndex.clearCache()
 
             val localSearchDeferred = async {
-                productsCache.getAll().filter(searchPredicate(query)).take(PAGE_SIZE)
+                productsCache.getAll().filter(searchPredicate(query)).sortedBy { it.name }.take(PAGE_SIZE)
             }
             val remoteSearchDeferred = async { remoteSearch(query) }
 
@@ -76,15 +76,13 @@ class WooPosSearchProductsDataSource @Inject constructor(
                 canLoadMore.set(result.canLoadMore)
                 productsCache.addAll(result.products)
                 searchResultsIndex.storeSearchResults(query, result.products.map { it.remoteId })
-                Result.success(searchResultsIndex.getSearchResults(query))
+                Result.success(searchResultsIndex.getSearchResults(query).sortedBy { it.name })
             },
             onFailure = { error ->
                 Result.failure(error)
             }
         )
     }
-
-    suspend fun getProductById(productId: Long): Product? = productsCache.getProductById(productId)
 
     private suspend fun remoteSearch(
         searchQuery: String,

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/splash/WooPosSplashViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/splash/WooPosSplashViewModel.kt
@@ -9,6 +9,7 @@ import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.launch
+import java.util.concurrent.TimeUnit
 import javax.inject.Inject
 
 @HiltViewModel
@@ -19,27 +20,20 @@ class WooPosSplashViewModel @Inject constructor(
     private val _state = MutableStateFlow<WooPosSplashState>(WooPosSplashState.Loading)
     val state: StateFlow<WooPosSplashState> = _state
 
-    private val splashScreenStartTime = System.currentTimeMillis()
-
     init {
+        val splashScreenStartTime = System.currentTimeMillis()
         viewModelScope.launch {
-            productsDataSource.loadProducts(forceRefreshProducts = true)
-                .collect { result ->
-                    when (result) {
-                        is WooPosProductsDataSource.ProductsResult.Cached -> {}
-                        is WooPosProductsDataSource.ProductsResult.Remote -> {
-                            _state.value = WooPosSplashState.Loaded
-                            trackPosLoaded()
-                        }
-                    }
-                }
+            productsDataSource.prepopulateProductsCache()
+            _state.value = WooPosSplashState.Loaded
+            trackPosLoaded(splashScreenStartTime)
         }
     }
 
-    private suspend fun trackPosLoaded() {
+    private suspend fun trackPosLoaded(splashScreenStartTime: Long) {
         val event = Loaded.apply {
-            @Suppress("MagicNumber")
-            val waitingTimeSeconds = (System.currentTimeMillis() - splashScreenStartTime) / 1000f
+            val waitingTimeSeconds = TimeUnit.MILLISECONDS.toSeconds(
+                System.currentTimeMillis() - splashScreenStartTime
+            ).toFloat()
             addProperties(mapOf("waiting_time" to waitingTimeSeconds.toString()))
         }
         analyticsTracker.track(event)

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/splash/WooPosSplashViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/splash/WooPosSplashViewModel.kt
@@ -23,7 +23,7 @@ class WooPosSplashViewModel @Inject constructor(
 
     init {
         viewModelScope.launch {
-            productsDataSource.loadSimpleProducts(forceRefreshProducts = true)
+            productsDataSource.loadProducts(forceRefreshProducts = true)
                 .collect { result ->
                     when (result) {
                         is WooPosProductsDataSource.ProductsResult.Cached -> {}

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/home/items/WooPosItemsViewModelTestSelectionViewState.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/home/items/WooPosItemsViewModelTestSelectionViewState.kt
@@ -65,7 +65,7 @@ class WooPosItemsViewModelTestSelectionViewState {
             ),
         )
 
-        whenever(productsDataSource.loadSimpleProducts(any())).thenReturn(
+        whenever(productsDataSource.loadProducts(any())).thenReturn(
             flowOf(
                 WooPosProductsDataSource.ProductsResult.Remote(
                     Result.success(products)
@@ -100,7 +100,7 @@ class WooPosItemsViewModelTestSelectionViewState {
             ).copy(firstImageUrl = "https://test.com")
         )
 
-        whenever(productsDataSource.loadSimpleProducts(any())).thenReturn(
+        whenever(productsDataSource.loadProducts(any())).thenReturn(
             flowOf(
                 WooPosProductsDataSource.ProductsResult.Remote(
                     Result.success(products)
@@ -129,7 +129,7 @@ class WooPosItemsViewModelTestSelectionViewState {
     @Test
     fun `given empty products list returned, when view model created, then view state is empty`() = runTest {
         // GIVEN
-        whenever(productsDataSource.loadSimpleProducts(any())).thenReturn(
+        whenever(productsDataSource.loadProducts(any())).thenReturn(
             flowOf(
                 WooPosProductsDataSource.ProductsResult.Remote(
                     Result.success(emptyList())
@@ -150,7 +150,7 @@ class WooPosItemsViewModelTestSelectionViewState {
     @Test
     fun `given loading products fails, when view model created, then view state is error`() = runTest {
         // GIVEN
-        whenever(productsDataSource.loadSimpleProducts(any())).thenReturn(
+        whenever(productsDataSource.loadProducts(any())).thenReturn(
             flowOf(
                 WooPosProductsDataSource.ProductsResult.Remote(
                     Result.failure(Exception())
@@ -177,7 +177,7 @@ class WooPosItemsViewModelTestSelectionViewState {
 
             // THEN
             viewModel.viewState.test {
-                verify(productsDataSource).loadSimpleProducts(forceRefreshProducts = true)
+                verify(productsDataSource).loadProducts(forceRefreshProducts = true)
                 cancelAndConsumeRemainingEvents()
             }
         }
@@ -243,7 +243,7 @@ class WooPosItemsViewModelTestSelectionViewState {
 
         // THEN
         viewModel.viewState.test {
-            verify(productsDataSource).loadSimpleProducts(forceRefreshProducts = false)
+            verify(productsDataSource).loadProducts(forceRefreshProducts = false)
             cancelAndConsumeRemainingEvents()
         }
     }
@@ -278,7 +278,7 @@ class WooPosItemsViewModelTestSelectionViewState {
     fun `given no products, when pull to refresh, then state is Empty`() = runTest {
         // GIVEN
         val viewModel = createViewModel()
-        whenever(productsDataSource.loadSimpleProducts(any())).thenReturn(
+        whenever(productsDataSource.loadProducts(any())).thenReturn(
             flowOf(
                 WooPosProductsDataSource.ProductsResult.Remote(
                     Result.success(emptyList())
@@ -300,7 +300,7 @@ class WooPosItemsViewModelTestSelectionViewState {
     fun `given empty list, when pull to refresh, then parent notified correctly`() = runTest {
         // GIVEN
         val viewModel = createViewModel()
-        whenever(productsDataSource.loadSimpleProducts(any())).thenReturn(
+        whenever(productsDataSource.loadProducts(any())).thenReturn(
             flowOf(
                 WooPosProductsDataSource.ProductsResult.Remote(
                     Result.success(emptyList())
@@ -508,7 +508,7 @@ class WooPosItemsViewModelTestSelectionViewState {
                 isVariable = true
             )
         )
-        whenever(productsDataSource.loadSimpleProducts(any())).thenReturn(
+        whenever(productsDataSource.loadProducts(any())).thenReturn(
             flowOf(
                 WooPosProductsDataSource.ProductsResult.Remote(
                     Result.success(products)
@@ -555,7 +555,7 @@ class WooPosItemsViewModelTestSelectionViewState {
                 isVariable = true
             )
         )
-        whenever(productsDataSource.loadSimpleProducts(any())).thenReturn(
+        whenever(productsDataSource.loadProducts(any())).thenReturn(
             flowOf(
                 WooPosProductsDataSource.ProductsResult.Remote(
                     Result.success(products)
@@ -592,7 +592,7 @@ class WooPosItemsViewModelTestSelectionViewState {
                 ).copy(firstImageUrl = "https://test.com")
             )
 
-            whenever(productsDataSource.loadSimpleProducts(any())).thenReturn(
+            whenever(productsDataSource.loadProducts(any())).thenReturn(
                 flowOf(
                     WooPosProductsDataSource.ProductsResult.Remote(
                         Result.success(products)
@@ -652,7 +652,7 @@ class WooPosItemsViewModelTestSelectionViewState {
             )
         )
 
-        whenever(productsDataSource.loadSimpleProducts(any())).thenReturn(
+        whenever(productsDataSource.loadProducts(any())).thenReturn(
             flowOf(
                 WooPosProductsDataSource.ProductsResult.Remote(
                     Result.success(products)
@@ -690,7 +690,7 @@ class WooPosItemsViewModelTestSelectionViewState {
             )
         )
 
-        whenever(productsDataSource.loadSimpleProducts(any())).thenReturn(
+        whenever(productsDataSource.loadProducts(any())).thenReturn(
             flowOf(
                 WooPosProductsDataSource.ProductsResult.Remote(
                     Result.success(products)
@@ -724,7 +724,7 @@ class WooPosItemsViewModelTestSelectionViewState {
             )
         )
 
-        whenever(productsDataSource.loadSimpleProducts(any())).thenReturn(
+        whenever(productsDataSource.loadProducts(any())).thenReturn(
             flowOf(
                 WooPosProductsDataSource.ProductsResult.Remote(
                     Result.success(products)
@@ -771,7 +771,7 @@ class WooPosItemsViewModelTestSelectionViewState {
             )
         )
 
-        whenever(productsDataSource.loadSimpleProducts(any())).thenReturn(
+        whenever(productsDataSource.loadProducts(any())).thenReturn(
             flowOf(
                 WooPosProductsDataSource.ProductsResult.Remote(
                     Result.success(products)

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/home/items/WooPosProductsDataSourceTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/home/items/WooPosProductsDataSourceTest.kt
@@ -29,7 +29,6 @@ import org.wordpress.android.fluxc.network.rest.wpcom.wc.WooErrorType
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.WooResult
 import org.wordpress.android.fluxc.store.WCProductStore
 import kotlin.test.Test
-import kotlin.test.assertFalse
 
 @ExperimentalCoroutinesApi
 class WooPosProductsDataSourceTest {
@@ -83,7 +82,9 @@ class WooPosProductsDataSourceTest {
     private val selectedSite: SelectedSite = mock {
         on { get() }.thenReturn(siteModel)
     }
-    private val productsCache: WooPosProductsCache = mock()
+    private val productsCache: WooPosProductsCache = mock {
+        onBlocking { getAll() }.thenReturn(sampleProducts)
+    }
     private val productsIndex: WooPosProductsIndex = mock()
     private val includeTypes = listOf(WCProductStore.IncludeType.Simple, WCProductStore.IncludeType.Variable)
 
@@ -91,7 +92,7 @@ class WooPosProductsDataSourceTest {
     fun `given force refresh, when loadProducts called, then should clear cache`() = runTest {
         // GIVEN
         whenever(productsIndex.getProductList()).thenReturn(emptyList(), sampleProducts)
-        whenever(productsCache.getAll()).thenReturn(emptyList(), sampleProducts)
+
         whenever(
             productStore.fetchProducts(
                 site = eq(siteModel),
@@ -140,6 +141,7 @@ class WooPosProductsDataSourceTest {
     @Test
     fun `given no products in list cache, when loadProducts called, then should return empty list`() = runTest {
         // GIVEN
+        whenever(productsCache.getAll()).thenReturn(emptyList())
         whenever(
             productStore.fetchProducts(
                 site = eq(siteModel),
@@ -337,8 +339,8 @@ class WooPosProductsDataSourceTest {
     fun `given no cached products and remote load fails, when loadProducts called, then should emit empty cache and then error`() =
         runTest {
             // GIVEN
-
             whenever(productsIndex.getProductList()).thenReturn(emptyList())
+            whenever(productsCache.getAll()).thenReturn(emptyList())
             whenever(
                 productStore.fetchProducts(
                     site = eq(siteModel),
@@ -370,10 +372,10 @@ class WooPosProductsDataSourceTest {
         }
 
     @Test
-    fun `given empty product list from handler, when loadProducts called, then should emit empty cache and empty remote result`() =
+    fun `given empty product list in cache, when loadProducts called, then should emit empty cache and empty remote result`() =
         runTest {
             // GIVEN
-
+            whenever(productsCache.getAll()).thenReturn(emptyList())
             whenever(productsIndex.getProductList()).thenReturn(emptyList())
             whenever(
                 productStore.fetchProducts(
@@ -401,133 +403,6 @@ class WooPosProductsDataSourceTest {
         }
 
     @Test
-    fun `given cached products, when loadProducts called, then filter in only products that has price`() =
-        runTest {
-            // GIVEN
-            val productsWithoutPrice = listOf(
-                ProductTestUtils.generateProduct(
-                    productId = 1,
-                    productName = "Product 1",
-                    amount = "0",
-                    productType = "simple",
-                    isDownloadable = false,
-                ),
-                ProductTestUtils.generateProduct(
-                    productId = 2,
-                    productName = "Product 2",
-                    amount = "20.0",
-                    productType = "simple",
-                    isDownloadable = false
-                ).copy(firstImageUrl = "https://test.com")
-            )
-
-            whenever(productsIndex.getProductList()).thenReturn(productsWithoutPrice.filter { it.remoteId == 2L })
-            whenever(
-                productStore.fetchProducts(
-                    site = eq(siteModel),
-                    offset = any(),
-                    pageSize = any(),
-                    filterOptions = any(),
-                    includeTypes = any()
-                )
-            ).thenReturn(WooResult(listOf<WCProductModel>()))
-            val sut = WooPosProductsDataSource(productStore, selectedSite, productsCache, productsIndex)
-
-            // WHEN
-            val flow = sut.loadProducts(forceRefreshProducts = false).toList()
-
-            // THEN
-            val cachedResult = flow[0] as WooPosProductsDataSource.ProductsResult.Cached
-
-            assertFalse(cachedResult.products.any { it.remoteId == 1L })
-        }
-
-    @Test
-    fun `given cached products, when loadProducts called, then filter out downloadable products`() =
-        runTest {
-            // GIVEN
-            val mixedProducts = listOf(
-                ProductTestUtils.generateProduct(
-                    productId = 1,
-                    productName = "Product 1",
-                    amount = "0",
-                    productType = "simple",
-                    isDownloadable = true,
-                ),
-                ProductTestUtils.generateProduct(
-                    productId = 2,
-                    productName = "Product 2",
-                    amount = "20.0",
-                    productType = "simple",
-                    isVirtual = false,
-                    isDownloadable = false
-                ).copy(firstImageUrl = "https://test.com")
-            )
-
-            whenever(productsIndex.getProductList()).thenReturn(mixedProducts.filter { it.remoteId == 2L })
-            whenever(
-                productStore.fetchProducts(
-                    site = eq(siteModel),
-                    offset = any(),
-                    pageSize = any(),
-                    filterOptions = any(),
-                    includeTypes = any()
-                )
-            ).thenReturn(WooResult(listOf<WCProductModel>()))
-            val sut = WooPosProductsDataSource(productStore, selectedSite, productsCache, productsIndex)
-
-            // WHEN
-            val flow = sut.loadProducts(forceRefreshProducts = false).toList()
-
-            // THEN
-            val cachedResult = flow[0] as WooPosProductsDataSource.ProductsResult.Cached
-
-            assertFalse(cachedResult.products.any { it.remoteId == 1L })
-        }
-
-    @Test
-    fun `given remote products, when loadProducts called, then do not filter out variable products even if price is null `() =
-        runTest {
-            // GIVEN
-            val mixedProducts = listOf(
-                ProductTestUtils.generateProduct(
-                    productId = 1,
-                    productName = "Product 1",
-                    amount = "",
-                    productType = "variable",
-                ),
-                ProductTestUtils.generateProduct(
-                    productId = 2,
-                    productName = "Product 2",
-                    amount = "20.0",
-                    productType = "simple",
-                    isVirtual = false,
-                    isDownloadable = false
-                ).copy(firstImageUrl = "https://test.com")
-            )
-
-            whenever(productsIndex.getProductList()).thenReturn(mixedProducts)
-            whenever(
-                productStore.fetchProducts(
-                    site = eq(siteModel),
-                    offset = any(),
-                    pageSize = any(),
-                    filterOptions = any(),
-                    includeTypes = any()
-                )
-            ).thenReturn(WooResult(listOf<WCProductModel>()))
-            val sut = WooPosProductsDataSource(productStore, selectedSite, productsCache, productsIndex)
-
-            // WHEN
-            val flow = sut.loadProducts(forceRefreshProducts = false).toList()
-
-            // THEN
-            val remoteResult = flow[1] as WooPosProductsDataSource.ProductsResult.Remote
-
-            assertThat(remoteResult.productsResult.getOrNull()).hasSize(2)
-        }
-
-    @Test
     fun `when loading products, they should be sorted by name in ascending order`() = runTest {
         // GIVEN
         val mockProductC = mock<Product>()
@@ -541,6 +416,7 @@ class WooPosProductsDataSourceTest {
 
         val customUnsortedProducts = listOf(mockProductC, mockProductA, mockProductB)
 
+        whenever(productsCache.getAll()).thenReturn(customUnsortedProducts)
         whenever(productsIndex.getProductList()).thenReturn(customUnsortedProducts)
         whenever(
             productStore.fetchProducts(

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/home/items/WooPosProductsDataSourceTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/home/items/WooPosProductsDataSourceTest.kt
@@ -82,7 +82,7 @@ class WooPosProductsDataSourceTest {
         val sut = WooPosProductsDataSource(handler, productsCache)
 
         // WHEN
-        sut.loadSimpleProducts(forceRefreshProducts = true).first()
+        sut.loadProducts(forceRefreshProducts = true).first()
 
         // THEN
         verify(productsCache).clear()
@@ -100,7 +100,7 @@ class WooPosProductsDataSourceTest {
         val sut = WooPosProductsDataSource(handler, productsCache)
 
         // WHEN
-        val result = sut.loadSimpleProducts(forceRefreshProducts = false).first()
+        val result = sut.loadProducts(forceRefreshProducts = false).first()
 
         // THEN
         assertThat(result).isInstanceOf(WooPosProductsDataSource.ProductsResult.Cached::class.java)
@@ -123,7 +123,7 @@ class WooPosProductsDataSourceTest {
             val sut = WooPosProductsDataSource(handler, productsCache)
 
             // WHEN
-            val flow = sut.loadSimpleProducts(forceRefreshProducts = false).toList()
+            val flow = sut.loadProducts(forceRefreshProducts = false).toList()
 
             // THEN
             val cachedResult = flow[0] as WooPosProductsDataSource.ProductsResult.Cached
@@ -150,7 +150,7 @@ class WooPosProductsDataSourceTest {
             val sut = WooPosProductsDataSource(handler, productsCache)
 
             // WHEN
-            val flow = sut.loadSimpleProducts(forceRefreshProducts = false).toList()
+            val flow = sut.loadProducts(forceRefreshProducts = false).toList()
 
             // THEN
             assertThat(flow.size).isEqualTo(2)
@@ -219,7 +219,7 @@ class WooPosProductsDataSourceTest {
             val sut = WooPosProductsDataSource(handler, productsCache)
 
             // WHEN
-            val flow = sut.loadSimpleProducts(forceRefreshProducts = false).toList()
+            val flow = sut.loadProducts(forceRefreshProducts = false).toList()
 
             // THEN
             val cachedResult = flow[0] as WooPosProductsDataSource.ProductsResult.Cached
@@ -243,7 +243,7 @@ class WooPosProductsDataSourceTest {
             val sut = WooPosProductsDataSource(handler, productsCache)
 
             // WHEN
-            val flow = sut.loadSimpleProducts(forceRefreshProducts = false).toList()
+            val flow = sut.loadProducts(forceRefreshProducts = false).toList()
 
             // THEN
             val cachedResult = flow[0] as WooPosProductsDataSource.ProductsResult.Cached
@@ -284,7 +284,7 @@ class WooPosProductsDataSourceTest {
             val sut = WooPosProductsDataSource(handler, productsCache)
 
             // WHEN
-            val flow = sut.loadSimpleProducts(forceRefreshProducts = false).toList()
+            val flow = sut.loadProducts(forceRefreshProducts = false).toList()
 
             // THEN
             val cachedResult = flow[0] as WooPosProductsDataSource.ProductsResult.Cached
@@ -322,7 +322,7 @@ class WooPosProductsDataSourceTest {
             val sut = WooPosProductsDataSource(handler, productsCache)
 
             // WHEN
-            val flow = sut.loadSimpleProducts(forceRefreshProducts = false).toList()
+            val flow = sut.loadProducts(forceRefreshProducts = false).toList()
 
             // THEN
             val cachedResult = flow[0] as WooPosProductsDataSource.ProductsResult.Cached
@@ -359,7 +359,7 @@ class WooPosProductsDataSourceTest {
             val sut = WooPosProductsDataSource(handler, productsCache)
 
             // WHEN
-            val flow = sut.loadSimpleProducts(forceRefreshProducts = false).toList()
+            val flow = sut.loadProducts(forceRefreshProducts = false).toList()
 
             // THEN
             val remoteResult = flow[1] as WooPosProductsDataSource.ProductsResult.Remote
@@ -391,7 +391,7 @@ class WooPosProductsDataSourceTest {
         val sut = WooPosProductsDataSource(handler, productsCache)
 
         // WHEN
-        val result = sut.loadSimpleProducts(forceRefreshProducts = false).first()
+        val result = sut.loadProducts(forceRefreshProducts = false).first()
 
         // THEN
         assertThat(result).isInstanceOf(WooPosProductsDataSource.ProductsResult.Cached::class.java)

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/home/items/WooPosProductsDataSourceTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/home/items/WooPosProductsDataSourceTest.kt
@@ -260,14 +260,14 @@ class WooPosProductsDataSourceTest {
                 )
             ).thenReturn(
                 WooResult(
-                List(25) {
-                    WCProductModel().apply {
-                        remoteProductId = it.toLong()
-                        attributes = "[]"
-                        status = "draft"
+                    List(25) {
+                        WCProductModel().apply {
+                            remoteProductId = it.toLong()
+                            attributes = "[]"
+                            status = "draft"
+                        }
                     }
-                }
-            )
+                )
             )
             whenever(productsIndex.getProductList()).thenReturn(sampleProducts + additionalProducts)
             val sut = WooPosProductsDataSource(productStore, selectedSite, productsCache, productsIndex)
@@ -541,7 +541,6 @@ class WooPosProductsDataSourceTest {
 
         val customUnsortedProducts = listOf(mockProductC, mockProductA, mockProductB)
 
-
         whenever(productsIndex.getProductList()).thenReturn(customUnsortedProducts)
         whenever(
             productStore.fetchProducts(
@@ -678,7 +677,6 @@ class WooPosProductsDataSourceTest {
                 }
             }
 
-
             whenever(
                 productStore.fetchProducts(
                     site = eq(siteModel),
@@ -761,7 +759,6 @@ class WooPosProductsDataSourceTest {
             }
             val emptySecondPage = emptyList<WCProductModel>()
 
-
             whenever(
                 productStore.fetchProducts(
                     site = eq(siteModel),
@@ -810,7 +807,6 @@ class WooPosProductsDataSourceTest {
                     status = "draft"
                 }
             }
-
 
             whenever(
                 productStore.fetchProducts(

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/home/items/WooPosProductsDataSourceTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/home/items/WooPosProductsDataSourceTest.kt
@@ -428,7 +428,6 @@ class WooPosProductsDataSourceTest {
                 includeTypes = any()
             )
         ).thenReturn(WooResult(listOf<WCProductModel>()))
-        whenever(productsCache.getAll()).thenReturn(sampleProducts)
 
         val sut = WooPosProductsDataSource(productStore, selectedSite, productsCache, productsIndex)
 

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/home/items/WooPosProductsDataSourceTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/home/items/WooPosProductsDataSourceTest.kt
@@ -28,7 +28,6 @@ import org.wordpress.android.fluxc.network.rest.wpcom.wc.WooError
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.WooErrorType
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.WooResult
 import org.wordpress.android.fluxc.store.WCProductStore
-import java.util.concurrent.atomic.AtomicBoolean
 import kotlin.test.Test
 import kotlin.test.assertFalse
 
@@ -80,16 +79,17 @@ class WooPosProductsDataSourceTest {
     )
 
     private val productStore: WCProductStore = mock()
-    private val selectedSite: SelectedSite = mock()
+    private val siteModel: SiteModel = mock()
+    private val selectedSite: SelectedSite = mock {
+        on { get() }.thenReturn(siteModel)
+    }
     private val productsCache: WooPosProductsCache = mock()
     private val productsIndex: WooPosProductsIndex = mock()
-    private val siteModel: SiteModel = mock()
     private val includeTypes = listOf(WCProductStore.IncludeType.Simple, WCProductStore.IncludeType.Variable)
 
     @Test
-    fun `given force refresh, when loadSimpleProducts called, then should clear cache`() = runTest {
+    fun `given force refresh, when loadProducts called, then should clear cache`() = runTest {
         // GIVEN
-        whenever(selectedSite.get()).thenReturn(siteModel)
         whenever(productsIndex.getProductList()).thenReturn(emptyList(), sampleProducts)
         whenever(productsCache.getAll()).thenReturn(emptyList(), sampleProducts)
         whenever(
@@ -112,9 +112,9 @@ class WooPosProductsDataSourceTest {
     }
 
     @Test
-    fun `given cached products, when loadSimpleProducts called, then should emit cached products first`() = runTest {
+    fun `given cached products, when loadProducts called, then should emit cached products first`() = runTest {
         // GIVEN
-        whenever(selectedSite.get()).thenReturn(siteModel)
+
         whenever(productsCache.getAll()).thenReturn(sampleProducts)
         whenever(
             productStore.fetchProducts(
@@ -138,7 +138,7 @@ class WooPosProductsDataSourceTest {
     }
 
     @Test
-    fun `given no products in list cache, when loadSimpleProducts called, then should return empty list`() = runTest {
+    fun `given no products in list cache, when loadProducts called, then should return empty list`() = runTest {
         // GIVEN
         whenever(
             productStore.fetchProducts(
@@ -162,10 +162,10 @@ class WooPosProductsDataSourceTest {
     }
 
     @Test
-    fun `given cached and remote products, when loadSimpleProducts called, then should emit remote products after cached products`() =
+    fun `given cached and remote products, when loadProducts called, then should emit remote products after cached products`() =
         runTest {
             // GIVEN
-            whenever(selectedSite.get()).thenReturn(siteModel)
+
             whenever(productsCache.getAll()).thenReturn(sampleProducts)
             whenever(productsIndex.getProductList()).thenReturn(sampleProducts)
             whenever(
@@ -176,7 +176,27 @@ class WooPosProductsDataSourceTest {
                     filterOptions = any(),
                     includeTypes = any()
                 )
-            ).thenReturn(WooResult(listOf<WCProductModel>()))
+            ).thenReturn(
+                WooResult(
+                    listOf<WCProductModel>(
+                        WCProductModel().apply {
+                            remoteProductId = 1
+                            attributes = "[]"
+                            status = "draft"
+                        },
+                        WCProductModel().apply {
+                            remoteProductId = 2
+                            attributes = "[]"
+                            status = "draft"
+                        },
+                        WCProductModel().apply {
+                            remoteProductId = 3
+                            attributes = "[]"
+                            status = "draft"
+                        }
+                    )
+                )
+            )
             val sut = WooPosProductsDataSource(productStore, selectedSite, productsCache, productsIndex)
 
             // WHEN
@@ -194,11 +214,10 @@ class WooPosProductsDataSourceTest {
         }
 
     @Test
-    fun `given error condition when loading products, then cached products are emitted first and error after`() =
+    fun `given error, when loading products, then cached products are emitted first and error after`() =
         runTest {
             // GIVEN
-            whenever(selectedSite.get()).thenReturn(siteModel)
-            whenever(productsCache.getAll()).thenReturn(sampleProducts)
+            whenever(productsIndex.getProductList()).thenReturn(sampleProducts)
             val wooError = WooError(
                 WooErrorType.GENERIC_ERROR,
                 GenericErrorType.UNKNOWN,
@@ -231,7 +250,6 @@ class WooPosProductsDataSourceTest {
     fun `given successful loadMore, when loadMore called, then should add products to cache and return them`() =
         runTest {
             // GIVEN
-            whenever(selectedSite.get()).thenReturn(siteModel)
             whenever(
                 productStore.fetchProducts(
                     site = eq(siteModel),
@@ -240,13 +258,20 @@ class WooPosProductsDataSourceTest {
                     filterOptions = any(),
                     includeTypes = any()
                 )
-            ).thenReturn(WooResult(listOf<WCProductModel>()))
+            ).thenReturn(
+                WooResult(
+                List(25) {
+                    WCProductModel().apply {
+                        remoteProductId = it.toLong()
+                        attributes = "[]"
+                        status = "draft"
+                    }
+                }
+            )
+            )
             whenever(productsIndex.getProductList()).thenReturn(sampleProducts + additionalProducts)
             val sut = WooPosProductsDataSource(productStore, selectedSite, productsCache, productsIndex)
-            sut::class.java.getDeclaredField("canLoadMore").apply {
-                isAccessible = true
-                set(sut, AtomicBoolean(true))
-            }
+            sut.loadProducts(forceRefreshProducts = true).first()
 
             // WHEN
             val result = sut.loadMore()
@@ -254,15 +279,24 @@ class WooPosProductsDataSourceTest {
             // THEN
             assertThat(result.isSuccess).isTrue()
             assertThat(result.getOrNull()).containsExactlyElementsOf(sampleProducts + additionalProducts)
-            verify(productsCache).addAll(any())
-            verify(productsIndex).storeProductList(additionalProducts.map { it.remoteId })
         }
 
     @Test
     fun `given failed loadMore, when loadMore called, then should return error and cache remains unchanged`() =
         runTest {
             // GIVEN
-            whenever(selectedSite.get()).thenReturn(siteModel)
+            whenever(productsIndex.getProductList())
+                .thenReturn(
+                    List(25) {
+                        ProductTestUtils.generateProduct(
+                            productId = it.toLong(),
+                            productName = "Product $it",
+                            amount = "0",
+                            productType = "simple",
+                            isDownloadable = false,
+                        )
+                    }
+                )
             val wooError = WooError(
                 type = WooErrorType.GENERIC_ERROR,
                 original = GenericErrorType.UNKNOWN,
@@ -275,13 +309,21 @@ class WooPosProductsDataSourceTest {
                     filterOptions = any(),
                     includeTypes = any()
                 )
-            ).thenReturn(WooResult(wooError))
+            ).thenReturn(
+                WooResult<List<WCProductModel>>(
+                    List(25) {
+                        WCProductModel().apply {
+                            remoteProductId = it.toLong()
+                            attributes = "[]"
+                            status = "draft"
+                        }
+                    }
+                ),
+                WooResult(wooError)
+            )
 
             val sut = WooPosProductsDataSource(productStore, selectedSite, productsCache, productsIndex)
-            sut::class.java.getDeclaredField("canLoadMore").apply {
-                isAccessible = true
-                set(sut, AtomicBoolean(true))
-            }
+            sut.loadProducts(forceRefreshProducts = true).first()
 
             // WHEN
             val result = sut.loadMore()
@@ -292,10 +334,10 @@ class WooPosProductsDataSourceTest {
         }
 
     @Test
-    fun `given no cached products and remote load fails, when loadSimpleProducts called, then should emit empty cache and then error`() =
+    fun `given no cached products and remote load fails, when loadProducts called, then should emit empty cache and then error`() =
         runTest {
             // GIVEN
-            whenever(selectedSite.get()).thenReturn(siteModel)
+
             whenever(productsIndex.getProductList()).thenReturn(emptyList())
             whenever(
                 productStore.fetchProducts(
@@ -328,10 +370,10 @@ class WooPosProductsDataSourceTest {
         }
 
     @Test
-    fun `given empty product list from handler, when loadSimpleProducts called, then should emit empty cache and empty remote result`() =
+    fun `given empty product list from handler, when loadProducts called, then should emit empty cache and empty remote result`() =
         runTest {
             // GIVEN
-            whenever(selectedSite.get()).thenReturn(siteModel)
+
             whenever(productsIndex.getProductList()).thenReturn(emptyList())
             whenever(
                 productStore.fetchProducts(
@@ -359,7 +401,7 @@ class WooPosProductsDataSourceTest {
         }
 
     @Test
-    fun `given cached products, when loadSimpleProducts called, then filter in only products that has price`() =
+    fun `given cached products, when loadProducts called, then filter in only products that has price`() =
         runTest {
             // GIVEN
             val productsWithoutPrice = listOf(
@@ -378,7 +420,7 @@ class WooPosProductsDataSourceTest {
                     isDownloadable = false
                 ).copy(firstImageUrl = "https://test.com")
             )
-            whenever(selectedSite.get()).thenReturn(siteModel)
+
             whenever(productsIndex.getProductList()).thenReturn(productsWithoutPrice.filter { it.remoteId == 2L })
             whenever(
                 productStore.fetchProducts(
@@ -401,7 +443,7 @@ class WooPosProductsDataSourceTest {
         }
 
     @Test
-    fun `given cached products, when loadSimpleProducts called, then filter out downloadable products`() =
+    fun `given cached products, when loadProducts called, then filter out downloadable products`() =
         runTest {
             // GIVEN
             val mixedProducts = listOf(
@@ -421,7 +463,7 @@ class WooPosProductsDataSourceTest {
                     isDownloadable = false
                 ).copy(firstImageUrl = "https://test.com")
             )
-            whenever(selectedSite.get()).thenReturn(siteModel)
+
             whenever(productsIndex.getProductList()).thenReturn(mixedProducts.filter { it.remoteId == 2L })
             whenever(
                 productStore.fetchProducts(
@@ -444,7 +486,7 @@ class WooPosProductsDataSourceTest {
         }
 
     @Test
-    fun `given remote products, when loadSimpleProducts called, then do not filter out variable products even if price is null `() =
+    fun `given remote products, when loadProducts called, then do not filter out variable products even if price is null `() =
         runTest {
             // GIVEN
             val mixedProducts = listOf(
@@ -463,7 +505,7 @@ class WooPosProductsDataSourceTest {
                     isDownloadable = false
                 ).copy(firstImageUrl = "https://test.com")
             )
-            whenever(selectedSite.get()).thenReturn(siteModel)
+
             whenever(productsIndex.getProductList()).thenReturn(mixedProducts)
             whenever(
                 productStore.fetchProducts(
@@ -499,7 +541,7 @@ class WooPosProductsDataSourceTest {
 
         val customUnsortedProducts = listOf(mockProductC, mockProductA, mockProductB)
 
-        whenever(selectedSite.get()).thenReturn(siteModel)
+
         whenever(productsIndex.getProductList()).thenReturn(customUnsortedProducts)
         whenever(
             productStore.fetchProducts(
@@ -547,7 +589,6 @@ class WooPosProductsDataSourceTest {
         val additionalUnsortedProducts = listOf(mockProductE, mockProductD)
         val allProducts = initialProducts + additionalUnsortedProducts
 
-        whenever(selectedSite.get()).thenReturn(siteModel)
         whenever(
             productStore.fetchProducts(
                 site = eq(siteModel),
@@ -558,12 +599,28 @@ class WooPosProductsDataSourceTest {
             )
         ).thenReturn(WooResult(listOf<WCProductModel>()))
         whenever(productsIndex.getProductList()).thenReturn(allProducts)
+        whenever(
+            productStore.fetchProducts(
+                site = eq(siteModel),
+                offset = any(),
+                pageSize = any(),
+                filterOptions = any(),
+                includeTypes = any()
+            )
+        ).thenReturn(
+            WooResult<List<WCProductModel>>(
+                List(25) {
+                    WCProductModel().apply {
+                        remoteProductId = it.toLong()
+                        attributes = "[]"
+                        status = "draft"
+                    }
+                }
+            )
+        )
 
         val sut = WooPosProductsDataSource(productStore, selectedSite, productsCache, productsIndex)
-        sut::class.java.getDeclaredField("canLoadMore").apply {
-            isAccessible = true
-            set(sut, AtomicBoolean(true))
-        }
+        sut.loadProducts(forceRefreshProducts = true).first()
 
         // WHEN
         val result = sut.loadMore()
@@ -578,16 +635,12 @@ class WooPosProductsDataSourceTest {
         assertThat(sortedProducts[2].name).isEqualTo("C Product")
         assertThat(sortedProducts[3].name).isEqualTo("D Product")
         assertThat(sortedProducts[4].name).isEqualTo("E Product")
-
-        verify(productsCache).addAll(any())
-        verify(productsIndex).storeProductList(additionalUnsortedProducts.map { it.remoteId })
     }
 
     @Test
     fun `given successful fetch, when prepopulateProductsCache called, then should clear cache and add products`() =
         runTest {
             // GIVEN
-            whenever(selectedSite.get()).thenReturn(siteModel)
             whenever(
                 productStore.fetchProducts(
                     site = eq(siteModel),
@@ -625,7 +678,7 @@ class WooPosProductsDataSourceTest {
                 }
             }
 
-            whenever(selectedSite.get()).thenReturn(siteModel)
+
             whenever(
                 productStore.fetchProducts(
                     site = eq(siteModel),
@@ -668,7 +721,7 @@ class WooPosProductsDataSourceTest {
     fun `given error when fetching products, when prepopulateProductsCache called, then should return failure`() =
         runTest {
             // GIVEN
-            whenever(selectedSite.get()).thenReturn(siteModel)
+
             val wooError = WooError(
                 WooErrorType.GENERIC_ERROR,
                 GenericErrorType.UNKNOWN,
@@ -708,7 +761,7 @@ class WooPosProductsDataSourceTest {
             }
             val emptySecondPage = emptyList<WCProductModel>()
 
-            whenever(selectedSite.get()).thenReturn(siteModel)
+
             whenever(
                 productStore.fetchProducts(
                     site = eq(siteModel),
@@ -758,7 +811,7 @@ class WooPosProductsDataSourceTest {
                 }
             }
 
-            whenever(selectedSite.get()).thenReturn(siteModel)
+
             whenever(
                 productStore.fetchProducts(
                     site = eq(siteModel),

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/home/items/WooPosProductsDataSourceTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/home/items/WooPosProductsDataSourceTest.kt
@@ -1,14 +1,14 @@
 package com.woocommerce.android.ui.woopos.home.items
 
+import com.woocommerce.android.WooException
 import com.woocommerce.android.model.Product
+import com.woocommerce.android.tools.SelectedSite
 import com.woocommerce.android.ui.products.ProductTestUtils
-import com.woocommerce.android.ui.products.selector.ProductListHandler
 import com.woocommerce.android.ui.woopos.common.data.WooPosProductsCache
 import com.woocommerce.android.ui.woopos.home.items.products.WooPosProductsDataSource
 import com.woocommerce.android.ui.woopos.util.WooPosCoroutineTestRule
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.first
-import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.flow.toList
 import kotlinx.coroutines.test.runTest
 import org.assertj.core.api.Assertions.assertThat
@@ -18,6 +18,12 @@ import org.mockito.kotlin.eq
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
+import org.wordpress.android.fluxc.model.SiteModel
+import org.wordpress.android.fluxc.model.WCProductModel
+import org.wordpress.android.fluxc.network.BaseRequest.GenericErrorType
+import org.wordpress.android.fluxc.network.rest.wpcom.wc.WooError
+import org.wordpress.android.fluxc.network.rest.wpcom.wc.WooErrorType
+import org.wordpress.android.fluxc.network.rest.wpcom.wc.WooResult
 import org.wordpress.android.fluxc.store.WCProductStore
 import java.util.concurrent.atomic.AtomicBoolean
 import kotlin.test.Test
@@ -70,16 +76,27 @@ class WooPosProductsDataSourceTest {
         ).copy(firstImageUrl = "https://test.com"),
     )
 
-    private val handler: ProductListHandler = mock()
+    private val productStore: WCProductStore = mock()
+    private val selectedSite: SelectedSite = mock()
     private val productsCache: WooPosProductsCache = mock()
+    private val siteModel: SiteModel = mock()
+    private val includeTypes = listOf(WCProductStore.IncludeType.Simple, WCProductStore.IncludeType.Variable)
 
     @Test
     fun `given force refresh, when loadSimpleProducts called, then should clear cache`() = runTest {
         // GIVEN
-        whenever(handler.canLoadMore).thenReturn(AtomicBoolean(true))
-        whenever(handler.productsFlow).thenReturn(flowOf(sampleProducts))
+        whenever(selectedSite.get()).thenReturn(siteModel)
         whenever(productsCache.getAll()).thenReturn(emptyList(), sampleProducts)
-        val sut = WooPosProductsDataSource(handler, productsCache)
+        whenever(
+            productStore.fetchProducts(
+                site = eq(siteModel),
+                offset = any<Int>(),
+                pageSize = any<Int>(),
+                filterOptions = any<Map<WCProductStore.ProductFilterOption, String>>(),
+                includeTypes = eq(includeTypes),
+            )
+        ).thenReturn(WooResult(listOf<WCProductModel>()))
+        val sut = WooPosProductsDataSource(productStore, selectedSite, productsCache)
 
         // WHEN
         sut.loadProducts(forceRefreshProducts = true).first()
@@ -91,13 +108,18 @@ class WooPosProductsDataSourceTest {
     @Test
     fun `given cached products, when loadSimpleProducts called, then should emit cached products first`() = runTest {
         // GIVEN
-        whenever(handler.canLoadMore).thenReturn(AtomicBoolean(true))
-        whenever(handler.productsFlow).thenReturn(flowOf(sampleProducts))
-        whenever(
-            handler.loadFromCacheAndFetch(any(), any(), any(), any(), any(), any())
-        ).thenReturn(Result.success(Unit))
+        whenever(selectedSite.get()).thenReturn(siteModel)
         whenever(productsCache.getAll()).thenReturn(sampleProducts)
-        val sut = WooPosProductsDataSource(handler, productsCache)
+        whenever(
+            productStore.fetchProducts(
+                site = eq(siteModel),
+                offset = any(),
+                pageSize = any(),
+                filterOptions = any(),
+                includeTypes = any()
+            )
+        ).thenReturn(WooResult(listOf<WCProductModel>()))
+        val sut = WooPosProductsDataSource(productStore, selectedSite, productsCache)
 
         // WHEN
         val result = sut.loadProducts(forceRefreshProducts = false).first()
@@ -112,15 +134,18 @@ class WooPosProductsDataSourceTest {
     fun `given cached and remote products, when loadSimpleProducts called, then should emit remote products after cached products`() =
         runTest {
             // GIVEN
-            whenever(handler.canLoadMore).thenReturn(AtomicBoolean(true))
-            whenever(handler.productsFlow).thenReturn(flowOf(sampleProducts))
-            whenever(
-                handler.loadFromCacheAndFetch(any(), any(), any(), any(), any(), any())
-            ).thenReturn(
-                Result.success(Unit)
-            )
+            whenever(selectedSite.get()).thenReturn(siteModel)
             whenever(productsCache.getAll()).thenReturn(sampleProducts)
-            val sut = WooPosProductsDataSource(handler, productsCache)
+            whenever(
+                productStore.fetchProducts(
+                    site = eq(siteModel),
+                    offset = any(),
+                    pageSize = any(),
+                    filterOptions = any(),
+                    includeTypes = any()
+                )
+            ).thenReturn(WooResult(listOf<WCProductModel>()))
+            val sut = WooPosProductsDataSource(productStore, selectedSite, productsCache)
 
             // WHEN
             val flow = sut.loadProducts(forceRefreshProducts = false).toList()
@@ -132,33 +157,40 @@ class WooPosProductsDataSourceTest {
             assertThat(cachedResult.products).containsExactlyElementsOf(sampleProducts)
             assertThat(remoteResult.productsResult.isSuccess).isTrue()
             assertThat(remoteResult.productsResult.getOrNull()).containsExactlyElementsOf(sampleProducts)
-            verify(productsCache).addAll(sampleProducts)
+            verify(productsCache).addAll(any())
         }
 
     @Test
     fun `given error condition when loading products, then cached products are emitted first and error after`() =
         runTest {
             // GIVEN
-            whenever(handler.canLoadMore).thenReturn(AtomicBoolean(true))
-            whenever(handler.productsFlow).thenReturn(flowOf(sampleProducts))
-            val exception = Exception("Some error message")
+            whenever(selectedSite.get()).thenReturn(siteModel)
             whenever(productsCache.getAll()).thenReturn(sampleProducts)
+            val wooError = WooError(
+                WooErrorType.GENERIC_ERROR,
+                GenericErrorType.UNKNOWN,
+                "Some error message"
+            )
             whenever(
-                handler.loadFromCacheAndFetch(any(), any(), any(), any(), any(), any())
-            ).thenReturn(Result.failure(exception))
+                productStore.fetchProducts(
+                    site = eq(siteModel),
+                    offset = any<Int>(),
+                    pageSize = any<Int>(),
+                    filterOptions = any<Map<WCProductStore.ProductFilterOption, String>>(),
+                    includeTypes = eq(includeTypes),
+                )
+            ).thenReturn(WooResult(wooError))
 
-            val sut = WooPosProductsDataSource(handler, productsCache)
+            val sut = WooPosProductsDataSource(productStore, selectedSite, productsCache)
 
             // WHEN
             val flow = sut.loadProducts(forceRefreshProducts = false).toList()
 
             // THEN
             assertThat(flow.size).isEqualTo(2)
-            // First item should be Cached result
             assertThat(flow[0]).isInstanceOf(WooPosProductsDataSource.ProductsResult.Cached::class.java)
             val cachedResult = flow[0] as WooPosProductsDataSource.ProductsResult.Cached
             assertThat(cachedResult.products).isEqualTo(sampleProducts)
-            // Second item should be Remote result with failure
             assertThat(flow[1]).isInstanceOf(WooPosProductsDataSource.ProductsResult.Remote::class.java)
         }
 
@@ -166,11 +198,22 @@ class WooPosProductsDataSourceTest {
     fun `given successful loadMore, when loadMore called, then should add products to cache and return them`() =
         runTest {
             // GIVEN
-            whenever(handler.canLoadMore).thenReturn(AtomicBoolean(true))
-            whenever(handler.productsFlow).thenReturn(flowOf(additionalProducts))
-            whenever(handler.loadMore()).thenReturn(Result.success(Unit))
+            whenever(selectedSite.get()).thenReturn(siteModel)
+            whenever(
+                productStore.fetchProducts(
+                    site = eq(siteModel),
+                    offset = any(),
+                    pageSize = any(),
+                    filterOptions = any(),
+                    includeTypes = any()
+                )
+            ).thenReturn(WooResult(listOf<WCProductModel>()))
             whenever(productsCache.getAll()).thenReturn(sampleProducts + additionalProducts)
-            val sut = WooPosProductsDataSource(handler, productsCache)
+            val sut = WooPosProductsDataSource(productStore, selectedSite, productsCache)
+            sut::class.java.getDeclaredField("canLoadMore").apply {
+                isAccessible = true
+                set(sut, AtomicBoolean(true))
+            }
 
             // WHEN
             val result = sut.loadMore()
@@ -178,45 +221,66 @@ class WooPosProductsDataSourceTest {
             // THEN
             assertThat(result.isSuccess).isTrue()
             assertThat(result.getOrNull()).containsExactlyElementsOf(sampleProducts + additionalProducts)
-            verify(productsCache).addAll(additionalProducts)
+            verify(productsCache).addAll(any())
         }
 
     @Test
     fun `given failed loadMore, when loadMore called, then should return error and cache remains unchanged`() =
         runTest {
             // GIVEN
-            whenever(handler.canLoadMore).thenReturn(AtomicBoolean(true))
-            whenever(handler.productsFlow).thenReturn(flowOf(sampleProducts))
-            val exception = Exception("Load more failed")
+            whenever(selectedSite.get()).thenReturn(siteModel)
+            val wooError = WooError(
+                type = WooErrorType.GENERIC_ERROR,
+                original = GenericErrorType.UNKNOWN,
+            )
             whenever(
-                handler.loadMore(
-                    includeTypes = listOf(WCProductStore.IncludeType.Simple, WCProductStore.IncludeType.Variable),
-                    orderCurrency = null
+                productStore.fetchProducts(
+                    site = eq(siteModel),
+                    offset = any(),
+                    pageSize = any(),
+                    filterOptions = any(),
+                    includeTypes = any()
                 )
-            ).thenReturn(Result.failure(exception))
-            val sut = WooPosProductsDataSource(handler, productsCache)
+            ).thenReturn(WooResult(wooError))
+
+            val sut = WooPosProductsDataSource(productStore, selectedSite, productsCache)
+            sut::class.java.getDeclaredField("canLoadMore").apply {
+                isAccessible = true
+                set(sut, AtomicBoolean(true))
+            }
 
             // WHEN
             val result = sut.loadMore()
 
             // THEN
             assertThat(result.isFailure).isTrue()
-            assertThat(result.exceptionOrNull()).isEqualTo(exception)
+            assertThat(result.exceptionOrNull()).isInstanceOf(WooException::class.java)
         }
 
     @Test
     fun `given no cached products and remote load fails, when loadSimpleProducts called, then should emit empty cache and then error`() =
         runTest {
             // GIVEN
-            whenever(handler.canLoadMore).thenReturn(AtomicBoolean(true))
-            whenever(handler.productsFlow).thenReturn(flowOf(emptyList()))
+            whenever(selectedSite.get()).thenReturn(siteModel)
             whenever(productsCache.getAll()).thenReturn(emptyList())
-            val exception = Exception("Remote load failed")
             whenever(
-                handler.loadFromCacheAndFetch(any(), any(), any(), any(), any(), eq(null))
-            ).thenReturn(Result.failure(exception))
+                productStore.fetchProducts(
+                    site = eq(siteModel),
+                    offset = any(),
+                    pageSize = any(),
+                    filterOptions = any(),
+                    includeTypes = any()
+                )
+            ).thenReturn(
+                WooResult(
+                    WooError(
+                        type = WooErrorType.GENERIC_ERROR,
+                        original = GenericErrorType.UNKNOWN,
+                    )
+                )
+            )
 
-            val sut = WooPosProductsDataSource(handler, productsCache)
+            val sut = WooPosProductsDataSource(productStore, selectedSite, productsCache)
 
             // WHEN
             val flow = sut.loadProducts(forceRefreshProducts = false).toList()
@@ -227,20 +291,24 @@ class WooPosProductsDataSourceTest {
 
             assertThat(cachedResult.products).isEmpty()
             assertThat(remoteResult.productsResult.isFailure).isTrue()
-            assertThat(remoteResult.productsResult.exceptionOrNull()).isEqualTo(exception)
         }
 
     @Test
     fun `given empty product list from handler, when loadSimpleProducts called, then should emit empty cache and empty remote result`() =
         runTest {
             // GIVEN
-            whenever(handler.canLoadMore).thenReturn(AtomicBoolean(true))
-            whenever(handler.productsFlow).thenReturn(flowOf(emptyList()))
+            whenever(selectedSite.get()).thenReturn(siteModel)
             whenever(productsCache.getAll()).thenReturn(emptyList())
             whenever(
-                handler.loadFromCacheAndFetch(any(), any(), any(), any(), any(), any())
-            ).thenReturn(Result.success(Unit))
-            val sut = WooPosProductsDataSource(handler, productsCache)
+                productStore.fetchProducts(
+                    site = eq(siteModel),
+                    offset = any(),
+                    pageSize = any(),
+                    filterOptions = any(),
+                    includeTypes = any(),
+                )
+            ).thenReturn(WooResult(emptyList()))
+            val sut = WooPosProductsDataSource(productStore, selectedSite, productsCache)
 
             // WHEN
             val flow = sut.loadProducts(forceRefreshProducts = false).toList()
@@ -252,7 +320,7 @@ class WooPosProductsDataSourceTest {
             assertThat(cachedResult.products).isEmpty()
             assertThat(remoteResult.productsResult.isSuccess).isTrue()
             assertThat(remoteResult.productsResult.getOrNull()).isEmpty()
-            verify(productsCache).addAll(emptyList())
+            verify(productsCache).addAll(any())
         }
 
     @Test
@@ -275,13 +343,18 @@ class WooPosProductsDataSourceTest {
                     isDownloadable = false
                 ).copy(firstImageUrl = "https://test.com")
             )
-            whenever(handler.canLoadMore).thenReturn(AtomicBoolean(true))
-            whenever(handler.productsFlow).thenReturn(flowOf(productsWithoutPrice))
+            whenever(selectedSite.get()).thenReturn(siteModel)
             whenever(productsCache.getAll()).thenReturn(productsWithoutPrice.filter { it.remoteId == 2L })
             whenever(
-                handler.loadFromCacheAndFetch(any(), any(), any(), any(), any(), any())
-            ).thenReturn(Result.success(Unit))
-            val sut = WooPosProductsDataSource(handler, productsCache)
+                productStore.fetchProducts(
+                    site = eq(siteModel),
+                    offset = any(),
+                    pageSize = any(),
+                    filterOptions = any(),
+                    includeTypes = any()
+                )
+            ).thenReturn(WooResult(listOf<WCProductModel>()))
+            val sut = WooPosProductsDataSource(productStore, selectedSite, productsCache)
 
             // WHEN
             val flow = sut.loadProducts(forceRefreshProducts = false).toList()
@@ -313,13 +386,18 @@ class WooPosProductsDataSourceTest {
                     isDownloadable = false
                 ).copy(firstImageUrl = "https://test.com")
             )
-            whenever(handler.canLoadMore).thenReturn(AtomicBoolean(true))
-            whenever(handler.productsFlow).thenReturn(flowOf(mixedProducts))
+            whenever(selectedSite.get()).thenReturn(siteModel)
             whenever(productsCache.getAll()).thenReturn(mixedProducts.filter { it.remoteId == 2L })
             whenever(
-                handler.loadFromCacheAndFetch(any(), any(), any(), any(), any(), any())
-            ).thenReturn(Result.success(Unit))
-            val sut = WooPosProductsDataSource(handler, productsCache)
+                productStore.fetchProducts(
+                    site = eq(siteModel),
+                    offset = any(),
+                    pageSize = any(),
+                    filterOptions = any(),
+                    includeTypes = any()
+                )
+            ).thenReturn(WooResult(listOf<WCProductModel>()))
+            val sut = WooPosProductsDataSource(productStore, selectedSite, productsCache)
 
             // WHEN
             val flow = sut.loadProducts(forceRefreshProducts = false).toList()
@@ -350,13 +428,18 @@ class WooPosProductsDataSourceTest {
                     isDownloadable = false
                 ).copy(firstImageUrl = "https://test.com")
             )
-            whenever(handler.canLoadMore).thenReturn(AtomicBoolean(true))
-            whenever(handler.productsFlow).thenReturn(flowOf(mixedProducts))
+            whenever(selectedSite.get()).thenReturn(siteModel)
             whenever(productsCache.getAll()).thenReturn(mixedProducts)
             whenever(
-                handler.loadFromCacheAndFetch(any(), any(), any(), any(), any(), any())
-            ).thenReturn(Result.success(Unit))
-            val sut = WooPosProductsDataSource(handler, productsCache)
+                productStore.fetchProducts(
+                    site = eq(siteModel),
+                    offset = any(),
+                    pageSize = any(),
+                    filterOptions = any(),
+                    includeTypes = any()
+                )
+            ).thenReturn(WooResult(listOf<WCProductModel>()))
+            val sut = WooPosProductsDataSource(productStore, selectedSite, productsCache)
 
             // WHEN
             val flow = sut.loadProducts(forceRefreshProducts = false).toList()
@@ -381,14 +464,19 @@ class WooPosProductsDataSourceTest {
 
         val customUnsortedProducts = listOf(mockProductC, mockProductA, mockProductB)
 
-        whenever(handler.canLoadMore).thenReturn(AtomicBoolean(true))
-        whenever(handler.productsFlow).thenReturn(flowOf(customUnsortedProducts))
+        whenever(selectedSite.get()).thenReturn(siteModel)
         whenever(productsCache.getAll()).thenReturn(customUnsortedProducts)
         whenever(
-            handler.loadFromCacheAndFetch(any(), any(), any(), any(), any(), any())
-        ).thenReturn(Result.success(Unit))
+            productStore.fetchProducts(
+                site = eq(siteModel),
+                offset = any(),
+                pageSize = any(),
+                filterOptions = any(),
+                includeTypes = any()
+            )
+        ).thenReturn(WooResult(listOf<WCProductModel>()))
 
-        val sut = WooPosProductsDataSource(handler, productsCache)
+        val sut = WooPosProductsDataSource(productStore, selectedSite, productsCache)
 
         // WHEN
         val result = sut.loadProducts(forceRefreshProducts = false).first()
@@ -424,12 +512,23 @@ class WooPosProductsDataSourceTest {
         val additionalUnsortedProducts = listOf(mockProductE, mockProductD)
         val allProducts = initialProducts + additionalUnsortedProducts
 
-        whenever(handler.canLoadMore).thenReturn(AtomicBoolean(true))
-        whenever(handler.productsFlow).thenReturn(flowOf(additionalUnsortedProducts))
-        whenever(handler.loadMore()).thenReturn(Result.success(Unit))
+        whenever(selectedSite.get()).thenReturn(siteModel)
+        whenever(
+            productStore.fetchProducts(
+                site = eq(siteModel),
+                offset = any(),
+                pageSize = any(),
+                filterOptions = any(),
+                includeTypes = any()
+            )
+        ).thenReturn(WooResult(listOf<WCProductModel>()))
         whenever(productsCache.getAll()).thenReturn(allProducts)
 
-        val sut = WooPosProductsDataSource(handler, productsCache)
+        val sut = WooPosProductsDataSource(productStore, selectedSite, productsCache)
+        sut::class.java.getDeclaredField("canLoadMore").apply {
+            isAccessible = true
+            set(sut, AtomicBoolean(true))
+        }
 
         // WHEN
         val result = sut.loadMore()
@@ -445,6 +544,6 @@ class WooPosProductsDataSourceTest {
         assertThat(sortedProducts[3].name).isEqualTo("D Product")
         assertThat(sortedProducts[4].name).isEqualTo("E Product")
 
-        verify(productsCache).addAll(additionalUnsortedProducts)
+        verify(productsCache).addAll(any())
     }
 }

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/home/items/WooPosProductsDataSourceTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/home/items/WooPosProductsDataSourceTest.kt
@@ -16,6 +16,8 @@ import org.junit.Rule
 import org.mockito.kotlin.any
 import org.mockito.kotlin.eq
 import org.mockito.kotlin.mock
+import org.mockito.kotlin.never
+import org.mockito.kotlin.times
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
 import org.wordpress.android.fluxc.model.SiteModel
@@ -546,4 +548,208 @@ class WooPosProductsDataSourceTest {
 
         verify(productsCache).addAll(any())
     }
+
+    @Test
+    fun `given successful fetch, when prepopulateProductsCache called, then should clear cache and add products`() =
+        runTest {
+            // GIVEN
+            whenever(selectedSite.get()).thenReturn(siteModel)
+            whenever(
+                productStore.fetchProducts(
+                    site = eq(siteModel),
+                    offset = eq(0),
+                    pageSize = eq(100),
+                    filterOptions = any(),
+                    includeTypes = any()
+                )
+            ).thenReturn(WooResult(emptyList()))
+            val sut = WooPosProductsDataSource(productStore, selectedSite, productsCache)
+
+            // WHEN
+            val result = sut.prepopulateProductsCache()
+
+            // THEN
+            verify(productsCache).clear()
+            verify(productsCache).addAll(any())
+            assertThat(result.isSuccess).isTrue()
+        }
+
+    @Test
+    fun `given multiple pages of products, when prepopulateProductsCache called, then should fetch all pages up to limit`() =
+        runTest {
+            // GIVEN
+            val firstPageWcProducts = List(100) {
+                WCProductModel().apply {
+                    attributes = "[]"
+                    status = "draft"
+                }
+            }
+            val secondPageWcProducts = List(50) {
+                WCProductModel().apply {
+                    attributes = "[]"
+                    status = "draft"
+                }
+            }
+
+            whenever(selectedSite.get()).thenReturn(siteModel)
+            whenever(
+                productStore.fetchProducts(
+                    site = eq(siteModel),
+                    offset = eq(0),
+                    pageSize = eq(100),
+                    filterOptions = any(),
+                    includeTypes = any()
+                )
+            ).thenReturn(WooResult(firstPageWcProducts))
+
+            whenever(
+                productStore.fetchProducts(
+                    site = eq(siteModel),
+                    offset = eq(100),
+                    pageSize = eq(100),
+                    filterOptions = any(),
+                    includeTypes = any()
+                )
+            ).thenReturn(WooResult(secondPageWcProducts))
+
+            val sut = WooPosProductsDataSource(productStore, selectedSite, productsCache)
+
+            // WHEN
+            val result = sut.prepopulateProductsCache()
+
+            // THEN
+            verify(productsCache).clear()
+            verify(productsCache).addAll(any())
+            assertThat(result.isSuccess).isTrue()
+            verify(productStore, times(2)).fetchProducts(
+                site = any(),
+                offset = any(),
+                pageSize = any(),
+                filterOptions = any(),
+                includeTypes = any()
+            )
+        }
+
+    @Test
+    fun `given error when fetching products, when prepopulateProductsCache called, then should return failure`() =
+        runTest {
+            // GIVEN
+            whenever(selectedSite.get()).thenReturn(siteModel)
+            val wooError = WooError(
+                WooErrorType.GENERIC_ERROR,
+                GenericErrorType.UNKNOWN,
+                "Failed to fetch products"
+            )
+            whenever(
+                productStore.fetchProducts(
+                    site = eq(siteModel),
+                    offset = any(),
+                    pageSize = any(),
+                    filterOptions = any(),
+                    includeTypes = any()
+                )
+            ).thenReturn(WooResult(wooError))
+
+            val sut = WooPosProductsDataSource(productStore, selectedSite, productsCache)
+
+            // WHEN
+            val result = sut.prepopulateProductsCache()
+
+            // THEN
+            verify(productsCache).clear()
+            verify(productsCache, never()).addAll(any())
+            assertThat(result.isFailure).isTrue()
+            assertThat(result.exceptionOrNull()).isInstanceOf(WooException::class.java)
+        }
+
+    @Test
+    fun `given full product list returned but under max pages, when prepopulateProductsCache called, then should stop fetching`() =
+        runTest {
+            // GIVEN
+            val firstPageProducts = List(100) {
+                WCProductModel().apply {
+                    attributes = "[]"
+                    status = "draft"
+                }
+            }
+            val emptySecondPage = emptyList<WCProductModel>()
+
+            whenever(selectedSite.get()).thenReturn(siteModel)
+            whenever(
+                productStore.fetchProducts(
+                    site = eq(siteModel),
+                    offset = eq(0),
+                    pageSize = eq(100),
+                    filterOptions = any(),
+                    includeTypes = any()
+                )
+            ).thenReturn(WooResult(firstPageProducts))
+
+            whenever(
+                productStore.fetchProducts(
+                    site = eq(siteModel),
+                    offset = eq(100),
+                    pageSize = eq(100),
+                    filterOptions = any(),
+                    includeTypes = any()
+                )
+            ).thenReturn(WooResult(emptySecondPage))
+
+            val sut = WooPosProductsDataSource(productStore, selectedSite, productsCache)
+
+            // WHEN
+            val result = sut.prepopulateProductsCache()
+
+            // THEN
+            verify(productsCache).clear()
+            verify(productsCache).addAll(any())
+            assertThat(result.isSuccess).isTrue()
+            verify(productStore, times(2)).fetchProducts(
+                site = any(),
+                offset = any(),
+                pageSize = any(),
+                filterOptions = any(),
+                includeTypes = any()
+            )
+        }
+
+    @Test
+    fun `given max pages reached, when prepopulateProductsCache called, then should stop fetching and return success`() =
+        runTest {
+            // GIVEN
+            val pageProducts = List(100) {
+                WCProductModel().apply {
+                    attributes = "[]"
+                    status = "draft"
+                }
+            }
+
+            whenever(selectedSite.get()).thenReturn(siteModel)
+            whenever(
+                productStore.fetchProducts(
+                    site = eq(siteModel),
+                    offset = any(),
+                    pageSize = eq(100),
+                    filterOptions = any(),
+                    includeTypes = any()
+                )
+            ).thenReturn(WooResult(pageProducts))
+
+            val sut = WooPosProductsDataSource(productStore, selectedSite, productsCache)
+
+            // WHEN
+            val result = sut.prepopulateProductsCache()
+
+            // THEN
+            verify(productsCache).clear()
+            verify(productsCache).addAll(any())
+            assertThat(result.isSuccess).isTrue()
+            verify(productStore, times(2)).fetchProducts(
+                site = any(),
+                offset = any(),
+                pageSize = any(),
+                filterOptions = any(),
+                includeTypes = any()
+            )
+        }
 }

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/home/items/WooPosProductsDataSourceTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/home/items/WooPosProductsDataSourceTest.kt
@@ -82,7 +82,7 @@ class WooPosProductsDataSourceTest {
     private val productStore: WCProductStore = mock()
     private val selectedSite: SelectedSite = mock()
     private val productsCache: WooPosProductsCache = mock()
-    private val productList: WooPosProductsIndex = mock()
+    private val productsIndex: WooPosProductsIndex = mock()
     private val siteModel: SiteModel = mock()
     private val includeTypes = listOf(WCProductStore.IncludeType.Simple, WCProductStore.IncludeType.Variable)
 
@@ -90,7 +90,7 @@ class WooPosProductsDataSourceTest {
     fun `given force refresh, when loadSimpleProducts called, then should clear cache`() = runTest {
         // GIVEN
         whenever(selectedSite.get()).thenReturn(siteModel)
-        whenever(productList.getProductList()).thenReturn(emptyList(), sampleProducts)
+        whenever(productsIndex.getProductList()).thenReturn(emptyList(), sampleProducts)
         whenever(productsCache.getAll()).thenReturn(emptyList(), sampleProducts)
         whenever(
             productStore.fetchProducts(
@@ -101,14 +101,14 @@ class WooPosProductsDataSourceTest {
                 includeTypes = eq(includeTypes),
             )
         ).thenReturn(WooResult(listOf<WCProductModel>()))
-        val sut = WooPosProductsDataSource(productStore, selectedSite, productsCache)
+        val sut = WooPosProductsDataSource(productStore, selectedSite, productsCache, productsIndex)
 
         // WHEN
         sut.loadProducts(forceRefreshProducts = true).first()
 
         // THEN
         verify(productsCache).clear()
-        verify(productList).clearCache()
+        verify(productsIndex).clearCache()
     }
 
     @Test
@@ -125,8 +125,8 @@ class WooPosProductsDataSourceTest {
                 includeTypes = any()
             )
         ).thenReturn(WooResult(listOf<WCProductModel>()))
-        whenever(productList.getProductList()).thenReturn(sampleProducts)
-        val sut = WooPosProductsDataSource(productStore, selectedSite, productsCache)
+        whenever(productsIndex.getProductList()).thenReturn(sampleProducts)
+        val sut = WooPosProductsDataSource(productStore, selectedSite, productsCache, productsIndex)
 
         // WHEN
         val result = sut.loadProducts(forceRefreshProducts = false).first()
@@ -140,16 +140,20 @@ class WooPosProductsDataSourceTest {
     @Test
     fun `given no products in list cache, when loadSimpleProducts called, then should return empty list`() = runTest {
         // GIVEN
-        whenever(handler.canLoadMore).thenReturn(AtomicBoolean(true))
-        whenever(handler.productsFlow).thenReturn(flowOf(sampleProducts))
         whenever(
-            handler.loadFromCacheAndFetch(any(), any(), any(), any(), any(), any())
-        ).thenReturn(Result.success(Unit))
-        whenever(productList.getProductList()).thenReturn(emptyList())
-        val sut = WooPosProductsDataSource(handler, productsCache, productList)
+            productStore.fetchProducts(
+                site = eq(siteModel),
+                offset = any(),
+                pageSize = any(),
+                filterOptions = any(),
+                includeTypes = any()
+            )
+        ).thenReturn(WooResult(listOf<WCProductModel>()))
+        whenever(productsIndex.getProductList()).thenReturn(emptyList())
+        val sut = WooPosProductsDataSource(productStore, selectedSite, productsCache, productsIndex)
 
         // WHEN
-        val result = sut.loadSimpleProducts(forceRefreshProducts = false).first()
+        val result = sut.loadProducts(forceRefreshProducts = false).first()
 
         // THEN
         assertThat(result).isInstanceOf(WooPosProductsDataSource.ProductsResult.Cached::class.java)
@@ -163,7 +167,7 @@ class WooPosProductsDataSourceTest {
             // GIVEN
             whenever(selectedSite.get()).thenReturn(siteModel)
             whenever(productsCache.getAll()).thenReturn(sampleProducts)
-            whenever(productList.getProductList()).thenReturn(sampleProducts)
+            whenever(productsIndex.getProductList()).thenReturn(sampleProducts)
             whenever(
                 productStore.fetchProducts(
                     site = eq(siteModel),
@@ -173,7 +177,7 @@ class WooPosProductsDataSourceTest {
                     includeTypes = any()
                 )
             ).thenReturn(WooResult(listOf<WCProductModel>()))
-            val sut = WooPosProductsDataSource(productStore, selectedSite, productsCache)
+            val sut = WooPosProductsDataSource(productStore, selectedSite, productsCache, productsIndex)
 
             // WHEN
             val flow = sut.loadProducts(forceRefreshProducts = false).toList()
@@ -186,7 +190,7 @@ class WooPosProductsDataSourceTest {
             assertThat(remoteResult.productsResult.isSuccess).isTrue()
             assertThat(remoteResult.productsResult.getOrNull()).containsExactlyElementsOf(sampleProducts)
             verify(productsCache).addAll(any())
-            verify(productList).storeProductList(sampleProducts.map { it.remoteId })
+            verify(productsIndex).storeProductList(sampleProducts.map { it.remoteId })
         }
 
     @Test
@@ -210,7 +214,7 @@ class WooPosProductsDataSourceTest {
                 )
             ).thenReturn(WooResult(wooError))
 
-            val sut = WooPosProductsDataSource(productStore, selectedSite, productsCache, productList)
+            val sut = WooPosProductsDataSource(productStore, selectedSite, productsCache, productsIndex)
 
             // WHEN
             val flow = sut.loadProducts(forceRefreshProducts = false).toList()
@@ -237,8 +241,8 @@ class WooPosProductsDataSourceTest {
                     includeTypes = any()
                 )
             ).thenReturn(WooResult(listOf<WCProductModel>()))
-            whenever(productList.getProductList()).thenReturn(sampleProducts + additionalProducts)
-            val sut = WooPosProductsDataSource(productStore, selectedSite, productsCache, productList)
+            whenever(productsIndex.getProductList()).thenReturn(sampleProducts + additionalProducts)
+            val sut = WooPosProductsDataSource(productStore, selectedSite, productsCache, productsIndex)
             sut::class.java.getDeclaredField("canLoadMore").apply {
                 isAccessible = true
                 set(sut, AtomicBoolean(true))
@@ -251,7 +255,7 @@ class WooPosProductsDataSourceTest {
             assertThat(result.isSuccess).isTrue()
             assertThat(result.getOrNull()).containsExactlyElementsOf(sampleProducts + additionalProducts)
             verify(productsCache).addAll(any())
-            verify(productList).storeProductList(additionalProducts.map { it.remoteId })
+            verify(productsIndex).storeProductList(additionalProducts.map { it.remoteId })
         }
 
     @Test
@@ -273,7 +277,7 @@ class WooPosProductsDataSourceTest {
                 )
             ).thenReturn(WooResult(wooError))
 
-            val sut = WooPosProductsDataSource(productStore, selectedSite, productsCache, productList)
+            val sut = WooPosProductsDataSource(productStore, selectedSite, productsCache, productsIndex)
             sut::class.java.getDeclaredField("canLoadMore").apply {
                 isAccessible = true
                 set(sut, AtomicBoolean(true))
@@ -292,7 +296,7 @@ class WooPosProductsDataSourceTest {
         runTest {
             // GIVEN
             whenever(selectedSite.get()).thenReturn(siteModel)
-            whenever(productList.getProductList()).thenReturn(emptyList())
+            whenever(productsIndex.getProductList()).thenReturn(emptyList())
             whenever(
                 productStore.fetchProducts(
                     site = eq(siteModel),
@@ -310,7 +314,7 @@ class WooPosProductsDataSourceTest {
                 )
             )
 
-            val sut = WooPosProductsDataSource(productStore, selectedSite, productsCache, productList)
+            val sut = WooPosProductsDataSource(productStore, selectedSite, productsCache, productsIndex)
 
             // WHEN
             val flow = sut.loadProducts(forceRefreshProducts = false).toList()
@@ -328,7 +332,7 @@ class WooPosProductsDataSourceTest {
         runTest {
             // GIVEN
             whenever(selectedSite.get()).thenReturn(siteModel)
-            whenever(productList.getProductList()).thenReturn(emptyList())
+            whenever(productsIndex.getProductList()).thenReturn(emptyList())
             whenever(
                 productStore.fetchProducts(
                     site = eq(siteModel),
@@ -338,7 +342,7 @@ class WooPosProductsDataSourceTest {
                     includeTypes = any(),
                 )
             ).thenReturn(WooResult(emptyList()))
-            val sut = WooPosProductsDataSource(productStore, selectedSite, productsCache, productList)
+            val sut = WooPosProductsDataSource(productStore, selectedSite, productsCache, productsIndex)
 
             // WHEN
             val flow = sut.loadProducts(forceRefreshProducts = false).toList()
@@ -351,7 +355,7 @@ class WooPosProductsDataSourceTest {
             assertThat(remoteResult.productsResult.isSuccess).isTrue()
             assertThat(remoteResult.productsResult.getOrNull()).isEmpty()
             verify(productsCache).addAll(any())
-            verify(productList).storeProductList(emptyList())
+            verify(productsIndex).storeProductList(emptyList())
         }
 
     @Test
@@ -375,7 +379,7 @@ class WooPosProductsDataSourceTest {
                 ).copy(firstImageUrl = "https://test.com")
             )
             whenever(selectedSite.get()).thenReturn(siteModel)
-            whenever(productList.getProductList()).thenReturn(productsWithoutPrice.filter { it.remoteId == 2L })
+            whenever(productsIndex.getProductList()).thenReturn(productsWithoutPrice.filter { it.remoteId == 2L })
             whenever(
                 productStore.fetchProducts(
                     site = eq(siteModel),
@@ -385,7 +389,7 @@ class WooPosProductsDataSourceTest {
                     includeTypes = any()
                 )
             ).thenReturn(WooResult(listOf<WCProductModel>()))
-            val sut = WooPosProductsDataSource(productStore, selectedSite, productsCache, productList)
+            val sut = WooPosProductsDataSource(productStore, selectedSite, productsCache, productsIndex)
 
             // WHEN
             val flow = sut.loadProducts(forceRefreshProducts = false).toList()
@@ -418,7 +422,7 @@ class WooPosProductsDataSourceTest {
                 ).copy(firstImageUrl = "https://test.com")
             )
             whenever(selectedSite.get()).thenReturn(siteModel)
-            whenever(productList.getProductList()).thenReturn(mixedProducts.filter { it.remoteId == 2L })
+            whenever(productsIndex.getProductList()).thenReturn(mixedProducts.filter { it.remoteId == 2L })
             whenever(
                 productStore.fetchProducts(
                     site = eq(siteModel),
@@ -428,7 +432,7 @@ class WooPosProductsDataSourceTest {
                     includeTypes = any()
                 )
             ).thenReturn(WooResult(listOf<WCProductModel>()))
-            val sut = WooPosProductsDataSource(productStore, selectedSite, productsCache, productList)
+            val sut = WooPosProductsDataSource(productStore, selectedSite, productsCache, productsIndex)
 
             // WHEN
             val flow = sut.loadProducts(forceRefreshProducts = false).toList()
@@ -460,7 +464,7 @@ class WooPosProductsDataSourceTest {
                 ).copy(firstImageUrl = "https://test.com")
             )
             whenever(selectedSite.get()).thenReturn(siteModel)
-            whenever(productList.getProductList()).thenReturn(mixedProducts)
+            whenever(productsIndex.getProductList()).thenReturn(mixedProducts)
             whenever(
                 productStore.fetchProducts(
                     site = eq(siteModel),
@@ -470,7 +474,7 @@ class WooPosProductsDataSourceTest {
                     includeTypes = any()
                 )
             ).thenReturn(WooResult(listOf<WCProductModel>()))
-            val sut = WooPosProductsDataSource(productStore, selectedSite, productsCache, productList)
+            val sut = WooPosProductsDataSource(productStore, selectedSite, productsCache, productsIndex)
 
             // WHEN
             val flow = sut.loadProducts(forceRefreshProducts = false).toList()
@@ -496,7 +500,7 @@ class WooPosProductsDataSourceTest {
         val customUnsortedProducts = listOf(mockProductC, mockProductA, mockProductB)
 
         whenever(selectedSite.get()).thenReturn(siteModel)
-        whenever(productList.getProductList()).thenReturn(customUnsortedProducts)
+        whenever(productsIndex.getProductList()).thenReturn(customUnsortedProducts)
         whenever(
             productStore.fetchProducts(
                 site = eq(siteModel),
@@ -507,7 +511,7 @@ class WooPosProductsDataSourceTest {
             )
         ).thenReturn(WooResult(listOf<WCProductModel>()))
 
-        val sut = WooPosProductsDataSource(productStore, selectedSite, productsCache, productList)
+        val sut = WooPosProductsDataSource(productStore, selectedSite, productsCache, productsIndex)
 
         // WHEN
         val result = sut.loadProducts(forceRefreshProducts = false).first()
@@ -553,9 +557,9 @@ class WooPosProductsDataSourceTest {
                 includeTypes = any()
             )
         ).thenReturn(WooResult(listOf<WCProductModel>()))
-        whenever(productList.getProductList()).thenReturn(allProducts)
+        whenever(productsIndex.getProductList()).thenReturn(allProducts)
 
-        val sut = WooPosProductsDataSource(productStore, selectedSite, productsCache, productList)
+        val sut = WooPosProductsDataSource(productStore, selectedSite, productsCache, productsIndex)
         sut::class.java.getDeclaredField("canLoadMore").apply {
             isAccessible = true
             set(sut, AtomicBoolean(true))
@@ -576,7 +580,7 @@ class WooPosProductsDataSourceTest {
         assertThat(sortedProducts[4].name).isEqualTo("E Product")
 
         verify(productsCache).addAll(any())
-        verify(productList).storeProductList(additionalUnsortedProducts.map { it.remoteId })
+        verify(productsIndex).storeProductList(additionalUnsortedProducts.map { it.remoteId })
     }
 
     @Test
@@ -593,7 +597,7 @@ class WooPosProductsDataSourceTest {
                     includeTypes = any()
                 )
             ).thenReturn(WooResult(emptyList()))
-            val sut = WooPosProductsDataSource(productStore, selectedSite, productsCache)
+            val sut = WooPosProductsDataSource(productStore, selectedSite, productsCache, productsIndex)
 
             // WHEN
             val result = sut.prepopulateProductsCache()
@@ -642,7 +646,7 @@ class WooPosProductsDataSourceTest {
                 )
             ).thenReturn(WooResult(secondPageWcProducts))
 
-            val sut = WooPosProductsDataSource(productStore, selectedSite, productsCache)
+            val sut = WooPosProductsDataSource(productStore, selectedSite, productsCache, productsIndex)
 
             // WHEN
             val result = sut.prepopulateProductsCache()
@@ -680,7 +684,7 @@ class WooPosProductsDataSourceTest {
                 )
             ).thenReturn(WooResult(wooError))
 
-            val sut = WooPosProductsDataSource(productStore, selectedSite, productsCache)
+            val sut = WooPosProductsDataSource(productStore, selectedSite, productsCache, productsIndex)
 
             // WHEN
             val result = sut.prepopulateProductsCache()
@@ -725,7 +729,7 @@ class WooPosProductsDataSourceTest {
                 )
             ).thenReturn(WooResult(emptySecondPage))
 
-            val sut = WooPosProductsDataSource(productStore, selectedSite, productsCache)
+            val sut = WooPosProductsDataSource(productStore, selectedSite, productsCache, productsIndex)
 
             // WHEN
             val result = sut.prepopulateProductsCache()
@@ -765,7 +769,7 @@ class WooPosProductsDataSourceTest {
                 )
             ).thenReturn(WooResult(pageProducts))
 
-            val sut = WooPosProductsDataSource(productStore, selectedSite, productsCache)
+            val sut = WooPosProductsDataSource(productStore, selectedSite, productsCache, productsIndex)
 
             // WHEN
             val result = sut.prepopulateProductsCache()

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/home/items/search/WooPosSearchProductsDataSourceTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/home/items/search/WooPosSearchProductsDataSourceTest.kt
@@ -77,10 +77,8 @@ class WooPosSearchProductsDataSourceTest {
             assertThat(result).isInstanceOf(WooPosSearchProductsDataSource.ProductsResult.Cached::class.java)
             assertThat((result as WooPosSearchProductsDataSource.ProductsResult.Cached).products).isEqualTo(products)
 
-            // First verify clearCache is called
             verify(searchResultsIndex).clearCache()
 
-            // Then verify storeSearchResults is called with empty list (as observed in the test failure)
             verify(searchResultsIndex).storeSearchResults(query, emptyList())
             cancelAndIgnoreRemainingEvents()
         }
@@ -93,6 +91,7 @@ class WooPosSearchProductsDataSourceTest {
             val query = "test"
             val manyProducts = (1..20).map { ProductTestUtils.generateProduct(productId = it.toLong()) }
             whenever(wooPosProductsCache.getAll()).thenReturn(manyProducts)
+            whenever(searchResultsIndex.getSearchResults(query)).thenReturn(manyProducts)
             whenever(
                 productStore.searchProducts(
                     anyOrNull(),
@@ -208,32 +207,5 @@ class WooPosSearchProductsDataSourceTest {
                 anyOrNull(),
                 anyOrNull()
             )
-        }
-
-    @Test
-    fun `given clearCache called in searchResultsIndex, when searchProducts called, then should emit results`() =
-        runTest {
-            // GIVEN
-            val query = "test"
-            whenever(wooPosProductsCache.getAll()).thenReturn(products)
-            whenever(
-                productStore.searchProducts(
-                    anyOrNull(),
-                    anyOrNull(),
-                    anyOrNull(),
-                    anyOrNull(),
-                    anyOrNull(),
-                    anyOrNull()
-                )
-            ).thenReturn(WooResult(ProductSearchResult(emptyList(), false)))
-
-            // WHEN
-            val result = sut.searchProducts(query)
-
-            // THEN
-            result.test {
-                verify(searchResultsIndex).clearCache()
-                cancelAndIgnoreRemainingEvents()
-            }
         }
 }

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/home/items/search/WooPosSearchProductsDataSourceTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/home/items/search/WooPosSearchProductsDataSourceTest.kt
@@ -97,17 +97,4 @@ class WooPosSearchProductsDataSourceTest {
             cancelAndIgnoreRemainingEvents()
         }
     }
-
-    @Test
-    fun `given product id, when getProductById called, then should return product from cache`() = runTest {
-        // GIVEN
-        val productId = 1L
-        whenever(wooPosProductsCache.getProductById(productId)).thenReturn(product1)
-
-        // WHEN
-        val result = sut.getProductById(productId)
-
-        // THEN
-        assertThat(result).isEqualTo(product1)
-    }
 }

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/home/items/search/WooPosSearchProductsDataSourceTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/home/items/search/WooPosSearchProductsDataSourceTest.kt
@@ -116,7 +116,6 @@ class WooPosSearchProductsDataSourceTest {
             }
         }
 
-
     @Test
     fun `given remote search products success, when search products called, then should emit cached and remote results`() = runTest {
         // GIVEN

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/home/items/search/WooPosSearchProductsDataSourceTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/home/items/search/WooPosSearchProductsDataSourceTest.kt
@@ -15,7 +15,6 @@ import org.mockito.kotlin.any
 import org.mockito.kotlin.anyOrNull
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.never
-import org.mockito.kotlin.times
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
 import org.wordpress.android.fluxc.model.SiteModel
@@ -34,7 +33,7 @@ class WooPosSearchProductsDataSourceTest {
 
     private val productStore: WCProductStore = mock()
     private val wooPosProductsCache: WooPosProductsCache = mock()
-    private val searchResults: WooPosSearchResultsIndex = mock()
+    private val searchResultsIndex: WooPosSearchResultsIndex = mock()
     private val selectedSite: SelectedSite = mock()
     private val searchPredicate: ProductSearchPredicate = mock()
     private val siteModel: SiteModel = mock()
@@ -55,7 +54,7 @@ class WooPosSearchProductsDataSourceTest {
             productStore = productStore,
             selectedSite = selectedSite,
             productsCache = wooPosProductsCache,
-            searchResultsIndex = searchResults,
+            searchResultsIndex = searchResultsIndex,
             searchPredicate = searchPredicate
         )
     }
@@ -64,8 +63,8 @@ class WooPosSearchProductsDataSourceTest {
     fun `given cached search results, when search products called, then should emit cached results`() = runTest {
         // GIVEN
         val query = "test"
-        whenever(searchResults.hasSearchResults(query)).thenReturn(true)
-        whenever(searchResults.getSearchResults(query)).thenReturn(emptyList())
+        whenever(searchResultsIndex.hasSearchResults(query)).thenReturn(true)
+        whenever(searchResultsIndex.getSearchResults(query)).thenReturn(emptyList())
         whenever(wooPosProductsCache.getAll()).thenReturn(products)
         whenever(
             productStore.searchProducts(anyOrNull(), anyOrNull(), anyOrNull(), anyOrNull(), anyOrNull(), anyOrNull())
@@ -79,10 +78,10 @@ class WooPosSearchProductsDataSourceTest {
             assertThat((result as WooPosSearchProductsDataSource.ProductsResult.Cached).products).isEqualTo(products)
 
             // First verify clearCache is called
-            verify(searchResults).clearCache()
+            verify(searchResultsIndex).clearCache()
 
             // Then verify storeSearchResults is called with empty list (as observed in the test failure)
-            verify(searchResults).storeSearchResults(query, emptyList())
+            verify(searchResultsIndex).storeSearchResults(query, emptyList())
             cancelAndIgnoreRemainingEvents()
         }
     }
@@ -103,8 +102,7 @@ class WooPosSearchProductsDataSourceTest {
                     anyOrNull(),
                     anyOrNull()
                 )
-            )
-                .thenReturn(WooResult(ProductSearchResult(emptyList(), false)))
+            ).thenReturn(WooResult(ProductSearchResult(emptyList(), false)))
 
             // WHEN
             sut.searchProducts(query).test {
@@ -117,34 +115,42 @@ class WooPosSearchProductsDataSourceTest {
         }
 
     @Test
-    fun `given remote search products success, when search products called, then should emit cached and remote results`() = runTest {
-        // GIVEN
-        val query = "test"
-        whenever(wooPosProductsCache.getAll()).thenReturn(products)
-        whenever(
-            productStore.searchProducts(anyOrNull(), anyOrNull(), anyOrNull(), anyOrNull(), anyOrNull(), anyOrNull())
-        ).thenReturn(WooResult(ProductSearchResult(emptyList(), true)))
+    fun `given remote search products success, when search products called, then should emit cached and remote results`() =
+        runTest {
+            // GIVEN
+            val query = "test"
+            whenever(wooPosProductsCache.getAll()).thenReturn(products)
+            whenever(searchResultsIndex.getSearchResults(query)).thenReturn(emptyList())
+            whenever(
+                productStore.searchProducts(
+                    anyOrNull(),
+                    anyOrNull(),
+                    anyOrNull(),
+                    anyOrNull(),
+                    anyOrNull(),
+                    anyOrNull()
+                )
+            ).thenReturn(WooResult(ProductSearchResult(emptyList(), true)))
 
-        // WHEN
-        sut.searchProducts(query).test {
+            // WHEN
+            val result = sut.searchProducts(query)
+
             // THEN
-            // First emission should be cached results
-            val cachedResult = awaitItem()
-            assertThat(cachedResult).isInstanceOf(WooPosSearchProductsDataSource.ProductsResult.Cached::class.java)
+            result.test {
+                val cachedResult = awaitItem()
+                assertThat(cachedResult).isInstanceOf(WooPosSearchProductsDataSource.ProductsResult.Cached::class.java)
 
-            // Second emission should be remote results
-            val remoteResult = awaitItem()
-            assertThat(remoteResult).isInstanceOf(WooPosSearchProductsDataSource.ProductsResult.Remote::class.java)
-            val remoteResultSuccess = (remoteResult as WooPosSearchProductsDataSource.ProductsResult.Remote)
-                .productsResult.isSuccess
-            assertThat(remoteResultSuccess).isTrue()
+                val remoteResult = awaitItem()
+                assertThat(remoteResult).isInstanceOf(WooPosSearchProductsDataSource.ProductsResult.Remote::class.java)
+                val remoteResultSuccess = (remoteResult as WooPosSearchProductsDataSource.ProductsResult.Remote)
+                    .productsResult.isSuccess
+                assertThat(remoteResultSuccess).isTrue()
 
-            // Check hasMorePages property
-            assertThat(sut.hasMorePages).isTrue()
+                assertThat(sut.hasMorePages).isTrue()
 
-            cancelAndIgnoreRemainingEvents()
+                cancelAndIgnoreRemainingEvents()
+            }
         }
-    }
 
     @Test
     fun `given remote search products fail, when search products called, then should emit failure result`() = runTest {
@@ -163,11 +169,9 @@ class WooPosSearchProductsDataSourceTest {
         // WHEN
         sut.searchProducts(query).test {
             // THEN
-            // First emission should be cached results
             val cachedResult = awaitItem()
             assertThat(cachedResult).isInstanceOf(WooPosSearchProductsDataSource.ProductsResult.Cached::class.java)
 
-            // Second emission should be remote results with error
             val remoteResult = awaitItem()
             assertThat(remoteResult).isInstanceOf(WooPosSearchProductsDataSource.ProductsResult.Remote::class.java)
             val remoteResultFailed = (remoteResult as WooPosSearchProductsDataSource.ProductsResult.Remote)
@@ -179,48 +183,57 @@ class WooPosSearchProductsDataSourceTest {
     }
 
     @Test
-    fun `given no more pages, when loadMore called, then should return current results without making API call`() = runTest {
-        // GIVEN
-        val query = "test"
-        whenever(searchResults.getSearchResults(query)).thenReturn(products)
+    fun `given no more pages, when loadMore called, then should return current results without making API call`() =
+        runTest {
+            // GIVEN
+            val query = "test"
+            whenever(searchResultsIndex.getSearchResults(query)).thenReturn(products)
 
-        // Set hasMorePages to false
-        val canLoadMoreField = WooPosSearchProductsDataSource::class.java.getDeclaredField("canLoadMore")
-        canLoadMoreField.isAccessible = true
-        val canLoadMore = canLoadMoreField.get(sut) as AtomicBoolean
-        canLoadMore.set(false)
+            val canLoadMoreField = WooPosSearchProductsDataSource::class.java.getDeclaredField("canLoadMore")
+            canLoadMoreField.isAccessible = true
+            val canLoadMore = canLoadMoreField.get(sut) as AtomicBoolean
+            canLoadMore.set(false)
 
-        // WHEN
-        val result = sut.loadMore(query)
+            // WHEN
+            val result = sut.loadMore(query)
 
-        // THEN
-        assertThat(result.isSuccess).isTrue()
-        assertThat(result.getOrNull()).isEqualTo(products)
-        verify(productStore, never()).searchProducts(
-            anyOrNull(),
-            anyOrNull(),
-            anyOrNull(),
-            anyOrNull(),
-            anyOrNull(),
-            anyOrNull()
-        )
-    }
+            // THEN
+            assertThat(result.isSuccess).isTrue()
+            assertThat(result.getOrNull()).isEqualTo(products)
+            verify(productStore, never()).searchProducts(
+                anyOrNull(),
+                anyOrNull(),
+                anyOrNull(),
+                anyOrNull(),
+                anyOrNull(),
+                anyOrNull()
+            )
+        }
 
     @Test
-    fun `given clearCache called in searchResultsIndex, when searchProducts called, then should emit results`() = runTest {
-        // GIVEN
-        val query = "test"
-        whenever(wooPosProductsCache.getAll()).thenReturn(products)
-        whenever(
-            productStore.searchProducts(anyOrNull(), anyOrNull(), anyOrNull(), anyOrNull(), anyOrNull(), anyOrNull())
-        ).thenReturn(WooResult(ProductSearchResult(emptyList(), false)))
+    fun `given clearCache called in searchResultsIndex, when searchProducts called, then should emit results`() =
+        runTest {
+            // GIVEN
+            val query = "test"
+            whenever(wooPosProductsCache.getAll()).thenReturn(products)
+            whenever(
+                productStore.searchProducts(
+                    anyOrNull(),
+                    anyOrNull(),
+                    anyOrNull(),
+                    anyOrNull(),
+                    anyOrNull(),
+                    anyOrNull()
+                )
+            ).thenReturn(WooResult(ProductSearchResult(emptyList(), false)))
 
-        // WHEN
-        sut.searchProducts(query).test {
+            // WHEN
+            val result = sut.searchProducts(query)
+
             // THEN
-            awaitItem()
-            verify(searchResults, times(1)).clearCache()
-            cancelAndIgnoreRemainingEvents()
+            result.test {
+                verify(searchResultsIndex).clearCache()
+                cancelAndIgnoreRemainingEvents()
+            }
         }
-    }
 }

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/home/items/search/WooPosSearchProductsDataSourceTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/home/items/search/WooPosSearchProductsDataSourceTest.kt
@@ -63,8 +63,7 @@ class WooPosSearchProductsDataSourceTest {
         whenever(wooPosProductsCache.getAll()).thenReturn(products)
         whenever(
             productStore.searchProducts(anyOrNull(), anyOrNull(), anyOrNull(), anyOrNull(), anyOrNull(), anyOrNull())
-        )
-            .thenReturn(WooResult(ProductSearchResult(emptyList(), false)))
+        ).thenReturn(WooResult(ProductSearchResult(emptyList(), false)))
 
         // WHEN
         sut.searchProducts(query).test {
@@ -72,29 +71,37 @@ class WooPosSearchProductsDataSourceTest {
             val result = awaitItem()
             assertThat(result).isInstanceOf(WooPosSearchProductsDataSource.ProductsResult.Cached::class.java)
             assertThat((result as WooPosSearchProductsDataSource.ProductsResult.Cached).products).isEqualTo(products)
-            verify(searchResults).storeSearchResults(query, products.map { it.remoteId })
+            verify(searchResults).storeSearchResults(query, emptyList())
             cancelAndIgnoreRemainingEvents()
         }
     }
 
     @Test
-    fun `given more products than page size, when search products called, then should limit local results to page size`() = runTest {
-        // GIVEN
-        val query = "test"
-        val manyProducts = (1..20).map { ProductTestUtils.generateProduct(productId = it.toLong()) }
-        whenever(wooPosProductsCache.getAll()).thenReturn(manyProducts)
-        whenever(
-            productStore.searchProducts(anyOrNull(), anyOrNull(), anyOrNull(), anyOrNull(), anyOrNull(), anyOrNull())
-        )
-            .thenReturn(WooResult(ProductSearchResult(emptyList(), false)))
+    fun `given more products than page size, when search products called, then should limit local results to page size`() =
+        runTest {
+            // GIVEN
+            val query = "test"
+            val manyProducts = (1..20).map { ProductTestUtils.generateProduct(productId = it.toLong()) }
+            whenever(wooPosProductsCache.getAll()).thenReturn(manyProducts)
+            whenever(
+                productStore.searchProducts(
+                    anyOrNull(),
+                    anyOrNull(),
+                    anyOrNull(),
+                    anyOrNull(),
+                    anyOrNull(),
+                    anyOrNull()
+                )
+            )
+                .thenReturn(WooResult(ProductSearchResult(emptyList(), false)))
 
-        // WHEN
-        sut.searchProducts(query).test {
-            // THEN
-            val result = awaitItem()
-            assertThat(result).isInstanceOf(WooPosSearchProductsDataSource.ProductsResult.Cached::class.java)
-            assertThat((result as WooPosSearchProductsDataSource.ProductsResult.Cached).products.size).isEqualTo(15)
-            cancelAndIgnoreRemainingEvents()
+            // WHEN
+            sut.searchProducts(query).test {
+                // THEN
+                val result = awaitItem()
+                assertThat(result).isInstanceOf(WooPosSearchProductsDataSource.ProductsResult.Cached::class.java)
+                assertThat((result as WooPosSearchProductsDataSource.ProductsResult.Cached).products.size).isEqualTo(15)
+                cancelAndIgnoreRemainingEvents()
+            }
         }
-    }
 }

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/splash/WooPosSplashViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/splash/WooPosSplashViewModelTest.kt
@@ -44,7 +44,7 @@ class WooPosSplashViewModelTest {
     @Test
     fun `given products load successfully, when vm created, should update state to Loaded`() = runTest {
         // GIVEN
-        whenever(productsDataSource.loadSimpleProducts(forceRefreshProducts = true)).thenReturn(
+        whenever(productsDataSource.loadProducts(forceRefreshProducts = true)).thenReturn(
             flowOf(ProductsResult.Remote(Result.success(emptyList())))
         )
 
@@ -58,7 +58,7 @@ class WooPosSplashViewModelTest {
     @Test
     fun `given products load successfully, when vm created, should track event`() = runTest {
         // GIVEN
-        whenever(productsDataSource.loadSimpleProducts(forceRefreshProducts = true)).thenReturn(
+        whenever(productsDataSource.loadProducts(forceRefreshProducts = true)).thenReturn(
             flowOf(ProductsResult.Remote(Result.success(emptyList())))
         )
 
@@ -72,7 +72,7 @@ class WooPosSplashViewModelTest {
     @Test
     fun `given products are cached, when vm created, should remain in loading state`() = runTest {
         // GIVEN
-        whenever(productsDataSource.loadSimpleProducts(forceRefreshProducts = true)).thenReturn(
+        whenever(productsDataSource.loadProducts(forceRefreshProducts = true)).thenReturn(
             flowOf(ProductsResult.Cached(emptyList()))
         )
 

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/splash/WooPosSplashViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/splash/WooPosSplashViewModelTest.kt
@@ -1,22 +1,19 @@
 package com.woocommerce.android.ui.woopos.splash
 
 import com.woocommerce.android.ui.woopos.home.items.products.WooPosProductsDataSource
-import com.woocommerce.android.ui.woopos.home.items.products.WooPosProductsDataSource.ProductsResult
 import com.woocommerce.android.ui.woopos.util.WooPosCoroutineTestRule
-import com.woocommerce.android.ui.woopos.util.analytics.WooPosAnalyticsEvent.Event
 import com.woocommerce.android.ui.woopos.util.analytics.WooPosAnalyticsTracker
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
-import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.test.StandardTestDispatcher
 import kotlinx.coroutines.test.resetMain
 import kotlinx.coroutines.test.runTest
 import kotlinx.coroutines.test.setMain
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.Rule
+import org.mockito.kotlin.any
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.verify
-import org.mockito.kotlin.whenever
 import kotlin.test.Test
 
 @ExperimentalCoroutinesApi
@@ -42,12 +39,7 @@ class WooPosSplashViewModelTest {
     }
 
     @Test
-    fun `given products load successfully, when vm created, should update state to Loaded`() = runTest {
-        // GIVEN
-        whenever(productsDataSource.loadProducts(forceRefreshProducts = true)).thenReturn(
-            flowOf(ProductsResult.Remote(Result.success(emptyList())))
-        )
-
+    fun `when products are prepopulated, should update state to Loaded`() = runTest {
         // WHEN
         val sut = createSut()
 
@@ -56,31 +48,21 @@ class WooPosSplashViewModelTest {
     }
 
     @Test
-    fun `given products load successfully, when vm created, should track event`() = runTest {
-        // GIVEN
-        whenever(productsDataSource.loadProducts(forceRefreshProducts = true)).thenReturn(
-            flowOf(ProductsResult.Remote(Result.success(emptyList())))
-        )
-
+    fun `when products are prepopulated, should track event`() = runTest {
         // WHEN
-        val sut = createSut()
+        createSut()
 
         // THEN
-        verify(analyticsTracker).track(Event.Loaded)
+        verify(analyticsTracker).track(any())
     }
 
     @Test
-    fun `given products are cached, when vm created, should remain in loading state`() = runTest {
-        // GIVEN
-        whenever(productsDataSource.loadProducts(forceRefreshProducts = true)).thenReturn(
-            flowOf(ProductsResult.Cached(emptyList()))
-        )
-
+    fun `when products are prepopulated, should track event with timing properties`() = runTest {
         // WHEN
-        val sut = createSut()
+        createSut()
 
         // THEN
-        assertThat(sut.state.value).isEqualTo(WooPosSplashState.Loading)
+        verify(analyticsTracker).track(any())
     }
 
     private fun createSut() = WooPosSplashViewModel(productsDataSource, analyticsTracker)

--- a/libs/fluxc-plugin/src/main/kotlin/org/wordpress/android/fluxc/store/WCProductStore.kt
+++ b/libs/fluxc-plugin/src/main/kotlin/org/wordpress/android/fluxc/store/WCProductStore.kt
@@ -1677,6 +1677,42 @@ class WCProductStore @Inject constructor(
         }
     }
 
+    /**
+     * Fetches products from the API and returns them directly as a list.
+     *
+     * @param site The site to fetch products for
+     * @param offset Pagination offset
+     * @param pageSize Number of products to fetch per page
+     * @param filterOptions Map of filter options to apply
+     * @param includeTypes List of product types to include
+     * @return A WooResult containing the list of products if successful, or an error
+     */
+    suspend fun fetchProducts(
+        site: SiteModel,
+        offset: Int = 0,
+        pageSize: Int = DEFAULT_PRODUCT_PAGE_SIZE,
+        filterOptions: Map<ProductFilterOption, String> = emptyMap(),
+        includeTypes: List<IncludeType> = emptyList(),
+    ): WooResult<List<WCProductModel>> {
+        return coroutineEngine.withDefaultContext(API, this, "fetchProductsList") {
+            val response = wcProductRestClient.fetchProductsWithSyncRequest(
+                site = site,
+                offset = offset,
+                pageSize = pageSize,
+                filterOptions = filterOptions,
+                includeTypes = includeTypes
+            )
+
+            when {
+                response.isError -> WooResult(response.error)
+                response.result != null -> {
+                    WooResult(response.result.map { it.product })
+                }
+                else -> WooResult(WooError(WooErrorType.GENERIC_ERROR, UNKNOWN))
+            }
+        }
+    }
+
     suspend fun searchProducts(
         site: SiteModel,
         searchString: String,


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: WOOMOB-277
<!-- Id number of the GitHub issue this PR addresses. -->

<!-- 
━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
🛠 Need an AI review?  
Add a comment: `@coderabbitai review`
━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
-->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
The PR:
* Stops uses the code that stores the products in the shared table with the main app
* Adds 200 (max) products fetch on the splash screen so we can have more data in the cache for faster search

### Steps to reproduce
<!-- Step-by-step testing instructions. For new user flows, consider instead stating the goal of the workflow and see if your PR reviewer can accomplish the workflow without specific steps! -->
There should be no visual changes, so validate the code and make sure no regressions introduced

- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.

## Reviewer (or Author, in the case of optional code reviews):

Please make sure these conditions are met before approving the PR, or request changes if the PR needs improvement:

- [ ] The PR is small and has a clear, single focus, or a valid explanation is provided in the description. If needed, please request to split it into smaller PRs.
- [ ] Ensure Adequate Unit Test Coverage: The changes are reasonably covered by unit tests or an explanation is provided in the PR description.
- [ ] Manual Testing: The author listed all the tests they ran, including smoke tests when needed (e.g., for refactorings). The reviewer confirmed that the PR works as expected on big (tablet) and small (phone) in case of UI changes, and no regressions are added.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->