### PR TITLE
Remove Cart visibility state since it's always visible

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/WooPosHomeScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/WooPosHomeScreen.kt
@@ -90,9 +90,7 @@ private fun WooPosHomeScreen(
 
     val productsWidthAnimatedDp by animateDpAsState(
         when (state.screenPositionState) {
-            WooPosHomeState.ScreenPositionState.Cart.Hidden -> screenWidthDp
-
-            is WooPosHomeState.ScreenPositionState.Cart.Visible,
+            is WooPosHomeState.ScreenPositionState.Cart,
             WooPosHomeState.ScreenPositionState.Checkout.CartWithTotals -> productsWidthDp
 
             WooPosHomeState.ScreenPositionState.Checkout.FullScreenTotals -> productsWidthDp - cartWidthDp
@@ -249,7 +247,7 @@ fun WooPosHomeCartScreenPreview() {
     WooPosTheme {
         WooPosHomeScreen(
             state = WooPosHomeState(
-                screenPositionState = WooPosHomeState.ScreenPositionState.Cart.Visible,
+                screenPositionState = WooPosHomeState.ScreenPositionState.Cart,
                 productsInfoDialog = ProductsInfoDialog(isVisible = false),
                 exitConfirmationDialog = WooPosHomeState.ExitConfirmationDialog(isVisible = false),
             ),

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/WooPosHomeState.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/WooPosHomeState.kt
@@ -15,13 +15,7 @@ data class WooPosHomeState(
     @Parcelize
     sealed class ScreenPositionState : Parcelable {
         @Parcelize
-        sealed class Cart : ScreenPositionState() {
-            @Parcelize
-            data object Visible : Cart()
-
-            @Parcelize
-            data object Hidden : Cart()
-        }
+        data object Cart : ScreenPositionState()
 
         @Parcelize
         sealed class Checkout : ScreenPositionState() {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/WooPosHomeViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/WooPosHomeViewModel.kt
@@ -37,7 +37,7 @@ class WooPosHomeViewModel @Inject constructor(
         scope = viewModelScope,
         key = "home_state",
         initialValue = WooPosHomeState(
-            screenPositionState = ScreenPositionState.Cart.Visible,
+            screenPositionState = ScreenPositionState.Cart,
             productsInfoDialog = ProductsInfoDialog(isVisible = false),
             exitConfirmationDialog = ExitConfirmationDialog(isVisible = false),
         )
@@ -60,7 +60,7 @@ class WooPosHomeViewModel @Inject constructor(
                 when (_state.value.screenPositionState) {
                     ScreenPositionState.Checkout.CartWithTotals -> {
                         _state.value = _state.value.copy(
-                            screenPositionState = ScreenPositionState.Cart.Visible
+                            screenPositionState = ScreenPositionState.Cart
                         )
                         sendEventToChildren(ParentToChildrenEvent.BackFromCheckoutToCartClicked)
                         viewModelScope.launch {
@@ -70,7 +70,7 @@ class WooPosHomeViewModel @Inject constructor(
 
                     ScreenPositionState.Checkout.FullScreenTotals -> {
                         _state.value = _state.value.copy(
-                            screenPositionState = ScreenPositionState.Cart.Visible
+                            screenPositionState = ScreenPositionState.Cart
                         )
                     }
 
@@ -120,7 +120,7 @@ class WooPosHomeViewModel @Inject constructor(
 
                     is ChildToParentEvent.BackFromCheckoutToCartClicked -> {
                         _state.value = _state.value.copy(
-                            screenPositionState = ScreenPositionState.Cart.Visible
+                            screenPositionState = ScreenPositionState.Cart
                         )
                         sendEventToChildren(ParentToChildrenEvent.BackFromCheckoutToCartClicked)
                     }
@@ -133,7 +133,7 @@ class WooPosHomeViewModel @Inject constructor(
 
                     is ChildToParentEvent.NewTransactionClicked -> {
                         _state.value = _state.value.copy(
-                            screenPositionState = ScreenPositionState.Cart.Visible
+                            screenPositionState = ScreenPositionState.Cart
                         )
                     }
 

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/home/WooPosHomeViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/home/WooPosHomeViewModelTest.kt
@@ -53,7 +53,7 @@ class WooPosHomeViewModelTest {
             // THEN
             verify(parentToChildrenEventSender).sendToChildren(ParentToChildrenEvent.BackFromCheckoutToCartClicked)
             assertThat(viewModel.state.value.screenPositionState)
-                .isEqualTo(WooPosHomeState.ScreenPositionState.Cart.Visible)
+                .isEqualTo(WooPosHomeState.ScreenPositionState.Cart)
         }
 
     @Test
@@ -93,7 +93,7 @@ class WooPosHomeViewModelTest {
                 )
             )
             assertThat(viewModel.state.value.screenPositionState)
-                .isEqualTo(WooPosHomeState.ScreenPositionState.Cart.Visible)
+                .isEqualTo(WooPosHomeState.ScreenPositionState.Cart)
         }
 
     @Test


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #WOOMOB-360
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

This PR is just a code cleanup - it removes visibility state of the Cart section, since it's always visible now. 

### Testing information
<!-- This is your opportunity to break out individual scenarios that need testing (when necessary) and/or include a checklist for the reviewer to go through. Consider documenting the following from your own completed testing: devices used, alternate workflows, edge cases, affected areas, critical flows, areas not tested, and any remaining unknowns. Provide feedback on this new section of the PR template through Sept 30, 2024 to Apps Quality; additional context here: p91TBi-b8z-p2#comment-12036 -->

##### Test 1
1. Turn on airplane mode
2. Open the POS
3. Check the state

##### Test 2
1. Turn off airplane mode
2. Open the POS
3. Check the state

##### Test 3
1. Open the POS
2. Add items to the cart
3. Move the the checkout
4. Move back to the product selection
5. Move to the checkout
6. Finish a payment

### The tests that have been performed
<!-- To give the reviewer an idea of what could be missed in terms of testing -->

I've ran the above tests.

### Images/gif
<!-- Include before and after images or gifs when appropriate. -->

No user facing changes.

- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.

## Reviewer (or Author, in the case of optional code reviews):

Please make sure these conditions are met before approving the PR, or request changes if the PR needs improvement:

- [x] The PR is small and has a clear, single focus, or a valid explanation is provided in the description. If needed, please request to split it into smaller PRs.
- [x] Ensure Adequate Unit Test Coverage: The changes are reasonably covered by unit tests or an explanation is provided in the PR description.
- [x] Manual Testing: The author listed all the tests they ran, including smoke tests when needed (e.g., for refactorings). The reviewer confirmed that the PR works as expected on big (tablet) and small (phone) in case of UI changes, and no regressions are added.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->