### PR TITLE
[Jetpack Performance Experiment] Use the experiment for orders fetching endpoint

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/config/FirebaseRemoteConfigRepository.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/config/FirebaseRemoteConfigRepository.kt
@@ -21,6 +21,8 @@ class FirebaseRemoteConfigRepository @Inject constructor(
     companion object {
         private const val DEBUG_INTERVAL = 10L
         private const val RELEASE_INTERVAL = 31200L
+
+        const val KEY_ENABLE_JETPACK_APP_PASSWORDS_EXPERIMENT = "wcandroid_enable_jetpack_app_passwords_experiment"
     }
 
     private val minimumFetchIntervalInSeconds =
@@ -36,7 +38,9 @@ class FirebaseRemoteConfigRepository @Inject constructor(
     override val fetchStatus: Flow<RemoteConfigFetchStatus> = _fetchStatus.asStateFlow()
 
     private val defaultValues by lazy {
-        mapOf<String, String>()
+        mapOf(
+            KEY_ENABLE_JETPACK_APP_PASSWORDS_EXPERIMENT to false.toString()
+        )
     }
 
     init {
@@ -69,4 +73,8 @@ class FirebaseRemoteConfigRepository @Inject constructor(
     @VisibleForTesting
     fun observeStringRemoteValue(key: String) = changesTrigger
         .map { remoteConfig.getString(key) }
+
+    override fun isJetpackAppPasswordsExperimentEnabled(): Boolean {
+        return remoteConfig.getBoolean(KEY_ENABLE_JETPACK_APP_PASSWORDS_EXPERIMENT)
+    }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/config/RemoteConfigRepository.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/config/RemoteConfigRepository.kt
@@ -5,6 +5,8 @@ import kotlinx.coroutines.flow.Flow
 interface RemoteConfigRepository {
     val fetchStatus: Flow<RemoteConfigFetchStatus>
     fun fetchRemoteConfig()
+
+    fun isJetpackAppPasswordsExperimentEnabled(): Boolean
 }
 
 enum class RemoteConfigFetchStatus {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/list/OrderListItemDataSource.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/list/OrderListItemDataSource.kt
@@ -27,6 +27,7 @@ import org.wordpress.android.fluxc.store.WCOrderStore
 import org.wordpress.android.fluxc.store.WCOrderStore.FetchOrderListPayload
 import org.wordpress.android.util.DateTimeUtils
 import java.util.Date
+import javax.inject.Inject
 
 /**
  * Works with a [androidx.paging.PagedList] by providing the logic needed to fetch the data used to populate
@@ -36,7 +37,7 @@ import java.util.Date
  * in FluxC to get a better understanding of how this works with the underlying internal list management code.
  */
 @Suppress("LongParameterList")
-class OrderListItemDataSource(
+class OrderListItemDataSource @Inject constructor(
     private val dispatcher: Dispatcher,
     private val orderStore: WCOrderStore,
     private val networkStatus: NetworkStatus,

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/list/OrderListItemDataSource.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/list/OrderListItemDataSource.kt
@@ -1,6 +1,7 @@
 package com.woocommerce.android.ui.orders.list
 
 import com.woocommerce.android.R
+import com.woocommerce.android.config.RemoteConfigRepository
 import com.woocommerce.android.extensions.getBillingName
 import com.woocommerce.android.model.TimeGroup
 import com.woocommerce.android.model.TimeGroup.GROUP_FUTURE
@@ -43,7 +44,8 @@ class OrderListItemDataSource @Inject constructor(
     private val networkStatus: NetworkStatus,
     private val fetcher: FetchOrdersRepository,
     private val resourceProvider: ResourceProvider,
-    private val dateUtils: DateUtils
+    private val dateUtils: DateUtils,
+    private val remoteConfigRepository: RemoteConfigRepository
 ) : ListItemDataSourceInterface<WCOrderListDescriptor, OrderListItemIdentifier, OrderListItemUIType> {
     override fun getItemsAndFetchIfNecessary(
         listDescriptor: WCOrderListDescriptor,
@@ -183,7 +185,11 @@ class OrderListItemDataSource @Inject constructor(
     }
 
     override fun fetchList(listDescriptor: WCOrderListDescriptor, offset: Long) {
-        val fetchOrderListPayload = FetchOrderListPayload(listDescriptor, offset)
+        val fetchOrderListPayload = FetchOrderListPayload(
+            listDescriptor = listDescriptor,
+            offset = offset,
+            useAppPasswordsForJetpackSites = remoteConfigRepository.isJetpackAppPasswordsExperimentEnabled()
+        )
         dispatcher.dispatch(WCOrderActionBuilder.newFetchOrderListAction(fetchOrderListPayload))
     }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/list/OrderListViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/list/OrderListViewModel.kt
@@ -65,6 +65,7 @@ import com.woocommerce.android.viewmodel.MultiLiveEvent.Event
 import com.woocommerce.android.viewmodel.ResourceProvider
 import com.woocommerce.android.viewmodel.ScopedViewModel
 import com.woocommerce.android.widgets.WCEmptyView.EmptyViewType
+import dagger.Lazy
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.map
@@ -99,12 +100,10 @@ class OrderListViewModel @Inject constructor(
     private val dispatchers: CoroutineDispatchers,
     private val orderListRepository: OrderListRepository,
     private val orderDetailRepository: OrderDetailRepository,
-    private val orderStore: WCOrderStore,
     private val listStore: ListStore,
     private val networkStatus: NetworkStatus,
     private val dispatcher: Dispatcher,
     private val selectedSite: SelectedSite,
-    private val fetcher: FetchOrdersRepository,
     private val resourceProvider: ResourceProvider,
     private val getWCOrderListDescriptorWithFilters: GetWCOrderListDescriptorWithFilters,
     private val getWCOrderListDescriptorWithFiltersAndSearchQuery: GetWCOrderListDescriptorWithFiltersAndSearchQuery,
@@ -118,7 +117,8 @@ class OrderListViewModel @Inject constructor(
     private val showTestNotification: ShowTestNotification,
     private val dateUtils: DateUtils,
     private val shouldUpdateOrdersList: ShouldUpdateOrdersList,
-    private val observeOrdersListLastUpdate: ObserveOrdersListLastUpdate
+    private val observeOrdersListLastUpdate: ObserveOrdersListLastUpdate,
+    private val dataSourceLazyProvider: Lazy<OrderListItemDataSource>,
 ) : ScopedViewModel(savedState), LifecycleOwner {
     companion object {
         const val BULK_UPDATE_COUNT_LIMIT = 100
@@ -136,16 +136,8 @@ class OrderListViewModel @Inject constructor(
     internal var ordersPagedListWrapper: PagedListWrapper<OrderListItemUIType>? = null
     internal var activePagedListWrapper: PagedListWrapper<OrderListItemUIType>? = null
 
-    private val dataSource by lazy {
-        OrderListItemDataSource(
-            dispatcher,
-            orderStore,
-            networkStatus,
-            fetcher,
-            resourceProvider,
-            dateUtils
-        )
-    }
+    private val dataSource
+        get() = dataSourceLazyProvider.get()
 
     /**
      * Saving more data than necessary into the SavedState has associated risks which were not known at the time this

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/OrderListViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/OrderListViewModelTest.kt
@@ -31,6 +31,7 @@ import com.woocommerce.android.ui.orders.list.BulkUpdateOrderResult
 import com.woocommerce.android.ui.orders.list.FetchOrdersRepository
 import com.woocommerce.android.ui.orders.list.ObserveOrdersListLastUpdate
 import com.woocommerce.android.ui.orders.list.OrderListFragmentArgs
+import com.woocommerce.android.ui.orders.list.OrderListItemDataSource
 import com.woocommerce.android.ui.orders.list.OrderListItemIdentifier
 import com.woocommerce.android.ui.orders.list.OrderListItemUIType
 import com.woocommerce.android.ui.orders.list.OrderListRepository
@@ -98,7 +99,6 @@ class OrderListViewModelTest : BaseUnitTest() {
     }
     private val orderDetailRepository: OrderDetailRepository = mock()
     private val dispatcher: Dispatcher = mock()
-    private val orderStore: WCOrderStore = mock()
     private val resourceProvider: ResourceProvider = mock {
         on { getString(any()) } doAnswer { it.arguments[0].toString() }
         on { getString(any(), any()) } doAnswer { it.arguments[0].toString() + it.arguments[1].toString() }
@@ -108,7 +108,6 @@ class OrderListViewModelTest : BaseUnitTest() {
     private lateinit var viewModel: OrderListViewModel
     private val listStore: ListStore = mock()
     private val pagedListWrapper: PagedListWrapper<OrderListItemUIType> = mock()
-    private val orderFetcher: FetchOrdersRepository = mock()
     private val getWCOrderListDescriptorWithFilters: GetWCOrderListDescriptorWithFilters = mock()
     private val getWCOrderListDescriptorWithFiltersAndSearchQuery: GetWCOrderListDescriptorWithFiltersAndSearchQuery =
         mock()
@@ -121,6 +120,7 @@ class OrderListViewModelTest : BaseUnitTest() {
     private val showTestNotification = mock<ShowTestNotification>()
     private val shouldUpdateOrdersList = mock<ShouldUpdateOrdersList>()
     private val observeOrdersListLastUpdate = mock<ObserveOrdersListLastUpdate>()
+    private val orderListItemDataSource = mock<OrderListItemDataSource>()
 
     @Before
     fun setup() = testBlocking {
@@ -155,12 +155,10 @@ class OrderListViewModelTest : BaseUnitTest() {
         dispatchers = coroutinesTestRule.testDispatchers,
         orderListRepository = orderListRepository,
         orderDetailRepository = orderDetailRepository,
-        orderStore = orderStore,
         listStore = listStore,
         networkStatus = networkStatus,
         dispatcher = dispatcher,
         selectedSite = selectedSite,
-        fetcher = orderFetcher,
         resourceProvider = resourceProvider,
         getWCOrderListDescriptorWithFilters = getWCOrderListDescriptorWithFilters,
         getWCOrderListDescriptorWithFiltersAndSearchQuery = getWCOrderListDescriptorWithFiltersAndSearchQuery,
@@ -174,7 +172,8 @@ class OrderListViewModelTest : BaseUnitTest() {
         showTestNotification = showTestNotification,
         dateUtils = mock(),
         shouldUpdateOrdersList = shouldUpdateOrdersList,
-        observeOrdersListLastUpdate = observeOrdersListLastUpdate
+        observeOrdersListLastUpdate = observeOrdersListLastUpdate,
+        dataSourceLazyProvider = { orderListItemDataSource }
     )
 
     @Test

--- a/libs/fluxc-plugin/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/order/OrderRestClient.kt
+++ b/libs/fluxc-plugin/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/order/OrderRestClient.kt
@@ -8,15 +8,14 @@ import org.wordpress.android.fluxc.action.WCOrderAction
 import org.wordpress.android.fluxc.generated.WCOrderActionBuilder
 import org.wordpress.android.fluxc.generated.endpoint.WOOCOMMERCE
 import org.wordpress.android.fluxc.model.LocalOrRemoteId.RemoteId
-import org.wordpress.android.fluxc.persistence.entity.OrderEntity
 import org.wordpress.android.fluxc.model.SiteModel
-import org.wordpress.android.fluxc.model.metadata.WCMetaData
-import org.wordpress.android.fluxc.model.metadata.WCMetaData.OrderAttributionInfoKeys
 import org.wordpress.android.fluxc.model.WCOrderListDescriptor
 import org.wordpress.android.fluxc.model.WCOrderShipmentProviderModel
 import org.wordpress.android.fluxc.model.WCOrderShipmentTrackingModel
 import org.wordpress.android.fluxc.model.WCOrderStatusModel
 import org.wordpress.android.fluxc.model.WCOrderSummaryModel
+import org.wordpress.android.fluxc.model.metadata.WCMetaData
+import org.wordpress.android.fluxc.model.metadata.WCMetaData.OrderAttributionInfoKeys
 import org.wordpress.android.fluxc.model.order.UpdateOrderRequest
 import org.wordpress.android.fluxc.network.BaseRequest
 import org.wordpress.android.fluxc.network.rest.wpapi.WPAPINetworkError
@@ -27,6 +26,7 @@ import org.wordpress.android.fluxc.network.rest.wpcom.wc.order.OrderDto.Billing
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.order.OrderDto.Shipping
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.order.OrderDtoMapper.Companion.toDto
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.toWooError
+import org.wordpress.android.fluxc.persistence.entity.OrderEntity
 import org.wordpress.android.fluxc.persistence.entity.OrderNoteEntity
 import org.wordpress.android.fluxc.store.WCOrderStore
 import org.wordpress.android.fluxc.store.WCOrderStore.AddOrderShipmentTrackingResponsePayload
@@ -53,7 +53,6 @@ import org.wordpress.android.fluxc.utils.putIfNotEmpty
 import org.wordpress.android.fluxc.utils.toWooPayload
 import org.wordpress.android.util.AppLog
 import org.wordpress.android.util.AppLog.T
-import java.util.Calendar
 import javax.inject.Inject
 import kotlin.collections.MutableMap.MutableEntry
 
@@ -230,10 +229,10 @@ class OrderRestClient @Inject constructor(
      */
     fun fetchOrderListSummaries(
         listDescriptor: WCOrderListDescriptor,
-        offset: Long,
-        requestStartTime: Calendar
+        offset: Long
     ) {
         coroutineEngine.launch(T.API, this, "fetchOrderListSummaries") {
+            val startTime = System.currentTimeMillis()
             val url = WOOCOMMERCE.orders.pathV3
             val networkPageSize = listDescriptor.config.networkPageSize
             val params = mutableMapOf(
@@ -272,7 +271,7 @@ class OrderRestClient @Inject constructor(
                         orderSummaries = orderSummaries,
                         loadedMore = offset > 0,
                         canLoadMore = canLoadMore,
-                        requestStartTime = requestStartTime
+                        requestDurationMs = System.currentTimeMillis() - startTime
                     )
                     dispatcher.dispatch(WCOrderActionBuilder.newFetchedOrderListAction(payload))
                 }
@@ -280,8 +279,7 @@ class OrderRestClient @Inject constructor(
                     val orderError = wpAPINetworkErrorToOrderError(response.error)
                     val payload = FetchOrderListResponsePayload(
                         error = orderError,
-                        listDescriptor = listDescriptor,
-                        requestStartTime = requestStartTime
+                        listDescriptor = listDescriptor
                     )
                     dispatcher.dispatch(WCOrderActionBuilder.newFetchedOrderListAction(payload))
                 }

--- a/libs/fluxc-plugin/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/order/OrderRestClient.kt
+++ b/libs/fluxc-plugin/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/order/OrderRestClient.kt
@@ -20,6 +20,7 @@ import org.wordpress.android.fluxc.model.order.UpdateOrderRequest
 import org.wordpress.android.fluxc.network.BaseRequest
 import org.wordpress.android.fluxc.network.rest.wpapi.WPAPINetworkError
 import org.wordpress.android.fluxc.network.rest.wpapi.WPAPIResponse
+import org.wordpress.android.fluxc.network.rest.wpcom.wc.WooExperimentalNetwork
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.WooNetwork
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.WooPayload
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.order.OrderDto.Billing
@@ -61,6 +62,7 @@ class OrderRestClient @Inject constructor(
     private val dispatcher: Dispatcher,
     private val orderDtoMapper: OrderDtoMapper,
     private val wooNetwork: WooNetwork,
+    private val wooExperimentalNetwork: WooExperimentalNetwork,
     private val coroutineEngine: CoroutineEngine
 ) {
     /**
@@ -229,7 +231,8 @@ class OrderRestClient @Inject constructor(
      */
     fun fetchOrderListSummaries(
         listDescriptor: WCOrderListDescriptor,
-        offset: Long
+        offset: Long,
+        useAppPasswordsForJetpackSites: Boolean
     ) {
         coroutineEngine.launch(T.API, this, "fetchOrderListSummaries") {
             val startTime = System.currentTimeMillis()
@@ -249,7 +252,13 @@ class OrderRestClient @Inject constructor(
                 "status" to listDescriptor.statusFilter.takeUnless { it.isNullOrBlank() }
             )
 
-            val response = wooNetwork.executeGetGsonRequest(
+            val network = if (useAppPasswordsForJetpackSites) {
+                wooExperimentalNetwork
+            } else {
+                wooNetwork
+            }
+
+            val response = network.executeGetGsonRequest(
                 site = listDescriptor.site,
                 path = url,
                 clazz = Array<OrderSummaryApiResponse>::class.java,

--- a/libs/fluxc-plugin/src/main/kotlin/org/wordpress/android/fluxc/store/WCOrderStore.kt
+++ b/libs/fluxc-plugin/src/main/kotlin/org/wordpress/android/fluxc/store/WCOrderStore.kt
@@ -13,7 +13,6 @@ import org.wordpress.android.fluxc.annotations.action.Action
 import org.wordpress.android.fluxc.generated.ListActionBuilder
 import org.wordpress.android.fluxc.model.LocalOrRemoteId.LocalId
 import org.wordpress.android.fluxc.model.LocalOrRemoteId.RemoteId
-import org.wordpress.android.fluxc.persistence.entity.OrderEntity
 import org.wordpress.android.fluxc.model.SiteModel
 import org.wordpress.android.fluxc.model.WCOrderListDescriptor
 import org.wordpress.android.fluxc.model.WCOrderShipmentProviderModel
@@ -34,6 +33,7 @@ import org.wordpress.android.fluxc.persistence.OrderSqlUtils
 import org.wordpress.android.fluxc.persistence.dao.MetaDataDao
 import org.wordpress.android.fluxc.persistence.dao.OrderNotesDao
 import org.wordpress.android.fluxc.persistence.dao.OrdersDaoDecorator
+import org.wordpress.android.fluxc.persistence.entity.OrderEntity
 import org.wordpress.android.fluxc.persistence.entity.OrderNoteEntity
 import org.wordpress.android.fluxc.store.ListStore.FetchedListItemsPayload
 import org.wordpress.android.fluxc.store.ListStore.ListError
@@ -48,7 +48,6 @@ import org.wordpress.android.fluxc.store.WCOrderStore.UpdateOrdersStatusResult.F
 import org.wordpress.android.fluxc.tools.CoroutineEngine
 import org.wordpress.android.util.AppLog
 import org.wordpress.android.util.AppLog.T.API
-import java.util.Calendar
 import java.util.Locale
 import javax.inject.Inject
 import javax.inject.Singleton
@@ -77,8 +76,7 @@ class WCOrderStore @Inject constructor(
 
     class FetchOrderListPayload(
         val listDescriptor: WCOrderListDescriptor,
-        val offset: Long,
-        val requestStartTime: Calendar = Calendar.getInstance()
+        val offset: Long
     ) : Payload<BaseNetworkError>()
 
     class FetchOrdersByIdsPayload(
@@ -105,13 +103,12 @@ class WCOrderStore @Inject constructor(
         var orderSummaries: List<WCOrderSummaryModel> = emptyList(),
         var loadedMore: Boolean = false,
         var canLoadMore: Boolean = false,
-        val requestStartTime: Calendar
+        val requestDurationMs: Long = 0,
     ) : Payload<OrderError>() {
         constructor(
             error: OrderError,
-            listDescriptor: WCOrderListDescriptor,
-            requestStartTime: Calendar
-        ) : this(listDescriptor, requestStartTime = requestStartTime) {
+            listDescriptor: WCOrderListDescriptor
+        ) : this(listDescriptor, requestDurationMs = 0) {
             this.error = error
         }
     }
@@ -565,8 +562,7 @@ class WCOrderStore @Inject constructor(
     private fun fetchOrderList(payload: FetchOrderListPayload) {
         wcOrderRestClient.fetchOrderListSummaries(
             listDescriptor = payload.listDescriptor,
-            offset = payload.offset,
-            requestStartTime = payload.requestStartTime
+            offset = payload.offset
         )
     }
 
@@ -944,11 +940,10 @@ class WCOrderStore @Inject constructor(
             fetchOutdatedOrMissingOrders(payload.listDescriptor.site, payload.orderSummaries)
         }
 
-        val duration = Calendar.getInstance().timeInMillis - payload.requestStartTime.timeInMillis
         emitChange(
             OnOrderSummariesFetched(
                 listDescriptor = payload.listDescriptor,
-                duration = duration,
+                duration = payload.requestDurationMs,
                 error = payload.error
             )
         )

--- a/libs/fluxc-plugin/src/main/kotlin/org/wordpress/android/fluxc/store/WCOrderStore.kt
+++ b/libs/fluxc-plugin/src/main/kotlin/org/wordpress/android/fluxc/store/WCOrderStore.kt
@@ -76,7 +76,8 @@ class WCOrderStore @Inject constructor(
 
     class FetchOrderListPayload(
         val listDescriptor: WCOrderListDescriptor,
-        val offset: Long
+        val offset: Long,
+        val useAppPasswordsForJetpackSites: Boolean
     ) : Payload<BaseNetworkError>()
 
     class FetchOrdersByIdsPayload(
@@ -562,7 +563,8 @@ class WCOrderStore @Inject constructor(
     private fun fetchOrderList(payload: FetchOrderListPayload) {
         wcOrderRestClient.fetchOrderListSummaries(
             listDescriptor = payload.listDescriptor,
-            offset = payload.offset
+            offset = payload.offset,
+            useAppPasswordsForJetpackSites = payload.useAppPasswordsForJetpackSites
         )
     }
 

--- a/libs/fluxc-tests/src/test/java/org/wordpress/android/fluxc/wc/order/WCOrderStoreTest.kt
+++ b/libs/fluxc-tests/src/test/java/org/wordpress/android/fluxc/wc/order/WCOrderStoreTest.kt
@@ -30,7 +30,6 @@ import org.wordpress.android.fluxc.UnitTestUtils
 import org.wordpress.android.fluxc.generated.WCOrderActionBuilder
 import org.wordpress.android.fluxc.generated.WCOrderActionBuilder.newFetchedOrderListAction
 import org.wordpress.android.fluxc.model.LocalOrRemoteId.LocalId
-import org.wordpress.android.fluxc.persistence.entity.OrderEntity
 import org.wordpress.android.fluxc.model.SiteModel
 import org.wordpress.android.fluxc.model.WCOrderListDescriptor
 import org.wordpress.android.fluxc.model.WCOrderStatusModel
@@ -46,6 +45,7 @@ import org.wordpress.android.fluxc.persistence.WellSqlConfig
 import org.wordpress.android.fluxc.persistence.dao.MetaDataDao
 import org.wordpress.android.fluxc.persistence.dao.OrderNotesDao
 import org.wordpress.android.fluxc.persistence.dao.OrdersDaoDecorator
+import org.wordpress.android.fluxc.persistence.entity.OrderEntity
 import org.wordpress.android.fluxc.store.InsertOrder
 import org.wordpress.android.fluxc.store.WCOrderFetcher
 import org.wordpress.android.fluxc.store.WCOrderStore
@@ -58,7 +58,6 @@ import org.wordpress.android.fluxc.store.WCOrderStore.OrderError
 import org.wordpress.android.fluxc.store.WCOrderStore.OrderErrorType
 import org.wordpress.android.fluxc.store.WCOrderStore.RemoteOrderPayload
 import org.wordpress.android.fluxc.tools.initCoroutineEngine
-import java.util.Calendar
 import kotlin.test.assertEquals
 import kotlin.test.assertNull
 import kotlin.test.assertTrue
@@ -314,7 +313,6 @@ class WCOrderStoreTest {
                 newFetchedOrderListAction(
                     FetchOrderListResponsePayload(
                         WCOrderListDescriptor(site = site),
-                        requestStartTime = Calendar.getInstance(),
                         orderSummaries = upToDate.summaries + outdated.summaries + missing.summaries
                     )
                 )


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: WOOMOB-297
Closes: WOOMOB-298

### Description
This PR adds the following:
- Simplifies the code for tracking the order fetching duration (9f89f33)
- A new remote feature flag to control the experiment.
- Use the application passwords network when the experiment is enabled.

### Steps to reproduce
For now, let's just focus on the happy path, I'll prepare a detailed testing plan that we'll follow before enabling the experiment.

1. Open the app and ensure you are signed in using WordPress.com.
2. Open the orders list screen.
3. Refresh if needed.
4. Check logcat and confirm the following was reported: `Request successful for site: {site url}, using Application Passwords`

### Testing information
- Confirm that the orders fetching is done using application passwords.

### The tests that have been performed
^

- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.

## Reviewer (or Author, in the case of optional code reviews):

Please make sure these conditions are met before approving the PR, or request changes if the PR needs improvement:

- [ ] The PR is small and has a clear, single focus, or a valid explanation is provided in the description. If needed, please request to split it into smaller PRs.
- [ ] Ensure Adequate Unit Test Coverage: The changes are reasonably covered by unit tests or an explanation is provided in the PR description.
- [ ] Manual Testing: The author listed all the tests they ran, including smoke tests when needed (e.g., for refactorings). The reviewer confirmed that the PR works as expected on big (tablet) and small (phone) in case of UI changes, and no regressions are added.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md --