### PR TITLE
[WOOPRD-466][Woo POS][Product search] Implement search input based on the design

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/common/composeui/component/WooPosSearchInput.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/common/composeui/component/WooPosSearchInput.kt
@@ -101,6 +101,7 @@ fun WooPosSearchInput(
         }
     }
 }
+
 @SuppressLint("UnusedBoxWithConstraintsScope")
 @Composable
 private fun AnimatedSearchInput(

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/common/composeui/component/WooPosSearchInput.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/common/composeui/component/WooPosSearchInput.kt
@@ -353,7 +353,8 @@ fun WooPosSearchInputOpenSearchPreview() {
                         "Search products...",
                         cursorPosition = 0
                     ),
-                    false
+                    isLoading = false,
+                    hasAnimationPlayed = true
                 ),
                 onEvent = {}
             )

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/common/composeui/component/WooPosSearchInput.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/common/composeui/component/WooPosSearchInput.kt
@@ -13,6 +13,7 @@ import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.BoxWithConstraints
 import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
@@ -43,6 +44,7 @@ import androidx.compose.ui.focus.FocusRequester
 import androidx.compose.ui.focus.focusRequester
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.TextRange
+import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.input.ImeAction
 import androidx.compose.ui.text.input.TextFieldValue
 import androidx.compose.ui.unit.Dp
