### PR TITLE
[Shipping labels] Fix shipping labels incorrect item quantity

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/ShippableItemsMapper.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/ShippableItemsMapper.kt
@@ -31,9 +31,9 @@ fun List<ShippableItemModel>.toUIModel(
     dimensionUnit: String,
     weightUnit: String
 ): ShippableItemsUI {
-    val shippableItemsUI = this.map { item -> item.toUIModel(currencyFormatter, dimensionUnit, weightUnit) }
-    val formattedTotalPrice = this.getFormattedTotalPrice(currencyFormatter)
-    val formattedTotalWeight = this.getFormattedTotalWeight(weightUnit)
+    val shippableItemsUI = map { item -> item.toUIModel(currencyFormatter, dimensionUnit, weightUnit) }
+    val formattedTotalPrice = getFormattedTotalPrice(currencyFormatter)
+    val formattedTotalWeight = getFormattedTotalWeight(weightUnit)
 
     return ShippableItemsUI(
         shippableItems = shippableItemsUI,
@@ -79,9 +79,9 @@ fun List<ShippableItemModel>.toSelectableUIModel(
     dimensionUnit: String,
     weightUnit: String
 ): SelectableShippableItemsUI {
-    val shippableItemsUI = this.map { item -> item.toSelectableUIModel(currencyFormatter, dimensionUnit, weightUnit) }
-    val formattedTotalPrice = this.getFormattedTotalPrice(currencyFormatter)
-    val formattedTotalWeight = this.getFormattedTotalWeight(weightUnit)
+    val shippableItemsUI = map { item -> item.toSelectableUIModel(currencyFormatter, dimensionUnit, weightUnit) }
+    val formattedTotalPrice = getFormattedTotalPrice(currencyFormatter)
+    val formattedTotalWeight = getFormattedTotalWeight(weightUnit)
 
     return SelectableShippableItemsUI(
         shippableItems = shippableItemsUI,
@@ -92,25 +92,25 @@ fun List<ShippableItemModel>.toSelectableUIModel(
 }
 
 fun List<ShippableItemModel>.getFormattedTotalPrice(currencyFormatter: CurrencyFormatter): String {
-    val totalPrice = this.sumOf { it.price }
-    val formattedTotalPrice = this.firstOrNull()?.currency?.let {
+    val totalPrice = sumOf { it.price }
+    val formattedTotalPrice = firstOrNull()?.currency?.let {
         currencyFormatter.formatCurrency(totalPrice, it)
     } ?: currencyFormatter.formatCurrency(totalPrice)
     return formattedTotalPrice
 }
 
 fun List<ShippableItemModel>.getFormattedTotalWeight(weightUnit: String): String {
-    val totalWeight = this.sumByFloat { it.weight * it.quantity }
+    val totalWeight = sumByFloat { it.weight * it.quantity }
     return "${totalWeight.formatToString()} $weightUnit"
 }
 
 fun Order.getShippingLinesSummary(
     currencyFormatter: CurrencyFormatter
 ): List<ShippingLineSummaryUI> {
-    return this.shippingLines.map {
+    return shippingLines.map {
         ShippingLineSummaryUI(
             title = it.methodTitle,
-            amount = currencyFormatter.formatCurrency(it.total, this.currency)
+            amount = currencyFormatter.formatCurrency(it.total, currency)
         )
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/ShippableItemsMapper.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/ShippableItemsMapper.kt
@@ -85,7 +85,6 @@ fun List<ShippableItemModel>.toSelectableUIModel(
 
     return SelectableShippableItemsUI(
         shippableItems = shippableItemsUI,
-        totalItemQuantity = sumByFloat { it.quantity }.toInt(),
         formattedTotalWeight = formattedTotalWeight,
         formattedTotalPrice = formattedTotalPrice
     )

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/ShippableItemsMapper.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/ShippableItemsMapper.kt
@@ -85,6 +85,7 @@ fun List<ShippableItemModel>.toSelectableUIModel(
 
     return SelectableShippableItemsUI(
         shippableItems = shippableItemsUI,
+        totalItemQuantity = sumByFloat { it.quantity }.toInt(),
         formattedTotalWeight = formattedTotalWeight,
         formattedTotalPrice = formattedTotalPrice
     )

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/WooShippingLabelCreationScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/WooShippingLabelCreationScreen.kt
@@ -1,7 +1,6 @@
 package com.woocommerce.android.ui.orders.wooshippinglabels
 
 import android.content.res.Configuration
-import android.os.Parcelable
 import androidx.compose.foundation.background
 import androidx.compose.foundation.border
 import androidx.compose.foundation.clickable
@@ -89,7 +88,6 @@ import com.woocommerce.android.ui.orders.wooshippinglabels.packages.ui.PackageDa
 import com.woocommerce.android.ui.orders.wooshippinglabels.rates.ui.ShippingRateUI
 import com.woocommerce.android.ui.orders.wooshippinglabels.rates.ui.ShippingRatesSection
 import com.woocommerce.android.ui.orders.wooshippinglabels.rates.ui.ShippingSortOption
-import kotlinx.parcelize.Parcelize
 
 @Composable
 fun WooShippingLabelCreationScreen(viewModel: WooShippingLabelCreationViewModel) {
@@ -791,25 +789,6 @@ internal fun ErrorScreen(
 ) = Scaffold(topBar = { TopBar(onNavigateBack) }) { padding ->
     ErrorMessageWithButton(modifier = modifier.padding(padding), onRetryClick = onRetryClick)
 }
-
-@Parcelize
-data class ShippableItemUI(
-    val itemId: Long,
-    val productId: Long,
-    val title: String,
-    val formattedSize: String,
-    val formattedWeight: String,
-    val formattedPrice: String,
-    val quantity: Float,
-    val imageUrl: String? = null
-) : Parcelable
-
-@Parcelize
-data class ShippableItemsUI(
-    val shippableItems: List<ShippableItemUI>,
-    val formattedTotalWeight: String,
-    val formattedTotalPrice: String
-) : Parcelable
 
 @Preview(name = "dark", uiMode = Configuration.UI_MODE_NIGHT_YES, device = Devices.PIXEL)
 @Preview(name = "light", uiMode = Configuration.UI_MODE_NIGHT_NO, device = Devices.PIXEL)

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/WooShippingLabelCreationViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/WooShippingLabelCreationViewModel.kt
@@ -857,4 +857,24 @@ data class WooShippingAddresses(
     }
 }
 
-fun ShippableItemsUI.totalItemQuantity() = shippableItems.sumByFloat { it.quantity }.toInt()
+@Parcelize
+data class ShippableItemUI(
+    val itemId: Long,
+    val productId: Long,
+    val title: String,
+    val formattedSize: String,
+    val formattedWeight: String,
+    val formattedPrice: String,
+    val quantity: Float,
+    val imageUrl: String? = null
+) : Parcelable
+
+@Parcelize
+data class ShippableItemsUI(
+    val shippableItems: List<ShippableItemUI>,
+    val formattedTotalWeight: String,
+    val formattedTotalPrice: String
+) : Parcelable {
+    val totalItemQuantity
+        get() = shippableItems.sumByFloat { it.quantity }.toInt()
+}

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/WooShippingLabelCreationViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/WooShippingLabelCreationViewModel.kt
@@ -856,3 +856,5 @@ data class WooShippingAddresses(
         )
     }
 }
+
+fun ShippableItemsUI.totalItemQuantity() = shippableItems.sumByFloat { it.quantity }.toInt()

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/WooShippingProductsCard.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/WooShippingProductsCard.kt
@@ -138,7 +138,7 @@ private fun ShippingProductsCardHeader(
     ) {
         Row(verticalAlignment = Alignment.CenterVertically) {
             ProductsSummary(
-                totalItems = shippableItems.shippableItems.size,
+                totalItems = shippableItems.totalItemQuantity(),
                 totalWeight = shippableItems.formattedTotalWeight,
                 totalPrice = shippableItems.formattedTotalPrice,
                 modifier = Modifier

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/WooShippingProductsCard.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/WooShippingProductsCard.kt
@@ -138,7 +138,7 @@ private fun ShippingProductsCardHeader(
     ) {
         Row(verticalAlignment = Alignment.CenterVertically) {
             ProductsSummary(
-                totalItems = shippableItems.totalItemQuantity(),
+                totalItems = shippableItems.totalItemQuantity,
                 totalWeight = shippableItems.formattedTotalWeight,
                 totalPrice = shippableItems.formattedTotalPrice,
                 modifier = Modifier

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/split/WooShippingSplitShipmentScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/split/WooShippingSplitShipmentScreen.kt
@@ -473,7 +473,7 @@ fun SelectableProductsSection(
 ) {
     Column(modifier = modifier) {
         ProductsSummary(
-            totalItems = shipment.shippableItems.size,
+            totalItems = shipment.totalItemQuantity,
             totalWeight = shipment.formattedTotalWeight,
             totalPrice = shipment.formattedTotalPrice,
             modifier = Modifier.padding(top = 8.dp, bottom = 8.dp)
@@ -559,11 +559,13 @@ private fun WooShippingSplitShipmentScreenPreview() = WooThemeWithBackground {
             selectableItems = mapOf(
                 0 to SelectableShippableItemsUI(
                     shippableItems = emptyList(),
+                    totalItemQuantity = 1,
                     formattedTotalWeight = "",
                     formattedTotalPrice = ""
                 ),
                 1 to SelectableShippableItemsUI(
                     shippableItems = emptyList(),
+                    totalItemQuantity = 1,
                     formattedTotalWeight = "",
                     formattedTotalPrice = ""
                 )

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/split/WooShippingSplitShipmentScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/split/WooShippingSplitShipmentScreen.kt
@@ -559,13 +559,11 @@ private fun WooShippingSplitShipmentScreenPreview() = WooThemeWithBackground {
             selectableItems = mapOf(
                 0 to SelectableShippableItemsUI(
                     shippableItems = emptyList(),
-                    totalItemQuantity = 1,
                     formattedTotalWeight = "",
                     formattedTotalPrice = ""
                 ),
                 1 to SelectableShippableItemsUI(
                     shippableItems = emptyList(),
-                    totalItemQuantity = 1,
                     formattedTotalWeight = "",
                     formattedTotalPrice = ""
                 )

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/split/WooShippingSplitShipmentViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/split/WooShippingSplitShipmentViewModel.kt
@@ -179,6 +179,7 @@ class WooShippingSplitShipmentViewModel @Inject constructor(
 
 data class SelectableShippableItemsUI(
     val shippableItems: List<SelectableShippableItemUI>,
+    val totalItemQuantity: Int,
     val formattedTotalWeight: String,
     val formattedTotalPrice: String
 )

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/split/WooShippingSplitShipmentViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/split/WooShippingSplitShipmentViewModel.kt
@@ -3,6 +3,7 @@ package com.woocommerce.android.ui.orders.wooshippinglabels.split
 import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.asLiveData
 import com.woocommerce.android.R
+import com.woocommerce.android.extensions.sumByFloat
 import com.woocommerce.android.ui.orders.wooshippinglabels.ShippableItemUI
 import com.woocommerce.android.ui.orders.wooshippinglabels.components.ShippingLabelsSnackbarData
 import com.woocommerce.android.ui.orders.wooshippinglabels.models.ShippableItemModel
@@ -179,23 +180,27 @@ class WooShippingSplitShipmentViewModel @Inject constructor(
 
 data class SelectableShippableItemsUI(
     val shippableItems: List<SelectableShippableItemUI>,
-    val totalItemQuantity: Int,
     val formattedTotalWeight: String,
     val formattedTotalPrice: String
-)
+) {
+    val totalItemQuantity: Int
+        get() = shippableItems.sumByFloat { it.shippableItem.quantity }.toInt()
+}
 
-sealed class SelectableShippableItemUI {
+sealed interface SelectableShippableItemUI {
+    val shippableItem: ShippableItemUI
+
     data class SingleSelectableShippableItemUI(
-        val shippableItem: ShippableItemUI,
+        override val shippableItem: ShippableItemUI,
         val isSelected: Boolean = false
-    ) : SelectableShippableItemUI()
+    ) : SelectableShippableItemUI
 
     data class ExpandableSelectableShippableItemUI(
-        val shippableItem: ShippableItemUI,
+        override val shippableItem: ShippableItemUI,
         val innerShippableItem: ShippableItemUI,
         val isExpanded: Boolean = false,
         val selectedIndexes: Set<Int> = emptySet(),
-    ) : SelectableShippableItemUI() {
+    ) : SelectableShippableItemUI {
         val isSelected: Boolean
             get() = selectedIndexes.size == shippableItem.quantity.toInt()
     }

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/WooShippingLabelCreationViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/WooShippingLabelCreationViewModelTest.kt
@@ -1102,21 +1102,22 @@ class WooShippingLabelCreationViewModelTest : BaseUnitTest() {
     }
 
     @Test
-    fun `when StartHazmatFormEdit is triggered with a selected category, the event contains the expected category value`() = testBlocking {
-        var event: MultiLiveEvent.Event? = null
-        whenever(orderDetailRepository.getOrderById(any())) doReturn null
-        whenever(observeOriginAddresses()) doReturn flowOf(defaultOriginAddresses)
-        whenever(observeStoreOptions()) doReturn flowOf(defaultStoreOptions)
+    fun `when StartHazmatFormEdit is triggered with a selected category, the event contains the expected category value`() =
+        testBlocking {
+            var event: MultiLiveEvent.Event? = null
+            whenever(orderDetailRepository.getOrderById(any())) doReturn null
+            whenever(observeOriginAddresses()) doReturn flowOf(defaultOriginAddresses)
+            whenever(observeStoreOptions()) doReturn flowOf(defaultStoreOptions)
 
-        createViewModel()
+            createViewModel()
 
-        sut.onHazmatCategorySelected(ShippingLabelHazmatCategory.CLASS_1)
-        sut.onHazmatNoticeClick()
+            sut.onHazmatCategorySelected(ShippingLabelHazmatCategory.CLASS_1)
+            sut.onHazmatNoticeClick()
 
-        sut.event.observeForever { event = it }
+            sut.event.observeForever { event = it }
 
-        assertThat(event).isEqualTo(StartHazmatFormEdit(ShippingLabelHazmatCategory.CLASS_1))
-    }
+            assertThat(event).isEqualTo(StartHazmatFormEdit(ShippingLabelHazmatCategory.CLASS_1))
+        }
 
     @Test
     fun `when initialized, show expected item quantity`() = testBlocking {
@@ -1136,6 +1137,6 @@ class WooShippingLabelCreationViewModelTest : BaseUnitTest() {
         val currentViewState = sut.viewState.value
         assert(currentViewState is DataState)
         val dataState = currentViewState as DataState
-        assertThat(dataState.shippableItems.totalItemQuantity()).isEqualTo(expectedItemQuantity)
+        assertThat(dataState.shippableItems.totalItemQuantity).isEqualTo(expectedItemQuantity)
     }
 }

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/WooShippingLabelCreationViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/WooShippingLabelCreationViewModelTest.kt
@@ -1117,4 +1117,25 @@ class WooShippingLabelCreationViewModelTest : BaseUnitTest() {
 
         assertThat(event).isEqualTo(StartHazmatFormEdit(ShippingLabelHazmatCategory.CLASS_1))
     }
+
+    @Test
+    fun `when initialized, show expected item quantity`() = testBlocking {
+        val order = OrderTestUtils.generateTestOrder(orderId = orderId)
+        whenever(orderDetailRepository.getOrderById(any())) doReturn order
+        whenever(getShippableItems(any())) doReturn defaultShippableItems
+        whenever(observeOriginAddresses()) doReturn flowOf(defaultOriginAddresses)
+        whenever(observeStoreOptions()) doReturn flowOf(defaultStoreOptions)
+        whenever(shouldRequireCustomsForm.invoke(any())) doReturn false
+
+        val expectedItemQuantity = defaultShippableItems.size
+
+        createViewModel()
+
+        advanceUntilIdle()
+
+        val currentViewState = sut.viewState.value
+        assert(currentViewState is DataState)
+        val dataState = currentViewState as DataState
+        assertThat(dataState.shippableItems.totalItemQuantity()).isEqualTo(expectedItemQuantity)
+    }
 }

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/split/WooShippingSplitShipmentViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/split/WooShippingSplitShipmentViewModelTest.kt
@@ -297,6 +297,26 @@ class WooShippingSplitShipmentViewModelTest : BaseUnitTest() {
         assertThat(snackbarData.messageParameters).isEqualTo(listOf(5, 2))
     }
 
+    @Test
+    fun `when initialized, then display the correct item quantity`() = testBlocking {
+        val shipmentArgs = SplitShipmentArgs(
+            orderId = 1L,
+            storeOptions = StoreOptionsModel.EMPTY,
+            shipments = twoShipment
+        )
+
+        val expectedQuantity = 6 // Total single items in the Shipment 1 from `twoShipment`
+
+        createViewModel(shipmentArgs)
+
+        sut.viewState.observeForTesting { }
+
+        val state = sut.viewState.value!!
+
+        val selectableItems = state.selectableItems.getValue(1)
+        assertThat(selectableItems.totalItemQuantity).isEqualTo(expectedQuantity)
+    }
+
     private val defaultShipment = mapOf(
         1 to listOf(
             ShippableItemModel(


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Ref WOOMOB-17
<!-- Id number of the GitHub issue this PR addresses. -->

<!-- 
━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
🛠 Need an AI review?  
Add a comment: `@coderabbitai review`
━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
-->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
This PR fixes the incorrect item quantity display on the shipping labels and split shipment screens. With this change, Android will align with the Figma designs and the current iOS implementation.

> [!NOTE]  
> On the split shipment screen, the price on the product group item is also incorrect but I'll fix it with another PR.

### Steps to reproduce
<!-- Step-by-step testing instructions. For new user flows, consider instead stating the goal of the workflow and see if your PR reviewer can accomplish the workflow without specific steps! -->
1. Open the orders tab
2. Tap on an order eligible for shipping label creation. It’s better to choose one with different product types and multiple quantities.
3. Tap on Create shipping label.
4. Tap on Split shipment.

### The tests that have been performed
<!-- To give the reviewer an idea of what could be missed in terms of testing -->
Steps above

### Images/gif
<!-- Include before and after images or gifs when appropriate. -->
|Before|After|
|-|-|
|<img src="https://github.com/user-attachments/assets/b7ca008f-8b1a-4d8a-a005-6bd591cddd47" width=360>|<img src="https://github.com/user-attachments/assets/396208bc-d90e-4a91-95f4-557cb50ddca4" width=360>|
|<img src="https://github.com/user-attachments/assets/4698c170-34c8-4dc0-bd10-a0e91252d276" width=360>|<img src="https://github.com/user-attachments/assets/0de2e326-d666-4e3d-9dc1-e2a0cd2df077" width=360>|

- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.

## Reviewer (or Author, in the case of optional code reviews):

Please make sure these conditions are met before approving the PR, or request changes if the PR needs improvement:

- [ ] The PR is small and has a clear, single focus, or a valid explanation is provided in the description. If needed, please request to split it into smaller PRs.
- [ ] Ensure Adequate Unit Test Coverage: The changes are reasonably covered by unit tests or an explanation is provided in the PR description.
- [ ] Manual Testing: The author listed all the tests they ran, including smoke tests when needed (e.g., for refactorings). The reviewer confirmed that the PR works as expected on big (tablet) and small (phone) in case of UI changes, and no regressions are added.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->