### PR TITLE
POC - Reusing ItemsVM for both products and coupons

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/di/WooPosModule.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/di/WooPosModule.kt
@@ -2,10 +2,18 @@ package com.woocommerce.android.di
 
 import com.woocommerce.android.ui.woopos.common.data.WooPosProductsCache
 import com.woocommerce.android.ui.woopos.common.data.WooPosProductsInMemoryCache
+import com.woocommerce.android.ui.woopos.home.items.coupons.WooPosCouponsDataSource
+import com.woocommerce.android.ui.woopos.home.items.products.WooPosProductsDataSource
+import com.woocommerce.android.ui.woopos.home.items.providers.CouponItemsProvider
+import com.woocommerce.android.ui.woopos.home.items.providers.ProductItemsProvider
+import com.woocommerce.android.ui.woopos.home.items.providers.WooPosItemDataProvider
+import com.woocommerce.android.ui.woopos.util.format.WooPosFormatPrice
 import dagger.Binds
 import dagger.Module
+import dagger.Provides
 import dagger.hilt.InstallIn
 import dagger.hilt.components.SingletonComponent
+import javax.inject.Named
 import javax.inject.Singleton
 
 @Module
@@ -14,4 +22,23 @@ abstract class WooPosModule {
     @Binds
     @Singleton
     abstract fun provideWooPosProductsCache(implementation: WooPosProductsInMemoryCache): WooPosProductsCache
+
+    companion object {
+        @Provides
+        @Named("ProductProvider")
+        fun provideFirstDataProvider(
+            productsDataSource: WooPosProductsDataSource,
+            priceFormat: WooPosFormatPrice
+        ): WooPosItemDataProvider {
+            return ProductItemsProvider(productsDataSource, priceFormat)
+        }
+
+        @Provides
+        @Named("CouponsProvider")
+        fun provideSecondDataProvider(
+            couponsDataSource: WooPosCouponsDataSource,
+        ): WooPosItemDataProvider {
+            return CouponItemsProvider(couponsDataSource)
+        }
+    }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/items/WooPosItemSelectionViewState.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/items/WooPosItemSelectionViewState.kt
@@ -33,4 +33,9 @@ sealed class WooPosItemSelectionViewState(
         val price: String,
         val imageUrl: String?,
     ) : WooPosItemSelectionViewState(id, name)
+
+    data class Coupon(
+        override val id: Long,
+        override val name: String,
+    ) : WooPosItemSelectionViewState(id, name)
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/items/WooPosItemsList.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/items/WooPosItemsList.kt
@@ -59,7 +59,10 @@ import com.woocommerce.android.ui.woopos.common.composeui.designsystem.WooPosSpa
 import com.woocommerce.android.ui.woopos.common.composeui.designsystem.WooPosTheme
 import com.woocommerce.android.ui.woopos.common.composeui.designsystem.WooPosTypography
 import com.woocommerce.android.ui.woopos.common.composeui.designsystem.toAdaptivePadding
+import com.woocommerce.android.ui.woopos.home.items.WooPosItemSelectionViewState.Coupon
 import com.woocommerce.android.ui.woopos.home.items.WooPosItemSelectionViewState.Product
+import com.woocommerce.android.ui.woopos.home.items.WooPosItemSelectionViewState.Product.Simple
+import com.woocommerce.android.ui.woopos.home.items.WooPosItemSelectionViewState.Product.Variable
 import com.woocommerce.android.ui.woopos.home.items.WooPosItemSelectionViewState.Variation
 import com.woocommerce.android.ui.woopos.home.items.WooPosItemsViewState.Content.BannerState
 import kotlinx.coroutines.flow.distinctUntilChanged
@@ -82,20 +85,20 @@ fun WooPosItemList(
         items(
             state.items,
             key = { product -> product.id }
-        ) { product ->
-            when (product) {
-                is Product.Simple -> {
+        ) { posItem ->
+            when (posItem) {
+                is Simple -> {
                     ProductItem(
                         modifier = Modifier.animateItem(),
-                        item = product,
+                        item = posItem,
                         onItemClicked = onItemClicked
                     )
                 }
 
-                is Product.Variable -> {
+                is Variable -> {
                     VariableProductItem(
                         modifier = Modifier.animateItem(),
-                        item = product,
+                        item = posItem,
                         onItemClicked = onItemClicked
                     )
                 }
@@ -103,10 +106,16 @@ fun WooPosItemList(
                 is Variation -> {
                     VariationItem(
                         modifier = Modifier.animateItem(),
-                        item = product,
+                        item = posItem,
                         onItemClicked = onItemClicked
                     )
                 }
+
+                is Coupon -> CouponItem(
+                    modifier = Modifier.animateItem(),
+                    item = posItem,
+                    onItemClicked = onItemClicked
+                )
             }
         }
 
@@ -180,6 +189,19 @@ private fun VariationItem(
 }
 
 @Composable
+private fun CouponItem(
+    modifier: Modifier = Modifier,
+    item: Coupon,
+    onItemClicked: (item: WooPosItemSelectionViewState) -> Unit
+) {
+    val itemContentDescription = stringResource(
+        id = R.string.woopos_coupon_item_content_description,
+        item.name,
+    )
+    WooPosItemCard(modifier, itemContentDescription, onItemClicked, item)
+}
+
+@Composable
 fun WooPosItemCard(
     modifier: Modifier,
     itemContentDescription: String,
@@ -234,6 +256,7 @@ private fun ProductInfo(item: WooPosItemSelectionViewState) {
             is Product.Simple -> SimpleProductDetails(item = item)
             is Product.Variable -> VariableProductDetails()
             is Variation -> VariationProductDetails(item = item)
+            is Coupon -> CouponDetails(item = item)
         }
     }
 }
@@ -244,6 +267,7 @@ private fun ProductImage(item: WooPosItemSelectionViewState) {
         is Product.Simple -> item.imageUrl
         is Product.Variable -> item.imageUrl
         is Variation -> item.imageUrl
+        is Coupon -> R.drawable.ic_coupon_percentage
     }
     Box(
         modifier = Modifier
@@ -291,6 +315,15 @@ private fun VariableProductDetails() {
 fun VariationProductDetails(item: Variation) {
     WooPosText(
         text = item.price,
+        style = WooPosTypography.BodyLarge,
+        color = WooPosTheme.colors.onSurfaceVariantHighest,
+    )
+}
+
+@Composable
+fun CouponDetails(item: Coupon) {
+    WooPosText(
+        text = item.name,
         style = WooPosTypography.BodyLarge,
         color = WooPosTheme.colors.onSurfaceVariantHighest,
     )

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/items/WooPosItemsViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/items/WooPosItemsViewModel.kt
@@ -4,6 +4,7 @@ import android.os.Parcelable
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.woocommerce.android.R
+import com.woocommerce.android.model.Coupon
 import com.woocommerce.android.model.Product
 import com.woocommerce.android.ui.products.ProductType
 import com.woocommerce.android.ui.woopos.featureflags.WooPosIsCouponsEnabled
@@ -11,6 +12,8 @@ import com.woocommerce.android.ui.woopos.featureflags.WooPosIsProductsSearchEnab
 import com.woocommerce.android.ui.woopos.home.ChildToParentEvent
 import com.woocommerce.android.ui.woopos.home.WooPosChildrenToParentEventSender
 import com.woocommerce.android.ui.woopos.home.items.WooPosItemNavigationData.VariableProductData
+import com.woocommerce.android.ui.woopos.home.items.WooPosItemsViewState.Content
+import com.woocommerce.android.ui.woopos.home.items.coupons.WooPosCouponsDataSource
 import com.woocommerce.android.ui.woopos.home.items.navigation.WooPosItemsNavigator
 import com.woocommerce.android.ui.woopos.home.items.navigation.WooPosItemsNavigator.WooPosItemsScreenNavigationEvent
 import com.woocommerce.android.ui.woopos.home.items.navigation.WooPosItemsNavigator.WooPosItemsScreenNavigationEvent.NavigateToVariationsScreen
@@ -25,6 +28,7 @@ import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.launch
@@ -42,6 +46,7 @@ class WooPosItemsViewModel @Inject constructor(
     private val searchHelper: WooPosItemsSearchHelper,
     private val isProductsSearchEnabled: WooPosIsProductsSearchEnabled,
     private val isCouponsEnabled: WooPosIsCouponsEnabled,
+    private val couponsDataSource: WooPosCouponsDataSource,
 ) : ViewModel() {
     private var loadMoreProductsJob: Job? = null
 
@@ -55,17 +60,49 @@ class WooPosItemsViewModel @Inject constructor(
             initialValue = _viewState.value,
         )
 
+    private val couponsList = couponsDataSource.couponsFlow
+
     init {
+        viewModelScope.launch {
+            couponsList
+                .map { coupons ->
+                    if (coupons.isNullOrEmpty()) {
+                        WooPosItemsViewState.Empty()
+                    } else {
+                        WooPosItemsViewState.Content(
+                            items = coupons.map { it.toItemSelectionViewState() },
+                            paginationState = WooPosPaginationState.None,
+                            pullToRefreshState = WooPosPullToRefreshState.Enabled,
+                            couponsEnabled = isCouponsEnabled.invoke(),
+                            bannerState = WooPosItemsViewState.Content.BannerState(
+                                isBannerHiddenByUser = isBannerHiddenByUser(),
+                                title = R.string.woopos_banner_simple_products_only_title,
+                                message = R.string.woopos_banner_simple_products_only_message,
+                                icon = R.drawable.info,
+                            ),
+                            search = searchHelper.getInitialSearchState(isProductsSearchEnabled())
+                        )
+                    }
+                }
+                // Collect each new view state emitted from the flow.
+                .collect { newState ->
+                    // Update your internal view state.
+                    _viewState.value = newState
+                }
+        }
+
         searchHelper.initialize(
             coroutineScope = viewModelScope,
             viewStateFlow = _viewState
         )
 
-        loadProducts(
-            forceRefreshProducts = false,
-            withPullToRefresh = false,
-            withCart = true,
-        )
+        // TODO: If Coupons load coupons otherwise load products
+//        loadProducts(
+//            forceRefreshProducts = false,
+//            withPullToRefresh = false,
+//            withCart = true,
+//        )
+        fetchCoupons(withPullToRefresh = false, withCart = true)
     }
 
     fun onUIEvent(event: WooPosItemsUIEvent) {
@@ -79,8 +116,13 @@ class WooPosItemsViewModel @Inject constructor(
             }
 
             WooPosItemsUIEvent.PullToRefreshTriggered -> {
+                // TODO: If Coupons load coupons otherwise load products
                 loadProducts(
                     forceRefreshProducts = true,
+                    withPullToRefresh = true,
+                    withCart = true,
+                )
+                fetchCoupons(
                     withPullToRefresh = true,
                     withCart = true,
                 )
@@ -88,8 +130,13 @@ class WooPosItemsViewModel @Inject constructor(
             }
 
             WooPosItemsUIEvent.ProductsLoadingErrorRetryButtonClicked -> {
+                // TODO: If Coupons load coupons otherwise load products
                 loadProducts(
                     forceRefreshProducts = false,
+                    withPullToRefresh = false,
+                    withCart = false,
+                )
+                fetchCoupons(
                     withPullToRefresh = false,
                     withCart = false,
                 )
@@ -160,6 +207,14 @@ class WooPosItemsViewModel @Inject constructor(
                         )
                     )
                 }
+            }
+
+            is WooPosItemSelectionViewState.Coupon -> {
+                sendEventToParent(
+                    ChildToParentEvent.ItemClickedInProductSelector(
+                        ItemClickedData.Coupon(id = event.item.id, couponCode = event.item.name)
+                    )
+                )
             }
 
             is WooPosItemSelectionViewState.Variation -> {
@@ -247,6 +302,24 @@ class WooPosItemsViewModel @Inject constructor(
         }
     }
 
+    private fun fetchCoupons(
+        withPullToRefresh: Boolean,
+        withCart: Boolean
+    ) {
+        viewModelScope.launch {
+            _viewState.value = if (withPullToRefresh) {
+                buildProductsReloadingState()
+            } else {
+                WooPosItemsViewState.Loading(withCart = withCart)
+            }
+            val result = couponsDataSource.clearCacheAndFetchFirstPage()
+
+            if (!result.isSuccess) {
+                _viewState.value = WooPosItemsViewState.Error()
+            }
+        }
+    }
+
     private fun buildProductsReloadingState() =
         when (val state = viewState.value) {
             is WooPosItemsViewState.Content -> state.copy(pullToRefreshState = WooPosPullToRefreshState.Refreshing)
@@ -291,27 +364,44 @@ class WooPosItemsViewModel @Inject constructor(
         }
     }
 
+    private fun Coupon.toItemSelectionViewState(): WooPosItemSelectionViewState {
+        return WooPosItemSelectionViewState.Coupon(
+                id = this.id,
+                name = this.code ?: "", // TODO handle null case properly
+            )
+    }
+
     private fun onEndOfProductsListReached() {
         val currentState = _viewState.value
-        if (currentState !is WooPosItemsViewState.Content) {
+        if (currentState !is Content) {
             return
         }
-
-        if (!productsDataSource.hasMorePages) {
-            return
-        }
-
-        _viewState.value = currentState.copy(paginationState = WooPosPaginationState.Loading)
-
-        loadMoreProductsJob?.cancel()
-        loadMoreProductsJob = viewModelScope.launch {
-            val result = productsDataSource.loadMore()
-            _viewState.value = if (result.isSuccess) {
-                result.getOrThrow().toContentState()
-            } else {
-                currentState.copy(paginationState = WooPosPaginationState.Error)
+        viewModelScope.launch {
+            val result = couponsDataSource.loadMore()
+            if (!result.isSuccess) {
+                _viewState.value = currentState.copy(paginationState = WooPosPaginationState.Error)
             }
         }
+//        val currentState = _viewState.value
+//        if (currentState !is WooPosItemsViewState.Content) {
+//            return
+//        }
+//
+//        if (!productsDataSource.hasMorePages) {
+//            return
+//        }
+//
+//        _viewState.value = currentState.copy(paginationState = WooPosPaginationState.Loading)
+//
+//        loadMoreProductsJob?.cancel()
+//        loadMoreProductsJob = viewModelScope.launch {
+//            val result = productsDataSource.loadMore()
+//            _viewState.value = if (result.isSuccess) {
+//                result.getOrThrow().toContentState()
+//            } else {
+//                currentState.copy(paginationState = WooPosPaginationState.Error)
+//            }
+//        }
     }
 
     private fun notifyParentAboutStatusChange(newState: WooPosItemsViewState) {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/items/WooPosItemsViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/items/WooPosItemsViewModel.kt
@@ -4,54 +4,50 @@ import android.os.Parcelable
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.woocommerce.android.R
-import com.woocommerce.android.model.Coupon
-import com.woocommerce.android.model.Product
-import com.woocommerce.android.ui.products.ProductType
 import com.woocommerce.android.ui.woopos.featureflags.WooPosIsCouponsEnabled
 import com.woocommerce.android.ui.woopos.featureflags.WooPosIsProductsSearchEnabled
 import com.woocommerce.android.ui.woopos.home.ChildToParentEvent
 import com.woocommerce.android.ui.woopos.home.WooPosChildrenToParentEventSender
 import com.woocommerce.android.ui.woopos.home.items.WooPosItemNavigationData.VariableProductData
-import com.woocommerce.android.ui.woopos.home.items.WooPosItemsViewState.Content
-import com.woocommerce.android.ui.woopos.home.items.coupons.WooPosCouponsDataSource
 import com.woocommerce.android.ui.woopos.home.items.navigation.WooPosItemsNavigator
 import com.woocommerce.android.ui.woopos.home.items.navigation.WooPosItemsNavigator.WooPosItemsScreenNavigationEvent
 import com.woocommerce.android.ui.woopos.home.items.navigation.WooPosItemsNavigator.WooPosItemsScreenNavigationEvent.NavigateToVariationsScreen
-import com.woocommerce.android.ui.woopos.home.items.products.WooPosProductsDataSource
+import com.woocommerce.android.ui.woopos.home.items.providers.WooPosItemDataProvider
 import com.woocommerce.android.ui.woopos.util.analytics.WooPosAnalyticsEvent.Event.ProductsPullToRefreshTriggered
 import com.woocommerce.android.ui.woopos.util.analytics.WooPosAnalyticsTracker
 import com.woocommerce.android.ui.woopos.util.datastore.WooPosPreferencesRepository
-import com.woocommerce.android.ui.woopos.util.format.WooPosFormatPrice
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.first
-import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.launch
 import kotlinx.parcelize.Parcelize
 import javax.inject.Inject
+import javax.inject.Named
 
 @HiltViewModel
 class WooPosItemsViewModel @Inject constructor(
-    private val productsDataSource: WooPosProductsDataSource,
+    @Named("ProductProvider") private val productDataProvider: WooPosItemDataProvider,
+    @Named("CouponsProvider") private val couponDataProvider: WooPosItemDataProvider,
     private val fromChildToParentEventSender: WooPosChildrenToParentEventSender,
-    private val priceFormat: WooPosFormatPrice,
     private val preferencesRepository: WooPosPreferencesRepository,
     private val navigator: WooPosItemsNavigator,
     private val analyticsTracker: WooPosAnalyticsTracker,
     private val searchHelper: WooPosItemsSearchHelper,
     private val isProductsSearchEnabled: WooPosIsProductsSearchEnabled,
     private val isCouponsEnabled: WooPosIsCouponsEnabled,
-    private val couponsDataSource: WooPosCouponsDataSource,
 ) : ViewModel() {
-    private var loadMoreProductsJob: Job? = null
-
     private val _viewState =
         MutableStateFlow<WooPosItemsViewState>(WooPosItemsViewState.Loading(withCart = true))
+
+    var currentDataProvider = productDataProvider
+
+    private var collectDataJob: Job? = null
+
     val viewState: StateFlow<WooPosItemsViewState> = _viewState
         .onEach { notifyParentAboutStatusChange(it) }
         .stateIn(
@@ -60,49 +56,66 @@ class WooPosItemsViewModel @Inject constructor(
             initialValue = _viewState.value,
         )
 
-    private val couponsList = couponsDataSource.couponsFlow
-
     init {
-        viewModelScope.launch {
-            couponsList
-                .map { coupons ->
-                    if (coupons.isNullOrEmpty()) {
-                        WooPosItemsViewState.Empty()
-                    } else {
-                        WooPosItemsViewState.Content(
-                            items = coupons.map { it.toItemSelectionViewState() },
-                            paginationState = WooPosPaginationState.None,
-                            pullToRefreshState = WooPosPullToRefreshState.Enabled,
-                            couponsEnabled = isCouponsEnabled.invoke(),
-                            bannerState = WooPosItemsViewState.Content.BannerState(
-                                isBannerHiddenByUser = isBannerHiddenByUser(),
-                                title = R.string.woopos_banner_simple_products_only_title,
-                                message = R.string.woopos_banner_simple_products_only_message,
-                                icon = R.drawable.info,
-                            ),
-                            search = searchHelper.getInitialSearchState(isProductsSearchEnabled())
-                        )
-                    }
-                }
-                // Collect each new view state emitted from the flow.
-                .collect { newState ->
-                    // Update your internal view state.
-                    _viewState.value = newState
-                }
-        }
 
         searchHelper.initialize(
             coroutineScope = viewModelScope,
             viewStateFlow = _viewState
         )
+        viewModelScope.launch {
+            productDataProvider.init()
+        }
+        viewModelScope.launch {
+            couponDataProvider.init()
+        }
 
-        // TODO: If Coupons load coupons otherwise load products
-//        loadProducts(
-//            forceRefreshProducts = false,
-//            withPullToRefresh = false,
-//            withCart = true,
-//        )
-        fetchCoupons(withPullToRefresh = false, withCart = true)
+        updateDataProvider(productDataProvider)
+
+    }
+
+    private fun updateDataProvider(dataProvider: WooPosItemDataProvider) {
+        currentDataProvider = dataProvider
+
+        collectDataJob?.cancel()
+        collectDataJob = viewModelScope.launch {
+            currentDataProvider.data.collect { data ->
+                _viewState.value =
+                    when {
+                        data.error != null && data.paginationState != WooPosPaginationState.Error -> {
+                            WooPosItemsViewState.Error(
+                                pullToRefreshState = data.pullToRefreshState,
+                            )
+                        }
+
+                        data.items.isEmpty() && data.pullToRefreshState == WooPosPullToRefreshState.Disabled && data.paginationState == WooPosPaginationState.None -> {
+                            WooPosItemsViewState.Loading(
+                                pullToRefreshState = data.pullToRefreshState,
+                                withCart = true
+                            )
+                        }
+
+                        data.items.isEmpty() && data.pullToRefreshState != WooPosPullToRefreshState.Refreshing && data.paginationState != WooPosPaginationState.Loading -> {
+                            WooPosItemsViewState.Empty(pullToRefreshState = data.pullToRefreshState)
+                        }
+
+                        else -> {
+                            WooPosItemsViewState.Content(
+                                items = data.items,
+                                paginationState = data.paginationState,
+                                pullToRefreshState = data.pullToRefreshState,
+                                couponsEnabled = isCouponsEnabled.invoke(),
+                                bannerState = WooPosItemsViewState.Content.BannerState(
+                                    isBannerHiddenByUser = isBannerHiddenByUser(),
+                                    title = R.string.woopos_banner_simple_products_only_title,
+                                    message = R.string.woopos_banner_simple_products_only_message,
+                                    icon = R.drawable.info,
+                                ),
+                                search = searchHelper.getInitialSearchState(isProductsSearchEnabled())
+                            )
+                        }
+                    }
+            }
+        }
     }
 
     fun onUIEvent(event: WooPosItemsUIEvent) {
@@ -116,30 +129,16 @@ class WooPosItemsViewModel @Inject constructor(
             }
 
             WooPosItemsUIEvent.PullToRefreshTriggered -> {
-                // TODO: If Coupons load coupons otherwise load products
-                loadProducts(
-                    forceRefreshProducts = true,
-                    withPullToRefresh = true,
-                    withCart = true,
-                )
-                fetchCoupons(
-                    withPullToRefresh = true,
-                    withCart = true,
-                )
-                viewModelScope.launch { analyticsTracker.track(ProductsPullToRefreshTriggered) }
+                viewModelScope.launch {
+                    currentDataProvider.fetchItems(forceRefresh = true)
+                    analyticsTracker.track(ProductsPullToRefreshTriggered)
+                }
             }
 
             WooPosItemsUIEvent.ProductsLoadingErrorRetryButtonClicked -> {
-                // TODO: If Coupons load coupons otherwise load products
-                loadProducts(
-                    forceRefreshProducts = false,
-                    withPullToRefresh = false,
-                    withCart = false,
-                )
-                fetchCoupons(
-                    withPullToRefresh = false,
-                    withCart = false,
-                )
+                viewModelScope.launch {
+                    currentDataProvider.fetchItems(forceRefresh = false)
+                }
             }
 
             WooPosItemsUIEvent.SimpleProductsBannerClosed -> {
@@ -164,15 +163,14 @@ class WooPosItemsViewModel @Inject constructor(
                 event.query,
                 event.cursorPosition
             )
+
             WooPosItemsUIEvent.SearchAnimationComplete -> searchHelper.onAnimationComplete()
 
             WooPosItemsUIEvent.CouponsButtonClicked -> {
-                sendEventToParent(
-                    ChildToParentEvent.ItemClickedInProductSelector(
-                        // CouponsProject: Show available coupons instead
-                        ItemClickedData.Coupon(id = 0, couponCode = "DummyCoupon")
-                    )
-                )
+                if (currentDataProvider == productDataProvider)
+                    updateDataProvider(couponDataProvider)
+                else
+                    updateDataProvider(productDataProvider)
             }
         }
     }
@@ -244,164 +242,9 @@ class WooPosItemsViewModel @Inject constructor(
         }
     }
 
-    private fun loadProducts(
-        forceRefreshProducts: Boolean,
-        withPullToRefresh: Boolean,
-        withCart: Boolean
-    ) {
-        viewModelScope.launch {
-            _viewState.value = if (withPullToRefresh) {
-                buildProductsReloadingState()
-            } else {
-                WooPosItemsViewState.Loading(withCart = withCart)
-            }
-
-            productsDataSource.loadSimpleProducts(forceRefreshProducts = forceRefreshProducts).collect { result ->
-                when (result) {
-                    is WooPosProductsDataSource.ProductsResult.Cached -> {
-                        if (result.products.isNotEmpty()) {
-                            _viewState.value = result.products.toContentState()
-                        }
-                    }
-
-                    is WooPosProductsDataSource.ProductsResult.Remote -> {
-                        _viewState.value = when {
-                            result.productsResult.isSuccess -> {
-                                val products = result.productsResult.getOrThrow()
-                                if (products.isNotEmpty()) {
-                                    val currentState = _viewState.value
-                                    var paginationState = if (loadMoreProductsJob?.isActive == true) {
-                                        WooPosPaginationState.Loading
-                                    } else {
-                                        WooPosPaginationState.None
-                                    }
-                                    if (currentState is WooPosItemsViewState.Content) {
-                                        currentState.copy(
-                                            items = products.map { it.toItemSelectionViewState() },
-                                            paginationState = paginationState,
-                                            pullToRefreshState = if (searchHelper.isSearchOpen()) {
-                                                WooPosPullToRefreshState.Disabled
-                                            } else {
-                                                WooPosPullToRefreshState.Enabled
-                                            },
-                                        )
-                                    } else {
-                                        products.toContentState(
-                                            paginationState = paginationState
-                                        )
-                                    }
-                                } else {
-                                    WooPosItemsViewState.Empty()
-                                }
-                            }
-                            else -> WooPosItemsViewState.Error()
-                        }
-                    }
-                }
-            }
-        }
-    }
-
-    private fun fetchCoupons(
-        withPullToRefresh: Boolean,
-        withCart: Boolean
-    ) {
-        viewModelScope.launch {
-            _viewState.value = if (withPullToRefresh) {
-                buildProductsReloadingState()
-            } else {
-                WooPosItemsViewState.Loading(withCart = withCart)
-            }
-            val result = couponsDataSource.clearCacheAndFetchFirstPage()
-
-            if (!result.isSuccess) {
-                _viewState.value = WooPosItemsViewState.Error()
-            }
-        }
-    }
-
-    private fun buildProductsReloadingState() =
-        when (val state = viewState.value) {
-            is WooPosItemsViewState.Content -> state.copy(pullToRefreshState = WooPosPullToRefreshState.Refreshing)
-            is WooPosItemsViewState.Loading -> state.copy(pullToRefreshState = WooPosPullToRefreshState.Refreshing)
-            is WooPosItemsViewState.Error -> state.copy(pullToRefreshState = WooPosPullToRefreshState.Refreshing)
-            is WooPosItemsViewState.Empty -> state.copy(pullToRefreshState = WooPosPullToRefreshState.Refreshing)
-        }
-
-    private suspend fun List<Product>.toContentState(
-        paginationState: WooPosPaginationState = WooPosPaginationState.None
-    ) = WooPosItemsViewState.Content(
-        items = map { it.toItemSelectionViewState() },
-        paginationState = paginationState,
-        pullToRefreshState = WooPosPullToRefreshState.Enabled,
-        couponsEnabled = isCouponsEnabled.invoke(),
-        bannerState = WooPosItemsViewState.Content.BannerState(
-            isBannerHiddenByUser = isBannerHiddenByUser(),
-            title = R.string.woopos_banner_simple_products_only_title,
-            message = R.string.woopos_banner_simple_products_only_message,
-            icon = R.drawable.info,
-        ),
-        search = searchHelper.getInitialSearchState(isProductsSearchEnabled())
-    )
-
-    private suspend fun Product.toItemSelectionViewState(): WooPosItemSelectionViewState {
-        return if (this.isVariable()) {
-            WooPosItemSelectionViewState.Product.Variable(
-                id = this.remoteId,
-                name = this.name,
-                price = priceFormat(this.price),
-                imageUrl = this.firstImageUrl,
-                numOfVariations = this.numVariations,
-                variationIds = this.variationIds
-            )
-        } else {
-            WooPosItemSelectionViewState.Product.Simple(
-                id = this.remoteId,
-                name = this.name,
-                price = priceFormat(this.price),
-                imageUrl = this.firstImageUrl,
-            )
-        }
-    }
-
-    private fun Coupon.toItemSelectionViewState(): WooPosItemSelectionViewState {
-        return WooPosItemSelectionViewState.Coupon(
-                id = this.id,
-                name = this.code ?: "", // TODO handle null case properly
-            )
-    }
-
     private fun onEndOfProductsListReached() {
-        val currentState = _viewState.value
-        if (currentState !is Content) {
-            return
-        }
-        viewModelScope.launch {
-            val result = couponsDataSource.loadMore()
-            if (!result.isSuccess) {
-                _viewState.value = currentState.copy(paginationState = WooPosPaginationState.Error)
-            }
-        }
-//        val currentState = _viewState.value
-//        if (currentState !is WooPosItemsViewState.Content) {
-//            return
-//        }
-//
-//        if (!productsDataSource.hasMorePages) {
-//            return
-//        }
-//
-//        _viewState.value = currentState.copy(paginationState = WooPosPaginationState.Loading)
-//
-//        loadMoreProductsJob?.cancel()
-//        loadMoreProductsJob = viewModelScope.launch {
-//            val result = productsDataSource.loadMore()
-//            _viewState.value = if (result.isSuccess) {
-//                result.getOrThrow().toContentState()
-//            } else {
-//                currentState.copy(paginationState = WooPosPaginationState.Error)
-//            }
-//        }
+        // todo if no more pages or not content, don't start.
+        viewModelScope.launch { currentDataProvider.loadMore() }
     }
 
     private fun notifyParentAboutStatusChange(newState: WooPosItemsViewState) {
@@ -434,10 +277,6 @@ class WooPosItemsViewModel @Inject constructor(
     private suspend fun isBannerHiddenByUser(): Boolean {
         return preferencesRepository.isSimpleProductsOnlyBannerWasHiddenByUser.first()
     }
-
-    private fun Product.isVariable() =
-        productType == ProductType.VARIABLE ||
-            productType == ProductType.VARIATION
 
     @Parcelize
     sealed class ItemClickedData(open val id: Long) : Parcelable {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/items/coupons/WooPosCouponsDataSource.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/items/coupons/WooPosCouponsDataSource.kt
@@ -1,0 +1,17 @@
+package com.woocommerce.android.ui.woopos.home.items.coupons
+
+import com.woocommerce.android.model.Coupon
+import com.woocommerce.android.ui.coupons.CouponListHandler
+import kotlinx.coroutines.flow.Flow
+import javax.inject.Inject
+import javax.inject.Singleton
+
+@Singleton
+class WooPosCouponsDataSource @Inject constructor(private val handler: CouponListHandler) {
+    val couponsFlow: Flow<List<Coupon>> = handler.couponsFlow
+
+    suspend fun clearCacheAndFetchFirstPage() =
+        handler.fetchCoupons(searchQuery = null, forceRefresh = true)
+
+    suspend fun loadMore() = handler.loadMore()
+}

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/items/providers/CouponItemsProvider.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/items/providers/CouponItemsProvider.kt
@@ -1,0 +1,64 @@
+package com.woocommerce.android.ui.woopos.home.items.providers
+
+import com.woocommerce.android.ui.woopos.home.items.WooPosItemSelectionViewState
+import com.woocommerce.android.ui.woopos.home.items.coupons.WooPosCouponsDataSource
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.map
+import javax.inject.Inject
+
+class CouponItemsProvider @Inject constructor(
+    private val couponsDataSource: WooPosCouponsDataSource,
+) : WooPosItemDataProvider {
+    private val _data = MutableStateFlow(DataProviderState.fetching(emptyList(), isPullToRefresh = false))
+    override val data: Flow<DataProviderState> = _data
+
+    private val couponsList = couponsDataSource.couponsFlow
+
+    override suspend fun init() {
+        fetchItems(
+            forceRefresh = false,
+        )
+
+        couponsList
+            .map { coupons ->
+                coupons.map { coupon ->
+                    WooPosItemSelectionViewState.Coupon(
+                        id = coupon.id,
+                        name = coupon.code ?: "",
+                    )
+                }
+            }
+            // Collect each new view state emitted from the flow.
+            .collect { newState ->
+                // TODO we need to differentiate between cached and remote
+                //  data - essentially whether we should keep showing loading.
+                _data.value = DataProviderState.dataShown(newState)
+            }
+    }
+
+    override suspend fun fetchItems(
+        forceRefresh: Boolean, // todo should this be called pullToRefresh?
+    ) {
+        _data.value = DataProviderState.fetching(_data.value.items, isPullToRefresh = forceRefresh)
+        val result = couponsDataSource.clearCacheAndFetchFirstPage()
+
+        if (!result.isSuccess) {
+            _data.value = DataProviderState.remoteRequestFailed(
+                _data.value.items,
+                result.exceptionOrNull()?.message ?: ""
+            )
+        }
+    }
+
+    override suspend fun loadMore() {
+        _data.value = DataProviderState.loadingMore(_data.value.items)
+        val result = couponsDataSource.loadMore()
+        if (!result.isSuccess) {
+            _data.value = DataProviderState.loadingMoreFailed(
+                _data.value.items,
+                result.exceptionOrNull()?.message ?: ""
+            )
+        }
+    }
+}

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/items/providers/ProductItemsProvider.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/items/providers/ProductItemsProvider.kt
@@ -1,0 +1,87 @@
+package com.woocommerce.android.ui.woopos.home.items.providers
+
+import com.woocommerce.android.model.Product
+import com.woocommerce.android.ui.products.ProductType
+import com.woocommerce.android.ui.woopos.home.items.WooPosItemSelectionViewState
+import com.woocommerce.android.ui.woopos.home.items.products.WooPosProductsDataSource
+import com.woocommerce.android.ui.woopos.util.format.WooPosFormatPrice
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableStateFlow
+import javax.inject.Inject
+
+class ProductItemsProvider @Inject constructor(
+    private val productsDataSource: WooPosProductsDataSource,
+    private val priceFormat: WooPosFormatPrice,
+) : WooPosItemDataProvider {
+    private val _data = MutableStateFlow(DataProviderState.fetching(emptyList(), isPullToRefresh = false))
+    override val data: Flow<DataProviderState> = _data
+
+    override suspend fun init() {
+        fetchItems(
+            forceRefresh = false,
+        )
+    }
+
+    override suspend fun fetchItems(
+        forceRefresh: Boolean,
+    ) {
+        _data.value = DataProviderState.fetching(_data.value.items, isPullToRefresh = forceRefresh)
+
+        productsDataSource.loadSimpleProducts(forceRefreshProducts = forceRefresh).collect { result ->
+            when (result) {
+                is WooPosProductsDataSource.ProductsResult.Cached -> {
+                    _data.value = DataProviderState.fetching(
+                        result.products.map { it.toItemSelectionViewState() },
+                        isPullToRefresh = forceRefresh
+                    )
+                }
+
+                is WooPosProductsDataSource.ProductsResult.Remote -> {
+                    if (result.productsResult.isSuccess) {
+                        val products = result.productsResult.getOrThrow()
+                        _data.value = DataProviderState.dataShown(
+                            products.map { it.toItemSelectionViewState() }
+                        )
+                    } else {
+                        _data.value = DataProviderState.remoteRequestFailed(_data.value.items, "")
+                    }
+                }
+            }
+        }
+    }
+
+    override suspend fun loadMore() {
+        _data.value = DataProviderState.loadingMore(_data.value.items)
+
+        val result = productsDataSource.loadMore()
+        _data.value = if (result.isSuccess) {
+            DataProviderState.dataShown(result.getOrThrow().map { it.toItemSelectionViewState() })
+        } else {
+            DataProviderState.loadingMoreFailed(_data.value.items, "")
+        }
+    }
+
+    private suspend fun Product.toItemSelectionViewState(): WooPosItemSelectionViewState {
+        return if (this.isVariable()) {
+            WooPosItemSelectionViewState.Product.Variable(
+                id = this.remoteId,
+                name = this.name,
+                price = priceFormat(this.price),
+                imageUrl = this.firstImageUrl,
+                numOfVariations = this.numVariations,
+                variationIds = this.variationIds
+            )
+        } else {
+            WooPosItemSelectionViewState.Product.Simple(
+                id = this.remoteId,
+                name = this.name,
+                price = priceFormat(this.price),
+                imageUrl = this.firstImageUrl,
+            )
+        }
+    }
+
+    private fun Product.isVariable() =
+        productType == ProductType.VARIABLE ||
+            productType == ProductType.VARIATION
+}

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/items/providers/WooPosItemDataProvider.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/items/providers/WooPosItemDataProvider.kt
@@ -1,0 +1,68 @@
+package com.woocommerce.android.ui.woopos.home.items.providers
+
+import com.woocommerce.android.ui.woopos.home.items.WooPosItemSelectionViewState
+import com.woocommerce.android.ui.woopos.home.items.WooPosPaginationState
+import com.woocommerce.android.ui.woopos.home.items.WooPosPullToRefreshState
+import kotlinx.coroutines.flow.Flow
+
+interface WooPosItemDataProvider {
+    val data: Flow<DataProviderState>
+    suspend fun init()
+    suspend fun fetchItems(forceRefresh: Boolean)
+    suspend fun loadMore()
+}
+
+data class DataProviderState(
+    val items: List<WooPosItemSelectionViewState>,
+    val error: String?,
+    val pullToRefreshState: WooPosPullToRefreshState,
+    val paginationState: WooPosPaginationState,
+) {
+    companion object {
+        fun fetching(
+            data: List<WooPosItemSelectionViewState> = emptyList(),
+            isPullToRefresh: Boolean
+        ): DataProviderState =
+            DataProviderState(
+                items = data,
+                error = null,
+                pullToRefreshState = if (isPullToRefresh)
+                    WooPosPullToRefreshState.Refreshing
+                else
+                    WooPosPullToRefreshState.Disabled,
+                paginationState = WooPosPaginationState.None
+            )
+
+        fun dataShown(data: List<WooPosItemSelectionViewState>): DataProviderState =
+            DataProviderState(
+                items = data,
+                error = null,
+                pullToRefreshState = WooPosPullToRefreshState.Enabled,
+                paginationState = WooPosPaginationState.None
+            )
+
+        fun remoteRequestFailed(data: List<WooPosItemSelectionViewState>, remoteError: String): DataProviderState =
+            DataProviderState(
+                items = data,
+                error = remoteError,
+                pullToRefreshState = WooPosPullToRefreshState.Enabled,
+                paginationState = WooPosPaginationState.None
+            )
+
+        fun loadingMore(data: List<WooPosItemSelectionViewState>): DataProviderState =
+            DataProviderState(
+                items = data,
+                error = null,
+                pullToRefreshState = WooPosPullToRefreshState.Disabled,
+                paginationState = WooPosPaginationState.Loading
+            )
+
+        fun loadingMoreFailed(data: List<WooPosItemSelectionViewState>, loadMoreError: String): DataProviderState =
+            DataProviderState(
+                items = data,
+                error = loadMoreError,
+                pullToRefreshState = WooPosPullToRefreshState.Enabled,
+                paginationState = WooPosPaginationState.Error
+            )
+    }
+}

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/items/search/WooPosItemsSearchViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/items/search/WooPosItemsSearchViewModel.kt
@@ -5,11 +5,16 @@ import androidx.lifecycle.viewModelScope
 import com.woocommerce.android.model.Product
 import com.woocommerce.android.ui.products.ProductType
 import com.woocommerce.android.ui.woopos.home.ChildToParentEvent
+import com.woocommerce.android.ui.woopos.home.ChildToParentEvent.ItemClickedInProductSelector
 import com.woocommerce.android.ui.woopos.home.ParentToChildrenEvent
 import com.woocommerce.android.ui.woopos.home.WooPosChildrenToParentEventSender
 import com.woocommerce.android.ui.woopos.home.WooPosParentToChildrenEventReceiver
 import com.woocommerce.android.ui.woopos.home.items.WooPosItemNavigationData.VariableProductData
 import com.woocommerce.android.ui.woopos.home.items.WooPosItemSelectionViewState
+import com.woocommerce.android.ui.woopos.home.items.WooPosItemSelectionViewState.Coupon
+import com.woocommerce.android.ui.woopos.home.items.WooPosItemSelectionViewState.Product.Simple
+import com.woocommerce.android.ui.woopos.home.items.WooPosItemSelectionViewState.Product.Variable
+import com.woocommerce.android.ui.woopos.home.items.WooPosItemSelectionViewState.Variation
 import com.woocommerce.android.ui.woopos.home.items.WooPosItemsViewModel.ItemClickedData
 import com.woocommerce.android.ui.woopos.home.items.WooPosPaginationState
 import com.woocommerce.android.ui.woopos.home.items.navigation.WooPosItemsNavigator
@@ -172,10 +177,10 @@ class WooPosItemsSearchViewModel @Inject constructor(
 
     private fun handleItemClicked(item: WooPosItemSelectionViewState) {
         when (item) {
-            is WooPosItemSelectionViewState.Product.Simple -> {
+            is Simple -> {
                 viewModelScope.launch {
                     childToParentEventSender.sendToParent(
-                        ChildToParentEvent.ItemClickedInProductSelector(
+                        ItemClickedInProductSelector(
                             ItemClickedData.Product.Simple(id = item.id)
                         )
                     )
@@ -184,7 +189,7 @@ class WooPosItemsSearchViewModel @Inject constructor(
                 storeRecentSearch()
             }
 
-            is WooPosItemSelectionViewState.Product.Variable -> {
+            is Variable -> {
                 viewModelScope.launch {
                     navigator.sendNavigationEvent(
                         NavigateToVariationsScreen(
@@ -198,7 +203,11 @@ class WooPosItemsSearchViewModel @Inject constructor(
                 }
             }
 
-            is WooPosItemSelectionViewState.Variation -> {
+            is Variation -> {
+                error("Variation item click is not supported")
+            }
+
+            is Coupon -> {
                 error("Variation item click is not supported")
             }
         }

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -4273,6 +4273,7 @@
     <string name="woopos_variable_product_item_content_description">Variable Product %s, Price %s</string>
     <string name="woopos_variation_item_content_description">Variation %s, Price %s</string>
     <string name="woopos_cart_item_product_content_description">Product in cart %s, Price %s</string>
+    <string name="woopos_coupon_item_content_description">Coupon %s</string>
     <string name="woopos_cart_item_coupon_content_description">Coupon in cart %s</string>
     <string name="woopos_cart_title">Cart</string>
     <string name="woopos_clear_cart_button">Clear</string>


### PR DESCRIPTION
**_This is a POC, not a production ready code._**

The goal of this POC is to showcase how we could re-use the WooPosItemsListViewModel for displaying both product list and coupons list. The code is very far from perfect, but hopefully showcases that almost all the code can be re-used between the two.

The benefits I see in this approach:
- We can easily extend the code and add for example support for custom grids just by introducing a new type of DataProvider.
- Components like the heading, search icon, customers icon, ... dont' need to be re-implemented or re-added on each sub-screen and can be defined in a central place.
- If we ever decide to split it, it should by a matter of copy-pasting the VM and using just one provider per VM.

The downsides of this approach
- Makes critical changes to the product list so the risk of introducing bugs definitely isn't low.
- Re-using the same code for multiple purposes could potentially bite us - risk of the shared code growing + risk of being forced to put `if` statements for things that differ between the screens (the question is whether there will be any major differences).

I really wanted to see how this POC would look. I'm not disappointed but also not thrilled - especially the risk of introducing bugs raises a red alert. On the other hand, the more code we write the more difficult will be to create something re-usable/merge multiple VMs. I'm open to both approaches, so let me know what is your preference and I'll go with that.

P.S. This POC introduces some bugs - I wasn't focusing on making sure it works 100%, I focused on making it somewhat work.



https://github.com/user-attachments/assets/3901dc75-3098-41ea-a734-88a63007e1b2



