### PR TITLE
[WOOMOB-339][Woo POS][Product Search] Do not show placeholder when product doesn't exist in the cart

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/cart/WooPosCartScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/cart/WooPosCartScreen.kt
@@ -59,7 +59,9 @@ import androidx.compose.ui.unit.dp
 import androidx.constraintlayout.compose.ConstraintLayout
 import androidx.constraintlayout.compose.Dimension
 import androidx.hilt.navigation.compose.hiltViewModel
-import coil.compose.AsyncImage
+import coil.compose.AsyncImagePainter
+import coil.compose.rememberAsyncImagePainter
+import coil.imageLoader
 import coil.request.ImageRequest
 import com.woocommerce.android.R
 import com.woocommerce.android.extensions.isNotNullOrEmpty
@@ -410,23 +412,38 @@ private fun ProductItem(
         ) {
             Box(
                 modifier = Modifier
-                    .background(MaterialTheme.colorScheme.surfaceDim),
+                    .background(MaterialTheme.colorScheme.surfaceDim)
+                    .size(96.dp),
                 contentAlignment = Alignment.Center
             ) {
-                Image(
-                    painter = painterResource(R.drawable.ic_box),
-                    contentDescription = null,
-                    colorFilter = ColorFilter.tint(WooPosTheme.colors.onSurfaceVariantLowest),
-                    modifier = Modifier.size(36.dp, 36.dp)
-                )
-                AsyncImage(
+                val asyncImagePainter = rememberAsyncImagePainter(
                     model = ImageRequest.Builder(LocalContext.current)
                         .data(item.imageUrl)
                         .crossfade(true)
                         .build(),
+                    imageLoader = LocalContext.current.imageLoader,
+                    contentScale = ContentScale.Crop
+                )
+
+                val isNotLoaded = asyncImagePainter.state !is AsyncImagePainter.State.Success
+
+                if (isNotLoaded) {
+                    Image(
+                        painter = painterResource(R.drawable.ic_box),
+                        contentDescription = null,
+                        colorFilter = ColorFilter.tint(WooPosTheme.colors.onSurfaceVariantLowest),
+                        modifier = Modifier.alpha(if (item.productDoesNotExist) 0.5f else 1f)
+                            .size(36.dp)
+                    )
+                }
+
+                Image(
+                    painter = asyncImagePainter,
                     contentDescription = null,
                     contentScale = ContentScale.Crop,
-                    modifier = Modifier.size(96.dp).alpha(if (item.productDoesNotExist) 0.5f else 1f)
+                    modifier = Modifier
+                        .size(96.dp)
+                        .alpha(if (item.productDoesNotExist) 0.5f else 1f)
                 )
             }
 
@@ -444,7 +461,8 @@ private fun ProductItem(
                     fontWeight = FontWeight.Bold,
                     overflow = TextOverflow.Ellipsis,
                     color = MaterialTheme.colorScheme.onSurface,
-                    modifier = Modifier.clearAndSetSemantics { }
+                    modifier = Modifier
+                        .clearAndSetSemantics { }
                         .alpha(if (item.productDoesNotExist) 0.2f else 1f)
                 )
                 Spacer(modifier = Modifier.height(WooPosSpacing.XSmall.value.toAdaptivePadding()))
@@ -455,7 +473,8 @@ private fun ProductItem(
                         color = WooPosTheme.colors.onSurfaceVariantHighest,
                         maxLines = 1,
                         overflow = TextOverflow.Ellipsis,
-                        modifier = Modifier.clearAndSetSemantics { }
+                        modifier = Modifier
+                            .clearAndSetSemantics { }
                             .alpha(if (item.productDoesNotExist) 0.5f else 1f)
                     )
                     Spacer(modifier = Modifier.height(WooPosSpacing.XSmall.value.toAdaptivePadding()))
@@ -464,7 +483,8 @@ private fun ProductItem(
                     text = item.price,
                     style = WooPosTypography.BodySmall,
                     color = WooPosTheme.colors.onSurfaceVariantHighest,
-                    modifier = Modifier.clearAndSetSemantics { }
+                    modifier = Modifier
+                        .clearAndSetSemantics { }
                         .alpha(if (item.productDoesNotExist) 0.5f else 1f)
                 )
             }


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #WOOMOB-339
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
The PR fixes a bug when the placeholder was visible when alpha was applied to the deleted on the BE product in the cart

### Steps to reproduce
<!-- Step-by-step testing instructions. For new user flows, consider instead stating the goal of the workflow and see if your PR reviewer can accomplish the workflow without specific steps! -->
Easier to use this patch to simulate the case

[Randomly_mark_simple_products_as_non-existent_and_conditionally_update_image_URL.patch](https://github.com/user-attachments/files/19831893/Randomly_mark_simple_products_as_non-existent_and_conditionally_update_image_URL.patch)

* Open POS
* Add a few items to the cart
* Click checkout
* Notice that some items "do not exist". Some with image some without


### Testing information
<!-- This is your opportunity to break out individual scenarios that need testing (when necessary) and/or include a checklist for the reviewer to go through. Consider documenting the following from your own completed testing: devices used, alternate workflows, edge cases, affected areas, critical flows, areas not tested, and any remaining unknowns. Provide feedback on this new section of the PR template through Sept 30, 2024 to Apps Quality; additional context here: p91TBi-b8z-p2#comment-12036 -->
Notice that there are 2 cases:
* When image successfully loaded
* When image doesn't exist or not loaded 

### The tests that have been performed
<!-- To give the reviewer an idea of what could be missed in terms of testing -->

Using the applied patch, I did the checout

### Images/gif
<!-- Include before and after images or gifs when appropriate. -->
<img width="865" alt="image" src="https://github.com/user-attachments/assets/8bf039fb-9b2b-4948-80a4-d8fa57b6254d" />


- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.

## Reviewer (or Author, in the case of optional code reviews):

Please make sure these conditions are met before approving the PR, or request changes if the PR needs improvement:

- [ ] The PR is small and has a clear, single focus, or a valid explanation is provided in the description. If needed, please request to split it into smaller PRs.
- [ ] Ensure Adequate Unit Test Coverage: The changes are reasonably covered by unit tests or an explanation is provided in the PR description.
- [ ] Manual Testing: The author listed all the tests they ran, including smoke tests when needed (e.g., for refactorings). The reviewer confirmed that the PR works as expected on big (tablet) and small (phone) in case of UI changes, and no regressions are added.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->