### PR TITLE
[WOOMOB-175][POS][Coupons] Implement coupons list

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/coupons/CouponListHandler.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/coupons/CouponListHandler.kt
@@ -33,7 +33,7 @@ class CouponListHandler @Inject constructor(private val repository: CouponReposi
     suspend fun fetchCoupons(
         searchQuery: String? = null,
         forceRefresh: Boolean = false
-    ): Result<Unit> = mutex.withLock {
+    ): Result<Boolean> = mutex.withLock {
         // Reset pagination attributes
         page = 1
         canLoadMore = true
@@ -43,22 +43,22 @@ class CouponListHandler @Inject constructor(private val repository: CouponReposi
             if (forceRefresh) {
                 loadCoupons()
             } else {
-                Result.success(Unit)
+                Result.success(canLoadMore)
             }
         } else {
             searchResults.value = emptyList()
             if (searchQuery.isEmpty()) {
                 // If the query is empty, clear search results directly
                 canLoadMore = false
-                Result.success(Unit)
+                Result.success(canLoadMore)
             } else {
                 searchCoupons()
             }
         }
     }
 
-    suspend fun loadMore(): Result<Unit> = mutex.withLock {
-        if (!canLoadMore) return@withLock Result.success(Unit)
+    suspend fun loadMore(): Result<Boolean> = mutex.withLock {
+        if (!canLoadMore) return@withLock Result.success(canLoadMore)
         return if (searchQuery.value == null) {
             loadCoupons()
         } else {
@@ -66,14 +66,14 @@ class CouponListHandler @Inject constructor(private val repository: CouponReposi
         }
     }
 
-    private suspend fun loadCoupons(): Result<Unit> {
+    private suspend fun loadCoupons(): Result<Boolean> {
         return repository.fetchCoupons(page, PAGE_SIZE).onSuccess {
             canLoadMore = it
             page++
-        }.map { }
+        }.map { canLoadMore }
     }
 
-    private suspend fun searchCoupons(): Result<Unit> {
+    private suspend fun searchCoupons(): Result<Boolean> {
         return repository.searchCoupons(
             searchString = searchQuery.value!!,
             page = page,
@@ -82,6 +82,6 @@ class CouponListHandler @Inject constructor(private val repository: CouponReposi
             canLoadMore = result.canLoadMore
             page++
             searchResults.update { it + result.coupons }
-        }.map { }
+        }.map { canLoadMore }
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/items/coupons/WooPosCouponsDataSource.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/items/coupons/WooPosCouponsDataSource.kt
@@ -18,6 +18,4 @@ class WooPosCouponsDataSource @Inject constructor(private val handler: CouponLis
     suspend fun loadMore(): Result<CanLoadMore> {
         return handler.loadMore()
     }
-
-
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/items/coupons/WooPosCouponsDataSource.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/items/coupons/WooPosCouponsDataSource.kt
@@ -2,36 +2,21 @@ package com.woocommerce.android.ui.woopos.home.items.coupons
 
 import com.woocommerce.android.model.Coupon
 import com.woocommerce.android.ui.coupons.CouponListHandler
-import com.woocommerce.android.ui.woopos.home.items.coupons.WooPosCouponsDataSource.FetchingCouponsState.FETCHING_FIRST_PAGE
-import com.woocommerce.android.ui.woopos.home.items.coupons.WooPosCouponsDataSource.FetchingCouponsState.IDLE
-import com.woocommerce.android.ui.woopos.home.items.coupons.WooPosCouponsDataSource.FetchingCouponsState.LOADING_MORE
 import kotlinx.coroutines.flow.Flow
-import kotlinx.coroutines.flow.MutableStateFlow
 import javax.inject.Inject
 import javax.inject.Singleton
 
 @Singleton
 class WooPosCouponsDataSource @Inject constructor(private val handler: CouponListHandler) {
-    private val _fetchingState: MutableStateFlow<FetchingCouponsState> = MutableStateFlow(IDLE)
-    val fetchingState: Flow<FetchingCouponsState> = _fetchingState
-
     val couponsFlow: Flow<List<Coupon>> = handler.couponsFlow
 
     suspend fun clearCacheAndFetchFirstPage(): Result<Unit> {
-        _fetchingState.emit(FETCHING_FIRST_PAGE)
-        return handler.fetchCoupons(searchQuery = null, forceRefresh = true).also {
-            _fetchingState.emit(IDLE)
-        }
+        return handler.fetchCoupons(searchQuery = null, forceRefresh = true)
     }
 
     suspend fun loadMore(): Result<Unit> {
-        _fetchingState.emit(LOADING_MORE)
-        return handler.loadMore().also {
-            _fetchingState.emit(IDLE)
-        }
+        return handler.loadMore()
     }
 
-    enum class FetchingCouponsState {
-        IDLE, LOADING_MORE, FETCHING_FIRST_PAGE
-    }
+
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/items/coupons/WooPosCouponsDataSource.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/items/coupons/WooPosCouponsDataSource.kt
@@ -5,16 +5,17 @@ import com.woocommerce.android.ui.coupons.CouponListHandler
 import kotlinx.coroutines.flow.Flow
 import javax.inject.Inject
 import javax.inject.Singleton
+import kotlin.Boolean as CanLoadMore
 
 @Singleton
 class WooPosCouponsDataSource @Inject constructor(private val handler: CouponListHandler) {
     val couponsFlow: Flow<List<Coupon>> = handler.couponsFlow
 
-    suspend fun clearCacheAndFetchFirstPage(): Result<Unit> {
+    suspend fun clearCacheAndFetchFirstPage(): Result<CanLoadMore> {
         return handler.fetchCoupons(searchQuery = null, forceRefresh = true)
     }
 
-    suspend fun loadMore(): Result<Unit> {
+    suspend fun loadMore(): Result<CanLoadMore> {
         return handler.loadMore()
     }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/items/coupons/WooPosCouponsDataSource.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/items/coupons/WooPosCouponsDataSource.kt
@@ -1,17 +1,37 @@
 package com.woocommerce.android.ui.woopos.home.items.coupons
 
+import com.woocommerce.android.model.Coupon
 import com.woocommerce.android.ui.coupons.CouponListHandler
+import com.woocommerce.android.ui.woopos.home.items.coupons.WooPosCouponsDataSource.FetchingCouponsState.FETCHING_FIRST_PAGE
+import com.woocommerce.android.ui.woopos.home.items.coupons.WooPosCouponsDataSource.FetchingCouponsState.IDLE
+import com.woocommerce.android.ui.woopos.home.items.coupons.WooPosCouponsDataSource.FetchingCouponsState.LOADING_MORE
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableStateFlow
 import javax.inject.Inject
 import javax.inject.Singleton
 
 @Singleton
-@Suppress("unused")
 class WooPosCouponsDataSource @Inject constructor(private val handler: CouponListHandler) {
+    private val _fetchingState: MutableStateFlow<FetchingCouponsState> = MutableStateFlow(IDLE)
+    val fetchingState: Flow<FetchingCouponsState> = _fetchingState
+
+    val couponsFlow: Flow<List<Coupon>> = handler.couponsFlow
+
     suspend fun clearCacheAndFetchFirstPage(): Result<Unit> {
-        return handler.fetchCoupons(searchQuery = null, forceRefresh = true)
+        _fetchingState.emit(FETCHING_FIRST_PAGE)
+        return handler.fetchCoupons(searchQuery = null, forceRefresh = true).also {
+            _fetchingState.emit(IDLE)
+        }
     }
 
     suspend fun loadMore(): Result<Unit> {
-        return handler.loadMore()
+        _fetchingState.emit(LOADING_MORE)
+        return handler.loadMore().also {
+            _fetchingState.emit(IDLE)
+        }
+    }
+
+    enum class FetchingCouponsState {
+        IDLE, LOADING_MORE, FETCHING_FIRST_PAGE
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/items/coupons/WooPosCouponsListViewStateManager.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/items/coupons/WooPosCouponsListViewStateManager.kt
@@ -62,8 +62,8 @@ class WooPosCouponsListViewStateManager @Inject constructor(
         viewModelScope.launch(Dispatchers.IO) {
             fetchingState.emit(FETCHING_FIRST_PAGE)
             val result = couponsDataSource.clearCacheAndFetchFirstPage()
-            delay(500) // avoid UI flickering when there is no network connection
             if (!result.isSuccess) {
+                delay(500) // avoid UI flickering when there is no network connection
                 fetchingState.emit(ERROR_FETCHING_FIRST_PAGE)
             } else {
                 fetchingState.emit(IDLE)
@@ -75,8 +75,8 @@ class WooPosCouponsListViewStateManager @Inject constructor(
         viewModelScope.launch(Dispatchers.IO) {
             fetchingState.emit(LOADING_MORE)
             val result = couponsDataSource.loadMore()
-            delay(500) // avoid UI flickering when there is no network connection
             if (!result.isSuccess) {
+                delay(500) // avoid UI flickering when there is no network connection
                 fetchingState.emit(ERROR_LOADING_MORE)
             } else {
                 fetchingState.emit(IDLE)

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/items/coupons/WooPosCouponsListViewStateManager.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/items/coupons/WooPosCouponsListViewStateManager.kt
@@ -120,9 +120,9 @@ class WooPosCouponsListViewStateManager @Inject constructor(
 
     private fun mapFetchingStateToPaginationState(fetchingState: FetchingCouponsState) =
         when (fetchingState) {
-            IDLE, FETCHING_FIRST_PAGE, ERROR_FETCHING_FIRST_PAGE -> None
-            LOADING_MORE -> Loading
+            IDLE, FETCHING_FIRST_PAGE, LOADING_MORE -> if (canLoadMore) Loading else None
             ERROR_LOADING_MORE -> Error
+            ERROR_FETCHING_FIRST_PAGE -> error("Full screen error should be displayed")
         }
 
     private fun mapFetchingStateToPTRState(fetchingState: FetchingCouponsState) =

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/items/coupons/WooPosCouponsListViewStateManager.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/items/coupons/WooPosCouponsListViewStateManager.kt
@@ -16,11 +16,13 @@ import com.woocommerce.android.ui.woopos.home.items.coupons.WooPosCouponsListVie
 import com.woocommerce.android.ui.woopos.home.items.coupons.WooPosCouponsListViewStateManager.FetchingCouponsState.LOADING_MORE
 import com.woocommerce.android.ui.woopos.util.GetCachedStoreCurrency
 import com.woocommerce.android.ui.woopos.util.format.WooPosFormatCouponSummary
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.combine
-import kotlinx.coroutines.flow.onStart
+import kotlinx.coroutines.launch
 import javax.inject.Inject
 
 class WooPosCouponsListViewStateManager @Inject constructor(
@@ -52,31 +54,33 @@ class WooPosCouponsListViewStateManager @Inject constructor(
                 )
             }
         }
-    }.onStart {
-        fetchCoupons()
     }
 
     val viewState: Flow<WooPosCouponsViewState> = contentFlow
 
-    suspend fun fetchCoupons() {
-        fetchingState.emit(FETCHING_FIRST_PAGE)
-        val result = couponsDataSource.clearCacheAndFetchFirstPage()
-        delay(500) // avoid UI flickering when there is no network connection
-        if (!result.isSuccess) {
-            fetchingState.emit(ERROR_FETCHING_FIRST_PAGE)
-        } else {
-            fetchingState.emit(IDLE)
+    fun fetchCoupons(viewModelScope: CoroutineScope) {
+        viewModelScope.launch(Dispatchers.IO) {
+            fetchingState.emit(FETCHING_FIRST_PAGE)
+            val result = couponsDataSource.clearCacheAndFetchFirstPage()
+            delay(500) // avoid UI flickering when there is no network connection
+            if (!result.isSuccess) {
+                fetchingState.emit(ERROR_FETCHING_FIRST_PAGE)
+            } else {
+                fetchingState.emit(IDLE)
+            }
         }
     }
 
-    suspend fun loadMore() {
-        fetchingState.emit(LOADING_MORE)
-        val result = couponsDataSource.loadMore()
-        delay(500) // avoid UI flickering when there is no network connection
-        if (!result.isSuccess) {
-            fetchingState.emit(ERROR_LOADING_MORE)
-        } else {
-//            fetchingState.emit(IDLE)
+    fun loadMore(viewModelScope: CoroutineScope) {
+        viewModelScope.launch(Dispatchers.IO) {
+            fetchingState.emit(LOADING_MORE)
+            val result = couponsDataSource.loadMore()
+            delay(500) // avoid UI flickering when there is no network connection
+            if (!result.isSuccess) {
+                fetchingState.emit(ERROR_LOADING_MORE)
+            } else {
+                fetchingState.emit(IDLE)
+            }
         }
     }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/items/coupons/WooPosCouponsListViewStateManager.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/items/coupons/WooPosCouponsListViewStateManager.kt
@@ -90,7 +90,7 @@ class WooPosCouponsListViewStateManager @Inject constructor(
                 delay(500) // avoid UI flickering when there is no network connection
                 fetchingState.emit(ERROR_LOADING_MORE)
             } else {
-                fetchingState.emit(IDLE)
+                // Do not emit IDLE here to avoid flickering UI, we'll hide loading more state when we ran out of items
             }
         }
     }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/items/coupons/WooPosCouponsListViewStateManager.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/items/coupons/WooPosCouponsListViewStateManager.kt
@@ -46,22 +46,27 @@ class WooPosCouponsListViewStateManager @Inject constructor(
     }
 
     private val contentFlow = couponsDataSource.couponsFlow.combine(fetchingState) { coupons, fetchingState ->
-        if (fetchingState == FETCHING_FIRST_PAGE) {
-            WooPosCouponsViewState.Loading()
-        } else if (fetchingState == ERROR_FETCHING_FIRST_PAGE) {
-            WooPosCouponsViewState.Error()
-        } else if (coupons.isEmpty()) {
-            return@combine if (fetchingState == IDLE) {
-                WooPosCouponsViewState.Empty()
-            } else {
+        when (fetchingState) {
+            FETCHING_FIRST_PAGE -> {
                 WooPosCouponsViewState.Loading()
             }
-        } else {
-            WooPosCouponsViewState.Content(
-                items = mapCouponsToSelectionState(coupons),
-                paginationState = getPaginationState(fetchingState),
-                pullToRefreshState = getPullToRefreshState(fetchingState)
-            )
+
+            ERROR_FETCHING_FIRST_PAGE -> {
+                WooPosCouponsViewState.Error()
+            }
+
+            IDLE, LOADING_MORE, ERROR_LOADING_MORE -> {
+                when {
+                    coupons.isEmpty() -> WooPosCouponsViewState.Empty()
+                    else -> {
+                        WooPosCouponsViewState.Content(
+                            items = mapCouponsToSelectionState(coupons),
+                            paginationState = getPaginationState(fetchingState),
+                            pullToRefreshState = getPullToRefreshState(fetchingState)
+                        )
+                    }
+                }
+            }
         }
     }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/items/coupons/WooPosCouponsListViewStateManager.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/items/coupons/WooPosCouponsListViewStateManager.kt
@@ -9,10 +9,10 @@ import com.woocommerce.android.ui.woopos.home.items.WooPosPaginationState.None
 import com.woocommerce.android.ui.woopos.home.items.WooPosPullToRefreshState.Enabled
 import com.woocommerce.android.ui.woopos.home.items.WooPosPullToRefreshState.Refreshing
 import com.woocommerce.android.ui.woopos.home.items.coupons.WooPosCouponsListViewStateManager.FetchingCouponsState.ERROR_FETCHING_FIRST_PAGE
-import com.woocommerce.android.ui.woopos.home.items.coupons.WooPosCouponsListViewStateManager.FetchingCouponsState.ERROR_LOADING_MORE
+import com.woocommerce.android.ui.woopos.home.items.coupons.WooPosCouponsListViewStateManager.FetchingCouponsState.ERROR_FETCHING_MORE
 import com.woocommerce.android.ui.woopos.home.items.coupons.WooPosCouponsListViewStateManager.FetchingCouponsState.FETCHING_FIRST_PAGE
+import com.woocommerce.android.ui.woopos.home.items.coupons.WooPosCouponsListViewStateManager.FetchingCouponsState.FETCHING_MORE
 import com.woocommerce.android.ui.woopos.home.items.coupons.WooPosCouponsListViewStateManager.FetchingCouponsState.IDLE
-import com.woocommerce.android.ui.woopos.home.items.coupons.WooPosCouponsListViewStateManager.FetchingCouponsState.LOADING_MORE
 import com.woocommerce.android.ui.woopos.util.GetCachedStoreCurrency
 import com.woocommerce.android.ui.woopos.util.format.WooPosFormatCouponSummary
 import kotlinx.coroutines.CoroutineDispatcher
@@ -42,7 +42,7 @@ class WooPosCouponsListViewStateManager @Inject constructor(
     private var canLoadMore: Boolean = false
 
     enum class FetchingCouponsState {
-        IDLE, LOADING_MORE, FETCHING_FIRST_PAGE, ERROR_LOADING_MORE, ERROR_FETCHING_FIRST_PAGE
+        IDLE, FETCHING_FIRST_PAGE, FETCHING_MORE, ERROR_FETCHING_FIRST_PAGE, ERROR_FETCHING_MORE
     }
 
     private val contentFlow = couponsDataSource.couponsFlow.combine(fetchingState) { coupons, fetchingState ->
@@ -55,7 +55,7 @@ class WooPosCouponsListViewStateManager @Inject constructor(
                 WooPosCouponsViewState.Error()
             }
 
-            IDLE, LOADING_MORE, ERROR_LOADING_MORE -> {
+            IDLE, FETCHING_MORE, ERROR_FETCHING_MORE -> {
                 when {
                     coupons.isEmpty() -> WooPosCouponsViewState.Empty()
                     else -> {
@@ -92,7 +92,7 @@ class WooPosCouponsListViewStateManager @Inject constructor(
     }
 
     fun endOfListReached(viewModelScope: CoroutineScope) {
-        if (fetchingState.value == ERROR_LOADING_MORE) return
+        if (fetchingState.value == ERROR_FETCHING_MORE) return
 
         fetchingFirstPageJob?.invokeOnCompletion {
             retryLoadMore(viewModelScope)
@@ -105,11 +105,11 @@ class WooPosCouponsListViewStateManager @Inject constructor(
         }
 
         loadingMoreJob = viewModelScope.launch(dispatcher) {
-            fetchingState.emit(LOADING_MORE)
+            fetchingState.emit(FETCHING_MORE)
             val result = couponsDataSource.loadMore()
             if (!result.isSuccess) {
                 delay(AVOID_UI_FLICKERING_DELAY)
-                fetchingState.emit(ERROR_LOADING_MORE)
+                fetchingState.emit(ERROR_FETCHING_MORE)
             } else {
                 canLoadMore = result.getOrNull() ?: false
                 fetchingState.emit(IDLE)
@@ -129,14 +129,14 @@ class WooPosCouponsListViewStateManager @Inject constructor(
 
     private fun getPaginationState(fetchingState: FetchingCouponsState) =
         when (fetchingState) {
-            IDLE, FETCHING_FIRST_PAGE, LOADING_MORE -> if (canLoadMore) Loading else None
-            ERROR_LOADING_MORE -> Error
+            IDLE, FETCHING_FIRST_PAGE, FETCHING_MORE -> if (canLoadMore) Loading else None
+            ERROR_FETCHING_MORE -> Error
             ERROR_FETCHING_FIRST_PAGE -> error("Full screen error should be displayed")
         }
 
     private fun getPullToRefreshState(fetchingState: FetchingCouponsState) =
         when (fetchingState) {
-            ERROR_LOADING_MORE, IDLE, LOADING_MORE -> Enabled
+            ERROR_FETCHING_MORE, IDLE, FETCHING_MORE -> Enabled
             FETCHING_FIRST_PAGE -> Refreshing
             ERROR_FETCHING_FIRST_PAGE -> error("Full screen error should be displayed")
         }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/items/coupons/WooPosCouponsListViewStateManager.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/items/coupons/WooPosCouponsListViewStateManager.kt
@@ -19,6 +19,7 @@ import com.woocommerce.android.ui.woopos.util.format.WooPosFormatCouponSummary
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
+import kotlinx.coroutines.cancelAndJoin
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -35,6 +36,7 @@ class WooPosCouponsListViewStateManager @Inject constructor(
 
     private var loadingMoreJob: Job? = null
     private var fetchingFirstPageJob: Job? = null
+    private var canLoadMore: Boolean = false
 
     enum class FetchingCouponsState {
         IDLE, LOADING_MORE, FETCHING_FIRST_PAGE, ERROR_LOADING_MORE, ERROR_FETCHING_FIRST_PAGE
@@ -63,34 +65,40 @@ class WooPosCouponsListViewStateManager @Inject constructor(
     val viewState: Flow<WooPosCouponsViewState> = contentFlow
 
     fun fetchCoupons(viewModelScope: CoroutineScope) {
-        if(fetchingFirstPageJob?.isActive == true) {
+        if (fetchingFirstPageJob?.isActive == true) {
             return
         }
-        loadingMoreJob?.cancel()
+
         fetchingFirstPageJob = viewModelScope.launch(Dispatchers.IO) {
+            loadingMoreJob?.cancelAndJoin()
             fetchingState.emit(FETCHING_FIRST_PAGE)
             val result = couponsDataSource.clearCacheAndFetchFirstPage()
             if (!result.isSuccess) {
                 delay(500) // avoid UI flickering when there is no network connection
                 fetchingState.emit(ERROR_FETCHING_FIRST_PAGE)
             } else {
+                canLoadMore = result.getOrNull() ?: false
                 fetchingState.emit(IDLE)
             }
         }
     }
 
     fun loadMore(viewModelScope: CoroutineScope) {
-        if (loadingMoreJob?.isActive == true) {
+        if (!canLoadMore || loadingMoreJob?.isActive == true) {
             return
         }
         loadingMoreJob = viewModelScope.launch(Dispatchers.IO) {
+            fetchingFirstPageJob?.join()
             fetchingState.emit(LOADING_MORE)
             val result = couponsDataSource.loadMore()
             if (!result.isSuccess) {
                 delay(500) // avoid UI flickering when there is no network connection
                 fetchingState.emit(ERROR_LOADING_MORE)
             } else {
-                // Do not emit IDLE here to avoid flickering UI, we'll hide loading more state when we ran out of items
+                canLoadMore = result.getOrNull() ?: false
+                if (!canLoadMore) {
+                    fetchingState.emit(IDLE)
+                }
             }
         }
     }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/items/coupons/WooPosCouponsListViewStateManager.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/items/coupons/WooPosCouponsListViewStateManager.kt
@@ -57,8 +57,8 @@ class WooPosCouponsListViewStateManager @Inject constructor(
             } else {
                 WooPosCouponsViewState.Content(
                     items = mapCouponsToSelectionState(coupons),
-                    paginationState = mapFetchingStateToPaginationState(fetchingState),
-                    pullToRefreshState = mapFetchingStateToPTRState(fetchingState)
+                    paginationState = getPaginationState(fetchingState),
+                    pullToRefreshState = getPullToRefreshState(fetchingState)
                 )
             }
         }
@@ -118,18 +118,19 @@ class WooPosCouponsListViewStateManager @Inject constructor(
         )
     }
 
-    private fun mapFetchingStateToPaginationState(fetchingState: FetchingCouponsState) =
+    private fun getPaginationState(fetchingState: FetchingCouponsState) =
         when (fetchingState) {
             IDLE, FETCHING_FIRST_PAGE, LOADING_MORE -> if (canLoadMore) Loading else None
             ERROR_LOADING_MORE -> Error
             ERROR_FETCHING_FIRST_PAGE -> error("Full screen error should be displayed")
         }
 
-    private fun mapFetchingStateToPTRState(fetchingState: FetchingCouponsState) =
+    private fun getPullToRefreshState(fetchingState: FetchingCouponsState) =
         when (fetchingState) {
-            ERROR_LOADING_MORE, IDLE, ERROR_FETCHING_FIRST_PAGE -> Enabled
+            ERROR_LOADING_MORE, IDLE -> Enabled
             // We might need to keep this enabled and cancel the loadMore job when PTR starts.
             LOADING_MORE -> Disabled
             FETCHING_FIRST_PAGE -> Refreshing
+            ERROR_FETCHING_FIRST_PAGE -> error("Full screen error should be displayed")
         }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/items/coupons/WooPosCouponsListViewStateManager.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/items/coupons/WooPosCouponsListViewStateManager.kt
@@ -89,15 +89,18 @@ class WooPosCouponsListViewStateManager @Inject constructor(
 
     fun endOfListReached(viewModelScope: CoroutineScope) {
         if (fetchingState.value == ERROR_LOADING_MORE) return
-        retryLoadMore(viewModelScope)
+
+        fetchingFirstPageJob?.invokeOnCompletion {
+            retryLoadMore(viewModelScope)
+        } ?: retryLoadMore(viewModelScope)
     }
 
     fun retryLoadMore(viewModelScope: CoroutineScope) {
-        if (!canLoadMore || loadingMoreJob?.isActive == true) {
+        if (!canLoadMore || loadingMoreJob?.isActive == true || fetchingFirstPageJob?.isActive == true) {
             return
         }
+
         loadingMoreJob = viewModelScope.launch(dispatcher) {
-            fetchingFirstPageJob?.join()
             fetchingState.emit(LOADING_MORE)
             val result = couponsDataSource.loadMore()
             if (!result.isSuccess) {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/items/coupons/WooPosCouponsListViewStateManager.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/items/coupons/WooPosCouponsListViewStateManager.kt
@@ -43,7 +43,9 @@ class WooPosCouponsListViewStateManager @Inject constructor(
     }
 
     private val contentFlow = couponsDataSource.couponsFlow.combine(fetchingState) { coupons, fetchingState ->
-        if (coupons.isEmpty()) {
+        if (fetchingState == FETCHING_FIRST_PAGE) {
+            WooPosCouponsViewState.Loading()
+        } else if (coupons.isEmpty()) {
             return@combine if (fetchingState == IDLE) {
                 WooPosCouponsViewState.Empty()
             } else {
@@ -83,6 +85,11 @@ class WooPosCouponsListViewStateManager @Inject constructor(
         }
     }
 
+    fun endOfListReached(viewModelScope: CoroutineScope) {
+        if (fetchingState.value == ERROR_LOADING_MORE) return
+        loadMore(viewModelScope)
+    }
+
     fun loadMore(viewModelScope: CoroutineScope) {
         if (!canLoadMore || loadingMoreJob?.isActive == true) {
             return
@@ -96,9 +103,7 @@ class WooPosCouponsListViewStateManager @Inject constructor(
                 fetchingState.emit(ERROR_LOADING_MORE)
             } else {
                 canLoadMore = result.getOrNull() ?: false
-                if (!canLoadMore) {
-                    fetchingState.emit(IDLE)
-                }
+                fetchingState.emit(IDLE)
             }
         }
     }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/items/coupons/WooPosCouponsListViewStateManager.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/items/coupons/WooPosCouponsListViewStateManager.kt
@@ -6,7 +6,6 @@ import com.woocommerce.android.ui.woopos.home.items.WooPosItemSelectionViewState
 import com.woocommerce.android.ui.woopos.home.items.WooPosPaginationState.Error
 import com.woocommerce.android.ui.woopos.home.items.WooPosPaginationState.Loading
 import com.woocommerce.android.ui.woopos.home.items.WooPosPaginationState.None
-import com.woocommerce.android.ui.woopos.home.items.WooPosPullToRefreshState.Disabled
 import com.woocommerce.android.ui.woopos.home.items.WooPosPullToRefreshState.Enabled
 import com.woocommerce.android.ui.woopos.home.items.WooPosPullToRefreshState.Refreshing
 import com.woocommerce.android.ui.woopos.home.items.coupons.WooPosCouponsListViewStateManager.FetchingCouponsState.ERROR_FETCHING_FIRST_PAGE
@@ -132,9 +131,7 @@ class WooPosCouponsListViewStateManager @Inject constructor(
 
     private fun getPullToRefreshState(fetchingState: FetchingCouponsState) =
         when (fetchingState) {
-            ERROR_LOADING_MORE, IDLE -> Enabled
-            // We might need to keep this enabled and cancel the loadMore job when PTR starts.
-            LOADING_MORE -> Disabled
+            ERROR_LOADING_MORE, IDLE, LOADING_MORE -> Enabled
             FETCHING_FIRST_PAGE -> Refreshing
             ERROR_FETCHING_FIRST_PAGE -> error("Full screen error should be displayed")
         }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/items/coupons/WooPosCouponsListViewStateManager.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/items/coupons/WooPosCouponsListViewStateManager.kt
@@ -1,21 +1,26 @@
 package com.woocommerce.android.ui.woopos.home.items.coupons
 
+import com.woocommerce.android.model.Coupon
 import com.woocommerce.android.ui.woopos.home.items.WooPosCouponsViewState
 import com.woocommerce.android.ui.woopos.home.items.WooPosItemSelectionViewState
-import com.woocommerce.android.ui.woopos.home.items.WooPosPaginationState
-import com.woocommerce.android.ui.woopos.home.items.WooPosPullToRefreshState
-import com.woocommerce.android.ui.woopos.home.items.coupons.WooPosCouponsDataSource.FetchingCouponsState.FETCHING_FIRST_PAGE
-import com.woocommerce.android.ui.woopos.home.items.coupons.WooPosCouponsDataSource.FetchingCouponsState.IDLE
-import com.woocommerce.android.ui.woopos.home.items.coupons.WooPosCouponsDataSource.FetchingCouponsState.LOADING_MORE
+import com.woocommerce.android.ui.woopos.home.items.WooPosPaginationState.Error
+import com.woocommerce.android.ui.woopos.home.items.WooPosPaginationState.Loading
+import com.woocommerce.android.ui.woopos.home.items.WooPosPaginationState.None
+import com.woocommerce.android.ui.woopos.home.items.WooPosPullToRefreshState.Disabled
+import com.woocommerce.android.ui.woopos.home.items.WooPosPullToRefreshState.Enabled
+import com.woocommerce.android.ui.woopos.home.items.WooPosPullToRefreshState.Refreshing
+import com.woocommerce.android.ui.woopos.home.items.coupons.WooPosCouponsListViewStateManager.FetchingCouponsState.ERROR_FETCHING_FIRST_PAGE
+import com.woocommerce.android.ui.woopos.home.items.coupons.WooPosCouponsListViewStateManager.FetchingCouponsState.ERROR_LOADING_MORE
+import com.woocommerce.android.ui.woopos.home.items.coupons.WooPosCouponsListViewStateManager.FetchingCouponsState.FETCHING_FIRST_PAGE
+import com.woocommerce.android.ui.woopos.home.items.coupons.WooPosCouponsListViewStateManager.FetchingCouponsState.IDLE
+import com.woocommerce.android.ui.woopos.home.items.coupons.WooPosCouponsListViewStateManager.FetchingCouponsState.LOADING_MORE
 import com.woocommerce.android.ui.woopos.util.GetCachedStoreCurrency
 import com.woocommerce.android.ui.woopos.util.format.WooPosFormatCouponSummary
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.Flow
-import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.combine
-import kotlinx.coroutines.flow.merge
 import kotlinx.coroutines.flow.onStart
-import kotlinx.coroutines.flow.scan
 import javax.inject.Inject
 
 class WooPosCouponsListViewStateManager @Inject constructor(
@@ -23,83 +28,80 @@ class WooPosCouponsListViewStateManager @Inject constructor(
     private val formatCouponSummary: WooPosFormatCouponSummary,
     private val getCachedStoreCurrency: GetCachedStoreCurrency,
 ) {
-    private val errorStates = MutableSharedFlow<CouponsErrorEvent>()
+    private val fetchingState: MutableStateFlow<FetchingCouponsState> = MutableStateFlow(IDLE)
 
-    private val contentFlow =
-        couponsDataSource.couponsFlow.combine(couponsDataSource.fetchingState) { coupons, fetchingState ->
-            if (coupons.isEmpty()) {
-                if (fetchingState == IDLE) WooPosCouponsViewState.Empty()
-                else WooPosCouponsViewState.Loading()
-            } else {
-                WooPosCouponsViewState.Content(
-                    items = coupons.map { coupon ->
-                        WooPosItemSelectionViewState.Coupon(
-                            id = coupon.id,
-                            name = coupon.code.orEmpty(),
-                            summary = formatCouponSummary(coupon, getCachedStoreCurrency())
-                        )
-                    }, paginationState = when (fetchingState) {
-                        IDLE, FETCHING_FIRST_PAGE -> WooPosPaginationState.None
-                        LOADING_MORE -> WooPosPaginationState.Loading
-                    }, pullToRefreshState = when (fetchingState) {
-                        IDLE -> WooPosPullToRefreshState.Enabled
-                        // We might need to keep this enabled and cancel the loadMore job when PTR starts.
-                        LOADING_MORE -> WooPosPullToRefreshState.Disabled
-                        FETCHING_FIRST_PAGE -> WooPosPullToRefreshState.Refreshing
-                    }
-                )
-            }
-        }.onStart {
-            // initial load
-            val result = couponsDataSource.clearCacheAndFetchFirstPage()
-            if (!result.isSuccess) {
-                // emit an Error state if first‐page fails
-                errorStates.emit(CouponsErrorEvent.FullScreen)
-            }
-        }
-
-    val viewState: Flow<WooPosCouponsViewState> = merge(
-        contentFlow,
-        errorStates
-    ).scan(WooPosCouponsViewState.Loading() as WooPosCouponsViewState) { previousState, newState ->
-        when (newState) {
-            CouponsErrorEvent.FullScreen -> {
-                WooPosCouponsViewState.Error()
-            }
-
-            CouponsErrorEvent.Pagination -> {
-                if (previousState is WooPosCouponsViewState.Content) {
-                    previousState.copy(paginationState = WooPosPaginationState.Error)
-                } else {
-                    WooPosCouponsViewState.Error()
-                }
-            }
-
-            is WooPosCouponsViewState.Content -> newState
-            is WooPosCouponsViewState.Error -> newState
-            is WooPosCouponsViewState.Loading -> newState
-            is WooPosCouponsViewState.Empty -> newState
-            else -> error("Unknown state: $newState")
-        }
+    enum class FetchingCouponsState {
+        IDLE, LOADING_MORE, FETCHING_FIRST_PAGE, ERROR_LOADING_MORE, ERROR_FETCHING_FIRST_PAGE
     }
 
+    private val contentFlow = couponsDataSource.couponsFlow.combine(fetchingState) { coupons, fetchingState ->
+        if (coupons.isEmpty()) {
+            return@combine if (fetchingState == IDLE) {
+                WooPosCouponsViewState.Empty()
+            } else {
+                WooPosCouponsViewState.Loading()
+            }
+        } else {
+            return@combine if (fetchingState == ERROR_FETCHING_FIRST_PAGE) {
+                WooPosCouponsViewState.Error()
+            } else {
+                WooPosCouponsViewState.Content(
+                    items = mapCouponsToSelectionState(coupons),
+                    paginationState = mapFetchingStateToPaginationState(fetchingState),
+                    pullToRefreshState = mapFetchingStateToPTRState(fetchingState)
+                )
+            }
+        }
+    }.onStart {
+        fetchCoupons()
+    }
+
+    val viewState: Flow<WooPosCouponsViewState> = contentFlow
+
     suspend fun fetchCoupons() {
+        fetchingState.emit(FETCHING_FIRST_PAGE)
         val result = couponsDataSource.clearCacheAndFetchFirstPage()
+        delay(500) // avoid UI flickering when there is no network connection
         if (!result.isSuccess) {
-            delay(500) // avoid UI flickering when there is no network connection
-            errorStates.emit(CouponsErrorEvent.FullScreen)
+            fetchingState.emit(ERROR_FETCHING_FIRST_PAGE)
+        } else {
+            fetchingState.emit(IDLE)
         }
     }
 
     suspend fun loadMore() {
+        fetchingState.emit(LOADING_MORE)
         val result = couponsDataSource.loadMore()
+        delay(500) // avoid UI flickering when there is no network connection
         if (!result.isSuccess) {
-            delay(500) // avoid UI flickering when there is no network connection
-            errorStates.emit(CouponsErrorEvent.Pagination)
+            fetchingState.emit(ERROR_LOADING_MORE)
+        } else {
+            fetchingState.emit(IDLE)
         }
     }
 
-    private enum class CouponsErrorEvent {
-        FullScreen, Pagination
+    private suspend fun WooPosCouponsListViewStateManager.mapCouponsToSelectionState(
+        coupons: List<Coupon>
+    ) = coupons.map { coupon ->
+        WooPosItemSelectionViewState.Coupon(
+            id = coupon.id,
+            name = coupon.code.orEmpty(),
+            summary = formatCouponSummary(coupon, getCachedStoreCurrency())
+        )
     }
+
+    private fun mapFetchingStateToPaginationState(fetchingState: FetchingCouponsState) =
+        when (fetchingState) {
+            IDLE, FETCHING_FIRST_PAGE, ERROR_FETCHING_FIRST_PAGE -> None
+            LOADING_MORE -> Loading
+            ERROR_LOADING_MORE -> Error
+        }
+
+    private fun mapFetchingStateToPTRState(fetchingState: FetchingCouponsState) =
+        when (fetchingState) {
+            ERROR_LOADING_MORE, IDLE, ERROR_FETCHING_FIRST_PAGE -> Enabled
+            // We might need to keep this enabled and cancel the loadMore job when PTR starts.
+            LOADING_MORE -> Disabled
+            FETCHING_FIRST_PAGE -> Refreshing
+        }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/items/coupons/WooPosCouponsListViewStateManager.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/items/coupons/WooPosCouponsListViewStateManager.kt
@@ -16,6 +16,7 @@ import com.woocommerce.android.ui.woopos.home.items.coupons.WooPosCouponsListVie
 import com.woocommerce.android.ui.woopos.home.items.coupons.WooPosCouponsListViewStateManager.FetchingCouponsState.LOADING_MORE
 import com.woocommerce.android.ui.woopos.util.GetCachedStoreCurrency
 import com.woocommerce.android.ui.woopos.util.format.WooPosFormatCouponSummary
+import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
@@ -27,10 +28,13 @@ import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.launch
 import javax.inject.Inject
 
+private const val AVOID_UI_FLICKERING_DELAY = 500L
+
 class WooPosCouponsListViewStateManager @Inject constructor(
     private val couponsDataSource: WooPosCouponsDataSource,
     private val formatCouponSummary: WooPosFormatCouponSummary,
     private val getCachedStoreCurrency: GetCachedStoreCurrency,
+    private val dispatcher: CoroutineDispatcher = Dispatchers.IO
 ) {
     private val fetchingState: MutableStateFlow<FetchingCouponsState> = MutableStateFlow(IDLE)
 
@@ -45,6 +49,8 @@ class WooPosCouponsListViewStateManager @Inject constructor(
     private val contentFlow = couponsDataSource.couponsFlow.combine(fetchingState) { coupons, fetchingState ->
         if (fetchingState == FETCHING_FIRST_PAGE) {
             WooPosCouponsViewState.Loading()
+        } else if (fetchingState == ERROR_FETCHING_FIRST_PAGE) {
+            WooPosCouponsViewState.Error()
         } else if (coupons.isEmpty()) {
             return@combine if (fetchingState == IDLE) {
                 WooPosCouponsViewState.Empty()
@@ -52,15 +58,11 @@ class WooPosCouponsListViewStateManager @Inject constructor(
                 WooPosCouponsViewState.Loading()
             }
         } else {
-            return@combine if (fetchingState == ERROR_FETCHING_FIRST_PAGE) {
-                WooPosCouponsViewState.Error()
-            } else {
-                WooPosCouponsViewState.Content(
-                    items = mapCouponsToSelectionState(coupons),
-                    paginationState = getPaginationState(fetchingState),
-                    pullToRefreshState = getPullToRefreshState(fetchingState)
-                )
-            }
+            WooPosCouponsViewState.Content(
+                items = mapCouponsToSelectionState(coupons),
+                paginationState = getPaginationState(fetchingState),
+                pullToRefreshState = getPullToRefreshState(fetchingState)
+            )
         }
     }
 
@@ -71,35 +73,35 @@ class WooPosCouponsListViewStateManager @Inject constructor(
             return
         }
 
-        fetchingFirstPageJob = viewModelScope.launch(Dispatchers.IO) {
+        fetchingFirstPageJob = viewModelScope.launch(dispatcher) {
             loadingMoreJob?.cancelAndJoin()
             fetchingState.emit(FETCHING_FIRST_PAGE)
             val result = couponsDataSource.clearCacheAndFetchFirstPage()
-            if (!result.isSuccess) {
-                delay(500) // avoid UI flickering when there is no network connection
-                fetchingState.emit(ERROR_FETCHING_FIRST_PAGE)
-            } else {
+            if (result.isSuccess) {
                 canLoadMore = result.getOrNull() ?: false
                 fetchingState.emit(IDLE)
+            } else {
+                delay(AVOID_UI_FLICKERING_DELAY)
+                fetchingState.emit(ERROR_FETCHING_FIRST_PAGE)
             }
         }
     }
 
     fun endOfListReached(viewModelScope: CoroutineScope) {
         if (fetchingState.value == ERROR_LOADING_MORE) return
-        loadMore(viewModelScope)
+        retryLoadMore(viewModelScope)
     }
 
-    fun loadMore(viewModelScope: CoroutineScope) {
+    fun retryLoadMore(viewModelScope: CoroutineScope) {
         if (!canLoadMore || loadingMoreJob?.isActive == true) {
             return
         }
-        loadingMoreJob = viewModelScope.launch(Dispatchers.IO) {
+        loadingMoreJob = viewModelScope.launch(dispatcher) {
             fetchingFirstPageJob?.join()
             fetchingState.emit(LOADING_MORE)
             val result = couponsDataSource.loadMore()
             if (!result.isSuccess) {
-                delay(500) // avoid UI flickering when there is no network connection
+                delay(AVOID_UI_FLICKERING_DELAY)
                 fetchingState.emit(ERROR_LOADING_MORE)
             } else {
                 canLoadMore = result.getOrNull() ?: false

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/items/coupons/WooPosCouponsListViewStateManager.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/items/coupons/WooPosCouponsListViewStateManager.kt
@@ -1,73 +1,105 @@
 package com.woocommerce.android.ui.woopos.home.items.coupons
 
 import com.woocommerce.android.ui.woopos.home.items.WooPosCouponsViewState
-import com.woocommerce.android.ui.woopos.home.items.WooPosCouponsViewState.Content
 import com.woocommerce.android.ui.woopos.home.items.WooPosItemSelectionViewState
 import com.woocommerce.android.ui.woopos.home.items.WooPosPaginationState
-import com.woocommerce.android.ui.woopos.home.items.WooPosPaginationState.None
-import com.woocommerce.android.ui.woopos.home.items.WooPosPullToRefreshState.Enabled
+import com.woocommerce.android.ui.woopos.home.items.WooPosPullToRefreshState
+import com.woocommerce.android.ui.woopos.home.items.coupons.WooPosCouponsDataSource.FetchingCouponsState.FETCHING_FIRST_PAGE
+import com.woocommerce.android.ui.woopos.home.items.coupons.WooPosCouponsDataSource.FetchingCouponsState.IDLE
+import com.woocommerce.android.ui.woopos.home.items.coupons.WooPosCouponsDataSource.FetchingCouponsState.LOADING_MORE
+import com.woocommerce.android.ui.woopos.util.GetCachedStoreCurrency
+import com.woocommerce.android.ui.woopos.util.format.WooPosFormatCouponSummary
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.Flow
-import kotlinx.coroutines.flow.flow
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.flow.merge
+import kotlinx.coroutines.flow.onStart
+import kotlinx.coroutines.flow.scan
 import javax.inject.Inject
 
-class WooPosCouponsListViewStateManager @Inject constructor() {
-    val viewState: Flow<WooPosCouponsViewState> = flow {
-        while (true) {
-            emit(WooPosCouponsViewState.Loading())
-            delay(3000)
-            emit(WooPosCouponsViewState.Empty())
-            delay(3000)
-            emit(WooPosCouponsViewState.Error())
-            delay(3000)
-            emit(
-                Content(
-                    items = listOf(
+class WooPosCouponsListViewStateManager @Inject constructor(
+    private val couponsDataSource: WooPosCouponsDataSource,
+    private val formatCouponSummary: WooPosFormatCouponSummary,
+    private val getCachedStoreCurrency: GetCachedStoreCurrency,
+) {
+    private val errorStates = MutableSharedFlow<CouponsErrorEvent>()
+
+    private val contentFlow =
+        couponsDataSource.couponsFlow.combine(couponsDataSource.fetchingState) { coupons, fetchingState ->
+            if (coupons.isEmpty()) {
+                if (fetchingState == IDLE) WooPosCouponsViewState.Empty()
+                else WooPosCouponsViewState.Loading()
+            } else {
+                WooPosCouponsViewState.Content(
+                    items = coupons.map { coupon ->
                         WooPosItemSelectionViewState.Coupon(
-                            id = 1,
-                            name = "Coupon 1",
-                            summary = "10% off everything",
-                        ),
-                    ),
-                    paginationState = None,
-                    pullToRefreshState = Enabled,
+                            id = coupon.id,
+                            name = coupon.code.orEmpty(),
+                            summary = formatCouponSummary(coupon, getCachedStoreCurrency())
+                        )
+                    }, paginationState = when (fetchingState) {
+                        IDLE, FETCHING_FIRST_PAGE -> WooPosPaginationState.None
+                        LOADING_MORE -> WooPosPaginationState.Loading
+                    }, pullToRefreshState = when (fetchingState) {
+                        IDLE -> WooPosPullToRefreshState.Enabled
+                        // We might need to keep this enabled and cancel the loadMore job when PTR starts.
+                        LOADING_MORE -> WooPosPullToRefreshState.Disabled
+                        FETCHING_FIRST_PAGE -> WooPosPullToRefreshState.Refreshing
+                    }
                 )
-            )
-            delay(3000)
-            emit(
-                Content(
-                    items = listOf(
-                        WooPosItemSelectionViewState.Coupon(
-                            id = 1,
-                            name = "Coupon 1",
-                            summary = "10% off everything",
-                        ),
-                    ),
-                    paginationState = WooPosPaginationState.Loading,
-                    pullToRefreshState = Enabled,
-                )
-            )
-            delay(3000)
-            emit(
-                Content(
-                    items = listOf(
-                        WooPosItemSelectionViewState.Coupon(
-                            id = 1,
-                            name = "Coupon 1",
-                            summary = "10% off everything",
-                        ),
-                    ),
-                    paginationState = WooPosPaginationState.Error,
-                    pullToRefreshState = Enabled,
-                )
-            )
-            delay(3000)
+            }
+        }.onStart {
+            // initial load
+            val result = couponsDataSource.clearCacheAndFetchFirstPage()
+            if (!result.isSuccess) {
+                // emit an Error state if first‐page fails
+                errorStates.emit(CouponsErrorEvent.FullScreen)
+            }
+        }
+
+    val viewState: Flow<WooPosCouponsViewState> = merge(
+        contentFlow,
+        errorStates
+    ).scan(WooPosCouponsViewState.Loading() as WooPosCouponsViewState) { previousState, newState ->
+        when (newState) {
+            CouponsErrorEvent.FullScreen -> {
+                WooPosCouponsViewState.Error()
+            }
+
+            CouponsErrorEvent.Pagination -> {
+                if (previousState is WooPosCouponsViewState.Content) {
+                    previousState.copy(paginationState = WooPosPaginationState.Error)
+                } else {
+                    WooPosCouponsViewState.Error()
+                }
+            }
+
+            is WooPosCouponsViewState.Content -> newState
+            is WooPosCouponsViewState.Error -> newState
+            is WooPosCouponsViewState.Loading -> newState
+            is WooPosCouponsViewState.Empty -> newState
+            else -> error("Unknown state: $newState")
         }
     }
 
-    fun fetchCoupons() {
+    suspend fun fetchCoupons() {
+        val result = couponsDataSource.clearCacheAndFetchFirstPage()
+        if (!result.isSuccess) {
+            delay(500) // avoid UI flickering when there is no network connection
+            errorStates.emit(CouponsErrorEvent.FullScreen)
+        }
     }
 
-    fun loadMore() {
+    suspend fun loadMore() {
+        val result = couponsDataSource.loadMore()
+        if (!result.isSuccess) {
+            delay(500) // avoid UI flickering when there is no network connection
+            errorStates.emit(CouponsErrorEvent.Pagination)
+        }
+    }
+
+    private enum class CouponsErrorEvent {
+        FullScreen, Pagination
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/items/coupons/WooPosCouponsListViewStateManager.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/items/coupons/WooPosCouponsListViewStateManager.kt
@@ -76,7 +76,7 @@ class WooPosCouponsListViewStateManager @Inject constructor(
         if (!result.isSuccess) {
             fetchingState.emit(ERROR_LOADING_MORE)
         } else {
-            fetchingState.emit(IDLE)
+//            fetchingState.emit(IDLE)
         }
     }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/items/coupons/WooPosCouponsListViewStateManager.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/items/coupons/WooPosCouponsListViewStateManager.kt
@@ -18,6 +18,7 @@ import com.woocommerce.android.ui.woopos.util.GetCachedStoreCurrency
 import com.woocommerce.android.ui.woopos.util.format.WooPosFormatCouponSummary
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.Job
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -31,6 +32,9 @@ class WooPosCouponsListViewStateManager @Inject constructor(
     private val getCachedStoreCurrency: GetCachedStoreCurrency,
 ) {
     private val fetchingState: MutableStateFlow<FetchingCouponsState> = MutableStateFlow(IDLE)
+
+    private var loadingMoreJob: Job? = null
+    private var fetchingFirstPageJob: Job? = null
 
     enum class FetchingCouponsState {
         IDLE, LOADING_MORE, FETCHING_FIRST_PAGE, ERROR_LOADING_MORE, ERROR_FETCHING_FIRST_PAGE
@@ -59,7 +63,11 @@ class WooPosCouponsListViewStateManager @Inject constructor(
     val viewState: Flow<WooPosCouponsViewState> = contentFlow
 
     fun fetchCoupons(viewModelScope: CoroutineScope) {
-        viewModelScope.launch(Dispatchers.IO) {
+        if(fetchingFirstPageJob?.isActive == true) {
+            return
+        }
+        loadingMoreJob?.cancel()
+        fetchingFirstPageJob = viewModelScope.launch(Dispatchers.IO) {
             fetchingState.emit(FETCHING_FIRST_PAGE)
             val result = couponsDataSource.clearCacheAndFetchFirstPage()
             if (!result.isSuccess) {
@@ -72,7 +80,10 @@ class WooPosCouponsListViewStateManager @Inject constructor(
     }
 
     fun loadMore(viewModelScope: CoroutineScope) {
-        viewModelScope.launch(Dispatchers.IO) {
+        if (loadingMoreJob?.isActive == true) {
+            return
+        }
+        loadingMoreJob = viewModelScope.launch(Dispatchers.IO) {
             fetchingState.emit(LOADING_MORE)
             val result = couponsDataSource.loadMore()
             if (!result.isSuccess) {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/items/coupons/WooPosCouponsViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/items/coupons/WooPosCouponsViewModel.kt
@@ -81,7 +81,7 @@ class WooPosCouponsViewModel @Inject constructor(
     }
 
     private fun retryLoadMore() {
-        listViewStateManager.loadMore(viewModelScope)
+        listViewStateManager.retryLoadMore(viewModelScope)
     }
 
     private fun navigateBackToItemListScreen() {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/items/coupons/WooPosCouponsViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/items/coupons/WooPosCouponsViewModel.kt
@@ -6,7 +6,6 @@ import com.woocommerce.android.ui.woopos.home.ChildToParentEvent
 import com.woocommerce.android.ui.woopos.home.WooPosChildrenToParentEventSender
 import com.woocommerce.android.ui.woopos.home.items.WooPosCouponsViewState
 import com.woocommerce.android.ui.woopos.home.items.WooPosItemsViewModel.ItemClickedData
-import com.woocommerce.android.ui.woopos.home.items.WooPosPaginationState
 import com.woocommerce.android.ui.woopos.home.items.coupons.WooPosCouponsUIEvent.BackButtonClicked
 import com.woocommerce.android.ui.woopos.home.items.coupons.WooPosCouponsUIEvent.CouponClicked
 import com.woocommerce.android.ui.woopos.home.items.coupons.WooPosCouponsUIEvent.EndOfListReached
@@ -46,6 +45,8 @@ class WooPosCouponsViewModel @Inject constructor(
                 _viewState.value = newState
             }
         }
+
+        listViewStateManager.fetchCoupons(viewModelScope)
     }
 
     fun onUIEvent(event: WooPosCouponsUIEvent) {
@@ -73,25 +74,16 @@ class WooPosCouponsViewModel @Inject constructor(
     }
 
     private fun fetchCoupons() {
-        viewModelScope.launch(Dispatchers.IO) {
-            listViewStateManager.fetchCoupons()
-        }
+        listViewStateManager.fetchCoupons(viewModelScope)
     }
 
     private fun onEndOfListReached() {
-        viewModelScope.launch(Dispatchers.IO) {
-            val currentState = _viewState.value
-            if (currentState is WooPosCouponsViewState.Content
-                && currentState.paginationState == WooPosPaginationState.None
-            ) {
-                listViewStateManager.loadMore()
-            }
-        }
+        listViewStateManager.loadMore(viewModelScope)
     }
 
     private fun retryLoadMore() {
         viewModelScope.launch(Dispatchers.IO) {
-            listViewStateManager.loadMore()
+            listViewStateManager.loadMore(viewModelScope)
         }
     }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/items/coupons/WooPosCouponsViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/items/coupons/WooPosCouponsViewModel.kt
@@ -15,7 +15,6 @@ import com.woocommerce.android.ui.woopos.home.items.coupons.WooPosCouponsUIEvent
 import com.woocommerce.android.ui.woopos.home.items.navigation.WooPosItemsNavigator
 import com.woocommerce.android.ui.woopos.home.items.navigation.WooPosItemsNavigator.WooPosItemsScreenNavigationEvent
 import dagger.hilt.android.lifecycle.HiltViewModel
-import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
@@ -78,13 +77,11 @@ class WooPosCouponsViewModel @Inject constructor(
     }
 
     private fun onEndOfListReached() {
-        listViewStateManager.loadMore(viewModelScope)
+        listViewStateManager.endOfListReached(viewModelScope)
     }
 
     private fun retryLoadMore() {
-        viewModelScope.launch(Dispatchers.IO) {
-            listViewStateManager.loadMore(viewModelScope)
-        }
+        listViewStateManager.loadMore(viewModelScope)
     }
 
     private fun navigateBackToItemListScreen() {

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/coupons/CouponsListViewModelTests.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/coupons/CouponsListViewModelTests.kt
@@ -75,7 +75,7 @@ class CouponsListViewModelTests : BaseUnitTest() {
         setup {
             whenever(couponListHandler.fetchCoupons(null, true)).doSuspendableAnswer {
                 delay(1L)
-                return@doSuspendableAnswer Result.success(Unit)
+                return@doSuspendableAnswer Result.success(true)
             }
         }
 

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/coupons/selector/CouponSelectorViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/coupons/selector/CouponSelectorViewModelTest.kt
@@ -64,7 +64,7 @@ class CouponSelectorViewModelTest : BaseUnitTest() {
         setup {
             whenever(couponListHandler.fetchCoupons(forceRefresh = true)).doSuspendableAnswer {
                 delay(1L)
-                return@doSuspendableAnswer Result.success(Unit)
+                return@doSuspendableAnswer Result.success(false)
             }
         }
 

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/home/items/coupons/WooPosCouponsListViewStateManagerTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/home/items/coupons/WooPosCouponsListViewStateManagerTest.kt
@@ -1,0 +1,97 @@
+package com.woocommerce.android.ui.woopos.home.items.coupons
+
+import com.woocommerce.android.ui.woopos.home.items.WooPosCouponsViewState
+import com.woocommerce.android.ui.woopos.util.GetCachedStoreCurrency
+import com.woocommerce.android.ui.woopos.util.WooPosCoroutineTestRule
+import com.woocommerce.android.ui.woopos.util.format.WooPosFormatCouponSummary
+import com.woocommerce.android.viewmodel.ResourceProvider
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.last
+import kotlinx.coroutines.flow.take
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.test.runTest
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.mockito.kotlin.any
+import org.mockito.kotlin.anyOrNull
+import org.mockito.kotlin.doAnswer
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.whenever
+import org.mockito.kotlin.wheneverBlocking
+
+@ExperimentalCoroutinesApi
+class WooPosCouponsListViewStateManagerTest {
+
+    @JvmField
+    @Rule
+    val coroutinesTestRule = WooPosCoroutineTestRule()
+
+    private val formatCouponSummary: WooPosFormatCouponSummary = mock()
+    private val getCachedStoreCurrency: GetCachedStoreCurrency = mock()
+    private val couponsDataSource: WooPosCouponsDataSource = mock {
+        onBlocking { couponsFlow }.thenReturn(MutableStateFlow(emptyList()))
+    }
+
+    private val resourceProvider: ResourceProvider = mock {
+        on { getString(any()) } doAnswer { it.arguments[0].toString() }
+    }
+
+    private val sat = WooPosCouponsListViewStateManager(couponsDataSource, formatCouponSummary, getCachedStoreCurrency)
+
+    @Before
+    fun setup() {
+        wheneverBlocking { getCachedStoreCurrency() }.thenReturn("USD")
+        whenever(formatCouponSummary.invoke(anyOrNull(), anyOrNull())).thenAnswer { "" }
+    }
+
+    @Test
+    fun `given empty cache, when collecting viewState, then emits Empty`() = runTest {
+        // GIVEN
+        whenever(couponsDataSource.couponsFlow).thenReturn(MutableStateFlow(emptyList()))
+
+        // WHEN
+        val state = sat.viewState.take(1).last()
+
+        // THEN
+        assertThat(state).isInstanceOf(WooPosCouponsViewState.Error::class.java)
+    }
+
+    @Test
+    fun `given empty cache, when fetching first page, then emits Loading`() = runTest {
+        // GIVEN
+        whenever(couponsDataSource.couponsFlow).thenReturn(MutableStateFlow(emptyList()))
+        var currentState: WooPosCouponsViewState = WooPosCouponsViewState.Empty()
+        launch {
+            sat.viewState.collect {
+                currentState = it
+            }
+        }
+
+        // WHEN
+        sat.fetchCoupons(this)
+
+        // THEN
+        assertThat(currentState).isInstanceOf(WooPosCouponsViewState.Loading::class.java)
+    }
+
+    @Test
+    fun `given non-empty cache and successful initial fetch, when fetchCoupons, then emits Content→Loading→Content(pagination=Loading)`() =
+        runTest {
+
+        }
+
+    @Test
+    fun `given non-empty cache and failed initial fetch, when fetchCoupons, then emits Content→Loading→Error`() =
+        runTest {
+
+        }
+
+    @Test
+    fun `given initial fetch succeeded (canLoadMore), when loadMore fails, then emits pagination‐error`() =
+        runTest {
+
+        }
+}

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/home/items/coupons/WooPosCouponsListViewStateManagerTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/home/items/coupons/WooPosCouponsListViewStateManagerTest.kt
@@ -1,26 +1,32 @@
 package com.woocommerce.android.ui.woopos.home.items.coupons
 
+import app.cash.turbine.test
+import com.woocommerce.android.ui.coupons.CouponTestUtils
 import com.woocommerce.android.ui.woopos.home.items.WooPosCouponsViewState
+import com.woocommerce.android.ui.woopos.home.items.WooPosCouponsViewState.Content
+import com.woocommerce.android.ui.woopos.home.items.WooPosPaginationState
 import com.woocommerce.android.ui.woopos.util.GetCachedStoreCurrency
 import com.woocommerce.android.ui.woopos.util.WooPosCoroutineTestRule
 import com.woocommerce.android.ui.woopos.util.format.WooPosFormatCouponSummary
-import com.woocommerce.android.viewmodel.ResourceProvider
 import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableStateFlow
-import kotlinx.coroutines.flow.last
-import kotlinx.coroutines.flow.take
-import kotlinx.coroutines.launch
+import kotlinx.coroutines.test.advanceUntilIdle
 import kotlinx.coroutines.test.runTest
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
-import org.mockito.kotlin.any
 import org.mockito.kotlin.anyOrNull
-import org.mockito.kotlin.doAnswer
+import org.mockito.kotlin.doReturn
+import org.mockito.kotlin.doSuspendableAnswer
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.whenever
 import org.mockito.kotlin.wheneverBlocking
+import com.woocommerce.android.model.Coupon as CouponDBModel
+
+private const val MORE_PAGES_AVAILABLE = true
+private const val MORE_PAGES_NOT_AVAILABLE = false
 
 @ExperimentalCoroutinesApi
 class WooPosCouponsListViewStateManagerTest {
@@ -31,15 +37,18 @@ class WooPosCouponsListViewStateManagerTest {
 
     private val formatCouponSummary: WooPosFormatCouponSummary = mock()
     private val getCachedStoreCurrency: GetCachedStoreCurrency = mock()
+    private val couponsDataFlow = MutableStateFlow<List<CouponDBModel>>(emptyList())
+
     private val couponsDataSource: WooPosCouponsDataSource = mock {
-        onBlocking { couponsFlow }.thenReturn(MutableStateFlow(emptyList()))
+        on { couponsFlow } doReturn couponsDataFlow
     }
 
-    private val resourceProvider: ResourceProvider = mock {
-        on { getString(any()) } doAnswer { it.arguments[0].toString() }
-    }
-
-    private val sat = WooPosCouponsListViewStateManager(couponsDataSource, formatCouponSummary, getCachedStoreCurrency)
+    private val sat = WooPosCouponsListViewStateManager(
+        couponsDataSource,
+        formatCouponSummary,
+        getCachedStoreCurrency,
+        coroutinesTestRule.testDispatcher
+    )
 
     @Before
     fun setup() {
@@ -48,50 +57,318 @@ class WooPosCouponsListViewStateManagerTest {
     }
 
     @Test
-    fun `given empty cache, when collecting viewState, then emits Empty`() = runTest {
+    fun `given empty db, when fetching first page in progress, then Loading state`() = runTest {
         // GIVEN
-        whenever(couponsDataSource.couponsFlow).thenReturn(MutableStateFlow(emptyList()))
+        whenever(couponsDataSource.clearCacheAndFetchFirstPage()).doSuspendableAnswer {
+            couponsDataFlow.emit(emptyList()) // cache empty
+            delay(500)
+            couponsDataFlow.emit(listOf(CouponTestUtils.generateTestCoupon(0L))) // remote data
+            Result.success(true)
+        }
 
-        // WHEN
-        val state = sat.viewState.take(1).last()
+        sat.viewState.test {
+            // WHEN
+            sat.fetchCoupons(this)
 
-        // THEN
-        assertThat(state).isInstanceOf(WooPosCouponsViewState.Error::class.java)
+            // THEN
+            assertThat(expectMostRecentItem()).isInstanceOf(WooPosCouponsViewState.Loading::class.java)
+
+            cancelAndIgnoreRemainingEvents()
+        }
     }
 
     @Test
-    fun `given empty cache, when fetching first page, then emits Loading`() = runTest {
+    fun `given full db, when fetching first page in progress, then Loading state`() = runTest {
         // GIVEN
-        whenever(couponsDataSource.couponsFlow).thenReturn(MutableStateFlow(emptyList()))
-        var currentState: WooPosCouponsViewState = WooPosCouponsViewState.Empty()
-        launch {
-            sat.viewState.collect {
-                currentState = it
+        whenever(couponsDataSource.clearCacheAndFetchFirstPage()).doSuspendableAnswer {
+            couponsDataFlow.emit(listOf(CouponTestUtils.generateTestCoupon(1L))) // cache empty
+            delay(500)
+            couponsDataFlow.emit(listOf(CouponTestUtils.generateTestCoupon(2L))) // remote data
+            Result.success(true)
+        }
+
+        sat.viewState.test {
+            // WHEN
+            sat.fetchCoupons(this)
+
+            // THEN
+            assertThat(expectMostRecentItem()).isInstanceOf(WooPosCouponsViewState.Loading::class.java)
+
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    @Test
+    fun `given empty db, when fetching first page completes, then Empty state`() = runTest {
+        // GIVEN
+        whenever(couponsDataSource.clearCacheAndFetchFirstPage()).doSuspendableAnswer {
+            couponsDataFlow.emit(listOf(CouponTestUtils.generateTestCoupon(1L))) // remote
+            delay(500)
+            couponsDataFlow.emit(emptyList()) // remote
+            Result.success(true)
+        }
+
+        sat.viewState.test {
+            // WHEN
+            sat.fetchCoupons(this)
+
+            // THEN
+            advanceUntilIdle()
+            assertThat(expectMostRecentItem()).isInstanceOf(WooPosCouponsViewState.Empty::class.java)
+
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    @Test
+    fun `given non-empty db, when fetching first page completes, then Content state`() = runTest {
+        // GIVEN
+        whenever(couponsDataSource.clearCacheAndFetchFirstPage()).doSuspendableAnswer {
+            couponsDataFlow.emit(listOf(CouponTestUtils.generateTestCoupon(0L))) // cache
+            delay(500)
+            couponsDataFlow.emit(listOf(CouponTestUtils.generateTestCoupon(1L))) // remote
+            Result.success(true)
+        }
+
+        sat.viewState.test {
+            // WHEN
+            sat.fetchCoupons(this)
+            advanceUntilIdle()
+
+            // THEN
+            assertThat(expectMostRecentItem()).isInstanceOf(Content::class.java)
+
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    @Test
+    fun `when first page fetch fails, then emits Loading then Error`() = runTest {
+        // GIVEN
+        whenever(couponsDataSource.clearCacheAndFetchFirstPage())
+            .doSuspendableAnswer {
+                delay(1) // workaround for bug in mockito
+                Result.failure(IllegalArgumentException("Test exception"))
             }
+
+        sat.viewState.test {
+            // WHEN
+            sat.fetchCoupons(this)
+
+            // THEN
+            skipItems(1) // Loading
+            advanceUntilIdle()
+            assertThat(awaitItem()).isInstanceOf(WooPosCouponsViewState.Loading::class.java)
+            assertThat(awaitItem()).isInstanceOf(WooPosCouponsViewState.Error::class.java)
+
+            cancelAndIgnoreRemainingEvents()
         }
-
-        // WHEN
-        sat.fetchCoupons(this)
-
-        // THEN
-        assertThat(currentState).isInstanceOf(WooPosCouponsViewState.Loading::class.java)
     }
 
     @Test
-    fun `given non-empty cache and successful initial fetch, when fetchCoupons, then emits Content→Loading→Content(pagination=Loading)`() =
-        runTest {
-
+    fun `given first page failed, when retry succeeds, then emits Content`() = runTest {
+        // GIVEN
+        whenever(couponsDataSource.clearCacheAndFetchFirstPage())
+            .doReturn(Result.failure<Boolean>(IllegalArgumentException("Test exception")))
+        sat.fetchCoupons(this)
+        advanceUntilIdle()
+        whenever(couponsDataSource.clearCacheAndFetchFirstPage()).doSuspendableAnswer {
+            delay(1) // workaround for bug in mockito
+            couponsDataFlow.emit(listOf(CouponTestUtils.generateTestCoupon(0L))) // cache
+            Result.success(true)
         }
+
+        sat.viewState.test {
+            // WHEN
+            sat.fetchCoupons(this)
+
+            // THEN
+            advanceUntilIdle()
+            assertThat(expectMostRecentItem()).isInstanceOf(Content::class.java)
+
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
 
     @Test
-    fun `given non-empty cache and failed initial fetch, when fetchCoupons, then emits Content→Loading→Error`() =
-        runTest {
+    fun `given first page failed, when retry fails, then emits Error`() = runTest {
+        // GIVEN
+        whenever(couponsDataSource.clearCacheAndFetchFirstPage())
+            .doReturn(Result.failure<Boolean>(IllegalArgumentException("Test exception")))
+        sat.fetchCoupons(this)
+        advanceUntilIdle()
+        whenever(couponsDataSource.clearCacheAndFetchFirstPage())
+            .doReturn(Result.failure<Boolean>(IllegalArgumentException("Test exception")))
 
+        sat.viewState.test {
+            // WHEN
+            sat.fetchCoupons(this)
+
+            // THEN
+            advanceUntilIdle()
+            assertThat(expectMostRecentItem()).isInstanceOf(WooPosCouponsViewState.Error::class.java)
+
+            cancelAndIgnoreRemainingEvents()
         }
+    }
 
     @Test
-    fun `given initial fetch succeeded (canLoadMore), when loadMore fails, then emits pagination‐error`() =
-        runTest {
-
+    fun `given more pages available, when content shown, then pagination state loading`() = runTest {
+        // GIVEN
+        whenever(couponsDataSource.clearCacheAndFetchFirstPage()).doSuspendableAnswer {
+            delay(1) // workaround for bug in mockito
+            couponsDataFlow.emit(listOf(CouponTestUtils.generateTestCoupon(0L))) // cache
+            Result.success(MORE_PAGES_AVAILABLE)
         }
+
+        sat.viewState.test {
+            // WHEN
+            sat.fetchCoupons(this)
+
+            advanceUntilIdle()
+
+            // THEN
+            val state = expectMostRecentItem() as Content
+            assertThat(state.paginationState).isInstanceOf(WooPosPaginationState.Loading::class.java)
+
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    @Test
+    fun `given more pages not available, when content shown, then pagination state None`() = runTest {
+        // GIVEN
+        whenever(couponsDataSource.clearCacheAndFetchFirstPage()).doSuspendableAnswer {
+            delay(1) // workaround for bug in mockito
+            couponsDataFlow.emit(listOf(CouponTestUtils.generateTestCoupon(0L))) // cache
+            Result.success(MORE_PAGES_NOT_AVAILABLE)
+        }
+
+        sat.viewState.test {
+            // WHEN
+            sat.fetchCoupons(this)
+
+            // THEN
+            advanceUntilIdle()
+            val state = expectMostRecentItem()
+            assertThat(state).isInstanceOf(Content::class.java)
+            assertThat((state as Content).paginationState)
+                .isInstanceOf(WooPosPaginationState.None::class.java)
+
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    @Test
+    fun `when end of list reached and load more fails, then pagination state Error`() = runTest {
+        // GIVEN
+        whenever(couponsDataSource.clearCacheAndFetchFirstPage()).doSuspendableAnswer {
+            couponsDataFlow.emit(listOf(CouponTestUtils.generateTestCoupon(0L))) // cache
+            delay(1) // workaround for bug in mockito
+            Result.success(MORE_PAGES_AVAILABLE)
+        }
+        sat.fetchCoupons(this)
+        advanceUntilIdle()
+        whenever(couponsDataSource.loadMore()).doSuspendableAnswer {
+            delay(1) // workaround for bug in mockito
+            Result.failure(IllegalArgumentException("Test exception"))
+        }
+
+        sat.viewState.test {
+            // WHEN
+            sat.endOfListReached(this)
+
+            advanceUntilIdle()
+
+            // THEN
+            val state = expectMostRecentItem() as Content
+            assertThat(state.paginationState).isInstanceOf(WooPosPaginationState.Error::class.java)
+
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    @Test
+    fun `given pagination state error, when end of list reached, then nothing happens`() = runTest {
+        // GIVEN
+        whenever(couponsDataSource.clearCacheAndFetchFirstPage()).doSuspendableAnswer {
+            couponsDataFlow.emit(listOf(CouponTestUtils.generateTestCoupon(0L))) // cache
+            delay(1) // workaround for bug in mockito
+            Result.success(MORE_PAGES_AVAILABLE)
+        }
+        sat.fetchCoupons(this)
+        advanceUntilIdle()
+        whenever(couponsDataSource.loadMore()).doSuspendableAnswer {
+            delay(1) // workaround for bug in mockito
+            Result.failure(IllegalArgumentException("Test exception"))
+        }
+        sat.endOfListReached(this)
+
+
+        sat.viewState.test {
+            advanceUntilIdle()
+            expectMostRecentItem() // ignore previous events
+            // WHEN
+            sat.endOfListReached(this)
+            advanceUntilIdle()
+
+            // THEN
+            expectNoEvents() // no new events
+
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    @Test
+    fun `when load more retried, then pagination state Loading`() = runTest {
+        // GIVEN
+        whenever(couponsDataSource.clearCacheAndFetchFirstPage()).doSuspendableAnswer {
+            couponsDataFlow.emit(listOf(CouponTestUtils.generateTestCoupon(0L))) // cache
+            delay(1) // workaround for bug in mockito
+            Result.success(MORE_PAGES_AVAILABLE)
+        }
+        sat.fetchCoupons(this)
+        advanceUntilIdle()
+        whenever(couponsDataSource.loadMore()).doSuspendableAnswer {
+            delay(1) // workaround for bug in mockito
+            Result.failure(IllegalArgumentException("Test exception"))
+        }
+
+        sat.viewState.test {
+            // WHEN
+            sat.retryLoadMore(this)
+
+            // THEN
+            val state = expectMostRecentItem() as Content
+            assertThat(state.paginationState).isInstanceOf(WooPosPaginationState.Loading::class.java)
+
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    @Test
+    fun `loading is still shown until remote request finishes`() = runTest {
+        // GIVEN
+        whenever(couponsDataSource.clearCacheAndFetchFirstPage()).doSuspendableAnswer {
+            couponsDataFlow.emit(listOf(CouponTestUtils.generateTestCoupon(1L))) // remote
+            delay(500)
+            couponsDataFlow.emit(emptyList()) // remote
+            Result.success(true)
+        }
+
+        sat.viewState.test {
+            // WHEN
+            sat.fetchCoupons(this)
+            skipItems(2) // Empty + Loading
+
+            // THEN
+            testScheduler.advanceTimeBy(499)
+            expectNoEvents()      // OK, still Loading
+            testScheduler.advanceTimeBy(2)
+
+            assertThat(expectMostRecentItem()).isInstanceOf(WooPosCouponsViewState.Empty::class.java)
+
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
 }

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/home/items/coupons/WooPosCouponsListViewStateManagerTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/home/items/coupons/WooPosCouponsListViewStateManagerTest.kt
@@ -304,7 +304,6 @@ class WooPosCouponsListViewStateManagerTest {
         }
         sat.endOfListReached(this)
 
-
         sat.viewState.test {
             advanceUntilIdle()
             expectMostRecentItem() // ignore previous events
@@ -363,7 +362,7 @@ class WooPosCouponsListViewStateManagerTest {
 
             // THEN
             testScheduler.advanceTimeBy(499)
-            expectNoEvents()      // OK, still Loading
+            expectNoEvents() // Still Loading
             testScheduler.advanceTimeBy(2)
 
             assertThat(expectMostRecentItem()).isInstanceOf(WooPosCouponsViewState.Empty::class.java)


### PR DESCRIPTION
~**Do not merge label - the parent PR https://github.com/woocommerce/woocommerce-android/pull/13963 needs to be merged first.**~
<!-- Remember about a good descriptive title. -->

Closes: #WOOMOB-175
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

This PR implements a helper class (WooPosCouponsListViewStateManager) that provides a flow with a viewState for the coupons list and connects it to the UI. It handles things like showing proper loading indicator, showing proper errors, cancelling ongoing jobs and similar.

I had to add `delay(1)` to certain lines in the unit tests due to [a bug in Mockito](https://github.com/mockito/mockito-kotlin/issues/487). It incorrectly wraps Kotlin.Result into another Kotlin.Result when it's mocked inside one of the doAnswer methods. 

Note
- PTR doesn't work at the moment - I'll need to look into that, but I plan to fix it in a separate PR.
- The PR currently shows loading state when it's fetching the first page even when the data are in the cache - considering the cache might contain hundreds of items which will be cleared when the `fetch first page` request finishes, I decided not to show them. However, this is worth discussing and perhaps coming up with a more reasonable solution. Perhaps, we could stop clearing the cache since coupons are unlikely to change and even if they do, we use only the coupon code and everything else is calculated on the backend, wdyt? (@staskus I assume you don't store coupons into a persistent storage on iOS or do you?)

### Testing information
<!-- This is your opportunity to break out individual scenarios that need testing (when necessary) and/or include a checklist for the reviewer to go through. Consider documenting the following from your own completed testing: devices used, alternate workflows, edge cases, affected areas, critical flows, areas not tested, and any remaining unknowns. Provide feedback on this new section of the PR template through Sept 30, 2024 to Apps Quality; additional context here: p91TBi-b8z-p2#comment-12036 -->

Test the coupons list in the POS
- pagination
- fetching first page error
- loading more error
- rotation
- ....

### The tests that have been performed
<!-- To give the reviewer an idea of what could be missed in terms of testing -->

I have ran the above tests multiple times on an emulator and OnePlus Pad 2.


### Images/gif

https://github.com/user-attachments/assets/aae4fee6-0565-4fd6-9b36-7000f5a5766e


<!-- Include before and after images or gifs when appropriate. -->



- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.

## Reviewer (or Author, in the case of optional code reviews):

Please make sure these conditions are met before approving the PR, or request changes if the PR needs improvement:

- [x] The PR is small and has a clear, single focus, or a valid explanation is provided in the description. If needed, please request to split it into smaller PRs.
- [x] Ensure Adequate Unit Test Coverage: The changes are reasonably covered by unit tests or an explanation is provided in the PR description.
- [x] Manual Testing: The author listed all the tests they ran, including smoke tests when needed (e.g., for refactorings). The reviewer confirmed that the PR works as expected on big (tablet) and small (phone) in case of UI changes, and no regressions are added.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->