### PR TITLE
[Woo POS] [WOOMOB-355] Extract Product List Into Standalone VM

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/common/composeui/component/WooPosPaginationErrorIndicator.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/common/composeui/component/WooPosPaginationErrorIndicator.kt
@@ -31,9 +31,8 @@ import com.woocommerce.android.ui.woopos.common.composeui.designsystem.WooPosTyp
 import com.woocommerce.android.ui.woopos.common.composeui.designsystem.toAdaptivePadding
 import com.woocommerce.android.ui.woopos.home.items.WooPosItemList
 import com.woocommerce.android.ui.woopos.home.items.WooPosItemSelectionViewState.Product
-import com.woocommerce.android.ui.woopos.home.items.WooPosItemsViewState
-import com.woocommerce.android.ui.woopos.home.items.WooPosItemsViewState.Tab.HighlightLevel
 import com.woocommerce.android.ui.woopos.home.items.WooPosPaginationState
+import com.woocommerce.android.ui.woopos.home.items.WooPosProductsViewState
 import com.woocommerce.android.ui.woopos.home.items.WooPosPullToRefreshState
 
 @Composable
@@ -124,8 +123,7 @@ private fun WooPosPaginationErrorIndicatorContent(
 @WooPosPreview
 fun WooPosPaginationErrorScreenPreview() {
     val itemsState =
-        WooPosItemsViewState.Content(
-            contentType = WooPosItemsViewState.Content.ContentState.ProductList,
+        WooPosProductsViewState.Content(
             items = listOf(
                 Product.Simple(
                     1,
@@ -152,17 +150,6 @@ fun WooPosPaginationErrorScreenPreview() {
             ),
             paginationState = WooPosPaginationState.Error,
             pullToRefreshState = WooPosPullToRefreshState.Refreshing,
-            bannerState = WooPosItemsViewState.Content.BannerState(
-                isBannerHiddenByUser = true,
-                title = R.string.woopos_banner_simple_products_only_title,
-                message = R.string.woopos_banner_simple_products_only_message,
-                icon = R.drawable.info,
-            ),
-            tabs = listOf(
-                WooPosItemsViewState.Tab(R.string.woopos_products_screen_title, highlightLevel = HighlightLevel.Full),
-                WooPosItemsViewState.Tab(R.string.woopos_coupons_screen_title, highlightLevel = HighlightLevel.Normal),
-            ),
-            search = WooPosItemsViewState.Content.SearchState.Hidden
         )
     WooPosTheme {
         WooPosItemList(

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/WooPosHomeChildToParentCommunication.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/WooPosHomeChildToParentCommunication.kt
@@ -35,10 +35,6 @@ sealed class ChildToParentEvent {
     data object OrderSuccessfullyPaidByCard : ChildToParentEvent()
     data object ExitPosClicked : ChildToParentEvent()
     data object ProductsDialogInfoIconClicked : ChildToParentEvent()
-    sealed class ProductsStatusChanged : ChildToParentEvent() {
-        data object FullScreen : ProductsStatusChanged()
-        data object WithCart : ProductsStatusChanged()
-    }
 
     data class ToastMessageDisplayed(val message: String) : ChildToParentEvent()
     sealed class NavigationEvent : ChildToParentEvent() {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/WooPosHomeScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/WooPosHomeScreen.kt
@@ -35,8 +35,8 @@ import com.woocommerce.android.ui.woopos.common.composeui.isPreviewMode
 import com.woocommerce.android.ui.woopos.home.WooPosHomeState.ProductsInfoDialog
 import com.woocommerce.android.ui.woopos.home.cart.WooPosCartScreen
 import com.woocommerce.android.ui.woopos.home.cart.WooPosCartScreenProductsPreview
-import com.woocommerce.android.ui.woopos.home.items.WooPosItemsScreenPreview
 import com.woocommerce.android.ui.woopos.home.items.navigation.WooPosItemsScreens
+import com.woocommerce.android.ui.woopos.home.items.products.WooPosItemsScreenPreview
 import com.woocommerce.android.ui.woopos.home.toolbar.PreviewWooPosFloatingToolbarStatusConnectedWithMenu
 import com.woocommerce.android.ui.woopos.home.toolbar.WooPosFloatingToolbar
 import com.woocommerce.android.ui.woopos.home.totals.WooPosTotalsScreen

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/WooPosHomeViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/WooPosHomeViewModel.kt
@@ -166,8 +166,6 @@ class WooPosHomeViewModel @Inject constructor(
                         )
                     }
 
-                    is ChildToParentEvent.ProductsStatusChanged -> handleProductsStatusChanged(event)
-
                     ChildToParentEvent.ProductsDialogInfoIconClicked -> {
                         _state.value = _state.value.copy(
                             productsInfoDialog = ProductsInfoDialog(isVisible = true)
@@ -227,28 +225,6 @@ class WooPosHomeViewModel @Inject constructor(
                 }
             )
         )
-    }
-
-    private fun handleProductsStatusChanged(event: ChildToParentEvent.ProductsStatusChanged) {
-        val screenPosition = _state.value.screenPositionState
-        val newScreenPositionState = when (event) {
-            ChildToParentEvent.ProductsStatusChanged.FullScreen -> {
-                when (screenPosition) {
-                    is ScreenPositionState.Cart -> ScreenPositionState.Cart.Hidden
-                    is ScreenPositionState.Checkout -> screenPosition
-                }
-            }
-            ChildToParentEvent.ProductsStatusChanged.WithCart -> {
-                when (screenPosition) {
-                    ScreenPositionState.Cart.Hidden -> ScreenPositionState.Cart.Visible
-
-                    ScreenPositionState.Cart.Visible,
-                    ScreenPositionState.Checkout.CartWithTotals,
-                    ScreenPositionState.Checkout.FullScreenTotals -> screenPosition
-                }
-            }
-        }
-        _state.value = _state.value.copy(screenPositionState = newScreenPositionState)
     }
 
     private fun sendEventToChildren(event: ParentToChildrenEvent) {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/items/WooPosItemsList.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/items/WooPosItemsList.kt
@@ -61,7 +61,6 @@ import com.woocommerce.android.ui.woopos.common.composeui.designsystem.WooPosTyp
 import com.woocommerce.android.ui.woopos.common.composeui.designsystem.toAdaptivePadding
 import com.woocommerce.android.ui.woopos.home.items.WooPosItemSelectionViewState.Product
 import com.woocommerce.android.ui.woopos.home.items.WooPosItemSelectionViewState.Variation
-import com.woocommerce.android.ui.woopos.home.items.WooPosItemsViewState.Content.BannerState
 import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.filter
 
@@ -437,9 +436,7 @@ private fun InfiniteListHandler(
 fun ItemListPreview() {
     WooPosTheme {
         WooPosItemList(
-            WooPosItemsViewState.Content(
-                contentType = WooPosItemsViewState.Content.ContentState.ProductList,
-                WooPosItemsViewState.Content.SearchState.Hidden,
+            WooPosProductsViewState.Content(
                 listOf(
                     Product.Simple(
                         id = 1,
@@ -451,22 +448,6 @@ fun ItemListPreview() {
                     Product.Variable(id = 2, name = "Variable Product", price = "$10.00", "", 1, listOf()),
                     Variation(3, "Variation", 0, "$10", ""),
                 ),
-                BannerState(
-                    false,
-                    R.string.woopos_banner_simple_products_only_title,
-                    R.string.woopos_banner_simple_products_only_message,
-                    R.drawable.info
-                ),
-                tabs = listOf(
-                    WooPosItemsViewState.Tab(
-                        stringId = R.string.woopos_products_screen_title,
-                        highlightLevel = WooPosItemsViewState.Tab.HighlightLevel.Full
-                    ),
-                    WooPosItemsViewState.Tab(
-                        stringId = R.string.woopos_coupons_screen_title,
-                        highlightLevel = WooPosItemsViewState.Tab.HighlightLevel.Normal
-                    )
-                )
             ),
             listState = LazyListState(),
             onItemClicked = {},

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/items/WooPosItemsScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/items/WooPosItemsScreen.kt
@@ -1,7 +1,5 @@
 package com.woocommerce.android.ui.woopos.home.items
 
-import androidx.compose.animation.AnimatedVisibility
-import androidx.compose.animation.shrinkVertically
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Spacer
@@ -12,34 +10,21 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.LazyListState
 import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.material.ExperimentalMaterialApi
-import androidx.compose.material.pullrefresh.PullRefreshIndicator
-import androidx.compose.material.pullrefresh.pullRefresh
-import androidx.compose.material.pullrefresh.rememberPullRefreshState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.State
 import androidx.compose.runtime.collectAsState
-import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.res.stringResource
 import androidx.hilt.navigation.compose.hiltViewModel
 import com.woocommerce.android.R
 import com.woocommerce.android.ui.woopos.common.composeui.WooPosPreview
-import com.woocommerce.android.ui.woopos.common.composeui.component.Button
-import com.woocommerce.android.ui.woopos.common.composeui.component.WooPosErrorScreen
-import com.woocommerce.android.ui.woopos.common.composeui.component.WooPosPaginationErrorIndicator
 import com.woocommerce.android.ui.woopos.common.composeui.component.WooPosSearchInputState
 import com.woocommerce.android.ui.woopos.common.composeui.component.WooPosSearchUIEvent
 import com.woocommerce.android.ui.woopos.common.composeui.designsystem.WooPosSpacing
 import com.woocommerce.android.ui.woopos.common.composeui.designsystem.WooPosTheme
 import com.woocommerce.android.ui.woopos.common.composeui.designsystem.toAdaptivePadding
-import com.woocommerce.android.ui.woopos.home.items.WooPosItemSelectionViewState.Product
-import com.woocommerce.android.ui.woopos.home.items.WooPosItemsUIEvent.EndOfItemsListReached
-import com.woocommerce.android.ui.woopos.home.items.WooPosItemsUIEvent.ProductsLoadingErrorRetryButtonClicked
-import com.woocommerce.android.ui.woopos.home.items.WooPosItemsUIEvent.PullToRefreshTriggered
 import com.woocommerce.android.ui.woopos.home.items.WooPosItemsUIEvent.SearchChanged
-import com.woocommerce.android.ui.woopos.home.items.WooPosItemsViewState.Content.ContentState.CouponsList
-import com.woocommerce.android.ui.woopos.home.items.WooPosItemsViewState.Content.ContentState.ProductList
 import com.woocommerce.android.ui.woopos.home.items.coupons.WooPosCouponsScreen
+import com.woocommerce.android.ui.woopos.home.items.products.WooPosProductsScreen
 import com.woocommerce.android.ui.woopos.home.items.search.WooPosItemsSearchScreen
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
@@ -76,17 +61,6 @@ private fun WooPosItemsScreen(
         onToolbarInfoIconClicked = {
             onUIEvent(WooPosItemsUIEvent.SimpleProductsDialogInfoIconClicked)
         },
-        onSimpleProductsBannerLearnMoreClicked = {
-            onUIEvent(WooPosItemsUIEvent.SimpleProductsBannerLearnMoreClicked)
-        },
-        onSimpleProductsBannerClosed = {
-            onUIEvent(WooPosItemsUIEvent.SimpleProductsBannerClosed)
-        },
-        onItemClicked = { item ->
-            onUIEvent(WooPosItemsUIEvent.ItemClicked(item))
-        },
-        onEndOfItemListReached = { onUIEvent(EndOfItemsListReached) },
-        onRetryClicked = { onUIEvent(ProductsLoadingErrorRetryButtonClicked) },
         onSearchEvent = {
             when (it) {
                 WooPosSearchUIEvent.Clear -> onUIEvent(WooPosItemsUIEvent.ClearSearchClicked)
@@ -104,7 +78,6 @@ private fun WooPosItemsScreen(
             }
         },
         onTabClicked = { onUIEvent(WooPosItemsUIEvent.OnTabClicked(it)) },
-        onPullToRefreshTriggered = { onUIEvent(PullToRefreshTriggered) },
     )
 }
 
@@ -115,27 +88,12 @@ private fun MainItemsList(
     state: State<WooPosItemsViewState>,
     listState: LazyListState,
     onToolbarInfoIconClicked: () -> Unit,
-    onSimpleProductsBannerLearnMoreClicked: () -> Unit,
-    onSimpleProductsBannerClosed: () -> Unit,
-    onItemClicked: (item: WooPosItemSelectionViewState) -> Unit,
-    onEndOfItemListReached: () -> Unit,
-    onRetryClicked: () -> Unit,
     onSearchEvent: (WooPosSearchUIEvent) -> Unit,
     onTabClicked: (WooPosItemsViewState.Tab) -> Unit,
-    onPullToRefreshTriggered: () -> Unit,
 ) {
-    val pullToRefreshState = rememberPullRefreshState(
-        refreshing = state.value.pullToRefreshState == WooPosPullToRefreshState.Refreshing,
-        onRefresh = onPullToRefreshTriggered,
-    )
-
     Box(
         modifier = modifier
             .fillMaxSize()
-            .pullRefresh(
-                state = pullToRefreshState,
-                enabled = state.value.pullToRefreshState == WooPosPullToRefreshState.Enabled,
-            )
             .padding(
                 start = WooPosSpacing.Medium.value.toAdaptivePadding(),
                 end = WooPosSpacing.Medium.value.toAdaptivePadding(),
@@ -156,178 +114,38 @@ private fun MainItemsList(
             Spacer(modifier = Modifier.height(WooPosSpacing.Large.value))
 
             when (val itemsState = state.value) {
-                is WooPosItemsViewState.Content -> {
+                is WooPosItemsViewState.ProductList -> {
                     Column {
-                        SimpleProductsBanner(
-                            itemsState.bannerState,
-                            onSimpleProductsBannerLearnMoreClicked,
-                            onSimpleProductsBannerClosed
-                        )
-
-                        when (itemsState.search) {
-                            is WooPosItemsViewState.Content.SearchState.Visible -> {
-                                when (itemsState.search.state) {
+                        when (val searchState = itemsState.search) {
+                            WooPosItemsViewState.SearchState.Hidden -> {
+                                WooPosProductsScreen(modifier = Modifier, listState = listState)
+                            }
+                            is WooPosItemsViewState.SearchState.Visible -> {
+                                when (searchState.state) {
                                     WooPosSearchInputState.Closed -> {
-                                        Content(itemsState, listState, onItemClicked, onEndOfItemListReached)
+                                        WooPosProductsScreen(modifier = Modifier, listState = listState)
                                     }
 
                                     is WooPosSearchInputState.Open -> WooPosItemsSearchScreen()
                                 }
                             }
-
-                            WooPosItemsViewState.Content.SearchState.Hidden -> {
-                                Content(itemsState, listState, onItemClicked, onEndOfItemListReached)
-                            }
                         }
                     }
                 }
-
-                is WooPosItemsViewState.Loading -> WooPosItemsLoadingIndicator()
-
-                is WooPosItemsViewState.Empty -> WooPosItemsEmptyList(
-                    title = stringResource(id = R.string.woopos_products_empty_list_title),
-                    message = stringResource(id = R.string.woopos_products_empty_list_message),
-                    contentDescription = stringResource(id = R.string.woopos_products_empty_list_image_description),
-                )
-
-                is WooPosItemsViewState.Error -> ProductsError { onRetryClicked() }
-            }
-        }
-        PullRefreshIndicator(
-            modifier = Modifier.align(Alignment.TopCenter),
-            refreshing = state.value.pullToRefreshState == WooPosPullToRefreshState.Refreshing,
-            state = pullToRefreshState
-        )
-    }
-}
-
-@Composable
-private fun Content(
-    itemsState: WooPosItemsViewState.Content,
-    listState: LazyListState,
-    onItemClicked: (item: WooPosItemSelectionViewState) -> Unit,
-    onEndOfItemListReached: () -> Unit
-) {
-    when (itemsState.contentType) {
-        CouponsList -> {
-            WooPosCouponsScreen(modifier = Modifier)
-        }
-        ProductList -> {
-            WooPosItemList(
-                itemsState,
-                listState,
-                onItemClicked,
-                onEndOfItemListReached,
-            ) {
-                ProductsPaginationError(
-                    onRetryClicked = {
-                        onEndOfItemListReached()
-                    }
-                )
+                is WooPosItemsViewState.CouponList -> WooPosCouponsScreen(modifier = Modifier)
             }
         }
     }
-}
-
-@Composable
-private fun SimpleProductsBanner(
-    bannerState: WooPosItemsViewState.Content.BannerState,
-    onSimpleProductsBannerLearnMoreClicked: () -> Unit,
-    onSimpleProductsBannerClosed: () -> Unit
-) {
-    AnimatedVisibility(
-        visible = !bannerState.isBannerHiddenByUser,
-        exit = shrinkVertically(),
-    ) {
-        WooPosBanner(
-            title = stringResource(id = bannerState.title),
-            message = stringResource(id = bannerState.message),
-            bannerIcon = R.drawable.info,
-            onClose = {
-                onSimpleProductsBannerClosed()
-            },
-            onLearnMore = {
-                onSimpleProductsBannerLearnMoreClicked()
-            }
-        )
-    }
-}
-
-@Composable
-fun ProductsError(onRetryClicked: () -> Unit) {
-    Box(
-        modifier = Modifier.fillMaxSize(),
-        contentAlignment = Alignment.Center,
-    ) {
-        WooPosErrorScreen(
-            message = stringResource(id = R.string.woopos_products_loading_error_title),
-            reason = stringResource(id = R.string.woopos_products_loading_error_message),
-            primaryButton = Button(
-                text = stringResource(id = R.string.woopos_products_loading_error_retry_button),
-                click = onRetryClicked
-            )
-        )
-    }
-}
-
-@Composable
-private fun ProductsPaginationError(onRetryClicked: () -> Unit) {
-    WooPosPaginationErrorIndicator(
-        message = stringResource(id = R.string.woopos_items_pagination_error_title),
-        description = stringResource(id = R.string.woopos_items_pagination_error_description),
-        primaryButton = Button(
-            text = stringResource(id = R.string.woopos_items_pagination_try_again_label),
-            click = onRetryClicked
-        ),
-    )
 }
 
 @OptIn(ExperimentalMaterialApi::class)
 @Composable
 @WooPosPreview
-fun WooPosItemsScreenPreview(modifier: Modifier = Modifier) {
+fun WooPosItemsScreenSearchVisiblePreview(modifier: Modifier = Modifier) {
     val productState = MutableStateFlow(
-        WooPosItemsViewState.Content(
-            contentType = ProductList,
-            items = listOf(
-                Product.Simple(
-                    1,
-                    name = "Product 1, Product 1, Product 1, " +
-                        "Product 1, Product 1, Product 1, Product 1, Product 1" +
-                        "Product 1, Product 1, Product 1, Product 1, Product 1",
-                    price = "10.0$",
-                    imageUrl = null,
-                ),
-                Product.Simple(
-                    2,
-                    name = "Product 2",
-                    price = "2000.00$",
-                    imageUrl = null,
-                ),
-                Product.Variable(
-                    3,
-                    name = "Product 3",
-                    price = "2000.00$",
-                    imageUrl = null,
-                    numOfVariations = 20,
-                    variationIds = listOf()
-                ),
-                Product.Simple(
-                    4,
-                    name = "Product 4",
-                    price = "1.0$",
-                    imageUrl = null,
-                ),
-            ),
-            paginationState = WooPosPaginationState.Loading,
-            pullToRefreshState = WooPosPullToRefreshState.Refreshing,
-            bannerState = WooPosItemsViewState.Content.BannerState(
-                isBannerHiddenByUser = true,
-                title = R.string.woopos_banner_simple_products_only_title,
-                message = R.string.woopos_banner_simple_products_only_message,
-                icon = R.drawable.info,
-            ),
-            search = WooPosItemsViewState.Content.SearchState.Visible(
+        WooPosItemsViewState.ProductList(
+            banner = WooPosItemsViewState.BannerState.Hidden,
+            search = WooPosItemsViewState.SearchState.Visible(
                 state = WooPosSearchInputState.Open(
                     input = WooPosSearchInputState.Open.Input.Query("", 0),
                     isLoading = false,
@@ -349,214 +167,22 @@ fun WooPosItemsScreenPreview(modifier: Modifier = Modifier) {
 @OptIn(ExperimentalMaterialApi::class)
 @Composable
 @WooPosPreview
-fun WooPosItemsScreenPaginationErrorPreview(modifier: Modifier = Modifier) {
+fun WooPosItemsScreenSearchHiddenPreview(modifier: Modifier = Modifier) {
     val productState = MutableStateFlow(
-        WooPosItemsViewState.Content(
-            contentType = ProductList,
-            items = listOf(
-                Product.Simple(
-                    1,
-                    name = "Product 1, Product 1, Product 1, " +
-                        "Product 1, Product 1, Product 1, Product 1, Product 1" +
-                        "Product 1, Product 1, Product 1, Product 1, Product 1",
-                    price = "10.0$",
-                    imageUrl = null,
-                ),
-                Product.Simple(
-                    2,
-                    name = "Product 2",
-                    price = "2000.00$",
-                    imageUrl = null,
-                ),
-                Product.Variable(
-                    3,
-                    name = "Product 3",
-                    price = "2000.00$",
-                    imageUrl = null,
-                    numOfVariations = 20,
-                    variationIds = listOf()
-                ),
+        WooPosItemsViewState.ProductList(
+            banner = WooPosItemsViewState.BannerState.Hidden,
+            search = WooPosItemsViewState.SearchState.Visible(
+                state = WooPosSearchInputState.Open(
+                    input = WooPosSearchInputState.Open.Input.Query("", 0),
+                    isLoading = false,
+                )
             ),
-            paginationState = WooPosPaginationState.Error,
-            pullToRefreshState = WooPosPullToRefreshState.Refreshing,
-            bannerState = WooPosItemsViewState.Content.BannerState(
-                isBannerHiddenByUser = true,
-                title = R.string.woopos_banner_simple_products_only_title,
-                message = R.string.woopos_banner_simple_products_only_message,
-                icon = R.drawable.info,
-            ),
-            search = WooPosItemsViewState.Content.SearchState.Hidden,
             tabs = tabs()
         )
     )
     WooPosTheme {
         WooPosItemsScreen(
             modifier = modifier,
-            itemsStateFlow = productState,
-            listState = rememberLazyListState(),
-            onUIEvent = {},
-        )
-    }
-}
-
-@OptIn(ExperimentalMaterialApi::class)
-@Composable
-@WooPosPreview
-fun WooPosItemsScreenLoadingPreview() {
-    val productState = MutableStateFlow(
-        WooPosItemsViewState.Loading(
-            pullToRefreshState = WooPosPullToRefreshState.Refreshing,
-            withCart = false,
-            tabs = tabs()
-        )
-    )
-    WooPosTheme {
-        WooPosItemsScreen(
-            itemsStateFlow = productState,
-            listState = rememberLazyListState(),
-            onUIEvent = {},
-        )
-    }
-}
-
-@OptIn(ExperimentalMaterialApi::class)
-@Composable
-@WooPosPreview
-fun WooPosProductsScreenEmptyListPreview() {
-    val productState = MutableStateFlow(
-        WooPosItemsViewState.Empty(
-            tabs = tabs(),
-            pullToRefreshState = WooPosPullToRefreshState.Refreshing,
-        )
-    )
-    WooPosTheme {
-        WooPosItemsScreen(
-            itemsStateFlow = productState,
-            listState = rememberLazyListState(),
-            onUIEvent = {},
-        )
-    }
-}
-
-@OptIn(ExperimentalMaterialApi::class)
-@Composable
-@WooPosPreview
-fun WooPosProductsScreenErrorPreview() {
-    val productState = MutableStateFlow(
-        WooPosItemsViewState.Error(
-            tabs = tabs(),
-        )
-    )
-    WooPosTheme {
-        WooPosItemsScreen(
-            itemsStateFlow = productState,
-            listState = rememberLazyListState(),
-            onUIEvent = {},
-        )
-    }
-}
-
-@OptIn(ExperimentalMaterialApi::class)
-@Composable
-@WooPosPreview
-fun WooPosHomeScreenItemsWithSimpleProductsOnlyBannerPreview() {
-    val productState = MutableStateFlow(
-        WooPosItemsViewState.Content(
-            contentType = ProductList,
-            items = listOf(
-                Product.Simple(
-                    1,
-                    name = "Product 1, Product 1, Product 1, " +
-                        "Product 1, Product 1, Product 1, Product 1, Product 1" +
-                        "Product 1, Product 1, Product 1, Product 1, Product 1",
-                    price = "10.0$",
-                    imageUrl = null,
-                ),
-                Product.Simple(
-                    2,
-                    name = "Product 2",
-                    price = "2000.00$",
-                    imageUrl = null,
-                ),
-                Product.Simple(
-                    3,
-                    name = "Product 3",
-                    price = "1.0$",
-                    imageUrl = null,
-                ),
-            ),
-            pullToRefreshState = WooPosPullToRefreshState.Refreshing,
-            bannerState = WooPosItemsViewState.Content.BannerState(
-                isBannerHiddenByUser = false,
-                title = R.string.woopos_banner_simple_products_only_title,
-                message = R.string.woopos_banner_simple_products_only_message,
-                icon = R.drawable.info,
-            ),
-            search = WooPosItemsViewState.Content.SearchState.Visible(
-                state = WooPosSearchInputState.Open(
-                    input = WooPosSearchInputState.Open.Input.Query("", 0),
-                    isLoading = false,
-                )
-            ),
-            tabs = tabs()
-        )
-    )
-    WooPosTheme {
-        WooPosItemsScreen(
-            itemsStateFlow = productState,
-            listState = rememberLazyListState(),
-            onUIEvent = {},
-        )
-    }
-}
-
-@OptIn(ExperimentalMaterialApi::class)
-@Composable
-@WooPosPreview
-fun WooPosHomeScreenItemsWithInfoIconInToolbarPreview() {
-    val productState = MutableStateFlow(
-        WooPosItemsViewState.Content(
-            contentType = ProductList,
-            items = listOf(
-                Product.Simple(
-                    1,
-                    name = "Product 1, Product 1, Product 1, " +
-                        "Product 1, Product 1, Product 1, Product 1, Product 1" +
-                        "Product 1, Product 1, Product 1, Product 1, Product 1",
-                    price = "10.0$",
-                    imageUrl = null,
-                ),
-                Product.Simple(
-                    2,
-                    name = "Product 2",
-                    price = "2000.00$",
-                    imageUrl = null,
-                ),
-                Product.Simple(
-                    3,
-                    name = "Product 3",
-                    price = "1.0$",
-                    imageUrl = null,
-                ),
-            ),
-            pullToRefreshState = WooPosPullToRefreshState.Disabled,
-            bannerState = WooPosItemsViewState.Content.BannerState(
-                isBannerHiddenByUser = true,
-                title = R.string.woopos_banner_simple_products_only_title,
-                message = R.string.woopos_banner_simple_products_only_message,
-                icon = R.drawable.info,
-            ),
-            search = WooPosItemsViewState.Content.SearchState.Visible(
-                state = WooPosSearchInputState.Open(
-                    input = WooPosSearchInputState.Open.Input.Query("", 0),
-                    isLoading = false,
-                )
-            ),
-            tabs = tabs()
-        )
-    )
-    WooPosTheme {
-        WooPosItemsScreen(
             itemsStateFlow = productState,
             listState = rememberLazyListState(),
             onUIEvent = {},

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/items/WooPosItemsScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/items/WooPosItemsScreen.kt
@@ -58,9 +58,6 @@ private fun WooPosItemsScreen(
         modifier = modifier,
         state = state,
         listState = listState,
-        onToolbarInfoIconClicked = {
-            onUIEvent(WooPosItemsUIEvent.SimpleProductsDialogInfoIconClicked)
-        },
         onSearchEvent = {
             when (it) {
                 WooPosSearchUIEvent.Clear -> onUIEvent(WooPosItemsUIEvent.ClearSearchClicked)
@@ -87,7 +84,6 @@ private fun MainItemsList(
     modifier: Modifier,
     state: State<WooPosItemsViewState>,
     listState: LazyListState,
-    onToolbarInfoIconClicked: () -> Unit,
     onSearchEvent: (WooPosSearchUIEvent) -> Unit,
     onTabClicked: (WooPosItemsViewState.Tab) -> Unit,
 ) {
@@ -106,7 +102,6 @@ private fun MainItemsList(
         ) {
             WooPosItemsToolbar(
                 state = state.value,
-                onToolbarInfoIconClicked = onToolbarInfoIconClicked,
                 onTabClicked = onTabClicked,
                 onSearchEvent = onSearchEvent,
             )

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/items/WooPosItemsSearchHelper.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/items/WooPosItemsSearchHelper.kt
@@ -6,6 +6,7 @@ import com.woocommerce.android.ui.woopos.home.ChildToParentEvent
 import com.woocommerce.android.ui.woopos.home.ParentToChildrenEvent
 import com.woocommerce.android.ui.woopos.home.WooPosChildrenToParentEventSender
 import com.woocommerce.android.ui.woopos.home.WooPosParentToChildrenEventReceiver
+import com.woocommerce.android.ui.woopos.home.items.WooPosItemsViewState.SearchState
 import com.woocommerce.android.viewmodel.ResourceProvider
 import dagger.hilt.android.scopes.ActivityRetainedScoped
 import kotlinx.coroutines.CoroutineScope
@@ -75,7 +76,7 @@ class WooPosItemsSearchHelper @Inject constructor(
             val currentOpenState = getCurrentSearchOpenState() ?: return
             updateSearchState(
                 currentState.copy(
-                    search = WooPosItemsViewState.Content.SearchState.Visible(
+                    search = SearchState.Visible(
                         state = WooPosSearchInputState.Open(
                             input = WooPosSearchInputState.Open.Input.Query(newQuery, cursorPosition),
                             isLoading = false,
@@ -91,7 +92,7 @@ class WooPosItemsSearchHelper @Inject constructor(
         val currentState = getCurrentContentState() ?: return
         updateSearchState(
             currentState.copy(
-                search = WooPosItemsViewState.Content.SearchState.Visible(
+                search = SearchState.Visible(
                     state = WooPosSearchInputState.Closed
                 )
             )
@@ -133,7 +134,7 @@ class WooPosItemsSearchHelper @Inject constructor(
         val currentState = getCurrentContentState() ?: return
         updateSearchState(
             currentState.copy(
-                search = WooPosItemsViewState.Content.SearchState.Visible(
+                search = SearchState.Visible(
                     state = WooPosSearchInputState.Open(
                         input = WooPosSearchInputState.Open.Input.Hint(
                             resourceProvider.getString(R.string.woopos_search_products)
@@ -146,13 +147,13 @@ class WooPosItemsSearchHelper @Inject constructor(
         )
     }
 
-    fun getInitialSearchState(isProductsSearchEnabled: Boolean): WooPosItemsViewState.Content.SearchState {
+    fun getInitialSearchState(isProductsSearchEnabled: Boolean): SearchState {
         return when (isProductsSearchEnabled) {
-            true -> WooPosItemsViewState.Content.SearchState.Visible(
+            true -> SearchState.Visible(
                 state = WooPosSearchInputState.Closed
             )
 
-            false -> WooPosItemsViewState.Content.SearchState.Hidden
+            false -> SearchState.Hidden
         }
     }
 
@@ -173,11 +174,11 @@ class WooPosItemsSearchHelper @Inject constructor(
         )
     }
 
-    private fun updateSearchState(newState: WooPosItemsViewState.Content) {
+    private fun updateSearchState(newState: WooPosItemsViewState) {
         var pullToRefreshState = when (val searchState = newState.search) {
-            WooPosItemsViewState.Content.SearchState.Hidden -> WooPosPullToRefreshState.Enabled
+            SearchState.Hidden -> WooPosPullToRefreshState.Enabled
 
-            is WooPosItemsViewState.Content.SearchState.Visible -> {
+            is SearchState.Visible -> {
                 when (searchState.state) {
                     WooPosSearchInputState.Closed -> WooPosPullToRefreshState.Enabled
 
@@ -188,17 +189,23 @@ class WooPosItemsSearchHelper @Inject constructor(
         viewStateFlow.value = newState.copy(pullToRefreshState = pullToRefreshState)
     }
 
-    private fun getCurrentContentState(): WooPosItemsViewState.Content? {
-        return viewStateFlow.value as? WooPosItemsViewState.Content
+    private fun getCurrentContentState(): WooPosItemsViewState {
+        return viewStateFlow.value
     }
 
-    private fun getCurrentSearchVisibleState(): WooPosItemsViewState.Content.SearchState.Visible? {
+    private fun getCurrentSearchVisibleState(): SearchState.Visible? {
         val currentState = getCurrentContentState() ?: return null
-        return currentState.search as? WooPosItemsViewState.Content.SearchState.Visible
+        return currentState.search as? SearchState.Visible
     }
 
     private fun getCurrentSearchOpenState(): WooPosSearchInputState.Open? {
         val searchState = getCurrentSearchVisibleState() ?: return null
         return searchState.state as? WooPosSearchInputState.Open
+    }
+    private fun WooPosItemsViewState.copy(search: SearchState.Visible): WooPosItemsViewState {
+        return when (this) {
+            is WooPosItemsViewState.ProductList -> this.copy(search = search)
+            is WooPosItemsViewState.CouponList -> this
+        }
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/items/WooPosItemsSearchHelper.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/items/WooPosItemsSearchHelper.kt
@@ -68,7 +68,7 @@ class WooPosItemsSearchHelper @Inject constructor(
             )
         }
 
-        val currentState = getCurrentContentState() ?: return
+        val currentState = getCurrentContentState()
 
         if (newQuery.isEmpty()) {
             updateToInitialOpenState()
@@ -89,7 +89,7 @@ class WooPosItemsSearchHelper @Inject constructor(
     }
 
     fun onCloseSearchClicked() {
-        val currentState = getCurrentContentState() ?: return
+        val currentState = getCurrentContentState()
         updateSearchState(
             currentState.copy(
                 search = SearchState.Visible(
@@ -110,7 +110,7 @@ class WooPosItemsSearchHelper @Inject constructor(
 
     @Suppress("ReturnCount")
     fun onAnimationComplete() {
-        val currentState = getCurrentContentState() ?: return
+        val currentState = getCurrentContentState()
         val searchState = getCurrentSearchVisibleState() ?: return
         val openState = getCurrentSearchOpenState() ?: return
 
@@ -131,7 +131,7 @@ class WooPosItemsSearchHelper @Inject constructor(
     }
 
     private fun updateToInitialOpenState() {
-        val currentState = getCurrentContentState() ?: return
+        val currentState = getCurrentContentState()
         updateSearchState(
             currentState.copy(
                 search = SearchState.Visible(
@@ -159,7 +159,7 @@ class WooPosItemsSearchHelper @Inject constructor(
 
     @Suppress("ReturnCount")
     private fun updateLoadingState(isLoading: Boolean) {
-        val currentState = getCurrentContentState() ?: return
+        val currentState = getCurrentContentState()
         val searchState = getCurrentSearchVisibleState() ?: return
         val searchStateValue = getCurrentSearchOpenState() ?: return
 
@@ -186,7 +186,7 @@ class WooPosItemsSearchHelper @Inject constructor(
                 }
             }
         }
-        viewStateFlow.value = newState.copy(pullToRefreshState = pullToRefreshState)
+        // TODO("viewStateFlow.value = newState.copy(pullToRefreshState = pullToRefreshState)")
     }
 
     private fun getCurrentContentState(): WooPosItemsViewState {
@@ -194,7 +194,7 @@ class WooPosItemsSearchHelper @Inject constructor(
     }
 
     private fun getCurrentSearchVisibleState(): SearchState.Visible? {
-        val currentState = getCurrentContentState() ?: return null
+        val currentState = getCurrentContentState()
         return currentState.search as? SearchState.Visible
     }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/items/WooPosItemsSearchHelper.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/items/WooPosItemsSearchHelper.kt
@@ -186,7 +186,7 @@ class WooPosItemsSearchHelper @Inject constructor(
                 }
             }
         }
-        // TODO("viewStateFlow.value = newState.copy(pullToRefreshState = pullToRefreshState)")
+         viewStateFlow.value = newState // TODO .copy(pullToRefreshState = pullToRefreshState)
     }
 
     private fun getCurrentContentState(): WooPosItemsViewState {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/items/WooPosItemsSearchHelper.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/items/WooPosItemsSearchHelper.kt
@@ -175,18 +175,18 @@ class WooPosItemsSearchHelper @Inject constructor(
     }
 
     private fun updateSearchState(newState: WooPosItemsViewState) {
-        var pullToRefreshState = when (val searchState = newState.search) {
-            SearchState.Hidden -> WooPosPullToRefreshState.Enabled
-
-            is SearchState.Visible -> {
-                when (searchState.state) {
-                    WooPosSearchInputState.Closed -> WooPosPullToRefreshState.Enabled
-
-                    is WooPosSearchInputState.Open -> WooPosPullToRefreshState.Disabled
-                }
-            }
-        }
-         viewStateFlow.value = newState // TODO .copy(pullToRefreshState = pullToRefreshState)
+//        var pullToRefreshState = when (val searchState = newState.search) {
+//            SearchState.Hidden -> WooPosPullToRefreshState.Enabled
+//
+//            is SearchState.Visible -> {
+//                when (searchState.state) {
+//                    WooPosSearchInputState.Closed -> WooPosPullToRefreshState.Enabled
+//
+//                    is WooPosSearchInputState.Open -> WooPosPullToRefreshState.Disabled
+//                }
+//            }
+//        }
+        viewStateFlow.value = newState // TODO .copy(pullToRefreshState = pullToRefreshState)
     }
 
     private fun getCurrentContentState(): WooPosItemsViewState {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/items/WooPosItemsSearchHelper.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/items/WooPosItemsSearchHelper.kt
@@ -43,6 +43,7 @@ class WooPosItemsSearchHelper @Inject constructor(
                     ParentToChildrenEvent.SearchEvent.Finished -> {
                         updateLoadingState(isLoading = false)
                     }
+
                     is ParentToChildrenEvent.OrderSuccessfullyPaid -> {
                         onCloseSearchClicked()
                     }
@@ -74,14 +75,12 @@ class WooPosItemsSearchHelper @Inject constructor(
             updateToInitialOpenState()
         } else {
             val currentOpenState = getCurrentSearchOpenState() ?: return
-            updateSearchState(
-                currentState.copy(
-                    search = SearchState.Visible(
-                        state = WooPosSearchInputState.Open(
-                            input = WooPosSearchInputState.Open.Input.Query(newQuery, cursorPosition),
-                            isLoading = false,
-                            hasAnimationPlayed = currentOpenState.hasAnimationPlayed
-                        )
+            viewStateFlow.value = currentState.copy(
+                search = SearchState.Visible(
+                    state = WooPosSearchInputState.Open(
+                        input = WooPosSearchInputState.Open.Input.Query(newQuery, cursorPosition),
+                        isLoading = false,
+                        hasAnimationPlayed = currentOpenState.hasAnimationPlayed
                     )
                 )
             )
@@ -90,11 +89,9 @@ class WooPosItemsSearchHelper @Inject constructor(
 
     fun onCloseSearchClicked() {
         val currentState = getCurrentContentState()
-        updateSearchState(
-            currentState.copy(
-                search = SearchState.Visible(
-                    state = WooPosSearchInputState.Closed
-                )
+        viewStateFlow.value = currentState.copy(
+            search = SearchState.Visible(
+                state = WooPosSearchInputState.Closed
             )
         )
     }
@@ -114,12 +111,10 @@ class WooPosItemsSearchHelper @Inject constructor(
         val searchState = getCurrentSearchVisibleState() ?: return
         val openState = getCurrentSearchOpenState() ?: return
 
-        updateSearchState(
-            currentState.copy(
-                search = searchState.copy(
-                    state = openState.copy(
-                        hasAnimationPlayed = true
-                    )
+        viewStateFlow.value = currentState.copy(
+            search = searchState.copy(
+                state = openState.copy(
+                    hasAnimationPlayed = true
                 )
             )
         )
@@ -132,16 +127,14 @@ class WooPosItemsSearchHelper @Inject constructor(
 
     private fun updateToInitialOpenState() {
         val currentState = getCurrentContentState()
-        updateSearchState(
-            currentState.copy(
-                search = SearchState.Visible(
-                    state = WooPosSearchInputState.Open(
-                        input = WooPosSearchInputState.Open.Input.Hint(
-                            resourceProvider.getString(R.string.woopos_search_products)
-                        ),
-                        isLoading = false,
-                        hasAnimationPlayed = false
-                    )
+        viewStateFlow.value = currentState.copy(
+            search = SearchState.Visible(
+                state = WooPosSearchInputState.Open(
+                    input = WooPosSearchInputState.Open.Input.Hint(
+                        resourceProvider.getString(R.string.woopos_search_products)
+                    ),
+                    isLoading = false,
+                    hasAnimationPlayed = false
                 )
             )
         )
@@ -163,30 +156,13 @@ class WooPosItemsSearchHelper @Inject constructor(
         val searchState = getCurrentSearchVisibleState() ?: return
         val searchStateValue = getCurrentSearchOpenState() ?: return
 
-        updateSearchState(
-            currentState.copy(
-                search = searchState.copy(
-                    state = searchStateValue.copy(
-                        isLoading = isLoading
-                    )
+        viewStateFlow.value = currentState.copy(
+            search = searchState.copy(
+                state = searchStateValue.copy(
+                    isLoading = isLoading
                 )
             )
         )
-    }
-
-    private fun updateSearchState(newState: WooPosItemsViewState) {
-//        var pullToRefreshState = when (val searchState = newState.search) {
-//            SearchState.Hidden -> WooPosPullToRefreshState.Enabled
-//
-//            is SearchState.Visible -> {
-//                when (searchState.state) {
-//                    WooPosSearchInputState.Closed -> WooPosPullToRefreshState.Enabled
-//
-//                    is WooPosSearchInputState.Open -> WooPosPullToRefreshState.Disabled
-//                }
-//            }
-//        }
-        viewStateFlow.value = newState // TODO .copy(pullToRefreshState = pullToRefreshState)
     }
 
     private fun getCurrentContentState(): WooPosItemsViewState {
@@ -202,6 +178,7 @@ class WooPosItemsSearchHelper @Inject constructor(
         val searchState = getCurrentSearchVisibleState() ?: return null
         return searchState.state as? WooPosSearchInputState.Open
     }
+
     private fun WooPosItemsViewState.copy(search: SearchState.Visible): WooPosItemsViewState {
         return when (this) {
             is WooPosItemsViewState.ProductList -> this.copy(search = search)

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/items/WooPosItemsToolbar.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/items/WooPosItemsToolbar.kt
@@ -12,8 +12,6 @@ import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.width
-import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.outlined.Info
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.remember
@@ -25,12 +23,12 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import com.woocommerce.android.R
 import com.woocommerce.android.ui.woopos.common.composeui.WooPosPreview
-import com.woocommerce.android.ui.woopos.common.composeui.component.WooPosCircularIconButton
 import com.woocommerce.android.ui.woopos.common.composeui.component.WooPosSearchInput
 import com.woocommerce.android.ui.woopos.common.composeui.component.WooPosSearchInputState
 import com.woocommerce.android.ui.woopos.common.composeui.component.WooPosSearchUIEvent
 import com.woocommerce.android.ui.woopos.common.composeui.component.WooPosText
 import com.woocommerce.android.ui.woopos.common.composeui.designsystem.WooPosSpacing
+import com.woocommerce.android.ui.woopos.common.composeui.designsystem.WooPosSpacing.Medium
 import com.woocommerce.android.ui.woopos.common.composeui.designsystem.WooPosTheme
 import com.woocommerce.android.ui.woopos.common.composeui.designsystem.WooPosTypography
 import com.woocommerce.android.ui.woopos.home.items.WooPosItemsViewState.Tab.HighlightLevel.Full
@@ -43,9 +41,9 @@ fun WooPosItemsToolbar(
     onToolbarInfoIconClicked: () -> Unit,
     onSearchEvent: (WooPosSearchUIEvent) -> Unit,
 ) {
-    val isSearchExpanded = state is WooPosItemsViewState.Content &&
-        state.search is WooPosItemsViewState.Content.SearchState.Visible &&
-        state.search.state is WooPosSearchInputState.Open
+    val isSearchExpanded = state is WooPosItemsViewState.ProductList &&
+        state.search is WooPosItemsViewState.SearchState.Visible &&
+        (state.search as WooPosItemsViewState.SearchState.Visible).state is WooPosSearchInputState.Open
 
     Row(
         modifier = Modifier
@@ -82,34 +80,22 @@ fun WooPosItemsToolbar(
             verticalAlignment = Alignment.CenterVertically,
         ) {
             when (state) {
-                is WooPosItemsViewState.Content -> {
+                is WooPosItemsViewState.ProductList -> {
                     when (val searchState = state.search) {
-                        WooPosItemsViewState.Content.SearchState.Hidden -> Unit
-                        is WooPosItemsViewState.Content.SearchState.Visible -> {
+                        WooPosItemsViewState.SearchState.Hidden -> Unit
+                        is WooPosItemsViewState.SearchState.Visible -> {
                             WooPosSearchInput(
                                 state = searchState.state,
                                 onEvent = onSearchEvent,
                                 modifier = Modifier.weight(1f)
                             )
 
-                            Spacer(modifier = Modifier.width(WooPosSpacing.Medium.value))
+                            Spacer(modifier = Modifier.width(Medium.value))
                         }
-                    }
-
-                    if (state.bannerState.isBannerHiddenByUser) {
-                        WooPosCircularIconButton(
-                            icon = Icons.Outlined.Info,
-                            contentDescription = stringResource(
-                                id = R.string.woopos_banner_simple_products_info_content_description
-                            ),
-                            onClick = { onToolbarInfoIconClicked() }
-                        )
                     }
                 }
 
-                is WooPosItemsViewState.Empty,
-                is WooPosItemsViewState.Error,
-                is WooPosItemsViewState.Loading -> Unit
+                is WooPosItemsViewState.CouponList -> Unit
             }
         }
     }
@@ -131,19 +117,10 @@ fun WooPosItemsToolbarPreview() {
 
     WooPosTheme {
         WooPosItemsToolbar(
-            state = WooPosItemsViewState.Content(
-                items = emptyList(),
-                paginationState = WooPosPaginationState.Error,
-                pullToRefreshState = WooPosPullToRefreshState.Refreshing,
-                bannerState = WooPosItemsViewState.Content.BannerState(
-                    isBannerHiddenByUser = true,
-                    title = R.string.woopos_banner_simple_products_only_title,
-                    message = R.string.woopos_banner_simple_products_only_message,
-                    icon = R.drawable.info,
-                ),
+            state = WooPosItemsViewState.ProductList(
                 tabs = tabs,
-                search = WooPosItemsViewState.Content.SearchState.Hidden,
-                contentType = WooPosItemsViewState.Content.ContentState.ProductList,
+                search = WooPosItemsViewState.SearchState.Hidden,
+                banner = WooPosItemsViewState.BannerState.Hidden,
             ),
             onTabClicked = {},
             onToolbarInfoIconClicked = {},

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/items/WooPosItemsToolbar.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/items/WooPosItemsToolbar.kt
@@ -38,7 +38,6 @@ import com.woocommerce.android.ui.woopos.home.items.WooPosItemsViewState.Tab.Hig
 fun WooPosItemsToolbar(
     state: WooPosItemsViewState,
     onTabClicked: (WooPosItemsViewState.Tab) -> Unit,
-    onToolbarInfoIconClicked: () -> Unit,
     onSearchEvent: (WooPosSearchUIEvent) -> Unit,
 ) {
     val isSearchExpanded = state is WooPosItemsViewState.ProductList &&
@@ -123,7 +122,6 @@ fun WooPosItemsToolbarPreview() {
                 banner = WooPosItemsViewState.BannerState.Hidden,
             ),
             onTabClicked = {},
-            onToolbarInfoIconClicked = {},
             onSearchEvent = {}
         )
     }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/items/WooPosItemsUIEvent.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/items/WooPosItemsUIEvent.kt
@@ -1,10 +1,6 @@
 package com.woocommerce.android.ui.woopos.home.items
 
 sealed class WooPosItemsUIEvent {
-    data class ItemClicked(val item: WooPosItemSelectionViewState) : WooPosItemsUIEvent()
-    data object EndOfItemsListReached : WooPosItemsUIEvent()
-    data object PullToRefreshTriggered : WooPosItemsUIEvent()
-    data object ProductsLoadingErrorRetryButtonClicked : WooPosItemsUIEvent()
     data object SimpleProductsBannerClosed : WooPosItemsUIEvent()
     data object SimpleProductsBannerLearnMoreClicked : WooPosItemsUIEvent()
     data object SimpleProductsDialogInfoIconClicked : WooPosItemsUIEvent()
@@ -17,5 +13,5 @@ sealed class WooPosItemsUIEvent {
         val cursorPosition: Int,
     ) : WooPosItemsUIEvent()
     data object CloseSearchClicked : WooPosItemsUIEvent()
-    object SearchAnimationComplete : WooPosItemsUIEvent()
+    data object SearchAnimationComplete : WooPosItemsUIEvent()
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/items/WooPosItemsViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/items/WooPosItemsViewModel.kt
@@ -33,7 +33,7 @@ class WooPosItemsViewModel @Inject constructor(
         WooPosItemsViewState.ProductList(
             tabs = tabsHelper.defaultTabs,
             search = searchHelper.getInitialSearchState(isProductsSearchEnabled()),
-            banner =  WooPosItemsViewState.BannerState.Hidden, // TODO Fix as part of the move to `More` menu.
+            banner = WooPosItemsViewState.BannerState.Hidden, // TODO Fix as part of the move to `More` menu.
         )
     )
     val viewState: StateFlow<WooPosItemsViewState> = _viewState
@@ -116,11 +116,13 @@ class WooPosItemsViewModel @Inject constructor(
             R.string.woopos_products_screen_title -> WooPosItemsViewState.ProductList(
                 tabs = tabsHelper.selectTab(state.tabs, selectedTab),
                 search = searchHelper.getInitialSearchState(isProductsSearchEnabled()),
-                banner =  WooPosItemsViewState.BannerState.Hidden, // TODO Fix as part of the move to `More` menu.
+                banner = WooPosItemsViewState.BannerState.Hidden, // TODO Fix as part of the move to `More` menu.
             )
+
             R.string.woopos_coupons_screen_title -> WooPosItemsViewState.CouponList(
                 tabs = tabsHelper.selectTab(state.tabs, selectedTab),
             )
+
             else -> error("Invalid tab $selectedTab")
         }
     }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/items/WooPosItemsViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/items/WooPosItemsViewModel.kt
@@ -4,29 +4,17 @@ import android.os.Parcelable
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.woocommerce.android.R
-import com.woocommerce.android.model.Product
-import com.woocommerce.android.ui.products.ProductType
 import com.woocommerce.android.ui.woopos.featureflags.WooPosIsProductsSearchEnabled
 import com.woocommerce.android.ui.woopos.home.ChildToParentEvent
 import com.woocommerce.android.ui.woopos.home.WooPosChildrenToParentEventSender
-import com.woocommerce.android.ui.woopos.home.items.WooPosItemNavigationData.VariableProductData
-import com.woocommerce.android.ui.woopos.home.items.WooPosItemsViewState.Content.ContentState
 import com.woocommerce.android.ui.woopos.home.items.WooPosItemsViewState.Tab
 import com.woocommerce.android.ui.woopos.home.items.navigation.WooPosItemsNavigator
 import com.woocommerce.android.ui.woopos.home.items.navigation.WooPosItemsNavigator.WooPosItemsScreenNavigationEvent
-import com.woocommerce.android.ui.woopos.home.items.navigation.WooPosItemsNavigator.WooPosItemsScreenNavigationEvent.NavigateToVariationsScreen
-import com.woocommerce.android.ui.woopos.home.items.products.WooPosProductsDataSource
-import com.woocommerce.android.ui.woopos.util.analytics.WooPosAnalyticsEvent.Event.ProductsPullToRefreshTriggered
-import com.woocommerce.android.ui.woopos.util.analytics.WooPosAnalyticsTracker
 import com.woocommerce.android.ui.woopos.util.datastore.WooPosPreferencesRepository
-import com.woocommerce.android.ui.woopos.util.format.WooPosFormatPrice
 import dagger.hilt.android.lifecycle.HiltViewModel
-import kotlinx.coroutines.Job
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
-import kotlinx.coroutines.flow.first
-import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.launch
 import kotlinx.parcelize.Parcelize
@@ -34,26 +22,21 @@ import javax.inject.Inject
 
 @HiltViewModel
 class WooPosItemsViewModel @Inject constructor(
-    private val productsDataSource: WooPosProductsDataSource,
     private val fromChildToParentEventSender: WooPosChildrenToParentEventSender,
-    private val priceFormat: WooPosFormatPrice,
     private val preferencesRepository: WooPosPreferencesRepository,
     private val navigator: WooPosItemsNavigator,
-    private val analyticsTracker: WooPosAnalyticsTracker,
     private val searchHelper: WooPosItemsSearchHelper,
     private val isProductsSearchEnabled: WooPosIsProductsSearchEnabled,
     private val tabsHelper: WooPosItemsTabsHelper,
 ) : ViewModel() {
-    private var loadMoreProductsJob: Job? = null
-
     private val _viewState = MutableStateFlow<WooPosItemsViewState>(
-        WooPosItemsViewState.Loading(
+        WooPosItemsViewState.ProductList(
             tabs = tabsHelper.defaultTabs,
-            withCart = true
+            search = searchHelper.getInitialSearchState(isProductsSearchEnabled()),
+            banner =  WooPosItemsViewState.BannerState.Hidden, // TODO Fix as part of the move to `More` menu.
         )
     )
     val viewState: StateFlow<WooPosItemsViewState> = _viewState
-        .onEach { notifyParentAboutStatusChange(it) }
         .stateIn(
             viewModelScope,
             started = SharingStarted.WhileSubscribed(),
@@ -65,41 +48,10 @@ class WooPosItemsViewModel @Inject constructor(
             coroutineScope = viewModelScope,
             viewStateFlow = _viewState
         )
-
-        loadProducts(
-            forceRefreshProducts = false,
-            withPullToRefresh = false,
-            withCart = true,
-        )
     }
 
     fun onUIEvent(event: WooPosItemsUIEvent) {
         when (event) {
-            is WooPosItemsUIEvent.EndOfItemsListReached -> {
-                onEndOfProductsListReached()
-            }
-
-            is WooPosItemsUIEvent.ItemClicked -> {
-                handleItemClick(event)
-            }
-
-            WooPosItemsUIEvent.PullToRefreshTriggered -> {
-                loadProducts(
-                    forceRefreshProducts = true,
-                    withPullToRefresh = true,
-                    withCart = true,
-                )
-                viewModelScope.launch { analyticsTracker.track(ProductsPullToRefreshTriggered) }
-            }
-
-            WooPosItemsUIEvent.ProductsLoadingErrorRetryButtonClicked -> {
-                loadProducts(
-                    forceRefreshProducts = false,
-                    withPullToRefresh = false,
-                    withCart = false,
-                )
-            }
-
             WooPosItemsUIEvent.SimpleProductsBannerClosed -> {
                 onSimpleProductsOnlyBannerClosed()
             }
@@ -137,35 +89,6 @@ class WooPosItemsViewModel @Inject constructor(
         }
     }
 
-    private fun handleItemClick(event: WooPosItemsUIEvent.ItemClicked) {
-        when (event.item) {
-            is WooPosItemSelectionViewState.Product.Simple -> {
-                onItemClicked(
-                    ItemClickedData.Product.Simple(
-                        id = event.item.id
-                    )
-                )
-            }
-
-            is WooPosItemSelectionViewState.Product.Variable -> {
-                viewModelScope.launch {
-                    navigator.sendNavigationEvent(
-                        NavigateToVariationsScreen(
-                            VariableProductData(
-                                id = event.item.id,
-                                name = event.item.name,
-                                numOfVariations = event.item.numOfVariations,
-                            )
-                        )
-                    )
-                }
-            }
-
-            is WooPosItemSelectionViewState.Variation -> {
-            }
-        }
-    }
-
     private fun onSimpleProductsOnlyBannerLearnMoreClicked() {
         onSimpleProductsDialogInfoClicked()
     }
@@ -178,210 +101,29 @@ class WooPosItemsViewModel @Inject constructor(
 
     private fun onSimpleProductsOnlyBannerClosed() {
         viewModelScope.launch {
-            val currentState = _viewState.value as WooPosItemsViewState.Content
+            val currentState = _viewState.value as WooPosItemsViewState.ProductList
             preferencesRepository.setSimpleProductsOnlyBannerWasHiddenByUser(true)
-            _viewState.value = currentState.copy(
-                bannerState = currentState.bannerState.copy(
-                    isBannerHiddenByUser = true
-                )
-            )
+            _viewState.value = currentState.copy(banner = WooPosItemsViewState.BannerState.Hidden)
         }
     }
-
-    private fun loadProducts(
-        forceRefreshProducts: Boolean,
-        withPullToRefresh: Boolean,
-        withCart: Boolean
-    ) {
-        viewModelScope.launch {
-            _viewState.value = if (withPullToRefresh) {
-                buildProductsReloadingState()
-            } else {
-                WooPosItemsViewState.Loading(
-                    withCart = withCart,
-                    tabs = tabsHelper.defaultTabs,
-                )
-            }
-
-            productsDataSource.loadProducts(forceRefreshProducts = forceRefreshProducts).collect { result ->
-                val currentState = _viewState.value
-                when (result) {
-                    is WooPosProductsDataSource.ProductsResult.Cached -> {
-                        if (result.products.isNotEmpty()) {
-                            _viewState.value = result.products.toContentState(
-                                tabs = currentState.tabs
-                            )
-                        }
-                    }
-
-                    is WooPosProductsDataSource.ProductsResult.Remote -> {
-                        _viewState.value = when {
-                            result.productsResult.isSuccess -> {
-                                val products = result.productsResult.getOrThrow()
-                                if (products.isNotEmpty()) {
-                                    val currentState = _viewState.value
-                                    val paginationState = if (loadMoreProductsJob?.isActive == true) {
-                                        WooPosPaginationState.Loading
-                                    } else {
-                                        WooPosPaginationState.None
-                                    }
-                                    if (currentState is WooPosItemsViewState.Content) {
-                                        currentState.copy(
-                                            items = products.map { it.toItemSelectionViewState() },
-                                            paginationState = paginationState,
-                                            pullToRefreshState = if (searchHelper.isSearchOpen()) {
-                                                WooPosPullToRefreshState.Disabled
-                                            } else {
-                                                WooPosPullToRefreshState.Enabled
-                                            },
-                                        )
-                                    } else {
-                                        products.toContentState(
-                                            tabs = currentState.tabs,
-                                            paginationState = paginationState,
-                                        )
-                                    }
-                                } else {
-                                    WooPosItemsViewState.Empty(tabs = _viewState.value.tabs)
-                                }
-                            }
-
-                            else -> WooPosItemsViewState.Error(tabs = _viewState.value.tabs)
-                        }
-                    }
-                }
-            }
-        }
-    }
-
-    private fun buildProductsReloadingState() =
-        when (val state = viewState.value) {
-            is WooPosItemsViewState.Content -> state.copy(pullToRefreshState = WooPosPullToRefreshState.Refreshing)
-            is WooPosItemsViewState.Loading -> state.copy(pullToRefreshState = WooPosPullToRefreshState.Refreshing)
-            is WooPosItemsViewState.Error -> state.copy(pullToRefreshState = WooPosPullToRefreshState.Refreshing)
-            is WooPosItemsViewState.Empty -> state.copy(pullToRefreshState = WooPosPullToRefreshState.Refreshing)
-        }
 
     private fun selectTab(selectedTab: Tab) {
         if (_viewState.value.tabs.size == 1) return
 
-        val newContentState = when (selectedTab.stringId) {
-            R.string.woopos_products_screen_title -> ContentState.ProductList
-            R.string.woopos_coupons_screen_title -> ContentState.CouponsList
+        val state = _viewState.value
+
+        _viewState.value = when (selectedTab.stringId) {
+            R.string.woopos_products_screen_title -> WooPosItemsViewState.ProductList(
+                tabs = tabsHelper.selectTab(state.tabs, selectedTab),
+                search = searchHelper.getInitialSearchState(isProductsSearchEnabled()),
+                banner =  WooPosItemsViewState.BannerState.Hidden, // TODO Fix as part of the move to `More` menu.
+            )
+            R.string.woopos_coupons_screen_title -> WooPosItemsViewState.CouponList(
+                tabs = tabsHelper.selectTab(state.tabs, selectedTab),
+            )
             else -> error("Invalid tab $selectedTab")
         }
-
-        _viewState.value = when (val state = _viewState.value) {
-            is WooPosItemsViewState.Content -> {
-                state.copy(
-                    contentType = newContentState,
-                    tabs = tabsHelper.selectTab(state.tabs, selectedTab)
-                )
-            }
-
-            is WooPosItemsViewState.Loading -> state.copy(tabs = tabsHelper.selectTab(state.tabs, selectedTab))
-
-            is WooPosItemsViewState.Error -> state.copy(tabs = tabsHelper.selectTab(state.tabs, selectedTab))
-
-            is WooPosItemsViewState.Empty -> state.copy(tabs = tabsHelper.selectTab(state.tabs, selectedTab))
-        }
     }
-
-    private suspend fun List<Product>.toContentState(
-        tabs: List<Tab>,
-        paginationState: WooPosPaginationState = WooPosPaginationState.None
-    ) = WooPosItemsViewState.Content(
-        contentType = ContentState.ProductList,
-        items = map { it.toItemSelectionViewState() },
-        paginationState = paginationState,
-        pullToRefreshState = WooPosPullToRefreshState.Enabled,
-        bannerState = WooPosItemsViewState.Content.BannerState(
-            isBannerHiddenByUser = isBannerHiddenByUser(),
-            title = R.string.woopos_banner_simple_products_only_title,
-            message = R.string.woopos_banner_simple_products_only_message,
-            icon = R.drawable.info,
-        ),
-        search = searchHelper.getInitialSearchState(isProductsSearchEnabled()),
-        tabs = tabs,
-    )
-
-    private suspend fun Product.toItemSelectionViewState(): WooPosItemSelectionViewState {
-        return if (this.isVariable()) {
-            WooPosItemSelectionViewState.Product.Variable(
-                id = this.remoteId,
-                name = this.name,
-                price = priceFormat(this.price),
-                imageUrl = this.firstImageUrl,
-                numOfVariations = this.numVariations,
-                variationIds = this.variationIds
-            )
-        } else {
-            WooPosItemSelectionViewState.Product.Simple(
-                id = this.remoteId,
-                name = this.name,
-                price = priceFormat(this.price),
-                imageUrl = this.firstImageUrl,
-            )
-        }
-    }
-
-    private fun onEndOfProductsListReached() {
-        val currentState = _viewState.value
-        if (currentState !is WooPosItemsViewState.Content) {
-            return
-        }
-
-        if (!productsDataSource.hasMorePages) {
-            return
-        }
-
-        _viewState.value = currentState.copy(paginationState = WooPosPaginationState.Loading)
-
-        loadMoreProductsJob?.cancel()
-        loadMoreProductsJob = viewModelScope.launch {
-            val result = productsDataSource.loadMore()
-            _viewState.value = if (result.isSuccess) {
-                result.getOrThrow().toContentState(tabs = currentState.tabs)
-            } else {
-                currentState.copy(paginationState = WooPosPaginationState.Error)
-            }
-        }
-    }
-
-    private fun notifyParentAboutStatusChange(newState: WooPosItemsViewState) {
-        sendEventToParent(
-            when (newState) {
-                is WooPosItemsViewState.Content -> ChildToParentEvent.ProductsStatusChanged.WithCart
-
-                is WooPosItemsViewState.Empty,
-                is WooPosItemsViewState.Error -> ChildToParentEvent.ProductsStatusChanged.FullScreen
-
-                is WooPosItemsViewState.Loading -> {
-                    if (newState.withCart) {
-                        ChildToParentEvent.ProductsStatusChanged.WithCart
-                    } else {
-                        ChildToParentEvent.ProductsStatusChanged.FullScreen
-                    }
-                }
-            }
-        )
-    }
-
-    private fun onItemClicked(itemData: ItemClickedData) {
-        sendEventToParent(ChildToParentEvent.ItemClickedInProductSelector(itemData))
-    }
-
-    private fun sendEventToParent(event: ChildToParentEvent) {
-        viewModelScope.launch { fromChildToParentEventSender.sendToParent(event) }
-    }
-
-    private suspend fun isBannerHiddenByUser(): Boolean {
-        return preferencesRepository.isSimpleProductsOnlyBannerWasHiddenByUser.first()
-    }
-
-    private fun Product.isVariable() =
-        productType == ProductType.VARIABLE ||
-            productType == ProductType.VARIATION
 
     @Parcelize
     sealed class ItemClickedData(open val id: Long) : Parcelable {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/items/WooPosItemsViewState.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/items/WooPosItemsViewState.kt
@@ -38,7 +38,7 @@ sealed class WooPosItemsViewState private constructor(
         data object Hidden : SearchState()
     }
 
-    sealed class BannerState() {
+    sealed class BannerState {
         data class Visible(
             @StringRes val title: Int,
             @StringRes val message: Int,

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/items/WooPosItemsViewState.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/items/WooPosItemsViewState.kt
@@ -4,56 +4,47 @@ import androidx.annotation.DrawableRes
 import androidx.annotation.StringRes
 import com.woocommerce.android.ui.woopos.common.composeui.component.WooPosSearchInputState
 
-sealed class WooPosItemsViewState(
+sealed class WooPosItemsViewState private constructor(
     open val tabs: List<Tab>,
-    override val pullToRefreshState: WooPosPullToRefreshState,
-) : WooPosBaseViewState(pullToRefreshState) {
-    data class Content(
-        val contentType: ContentState,
-        val search: SearchState,
-        override val items: List<WooPosItemSelectionViewState>,
-        val bannerState: BannerState,
-        override val paginationState: WooPosPaginationState = WooPosPaginationState.None,
-        override val pullToRefreshState: WooPosPullToRefreshState = WooPosPullToRefreshState.Enabled,
+    open val search: SearchState,
+    open val banner: BannerState,
+) {
+    data class ProductList(
         override val tabs: List<Tab>,
-    ) : WooPosItemsViewState(tabs, pullToRefreshState), WooPosContentViewState {
-        data class BannerState(
-            val isBannerHiddenByUser: Boolean,
-            @StringRes val title: Int,
-            @StringRes val message: Int,
-            @DrawableRes val icon: Int
-        )
+        override val search: SearchState,
+        override val banner: BannerState,
+    ) : WooPosItemsViewState(
+        tabs = tabs,
+        search = search,
+        banner = banner,
+    )
 
-        sealed class SearchState {
-            data class Visible(val state: WooPosSearchInputState) : SearchState()
-            object Hidden : SearchState()
-        }
-
-        sealed class ContentState {
-            data object ProductList : ContentState()
-            data object CouponsList : ContentState()
-        }
-    }
-
-    data class Loading(
-        override val pullToRefreshState: WooPosPullToRefreshState = WooPosPullToRefreshState.Enabled,
+    data class CouponList(
         override val tabs: List<Tab>,
-        val withCart: Boolean
-    ) : WooPosItemsViewState(tabs, pullToRefreshState)
-
-    data class Error(
-        override val tabs: List<Tab>,
-        override val pullToRefreshState: WooPosPullToRefreshState = WooPosPullToRefreshState.Enabled,
-    ) : WooPosItemsViewState(tabs, pullToRefreshState)
-
-    data class Empty(
-        override val tabs: List<Tab>,
-        override val pullToRefreshState: WooPosPullToRefreshState = WooPosPullToRefreshState.Enabled,
-    ) : WooPosItemsViewState(tabs, pullToRefreshState)
+    ) : WooPosItemsViewState(
+        tabs = tabs,
+        search = SearchState.Hidden,
+        banner = BannerState.Hidden,
+    )
 
     data class Tab(@StringRes val stringId: Int, val highlightLevel: HighlightLevel) {
         enum class HighlightLevel {
             Full, Normal
         }
+    }
+
+    sealed class SearchState {
+        data class Visible(val state: WooPosSearchInputState) : SearchState()
+        data object Hidden : SearchState()
+    }
+
+    sealed class BannerState() {
+        data class Visible(
+            @StringRes val title: Int,
+            @StringRes val message: Int,
+            @DrawableRes val icon: Int
+        ) : BannerState()
+
+        data object Hidden : BannerState()
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/items/WooPosItemsViewState.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/items/WooPosItemsViewState.kt
@@ -4,7 +4,7 @@ import androidx.annotation.DrawableRes
 import androidx.annotation.StringRes
 import com.woocommerce.android.ui.woopos.common.composeui.component.WooPosSearchInputState
 
-sealed class WooPosItemsViewState private constructor(
+sealed class WooPosItemsViewState(
     open val tabs: List<Tab>,
     open val search: SearchState,
     open val banner: BannerState,

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/items/WooPosProductsViewState.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/items/WooPosProductsViewState.kt
@@ -1,0 +1,23 @@
+package com.woocommerce.android.ui.woopos.home.items
+
+sealed class WooPosProductsViewState(
+    override val pullToRefreshState: WooPosPullToRefreshState,
+) : WooPosBaseViewState(pullToRefreshState) {
+    data class Content(
+        override val items: List<WooPosItemSelectionViewState>,
+        override val paginationState: WooPosPaginationState = WooPosPaginationState.None,
+        override val pullToRefreshState: WooPosPullToRefreshState = WooPosPullToRefreshState.Enabled,
+    ) : WooPosProductsViewState(pullToRefreshState), WooPosContentViewState
+
+    data class Loading(
+        override val pullToRefreshState: WooPosPullToRefreshState = WooPosPullToRefreshState.Enabled,
+    ) : WooPosProductsViewState(pullToRefreshState)
+
+    data class Error(
+        override val pullToRefreshState: WooPosPullToRefreshState = WooPosPullToRefreshState.Enabled,
+    ) : WooPosProductsViewState(pullToRefreshState)
+
+    data class Empty(
+        override val pullToRefreshState: WooPosPullToRefreshState = WooPosPullToRefreshState.Enabled,
+    ) : WooPosProductsViewState(pullToRefreshState)
+}

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/items/products/WooPosProductsScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/items/products/WooPosProductsScreen.kt
@@ -4,7 +4,6 @@ import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.LazyListState
 import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.material.ExperimentalMaterialApi
@@ -23,9 +22,7 @@ import com.woocommerce.android.ui.woopos.common.composeui.WooPosPreview
 import com.woocommerce.android.ui.woopos.common.composeui.component.Button
 import com.woocommerce.android.ui.woopos.common.composeui.component.WooPosErrorScreen
 import com.woocommerce.android.ui.woopos.common.composeui.component.WooPosPaginationErrorIndicator
-import com.woocommerce.android.ui.woopos.common.composeui.designsystem.WooPosSpacing
 import com.woocommerce.android.ui.woopos.common.composeui.designsystem.WooPosTheme
-import com.woocommerce.android.ui.woopos.common.composeui.designsystem.toAdaptivePadding
 import com.woocommerce.android.ui.woopos.home.items.WooPosItemList
 import com.woocommerce.android.ui.woopos.home.items.WooPosItemSelectionViewState
 import com.woocommerce.android.ui.woopos.home.items.WooPosItemSelectionViewState.Product
@@ -100,12 +97,6 @@ private fun ProductsList(
             .pullRefresh(
                 state = pullToRefreshState,
                 enabled = state.value.pullToRefreshState == WooPosPullToRefreshState.Enabled,
-            )
-            .padding(
-                start = WooPosSpacing.Medium.value.toAdaptivePadding(),
-                end = WooPosSpacing.Medium.value.toAdaptivePadding(),
-                top = WooPosSpacing.XLarge.value.toAdaptivePadding(),
-                bottom = WooPosSpacing.None.value.toAdaptivePadding(),
             )
     ) {
         Column(

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/items/products/WooPosProductsScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/items/products/WooPosProductsScreen.kt
@@ -1,0 +1,412 @@
+package com.woocommerce.android.ui.woopos.home.items.products
+
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxHeight
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.lazy.LazyListState
+import androidx.compose.foundation.lazy.rememberLazyListState
+import androidx.compose.material.ExperimentalMaterialApi
+import androidx.compose.material.pullrefresh.PullRefreshIndicator
+import androidx.compose.material.pullrefresh.pullRefresh
+import androidx.compose.material.pullrefresh.rememberPullRefreshState
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.State
+import androidx.compose.runtime.collectAsState
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.hilt.navigation.compose.hiltViewModel
+import com.woocommerce.android.R
+import com.woocommerce.android.ui.woopos.common.composeui.WooPosPreview
+import com.woocommerce.android.ui.woopos.common.composeui.component.Button
+import com.woocommerce.android.ui.woopos.common.composeui.component.WooPosErrorScreen
+import com.woocommerce.android.ui.woopos.common.composeui.component.WooPosPaginationErrorIndicator
+import com.woocommerce.android.ui.woopos.common.composeui.designsystem.WooPosSpacing
+import com.woocommerce.android.ui.woopos.common.composeui.designsystem.WooPosTheme
+import com.woocommerce.android.ui.woopos.common.composeui.designsystem.toAdaptivePadding
+import com.woocommerce.android.ui.woopos.home.items.WooPosItemList
+import com.woocommerce.android.ui.woopos.home.items.WooPosItemSelectionViewState
+import com.woocommerce.android.ui.woopos.home.items.WooPosItemSelectionViewState.Product
+import com.woocommerce.android.ui.woopos.home.items.WooPosItemsEmptyList
+import com.woocommerce.android.ui.woopos.home.items.WooPosItemsLoadingIndicator
+import com.woocommerce.android.ui.woopos.home.items.WooPosPaginationState
+import com.woocommerce.android.ui.woopos.home.items.WooPosProductsViewState
+import com.woocommerce.android.ui.woopos.home.items.WooPosPullToRefreshState
+import com.woocommerce.android.ui.woopos.home.items.products.WooPosProductsUIEvent.EndOfItemsListReached
+import com.woocommerce.android.ui.woopos.home.items.products.WooPosProductsUIEvent.ProductsLoadingErrorRetryButtonClicked
+import com.woocommerce.android.ui.woopos.home.items.products.WooPosProductsUIEvent.PullToRefreshTriggered
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+
+@OptIn(ExperimentalMaterialApi::class)
+@Composable
+fun WooPosProductsScreen(
+    modifier: Modifier = Modifier,
+    listState: LazyListState,
+) {
+    val productsViewModel: WooPosProductsViewModel = hiltViewModel()
+    WooPosProductsScreen(
+        modifier = modifier,
+        itemsStateFlow = productsViewModel.viewState,
+        listState = listState,
+        onUIEvent = { productsViewModel.onUIEvent(it) },
+    )
+}
+
+@ExperimentalMaterialApi
+@Composable
+private fun WooPosProductsScreen(
+    modifier: Modifier = Modifier,
+    itemsStateFlow: StateFlow<WooPosProductsViewState>,
+    listState: LazyListState,
+    onUIEvent: (WooPosProductsUIEvent) -> Unit,
+) {
+    val state = itemsStateFlow.collectAsState()
+
+    ProductsList(
+        modifier = modifier,
+        state = state,
+        listState = listState,
+        onItemClicked = { item ->
+            onUIEvent(WooPosProductsUIEvent.ItemClicked(item))
+        },
+        onEndOfItemListReached = { onUIEvent(EndOfItemsListReached) },
+        onRetryClicked = { onUIEvent(ProductsLoadingErrorRetryButtonClicked) },
+        onPullToRefreshTriggered = { onUIEvent(PullToRefreshTriggered) },
+    )
+}
+
+@ExperimentalMaterialApi
+@Composable
+private fun ProductsList(
+    modifier: Modifier,
+    state: State<WooPosProductsViewState>,
+    listState: LazyListState,
+    onItemClicked: (item: WooPosItemSelectionViewState) -> Unit,
+    onEndOfItemListReached: () -> Unit,
+    onRetryClicked: () -> Unit,
+    onPullToRefreshTriggered: () -> Unit,
+) {
+    val pullToRefreshState = rememberPullRefreshState(
+        refreshing = state.value.pullToRefreshState == WooPosPullToRefreshState.Refreshing,
+        onRefresh = onPullToRefreshTriggered,
+    )
+
+    Box(
+        modifier = modifier
+            .fillMaxSize()
+            .pullRefresh(
+                state = pullToRefreshState,
+                enabled = state.value.pullToRefreshState == WooPosPullToRefreshState.Enabled,
+            )
+            .padding(
+                start = WooPosSpacing.Medium.value.toAdaptivePadding(),
+                end = WooPosSpacing.Medium.value.toAdaptivePadding(),
+                top = WooPosSpacing.XLarge.value.toAdaptivePadding(),
+                bottom = WooPosSpacing.None.value.toAdaptivePadding(),
+            )
+    ) {
+        Column(
+            modifier.fillMaxHeight()
+        ) {
+            when (val itemsState = state.value) {
+                is WooPosProductsViewState.Content -> {
+                    Content(itemsState, listState, onItemClicked, onEndOfItemListReached)
+                }
+
+                is WooPosProductsViewState.Loading -> WooPosItemsLoadingIndicator()
+
+                is WooPosProductsViewState.Empty -> WooPosItemsEmptyList(
+                    title = stringResource(id = R.string.woopos_products_empty_list_title),
+                    message = stringResource(id = R.string.woopos_products_empty_list_message),
+                    contentDescription = stringResource(id = R.string.woopos_products_empty_list_image_description),
+                )
+
+                is WooPosProductsViewState.Error -> ProductsError { onRetryClicked() }
+            }
+        }
+        PullRefreshIndicator(
+            modifier = Modifier.align(Alignment.TopCenter),
+            refreshing = state.value.pullToRefreshState == WooPosPullToRefreshState.Refreshing,
+            state = pullToRefreshState
+        )
+    }
+}
+
+@Composable
+private fun Content(
+    itemsState: WooPosProductsViewState.Content,
+    listState: LazyListState,
+    onItemClicked: (item: WooPosItemSelectionViewState) -> Unit,
+    onEndOfItemListReached: () -> Unit
+) {
+    WooPosItemList(
+        itemsState,
+        listState,
+        onItemClicked,
+        onEndOfItemListReached,
+    ) {
+        ProductsPaginationError(
+            onRetryClicked = {
+                onEndOfItemListReached()
+            }
+        )
+    }
+}
+
+@Composable
+fun ProductsError(onRetryClicked: () -> Unit) {
+    Box(
+        modifier = Modifier.fillMaxSize(),
+        contentAlignment = Alignment.Center,
+    ) {
+        WooPosErrorScreen(
+            message = stringResource(id = R.string.woopos_products_loading_error_title),
+            reason = stringResource(id = R.string.woopos_products_loading_error_message),
+            primaryButton = Button(
+                text = stringResource(id = R.string.woopos_products_loading_error_retry_button),
+                click = onRetryClicked
+            )
+        )
+    }
+}
+
+@Composable
+private fun ProductsPaginationError(onRetryClicked: () -> Unit) {
+    WooPosPaginationErrorIndicator(
+        message = stringResource(id = R.string.woopos_items_pagination_error_title),
+        description = stringResource(id = R.string.woopos_items_pagination_error_description),
+        primaryButton = Button(
+            text = stringResource(id = R.string.woopos_items_pagination_try_again_label),
+            click = onRetryClicked
+        ),
+    )
+}
+
+@OptIn(ExperimentalMaterialApi::class)
+@Composable
+@WooPosPreview
+fun WooPosItemsScreenPreview(modifier: Modifier = Modifier) {
+    val productState = MutableStateFlow(
+        WooPosProductsViewState.Content(
+            items = listOf(
+                Product.Simple(
+                    1,
+                    name = "Product 1, Product 1, Product 1, " +
+                        "Product 1, Product 1, Product 1, Product 1, Product 1" +
+                        "Product 1, Product 1, Product 1, Product 1, Product 1",
+                    price = "10.0$",
+                    imageUrl = null,
+                ),
+                Product.Simple(
+                    2,
+                    name = "Product 2",
+                    price = "2000.00$",
+                    imageUrl = null,
+                ),
+                Product.Variable(
+                    3,
+                    name = "Product 3",
+                    price = "2000.00$",
+                    imageUrl = null,
+                    numOfVariations = 20,
+                    variationIds = listOf()
+                ),
+                Product.Simple(
+                    4,
+                    name = "Product 4",
+                    price = "1.0$",
+                    imageUrl = null,
+                ),
+            ),
+            paginationState = WooPosPaginationState.Loading,
+            pullToRefreshState = WooPosPullToRefreshState.Refreshing,
+        )
+    )
+    WooPosTheme {
+        WooPosProductsScreen(
+            modifier = modifier,
+            itemsStateFlow = productState,
+            listState = rememberLazyListState(),
+            onUIEvent = {},
+        )
+    }
+}
+
+@OptIn(ExperimentalMaterialApi::class)
+@Composable
+@WooPosPreview
+fun WooPosItemsScreenPaginationErrorPreview(modifier: Modifier = Modifier) {
+    val productState = MutableStateFlow(
+        WooPosProductsViewState.Content(
+            items = listOf(
+                Product.Simple(
+                    1,
+                    name = "Product 1, Product 1, Product 1, " +
+                        "Product 1, Product 1, Product 1, Product 1, Product 1" +
+                        "Product 1, Product 1, Product 1, Product 1, Product 1",
+                    price = "10.0$",
+                    imageUrl = null,
+                ),
+                Product.Simple(
+                    2,
+                    name = "Product 2",
+                    price = "2000.00$",
+                    imageUrl = null,
+                ),
+                Product.Variable(
+                    3,
+                    name = "Product 3",
+                    price = "2000.00$",
+                    imageUrl = null,
+                    numOfVariations = 20,
+                    variationIds = listOf()
+                ),
+            ),
+            paginationState = WooPosPaginationState.Error,
+            pullToRefreshState = WooPosPullToRefreshState.Refreshing,
+        )
+    )
+    WooPosTheme {
+        WooPosProductsScreen(
+            modifier = modifier,
+            itemsStateFlow = productState,
+            listState = rememberLazyListState(),
+            onUIEvent = {},
+        )
+    }
+}
+
+@OptIn(ExperimentalMaterialApi::class)
+@Composable
+@WooPosPreview
+fun WooPosItemsScreenLoadingPreview() {
+    val productState = MutableStateFlow(
+        WooPosProductsViewState.Loading(
+            pullToRefreshState = WooPosPullToRefreshState.Refreshing,
+        )
+    )
+    WooPosTheme {
+        WooPosProductsScreen(
+            itemsStateFlow = productState,
+            listState = rememberLazyListState(),
+            onUIEvent = {},
+        )
+    }
+}
+
+@OptIn(ExperimentalMaterialApi::class)
+@Composable
+@WooPosPreview
+fun WooPosProductsScreenEmptyListPreview() {
+    val productState = MutableStateFlow(
+        WooPosProductsViewState.Empty(
+            pullToRefreshState = WooPosPullToRefreshState.Refreshing,
+        )
+    )
+    WooPosTheme {
+        WooPosProductsScreen(
+            itemsStateFlow = productState,
+            listState = rememberLazyListState(),
+            onUIEvent = {},
+        )
+    }
+}
+
+@OptIn(ExperimentalMaterialApi::class)
+@Composable
+@WooPosPreview
+fun WooPosProductsScreenErrorPreview() {
+    val productState = MutableStateFlow(
+        WooPosProductsViewState.Error()
+    )
+    WooPosTheme {
+        WooPosProductsScreen(
+            itemsStateFlow = productState,
+            listState = rememberLazyListState(),
+            onUIEvent = {},
+        )
+    }
+}
+
+@OptIn(ExperimentalMaterialApi::class)
+@Composable
+@WooPosPreview
+fun WooPosHomeScreenItemsWithSimpleProductsOnlyBannerPreview() {
+    val productState = MutableStateFlow(
+        WooPosProductsViewState.Content(
+            items = listOf(
+                Product.Simple(
+                    1,
+                    name = "Product 1, Product 1, Product 1, " +
+                        "Product 1, Product 1, Product 1, Product 1, Product 1" +
+                        "Product 1, Product 1, Product 1, Product 1, Product 1",
+                    price = "10.0$",
+                    imageUrl = null,
+                ),
+                Product.Simple(
+                    2,
+                    name = "Product 2",
+                    price = "2000.00$",
+                    imageUrl = null,
+                ),
+                Product.Simple(
+                    3,
+                    name = "Product 3",
+                    price = "1.0$",
+                    imageUrl = null,
+                ),
+            ),
+            pullToRefreshState = WooPosPullToRefreshState.Refreshing,
+        )
+    )
+    WooPosTheme {
+        WooPosProductsScreen(
+            itemsStateFlow = productState,
+            listState = rememberLazyListState(),
+            onUIEvent = {},
+        )
+    }
+}
+
+@OptIn(ExperimentalMaterialApi::class)
+@Composable
+@WooPosPreview
+fun WooPosHomeScreenItemsWithInfoIconInToolbarPreview() {
+    val productState = MutableStateFlow(
+        WooPosProductsViewState.Content(
+            items = listOf(
+                Product.Simple(
+                    1,
+                    name = "Product 1, Product 1, Product 1, " +
+                        "Product 1, Product 1, Product 1, Product 1, Product 1" +
+                        "Product 1, Product 1, Product 1, Product 1, Product 1",
+                    price = "10.0$",
+                    imageUrl = null,
+                ),
+                Product.Simple(
+                    2,
+                    name = "Product 2",
+                    price = "2000.00$",
+                    imageUrl = null,
+                ),
+                Product.Simple(
+                    3,
+                    name = "Product 3",
+                    price = "1.0$",
+                    imageUrl = null,
+                ),
+            ),
+            pullToRefreshState = WooPosPullToRefreshState.Disabled,
+        )
+    )
+    WooPosTheme {
+        WooPosProductsScreen(
+            itemsStateFlow = productState,
+            listState = rememberLazyListState(),
+            onUIEvent = {},
+        )
+    }
+}

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/items/products/WooPosProductsUIEvent.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/items/products/WooPosProductsUIEvent.kt
@@ -1,0 +1,11 @@
+package com.woocommerce.android.ui.woopos.home.items.products
+
+import com.woocommerce.android.ui.woopos.home.items.WooPosItemSelectionViewState
+
+sealed class WooPosProductsUIEvent {
+    data class ItemClicked(val item: WooPosItemSelectionViewState) : WooPosProductsUIEvent()
+    data object EndOfItemsListReached : WooPosProductsUIEvent()
+    data object PullToRefreshTriggered : WooPosProductsUIEvent()
+    data object ProductsLoadingErrorRetryButtonClicked : WooPosProductsUIEvent()
+    data object BackButtonClicked : WooPosProductsUIEvent()
+}

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/items/products/WooPosProductsUIEvent.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/items/products/WooPosProductsUIEvent.kt
@@ -7,5 +7,4 @@ sealed class WooPosProductsUIEvent {
     data object EndOfItemsListReached : WooPosProductsUIEvent()
     data object PullToRefreshTriggered : WooPosProductsUIEvent()
     data object ProductsLoadingErrorRetryButtonClicked : WooPosProductsUIEvent()
-    data object BackButtonClicked : WooPosProductsUIEvent()
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/items/products/WooPosProductsViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/items/products/WooPosProductsViewModel.kt
@@ -52,7 +52,6 @@ class WooPosProductsViewModel @Inject constructor(
         loadProducts(
             forceRefreshProducts = false,
             withPullToRefresh = false,
-            withCart = true,
         )
     }
 
@@ -70,7 +69,6 @@ class WooPosProductsViewModel @Inject constructor(
                 loadProducts(
                     forceRefreshProducts = true,
                     withPullToRefresh = true,
-                    withCart = true,
                 )
                 viewModelScope.launch { analyticsTracker.track(ProductsPullToRefreshTriggered) }
             }
@@ -79,7 +77,6 @@ class WooPosProductsViewModel @Inject constructor(
                 loadProducts(
                     forceRefreshProducts = false,
                     withPullToRefresh = false,
-                    withCart = false,
                 )
             }
 
@@ -128,7 +125,6 @@ class WooPosProductsViewModel @Inject constructor(
     private fun loadProducts(
         forceRefreshProducts: Boolean,
         withPullToRefresh: Boolean,
-        withCart: Boolean
     ) {
         viewModelScope.launch {
             _viewState.value = if (withPullToRefresh) {
@@ -160,11 +156,12 @@ class WooPosProductsViewModel @Inject constructor(
                                         currentState.copy(
                                             items = products.map { it.toItemSelectionViewState() },
                                             paginationState = paginationState,
-                                            pullToRefreshState = // TODO( "Add pull to refresh state when search is open"),
+                                            // TODO( "Add pull to refresh state when search is open"),
+                                            pullToRefreshState =
 //                                            if (searchHelper.isSearchOpen()) {
 //                                                WooPosPullToRefreshState.Disabled
 //                                            } else {
-                                                WooPosPullToRefreshState.Enabled
+                                            WooPosPullToRefreshState.Enabled
 //                                            },
                                         )
                                     } else {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/items/products/WooPosProductsViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/items/products/WooPosProductsViewModel.kt
@@ -13,7 +13,6 @@ import com.woocommerce.android.ui.woopos.home.items.WooPosPaginationState
 import com.woocommerce.android.ui.woopos.home.items.WooPosProductsViewState
 import com.woocommerce.android.ui.woopos.home.items.WooPosPullToRefreshState
 import com.woocommerce.android.ui.woopos.home.items.navigation.WooPosItemsNavigator
-import com.woocommerce.android.ui.woopos.home.items.navigation.WooPosItemsNavigator.WooPosItemsScreenNavigationEvent
 import com.woocommerce.android.ui.woopos.home.items.navigation.WooPosItemsNavigator.WooPosItemsScreenNavigationEvent.NavigateToVariationsScreen
 import com.woocommerce.android.ui.woopos.util.analytics.WooPosAnalyticsEvent.Event.ProductsPullToRefreshTriggered
 import com.woocommerce.android.ui.woopos.util.analytics.WooPosAnalyticsTracker
@@ -79,18 +78,6 @@ class WooPosProductsViewModel @Inject constructor(
                     withPullToRefresh = false,
                 )
             }
-
-            WooPosProductsUIEvent.BackButtonClicked -> {
-                navigateBackToItemListScreen()
-            }
-        }
-    }
-
-    private fun navigateBackToItemListScreen() {
-        viewModelScope.launch {
-            navigator.sendNavigationEvent(
-                WooPosItemsScreenNavigationEvent.NavigateBackToItemListScreen
-            )
         }
     }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/items/products/WooPosProductsViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/items/products/WooPosProductsViewModel.kt
@@ -160,13 +160,11 @@ class WooPosProductsViewModel @Inject constructor(
                                         currentState.copy(
                                             items = products.map { it.toItemSelectionViewState() },
                                             paginationState = paginationState,
-                                            pullToRefreshState = TODO(
-                                                "Add pull to refresh state when search is open"
-                                            ),
+                                            pullToRefreshState = // TODO( "Add pull to refresh state when search is open"),
 //                                            if (searchHelper.isSearchOpen()) {
 //                                                WooPosPullToRefreshState.Disabled
 //                                            } else {
-//                                                WooPosPullToRefreshState.Enabled
+                                                WooPosPullToRefreshState.Enabled
 //                                            },
                                         )
                                     } else {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/items/products/WooPosProductsViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/items/products/WooPosProductsViewModel.kt
@@ -143,13 +143,7 @@ class WooPosProductsViewModel @Inject constructor(
                                         currentState.copy(
                                             items = products.map { it.toItemSelectionViewState() },
                                             paginationState = paginationState,
-                                            // TODO( "Add pull to refresh state when search is open"),
-                                            pullToRefreshState =
-//                                            if (searchHelper.isSearchOpen()) {
-//                                                WooPosPullToRefreshState.Disabled
-//                                            } else {
-                                            WooPosPullToRefreshState.Enabled
-//                                            },
+                                            pullToRefreshState = WooPosPullToRefreshState.Enabled
                                         )
                                     } else {
                                         products.toContentState(

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/items/products/WooPosProductsViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/items/products/WooPosProductsViewModel.kt
@@ -1,0 +1,260 @@
+package com.woocommerce.android.ui.woopos.home.items.products
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.woocommerce.android.model.Product
+import com.woocommerce.android.ui.products.ProductType
+import com.woocommerce.android.ui.woopos.home.ChildToParentEvent
+import com.woocommerce.android.ui.woopos.home.WooPosChildrenToParentEventSender
+import com.woocommerce.android.ui.woopos.home.items.WooPosItemNavigationData.VariableProductData
+import com.woocommerce.android.ui.woopos.home.items.WooPosItemSelectionViewState
+import com.woocommerce.android.ui.woopos.home.items.WooPosItemsViewModel.ItemClickedData
+import com.woocommerce.android.ui.woopos.home.items.WooPosPaginationState
+import com.woocommerce.android.ui.woopos.home.items.WooPosProductsViewState
+import com.woocommerce.android.ui.woopos.home.items.WooPosPullToRefreshState
+import com.woocommerce.android.ui.woopos.home.items.navigation.WooPosItemsNavigator
+import com.woocommerce.android.ui.woopos.home.items.navigation.WooPosItemsNavigator.WooPosItemsScreenNavigationEvent
+import com.woocommerce.android.ui.woopos.home.items.navigation.WooPosItemsNavigator.WooPosItemsScreenNavigationEvent.NavigateToVariationsScreen
+import com.woocommerce.android.ui.woopos.util.analytics.WooPosAnalyticsEvent.Event.ProductsPullToRefreshTriggered
+import com.woocommerce.android.ui.woopos.util.analytics.WooPosAnalyticsTracker
+import com.woocommerce.android.ui.woopos.util.format.WooPosFormatPrice
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.SharingStarted
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.stateIn
+import kotlinx.coroutines.launch
+import javax.inject.Inject
+
+@HiltViewModel
+class WooPosProductsViewModel @Inject constructor(
+    private val productsDataSource: WooPosProductsDataSource,
+    private val fromChildToParentEventSender: WooPosChildrenToParentEventSender,
+    private val priceFormat: WooPosFormatPrice,
+    private val navigator: WooPosItemsNavigator,
+    private val analyticsTracker: WooPosAnalyticsTracker,
+) : ViewModel() {
+    private var loadMoreProductsJob: Job? = null
+
+    private val _viewState = MutableStateFlow<WooPosProductsViewState>(
+        WooPosProductsViewState.Loading()
+    )
+
+    val viewState: StateFlow<WooPosProductsViewState> = _viewState
+        .stateIn(
+            viewModelScope,
+            started = SharingStarted.WhileSubscribed(),
+            initialValue = _viewState.value,
+        )
+
+    init {
+        loadProducts(
+            forceRefreshProducts = false,
+            withPullToRefresh = false,
+            withCart = true,
+        )
+    }
+
+    fun onUIEvent(event: WooPosProductsUIEvent) {
+        when (event) {
+            is WooPosProductsUIEvent.EndOfItemsListReached -> {
+                onEndOfProductsListReached()
+            }
+
+            is WooPosProductsUIEvent.ItemClicked -> {
+                handleItemClick(event)
+            }
+
+            WooPosProductsUIEvent.PullToRefreshTriggered -> {
+                loadProducts(
+                    forceRefreshProducts = true,
+                    withPullToRefresh = true,
+                    withCart = true,
+                )
+                viewModelScope.launch { analyticsTracker.track(ProductsPullToRefreshTriggered) }
+            }
+
+            WooPosProductsUIEvent.ProductsLoadingErrorRetryButtonClicked -> {
+                loadProducts(
+                    forceRefreshProducts = false,
+                    withPullToRefresh = false,
+                    withCart = false,
+                )
+            }
+
+            WooPosProductsUIEvent.BackButtonClicked -> {
+                navigateBackToItemListScreen()
+            }
+        }
+    }
+
+    private fun navigateBackToItemListScreen() {
+        viewModelScope.launch {
+            navigator.sendNavigationEvent(
+                WooPosItemsScreenNavigationEvent.NavigateBackToItemListScreen
+            )
+        }
+    }
+
+    private fun handleItemClick(event: WooPosProductsUIEvent.ItemClicked) {
+        when (event.item) {
+            is WooPosItemSelectionViewState.Product.Simple -> {
+                onItemClicked(
+                    ItemClickedData.Product.Simple(
+                        id = event.item.id
+                    )
+                )
+            }
+
+            is WooPosItemSelectionViewState.Product.Variable -> {
+                viewModelScope.launch {
+                    navigator.sendNavigationEvent(
+                        NavigateToVariationsScreen(
+                            VariableProductData(
+                                id = event.item.id,
+                                name = event.item.name,
+                                numOfVariations = event.item.numOfVariations,
+                            )
+                        )
+                    )
+                }
+            }
+
+            is WooPosItemSelectionViewState.Variation -> error("Variation item not support in products list")
+        }
+    }
+
+    private fun loadProducts(
+        forceRefreshProducts: Boolean,
+        withPullToRefresh: Boolean,
+        withCart: Boolean
+    ) {
+        viewModelScope.launch {
+            _viewState.value = if (withPullToRefresh) {
+                buildProductsReloadingState()
+            } else {
+                WooPosProductsViewState.Loading()
+            }
+
+            productsDataSource.loadProducts(forceRefreshProducts = forceRefreshProducts).collect { result ->
+                when (result) {
+                    is WooPosProductsDataSource.ProductsResult.Cached -> {
+                        if (result.products.isNotEmpty()) {
+                            _viewState.value = result.products.toContentState()
+                        }
+                    }
+
+                    is WooPosProductsDataSource.ProductsResult.Remote -> {
+                        _viewState.value = when {
+                            result.productsResult.isSuccess -> {
+                                val products = result.productsResult.getOrThrow()
+                                if (products.isNotEmpty()) {
+                                    val currentState = _viewState.value
+                                    val paginationState = if (loadMoreProductsJob?.isActive == true) {
+                                        WooPosPaginationState.Loading
+                                    } else {
+                                        WooPosPaginationState.None
+                                    }
+                                    if (currentState is WooPosProductsViewState.Content) {
+                                        currentState.copy(
+                                            items = products.map { it.toItemSelectionViewState() },
+                                            paginationState = paginationState,
+                                            pullToRefreshState = TODO(
+                                                "Add pull to refresh state when search is open"
+                                            ),
+//                                            if (searchHelper.isSearchOpen()) {
+//                                                WooPosPullToRefreshState.Disabled
+//                                            } else {
+//                                                WooPosPullToRefreshState.Enabled
+//                                            },
+                                        )
+                                    } else {
+                                        products.toContentState(
+                                            paginationState = paginationState,
+                                        )
+                                    }
+                                } else {
+                                    WooPosProductsViewState.Empty()
+                                }
+                            }
+
+                            else -> WooPosProductsViewState.Error()
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    private fun buildProductsReloadingState() =
+        when (val state = viewState.value) {
+            is WooPosProductsViewState.Content -> state.copy(pullToRefreshState = WooPosPullToRefreshState.Refreshing)
+            is WooPosProductsViewState.Loading -> state.copy(pullToRefreshState = WooPosPullToRefreshState.Refreshing)
+            is WooPosProductsViewState.Error -> state.copy(pullToRefreshState = WooPosPullToRefreshState.Refreshing)
+            is WooPosProductsViewState.Empty -> state.copy(pullToRefreshState = WooPosPullToRefreshState.Refreshing)
+        }
+
+    private suspend fun List<Product>.toContentState(
+        paginationState: WooPosPaginationState = WooPosPaginationState.None
+    ) = WooPosProductsViewState.Content(
+        items = map { it.toItemSelectionViewState() },
+        paginationState = paginationState,
+        pullToRefreshState = WooPosPullToRefreshState.Enabled,
+    )
+
+    private suspend fun Product.toItemSelectionViewState(): WooPosItemSelectionViewState {
+        return if (this.isVariable()) {
+            WooPosItemSelectionViewState.Product.Variable(
+                id = this.remoteId,
+                name = this.name,
+                price = priceFormat(this.price),
+                imageUrl = this.firstImageUrl,
+                numOfVariations = this.numVariations,
+                variationIds = this.variationIds
+            )
+        } else {
+            WooPosItemSelectionViewState.Product.Simple(
+                id = this.remoteId,
+                name = this.name,
+                price = priceFormat(this.price),
+                imageUrl = this.firstImageUrl,
+            )
+        }
+    }
+
+    private fun onEndOfProductsListReached() {
+        val currentState = _viewState.value
+        if (currentState !is WooPosProductsViewState.Content) {
+            return
+        }
+
+        if (!productsDataSource.hasMorePages) {
+            return
+        }
+
+        _viewState.value = currentState.copy(paginationState = WooPosPaginationState.Loading)
+
+        loadMoreProductsJob?.cancel()
+        loadMoreProductsJob = viewModelScope.launch {
+            val result = productsDataSource.loadMore()
+            _viewState.value = if (result.isSuccess) {
+                result.getOrThrow().toContentState()
+            } else {
+                currentState.copy(paginationState = WooPosPaginationState.Error)
+            }
+        }
+    }
+
+    private fun onItemClicked(itemData: ItemClickedData) {
+        sendEventToParent(ChildToParentEvent.ItemClickedInProductSelector(itemData))
+    }
+
+    private fun sendEventToParent(event: ChildToParentEvent) {
+        viewModelScope.launch { fromChildToParentEventSender.sendToParent(event) }
+    }
+
+    private fun Product.isVariable() =
+        productType == ProductType.VARIABLE ||
+            productType == ProductType.VARIATION
+}

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/home/WooPosHomeViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/home/WooPosHomeViewModelTest.kt
@@ -22,7 +22,6 @@ import org.mockito.kotlin.mock
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
 import kotlin.test.Test
-import kotlin.test.assertTrue
 
 @ExperimentalCoroutinesApi
 class WooPosHomeViewModelTest {
@@ -49,7 +48,7 @@ class WooPosHomeViewModelTest {
             val viewModel = createViewModel()
 
             // WHEN
-            viewModel.onUIEvent(WooPosHomeUIEvent.SystemBackClicked)
+            viewModel.onUIEvent(SystemBackClicked)
 
             // THEN
             verify(parentToChildrenEventSender).sendToChildren(ParentToChildrenEvent.BackFromCheckoutToCartClicked)
@@ -65,7 +64,7 @@ class WooPosHomeViewModelTest {
         val viewModel = createViewModel()
 
         // WHEN
-        viewModel.onUIEvent(WooPosHomeUIEvent.SystemBackClicked)
+        viewModel.onUIEvent(SystemBackClicked)
 
         // THEN
         assertThat(viewModel.state.value.exitConfirmationDialog).isEqualTo(
@@ -85,7 +84,7 @@ class WooPosHomeViewModelTest {
             val viewModel = createViewModel()
 
             // WHEN
-            viewModel.onUIEvent(WooPosHomeUIEvent.SystemBackClicked)
+            viewModel.onUIEvent(SystemBackClicked)
 
             // THEN
             verify(parentToChildrenEventSender).sendToChildren(
@@ -271,20 +270,21 @@ class WooPosHomeViewModelTest {
 
     @Test
     fun `given home screen is at checkout, when products are updated, then should not modify screen position`() {
-        val itemClickedData = listOf(
-            ItemClickedData.Product.Simple(
-                id = 1L
-            )
-        )
-        whenever(childrenToParentEventReceiver.events).thenReturn(
-            flowOf(
-                ChildToParentEvent.CheckoutClicked(itemClickedData),
-                ChildToParentEvent.ProductsStatusChanged.FullScreen
-            )
-        )
-        val viewModel = createViewModel()
-
-        assertTrue(viewModel.state.value.screenPositionState is WooPosHomeState.ScreenPositionState.Checkout)
+        TODO("Test not implemented - ProductsStatusChanged has been removed")
+//        val itemClickedData = listOf(
+//            ItemClickedData.Product.Simple(
+//                id = 1L
+//            )
+//        )
+//        whenever(childrenToParentEventReceiver.events).thenReturn(
+//            flowOf(
+//                ChildToParentEvent.CheckoutClicked(itemClickedData),
+//                ChildToParentEvent.ProductsStatusChanged.FullScreen
+//            )
+//        )
+//        val viewModel = createViewModel()
+//
+//        assertTrue(viewModel.state.value.screenPositionState is WooPosHomeState.ScreenPositionState.Checkout)
     }
 
     @Test

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/home/WooPosHomeViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/home/WooPosHomeViewModelTest.kt
@@ -269,25 +269,6 @@ class WooPosHomeViewModelTest {
     }
 
     @Test
-    fun `given home screen is at checkout, when products are updated, then should not modify screen position`() {
-        TODO("Test not implemented - ProductsStatusChanged has been removed")
-//        val itemClickedData = listOf(
-//            ItemClickedData.Product.Simple(
-//                id = 1L
-//            )
-//        )
-//        whenever(childrenToParentEventReceiver.events).thenReturn(
-//            flowOf(
-//                ChildToParentEvent.CheckoutClicked(itemClickedData),
-//                ChildToParentEvent.ProductsStatusChanged.FullScreen
-//            )
-//        )
-//        val viewModel = createViewModel()
-//
-//        assertTrue(viewModel.state.value.screenPositionState is WooPosHomeState.ScreenPositionState.Checkout)
-    }
-
-    @Test
     fun `given home screen is at checkout, when go back to checkout clicked after failed payment, then should show cart with totals`() = runTest {
         // GIVEN
         val events = MutableSharedFlow<ChildToParentEvent>()

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/home/items/WooPosItemsSearchHelperTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/home/items/WooPosItemsSearchHelperTest.kt
@@ -57,8 +57,8 @@ class WooPosItemsSearchHelperTest {
         val result = searchHelper.getInitialSearchState(isProductsSearchEnabled)
 
         // THEN
-        assertThat(result).isInstanceOf(WooPosItemsViewState.Content.SearchState.Visible::class.java)
-        val visibleState = result as WooPosItemsViewState.Content.SearchState.Visible
+        assertThat(result).isInstanceOf(WooPosItemsViewState.SearchState.Visible::class.java)
+        val visibleState = result as WooPosItemsViewState.SearchState.Visible
         assertThat(visibleState.state).isInstanceOf(WooPosSearchInputState.Closed::class.java)
     }
 
@@ -71,7 +71,7 @@ class WooPosItemsSearchHelperTest {
         val result = searchHelper.getInitialSearchState(isProductsSearchEnabled)
 
         // THEN
-        assertThat(result).isInstanceOf(WooPosItemsViewState.Content.SearchState.Hidden::class.java)
+        assertThat(result).isInstanceOf(WooPosItemsViewState.SearchState.Hidden::class.java)
     }
 
     @Test
@@ -102,8 +102,8 @@ class WooPosItemsSearchHelperTest {
         searchHelper.onSearchChanged(searchQuery, cursorPosition)
 
         // THEN
-        val currentState = viewStateFlow.value as WooPosItemsViewState.Content
-        val searchState = currentState.search as WooPosItemsViewState.Content.SearchState.Visible
+        val currentState = viewStateFlow.value as WooPosItemsViewState.ProductList
+        val searchState = currentState.search as WooPosItemsViewState.SearchState.Visible
         val openState = searchState.state as WooPosSearchInputState.Open
         assertThat(openState.input).isInstanceOf(WooPosSearchInputState.Open.Input.Query::class.java)
         val queryInput = openState.input as WooPosSearchInputState.Open.Input.Query
@@ -122,8 +122,8 @@ class WooPosItemsSearchHelperTest {
         searchHelper.onSearchChanged(emptyQuery, cursorPosition)
 
         // THEN
-        val currentState = viewStateFlow.value as WooPosItemsViewState.Content
-        val searchState = currentState.search as WooPosItemsViewState.Content.SearchState.Visible
+        val currentState = viewStateFlow.value as WooPosItemsViewState.ProductList
+        val searchState = currentState.search as WooPosItemsViewState.SearchState.Visible
         val openState = searchState.state as WooPosSearchInputState.Open
         assertThat(openState.input).isInstanceOf(WooPosSearchInputState.Open.Input.Hint::class.java)
     }
@@ -138,8 +138,8 @@ class WooPosItemsSearchHelperTest {
         searchHelper.onCloseSearchClicked()
 
         // THEN
-        val currentState = viewStateFlow.value as WooPosItemsViewState.Content
-        val searchState = currentState.search as WooPosItemsViewState.Content.SearchState.Visible
+        val currentState = viewStateFlow.value as WooPosItemsViewState.ProductList
+        val searchState = currentState.search as WooPosItemsViewState.SearchState.Visible
         assertThat(searchState.state).isInstanceOf(WooPosSearchInputState.Closed::class.java)
     }
 
@@ -154,8 +154,8 @@ class WooPosItemsSearchHelperTest {
             searchHelper.onClearSearchClicked()
 
             // THEN
-            val currentState = viewStateFlow.value as WooPosItemsViewState.Content
-            val searchState = currentState.search as WooPosItemsViewState.Content.SearchState.Visible
+            val currentState = viewStateFlow.value as WooPosItemsViewState.ProductList
+            val searchState = currentState.search as WooPosItemsViewState.SearchState.Visible
             val openState = searchState.state as WooPosSearchInputState.Open
             assertThat(openState.input).isInstanceOf(WooPosSearchInputState.Open.Input.Hint::class.java)
         }
@@ -172,8 +172,8 @@ class WooPosItemsSearchHelperTest {
         advanceUntilIdle()
 
         // THEN
-        val currentState = viewStateFlow.value as WooPosItemsViewState.Content
-        val searchState = currentState.search as WooPosItemsViewState.Content.SearchState.Visible
+        val currentState = viewStateFlow.value as WooPosItemsViewState.ProductList
+        val searchState = currentState.search as WooPosItemsViewState.SearchState.Visible
         val openState = searchState.state as WooPosSearchInputState.Open
         assertThat(openState.isLoading).isTrue
     }
@@ -189,52 +189,55 @@ class WooPosItemsSearchHelperTest {
         searchHelper.initialize(this, viewStateFlow)
 
         // THEN
-        val currentState = viewStateFlow.value as WooPosItemsViewState.Content
-        val searchState = currentState.search as WooPosItemsViewState.Content.SearchState.Visible
+        val currentState = viewStateFlow.value as WooPosItemsViewState.ProductList
+        val searchState = currentState.search as WooPosItemsViewState.SearchState.Visible
         val openState = searchState.state as WooPosSearchInputState.Open
         assertThat(openState.isLoading).isFalse
     }
 
     @Test
     fun `when closed search, then pull to refresh is enabled`() = runTest {
-        // GIVEN
-        searchHelper.initialize(this, viewStateFlow)
-
-        // WHEN
-        searchHelper.onCloseSearchClicked()
-
-        // THEN
-        val currentState = viewStateFlow.value as WooPosItemsViewState.Content
-        assertThat(currentState.pullToRefreshState).isEqualTo(WooPosPullToRefreshState.Enabled)
+        TODO("Implement this test")
+//        // GIVEN
+//        searchHelper.initialize(this, viewStateFlow)
+//
+//        // WHEN
+//        searchHelper.onCloseSearchClicked()
+//
+//        // THEN
+//        val currentState = viewStateFlow.value as WooPosItemsViewState.ProductList
+//        assertThat(currentState.pullToRefreshState).isEqualTo(WooPosPullToRefreshState.Enabled)
     }
 
     @Test
     fun `when search changed, then pull to refresh is disabled`() = runTest {
-        // GIVEN
-        searchHelper.initialize(this, viewStateFlow)
-
-        // WHEN
-        searchHelper.onSearchChanged("test query", "test query".length)
-
-        // THEN
-        val currentState = viewStateFlow.value as WooPosItemsViewState.Content
-        assertThat(currentState.pullToRefreshState).isEqualTo(WooPosPullToRefreshState.Disabled)
+        TODO("Implement this test")
+//        // GIVEN
+//        searchHelper.initialize(this, viewStateFlow)
+//
+//        // WHEN
+//        searchHelper.onSearchChanged("test query", "test query".length)
+//
+//        // THEN
+//        val currentState = viewStateFlow.value as WooPosItemsViewState.ProductList
+//        assertThat(currentState.pullToRefreshState).isEqualTo(WooPosPullToRefreshState.Disabled)
     }
 
     @Test
     fun `when hidden search state, then pull to refresh is enabled`() = runTest {
+        TODO("Implement this test")
         // GIVEN
-        searchHelper.initialize(this, viewStateFlow)
-        val contentState = createContentState().copy(
-            search = WooPosItemsViewState.Content.SearchState.Hidden
-        )
-
-        // WHEN
-        viewStateFlow.value = contentState
-
-        // THEN
-        val currentState = viewStateFlow.value as WooPosItemsViewState.Content
-        assertThat(currentState.pullToRefreshState).isEqualTo(WooPosPullToRefreshState.Enabled)
+//        searchHelper.initialize(this, viewStateFlow)
+//        val contentState = createContentState().copy(
+//            search = WooPosItemsViewState.SearchState.Hidden
+//        )
+//
+//        // WHEN
+//        viewStateFlow.value = contentState
+//
+//        // THEN
+//        val currentState = viewStateFlow.value as WooPosItemsViewState.ProductList
+//        assertThat(currentState.pullToRefreshState).isEqualTo(WooPosPullToRefreshState.Enabled)
     }
 
     @Test
@@ -246,8 +249,8 @@ class WooPosItemsSearchHelperTest {
         searchHelper.onAnimationComplete()
 
         // THEN
-        val currentState = viewStateFlow.value as WooPosItemsViewState.Content
-        val searchState = currentState.search as WooPosItemsViewState.Content.SearchState.Visible
+        val currentState = viewStateFlow.value as WooPosItemsViewState.ProductList
+        val searchState = currentState.search as WooPosItemsViewState.SearchState.Visible
         val openState = searchState.state as WooPosSearchInputState.Open
         assertThat(openState.hasAnimationPlayed).isTrue
     }
@@ -264,8 +267,8 @@ class WooPosItemsSearchHelperTest {
         advanceUntilIdle()
 
         // THEN
-        val afterReopenState = viewStateFlow.value as WooPosItemsViewState.Content
-        val afterReopenSearchState = afterReopenState.search as WooPosItemsViewState.Content.SearchState.Visible
+        val afterReopenState = viewStateFlow.value as WooPosItemsViewState.ProductList
+        val afterReopenSearchState = afterReopenState.search as WooPosItemsViewState.SearchState.Visible
         assertThat(afterReopenSearchState.state).isInstanceOf(WooPosSearchInputState.Open::class.java)
 
         val openState = afterReopenSearchState.state as WooPosSearchInputState.Open
@@ -283,8 +286,8 @@ class WooPosItemsSearchHelperTest {
         searchHelper.onClearSearchClicked()
 
         // THEN
-        val currentState = viewStateFlow.value as WooPosItemsViewState.Content
-        val searchState = currentState.search as WooPosItemsViewState.Content.SearchState.Visible
+        val currentState = viewStateFlow.value as WooPosItemsViewState.ProductList
+        val searchState = currentState.search as WooPosItemsViewState.SearchState.Visible
         val openState = searchState.state as WooPosSearchInputState.Open
         assertThat(openState.hasAnimationPlayed).isFalse
     }
@@ -307,29 +310,20 @@ class WooPosItemsSearchHelperTest {
         advanceUntilIdle()
 
         // THEN
-        val currentState = viewStateFlow.value as WooPosItemsViewState.Content
-        val searchState = currentState.search as WooPosItemsViewState.Content.SearchState.Visible
+        val currentState = viewStateFlow.value as WooPosItemsViewState.ProductList
+        val searchState = currentState.search as WooPosItemsViewState.SearchState.Visible
         assertThat(searchState.state).isInstanceOf(WooPosSearchInputState.Closed::class.java)
     }
 
-    private fun createContentState(): WooPosItemsViewState.Content {
-        return WooPosItemsViewState.Content(
-            contentType = WooPosItemsViewState.Content.ContentState.ProductList,
-            search = WooPosItemsViewState.Content.SearchState.Visible(
+    private fun createContentState(): WooPosItemsViewState.ProductList {
+        return WooPosItemsViewState.ProductList(
+            search = WooPosItemsViewState.SearchState.Visible(
                 state = WooPosSearchInputState.Open(
                     input = WooPosSearchInputState.Open.Input.Hint("Search products"),
                     isLoading = false
                 )
             ),
-            items = emptyList(),
-            bannerState = WooPosItemsViewState.Content.BannerState(
-                isBannerHiddenByUser = false,
-                title = R.string.app_name,
-                message = R.string.app_name,
-                icon = R.drawable.ic_woo
-            ),
-            paginationState = WooPosPaginationState.None,
-            pullToRefreshState = WooPosPullToRefreshState.Enabled,
+            banner = WooPosItemsViewState.BannerState.Hidden,
             tabs = listOf(
                 WooPosItemsViewState.Tab(
                     R.string.woopos_products_screen_title,

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/home/items/WooPosItemsSearchHelperTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/home/items/WooPosItemsSearchHelperTest.kt
@@ -196,51 +196,6 @@ class WooPosItemsSearchHelperTest {
     }
 
     @Test
-    fun `when closed search, then pull to refresh is enabled`() = runTest {
-        TODO("Implement this test")
-//        // GIVEN
-//        searchHelper.initialize(this, viewStateFlow)
-//
-//        // WHEN
-//        searchHelper.onCloseSearchClicked()
-//
-//        // THEN
-//        val currentState = viewStateFlow.value as WooPosItemsViewState.ProductList
-//        assertThat(currentState.pullToRefreshState).isEqualTo(WooPosPullToRefreshState.Enabled)
-    }
-
-    @Test
-    fun `when search changed, then pull to refresh is disabled`() = runTest {
-        TODO("Implement this test")
-//        // GIVEN
-//        searchHelper.initialize(this, viewStateFlow)
-//
-//        // WHEN
-//        searchHelper.onSearchChanged("test query", "test query".length)
-//
-//        // THEN
-//        val currentState = viewStateFlow.value as WooPosItemsViewState.ProductList
-//        assertThat(currentState.pullToRefreshState).isEqualTo(WooPosPullToRefreshState.Disabled)
-    }
-
-    @Test
-    fun `when hidden search state, then pull to refresh is enabled`() = runTest {
-        TODO("Implement this test")
-        // GIVEN
-//        searchHelper.initialize(this, viewStateFlow)
-//        val contentState = createContentState().copy(
-//            search = WooPosItemsViewState.SearchState.Hidden
-//        )
-//
-//        // WHEN
-//        viewStateFlow.value = contentState
-//
-//        // THEN
-//        val currentState = viewStateFlow.value as WooPosItemsViewState.ProductList
-//        assertThat(currentState.pullToRefreshState).isEqualTo(WooPosPullToRefreshState.Enabled)
-    }
-
-    @Test
     fun `when animation completes, then hasAnimationPlayed flag is set to true`() = runTest {
         // GIVEN
         searchHelper.initialize(this, viewStateFlow)

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/home/items/WooPosItemsViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/home/items/WooPosItemsViewModelTest.kt
@@ -5,7 +5,6 @@ import com.woocommerce.android.R
 import com.woocommerce.android.ui.products.ProductTestUtils
 import com.woocommerce.android.ui.woopos.common.composeui.component.WooPosSearchInputState
 import com.woocommerce.android.ui.woopos.featureflags.WooPosIsProductsSearchEnabled
-import com.woocommerce.android.ui.woopos.home.ChildToParentEvent
 import com.woocommerce.android.ui.woopos.home.WooPosChildrenToParentEventSender
 import com.woocommerce.android.ui.woopos.home.items.navigation.WooPosItemsNavigator
 import com.woocommerce.android.ui.woopos.home.items.products.WooPosProductsDataSource
@@ -26,7 +25,6 @@ import org.mockito.kotlin.mock
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
 import java.math.BigDecimal
-import kotlin.test.assertTrue
 
 @ExperimentalCoroutinesApi
 class WooPosItemsViewModelTest {
@@ -90,159 +88,6 @@ class WooPosItemsViewModelTest {
             )
         )
     }
-
-    @Test
-    fun `when simple products only banner is closed, then state is updated to true`() = runTest {
-        // GIVEN
-        whenever(posPreferencesRepository.isSimpleProductsOnlyBannerWasHiddenByUser).thenReturn(
-            flowOf(true)
-        )
-        val viewModel = createViewModel()
-        viewModel.viewState.test {
-            val contentState = awaitItem() as WooPosItemsViewState.Content
-            // WHEN
-            viewModel.onUIEvent(WooPosItemsUIEvent.SimpleProductsBannerClosed)
-
-            // THEN
-            assertTrue(contentState.bannerState.isBannerHiddenByUser)
-        }
-    }
-
-    @Test
-    fun `when simple products only banner is closed, then data store is updated to true`() = runTest {
-        // GIVEN
-        whenever(posPreferencesRepository.isSimpleProductsOnlyBannerWasHiddenByUser).thenReturn(
-            flowOf(true)
-        )
-        val viewModel = createViewModel()
-
-        // WHEN
-        viewModel.onUIEvent(WooPosItemsUIEvent.SimpleProductsBannerClosed)
-
-        // THEN
-        verify(posPreferencesRepository).setSimpleProductsOnlyBannerWasHiddenByUser(true)
-    }
-
-    @Test
-    fun `given simple products only banner is shown, when view model init, then state is updated with false`() =
-        runTest {
-            // GIVEN
-            whenever(posPreferencesRepository.isSimpleProductsOnlyBannerWasHiddenByUser).thenReturn(
-                flowOf(false)
-            )
-
-            // WHEN
-            val viewModel = createViewModel()
-
-            // THEN
-            viewModel.viewState.test {
-                val contentState = awaitItem() as WooPosItemsViewState.Content
-                assertThat(contentState.bannerState.isBannerHiddenByUser).isFalse()
-            }
-        }
-
-    @Test
-    fun `given simple products only banner already closed by user, when view model init, then banner state is updated to true`() =
-        runTest {
-            // GIVEN
-            whenever(posPreferencesRepository.isSimpleProductsOnlyBannerWasHiddenByUser).thenReturn(
-                flowOf(true)
-            )
-
-            // WHEN
-            val viewModel = createViewModel()
-
-            // THEN
-            viewModel.viewState.test {
-                val contentState = awaitItem() as WooPosItemsViewState.Content
-                assertTrue(contentState.bannerState.isBannerHiddenByUser)
-            }
-        }
-
-    @Test
-    fun `given simple products only banner is shown, then correct title is displayed`() = runTest {
-        // GIVEN
-        whenever(posPreferencesRepository.isSimpleProductsOnlyBannerWasHiddenByUser).thenReturn(
-            flowOf(false)
-        )
-
-        // WHEN
-        val viewModel = createViewModel()
-
-        // THEN
-        viewModel.viewState.test {
-            val contentState = awaitItem() as WooPosItemsViewState.Content
-            assertThat(contentState.bannerState.title).isEqualTo(R.string.woopos_banner_simple_products_only_title)
-        }
-    }
-
-    @Test
-    fun `given simple products only banner is shown, then correct message is displayed`() = runTest {
-        // GIVEN
-        whenever(posPreferencesRepository.isSimpleProductsOnlyBannerWasHiddenByUser).thenReturn(
-            flowOf(false)
-        )
-
-        // WHEN
-        val viewModel = createViewModel()
-
-        // THEN
-        viewModel.viewState.test {
-            val contentState = awaitItem() as WooPosItemsViewState.Content
-
-            assertThat(contentState.bannerState.message).isEqualTo(R.string.woopos_banner_simple_products_only_message)
-        }
-    }
-
-    @Test
-    fun `given simple products only banner is shown, then correct banner icon is displayed`() = runTest {
-        // GIVEN
-        whenever(posPreferencesRepository.isSimpleProductsOnlyBannerWasHiddenByUser).thenReturn(
-            flowOf(false)
-        )
-
-        // WHEN
-        val viewModel = createViewModel()
-
-        // THEN
-        viewModel.viewState.test {
-            val contentState = awaitItem() as WooPosItemsViewState.Content
-            assertThat(contentState.bannerState.icon).isEqualTo(R.drawable.info)
-        }
-    }
-
-    @Test
-    fun `given info icon displayed, when clicked, then appropriate event is triggered`() = runTest {
-        // GIVEN
-        whenever(posPreferencesRepository.isSimpleProductsOnlyBannerWasHiddenByUser).thenReturn(
-            flowOf(true)
-        )
-        val viewModel = createViewModel()
-
-        // WHEN
-        viewModel.onUIEvent(WooPosItemsUIEvent.SimpleProductsDialogInfoIconClicked)
-
-        // THEN
-        verify(fromChildToParentEventSender).sendToParent(ChildToParentEvent.ProductsDialogInfoIconClicked)
-    }
-
-    @Test
-    fun `given simple products banner displayed, when learn more clicked, then appropriate event is triggered`() =
-        runTest {
-            // GIVEN
-            whenever(posPreferencesRepository.isSimpleProductsOnlyBannerWasHiddenByUser).thenReturn(
-                flowOf(false)
-            )
-            val viewModel = createViewModel()
-
-            // WHEN
-            viewModel.onUIEvent(WooPosItemsUIEvent.SimpleProductsBannerLearnMoreClicked)
-
-            // THEN
-            verify(fromChildToParentEventSender).sendToParent(ChildToParentEvent.ProductsDialogInfoIconClicked)
-        }
-
-
 
     @Test
     fun `given variations screen, when clicked back, then trigger proper event`() = runTest {

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/home/items/WooPosItemsViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/home/items/WooPosItemsViewModelTest.kt
@@ -2,16 +2,12 @@ package com.woocommerce.android.ui.woopos.home.items
 
 import app.cash.turbine.test
 import com.woocommerce.android.R
-import com.woocommerce.android.ui.products.ProductTestUtils
 import com.woocommerce.android.ui.woopos.common.composeui.component.WooPosSearchInputState
 import com.woocommerce.android.ui.woopos.featureflags.WooPosIsProductsSearchEnabled
 import com.woocommerce.android.ui.woopos.home.WooPosChildrenToParentEventSender
 import com.woocommerce.android.ui.woopos.home.items.navigation.WooPosItemsNavigator
-import com.woocommerce.android.ui.woopos.home.items.products.WooPosProductsDataSource
 import com.woocommerce.android.ui.woopos.util.WooPosCoroutineTestRule
-import com.woocommerce.android.ui.woopos.util.analytics.WooPosAnalyticsTracker
 import com.woocommerce.android.ui.woopos.util.datastore.WooPosPreferencesRepository
-import com.woocommerce.android.ui.woopos.util.format.WooPosFormatPrice
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.test.runTest
@@ -24,7 +20,6 @@ import org.mockito.kotlin.eq
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
-import java.math.BigDecimal
 
 @ExperimentalCoroutinesApi
 class WooPosItemsViewModelTest {
@@ -43,15 +38,11 @@ class WooPosItemsViewModelTest {
         )
     )
 
-    private val productsDataSource: WooPosProductsDataSource = mock()
+
     private val fromChildToParentEventSender: WooPosChildrenToParentEventSender = mock()
     private val posPreferencesRepository: WooPosPreferencesRepository = mock()
     private val wooPosItemsNavigator: WooPosItemsNavigator = mock()
-    private val priceFormat: WooPosFormatPrice = mock {
-        onBlocking { invoke(BigDecimal("10.0")) }.thenReturn("$10.0")
-        onBlocking { invoke(BigDecimal("20.0")) }.thenReturn("$20.0")
-    }
-    private val analyticsTracker: WooPosAnalyticsTracker = mock()
+
     private val isProductsSearchEnabled: WooPosIsProductsSearchEnabled = mock()
     private val searchHelper: WooPosItemsSearchHelper = mock()
     private val tabsHelper: WooPosItemsTabsHelper = mock {
@@ -64,24 +55,6 @@ class WooPosItemsViewModelTest {
             flowOf(false)
         )
 
-        val products = listOf(
-            ProductTestUtils.generateProduct(
-                productId = 1,
-                productName = "Product 1",
-                amount = "10.0",
-                productType = "simple",
-                isDownloadable = false,
-            ),
-        )
-
-        whenever(productsDataSource.loadProducts(any())).thenReturn(
-            flowOf(
-                WooPosProductsDataSource.ProductsResult.Remote(
-                    Result.success(products)
-                )
-            )
-        )
-
         whenever(searchHelper.getInitialSearchState(any())).thenReturn(
             WooPosItemsViewState.SearchState.Visible(
                 state = WooPosSearchInputState.Closed
@@ -92,28 +65,29 @@ class WooPosItemsViewModelTest {
     @Test
     fun `given variations screen, when clicked back, then trigger proper event`() = runTest {
         // GIVEN
-        val products = listOf(
-            ProductTestUtils.generateProduct(
-                productId = 1,
-                productName = "Product 1",
-                amount = "10.0",
-                productType = "variable",
-                isVariable = true
-            )
-        )
-        whenever(productsDataSource.loadProducts(any())).thenReturn(
-            flowOf(
-                WooPosProductsDataSource.ProductsResult.Remote(
-                    Result.success(products)
-                )
-            )
-        )
-        val viewModel = createViewModel()
-        viewModel.onUIEvent(WooPosItemsUIEvent.BackButtonClicked)
-
-        verify(wooPosItemsNavigator).sendNavigationEvent(
-            WooPosItemsNavigator.WooPosItemsScreenNavigationEvent.NavigateBackToItemListScreen
-        )
+        TODO("Implement this test")
+//        val products = listOf(
+//            ProductTestUtils.generateProduct(
+//                productId = 1,
+//                productName = "Product 1",
+//                amount = "10.0",
+//                productType = "variable",
+//                isVariable = true
+//            )
+//        )
+//        whenever(productsDataSource.loadProducts(any())).thenReturn(
+//            flowOf(
+//                WooPosProductsDataSource.ProductsResult.Remote(
+//                    Result.success(products)
+//                )
+//            )
+//        )
+//        val viewModel = createViewModel()
+//        viewModel.onUIEvent(WooPosItemsUIEvent.BackButtonClicked)
+//
+//        verify(wooPosItemsNavigator).sendNavigationEvent(
+//            WooPosItemsNavigator.WooPosItemsScreenNavigationEvent.NavigateBackToItemListScreen
+//        )
     }
 
 
@@ -121,22 +95,6 @@ class WooPosItemsViewModelTest {
     @Test
     fun `given products search feature enabled, when view model created, then search state is visible`() = runTest {
         // GIVEN
-        val products = listOf(
-            ProductTestUtils.generateProduct(
-                productId = 1,
-                productName = "Product 1",
-                amount = "10.0",
-                productType = "simple"
-            )
-        )
-
-        whenever(productsDataSource.loadProducts(any())).thenReturn(
-            flowOf(
-                WooPosProductsDataSource.ProductsResult.Remote(
-                    Result.success(products)
-                )
-            )
-        )
         whenever(isProductsSearchEnabled()).thenReturn(true)
         whenever(searchHelper.getInitialSearchState(true)).thenReturn(
             WooPosItemsViewState.SearchState.Visible(
@@ -149,7 +107,7 @@ class WooPosItemsViewModelTest {
 
         // THEN
         viewModel.viewState.test {
-            val contentState = awaitItem() as WooPosItemsViewState.Content
+            val contentState = awaitItem() as WooPosItemsViewState.ProductList
             assertThat(contentState.search).isInstanceOf(WooPosItemsViewState.SearchState.Visible::class.java)
             val searchState = contentState.search as WooPosItemsViewState.SearchState.Visible
             assertThat(searchState.state).isEqualTo(WooPosSearchInputState.Closed)
@@ -159,22 +117,6 @@ class WooPosItemsViewModelTest {
     @Test
     fun `given products search feature disabled, when view model created, then search state is hidden`() = runTest {
         // GIVEN
-        val products = listOf(
-            ProductTestUtils.generateProduct(
-                productId = 1,
-                productName = "Product 1",
-                amount = "10.0",
-                productType = "simple"
-            )
-        )
-
-        whenever(productsDataSource.loadProducts(any())).thenReturn(
-            flowOf(
-                WooPosProductsDataSource.ProductsResult.Remote(
-                    Result.success(products)
-                )
-            )
-        )
         whenever(isProductsSearchEnabled()).thenReturn(false)
         whenever(searchHelper.getInitialSearchState(false)).thenReturn(
             WooPosItemsViewState.SearchState.Hidden
@@ -185,7 +127,7 @@ class WooPosItemsViewModelTest {
 
         // THEN
         viewModel.viewState.test {
-            val contentState = awaitItem() as WooPosItemsViewState.Content
+            val contentState = awaitItem() as WooPosItemsViewState.ProductList
             assertThat(contentState.search).isInstanceOf(WooPosItemsViewState.SearchState.Hidden::class.java)
         }
     }
@@ -193,22 +135,6 @@ class WooPosItemsViewModelTest {
     @Test
     fun `given search visible, when close search clicked, then search state is closed`() = runTest {
         // GIVEN
-        val products = listOf(
-            ProductTestUtils.generateProduct(
-                productId = 1,
-                productName = "Product 1",
-                amount = "10.0",
-                productType = "simple"
-            )
-        )
-
-        whenever(productsDataSource.loadProducts(any())).thenReturn(
-            flowOf(
-                WooPosProductsDataSource.ProductsResult.Remote(
-                    Result.success(products)
-                )
-            )
-        )
         whenever(isProductsSearchEnabled()).thenReturn(true)
 
         // WHEN
@@ -240,22 +166,6 @@ class WooPosItemsViewModelTest {
 
     @Test
     fun `given search visible, when close search clicked, then search helper is called`() = runTest {
-        val products = listOf(
-            ProductTestUtils.generateProduct(
-                productId = 1,
-                productName = "Product 1",
-                amount = "10.0",
-                productType = "simple"
-            )
-        )
-
-        whenever(productsDataSource.loadProducts(any())).thenReturn(
-            flowOf(
-                WooPosProductsDataSource.ProductsResult.Remote(
-                    Result.success(products)
-                )
-            )
-        )
         whenever(isProductsSearchEnabled()).thenReturn(true)
 
         val viewModel = createViewModel()
@@ -267,23 +177,6 @@ class WooPosItemsViewModelTest {
     @Test
     fun `when tab clicked, then tab is selected and state is updated`() = runTest {
         // GIVEN
-        val products = listOf(
-            ProductTestUtils.generateProduct(
-                productId = 1,
-                productName = "Product 1",
-                amount = "10.0",
-                productType = "simple"
-            )
-        )
-
-        whenever(productsDataSource.loadProducts(any())).thenReturn(
-            flowOf(
-                WooPosProductsDataSource.ProductsResult.Remote(
-                    Result.success(products)
-                )
-            )
-        )
-
         val couponsTab = WooPosItemsViewState.Tab(
             R.string.woopos_coupons_screen_title,
             WooPosItemsViewState.Tab.HighlightLevel.Normal
@@ -309,19 +202,15 @@ class WooPosItemsViewModelTest {
 
         // THEN
         viewModel.viewState.test {
-            val value = awaitItem() as WooPosItemsViewState.Content
-            assertThat(value.contentType).isEqualTo(WooPosItemsViewState.Content.ContentState.CouponsList)
+            val value = awaitItem()
+            assertThat(value).isInstanceOf(WooPosItemsViewState.CouponList::class.java)
         }
     }
-
     private fun createViewModel() =
         WooPosItemsViewModel(
-            productsDataSource,
             fromChildToParentEventSender,
-            priceFormat,
             posPreferencesRepository,
             wooPosItemsNavigator,
-            analyticsTracker,
             searchHelper,
             isProductsSearchEnabled,
             tabsHelper,

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/home/items/WooPosItemsViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/home/items/WooPosItemsViewModelTest.kt
@@ -65,29 +65,15 @@ class WooPosItemsViewModelTest {
     @Test
     fun `given variations screen, when clicked back, then trigger proper event`() = runTest {
         // GIVEN
-        TODO("Implement this test")
-//        val products = listOf(
-//            ProductTestUtils.generateProduct(
-//                productId = 1,
-//                productName = "Product 1",
-//                amount = "10.0",
-//                productType = "variable",
-//                isVariable = true
-//            )
-//        )
-//        whenever(productsDataSource.loadProducts(any())).thenReturn(
-//            flowOf(
-//                WooPosProductsDataSource.ProductsResult.Remote(
-//                    Result.success(products)
-//                )
-//            )
-//        )
-//        val viewModel = createViewModel()
-//        viewModel.onUIEvent(WooPosItemsUIEvent.BackButtonClicked)
-//
-//        verify(wooPosItemsNavigator).sendNavigationEvent(
-//            WooPosItemsNavigator.WooPosItemsScreenNavigationEvent.NavigateBackToItemListScreen
-//        )
+        val viewModel = createViewModel()
+
+        // WHEN
+        viewModel.onUIEvent(WooPosItemsUIEvent.BackButtonClicked)
+
+        // THEN
+        verify(wooPosItemsNavigator).sendNavigationEvent(
+            WooPosItemsNavigator.WooPosItemsScreenNavigationEvent.NavigateBackToItemListScreen
+        )
     }
 
 

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/home/items/WooPosItemsViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/home/items/WooPosItemsViewModelTest.kt
@@ -7,11 +7,9 @@ import com.woocommerce.android.ui.woopos.common.composeui.component.WooPosSearch
 import com.woocommerce.android.ui.woopos.featureflags.WooPosIsProductsSearchEnabled
 import com.woocommerce.android.ui.woopos.home.ChildToParentEvent
 import com.woocommerce.android.ui.woopos.home.WooPosChildrenToParentEventSender
-import com.woocommerce.android.ui.woopos.home.items.WooPosItemSelectionViewState.Product
 import com.woocommerce.android.ui.woopos.home.items.navigation.WooPosItemsNavigator
 import com.woocommerce.android.ui.woopos.home.items.products.WooPosProductsDataSource
 import com.woocommerce.android.ui.woopos.util.WooPosCoroutineTestRule
-import com.woocommerce.android.ui.woopos.util.analytics.WooPosAnalyticsEvent.Event.ProductsPullToRefreshTriggered
 import com.woocommerce.android.ui.woopos.util.analytics.WooPosAnalyticsTracker
 import com.woocommerce.android.ui.woopos.util.datastore.WooPosPreferencesRepository
 import com.woocommerce.android.ui.woopos.util.format.WooPosFormatPrice
@@ -87,281 +85,10 @@ class WooPosItemsViewModelTest {
         )
 
         whenever(searchHelper.getInitialSearchState(any())).thenReturn(
-            WooPosItemsViewState.Content.SearchState.Visible(
+            WooPosItemsViewState.SearchState.Visible(
                 state = WooPosSearchInputState.Closed
             )
         )
-    }
-
-    @Test
-    fun `given products from data source, when view model created, then view state updated correctly`() = runTest {
-        // WHEN
-        val products = listOf(
-            ProductTestUtils.generateProduct(
-                productId = 1,
-                productName = "Product 1",
-                amount = "10.0",
-                productType = "simple",
-                isDownloadable = false,
-            ),
-            ProductTestUtils.generateProduct(
-                productId = 2,
-                productName = "Product 2",
-                amount = "20.0",
-                productType = "simple",
-                isDownloadable = false,
-            ).copy(firstImageUrl = "https://test.com")
-        )
-
-        whenever(productsDataSource.loadProducts(any())).thenReturn(
-            flowOf(
-                WooPosProductsDataSource.ProductsResult.Remote(
-                    Result.success(products)
-                )
-            )
-        )
-        val viewModel = createViewModel()
-
-        // THEN
-        viewModel.viewState.test {
-            val value = awaitItem() as WooPosItemsViewState.Content
-
-            @Suppress("UNCHECKED_CAST")
-            val items = value.items as List<Product.Simple>
-            assertThat(items).hasSize(2)
-            assertThat(items[0].id).isEqualTo(1)
-            assertThat(items[0].name).isEqualTo("Product 1")
-            assertThat(items[0].price).isEqualTo("$10.0")
-            assertThat(items[1].id).isEqualTo(2)
-            assertThat(items[1].name).isEqualTo("Product 2")
-            assertThat(items[1].price).isEqualTo("$20.0")
-            assertThat(items[1].imageUrl).isEqualTo("https://test.com")
-        }
-    }
-
-    @Test
-    fun `given empty products list returned, when view model created, then view state is empty`() = runTest {
-        // GIVEN
-        whenever(productsDataSource.loadProducts(any())).thenReturn(
-            flowOf(
-                WooPosProductsDataSource.ProductsResult.Remote(
-                    Result.success(emptyList())
-                )
-            )
-        )
-
-        // WHEN
-        val viewModel = createViewModel()
-
-        // THEN
-        viewModel.viewState.test {
-            val value = awaitItem()
-            assertThat(value).isEqualTo(
-                WooPosItemsViewState.Empty(tabs)
-            )
-        }
-    }
-
-    @Test
-    fun `given loading products fails, when view model created, then view state is error`() = runTest {
-        // GIVEN
-        whenever(productsDataSource.loadProducts(any())).thenReturn(
-            flowOf(
-                WooPosProductsDataSource.ProductsResult.Remote(
-                    Result.failure(Exception())
-                )
-            )
-        )
-
-        // WHEN
-        val viewModel = createViewModel()
-
-        // THEN
-        viewModel.viewState.test {
-            val value = awaitItem()
-            assertThat(value).isEqualTo(
-                WooPosItemsViewState.Error(
-                    tabs = tabs
-                )
-            )
-        }
-    }
-
-    @Test
-    fun `given products from data source, when pulled to refresh, then should remove products and fetch again`() =
-        runTest {
-            // WHEN
-            val viewModel = createViewModel()
-            viewModel.onUIEvent(WooPosItemsUIEvent.PullToRefreshTriggered)
-
-            // THEN
-            viewModel.viewState.test {
-                verify(productsDataSource).loadProducts(forceRefreshProducts = true)
-                cancelAndConsumeRemainingEvents()
-            }
-        }
-
-    @Test
-    fun `given content state, when end of products grid reached and no more pages, then do not load more`() = runTest {
-        // GIVEN
-        whenever(productsDataSource.hasMorePages).thenReturn(false)
-        val viewModel = createViewModel()
-
-        // WHEN
-        viewModel.onUIEvent(WooPosItemsUIEvent.EndOfItemsListReached)
-
-        // THEN
-        viewModel.viewState.test {
-            val value = awaitItem() as WooPosItemsViewState.Content
-            assertThat(value.paginationState).isEqualTo(WooPosPaginationState.None)
-        }
-    }
-
-    @Test
-    fun `when product clicked, then send event to parent`() = runTest {
-        // GIVEN
-        val product = Product.Simple(id = 1, name = "", price = "", imageUrl = null)
-        val viewModel = createViewModel()
-
-        // WHEN
-        viewModel.onUIEvent(WooPosItemsUIEvent.ItemClicked(product))
-
-        // THEN
-        viewModel.viewState.test {
-            verify(fromChildToParentEventSender).sendToParent(
-                ChildToParentEvent.ItemClickedInProductSelector(
-                    WooPosItemsViewModel.ItemClickedData.Product.Simple(
-                        id = product.id
-                    )
-                )
-            )
-            cancelAndConsumeRemainingEvents()
-        }
-    }
-
-    @Test
-    fun `given load more products is called, when products source loads successfully then state is updated`() =
-        runTest {
-            // GIVEN
-            val viewModel = createViewModel()
-
-            // WHEN
-            viewModel.onUIEvent(WooPosItemsUIEvent.EndOfItemsListReached)
-
-            // THEN
-            viewModel.viewState.test {
-                val value = awaitItem() as WooPosItemsViewState.Content
-                assertThat(value.paginationState).isEqualTo(WooPosPaginationState.None)
-            }
-        }
-
-    @Test
-    fun `when loading without pull to refresh, then should not ask to remove products`() = runTest {
-        // WHEN
-        val viewModel = createViewModel()
-
-        // THEN
-        viewModel.viewState.test {
-            verify(productsDataSource).loadProducts(forceRefreshProducts = false)
-            cancelAndConsumeRemainingEvents()
-        }
-    }
-
-    @Test
-    fun `when vm created and loading products, then view state is Loading`() = runTest {
-        // WHEN
-        val viewModel = createViewModel()
-
-        // THEN
-        assertThat(viewModel.viewState.value).isInstanceOf(WooPosItemsViewState.Loading::class.java)
-    }
-
-    @Test
-    fun `given error from load more, when list end reached, then state is pagination error`() = runTest {
-        // GIVEN
-        whenever(productsDataSource.loadMore()).thenReturn(Result.failure(Exception()))
-        whenever(productsDataSource.hasMorePages).thenReturn(true)
-        val viewModel = createViewModel()
-
-        // WHEN
-        viewModel.onUIEvent(WooPosItemsUIEvent.EndOfItemsListReached)
-
-        // THEN
-        viewModel.viewState.test {
-            val value = awaitItem() as WooPosContentViewState
-            assertThat(value.paginationState).isInstanceOf(WooPosPaginationState.Error::class.java)
-        }
-    }
-
-    @Test
-    fun `given no products, when pull to refresh, then state is Empty`() = runTest {
-        // GIVEN
-        val viewModel = createViewModel()
-        whenever(productsDataSource.loadProducts(any())).thenReturn(
-            flowOf(
-                WooPosProductsDataSource.ProductsResult.Remote(
-                    Result.success(emptyList())
-                )
-            )
-        )
-
-        // WHEN
-        viewModel.onUIEvent(WooPosItemsUIEvent.PullToRefreshTriggered)
-
-        // THEN
-        viewModel.viewState.test {
-            val value = awaitItem()
-            assertThat(value).isInstanceOf(WooPosItemsViewState.Empty::class.java)
-        }
-    }
-
-    @Test
-    fun `given empty list, when pull to refresh, then parent notified correctly`() = runTest {
-        // GIVEN
-        val viewModel = createViewModel()
-        whenever(productsDataSource.loadProducts(any())).thenReturn(
-            flowOf(
-                WooPosProductsDataSource.ProductsResult.Remote(
-                    Result.success(emptyList())
-                )
-            )
-        )
-
-        // WHEN
-        viewModel.onUIEvent(WooPosItemsUIEvent.PullToRefreshTriggered)
-
-        // THEN
-        viewModel.viewState.test {
-            verify(fromChildToParentEventSender).sendToParent(ChildToParentEvent.ProductsStatusChanged.FullScreen)
-            cancelAndConsumeRemainingEvents()
-        }
-    }
-
-    @Test
-    fun `given products, when pull to refresh, then parent notified correctly`() = runTest {
-        // GIVEN
-        val viewModel = createViewModel()
-
-        // WHEN
-        viewModel.onUIEvent(WooPosItemsUIEvent.PullToRefreshTriggered)
-
-        // THEN
-        viewModel.viewState.test {
-            verify(fromChildToParentEventSender).sendToParent(ChildToParentEvent.ProductsStatusChanged.WithCart)
-            cancelAndConsumeRemainingEvents()
-        }
-    }
-
-    @Test
-    fun `when pull to refresh, then should track event`() = runTest {
-        // GIVEN
-        val viewModel = createViewModel()
-
-        // WHEN
-        viewModel.onUIEvent(WooPosItemsUIEvent.PullToRefreshTriggered)
-
-        // THEN
-        verify(analyticsTracker).track(ProductsPullToRefreshTriggered)
     }
 
     @Test
@@ -515,52 +242,7 @@ class WooPosItemsViewModelTest {
             verify(fromChildToParentEventSender).sendToParent(ChildToParentEvent.ProductsDialogInfoIconClicked)
         }
 
-    @Test
-    fun `given variable product, when clicked on it, then trigger proper event`() = runTest {
-        // GIVEN
-        val products = listOf(
-            ProductTestUtils.generateProduct(
-                productId = 1,
-                productName = "Product 1",
-                amount = "10.0",
-                productType = "variable",
-                isVariable = true
-            )
-        )
-        whenever(productsDataSource.loadProducts(any())).thenReturn(
-            flowOf(
-                WooPosProductsDataSource.ProductsResult.Remote(
-                    Result.success(products)
-                )
-            )
-        )
-        val viewModel = createViewModel()
 
-        // WHEN
-        viewModel.onUIEvent(
-            WooPosItemsUIEvent.ItemClicked(
-                Product.Variable(
-                    id = 1L,
-                    name = "Product 1",
-                    numOfVariations = 10,
-                    variationIds = emptyList(),
-                    price = "$10.0",
-                    imageUrl = null
-                )
-            )
-        )
-
-        // THEN
-        verify(wooPosItemsNavigator).sendNavigationEvent(
-            WooPosItemsNavigator.WooPosItemsScreenNavigationEvent.NavigateToVariationsScreen(
-                WooPosItemNavigationData.VariableProductData(
-                    id = 1,
-                    name = "Product 1",
-                    numOfVariations = 10,
-                )
-            )
-        )
-    }
 
     @Test
     fun `given variations screen, when clicked back, then trigger proper event`() = runTest {
@@ -589,45 +271,7 @@ class WooPosItemsViewModelTest {
         )
     }
 
-    @Test
-    fun `given variable products from data source, when view model created, then items list updated correctly`() =
-        runTest {
-            // GIVEN
-            val products = listOf(
-                ProductTestUtils.generateProduct(
-                    productId = 1,
-                    productName = "Product 1",
-                    amount = "10.0",
-                    productType = "simple",
-                    isDownloadable = false,
-                ),
-                ProductTestUtils.generateProduct(
-                    productId = 2,
-                    productName = "Product 2",
-                    amount = "20.0",
-                    productType = "variable",
-                    isDownloadable = false,
-                    isVariable = true
-                ).copy(firstImageUrl = "https://test.com")
-            )
 
-            whenever(productsDataSource.loadProducts(any())).thenReturn(
-                flowOf(
-                    WooPosProductsDataSource.ProductsResult.Remote(
-                        Result.success(products)
-                    )
-                )
-            )
-
-            // WHEN
-            val viewModel = createViewModel()
-            viewModel.viewState.test {
-                // THEN
-                val value = awaitItem() as WooPosItemsViewState.Content
-
-                assertThat(value.items.filterIsInstance<Product.Variable>().size).isEqualTo(1)
-            }
-        }
 
     @Test
     fun `given products search feature enabled, when view model created, then search state is visible`() = runTest {
@@ -650,7 +294,7 @@ class WooPosItemsViewModelTest {
         )
         whenever(isProductsSearchEnabled()).thenReturn(true)
         whenever(searchHelper.getInitialSearchState(true)).thenReturn(
-            WooPosItemsViewState.Content.SearchState.Visible(
+            WooPosItemsViewState.SearchState.Visible(
                 state = WooPosSearchInputState.Closed
             )
         )
@@ -661,8 +305,8 @@ class WooPosItemsViewModelTest {
         // THEN
         viewModel.viewState.test {
             val contentState = awaitItem() as WooPosItemsViewState.Content
-            assertThat(contentState.search).isInstanceOf(WooPosItemsViewState.Content.SearchState.Visible::class.java)
-            val searchState = contentState.search as WooPosItemsViewState.Content.SearchState.Visible
+            assertThat(contentState.search).isInstanceOf(WooPosItemsViewState.SearchState.Visible::class.java)
+            val searchState = contentState.search as WooPosItemsViewState.SearchState.Visible
             assertThat(searchState.state).isEqualTo(WooPosSearchInputState.Closed)
         }
     }
@@ -688,7 +332,7 @@ class WooPosItemsViewModelTest {
         )
         whenever(isProductsSearchEnabled()).thenReturn(false)
         whenever(searchHelper.getInitialSearchState(false)).thenReturn(
-            WooPosItemsViewState.Content.SearchState.Hidden
+            WooPosItemsViewState.SearchState.Hidden
         )
 
         // WHEN
@@ -697,7 +341,7 @@ class WooPosItemsViewModelTest {
         // THEN
         viewModel.viewState.test {
             val contentState = awaitItem() as WooPosItemsViewState.Content
-            assertThat(contentState.search).isInstanceOf(WooPosItemsViewState.Content.SearchState.Hidden::class.java)
+            assertThat(contentState.search).isInstanceOf(WooPosItemsViewState.SearchState.Hidden::class.java)
         }
     }
 

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/home/items/WooPosItemsViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/home/items/WooPosItemsViewModelTest.kt
@@ -38,7 +38,6 @@ class WooPosItemsViewModelTest {
         )
     )
 
-
     private val fromChildToParentEventSender: WooPosChildrenToParentEventSender = mock()
     private val posPreferencesRepository: WooPosPreferencesRepository = mock()
     private val wooPosItemsNavigator: WooPosItemsNavigator = mock()
@@ -75,8 +74,6 @@ class WooPosItemsViewModelTest {
             WooPosItemsNavigator.WooPosItemsScreenNavigationEvent.NavigateBackToItemListScreen
         )
     }
-
-
 
     @Test
     fun `given products search feature enabled, when view model created, then search state is visible`() = runTest {

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/home/items/products/WooPosProductsViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/home/items/products/WooPosProductsViewModelTest.kt
@@ -1,388 +1,423 @@
 package com.woocommerce.android.ui.woopos.home.items.products
 
-import app.cash.turbine.test
-import com.woocommerce.android.ui.products.ProductTestUtils
-import com.woocommerce.android.ui.woopos.home.ChildToParentEvent
-import com.woocommerce.android.ui.woopos.home.items.WooPosContentViewState
-import com.woocommerce.android.ui.woopos.home.items.WooPosItemNavigationData
-import com.woocommerce.android.ui.woopos.home.items.WooPosItemSelectionViewState.Product
-import com.woocommerce.android.ui.woopos.home.items.WooPosItemsUIEvent
-import com.woocommerce.android.ui.woopos.home.items.WooPosItemsViewModel
-import com.woocommerce.android.ui.woopos.home.items.WooPosItemsViewState
-import com.woocommerce.android.ui.woopos.home.items.WooPosPaginationState
-import com.woocommerce.android.ui.woopos.home.items.navigation.WooPosItemsNavigator
-import com.woocommerce.android.ui.woopos.util.WooPosCoroutineTestRule
-import com.woocommerce.android.ui.woopos.util.analytics.WooPosAnalyticsEvent.Event.ProductsPullToRefreshTriggered
-import kotlinx.coroutines.flow.flowOf
-import kotlinx.coroutines.test.runTest
-import org.assertj.core.api.Assertions.assertThat
-import org.junit.Rule
-import org.junit.Test
-import org.mockito.kotlin.any
-import org.mockito.kotlin.verify
-import org.mockito.kotlin.whenever
-
+//
+//import app.cash.turbine.test
+//import com.woocommerce.android.ui.products.ProductTestUtils
+//import com.woocommerce.android.ui.woopos.common.composeui.component.WooPosSearchInputState
+//import com.woocommerce.android.ui.woopos.home.ChildToParentEvent
+//import com.woocommerce.android.ui.woopos.home.items.WooPosContentViewState
+//import com.woocommerce.android.ui.woopos.home.items.WooPosItemNavigationData
+//import com.woocommerce.android.ui.woopos.home.items.WooPosItemSelectionViewState.Product
+//import com.woocommerce.android.ui.woopos.home.items.WooPosItemsUIEvent
+//import com.woocommerce.android.ui.woopos.home.items.WooPosItemsViewModel
+//import com.woocommerce.android.ui.woopos.home.items.WooPosItemsViewState
+//import com.woocommerce.android.ui.woopos.home.items.WooPosPaginationState
+//import com.woocommerce.android.ui.woopos.home.items.navigation.WooPosItemsNavigator
+//import com.woocommerce.android.ui.woopos.util.WooPosCoroutineTestRule
+//import com.woocommerce.android.ui.woopos.util.analytics.WooPosAnalyticsEvent.Event.ProductsPullToRefreshTriggered
+//import com.woocommerce.android.ui.woopos.util.analytics.WooPosAnalyticsTracker
+//import com.woocommerce.android.ui.woopos.util.format.WooPosFormatPrice
+//import kotlinx.coroutines.flow.flowOf
+//import kotlinx.coroutines.test.runTest
+//import org.assertj.core.api.Assertions.assertThat
+//import org.junit.Before
+//import org.junit.Rule
+//import org.junit.Test
+//import org.mockito.kotlin.any
+//import org.mockito.kotlin.mock
+//import org.mockito.kotlin.verify
+//import org.mockito.kotlin.whenever
+//import java.math.BigDecimal
+//
 class WooPosProductsViewModelTest {
-
-    @Rule
-    @JvmField
-    val coroutinesTestRule = WooPosCoroutineTestRule()
-
-    @Test
-    fun `given products from data source, when view model created, then view state updated correctly`() = runTest {
-        // WHEN
-        val products = listOf(
-            ProductTestUtils.generateProduct(
-                productId = 1,
-                productName = "Product 1",
-                amount = "10.0",
-                productType = "simple",
-                isDownloadable = false,
-            ),
-            ProductTestUtils.generateProduct(
-                productId = 2,
-                productName = "Product 2",
-                amount = "20.0",
-                productType = "simple",
-                isDownloadable = false,
-            ).copy(firstImageUrl = "https://test.com")
-        )
-
-        whenever(productsDataSource.loadProducts(any())).thenReturn(
-            flowOf(
-                WooPosProductsDataSource.ProductsResult.Remote(
-                    Result.success(products)
-                )
-            )
-        )
-        val viewModel = createViewModel()
-
-        // THEN
-        viewModel.viewState.test {
-            val value = awaitItem() as WooPosItemsViewState.Content
-
-            @Suppress("UNCHECKED_CAST")
-            val items = value.items as List<Product.Simple>
-            assertThat(items).hasSize(2)
-            assertThat(items[0].id).isEqualTo(1)
-            assertThat(items[0].name).isEqualTo("Product 1")
-            assertThat(items[0].price).isEqualTo("$10.0")
-            assertThat(items[1].id).isEqualTo(2)
-            assertThat(items[1].name).isEqualTo("Product 2")
-            assertThat(items[1].price).isEqualTo("$20.0")
-            assertThat(items[1].imageUrl).isEqualTo("https://test.com")
-        }
-    }
-
-    @Test
-    fun `given empty products list returned, when view model created, then view state is empty`() = runTest {
-        // GIVEN
-        whenever(productsDataSource.loadProducts(any())).thenReturn(
-            flowOf(
-                WooPosProductsDataSource.ProductsResult.Remote(
-                    Result.success(emptyList())
-                )
-            )
-        )
-
-        // WHEN
-        val viewModel = createViewModel()
-
-        // THEN
-        viewModel.viewState.test {
-            val value = awaitItem()
-            assertThat(value).isEqualTo(
-                WooPosItemsViewState.Empty(tabs)
-            )
-        }
-    }
-
-    @Test
-    fun `given loading products fails, when view model created, then view state is error`() = runTest {
-        // GIVEN
-        whenever(productsDataSource.loadProducts(any())).thenReturn(
-            flowOf(
-                WooPosProductsDataSource.ProductsResult.Remote(
-                    Result.failure(Exception())
-                )
-            )
-        )
-
-        // WHEN
-        val viewModel = createViewModel()
-
-        // THEN
-        viewModel.viewState.test {
-            val value = awaitItem()
-            assertThat(value).isEqualTo(
-                WooPosItemsViewState.Error(
-                    tabs = tabs
-                )
-            )
-        }
-    }
-
-    @Test
-    fun `given products from data source, when pulled to refresh, then should remove products and fetch again`() =
-        runTest {
-            // WHEN
-            val viewModel = createViewModel()
-            viewModel.onUIEvent(WooPosItemsUIEvent.PullToRefreshTriggered)
-
-            // THEN
-            viewModel.viewState.test {
-                verify(productsDataSource).loadProducts(forceRefreshProducts = true)
-                cancelAndConsumeRemainingEvents()
-            }
-        }
-
-    @Test
-    fun `given content state, when end of products grid reached and no more pages, then do not load more`() = runTest {
-        // GIVEN
-        whenever(productsDataSource.hasMorePages).thenReturn(false)
-        val viewModel = createViewModel()
-
-        // WHEN
-        viewModel.onUIEvent(WooPosItemsUIEvent.EndOfItemsListReached)
-
-        // THEN
-        viewModel.viewState.test {
-            val value = awaitItem() as WooPosItemsViewState.Content
-            assertThat(value.paginationState).isEqualTo(WooPosPaginationState.None)
-        }
-    }
-
-    @Test
-    fun `when product clicked, then send event to parent`() = runTest {
-        // GIVEN
-        val product = Product.Simple(id = 1, name = "", price = "", imageUrl = null)
-        val viewModel = createViewModel()
-
-        // WHEN
-        viewModel.onUIEvent(WooPosItemsUIEvent.ItemClicked(product))
-
-        // THEN
-        viewModel.viewState.test {
-            verify(fromChildToParentEventSender).sendToParent(
-                ChildToParentEvent.ItemClickedInProductSelector(
-                    WooPosItemsViewModel.ItemClickedData.Product.Simple(
-                        id = product.id
-                    )
-                )
-            )
-            cancelAndConsumeRemainingEvents()
-        }
-    }
-
-    @Test
-    fun `given load more products is called, when products source loads successfully then state is updated`() =
-        runTest {
-            // GIVEN
-            val viewModel = createViewModel()
-
-            // WHEN
-            viewModel.onUIEvent(WooPosItemsUIEvent.EndOfItemsListReached)
-
-            // THEN
-            viewModel.viewState.test {
-                val value = awaitItem() as WooPosItemsViewState.Content
-                assertThat(value.paginationState).isEqualTo(WooPosPaginationState.None)
-            }
-        }
-
-    @Test
-    fun `when loading without pull to refresh, then should not ask to remove products`() = runTest {
-        // WHEN
-        val viewModel = createViewModel()
-
-        // THEN
-        viewModel.viewState.test {
-            verify(productsDataSource).loadProducts(forceRefreshProducts = false)
-            cancelAndConsumeRemainingEvents()
-        }
-    }
-
-    @Test
-    fun `when vm created and loading products, then view state is Loading`() = runTest {
-        // WHEN
-        val viewModel = createViewModel()
-
-        // THEN
-        assertThat(viewModel.viewState.value).isInstanceOf(WooPosItemsViewState.Loading::class.java)
-    }
-
-    @Test
-    fun `given error from load more, when list end reached, then state is pagination error`() = runTest {
-        // GIVEN
-        whenever(productsDataSource.loadMore()).thenReturn(Result.failure(Exception()))
-        whenever(productsDataSource.hasMorePages).thenReturn(true)
-        val viewModel = createViewModel()
-
-        // WHEN
-        viewModel.onUIEvent(WooPosItemsUIEvent.EndOfItemsListReached)
-
-        // THEN
-        viewModel.viewState.test {
-            val value = awaitItem() as WooPosContentViewState
-            assertThat(value.paginationState).isInstanceOf(WooPosPaginationState.Error::class.java)
-        }
-    }
-
-    @Test
-    fun `given no products, when pull to refresh, then state is Empty`() = runTest {
-        // GIVEN
-        val viewModel = createViewModel()
-        whenever(productsDataSource.loadProducts(any())).thenReturn(
-            flowOf(
-                WooPosProductsDataSource.ProductsResult.Remote(
-                    Result.success(emptyList())
-                )
-            )
-        )
-
-        // WHEN
-        viewModel.onUIEvent(WooPosItemsUIEvent.PullToRefreshTriggered)
-
-        // THEN
-        viewModel.viewState.test {
-            val value = awaitItem()
-            assertThat(value).isInstanceOf(WooPosItemsViewState.Empty::class.java)
-        }
-    }
-
-    @Test
-    fun `given empty list, when pull to refresh, then parent notified correctly`() = runTest {
-        // GIVEN
-        val viewModel = createViewModel()
-        whenever(productsDataSource.loadProducts(any())).thenReturn(
-            flowOf(
-                WooPosProductsDataSource.ProductsResult.Remote(
-                    Result.success(emptyList())
-                )
-            )
-        )
-
-        // WHEN
-        viewModel.onUIEvent(WooPosItemsUIEvent.PullToRefreshTriggered)
-
-        // THEN
-        viewModel.viewState.test {
-            verify(fromChildToParentEventSender).sendToParent(ChildToParentEvent.ProductsStatusChanged.FullScreen)
-            cancelAndConsumeRemainingEvents()
-        }
-    }
-
-    @Test
-    fun `given products, when pull to refresh, then parent notified correctly`() = runTest {
-        // GIVEN
-        val viewModel = createViewModel()
-
-        // WHEN
-        viewModel.onUIEvent(WooPosItemsUIEvent.PullToRefreshTriggered)
-
-        // THEN
-        viewModel.viewState.test {
-            verify(fromChildToParentEventSender).sendToParent(ChildToParentEvent.ProductsStatusChanged.WithCart)
-            cancelAndConsumeRemainingEvents()
-        }
-    }
-
-    @Test
-    fun `when pull to refresh, then should track event`() = runTest {
-        // GIVEN
-        val viewModel = createViewModel()
-
-        // WHEN
-        viewModel.onUIEvent(WooPosItemsUIEvent.PullToRefreshTriggered)
-
-        // THEN
-        verify(analyticsTracker).track(ProductsPullToRefreshTriggered)
-    }
-
-    @Test
-    fun `given variable product, when clicked on it, then trigger proper event`() = runTest {
-        // GIVEN
-        val products = listOf(
-            ProductTestUtils.generateProduct(
-                productId = 1,
-                productName = "Product 1",
-                amount = "10.0",
-                productType = "variable",
-                isVariable = true
-            )
-        )
-        whenever(productsDataSource.loadProducts(any())).thenReturn(
-            flowOf(
-                WooPosProductsDataSource.ProductsResult.Remote(
-                    Result.success(products)
-                )
-            )
-        )
-        val viewModel = createViewModel()
-
-        // WHEN
-        viewModel.onUIEvent(
-            WooPosItemsUIEvent.ItemClicked(
-                Product.Variable(
-                    id = 1L,
-                    name = "Product 1",
-                    numOfVariations = 10,
-                    variationIds = emptyList(),
-                    price = "$10.0",
-                    imageUrl = null
-                )
-            )
-        )
-
-        // THEN
-        verify(wooPosItemsNavigator).sendNavigationEvent(
-            WooPosItemsNavigator.WooPosItemsScreenNavigationEvent.NavigateToVariationsScreen(
-                WooPosItemNavigationData.VariableProductData(
-                    id = 1,
-                    name = "Product 1",
-                    numOfVariations = 10,
-                )
-            )
-        )
-    }
-
-    @Test
-    fun `given variable products from data source, when view model created, then items list updated correctly`() =
-        runTest {
-            // GIVEN
-            val products = listOf(
-                ProductTestUtils.generateProduct(
-                    productId = 1,
-                    productName = "Product 1",
-                    amount = "10.0",
-                    productType = "simple",
-                    isDownloadable = false,
-                ),
-                ProductTestUtils.generateProduct(
-                    productId = 2,
-                    productName = "Product 2",
-                    amount = "20.0",
-                    productType = "variable",
-                    isDownloadable = false,
-                    isVariable = true
-                ).copy(firstImageUrl = "https://test.com")
-            )
-
-            whenever(productsDataSource.loadProducts(any())).thenReturn(
-                flowOf(
-                    WooPosProductsDataSource.ProductsResult.Remote(
-                        Result.success(products)
-                    )
-                )
-            )
-
-            // WHEN
-            val viewModel = createViewModel()
-            viewModel.viewState.test {
-                // THEN
-                val value = awaitItem() as WooPosItemsViewState.Content
-
-                assertThat(value.items.filterIsInstance<Product.Variable>().size).isEqualTo(1)
-            }
-        }
+//
+//    @Rule
+//    @JvmField
+//    val coroutinesTestRule = WooPosCoroutineTestRule()
+//
+//    private val priceFormat: WooPosFormatPrice = mock {
+//        onBlocking { invoke(BigDecimal("10.0")) }.thenReturn("$10.0")
+//        onBlocking { invoke(BigDecimal("20.0")) }.thenReturn("$20.0")
+//    }
+//    private val analyticsTracker: WooPosAnalyticsTracker = mock()
+//    private val productsDataSource: WooPosProductsDataSource = mock()
+//
+//    @Before
+//    fun setup() {
+//        val products = listOf(
+//            ProductTestUtils.generateProduct(
+//                productId = 1,
+//                productName = "Product 1",
+//                amount = "10.0",
+//                productType = "simple",
+//                isDownloadable = false,
+//            ),
+//        )
+//
+//        whenever(productsDataSource.loadProducts(any())).thenReturn(
+//            flowOf(
+//                WooPosProductsDataSource.ProductsResult.Remote(
+//                    Result.success(products)
+//                )
+//            )
+//        )
+//    }
+//
+//    @Test
+//    fun `given products from data source, when view model created, then view state updated correctly`() = runTest {
+//        // WHEN
+//        val products = listOf(
+//            ProductTestUtils.generateProduct(
+//                productId = 1,
+//                productName = "Product 1",
+//                amount = "10.0",
+//                productType = "simple",
+//                isDownloadable = false,
+//            ),
+//            ProductTestUtils.generateProduct(
+//                productId = 2,
+//                productName = "Product 2",
+//                amount = "20.0",
+//                productType = "simple",
+//                isDownloadable = false,
+//            ).copy(firstImageUrl = "https://test.com")
+//        )
+//
+//        whenever(productsDataSource.loadProducts(any())).thenReturn(
+//            flowOf(
+//                WooPosProductsDataSource.ProductsResult.Remote(
+//                    Result.success(products)
+//                )
+//            )
+//        )
+//        val viewModel = createViewModel()
+//
+//        // THEN
+//        viewModel.viewState.test {
+//            val value = awaitItem() as WooPosItemsViewState.Content
+//
+//            @Suppress("UNCHECKED_CAST")
+//            val items = value.items as List<Product.Simple>
+//            assertThat(items).hasSize(2)
+//            assertThat(items[0].id).isEqualTo(1)
+//            assertThat(items[0].name).isEqualTo("Product 1")
+//            assertThat(items[0].price).isEqualTo("$10.0")
+//            assertThat(items[1].id).isEqualTo(2)
+//            assertThat(items[1].name).isEqualTo("Product 2")
+//            assertThat(items[1].price).isEqualTo("$20.0")
+//            assertThat(items[1].imageUrl).isEqualTo("https://test.com")
+//        }
+//    }
+//
+//    @Test
+//    fun `given empty products list returned, when view model created, then view state is empty`() = runTest {
+//        // GIVEN
+//        whenever(productsDataSource.loadProducts(any())).thenReturn(
+//            flowOf(
+//                WooPosProductsDataSource.ProductsResult.Remote(
+//                    Result.success(emptyList())
+//                )
+//            )
+//        )
+//
+//        // WHEN
+//        val viewModel = createViewModel()
+//
+//        // THEN
+//        viewModel.viewState.test {
+//            val value = awaitItem()
+//            assertThat(value).isEqualTo(
+//                WooPosItemsViewState.Empty(tabs)
+//            )
+//        }
+//    }
+//
+//    @Test
+//    fun `given loading products fails, when view model created, then view state is error`() = runTest {
+//        // GIVEN
+//        whenever(productsDataSource.loadProducts(any())).thenReturn(
+//            flowOf(
+//                WooPosProductsDataSource.ProductsResult.Remote(
+//                    Result.failure(Exception())
+//                )
+//            )
+//        )
+//
+//        // WHEN
+//        val viewModel = createViewModel()
+//
+//        // THEN
+//        viewModel.viewState.test {
+//            val value = awaitItem()
+//            assertThat(value).isEqualTo(
+//                WooPosItemsViewState.Error(
+//                    tabs = tabs
+//                )
+//            )
+//        }
+//    }
+//
+//    @Test
+//    fun `given products from data source, when pulled to refresh, then should remove products and fetch again`() =
+//        runTest {
+//            // WHEN
+//            val viewModel = createViewModel()
+//            viewModel.onUIEvent(WooPosItemsUIEvent.PullToRefreshTriggered)
+//
+//            // THEN
+//            viewModel.viewState.test {
+//                verify(productsDataSource).loadProducts(forceRefreshProducts = true)
+//                cancelAndConsumeRemainingEvents()
+//            }
+//        }
+//
+//    @Test
+//    fun `given content state, when end of products grid reached and no more pages, then do not load more`() = runTest {
+//        // GIVEN
+//        whenever(productsDataSource.hasMorePages).thenReturn(false)
+//        val viewModel = createViewModel()
+//
+//        // WHEN
+//        viewModel.onUIEvent(WooPosItemsUIEvent.EndOfItemsListReached)
+//
+//        // THEN
+//        viewModel.viewState.test {
+//            val value = awaitItem() as WooPosItemsViewState.Content
+//            assertThat(value.paginationState).isEqualTo(WooPosPaginationState.None)
+//        }
+//    }
+//
+//    @Test
+//    fun `when product clicked, then send event to parent`() = runTest {
+//        // GIVEN
+//        val product = Product.Simple(id = 1, name = "", price = "", imageUrl = null)
+//        val viewModel = createViewModel()
+//
+//        // WHEN
+//        viewModel.onUIEvent(WooPosItemsUIEvent.ItemClicked(product))
+//
+//        // THEN
+//        viewModel.viewState.test {
+//            verify(fromChildToParentEventSender).sendToParent(
+//                ChildToParentEvent.ItemClickedInProductSelector(
+//                    WooPosItemsViewModel.ItemClickedData.Product.Simple(
+//                        id = product.id
+//                    )
+//                )
+//            )
+//            cancelAndConsumeRemainingEvents()
+//        }
+//    }
+//
+//    @Test
+//    fun `given load more products is called, when products source loads successfully then state is updated`() =
+//        runTest {
+//            // GIVEN
+//            val viewModel = createViewModel()
+//
+//            // WHEN
+//            viewModel.onUIEvent(WooPosItemsUIEvent.EndOfItemsListReached)
+//
+//            // THEN
+//            viewModel.viewState.test {
+//                val value = awaitItem() as WooPosItemsViewState.Content
+//                assertThat(value.paginationState).isEqualTo(WooPosPaginationState.None)
+//            }
+//        }
+//
+//    @Test
+//    fun `when loading without pull to refresh, then should not ask to remove products`() = runTest {
+//        // WHEN
+//        val viewModel = createViewModel()
+//
+//        // THEN
+//        viewModel.viewState.test {
+//            verify(productsDataSource).loadProducts(forceRefreshProducts = false)
+//            cancelAndConsumeRemainingEvents()
+//        }
+//    }
+//
+//    @Test
+//    fun `when vm created and loading products, then view state is Loading`() = runTest {
+//        // WHEN
+//        val viewModel = createViewModel()
+//
+//        // THEN
+//        assertThat(viewModel.viewState.value).isInstanceOf(WooPosItemsViewState.Loading::class.java)
+//    }
+//
+//    @Test
+//    fun `given error from load more, when list end reached, then state is pagination error`() = runTest {
+//        // GIVEN
+//        whenever(productsDataSource.loadMore()).thenReturn(Result.failure(Exception()))
+//        whenever(productsDataSource.hasMorePages).thenReturn(true)
+//        val viewModel = createViewModel()
+//
+//        // WHEN
+//        viewModel.onUIEvent(WooPosItemsUIEvent.EndOfItemsListReached)
+//
+//        // THEN
+//        viewModel.viewState.test {
+//            val value = awaitItem() as WooPosContentViewState
+//            assertThat(value.paginationState).isInstanceOf(WooPosPaginationState.Error::class.java)
+//        }
+//    }
+//
+//    @Test
+//    fun `given no products, when pull to refresh, then state is Empty`() = runTest {
+//        // GIVEN
+//        val viewModel = createViewModel()
+//        whenever(productsDataSource.loadProducts(any())).thenReturn(
+//            flowOf(
+//                WooPosProductsDataSource.ProductsResult.Remote(
+//                    Result.success(emptyList())
+//                )
+//            )
+//        )
+//
+//        // WHEN
+//        viewModel.onUIEvent(WooPosItemsUIEvent.PullToRefreshTriggered)
+//
+//        // THEN
+//        viewModel.viewState.test {
+//            val value = awaitItem()
+//            assertThat(value).isInstanceOf(WooPosItemsViewState.Empty::class.java)
+//        }
+//    }
+//
+//    @Test
+//    fun `given empty list, when pull to refresh, then parent notified correctly`() = runTest {
+//        // GIVEN
+//        val viewModel = createViewModel()
+//        whenever(productsDataSource.loadProducts(any())).thenReturn(
+//            flowOf(
+//                WooPosProductsDataSource.ProductsResult.Remote(
+//                    Result.success(emptyList())
+//                )
+//            )
+//        )
+//
+//        // WHEN
+//        viewModel.onUIEvent(WooPosItemsUIEvent.PullToRefreshTriggered)
+//
+//        // THEN
+//        viewModel.viewState.test {
+//            verify(fromChildToParentEventSender).sendToParent(ChildToParentEvent.ProductsStatusChanged.FullScreen)
+//            cancelAndConsumeRemainingEvents()
+//        }
+//    }
+//
+//    @Test
+//    fun `given products, when pull to refresh, then parent notified correctly`() = runTest {
+//        // GIVEN
+//        val viewModel = createViewModel()
+//
+//        // WHEN
+//        viewModel.onUIEvent(WooPosItemsUIEvent.PullToRefreshTriggered)
+//
+//        // THEN
+//        viewModel.viewState.test {
+//            verify(fromChildToParentEventSender).sendToParent(ChildToParentEvent.ProductsStatusChanged.WithCart)
+//            cancelAndConsumeRemainingEvents()
+//        }
+//    }
+//
+//    @Test
+//    fun `when pull to refresh, then should track event`() = runTest {
+//        // GIVEN
+//        val viewModel = createViewModel()
+//
+//        // WHEN
+//        viewModel.onUIEvent(WooPosItemsUIEvent.PullToRefreshTriggered)
+//
+//        // THEN
+//        verify(analyticsTracker).track(ProductsPullToRefreshTriggered)
+//    }
+//
+//    @Test
+//    fun `given variable product, when clicked on it, then trigger proper event`() = runTest {
+//        // GIVEN
+//        val products = listOf(
+//            ProductTestUtils.generateProduct(
+//                productId = 1,
+//                productName = "Product 1",
+//                amount = "10.0",
+//                productType = "variable",
+//                isVariable = true
+//            )
+//        )
+//        whenever(productsDataSource.loadProducts(any())).thenReturn(
+//            flowOf(
+//                WooPosProductsDataSource.ProductsResult.Remote(
+//                    Result.success(products)
+//                )
+//            )
+//        )
+//        val viewModel = createViewModel()
+//
+//        // WHEN
+//        viewModel.onUIEvent(
+//            WooPosItemsUIEvent.ItemClicked(
+//                Product.Variable(
+//                    id = 1L,
+//                    name = "Product 1",
+//                    numOfVariations = 10,
+//                    variationIds = emptyList(),
+//                    price = "$10.0",
+//                    imageUrl = null
+//                )
+//            )
+//        )
+//
+//        // THEN
+//        verify(wooPosItemsNavigator).sendNavigationEvent(
+//            WooPosItemsNavigator.WooPosItemsScreenNavigationEvent.NavigateToVariationsScreen(
+//                WooPosItemNavigationData.VariableProductData(
+//                    id = 1,
+//                    name = "Product 1",
+//                    numOfVariations = 10,
+//                )
+//            )
+//        )
+//    }
+//
+//    @Test
+//    fun `given variable products from data source, when view model created, then items list updated correctly`() =
+//        runTest {
+//            // GIVEN
+//            val products = listOf(
+//                ProductTestUtils.generateProduct(
+//                    productId = 1,
+//                    productName = "Product 1",
+//                    amount = "10.0",
+//                    productType = "simple",
+//                    isDownloadable = false,
+//                ),
+//                ProductTestUtils.generateProduct(
+//                    productId = 2,
+//                    productName = "Product 2",
+//                    amount = "20.0",
+//                    productType = "variable",
+//                    isDownloadable = false,
+//                    isVariable = true
+//                ).copy(firstImageUrl = "https://test.com")
+//            )
+//
+//            whenever(productsDataSource.loadProducts(any())).thenReturn(
+//                flowOf(
+//                    WooPosProductsDataSource.ProductsResult.Remote(
+//                        Result.success(products)
+//                    )
+//                )
+//            )
+//
+//            // WHEN
+//            val viewModel = createViewModel()
+//            viewModel.viewState.test {
+//                // THEN
+//                val value = awaitItem() as WooPosItemsViewState.Content
+//
+//                assertThat(value.items.filterIsInstance<Product.Variable>().size).isEqualTo(1)
+//            }
+//        }
 }

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/home/items/products/WooPosProductsViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/home/items/products/WooPosProductsViewModelTest.kt
@@ -1,0 +1,388 @@
+package com.woocommerce.android.ui.woopos.home.items.products
+
+import app.cash.turbine.test
+import com.woocommerce.android.ui.products.ProductTestUtils
+import com.woocommerce.android.ui.woopos.home.ChildToParentEvent
+import com.woocommerce.android.ui.woopos.home.items.WooPosContentViewState
+import com.woocommerce.android.ui.woopos.home.items.WooPosItemNavigationData
+import com.woocommerce.android.ui.woopos.home.items.WooPosItemSelectionViewState.Product
+import com.woocommerce.android.ui.woopos.home.items.WooPosItemsUIEvent
+import com.woocommerce.android.ui.woopos.home.items.WooPosItemsViewModel
+import com.woocommerce.android.ui.woopos.home.items.WooPosItemsViewState
+import com.woocommerce.android.ui.woopos.home.items.WooPosPaginationState
+import com.woocommerce.android.ui.woopos.home.items.navigation.WooPosItemsNavigator
+import com.woocommerce.android.ui.woopos.util.WooPosCoroutineTestRule
+import com.woocommerce.android.ui.woopos.util.analytics.WooPosAnalyticsEvent.Event.ProductsPullToRefreshTriggered
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.test.runTest
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.Rule
+import org.junit.Test
+import org.mockito.kotlin.any
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
+
+class WooPosProductsViewModelTest {
+
+    @Rule
+    @JvmField
+    val coroutinesTestRule = WooPosCoroutineTestRule()
+
+    @Test
+    fun `given products from data source, when view model created, then view state updated correctly`() = runTest {
+        // WHEN
+        val products = listOf(
+            ProductTestUtils.generateProduct(
+                productId = 1,
+                productName = "Product 1",
+                amount = "10.0",
+                productType = "simple",
+                isDownloadable = false,
+            ),
+            ProductTestUtils.generateProduct(
+                productId = 2,
+                productName = "Product 2",
+                amount = "20.0",
+                productType = "simple",
+                isDownloadable = false,
+            ).copy(firstImageUrl = "https://test.com")
+        )
+
+        whenever(productsDataSource.loadProducts(any())).thenReturn(
+            flowOf(
+                WooPosProductsDataSource.ProductsResult.Remote(
+                    Result.success(products)
+                )
+            )
+        )
+        val viewModel = createViewModel()
+
+        // THEN
+        viewModel.viewState.test {
+            val value = awaitItem() as WooPosItemsViewState.Content
+
+            @Suppress("UNCHECKED_CAST")
+            val items = value.items as List<Product.Simple>
+            assertThat(items).hasSize(2)
+            assertThat(items[0].id).isEqualTo(1)
+            assertThat(items[0].name).isEqualTo("Product 1")
+            assertThat(items[0].price).isEqualTo("$10.0")
+            assertThat(items[1].id).isEqualTo(2)
+            assertThat(items[1].name).isEqualTo("Product 2")
+            assertThat(items[1].price).isEqualTo("$20.0")
+            assertThat(items[1].imageUrl).isEqualTo("https://test.com")
+        }
+    }
+
+    @Test
+    fun `given empty products list returned, when view model created, then view state is empty`() = runTest {
+        // GIVEN
+        whenever(productsDataSource.loadProducts(any())).thenReturn(
+            flowOf(
+                WooPosProductsDataSource.ProductsResult.Remote(
+                    Result.success(emptyList())
+                )
+            )
+        )
+
+        // WHEN
+        val viewModel = createViewModel()
+
+        // THEN
+        viewModel.viewState.test {
+            val value = awaitItem()
+            assertThat(value).isEqualTo(
+                WooPosItemsViewState.Empty(tabs)
+            )
+        }
+    }
+
+    @Test
+    fun `given loading products fails, when view model created, then view state is error`() = runTest {
+        // GIVEN
+        whenever(productsDataSource.loadProducts(any())).thenReturn(
+            flowOf(
+                WooPosProductsDataSource.ProductsResult.Remote(
+                    Result.failure(Exception())
+                )
+            )
+        )
+
+        // WHEN
+        val viewModel = createViewModel()
+
+        // THEN
+        viewModel.viewState.test {
+            val value = awaitItem()
+            assertThat(value).isEqualTo(
+                WooPosItemsViewState.Error(
+                    tabs = tabs
+                )
+            )
+        }
+    }
+
+    @Test
+    fun `given products from data source, when pulled to refresh, then should remove products and fetch again`() =
+        runTest {
+            // WHEN
+            val viewModel = createViewModel()
+            viewModel.onUIEvent(WooPosItemsUIEvent.PullToRefreshTriggered)
+
+            // THEN
+            viewModel.viewState.test {
+                verify(productsDataSource).loadProducts(forceRefreshProducts = true)
+                cancelAndConsumeRemainingEvents()
+            }
+        }
+
+    @Test
+    fun `given content state, when end of products grid reached and no more pages, then do not load more`() = runTest {
+        // GIVEN
+        whenever(productsDataSource.hasMorePages).thenReturn(false)
+        val viewModel = createViewModel()
+
+        // WHEN
+        viewModel.onUIEvent(WooPosItemsUIEvent.EndOfItemsListReached)
+
+        // THEN
+        viewModel.viewState.test {
+            val value = awaitItem() as WooPosItemsViewState.Content
+            assertThat(value.paginationState).isEqualTo(WooPosPaginationState.None)
+        }
+    }
+
+    @Test
+    fun `when product clicked, then send event to parent`() = runTest {
+        // GIVEN
+        val product = Product.Simple(id = 1, name = "", price = "", imageUrl = null)
+        val viewModel = createViewModel()
+
+        // WHEN
+        viewModel.onUIEvent(WooPosItemsUIEvent.ItemClicked(product))
+
+        // THEN
+        viewModel.viewState.test {
+            verify(fromChildToParentEventSender).sendToParent(
+                ChildToParentEvent.ItemClickedInProductSelector(
+                    WooPosItemsViewModel.ItemClickedData.Product.Simple(
+                        id = product.id
+                    )
+                )
+            )
+            cancelAndConsumeRemainingEvents()
+        }
+    }
+
+    @Test
+    fun `given load more products is called, when products source loads successfully then state is updated`() =
+        runTest {
+            // GIVEN
+            val viewModel = createViewModel()
+
+            // WHEN
+            viewModel.onUIEvent(WooPosItemsUIEvent.EndOfItemsListReached)
+
+            // THEN
+            viewModel.viewState.test {
+                val value = awaitItem() as WooPosItemsViewState.Content
+                assertThat(value.paginationState).isEqualTo(WooPosPaginationState.None)
+            }
+        }
+
+    @Test
+    fun `when loading without pull to refresh, then should not ask to remove products`() = runTest {
+        // WHEN
+        val viewModel = createViewModel()
+
+        // THEN
+        viewModel.viewState.test {
+            verify(productsDataSource).loadProducts(forceRefreshProducts = false)
+            cancelAndConsumeRemainingEvents()
+        }
+    }
+
+    @Test
+    fun `when vm created and loading products, then view state is Loading`() = runTest {
+        // WHEN
+        val viewModel = createViewModel()
+
+        // THEN
+        assertThat(viewModel.viewState.value).isInstanceOf(WooPosItemsViewState.Loading::class.java)
+    }
+
+    @Test
+    fun `given error from load more, when list end reached, then state is pagination error`() = runTest {
+        // GIVEN
+        whenever(productsDataSource.loadMore()).thenReturn(Result.failure(Exception()))
+        whenever(productsDataSource.hasMorePages).thenReturn(true)
+        val viewModel = createViewModel()
+
+        // WHEN
+        viewModel.onUIEvent(WooPosItemsUIEvent.EndOfItemsListReached)
+
+        // THEN
+        viewModel.viewState.test {
+            val value = awaitItem() as WooPosContentViewState
+            assertThat(value.paginationState).isInstanceOf(WooPosPaginationState.Error::class.java)
+        }
+    }
+
+    @Test
+    fun `given no products, when pull to refresh, then state is Empty`() = runTest {
+        // GIVEN
+        val viewModel = createViewModel()
+        whenever(productsDataSource.loadProducts(any())).thenReturn(
+            flowOf(
+                WooPosProductsDataSource.ProductsResult.Remote(
+                    Result.success(emptyList())
+                )
+            )
+        )
+
+        // WHEN
+        viewModel.onUIEvent(WooPosItemsUIEvent.PullToRefreshTriggered)
+
+        // THEN
+        viewModel.viewState.test {
+            val value = awaitItem()
+            assertThat(value).isInstanceOf(WooPosItemsViewState.Empty::class.java)
+        }
+    }
+
+    @Test
+    fun `given empty list, when pull to refresh, then parent notified correctly`() = runTest {
+        // GIVEN
+        val viewModel = createViewModel()
+        whenever(productsDataSource.loadProducts(any())).thenReturn(
+            flowOf(
+                WooPosProductsDataSource.ProductsResult.Remote(
+                    Result.success(emptyList())
+                )
+            )
+        )
+
+        // WHEN
+        viewModel.onUIEvent(WooPosItemsUIEvent.PullToRefreshTriggered)
+
+        // THEN
+        viewModel.viewState.test {
+            verify(fromChildToParentEventSender).sendToParent(ChildToParentEvent.ProductsStatusChanged.FullScreen)
+            cancelAndConsumeRemainingEvents()
+        }
+    }
+
+    @Test
+    fun `given products, when pull to refresh, then parent notified correctly`() = runTest {
+        // GIVEN
+        val viewModel = createViewModel()
+
+        // WHEN
+        viewModel.onUIEvent(WooPosItemsUIEvent.PullToRefreshTriggered)
+
+        // THEN
+        viewModel.viewState.test {
+            verify(fromChildToParentEventSender).sendToParent(ChildToParentEvent.ProductsStatusChanged.WithCart)
+            cancelAndConsumeRemainingEvents()
+        }
+    }
+
+    @Test
+    fun `when pull to refresh, then should track event`() = runTest {
+        // GIVEN
+        val viewModel = createViewModel()
+
+        // WHEN
+        viewModel.onUIEvent(WooPosItemsUIEvent.PullToRefreshTriggered)
+
+        // THEN
+        verify(analyticsTracker).track(ProductsPullToRefreshTriggered)
+    }
+
+    @Test
+    fun `given variable product, when clicked on it, then trigger proper event`() = runTest {
+        // GIVEN
+        val products = listOf(
+            ProductTestUtils.generateProduct(
+                productId = 1,
+                productName = "Product 1",
+                amount = "10.0",
+                productType = "variable",
+                isVariable = true
+            )
+        )
+        whenever(productsDataSource.loadProducts(any())).thenReturn(
+            flowOf(
+                WooPosProductsDataSource.ProductsResult.Remote(
+                    Result.success(products)
+                )
+            )
+        )
+        val viewModel = createViewModel()
+
+        // WHEN
+        viewModel.onUIEvent(
+            WooPosItemsUIEvent.ItemClicked(
+                Product.Variable(
+                    id = 1L,
+                    name = "Product 1",
+                    numOfVariations = 10,
+                    variationIds = emptyList(),
+                    price = "$10.0",
+                    imageUrl = null
+                )
+            )
+        )
+
+        // THEN
+        verify(wooPosItemsNavigator).sendNavigationEvent(
+            WooPosItemsNavigator.WooPosItemsScreenNavigationEvent.NavigateToVariationsScreen(
+                WooPosItemNavigationData.VariableProductData(
+                    id = 1,
+                    name = "Product 1",
+                    numOfVariations = 10,
+                )
+            )
+        )
+    }
+
+    @Test
+    fun `given variable products from data source, when view model created, then items list updated correctly`() =
+        runTest {
+            // GIVEN
+            val products = listOf(
+                ProductTestUtils.generateProduct(
+                    productId = 1,
+                    productName = "Product 1",
+                    amount = "10.0",
+                    productType = "simple",
+                    isDownloadable = false,
+                ),
+                ProductTestUtils.generateProduct(
+                    productId = 2,
+                    productName = "Product 2",
+                    amount = "20.0",
+                    productType = "variable",
+                    isDownloadable = false,
+                    isVariable = true
+                ).copy(firstImageUrl = "https://test.com")
+            )
+
+            whenever(productsDataSource.loadProducts(any())).thenReturn(
+                flowOf(
+                    WooPosProductsDataSource.ProductsResult.Remote(
+                        Result.success(products)
+                    )
+                )
+            )
+
+            // WHEN
+            val viewModel = createViewModel()
+            viewModel.viewState.test {
+                // THEN
+                val value = awaitItem() as WooPosItemsViewState.Content
+
+                assertThat(value.items.filterIsInstance<Product.Variable>().size).isEqualTo(1)
+            }
+        }
+}

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/home/items/products/WooPosProductsViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/home/items/products/WooPosProductsViewModelTest.kt
@@ -1,423 +1,431 @@
 package com.woocommerce.android.ui.woopos.home.items.products
 
-//
-//import app.cash.turbine.test
-//import com.woocommerce.android.ui.products.ProductTestUtils
-//import com.woocommerce.android.ui.woopos.common.composeui.component.WooPosSearchInputState
-//import com.woocommerce.android.ui.woopos.home.ChildToParentEvent
-//import com.woocommerce.android.ui.woopos.home.items.WooPosContentViewState
-//import com.woocommerce.android.ui.woopos.home.items.WooPosItemNavigationData
-//import com.woocommerce.android.ui.woopos.home.items.WooPosItemSelectionViewState.Product
-//import com.woocommerce.android.ui.woopos.home.items.WooPosItemsUIEvent
-//import com.woocommerce.android.ui.woopos.home.items.WooPosItemsViewModel
-//import com.woocommerce.android.ui.woopos.home.items.WooPosItemsViewState
-//import com.woocommerce.android.ui.woopos.home.items.WooPosPaginationState
-//import com.woocommerce.android.ui.woopos.home.items.navigation.WooPosItemsNavigator
-//import com.woocommerce.android.ui.woopos.util.WooPosCoroutineTestRule
-//import com.woocommerce.android.ui.woopos.util.analytics.WooPosAnalyticsEvent.Event.ProductsPullToRefreshTriggered
-//import com.woocommerce.android.ui.woopos.util.analytics.WooPosAnalyticsTracker
-//import com.woocommerce.android.ui.woopos.util.format.WooPosFormatPrice
-//import kotlinx.coroutines.flow.flowOf
-//import kotlinx.coroutines.test.runTest
-//import org.assertj.core.api.Assertions.assertThat
-//import org.junit.Before
-//import org.junit.Rule
-//import org.junit.Test
-//import org.mockito.kotlin.any
-//import org.mockito.kotlin.mock
-//import org.mockito.kotlin.verify
-//import org.mockito.kotlin.whenever
-//import java.math.BigDecimal
-//
+import app.cash.turbine.test
+import com.woocommerce.android.ui.products.ProductTestUtils
+import com.woocommerce.android.ui.woopos.home.ChildToParentEvent
+import com.woocommerce.android.ui.woopos.home.WooPosChildrenToParentEventSender
+import com.woocommerce.android.ui.woopos.home.items.WooPosContentViewState
+import com.woocommerce.android.ui.woopos.home.items.WooPosItemNavigationData
+import com.woocommerce.android.ui.woopos.home.items.WooPosItemSelectionViewState.Product
+import com.woocommerce.android.ui.woopos.home.items.WooPosItemsViewModel
+import com.woocommerce.android.ui.woopos.home.items.WooPosPaginationState
+import com.woocommerce.android.ui.woopos.home.items.WooPosProductsViewState
+import com.woocommerce.android.ui.woopos.home.items.navigation.WooPosItemsNavigator
+import com.woocommerce.android.ui.woopos.util.WooPosCoroutineTestRule
+import com.woocommerce.android.ui.woopos.util.analytics.WooPosAnalyticsEvent.Event.ProductsPullToRefreshTriggered
+import com.woocommerce.android.ui.woopos.util.analytics.WooPosAnalyticsTracker
+import com.woocommerce.android.ui.woopos.util.format.WooPosFormatPrice
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.test.runTest
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.mockito.kotlin.any
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
+import java.math.BigDecimal
+
 class WooPosProductsViewModelTest {
-//
-//    @Rule
-//    @JvmField
-//    val coroutinesTestRule = WooPosCoroutineTestRule()
-//
-//    private val priceFormat: WooPosFormatPrice = mock {
-//        onBlocking { invoke(BigDecimal("10.0")) }.thenReturn("$10.0")
-//        onBlocking { invoke(BigDecimal("20.0")) }.thenReturn("$20.0")
-//    }
-//    private val analyticsTracker: WooPosAnalyticsTracker = mock()
-//    private val productsDataSource: WooPosProductsDataSource = mock()
-//
-//    @Before
-//    fun setup() {
-//        val products = listOf(
-//            ProductTestUtils.generateProduct(
-//                productId = 1,
-//                productName = "Product 1",
-//                amount = "10.0",
-//                productType = "simple",
-//                isDownloadable = false,
-//            ),
-//        )
-//
-//        whenever(productsDataSource.loadProducts(any())).thenReturn(
-//            flowOf(
-//                WooPosProductsDataSource.ProductsResult.Remote(
-//                    Result.success(products)
-//                )
-//            )
-//        )
-//    }
-//
-//    @Test
-//    fun `given products from data source, when view model created, then view state updated correctly`() = runTest {
-//        // WHEN
-//        val products = listOf(
-//            ProductTestUtils.generateProduct(
-//                productId = 1,
-//                productName = "Product 1",
-//                amount = "10.0",
-//                productType = "simple",
-//                isDownloadable = false,
-//            ),
-//            ProductTestUtils.generateProduct(
-//                productId = 2,
-//                productName = "Product 2",
-//                amount = "20.0",
-//                productType = "simple",
-//                isDownloadable = false,
-//            ).copy(firstImageUrl = "https://test.com")
-//        )
-//
-//        whenever(productsDataSource.loadProducts(any())).thenReturn(
-//            flowOf(
-//                WooPosProductsDataSource.ProductsResult.Remote(
-//                    Result.success(products)
-//                )
-//            )
-//        )
-//        val viewModel = createViewModel()
-//
-//        // THEN
-//        viewModel.viewState.test {
-//            val value = awaitItem() as WooPosItemsViewState.Content
-//
-//            @Suppress("UNCHECKED_CAST")
-//            val items = value.items as List<Product.Simple>
-//            assertThat(items).hasSize(2)
-//            assertThat(items[0].id).isEqualTo(1)
-//            assertThat(items[0].name).isEqualTo("Product 1")
-//            assertThat(items[0].price).isEqualTo("$10.0")
-//            assertThat(items[1].id).isEqualTo(2)
-//            assertThat(items[1].name).isEqualTo("Product 2")
-//            assertThat(items[1].price).isEqualTo("$20.0")
-//            assertThat(items[1].imageUrl).isEqualTo("https://test.com")
-//        }
-//    }
-//
-//    @Test
-//    fun `given empty products list returned, when view model created, then view state is empty`() = runTest {
-//        // GIVEN
-//        whenever(productsDataSource.loadProducts(any())).thenReturn(
-//            flowOf(
-//                WooPosProductsDataSource.ProductsResult.Remote(
-//                    Result.success(emptyList())
-//                )
-//            )
-//        )
-//
-//        // WHEN
-//        val viewModel = createViewModel()
-//
-//        // THEN
-//        viewModel.viewState.test {
-//            val value = awaitItem()
-//            assertThat(value).isEqualTo(
-//                WooPosItemsViewState.Empty(tabs)
-//            )
-//        }
-//    }
-//
-//    @Test
-//    fun `given loading products fails, when view model created, then view state is error`() = runTest {
-//        // GIVEN
-//        whenever(productsDataSource.loadProducts(any())).thenReturn(
-//            flowOf(
-//                WooPosProductsDataSource.ProductsResult.Remote(
-//                    Result.failure(Exception())
-//                )
-//            )
-//        )
-//
-//        // WHEN
-//        val viewModel = createViewModel()
-//
-//        // THEN
-//        viewModel.viewState.test {
-//            val value = awaitItem()
-//            assertThat(value).isEqualTo(
-//                WooPosItemsViewState.Error(
-//                    tabs = tabs
-//                )
-//            )
-//        }
-//    }
-//
-//    @Test
-//    fun `given products from data source, when pulled to refresh, then should remove products and fetch again`() =
-//        runTest {
-//            // WHEN
-//            val viewModel = createViewModel()
-//            viewModel.onUIEvent(WooPosItemsUIEvent.PullToRefreshTriggered)
-//
-//            // THEN
-//            viewModel.viewState.test {
-//                verify(productsDataSource).loadProducts(forceRefreshProducts = true)
-//                cancelAndConsumeRemainingEvents()
-//            }
-//        }
-//
-//    @Test
-//    fun `given content state, when end of products grid reached and no more pages, then do not load more`() = runTest {
-//        // GIVEN
-//        whenever(productsDataSource.hasMorePages).thenReturn(false)
-//        val viewModel = createViewModel()
-//
-//        // WHEN
-//        viewModel.onUIEvent(WooPosItemsUIEvent.EndOfItemsListReached)
-//
-//        // THEN
-//        viewModel.viewState.test {
-//            val value = awaitItem() as WooPosItemsViewState.Content
-//            assertThat(value.paginationState).isEqualTo(WooPosPaginationState.None)
-//        }
-//    }
-//
-//    @Test
-//    fun `when product clicked, then send event to parent`() = runTest {
-//        // GIVEN
-//        val product = Product.Simple(id = 1, name = "", price = "", imageUrl = null)
-//        val viewModel = createViewModel()
-//
-//        // WHEN
-//        viewModel.onUIEvent(WooPosItemsUIEvent.ItemClicked(product))
-//
-//        // THEN
-//        viewModel.viewState.test {
-//            verify(fromChildToParentEventSender).sendToParent(
-//                ChildToParentEvent.ItemClickedInProductSelector(
-//                    WooPosItemsViewModel.ItemClickedData.Product.Simple(
-//                        id = product.id
-//                    )
-//                )
-//            )
-//            cancelAndConsumeRemainingEvents()
-//        }
-//    }
-//
-//    @Test
-//    fun `given load more products is called, when products source loads successfully then state is updated`() =
-//        runTest {
-//            // GIVEN
-//            val viewModel = createViewModel()
-//
-//            // WHEN
-//            viewModel.onUIEvent(WooPosItemsUIEvent.EndOfItemsListReached)
-//
-//            // THEN
-//            viewModel.viewState.test {
-//                val value = awaitItem() as WooPosItemsViewState.Content
-//                assertThat(value.paginationState).isEqualTo(WooPosPaginationState.None)
-//            }
-//        }
-//
-//    @Test
-//    fun `when loading without pull to refresh, then should not ask to remove products`() = runTest {
-//        // WHEN
-//        val viewModel = createViewModel()
-//
-//        // THEN
-//        viewModel.viewState.test {
-//            verify(productsDataSource).loadProducts(forceRefreshProducts = false)
-//            cancelAndConsumeRemainingEvents()
-//        }
-//    }
-//
-//    @Test
-//    fun `when vm created and loading products, then view state is Loading`() = runTest {
-//        // WHEN
-//        val viewModel = createViewModel()
-//
-//        // THEN
-//        assertThat(viewModel.viewState.value).isInstanceOf(WooPosItemsViewState.Loading::class.java)
-//    }
-//
-//    @Test
-//    fun `given error from load more, when list end reached, then state is pagination error`() = runTest {
-//        // GIVEN
-//        whenever(productsDataSource.loadMore()).thenReturn(Result.failure(Exception()))
-//        whenever(productsDataSource.hasMorePages).thenReturn(true)
-//        val viewModel = createViewModel()
-//
-//        // WHEN
-//        viewModel.onUIEvent(WooPosItemsUIEvent.EndOfItemsListReached)
-//
-//        // THEN
-//        viewModel.viewState.test {
-//            val value = awaitItem() as WooPosContentViewState
-//            assertThat(value.paginationState).isInstanceOf(WooPosPaginationState.Error::class.java)
-//        }
-//    }
-//
-//    @Test
-//    fun `given no products, when pull to refresh, then state is Empty`() = runTest {
-//        // GIVEN
-//        val viewModel = createViewModel()
-//        whenever(productsDataSource.loadProducts(any())).thenReturn(
-//            flowOf(
-//                WooPosProductsDataSource.ProductsResult.Remote(
-//                    Result.success(emptyList())
-//                )
-//            )
-//        )
-//
-//        // WHEN
-//        viewModel.onUIEvent(WooPosItemsUIEvent.PullToRefreshTriggered)
-//
-//        // THEN
-//        viewModel.viewState.test {
-//            val value = awaitItem()
-//            assertThat(value).isInstanceOf(WooPosItemsViewState.Empty::class.java)
-//        }
-//    }
-//
-//    @Test
-//    fun `given empty list, when pull to refresh, then parent notified correctly`() = runTest {
-//        // GIVEN
-//        val viewModel = createViewModel()
-//        whenever(productsDataSource.loadProducts(any())).thenReturn(
-//            flowOf(
-//                WooPosProductsDataSource.ProductsResult.Remote(
-//                    Result.success(emptyList())
-//                )
-//            )
-//        )
-//
-//        // WHEN
-//        viewModel.onUIEvent(WooPosItemsUIEvent.PullToRefreshTriggered)
-//
-//        // THEN
-//        viewModel.viewState.test {
-//            verify(fromChildToParentEventSender).sendToParent(ChildToParentEvent.ProductsStatusChanged.FullScreen)
-//            cancelAndConsumeRemainingEvents()
-//        }
-//    }
-//
-//    @Test
-//    fun `given products, when pull to refresh, then parent notified correctly`() = runTest {
-//        // GIVEN
-//        val viewModel = createViewModel()
-//
-//        // WHEN
-//        viewModel.onUIEvent(WooPosItemsUIEvent.PullToRefreshTriggered)
-//
-//        // THEN
-//        viewModel.viewState.test {
-//            verify(fromChildToParentEventSender).sendToParent(ChildToParentEvent.ProductsStatusChanged.WithCart)
-//            cancelAndConsumeRemainingEvents()
-//        }
-//    }
-//
-//    @Test
-//    fun `when pull to refresh, then should track event`() = runTest {
-//        // GIVEN
-//        val viewModel = createViewModel()
-//
-//        // WHEN
-//        viewModel.onUIEvent(WooPosItemsUIEvent.PullToRefreshTriggered)
-//
-//        // THEN
-//        verify(analyticsTracker).track(ProductsPullToRefreshTriggered)
-//    }
-//
-//    @Test
-//    fun `given variable product, when clicked on it, then trigger proper event`() = runTest {
-//        // GIVEN
-//        val products = listOf(
-//            ProductTestUtils.generateProduct(
-//                productId = 1,
-//                productName = "Product 1",
-//                amount = "10.0",
-//                productType = "variable",
-//                isVariable = true
-//            )
-//        )
-//        whenever(productsDataSource.loadProducts(any())).thenReturn(
-//            flowOf(
-//                WooPosProductsDataSource.ProductsResult.Remote(
-//                    Result.success(products)
-//                )
-//            )
-//        )
-//        val viewModel = createViewModel()
-//
-//        // WHEN
-//        viewModel.onUIEvent(
-//            WooPosItemsUIEvent.ItemClicked(
-//                Product.Variable(
-//                    id = 1L,
-//                    name = "Product 1",
-//                    numOfVariations = 10,
-//                    variationIds = emptyList(),
-//                    price = "$10.0",
-//                    imageUrl = null
-//                )
-//            )
-//        )
-//
-//        // THEN
-//        verify(wooPosItemsNavigator).sendNavigationEvent(
-//            WooPosItemsNavigator.WooPosItemsScreenNavigationEvent.NavigateToVariationsScreen(
-//                WooPosItemNavigationData.VariableProductData(
-//                    id = 1,
-//                    name = "Product 1",
-//                    numOfVariations = 10,
-//                )
-//            )
-//        )
-//    }
-//
-//    @Test
-//    fun `given variable products from data source, when view model created, then items list updated correctly`() =
-//        runTest {
-//            // GIVEN
-//            val products = listOf(
-//                ProductTestUtils.generateProduct(
-//                    productId = 1,
-//                    productName = "Product 1",
-//                    amount = "10.0",
-//                    productType = "simple",
-//                    isDownloadable = false,
-//                ),
-//                ProductTestUtils.generateProduct(
-//                    productId = 2,
-//                    productName = "Product 2",
-//                    amount = "20.0",
-//                    productType = "variable",
-//                    isDownloadable = false,
-//                    isVariable = true
-//                ).copy(firstImageUrl = "https://test.com")
-//            )
-//
-//            whenever(productsDataSource.loadProducts(any())).thenReturn(
-//                flowOf(
-//                    WooPosProductsDataSource.ProductsResult.Remote(
-//                        Result.success(products)
-//                    )
-//                )
-//            )
-//
-//            // WHEN
-//            val viewModel = createViewModel()
-//            viewModel.viewState.test {
-//                // THEN
-//                val value = awaitItem() as WooPosItemsViewState.Content
-//
-//                assertThat(value.items.filterIsInstance<Product.Variable>().size).isEqualTo(1)
-//            }
-//        }
+
+    @Rule
+    @JvmField
+    val coroutinesTestRule = WooPosCoroutineTestRule()
+
+    private val priceFormat: WooPosFormatPrice = mock {
+        onBlocking { invoke(BigDecimal("10.0")) }.thenReturn("$10.0")
+        onBlocking { invoke(BigDecimal("20.0")) }.thenReturn("$20.0")
+    }
+    private val fromChildToParentEventSender: WooPosChildrenToParentEventSender = mock()
+    private val analyticsTracker: WooPosAnalyticsTracker = mock()
+    private val productsDataSource: WooPosProductsDataSource = mock()
+    private val wooPosItemsNavigator: WooPosItemsNavigator = mock()
+
+    @Before
+    fun setup() {
+        val products = listOf(
+            ProductTestUtils.generateProduct(
+                productId = 1,
+                productName = "Product 1",
+                amount = "10.0",
+                productType = "simple",
+                isDownloadable = false,
+            ),
+        )
+
+        whenever(productsDataSource.loadProducts(any())).thenReturn(
+            flowOf(
+                WooPosProductsDataSource.ProductsResult.Remote(
+                    Result.success(products)
+                )
+            )
+        )
+    }
+
+    @Test
+    fun `given products from data source, when view model created, then view state updated correctly`() = runTest {
+        // WHEN
+        val products = listOf(
+            ProductTestUtils.generateProduct(
+                productId = 1,
+                productName = "Product 1",
+                amount = "10.0",
+                productType = "simple",
+                isDownloadable = false,
+            ),
+            ProductTestUtils.generateProduct(
+                productId = 2,
+                productName = "Product 2",
+                amount = "20.0",
+                productType = "simple",
+                isDownloadable = false,
+            ).copy(firstImageUrl = "https://test.com")
+        )
+
+        whenever(productsDataSource.loadProducts(any())).thenReturn(
+            flowOf(
+                WooPosProductsDataSource.ProductsResult.Remote(
+                    Result.success(products)
+                )
+            )
+        )
+        val viewModel = createViewModel()
+
+        // THEN
+        viewModel.viewState.test {
+            val value = awaitItem() as WooPosProductsViewState.Content
+
+            @Suppress("UNCHECKED_CAST")
+            val items = value.items as List<Product.Simple>
+            assertThat(items).hasSize(2)
+            assertThat(items[0].id).isEqualTo(1)
+            assertThat(items[0].name).isEqualTo("Product 1")
+            assertThat(items[0].price).isEqualTo("$10.0")
+            assertThat(items[1].id).isEqualTo(2)
+            assertThat(items[1].name).isEqualTo("Product 2")
+            assertThat(items[1].price).isEqualTo("$20.0")
+            assertThat(items[1].imageUrl).isEqualTo("https://test.com")
+        }
+    }
+
+    @Test
+    fun `given empty products list returned, when view model created, then view state is empty`() = runTest {
+        // GIVEN
+        whenever(productsDataSource.loadProducts(any())).thenReturn(
+            flowOf(
+                WooPosProductsDataSource.ProductsResult.Remote(
+                    Result.success(emptyList())
+                )
+            )
+        )
+
+        // WHEN
+        val viewModel = createViewModel()
+
+        // THEN
+        viewModel.viewState.test {
+            val value = awaitItem()
+            assertThat(value).isEqualTo(
+                WooPosProductsViewState.Empty()
+            )
+        }
+    }
+
+    @Test
+    fun `given loading products fails, when view model created, then view state is error`() = runTest {
+        // GIVEN
+        whenever(productsDataSource.loadProducts(any())).thenReturn(
+            flowOf(
+                WooPosProductsDataSource.ProductsResult.Remote(
+                    Result.failure(Exception())
+                )
+            )
+        )
+
+        // WHEN
+        val viewModel = createViewModel()
+
+        // THEN
+        viewModel.viewState.test {
+            val value = awaitItem()
+            assertThat(value).isEqualTo(
+                WooPosProductsViewState.Error()
+            )
+        }
+    }
+
+    @Test
+    fun `given products from data source, when pulled to refresh, then should remove products and fetch again`() =
+        runTest {
+            // WHEN
+            val viewModel = createViewModel()
+            viewModel.onUIEvent(WooPosProductsUIEvent.PullToRefreshTriggered)
+
+            // THEN
+            viewModel.viewState.test {
+                verify(productsDataSource).loadProducts(forceRefreshProducts = true)
+                cancelAndConsumeRemainingEvents()
+            }
+        }
+
+    @Test
+    fun `given content state, when end of products grid reached and no more pages, then do not load more`() = runTest {
+        // GIVEN
+        whenever(productsDataSource.hasMorePages).thenReturn(false)
+        val viewModel = createViewModel()
+
+        // WHEN
+        viewModel.onUIEvent(WooPosProductsUIEvent.EndOfItemsListReached)
+
+        // THEN
+        viewModel.viewState.test {
+            val value = awaitItem() as WooPosProductsViewState.Content
+            assertThat(value.paginationState).isEqualTo(WooPosPaginationState.None)
+        }
+    }
+
+    @Test
+    fun `when product clicked, then send event to parent`() = runTest {
+        // GIVEN
+        val product = Product.Simple(id = 1, name = "", price = "", imageUrl = null)
+        val viewModel = createViewModel()
+
+        // WHEN
+        viewModel.onUIEvent(WooPosProductsUIEvent.ItemClicked(product))
+
+        // THEN
+        viewModel.viewState.test {
+            verify(fromChildToParentEventSender).sendToParent(
+                ChildToParentEvent.ItemClickedInProductSelector(
+                    WooPosItemsViewModel.ItemClickedData.Product.Simple(
+                        id = product.id
+                    )
+                )
+            )
+            cancelAndConsumeRemainingEvents()
+        }
+    }
+
+    @Test
+    fun `given load more products is called, when products source loads successfully then state is updated`() =
+        runTest {
+            // GIVEN
+            val viewModel = createViewModel()
+
+            // WHEN
+            viewModel.onUIEvent(WooPosProductsUIEvent.EndOfItemsListReached)
+
+            // THEN
+            viewModel.viewState.test {
+                val value = awaitItem() as WooPosProductsViewState.Content
+                assertThat(value.paginationState).isEqualTo(WooPosPaginationState.None)
+            }
+        }
+
+    @Test
+    fun `when loading without pull to refresh, then should not ask to remove products`() = runTest {
+        // WHEN
+        val viewModel = createViewModel()
+
+        // THEN
+        viewModel.viewState.test {
+            verify(productsDataSource).loadProducts(forceRefreshProducts = false)
+            cancelAndConsumeRemainingEvents()
+        }
+    }
+
+    @Test
+    fun `when vm created and loading products, then view state is Loading`() = runTest {
+        // WHEN
+        val viewModel = createViewModel()
+
+        // THEN
+        assertThat(viewModel.viewState.value).isInstanceOf(WooPosProductsViewState.Loading::class.java)
+    }
+
+    @Test
+    fun `given error from load more, when list end reached, then state is pagination error`() = runTest {
+        // GIVEN
+        whenever(productsDataSource.loadMore()).thenReturn(Result.failure(Exception()))
+        whenever(productsDataSource.hasMorePages).thenReturn(true)
+        val viewModel = createViewModel()
+
+        // WHEN
+        viewModel.onUIEvent(WooPosProductsUIEvent.EndOfItemsListReached)
+
+        // THEN
+        viewModel.viewState.test {
+            val value = awaitItem() as WooPosContentViewState
+            assertThat(value.paginationState).isInstanceOf(WooPosPaginationState.Error::class.java)
+        }
+    }
+
+    @Test
+    fun `given no products, when pull to refresh, then state is Empty`() = runTest {
+        // GIVEN
+        val viewModel = createViewModel()
+        whenever(productsDataSource.loadProducts(any())).thenReturn(
+            flowOf(
+                WooPosProductsDataSource.ProductsResult.Remote(
+                    Result.success(emptyList())
+                )
+            )
+        )
+
+        // WHEN
+        viewModel.onUIEvent(WooPosProductsUIEvent.PullToRefreshTriggered)
+
+        // THEN
+        viewModel.viewState.test {
+            val value = awaitItem()
+            assertThat(value).isInstanceOf(WooPosProductsViewState.Empty::class.java)
+        }
+    }
+
+    @Test
+    fun `given empty list, when pull to refresh, then parent notified correctly`() = runTest {
+        // GIVEN
+        val viewModel = createViewModel()
+        whenever(productsDataSource.loadProducts(any())).thenReturn(
+            flowOf(
+                WooPosProductsDataSource.ProductsResult.Remote(
+                    Result.success(emptyList())
+                )
+            )
+        )
+
+        // WHEN
+        viewModel.onUIEvent(WooPosProductsUIEvent.PullToRefreshTriggered)
+
+        // THEN
+        viewModel.viewState.test {
+            verify(fromChildToParentEventSender).sendToParent(ChildToParentEvent.ProductsStatusChanged.FullScreen)
+            cancelAndConsumeRemainingEvents()
+        }
+    }
+
+    @Test
+    fun `given products, when pull to refresh, then parent notified correctly`() = runTest {
+        // GIVEN
+        val viewModel = createViewModel()
+
+        // WHEN
+        viewModel.onUIEvent(WooPosProductsUIEvent.PullToRefreshTriggered)
+
+        // THEN
+        viewModel.viewState.test {
+            verify(fromChildToParentEventSender).sendToParent(ChildToParentEvent.ProductsStatusChanged.WithCart)
+            cancelAndConsumeRemainingEvents()
+        }
+    }
+
+    @Test
+    fun `when pull to refresh, then should track event`() = runTest {
+        // GIVEN
+        val viewModel = createViewModel()
+
+        // WHEN
+        viewModel.onUIEvent(WooPosProductsUIEvent.PullToRefreshTriggered)
+
+        // THEN
+        verify(analyticsTracker).track(ProductsPullToRefreshTriggered)
+    }
+
+    @Test
+    fun `given variable product, when clicked on it, then trigger proper event`() = runTest {
+        // GIVEN
+        val products = listOf(
+            ProductTestUtils.generateProduct(
+                productId = 1,
+                productName = "Product 1",
+                amount = "10.0",
+                productType = "variable",
+                isVariable = true
+            )
+        )
+        whenever(productsDataSource.loadProducts(any())).thenReturn(
+            flowOf(
+                WooPosProductsDataSource.ProductsResult.Remote(
+                    Result.success(products)
+                )
+            )
+        )
+        val viewModel = createViewModel()
+
+        // WHEN
+        viewModel.onUIEvent(
+            WooPosProductsUIEvent.ItemClicked(
+                Product.Variable(
+                    id = 1L,
+                    name = "Product 1",
+                    numOfVariations = 10,
+                    variationIds = emptyList(),
+                    price = "$10.0",
+                    imageUrl = null
+                )
+            )
+        )
+
+        // THEN
+        verify(wooPosItemsNavigator).sendNavigationEvent(
+            WooPosItemsNavigator.WooPosItemsScreenNavigationEvent.NavigateToVariationsScreen(
+                WooPosItemNavigationData.VariableProductData(
+                    id = 1,
+                    name = "Product 1",
+                    numOfVariations = 10,
+                )
+            )
+        )
+    }
+
+    @Test
+    fun `given variable products from data source, when view model created, then items list updated correctly`() =
+        runTest {
+            // GIVEN
+            val products = listOf(
+                ProductTestUtils.generateProduct(
+                    productId = 1,
+                    productName = "Product 1",
+                    amount = "10.0",
+                    productType = "simple",
+                    isDownloadable = false,
+                ),
+                ProductTestUtils.generateProduct(
+                    productId = 2,
+                    productName = "Product 2",
+                    amount = "20.0",
+                    productType = "variable",
+                    isDownloadable = false,
+                    isVariable = true
+                ).copy(firstImageUrl = "https://test.com")
+            )
+
+            whenever(productsDataSource.loadProducts(any())).thenReturn(
+                flowOf(
+                    WooPosProductsDataSource.ProductsResult.Remote(
+                        Result.success(products)
+                    )
+                )
+            )
+
+            // WHEN
+            val viewModel = createViewModel()
+            viewModel.viewState.test {
+                // THEN
+                val value = awaitItem() as WooPosProductsViewState.Content
+
+                assertThat(value.items.filterIsInstance<Product.Variable>().size).isEqualTo(1)
+            }
+        }
+
+    private fun createViewModel(): WooPosProductsViewModel {
+        return WooPosProductsViewModel(
+            productsDataSource = productsDataSource,
+            priceFormat = priceFormat,
+            analyticsTracker = analyticsTracker,
+            fromChildToParentEventSender = fromChildToParentEventSender,
+            navigator = wooPosItemsNavigator,
+        )
+    }
 }

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/home/items/products/WooPosProductsViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/home/items/products/WooPosProductsViewModelTest.kt
@@ -15,6 +15,7 @@ import com.woocommerce.android.ui.woopos.util.WooPosCoroutineTestRule
 import com.woocommerce.android.ui.woopos.util.analytics.WooPosAnalyticsEvent.Event.ProductsPullToRefreshTriggered
 import com.woocommerce.android.ui.woopos.util.analytics.WooPosAnalyticsTracker
 import com.woocommerce.android.ui.woopos.util.format.WooPosFormatPrice
+import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.test.runTest
 import org.assertj.core.api.Assertions.assertThat
@@ -29,6 +30,7 @@ import java.math.BigDecimal
 
 class WooPosProductsViewModelTest {
 
+    @OptIn(ExperimentalCoroutinesApi::class)
     @Rule
     @JvmField
     val coroutinesTestRule = WooPosCoroutineTestRule()
@@ -280,43 +282,6 @@ class WooPosProductsViewModelTest {
         viewModel.viewState.test {
             val value = awaitItem()
             assertThat(value).isInstanceOf(WooPosProductsViewState.Empty::class.java)
-        }
-    }
-
-    @Test
-    fun `given empty list, when pull to refresh, then parent notified correctly`() = runTest {
-        // GIVEN
-        val viewModel = createViewModel()
-        whenever(productsDataSource.loadProducts(any())).thenReturn(
-            flowOf(
-                WooPosProductsDataSource.ProductsResult.Remote(
-                    Result.success(emptyList())
-                )
-            )
-        )
-
-        // WHEN
-        viewModel.onUIEvent(WooPosProductsUIEvent.PullToRefreshTriggered)
-
-        // THEN
-        viewModel.viewState.test {
-            verify(fromChildToParentEventSender).sendToParent(ChildToParentEvent.ProductsStatusChanged.FullScreen)
-            cancelAndConsumeRemainingEvents()
-        }
-    }
-
-    @Test
-    fun `given products, when pull to refresh, then parent notified correctly`() = runTest {
-        // GIVEN
-        val viewModel = createViewModel()
-
-        // WHEN
-        viewModel.onUIEvent(WooPosProductsUIEvent.PullToRefreshTriggered)
-
-        // THEN
-        viewModel.viewState.test {
-            verify(fromChildToParentEventSender).sendToParent(ChildToParentEvent.ProductsStatusChanged.WithCart)
-            cancelAndConsumeRemainingEvents()
         }
     }
 


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #WOOMOB-355
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

I'm sorry for the size of this PR. However, considering the nature of the PR I didn't come up with a reasonable approach how to split it - if you have some ideas, I'll be happy to update it/split it.

Goal of this PR is to move the ProductList out of the WooPosItemsViewModel/Screen. This main reason for this refactoring is that the current structure doesn't meet the evolving needs. We need to support multiple types of lists, such as search, coupons, customers, variations .... . However, in the current state the Product List is displayed inside the generic WooPosItemsViewModel which is used even for the other types of lists, which doesn't make much sense.

Originally, I didn't plan to make any other changes to the code other then the necessary changes for this refactoring. However, when I started working on this I realized there are a couple cases whose migration requires an extra effort and it doesn't make sense to spent time migrating them, considering we are going to remove them later this week:
1. Simple Products - I change the state of the banner to `Hidden` in all the places. I'll remove the deadcode in a follow up PR to avoid increasing the size of this PR even more.
2. ProductsStatusChanged - I removed this childToParent event since we decided to always show the list with a cart next to it. 
3. I removed the PTR handling in the searchHelper since it's not longer necessary - there is always just one list present as opposed to the previous state in which search list was rendered kind of on top of the product list.

 ̶D̶o̶ ̶n̶o̶t̶ ̶m̶e̶r̶g̶e̶ ̶l̶a̶b̶e̶l̶:̶ ̶T̶h̶e̶r̶e̶ ̶a̶r̶e̶ ̶s̶e̶v̶e̶r̶a̶l̶ ̶T̶O̶D̶O̶s̶ ̶i̶n̶ ̶t̶h̶e̶ ̶c̶o̶d̶e̶ ̶a̶t̶ ̶t̶h̶e̶ ̶m̶o̶m̶e̶n̶t̶.̶ ̶A̶l̶l̶ ̶o̶f̶ ̶t̶h̶e̶m̶ ̶a̶r̶e̶ ̶r̶e̶l̶a̶t̶e̶d̶ ̶t̶o̶ ̶p̶r̶o̶p̶a̶g̶a̶t̶i̶n̶g̶ ̶s̶t̶a̶t̶e̶ ̶f̶o̶r̶ ̶P̶u̶l̶l̶T̶o̶R̶e̶f̶r̶e̶s̶h̶ ̶b̶a̶s̶e̶d̶ ̶o̶n̶ ̶S̶e̶a̶r̶c̶h̶H̶e̶l̶p̶e̶r̶'̶s̶ ̶s̶t̶a̶t̶e̶.̶ ̶I̶ ̶w̶a̶n̶t̶e̶d̶ ̶t̶o̶ ̶d̶i̶s̶c̶u̶s̶s̶ ̶t̶h̶i̶s̶ ̶w̶i̶t̶h̶ ̶y̶o̶u̶ ̶f̶i̶r̶s̶t̶ ̶s̶i̶n̶c̶e̶ ̶y̶o̶u̶ ̶h̶a̶v̶e̶ ̶m̶o̶r̶e̶ ̶c̶o̶n̶t̶e̶x̶t̶ ̶a̶n̶d̶ ̶l̶i̶k̶e̶l̶y̶ ̶a̶ ̶b̶e̶t̶t̶e̶r̶ ̶i̶d̶e̶a̶ ̶a̶b̶o̶u̶t̶ ̶a̶ ̶p̶r̶o̶p̶e̶r̶ ̶s̶o̶l̶u̶t̶i̶o̶n̶.̶ ̶I̶'̶m̶ ̶w̶o̶n̶d̶e̶r̶i̶n̶g̶ ̶i̶f̶ ̶t̶h̶e̶ ̶s̶e̶a̶r̶c̶h̶H̶e̶l̶p̶e̶r̶ ̶s̶h̶o̶u̶l̶d̶ ̶
̶1̶.̶ ̶p̶r̶o̶p̶a̶g̶a̶t̶e̶ ̶t̶h̶e̶ ̶P̶T̶R̶ ̶s̶t̶a̶t̶e̶ ̶f̶r̶o̶m̶ ̶t̶h̶e̶ ̶I̶t̶e̶m̶s̶ ̶l̶i̶s̶t̶ ̶t̶o̶ ̶P̶r̶o̶d̶u̶c̶t̶ ̶l̶i̶s̶t̶ ̶t̶h̶r̶o̶u̶g̶h̶ ̶t̶h̶e̶ ̶p̶a̶r̶e̶n̶t̶
̶3̶.̶ ̶i̶f̶ ̶w̶e̶ ̶s̶h̶o̶u̶l̶d̶ ̶m̶o̶v̶e̶ ̶e̶v̶e̶n̶ ̶t̶h̶e̶ ̶s̶e̶a̶r̶c̶h̶H̶e̶l̶p̶e̶r̶ ̶i̶n̶s̶i̶d̶e̶ ̶t̶h̶e̶ ̶P̶r̶o̶d̶u̶c̶t̶V̶M̶ ̶
̶4̶.̶ ̶i̶f̶ ̶w̶e̶ ̶s̶h̶o̶u̶l̶d̶ ̶i̶n̶c̶r̶e̶a̶s̶e̶ ̶t̶h̶e̶ ̶s̶c̶o̶p̶e̶ ̶o̶f̶ ̶t̶h̶e̶ ̶s̶e̶a̶r̶c̶h̶H̶e̶l̶p̶e̶r̶ ̶t̶o̶ ̶`̶p̶a̶r̶e̶n̶t̶`̶ ̶a̶n̶d̶ ̶i̶n̶j̶e̶c̶t̶ ̶t̶h̶e̶ ̶s̶a̶m̶e̶ ̶i̶n̶s̶t̶a̶n̶c̶e̶ ̶i̶n̶ ̶b̶o̶t̶h̶ ̶I̶t̶e̶m̶s̶V̶M̶ ̶a̶n̶d̶ ̶P̶r̶o̶d̶u̶c̶t̶s̶V̶M̶ ̶o̶r̶ ̶a̶ ̶d̶i̶f̶f̶e̶r̶e̶n̶t̶ ̶s̶o̶l̶u̶t̶i̶o̶n̶.̶
̶5̶.̶ ̶i̶f̶ ̶w̶e̶ ̶c̶a̶n̶ ̶c̶o̶m̶p̶l̶e̶t̶e̶l̶y̶ ̶r̶e̶m̶o̶v̶e̶ ̶i̶t̶ ̶s̶i̶n̶c̶e̶ ̶i̶t̶'̶s̶ ̶n̶o̶ ̶l̶o̶n̶g̶e̶r̶ ̶n̶e̶c̶e̶s̶s̶a̶r̶y̶ ̶c̶o̶n̶s̶i̶d̶e̶r̶i̶n̶g̶ ̶t̶h̶e̶ ̶p̶r̶o̶d̶u̶c̶t̶ ̶l̶i̶s̶t̶ ̶i̶s̶ ̶i̶n̶ ̶i̶t̶s̶ ̶o̶w̶n̶ ̶V̶M̶
̶6̶.̶ ̶d̶i̶f̶f̶e̶r̶e̶n̶t̶ ̶s̶o̶l̶u̶t̶i̶o̶n̶

### Testing information
<!-- This is your opportunity to break out individual scenarios that need testing (when necessary) and/or include a checklist for the reviewer to go through. Consider documenting the following from your own completed testing: devices used, alternate workflows, edge cases, affected areas, critical flows, areas not tested, and any remaining unknowns. Provide feedback on this new section of the PR template through Sept 30, 2024 to Apps Quality; additional context here: p91TBi-b8z-p2#comment-12036 -->

This PR requires testing of the product list, search and cart sections of the POS. Also test that when you disable the Copouns and Search Feature Flags the features aren't visible and the product list works as expected.

The only UI facing changes that are expected:
- Simple Product Banner is always hidden.
- Cart is always visible.
- Temporary: PTR isn't disabled in search.

### The tests that have been performed
<!-- To give the reviewer an idea of what could be missed in terms of testing -->

### Images/gif
<!-- Include before and after images or gifs when appropriate. -->

- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.

## Reviewer (or Author, in the case of optional code reviews):

Please make sure these conditions are met before approving the PR, or request changes if the PR needs improvement:

- [x] The PR is small and has a clear, single focus, or a valid explanation is provided in the description. If needed, please request to split it into smaller PRs.
- [x] Ensure Adequate Unit Test Coverage: The changes are reasonably covered by unit tests or an explanation is provided in the PR description.
- [x] Manual Testing: The author listed all the tests they ran, including smoke tests when needed (e.g., for refactorings). The reviewer confirmed that the PR works as expected on big (tablet) and small (phone) in case of UI changes, and no regressions are added.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->woo