### PR TITLE
[Woo POS[[WOOMOB-364] Move Variations under Products

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/items/WooPosItemSelectionViewState.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/items/WooPosItemSelectionViewState.kt
@@ -8,29 +8,30 @@ sealed class WooPosItemSelectionViewState(
         override val id: Long,
         override val name: String,
         open val price: String,
+        open val imageUrl: String?,
     ) : WooPosItemSelectionViewState(id, name) {
         data class Simple(
             override val id: Long,
             override val name: String,
             override val price: String,
-            val imageUrl: String?,
-        ) : Product(id, name, price)
+            override val imageUrl: String?,
+        ) : Product(id, name, price, imageUrl)
 
         data class Variable(
             override val id: Long,
             override val name: String,
             override val price: String,
-            val imageUrl: String?,
+            override val imageUrl: String?,
             val numOfVariations: Int,
             val variationIds: List<Long>,
-        ) : Product(id, name, price)
-    }
+        ) : Product(id, name, price, imageUrl)
 
-    data class Variation(
-        override val id: Long,
-        override val name: String,
-        val productId: Long,
-        val price: String,
-        val imageUrl: String?,
-    ) : WooPosItemSelectionViewState(id, name)
+        data class Variation(
+            override val id: Long,
+            override val name: String,
+            override val price: String,
+            override val imageUrl: String?,
+            val productId: Long,
+        ) : Product(id, name, price, imageUrl)
+    }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/items/WooPosItemsList.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/items/WooPosItemsList.kt
@@ -1,6 +1,5 @@
 package com.woocommerce.android.ui.woopos.home.items
 
-import androidx.compose.foundation.ExperimentalFoundationApi
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
@@ -63,7 +62,6 @@ import com.woocommerce.android.ui.woopos.home.items.WooPosItemSelectionViewState
 import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.filter
 
-@OptIn(ExperimentalFoundationApi::class)
 @Composable
 fun WooPosItemList(
     state: WooPosContentViewState,
@@ -146,7 +144,7 @@ private fun ProductItem(
         item.name,
         item.price
     )
-    WooPosItemCard(modifier, itemContentDescription, onItemClicked, item)
+    WooPosProductCard(modifier, itemContentDescription, onItemClicked, item)
 }
 
 @Composable
@@ -160,7 +158,7 @@ private fun VariableProductItem(
         item.name,
         item.price
     )
-    WooPosItemCard(modifier, itemContentDescription, onItemClicked, item)
+    WooPosProductCard(modifier, itemContentDescription, onItemClicked, item)
 }
 
 @Composable
@@ -174,11 +172,11 @@ private fun VariationItem(
         item.name,
         item.price
     )
-    WooPosItemCard(modifier, itemContentDescription, onItemClicked, item)
+    WooPosProductCard(modifier, itemContentDescription, onItemClicked, item)
 }
 
 @Composable
