### PR TITLE
Fix WooPosGetCachedStoreCurrency after invalid merge

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/items/coupons/WooPosCouponsListViewStateManager.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/items/coupons/WooPosCouponsListViewStateManager.kt
@@ -13,7 +13,7 @@ import com.woocommerce.android.ui.woopos.home.items.coupons.WooPosCouponsListVie
 import com.woocommerce.android.ui.woopos.home.items.coupons.WooPosCouponsListViewStateManager.FetchingCouponsState.FETCHING_FIRST_PAGE
 import com.woocommerce.android.ui.woopos.home.items.coupons.WooPosCouponsListViewStateManager.FetchingCouponsState.FETCHING_MORE
 import com.woocommerce.android.ui.woopos.home.items.coupons.WooPosCouponsListViewStateManager.FetchingCouponsState.IDLE
-import com.woocommerce.android.ui.woopos.util.GetCachedStoreCurrency
+import com.woocommerce.android.ui.woopos.util.WooPosGetCachedStoreCurrency
 import com.woocommerce.android.ui.woopos.util.format.WooPosFormatCouponSummary
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.CoroutineScope
@@ -32,7 +32,7 @@ private const val AVOID_UI_FLICKERING_DELAY = 500L
 class WooPosCouponsListViewStateManager @Inject constructor(
     private val couponsDataSource: WooPosCouponsDataSource,
     private val formatCouponSummary: WooPosFormatCouponSummary,
-    private val getCachedStoreCurrency: GetCachedStoreCurrency,
+    private val getCachedStoreCurrency: WooPosGetCachedStoreCurrency,
     private val dispatcher: CoroutineDispatcher = Dispatchers.IO
 ) {
     private val fetchingState: MutableStateFlow<FetchingCouponsState> = MutableStateFlow(IDLE)

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/home/items/coupons/WooPosCouponsListViewStateManagerTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/home/items/coupons/WooPosCouponsListViewStateManagerTest.kt
@@ -5,8 +5,8 @@ import com.woocommerce.android.ui.coupons.CouponTestUtils
 import com.woocommerce.android.ui.woopos.home.items.WooPosCouponsViewState
 import com.woocommerce.android.ui.woopos.home.items.WooPosCouponsViewState.Content
 import com.woocommerce.android.ui.woopos.home.items.WooPosPaginationState
-import com.woocommerce.android.ui.woopos.util.GetCachedStoreCurrency
 import com.woocommerce.android.ui.woopos.util.WooPosCoroutineTestRule
+import com.woocommerce.android.ui.woopos.util.WooPosGetCachedStoreCurrency
 import com.woocommerce.android.ui.woopos.util.format.WooPosFormatCouponSummary
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.delay
@@ -36,7 +36,7 @@ class WooPosCouponsListViewStateManagerTest {
     val coroutinesTestRule = WooPosCoroutineTestRule()
 
     private val formatCouponSummary: WooPosFormatCouponSummary = mock()
-    private val getCachedStoreCurrency: GetCachedStoreCurrency = mock()
+    private val getCachedStoreCurrency: WooPosGetCachedStoreCurrency = mock()
     private val couponsDataFlow = MutableStateFlow<List<CouponDBModel>>(emptyList())
 
     private val couponsDataSource: WooPosCouponsDataSource = mock {


### PR DESCRIPTION
This PR fixes broken trunk after merge of https://github.com/woocommerce/woocommerce-android/pull/13971. The PR wasn't up-to-date with trunk which contained renamed GetCachedStoreCurrency => WooPosGetCachedStoreCurrency.