### PR TITLE
[Shipping labels] Removing shipment action

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/split/GetSplitMovements.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/split/GetSplitMovements.kt
@@ -6,54 +6,54 @@ import javax.inject.Inject
 
 class GetSplitMovements @Inject constructor() {
     operator fun invoke(
-        currentShipment: Int,
+        sourceShipmentKey: Int,
         shipments: Map<Int, List<ShippableItemModel>>,
         selection: Map<Int, SelectableShippableItemsUI>
     ): List<SplitMovement> {
-        val currentShipmentItems = mutableListOf<ShippableItemModel>()
+        val sourceShipmentItems = mutableListOf<ShippableItemModel>()
         val nextShipmentItems = mutableListOf<ShippableItemModel>()
 
-        selection[currentShipment]?.shippableItems?.forEachIndexed { index, item ->
+        selection[sourceShipmentKey]?.shippableItems?.forEachIndexed { index, item ->
             when {
                 item is SelectableShippableItemUI.SingleSelectableShippableItemUI && item.isSelected -> {
-                    nextShipmentItems.add(shipments.getValue(currentShipment)[index])
+                    nextShipmentItems.add(shipments.getValue(sourceShipmentKey)[index])
                 }
 
                 item is SelectableShippableItemUI.SingleSelectableShippableItemUI && !item.isSelected -> {
-                    currentShipmentItems.add(shipments.getValue(currentShipment)[index])
+                    sourceShipmentItems.add(shipments.getValue(sourceShipmentKey)[index])
                 }
 
                 item is SelectableShippableItemUI.ExpandableSelectableShippableItemUI && item.isSelected -> {
-                    nextShipmentItems.add(shipments.getValue(currentShipment)[index])
+                    nextShipmentItems.add(shipments.getValue(sourceShipmentKey)[index])
                 }
 
                 item is SelectableShippableItemUI.ExpandableSelectableShippableItemUI &&
                     !item.isSelected &&
                     item.selectedIndexes.isNotEmpty() -> {
                     val selected = item.selectedIndexes.size
-                    val currentItem = shipments.getValue(currentShipment)[index]
+                    val sourceItem = shipments.getValue(sourceShipmentKey)[index]
 
-                    currentShipmentItems.add(currentItem.copy(quantity = currentItem.quantity - selected))
-                    nextShipmentItems.add(currentItem.copy(quantity = selected.toFloat()))
+                    sourceShipmentItems.add(sourceItem.copy(quantity = sourceItem.quantity - selected))
+                    nextShipmentItems.add(sourceItem.copy(quantity = selected.toFloat()))
                 }
 
                 else -> {
-                    currentShipmentItems.add(shipments.getValue(currentShipment)[index])
+                    sourceShipmentItems.add(shipments.getValue(sourceShipmentKey)[index])
                 }
             }
         }
 
         return if (nextShipmentItems.isNotEmpty()) {
             getPossibleKeys(
-                currentShipment = currentShipment,
+                sourceShipmentKey = sourceShipmentKey,
                 items = shipments,
-                isRemoveMovement = currentShipmentItems.isEmpty()
+                isRemoveMovement = sourceShipmentItems.isEmpty()
             ).map { key ->
                 SplitMovement(
-                    currentShipment = currentShipment,
-                    updatedCurrentShipmentItems = currentShipmentItems,
-                    updatedShipment = key,
-                    updatedShipmentItems = nextShipmentItems
+                    sourceShipmentKey = sourceShipmentKey,
+                    updatedSourceShipmentItems = sourceShipmentItems,
+                    destinationShipmentKey = key,
+                    movingShipmentItems = nextShipmentItems
                 )
             }
         } else {
@@ -62,27 +62,27 @@ class GetSplitMovements @Inject constructor() {
     }
 
     private fun getPossibleKeys(
-        currentShipment: Int,
+        sourceShipmentKey: Int,
         items: Map<Int, List<ShippableItemModel>>,
         isRemoveMovement: Boolean
     ): List<Int> {
-        val otherKeys = items.keys.filter { it != currentShipment }
+        val otherKeys = items.keys.filter { it != sourceShipmentKey }
         if (isRemoveMovement) return otherKeys
 
-        var nextKey = (otherKeys.maxOrNull() ?: currentShipment) + 1
-        if (nextKey == currentShipment) nextKey++
+        var nextKey = (otherKeys.maxOrNull() ?: sourceShipmentKey) + 1
+        if (nextKey == sourceShipmentKey) nextKey++
         return otherKeys + nextKey
     }
 }
 
 data class SplitMovement(
-    val currentShipment: Int,
-    val updatedCurrentShipmentItems: List<ShippableItemModel>,
-    val updatedShipment: Int,
-    val updatedShipmentItems: List<ShippableItemModel>
+    val sourceShipmentKey: Int,
+    val updatedSourceShipmentItems: List<ShippableItemModel>,
+    val destinationShipmentKey: Int,
+    val movingShipmentItems: List<ShippableItemModel>
 ) {
     val totalItemsToMove: Int
-        get() = updatedShipmentItems.sumByFloat { it.quantity }.toInt()
+        get() = movingShipmentItems.sumByFloat { it.quantity }.toInt()
     val isRemoveMovement: Boolean
-        get() = updatedCurrentShipmentItems.isEmpty()
+        get() = updatedSourceShipmentItems.isEmpty()
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/split/WooShippingSplitShipmentScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/split/WooShippingSplitShipmentScreen.kt
@@ -153,9 +153,9 @@ fun WooShippingSplitShipmentScreen(
 
                     val onUpdateShipmentAndChangeSelection: (splitMovement: SplitMovement) -> Unit = { splitMovement ->
                         if (splitMovement.isRemoveMovement) {
-                            val nextPage = shipments.indexOfFirst { it == splitMovement.updatedShipment }
+                            val nextPage = shipments.indexOfFirst { it == splitMovement.destinationShipmentKey }
                                 .takeIf { it != -1 && it < shipments.lastIndex }
-                                ?: shipments.first { it != splitMovement.currentShipment }
+                                ?: shipments.first { it != splitMovement.sourceShipmentKey }
                             onUpdateSelectedShipment(shipments[nextPage])
                             onUpdateShipment(splitMovement)
                         } else {
@@ -412,7 +412,8 @@ private fun SplitMovements(
                     modifier = Modifier.weight(1f)
                 )
 
-                val containsOnlyANewKey = movements.size == 1 && (movements.first().updatedShipment in shipments).not()
+                val containsOnlyANewKey = movements.size == 1 &&
+                    (movements.first().destinationShipmentKey in shipments).not()
                 if (containsOnlyANewKey) {
                     Text(
                         text = stringResource(R.string.woo_shipping_split_move_to_new).uppercase(),
@@ -454,7 +455,7 @@ private fun SplitMovements(
                                     expanded = false
                                 }) {
                                     Text(
-                                        text = shipmentIndex[movement.updatedShipment]?.let {
+                                        text = shipmentIndex[movement.destinationShipmentKey]?.let {
                                             stringResource(R.string.woo_shipping_split_shipment_shipment_name, it + 1)
                                         } ?: stringResource(R.string.woo_shipping_split_shipment_shipment_new),
                                         style = MaterialTheme.typography.subtitle1

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/split/WooShippingSplitShipmentViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/split/WooShippingSplitShipmentViewModel.kt
@@ -66,7 +66,7 @@ class WooShippingSplitShipmentViewModel @Inject constructor(
             shipmentSelected = shipmentSelected,
             selectableItems = selectableItems,
             splitMovements = getSplitMovements(
-                currentShipment = shipmentSelected,
+                sourceShipmentKey = shipmentSelected,
                 shipments = currentShipments.value,
                 selection = selectableItems
             ),
@@ -133,15 +133,15 @@ class WooShippingSplitShipmentViewModel @Inject constructor(
         val currentShipmentBackup = currentShipments.value
         currentShipments.update {
             val shipments = it.toMutableMap()
-            if (splitMovement.updatedCurrentShipmentItems.isEmpty()) {
-                shipments.remove(splitMovement.currentShipment)
+            if (splitMovement.updatedSourceShipmentItems.isEmpty()) {
+                shipments.remove(splitMovement.sourceShipmentKey)
             } else {
-                shipments[splitMovement.currentShipment] = splitMovement.updatedCurrentShipmentItems
+                shipments[splitMovement.sourceShipmentKey] = splitMovement.updatedSourceShipmentItems
             }
-            shipments[splitMovement.updatedShipment] = shipments[splitMovement.updatedShipment]
+            shipments[splitMovement.destinationShipmentKey] = shipments[splitMovement.destinationShipmentKey]
                 ?.takeIf { it.isNotEmpty() }
-                ?.combine(splitMovement.updatedShipmentItems)
-                ?: splitMovement.updatedShipmentItems
+                ?.combine(splitMovement.movingShipmentItems)
+                ?: splitMovement.movingShipmentItems
             shipments
         }
 
@@ -167,7 +167,7 @@ class WooShippingSplitShipmentViewModel @Inject constructor(
         splitMessage.value = SplitShipmentMessage.Success(
             ShippingLabelsSnackbarData(
                 message = snackbarMessage,
-                messageParameters = listOf(splitMovement.totalItemsToMove, splitMovement.updatedShipment + 1),
+                messageParameters = listOf(splitMovement.totalItemsToMove, splitMovement.destinationShipmentKey + 1),
                 actionLabel = R.string.undo,
                 dismissAction = { splitMessage.value = null },
                 action = undoAction

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/split/WooShippingSplitShipmentViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/split/WooShippingSplitShipmentViewModel.kt
@@ -96,9 +96,17 @@ class WooShippingSplitShipmentViewModel @Inject constructor(
         )
     }
 
-    @Suppress("UnusedParameter")
-    fun onRemoveShipment(removingShipmentKey: Int, movingToShipmentKey: Int) {
-        // TODO handle removing shipment
+    fun onRemoveShipment(removingShipmentKey: Int, destinationShipmentKey: Int) {
+        val movingShipmentItems = currentShipments.value[removingShipmentKey] ?: return
+        onUpdateShipment(
+            SplitMovement(
+                sourceShipmentKey = removingShipmentKey,
+                updatedSourceShipmentItems = emptyList(),
+                destinationShipmentKey = destinationShipmentKey,
+                movingShipmentItems = movingShipmentItems
+            )
+        )
+        removeShipmentSheet.value = null
     }
 
     fun onDismissRemoveSheet() {
@@ -142,7 +150,13 @@ class WooShippingSplitShipmentViewModel @Inject constructor(
                 ?.takeIf { it.isNotEmpty() }
                 ?.combine(splitMovement.movingShipmentItems)
                 ?: splitMovement.movingShipmentItems
-            shipments
+            reindexShipments(shipments)
+        }
+
+        if (currentShipments.value.size == 1) {
+            // The shipments row was removed. Since the pager can no longer manage the selected shipment, update it
+            // manually.
+            shipmentSelected.update { currentShipments.value.keys.first() }
         }
 
         val undoAction = {
@@ -156,6 +170,15 @@ class WooShippingSplitShipmentViewModel @Inject constructor(
 
         showUndoSnackbar(splitMovement, undoAction)
     }
+
+    /**
+     * Reindexes the keys of the given shipments so that they form a consecutive sequence starting from 0. For example,
+     * if "Shipment 1" was removed from "Shipment 0, Shipment 1, Shipment 2", the remaining shipments will be reindexed
+     * as "Shipment 0, Shipment 1".
+     */
+    private fun reindexShipments(
+        shipments: Map<Int, List<ShippableItemModel>>
+    ) = shipments.values.mapIndexed { index, items -> index to items }.toMap()
 
     private fun showUndoSnackbar(splitMovement: SplitMovement, undoAction: () -> Unit) {
         val snackbarMessage = if (splitMovement.totalItemsToMove > 1) {

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/split/GetSplitMovementsTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/split/GetSplitMovementsTest.kt
@@ -21,7 +21,7 @@ class GetSplitMovementsTest : BaseUnitTest() {
     @Test
     fun `when there is no items selection, then movements is empty`() {
         val result = sut.invoke(
-            currentShipment = defaultShipments.keys.first(),
+            sourceShipmentKey = defaultShipments.keys.first(),
             shipments = defaultShipments,
             selection = defaultSelection
         )
@@ -38,7 +38,7 @@ class GetSplitMovementsTest : BaseUnitTest() {
         selection[key] = defaultSelection.getValue(key).copy(shippableItems = updatedList)
 
         val result = sut.invoke(
-            currentShipment = defaultShipments.keys.first(),
+            sourceShipmentKey = defaultShipments.keys.first(),
             shipments = defaultShipments,
             selection = selection
         )
@@ -56,7 +56,7 @@ class GetSplitMovementsTest : BaseUnitTest() {
         selection[key] = defaultSelection.getValue(key).copy(shippableItems = updatedList)
 
         val result = sut.invoke(
-            currentShipment = defaultShipments.keys.first(),
+            sourceShipmentKey = defaultShipments.keys.first(),
             shipments = defaultShipments,
             selection = selection
         )
@@ -74,7 +74,7 @@ class GetSplitMovementsTest : BaseUnitTest() {
         selection[key] = defaultSelection.getValue(key).copy(shippableItems = updatedList)
 
         val result = sut.invoke(
-            currentShipment = defaultShipments.keys.first(),
+            sourceShipmentKey = defaultShipments.keys.first(),
             shipments = defaultShipments,
             selection = selection
         )
@@ -88,7 +88,7 @@ class GetSplitMovementsTest : BaseUnitTest() {
         val selection = defaultSelection
 
         val result = sut.invoke(
-            currentShipment = keyNotInSelection,
+            sourceShipmentKey = keyNotInSelection,
             shipments = defaultShipments,
             selection = selection
         )
@@ -114,13 +114,13 @@ class GetSplitMovementsTest : BaseUnitTest() {
         selection[0] = defaultSelection.getValue(0).copy(shippableItems = allItemsSelected)
 
         val result = sut.invoke(
-            currentShipment = 0,
+            sourceShipmentKey = 0,
             shipments = twoShipments,
             selection = selection
         )
 
         assertThat(result.size).isEqualTo(1)
-        val isAnExistingKey = result.first().updatedShipment in twoShipments.keys
+        val isAnExistingKey = result.first().destinationShipmentKey in twoShipments.keys
         assertThat(isAnExistingKey).isTrue
     }
 
@@ -140,13 +140,13 @@ class GetSplitMovementsTest : BaseUnitTest() {
         selection[0] = defaultSelection.getValue(0).copy(shippableItems = expandableItemsSelected)
 
         val result = sut.invoke(
-            currentShipment = 0,
+            sourceShipmentKey = 0,
             shipments = twoShipments,
             selection = selection
         )
 
         assertThat(result.size).isEqualTo(2)
-        val hasNewKey = result.any { (it.updatedShipment in twoShipments.keys).not() }
+        val hasNewKey = result.any { (it.destinationShipmentKey in twoShipments.keys).not() }
         assertThat(hasNewKey).isTrue
     }
 

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/split/WooShippingSplitShipmentViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/split/WooShippingSplitShipmentViewModelTest.kt
@@ -161,10 +161,10 @@ class WooShippingSplitShipmentViewModelTest : BaseUnitTest() {
         val updatedShipmentItems = defaultShipment.getValue(1).subList(fromIndex = 0, toIndex = 1)
 
         val movement = SplitMovement(
-            currentShipment = 1,
-            updatedCurrentShipmentItems = updatedCurrentShipmentItems,
-            updatedShipment = 2,
-            updatedShipmentItems = updatedShipmentItems
+            sourceShipmentKey = 1,
+            updatedSourceShipmentItems = updatedCurrentShipmentItems,
+            destinationShipmentKey = 2,
+            movingShipmentItems = updatedShipmentItems
         )
 
         createViewModel(shipmentArgs)
@@ -207,10 +207,10 @@ class WooShippingSplitShipmentViewModelTest : BaseUnitTest() {
             )
 
             val movement = SplitMovement(
-                currentShipment = 1,
-                updatedCurrentShipmentItems = updatedCurrentShipmentItems,
-                updatedShipment = 2,
-                updatedShipmentItems = updatedShipmentItems
+                sourceShipmentKey = 1,
+                updatedSourceShipmentItems = updatedCurrentShipmentItems,
+                destinationShipmentKey = 2,
+                movingShipmentItems = updatedShipmentItems
             )
 
             createViewModel(shipmentArgs)
@@ -243,10 +243,10 @@ class WooShippingSplitShipmentViewModelTest : BaseUnitTest() {
         val updatedShipmentItems = defaultShipment.getValue(1).subList(fromIndex = 0, toIndex = 1)
 
         val movement = SplitMovement(
-            currentShipment = 0,
-            updatedCurrentShipmentItems = updatedCurrentShipmentItems,
-            updatedShipment = 1,
-            updatedShipmentItems = updatedShipmentItems
+            sourceShipmentKey = 0,
+            updatedSourceShipmentItems = updatedCurrentShipmentItems,
+            destinationShipmentKey = 1,
+            movingShipmentItems = updatedShipmentItems
         )
 
         createViewModel(shipmentArgs)
@@ -275,10 +275,10 @@ class WooShippingSplitShipmentViewModelTest : BaseUnitTest() {
         val updatedShipmentItems = defaultShipment.getValue(1).subList(fromIndex = 1, toIndex = 2)
 
         val movement = SplitMovement(
-            currentShipment = 0,
-            updatedCurrentShipmentItems = updatedCurrentShipmentItems,
-            updatedShipment = 1,
-            updatedShipmentItems = updatedShipmentItems
+            sourceShipmentKey = 0,
+            updatedSourceShipmentItems = updatedCurrentShipmentItems,
+            destinationShipmentKey = 1,
+            movingShipmentItems = updatedShipmentItems
         )
 
         createViewModel(shipmentArgs)

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/split/WooShippingSplitShipmentViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/split/WooShippingSplitShipmentViewModelTest.kt
@@ -48,7 +48,7 @@ class WooShippingSplitShipmentViewModelTest : BaseUnitTest() {
 
         val state = sut.viewState.value!!
 
-        val selectableItems = state.selectableItems.getValue(1)
+        val selectableItems = state.selectableItems.getValue(0)
         val expandableProducts = selectableItems.shippableItems
             .filterIsInstance<SelectableShippableItemUI.ExpandableSelectableShippableItemUI>()
         assertThat(expandableProducts.size).isEqualTo(2)
@@ -69,7 +69,7 @@ class WooShippingSplitShipmentViewModelTest : BaseUnitTest() {
 
             val state = sut.viewState.value!!
 
-            val selectableItems = state.selectableItems.getValue(1)
+            val selectableItems = state.selectableItems.getValue(0)
             val expandableProducts = selectableItems.shippableItems
                 .filterIsInstance<SelectableShippableItemUI.SingleSelectableShippableItemUI>()
             assertThat(expandableProducts.size).isEqualTo(1)
@@ -92,7 +92,7 @@ class WooShippingSplitShipmentViewModelTest : BaseUnitTest() {
 
         val state = sut.viewState.value!!
 
-        val selectableItems = state.selectableItems.getValue(1)
+        val selectableItems = state.selectableItems.getValue(0)
         val expandableProducts = selectableItems.shippableItems.filter {
             it is SelectableShippableItemUI.ExpandableSelectableShippableItemUI &&
                 it.isSelected
@@ -117,7 +117,7 @@ class WooShippingSplitShipmentViewModelTest : BaseUnitTest() {
 
         val state = sut.viewState.value!!
 
-        val selectableItems = state.selectableItems.getValue(1)
+        val selectableItems = state.selectableItems.getValue(0)
         val expandableProducts = selectableItems.shippableItems.filter {
             it is SelectableShippableItemUI.ExpandableSelectableShippableItemUI &&
                 it.isSelected
@@ -142,7 +142,7 @@ class WooShippingSplitShipmentViewModelTest : BaseUnitTest() {
 
         val state = sut.viewState.value!!
 
-        val selectableItems = state.selectableItems.getValue(1)
+        val selectableItems = state.selectableItems.getValue(0)
         val expandableProducts = selectableItems.shippableItems.filter {
             it is SelectableShippableItemUI.SingleSelectableShippableItemUI &&
                 it.isSelected
@@ -157,13 +157,13 @@ class WooShippingSplitShipmentViewModelTest : BaseUnitTest() {
             storeOptions = StoreOptionsModel.EMPTY,
             shipments = defaultShipment
         )
-        val updatedCurrentShipmentItems = defaultShipment.getValue(1).subList(fromIndex = 1, toIndex = 3)
-        val updatedShipmentItems = defaultShipment.getValue(1).subList(fromIndex = 0, toIndex = 1)
+        val updatedCurrentShipmentItems = defaultShipment.getValue(0).subList(fromIndex = 1, toIndex = 3)
+        val updatedShipmentItems = defaultShipment.getValue(0).subList(fromIndex = 0, toIndex = 1)
 
         val movement = SplitMovement(
-            sourceShipmentKey = 1,
+            sourceShipmentKey = 0,
             updatedSourceShipmentItems = updatedCurrentShipmentItems,
-            destinationShipmentKey = 2,
+            destinationShipmentKey = 1,
             movingShipmentItems = updatedShipmentItems
         )
 
@@ -177,8 +177,8 @@ class WooShippingSplitShipmentViewModelTest : BaseUnitTest() {
 
         val selectableItems = state.selectableItems
         assertThat(selectableItems.size).isEqualTo(2)
-        assertThat(selectableItems.getValue(1).shippableItems.size).isEqualTo(updatedCurrentShipmentItems.size)
-        assertThat(selectableItems.getValue(2).shippableItems.size).isEqualTo(updatedShipmentItems.size)
+        assertThat(selectableItems.getValue(0).shippableItems.size).isEqualTo(updatedCurrentShipmentItems.size)
+        assertThat(selectableItems.getValue(1).shippableItems.size).isEqualTo(updatedShipmentItems.size)
     }
 
     @Test
@@ -189,7 +189,7 @@ class WooShippingSplitShipmentViewModelTest : BaseUnitTest() {
                 storeOptions = StoreOptionsModel.EMPTY,
                 shipments = twoShipment
             )
-            val updatedCurrentShipmentItems = defaultShipment.getValue(1)
+            val updatedCurrentShipmentItems = defaultShipment.getValue(0)
             val updatedShipmentItems = listOf(
                 ShippableItemModel(
                     itemId = 3L,
@@ -207,9 +207,9 @@ class WooShippingSplitShipmentViewModelTest : BaseUnitTest() {
             )
 
             val movement = SplitMovement(
-                sourceShipmentKey = 1,
+                sourceShipmentKey = 0,
                 updatedSourceShipmentItems = updatedCurrentShipmentItems,
-                destinationShipmentKey = 2,
+                destinationShipmentKey = 1,
                 movingShipmentItems = updatedShipmentItems
             )
 
@@ -223,9 +223,9 @@ class WooShippingSplitShipmentViewModelTest : BaseUnitTest() {
 
             val selectableItems = state.selectableItems
             assertThat(selectableItems.size).isEqualTo(2)
-            assertThat(selectableItems.getValue(2).shippableItems.size).isEqualTo(1)
+            assertThat(selectableItems.getValue(1).shippableItems.size).isEqualTo(1)
             val item = selectableItems
-                .getValue(2)
+                .getValue(1)
                 .shippableItems
                 .first() as SelectableShippableItemUI.ExpandableSelectableShippableItemUI
             // Assert that quantity is combined 3f + 3f
@@ -239,8 +239,8 @@ class WooShippingSplitShipmentViewModelTest : BaseUnitTest() {
             storeOptions = StoreOptionsModel.EMPTY,
             shipments = defaultShipment
         )
-        val updatedCurrentShipmentItems = defaultShipment.getValue(1).subList(fromIndex = 1, toIndex = 3)
-        val updatedShipmentItems = defaultShipment.getValue(1).subList(fromIndex = 0, toIndex = 1)
+        val updatedCurrentShipmentItems = defaultShipment.getValue(0).subList(fromIndex = 1, toIndex = 3)
+        val updatedShipmentItems = defaultShipment.getValue(0).subList(fromIndex = 0, toIndex = 1)
 
         val movement = SplitMovement(
             sourceShipmentKey = 0,
@@ -271,8 +271,8 @@ class WooShippingSplitShipmentViewModelTest : BaseUnitTest() {
             storeOptions = StoreOptionsModel.EMPTY,
             shipments = defaultShipment
         )
-        val updatedCurrentShipmentItems = defaultShipment.getValue(1).subList(fromIndex = 0, toIndex = 1)
-        val updatedShipmentItems = defaultShipment.getValue(1).subList(fromIndex = 1, toIndex = 2)
+        val updatedCurrentShipmentItems = defaultShipment.getValue(0).subList(fromIndex = 0, toIndex = 1)
+        val updatedShipmentItems = defaultShipment.getValue(0).subList(fromIndex = 1, toIndex = 2)
 
         val movement = SplitMovement(
             sourceShipmentKey = 0,
@@ -312,7 +312,7 @@ class WooShippingSplitShipmentViewModelTest : BaseUnitTest() {
 
         val state = sut.viewState.value!!
 
-        val selectableItems = state.selectableItems.getValue(1)
+        val selectableItems = state.selectableItems.getValue(0)
         assertThat(selectableItems.totalItemQuantity).isEqualTo(expectedQuantity)
     }
 
@@ -323,13 +323,13 @@ class WooShippingSplitShipmentViewModelTest : BaseUnitTest() {
             storeOptions = StoreOptionsModel.EMPTY,
             shipments = twoShipment
         )
-        val movingItems = twoShipment.getValue(2)
+        val movingItems = twoShipment.getValue(1)
 
         // Removing "Shipment 2"
         val movement = SplitMovement(
-            sourceShipmentKey = 2,
+            sourceShipmentKey = 1,
             updatedSourceShipmentItems = emptyList(),
-            destinationShipmentKey = 1,
+            destinationShipmentKey = 0,
             movingShipmentItems = movingItems
         )
 
@@ -351,16 +351,16 @@ class WooShippingSplitShipmentViewModelTest : BaseUnitTest() {
             storeOptions = StoreOptionsModel.EMPTY,
             shipments = twoShipment
         )
-        val movingItems = twoShipment.getValue(2)
+        val movingItems = twoShipment.getValue(1)
 
         // Removing "Shipment 2"
         val movement = SplitMovement(
-            sourceShipmentKey = 2,
+            sourceShipmentKey = 1,
             updatedSourceShipmentItems = emptyList(),
-            destinationShipmentKey = 1,
+            destinationShipmentKey = 0,
             movingShipmentItems = movingItems
         )
-        val expectedItemCount = twoShipment.getValue(1).size + twoShipment.getValue(2).size
+        val expectedItemCount = twoShipment.getValue(0).size + twoShipment.getValue(1).size
 
         createViewModel(shipmentArgs)
 
@@ -375,7 +375,7 @@ class WooShippingSplitShipmentViewModelTest : BaseUnitTest() {
     }
 
     private val defaultShipment = mapOf(
-        1 to listOf(
+        0 to listOf(
             ShippableItemModel(
                 itemId = 1L,
                 productId = 1L,
@@ -418,7 +418,7 @@ class WooShippingSplitShipmentViewModelTest : BaseUnitTest() {
         )
     )
     private val twoShipment = mapOf(
-        1 to listOf(
+        0 to listOf(
             ShippableItemModel(
                 itemId = 1L,
                 productId = 1L,
@@ -446,7 +446,7 @@ class WooShippingSplitShipmentViewModelTest : BaseUnitTest() {
                 weight = 8f
             )
         ),
-        2 to listOf(
+        1 to listOf(
             ShippableItemModel(
                 itemId = 3L,
                 productId = 3L,

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/split/WooShippingSplitShipmentViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/split/WooShippingSplitShipmentViewModelTest.kt
@@ -24,7 +24,11 @@ class WooShippingSplitShipmentViewModelTest : BaseUnitTest() {
     lateinit var sut: WooShippingSplitShipmentViewModel
 
     private fun createViewModel(
-        shipmentArgs: SplitShipmentArgs
+        shipmentArgs: SplitShipmentArgs = SplitShipmentArgs(
+            orderId = 1L,
+            storeOptions = StoreOptionsModel.EMPTY,
+            shipments = defaultShipment
+        )
     ) {
         val savedState = WooShippingSplitShipmentFragmentArgs(shipmentArgs).toSavedStateHandle()
         sut = WooShippingSplitShipmentViewModel(
@@ -36,13 +40,7 @@ class WooShippingSplitShipmentViewModelTest : BaseUnitTest() {
 
     @Test
     fun `when split shipments is opened, then display the correct number of expandable products`() = testBlocking {
-        val shipmentArgs = SplitShipmentArgs(
-            orderId = 1L,
-            storeOptions = StoreOptionsModel.EMPTY,
-            shipments = defaultShipment
-        )
-
-        createViewModel(shipmentArgs)
+        createViewModel()
 
         sut.viewState.observeForTesting { }
 
@@ -78,13 +76,8 @@ class WooShippingSplitShipmentViewModelTest : BaseUnitTest() {
     @Test
     fun `when an expandable product inner selection changes, then the product is updated`() = testBlocking {
         val shippableItemIndex = 2
-        val shipmentArgs = SplitShipmentArgs(
-            orderId = 1L,
-            storeOptions = StoreOptionsModel.EMPTY,
-            shipments = defaultShipment
-        )
 
-        createViewModel(shipmentArgs)
+        createViewModel()
 
         sut.onUpdateSelection(shippableItemIndex, List(3) { it }.toSet())
 
@@ -103,13 +96,8 @@ class WooShippingSplitShipmentViewModelTest : BaseUnitTest() {
     @Test
     fun `when an expandable product selection changes, then the product is updated`() = testBlocking {
         val shippableItemIndex = 2
-        val shipmentArgs = SplitShipmentArgs(
-            orderId = 1L,
-            storeOptions = StoreOptionsModel.EMPTY,
-            shipments = defaultShipment
-        )
 
-        createViewModel(shipmentArgs)
+        createViewModel()
 
         sut.onUpdateSelection(shippableItemIndex, null)
 
@@ -128,13 +116,8 @@ class WooShippingSplitShipmentViewModelTest : BaseUnitTest() {
     @Test
     fun `when a single product selection changes, then the product is updated`() = testBlocking {
         val shippableItemIndex = 0
-        val shipmentArgs = SplitShipmentArgs(
-            orderId = 1L,
-            storeOptions = StoreOptionsModel.EMPTY,
-            shipments = defaultShipment
-        )
 
-        createViewModel(shipmentArgs)
+        createViewModel()
 
         sut.onUpdateSelection(shippableItemIndex, null)
 
@@ -152,11 +135,6 @@ class WooShippingSplitShipmentViewModelTest : BaseUnitTest() {
 
     @Test
     fun `when moving a shippable item to a new shipment, then a new shipment is created`() = testBlocking {
-        val shipmentArgs = SplitShipmentArgs(
-            orderId = 1L,
-            storeOptions = StoreOptionsModel.EMPTY,
-            shipments = defaultShipment
-        )
         val updatedCurrentShipmentItems = defaultShipment.getValue(0).subList(fromIndex = 1, toIndex = 3)
         val updatedShipmentItems = defaultShipment.getValue(0).subList(fromIndex = 0, toIndex = 1)
 
@@ -167,7 +145,7 @@ class WooShippingSplitShipmentViewModelTest : BaseUnitTest() {
             movingShipmentItems = updatedShipmentItems
         )
 
-        createViewModel(shipmentArgs)
+        createViewModel()
 
         sut.onUpdateShipment(movement)
 
@@ -234,11 +212,6 @@ class WooShippingSplitShipmentViewModelTest : BaseUnitTest() {
 
     @Test
     fun `when moving a shippable item to new shipment, then show singular snackbar`() = testBlocking {
-        val shipmentArgs = SplitShipmentArgs(
-            orderId = 1L,
-            storeOptions = StoreOptionsModel.EMPTY,
-            shipments = defaultShipment
-        )
         val updatedCurrentShipmentItems = defaultShipment.getValue(0).subList(fromIndex = 1, toIndex = 3)
         val updatedShipmentItems = defaultShipment.getValue(0).subList(fromIndex = 0, toIndex = 1)
 
@@ -249,7 +222,7 @@ class WooShippingSplitShipmentViewModelTest : BaseUnitTest() {
             movingShipmentItems = updatedShipmentItems
         )
 
-        createViewModel(shipmentArgs)
+        createViewModel()
 
         sut.onUpdateShipment(movement)
 
@@ -266,11 +239,6 @@ class WooShippingSplitShipmentViewModelTest : BaseUnitTest() {
 
     @Test
     fun `when moving shippable items to new shipment, then show plural snackbar`() = testBlocking {
-        val shipmentArgs = SplitShipmentArgs(
-            orderId = 1L,
-            storeOptions = StoreOptionsModel.EMPTY,
-            shipments = defaultShipment
-        )
         val updatedCurrentShipmentItems = defaultShipment.getValue(0).subList(fromIndex = 0, toIndex = 1)
         val updatedShipmentItems = defaultShipment.getValue(0).subList(fromIndex = 1, toIndex = 2)
 
@@ -281,7 +249,7 @@ class WooShippingSplitShipmentViewModelTest : BaseUnitTest() {
             movingShipmentItems = updatedShipmentItems
         )
 
-        createViewModel(shipmentArgs)
+        createViewModel()
 
         sut.onUpdateShipment(movement)
 
@@ -318,11 +286,6 @@ class WooShippingSplitShipmentViewModelTest : BaseUnitTest() {
 
     @Test
     fun `when removing a shipment, then the total shipment count is reduced by 1`() = testBlocking {
-        val shipmentArgs = SplitShipmentArgs(
-            orderId = 1L,
-            storeOptions = StoreOptionsModel.EMPTY,
-            shipments = twoShipment
-        )
         val movingItems = twoShipment.getValue(1)
 
         // Removing "Shipment 2"
@@ -333,7 +296,7 @@ class WooShippingSplitShipmentViewModelTest : BaseUnitTest() {
             movingShipmentItems = movingItems
         )
 
-        createViewModel(shipmentArgs)
+        createViewModel()
 
         sut.onUpdateShipment(movement)
 

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/split/WooShippingSplitShipmentViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/split/WooShippingSplitShipmentViewModelTest.kt
@@ -46,7 +46,7 @@ class WooShippingSplitShipmentViewModelTest : BaseUnitTest() {
 
         val state = sut.viewState.value!!
 
-        val selectableItems = state.selectableItems.getValue(0)
+        val selectableItems = state.selectableItems[0]!!
         val expandableProducts = selectableItems.shippableItems
             .filterIsInstance<SelectableShippableItemUI.ExpandableSelectableShippableItemUI>()
         assertThat(expandableProducts.size).isEqualTo(2)
@@ -67,7 +67,7 @@ class WooShippingSplitShipmentViewModelTest : BaseUnitTest() {
 
             val state = sut.viewState.value!!
 
-            val selectableItems = state.selectableItems.getValue(0)
+            val selectableItems = state.selectableItems[0]!!
             val expandableProducts = selectableItems.shippableItems
                 .filterIsInstance<SelectableShippableItemUI.SingleSelectableShippableItemUI>()
             assertThat(expandableProducts.size).isEqualTo(1)
@@ -85,7 +85,7 @@ class WooShippingSplitShipmentViewModelTest : BaseUnitTest() {
 
         val state = sut.viewState.value!!
 
-        val selectableItems = state.selectableItems.getValue(0)
+        val selectableItems = state.selectableItems[0]!!
         val expandableProducts = selectableItems.shippableItems.filter {
             it is SelectableShippableItemUI.ExpandableSelectableShippableItemUI &&
                 it.isSelected
@@ -105,7 +105,7 @@ class WooShippingSplitShipmentViewModelTest : BaseUnitTest() {
 
         val state = sut.viewState.value!!
 
-        val selectableItems = state.selectableItems.getValue(0)
+        val selectableItems = state.selectableItems[0]!!
         val expandableProducts = selectableItems.shippableItems.filter {
             it is SelectableShippableItemUI.ExpandableSelectableShippableItemUI &&
                 it.isSelected
@@ -125,7 +125,7 @@ class WooShippingSplitShipmentViewModelTest : BaseUnitTest() {
 
         val state = sut.viewState.value!!
 
-        val selectableItems = state.selectableItems.getValue(0)
+        val selectableItems = state.selectableItems[0]!!
         val expandableProducts = selectableItems.shippableItems.filter {
             it is SelectableShippableItemUI.SingleSelectableShippableItemUI &&
                 it.isSelected
@@ -135,8 +135,8 @@ class WooShippingSplitShipmentViewModelTest : BaseUnitTest() {
 
     @Test
     fun `when moving a shippable item to a new shipment, then a new shipment is created`() = testBlocking {
-        val updatedCurrentShipmentItems = defaultShipment.getValue(0).subList(fromIndex = 1, toIndex = 3)
-        val updatedShipmentItems = defaultShipment.getValue(0).subList(fromIndex = 0, toIndex = 1)
+        val updatedCurrentShipmentItems = defaultShipment[0]!!.subList(fromIndex = 1, toIndex = 3)
+        val updatedShipmentItems = defaultShipment[0]!!.subList(fromIndex = 0, toIndex = 1)
 
         val movement = SplitMovement(
             sourceShipmentKey = 0,
@@ -155,8 +155,8 @@ class WooShippingSplitShipmentViewModelTest : BaseUnitTest() {
 
         val selectableItems = state.selectableItems
         assertThat(selectableItems.size).isEqualTo(2)
-        assertThat(selectableItems.getValue(0).shippableItems.size).isEqualTo(updatedCurrentShipmentItems.size)
-        assertThat(selectableItems.getValue(1).shippableItems.size).isEqualTo(updatedShipmentItems.size)
+        assertThat(selectableItems[0]!!.shippableItems.size).isEqualTo(updatedCurrentShipmentItems.size)
+        assertThat(selectableItems[1]!!.shippableItems.size).isEqualTo(updatedShipmentItems.size)
     }
 
     @Test
@@ -167,7 +167,7 @@ class WooShippingSplitShipmentViewModelTest : BaseUnitTest() {
                 storeOptions = StoreOptionsModel.EMPTY,
                 shipments = twoShipment
             )
-            val updatedCurrentShipmentItems = defaultShipment.getValue(0)
+            val updatedCurrentShipmentItems = defaultShipment[0]!!
             val updatedShipmentItems = listOf(
                 ShippableItemModel(
                     itemId = 3L,
@@ -201,10 +201,8 @@ class WooShippingSplitShipmentViewModelTest : BaseUnitTest() {
 
             val selectableItems = state.selectableItems
             assertThat(selectableItems.size).isEqualTo(2)
-            assertThat(selectableItems.getValue(1).shippableItems.size).isEqualTo(1)
-            val item = selectableItems
-                .getValue(1)
-                .shippableItems
+            assertThat(selectableItems[1]!!.shippableItems.size).isEqualTo(1)
+            val item = selectableItems[1]!!.shippableItems
                 .first() as SelectableShippableItemUI.ExpandableSelectableShippableItemUI
             // Assert that quantity is combined 3f + 3f
             assertThat(item.shippableItem.quantity).isEqualTo(6f)
@@ -212,8 +210,8 @@ class WooShippingSplitShipmentViewModelTest : BaseUnitTest() {
 
     @Test
     fun `when moving a shippable item to new shipment, then show singular snackbar`() = testBlocking {
-        val updatedCurrentShipmentItems = defaultShipment.getValue(0).subList(fromIndex = 1, toIndex = 3)
-        val updatedShipmentItems = defaultShipment.getValue(0).subList(fromIndex = 0, toIndex = 1)
+        val updatedCurrentShipmentItems = defaultShipment[0]!!.subList(fromIndex = 1, toIndex = 3)
+        val updatedShipmentItems = defaultShipment[0]!!.subList(fromIndex = 0, toIndex = 1)
 
         val movement = SplitMovement(
             sourceShipmentKey = 0,
@@ -239,8 +237,8 @@ class WooShippingSplitShipmentViewModelTest : BaseUnitTest() {
 
     @Test
     fun `when moving shippable items to new shipment, then show plural snackbar`() = testBlocking {
-        val updatedCurrentShipmentItems = defaultShipment.getValue(0).subList(fromIndex = 0, toIndex = 1)
-        val updatedShipmentItems = defaultShipment.getValue(0).subList(fromIndex = 1, toIndex = 2)
+        val updatedCurrentShipmentItems = defaultShipment[0]!!.subList(fromIndex = 0, toIndex = 1)
+        val updatedShipmentItems = defaultShipment[0]!!.subList(fromIndex = 1, toIndex = 2)
 
         val movement = SplitMovement(
             sourceShipmentKey = 0,
@@ -280,13 +278,13 @@ class WooShippingSplitShipmentViewModelTest : BaseUnitTest() {
 
         val state = sut.viewState.value!!
 
-        val selectableItems = state.selectableItems.getValue(0)
+        val selectableItems = state.selectableItems[0]!!
         assertThat(selectableItems.totalItemQuantity).isEqualTo(expectedQuantity)
     }
 
     @Test
     fun `when removing a shipment, then the total shipment count is reduced by 1`() = testBlocking {
-        val movingItems = twoShipment.getValue(1)
+        val movingItems = twoShipment[1]!!
 
         // Removing "Shipment 2"
         val movement = SplitMovement(
@@ -314,7 +312,7 @@ class WooShippingSplitShipmentViewModelTest : BaseUnitTest() {
             storeOptions = StoreOptionsModel.EMPTY,
             shipments = twoShipment
         )
-        val movingItems = twoShipment.getValue(1)
+        val movingItems = twoShipment[1]!!
 
         // Removing "Shipment 2"
         val movement = SplitMovement(
@@ -323,7 +321,7 @@ class WooShippingSplitShipmentViewModelTest : BaseUnitTest() {
             destinationShipmentKey = 0,
             movingShipmentItems = movingItems
         )
-        val expectedItemCount = twoShipment.getValue(0).size + twoShipment.getValue(1).size
+        val expectedItemCount = twoShipment[0]!!.size + twoShipment[1]!!.size
 
         createViewModel(shipmentArgs)
 

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/split/WooShippingSplitShipmentViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/split/WooShippingSplitShipmentViewModelTest.kt
@@ -316,6 +316,64 @@ class WooShippingSplitShipmentViewModelTest : BaseUnitTest() {
         assertThat(selectableItems.totalItemQuantity).isEqualTo(expectedQuantity)
     }
 
+    @Test
+    fun `when removing a shipment, then the total shipment count is reduced by 1`() = testBlocking {
+        val shipmentArgs = SplitShipmentArgs(
+            orderId = 1L,
+            storeOptions = StoreOptionsModel.EMPTY,
+            shipments = twoShipment
+        )
+        val movingItems = twoShipment.getValue(2)
+
+        // Removing "Shipment 2"
+        val movement = SplitMovement(
+            sourceShipmentKey = 2,
+            updatedSourceShipmentItems = emptyList(),
+            destinationShipmentKey = 1,
+            movingShipmentItems = movingItems
+        )
+
+        createViewModel(shipmentArgs)
+
+        sut.onUpdateShipment(movement)
+
+        sut.viewState.observeForTesting { }
+
+        val state = sut.viewState.value!!
+
+        assertThat(state.selectableItems.size).isEqualTo(1)
+    }
+
+    @Test
+    fun `when removing a shipment, then all items are moved to destination shipment`() = testBlocking {
+        val shipmentArgs = SplitShipmentArgs(
+            orderId = 1L,
+            storeOptions = StoreOptionsModel.EMPTY,
+            shipments = twoShipment
+        )
+        val movingItems = twoShipment.getValue(2)
+
+        // Removing "Shipment 2"
+        val movement = SplitMovement(
+            sourceShipmentKey = 2,
+            updatedSourceShipmentItems = emptyList(),
+            destinationShipmentKey = 1,
+            movingShipmentItems = movingItems
+        )
+        val expectedItemCount = twoShipment.getValue(1).size + twoShipment.getValue(2).size
+
+        createViewModel(shipmentArgs)
+
+        sut.onUpdateShipment(movement)
+
+        sut.viewState.observeForTesting { }
+
+        val state = sut.viewState.value!!
+
+        val modifiedShipment = state.selectableItems.values.first()
+        assertThat(modifiedShipment.shippableItems.size).isEqualTo(expectedItemCount)
+    }
+
     private val defaultShipment = mapOf(
         1 to listOf(
             ShippableItemModel(


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Ref WOOMOB-285
<!-- 
━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
🛠 Need an AI review?  
Add a comment: `@coderabbitai review`
━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
-->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
This adds removing shipment action to the Remove shipment sheet.

**Known issue:** The product card displays incorrect prices.

### Steps to reproduce
<!-- Step-by-step testing instructions. For new user flows, consider instead stating the goal of the workflow and see if your PR reviewer can accomplish the workflow without specific steps! -->
1. Open the orders tab.
2. Tap on an order eligible for shipping label creation. It’s better to choose one with multiple items.
3. Tap on Create shipping label.
4. Tap on Split shipment.
5. Choose some items and move them to a new shipment.
6. Tap the more button in the shipments tab.
7. Remove a shipment.

### The tests that have been performed
<!-- To give the reviewer an idea of what could be missed in terms of testing -->
Steps above.

### Images/gif
<!-- Include before and after images or gifs when appropriate. -->
[Screen_recording_20250418_003756.webm](https://github.com/user-attachments/assets/6c802976-8de8-4413-bba4-d8856a6777b7)

- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.

## Reviewer (or Author, in the case of optional code reviews):

Please make sure these conditions are met before approving the PR, or request changes if the PR needs improvement:

- [ ] The PR is small and has a clear, single focus, or a valid explanation is provided in the description. If needed, please request to split it into smaller PRs.
- [ ] Ensure Adequate Unit Test Coverage: The changes are reasonably covered by unit tests or an explanation is provided in the PR description.
- [ ] Manual Testing: The author listed all the tests they ran, including smoke tests when needed (e.g., for refactorings). The reviewer confirmed that the PR works as expected on big (tablet) and small (phone) in case of UI changes, and no regressions are added.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->