### PR TITLE
[SDK 35] Fix NPE crash related to ApiFaker

### DIFF
--- a/libs/apifaker/src/main/java/com/woocommerce/android/apifaker/ApiFakerUiHelper.kt
+++ b/libs/apifaker/src/main/java/com/woocommerce/android/apifaker/ApiFakerUiHelper.kt
@@ -76,7 +76,7 @@ class ApiFakerUiHelper @Inject constructor() : ActivityLifecycleCallbacks {
         // This works only for activities that has the content view as a direct child of the FrameLayout, which is true
         // for all AppCompat activities, so it should work for all the cases we need.
         val contentLayout = findViewById<View>(android.R.id.content) as? FrameLayout ?: return
-        val activityLayout = contentLayout.getChildAt(0)
+        val activityLayout = contentLayout.getChildAt(0) ?: return
 
         val apiFakerHint = FrameLayout(context).apply {
             id = apiFakerHintId
@@ -124,7 +124,7 @@ class ApiFakerUiHelper @Inject constructor() : ActivityLifecycleCallbacks {
 
     private fun View.hideApiFakerHint(animate: Boolean) {
         val contentLayout = findViewById<ViewGroup>(android.R.id.content)
-        val activityLayout = contentLayout.getChildAt(0)
+        val activityLayout = contentLayout.getChildAt(0) ?: return
 
         if (animate) {
             TransitionManager.beginDelayedTransition(contentLayout)


### PR DESCRIPTION
### Description
This PR fixes the crash reported here p91TBi-ddc-p2#comment-14191, the cause is that in the `ApiFakerHelperUI` we try to retrieve the activity root layout by getting it from the `android.R.id.content` layout, and we don't check if the layout exists or not. Empty Activities won't have any layout (like the `SignInHubActivity` used in Google sign in), and this leads to the NPE.

For information: this crash doesn't happen currently in `trunk` because the logic that causes the crash was added to support edge-to-edge changes.

### Steps to reproduce
Test Google Sign in.

### Testing information
Confirm the app doesn't crash.

### The tests that have been performed
^

- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.

## Reviewer (or Author, in the case of optional code reviews):

Please make sure these conditions are met before approving the PR, or request changes if the PR needs improvement:

- [x] The PR is small and has a clear, single focus, or a valid explanation is provided in the description. If needed, please request to split it into smaller PRs.
- [x] Ensure Adequate Unit Test Coverage: The changes are reasonably covered by unit tests or an explanation is provided in the PR description.
- [x] Manual Testing: The author listed all the tests they ran, including smoke tests when needed (e.g., for refactorings). The reviewer confirmed that the PR works as expected on big (tablet) and small (phone) in case of UI changes, and no regressions are added.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->