### PR TITLE
[Beta Fix][POS] Item list loading improvements

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/items/WooPosItemsSearchHelper.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/items/WooPosItemsSearchHelper.kt
@@ -7,11 +7,13 @@ import com.woocommerce.android.ui.woopos.home.ParentToChildrenEvent
 import com.woocommerce.android.ui.woopos.home.WooPosChildrenToParentEventSender
 import com.woocommerce.android.ui.woopos.home.WooPosParentToChildrenEventReceiver
 import com.woocommerce.android.viewmodel.ResourceProvider
+import dagger.hilt.android.scopes.ActivityRetainedScoped
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.launch
 import javax.inject.Inject
 
+@ActivityRetainedScoped
 class WooPosItemsSearchHelper @Inject constructor(
     private val resourceProvider: ResourceProvider,
     private val childToParentEventSender: WooPosChildrenToParentEventSender,

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/items/WooPosItemsViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/items/WooPosItemsViewModel.kt
@@ -196,6 +196,7 @@ class WooPosItemsViewModel @Inject constructor(
         withCart: Boolean
     ) {
         loadProductsJob?.cancel()
+        loadMoreProductsJob?.cancel()
         loadProductsJob = viewModelScope.launch {
             _viewState.value = if (withPullToRefresh) {
                 buildProductsReloadingState()

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/items/WooPosItemsViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/items/WooPosItemsViewModel.kt
@@ -294,19 +294,14 @@ class WooPosItemsViewModel @Inject constructor(
         }
     }
 
+    @Suppress("ReturnCount")
     private fun onEndOfProductsListReached() {
         val currentState = _viewState.value
-        if (currentState !is WooPosItemsViewState.Content) {
-            return
-        }
+        if (currentState !is WooPosItemsViewState.Content) return
 
-        if (loadMoreProductsJob?.isActive == true || loadProductsJob?.isActive == true) {
-            return
-        }
+        if (loadMoreProductsJob?.isActive == true || loadProductsJob?.isActive == true) return
 
-        if (!productsDataSource.hasMorePages) {
-            return
-        }
+        if (!productsDataSource.hasMorePages) return
 
         _viewState.value = currentState.copy(paginationState = WooPosPaginationState.Loading)
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/items/WooPosItemsViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/items/WooPosItemsViewModel.kt
@@ -44,6 +44,7 @@ class WooPosItemsViewModel @Inject constructor(
     private val isCouponsEnabled: WooPosIsCouponsEnabled,
 ) : ViewModel() {
     private var loadMoreProductsJob: Job? = null
+    private var loadProductsJob: Job? = null
 
     private val _viewState =
         MutableStateFlow<WooPosItemsViewState>(WooPosItemsViewState.Loading(withCart = true))
@@ -194,7 +195,8 @@ class WooPosItemsViewModel @Inject constructor(
         withPullToRefresh: Boolean,
         withCart: Boolean
     ) {
-        viewModelScope.launch {
+        loadProductsJob?.cancel()
+        loadProductsJob = viewModelScope.launch {
             _viewState.value = if (withPullToRefresh) {
                 buildProductsReloadingState()
             } else {
@@ -294,6 +296,10 @@ class WooPosItemsViewModel @Inject constructor(
     private fun onEndOfProductsListReached() {
         val currentState = _viewState.value
         if (currentState !is WooPosItemsViewState.Content) {
+            return
+        }
+
+        if (loadMoreProductsJob?.isActive == true || loadProductsJob?.isActive == true) {
             return
         }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/items/search/WooPosItemsSearchViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/items/search/WooPosItemsSearchViewModel.kt
@@ -10,6 +10,7 @@ import com.woocommerce.android.ui.woopos.home.WooPosChildrenToParentEventSender
 import com.woocommerce.android.ui.woopos.home.WooPosParentToChildrenEventReceiver
 import com.woocommerce.android.ui.woopos.home.items.WooPosItemNavigationData.VariableProductData
 import com.woocommerce.android.ui.woopos.home.items.WooPosItemSelectionViewState
+import com.woocommerce.android.ui.woopos.home.items.WooPosItemsSearchHelper
 import com.woocommerce.android.ui.woopos.home.items.WooPosItemsViewModel.ItemClickedData
 import com.woocommerce.android.ui.woopos.home.items.WooPosPaginationState
 import com.woocommerce.android.ui.woopos.home.items.navigation.WooPosItemsNavigator
@@ -35,6 +36,7 @@ class WooPosItemsSearchViewModel @Inject constructor(
     private val childToParentEventSender: WooPosChildrenToParentEventSender,
     private val parentToChildrenEventReceiver: WooPosParentToChildrenEventReceiver,
     private val navigator: WooPosItemsNavigator,
+    private val searchHelper: WooPosItemsSearchHelper,
 ) : ViewModel() {
     private val _viewState =
         MutableStateFlow<WooPosItemsSearchViewState>(WooPosItemsSearchViewState.Empty)
@@ -86,11 +88,15 @@ class WooPosItemsSearchViewModel @Inject constructor(
                     ParentToChildrenEvent.SearchEvent.Started -> Unit
                     ParentToChildrenEvent.SearchEvent.Finished -> Unit
                     is ParentToChildrenEvent.BackFromCheckoutToCartClicked -> Unit
-                    is ParentToChildrenEvent.ItemClickedInProductSelector -> Unit
                     is ParentToChildrenEvent.OrderSuccessfullyPaid -> Unit
                     is ParentToChildrenEvent.CheckoutClicked -> Unit
                     is ParentToChildrenEvent.SearchEvent.RecentSearchSelected -> Unit
                     is ParentToChildrenEvent.OrderCreated -> Unit
+                    is ParentToChildrenEvent.ItemClickedInProductSelector -> {
+                        if (event.itemData is ItemClickedData.Product.Variation && searchHelper.isSearchOpen()) {
+                            storeRecentSearch()
+                        }
+                    }
                 }
             }
         }

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/home/items/search/WooPosItemsSearchViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/home/items/search/WooPosItemsSearchViewModelTest.kt
@@ -50,6 +50,7 @@ class WooPosItemsSearchViewModelTest {
     private val mockChildToParentEventSender: WooPosChildrenToParentEventSender = mock()
     private val mockParentToChildrenEventReceiver: WooPosParentToChildrenEventReceiver = mock()
     private val mockNavigator: WooPosItemsNavigator = mock()
+    private val mockSearchHelper: com.woocommerce.android.ui.woopos.home.items.WooPosItemsSearchHelper = mock()
 
     private val defaultQuery = "test query"
     private val defaultProduct = ProductTestUtils.generateProduct(
@@ -795,5 +796,6 @@ class WooPosItemsSearchViewModelTest {
         childToParentEventSender = mockChildToParentEventSender,
         parentToChildrenEventReceiver = mockParentToChildrenEventReceiver,
         navigator = mockNavigator,
+        searchHelper = mockSearchHelper,
     )
 }


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #WOOMOB-325, #WOOMOB-324
<!-- Id number of the GitHub issue this PR addresses. -->

<!-- 
━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
🛠 Need an AI review?  
Add a comment: `@coderabbitai review`
━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
-->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
* [[Woo POS][Product Search] Load More Requests are duplicated](https://linear.app/a8c/issue/WOOMOB-325/[woo-pos][product-search]-load-more-requests-are-duplicated)
* [[Woo POS][Product Search] Initial Load More May Have Incorrect Page Offset](https://linear.app/a8c/issue/WOOMOB-324/[woo-pos][product-search]-initial-load-more-may-have-incorrect-page)

### Steps to reproduce
<!-- Step-by-step testing instructions. For new user flows, consider instead stating the goal of the workflow and see if your PR reviewer can accomplish the workflow without specific steps! -->
#### Duplicated network requests
1. Open network inspector and go to POS
2. Try loading next pages of items on the main list
3. Observe that some requests to "load more" items are duplicated

#### Initial Load More May Have Incorrect Page Offset
Scenario 1
1. Open network inspector and go to POS
2. Observe that "load more" request is triggered with offset equal to 0 even because the request to fetch 1st page didn't complete

Scenario 2
1. Open network inspector and go to POS
2. Wait for the 1st page of results to show up
3. Pull to refresh and immediately scroll down to trigger "load more"

### Testing information
<!-- This is your opportunity to break out individual scenarios that need testing (when necessary) and/or include a checklist for the reviewer to go through. Consider documenting the following from your own completed testing: devices used, alternate workflows, edge cases, affected areas, critical flows, areas not tested, and any remaining unknowns. Provide feedback on this new section of the PR template through Sept 30, 2024 to Apps Quality; additional context here: p91TBi-b8z-p2#comment-12036 -->
It should be verified that:
1. There are no redundant requests sent to the backend
2. "Load more" is not possible during ongoing items fetch or previous "load more" job

### The tests that have been performed
<!-- To give the reviewer an idea of what could be missed in terms of testing -->
I verified that pagination works and "load more" request doesn't collide with initial page loading job.

### Images/gif
<!-- Include before and after images or gifs when appropriate. -->
N/A

- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.

## Reviewer (or Author, in the case of optional code reviews):

Please make sure these conditions are met before approving the PR, or request changes if the PR needs improvement:

- [ ] The PR is small and has a clear, single focus, or a valid explanation is provided in the description. If needed, please request to split it into smaller PRs.
- [ ] Ensure Adequate Unit Test Coverage: The changes are reasonably covered by unit tests or an explanation is provided in the PR description.
- [ ] Manual Testing: The author listed all the tests they ran, including smoke tests when needed (e.g., for refactorings). The reviewer confirmed that the PR works as expected on big (tablet) and small (phone) in case of UI changes, and no regressions are added.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->