### PR TITLE
Support for starred packages on Carrier tab

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/packages/WooShippingLabelPackageCreationScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/packages/WooShippingLabelPackageCreationScreen.kt
@@ -232,7 +232,8 @@ fun WooShippingLabelsPackageCreationScreenPreview() {
                             )
                         )
                     ),
-                    onPackageSelected = { _, _ -> }
+                    onPackageSelected = { _, _ -> },
+                    onPackageStarred = { _, _ -> },
                 )
             }
         )

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/packages/WooShippingLabelPackageCreationViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/packages/WooShippingLabelPackageCreationViewModel.kt
@@ -253,6 +253,26 @@ class WooShippingLabelPackageCreationViewModel @Inject constructor(
             ?: Result.failure(Throwable("Failed to save package"))
     }
 
+    fun onCarrierPackageStarred(packageData: PackageData, isStarred: Boolean) {
+        _viewState.update { viewState ->
+            val predefinedPackages = viewState.predefinedPackagesData ?: return@update viewState
+            val updatedCarrierPackages = predefinedPackages.carrierPackages.mapValues { (_, packageGroupList) ->
+                packageGroupList.map { packageGroup ->
+                    val updatedPackages = packageGroup.packages.map {
+                        when {
+                            it.id == packageData.id -> it.copy(isStarred = isStarred)
+                            else -> it
+                        }
+                    }
+                    packageGroup.copy(packages = updatedPackages)
+                }
+            }
+            viewState.copy(
+                predefinedPackagesState = predefinedPackages.copy(carrierPackages = updatedCarrierPackages)
+            )
+        }
+    }
+
     @Parcelize
     data class ViewState(
         val pageTabs: List<PageTab> = emptyList(),

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/packages/components/PackageItemComponents.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/packages/components/PackageItemComponents.kt
@@ -80,7 +80,12 @@ fun WooShippingPackageListItem(
                         true -> Icons.Filled.Star
                         false -> Icons.Outlined.StarOutline
                     },
-                    contentDescription = "Star",
+                    contentDescription = stringResource(
+                        id = when (packageData.isStarred) {
+                            true -> R.string.woo_shipping_labels_package_creation_unstarred
+                            else -> R.string.woo_shipping_labels_package_creation_starred
+                        }
+                    )
                 )
             }
         }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/packages/components/PackageItemComponents.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/packages/components/PackageItemComponents.kt
