### PR TITLE
[Shipping labels] Fix split shipment move action for variant products

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/split/WooShippingSplitShipmentScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/split/WooShippingSplitShipmentScreen.kt
@@ -90,7 +90,7 @@ fun WooShippingSplitShipmentScreen(
     viewState: SplitShipmentViewState,
     onBack: () -> Unit,
     onDismissInstructions: () -> Unit,
-    onUpdateSelection: (shipmentKey: Int, index: Int, selectedIndexes: Set<Int>?) -> Unit,
+    onUpdateSelection: (index: Int, selectedIndexes: Set<Int>?) -> Unit,
     onUpdateShipment: (splitMovement: SplitMovement) -> Unit,
     onUpdateSelectedShipment: (shipmentKey: Int) -> Unit,
     onRemoveShipment: (shipmentKey: Int) -> Unit,
@@ -171,7 +171,6 @@ fun WooShippingSplitShipmentScreen(
                     )
                 } else {
                     SelectableProductsSection(
-                        shipmentKey = viewState.selectableItems.keys.first(),
                         shipment = viewState.selectableItems.values.first(),
                         onUpdateSelection = onUpdateSelection,
                         extraBottomPadding = productsExtraPadding,
@@ -220,7 +219,7 @@ private fun MultipleShipments(
     shipments: List<Int>,
     productsExtraPadding: Dp,
     onUpdateSelectedShipment: (shipmentKey: Int) -> Unit,
-    onUpdateSelection: (shipmentKey: Int, index: Int, selectedIndexes: Set<Int>?) -> Unit,
+    onUpdateSelection: (index: Int, selectedIndexes: Set<Int>?) -> Unit,
     onRemoveShipment: (shipmentKey: Int) -> Unit,
     modifier: Modifier
 ) {
@@ -302,7 +301,6 @@ private fun MultipleShipments(
         ) { page ->
             viewState.selectableItems.getValue(shipments[page]).let {
                 SelectableProductsSection(
-                    shipmentKey = shipments[page],
                     shipment = it,
                     onUpdateSelection = onUpdateSelection,
                     modifier = modifier.padding(top = 16.dp, start = 16.dp, end = 16.dp),
@@ -465,9 +463,8 @@ private fun SplitMovements(
 
 @Composable
 fun SelectableProductsSection(
-    shipmentKey: Int,
     shipment: SelectableShippableItemsUI,
-    onUpdateSelection: (shipmentKey: Int, index: Int, selectedIndexes: Set<Int>?) -> Unit,
+    onUpdateSelection: (index: Int, selectedIndexes: Set<Int>?) -> Unit,
     extraBottomPadding: Dp,
     modifier: Modifier = Modifier
 ) {
@@ -493,13 +490,7 @@ fun SelectableProductsSection(
                             quantity = shippableItem.shippableItem.quantity,
                             imageUrl = shippableItem.shippableItem.imageUrl,
                             isSelected = shippableItem.isSelected,
-                            onSelectionChange = {
-                                onUpdateSelection(
-                                    shipmentKey,
-                                    index,
-                                    null
-                                )
-                            },
+                            onSelectionChange = { onUpdateSelection(index, null) },
                             modifier = Modifier.padding(vertical = 8.dp)
                         )
                     }
@@ -514,13 +505,7 @@ fun SelectableProductsSection(
                             quantity = shippableItem.shippableItem.quantity,
                             imageUrl = shippableItem.shippableItem.imageUrl,
                             isSelected = shippableItem.isSelected,
-                            onSelectionChange = {
-                                onUpdateSelection(
-                                    shipmentKey,
-                                    index,
-                                    null
-                                )
-                            },
+                            onSelectionChange = { onUpdateSelection(index, null) },
                             isExpanded = expanded,
                             onExpand = { expanded = !expanded },
                             singleWeight = shippableItem.innerShippableItem.formattedWeight,
@@ -530,11 +515,7 @@ fun SelectableProductsSection(
                                 val indexes = shippableItem.selectedIndexes.toMutableSet()
                                 if (isSelected) indexes.remove(innerIndex) else indexes.add(innerIndex)
 
-                                onUpdateSelection(
-                                    shipmentKey,
-                                    index,
-                                    indexes
-                                )
+                                onUpdateSelection(index, indexes)
                             },
                             modifier = Modifier.padding(vertical = 8.dp)
                         )
@@ -571,7 +552,7 @@ private fun WooShippingSplitShipmentScreenPreview() = WooThemeWithBackground {
         ),
         onBack = {},
         onDismissInstructions = {},
-        onUpdateSelection = { _, _, _ -> },
+        onUpdateSelection = { _, _ -> },
         onUpdateShipment = {},
         onUpdateSelectedShipment = {},
         onRemoveShipment = {}

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/split/WooShippingSplitShipmentViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/split/WooShippingSplitShipmentViewModel.kt
@@ -208,14 +208,11 @@ sealed class SplitShipmentMessage {
 }
 
 fun List<ShippableItemModel>.combine(other: List<ShippableItemModel>): List<ShippableItemModel> {
-    val combinedMap = this.associateBy { it.productId }.toMutableMap()
+    val combinedMap = associateBy { it.itemId }.toMutableMap()
     other.forEach { otherItem ->
-        val existingItem = combinedMap[otherItem.productId]
-        if (existingItem != null) {
-            combinedMap[otherItem.productId] = existingItem.copy(quantity = existingItem.quantity + otherItem.quantity)
-        } else {
-            combinedMap[otherItem.productId] = otherItem
-        }
+        val existingItem = combinedMap[otherItem.itemId]
+        combinedMap[otherItem.itemId] = existingItem?.copy(quantity = existingItem.quantity + otherItem.quantity)
+            ?: otherItem
     }
     return combinedMap.values.toList()
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/split/WooShippingSplitShipmentViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/split/WooShippingSplitShipmentViewModel.kt
@@ -207,12 +207,6 @@ sealed class SplitShipmentMessage {
     data class Success(val snackbarData: ShippingLabelsSnackbarData) : SplitShipmentMessage()
 }
 
-fun List<ShippableItemModel>.combine(other: List<ShippableItemModel>): List<ShippableItemModel> {
-    val combinedMap = associateBy { it.itemId }.toMutableMap()
-    other.forEach { otherItem ->
-        val existingItem = combinedMap[otherItem.itemId]
-        combinedMap[otherItem.itemId] = existingItem?.copy(quantity = existingItem.quantity + otherItem.quantity)
-            ?: otherItem
-    }
-    return combinedMap.values.toList()
-}
+private fun List<ShippableItemModel>.combine(other: List<ShippableItemModel>) = (this + other)
+    .groupBy { it.itemId }
+    .map { (_, itemsWithSameId) -> itemsWithSameId.first().copy(quantity = itemsWithSameId.sumByFloat { it.quantity }) }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/split/WooShippingSplitShipmentViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/split/WooShippingSplitShipmentViewModel.kt
@@ -91,13 +91,9 @@ class WooShippingSplitShipmentViewModel @Inject constructor(
         removeShipmentSheet.value = shipmentKey
     }
 
-    fun onUpdateSelection(
-        shipmentKey: Int,
-        shippableItemIndex: Int,
-        selectedIndexes: Set<Int>? = null
-    ) {
+    fun onUpdateSelection(shippableItemIndex: Int, selectedIndexes: Set<Int>? = null) {
         val shipmentsMap = selectableItems.value?.toMutableMap() ?: return
-        val items = shipmentsMap.getValue(shipmentKey)
+        val items = shipmentsMap.getValue(shipmentSelected.value)
         val item = items.shippableItems[shippableItemIndex]
         val updatedItem = when (item) {
             is SelectableShippableItemUI.SingleSelectableShippableItemUI -> {
@@ -115,7 +111,7 @@ class WooShippingSplitShipmentViewModel @Inject constructor(
         }
         val updatedList = items.shippableItems.toMutableList()
         updatedList[shippableItemIndex] = updatedItem
-        shipmentsMap[shipmentKey] = items.copy(shippableItems = updatedList)
+        shipmentsMap[shipmentSelected.value] = items.copy(shippableItems = updatedList)
         selectableItems.value = shipmentsMap
     }
 

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/split/WooShippingSplitShipmentViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/split/WooShippingSplitShipmentViewModelTest.kt
@@ -17,7 +17,6 @@ import kotlin.test.Test
 
 @OptIn(ExperimentalCoroutinesApi::class)
 class WooShippingSplitShipmentViewModelTest : BaseUnitTest() {
-
     private val currencyFormatter: CurrencyFormatter = org.mockito.kotlin.mock {
         on { formatCurrency(amount = any(), any(), any()) }.doAnswer { it.getArgument<BigDecimal>(0).toString() }
     }
@@ -87,7 +86,7 @@ class WooShippingSplitShipmentViewModelTest : BaseUnitTest() {
 
         createViewModel(shipmentArgs)
 
-        sut.onUpdateSelection(1, shippableItemIndex, List(3) { it }.toSet())
+        sut.onUpdateSelection(shippableItemIndex, List(3) { it }.toSet())
 
         sut.viewState.observeForTesting { }
 
@@ -112,7 +111,7 @@ class WooShippingSplitShipmentViewModelTest : BaseUnitTest() {
 
         createViewModel(shipmentArgs)
 
-        sut.onUpdateSelection(1, shippableItemIndex, null)
+        sut.onUpdateSelection(shippableItemIndex, null)
 
         sut.viewState.observeForTesting { }
 
@@ -137,7 +136,7 @@ class WooShippingSplitShipmentViewModelTest : BaseUnitTest() {
 
         createViewModel(shipmentArgs)
 
-        sut.onUpdateSelection(1, shippableItemIndex, null)
+        sut.onUpdateSelection(shippableItemIndex, null)
 
         sut.viewState.observeForTesting { }
 


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
This PR fixes a bug that occurs when moving a product from an order containing two variations of the same product.

### Steps to reproduce
<!-- Step-by-step testing instructions. For new user flows, consider instead stating the goal of the workflow and see if your PR reviewer can accomplish the workflow without specific steps! -->
Open the orders tab
1. Tap on an order eligible for shipping label creation. Preferably, choose an order with 2 variations of the same product.
2. Tap on Create shipping label
3. Tap on Split shipment
4. Select items and move them.

### The tests that have been performed
<!-- To give the reviewer an idea of what could be missed in terms of testing -->
Steps above

### Images/gif
<!-- Include before and after images or gifs when appropriate. -->
#### Before
|Initial|After moving 1 item to Shipment 1|
|-|-|
|<img src="https://github.com/user-attachments/assets/c0456d87-7be2-4bde-ba5c-90aff18d6034" width=350>|<img src="https://github.com/user-attachments/assets/d3071c2a-bf8f-4beb-b22e-2bd06b2a9db1" width=350>|

#### After
|Initial|After moving 1 item to Shipment 1|
|-|-|
|<img src="https://github.com/user-attachments/assets/9f0efab3-7b14-45a6-ba84-a9281769682a" width=350>|<img src="https://github.com/user-attachments/assets/0e8d003e-8252-489b-861f-f5822f50b266" width=350>|

- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.

## Reviewer (or Author, in the case of optional code reviews):

Please make sure these conditions are met before approving the PR, or request changes if the PR needs improvement:

- [ ] The PR is small and has a clear, single focus, or a valid explanation is provided in the description. If needed, please request to split it into smaller PRs.
- [ ] Ensure Adequate Unit Test Coverage: The changes are reasonably covered by unit tests or an explanation is provided in the PR description.
- [ ] Manual Testing: The author listed all the tests they ran, including smoke tests when needed (e.g., for refactorings). The reviewer confirmed that the PR works as expected on big (tablet) and small (phone) in case of UI changes, and no regressions are added.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->