### PR TITLE
"Merge unfulfilled shipments" feature logic

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/split/WooShippingSplitShipmentViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/split/WooShippingSplitShipmentViewModel.kt
@@ -122,9 +122,17 @@ class WooShippingSplitShipmentViewModel @Inject constructor(
                 )
             )
         } else {
-            // Merging all unfulfilled shipments
+            mergeUnfulfilledShipments()
         }
         removeShipmentSheet.value = null
+    }
+
+    private fun mergeUnfulfilledShipments() {
+        currentShipments.value = currentShipments.value.run {
+            // TODO Once the purchasing shipments feature is implemented, exclude purchased shipments from the merging
+            //  action.
+            mapOf(keys.first() to values.reduce(List<ShippableItemModel>::combine))
+        }
     }
 
     fun onDismissRemoveSheet() {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/split/WooShippingSplitShipmentViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/split/WooShippingSplitShipmentViewModel.kt
@@ -52,6 +52,12 @@ class WooShippingSplitShipmentViewModel @Inject constructor(
                         weightUnit = storeOptions.weightUnit
                     )
                 }
+
+                if (shipments.size == 1) {
+                    // The shipments row was removed. Since the pager can no longer manage the selected shipment,
+                    // update it manually.
+                    shipmentSelected.update { shipments.keys.first() }
+                }
             }
         }
     }
