### PR TITLE
[WOOMOB-205][Woo POS][Product search] Removing bouncing for local searches

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/items/search/WooPosItemsSearchViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/items/search/WooPosItemsSearchViewModel.kt
@@ -17,18 +17,15 @@ import com.woocommerce.android.ui.woopos.home.items.navigation.WooPosItemsNaviga
 import com.woocommerce.android.ui.woopos.home.items.navigation.WooPosItemsNavigator.WooPosItemsScreenNavigationEvent.NavigateToVariationsScreen
 import com.woocommerce.android.ui.woopos.util.format.WooPosFormatPrice
 import dagger.hilt.android.lifecycle.HiltViewModel
-import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.ExperimentalCoroutinesApi
-import kotlinx.coroutines.FlowPreview
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.async
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
-import kotlinx.coroutines.flow.debounce
-import kotlinx.coroutines.flow.filter
 import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.launch
+import java.util.concurrent.atomic.AtomicReference
 import javax.inject.Inject
 
 @HiltViewModel
@@ -50,27 +47,15 @@ class WooPosItemsSearchViewModel @Inject constructor(
             initialValue = _viewState.value,
         )
 
-    private val searchQueryFlow = MutableStateFlow("")
     private var loadMoreJob: Job? = null
-    private var searchJob: Job? = null
+    private var localSearchJob: Job? = null
+    private var remoteSearchJob: Job? = null
+
+    private val currentQuery = AtomicReference("")
 
     init {
-        viewModelScope.launch { setEmptySearchQueryState() }
-
+        setEmptySearchQueryState()
         listenEventsFromParent()
-        startSearchDebouncing()
-    }
-
-    @OptIn(FlowPreview::class, ExperimentalCoroutinesApi::class)
-    private fun startSearchDebouncing() {
-        viewModelScope.launch {
-            searchQueryFlow
-                .debounce(SEARCH_DEBOUNCING_TIME)
-                .filter { it.isNotEmpty() }
-                .collect { query ->
-                    loadContent(query)
-                }
-        }
     }
 
     fun onUIEvent(event: WooPosItemsSearchUiEvent) {
@@ -79,7 +64,7 @@ class WooPosItemsSearchViewModel @Inject constructor(
             is WooPosItemsSearchUiEvent.ItemClicked -> handleItemClicked(event.item)
             WooPosItemsSearchUiEvent.LoadingErrorRetryButtonClicked -> {
                 val currentState = _viewState.value as? WooPosItemsSearchViewState.Error ?: return
-                loadContent(currentState.searchQuery)
+                doSearch(currentState.searchQuery)
             }
 
             is WooPosItemsSearchUiEvent.OnRecentSearchClicked -> {
@@ -94,11 +79,80 @@ class WooPosItemsSearchViewModel @Inject constructor(
         }
     }
 
+    private fun doSearch(query: String) {
+        localSearchJob?.cancel()
+        remoteSearchJob?.cancel()
+
+        currentQuery.set(query)
+
+        if (query.isEmpty()) {
+            setEmptySearchQueryState()
+        } else {
+            performLocalSearch(query)
+            performRemoteSearch(query)
+        }
+    }
+
+    private fun performLocalSearch(query: String) {
+        if (query.isEmpty()) return
+
+        localSearchJob?.cancel()
+        localSearchJob = viewModelScope.launch {
+            val localProducts = dataSource.searchLocalProducts(query)
+
+            if (query != currentQuery.get()) return@launch
+
+            if (localProducts.isEmpty()) {
+                _viewState.value = WooPosItemsSearchViewState.Loading
+            } else {
+                _viewState.value = localProducts.toContentState(
+                    searchQuery = query,
+                )
+            }
+        }
+    }
+
+    private fun performRemoteSearch(query: String) {
+        if (query.isEmpty()) return
+
+        remoteSearchJob?.cancel()
+        remoteSearchJob = viewModelScope.launch {
+            delay(SEARCH_DEBOUNCING_TIME)
+
+            if (query != currentQuery.get() || query.isEmpty()) {
+                return@launch
+            }
+
+            childToParentEventSender.sendToParent(ChildToParentEvent.SearchEvent.Started)
+            val result = dataSource.searchRemoteProducts(query)
+
+            if (query != currentQuery.get() || query.isEmpty()) {
+                childToParentEventSender.sendToParent(ChildToParentEvent.SearchEvent.Finished)
+                return@launch
+            }
+
+            if (result.isSuccess) {
+                val products = result.getOrThrow()
+                if (products.isEmpty()) {
+                    _viewState.value = WooPosItemsSearchViewState.Empty
+                } else {
+                    _viewState.value = products.toContentState(
+                        searchQuery = query,
+                    )
+                }
+            } else {
+                _viewState.value = WooPosItemsSearchViewState.Error(searchQuery = query)
+            }
+
+            childToParentEventSender.sendToParent(ChildToParentEvent.SearchEvent.Finished)
+        }
+    }
+
     private fun listenEventsFromParent() {
         viewModelScope.launch {
             parentToChildrenEventReceiver.events.collect { event ->
                 when (event) {
-                    is ParentToChildrenEvent.SearchEvent.ChangedQuery -> handleChangedSearchQuery(event)
+                    is ParentToChildrenEvent.SearchEvent.ChangedQuery -> doSearch(event.query)
 
                     ParentToChildrenEvent.SearchEvent.Started -> Unit
                     ParentToChildrenEvent.SearchEvent.Finished -> Unit
@@ -111,54 +165,6 @@ class WooPosItemsSearchViewModel @Inject constructor(
                         if (event.itemData is ItemClickedData.Product.Variation && searchHelper.isSearchOpen()) {
                             storeRecentSearch()
                         }
-                    }
-                }
-            }
-        }
-    }
-
-    private suspend fun CoroutineScope.handleChangedSearchQuery(
-        event: ParentToChildrenEvent.SearchEvent.ChangedQuery
-    ) {
-        searchJob?.cancel()
-
-        if (event.query.isEmpty()) {
-            setEmptySearchQueryState()
-        }
-        searchQueryFlow.value = event.query
-    }
-
-    private fun loadContent(searchQuery: String) {
-        searchJob?.cancel()
-        searchJob = viewModelScope.launch {
-            childToParentEventSender.sendToParent(ChildToParentEvent.SearchEvent.Started)
-
-            dataSource.searchProducts(searchQuery).collect { result ->
-                when (result) {
-                    is WooPosSearchProductsDataSource.ProductsResult.Cached -> {
-                        if (result.products.isEmpty()) {
-                            _viewState.value = WooPosItemsSearchViewState.Loading
-                        } else {
-                            _viewState.value = result.products.toContentState(
-                                searchQuery = searchQuery,
-                            )
-                        }
-                    }
-
-                    is WooPosSearchProductsDataSource.ProductsResult.Remote -> {
-                        if (result.productsResult.isSuccess) {
-                            val products = result.productsResult.getOrThrow()
-                            if (products.isEmpty()) {
-                                _viewState.value = WooPosItemsSearchViewState.Empty
-                            } else {
-                                _viewState.value = products.toContentState(
-                                    searchQuery = searchQuery,
-                                )
-                            }
-                        } else {
-                            _viewState.value = WooPosItemsSearchViewState.Error(searchQuery = searchQuery)
-                        }
-                        childToParentEventSender.sendToParent(ChildToParentEvent.SearchEvent.Finished)
                     }
                 }
             }
@@ -260,15 +266,17 @@ class WooPosItemsSearchViewModel @Inject constructor(
             )
         }
 
-    private suspend fun CoroutineScope.setEmptySearchQueryState() {
-        val lastSearchesDeferred = async { emptyStateRepository.getLastSearches() }
-        val popularItemsDeferred = async { emptyStateRepository.getPopularItems() }
+    private fun setEmptySearchQueryState() {
+        viewModelScope.launch {
+            val lastSearchesDeferred = async { emptyStateRepository.getLastSearches() }
+            val popularItemsDeferred = async { emptyStateRepository.getPopularItems() }
 
-        _viewState.value = WooPosItemsSearchViewState.EmptySearchQuery(
-            popularItems = popularItemsDeferred.await().let { it.take(minOf(MAX_ITEMS_COUNT, it.size)) }
-                .map { it.toViewModelProduct() },
-            recentSearches = lastSearchesDeferred.await().let { it.take(minOf(MAX_ITEMS_COUNT, it.size)) },
-        )
+            _viewState.value = WooPosItemsSearchViewState.EmptySearchQuery(
+                popularItems = popularItemsDeferred.await().let { it.take(minOf(MAX_ITEMS_COUNT, it.size)) }
+                    .map { it.toViewModelProduct() },
+                recentSearches = lastSearchesDeferred.await().let { it.take(minOf(MAX_ITEMS_COUNT, it.size)) },
+            )
+        }
     }
 
     private companion object {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/items/search/WooPosItemsSearchViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/items/search/WooPosItemsSearchViewModel.kt
@@ -64,7 +64,7 @@ class WooPosItemsSearchViewModel @Inject constructor(
             is WooPosItemsSearchUiEvent.ItemClicked -> handleItemClicked(event.item)
             WooPosItemsSearchUiEvent.LoadingErrorRetryButtonClicked -> {
                 val currentState = _viewState.value as? WooPosItemsSearchViewState.Error ?: return
-                doSearch(currentState.searchQuery)
+                performSearch(currentState.searchQuery)
             }
 
             is WooPosItemsSearchUiEvent.OnRecentSearchClicked -> {
@@ -79,7 +79,7 @@ class WooPosItemsSearchViewModel @Inject constructor(
         }
     }
 
-    private fun doSearch(query: String) {
+    private fun performSearch(query: String) {
         localSearchJob?.cancel()
         remoteSearchJob?.cancel()
 
@@ -94,8 +94,6 @@ class WooPosItemsSearchViewModel @Inject constructor(
     }
 
     private fun performLocalSearch(query: String) {
-        if (query.isEmpty()) return
-
         localSearchJob?.cancel()
         localSearchJob = viewModelScope.launch {
             val localProducts = dataSource.searchLocalProducts(query)
@@ -113,20 +111,18 @@ class WooPosItemsSearchViewModel @Inject constructor(
     }
 
     private fun performRemoteSearch(query: String) {
-        if (query.isEmpty()) return
-
         remoteSearchJob?.cancel()
         remoteSearchJob = viewModelScope.launch {
             delay(SEARCH_DEBOUNCING_TIME)
 
-            if (query != currentQuery.get() || query.isEmpty()) {
+            if (query != currentQuery.get()) {
                 return@launch
             }
 
             childToParentEventSender.sendToParent(ChildToParentEvent.SearchEvent.Started)
             val result = dataSource.searchRemoteProducts(query)
 
-            if (query != currentQuery.get() || query.isEmpty()) {
+            if (query != currentQuery.get()) {
                 childToParentEventSender.sendToParent(ChildToParentEvent.SearchEvent.Finished)
                 return@launch
             }
@@ -136,9 +132,7 @@ class WooPosItemsSearchViewModel @Inject constructor(
                 if (products.isEmpty()) {
                     _viewState.value = WooPosItemsSearchViewState.Empty
                 } else {
-                    _viewState.value = products.toContentState(
-                        searchQuery = query,
-                    )
+                    _viewState.value = products.toContentState(searchQuery = query)
                 }
             } else {
                 _viewState.value = WooPosItemsSearchViewState.Error(searchQuery = query)
@@ -152,7 +146,7 @@ class WooPosItemsSearchViewModel @Inject constructor(
         viewModelScope.launch {
             parentToChildrenEventReceiver.events.collect { event ->
                 when (event) {
-                    is ParentToChildrenEvent.SearchEvent.ChangedQuery -> doSearch(event.query)
+                    is ParentToChildrenEvent.SearchEvent.ChangedQuery -> performSearch(event.query)
 
                     ParentToChildrenEvent.SearchEvent.Started -> Unit
                     ParentToChildrenEvent.SearchEvent.Finished -> Unit

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/items/search/WooPosSearchProductsDataSource.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/items/search/WooPosSearchProductsDataSource.kt
@@ -8,11 +8,7 @@ import com.woocommerce.android.ui.woopos.common.data.WooPosProductsCache
 import com.woocommerce.android.ui.woopos.common.data.WooPosProductsTypesFilterConfig
 import com.woocommerce.android.util.WooLog
 import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.async
-import kotlinx.coroutines.coroutineScope
-import kotlinx.coroutines.flow.Flow
-import kotlinx.coroutines.flow.flow
-import kotlinx.coroutines.flow.flowOn
+import kotlinx.coroutines.withContext
 import org.wordpress.android.fluxc.store.WCProductStore
 import java.util.concurrent.atomic.AtomicBoolean
 import javax.inject.Inject
@@ -36,31 +32,17 @@ class WooPosSearchProductsDataSource @Inject constructor(
     val hasMorePages: Boolean
         get() = canLoadMore.get()
 
-    fun searchProducts(query: String): Flow<ProductsResult> = flow {
-        coroutineScope {
-            searchResultsIndex.clearCache()
+    suspend fun searchLocalProducts(query: String): List<Product> = withContext(Dispatchers.IO) {
+        sortProducts(productsCache.getAll().filter(searchPredicate(query))).take(PAGE_SIZE)
+    }
 
-            val localSearchDeferred = async {
-                sortProducts(productsCache.getAll().filter(searchPredicate(query))).take(PAGE_SIZE)
-            }
-            val remoteSearchDeferred = async { performRemoteSearch(query) }
+    suspend fun searchRemoteProducts(query: String): Result<List<Product>> = withContext(Dispatchers.IO) {
+        searchResultsIndex.clearCache()
 
-            emit(ProductsResult.Cached(localSearchDeferred.await()))
-
-            val remoteResults = remoteSearchDeferred.await()
-            remoteResults.fold(
-                onSuccess = { result ->
-                    emit(ProductsResult.Remote(Result.success(result.products)))
-                },
-                onFailure = { error ->
-                    emit(ProductsResult.Remote(Result.failure(error)))
-                }
-            )
-        }
-    }.flowOn(Dispatchers.IO)
-
-    private fun sortProducts(products: List<Product>): List<Product> {
-        return products.sortedBy { it.name.lowercase() }
+        performRemoteSearch(query).fold(
+            onSuccess = { result -> Result.success(result.products) },
+            onFailure = { error -> Result.failure(error) }
+        )
     }
 
     suspend fun loadMore(query: String): Result<List<Product>> {
@@ -119,6 +101,10 @@ class WooPosSearchProductsDataSource @Inject constructor(
                 Result.success(searchResults)
             }
         }
+    }
+
+    private fun sortProducts(products: List<Product>): List<Product> {
+        return products.sortedBy { it.name.lowercase() }
     }
 
     sealed class ProductsResult {

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/home/items/search/WooPosItemsSearchViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/home/items/search/WooPosItemsSearchViewModelTest.kt
@@ -732,7 +732,9 @@ class WooPosItemsSearchViewModelTest {
         remoteProduct: com.woocommerce.android.model.Product
     ) {
         wheneverBlocking { mockDataSource.searchLocalProducts(query) }.thenReturn(listOf(cachedProduct))
-        wheneverBlocking { mockDataSource.searchRemoteProducts(query) }.thenReturn(Result.success(listOf(remoteProduct)))
+        wheneverBlocking { mockDataSource.searchRemoteProducts(query) }.thenReturn(
+            Result.success(listOf(remoteProduct))
+        )
         whenever(mockParentToChildrenEventReceiver.events).thenReturn(
             flowOf(ParentToChildrenEvent.SearchEvent.ChangedQuery(query))
         )

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/home/items/search/WooPosItemsSearchViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/home/items/search/WooPosItemsSearchViewModelTest.kt
@@ -20,8 +20,6 @@ import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.emptyFlow
 import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.flow.flowOf
-import kotlinx.coroutines.flow.flowOn
-import kotlinx.coroutines.test.UnconfinedTestDispatcher
 import kotlinx.coroutines.test.advanceTimeBy
 import kotlinx.coroutines.test.advanceUntilIdle
 import kotlinx.coroutines.test.runTest
@@ -35,6 +33,7 @@ import org.mockito.kotlin.mock
 import org.mockito.kotlin.never
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
+import org.mockito.kotlin.wheneverBlocking
 import java.math.BigDecimal
 
 @ExperimentalCoroutinesApi
@@ -96,6 +95,7 @@ class WooPosItemsSearchViewModelTest {
     @Test
     fun `given empty popular items and recent searches, when view model created, then empty lists are shown`() =
         runTest {
+            // GIVEN
             // WHEN
             val viewModel = createViewModel()
 
@@ -112,6 +112,7 @@ class WooPosItemsSearchViewModelTest {
 
     @Test
     fun `given view model initialization, when view model created, then initial state is EmptySearchQuery`() = runTest {
+        // GIVEN
         // WHEN
         val viewModel = createViewModel()
 
@@ -424,21 +425,11 @@ class WooPosItemsSearchViewModelTest {
             )
         )
 
-        whenever(mockDataSource.searchProducts(query1)).thenReturn(
-            flowOf(
-                WooPosSearchProductsDataSource.ProductsResult.Remote(
-                    Result.success(emptyList())
-                )
-            )
-        )
+        whenever(mockDataSource.searchLocalProducts(query1)).thenReturn(emptyList())
+        whenever(mockDataSource.searchRemoteProducts(query1)).thenReturn(Result.success(emptyList()))
 
-        whenever(mockDataSource.searchProducts(query2)).thenReturn(
-            flowOf(
-                WooPosSearchProductsDataSource.ProductsResult.Remote(
-                    Result.success(products)
-                )
-            )
-        )
+        whenever(mockDataSource.searchLocalProducts(query2)).thenReturn(emptyList())
+        whenever(mockDataSource.searchRemoteProducts(query2)).thenReturn(Result.success(products))
 
         whenever(mockPriceFormat(BigDecimal("10.0"))).thenReturn("$10.0")
 
@@ -480,13 +471,8 @@ class WooPosItemsSearchViewModelTest {
         whenever(mockEmptyStateProvider.getPopularItems()).thenReturn(emptyList())
         whenever(mockEmptyStateProvider.getLastSearches()).thenReturn(emptyList())
 
-        whenever(mockDataSource.searchProducts(query)).thenReturn(
-            flow {
-                emit(WooPosSearchProductsDataSource.ProductsResult.Cached(emptyList()))
-                delay(100)
-                emit(WooPosSearchProductsDataSource.ProductsResult.Remote(Result.success(products)))
-            }.flowOn(UnconfinedTestDispatcher())
-        )
+        whenever(mockDataSource.searchLocalProducts(query)).thenReturn(emptyList())
+        whenever(mockDataSource.searchRemoteProducts(query)).thenReturn(Result.success(products))
 
         whenever(mockPriceFormat(BigDecimal("10.0"))).thenReturn("$10.0")
         whenever(mockParentToChildrenEventReceiver.events).thenReturn(
@@ -525,13 +511,8 @@ class WooPosItemsSearchViewModelTest {
             whenever(mockEmptyStateProvider.getPopularItems()).thenReturn(emptyList())
             whenever(mockEmptyStateProvider.getLastSearches()).thenReturn(emptyList())
 
-            whenever(mockDataSource.searchProducts(query)).thenReturn(
-                flowOf(
-                    WooPosSearchProductsDataSource.ProductsResult.Remote(
-                        Result.success(products)
-                    )
-                )
-            )
+            whenever(mockDataSource.searchLocalProducts(query)).thenReturn(emptyList())
+            whenever(mockDataSource.searchRemoteProducts(query)).thenReturn(Result.success(products))
 
             whenever(mockDataSource.hasMorePages).thenReturn(false)
 
@@ -571,23 +552,12 @@ class WooPosItemsSearchViewModelTest {
         whenever(mockEmptyStateProvider.getLastSearches()).thenReturn(emptyList())
 
         var searchAttempt = 0
-        whenever(mockDataSource.searchProducts(query)).thenAnswer {
+        whenever(mockDataSource.searchLocalProducts(query)).thenReturn(emptyList())
+        whenever(mockDataSource.searchRemoteProducts(query)).thenAnswer {
             if (searchAttempt++ == 0) {
-                flow {
-                    emit(
-                        WooPosSearchProductsDataSource.ProductsResult.Remote(
-                            Result.failure(Exception("Search failed"))
-                        )
-                    )
-                }
+                Result.failure<List<com.woocommerce.android.model.Product>>(Exception("Search failed"))
             } else {
-                flow {
-                    emit(
-                        WooPosSearchProductsDataSource.ProductsResult.Remote(
-                            Result.success(products)
-                        )
-                    )
-                }
+                Result.success(products)
             }
         }
 
@@ -727,32 +697,16 @@ class WooPosItemsSearchViewModelTest {
     }
 
     private fun mockSuccessfulSearch(query: String, products: List<com.woocommerce.android.model.Product>) {
-        whenever(mockDataSource.searchProducts(query)).thenReturn(
-            flow {
-                emit(WooPosSearchProductsDataSource.ProductsResult.Cached(emptyList()))
-                emit(
-                    WooPosSearchProductsDataSource.ProductsResult.Remote(
-                        Result.success(products)
-                    )
-                )
-            }
-        )
+        wheneverBlocking { mockDataSource.searchLocalProducts(query) }.thenReturn(emptyList())
+        wheneverBlocking { mockDataSource.searchRemoteProducts(query) }.thenReturn(Result.success(products))
         whenever(mockParentToChildrenEventReceiver.events).thenReturn(
             flowOf(ParentToChildrenEvent.SearchEvent.ChangedQuery(query))
         )
     }
 
     private fun mockFailedSearch(query: String, error: Exception) {
-        whenever(mockDataSource.searchProducts(query)).thenReturn(
-            flow {
-                emit(WooPosSearchProductsDataSource.ProductsResult.Cached(emptyList()))
-                emit(
-                    WooPosSearchProductsDataSource.ProductsResult.Remote(
-                        Result.failure(error)
-                    )
-                )
-            }
-        )
+        wheneverBlocking { mockDataSource.searchLocalProducts(query) }.thenReturn(emptyList())
+        wheneverBlocking { mockDataSource.searchRemoteProducts(query) }.thenReturn(Result.failure(error))
         whenever(mockParentToChildrenEventReceiver.events).thenReturn(
             flowOf(ParentToChildrenEvent.SearchEvent.ChangedQuery(query))
         )
@@ -777,13 +731,8 @@ class WooPosItemsSearchViewModelTest {
         cachedProduct: com.woocommerce.android.model.Product,
         remoteProduct: com.woocommerce.android.model.Product
     ) {
-        whenever(mockDataSource.searchProducts(query)).thenReturn(
-            flow {
-                emit(WooPosSearchProductsDataSource.ProductsResult.Cached(listOf(cachedProduct)))
-                delay(1)
-                emit(WooPosSearchProductsDataSource.ProductsResult.Remote(Result.success(listOf(remoteProduct))))
-            }.flowOn(coroutinesTestRule.testDispatcher)
-        )
+        wheneverBlocking { mockDataSource.searchLocalProducts(query) }.thenReturn(listOf(cachedProduct))
+        wheneverBlocking { mockDataSource.searchRemoteProducts(query) }.thenReturn(Result.success(listOf(remoteProduct)))
         whenever(mockParentToChildrenEventReceiver.events).thenReturn(
             flowOf(ParentToChildrenEvent.SearchEvent.ChangedQuery(query))
         )

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/home/items/search/WooPosItemsSearchViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/home/items/search/WooPosItemsSearchViewModelTest.kt
@@ -163,12 +163,10 @@ class WooPosItemsSearchViewModelTest {
 
             // WHEN
             val viewModel = createViewModel()
+            advanceTimeBy(600)
 
             // THEN
             viewModel.viewState.test {
-                val initialState = awaitItem()
-                assertThat(initialState).isInstanceOf(WooPosItemsSearchViewState.EmptySearchQuery::class.java)
-
                 val contentState = awaitItem()
                 assertThat(contentState).isInstanceOf(WooPosItemsSearchViewState.Content::class.java)
 
@@ -392,8 +390,6 @@ class WooPosItemsSearchViewModelTest {
 
         // THEN
         viewModel.viewState.test {
-            awaitItem() as WooPosItemsSearchViewState.EmptySearchQuery
-
             val cachedState = awaitItem() as WooPosItemsSearchViewState.Content
             assertThat(cachedState.items).hasSize(1)
             assertThat((cachedState.items[0] as Product.Simple).name).isEqualTo("Cached Product")
@@ -484,8 +480,6 @@ class WooPosItemsSearchViewModelTest {
 
         // THEN
         viewModel.viewState.test {
-            awaitItem() as WooPosItemsSearchViewState.EmptySearchQuery
-
             val loadingState = awaitItem()
             assertThat(loadingState).isInstanceOf(WooPosItemsSearchViewState.Loading::class.java)
 
@@ -551,15 +545,11 @@ class WooPosItemsSearchViewModelTest {
         whenever(mockEmptyStateProvider.getPopularItems()).thenReturn(emptyList())
         whenever(mockEmptyStateProvider.getLastSearches()).thenReturn(emptyList())
 
-        var searchAttempt = 0
         whenever(mockDataSource.searchLocalProducts(query)).thenReturn(emptyList())
-        whenever(mockDataSource.searchRemoteProducts(query)).thenAnswer {
-            if (searchAttempt++ == 0) {
-                Result.failure<List<com.woocommerce.android.model.Product>>(Exception("Search failed"))
-            } else {
-                Result.success(products)
-            }
-        }
+        whenever(mockDataSource.searchRemoteProducts(query)).thenReturn(
+            Result.failure(Exception("Search failed")),
+            Result.success(products)
+        )
 
         whenever(mockPriceFormat(BigDecimal("10.0"))).thenReturn("$10.0")
         whenever(mockParentToChildrenEventReceiver.events).thenReturn(
@@ -577,6 +567,8 @@ class WooPosItemsSearchViewModelTest {
             assertThat((errorState as WooPosItemsSearchViewState.Error).searchQuery).isEqualTo(query)
 
             viewModel.onUIEvent(WooPosItemsSearchUiEvent.LoadingErrorRetryButtonClicked)
+
+            skipItems(1)
 
             val contentState = awaitItem() as WooPosItemsSearchViewState.Content
             assertThat(contentState.searchQuery).isEqualTo(query)

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/home/items/search/WooPosSearchProductsDataSourceTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/home/items/search/WooPosSearchProductsDataSourceTest.kt
@@ -96,12 +96,14 @@ class WooPosSearchProductsDataSourceTest {
             whenever(searchResultsIndex.getSearchResults(query)).thenReturn(products)
             whenever(
                 productStore.searchProducts(
-                    anyOrNull(),
+                    site = anyOrNull(),
                     searchString = anyOrNull(),
+                    skuSearchOptions = anyOrNull(),
                     offset = anyOrNull(),
                     pageSize = anyOrNull(),
                     filterOptions = anyOrNull(),
                     includeTypes = anyOrNull(),
+                    orderCurrency = anyOrNull(),
                 )
             ).thenReturn(WooResult(ProductSearchResult(emptyList(), true)))
 
@@ -125,12 +127,14 @@ class WooPosSearchProductsDataSourceTest {
         )
         whenever(
             productStore.searchProducts(
-                anyOrNull(),
+                site = anyOrNull(),
                 searchString = anyOrNull(),
+                skuSearchOptions = anyOrNull(),
                 offset = anyOrNull(),
                 pageSize = anyOrNull(),
                 filterOptions = anyOrNull(),
                 includeTypes = anyOrNull(),
+                orderCurrency = anyOrNull(),
             )
         ).thenReturn(WooResult(error))
 
@@ -155,12 +159,14 @@ class WooPosSearchProductsDataSourceTest {
             assertThat(result.isSuccess).isTrue()
             assertThat(result.getOrNull()).isEqualTo(products)
             verify(productStore, never()).searchProducts(
-                anyOrNull(),
+                site = anyOrNull(),
                 searchString = anyOrNull(),
+                skuSearchOptions = anyOrNull(),
                 offset = anyOrNull(),
                 pageSize = anyOrNull(),
                 filterOptions = anyOrNull(),
                 includeTypes = anyOrNull(),
+                orderCurrency = anyOrNull(),
             )
         }
 }

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/home/items/search/WooPosSearchProductsDataSourceTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/home/items/search/WooPosSearchProductsDataSourceTest.kt
@@ -1,6 +1,5 @@
 package com.woocommerce.android.ui.woopos.home.items.search
 
-import app.cash.turbine.test
 import com.woocommerce.android.tools.SelectedSite
 import com.woocommerce.android.ui.products.ProductTestUtils
 import com.woocommerce.android.ui.woopos.common.data.WooPosProductsCache
@@ -25,7 +24,6 @@ import org.wordpress.android.fluxc.network.rest.wpcom.wc.WooErrorType
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.WooResult
 import org.wordpress.android.fluxc.store.WCProductStore
 import org.wordpress.android.fluxc.store.WCProductStore.ProductSearchResult
-import java.util.concurrent.atomic.AtomicBoolean
 
 @OptIn(ExperimentalCoroutinesApi::class)
 class WooPosSearchProductsDataSourceTest {
@@ -63,112 +61,61 @@ class WooPosSearchProductsDataSourceTest {
     }
 
     @Test
-    fun `given cached search results, when search products called, then should emit cached results`() = runTest {
+    fun `given cached products, when searchLocalProducts called, then should return filtered products`() = runTest {
         // GIVEN
         val query = "test"
-        whenever(searchResultsIndex.hasSearchResults(query)).thenReturn(true)
-        whenever(searchResultsIndex.getSearchResults(query)).thenReturn(emptyList())
         whenever(wooPosProductsCache.getAll()).thenReturn(products)
-        whenever(
-            productStore.searchProducts(
-                anyOrNull(),
-                anyOrNull(),
-                anyOrNull(),
-                anyOrNull(),
-                anyOrNull(),
-                anyOrNull(),
-                anyOrNull(),
-                anyOrNull(),
-            )
-        ).thenReturn(WooResult(ProductSearchResult(emptyList(), false)))
 
         // WHEN
-        sut.searchProducts(query).test {
-            // THEN
-            val result = awaitItem()
-            assertThat(result).isInstanceOf(WooPosSearchProductsDataSource.ProductsResult.Cached::class.java)
-            assertThat((result as WooPosSearchProductsDataSource.ProductsResult.Cached).products).isEqualTo(products)
+        val result = sut.searchLocalProducts(query)
 
-            verify(searchResultsIndex).clearCache()
-
-            verify(searchResultsIndex).storeSearchResults(query, emptyList())
-            cancelAndIgnoreRemainingEvents()
-        }
+        // THEN
+        assertThat(result).isEqualTo(products)
     }
 
     @Test
-    fun `given more products than page size, when search products called, then should limit local results to page size`() =
+    fun `given more products than page size, when searchLocalProducts called, then should limit results to page size`() =
         runTest {
             // GIVEN
             val query = "test"
             val manyProducts = (1..20).map { ProductTestUtils.generateProduct(productId = it.toLong()) }
             whenever(wooPosProductsCache.getAll()).thenReturn(manyProducts)
-            whenever(searchResultsIndex.getSearchResults(query)).thenReturn(manyProducts)
-            whenever(
-                productStore.searchProducts(
-                    anyOrNull(),
-                    anyOrNull(),
-                    anyOrNull(),
-                    anyOrNull(),
-                    anyOrNull(),
-                    anyOrNull(),
-                    anyOrNull(),
-                    anyOrNull(),
-                )
-            ).thenReturn(WooResult(ProductSearchResult(emptyList(), false)))
 
             // WHEN
-            sut.searchProducts(query).test {
-                // THEN
-                val result = awaitItem()
-                assertThat(result).isInstanceOf(WooPosSearchProductsDataSource.ProductsResult.Cached::class.java)
-                assertThat((result as WooPosSearchProductsDataSource.ProductsResult.Cached).products.size).isEqualTo(15)
-                cancelAndIgnoreRemainingEvents()
-            }
+            val result = sut.searchLocalProducts(query)
+
+            // THEN
+            assertThat(result.size).isEqualTo(15)
         }
 
     @Test
-    fun `given remote search products success, when search products called, then should emit cached and remote results`() =
+    fun `given remote search products success, when searchRemoteProducts called, then should return success result`() =
         runTest {
             // GIVEN
             val query = "test"
-            whenever(wooPosProductsCache.getAll()).thenReturn(products)
-            whenever(searchResultsIndex.getSearchResults(query)).thenReturn(emptyList())
+            whenever(searchResultsIndex.getSearchResults(query)).thenReturn(products)
             whenever(
                 productStore.searchProducts(
                     anyOrNull(),
-                    anyOrNull(),
-                    anyOrNull(),
-                    anyOrNull(),
-                    anyOrNull(),
-                    anyOrNull(),
-                    anyOrNull(),
-                    anyOrNull(),
+                    searchString = anyOrNull(),
+                    offset = anyOrNull(),
+                    pageSize = anyOrNull(),
+                    filterOptions = anyOrNull(),
+                    includeTypes = anyOrNull(),
                 )
             ).thenReturn(WooResult(ProductSearchResult(emptyList(), true)))
 
             // WHEN
-            val result = sut.searchProducts(query)
+            val result = sut.searchRemoteProducts(query)
 
             // THEN
-            result.test {
-                val cachedResult = awaitItem()
-                assertThat(cachedResult).isInstanceOf(WooPosSearchProductsDataSource.ProductsResult.Cached::class.java)
-
-                val remoteResult = awaitItem()
-                assertThat(remoteResult).isInstanceOf(WooPosSearchProductsDataSource.ProductsResult.Remote::class.java)
-                val remoteResultSuccess = (remoteResult as WooPosSearchProductsDataSource.ProductsResult.Remote)
-                    .productsResult.isSuccess
-                assertThat(remoteResultSuccess).isTrue()
-
-                assertThat(sut.hasMorePages).isTrue()
-
-                cancelAndIgnoreRemainingEvents()
-            }
+            assertThat(result.isSuccess).isTrue()
+            verify(searchResultsIndex).clearCache()
+            assertThat(sut.hasMorePages).isTrue()
         }
 
     @Test
-    fun `given remote search products fail, when search products called, then should emit failure result`() = runTest {
+    fun `given remote search products fail, when searchRemoteProducts called, then should return failure result`() = runTest {
         // GIVEN
         val query = "test"
         val error = WooError(
@@ -176,34 +123,22 @@ class WooPosSearchProductsDataSourceTest {
             message = "Error fetching products",
             original = BaseRequest.GenericErrorType.UNKNOWN
         )
-        whenever(wooPosProductsCache.getAll()).thenReturn(products)
         whenever(
             productStore.searchProducts(
                 anyOrNull(),
-                anyOrNull(),
-                anyOrNull(),
-                anyOrNull(),
-                anyOrNull(),
-                anyOrNull(),
-                anyOrNull(),
-                anyOrNull(),
+                searchString = anyOrNull(),
+                offset = anyOrNull(),
+                pageSize = anyOrNull(),
+                filterOptions = anyOrNull(),
+                includeTypes = anyOrNull(),
             )
         ).thenReturn(WooResult(error))
 
         // WHEN
-        sut.searchProducts(query).test {
-            // THEN
-            val cachedResult = awaitItem()
-            assertThat(cachedResult).isInstanceOf(WooPosSearchProductsDataSource.ProductsResult.Cached::class.java)
+        val result = sut.searchRemoteProducts(query)
 
-            val remoteResult = awaitItem()
-            assertThat(remoteResult).isInstanceOf(WooPosSearchProductsDataSource.ProductsResult.Remote::class.java)
-            val remoteResultFailed = (remoteResult as WooPosSearchProductsDataSource.ProductsResult.Remote)
-                .productsResult.isFailure
-            assertThat(remoteResultFailed).isTrue()
-
-            cancelAndIgnoreRemainingEvents()
-        }
+        // THEN
+        assertThat(result.isFailure).isTrue()
     }
 
     @Test
@@ -213,11 +148,6 @@ class WooPosSearchProductsDataSourceTest {
             val query = "test"
             whenever(searchResultsIndex.getSearchResults(query)).thenReturn(products)
 
-            val canLoadMoreField = WooPosSearchProductsDataSource::class.java.getDeclaredField("canLoadMore")
-            canLoadMoreField.isAccessible = true
-            val canLoadMore = canLoadMoreField.get(sut) as AtomicBoolean
-            canLoadMore.set(false)
-
             // WHEN
             val result = sut.loadMore(query)
 
@@ -226,13 +156,11 @@ class WooPosSearchProductsDataSourceTest {
             assertThat(result.getOrNull()).isEqualTo(products)
             verify(productStore, never()).searchProducts(
                 anyOrNull(),
-                anyOrNull(),
-                anyOrNull(),
-                anyOrNull(),
-                anyOrNull(),
-                anyOrNull(),
-                anyOrNull(),
-                anyOrNull(),
+                searchString = anyOrNull(),
+                offset = anyOrNull(),
+                pageSize = anyOrNull(),
+                filterOptions = anyOrNull(),
+                includeTypes = anyOrNull(),
             )
         }
 }


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #WOOMOB-205
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
The PR removes bouncing for the local search

@malinajirka, can you also install this one and tell if you feel it's better than with bouncing? Asking because probably we will apply these practices to all the searches

### Steps to reproduce
<!-- Step-by-step testing instructions. For new user flows, consider instead stating the goal of the workflow and see if your PR reviewer can accomplish the workflow without specific steps! -->
* Open POS
* Open search
* Search for something 
* Notice that results are shown immediately for the local data

### Testing information
<!-- This is your opportunity to break out individual scenarios that need testing (when necessary) and/or include a checklist for the reviewer to go through. Consider documenting the following from your own completed testing: devices used, alternate workflows, edge cases, affected areas, critical flows, areas not tested, and any remaining unknowns. Provide feedback on this new section of the PR template through Sept 30, 2024 to Apps Quality; additional context here: p91TBi-b8z-p2#comment-12036 -->
Sometimes, there is a weird visual bug, when the item is on top of the search. We have a ticket on that, so far no idea why this happens

### The tests that have been performed
<!-- To give the reviewer an idea of what could be missed in terms of testing -->
Above

### Images/gif
<!-- Include before and after images or gifs when appropriate. -->

https://github.com/user-attachments/assets/cea4356f-62e8-4b38-b38f-e1a1264e0ac9


- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.

## Reviewer (or Author, in the case of optional code reviews):

Please make sure these conditions are met before approving the PR, or request changes if the PR needs improvement:

- [ ] The PR is small and has a clear, single focus, or a valid explanation is provided in the description. If needed, please request to split it into smaller PRs.
- [ ] Ensure Adequate Unit Test Coverage: The changes are reasonably covered by unit tests or an explanation is provided in the PR description.
- [ ] Manual Testing: The author listed all the tests they ran, including smoke tests when needed (e.g., for refactorings). The reviewer confirmed that the PR works as expected on big (tablet) and small (phone) in case of UI changes, and no regressions are added.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->