### PR TITLE
[WOOMOB-350][Woo POS][Product Search] Crash if popular product selected after pull to refresh

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/common/data/WooPosPopularProductsProvider.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/common/data/WooPosPopularProductsProvider.kt
@@ -26,6 +26,10 @@ class WooPosPopularProductsProvider @Inject constructor(
 
     suspend fun getPopularProducts(): List<Product> = mutex.withLock { popularProductsCache }
 
+    suspend fun addPopularItemsToCache() = mutex.withLock {
+        productsCache.addAll(popularProductsCache)
+    }
+
     suspend fun fetchAndCachePopularProducts(): Result<Unit> = mutex.withLock {
         val result = productStore.fetchProducts(
             site = selectedSite.get(),

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/items/search/WooPosItemsEmptySearchQueryStateScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/items/search/WooPosItemsEmptySearchQueryStateScreen.kt
@@ -66,7 +66,7 @@ fun WooPosItemsEmptySearchQueryStateScreen(
                         PopularItemsSection(
                             popularItems = state.popularItems,
                             onPopularItemClicked = { popularItem ->
-                                onUIEvent(WooPosItemsSearchUiEvent.ItemClicked(popularItem))
+                                onUIEvent(WooPosItemsSearchUiEvent.OnPopularItemClicked(popularItem))
                             }
                         )
                     }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/items/search/WooPosItemsSearchEmptyStateRepository.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/items/search/WooPosItemsSearchEmptyStateRepository.kt
@@ -6,7 +6,6 @@ import com.woocommerce.android.ui.woopos.util.datastore.WooPosPreferencesReposit
 import kotlinx.coroutines.flow.first
 import javax.inject.Inject
 
-@Suppress("MagicNumber")
 class WooPosItemsSearchEmptyStateRepository @Inject constructor(
     private val preferencesRepository: WooPosPreferencesRepository,
     private val popularProductsProvider: WooPosPopularProductsProvider,
@@ -17,5 +16,9 @@ class WooPosItemsSearchEmptyStateRepository @Inject constructor(
 
     suspend fun addRecentSearch(search: String) {
         preferencesRepository.addRecentProductSearch(search)
+    }
+
+    suspend fun addPopularItemsToCache() {
+        popularProductsProvider.addPopularItemsToCache()
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/items/search/WooPosItemsSearchScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/items/search/WooPosItemsSearchScreen.kt
@@ -99,7 +99,7 @@ private fun WooPosItemsSearchContent(
     WooPosItemList(
         state = state,
         listState = listState,
-        onItemClicked = { onUIEvent(WooPosItemsSearchUiEvent.ItemClicked(it)) },
+        onItemClicked = { onUIEvent(WooPosItemsSearchUiEvent.OnItemClicked(it)) },
         onEndOfProductsListReached = { onUIEvent(WooPosItemsSearchUiEvent.OnNextPageRequested) },
         onErrorWhilePaginating = {
             WooPosPaginationErrorIndicator(

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/items/search/WooPosItemsSearchUiEvent.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/items/search/WooPosItemsSearchUiEvent.kt
@@ -3,8 +3,9 @@ package com.woocommerce.android.ui.woopos.home.items.search
 import com.woocommerce.android.ui.woopos.home.items.WooPosItemSelectionViewState
 
 sealed class WooPosItemsSearchUiEvent {
-    data class ItemClicked(val item: WooPosItemSelectionViewState) : WooPosItemsSearchUiEvent()
+    data class OnItemClicked(val item: WooPosItemSelectionViewState) : WooPosItemsSearchUiEvent()
     data object OnNextPageRequested : WooPosItemsSearchUiEvent()
     data object LoadingErrorRetryButtonClicked : WooPosItemsSearchUiEvent()
     data class OnRecentSearchClicked(val recentSearch: String) : WooPosItemsSearchUiEvent()
+    data class OnPopularItemClicked(val item: WooPosItemSelectionViewState) : WooPosItemsSearchUiEvent()
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/items/search/WooPosItemsSearchViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/items/search/WooPosItemsSearchViewModel.kt
@@ -5,6 +5,7 @@ import androidx.lifecycle.viewModelScope
 import com.woocommerce.android.model.Product
 import com.woocommerce.android.ui.products.ProductType
 import com.woocommerce.android.ui.woopos.home.ChildToParentEvent
+import com.woocommerce.android.ui.woopos.home.ChildToParentEvent.SearchEvent.RecentSearchSelected
 import com.woocommerce.android.ui.woopos.home.ParentToChildrenEvent
 import com.woocommerce.android.ui.woopos.home.WooPosChildrenToParentEventSender
 import com.woocommerce.android.ui.woopos.home.WooPosParentToChildrenEventReceiver
@@ -59,7 +60,7 @@ class WooPosItemsSearchViewModel @Inject constructor(
     fun onUIEvent(event: WooPosItemsSearchUiEvent) {
         when (event) {
             WooPosItemsSearchUiEvent.OnNextPageRequested -> onEndOfListReached()
-            is WooPosItemsSearchUiEvent.ItemClicked -> handleItemClicked(event.item)
+            is WooPosItemsSearchUiEvent.OnItemClicked -> handleItemClicked(event.item)
             WooPosItemsSearchUiEvent.LoadingErrorRetryButtonClicked -> {
                 val currentState = _viewState.value as? WooPosItemsSearchViewState.Error ?: return
                 viewModelScope.launch {
@@ -70,10 +71,17 @@ class WooPosItemsSearchViewModel @Inject constructor(
             is WooPosItemsSearchUiEvent.OnRecentSearchClicked -> {
                 viewModelScope.launch {
                     childToParentEventSender.sendToParent(
-                        ChildToParentEvent.SearchEvent.RecentSearchSelected(
+                        RecentSearchSelected(
                             event.recentSearch
                         )
                     )
+                }
+            }
+
+            is WooPosItemsSearchUiEvent.OnPopularItemClicked -> {
+                viewModelScope.launch {
+                    emptyStateRepository.addPopularItemsToCache()
+                    handleItemClicked(event.item)
                 }
             }
         }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/items/search/WooPosProductSearchPredicate.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/items/search/WooPosProductSearchPredicate.kt
@@ -5,7 +5,7 @@ import javax.inject.Inject
 import javax.inject.Singleton
 
 @Singleton
-class ProductSearchPredicate @Inject constructor() {
+class WooPosProductSearchPredicate @Inject constructor() {
     private val whitespaceRegex = "\\s+".toRegex()
 
     operator fun invoke(query: String): (Product) -> Boolean {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/items/search/WooPosSearchProductsDataSource.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/items/search/WooPosSearchProductsDataSource.kt
@@ -24,7 +24,7 @@ class WooPosSearchProductsDataSource @Inject constructor(
     private val selectedSite: SelectedSite,
     private val productsCache: WooPosProductsCache,
     private val searchResultsIndex: WooPosSearchResultsIndex,
-    private val searchPredicate: ProductSearchPredicate,
+    private val searchPredicate: WooPosProductSearchPredicate,
     private val productsTypesFilterConfig: WooPosProductsTypesFilterConfig
 ) {
     companion object {

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/home/items/search/WooPosItemsSearchViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/home/items/search/WooPosItemsSearchViewModelTest.kt
@@ -621,7 +621,7 @@ class WooPosItemsSearchViewModelTest {
 
         // WHEN
         val viewModel = createViewModel()
-        viewModel.onUIEvent(WooPosItemsSearchUiEvent.ItemClicked(simpleProduct))
+        viewModel.onUIEvent(WooPosItemsSearchUiEvent.OnItemClicked(simpleProduct))
 
         // THEN
         verify(mockChildToParentEventSender).sendToParent(
@@ -645,7 +645,7 @@ class WooPosItemsSearchViewModelTest {
 
         // WHEN
         val viewModel = createViewModel()
-        viewModel.onUIEvent(WooPosItemsSearchUiEvent.ItemClicked(variableProduct))
+        viewModel.onUIEvent(WooPosItemsSearchUiEvent.OnItemClicked(variableProduct))
         advanceUntilIdle()
 
         // THEN
@@ -676,7 +676,7 @@ class WooPosItemsSearchViewModelTest {
 
         // THEN
         assertThrows(IllegalStateException::class.java) {
-            viewModel.onUIEvent(WooPosItemsSearchUiEvent.ItemClicked(variation))
+            viewModel.onUIEvent(WooPosItemsSearchUiEvent.OnItemClicked(variation))
         }
     }
 
@@ -707,7 +707,7 @@ class WooPosItemsSearchViewModelTest {
             // WHEN
             val viewModel = createViewModel()
             advanceTimeBy(600)
-            viewModel.onUIEvent(WooPosItemsSearchUiEvent.ItemClicked(simpleProduct))
+            viewModel.onUIEvent(WooPosItemsSearchUiEvent.OnItemClicked(simpleProduct))
 
             // THEN
             verify(mockEmptyStateProvider).addRecentSearch(query)
@@ -720,7 +720,7 @@ class WooPosItemsSearchViewModelTest {
 
         // WHEN
         val viewModel = createViewModel()
-        viewModel.onUIEvent(WooPosItemsSearchUiEvent.ItemClicked(simpleProduct))
+        viewModel.onUIEvent(WooPosItemsSearchUiEvent.OnItemClicked(simpleProduct))
 
         // THEN
         verify(mockEmptyStateProvider, never()).addRecentSearch(any())

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/home/items/search/WooPosItemsSearchViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/home/items/search/WooPosItemsSearchViewModelTest.kt
@@ -726,6 +726,31 @@ class WooPosItemsSearchViewModelTest {
         verify(mockEmptyStateProvider, never()).addRecentSearch(any())
     }
 
+    @Test
+    fun `given popular item, when OnPopularItemClicked event is triggered, then add popular items to cache and handle item click`() =
+        runTest {
+            // GIVEN
+            val simpleProduct = Product.Simple(
+                id = 42L,
+                name = "Popular Product",
+                price = "$15.0",
+                imageUrl = "https://example.com/image.jpg"
+            )
+
+            // WHEN
+            val viewModel = createViewModel()
+            viewModel.onUIEvent(WooPosItemsSearchUiEvent.OnPopularItemClicked(simpleProduct))
+            advanceUntilIdle()
+
+            // THEN
+            verify(mockEmptyStateProvider).addPopularItemsToCache()
+            verify(mockChildToParentEventSender).sendToParent(
+                ChildToParentEvent.ItemClickedInProductSelector(
+                    ItemClickedData.Product.Simple(id = simpleProduct.id)
+                )
+            )
+        }
+
     private fun mockSuccessfulSearch(query: String, products: List<com.woocommerce.android.model.Product>) {
         whenever(mockDataSource.searchProducts(query)).thenReturn(
             flow {

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/home/items/search/WooPosSearchProductsDataSourceTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/home/items/search/WooPosSearchProductsDataSourceTest.kt
@@ -36,7 +36,7 @@ class WooPosSearchProductsDataSourceTest {
     private val wooPosProductsCache: WooPosProductsCache = mock()
     private val searchResultsIndex: WooPosSearchResultsIndex = mock()
     private val selectedSite: SelectedSite = mock()
-    private val searchPredicate: ProductSearchPredicate = mock()
+    private val searchPredicate: WooPosProductSearchPredicate = mock()
     private val siteModel: SiteModel = mock()
 
     private lateinit var sut: WooPosSearchProductsDataSource


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #WOOMOB-350
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
The PR fixes the crash by adding popular products to cache before passing them to the cart

### Steps to reproduce
<!-- Step-by-step testing instructions. For new user flows, consider instead stating the goal of the workflow and see if your PR reviewer can accomplish the workflow without specific steps! -->
* Open the POS
* Do pull to refresh on the products
* Open the search and select a popular product

### The tests that have been performed
<!-- To give the reviewer an idea of what could be missed in terms of testing -->
Above

### Images/gif
<!-- Include before and after images or gifs when appropriate. -->



https://github.com/user-attachments/assets/47f8f1ab-4fd0-4780-a0ea-7ccf60e1892a




- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.

## Reviewer (or Author, in the case of optional code reviews):

Please make sure these conditions are met before approving the PR, or request changes if the PR needs improvement:

- [x] The PR is small and has a clear, single focus, or a valid explanation is provided in the description. If needed, please request to split it into smaller PRs.
- [x] Ensure Adequate Unit Test Coverage: The changes are reasonably covered by unit tests or an explanation is provided in the PR description.
- [x] Manual Testing: The author listed all the tests they ran, including smoke tests when needed (e.g., for refactorings). The reviewer confirmed that the PR works as expected on big (tablet) and small (phone) in case of UI changes, and no regressions are added.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->