### PR TITLE
[WOOMOB-362][Woo POS][Product Search] Simplify WooPosBaseViewState and pagination

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/items/WooPosBaseViewState.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/items/WooPosBaseViewState.kt
@@ -1,9 +1,5 @@
 package com.woocommerce.android.ui.woopos.home.items
 
-sealed class WooPosBaseViewState(
-    open val pullToRefreshState: WooPosPullToRefreshState
-)
-
 interface WooPosContentViewState {
     val items: List<WooPosItemSelectionViewState>
     val pullToRefreshState: WooPosPullToRefreshState

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/items/WooPosCouponsViewState.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/items/WooPosCouponsViewState.kt
@@ -13,7 +13,7 @@ sealed class WooPosCouponsViewState(
     ) : WooPosCouponsViewState(pullToRefreshState)
 
     data class Error(
-        override val pullToRefreshState: WooPosPullToRefreshState = WooPosPullToRefreshState.Enabled,
+        override val pullToRefreshState: WooPosPullToRefreshState = WooPosPullToRefreshState.Disabled,
     ) : WooPosCouponsViewState(pullToRefreshState)
 
     data class Empty(

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/items/WooPosCouponsViewState.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/items/WooPosCouponsViewState.kt
@@ -1,8 +1,8 @@
 package com.woocommerce.android.ui.woopos.home.items
 
 sealed class WooPosCouponsViewState(
-    override val pullToRefreshState: WooPosPullToRefreshState,
-) : WooPosBaseViewState(pullToRefreshState) {
+    open val pullToRefreshState: WooPosPullToRefreshState,
+) {
     data class Content(
         val coupons: List<WooPosItemSelectionViewState>,
         val paginationState: WooPosPaginationState = WooPosPaginationState.None,

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/items/WooPosProductsViewState.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/items/WooPosProductsViewState.kt
@@ -1,8 +1,8 @@
 package com.woocommerce.android.ui.woopos.home.items
 
 sealed class WooPosProductsViewState(
-    override val pullToRefreshState: WooPosPullToRefreshState,
-) : WooPosBaseViewState(pullToRefreshState) {
+    open val pullToRefreshState: WooPosPullToRefreshState,
+) {
     data class Content(
         override val items: List<WooPosItemSelectionViewState>,
         override val paginationState: WooPosPaginationState = WooPosPaginationState.None,

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/items/WooPosProductsViewState.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/items/WooPosProductsViewState.kt
@@ -14,7 +14,7 @@ sealed class WooPosProductsViewState(
     ) : WooPosProductsViewState(pullToRefreshState)
 
     data class Error(
-        override val pullToRefreshState: WooPosPullToRefreshState = WooPosPullToRefreshState.Enabled,
+        override val pullToRefreshState: WooPosPullToRefreshState = WooPosPullToRefreshState.Disabled,
     ) : WooPosProductsViewState(pullToRefreshState)
 
     data class Empty(

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/items/WooPosVariationsViewState.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/items/WooPosVariationsViewState.kt
@@ -15,7 +15,7 @@ sealed class WooPosVariationsViewState(
     ) : WooPosVariationsViewState(pullToRefreshState)
 
     data class Error(
-        override val pullToRefreshState: WooPosPullToRefreshState = WooPosPullToRefreshState.Enabled,
+        override val pullToRefreshState: WooPosPullToRefreshState = WooPosPullToRefreshState.Disabled,
     ) : WooPosVariationsViewState(pullToRefreshState)
 
     data class Empty(

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/items/WooPosVariationsViewState.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/items/WooPosVariationsViewState.kt
@@ -11,7 +11,6 @@ sealed class WooPosVariationsViewState(
 
     data class Loading(
         override val pullToRefreshState: WooPosPullToRefreshState = WooPosPullToRefreshState.Enabled,
-        val withCart: Boolean
     ) : WooPosVariationsViewState(pullToRefreshState)
 
     data class Error(

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/items/WooPosVariationsViewState.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/items/WooPosVariationsViewState.kt
@@ -1,9 +1,8 @@
 package com.woocommerce.android.ui.woopos.home.items
 
 sealed class WooPosVariationsViewState(
-    override val pullToRefreshState: WooPosPullToRefreshState
-) : WooPosBaseViewState(pullToRefreshState) {
-
+    open val pullToRefreshState: WooPosPullToRefreshState
+) {
     data class Content(
         override val items: List<WooPosItemSelectionViewState.Variation>,
         override val pullToRefreshState: WooPosPullToRefreshState = WooPosPullToRefreshState.Enabled,

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/items/variations/WooPosVariationsViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/items/variations/WooPosVariationsViewModel.kt
@@ -38,7 +38,7 @@ class WooPosVariationsViewModel @Inject constructor(
 ) : ViewModel() {
 
     private val _viewState =
-        MutableStateFlow<WooPosVariationsViewState>(WooPosVariationsViewState.Loading(withCart = true))
+        MutableStateFlow<WooPosVariationsViewState>(WooPosVariationsViewState.Loading())
     val viewState: StateFlow<WooPosVariationsViewState> = _viewState
         .stateIn(
             viewModelScope,
@@ -58,7 +58,6 @@ class WooPosVariationsViewModel @Inject constructor(
         loadVariations(
             productId = productId,
             withPullToRefresh = false,
-            withCart = true,
             forceRefresh = false
         )
     }
@@ -67,14 +66,13 @@ class WooPosVariationsViewModel @Inject constructor(
         productId: Long,
         forceRefresh: Boolean,
         withPullToRefresh: Boolean,
-        withCart: Boolean,
     ) {
         fetchJob?.cancel()
         fetchJob = viewModelScope.launch {
             _viewState.value = if (withPullToRefresh) {
                 buildProductsReloadingState()
             } else {
-                WooPosVariationsViewState.Loading(withCart = withCart)
+                WooPosVariationsViewState.Loading()
             }
 
             variationsDataSource.fetchFirstPage(productId, forceRefresh = forceRefresh).collect { result ->
@@ -193,12 +191,12 @@ class WooPosVariationsViewModel @Inject constructor(
             }
 
             is WooPosVariationsUIEvents.PullToRefreshTriggered -> {
-                loadVariations(event.productId, forceRefresh = true, withPullToRefresh = true, withCart = false)
+                loadVariations(event.productId, forceRefresh = true, withPullToRefresh = true)
                 viewModelScope.launch { analyticsTracker.track(VariationsPullToRefreshTriggered) }
             }
 
             is WooPosVariationsUIEvents.VariationsLoadingErrorRetryButtonClicked -> {
-                loadVariations(event.productId, forceRefresh = true, withPullToRefresh = false, withCart = false)
+                loadVariations(event.productId, forceRefresh = true, withPullToRefresh = false)
             }
 
             is WooPosVariationsUIEvents.OnItemClicked -> {


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #WOOMOB-362
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
* Removes redundant `WooPosBaseViewState`
* At the beginning, I thought to make `WooPosPullToRefreshState` binary, but it is actually useful as we want to disable PTR on the error states. Now it's disabled but not by the state, but by the way layout is done (not scrollable)
* Removed unused `withCart` param in the variations

### Steps to reproduce
<!-- Step-by-step testing instructions. For new user flows, consider instead stating the goal of the workflow and see if your PR reviewer can accomplish the workflow without specific steps! -->
No user-facing changes are expected. Do smoke testing and PTR in different states and lists


### The tests that have been performed
<!-- To give the reviewer an idea of what could be missed in terms of testing -->
above

### Images/gif
<!-- Include before and after images or gifs when appropriate. -->
None

- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.

## Reviewer (or Author, in the case of optional code reviews):

Please make sure these conditions are met before approving the PR, or request changes if the PR needs improvement:

- [ ] The PR is small and has a clear, single focus, or a valid explanation is provided in the description. If needed, please request to split it into smaller PRs.
- [ ] Ensure Adequate Unit Test Coverage: The changes are reasonably covered by unit tests or an explanation is provided in the PR description.
- [ ] Manual Testing: The author listed all the tests they ran, including smoke tests when needed (e.g., for refactorings). The reviewer confirmed that the PR works as expected on big (tablet) and small (phone) in case of UI changes, and no regressions are added.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->