### PR TITLE
[WOOMOB-317][Woo POS][Product Search] Implement fetching of the popular products

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductSortingListAdapter.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductSortingListAdapter.kt
@@ -8,12 +8,11 @@ import androidx.recyclerview.widget.RecyclerView
 import com.woocommerce.android.databinding.ProductSortingListItemBinding
 import com.woocommerce.android.ui.products.ProductSortingListAdapter.ProductSortingViewHolder
 import com.woocommerce.android.ui.products.ProductSortingViewModel.SortingListItemUIModel
-import org.wordpress.android.fluxc.store.WCProductStore.ProductSorting
 
 class ProductSortingListAdapter(
-    private val onItemClicked: (option: ProductSorting) -> Unit,
+    private val onItemClicked: (option: SortingListItemUIModel.Sorting) -> Unit,
     private val options: List<SortingListItemUIModel>,
-    private val selectedOption: ProductSorting
+    private val selectedOption: SortingListItemUIModel.Sorting
 ) : RecyclerView.Adapter<ProductSortingViewHolder>() {
     init {
         setHasStableIds(true)
@@ -44,8 +43,8 @@ class ProductSortingListAdapter(
         RecyclerView.ViewHolder(viewBinding.root) {
         fun bind(
             item: SortingListItemUIModel,
-            onItemClicked: (option: ProductSorting) -> Unit,
-            selectedOption: ProductSorting
+            onItemClicked: (option: SortingListItemUIModel.Sorting) -> Unit,
+            selectedOption: SortingListItemUIModel.Sorting
         ) {
             viewBinding.sortingItemName.text = itemView.context.getString(item.stringResource)
             viewBinding.sortingItemTick.isVisible = item.value == selectedOption

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductSortingViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductSortingViewModel.kt
@@ -14,10 +14,6 @@ import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.parcelize.Parcelize
 import org.greenrobot.eventbus.EventBus
 import org.wordpress.android.fluxc.store.WCProductStore.ProductSorting
-import org.wordpress.android.fluxc.store.WCProductStore.ProductSorting.DATE_ASC
-import org.wordpress.android.fluxc.store.WCProductStore.ProductSorting.DATE_DESC
-import org.wordpress.android.fluxc.store.WCProductStore.ProductSorting.TITLE_ASC
-import org.wordpress.android.fluxc.store.WCProductStore.ProductSorting.TITLE_DESC
 import javax.inject.Inject
 
 @HiltViewModel
@@ -27,33 +23,45 @@ class ProductSortingViewModel @Inject constructor(
 ) : ScopedViewModel(savedState) {
     companion object {
         val SORTING_OPTIONS = listOf(
-            SortingListItemUIModel(R.string.product_list_sorting_newest_to_oldest, DATE_DESC),
-            SortingListItemUIModel(R.string.product_list_sorting_oldest_to_newest, DATE_ASC),
-            SortingListItemUIModel(R.string.product_list_sorting_a_to_z, TITLE_ASC),
-            SortingListItemUIModel(R.string.product_list_sorting_z_to_a, TITLE_DESC)
+            SortingListItemUIModel(R.string.product_list_sorting_newest_to_oldest, SortingListItemUIModel.Sorting.DATE_DESC),
+            SortingListItemUIModel(R.string.product_list_sorting_oldest_to_newest, SortingListItemUIModel.Sorting.DATE_ASC),
+            SortingListItemUIModel(R.string.product_list_sorting_a_to_z, SortingListItemUIModel.Sorting.TITLE_ASC),
+            SortingListItemUIModel(R.string.product_list_sorting_z_to_a, SortingListItemUIModel.Sorting.TITLE_DESC)
         )
     }
 
-    var sortingChoice: ProductSorting
+    var sortingChoice: SortingListItemUIModel.Sorting
         private set
 
     init {
-        sortingChoice = productListRepository.productSortingChoice
+        sortingChoice = when (productListRepository.productSortingChoice) {
+            ProductSorting.TITLE_ASC -> SortingListItemUIModel.Sorting.TITLE_ASC
+            ProductSorting.TITLE_DESC -> SortingListItemUIModel.Sorting.TITLE_DESC
+            ProductSorting.DATE_ASC -> SortingListItemUIModel.Sorting.DATE_ASC
+            ProductSorting.DATE_DESC -> SortingListItemUIModel.Sorting.DATE_DESC
+            ProductSorting.POPULARITY_ASC, ProductSorting.POPULARITY_DESC ->
+                error("Invalid sorting choice $productListRepository.productSortingChoice")
+        }
     }
 
-    fun onSortingOptionChanged(option: ProductSorting) {
+    fun onSortingOptionChanged(option: SortingListItemUIModel.Sorting) {
         // order="name/date,ascending,descending"
         val order = when (option) {
-            TITLE_ASC -> AnalyticsTracker.VALUE_SORT_NAME_ASC
-            TITLE_DESC -> AnalyticsTracker.VALUE_SORT_NAME_DESC
-            DATE_ASC -> AnalyticsTracker.VALUE_SORT_DATE_ASC
-            DATE_DESC -> AnalyticsTracker.VALUE_SORT_DATE_DESC
+            SortingListItemUIModel.Sorting.TITLE_ASC -> AnalyticsTracker.VALUE_SORT_NAME_ASC
+            SortingListItemUIModel.Sorting.TITLE_DESC -> AnalyticsTracker.VALUE_SORT_NAME_DESC
+            SortingListItemUIModel.Sorting.DATE_ASC -> AnalyticsTracker.VALUE_SORT_DATE_ASC
+            SortingListItemUIModel.Sorting.DATE_DESC -> AnalyticsTracker.VALUE_SORT_DATE_DESC
         }
         AnalyticsTracker.track(
             AnalyticsEvent.PRODUCT_LIST_SORTING_OPTION_SELECTED,
             mapOf(AnalyticsTracker.KEY_SORT_ORDER to order)
         )
-        productListRepository.productSortingChoice = option
+        productListRepository.productSortingChoice = when (option) {
+            SortingListItemUIModel.Sorting.TITLE_ASC -> ProductSorting.TITLE_ASC
+            SortingListItemUIModel.Sorting.TITLE_DESC -> ProductSorting.TITLE_DESC
+            SortingListItemUIModel.Sorting.DATE_ASC -> ProductSorting.DATE_ASC
+            SortingListItemUIModel.Sorting.DATE_DESC -> ProductSorting.DATE_DESC
+        }
         EventBus.getDefault().post(OnProductSortingChanged)
         triggerEvent(Exit)
     }
@@ -61,6 +69,13 @@ class ProductSortingViewModel @Inject constructor(
     @Parcelize
     data class SortingListItemUIModel(
         @StringRes val stringResource: Int,
-        val value: ProductSorting
-    ) : Parcelable
+        val value: Sorting,
+    ) : Parcelable {
+        enum class Sorting {
+            TITLE_ASC,
+            TITLE_DESC,
+            DATE_ASC,
+            DATE_DESC,
+        }
+    }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductSortingViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductSortingViewModel.kt
@@ -23,10 +23,22 @@ class ProductSortingViewModel @Inject constructor(
 ) : ScopedViewModel(savedState) {
     companion object {
         val SORTING_OPTIONS = listOf(
-            SortingListItemUIModel(R.string.product_list_sorting_newest_to_oldest, SortingListItemUIModel.Sorting.DATE_DESC),
-            SortingListItemUIModel(R.string.product_list_sorting_oldest_to_newest, SortingListItemUIModel.Sorting.DATE_ASC),
-            SortingListItemUIModel(R.string.product_list_sorting_a_to_z, SortingListItemUIModel.Sorting.TITLE_ASC),
-            SortingListItemUIModel(R.string.product_list_sorting_z_to_a, SortingListItemUIModel.Sorting.TITLE_DESC)
+            SortingListItemUIModel(
+                R.string.product_list_sorting_newest_to_oldest,
+                SortingListItemUIModel.Sorting.DATE_DESC
+            ),
+            SortingListItemUIModel(
+                R.string.product_list_sorting_oldest_to_newest,
+                SortingListItemUIModel.Sorting.DATE_ASC
+            ),
+            SortingListItemUIModel(
+                R.string.product_list_sorting_a_to_z,
+                SortingListItemUIModel.Sorting.TITLE_ASC
+            ),
+            SortingListItemUIModel(
+                R.string.product_list_sorting_z_to_a,
+                SortingListItemUIModel.Sorting.TITLE_DESC
+            )
         )
     }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/list/ProductListRepository.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/list/ProductListRepository.kt
@@ -54,7 +54,7 @@ class ProductListRepository @Inject constructor(
     var lastSearchQuery: String? = null
         private set
 
-    var lastIsSkuSearch = WCProductStore.SkuSearchOptions.Disabled
+    var lastIsSkuSearch = SkuSearchOptions.Disabled
         private set
 
     var productSortingChoice: WCProductStore.ProductSorting

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/list/ProductListViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/list/ProductListViewModel.kt
@@ -575,6 +575,8 @@ class ProductListViewModel @Inject constructor(
             WCProductStore.ProductSorting.DATE_DESC -> R.string.product_list_sorting_newest_to_oldest_short
             WCProductStore.ProductSorting.TITLE_DESC -> R.string.product_list_sorting_z_to_a_short
             WCProductStore.ProductSorting.TITLE_ASC -> R.string.product_list_sorting_a_to_z_short
+            WCProductStore.ProductSorting.POPULARITY_ASC, WCProductStore.ProductSorting.POPULARITY_DESC ->
+                error("Invalid sorting choice ${productRepository.productSortingChoice}")
         }
     }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/common/data/WooPosMockedPopularProductsProvider.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/common/data/WooPosMockedPopularProductsProvider.kt
@@ -1,11 +1,8 @@
 package com.woocommerce.android.ui.woopos.common.data
 
 import com.woocommerce.android.model.Product
+import com.woocommerce.android.model.toAppModel
 import com.woocommerce.android.tools.SelectedSite
-import com.woocommerce.android.ui.woopos.home.items.products.WooPosProductsDataSource.Companion.NORMAL_PAGE_SIZE
-import com.woocommerce.android.ui.woopos.home.items.products.WooPosProductsIndex
-import org.wordpress.android.fluxc.network.rest.wpcom.wc.product.ProductRestClient
-import org.wordpress.android.fluxc.network.rest.wpcom.wc.reports.ReportsRestClient
 import org.wordpress.android.fluxc.store.WCProductStore
 import org.wordpress.android.fluxc.store.WCProductStore.ProductSorting
 import javax.inject.Inject
@@ -15,21 +12,33 @@ import javax.inject.Singleton
 class WooPosMockedPopularProductsProvider @Inject constructor(
     private val selectedSite: SelectedSite,
     private val productStore: WCProductStore,
+    private val productsTypesFilterConfig: WooPosProductsTypesFilterConfig,
 ) {
     companion object {
         private const val MAX_POPULAR_PRODUCTS = 3
     }
 
-    suspend fun getPopularProducts(): List<Product> {
+    private val popularProductsCache = mutableListOf<Product>()
+
+    fun getPopularProducts(): List<Product> = popularProductsCache
+
+    suspend fun fetchPopularProducts(): Result<Unit> {
         val result = productStore.fetchProducts(
             site = selectedSite.get(),
             offset = 0,
             pageSize = MAX_POPULAR_PRODUCTS,
-            filterOptions = createProductFilters(),
-            includeTypes = createIncludedTypes(),
+            filterOptions = productsTypesFilterConfig.filters,
+            includeTypes = productsTypesFilterConfig.includeTypes,
             sortType = ProductSorting.POPULARITY_DESC,
         )
 
-
+        if (result.isError) {
+            return Result.failure(Exception(result.error.message))
+        } else {
+            val products = result.model ?: emptyList()
+            popularProductsCache.clear()
+            popularProductsCache.addAll(products.map { it.toAppModel() })
+            return Result.success(Unit)
+        }
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/common/data/WooPosMockedPopularProductsProvider.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/common/data/WooPosMockedPopularProductsProvider.kt
@@ -1,20 +1,35 @@
 package com.woocommerce.android.ui.woopos.common.data
 
 import com.woocommerce.android.model.Product
+import com.woocommerce.android.tools.SelectedSite
+import com.woocommerce.android.ui.woopos.home.items.products.WooPosProductsDataSource.Companion.NORMAL_PAGE_SIZE
 import com.woocommerce.android.ui.woopos.home.items.products.WooPosProductsIndex
+import org.wordpress.android.fluxc.network.rest.wpcom.wc.product.ProductRestClient
+import org.wordpress.android.fluxc.network.rest.wpcom.wc.reports.ReportsRestClient
+import org.wordpress.android.fluxc.store.WCProductStore
+import org.wordpress.android.fluxc.store.WCProductStore.ProductSorting
 import javax.inject.Inject
 import javax.inject.Singleton
 
 @Singleton
 class WooPosMockedPopularProductsProvider @Inject constructor(
-    private val productsIndex: WooPosProductsIndex,
+    private val selectedSite: SelectedSite,
+    private val productStore: WCProductStore,
 ) {
     companion object {
-        private const val MAX_POPULAR_PRODUCTS = 10
+        private const val MAX_POPULAR_PRODUCTS = 3
     }
 
     suspend fun getPopularProducts(): List<Product> {
-        val products = productsIndex.getProductList()
-        return products.shuffled().take(minOf(products.size, MAX_POPULAR_PRODUCTS))
+        val result = productStore.fetchProducts(
+            site = selectedSite.get(),
+            offset = 0,
+            pageSize = MAX_POPULAR_PRODUCTS,
+            filterOptions = createProductFilters(),
+            includeTypes = createIncludedTypes(),
+            sortType = ProductSorting.POPULARITY_DESC,
+        )
+
+
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/common/data/WooPosPopularProductsProvider.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/common/data/WooPosPopularProductsProvider.kt
@@ -9,7 +9,7 @@ import javax.inject.Inject
 import javax.inject.Singleton
 
 @Singleton
-class WooPosMockedPopularProductsProvider @Inject constructor(
+class WooPosPopularProductsProvider @Inject constructor(
     private val selectedSite: SelectedSite,
     private val productStore: WCProductStore,
     private val productsTypesFilterConfig: WooPosProductsTypesFilterConfig,

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/common/data/WooPosPopularProductsProvider.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/common/data/WooPosPopularProductsProvider.kt
@@ -3,6 +3,8 @@ package com.woocommerce.android.ui.woopos.common.data
 import com.woocommerce.android.model.Product
 import com.woocommerce.android.model.toAppModel
 import com.woocommerce.android.tools.SelectedSite
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
 import org.wordpress.android.fluxc.store.WCProductStore
 import org.wordpress.android.fluxc.store.WCProductStore.ProductSorting
 import javax.inject.Inject
@@ -12,17 +14,19 @@ import javax.inject.Singleton
 class WooPosPopularProductsProvider @Inject constructor(
     private val selectedSite: SelectedSite,
     private val productStore: WCProductStore,
+    private val productsCache: WooPosProductsCache,
     private val productsTypesFilterConfig: WooPosProductsTypesFilterConfig,
 ) {
     companion object {
         private const val MAX_POPULAR_PRODUCTS = 3
     }
 
+    private val mutex = Mutex()
     private val popularProductsCache = mutableListOf<Product>()
 
-    fun getPopularProducts(): List<Product> = popularProductsCache
+    suspend fun getPopularProducts(): List<Product> = mutex.withLock { popularProductsCache }
 
-    suspend fun fetchPopularProducts(): Result<Unit> {
+    suspend fun fetchPopularProducts(): Result<Unit> = mutex.withLock {
         val result = productStore.fetchProducts(
             site = selectedSite.get(),
             offset = 0,
@@ -36,8 +40,11 @@ class WooPosPopularProductsProvider @Inject constructor(
             return Result.failure(Exception(result.error.message))
         } else {
             val products = result.model ?: emptyList()
+            var productsAppModel = products.map { it.toAppModel() }
+
             popularProductsCache.clear()
-            popularProductsCache.addAll(products.map { it.toAppModel() })
+            popularProductsCache.addAll(productsAppModel)
+            productsCache.addAll(productsAppModel)
             return Result.success(Unit)
         }
     }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/common/data/WooPosPopularProductsProvider.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/common/data/WooPosPopularProductsProvider.kt
@@ -36,7 +36,7 @@ class WooPosPopularProductsProvider @Inject constructor(
             sortType = ProductSorting.POPULARITY_DESC,
         )
 
-        return  if (result.isError) {
+        return if (result.isError) {
             Result.failure(Exception(result.error.message))
         } else {
             val products = result.model ?: emptyList()

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/common/data/WooPosPopularProductsProvider.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/common/data/WooPosPopularProductsProvider.kt
@@ -26,7 +26,7 @@ class WooPosPopularProductsProvider @Inject constructor(
 
     suspend fun getPopularProducts(): List<Product> = mutex.withLock { popularProductsCache }
 
-    suspend fun fetchPopularProducts(): Result<Unit> = mutex.withLock {
+    suspend fun fetchAndCachePopularProducts(): Result<Unit> = mutex.withLock {
         val result = productStore.fetchProducts(
             site = selectedSite.get(),
             offset = 0,

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/common/data/WooPosPopularProductsProvider.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/common/data/WooPosPopularProductsProvider.kt
@@ -36,8 +36,8 @@ class WooPosPopularProductsProvider @Inject constructor(
             sortType = ProductSorting.POPULARITY_DESC,
         )
 
-        if (result.isError) {
-            return Result.failure(Exception(result.error.message))
+        return  if (result.isError) {
+            Result.failure(Exception(result.error.message))
         } else {
             val products = result.model ?: emptyList()
             var productsAppModel = products.map { it.toAppModel() }
@@ -45,7 +45,7 @@ class WooPosPopularProductsProvider @Inject constructor(
             popularProductsCache.clear()
             popularProductsCache.addAll(productsAppModel)
             productsCache.addAll(productsAppModel)
-            return Result.success(Unit)
+            Result.success(Unit)
         }
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/common/data/WooPosProductsTypesFilter.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/common/data/WooPosProductsTypesFilter.kt
@@ -1,0 +1,21 @@
+package com.woocommerce.android.ui.woopos.common.data
+
+import com.woocommerce.android.ui.products.ProductStatus
+import org.wordpress.android.fluxc.store.WCProductStore
+import org.wordpress.android.fluxc.store.WCProductStore.DownloadableOptions
+import org.wordpress.android.fluxc.store.WCProductStore.ProductFilterOption
+import javax.inject.Inject
+
+class WooPosProductsTypesFilter @Inject constructor() {
+    val filters: Map<ProductFilterOption, String> =
+        mapOf(
+            ProductFilterOption.STATUS to ProductStatus.PUBLISH.value,
+            ProductFilterOption.DOWNLOADABLE to DownloadableOptions.FALSE.toString()
+        )
+
+    val includeTypes: List<WCProductStore.IncludeType> =
+        listOf(
+            WCProductStore.IncludeType.Simple,
+            WCProductStore.IncludeType.Variable
+        )
+}

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/common/data/WooPosProductsTypesFilterConfig.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/common/data/WooPosProductsTypesFilterConfig.kt
@@ -6,7 +6,7 @@ import org.wordpress.android.fluxc.store.WCProductStore.DownloadableOptions
 import org.wordpress.android.fluxc.store.WCProductStore.ProductFilterOption
 import javax.inject.Inject
 
-class WooPosProductsTypesFilter @Inject constructor() {
+class WooPosProductsTypesFilterConfig @Inject constructor() {
     val filters: Map<ProductFilterOption, String> =
         mapOf(
             ProductFilterOption.STATUS to ProductStatus.PUBLISH.value,

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/items/products/WooPosProductsDataSource.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/items/products/WooPosProductsDataSource.kt
@@ -6,6 +6,7 @@ import com.woocommerce.android.model.toAppModel
 import com.woocommerce.android.tools.SelectedSite
 import com.woocommerce.android.ui.products.ProductStatus
 import com.woocommerce.android.ui.woopos.common.data.WooPosProductsCache
+import com.woocommerce.android.ui.woopos.common.data.WooPosProductsTypesFilter
 import com.woocommerce.android.util.WooLog
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.Flow
@@ -28,6 +29,7 @@ class WooPosProductsDataSource @Inject constructor(
     private val selectedSite: SelectedSite,
     private val productsCache: WooPosProductsCache,
     private val productsIndex: WooPosProductsIndex,
+    private val productsTypesFilter: WooPosProductsTypesFilter
 ) {
     private val canLoadMore = AtomicBoolean(false)
     private val offset = AtomicInteger(0)
@@ -126,18 +128,6 @@ class WooPosProductsDataSource @Inject constructor(
             Result.failure(WooException(result.error))
         }
     }
-
-    private fun createProductFilters(): Map<ProductFilterOption, String> {
-        return mapOf(
-            ProductFilterOption.STATUS to ProductStatus.PUBLISH.value,
-            ProductFilterOption.DOWNLOADABLE to DownloadableOptions.FALSE.toString()
-        )
-    }
-
-    private fun createIncludedTypes() = listOf(
-        WCProductStore.IncludeType.Simple,
-        WCProductStore.IncludeType.Variable
-    )
 
     private fun WooResult<*>.logFailure() {
         val errorMessage = error?.message ?: "Unknown error"

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/items/products/WooPosProductsDataSource.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/items/products/WooPosProductsDataSource.kt
@@ -4,9 +4,8 @@ import com.woocommerce.android.WooException
 import com.woocommerce.android.model.Product
 import com.woocommerce.android.model.toAppModel
 import com.woocommerce.android.tools.SelectedSite
-import com.woocommerce.android.ui.products.ProductStatus
 import com.woocommerce.android.ui.woopos.common.data.WooPosProductsCache
-import com.woocommerce.android.ui.woopos.common.data.WooPosProductsTypesFilter
+import com.woocommerce.android.ui.woopos.common.data.WooPosProductsTypesFilterConfig
 import com.woocommerce.android.util.WooLog
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.Flow
@@ -16,8 +15,6 @@ import kotlinx.coroutines.flow.take
 import kotlinx.coroutines.withContext
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.WooResult
 import org.wordpress.android.fluxc.store.WCProductStore
-import org.wordpress.android.fluxc.store.WCProductStore.DownloadableOptions
-import org.wordpress.android.fluxc.store.WCProductStore.ProductFilterOption
 import java.util.concurrent.atomic.AtomicBoolean
 import java.util.concurrent.atomic.AtomicInteger
 import javax.inject.Inject
@@ -29,7 +26,7 @@ class WooPosProductsDataSource @Inject constructor(
     private val selectedSite: SelectedSite,
     private val productsCache: WooPosProductsCache,
     private val productsIndex: WooPosProductsIndex,
-    private val productsTypesFilter: WooPosProductsTypesFilter
+    private val productsTypesFilterConfig: WooPosProductsTypesFilterConfig
 ) {
     private val canLoadMore = AtomicBoolean(false)
     private val offset = AtomicInteger(0)
@@ -49,8 +46,8 @@ class WooPosProductsDataSource @Inject constructor(
                 site = selectedSite.get(),
                 offset = currentPage * PRE_POPULATION_PAGE_SIZE,
                 pageSize = PRE_POPULATION_PAGE_SIZE,
-                filterOptions = createProductFilters(),
-                includeTypes = createIncludedTypes(),
+                filterOptions = productsTypesFilterConfig.filters,
+                includeTypes = productsTypesFilterConfig.includeTypes,
             )
 
             if (!result.isError) {
@@ -109,8 +106,8 @@ class WooPosProductsDataSource @Inject constructor(
             site = selectedSite.get(),
             offset = offset.get(),
             pageSize = NORMAL_PAGE_SIZE,
-            filterOptions = createProductFilters(),
-            includeTypes = createIncludedTypes(),
+            filterOptions = productsTypesFilterConfig.filters,
+            includeTypes = productsTypesFilterConfig.includeTypes,
         )
 
         return if (!result.isError) {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/items/search/WooPosItemsSearchEmptyStateRepository.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/items/search/WooPosItemsSearchEmptyStateRepository.kt
@@ -1,21 +1,17 @@
 package com.woocommerce.android.ui.woopos.home.items.search
 
 import com.woocommerce.android.model.Product
-import com.woocommerce.android.ui.woopos.common.data.WooPosMockedPopularProductsProvider
+import com.woocommerce.android.ui.woopos.common.data.WooPosPopularProductsProvider
 import com.woocommerce.android.ui.woopos.util.datastore.WooPosPreferencesRepository
-import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.first
 import javax.inject.Inject
 
 @Suppress("MagicNumber")
 class WooPosItemsSearchEmptyStateRepository @Inject constructor(
     private val preferencesRepository: WooPosPreferencesRepository,
-    private val popularProductsProvider: WooPosMockedPopularProductsProvider,
+    private val popularProductsProvider: WooPosPopularProductsProvider,
 ) {
-    suspend fun getPopularItems(): List<Product> {
-        delay(50)
-        return popularProductsProvider.getPopularProducts()
-    }
+    fun getPopularItems(): List<Product> = popularProductsProvider.getPopularProducts()
 
     suspend fun getLastSearches(): List<String> = preferencesRepository.recentProductSearches.first()
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/items/search/WooPosItemsSearchEmptyStateRepository.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/items/search/WooPosItemsSearchEmptyStateRepository.kt
@@ -11,7 +11,7 @@ class WooPosItemsSearchEmptyStateRepository @Inject constructor(
     private val preferencesRepository: WooPosPreferencesRepository,
     private val popularProductsProvider: WooPosPopularProductsProvider,
 ) {
-    fun getPopularItems(): List<Product> = popularProductsProvider.getPopularProducts()
+    suspend fun getPopularItems(): List<Product> = popularProductsProvider.getPopularProducts()
 
     suspend fun getLastSearches(): List<String> = preferencesRepository.recentProductSearches.first()
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/splash/WooPosSplashViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/splash/WooPosSplashViewModel.kt
@@ -7,10 +7,9 @@ import com.woocommerce.android.ui.woopos.home.items.products.WooPosProductsDataS
 import com.woocommerce.android.ui.woopos.util.analytics.WooPosAnalyticsEvent.Event.Loaded
 import com.woocommerce.android.ui.woopos.util.analytics.WooPosAnalyticsTracker
 import dagger.hilt.android.lifecycle.HiltViewModel
-import kotlinx.coroutines.async
-import kotlinx.coroutines.awaitAll
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.joinAll
 import kotlinx.coroutines.launch
 import java.util.concurrent.TimeUnit
 import javax.inject.Inject
@@ -27,9 +26,10 @@ class WooPosSplashViewModel @Inject constructor(
     init {
         val splashScreenStartTime = System.currentTimeMillis()
         viewModelScope.launch {
-            val productsJob = async { productsDataSource.prepopulateProductsCache() }
-            val popularProductsJob = async { popularProductsProvider.fetchPopularProducts() }
-            awaitAll(productsJob, popularProductsJob)
+            joinAll(
+                launch { productsDataSource.prepopulateProductsCache() },
+                launch { popularProductsProvider.fetchAndCachePopularProducts() }
+            )
             _state.value = WooPosSplashState.Loaded
             trackPosLoaded(splashScreenStartTime)
         }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/splash/WooPosSplashViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/splash/WooPosSplashViewModel.kt
@@ -2,10 +2,13 @@ package com.woocommerce.android.ui.woopos.splash
 
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import com.woocommerce.android.ui.woopos.common.data.WooPosPopularProductsProvider
 import com.woocommerce.android.ui.woopos.home.items.products.WooPosProductsDataSource
 import com.woocommerce.android.ui.woopos.util.analytics.WooPosAnalyticsEvent.Event.Loaded
 import com.woocommerce.android.ui.woopos.util.analytics.WooPosAnalyticsTracker
 import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.async
+import kotlinx.coroutines.awaitAll
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.launch
@@ -15,6 +18,7 @@ import javax.inject.Inject
 @HiltViewModel
 class WooPosSplashViewModel @Inject constructor(
     private val productsDataSource: WooPosProductsDataSource,
+    private val popularProductsProvider: WooPosPopularProductsProvider,
     private val analyticsTracker: WooPosAnalyticsTracker,
 ) : ViewModel() {
     private val _state = MutableStateFlow<WooPosSplashState>(WooPosSplashState.Loading)
@@ -23,7 +27,9 @@ class WooPosSplashViewModel @Inject constructor(
     init {
         val splashScreenStartTime = System.currentTimeMillis()
         viewModelScope.launch {
-            productsDataSource.prepopulateProductsCache()
+            val productsJob = async { productsDataSource.prepopulateProductsCache() }
+            val popularProductsJob = async { popularProductsProvider.fetchPopularProducts() }
+            awaitAll(productsJob, popularProductsJob)
             _state.value = WooPosSplashState.Loaded
             trackPosLoaded(splashScreenStartTime)
         }

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/common/data/WooPosPopularProductsProviderTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/common/data/WooPosPopularProductsProviderTest.kt
@@ -1,0 +1,200 @@
+package com.woocommerce.android.ui.woopos.common.data
+
+import com.woocommerce.android.tools.SelectedSite
+import kotlinx.coroutines.test.runTest
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.Test
+import org.mockito.kotlin.any
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
+import org.wordpress.android.fluxc.model.SiteModel
+import org.wordpress.android.fluxc.model.WCProductModel
+import org.wordpress.android.fluxc.network.BaseRequest.GenericErrorType
+import org.wordpress.android.fluxc.network.rest.wpcom.wc.WooError
+import org.wordpress.android.fluxc.network.rest.wpcom.wc.WooErrorType
+import org.wordpress.android.fluxc.network.rest.wpcom.wc.WooResult
+import org.wordpress.android.fluxc.store.WCProductStore
+import org.wordpress.android.fluxc.store.WCProductStore.ProductSorting
+
+class WooPosPopularProductsProviderTest {
+    private val productStore: WCProductStore = mock()
+    private val siteModel: SiteModel = mock()
+    private val selectedSite: SelectedSite = mock {
+        on { get() }.thenReturn(siteModel)
+    }
+    private val productsCache: WooPosProductsCache = mock()
+    private val productsTypesFilterConfig: WooPosProductsTypesFilterConfig = mock {
+        on { filters }.thenReturn(emptyMap())
+        on { includeTypes }.thenReturn(emptyList())
+    }
+
+    private val sampleProducts = listOf(
+        WCProductModel().apply {
+            remoteProductId = 1
+            name = "Product 1"
+            price = "10.0"
+            attributes = "[]"
+            status = "publish"
+        },
+        WCProductModel().apply {
+            remoteProductId = 2
+            name = "Product 2"
+            price = "20.0"
+            attributes = "[]"
+            status = "publish"
+        },
+        WCProductModel().apply {
+            remoteProductId = 3
+            name = "Product 3"
+            price = "30.0"
+            attributes = "[]"
+            status = "publish"
+        }
+    )
+
+    @Test
+    fun `given successful fetch, when fetchPopularProducts called, then should return success result`() = runTest {
+        // GIVEN
+        val successResult = WooResult(sampleProducts)
+
+        whenever(
+            productStore.fetchProducts(
+                site = siteModel,
+                offset = 0,
+                pageSize = 3,
+                filterOptions = emptyMap(),
+                includeTypes = emptyList(),
+                sortType = ProductSorting.POPULARITY_DESC
+            )
+        ).thenReturn(successResult)
+
+        val sut = createSut()
+
+        // WHEN
+        val result = sut.fetchPopularProducts()
+
+        // THEN
+        assertThat(result.isSuccess).isTrue()
+    }
+
+    @Test
+    fun `given successful fetch, when getPopularProducts called, then should return cached products`() = runTest {
+        // GIVEN
+        val successResult = WooResult(sampleProducts)
+
+        whenever(
+            productStore.fetchProducts(
+                site = siteModel,
+                offset = 0,
+                pageSize = 3,
+                filterOptions = emptyMap(),
+                includeTypes = emptyList(),
+                sortType = ProductSorting.POPULARITY_DESC
+            )
+        ).thenReturn(successResult)
+
+        val sut = createSut()
+
+        // WHEN
+        sut.fetchPopularProducts()
+        val popularProducts = sut.getPopularProducts()
+
+        // THEN
+        assertThat(popularProducts).hasSize(3)
+        assertThat(popularProducts[0].remoteId).isEqualTo(1)
+        assertThat(popularProducts[1].remoteId).isEqualTo(2)
+        assertThat(popularProducts[2].remoteId).isEqualTo(3)
+    }
+
+    @Test
+    fun `given failed fetch, when fetchPopularProducts called, then should return failure result`() = runTest {
+        // GIVEN
+        val wooError = WooError(
+            type = WooErrorType.GENERIC_ERROR,
+            original = GenericErrorType.UNKNOWN,
+            message = "Error fetching products"
+        )
+        val errorResult = WooResult<List<WCProductModel>>(wooError)
+
+        whenever(
+            productStore.fetchProducts(
+                site = siteModel,
+                offset = 0,
+                pageSize = 3,
+                filterOptions = emptyMap(),
+                includeTypes = emptyList(),
+                sortType = ProductSorting.POPULARITY_DESC
+            )
+        ).thenReturn(errorResult)
+
+        val sut = createSut()
+
+        // WHEN
+        val result = sut.fetchPopularProducts()
+
+        // THEN
+        assertThat(result.isFailure).isTrue()
+        assertThat(result.exceptionOrNull()?.message).isEqualTo("Error fetching products")
+    }
+
+    @Test
+    fun `given successful fetch, when fetchPopularProducts called, then should add products to both caches`() =
+        runTest {
+            // GIVEN
+            val successResult = WooResult(sampleProducts)
+
+            whenever(
+                productStore.fetchProducts(
+                    site = siteModel,
+                    offset = 0,
+                    pageSize = 3,
+                    filterOptions = emptyMap(),
+                    includeTypes = emptyList(),
+                    sortType = ProductSorting.POPULARITY_DESC
+                )
+            ).thenReturn(successResult)
+
+            val sut = createSut()
+
+            // WHEN
+            sut.fetchPopularProducts()
+
+            // THEN
+            verify(productsCache).addAll(any())
+        }
+
+    @Test
+    fun `given empty result, when fetchPopularProducts called, then should return empty list from getPopularProducts`() =
+        runTest {
+            // GIVEN
+            val emptyResult = WooResult(emptyList<WCProductModel>())
+
+            whenever(
+                productStore.fetchProducts(
+                    site = siteModel,
+                    offset = 0,
+                    pageSize = 3,
+                    filterOptions = emptyMap(),
+                    includeTypes = emptyList(),
+                    sortType = ProductSorting.POPULARITY_DESC
+                )
+            ).thenReturn(emptyResult)
+
+            val sut = createSut()
+
+            // WHEN
+            sut.fetchPopularProducts()
+            val popularProducts = sut.getPopularProducts()
+
+            // THEN
+            assertThat(popularProducts).isEmpty()
+        }
+
+    private fun createSut() = WooPosPopularProductsProvider(
+        selectedSite = selectedSite,
+        productStore = productStore,
+        productsCache = productsCache,
+        productsTypesFilterConfig = productsTypesFilterConfig
+    )
+}

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/common/data/WooPosPopularProductsProviderTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/common/data/WooPosPopularProductsProviderTest.kt
@@ -72,7 +72,7 @@ class WooPosPopularProductsProviderTest {
         val sut = createSut()
 
         // WHEN
-        val result = sut.fetchPopularProducts()
+        val result = sut.fetchAndCachePopularProducts()
 
         // THEN
         assertThat(result.isSuccess).isTrue()
@@ -97,7 +97,7 @@ class WooPosPopularProductsProviderTest {
         val sut = createSut()
 
         // WHEN
-        sut.fetchPopularProducts()
+        sut.fetchAndCachePopularProducts()
         val popularProducts = sut.getPopularProducts()
 
         // THEN
@@ -131,7 +131,7 @@ class WooPosPopularProductsProviderTest {
         val sut = createSut()
 
         // WHEN
-        val result = sut.fetchPopularProducts()
+        val result = sut.fetchAndCachePopularProducts()
 
         // THEN
         assertThat(result.isFailure).isTrue()
@@ -158,7 +158,7 @@ class WooPosPopularProductsProviderTest {
             val sut = createSut()
 
             // WHEN
-            sut.fetchPopularProducts()
+            sut.fetchAndCachePopularProducts()
 
             // THEN
             verify(productsCache).addAll(any())
@@ -184,7 +184,7 @@ class WooPosPopularProductsProviderTest {
             val sut = createSut()
 
             // WHEN
-            sut.fetchPopularProducts()
+            sut.fetchAndCachePopularProducts()
             val popularProducts = sut.getPopularProducts()
 
             // THEN

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/home/items/WooPosProductsDataSourceTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/home/items/WooPosProductsDataSourceTest.kt
@@ -103,7 +103,13 @@ class WooPosProductsDataSourceTest {
                 includeTypes = eq(productsTypesFilterConfig.includeTypes),
             )
         ).thenReturn(WooResult(listOf<WCProductModel>()))
-        val sut = WooPosProductsDataSource(productStore, selectedSite, productsCache, productsIndex, productsTypesFilterConfig)
+        val sut = WooPosProductsDataSource(
+            productStore,
+            selectedSite,
+            productsCache,
+            productsIndex,
+            productsTypesFilterConfig
+        )
 
         // WHEN
         sut.loadProducts(forceRefreshProducts = true).first()
@@ -128,7 +134,13 @@ class WooPosProductsDataSourceTest {
             )
         ).thenReturn(WooResult(listOf<WCProductModel>()))
         whenever(productsIndex.getProductList()).thenReturn(sampleProducts)
-        val sut = WooPosProductsDataSource(productStore, selectedSite, productsCache, productsIndex, productsTypesFilterConfig)
+        val sut = WooPosProductsDataSource(
+            productStore,
+            selectedSite,
+            productsCache,
+            productsIndex,
+            productsTypesFilterConfig
+        )
 
         // WHEN
         val result = sut.loadProducts(forceRefreshProducts = false).first()
@@ -153,7 +165,13 @@ class WooPosProductsDataSourceTest {
             )
         ).thenReturn(WooResult(listOf<WCProductModel>()))
         whenever(productsIndex.getProductList()).thenReturn(emptyList())
-        val sut = WooPosProductsDataSource(productStore, selectedSite, productsCache, productsIndex, productsTypesFilterConfig)
+        val sut = WooPosProductsDataSource(
+            productStore,
+            selectedSite,
+            productsCache,
+            productsIndex,
+            productsTypesFilterConfig
+        )
 
         // WHEN
         val result = sut.loadProducts(forceRefreshProducts = false).first()
@@ -200,7 +218,13 @@ class WooPosProductsDataSourceTest {
                     )
                 )
             )
-            val sut = WooPosProductsDataSource(productStore, selectedSite, productsCache, productsIndex, productsTypesFilterConfig)
+            val sut = WooPosProductsDataSource(
+                productStore,
+                selectedSite,
+                productsCache,
+                productsIndex,
+                productsTypesFilterConfig
+            )
 
             // WHEN
             val flow = sut.loadProducts(forceRefreshProducts = false).toList()
@@ -237,7 +261,13 @@ class WooPosProductsDataSourceTest {
             ).thenReturn(WooResult(wooError))
             whenever(productsCache.getAll()).thenReturn(sampleProducts)
 
-            val sut = WooPosProductsDataSource(productStore, selectedSite, productsCache, productsIndex, productsTypesFilterConfig)
+            val sut = WooPosProductsDataSource(
+                productStore,
+                selectedSite,
+                productsCache,
+                productsIndex,
+                productsTypesFilterConfig
+            )
 
             // WHEN
             val flow = sut.loadProducts(forceRefreshProducts = false).toList()
@@ -274,7 +304,13 @@ class WooPosProductsDataSourceTest {
                 )
             )
             whenever(productsIndex.getProductList()).thenReturn(sampleProducts + additionalProducts)
-            val sut = WooPosProductsDataSource(productStore, selectedSite, productsCache, productsIndex, productsTypesFilterConfig)
+            val sut = WooPosProductsDataSource(
+                productStore,
+                selectedSite,
+                productsCache,
+                productsIndex,
+                productsTypesFilterConfig
+            )
             sut.loadProducts(forceRefreshProducts = true).first()
 
             // WHEN
@@ -326,7 +362,13 @@ class WooPosProductsDataSourceTest {
                 WooResult(wooError)
             )
 
-            val sut = WooPosProductsDataSource(productStore, selectedSite, productsCache, productsIndex, productsTypesFilterConfig)
+            val sut = WooPosProductsDataSource(
+                productStore,
+                selectedSite,
+                productsCache,
+                productsIndex,
+                productsTypesFilterConfig
+            )
             sut.loadProducts(forceRefreshProducts = true).first()
 
             // WHEN
@@ -360,7 +402,13 @@ class WooPosProductsDataSourceTest {
                 )
             )
 
-            val sut = WooPosProductsDataSource(productStore, selectedSite, productsCache, productsIndex, productsTypesFilterConfig)
+            val sut = WooPosProductsDataSource(
+                productStore,
+                selectedSite,
+                productsCache,
+                productsIndex,
+                productsTypesFilterConfig
+            )
 
             // WHEN
             val flow = sut.loadProducts(forceRefreshProducts = false).toList()
@@ -388,7 +436,13 @@ class WooPosProductsDataSourceTest {
                     includeTypes = any(),
                 )
             ).thenReturn(WooResult(emptyList()))
-            val sut = WooPosProductsDataSource(productStore, selectedSite, productsCache, productsIndex, productsTypesFilterConfig)
+            val sut = WooPosProductsDataSource(
+                productStore,
+                selectedSite,
+                productsCache,
+                productsIndex,
+                productsTypesFilterConfig
+            )
 
             // WHEN
             val flow = sut.loadProducts(forceRefreshProducts = false).toList()
@@ -434,7 +488,13 @@ class WooPosProductsDataSourceTest {
             )
         ).thenReturn(WooResult(listOf<WCProductModel>()))
 
-        val sut = WooPosProductsDataSource(productStore, selectedSite, productsCache, productsIndex, productsTypesFilterConfig)
+        val sut = WooPosProductsDataSource(
+            productStore,
+            selectedSite,
+            productsCache,
+            productsIndex,
+            productsTypesFilterConfig
+        )
 
         // WHEN
         val result = sut.loadProducts(forceRefreshProducts = false).first()
@@ -449,6 +509,7 @@ class WooPosProductsDataSourceTest {
     }
 
     @Test
+    @Suppress("LongMethod")
     fun `when loading more products, they should be sorted by name in ascending order`() = runTest {
         // GIVEN
         val mockProductD = mock<Product>()
@@ -500,7 +561,13 @@ class WooPosProductsDataSourceTest {
             )
         )
 
-        val sut = WooPosProductsDataSource(productStore, selectedSite, productsCache, productsIndex, productsTypesFilterConfig)
+        val sut = WooPosProductsDataSource(
+            productStore,
+            selectedSite,
+            productsCache,
+            productsIndex,
+            productsTypesFilterConfig
+        )
         sut.loadProducts(forceRefreshProducts = true).first()
 
         // WHEN
@@ -531,7 +598,13 @@ class WooPosProductsDataSourceTest {
                     includeTypes = any()
                 )
             ).thenReturn(WooResult(emptyList()))
-            val sut = WooPosProductsDataSource(productStore, selectedSite, productsCache, productsIndex, productsTypesFilterConfig)
+            val sut = WooPosProductsDataSource(
+                productStore,
+                selectedSite,
+                productsCache,
+                productsIndex,
+                productsTypesFilterConfig
+            )
 
             // WHEN
             val result = sut.prepopulateProductsCache()
@@ -579,7 +652,13 @@ class WooPosProductsDataSourceTest {
                 )
             ).thenReturn(WooResult(secondPageWcProducts))
 
-            val sut = WooPosProductsDataSource(productStore, selectedSite, productsCache, productsIndex, productsTypesFilterConfig)
+            val sut = WooPosProductsDataSource(
+                productStore,
+                selectedSite,
+                productsCache,
+                productsIndex,
+                productsTypesFilterConfig
+            )
 
             // WHEN
             val result = sut.prepopulateProductsCache()
@@ -617,7 +696,13 @@ class WooPosProductsDataSourceTest {
                 )
             ).thenReturn(WooResult(wooError))
 
-            val sut = WooPosProductsDataSource(productStore, selectedSite, productsCache, productsIndex, productsTypesFilterConfig)
+            val sut = WooPosProductsDataSource(
+                productStore,
+                selectedSite,
+                productsCache,
+                productsIndex,
+                productsTypesFilterConfig
+            )
 
             // WHEN
             val result = sut.prepopulateProductsCache()
@@ -661,7 +746,13 @@ class WooPosProductsDataSourceTest {
                 )
             ).thenReturn(WooResult(emptySecondPage))
 
-            val sut = WooPosProductsDataSource(productStore, selectedSite, productsCache, productsIndex, productsTypesFilterConfig)
+            val sut = WooPosProductsDataSource(
+                productStore,
+                selectedSite,
+                productsCache,
+                productsIndex,
+                productsTypesFilterConfig
+            )
 
             // WHEN
             val result = sut.prepopulateProductsCache()
@@ -700,7 +791,13 @@ class WooPosProductsDataSourceTest {
                 )
             ).thenReturn(WooResult(pageProducts))
 
-            val sut = WooPosProductsDataSource(productStore, selectedSite, productsCache, productsIndex, productsTypesFilterConfig)
+            val sut = WooPosProductsDataSource(
+                productStore,
+                selectedSite,
+                productsCache,
+                productsIndex,
+                productsTypesFilterConfig
+            )
 
             // WHEN
             val result = sut.prepopulateProductsCache()

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/home/items/WooPosProductsDataSourceTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/home/items/WooPosProductsDataSourceTest.kt
@@ -5,6 +5,7 @@ import com.woocommerce.android.model.Product
 import com.woocommerce.android.tools.SelectedSite
 import com.woocommerce.android.ui.products.ProductTestUtils
 import com.woocommerce.android.ui.woopos.common.data.WooPosProductsCache
+import com.woocommerce.android.ui.woopos.common.data.WooPosProductsTypesFilterConfig
 import com.woocommerce.android.ui.woopos.home.items.products.WooPosProductsDataSource
 import com.woocommerce.android.ui.woopos.home.items.products.WooPosProductsIndex
 import com.woocommerce.android.ui.woopos.util.WooPosCoroutineTestRule
@@ -86,7 +87,7 @@ class WooPosProductsDataSourceTest {
         onBlocking { getAll() }.thenReturn(sampleProducts)
     }
     private val productsIndex: WooPosProductsIndex = mock()
-    private val includeTypes = listOf(WCProductStore.IncludeType.Simple, WCProductStore.IncludeType.Variable)
+    private val productsTypesFilterConfig = WooPosProductsTypesFilterConfig()
 
     @Test
     fun `given force refresh, when loadProducts called, then should clear cache`() = runTest {
@@ -99,10 +100,10 @@ class WooPosProductsDataSourceTest {
                 offset = any<Int>(),
                 pageSize = any<Int>(),
                 filterOptions = any<Map<WCProductStore.ProductFilterOption, String>>(),
-                includeTypes = eq(includeTypes),
+                includeTypes = eq(productsTypesFilterConfig.includeTypes),
             )
         ).thenReturn(WooResult(listOf<WCProductModel>()))
-        val sut = WooPosProductsDataSource(productStore, selectedSite, productsCache, productsIndex)
+        val sut = WooPosProductsDataSource(productStore, selectedSite, productsCache, productsIndex, productsTypesFilterConfig)
 
         // WHEN
         sut.loadProducts(forceRefreshProducts = true).first()
@@ -127,7 +128,7 @@ class WooPosProductsDataSourceTest {
             )
         ).thenReturn(WooResult(listOf<WCProductModel>()))
         whenever(productsIndex.getProductList()).thenReturn(sampleProducts)
-        val sut = WooPosProductsDataSource(productStore, selectedSite, productsCache, productsIndex)
+        val sut = WooPosProductsDataSource(productStore, selectedSite, productsCache, productsIndex, productsTypesFilterConfig)
 
         // WHEN
         val result = sut.loadProducts(forceRefreshProducts = false).first()
@@ -152,7 +153,7 @@ class WooPosProductsDataSourceTest {
             )
         ).thenReturn(WooResult(listOf<WCProductModel>()))
         whenever(productsIndex.getProductList()).thenReturn(emptyList())
-        val sut = WooPosProductsDataSource(productStore, selectedSite, productsCache, productsIndex)
+        val sut = WooPosProductsDataSource(productStore, selectedSite, productsCache, productsIndex, productsTypesFilterConfig)
 
         // WHEN
         val result = sut.loadProducts(forceRefreshProducts = false).first()
@@ -199,7 +200,7 @@ class WooPosProductsDataSourceTest {
                     )
                 )
             )
-            val sut = WooPosProductsDataSource(productStore, selectedSite, productsCache, productsIndex)
+            val sut = WooPosProductsDataSource(productStore, selectedSite, productsCache, productsIndex, productsTypesFilterConfig)
 
             // WHEN
             val flow = sut.loadProducts(forceRefreshProducts = false).toList()
@@ -231,12 +232,12 @@ class WooPosProductsDataSourceTest {
                     offset = any<Int>(),
                     pageSize = any<Int>(),
                     filterOptions = any<Map<WCProductStore.ProductFilterOption, String>>(),
-                    includeTypes = eq(includeTypes),
+                    includeTypes = eq(productsTypesFilterConfig.includeTypes),
                 )
             ).thenReturn(WooResult(wooError))
             whenever(productsCache.getAll()).thenReturn(sampleProducts)
 
-            val sut = WooPosProductsDataSource(productStore, selectedSite, productsCache, productsIndex)
+            val sut = WooPosProductsDataSource(productStore, selectedSite, productsCache, productsIndex, productsTypesFilterConfig)
 
             // WHEN
             val flow = sut.loadProducts(forceRefreshProducts = false).toList()
@@ -273,7 +274,7 @@ class WooPosProductsDataSourceTest {
                 )
             )
             whenever(productsIndex.getProductList()).thenReturn(sampleProducts + additionalProducts)
-            val sut = WooPosProductsDataSource(productStore, selectedSite, productsCache, productsIndex)
+            val sut = WooPosProductsDataSource(productStore, selectedSite, productsCache, productsIndex, productsTypesFilterConfig)
             sut.loadProducts(forceRefreshProducts = true).first()
 
             // WHEN
@@ -325,7 +326,7 @@ class WooPosProductsDataSourceTest {
                 WooResult(wooError)
             )
 
-            val sut = WooPosProductsDataSource(productStore, selectedSite, productsCache, productsIndex)
+            val sut = WooPosProductsDataSource(productStore, selectedSite, productsCache, productsIndex, productsTypesFilterConfig)
             sut.loadProducts(forceRefreshProducts = true).first()
 
             // WHEN
@@ -359,7 +360,7 @@ class WooPosProductsDataSourceTest {
                 )
             )
 
-            val sut = WooPosProductsDataSource(productStore, selectedSite, productsCache, productsIndex)
+            val sut = WooPosProductsDataSource(productStore, selectedSite, productsCache, productsIndex, productsTypesFilterConfig)
 
             // WHEN
             val flow = sut.loadProducts(forceRefreshProducts = false).toList()
@@ -387,7 +388,7 @@ class WooPosProductsDataSourceTest {
                     includeTypes = any(),
                 )
             ).thenReturn(WooResult(emptyList()))
-            val sut = WooPosProductsDataSource(productStore, selectedSite, productsCache, productsIndex)
+            val sut = WooPosProductsDataSource(productStore, selectedSite, productsCache, productsIndex, productsTypesFilterConfig)
 
             // WHEN
             val flow = sut.loadProducts(forceRefreshProducts = false).toList()
@@ -433,7 +434,7 @@ class WooPosProductsDataSourceTest {
             )
         ).thenReturn(WooResult(listOf<WCProductModel>()))
 
-        val sut = WooPosProductsDataSource(productStore, selectedSite, productsCache, productsIndex)
+        val sut = WooPosProductsDataSource(productStore, selectedSite, productsCache, productsIndex, productsTypesFilterConfig)
 
         // WHEN
         val result = sut.loadProducts(forceRefreshProducts = false).first()
@@ -499,7 +500,7 @@ class WooPosProductsDataSourceTest {
             )
         )
 
-        val sut = WooPosProductsDataSource(productStore, selectedSite, productsCache, productsIndex)
+        val sut = WooPosProductsDataSource(productStore, selectedSite, productsCache, productsIndex, productsTypesFilterConfig)
         sut.loadProducts(forceRefreshProducts = true).first()
 
         // WHEN
@@ -530,7 +531,7 @@ class WooPosProductsDataSourceTest {
                     includeTypes = any()
                 )
             ).thenReturn(WooResult(emptyList()))
-            val sut = WooPosProductsDataSource(productStore, selectedSite, productsCache, productsIndex)
+            val sut = WooPosProductsDataSource(productStore, selectedSite, productsCache, productsIndex, productsTypesFilterConfig)
 
             // WHEN
             val result = sut.prepopulateProductsCache()
@@ -578,7 +579,7 @@ class WooPosProductsDataSourceTest {
                 )
             ).thenReturn(WooResult(secondPageWcProducts))
 
-            val sut = WooPosProductsDataSource(productStore, selectedSite, productsCache, productsIndex)
+            val sut = WooPosProductsDataSource(productStore, selectedSite, productsCache, productsIndex, productsTypesFilterConfig)
 
             // WHEN
             val result = sut.prepopulateProductsCache()
@@ -616,7 +617,7 @@ class WooPosProductsDataSourceTest {
                 )
             ).thenReturn(WooResult(wooError))
 
-            val sut = WooPosProductsDataSource(productStore, selectedSite, productsCache, productsIndex)
+            val sut = WooPosProductsDataSource(productStore, selectedSite, productsCache, productsIndex, productsTypesFilterConfig)
 
             // WHEN
             val result = sut.prepopulateProductsCache()
@@ -660,7 +661,7 @@ class WooPosProductsDataSourceTest {
                 )
             ).thenReturn(WooResult(emptySecondPage))
 
-            val sut = WooPosProductsDataSource(productStore, selectedSite, productsCache, productsIndex)
+            val sut = WooPosProductsDataSource(productStore, selectedSite, productsCache, productsIndex, productsTypesFilterConfig)
 
             // WHEN
             val result = sut.prepopulateProductsCache()
@@ -699,7 +700,7 @@ class WooPosProductsDataSourceTest {
                 )
             ).thenReturn(WooResult(pageProducts))
 
-            val sut = WooPosProductsDataSource(productStore, selectedSite, productsCache, productsIndex)
+            val sut = WooPosProductsDataSource(productStore, selectedSite, productsCache, productsIndex, productsTypesFilterConfig)
 
             // WHEN
             val result = sut.prepopulateProductsCache()

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/home/items/WooPosProductsDataSourceTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/home/items/WooPosProductsDataSourceTest.kt
@@ -29,6 +29,7 @@ import org.wordpress.android.fluxc.network.rest.wpcom.wc.WooError
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.WooErrorType
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.WooResult
 import org.wordpress.android.fluxc.store.WCProductStore
+import org.wordpress.android.fluxc.store.WCProductStore.ProductSorting
 import kotlin.test.Test
 
 @ExperimentalCoroutinesApi
@@ -99,6 +100,7 @@ class WooPosProductsDataSourceTest {
                 site = eq(siteModel),
                 offset = any<Int>(),
                 pageSize = any<Int>(),
+                sortType = any(),
                 filterOptions = any<Map<WCProductStore.ProductFilterOption, String>>(),
                 includeTypes = eq(productsTypesFilterConfig.includeTypes),
             )
@@ -129,6 +131,7 @@ class WooPosProductsDataSourceTest {
                 site = eq(siteModel),
                 offset = any(),
                 pageSize = any(),
+                sortType = any(),
                 filterOptions = any(),
                 includeTypes = any()
             )
@@ -160,6 +163,7 @@ class WooPosProductsDataSourceTest {
                 site = eq(siteModel),
                 offset = any(),
                 pageSize = any(),
+                sortType = any(),
                 filterOptions = any(),
                 includeTypes = any()
             )
@@ -194,6 +198,7 @@ class WooPosProductsDataSourceTest {
                     site = eq(siteModel),
                     offset = any(),
                     pageSize = any(),
+                    sortType = any(),
                     filterOptions = any(),
                     includeTypes = any()
                 )
@@ -255,6 +260,7 @@ class WooPosProductsDataSourceTest {
                     site = eq(siteModel),
                     offset = any<Int>(),
                     pageSize = any<Int>(),
+                    sortType = any(),
                     filterOptions = any<Map<WCProductStore.ProductFilterOption, String>>(),
                     includeTypes = eq(productsTypesFilterConfig.includeTypes),
                 )
@@ -289,6 +295,7 @@ class WooPosProductsDataSourceTest {
                     site = eq(siteModel),
                     offset = any(),
                     pageSize = any(),
+                    sortType = any(),
                     filterOptions = any(),
                     includeTypes = any()
                 )
@@ -346,6 +353,7 @@ class WooPosProductsDataSourceTest {
                     site = eq(siteModel),
                     offset = any(),
                     pageSize = any(),
+                    sortType = any(),
                     filterOptions = any(),
                     includeTypes = any()
                 )
@@ -390,6 +398,7 @@ class WooPosProductsDataSourceTest {
                     site = eq(siteModel),
                     offset = any(),
                     pageSize = any(),
+                    sortType = any(),
                     filterOptions = any(),
                     includeTypes = any()
                 )
@@ -432,6 +441,7 @@ class WooPosProductsDataSourceTest {
                     site = eq(siteModel),
                     offset = any(),
                     pageSize = any(),
+                    sortType = any(),
                     filterOptions = any(),
                     includeTypes = any(),
                 )
@@ -483,6 +493,7 @@ class WooPosProductsDataSourceTest {
                 site = eq(siteModel),
                 offset = any(),
                 pageSize = any(),
+                sortType = any(),
                 filterOptions = any(),
                 includeTypes = any()
             )
@@ -536,6 +547,7 @@ class WooPosProductsDataSourceTest {
                 site = eq(siteModel),
                 offset = any(),
                 pageSize = any(),
+                sortType = any(),
                 filterOptions = any(),
                 includeTypes = any()
             )
@@ -546,6 +558,7 @@ class WooPosProductsDataSourceTest {
                 site = eq(siteModel),
                 offset = any(),
                 pageSize = any(),
+                sortType = any(),
                 filterOptions = any(),
                 includeTypes = any()
             )
@@ -594,6 +607,7 @@ class WooPosProductsDataSourceTest {
                     site = eq(siteModel),
                     offset = eq(0),
                     pageSize = eq(100),
+                    sortType = eq(ProductSorting.TITLE_ASC),
                     filterOptions = any(),
                     includeTypes = any()
                 )
@@ -637,6 +651,7 @@ class WooPosProductsDataSourceTest {
                     site = eq(siteModel),
                     offset = eq(0),
                     pageSize = eq(100),
+                    sortType = eq(ProductSorting.TITLE_ASC),
                     filterOptions = any(),
                     includeTypes = any()
                 )
@@ -647,6 +662,7 @@ class WooPosProductsDataSourceTest {
                     site = eq(siteModel),
                     offset = eq(100),
                     pageSize = eq(100),
+                    sortType = eq(ProductSorting.TITLE_ASC),
                     filterOptions = any(),
                     includeTypes = any()
                 )
@@ -671,6 +687,7 @@ class WooPosProductsDataSourceTest {
                 site = any(),
                 offset = any(),
                 pageSize = any(),
+                sortType = any(),
                 filterOptions = any(),
                 includeTypes = any()
             )
@@ -691,6 +708,7 @@ class WooPosProductsDataSourceTest {
                     site = eq(siteModel),
                     offset = any(),
                     pageSize = any(),
+                    sortType = eq(ProductSorting.TITLE_ASC),
                     filterOptions = any(),
                     includeTypes = any()
                 )
@@ -731,6 +749,7 @@ class WooPosProductsDataSourceTest {
                     site = eq(siteModel),
                     offset = eq(0),
                     pageSize = eq(100),
+                    sortType = eq(ProductSorting.TITLE_ASC),
                     filterOptions = any(),
                     includeTypes = any()
                 )
@@ -741,6 +760,7 @@ class WooPosProductsDataSourceTest {
                     site = eq(siteModel),
                     offset = eq(100),
                     pageSize = eq(100),
+                    sortType = eq(ProductSorting.TITLE_ASC),
                     filterOptions = any(),
                     includeTypes = any()
                 )
@@ -765,6 +785,7 @@ class WooPosProductsDataSourceTest {
                 site = any(),
                 offset = any(),
                 pageSize = any(),
+                sortType = any(),
                 filterOptions = any(),
                 includeTypes = any()
             )
@@ -786,6 +807,7 @@ class WooPosProductsDataSourceTest {
                     site = eq(siteModel),
                     offset = any(),
                     pageSize = eq(100),
+                    sortType = eq(ProductSorting.TITLE_ASC),
                     filterOptions = any(),
                     includeTypes = any()
                 )
@@ -810,6 +832,7 @@ class WooPosProductsDataSourceTest {
                 site = any(),
                 offset = any(),
                 pageSize = any(),
+                sortType = any(),
                 filterOptions = any(),
                 includeTypes = any()
             )

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/splash/WooPosSplashViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/splash/WooPosSplashViewModelTest.kt
@@ -1,5 +1,6 @@
 package com.woocommerce.android.ui.woopos.splash
 
+import com.woocommerce.android.ui.woopos.common.data.WooPosPopularProductsProvider
 import com.woocommerce.android.ui.woopos.home.items.products.WooPosProductsDataSource
 import com.woocommerce.android.ui.woopos.util.WooPosCoroutineTestRule
 import com.woocommerce.android.ui.woopos.util.analytics.WooPosAnalyticsTracker
@@ -14,12 +15,14 @@ import org.junit.Rule
 import org.mockito.kotlin.any
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
 import kotlin.test.Test
 
 @ExperimentalCoroutinesApi
 class WooPosSplashViewModelTest {
     private val productsDataSource: WooPosProductsDataSource = mock()
     private val analyticsTracker: WooPosAnalyticsTracker = mock()
+    private val popularProductsProvider: WooPosPopularProductsProvider = mock()
 
     @Rule
     @JvmField
@@ -65,5 +68,47 @@ class WooPosSplashViewModelTest {
         verify(analyticsTracker).track(any())
     }
 
-    private fun createSut() = WooPosSplashViewModel(productsDataSource, analyticsTracker)
+    @Test
+    fun `when products are prepopulated, should call both product sources`() = runTest {
+        // WHEN
+        createSut()
+
+        // THEN
+        verify(productsDataSource).prepopulateProductsCache()
+        verify(popularProductsProvider).fetchPopularProducts()
+    }
+
+    @Test
+    fun `given product population fails, should still update state to Loaded`() = runTest {
+        // GIVEN
+        whenever(productsDataSource.prepopulateProductsCache()).thenReturn(
+            Result.failure<Unit>(
+                Exception("Test exception")
+            )
+        )
+
+        // WHEN
+        val sut = createSut()
+
+        // THEN
+        assertThat(sut.state.value).isEqualTo(WooPosSplashState.Loaded)
+    }
+
+    @Test
+    fun `given popular products fetch fails, should still update state to Loaded`() = runTest {
+        // GIVEN
+        whenever(popularProductsProvider.fetchPopularProducts()).thenReturn(
+            Result.failure<Unit>(
+                Exception("Test exception")
+            )
+        )
+
+        // WHEN
+        val sut = createSut()
+
+        // THEN
+        assertThat(sut.state.value).isEqualTo(WooPosSplashState.Loaded)
+    }
+
+    private fun createSut() = WooPosSplashViewModel(productsDataSource, popularProductsProvider, analyticsTracker)
 }

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/splash/WooPosSplashViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/splash/WooPosSplashViewModelTest.kt
@@ -75,7 +75,7 @@ class WooPosSplashViewModelTest {
 
         // THEN
         verify(productsDataSource).prepopulateProductsCache()
-        verify(popularProductsProvider).fetchPopularProducts()
+        verify(popularProductsProvider).fetchAndCachePopularProducts()
     }
 
     @Test
@@ -97,7 +97,7 @@ class WooPosSplashViewModelTest {
     @Test
     fun `given popular products fetch fails, should still update state to Loaded`() = runTest {
         // GIVEN
-        whenever(popularProductsProvider.fetchPopularProducts()).thenReturn(
+        whenever(popularProductsProvider.fetchAndCachePopularProducts()).thenReturn(
             Result.failure<Unit>(
                 Exception("Test exception")
             )

--- a/libs/fluxc-plugin/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/product/ProductRestClient.kt
+++ b/libs/fluxc-plugin/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/product/ProductRestClient.kt
@@ -56,6 +56,8 @@ import org.wordpress.android.fluxc.store.WCProductStore.ProductFilterOption
 import org.wordpress.android.fluxc.store.WCProductStore.ProductSorting
 import org.wordpress.android.fluxc.store.WCProductStore.ProductSorting.DATE_ASC
 import org.wordpress.android.fluxc.store.WCProductStore.ProductSorting.DATE_DESC
+import org.wordpress.android.fluxc.store.WCProductStore.ProductSorting.POPULARITY_ASC
+import org.wordpress.android.fluxc.store.WCProductStore.ProductSorting.POPULARITY_DESC
 import org.wordpress.android.fluxc.store.WCProductStore.ProductSorting.TITLE_ASC
 import org.wordpress.android.fluxc.store.WCProductStore.ProductSorting.TITLE_DESC
 import org.wordpress.android.fluxc.store.WCProductStore.RemoteAddProductPayload
@@ -614,7 +616,7 @@ class ProductRestClient @Inject constructor(
 
         return response.toWooPayload { it.toList() }
     }
-    
+
     private fun buildProductParametersMap(
         pageSize: Int,
         sortType: ProductSorting,
@@ -689,11 +691,13 @@ class ProductRestClient @Inject constructor(
     private fun ProductSorting.asOrderByParameter(): String = when (this) {
         TITLE_ASC, TITLE_DESC -> "title"
         DATE_ASC, DATE_DESC -> "date"
+        POPULARITY_ASC, POPULARITY_DESC -> "popularity"
     }
 
     private fun ProductSorting.asSortOrderParameter(): String = when (this) {
-        TITLE_ASC, DATE_ASC -> "asc"
+        TITLE_ASC, DATE_ASC, POPULARITY_ASC -> "asc"
         TITLE_DESC, DATE_DESC -> "desc"
+        POPULARITY_DESC -> "desc"
     }
 
 

--- a/libs/fluxc-plugin/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/product/ProductRestClient.kt
+++ b/libs/fluxc-plugin/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/product/ProductRestClient.kt
@@ -696,8 +696,7 @@ class ProductRestClient @Inject constructor(
 
     private fun ProductSorting.asSortOrderParameter(): String = when (this) {
         TITLE_ASC, DATE_ASC, POPULARITY_ASC -> "asc"
-        TITLE_DESC, DATE_DESC -> "desc"
-        POPULARITY_DESC -> "desc"
+        POPULARITY_DESC, TITLE_DESC, DATE_DESC -> "desc"
     }
 
 

--- a/libs/fluxc-plugin/src/main/kotlin/org/wordpress/android/fluxc/persistence/ProductSqlUtils.kt
+++ b/libs/fluxc-plugin/src/main/kotlin/org/wordpress/android/fluxc/persistence/ProductSqlUtils.kt
@@ -40,6 +40,8 @@ import org.wordpress.android.fluxc.store.WCProductStore.ProductFilterOption
 import org.wordpress.android.fluxc.store.WCProductStore.ProductSorting
 import org.wordpress.android.fluxc.store.WCProductStore.ProductSorting.DATE_ASC
 import org.wordpress.android.fluxc.store.WCProductStore.ProductSorting.DATE_DESC
+import org.wordpress.android.fluxc.store.WCProductStore.ProductSorting.POPULARITY_ASC
+import org.wordpress.android.fluxc.store.WCProductStore.ProductSorting.POPULARITY_DESC
 import org.wordpress.android.fluxc.store.WCProductStore.ProductSorting.TITLE_ASC
 import org.wordpress.android.fluxc.store.WCProductStore.ProductSorting.TITLE_DESC
 import org.wordpress.android.fluxc.store.WCProductStore.SkuSearchOptions
@@ -382,12 +384,13 @@ object ProductSqlUtils {
         when (sortType) {
             TITLE_ASC, TITLE_DESC -> WCProductModelTable.NAME
             DATE_ASC, DATE_DESC -> WCProductModelTable.DATE_CREATED
+            POPULARITY_ASC, POPULARITY_DESC -> WCProductModelTable.TOTAL_SALES
         }
 
     private fun getSortOrder(sortType: ProductSorting) =
         when (sortType) {
-            TITLE_ASC, DATE_ASC -> SelectQuery.ORDER_ASCENDING
-            TITLE_DESC, DATE_DESC -> SelectQuery.ORDER_DESCENDING
+            TITLE_ASC, DATE_ASC, POPULARITY_ASC -> SelectQuery.ORDER_ASCENDING
+            TITLE_DESC, DATE_DESC, POPULARITY_DESC -> SelectQuery.ORDER_DESCENDING
         }
 
     fun deleteProductsForSite(site: SiteModel): Int {

--- a/libs/fluxc-plugin/src/main/kotlin/org/wordpress/android/fluxc/store/WCProductStore.kt
+++ b/libs/fluxc-plugin/src/main/kotlin/org/wordpress/android/fluxc/store/WCProductStore.kt
@@ -385,7 +385,9 @@ class WCProductStore @Inject constructor(
         TITLE_ASC,
         TITLE_DESC,
         DATE_ASC,
-        DATE_DESC
+        DATE_DESC,
+        POPULARITY_ASC,
+        POPULARITY_DESC
     }
 
     enum class ProductCategorySorting {
@@ -1691,6 +1693,7 @@ class WCProductStore @Inject constructor(
         site: SiteModel,
         offset: Int = 0,
         pageSize: Int = DEFAULT_PRODUCT_PAGE_SIZE,
+        sortType: ProductSorting = DEFAULT_PRODUCT_SORTING,
         filterOptions: Map<ProductFilterOption, String> = emptyMap(),
         includeTypes: List<IncludeType> = emptyList(),
     ): WooResult<List<WCProductModel>> {
@@ -1700,7 +1703,8 @@ class WCProductStore @Inject constructor(
                 offset = offset,
                 pageSize = pageSize,
                 filterOptions = filterOptions,
-                includeTypes = includeTypes
+                includeTypes = includeTypes,
+                sortType = sortType,
             )
 
             when {


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: WOOMOB-317
<!-- Id number of the GitHub issue this PR addresses. -->

<!-- 
━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
🛠 Need an AI review?  
Add a comment: `@coderabbitai review`
━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
-->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
The PR adds fetching of the three most popular products on the splash screen, so we can show them on empty search query state on the search

### Steps to reproduce
<!-- Step-by-step testing instructions. For new user flows, consider instead stating the goal of the workflow and see if your PR reviewer can accomplish the workflow without specific steps! -->
* Open the POS
* Click on Search
* Notice 3 most popular (most sold) products displayed

Those model types were used in the view layer for Product list sorting:
* Validate that there is no regresion in Products -> Sort products by

### Testing information
<!-- This is your opportunity to break out individual scenarios that need testing (when necessary) and/or include a checklist for the reviewer to go through. Consider documenting the following from your own completed testing: devices used, alternate workflows, edge cases, affected areas, critical flows, areas not tested, and any remaining unknowns. Provide feedback on this new section of the PR template through Sept 30, 2024 to Apps Quality; additional context here: p91TBi-b8z-p2#comment-12036 -->
* Simulate fetching error
* Think of other edge cases

### The tests that have been performed
<!-- To give the reviewer an idea of what could be missed in terms of testing -->
Above

### Images/gif
<!-- Include before and after images or gifs when appropriate. -->

https://github.com/user-attachments/assets/9198ebbb-f24e-4a63-98d8-bfab50d32ebf


- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.

## Reviewer (or Author, in the case of optional code reviews):

Please make sure these conditions are met before approving the PR, or request changes if the PR needs improvement:

- [x] The PR is small and has a clear, single focus, or a valid explanation is provided in the description. If needed, please request to split it into smaller PRs.
- [x] Ensure Adequate Unit Test Coverage: The changes are reasonably covered by unit tests or an explanation is provided in the PR description.
- [x] Manual Testing: The author listed all the tests they ran, including smoke tests when needed (e.g., for refactorings). The reviewer confirmed that the PR works as expected on big (tablet) and small (phone) in case of UI changes, and no regressions are added.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->