### PR TITLE
Fix price issue on split shipment screen

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/GetShippableItems.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/GetShippableItems.kt
@@ -33,7 +33,7 @@ class GetShippableItems @Inject constructor(
                 title = product.name,
                 imageUrl = product.firstImageUrl,
                 quantity = item.quantity,
-                price = item.total,
+                price = item.price,
                 currency = order.currency
             )
         }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/ShippableItemsMapper.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/ShippableItemsMapper.kt
@@ -18,7 +18,7 @@ fun ShippableItemModel.toUIModel(
         itemId = itemId,
         productId = productId,
         title = title,
-        formattedPrice = currencyFormatter.formatCurrency(price, currency),
+        formattedPrice = currencyFormatter.formatCurrency(shippingTotalValue, currency),
         quantity = quantity,
         imageUrl = imageUrl,
         formattedSize = getSizeWithUnits(dimensionUnit),
@@ -91,7 +91,7 @@ fun List<ShippableItemModel>.toSelectableUIModel(
 }
 
 fun List<ShippableItemModel>.getFormattedTotalPrice(currencyFormatter: CurrencyFormatter): String {
-    val totalPrice = sumOf { it.price }
+    val totalPrice = sumOf { it.shippingTotalValue }
     val formattedTotalPrice = firstOrNull()?.currency?.let {
         currencyFormatter.formatCurrency(totalPrice, it)
     } ?: currencyFormatter.formatCurrency(totalPrice)

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/customs/WooShippingCustomsFormViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/customs/WooShippingCustomsFormViewModel.kt
@@ -297,7 +297,7 @@ class WooShippingCustomsFormViewModel @Inject constructor(
                 input = "",
                 errorMessageId = R.string.woo_shipping_labels_customs_product_details_value_required
             )
-            else -> InputValue.Data(price.toString())
+            else -> InputValue.Data(shippingTotalValue.toString())
         },
         weightPerUnit = when {
             weight == 0f -> InputValue.Error(


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
This fixes the incorrect prices for products on the split shipment screen. 
In the case shown in the screenshots below, the unit price is $15 for the first product type and $12 for the second. 
For the first product group, the total price should be $105, but it was $735.
For the second product group, the total price should be $180, but it was $2700.

### Steps to reproduce
<!-- Step-by-step testing instructions. For new user flows, consider instead stating the goal of the workflow and see if your PR reviewer can accomplish the workflow without specific steps! -->
1. Open the orders tab.
2. Tap on an order eligible for shipping label creation. It’s better to choose one with multiple items.
3. Tap on Create shipping label.
4. Tap on Split shipment.

### The tests that have been performed
<!-- To give the reviewer an idea of what could be missed in terms of testing -->
Steps above.

### Images/gif
<!-- Include before and after images or gifs when appropriate. -->
|Before|After|
|-|-|
|<img src="https://github.com/user-attachments/assets/bceb56ac-b9ce-4d9b-9867-6fd3702b703a" width=360>|<img src="https://github.com/user-attachments/assets/fbf26666-d413-4f6f-9102-604160034fcf" width=360>|

- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.

## Reviewer (or Author, in the case of optional code reviews):

Please make sure these conditions are met before approving the PR, or request changes if the PR needs improvement:

- [ ] The PR is small and has a clear, single focus, or a valid explanation is provided in the description. If needed, please request to split it into smaller PRs.
- [ ] Ensure Adequate Unit Test Coverage: The changes are reasonably covered by unit tests or an explanation is provided in the PR description.
- [ ] Manual Testing: The author listed all the tests they ran, including smoke tests when needed (e.g., for refactorings). The reviewer confirmed that the PR works as expected on big (tablet) and small (phone) in case of UI changes, and no regressions are added.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->