### PR TITLE
[Beta Fix][POS] Item list loading improvements

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/items/WooPosItemsList.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/items/WooPosItemsList.kt
@@ -411,7 +411,7 @@ private fun InfiniteListHandler(
     state: WooPosContentViewState,
     onEndOfProductsListReached: () -> Unit
 ) {
-    val buffer = 5
+    val buffer = 5 // must be smaller than the page size, otherwise won't call onEndOfProductsListReached
     val loadMore = remember {
         derivedStateOf {
             val layoutInfo = listState.layoutInfo

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/items/WooPosItemsViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/items/WooPosItemsViewModel.kt
@@ -45,6 +45,7 @@ class WooPosItemsViewModel @Inject constructor(
 ) : ViewModel() {
     private var loadMoreProductsJob: Job? = null
     private var loadProductsJob: Job? = null
+    private var loadMoreAfterLoadCompletes = false
 
     private val _viewState =
         MutableStateFlow<WooPosItemsViewState>(WooPosItemsViewState.Loading(withCart = true))
@@ -244,8 +245,21 @@ class WooPosItemsViewModel @Inject constructor(
                             }
                             else -> WooPosItemsViewState.Error()
                         }
+
+                        if (loadMoreAfterLoadCompletes) {
+                            queueLoadMoreAfterLoadCompletes()
+                        }
                     }
                 }
+            }
+        }
+    }
+
+    private fun queueLoadMoreAfterLoadCompletes() {
+        loadProductsJob?.invokeOnCompletion { throwable ->
+            if (throwable == null && _viewState.value is WooPosItemsViewState.Content) {
+                loadMoreAfterLoadCompletes = false
+                onEndOfProductsListReached()
             }
         }
     }
