### PR TITLE
Fix dark theme for the Jetpack Connection WebView

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/jetpack/connection/JetpackActivationWebViewFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/jetpack/connection/JetpackActivationWebViewFragment.kt
@@ -6,12 +6,11 @@ import android.view.View
 import android.view.ViewGroup
 import android.webkit.CookieManager
 import android.webkit.WebStorage
-import androidx.compose.ui.platform.ComposeView
-import androidx.compose.ui.platform.ViewCompositionStrategy
 import androidx.fragment.app.viewModels
 import com.woocommerce.android.extensions.navigateBackWithResult
 import com.woocommerce.android.ui.base.BaseFragment
 import com.woocommerce.android.ui.common.webview.WebViewAuthenticator
+import com.woocommerce.android.ui.compose.composeView
 import com.woocommerce.android.ui.main.AppBarStatus
 import dagger.hilt.android.AndroidEntryPoint
 import org.wordpress.android.fluxc.network.UserAgent
@@ -22,6 +21,7 @@ class JetpackActivationWebViewFragment : BaseFragment() {
     companion object {
         const val JETPACK_CONNECTION_RESULT = "jetpack-connection-result"
     }
+
     override val activityAppBarStatus: AppBarStatus
         get() = AppBarStatus.Hidden
 
@@ -34,19 +34,15 @@ class JetpackActivationWebViewFragment : BaseFragment() {
     lateinit var userAgent: UserAgent
 
     override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?) =
-        ComposeView(requireContext()).apply {
-            setViewCompositionStrategy(ViewCompositionStrategy.DisposeOnViewTreeLifecycleDestroyed)
-
-            setContent {
-                JetpackActivationWebViewScreen(
-                    viewModel = viewModel,
-                    authenticator = authenticator,
-                    userAgent = userAgent,
-                    onUrlLoaded = viewModel::onUrlLoaded,
-                    onUrlFailed = viewModel::onUrlFailed,
-                    onDismiss = viewModel::onDismiss
-                )
-            }
+        composeView {
+            JetpackActivationWebViewScreen(
+                viewModel = viewModel,
+                authenticator = authenticator,
+                userAgent = userAgent,
+                onUrlLoaded = viewModel::onUrlLoaded,
+                onUrlFailed = viewModel::onUrlFailed,
+                onDismiss = viewModel::onDismiss
+            )
         }
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {


### PR DESCRIPTION
Closes: WOOMOB-27

### Description
This fixes the dark theme UI in the Jetpack Connection WebView, the issue was caused by not setting a theme.

### Steps to reproduce
IMO checking the screenshots is enough.

If you want to test it:
- Apply the following patch
<details>
<summary>patch</summary>

```patch
Index: WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/jetpack/dispatcher/JetpackActivationDispatcherFragment.kt
IDEA additional info:
Subsystem: com.intellij.openapi.diff.impl.patch.CharsetEP
<+>UTF-8
===================================================================
diff --git a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/jetpack/dispatcher/JetpackActivationDispatcherFragment.kt b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/jetpack/dispatcher/JetpackActivationDispatcherFragment.kt
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/jetpack/dispatcher/JetpackActivationDispatcherFragment.kt	(revision 7468d7e1cb6a14c53cdd021cdd4caec0f63d084e)
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/jetpack/dispatcher/JetpackActivationDispatcherFragment.kt	(date 1744977314327)
@@ -3,7 +3,9 @@
 import android.os.Bundle
 import androidx.fragment.app.viewModels
 import androidx.navigation.fragment.findNavController
+import com.woocommerce.android.R
 import com.woocommerce.android.ui.base.BaseFragment
+import com.woocommerce.android.ui.login.jetpack.connection.JetpackActivationWebViewFragmentArgs
 import com.woocommerce.android.ui.login.jetpack.dispatcher.JetpackActivationDispatcherViewModel.StartJetpackActivationForNewSite
 import com.woocommerce.android.ui.login.jetpack.dispatcher.JetpackActivationDispatcherViewModel.StartWPComAuthenticationForEmail
 import com.woocommerce.android.ui.login.jetpack.dispatcher.JetpackActivationDispatcherViewModel.StartWPComLoginForJetpackActivation
@@ -24,13 +26,20 @@
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         // Use the fragment as the lifecycle owner since we don't have any view here
-        viewModel.event.observe(this) { event ->
-            when (event) {
-                is StartJetpackActivationForNewSite -> navigateToJetpackActivationStartScreen(event)
-                is StartWPComLoginForJetpackActivation -> navigateToWPComEmailScreen(event)
-                is StartWPComAuthenticationForEmail -> navigateToWPComPasswordScreen(event)
-            }
-        }
+//        viewModel.event.observe(this) { event ->
+//            when (event) {
+//                is StartJetpackActivationForNewSite -> navigateToJetpackActivationStartScreen(event)
+//                is StartWPComLoginForJetpackActivation -> navigateToWPComEmailScreen(event)
+//                is StartWPComAuthenticationForEmail -> navigateToWPComPasswordScreen(event)
+//            }
+//        }
+
+        findNavController().navigate(
+            R.id.jetpackActivationWebViewFragment,
+            JetpackActivationWebViewFragmentArgs(
+                urlToLoad = "https://wordpress.com"
+            ).toBundle()
+        )
     }
 
     private fun navigateToJetpackActivationStartScreen(event: StartJetpackActivationForNewSite) {
```
</details>

- Sign in using site credentials.
- Start Jetpack installation from the banner in the dashboard screen.
- Tap on Log in to continue.
- Notice the WebView screen.

### Testing information
- Confirm the toolbar looks good in dark theme.

### The tests that have been performed
^

### Images/gif
| Before | After |
| --- | --- |
| ![Screenshot_20250418_130127](https://github.com/user-attachments/assets/a5f2191e-fef1-4be2-9b5e-ce176b99508b) | ![Screenshot_20250418_130217](https://github.com/user-attachments/assets/be2d52ef-9bb4-4dc1-9a21-aeabe8132d16) | 

- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.

## Reviewer (or Author, in the case of optional code reviews):

Please make sure these conditions are met before approving the PR, or request changes if the PR needs improvement:

- [ ] The PR is small and has a clear, single focus, or a valid explanation is provided in the description. If needed, please request to split it into smaller PRs.
- [ ] Ensure Adequate Unit Test Coverage: The changes are reasonably covered by unit tests or an explanation is provided in the PR description.
- [ ] Manual Testing: The author listed all the tests they ran, including smoke tests when needed (e.g., for refactorings). The reviewer confirmed that the PR works as expected on big (tablet) and small (phone) in case of UI changes, and no regressions are added.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->