@@ -177,12 +183,6 @@ class WooShippingSplitShipmentViewModel @Inject constructor(
                 ?.combine(splitMovement.movingShipmentItems)
                 ?: splitMovement.movingShipmentItems
             reindexShipments(shipments)
-        }
-
-        if (currentShipments.value.size == 1) {
-            // The shipments row was removed. Since the pager can no longer manage the selected shipment, update it
-            // manually.
-            shipmentSelected.update { currentShipments.value.keys.first() }
         }
 
         val undoAction = {

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/split/WooShippingSplitShipmentViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/split/WooShippingSplitShipmentViewModelTest.kt
@@ -187,7 +187,7 @@ class WooShippingSplitShipmentViewModelTest : BaseUnitTest() {
             val shipmentArgs = SplitShipmentArgs(
                 orderId = 1L,
                 storeOptions = StoreOptionsModel.EMPTY,
-                shipments = twoShipment
+                shipments = twoShipments
             )
             val updatedCurrentShipmentItems = defaultShipment.getValue(0)
             val updatedShipmentItems = listOf(
@@ -301,7 +301,7 @@ class WooShippingSplitShipmentViewModelTest : BaseUnitTest() {
         val shipmentArgs = SplitShipmentArgs(
             orderId = 1L,
             storeOptions = StoreOptionsModel.EMPTY,
-            shipments = twoShipment
+            shipments = twoShipments
         )
 
         val expectedQuantity = 6 // Total single items in the Shipment 1 from `twoShipment`
@@ -321,9 +321,9 @@ class WooShippingSplitShipmentViewModelTest : BaseUnitTest() {
         val shipmentArgs = SplitShipmentArgs(
             orderId = 1L,
             storeOptions = StoreOptionsModel.EMPTY,
-            shipments = twoShipment
+            shipments = twoShipments
         )
-        val movingItems = twoShipment.getValue(1)
+        val movingItems = twoShipments.getValue(1)
 
         // Removing "Shipment 2"
         val movement = SplitMovement(
@@ -349,9 +349,9 @@ class WooShippingSplitShipmentViewModelTest : BaseUnitTest() {
         val shipmentArgs = SplitShipmentArgs(
             orderId = 1L,
             storeOptions = StoreOptionsModel.EMPTY,
-            shipments = twoShipment
+            shipments = twoShipments
         )
-        val movingItems = twoShipment.getValue(1)
+        val movingItems = twoShipments.getValue(1)
 
         // Removing "Shipment 2"
         val movement = SplitMovement(
@@ -360,7 +360,7 @@ class WooShippingSplitShipmentViewModelTest : BaseUnitTest() {
             destinationShipmentKey = 0,
             movingShipmentItems = movingItems
         )
-        val expectedItemCount = twoShipment.getValue(0).size + twoShipment.getValue(1).size
+        val expectedItemCount = twoShipments.getValue(0).size + twoShipments.getValue(1).size
 
         createViewModel(shipmentArgs)
 
@@ -417,7 +417,7 @@ class WooShippingSplitShipmentViewModelTest : BaseUnitTest() {
             )
         )
     )
-    private val twoShipment = mapOf(
+    private val twoShipments = mapOf(
         0 to listOf(
             ShippableItemModel(
                 itemId = 1L,

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/split/WooShippingSplitShipmentViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/split/WooShippingSplitShipmentViewModelTest.kt
@@ -462,4 +462,64 @@ class WooShippingSplitShipmentViewModelTest : BaseUnitTest() {
             )
         )
     )
+    private val threeShipments = mapOf(
+        0 to listOf(
+            ShippableItemModel(
+                itemId = 1L,
+                productId = 1L,
+                title = "A product with quantity 1",
+                price = BigDecimal(30),
+                quantity = 1f,
+                imageUrl = null,
+                currency = "USD",
+                length = 3f,
+                width = 3f,
+                height = 3f,
+                weight = 8f
+            ),
+            ShippableItemModel(
+                itemId = 2L,
+                productId = 2L,
+                title = "A product with quantity 5",
+                price = BigDecimal(10),
+                quantity = 5f,
+                imageUrl = null,
+                currency = "USD",
+                length = 3f,
+                width = 3f,
+                height = 3f,
+                weight = 8f
+            )
+        ),
+        1 to listOf(
+            ShippableItemModel(
+                itemId = 3L,
+                productId = 3L,
+                title = "Another product with quantity 3",
+                price = BigDecimal(10),
+                quantity = 3f,
+                imageUrl = null,
+                currency = "USD",
+                length = 3f,
+                width = 3f,
+                height = 3f,
+                weight = 8f
+            )
+        ),
+        2 to listOf(
+            ShippableItemModel(
+                itemId = 3L,
+                productId = 3L,
+                title = "Another product with quantity 3",
+                price = BigDecimal(10),
+                quantity = 1f,
+                imageUrl = null,
+                currency = "USD",
+                length = 3f,
+                width = 3f,
+                height = 3f,
+                weight = 8f
+            )
+        )
+    )
 }

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/split/WooShippingSplitShipmentViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/split/WooShippingSplitShipmentViewModelTest.kt
@@ -374,6 +374,71 @@ class WooShippingSplitShipmentViewModelTest : BaseUnitTest() {
         assertThat(modifiedShipment.shippableItems.size).isEqualTo(expectedItemCount)
     }
 
+    @Test
+    fun `when there are 2 shipments, then do not display the Merge all unfulfilled option`() = testBlocking {
+        val shipmentArgs = SplitShipmentArgs(
+            orderId = 1L,
+            storeOptions = StoreOptionsModel.EMPTY,
+            shipments = twoShipments
+        )
+
+        createViewModel(shipmentArgs)
+
+        sut.viewState.observeForTesting { }
+
+        val state = sut.viewState.value!!
+
+        assertThat(state.overflowMenuItems.size).isEqualTo(2)
+    }
+
+    @Test
+    fun `when there are 3 shipments, then display the Merge all unfulfilled option`() = testBlocking {
+        val shipmentArgs = SplitShipmentArgs(
+            orderId = 1L,
+            storeOptions = StoreOptionsModel.EMPTY,
+            shipments = threeShipments
+        )
+
+        createViewModel(shipmentArgs)
+
+        sut.viewState.observeForTesting { }
+
+        val state = sut.viewState.value!!
+        val lastMenuItem = state.overflowMenuItems.last()
+        val expectedShipmentCountToBeMerged = threeShipments.size
+        val expectedMenuItemCount = expectedShipmentCountToBeMerged + 1
+
+        assertThat(state.overflowMenuItems.size).isEqualTo(expectedMenuItemCount)
+
+        // Verifying if the last item is "Merge all unfulfilled"
+        assertThat(lastMenuItem.size).isEqualTo(expectedShipmentCountToBeMerged)
+    }
+
+    @Test
+    fun `when merging unfulfilled shipments, a single unfulfilled shipment contains all items`() = testBlocking {
+        val shipmentArgs = SplitShipmentArgs(
+            orderId = 1L,
+            storeOptions = StoreOptionsModel.EMPTY,
+            shipments = threeShipments
+        )
+
+        createViewModel(shipmentArgs)
+
+        // Trigger merging all shipments
+        sut.onRemoveShipments(removingShipmentKeys = threeShipments.keys.toList(), destinationShipmentKey = null)
+
+        sut.viewState.observeForTesting { }
+
+        val state = sut.viewState.value!!
+        val currentShipments = state.selectableItems
+        val expectedItemQuantity = 10 // All items from `threeShipments`
+
+        // Verify there is only one shipment
+        assertThat(currentShipments.size).isEqualTo(1)
+
+        assertThat(currentShipments.values.first().totalItemQuantity).isEqualTo(expectedItemQuantity)
+    }
+
     private val defaultShipment = mapOf(
         0 to listOf(
             ShippableItemModel(


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes WOOMOB-285
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
This adds merging logic for the UI that was added in #13950.

> [!WARNING]  
> Review #13950 first.

### Steps to reproduce
<!-- Step-by-step testing instructions. For new user flows, consider instead stating the goal of the workflow and see if your PR reviewer can accomplish the workflow without specific steps! -->
1. Open the orders tab.
2. Tap on an order eligible for shipping label creation. It’s better to choose one with multiple items.
3. Tap on Create shipping label.
4. Tap on Split shipment.
5. Choose some items and move them to a new shipment.
6. Create at least 3 shipments.
7. Tap the more button in the shipments tab.
8. Tap Merge all unfulfilled button

### Testing information
<!-- This is your opportunity to break out individual scenarios that need testing (when necessary) and/or include a checklist for the reviewer to go through. Consider documenting the following from your own completed testing: devices used, alternate workflows, edge cases, affected areas, critical flows, areas not tested, and any remaining unknowns. Provide feedback on this new section of the PR template through Sept 30, 2024 to Apps Quality; additional context here: p91TBi-b8z-p2#comment-12036 -->
Please test making multiple changes to shipments.

### The tests that have been performed
<!-- To give the reviewer an idea of what could be missed in terms of testing -->
Steps above.

### Images/gif
<!-- Include before and after images or gifs when appropriate. -->
[Screen_recording_20250419_135954.webm](https://github.com/user-attachments/assets/91901642-8943-47ce-a4a9-f49a7ea8fcc6)

- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.

## Reviewer (or Author, in the case of optional code reviews):

Please make sure these conditions are met before approving the PR, or request changes if the PR needs improvement:

- [ ] The PR is small and has a clear, single focus, or a valid explanation is provided in the description. If needed, please request to split it into smaller PRs.
- [ ] Ensure Adequate Unit Test Coverage: The changes are reasonably covered by unit tests or an explanation is provided in the PR description.
- [ ] Manual Testing: The author listed all the tests they ran, including smoke tests when needed (e.g., for refactorings). The reviewer confirmed that the PR works as expected on big (tablet) and small (phone) in case of UI changes, and no regressions are added.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->