### PR TITLE
[SDK35 Update] Make POS screens scrollable with keyboard open

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/cashpayment/WooPosCashPaymentScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/cashpayment/WooPosCashPaymentScreen.kt
@@ -9,7 +9,9 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.imePadding
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.text.KeyboardOptions
+import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
@@ -107,6 +109,7 @@ private fun Collecting(
     Column(
         modifier = Modifier
             .fillMaxSize()
+            .verticalScroll(rememberScrollState())
             .imePadding(),
         verticalArrangement = Arrangement.SpaceBetween
     ) {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/emailreceipt/WooPosEmailReceiptScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/emailreceipt/WooPosEmailReceiptScreen.kt
@@ -7,7 +7,9 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.imePadding
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.text.KeyboardOptions
+import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
@@ -56,7 +58,7 @@ private fun WooPosEmailReceiptScreen(
     onEmailSent: () -> Unit,
     onBackClicked: () -> Unit,
 ) {
-    Column(modifier = Modifier.fillMaxSize()) {
+    Column(modifier = Modifier.fillMaxSize().verticalScroll(rememberScrollState()).imePadding()) {
         WooPosToolbar(
             titleText = stringResource(R.string.woopos_email_receipt_title),
             onBackClicked = onBackClicked,

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/items/search/WooPosItemsSearchScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/items/search/WooPosItemsSearchScreen.kt
@@ -2,6 +2,7 @@ package com.woocommerce.android.ui.woopos.home.items.search
 
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.imePadding
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.runtime.Composable
@@ -32,7 +33,7 @@ fun WooPosItemsSearchScreen(
     val viewModel = hiltViewModel<WooPosItemsSearchViewModel>()
     val state = viewModel.viewState.collectAsState().value
     WooPosItemsSearchScreen(
-        modifier = modifier,
+        modifier = modifier.imePadding(),
         state = state,
         onUIEvent = viewModel::onUIEvent,
     )


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #WOOMOB-318
<!-- Id number of the GitHub issue this PR addresses. -->

<!-- 
━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
🛠 Need an AI review?  
Add a comment: `@coderabbitai review`
━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
-->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
This PR fixes behavior of the POS screens where the keyboard is available (Search, Cash, Email screens) with SDK level 35. 
* Allowing Cash payment screen scroll when keyboard is open
* Allowing Email receipt screen scroll when keyboard is open
* Adjust padding of Search screen so that it's possible to scroll to the bottom of the results list (empty search state and results list)

Issue origin & context: p91TBi-ddc-p2

### Steps to reproduce
<!-- Step-by-step testing instructions. For new user flows, consider instead stating the goal of the workflow and see if your PR reviewer can accomplish the workflow without specific steps! -->
1. Run the POS on the base branch `13270-android-sdk-update-target-sdk-to-35`
2. Increase screen size and font size so that when a keyboard is open it overlaps buttons
3. Notice the screen is not scrolling, not allowing you to press buttons or making them scale ugly

### Testing information
<!-- This is your opportunity to break out individual scenarios that need testing (when necessary) and/or include a checklist for the reviewer to go through. Consider documenting the following from your own completed testing: devices used, alternate workflows, edge cases, affected areas, critical flows, areas not tested, and any remaining unknowns. Provide feedback on this new section of the PR template through Sept 30, 2024 to Apps Quality; additional context here: p91TBi-b8z-p2#comment-12036 -->
On the current branch verify the above issues are not happening on the following screens:
* Search
* Cash payment
* Email receipt

### The tests that have been performed
<!-- To give the reviewer an idea of what could be missed in terms of testing -->
Verified above

### Images/gif
<!-- Include before and after images or gifs when appropriate. -->
##### Cash payment scroll behavior improved (sticky toolbar)
https://github.com/user-attachments/assets/f769f421-d2b1-459c-ba11-0ee51731a86c

##### Search scroll
https://github.com/user-attachments/assets/e00dc64c-450f-4d5b-b1f0-860a9dc84e12

- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.

## Reviewer (or Author, in the case of optional code reviews):

Please make sure these conditions are met before approving the PR, or request changes if the PR needs improvement:

- [ ] The PR is small and has a clear, single focus, or a valid explanation is provided in the description. If needed, please request to split it into smaller PRs.
- [ ] Ensure Adequate Unit Test Coverage: The changes are reasonably covered by unit tests or an explanation is provided in the PR description.
- [ ] Manual Testing: The author listed all the tests they ran, including smoke tests when needed (e.g., for refactorings). The reviewer confirmed that the PR works as expected on big (tablet) and small (phone) in case of UI changes, and no regressions are added.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->