### PR TITLE
[Beta fix][POS][Crash] NPE when clicking item during PTR

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/common/data/WooPosProductsCache.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/common/data/WooPosProductsCache.kt
@@ -14,4 +14,6 @@ interface WooPosProductsCache {
     suspend fun getProductById(productId: Long): Product?
 
     suspend fun clear()
+
+    suspend fun setAll(products: List<Product>)
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/common/data/WooPosProductsInMemoryCache.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/common/data/WooPosProductsInMemoryCache.kt
@@ -39,7 +39,7 @@ class WooPosProductsInMemoryCache @Inject constructor() : WooPosProductsCache {
         addAllInternal(products)
     }
 
-    fun addAllInternal(products: List<Product>) {
+    private fun addAllInternal(products: List<Product>) {
         products.forEach { product ->
             productsCache[product.remoteId] = product
             if (productsCache.size > MAX_CACHE_SIZE) {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/common/data/WooPosProductsInMemoryCache.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/common/data/WooPosProductsInMemoryCache.kt
@@ -19,13 +19,7 @@ class WooPosProductsInMemoryCache @Inject constructor() : WooPosProductsCache {
     private val productsCache = LinkedHashMap<Long, Product>(INITIAL_CAPACITY, LOAD_FACTOR, true)
 
     override suspend fun addAll(products: List<Product>) = mutex.withLock {
-        products.forEach { product ->
-            productsCache[product.remoteId] = product
-            if (productsCache.size > MAX_CACHE_SIZE) {
-                val keysToRemove = productsCache.keys.take(productsCache.size - MAX_CACHE_SIZE)
-                keysToRemove.forEach { productsCache.remove(it) }
-            }
-        }
+        addAllInternal(products)
     }
 
     override suspend fun getAll(): List<Product> = mutex.withLock {
@@ -41,7 +35,17 @@ class WooPosProductsInMemoryCache @Inject constructor() : WooPosProductsCache {
     }
 
     override suspend fun setAll(products: List<Product>) = mutex.withLock {
-        clear()
-        addAll(products)
+        productsCache.clear()
+        addAllInternal(products)
+    }
+
+    fun addAllInternal(products: List<Product>) {
+        products.forEach { product ->
+            productsCache[product.remoteId] = product
+            if (productsCache.size > MAX_CACHE_SIZE) {
+                val keysToRemove = productsCache.keys.take(productsCache.size - MAX_CACHE_SIZE)
+                keysToRemove.forEach { productsCache.remove(it) }
+            }
+        }
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/common/data/WooPosProductsInMemoryCache.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/common/data/WooPosProductsInMemoryCache.kt
@@ -39,4 +39,9 @@ class WooPosProductsInMemoryCache @Inject constructor() : WooPosProductsCache {
     override suspend fun clear() = mutex.withLock {
         productsCache.clear()
     }
+
+    override suspend fun setAll(products: List<Product>) = mutex.withLock {
+        clear()
+        addAll(products)
+    }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/items/products/WooPosProductsDataSource.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/items/products/WooPosProductsDataSource.kt
@@ -8,6 +8,7 @@ import com.woocommerce.android.ui.woopos.common.data.WooPosProductsCache
 import com.woocommerce.android.ui.woopos.common.data.WooPosProductsTypesFilterConfig
 import com.woocommerce.android.util.WooLog
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.flow.flowOn
@@ -70,9 +71,6 @@ class WooPosProductsDataSource @Inject constructor(
 
     fun loadProducts(forceRefreshProducts: Boolean): Flow<ProductsResult> = flow {
         offset.set(0)
-        if (forceRefreshProducts) {
-            productsCache.clear()
-        }
         productsIndex.clearCache()
 
         val cachedProducts = sortProducts(productsCache.getAll()).take(NORMAL_PAGE_SIZE)
@@ -81,6 +79,10 @@ class WooPosProductsDataSource @Inject constructor(
         val fetchResult = fetchProducts()
 
         if (fetchResult.isSuccess) {
+            if (forceRefreshProducts) {
+                productsCache.clear()
+                productsCache.addAll(fetchResult.getOrThrow())
+            }
             emit(ProductsResult.Remote(Result.success(fetchResult.getOrThrow())))
         } else {
             emit(ProductsResult.Remote(Result.failure(fetchResult.exceptionOrNull() ?: Exception("Unknown error"))))

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/items/products/WooPosProductsDataSource.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/items/products/WooPosProductsDataSource.kt
@@ -79,8 +79,7 @@ class WooPosProductsDataSource @Inject constructor(
 
         if (fetchResult.isSuccess) {
             if (forceRefreshProducts) {
-                productsCache.clear()
-                productsCache.addAll(fetchResult.getOrThrow())
+                productsCache.setAll(fetchResult.getOrThrow())
             }
             emit(ProductsResult.Remote(Result.success(fetchResult.getOrThrow())))
         } else {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/items/products/WooPosProductsDataSource.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/items/products/WooPosProductsDataSource.kt
@@ -8,7 +8,6 @@ import com.woocommerce.android.ui.woopos.common.data.WooPosProductsCache
 import com.woocommerce.android.ui.woopos.common.data.WooPosProductsTypesFilterConfig
 import com.woocommerce.android.util.WooLog
 import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.flow.flowOn

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/items/products/WooPosProductsDataSource.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/items/products/WooPosProductsDataSource.kt
@@ -72,8 +72,10 @@ class WooPosProductsDataSource @Inject constructor(
         offset.set(0)
         productsIndex.clearCache()
 
-        val cachedProducts = sortProducts(productsCache.getAll()).take(NORMAL_PAGE_SIZE)
-        emit(ProductsResult.Cached(cachedProducts))
+        if (!forceRefreshProducts) {
+            val cachedProducts = sortProducts(productsCache.getAll()).take(NORMAL_PAGE_SIZE)
+            emit(ProductsResult.Cached(cachedProducts))
+        }
 
         val fetchResult = fetchProducts()
 

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/home/items/WooPosItemsViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/home/items/WooPosItemsViewModelTest.kt
@@ -905,7 +905,6 @@ class WooPosItemsViewModelTest {
             assertThat(awaitItem()).isInstanceOf(WooPosItemsViewState.Content::class.java)
         }
 
-        // Trigger PTR but don't let it complete
         val ptrFlow = MutableSharedFlow<WooPosProductsDataSource.ProductsResult>()
         whenever(productsDataSource.loadProducts(forceRefreshProducts = true)).thenReturn(ptrFlow)
         viewModel.onUIEvent(WooPosItemsUIEvent.PullToRefreshTriggered)

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/home/items/WooPosItemsViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/home/items/WooPosItemsViewModelTest.kt
@@ -881,6 +881,54 @@ class WooPosItemsViewModelTest {
         verify(productsDataSource, never()).loadMore()
     }
 
+    @Test
+    fun `given content and PTR triggered and ongoing, when visible item tapped, then ItemClickedInProductSelector sent to parent`() = runTest {
+        // GIVEN
+        val products = listOf(
+            ProductTestUtils.generateProduct(
+                productId = 1,
+                productName = "Product 1",
+                amount = "10.0",
+                productType = "simple"
+            )
+        )
+        val productsFlow = MutableSharedFlow<WooPosProductsDataSource.ProductsResult>(replay = 1)
+        productsFlow.tryEmit(
+            WooPosProductsDataSource.ProductsResult.Remote(
+                Result.success(products)
+            )
+        )
+        whenever(productsDataSource.loadProducts(any())).thenReturn(productsFlow)
+
+        val viewModel = createViewModel()
+        viewModel.viewState.test {
+            assertThat(awaitItem()).isInstanceOf(WooPosItemsViewState.Content::class.java)
+        }
+
+        // Trigger PTR but don't let it complete
+        val ptrFlow = MutableSharedFlow<WooPosProductsDataSource.ProductsResult>()
+        whenever(productsDataSource.loadProducts(forceRefreshProducts = true)).thenReturn(ptrFlow)
+        viewModel.onUIEvent(WooPosItemsUIEvent.PullToRefreshTriggered)
+
+        // Ensure state reflects refreshing
+        viewModel.viewState.test {
+            val refreshingState = awaitItem() as WooPosItemsViewState.Content
+            assertThat(refreshingState.pullToRefreshState).isEqualTo(WooPosPullToRefreshState.Refreshing)
+        }
+
+        val itemToClick = Product.Simple(id = 1, name = "Product 1", price = "$10.0", imageUrl = null)
+
+        // WHEN
+        viewModel.onUIEvent(WooPosItemsUIEvent.ItemClicked(itemToClick))
+
+        // THEN
+        verify(fromChildToParentEventSender).sendToParent(
+            ChildToParentEvent.ItemClickedInProductSelector(
+                WooPosItemsViewModel.ItemClickedData.Product.Simple(id = 1)
+            )
+        )
+    }
+
     private fun createViewModel() =
         WooPosItemsViewModel(
             productsDataSource,

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/home/items/WooPosItemsViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/home/items/WooPosItemsViewModelTest.kt
@@ -910,7 +910,6 @@ class WooPosItemsViewModelTest {
         whenever(productsDataSource.loadProducts(forceRefreshProducts = true)).thenReturn(ptrFlow)
         viewModel.onUIEvent(WooPosItemsUIEvent.PullToRefreshTriggered)
 
-        // Ensure state reflects refreshing
         viewModel.viewState.test {
             val refreshingState = awaitItem() as WooPosItemsViewState.Content
             assertThat(refreshingState.pullToRefreshState).isEqualTo(WooPosPullToRefreshState.Refreshing)

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/home/items/WooPosProductsDataSourceTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/home/items/WooPosProductsDataSourceTest.kt
@@ -91,7 +91,7 @@ class WooPosProductsDataSourceTest {
     private val productsTypesFilterConfig = WooPosProductsTypesFilterConfig()
 
     @Test
-    fun `given force refresh, when loadProducts called, then should clear cache`() = runTest {
+    fun `given force refresh, when loadProducts called, then should clear cache and insert products again`() = runTest {
         // GIVEN
         whenever(productsIndex.getProductList()).thenReturn(emptyList(), sampleProducts)
 
@@ -117,7 +117,7 @@ class WooPosProductsDataSourceTest {
         sut.loadProducts(forceRefreshProducts = true).first()
 
         // THEN
-        verify(productsCache).clear()
+        verify(productsCache).setAll(any())
         verify(productsIndex).clearCache()
     }
 

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/home/items/WooPosProductsDataSourceTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/home/items/WooPosProductsDataSourceTest.kt
@@ -124,7 +124,6 @@ class WooPosProductsDataSourceTest {
     @Test
     fun `given cached products, when loadProducts called, then should emit cached products first`() = runTest {
         // GIVEN
-
         whenever(productsCache.getAll()).thenReturn(sampleProducts)
         whenever(
             productStore.fetchProducts(
@@ -152,6 +151,36 @@ class WooPosProductsDataSourceTest {
         assertThat(result).isInstanceOf(WooPosProductsDataSource.ProductsResult.Cached::class.java)
         val cachedResult = result as WooPosProductsDataSource.ProductsResult.Cached
         assertThat(cachedResult.products).containsExactlyElementsOf(sampleProducts)
+    }
+
+    @Test
+    fun `given cached products, when loadProducts called with forceRefresh, then should not emit cached products`() = runTest {
+        // GIVEN
+        whenever(productsCache.getAll()).thenReturn(sampleProducts)
+        whenever(
+            productStore.fetchProducts(
+                site = eq(siteModel),
+                offset = any(),
+                pageSize = any(),
+                sortType = any(),
+                filterOptions = any(),
+                includeTypes = any()
+            )
+        ).thenReturn(WooResult(listOf<WCProductModel>()))
+        whenever(productsIndex.getProductList()).thenReturn(sampleProducts)
+        val sut = WooPosProductsDataSource(
+            productStore,
+            selectedSite,
+            productsCache,
+            productsIndex,
+            productsTypesFilterConfig
+        )
+
+        // WHEN
+        val result = sut.loadProducts(forceRefreshProducts = true).first()
+
+        // THEN
+        assertThat(result).isInstanceOf(WooPosProductsDataSource.ProductsResult.Remote::class.java)
     }
 
     @Test


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: WOOMOB-363
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
This PR fixes crash in POS in main items list.

### Steps to reproduce
<!-- Step-by-step testing instructions. For new user flows, consider instead stating the goal of the workflow and see if your PR reviewer can accomplish the workflow without specific steps! -->

To reproduce the crash:
1. When pull-to-refresh happens, loadProducts(forceRefreshProducts = true) is called
2. This immediately clears the cache: productsCache.clear()
3. Then it emits the cached products (which will be empty): emit(ProductsResult.Cached(cachedProducts))
4. Then it starts fetching new products asynchronously
5. If a user clicks a product during this window between clearing the cache and fetching new products, they'll get a null product (you can add a delay in `WooPosProductsDataSource::loadProducts` to simulate the bug)

The issue is that we're clearing the cache too early. Instead, we should:
* Keep the old products in cache until we have new ones
* Only clear and update the cache when we have successfully fetched new products

### Testing information
<!-- This is your opportunity to break out individual scenarios that need testing (when necessary) and/or include a checklist for the reviewer to go through. Consider documenting the following from your own completed testing: devices used, alternate workflows, edge cases, affected areas, critical flows, areas not tested, and any remaining unknowns. Provide feedback on this new section of the PR template through Sept 30, 2024 to Apps Quality; additional context here: p91TBi-b8z-p2#comment-12036 -->
Ensure that:
1. The crash is not happening
2. All the products are loaded on the main list
2. PTR and pagination work

### The tests that have been performed
<!-- To give the reviewer an idea of what could be missed in terms of testing -->
Verified above.

### Images/gif
<!-- Include before and after images or gifs when appropriate. -->
N/A

- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.

## Reviewer (or Author, in the case of optional code reviews):

Please make sure these conditions are met before approving the PR, or request changes if the PR needs improvement:

- [x] The PR is small and has a clear, single focus, or a valid explanation is provided in the description. If needed, please request to split it into smaller PRs.
- [x] Ensure Adequate Unit Test Coverage: The changes are reasonably covered by unit tests or an explanation is provided in the PR description.
- [x] Manual Testing: The author listed all the tests they ran, including smoke tests when needed (e.g., for refactorings). The reviewer confirmed that the PR works as expected on big (tablet) and small (phone) in case of UI changes, and no regressions are added.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->