@@ -76,10 +78,26 @@ fun WooPosSearchInput(
             .fillMaxWidth()
             .height(INPUT_FIELD_HEIGHT),
         verticalAlignment = Alignment.CenterVertically,
-        horizontalArrangement = Arrangement.End,
+        horizontalArrangement = Arrangement.Start,
     ) {
         when (state) {
             is WooPosSearchInputState.Open -> {
+                IconButton(
+                    onClick = { onEvent(WooPosSearchUIEvent.Close) }
+                ) {
+                    Icon(
+                        modifier = Modifier
+                            .size(28.dp),
+                        imageVector = Icons.AutoMirrored.Filled.ArrowBack,
+                        contentDescription = stringResource(
+                            R.string.woopos_search_back_content_description
+                        ),
+                        tint = MaterialTheme.colorScheme.onSurface,
+                    )
+                }
+
+                Spacer(modifier = Modifier.width(WooPosSpacing.Small.value))
+
                 AnimatedSearchInput(
                     state = state,
                     onEvent = onEvent,
@@ -87,6 +105,7 @@ fun WooPosSearchInput(
             }
 
             WooPosSearchInputState.Closed -> {
+                Spacer(modifier = Modifier.weight(1f))
                 WooPosCircularIconButton(
                     icon = Icons.Default.Search,
                     contentDescription = stringResource(
@@ -106,7 +125,6 @@ private fun AnimatedSearchInput(
     onEvent: (WooPosSearchUIEvent) -> Unit,
 ) {
     BoxWithConstraints(
-        modifier = Modifier.fillMaxWidth(),
         contentAlignment = Alignment.CenterEnd,
     ) {
         val maxWidthPx = maxWidth
@@ -149,7 +167,7 @@ private fun AnimatedSearchInput(
 
         OutlinedTextField(
             value = textFieldValue,
-            onValueChange = { newValue ->
+            onValueChange = { newValue: TextFieldValue ->
                 textFieldValue = newValue
                 onEvent(
                     WooPosSearchUIEvent.Search(
@@ -166,9 +184,13 @@ private fun AnimatedSearchInput(
                 WooPosText(
                     text = hint,
                     modifier = Modifier.alpha(iconAlpha),
-                    style = WooPosTypography.BodyMedium,
+                    style = WooPosTypography.BodyLarge,
+                    fontWeight = FontWeight.Bold,
+                    color = WooPosTheme.colors.onSurfaceVariantLowest,
                 )
             },
+            textStyle = WooPosTypography.BodyLarge.style
+                .copy(fontWeight = FontWeight.Bold),
             singleLine = true,
             keyboardOptions = KeyboardOptions(imeAction = ImeAction.Search),
             shape = RoundedCornerShape(cornerRadius),
@@ -183,22 +205,23 @@ private fun AnimatedSearchInput(
                 }
             ),
             colors = OutlinedTextFieldDefaults.colors(
-                unfocusedBorderColor = MaterialTheme.colorScheme.outline,
-                focusedBorderColor = MaterialTheme.colorScheme.outline,
-                cursorColor = MaterialTheme.colorScheme.onBackground,
+                unfocusedBorderColor = MaterialTheme.colorScheme.surface,
+                focusedBorderColor = MaterialTheme.colorScheme.primary,
+                unfocusedContainerColor = MaterialTheme.colorScheme.surfaceBright,
+                focusedContainerColor = MaterialTheme.colorScheme.surfaceBright,
+                cursorColor = MaterialTheme.colorScheme.primary,
+                unfocusedTextColor = MaterialTheme.colorScheme.onSurface,
+                focusedTextColor = MaterialTheme.colorScheme.onSurface,
             ),
             leadingIcon = {
-                IconButton(
-                    onClick = { isClosing = true },
-                    modifier = Modifier.alpha(iconAlpha)
-                ) {
-                    Icon(
-                        imageVector = Icons.AutoMirrored.Filled.ArrowBack,
-                        contentDescription = stringResource(
-                            R.string.woopos_search_back_content_description
-                        ),
-                    )
-                }
+                Icon(
+                    imageVector = Icons.Default.Search,
+                    contentDescription = null,
+                    modifier = Modifier
+                        .alpha(iconAlpha)
+                        .size(26.dp),
+                    tint = MaterialTheme.colorScheme.onSurface,
+                )
             },
             trailingIcon = {
                 when {
@@ -213,18 +236,21 @@ private fun AnimatedSearchInput(
                     textFieldValue.text.isNotEmpty() -> {
                         IconButton(
                             onClick = { onEvent(WooPosSearchUIEvent.Clear) },
-                            modifier = Modifier.alpha(iconAlpha)
+                            modifier = Modifier
+                                .alpha(iconAlpha)
+                                .size(26.dp)
                         ) {
                             Icon(
                                 imageVector = Icons.Default.Clear,
                                 contentDescription = stringResource(
-                                    R.string.woopos_search_back_content_description
+                                    R.string.woopos_search_clear_content_description
                                 ),
+                                tint = MaterialTheme.colorScheme.onSurface,
                             )
                         }
                     }
                 }
-            }
+            },
         )
 
         LaunchedEffect(Unit) {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/common/composeui/component/WooPosSearchInput.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/common/composeui/component/WooPosSearchInput.kt
@@ -194,7 +194,7 @@ private fun AnimatedSearchInput(
                         modifier = Modifier.alpha(iconAlpha),
                         style = WooPosTypography.BodyMedium,
                         fontWeight = FontWeight.Bold,
-                        color = MaterialTheme.colorScheme.onSurface,
+                        color = WooPosTheme.colors.onSurfaceVariantLowest,
                     )
                 },
                 textStyle = WooPosTypography.BodyMedium.style

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/common/composeui/component/WooPosSearchInput.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/common/composeui/component/WooPosSearchInput.kt
@@ -24,8 +24,8 @@ import androidx.compose.foundation.text.KeyboardActions
 import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
-import androidx.compose.material.icons.filled.Clear
 import androidx.compose.material.icons.filled.Search
+import androidx.compose.material.icons.outlined.Cancel
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
@@ -137,14 +137,15 @@ private fun AnimatedSearchInput(
                     isClosing = true
                 },
                 modifier = Modifier.alpha(backButtonAlpha)
+                    .size(48.dp)
             ) {
                 Icon(
-                    modifier = Modifier.size(28.dp),
                     imageVector = Icons.AutoMirrored.Filled.ArrowBack,
                     contentDescription = stringResource(
                         R.string.woopos_search_back_content_description
                     ),
                     tint = MaterialTheme.colorScheme.onSurface,
+                    modifier = Modifier.size(28.dp)
                 )
             }
 
@@ -222,14 +223,16 @@ private fun AnimatedSearchInput(
                     focusedTextColor = MaterialTheme.colorScheme.onSurface,
                 ),
                 leadingIcon = {
-                    Icon(
-                        imageVector = Icons.Default.Search,
-                        contentDescription = null,
-                        modifier = Modifier
-                            .alpha(iconAlpha)
-                            .size(26.dp),
-                        tint = MaterialTheme.colorScheme.onSurface,
-                    )
+                    IconButton(
+                        onClick = {},
+                        modifier = Modifier.size(32.dp)
+                    ) {
+                        Icon(
+                            imageVector = Icons.Default.Search,
+                            contentDescription = null,
+                            tint = MaterialTheme.colorScheme.onSurface,
+                        )
+                    }
                 },
                 trailingIcon = {
                     when {
@@ -246,10 +249,10 @@ private fun AnimatedSearchInput(
                                 onClick = { onEvent(WooPosSearchUIEvent.Clear) },
                                 modifier = Modifier
                                     .alpha(iconAlpha)
-                                    .size(26.dp)
+                                    .size(32.dp)
                             ) {
                                 Icon(
-                                    imageVector = Icons.Default.Clear,
+                                    imageVector = Icons.Outlined.Cancel,
                                     contentDescription = stringResource(
                                         R.string.woopos_search_clear_content_description
                                     ),

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/common/composeui/component/WooPosSearchInput.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/common/composeui/component/WooPosSearchInput.kt
@@ -184,12 +184,12 @@ private fun AnimatedSearchInput(
                 WooPosText(
                     text = hint,
                     modifier = Modifier.alpha(iconAlpha),
-                    style = WooPosTypography.BodyLarge,
+                    style = WooPosTypography.BodyMedium,
                     fontWeight = FontWeight.Bold,
                     color = WooPosTheme.colors.onSurfaceVariantLowest,
                 )
             },
-            textStyle = WooPosTypography.BodyLarge.style
+            textStyle = WooPosTypography.BodyMedium.style
                 .copy(fontWeight = FontWeight.Bold),
             singleLine = true,
             keyboardOptions = KeyboardOptions(imeAction = ImeAction.Search),

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/common/composeui/component/WooPosSearchInput.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/common/composeui/component/WooPosSearchInput.kt
@@ -82,22 +82,6 @@ fun WooPosSearchInput(
     ) {
         when (state) {
             is WooPosSearchInputState.Open -> {
-                IconButton(
-                    onClick = { onEvent(WooPosSearchUIEvent.Close) }
-                ) {
-                    Icon(
-                        modifier = Modifier
-                            .size(28.dp),
-                        imageVector = Icons.AutoMirrored.Filled.ArrowBack,
-                        contentDescription = stringResource(
-                            R.string.woopos_search_back_content_description
-                        ),
-                        tint = MaterialTheme.colorScheme.onSurface,
-                    )
-                }
-
-                Spacer(modifier = Modifier.width(WooPosSpacing.Small.value))
-
                 AnimatedSearchInput(
                     state = state,
                     onEvent = onEvent,
@@ -117,7 +101,6 @@ fun WooPosSearchInput(
         }
     }
 }
-
 @SuppressLint("UnusedBoxWithConstraintsScope")
 @Composable
 private fun AnimatedSearchInput(
@@ -125,11 +108,10 @@ private fun AnimatedSearchInput(
     onEvent: (WooPosSearchUIEvent) -> Unit,
 ) {
     BoxWithConstraints(
+        modifier = Modifier.fillMaxWidth(),
         contentAlignment = Alignment.CenterEnd,
     ) {
-        val maxWidthPx = maxWidth
         val focusRequester = remember { FocusRequester() }
-
         var isExpanded by remember { mutableStateOf(state.hasAnimationPlayed) }
         var isClosing by remember { mutableStateOf(false) }
 
@@ -137,121 +119,147 @@ private fun AnimatedSearchInput(
             targetState = if (isClosing) false else isExpanded,
             label = "searchTransition"
         )
-        val width = animateSearchWidth(transition, maxWidthPx)
+
+        val width = animateSearchWidth(transition, maxWidth)
         val height = animateSearchHeight(transition)
         val cornerRadius = animateCornerRadius(transition)
         val iconAlpha = animateIconAlpha(transition, isClosing)
+        val backButtonAlpha = animateIconAlpha(transition, isClosing)
 
-        val (hint, query) = when (state.input) {
-            is Input.Query -> "" to state.input.text
-            is Input.Hint -> state.input.text to ""
-        }
-
-        var textFieldValue by remember {
-            mutableStateOf(
-                TextFieldValue(
-                    text = query,
-                    selection = TextRange(state.input.cursorPosition)
-                )
-            )
-        }
-
-        LaunchedEffect(query) {
-            if (query != textFieldValue.text) {
-                textFieldValue = TextFieldValue(
-                    text = query,
-                    selection = TextRange(state.input.cursorPosition)
-                )
-            }
-        }
-
-        OutlinedTextField(
-            value = textFieldValue,
-            onValueChange = { newValue: TextFieldValue ->
-                textFieldValue = newValue
-                onEvent(
-                    WooPosSearchUIEvent.Search(
-                        newValue.text,
-                        newValue.selection.start
-                    )
-                )
-            },
-            modifier = Modifier
-                .width(width)
-                .height(height)
-                .focusRequester(focusRequester),
-            placeholder = {
-                WooPosText(
-                    text = hint,
-                    modifier = Modifier.alpha(iconAlpha),
-                    style = WooPosTypography.BodyMedium,
-                    fontWeight = FontWeight.Bold,
-                    color = WooPosTheme.colors.onSurfaceVariantLowest,
-                )
-            },
-            textStyle = WooPosTypography.BodyMedium.style
-                .copy(fontWeight = FontWeight.Bold),
-            singleLine = true,
-            keyboardOptions = KeyboardOptions(imeAction = ImeAction.Search),
-            shape = RoundedCornerShape(cornerRadius),
-            keyboardActions = KeyboardActions(
-                onSearch = {
-                    onEvent(
-                        WooPosSearchUIEvent.Search(
-                            textFieldValue.text,
-                            textFieldValue.selection.start
-                        )
-                    )
-                }
-            ),
-            colors = OutlinedTextFieldDefaults.colors(
-                unfocusedBorderColor = MaterialTheme.colorScheme.surface,
-                focusedBorderColor = MaterialTheme.colorScheme.primary,
-                unfocusedContainerColor = MaterialTheme.colorScheme.surfaceBright,
-                focusedContainerColor = MaterialTheme.colorScheme.surfaceBright,
-                cursorColor = MaterialTheme.colorScheme.primary,
-                unfocusedTextColor = MaterialTheme.colorScheme.onSurface,
-                focusedTextColor = MaterialTheme.colorScheme.onSurface,
-            ),
-            leadingIcon = {
+        Row(
+            verticalAlignment = Alignment.CenterVertically,
+            horizontalArrangement = Arrangement.End,
+            modifier = Modifier.width(width)
+        ) {
+            IconButton(
+                onClick = {
+                    isClosing = true
+                },
+                modifier = Modifier.alpha(backButtonAlpha)
+            ) {
                 Icon(
-                    imageVector = Icons.Default.Search,
-                    contentDescription = null,
-                    modifier = Modifier
-                        .alpha(iconAlpha)
-                        .size(26.dp),
+                    modifier = Modifier.size(28.dp),
+                    imageVector = Icons.AutoMirrored.Filled.ArrowBack,
+                    contentDescription = stringResource(
+                        R.string.woopos_search_back_content_description
+                    ),
                     tint = MaterialTheme.colorScheme.onSurface,
                 )
-            },
-            trailingIcon = {
-                when {
-                    state.isLoading -> {
-                        WooPosCircularLoadingIndicator(
-                            modifier = Modifier
-                                .size(24.dp)
-                                .alpha(iconAlpha)
+            }
+
+            Spacer(modifier = Modifier.width(WooPosSpacing.Small.value))
+
+            val (hint, query) = when (state.input) {
+                is Input.Query -> "" to state.input.text
+                is Input.Hint -> state.input.text to ""
+            }
+
+            var textFieldValue by remember {
+                mutableStateOf(
+                    TextFieldValue(
+                        text = query,
+                        selection = TextRange(state.input.cursorPosition)
+                    )
+                )
+            }
+
+            LaunchedEffect(query) {
+                if (query != textFieldValue.text) {
+                    textFieldValue = TextFieldValue(
+                        text = query,
+                        selection = TextRange(state.input.cursorPosition)
+                    )
+                }
+            }
+
+            OutlinedTextField(
+                value = textFieldValue,
+                onValueChange = { newValue: TextFieldValue ->
+                    textFieldValue = newValue
+                    onEvent(
+                        WooPosSearchUIEvent.Search(
+                            newValue.text,
+                            newValue.selection.start
+                        )
+                    )
+                },
+                modifier = Modifier
+                    .weight(1f)
+                    .height(height)
+                    .focusRequester(focusRequester),
+                placeholder = {
+                    WooPosText(
+                        text = hint,
+                        modifier = Modifier.alpha(iconAlpha),
+                        style = WooPosTypography.BodyMedium,
+                        fontWeight = FontWeight.Bold,
+                        color = MaterialTheme.colorScheme.onSurface,
+                    )
+                },
+                textStyle = WooPosTypography.BodyMedium.style
+                    .copy(fontWeight = FontWeight.Bold),
+                singleLine = true,
+                keyboardOptions = KeyboardOptions(imeAction = ImeAction.Search),
+                shape = RoundedCornerShape(cornerRadius),
+                keyboardActions = KeyboardActions(
+                    onSearch = {
+                        onEvent(
+                            WooPosSearchUIEvent.Search(
+                                textFieldValue.text,
+                                textFieldValue.selection.start
+                            )
                         )
                     }
-
-                    textFieldValue.text.isNotEmpty() -> {
-                        IconButton(
-                            onClick = { onEvent(WooPosSearchUIEvent.Clear) },
-                            modifier = Modifier
-                                .alpha(iconAlpha)
-                                .size(26.dp)
-                        ) {
-                            Icon(
-                                imageVector = Icons.Default.Clear,
-                                contentDescription = stringResource(
-                                    R.string.woopos_search_clear_content_description
-                                ),
-                                tint = MaterialTheme.colorScheme.onSurface,
+                ),
+                colors = OutlinedTextFieldDefaults.colors(
+                    unfocusedBorderColor = MaterialTheme.colorScheme.surface,
+                    focusedBorderColor = MaterialTheme.colorScheme.primary,
+                    unfocusedContainerColor = MaterialTheme.colorScheme.surfaceBright,
+                    focusedContainerColor = MaterialTheme.colorScheme.surfaceBright,
+                    cursorColor = MaterialTheme.colorScheme.primary,
+                    unfocusedTextColor = MaterialTheme.colorScheme.onSurface,
+                    focusedTextColor = MaterialTheme.colorScheme.onSurface,
+                ),
+                leadingIcon = {
+                    Icon(
+                        imageVector = Icons.Default.Search,
+                        contentDescription = null,
+                        modifier = Modifier
+                            .alpha(iconAlpha)
+                            .size(26.dp),
+                        tint = MaterialTheme.colorScheme.onSurface,
+                    )
+                },
+                trailingIcon = {
+                    when {
+                        state.isLoading -> {
+                            WooPosCircularLoadingIndicator(
+                                modifier = Modifier
+                                    .size(24.dp)
+                                    .alpha(iconAlpha)
                             )
                         }
+
+                        textFieldValue.text.isNotEmpty() -> {
+                            IconButton(
+                                onClick = { onEvent(WooPosSearchUIEvent.Clear) },
+                                modifier = Modifier
+                                    .alpha(iconAlpha)
+                                    .size(26.dp)
+                            ) {
+                                Icon(
+                                    imageVector = Icons.Default.Clear,
+                                    contentDescription = stringResource(
+                                        R.string.woopos_search_clear_content_description
+                                    ),
+                                    tint = MaterialTheme.colorScheme.onSurface,
+                                )
+                            }
+                        }
                     }
-                }
-            },
-        )
+                },
+            )
+        }
 
         LaunchedEffect(Unit) {
             if (!state.hasAnimationPlayed) {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/items/WooPosItemsToolbar.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/items/WooPosItemsToolbar.kt
@@ -28,7 +28,6 @@ import com.woocommerce.android.ui.woopos.common.composeui.component.WooPosSearch
 import com.woocommerce.android.ui.woopos.common.composeui.component.WooPosSearchUIEvent
 import com.woocommerce.android.ui.woopos.common.composeui.component.WooPosText
 import com.woocommerce.android.ui.woopos.common.composeui.designsystem.WooPosSpacing
-import com.woocommerce.android.ui.woopos.common.composeui.designsystem.WooPosSpacing.Medium
 import com.woocommerce.android.ui.woopos.common.composeui.designsystem.WooPosTheme
 import com.woocommerce.android.ui.woopos.common.composeui.designsystem.WooPosTypography
 import com.woocommerce.android.ui.woopos.home.items.WooPosItemsViewState.Tab.HighlightLevel.Full
@@ -88,8 +87,6 @@ fun WooPosItemsToolbar(
                                 onEvent = onSearchEvent,
                                 modifier = Modifier.weight(1f)
                             )
-
-                            Spacer(modifier = Modifier.width(Medium.value))
                         }
                     }
                 }

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -4409,8 +4409,8 @@
     <string name="woopos_email_receipt_send_error">Error trying to send this email. Try again</string>
 
     <string name="woopos_search_back_content_description">Back</string>
-    <string name="woopos_clear_back_content_description">Clear</string>
-    <string name="woopos_search_products">Search products…</string>
+    <string name="woopos_search_clear_content_description">Clear</string>
+    <string name="woopos_search_products">Search products</string>
     <string name="woopos_search_popular_items_title">Popular items</string>
     <string name="woopos_search_recent_searches_title">Recent searches</string>
     <string name="woopos_search_items_empty_title">Nothing found</string>


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #WOOPRD-466
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
Changes the UI of the search input based on the design. It's maybe not final so lets not merge it yet
* Font is smaller otherwise it's cut off by the internal input paddings ✅
* ~~The clear is standard from the library~~ (used another one)

I asked Wagner regarding this pdfdoF-6XY-p2#comment-8073 ✅

WSViBnnZyFv39tpr9v1gVy-fi-2128_21295

### Steps to reproduce
<!-- Step-by-step testing instructions. For new user flows, consider instead stating the goal of the workflow and see if your PR reviewer can accomplish the workflow without specific steps! -->
* Open POS
* Open Search
* Validate the search input design in dark and light mode 

### Testing information
<!-- This is your opportunity to break out individual scenarios that need testing (when necessary) and/or include a checklist for the reviewer to go through. Consider documenting the following from your own completed testing: devices used, alternate workflows, edge cases, affected areas, critical flows, areas not tested, and any remaining unknowns. Provide feedback on this new section of the PR template through Sept 30, 2024 to Apps Quality; additional context here: p91TBi-b8z-p2#comment-12036 -->
* Animation is slightly broken, but as we need to change it anyway, I decided not to spend time on fixing

### Images/gif
<!-- Include before and after images or gifs when appropriate. -->

https://github.com/user-attachments/assets/70ee9816-f418-4a22-b166-6bc1a75b813b


- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.

## Reviewer (or Author, in the case of optional code reviews):

Please make sure these conditions are met before approving the PR, or request changes if the PR needs improvement:

- [ ] The PR is small and has a clear, single focus, or a valid explanation is provided in the description. If needed, please request to split it into smaller PRs.
- [ ] Ensure Adequate Unit Test Coverage: The changes are reasonably covered by unit tests or an explanation is provided in the PR description.
- [ ] Manual Testing: The author listed all the tests they ran, including smoke tests when needed (e.g., for refactorings). The reviewer confirmed that the PR works as expected on big (tablet) and small (phone) in case of UI changes, and no regressions are added.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->