@@ -298,9 +312,22 @@ class WooPosItemsViewModel @Inject constructor(
     private fun onEndOfProductsListReached() {
         val currentState = _viewState.value
 
-        if (currentState !is WooPosItemsViewState.Content) return
-        if (loadMoreProductsJob?.isActive == true || loadProductsJob?.isActive == true) return
-        if (!productsDataSource.hasMorePages) return
+        if (currentState !is WooPosItemsViewState.Content) {
+            return
+        }
+
+        if (loadProductsJob?.isActive == true) {
+            loadMoreAfterLoadCompletes = true
+            _viewState.value = currentState.copy(paginationState = WooPosPaginationState.Loading)
+            return
+        }
+
+        if (loadMoreProductsJob?.isActive == true) {
+            return
+        }
+        if (!productsDataSource.hasMorePages) {
+            return
+        }
 
         _viewState.value = currentState.copy(paginationState = WooPosPaginationState.Loading)
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/items/WooPosItemsViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/items/WooPosItemsViewModel.kt
@@ -44,6 +44,7 @@ class WooPosItemsViewModel @Inject constructor(
     private val isCouponsEnabled: WooPosIsCouponsEnabled,
 ) : ViewModel() {
     private var loadMoreProductsJob: Job? = null
+    private var loadProductsJob: Job? = null
 
     private val _viewState =
         MutableStateFlow<WooPosItemsViewState>(WooPosItemsViewState.Loading(withCart = true))
@@ -194,7 +195,9 @@ class WooPosItemsViewModel @Inject constructor(
         withPullToRefresh: Boolean,
         withCart: Boolean
     ) {
-        viewModelScope.launch {
+        loadProductsJob?.cancel()
+        loadMoreProductsJob?.cancel()
+        loadProductsJob = viewModelScope.launch {
             _viewState.value = if (withPullToRefresh) {
                 buildProductsReloadingState()
             } else {
@@ -291,15 +294,13 @@ class WooPosItemsViewModel @Inject constructor(
         }
     }
 
+    @Suppress("ReturnCount")
     private fun onEndOfProductsListReached() {
         val currentState = _viewState.value
-        if (currentState !is WooPosItemsViewState.Content) {
-            return
-        }
 
-        if (!productsDataSource.hasMorePages) {
-            return
-        }
+        if (currentState !is WooPosItemsViewState.Content) return
+        if (loadMoreProductsJob?.isActive == true || loadProductsJob?.isActive == true) return
+        if (!productsDataSource.hasMorePages) return
 
         _viewState.value = currentState.copy(paginationState = WooPosPaginationState.Loading)
 

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/home/items/WooPosItemsViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/home/items/WooPosItemsViewModelTest.kt
@@ -790,11 +790,10 @@ class WooPosItemsViewModelTest {
     }
 
     @Test
-    fun `when initial products load is active and load more is triggered, then set loadMoreAfterLoadCompletes flag`() = runTest {
+    fun `given initial load in progress, when end of list reached, then pagination state set to loading`() = runTest {
         // GIVEN
         whenever(productsDataSource.hasMorePages).thenReturn(true)
 
-        // Use a controlled flow that won't complete immediately
         val productsFlow = MutableSharedFlow<WooPosProductsDataSource.ProductsResult>()
         whenever(productsDataSource.loadProducts(any())).thenReturn(productsFlow)
 

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/home/items/WooPosItemsViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/home/items/WooPosItemsViewModelTest.kt
@@ -790,7 +790,7 @@ class WooPosItemsViewModelTest {
     }
 
     @Test
-    fun `when initial products load is active and load more is triggered, then do not start load more job`() = runTest {
+    fun `when initial products load is active and load more is triggered, then set loadMoreAfterLoadCompletes flag`() = runTest {
         // GIVEN
         whenever(productsDataSource.hasMorePages).thenReturn(true)
 
@@ -799,10 +799,82 @@ class WooPosItemsViewModelTest {
         whenever(productsDataSource.loadProducts(any())).thenReturn(productsFlow)
 
         val viewModel = createViewModel()
+        val products = listOf(
+            ProductTestUtils.generateProduct(
+                productId = 1,
+                productName = "Product 1",
+                amount = "10.0",
+                productType = "simple"
+            )
+        )
+        val remoteResult = WooPosProductsDataSource.ProductsResult.Remote(
+            Result.success(products)
+        )
+        productsFlow.emit(remoteResult)
 
         // WHEN
         viewModel.onUIEvent(WooPosItemsUIEvent.EndOfItemsListReached)
 
+        // THEN
+        viewModel.viewState.test {
+            val value = awaitItem() as WooPosItemsViewState.Content
+            assertThat(value.paginationState).isEqualTo(WooPosPaginationState.Loading)
+            verify(productsDataSource, never()).loadMore()
+        }
+    }
+
+    @Test
+    fun `when loadMoreAfterLoadCompletes is set and initial load completes, then load more is triggered`() = runTest {
+        // GIVEN
+        whenever(productsDataSource.hasMorePages).thenReturn(true)
+        val viewModel = createViewModel()
+
+        // WHEN
+        viewModel.onUIEvent(WooPosItemsUIEvent.EndOfItemsListReached)
+        advanceUntilIdle()
+
+        // THEN
+        verify(productsDataSource).loadMore()
+    }
+
+    @Test
+    fun `when loadMoreAfterLoadCompletes is set and initial load fails, then load more is not triggered`() = runTest {
+        // GIVEN
+        whenever(productsDataSource.hasMorePages).thenReturn(true)
+        whenever(productsDataSource.loadProducts(any())).thenReturn(
+            flowOf(
+                WooPosProductsDataSource.ProductsResult.Remote(
+                    Result.failure(Exception())
+                )
+            )
+        )
+
+        val viewModel = createViewModel()
+
+        // WHEN
+        viewModel.onUIEvent(WooPosItemsUIEvent.EndOfItemsListReached)
+        advanceUntilIdle()
+
+        // THEN
+        verify(productsDataSource, never()).loadMore()
+    }
+
+    @Test
+    fun `when loadMoreAfterLoadCompletes is set and view state is not Content, then load more is not triggered`() = runTest {
+        // GIVEN
+        whenever(productsDataSource.hasMorePages).thenReturn(true)
+        whenever(productsDataSource.loadProducts(any())).thenReturn(
+            flowOf(
+                WooPosProductsDataSource.ProductsResult.Remote(
+                    Result.success(emptyList())
+                )
+            )
+        )
+
+        val viewModel = createViewModel()
+
+        // WHEN
+        viewModel.onUIEvent(WooPosItemsUIEvent.EndOfItemsListReached)
         advanceUntilIdle()
 
         // THEN

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/home/items/WooPosItemsViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/home/items/WooPosItemsViewModelTest.kt
@@ -837,7 +837,7 @@ class WooPosItemsViewModelTest {
     }
 
     @Test
-    fun `when loadMoreAfterLoadCompletes is set and initial load fails, then load more is not triggered`() = runTest {
+    fun `given load more queued, when initial load fails, then load more is not triggered`() = runTest {
         // GIVEN
         whenever(productsDataSource.hasMorePages).thenReturn(true)
         whenever(productsDataSource.loadProducts(any())).thenReturn(

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/home/items/WooPosItemsViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/home/items/WooPosItemsViewModelTest.kt
@@ -859,7 +859,7 @@ class WooPosItemsViewModelTest {
     }
 
     @Test
-    fun `when loadMoreAfterLoadCompletes is set and view state is not Content, then load more is not triggered`() = runTest {
+    fun `given load more queued, when items list is not displayed, then load more is not triggered`() = runTest {
         // GIVEN
         whenever(productsDataSource.hasMorePages).thenReturn(true)
         whenever(productsDataSource.loadProducts(any())).thenReturn(

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/home/items/WooPosItemsViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/home/items/WooPosItemsViewModelTest.kt
@@ -34,7 +34,7 @@ import java.math.BigDecimal
 import kotlin.test.assertTrue
 
 @ExperimentalCoroutinesApi
-class WooPosItemsViewModelTestSelectionViewState {
+class WooPosItemsViewModelTest {
     @Rule
     @JvmField
     val coroutinesTestRule = WooPosCoroutineTestRule()

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/home/items/WooPosItemsViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/home/items/WooPosItemsViewModelTest.kt
@@ -823,7 +823,7 @@ class WooPosItemsViewModelTest {
     }
 
     @Test
-    fun `when loadMoreAfterLoadCompletes is set and initial load completes, then load more is triggered`() = runTest {
+    fun `given load more queued, when initial load completes, then load more is triggered`() = runTest {
         // GIVEN
         whenever(productsDataSource.hasMorePages).thenReturn(true)
         val viewModel = createViewModel()

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/home/items/WooPosItemsViewModelTestSelectionViewState.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/home/items/WooPosItemsViewModelTestSelectionViewState.kt
@@ -17,7 +17,9 @@ import com.woocommerce.android.ui.woopos.util.analytics.WooPosAnalyticsTracker
 import com.woocommerce.android.ui.woopos.util.datastore.WooPosPreferencesRepository
 import com.woocommerce.android.ui.woopos.util.format.WooPosFormatPrice
 import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.test.advanceUntilIdle
 import kotlinx.coroutines.test.runTest
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.Before
@@ -25,6 +27,7 @@ import org.junit.Rule
 import org.junit.Test
 import org.mockito.kotlin.any
 import org.mockito.kotlin.mock
+import org.mockito.kotlin.never
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
 import java.math.BigDecimal
@@ -784,6 +787,26 @@ class WooPosItemsViewModelTestSelectionViewState {
         viewModel.onUIEvent(WooPosItemsUIEvent.CloseSearchClicked)
 
         verify(searchHelper).onCloseSearchClicked()
+    }
+
+    @Test
+    fun `when initial products load is active and load more is triggered, then do not start load more job`() = runTest {
+        // GIVEN
+        whenever(productsDataSource.hasMorePages).thenReturn(true)
+
+        // Use a controlled flow that won't complete immediately
+        val productsFlow = MutableSharedFlow<WooPosProductsDataSource.ProductsResult>()
+        whenever(productsDataSource.loadProducts(any())).thenReturn(productsFlow)
+
+        val viewModel = createViewModel()
+
+        // WHEN
+        viewModel.onUIEvent(WooPosItemsUIEvent.EndOfItemsListReached)
+
+        advanceUntilIdle()
+
+        // THEN
+        verify(productsDataSource, never()).loadMore()
     }
 
     private fun createViewModel() =


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #WOOMOB-325, #WOOMOB-324
<!-- Id number of the GitHub issue this PR addresses. -->

<!-- 
━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
🛠 Need an AI review?  
Add a comment: `@coderabbitai review`
━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
-->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
* [[Woo POS][Product Search] Load More Requests are duplicated](https://linear.app/a8c/issue/WOOMOB-325/[woo-pos][product-search]-load-more-requests-are-duplicated)
* [[Woo POS][Product Search] Initial Load More May Have Incorrect Page Offset](https://linear.app/a8c/issue/WOOMOB-324/[woo-pos][product-search]-initial-load-more-may-have-incorrect-page)

### Steps to reproduce
<!-- Step-by-step testing instructions. For new user flows, consider instead stating the goal of the workflow and see if your PR reviewer can accomplish the workflow without specific steps! -->
#### Duplicated network requests
1. Open network inspector and go to POS
2. Try loading next pages of items on the main list
3. Observe that some requests to "load more" items are duplicated

#### Initial Load More May Have Incorrect Page Offset
Scenario 1
1. Open network inspector and go to POS
2. Observe that "load more" request is triggered with offset equal to 0 even because the request to fetch 1st page didn't complete

Scenario 2
1. Open network inspector and go to POS
2. Wait for the 1st page of results to show up
3. Pull to refresh and immediately scroll down to trigger "load more"

### Testing information
<!-- This is your opportunity to break out individual scenarios that need testing (when necessary) and/or include a checklist for the reviewer to go through. Consider documenting the following from your own completed testing: devices used, alternate workflows, edge cases, affected areas, critical flows, areas not tested, and any remaining unknowns. Provide feedback on this new section of the PR template through Sept 30, 2024 to Apps Quality; additional context here: p91TBi-b8z-p2#comment-12036 -->
It should be verified that:
1. There are no redundant requests sent to the backend
2. "Load more" is not possible during ongoing items fetch or previous "load more" job
3. All of the available products are loaded on the main list

### The tests that have been performed
<!-- To give the reviewer an idea of what could be missed in terms of testing -->
I verified that pagination works and "load more" request doesn't collide with initial page loading job.

### Images/gif
<!-- Include before and after images or gifs when appropriate. -->
N/A

- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.

## Reviewer (or Author, in the case of optional code reviews):

Please make sure these conditions are met before approving the PR, or request changes if the PR needs improvement:

- [ ] The PR is small and has a clear, single focus, or a valid explanation is provided in the description. If needed, please request to split it into smaller PRs.
- [ ] Ensure Adequate Unit Test Coverage: The changes are reasonably covered by unit tests or an explanation is provided in the PR description.
- [ ] Manual Testing: The author listed all the tests they ran, including smoke tests when needed (e.g., for refactorings). The reviewer confirmed that the PR works as expected on big (tablet) and small (phone) in case of UI changes, and no regressions are added.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->