### PR TITLE
[WOOMOB-169][Woo POS] ChaChing sound on every succesful order paid

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/common/util/WooPosSoundHelper.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/common/util/WooPosSoundHelper.kt
@@ -1,0 +1,21 @@
+package com.woocommerce.android.ui.woopos.common.util
+
+import android.content.Context
+import android.media.MediaPlayer
+import androidx.core.net.toUri
+import com.woocommerce.android.R
+import dagger.hilt.android.qualifiers.ApplicationContext
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+import javax.inject.Inject
+
+class WooPosSoundHelper @Inject constructor(
+    @ApplicationContext private val context: Context
+) {
+    suspend fun playChaChing() = withContext(Dispatchers.IO) {
+        val chaChingUri = "android.resource://${context.packageName}/${R.raw.cha_ching}".toUri()
+        val mp = MediaPlayer.create(context, chaChingUri)
+        mp.setOnCompletionListener { it.release() }
+        mp.start()
+    }
+}

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/common/util/WooPosSoundHelper.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/common/util/WooPosSoundHelper.kt
@@ -2,7 +2,6 @@ package com.woocommerce.android.ui.woopos.common.util
 
 import android.content.Context
 import android.media.MediaPlayer
-import androidx.core.net.toUri
 import com.woocommerce.android.R
 import dagger.hilt.android.qualifiers.ApplicationContext
 import kotlinx.coroutines.Dispatchers
@@ -13,8 +12,7 @@ class WooPosSoundHelper @Inject constructor(
     @ApplicationContext private val context: Context
 ) {
     suspend fun playChaChing() = withContext(Dispatchers.IO) {
-        val chaChingUri = "android.resource://${context.packageName}/${R.raw.cha_ching}".toUri()
-        val mp = MediaPlayer.create(context, chaChingUri)
+        val mp = MediaPlayer.create(context, R.raw.cha_ching)
         mp.setOnCompletionListener { it.release() }
         mp.start()
     }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/WooPosHomeViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/WooPosHomeViewModel.kt
@@ -3,6 +3,7 @@ package com.woocommerce.android.ui.woopos.home
 import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import com.woocommerce.android.ui.woopos.common.util.WooPosSoundHelper
 import com.woocommerce.android.ui.woopos.home.ChildToParentEvent.NavigationEvent
 import com.woocommerce.android.ui.woopos.home.ParentToChildrenEvent.CheckoutClicked
 import com.woocommerce.android.ui.woopos.home.ParentToChildrenEvent.ItemClickedInProductSelector
@@ -31,6 +32,7 @@ class WooPosHomeViewModel @Inject constructor(
     private val parentToChildrenEventSender: WooPosParentToChildrenEventSender,
     private val wooPosItemsNavigator: WooPosItemsNavigator,
     private val analyticsTracker: WooPosAnalyticsTracker,
+    private val soundHelper: WooPosSoundHelper,
     savedStateHandle: SavedStateHandle,
 ) : ViewModel() {
     private val _state = savedStateHandle.getStateFlow(
@@ -235,6 +237,8 @@ class WooPosHomeViewModel @Inject constructor(
 
     private fun onOrderSuccessfullyPaid(paymentMethod: PaymentMethod) {
         viewModelScope.launch {
+            soundHelper.playChaChing()
+
             wooPosItemsNavigator.sendNavigationEvent(
                 WooPosItemsNavigator.WooPosItemsScreenNavigationEvent.NavigateBackToItemListScreen
             )

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/home/WooPosHomeViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/home/WooPosHomeViewModelTest.kt
@@ -3,6 +3,7 @@ package com.woocommerce.android.ui.woopos.home
 import androidx.arch.core.executor.testing.InstantTaskExecutorRule
 import androidx.lifecycle.SavedStateHandle
 import com.woocommerce.android.R
+import com.woocommerce.android.ui.woopos.common.util.WooPosSoundHelper
 import com.woocommerce.android.ui.woopos.home.ParentToChildrenEvent.OrderSuccessfullyPaid.PaymentMethod
 import com.woocommerce.android.ui.woopos.home.WooPosHomeUIEvent.ExitPosClicked
 import com.woocommerce.android.ui.woopos.home.WooPosHomeUIEvent.SystemBackClicked
@@ -37,6 +38,7 @@ class WooPosHomeViewModelTest {
     private val parentToChildrenEventSender: WooPosParentToChildrenEventSender = mock()
     private val wooPosItemsNavigator: WooPosItemsNavigator = mock()
     private val analyticsTracker: WooPosAnalyticsTracker = mock()
+    private val soundHelper: WooPosSoundHelper = mock()
 
     @Test
     fun `given state checkout, when SystemBackClicked passed, then BackFromCheckoutToCartClicked event should be sent`() =
@@ -414,6 +416,7 @@ class WooPosHomeViewModelTest {
             verify(wooPosItemsNavigator).sendNavigationEvent(
                 WooPosItemsNavigator.WooPosItemsScreenNavigationEvent.NavigateBackToItemListScreen
             )
+            verify(soundHelper).playChaChing()
         }
 
     @Test
@@ -440,6 +443,7 @@ class WooPosHomeViewModelTest {
         parentToChildrenEventSender,
         wooPosItemsNavigator,
         analyticsTracker,
+        soundHelper,
         SavedStateHandle()
     )
 }


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #WOOMOB-169
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
Add cha-ching sound on every successful order

### Steps to reproduce
<!-- Step-by-step testing instructions. For new user flows, consider instead stating the goal of the workflow and see if your PR reviewer can accomplish the workflow without specific steps! -->
* Open POS
* Process an order, both cash and card
* Hear the sound

### The tests that have been performed
<!-- To give the reviewer an idea of what could be missed in terms of testing -->
Above

### Images/gif
<!-- Include before and after images or gifs when appropriate. -->
none

- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.

## Reviewer (or Author, in the case of optional code reviews):

Please make sure these conditions are met before approving the PR, or request changes if the PR needs improvement:

- [ ] The PR is small and has a clear, single focus, or a valid explanation is provided in the description. If needed, please request to split it into smaller PRs.
- [ ] Ensure Adequate Unit Test Coverage: The changes are reasonably covered by unit tests or an explanation is provided in the PR description.
- [ ] Manual Testing: The author listed all the tests they ran, including smoke tests when needed (e.g., for refactorings). The reviewer confirmed that the PR works as expected on big (tablet) and small (phone) in case of UI changes, and no regressions are added.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->