@@ -14,7 +14,7 @@ import androidx.compose.material.MaterialTheme
 import androidx.compose.material.Text
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Star
-import androidx.compose.material.icons.outlined.Star
+import androidx.compose.material.icons.outlined.StarOutline
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -78,7 +78,7 @@ fun WooShippingPackageListItem(
                     tint = colorResource(id = R.color.color_on_surface_disabled),
                     imageVector = when (packageData.isStarred) {
                         true -> Icons.Filled.Star
-                        false -> Icons.Outlined.Star
+                        false -> Icons.Outlined.StarOutline
                     },
                     contentDescription = "Star",
                 )

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/packages/components/PackageItemComponents.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/packages/components/PackageItemComponents.kt
@@ -1,5 +1,6 @@
 package com.woocommerce.android.ui.orders.wooshippinglabels.packages.components
 
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
@@ -32,7 +33,8 @@ fun WooShippingPackageListItem(
     modifier: Modifier,
     packageData: PackageData,
     onPackageSelected: (PackageData, Boolean) -> Unit,
-    packageItemSupportsStarring: Boolean
+    packageItemSupportsStarring: Boolean,
+    onPackageStarred: (PackageData, Boolean) -> Unit = { _, _ -> }
 ) {
     Column(
         modifier = modifier,
@@ -68,11 +70,13 @@ fun WooShippingPackageListItem(
                     style = MaterialTheme.typography.body2
                 )
             }
-            if(packageItemSupportsStarring) {
+            if (packageItemSupportsStarring) {
                 Icon(
-                    modifier = Modifier.padding(end = 16.dp),
+                    modifier = Modifier
+                        .padding(end = 16.dp)
+                        .clickable { onPackageStarred(packageData, !packageData.isStarred) },
                     tint = colorResource(id = R.color.color_on_surface_disabled),
-                    imageVector = when (packageData.isPredefined) {
+                    imageVector = when (packageData.isStarred) {
                         true -> Icons.Filled.Star
                         false -> Icons.Outlined.Star
                     },

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/packages/components/PackageItemComponents.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/packages/components/PackageItemComponents.kt
@@ -1,6 +1,5 @@
 package com.woocommerce.android.ui.orders.wooshippinglabels.packages.components
 
-import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
@@ -35,12 +34,11 @@ fun WooShippingPackageListItem(
     onPackageSelected: (PackageData, Boolean) -> Unit
 ) {
     Column(
-        modifier = modifier
-            .clickable { onPackageSelected(packageData, packageData.isSelected.not()) }
-            .padding(top = 8.dp),
+        modifier = modifier,
         verticalArrangement = Arrangement.spacedBy(16.dp)
     ) {
         Row(
+            modifier = Modifier.padding(top = 8.dp),
             horizontalArrangement = Arrangement.spacedBy(8.dp),
             verticalAlignment = Alignment.CenterVertically
         ) {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/packages/components/PackageItemComponents.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/packages/components/PackageItemComponents.kt
@@ -9,8 +9,12 @@ import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.material.Divider
+import androidx.compose.material.Icon
 import androidx.compose.material.MaterialTheme
 import androidx.compose.material.Text
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Star
+import androidx.compose.material.icons.outlined.Star
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -44,7 +48,10 @@ fun WooShippingPackageListItem(
                 isSelected = packageData.isSelected,
                 onSelectionChange = { onPackageSelected(packageData, it) }
             )
-            Column(verticalArrangement = Arrangement.spacedBy(4.dp)) {
+            Column(
+                modifier = Modifier.weight(1f),
+                verticalArrangement = Arrangement.spacedBy(4.dp)
+            ) {
                 Text(
                     text = stringResource(id = packageData.descriptionResId),
                     style = MaterialTheme.typography.caption,
@@ -62,6 +69,15 @@ fun WooShippingPackageListItem(
                     style = MaterialTheme.typography.body2
                 )
             }
+            Icon(
+                modifier = Modifier.padding(end = 16.dp),
+                tint = colorResource(id = R.color.color_on_surface_disabled),
+                imageVector = when (packageData.isPredefined) {
+                    true -> Icons.Filled.Star
+                    false -> Icons.Outlined.Star
+                },
+                contentDescription = "Star",
+            )
         }
         Divider()
     }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/packages/components/PackageItemComponents.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/packages/components/PackageItemComponents.kt
@@ -31,7 +31,8 @@ import com.woocommerce.android.ui.orders.wooshippinglabels.packages.ui.PackageDa
 fun WooShippingPackageListItem(
     modifier: Modifier,
     packageData: PackageData,
-    onPackageSelected: (PackageData, Boolean) -> Unit
+    onPackageSelected: (PackageData, Boolean) -> Unit,
+    packageItemSupportsStarring: Boolean
 ) {
     Column(
         modifier = modifier,
@@ -67,15 +68,17 @@ fun WooShippingPackageListItem(
                     style = MaterialTheme.typography.body2
                 )
             }
-            Icon(
-                modifier = Modifier.padding(end = 16.dp),
-                tint = colorResource(id = R.color.color_on_surface_disabled),
-                imageVector = when (packageData.isPredefined) {
-                    true -> Icons.Filled.Star
-                    false -> Icons.Outlined.Star
-                },
-                contentDescription = "Star",
-            )
+            if(packageItemSupportsStarring) {
+                Icon(
+                    modifier = Modifier.padding(end = 16.dp),
+                    tint = colorResource(id = R.color.color_on_surface_disabled),
+                    imageVector = when (packageData.isPredefined) {
+                        true -> Icons.Filled.Star
+                        false -> Icons.Outlined.Star
+                    },
+                    contentDescription = "Star",
+                )
+            }
         }
         Divider()
     }
@@ -134,7 +137,8 @@ fun WooSavedPackageListItemPreview() {
                 isSelected = false,
                 id = "1",
             ),
-            onPackageSelected = { _, _ -> }
+            onPackageSelected = { _, _ -> },
+            packageItemSupportsStarring = true
         )
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/packages/ui/UIModels.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/packages/ui/UIModels.kt
@@ -63,7 +63,7 @@ data class PackageData(
         fun fromPackageDAO(
             dao: PackageDAO,
             isSelected: Boolean = false,
-            isPredefined: Boolean = true
+            isPredefined: Boolean = false
         ): PackageData = PackageData(
             id = dao.id,
             name = dao.name,

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/packages/ui/UIModels.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/packages/ui/UIModels.kt
@@ -63,7 +63,7 @@ data class PackageData(
         fun fromPackageDAO(
             dao: PackageDAO,
             isSelected: Boolean = false,
-            isPredefined: Boolean = false
+            isPredefined: Boolean = true
         ): PackageData = PackageData(
             id = dao.id,
             name = dao.name,

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/packages/ui/UIModels.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/packages/ui/UIModels.kt
@@ -16,6 +16,7 @@ data class PackageData(
     val weight: String,
     val isSelected: Boolean,
     val isLetter: Boolean,
+    val isStarred: Boolean = false,
     val isPredefined: Boolean = false,
     val dimensionUnit: String = "cm",
     val weightUnit: String = "kg",

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/packages/ui/WooShippingCarrierPackageScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/packages/ui/WooShippingCarrierPackageScreen.kt
@@ -3,6 +3,7 @@ package com.woocommerce.android.ui.orders.wooshippinglabels.packages.ui
 import android.content.res.Configuration
 import androidx.annotation.DrawableRes
 import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -255,7 +256,9 @@ private fun PackageListSection(
         Divider()
         packages.forEach { packageData ->
             WooShippingPackageListItem(
-                modifier = Modifier.padding(start = 16.dp),
+                modifier = Modifier
+                    .clickable { onPackageSelected(packageData, packageData.isSelected.not()) }
+                    .padding(start = 16.dp),
                 packageData = packageData,
                 onPackageSelected = onPackageSelected
             )

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/packages/ui/WooShippingCarrierPackageScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/packages/ui/WooShippingCarrierPackageScreen.kt
@@ -63,7 +63,8 @@ fun WooShippingCarrierPackageScreen(
         onPackageSelected = viewModel::onCarrierPackageSelected,
         onAddPackageClick = viewModel::onAddCarrierPackageClick,
         onRetryClick = viewModel::onRetryClick,
-        onTabChange = onTabChange
+        onTabChange = onTabChange,
+        onPackageStarred = viewModel::onCarrierPackageStarred
     )
 }
 
@@ -75,7 +76,8 @@ fun WooShippingCarrierPackageScreen(
     isAddPackageEnabled: Boolean = false,
     onAddPackageClick: () -> Unit = {},
     onRetryClick: () -> Unit,
-    onTabChange: (PageType) -> Unit
+    onTabChange: (PageType) -> Unit,
+    onPackageStarred: (PackageData, Boolean) -> Unit = { _, _ -> }
 ) {
     Column(modifier = modifier) {
         Box(modifier = modifier.weight(1f)) {
@@ -90,6 +92,7 @@ fun WooShippingCarrierPackageScreen(
                     modifier = modifier,
                     carrierPackages = packageState.carrierPackages,
                     onPackageSelected = onPackageSelected,
+                    onPackageStarred = onPackageStarred
                 )
 
                 packageState is PredefinedPackagesState.Error -> ErrorMessageWithButton(
@@ -128,6 +131,7 @@ fun WooShippingCarrierPackageContent(
     modifier: Modifier = Modifier,
     carrierPackages: Map<Carrier, List<CarrierPackageGroup>>,
     onPackageSelected: (PackageData, Boolean) -> Unit,
+    onPackageStarred: (PackageData, Boolean) -> Unit
 ) {
     val pagerState = rememberPagerState { carrierPackages.keys.size }
     Column(
@@ -146,7 +150,8 @@ fun WooShippingCarrierPackageContent(
                 .weight(1f),
             pagerState = pagerState,
             carrierPackages = carrierPackages,
-            onPackageSelected = onPackageSelected
+            onPackageSelected = onPackageSelected,
+            onPackageStarred = onPackageStarred
         )
     }
 }
@@ -199,7 +204,8 @@ private fun PackageListPager(
     modifier: Modifier,
     pagerState: PagerState,
     carrierPackages: Map<Carrier, List<CarrierPackageGroup>>,
-    onPackageSelected: (PackageData, Boolean) -> Unit
+    onPackageSelected: (PackageData, Boolean) -> Unit,
+    onPackageStarred: (PackageData, Boolean) -> Unit
 ) {
     HorizontalPager(
         state = pagerState,
@@ -210,7 +216,8 @@ private fun PackageListPager(
         val carrierPackageGroups = carrierPackages[carrierForPageIndex] ?: emptyList()
         PackageList(
             packageGroups = carrierPackageGroups,
-            onPackageSelected = onPackageSelected
+            onPackageSelected = onPackageSelected,
+            onPackageStarred = onPackageStarred
         )
     }
 }
@@ -218,7 +225,8 @@ private fun PackageListPager(
 @Composable
 private fun PackageList(
     packageGroups: List<CarrierPackageGroup>,
-    onPackageSelected: (PackageData, Boolean) -> Unit
+    onPackageSelected: (PackageData, Boolean) -> Unit,
+    onPackageStarred: (PackageData, Boolean) -> Unit
 ) {
     Column(
         modifier = Modifier
@@ -230,7 +238,8 @@ private fun PackageList(
             PackageListSection(
                 sectionHeader = group.groupName,
                 packages = group.packages,
-                onPackageSelected = onPackageSelected
+                onPackageSelected = onPackageSelected,
+                onPackageStarred = onPackageStarred
             )
         }
     }
@@ -240,7 +249,8 @@ private fun PackageList(
 private fun PackageListSection(
     sectionHeader: String,
     packages: List<PackageData>,
-    onPackageSelected: (PackageData, Boolean) -> Unit
+    onPackageSelected: (PackageData, Boolean) -> Unit,
+    onPackageStarred: (PackageData, Boolean) -> Unit
 ) {
     Column(
         modifier = Modifier
@@ -261,7 +271,8 @@ private fun PackageListSection(
                     .padding(start = 16.dp),
                 packageData = packageData,
                 onPackageSelected = onPackageSelected,
-                packageItemSupportsStarring = true
+                packageItemSupportsStarring = true,
+                onPackageStarred = onPackageStarred
             )
         }
     }
@@ -356,7 +367,8 @@ fun WooShippingCarrierPackageScreenPreview() {
                     )
                 )
             ),
-            onPackageSelected = { _, _ -> }
+            onPackageSelected = { _, _ -> },
+            onPackageStarred = { _, _ -> }
         )
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/packages/ui/WooShippingCarrierPackageScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/packages/ui/WooShippingCarrierPackageScreen.kt
@@ -260,7 +260,8 @@ private fun PackageListSection(
                     .clickable { onPackageSelected(packageData, packageData.isSelected.not()) }
                     .padding(start = 16.dp),
                 packageData = packageData,
-                onPackageSelected = onPackageSelected
+                onPackageSelected = onPackageSelected,
+                packageItemSupportsStarring = true
             )
         }
     }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/packages/ui/WooShippingSavedPackageScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/packages/ui/WooShippingSavedPackageScreen.kt
@@ -119,7 +119,8 @@ fun WooShippingSavedPackageContent(
             WooShippingPackageListItem(
                 modifier,
                 packageData,
-                onSavedPackageSelected
+                onSavedPackageSelected,
+                packageItemSupportsStarring = false
             )
         }
     }

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -4479,6 +4479,8 @@
     <string name="woo_shipping_labels_package_creation_carrier_loading_error">We are unable to load carrier packages.</string>
     <string name="woo_shipping_labels_package_creation_saved_loading_error">We are unable to load saved packages.</string>
     <string name="woo_shipping_labels_package_creation_shipping_rates_loading_error">We are unable to load shipping rates.</string>
+    <string name="woo_shipping_labels_package_creation_starred">Star this item</string>
+    <string name="woo_shipping_labels_package_creation_unstarred">Unstar this item</string>
     <string name="woo_shipping_labels_shipping_rates_missing_destination">Add a destination address to get shipping rates</string>
     <string name="woo_shipping_labels_shipping_rates_missing_destination_desc">We need to know where this package is going before we can show the available shipping rates.</string>
     <string name="woo_shipping_labels_shipping_rates_missing_weight">Add shipment weight to get shipping rates</string>


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: WOOMOB-320
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
Adds UI component for starring/un-starring carrier packages in shipping labels flow.

Note that these changes don't include updating the starred status in the backend side, only at the UI/ViewModel level 

### Testing information
1. Log into a site with shipping labels enabled. 
2. Open the orders tab.
3. Tap on an order eligible for shipping label creation. It’s better to choose one with multiple items.
4. Tap on Create shipping label.
5. Tap on Select Package
6. Select Carrier tab
7. Tap to star/unstar carrier packages. Check selection survives device rotation.

### The tests that have been performed
<!-- To give the reviewer an idea of what could be missed in terms of testing -->
The above

### Images/gif
<!-- Include before and after images or gifs when appropriate. -->

https://github.com/user-attachments/assets/e40a2133-9f64-4664-a344-4ce188695cac

- [ ] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.

## Reviewer (or Author, in the case of optional code reviews):

Please make sure these conditions are met before approving the PR, or request changes if the PR needs improvement:

- [x] The PR is small and has a clear, single focus, or a valid explanation is provided in the description. If needed, please request to split it into smaller PRs.
- [ ] Ensure Adequate Unit Test Coverage: The changes are reasonably covered by unit tests or an explanation is provided in the PR description.
- [ ] Manual Testing: The author listed all the tests they ran, including smoke tests when needed (e.g., for refactorings). The reviewer confirmed that the PR works as expected on big (tablet) and small (phone) in case of UI changes, and no regressions are added.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md --