-fun WooPosItemCard(
+fun WooPosProductCard(
     modifier: Modifier,
     itemContentDescription: String,
     onItemClicked: (item: WooPosItemSelectionViewState) -> Unit,

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/items/WooPosItemsList.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/items/WooPosItemsList.kt
@@ -60,7 +60,6 @@ import com.woocommerce.android.ui.woopos.common.composeui.designsystem.WooPosThe
 import com.woocommerce.android.ui.woopos.common.composeui.designsystem.WooPosTypography
 import com.woocommerce.android.ui.woopos.common.composeui.designsystem.toAdaptivePadding
 import com.woocommerce.android.ui.woopos.home.items.WooPosItemSelectionViewState.Product
-import com.woocommerce.android.ui.woopos.home.items.WooPosItemSelectionViewState.Variation
 import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.filter
 
@@ -99,7 +98,7 @@ fun WooPosItemList(
                     )
                 }
 
-                is Variation -> {
+                is Product.Variation -> {
                     VariationItem(
                         modifier = Modifier.animateItem(),
                         item = product,
@@ -167,7 +166,7 @@ private fun VariableProductItem(
 @Composable
 private fun VariationItem(
     modifier: Modifier = Modifier,
-    item: Variation,
+    item: Product.Variation,
     onItemClicked: (item: WooPosItemSelectionViewState) -> Unit
 ) {
     val itemContentDescription = stringResource(
@@ -183,7 +182,7 @@ fun WooPosItemCard(
     modifier: Modifier,
     itemContentDescription: String,
     onItemClicked: (item: WooPosItemSelectionViewState) -> Unit,
-    item: WooPosItemSelectionViewState
+    item: Product
 ) {
     WooPosCard(
         modifier = modifier
@@ -232,18 +231,13 @@ private fun ProductInfo(item: WooPosItemSelectionViewState) {
         when (item) {
             is Product.Simple -> SimpleProductDetails(item = item)
             is Product.Variable -> VariableProductDetails()
-            is Variation -> VariationProductDetails(item = item)
+            is Product.Variation -> VariationProductDetails(item = item)
         }
     }
 }
 
 @Composable
-private fun ProductImage(item: WooPosItemSelectionViewState) {
-    val imageUrl = when (item) {
-        is Product.Simple -> item.imageUrl
-        is Product.Variable -> item.imageUrl
-        is Variation -> item.imageUrl
-    }
+private fun ProductImage(item: Product) {
     Box(
         modifier = Modifier
             .size(112.dp)
@@ -258,7 +252,7 @@ private fun ProductImage(item: WooPosItemSelectionViewState) {
         )
         AsyncImage(
             model = ImageRequest.Builder(LocalContext.current)
-                .data(imageUrl)
+                .data(item.imageUrl)
                 .crossfade(true)
                 .build(),
             contentDescription = null,
@@ -287,7 +281,7 @@ private fun VariableProductDetails() {
 }
 
 @Composable
-fun VariationProductDetails(item: Variation) {
+fun VariationProductDetails(item: Product.Variation) {
     WooPosText(
         text = item.price,
         style = WooPosTypography.BodyLarge,
@@ -446,7 +440,7 @@ fun ItemListPreview() {
                         imageUrl = ""
                     ),
                     Product.Variable(id = 2, name = "Variable Product", price = "$10.00", "", 1, listOf()),
-                    Variation(3, "Variation", 0, "$10", ""),
+                    Product.Variation(3, "Variation", "$10", "", 0),
                 ),
             ),
             listState = LazyListState(),

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/items/WooPosVariationsViewState.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/items/WooPosVariationsViewState.kt
@@ -5,7 +5,7 @@ sealed class WooPosVariationsViewState(
 ) : WooPosBaseViewState(pullToRefreshState) {
 
     data class Content(
-        override val items: List<WooPosItemSelectionViewState.Variation>,
+        override val items: List<WooPosItemSelectionViewState.Product.Variation>,
         override val pullToRefreshState: WooPosPullToRefreshState = WooPosPullToRefreshState.Enabled,
         override val paginationState: WooPosPaginationState = WooPosPaginationState.None,
     ) : WooPosVariationsViewState(pullToRefreshState), WooPosContentViewState

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/items/products/WooPosProductsViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/items/products/WooPosProductsViewModel.kt
@@ -105,7 +105,7 @@ class WooPosProductsViewModel @Inject constructor(
                 }
             }
 
-            is WooPosItemSelectionViewState.Variation -> error("Variation item not support in products list")
+            is WooPosItemSelectionViewState.Product.Variation -> error("Variation item not supported in products list")
         }
     }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/items/search/WooPosItemsEmptySearchQueryStateScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/items/search/WooPosItemsEmptySearchQueryStateScreen.kt
@@ -40,8 +40,8 @@ import com.woocommerce.android.ui.woopos.common.composeui.designsystem.WooPosSpa
 import com.woocommerce.android.ui.woopos.common.composeui.designsystem.WooPosTheme
 import com.woocommerce.android.ui.woopos.common.composeui.designsystem.WooPosTypography
 import com.woocommerce.android.ui.woopos.common.composeui.designsystem.toAdaptivePadding
-import com.woocommerce.android.ui.woopos.home.items.WooPosItemCard
 import com.woocommerce.android.ui.woopos.home.items.WooPosItemSelectionViewState
+import com.woocommerce.android.ui.woopos.home.items.WooPosProductCard
 
 @Composable
 fun WooPosItemsEmptySearchQueryStateScreen(
@@ -115,7 +115,7 @@ private fun PopularItemsSection(
             popularItem.price
         )
 
-        WooPosItemCard(
+        WooPosProductCard(
             modifier = Modifier,
             itemContentDescription = itemContentDescription,
             onItemClicked = { onPopularItemClicked(popularItem) },

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/items/search/WooPosItemsSearchViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/items/search/WooPosItemsSearchViewModel.kt
@@ -205,7 +205,7 @@ class WooPosItemsSearchViewModel @Inject constructor(
                 }
             }
 
-            is WooPosItemSelectionViewState.Variation -> {
+            is WooPosItemSelectionViewState.Product.Variation -> {
                 error("Variation item click is not supported")
             }
         }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/items/variations/WooPosVariationsScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/items/variations/WooPosVariationsScreen.kt
@@ -140,7 +140,7 @@ private fun WooPosVariationsScreens(
                         listState = listState,
                         onItemClicked = {
                             onItemClicked(
-                                (it as WooPosItemSelectionViewState.Variation).productId,
+                                (it as WooPosItemSelectionViewState.Product.Variation).productId,
                                 it.id
                             )
                         },
@@ -258,7 +258,7 @@ fun WooPosVariationsScreenPreview() {
     val productState = MutableStateFlow(
         WooPosVariationsViewState.Content(
             items = listOf(
-                WooPosItemSelectionViewState.Variation(
+                WooPosItemSelectionViewState.Product.Variation(
                     1,
                     name = "Product 1, Product 1, Product 1, " +
                         "Product 1, Product 1, Product 1, Product 1, Product 1" +
@@ -267,14 +267,14 @@ fun WooPosVariationsScreenPreview() {
                     price = "10.0$",
                     imageUrl = null,
                 ),
-                WooPosItemSelectionViewState.Variation(
+                WooPosItemSelectionViewState.Product.Variation(
                     2,
                     name = "Product 2",
                     productId = 1,
                     price = "2000.00$",
                     imageUrl = null,
                 ),
-                WooPosItemSelectionViewState.Variation(
+                WooPosItemSelectionViewState.Product.Variation(
                     3,
                     name = "Product 3",
                     productId = 1,

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/items/variations/WooPosVariationsViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/items/variations/WooPosVariationsViewModel.kt
@@ -92,7 +92,7 @@ class WooPosVariationsViewModel @Inject constructor(
                                 if (variations.isNotEmpty()) {
                                     WooPosVariationsViewState.Content(
                                         items = variations.map {
-                                            WooPosItemSelectionViewState.Variation(
+                                            WooPosItemSelectionViewState.Product.Variation(
                                                 id = it.remoteVariationId,
                                                 name = it.getNameForPOS(getProductById(productId), resourceProvider),
                                                 productId = it.remoteProductId,
@@ -125,7 +125,7 @@ class WooPosVariationsViewModel @Inject constructor(
         } else {
             _viewState.value = WooPosVariationsViewState.Content(
                 items = variations.map {
-                    WooPosItemSelectionViewState.Variation(
+                    WooPosItemSelectionViewState.Product.Variation(
                         id = it.remoteVariationId,
                         name = it.getNameForPOS(getProductById(productId), resourceProvider),
                         productId = it.remoteProductId,
@@ -171,7 +171,7 @@ class WooPosVariationsViewModel @Inject constructor(
             _viewState.value = if (result.isSuccess) {
                 WooPosVariationsViewState.Content(
                     items = result.getOrThrow().map {
-                        WooPosItemSelectionViewState.Variation(
+                        WooPosItemSelectionViewState.Product.Variation(
                             id = it.remoteVariationId,
                             name = it.getNameForPOS(getProductById(productId), resourceProvider),
                             productId = it.remoteProductId,

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/home/items/search/WooPosItemsSearchViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/home/items/search/WooPosItemsSearchViewModelTest.kt
@@ -7,7 +7,6 @@ import com.woocommerce.android.ui.woopos.home.ParentToChildrenEvent
 import com.woocommerce.android.ui.woopos.home.WooPosChildrenToParentEventSender
 import com.woocommerce.android.ui.woopos.home.WooPosParentToChildrenEventReceiver
 import com.woocommerce.android.ui.woopos.home.items.WooPosItemNavigationData.VariableProductData
-import com.woocommerce.android.ui.woopos.home.items.WooPosItemSelectionViewState
 import com.woocommerce.android.ui.woopos.home.items.WooPosItemSelectionViewState.Product
 import com.woocommerce.android.ui.woopos.home.items.WooPosItemsViewModel.ItemClickedData
 import com.woocommerce.android.ui.woopos.home.items.WooPosPaginationState
@@ -663,7 +662,7 @@ class WooPosItemsSearchViewModelTest {
     @Test
     fun `given variation, when item clicked, then throw error`() = runTest {
         // GIVEN
-        val variation = WooPosItemSelectionViewState.Variation(
+        val variation = Product.Variation(
             id = 1,
             name = "Test Variation",
             price = "$10.0",


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #WOOMOB-364
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

This is a small refactoring PR which moves Variation under Product in the WooPosItemSelectionViewState. This will be useful for the coupons project as it'll allow us to easily create custom list-item for coupons while still having compile time safety.


### Testing information
<!-- This is your opportunity to break out individual scenarios that need testing (when necessary) and/or include a checklist for the reviewer to go through. Consider documenting the following from your own completed testing: devices used, alternate workflows, edge cases, affected areas, critical flows, areas not tested, and any remaining unknowns. Provide feedback on this new section of the PR template through Sept 30, 2024 to Apps Quality; additional context here: p91TBi-b8z-p2#comment-12036 -->

Smoke test displaying and selecting variable product and variation.

### The tests that have been performed
<!-- To give the reviewer an idea of what could be missed in terms of testing -->

### Images/gif
<!-- Include before and after images or gifs when appropriate. -->

This PR shouldn't introduce any UI facing changes.

- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.

## Reviewer (or Author, in the case of optional code reviews):

Please make sure these conditions are met before approving the PR, or request changes if the PR needs improvement:

- [x] The PR is small and has a clear, single focus, or a valid explanation is provided in the description. If needed, please request to split it into smaller PRs.
- [x] Ensure Adequate Unit Test Coverage: The changes are reasonably covered by unit tests or an explanation is provided in the PR description.
- [x] Manual Testing: The author listed all the tests they ran, including smoke tests when needed (e.g., for refactorings). The reviewer confirmed that the PR works as expected on big (tablet) and small (phone) in case of UI changes, and no regressions are added.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->O