### PR TITLE
Fix issues related to edge-to-edge and IME handling

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/compose/component/Toolbar.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/compose/component/Toolbar.kt
@@ -1,6 +1,7 @@
 package com.woocommerce.android.ui.compose.component
 
 import androidx.compose.foundation.layout.RowScope
+import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.material.Icon
 import androidx.compose.material.IconButton
 import androidx.compose.material.Text
@@ -27,6 +28,7 @@ fun ToolbarWithHelpButton(
     onNavigationButtonClick: (() -> Unit)? = null,
     navigationIcon: ImageVector? = Icons.AutoMirrored.Filled.ArrowBack,
     navigationIconContentDescription: String = stringResource(id = string.back),
+    windowInsets: WindowInsets = WindowInsets(0),
     onHelpButtonClick: (() -> Unit)
 ) {
     Toolbar(
@@ -37,7 +39,8 @@ fun ToolbarWithHelpButton(
         navigationIconContentDescription = navigationIconContentDescription,
         actionButtonIcon = ImageVector.vectorResource(id = drawable.ic_help_24dp),
         onActionButtonClick = onHelpButtonClick,
-        actionIconContentDescription = stringResource(id = string.help)
+        actionIconContentDescription = stringResource(id = string.help),
+        windowInsets = windowInsets
     )
 }
 
@@ -47,7 +50,8 @@ fun Toolbar(
     title: String = "",
     onNavigationButtonClick: (() -> Unit),
     navigationIcon: ImageVector = Icons.AutoMirrored.Filled.ArrowBack,
-    navigationIconContentDescription: String = stringResource(id = string.back)
+    navigationIconContentDescription: String = stringResource(id = string.back),
+    windowInsets: WindowInsets = WindowInsets(0),
 ) {
     Toolbar(
         modifier = modifier,
@@ -55,6 +59,7 @@ fun Toolbar(
         onNavigationButtonClick = onNavigationButtonClick,
         navigationIcon = navigationIcon,
         navigationIconContentDescription = navigationIconContentDescription,
+        windowInsets = windowInsets,
     )
 }
 
@@ -65,6 +70,7 @@ fun Toolbar(
     onNavigationButtonClick: (() -> Unit)? = null,
     navigationIcon: ImageVector? = Icons.AutoMirrored.Filled.ArrowBack,
     navigationIconContentDescription: String = stringResource(id = string.back),
+    windowInsets: WindowInsets = WindowInsets(0),
     actionButtonIcon: ImageVector,
     onActionButtonClick: (() -> Unit),
     actionIconContentDescription: String
@@ -75,6 +81,7 @@ fun Toolbar(
         onNavigationButtonClick = onNavigationButtonClick,
         navigationIcon = navigationIcon,
         navigationIconContentDescription = navigationIconContentDescription,
+        windowInsets = windowInsets,
         actions = {
             IconButton(onClick = onActionButtonClick) {
                 Icon(
@@ -93,6 +100,7 @@ fun Toolbar(
     onNavigationButtonClick: (() -> Unit)? = null,
     navigationIcon: ImageVector? = Icons.AutoMirrored.Filled.ArrowBack,
     navigationIconContentDescription: String = stringResource(id = string.back),
+    windowInsets: WindowInsets = WindowInsets(0),
     actions: @Composable RowScope.() -> Unit = {}
 ) {
     Toolbar(
@@ -101,6 +109,7 @@ fun Toolbar(
         onNavigationButtonClick = onNavigationButtonClick,
         navigationIcon = navigationIcon,
         navigationIconContentDescription = navigationIconContentDescription,
+        windowInsets = windowInsets,
         actions = actions
     )
 }
@@ -112,6 +121,7 @@ fun Toolbar(
     onNavigationButtonClick: (() -> Unit)? = null,
     navigationIcon: ImageVector? = Icons.AutoMirrored.Filled.ArrowBack,
     navigationIconContentDescription: String = stringResource(id = string.back),
+    windowInsets: WindowInsets = WindowInsets(0),
     onActionButtonClick: (() -> Unit),
     actionButtonText: String
 ) {
@@ -121,6 +131,7 @@ fun Toolbar(
         onNavigationButtonClick = onNavigationButtonClick,
         navigationIcon = navigationIcon,
         navigationIconContentDescription = navigationIconContentDescription,
+        windowInsets = windowInsets,
         actions = {
             TextButton(onClick = onActionButtonClick) {
                 Text(text = actionButtonText)
@@ -136,9 +147,11 @@ fun Toolbar(
     onNavigationButtonClick: (() -> Unit)? = null,
     navigationIcon: ImageVector? = null,
     navigationIconContentDescription: String = stringResource(id = string.back),
+    windowInsets: WindowInsets = WindowInsets(0),
     actions: @Composable RowScope.() -> Unit = {}
 ) {
     TopAppBar(
+        windowInsets = windowInsets,
         backgroundColor = colorResource(id = R.color.color_toolbar),
         title = title,
         navigationIcon = {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/coupons/edit/EditCouponScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/coupons/edit/EditCouponScreen.kt
@@ -7,7 +7,6 @@ import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.imePadding
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.rememberScrollState
@@ -102,7 +101,6 @@ fun EditCouponScreen(
             .verticalScroll(scrollState)
             .padding(vertical = dimensionResource(id = R.dimen.major_100))
             .fillMaxSize()
-            .imePadding()
     ) {
         DetailsSection(
             viewState = viewState,

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/jetpack/wpcom/JetpackActivationWPComEmailScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/jetpack/wpcom/JetpackActivationWPComEmailScreen.kt
@@ -6,7 +6,6 @@ import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
-import androidx.compose.foundation.layout.imePadding
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.text.KeyboardActions
@@ -68,7 +67,6 @@ fun JetpackActivationWPComEmailScreen(
             modifier = Modifier
                 .background(MaterialTheme.colors.surface)
                 .padding(paddingValues)
-                .imePadding()
                 .fillMaxSize()
                 .verticalScroll(rememberScrollState())
         ) {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/customerlist/CustomerListDialogFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/customerlist/CustomerListDialogFragment.kt
@@ -6,6 +6,7 @@ import android.view.View
 import android.view.ViewGroup
 import androidx.compose.ui.platform.ComposeView
 import androidx.compose.ui.platform.ViewCompositionStrategy
+import androidx.core.view.WindowCompat
 import androidx.fragment.app.DialogFragment
 import androidx.fragment.app.viewModels
 import androidx.navigation.fragment.findNavController
@@ -50,7 +51,7 @@ class CustomerListDialogFragment : DialogFragment() {
         setViewCompositionStrategy(ViewCompositionStrategy.DisposeOnViewTreeLifecycleDestroyed)
         setContent {
             WooThemeWithBackground {
-                OrderCustomerListScreen(viewModel)
+                OrderCustomerListScreen(viewModel, handleImeInsets = true)
             }
         }
     }
@@ -93,6 +94,9 @@ class CustomerListDialogFragment : DialogFragment() {
                 (DisplayUtils.getWindowPixelWidth(requireContext()) * TABLET_LANDSCAPE_WIDTH_RATIO).toInt(),
                 (DisplayUtils.getWindowPixelHeight(requireContext()) * TABLET_LANDSCAPE_HEIGHT_RATIO).toInt()
             )
+        }
+        dialog?.window?.let {
+            WindowCompat.setDecorFitsSystemWindows(it, false)
         }
     }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/customerlist/CustomerListDialogFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/customerlist/CustomerListDialogFragment.kt
@@ -51,7 +51,7 @@ class CustomerListDialogFragment : DialogFragment() {
         setViewCompositionStrategy(ViewCompositionStrategy.DisposeOnViewTreeLifecycleDestroyed)
         setContent {
             WooThemeWithBackground {
-                OrderCustomerListScreen(viewModel, handleImeInsets = true)
+                OrderCustomerListScreen(viewModel = viewModel, handleInsets = true)
             }
         }
     }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/customerlist/OrderCustomerListFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/customerlist/OrderCustomerListFragment.kt
@@ -35,7 +35,7 @@ class OrderCustomerListFragment : BaseFragment() {
         setViewCompositionStrategy(ViewCompositionStrategy.DisposeOnViewTreeLifecycleDestroyed)
         setContent {
             WooThemeWithBackground {
-                OrderCustomerListScreen(viewModel)
+                OrderCustomerListScreen(viewModel = viewModel, handleInsets = false)
             }
         }
     }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/customerlist/OrderCustomerListScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/customerlist/OrderCustomerListScreen.kt
@@ -2,6 +2,8 @@
 
 package com.woocommerce.android.ui.orders.creation.customerlist
 
+import androidx.compose.foundation.layout.imePadding
+import androidx.compose.foundation.layout.navigationBarsPadding
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material.FloatingActionButton
 import androidx.compose.material.Icon
@@ -26,11 +28,15 @@ import com.woocommerce.android.ui.customer.CustomerListScreen
 import org.wordpress.android.fluxc.model.customer.WCCustomerModel
 
 @Composable
-fun OrderCustomerListScreen(viewModel: CustomerListSelectionViewModel) {
+fun OrderCustomerListScreen(
+    viewModel: CustomerListSelectionViewModel,
+    handleImeInsets: Boolean = true,
+) {
     val state by viewModel.viewState.observeAsState()
     state?.let {
         OrderCustomerListScreen(
             state = it,
+            handleImeInsets = handleImeInsets,
             onNavigateBack = viewModel::onNavigateBack,
             onAddCustomerClicked = viewModel::onAddCustomerClicked,
             onCustomerSelected = viewModel::onCustomerSelected,
@@ -44,6 +50,7 @@ fun OrderCustomerListScreen(viewModel: CustomerListSelectionViewModel) {
 @Composable
 fun OrderCustomerListScreen(
     state: CustomerListViewState,
+    handleImeInsets: Boolean,
     onNavigateBack: () -> Unit,
     onAddCustomerClicked: () -> Unit,
     onCustomerSelected: (WCCustomerModel) -> Unit,
@@ -74,7 +81,10 @@ fun OrderCustomerListScreen(
         modifier = modifier
     ) { padding ->
         CustomerListScreen(
-            modifier = Modifier.padding(padding),
+            modifier = Modifier
+                .padding(padding)
+                .navigationBarsPadding()
+                .then(if (handleImeInsets) Modifier.imePadding() else Modifier),
             state = state,
             onCustomerSelected = onCustomerSelected,
             onSearchQueryChanged = onSearchQueryChanged,
@@ -161,6 +171,7 @@ fun OrderCustomerListScreenPreview() {
                     shouldResetScrollPosition = true
                 ),
             ),
+            handleImeInsets = false,
             onNavigateBack = {},
             onAddCustomerClicked = {},
             onCustomerSelected = {},

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/customerlist/OrderCustomerListScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/customerlist/OrderCustomerListScreen.kt
@@ -2,14 +2,14 @@
 
 package com.woocommerce.android.ui.orders.creation.customerlist
 
+import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.imePadding
 import androidx.compose.foundation.layout.navigationBarsPadding
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.statusBars
 import androidx.compose.material.FloatingActionButton
 import androidx.compose.material.Icon
-import androidx.compose.material.IconButton
 import androidx.compose.material.Scaffold
-import androidx.compose.material.Text
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material.icons.filled.Add
@@ -20,23 +20,30 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.colorResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
-import androidx.compose.ui.unit.dp
 import com.woocommerce.android.R
-import com.woocommerce.android.ui.compose.component.TopAppBarEdgeToEdge
+import com.woocommerce.android.ui.compose.component.Toolbar
 import com.woocommerce.android.ui.compose.theme.WooThemeWithBackground
 import com.woocommerce.android.ui.customer.CustomerListScreen
 import org.wordpress.android.fluxc.model.customer.WCCustomerModel
 
+/**
+ * @param handleInsets true if the screen should handle insets manually.
+ *  This is needed when the screen is used in a DialogFragment, otherwise the handling of insets at the root
+ *  layout will be enough.
+ *
+ *  Note: normally this shouldn't be needed, as we consume the insets in the root layout, but due to this
+ *  bug https://issuetracker.google.com/issues/411868840 the insets are re-applied when the keyboard is shown.
+ */
 @Composable
 fun OrderCustomerListScreen(
     viewModel: CustomerListSelectionViewModel,
-    handleImeInsets: Boolean = true,
+    handleInsets: Boolean
 ) {
     val state by viewModel.viewState.observeAsState()
     state?.let {
         OrderCustomerListScreen(
             state = it,
-            handleImeInsets = handleImeInsets,
+            handleInsets = handleInsets,
             onNavigateBack = viewModel::onNavigateBack,
             onAddCustomerClicked = viewModel::onAddCustomerClicked,
             onCustomerSelected = viewModel::onCustomerSelected,
@@ -50,7 +57,7 @@ fun OrderCustomerListScreen(
 @Composable
 fun OrderCustomerListScreen(
     state: CustomerListViewState,
-    handleImeInsets: Boolean,
+    handleInsets: Boolean,
     onNavigateBack: () -> Unit,
     onAddCustomerClicked: () -> Unit,
     onCustomerSelected: (WCCustomerModel) -> Unit,
@@ -61,18 +68,11 @@ fun OrderCustomerListScreen(
 ) {
     Scaffold(
         topBar = {
-            TopAppBarEdgeToEdge(
-                title = { Text(stringResource(id = R.string.order_creation_add_customer)) },
-                navigationIcon = {
-                    IconButton(onNavigateBack) {
-                        Icon(
-                            imageVector = Icons.AutoMirrored.Filled.ArrowBack,
-                            contentDescription = stringResource(id = R.string.back)
-                        )
-                    }
-                },
-                backgroundColor = colorResource(id = R.color.color_toolbar),
-                elevation = 0.dp,
+            Toolbar(
+                title = stringResource(id = R.string.order_creation_add_customer),
+                navigationIcon = Icons.AutoMirrored.Filled.ArrowBack,
+                onNavigationButtonClick = onNavigateBack,
+                windowInsets = if (handleInsets) WindowInsets.statusBars else WindowInsets(0),
             )
         },
         floatingActionButton = {
@@ -83,8 +83,7 @@ fun OrderCustomerListScreen(
         CustomerListScreen(
             modifier = Modifier
                 .padding(padding)
-                .navigationBarsPadding()
-                .then(if (handleImeInsets) Modifier.imePadding() else Modifier),
+                .then(if (handleInsets) Modifier.navigationBarsPadding().imePadding() else Modifier),
             state = state,
             onCustomerSelected = onCustomerSelected,
             onSearchQueryChanged = onSearchQueryChanged,
@@ -171,7 +170,7 @@ fun OrderCustomerListScreenPreview() {
                     shouldResetScrollPosition = true
                 ),
             ),
-            handleImeInsets = false,
+            handleInsets = false,
             onNavigateBack = {},
             onAddCustomerClicked = {},
             onCustomerSelected = {},

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/customerlist/OrderCustomerListScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/customerlist/OrderCustomerListScreen.kt
@@ -6,7 +6,7 @@ import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.imePadding
 import androidx.compose.foundation.layout.navigationBarsPadding
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.statusBars
+import androidx.compose.material.AppBarDefaults
 import androidx.compose.material.FloatingActionButton
 import androidx.compose.material.Icon
 import androidx.compose.material.Scaffold
@@ -72,7 +72,7 @@ fun OrderCustomerListScreen(
                 title = stringResource(id = R.string.order_creation_add_customer),
                 navigationIcon = Icons.AutoMirrored.Filled.ArrowBack,
                 onNavigationButtonClick = onNavigateBack,
-                windowInsets = if (handleInsets) WindowInsets.statusBars else WindowInsets(0),
+                windowInsets = if (handleInsets) AppBarDefaults.topAppBarWindowInsets else WindowInsets(0),
             )
         },
         floatingActionButton = {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/AppSettingsActivity.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/AppSettingsActivity.kt
@@ -5,6 +5,7 @@ import android.os.Bundle
 import android.view.View
 import androidx.appcompat.app.AppCompatActivity
 import androidx.appcompat.widget.Toolbar
+import androidx.core.view.WindowInsetsCompat
 import androidx.core.view.isVisible
 import androidx.core.view.updatePadding
 import androidx.fragment.app.DialogFragment
@@ -70,7 +71,12 @@ class AppSettingsActivity :
         binding = ActivityAppSettingsBinding.inflate(layoutInflater)
         setContentView(binding.root)
 
-        binding.root.doOnApplyWindowInsets(consumeInsets = true) {
+        binding.root.doOnApplyWindowInsets(
+            insetsMask = WindowInsetsCompat.Type.systemBars() or
+                WindowInsetsCompat.Type.displayCutout() or
+                WindowInsetsCompat.Type.ime(),
+            consumeInsets = true
+        ) {
             binding.root.updatePadding(
                 left = it.left,
                 right = it.right,

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ai/productinfo/AiProductPromptScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ai/productinfo/AiProductPromptScreen.kt
@@ -16,7 +16,6 @@ import androidx.compose.foundation.layout.defaultMinSize
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
-import androidx.compose.foundation.layout.imePadding
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.wrapContentWidth
@@ -148,7 +147,6 @@ fun AiProductPromptScreen(
                 .background(MaterialTheme.colors.surface)
                 .padding(padding)
                 .fillMaxSize()
-                .imePadding()
         ) {
             Column(
                 modifier = Modifier

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/selector/ProductSelectorDialogFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/selector/ProductSelectorDialogFragment.kt
@@ -33,7 +33,8 @@ class ProductSelectorDialogFragment : DialogFragment() {
         private const val TABLET_LANDSCAPE_HEIGHT_RATIO = 0.6f
     }
 
-    @Inject lateinit var navigator: ProductNavigator
+    @Inject
+    lateinit var navigator: ProductNavigator
 
     private val viewModel: ProductSelectorViewModel by viewModels()
 
@@ -64,7 +65,7 @@ class ProductSelectorDialogFragment : DialogFragment() {
 
             setContent {
                 WooThemeWithBackground {
-                    ProductSelectorScreen(viewModel)
+                    ProductSelectorScreen(viewModel, handleImeInsets = true)
                 }
             }
         }
@@ -99,6 +100,7 @@ class ProductSelectorDialogFragment : DialogFragment() {
                         event.data as Collection<SelectedItem>
                     )
                 }
+
                 is ProductNavigationTarget -> navigator.navigate(this, event)
                 is Exit -> findNavController().navigateUp()
             }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/selector/ProductSelectorDialogFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/selector/ProductSelectorDialogFragment.kt
@@ -65,7 +65,7 @@ class ProductSelectorDialogFragment : DialogFragment() {
 
             setContent {
                 WooThemeWithBackground {
-                    ProductSelectorScreen(viewModel, handleImeInsets = true)
+                    ProductSelectorScreen(viewModel = viewModel, handleInsets = true)
                 }
             }
         }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/selector/ProductSelectorFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/selector/ProductSelectorFragment.kt
@@ -54,7 +54,7 @@ class ProductSelectorFragment : BaseFragment() {
             setViewCompositionStrategy(ViewCompositionStrategy.DisposeOnViewTreeLifecycleDestroyed)
             setContent {
                 WooThemeWithBackground {
-                    ProductSelectorScreen(viewModel)
+                    ProductSelectorScreen(viewModel = viewModel, handleInsets = false)
                 }
             }
         }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/selector/ProductSelectorScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/selector/ProductSelectorScreen.kt
@@ -18,7 +18,6 @@ import androidx.compose.foundation.layout.navigationBarsPadding
 import androidx.compose.foundation.layout.offset
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
-import androidx.compose.foundation.layout.statusBars
 import androidx.compose.foundation.layout.statusBarsPadding
 import androidx.compose.foundation.layout.wrapContentWidth
 import androidx.compose.foundation.lazy.LazyColumn
@@ -26,6 +25,7 @@ import androidx.compose.foundation.lazy.itemsIndexed
 import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
+import androidx.compose.material.AppBarDefaults
 import androidx.compose.material.CircularProgressIndicator
 import androidx.compose.material.Divider
 import androidx.compose.material.MaterialTheme
@@ -102,7 +102,7 @@ fun ProductSelectorScreen(
                         Icons.Filled.Close
                     },
                     onNavigationButtonClick = viewModel::onNavigateBack,
-                    windowInsets = if (handleInsets) WindowInsets.statusBars else WindowInsets(0),
+                    windowInsets = if (handleInsets) AppBarDefaults.topAppBarWindowInsets else WindowInsets(0),
                 )
             }
         }) { padding ->

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/selector/ProductSelectorScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/selector/ProductSelectorScreen.kt
@@ -12,6 +12,7 @@ import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.imePadding
 import androidx.compose.foundation.layout.navigationBarsPadding
 import androidx.compose.foundation.layout.offset
 import androidx.compose.foundation.layout.padding
@@ -75,7 +76,10 @@ import com.woocommerce.android.ui.products.selector.components.SelectorListItem
 import com.woocommerce.android.util.StringUtils
 
 @Composable
-fun ProductSelectorScreen(viewModel: ProductSelectorViewModel) {
+fun ProductSelectorScreen(
+    viewModel: ProductSelectorViewModel,
+    handleImeInsets: Boolean = false
+) {
     val viewState by viewModel.viewState.observeAsState()
     BackHandler(onBack = viewModel::onNavigateBack)
     viewState?.let { state ->
@@ -106,13 +110,11 @@ fun ProductSelectorScreen(viewModel: ProductSelectorViewModel) {
                 )
             }
         }) { padding ->
-            val modifier = if (showToolbar) {
-                Modifier.padding(padding)
-            } else {
-                Modifier
-                    .padding(padding)
-                    .statusBarsPadding()
-            }.navigationBarsPadding()
+            val modifier = Modifier
+                .padding(padding)
+                .navigationBarsPadding()
+                .then(if (!showToolbar) Modifier.statusBarsPadding() else Modifier)
+                .then(if (handleImeInsets) Modifier.imePadding() else Modifier)
             ProductSelectorScreen(
                 modifier = modifier,
                 state = state,

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/selector/ProductSelectorScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/selector/ProductSelectorScreen.kt
@@ -9,6 +9,7 @@ import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
@@ -17,6 +18,7 @@ import androidx.compose.foundation.layout.navigationBarsPadding
 import androidx.compose.foundation.layout.offset
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.statusBars
 import androidx.compose.foundation.layout.statusBarsPadding
 import androidx.compose.foundation.layout.wrapContentWidth
 import androidx.compose.foundation.lazy.LazyColumn
@@ -26,8 +28,6 @@ import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.CircularProgressIndicator
 import androidx.compose.material.Divider
-import androidx.compose.material.Icon
-import androidx.compose.material.IconButton
 import androidx.compose.material.MaterialTheme
 import androidx.compose.material.Scaffold
 import androidx.compose.material.Text
@@ -45,7 +45,6 @@ import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.Preview
-import androidx.compose.ui.unit.dp
 import com.woocommerce.android.R
 import com.woocommerce.android.R.color
 import com.woocommerce.android.R.dimen
@@ -54,7 +53,7 @@ import com.woocommerce.android.ui.compose.animations.SkeletonView
 import com.woocommerce.android.ui.compose.component.InfiniteListHandler
 import com.woocommerce.android.ui.compose.component.SearchLayoutWithParams
 import com.woocommerce.android.ui.compose.component.SearchLayoutWithParamsState
-import com.woocommerce.android.ui.compose.component.TopAppBarEdgeToEdge
+import com.woocommerce.android.ui.compose.component.Toolbar
 import com.woocommerce.android.ui.compose.component.WCColoredButton
 import com.woocommerce.android.ui.compose.component.WCTextButton
 import com.woocommerce.android.ui.products.ProductType.BUNDLE
@@ -75,10 +74,18 @@ import com.woocommerce.android.ui.products.selector.SelectionState.SELECTED
 import com.woocommerce.android.ui.products.selector.components.SelectorListItem
 import com.woocommerce.android.util.StringUtils
 
+/**
+ * @param handleInsets true if the screen should handle insets manually.
+ *  This is needed when the screen is used in a DialogFragment, otherwise the handling of insets at the root
+ *  layout will be enough.
+ *
+ *  Note: normally this shouldn't be needed, as we consume the insets in the root layout, but due to this
+ *  bug https://issuetracker.google.com/issues/411868840 the insets are re-applied when the keyboard is shown.
+ */
 @Composable
 fun ProductSelectorScreen(
     viewModel: ProductSelectorViewModel,
-    handleImeInsets: Boolean = false
+    handleInsets: Boolean,
 ) {
     val viewState by viewModel.viewState.observeAsState()
     BackHandler(onBack = viewModel::onNavigateBack)
@@ -86,35 +93,31 @@ fun ProductSelectorScreen(
         val showToolbar = state.selectionMode != SelectionMode.LIVE
         Scaffold(topBar = {
             if (showToolbar) {
-                TopAppBarEdgeToEdge(
-                    title = {
-                        Text(
-                            text = state.screenTitleOverride
-                                ?: stringResource(id = string.coupon_conditions_products_select_products_title)
-                        )
+                Toolbar(
+                    title = state.screenTitleOverride
+                        ?: stringResource(id = string.coupon_conditions_products_select_products_title),
+                    navigationIcon = if (state.searchState.isActive) {
+                        Icons.AutoMirrored.Filled.ArrowBack
+                    } else {
+                        Icons.Filled.Close
                     },
-                    navigationIcon = {
-                        IconButton(viewModel::onNavigateBack) {
-                            Icon(
-                                imageVector = if (state.searchState.isActive) {
-                                    Icons.AutoMirrored.Filled.ArrowBack
-                                } else {
-                                    Icons.Filled.Close
-                                },
-                                contentDescription = stringResource(id = string.back)
-                            )
-                        }
-                    },
-                    backgroundColor = colorResource(id = R.color.color_toolbar),
-                    elevation = 0.dp,
+                    onNavigationButtonClick = viewModel::onNavigateBack,
+                    windowInsets = if (handleInsets) WindowInsets.statusBars else WindowInsets(0),
                 )
             }
         }) { padding ->
             val modifier = Modifier
                 .padding(padding)
-                .navigationBarsPadding()
-                .then(if (!showToolbar) Modifier.statusBarsPadding() else Modifier)
-                .then(if (handleImeInsets) Modifier.imePadding() else Modifier)
+                .then(
+                    if (handleInsets) {
+                        Modifier
+                            .navigationBarsPadding()
+                            .imePadding()
+                            .then(if (!showToolbar) Modifier.statusBarsPadding() else Modifier)
+                    } else {
+                        Modifier
+                    }
+                )
             ProductSelectorScreen(
                 modifier = modifier,
                 state = state,


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

### Description
This PR fixes some issues related to the IME insets handling in the app:
- In `MainActivity`, we were duplicating the handling of the IME insets in the app, we apply the padding on the root then on some internal fragments, which created some issues like in the Jetpack connection email screen. Normally this shouldn't cause issues as we consume the insets at the root level, but this seems like a Compose bug where the IME animation causes the insets to be re-applied, I created a bug report about this [here](https://issuetracker.google.com/issues/411868840), and I removed the duplicated padding to fix our issues.
- In some DialogFragments, we aren't handling the IME insets, I fixed this (check the Product Selector screenshot for an example).
- `AppSettingsActivity` wasn't handling the IME inset, I added this. 

### Steps to reproduce
I think the flows are clear, if you need exact steps for any test, please ping me.

### Testing information
- Confirm the insets are applied correctly.

### The tests that have been performed
<!-- To give the reviewer an idea of what could be missed in terms of testing -->

### Images/gif
##### Jetpack and Coupons

##### Other fixes
| Before | After |
| --- | --- |
| ![Screenshot_20250421_225746](https://github.com/user-attachments/assets/1c22326e-cf8f-430d-9db6-015278052b9e) | <img src=https://github.com/user-attachments/assets/ca28ad83-3b15-44b0-a1eb-87b8145b7004 /> |
| ![Screenshot_20250421_230017](https://github.com/user-attachments/assets/02ca0f9a-f2bf-4f47-87c2-9bafc1a20306) | <img src=https://github.com/user-attachments/assets/f8aa7e22-3546-4073-84ea-74f54c7c3c9d />
| ![Screenshot_20250420_000226](https://github.com/user-attachments/assets/5f596191-798a-4eb7-ab1a-aed4a7e8b8d9) | ![Screenshot_20250421_102043](https://github.com/user-attachments/assets/d0acd032-a18f-4482-8341-a0ab90eec5cd) |
| ![Screenshot_20250421_230145](https://github.com/user-attachments/assets/878263c3-354e-40ca-8ef5-aab39ea8e579) | ![Screenshot_20250421_230238](https://github.com/user-attachments/assets/02d1b85c-6ffb-4de0-8114-f1a415c9b4fe) |


- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.

## Reviewer (or Author, in the case of optional code reviews):

Please make sure these conditions are met before approving the PR, or request changes if the PR needs improvement:

- [x] The PR is small and has a clear, single focus, or a valid explanation is provided in the description. If needed, please request to split it into smaller PRs.
- [x] Ensure Adequate Unit Test Coverage: The changes are reasonably covered by unit tests or an explanation is provided in the PR description.
- [x] Manual Testing: The author listed all the tests they ran, including smoke tests when needed (e.g., for refactorings). The reviewer confirmed that the PR works as expected on big (tablet) and small (phone) in case of UI changes, and no regressions are added.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->