### PR TITLE
[WOOMOB-175][POS][Coupons]Product/Coupons Toggle Implementation

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/common/composeui/component/WooPosPaginationErrorIndicator.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/common/composeui/component/WooPosPaginationErrorIndicator.kt
@@ -124,6 +124,7 @@ private fun WooPosPaginationErrorIndicatorContent(
 fun WooPosPaginationErrorScreenPreview() {
     val itemsState =
         WooPosItemsViewState.Content(
+            contentType = WooPosItemsViewState.Content.ContentState.ProductList,
             items = listOf(
                 Product.Simple(
                     1,

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/items/WooPosCouponsViewState.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/items/WooPosCouponsViewState.kt
@@ -1,0 +1,22 @@
+package com.woocommerce.android.ui.woopos.home.items
+
+sealed class WooPosCouponsViewState(
+    override val pullToRefreshState: WooPosPullToRefreshState,
+) : WooPosBaseViewState(pullToRefreshState) {
+    data class Content(
+        val coupons: List<WooPosItemSelectionViewState>,
+        val paginationState: WooPosPaginationState = WooPosPaginationState.None,
+        override val pullToRefreshState: WooPosPullToRefreshState = WooPosPullToRefreshState.Enabled,
+    ) : WooPosCouponsViewState(pullToRefreshState)
+    data class Loading(
+        override val pullToRefreshState: WooPosPullToRefreshState = WooPosPullToRefreshState.Enabled,
+    ) : WooPosCouponsViewState(pullToRefreshState)
+
+    data class Error(
+        override val pullToRefreshState: WooPosPullToRefreshState = WooPosPullToRefreshState.Enabled,
+    ) : WooPosCouponsViewState(pullToRefreshState)
+
+    data class Empty(
+        override val pullToRefreshState: WooPosPullToRefreshState = WooPosPullToRefreshState.Enabled,
+    ) : WooPosCouponsViewState(pullToRefreshState)
+}

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/items/WooPosItemsList.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/items/WooPosItemsList.kt
@@ -438,6 +438,7 @@ fun ItemListPreview() {
     WooPosTheme {
         WooPosItemList(
             WooPosItemsViewState.Content(
+                contentType = WooPosItemsViewState.Content.ContentState.ProductList,
                 WooPosItemsViewState.Content.SearchState.Hidden,
                 listOf(
                     Product.Simple(

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/items/WooPosItemsScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/items/WooPosItemsScreen.kt
@@ -68,7 +68,6 @@ fun WooPosItemsScreen(
     modifier: Modifier = Modifier,
     listState: LazyListState,
 ) {
-    // CouponsProject: Needs to be renamed to WooPosItemsViewModel
     val productsViewModel: WooPosItemsViewModel = hiltViewModel()
     WooPosItemsScreen(
         modifier = modifier,

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/items/WooPosItemsScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/items/WooPosItemsScreen.kt
@@ -58,6 +58,9 @@ import com.woocommerce.android.ui.woopos.home.items.WooPosItemsUIEvent.EndOfItem
 import com.woocommerce.android.ui.woopos.home.items.WooPosItemsUIEvent.ProductsLoadingErrorRetryButtonClicked
 import com.woocommerce.android.ui.woopos.home.items.WooPosItemsUIEvent.PullToRefreshTriggered
 import com.woocommerce.android.ui.woopos.home.items.WooPosItemsUIEvent.SearchChanged
+import com.woocommerce.android.ui.woopos.home.items.WooPosItemsViewState.Content.ContentState.CouponsList
+import com.woocommerce.android.ui.woopos.home.items.WooPosItemsViewState.Content.ContentState.ProductList
+import com.woocommerce.android.ui.woopos.home.items.coupons.WooPosCouponsScreen
 import com.woocommerce.android.ui.woopos.home.items.search.WooPosItemsSearchScreen
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
@@ -193,18 +196,7 @@ private fun MainItemsList(
                             is WooPosItemsViewState.Content.SearchState.Visible -> {
                                 when (itemsState.search.state) {
                                     WooPosSearchInputState.Closed -> {
-                                        WooPosItemList(
-                                            itemsState,
-                                            listState,
-                                            onItemClicked,
-                                            onEndOfItemListReached,
-                                        ) {
-                                            ProductsPaginationError(
-                                                onRetryClicked = {
-                                                    onEndOfItemListReached()
-                                                }
-                                            )
-                                        }
+                                        Content(itemsState, listState, onItemClicked, onEndOfItemListReached)
                                     }
 
                                     is WooPosSearchInputState.Open -> WooPosItemsSearchScreen()
@@ -212,18 +204,7 @@ private fun MainItemsList(
                             }
 
                             WooPosItemsViewState.Content.SearchState.Hidden -> {
-                                WooPosItemList(
-                                    itemsState,
-                                    listState,
-                                    onItemClicked,
-                                    onEndOfItemListReached,
-                                ) {
-                                    ProductsPaginationError(
-                                        onRetryClicked = {
-                                            onEndOfItemListReached()
-                                        }
-                                    )
-                                }
+                                Content(itemsState, listState, onItemClicked, onEndOfItemListReached)
                             }
                         }
                     }
@@ -245,6 +226,34 @@ private fun MainItemsList(
             refreshing = state.value.pullToRefreshState == WooPosPullToRefreshState.Refreshing,
             state = pullToRefreshState
         )
+    }
+}
+
+@Composable
+private fun Content(
+    itemsState: WooPosItemsViewState.Content,
+    listState: LazyListState,
+    onItemClicked: (item: WooPosItemSelectionViewState) -> Unit,
+    onEndOfItemListReached: () -> Unit
+) {
+    when (itemsState.contentType) {
+        CouponsList -> {
+            WooPosCouponsScreen(modifier = Modifier)
+        }
+        ProductList -> {
+            WooPosItemList(
+                itemsState,
+                listState,
+                onItemClicked,
+                onEndOfItemListReached,
+            ) {
+                ProductsPaginationError(
+                    onRetryClicked = {
+                        onEndOfItemListReached()
+                    }
+                )
+            }
+        }
     }
 }
 
@@ -418,6 +427,7 @@ private fun ProductsPaginationError(onRetryClicked: () -> Unit) {
 fun WooPosItemsScreenPreview(modifier: Modifier = Modifier) {
     val productState = MutableStateFlow(
         WooPosItemsViewState.Content(
+            contentType = ProductList,
             items = listOf(
                 Product.Simple(
                     1,
@@ -480,6 +490,7 @@ fun WooPosItemsScreenPreview(modifier: Modifier = Modifier) {
 fun WooPosItemsScreenPaginationErrorPreview(modifier: Modifier = Modifier) {
     val productState = MutableStateFlow(
         WooPosItemsViewState.Content(
+            contentType = ProductList,
             items = listOf(
                 Product.Simple(
                     1,
@@ -582,6 +593,7 @@ fun WooPosProductsScreenErrorPreview() {
 fun WooPosHomeScreenItemsWithSimpleProductsOnlyBannerPreview() {
     val productState = MutableStateFlow(
         WooPosItemsViewState.Content(
+            contentType = ProductList,
             items = listOf(
                 Product.Simple(
                     1,
@@ -634,6 +646,7 @@ fun WooPosHomeScreenItemsWithSimpleProductsOnlyBannerPreview() {
 fun WooPosHomeScreenItemsWithInfoIconInToolbarPreview() {
     val productState = MutableStateFlow(
         WooPosItemsViewState.Content(
+            contentType = ProductList,
             items = listOf(
                 Product.Simple(
                     1,

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/items/WooPosItemsViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/items/WooPosItemsViewModel.kt
@@ -11,6 +11,7 @@ import com.woocommerce.android.ui.woopos.featureflags.WooPosIsProductsSearchEnab
 import com.woocommerce.android.ui.woopos.home.ChildToParentEvent
 import com.woocommerce.android.ui.woopos.home.WooPosChildrenToParentEventSender
 import com.woocommerce.android.ui.woopos.home.items.WooPosItemNavigationData.VariableProductData
+import com.woocommerce.android.ui.woopos.home.items.WooPosItemsViewState.Content.ContentState
 import com.woocommerce.android.ui.woopos.home.items.navigation.WooPosItemsNavigator
 import com.woocommerce.android.ui.woopos.home.items.navigation.WooPosItemsNavigator.WooPosItemsScreenNavigationEvent
 import com.woocommerce.android.ui.woopos.home.items.navigation.WooPosItemsNavigator.WooPosItemsScreenNavigationEvent.NavigateToVariationsScreen
@@ -120,12 +121,7 @@ class WooPosItemsViewModel @Inject constructor(
             WooPosItemsUIEvent.SearchAnimationComplete -> searchHelper.onAnimationComplete()
 
             WooPosItemsUIEvent.CouponsButtonClicked -> {
-                sendEventToParent(
-                    ChildToParentEvent.ItemClickedInProductSelector(
-                        // CouponsProject: Show available coupons instead
-                        ItemClickedData.Coupon(id = 5013)
-                    )
-                )
+                handleCouponsButtonClick()
             }
         }
     }
@@ -189,6 +185,18 @@ class WooPosItemsViewModel @Inject constructor(
         }
     }
 
+    private fun handleCouponsButtonClick() {
+        (_viewState.value as? WooPosItemsViewState.Content)?.let { currentState ->
+            _viewState.value = currentState.copy(
+                contentType =
+                when (currentState.contentType) {
+                    ContentState.CouponsList -> ContentState.ProductList
+                    ContentState.ProductList -> ContentState.CouponsList
+                }
+            )
+        }
+    }
+
     private fun loadProducts(
         forceRefreshProducts: Boolean,
         withPullToRefresh: Boolean,
@@ -215,7 +223,7 @@ class WooPosItemsViewModel @Inject constructor(
                                 val products = result.productsResult.getOrThrow()
                                 if (products.isNotEmpty()) {
                                     val currentState = _viewState.value
-                                    var paginationState = if (loadMoreProductsJob?.isActive == true) {
+                                    val paginationState = if (loadMoreProductsJob?.isActive == true) {
                                         WooPosPaginationState.Loading
                                     } else {
                                         WooPosPaginationState.None
@@ -258,6 +266,7 @@ class WooPosItemsViewModel @Inject constructor(
     private suspend fun List<Product>.toContentState(
         paginationState: WooPosPaginationState = WooPosPaginationState.None
     ) = WooPosItemsViewState.Content(
+        contentType = ContentState.ProductList,
         items = map { it.toItemSelectionViewState() },
         paginationState = paginationState,
         pullToRefreshState = WooPosPullToRefreshState.Enabled,

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/items/WooPosItemsViewState.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/items/WooPosItemsViewState.kt
@@ -8,6 +8,7 @@ sealed class WooPosItemsViewState(
     override val pullToRefreshState: WooPosPullToRefreshState,
 ) : WooPosBaseViewState(pullToRefreshState) {
     data class Content(
+        val contentType: ContentState,
         val search: SearchState,
         override val items: List<WooPosItemSelectionViewState>,
         val bannerState: BannerState,
@@ -25,6 +26,11 @@ sealed class WooPosItemsViewState(
         sealed class SearchState {
             data class Visible(val state: WooPosSearchInputState) : SearchState()
             object Hidden : SearchState()
+        }
+
+        sealed class ContentState {
+            data object ProductList : ContentState()
+            data object CouponsList : ContentState()
         }
     }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/items/coupons/WooPosCouponsDataSource.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/items/coupons/WooPosCouponsDataSource.kt
@@ -1,0 +1,17 @@
+package com.woocommerce.android.ui.woopos.home.items.coupons
+
+import com.woocommerce.android.model.Coupon
+import com.woocommerce.android.ui.coupons.CouponListHandler
+import kotlinx.coroutines.flow.Flow
+import javax.inject.Inject
+import javax.inject.Singleton
+
+@Singleton
+class WooPosCouponsDataSource @Inject constructor(private val handler: CouponListHandler) {
+    val couponsFlow: Flow<List<Coupon>> = handler.couponsFlow
+
+    suspend fun clearCacheAndFetchFirstPage() =
+        handler.fetchCoupons(searchQuery = null, forceRefresh = true)
+
+    suspend fun loadMore() = handler.loadMore()
+}

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/items/coupons/WooPosCouponsScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/items/coupons/WooPosCouponsScreen.kt
@@ -1,17 +1,26 @@
 package com.woocommerce.android.ui.woopos.home.items.coupons
 
-import androidx.compose.foundation.lazy.LazyListState
 import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
+import com.woocommerce.android.ui.woopos.common.composeui.WooPosPreview
+import com.woocommerce.android.ui.woopos.common.composeui.designsystem.WooPosTheme
 
 @Composable
 fun WooPosCouponsScreen(
     modifier: Modifier = Modifier,
-    listState: LazyListState,
 ) {
     Text(
         text = "Coupons List",
+        color = WooPosTheme.colors.onSurfaceVariantHighest,
+        modifier = modifier
+    )
+}
+
+@WooPosPreview
+@Composable
+fun WooPosCouponsScreenPreview(modifier: Modifier = Modifier) {
+    WooPosCouponsScreen(
         modifier = modifier,
     )
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/items/coupons/WooPosCouponsScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/items/coupons/WooPosCouponsScreen.kt
@@ -1,0 +1,17 @@
+package com.woocommerce.android.ui.woopos.home.items.coupons
+
+import androidx.compose.foundation.lazy.LazyListState
+import androidx.compose.material.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+
+@Composable
+fun WooPosCouponsScreen(
+    modifier: Modifier = Modifier,
+    listState: LazyListState,
+) {
+    Text(
+        text = "Coupons List",
+        modifier = modifier,
+    )
+}

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/items/coupons/WooPosCouponsUIEvent.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/items/coupons/WooPosCouponsUIEvent.kt
@@ -1,0 +1,9 @@
+package com.woocommerce.android.ui.woopos.home.items.coupons
+
+sealed class WooPosCouponsUIEvent {
+    data object EndOfItemsListReached : WooPosCouponsUIEvent()
+    data object PullToRefreshTriggered : WooPosCouponsUIEvent()
+    data object RetryLoadMoreTriggered : WooPosCouponsUIEvent()
+    data class CouponClicked(val couponId: Long) : WooPosCouponsUIEvent()
+    data object BackButtonClicked : WooPosCouponsUIEvent()
+}

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/items/coupons/WooPosCouponsViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/items/coupons/WooPosCouponsViewModel.kt
@@ -68,20 +68,15 @@ class WooPosCouponsViewModel @Inject constructor(
     }
 
     private fun handleCouponClicked(event: WooPosCouponsUIEvent.CouponClicked) {
-        // CouponsProject: handle coupon click
+        viewModelScope.launch {
+            fromChildToParentEventSender.sendToParent(
+                // CouponsProject: rename ItemClickedInProductSelector to ItemClicked
+                ChildToParentEvent.ItemClickedInProductSelector(ItemClickedData.Coupon(event.couponId))
+            )
+        }
     }
 
     private fun onEndOfProductsListReached() {
         // CouponsProject: Load More
     }
-
-    private fun onItemClicked(itemData: ItemClickedData) {
-        viewModelScope.launch {
-            fromChildToParentEventSender.sendToParent(
-                // CouponsProject: rename ItemClickedInProductSelector to ItemClicked
-                ChildToParentEvent.ItemClickedInProductSelector(itemData)
-            )
-        }
-    }
 }
-

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/items/coupons/WooPosCouponsViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/items/coupons/WooPosCouponsViewModel.kt
@@ -32,7 +32,7 @@ class WooPosCouponsViewModel @Inject constructor(
         )
 
     init {
-        // TODO load initial coupons
+        // CouponsProject: load initial coupons
     }
 
     fun onUIEvent(event: WooPosCouponsUIEvent) {
@@ -42,7 +42,7 @@ class WooPosCouponsViewModel @Inject constructor(
             }
 
             WooPosCouponsUIEvent.PullToRefreshTriggered -> {
-                // TODO PTR Action
+                // CouponsProject: PTR Action
             }
 
             is WooPosCouponsUIEvent.EndOfItemsListReached -> {
@@ -50,7 +50,7 @@ class WooPosCouponsViewModel @Inject constructor(
             }
 
             WooPosCouponsUIEvent.RetryLoadMoreTriggered -> {
-                // TODO retry load more action
+                // CouponsProject: retry load more action
             }
 
             WooPosCouponsUIEvent.BackButtonClicked -> {
@@ -68,17 +68,17 @@ class WooPosCouponsViewModel @Inject constructor(
     }
 
     private fun handleCouponClicked(event: WooPosCouponsUIEvent.CouponClicked) {
-        // TODO handle coupon click
+        // CouponsProject: handle coupon click
     }
 
     private fun onEndOfProductsListReached() {
-        // TODO Load More
+        // CouponsProject: Load More
     }
 
     private fun onItemClicked(itemData: ItemClickedData) {
         viewModelScope.launch {
             fromChildToParentEventSender.sendToParent(
-                // TODO rename ItemClickedInProductSelector to ItemClicked
+                // CouponsProject: rename ItemClickedInProductSelector to ItemClicked
                 ChildToParentEvent.ItemClickedInProductSelector(itemData)
             )
         }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/items/coupons/WooPosCouponsViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/items/coupons/WooPosCouponsViewModel.kt
@@ -1,0 +1,87 @@
+package com.woocommerce.android.ui.woopos.home.items.coupons
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.woocommerce.android.ui.woopos.home.ChildToParentEvent
+import com.woocommerce.android.ui.woopos.home.WooPosChildrenToParentEventSender
+import com.woocommerce.android.ui.woopos.home.items.WooPosCouponsViewState
+import com.woocommerce.android.ui.woopos.home.items.WooPosItemsViewModel.ItemClickedData
+import com.woocommerce.android.ui.woopos.home.items.navigation.WooPosItemsNavigator
+import com.woocommerce.android.ui.woopos.home.items.navigation.WooPosItemsNavigator.WooPosItemsScreenNavigationEvent
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.SharingStarted
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.stateIn
+import kotlinx.coroutines.launch
+import javax.inject.Inject
+
+@HiltViewModel
+class WooPosCouponsViewModel @Inject constructor(
+    private val fromChildToParentEventSender: WooPosChildrenToParentEventSender,
+    private val navigator: WooPosItemsNavigator,
+) : ViewModel() {
+    private val _viewState =
+        MutableStateFlow<WooPosCouponsViewState>(WooPosCouponsViewState.Loading())
+
+    val viewState: StateFlow<WooPosCouponsViewState> = _viewState
+        .stateIn(
+            viewModelScope,
+            started = SharingStarted.WhileSubscribed(),
+            initialValue = _viewState.value,
+        )
+
+    init {
+        // TODO load initial coupons
+    }
+
+    fun onUIEvent(event: WooPosCouponsUIEvent) {
+        when (event) {
+            is WooPosCouponsUIEvent.CouponClicked -> {
+                handleCouponClicked(event)
+            }
+
+            WooPosCouponsUIEvent.PullToRefreshTriggered -> {
+                // TODO PTR Action
+            }
+
+            is WooPosCouponsUIEvent.EndOfItemsListReached -> {
+                onEndOfProductsListReached()
+            }
+
+            WooPosCouponsUIEvent.RetryLoadMoreTriggered -> {
+                // TODO retry load more action
+            }
+
+            WooPosCouponsUIEvent.BackButtonClicked -> {
+                navigateBackToItemListScreen()
+            }
+        }
+    }
+
+    private fun navigateBackToItemListScreen() {
+        viewModelScope.launch {
+            navigator.sendNavigationEvent(
+                WooPosItemsScreenNavigationEvent.NavigateBackToItemListScreen
+            )
+        }
+    }
+
+    private fun handleCouponClicked(event: WooPosCouponsUIEvent.CouponClicked) {
+        // TODO handle coupon click
+    }
+
+    private fun onEndOfProductsListReached() {
+        // TODO Load More
+    }
+
+    private fun onItemClicked(itemData: ItemClickedData) {
+        viewModelScope.launch {
+            fromChildToParentEventSender.sendToParent(
+                // TODO rename ItemClickedInProductSelector to ItemClicked
+                ChildToParentEvent.ItemClickedInProductSelector(itemData)
+            )
+        }
+    }
+}
+

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/home/items/WooPosItemsSearchHelperTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/home/items/WooPosItemsSearchHelperTest.kt
@@ -196,6 +196,7 @@ class WooPosItemsSearchHelperTest {
 
     private fun createContentState(): WooPosItemsViewState.Content {
         return WooPosItemsViewState.Content(
+            contentType = WooPosItemsViewState.Content.ContentState.ProductList,
             search = WooPosItemsViewState.Content.SearchState.Visible(
                 state = WooPosSearchInputState.Open(
                     input = WooPosSearchInputState.Open.Input.Hint("Search products"),

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/home/items/coupons/WooPosCouponsDataSourceTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/home/items/coupons/WooPosCouponsDataSourceTest.kt
@@ -1,0 +1,17 @@
+package com.woocommerce.android.ui.woopos.home.items.coupons
+
+import com.woocommerce.android.ui.woopos.util.WooPosCoroutineTestRule
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.Rule
+
+@ExperimentalCoroutinesApi
+class WooPosCouponsDataSourceTest {
+    @Rule
+    @JvmField
+    val coroutineTestRule = WooPosCoroutineTestRule()
+
+    fun dummyTest() {
+        assertThat(true).isTrue()
+    }
+}

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/home/items/coupons/WooPosCouponsViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/home/items/coupons/WooPosCouponsViewModelTest.kt
@@ -1,0 +1,17 @@
+package com.woocommerce.android.ui.woopos.home.items.coupons
+
+import com.woocommerce.android.ui.woopos.util.WooPosCoroutineTestRule
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.Rule
+import org.junit.Test
+
+class WooPosCouponsViewModelTest {
+    @Rule
+    @JvmField
+    val coroutineTestRule = WooPosCoroutineTestRule()
+
+    @Test
+    fun dumymTest() {
+        assertThat(true).isTrue()
+    }
+}

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/home/items/coupons/WooPosCouponsViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/home/items/coupons/WooPosCouponsViewModelTest.kt
@@ -1,17 +1,19 @@
 package com.woocommerce.android.ui.woopos.home.items.coupons
 
 import com.woocommerce.android.ui.woopos.util.WooPosCoroutineTestRule
+import kotlinx.coroutines.ExperimentalCoroutinesApi
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.Rule
 import org.junit.Test
 
+@ExperimentalCoroutinesApi
 class WooPosCouponsViewModelTest {
     @Rule
     @JvmField
     val coroutineTestRule = WooPosCoroutineTestRule()
 
     @Test
-    fun dumymTest() {
+    fun dummyTest() {
         assertThat(true).isTrue()
     }
 }


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #WOOMOB-175
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

This PR introduces a dummy coupons list and implements a temporary toggle for switching between Products and Coupons within the WooPosItemsScreen.

Unit-tests-exemption - I'll add unit tests along with the actual implementation of the logic.

### Testing information
<!-- This is your opportunity to break out individual scenarios that need testing (when necessary) and/or include a checklist for the reviewer to go through. Consider documenting the following from your own completed testing: devices used, alternate workflows, edge cases, affected areas, critical flows, areas not tested, and any remaining unknowns. Provide feedback on this new section of the PR template through Sept 30, 2024 to Apps Quality; additional context here: p91TBi-b8z-p2#comment-12036 -->

Smoke test that the product list loads as expected.

### The tests that have been performed
<!-- To give the reviewer an idea of what could be missed in terms of testing -->

I've tested the product list + the toggle for switching, including rotating the screen and verifying the current list state is persisted.

### Images/gif
<!-- Include before and after images or gifs when appropriate. -->
![Apr-21-2025 11-09-27](https://github.com/user-attachments/assets/b22f1806-4d8e-431f-8334-556d9c37ce72)



- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.

## Reviewer (or Author, in the case of optional code reviews):

Please make sure these conditions are met before approving the PR, or request changes if the PR needs improvement:

- [x] The PR is small and has a clear, single focus, or a valid explanation is provided in the description. If needed, please request to split it into smaller PRs.
- [x] Ensure Adequate Unit Test Coverage: The changes are reasonably covered by unit tests or an explanation is provided in the PR description.
- [x] Manual Testing: The author listed all the tests they ran, including smoke tests when needed (e.g., for refactorings). The reviewer confirmed that the PR works as expected on big (tablet) and small (phone) in case of UI changes, and no regressions are added.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->