### PR TITLE
Fix Buildkite test collector support when tests execution fail

### DIFF
--- a/.buildkite/commands/run-unit-tests.sh
+++ b/.buildkite/commands/run-unit-tests.sh
@@ -15,11 +15,11 @@ TESTS_EXIT_STATUS=$?
 set -e
 
 if [[ "$TESTS_EXIT_STATUS" -eq 0 ]]; then
-  echo -e "--- ⚒️ Uploading code coverage"
+  echo -e "\n--- ⚒️ Uploading code coverage"
   .buildkite/commands/upload-code-coverage.sh
 fi
 
-echo -e "--- 🚦 Report Tests Status"
+echo -e "\n--- 🚦 Report Tests Status"
 results_file="WooCommerce/build/test-results/merged-test-results.xml"
 # Merge JUnit results into a single file (for performance reasons with reporting)
 # See https://github.com/woocommerce/woocommerce-android/pull/12064

--- a/.buildkite/commands/run-unit-tests.sh
+++ b/.buildkite/commands/run-unit-tests.sh
@@ -19,6 +19,7 @@ if [[ "$TESTS_EXIT_STATUS" -ne 0 ]]; then
   echo "^^^ +++"
   echo "Unit Tests failed!"
 else
+  echo
   echo "--- ⚒️ Uploading code coverage"
   .buildkite/commands/upload-code-coverage.sh
 fi

--- a/.buildkite/commands/run-unit-tests.sh
+++ b/.buildkite/commands/run-unit-tests.sh
@@ -10,7 +10,7 @@ bundle exec fastlane run configure_apply
 
 echo "--- 🧪 Testing"
 set +e
-./gradlew testJalapenoDebugUnitTest testDebugUnitTest
+./gradlew testJalapenoDebugUnitTest testDebugUnitTest jacocoTestReport
 TESTS_EXIT_STATUS=$?
 set -e
 
@@ -18,8 +18,10 @@ if [[ "$TESTS_EXIT_STATUS" -ne 0 ]]; then
   # Keep the (otherwise collapsed) current "Testing" section open in Buildkite logs on error. See https://buildkite.com/docs/pipelines/managing-log-output#collapsing-output
   echo "^^^ +++"
   echo "Unit Tests failed!"
+else
+  echo "--- ⚒️ Uploading code coverage"
+  .buildkite/commands/upload-code-coverage.sh
 fi
-
 
 echo "--- 🚦 Report Tests Status"
 results_file="WooCommerce/build/test-results/merged-test-results.xml"
@@ -35,9 +37,5 @@ fi
 
 echo "--- 🧪 Copying test logs for test collector"
 mkdir WooCommerce/build/buildkite-test-analytics && cp "$results_file" WooCommerce/build/buildkite-test-analytics
-
-echo "--- ⚒️ Generating and uploading code coverage"
-./gradlew jacocoTestReport
-.buildkite/commands/upload-code-coverage.sh
 
 exit $TESTS_EXIT_STATUS

--- a/.buildkite/commands/run-unit-tests.sh
+++ b/.buildkite/commands/run-unit-tests.sh
@@ -33,11 +33,11 @@ else
     annotate_test_failures "$results_file"
 fi
 
+echo "--- 🧪 Copying test logs for test collector"
+mkdir WooCommerce/build/buildkite-test-analytics && cp "$results_file" WooCommerce/build/buildkite-test-analytics
+
 echo "--- ⚒️ Generating and uploading code coverage"
 ./gradlew jacocoTestReport
 .buildkite/commands/upload-code-coverage.sh
-
-echo "--- 🧪 Copying test logs for test collector"
-mkdir WooCommerce/build/buildkite-test-analytics && cp "$results_file" WooCommerce/build/buildkite-test-analytics
 
 exit $TESTS_EXIT_STATUS

--- a/.buildkite/commands/run-unit-tests.sh
+++ b/.buildkite/commands/run-unit-tests.sh
@@ -8,19 +8,14 @@ install_gems
 echo "--- :closed_lock_with_key: Installing Secrets"
 bundle exec fastlane run configure_apply
 
-echo "--- 🧪 Testing"
+echo "+++ 🧪 Testing"
 set +e
 ./gradlew testJalapenoDebugUnitTest testDebugUnitTest jacocoTestReport
 TESTS_EXIT_STATUS=$?
 set -e
 
-if [[ "$TESTS_EXIT_STATUS" -ne 0 ]]; then
-  # Keep the (otherwise collapsed) current "Testing" section open in Buildkite logs on error. See https://buildkite.com/docs/pipelines/managing-log-output#collapsing-output
-  echo "^^^ +++"
-  echo "Unit Tests failed!"
-else
-  echo
-  echo "--- ⚒️ Uploading code coverage"
+if [[ "$TESTS_EXIT_STATUS" -eq 0 ]]; then
+  echo -e "--- ⚒️ Uploading code coverage"
   .buildkite/commands/upload-code-coverage.sh
 fi
 

--- a/.buildkite/commands/run-unit-tests.sh
+++ b/.buildkite/commands/run-unit-tests.sh
@@ -19,7 +19,7 @@ if [[ "$TESTS_EXIT_STATUS" -eq 0 ]]; then
   .buildkite/commands/upload-code-coverage.sh
 fi
 
-echo "--- 🚦 Report Tests Status"
+echo -e "--- 🚦 Report Tests Status"
 results_file="WooCommerce/build/test-results/merged-test-results.xml"
 # Merge JUnit results into a single file (for performance reasons with reporting)
 # See https://github.com/woocommerce/woocommerce-android/pull/12064

--- a/config/gradle/jacoco.gradle
+++ b/config/gradle/jacoco.gradle
@@ -16,6 +16,8 @@ rootProject.afterEvaluate {
                 ':libs:fluxc-plugin:testDebugUnitTest',
                 ':libs:fluxc-tests:testDebugUnitTest',
                 ':libs:login:testDebugUnitTest',
+                ':libs:apifaker:testDebugUnitTest',
+                ':libs:commons:testDebugUnitTest',
         )
 
         group = "Reporting"


### PR DESCRIPTION
Closes: AINFRA-258

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

This PR fixes unit tests collection in cases when unit tests fail.

#### Issue

I spotted, that `jacocoTestReport` doesn't reuse output of `:WooCommerce:testJalapenoDebugUnitTest` task. Take a random build from current pull requests, e.g:

https://buildkite.com/automattic/woocommerce-android/builds/28754/steps?jid=01966d6b-e9a2-49c3-adb8-ac77b8c0e369#01966d6b-e9a2-49c3-adb8-ac77b8c0e369/357-373

and see, that `:WooCommerce:testJalapenoDebugUnitTest` was executed when running `jacocoTestReport`, but just before, it was already executed in previous step. Looking at Gradle Scan for a reason why it was executed, one can spot

<img width="1138" alt="Screenshot 2025-04-29 at 13 27 24" src="https://github.com/user-attachments/assets/5e4cee8f-0740-49c8-abae-2ece9cb2a6d4" />

I don't know which operation exactly breaks `stableClasspath`, but I also don't think it's crucial to understand it at this moment.

This is problematic for several reasons:
- **not working Buildkite Test Collector collection when tests fail** 
In such case, we don't report it back to Buildkite as there's no `set +e`/`set -e` for `jacocoTestReport`, so this task failing due to tests failure, simply exists the job ([source](https://buildkite.com/automattic/woocommerce-android/builds/28794/steps?jid=01968140-dd82-4c02-819e-34f1b818b541), no `Tests` tab).
- unnecessary **longer job time** (there's no reason to run tests twice)
- **unpredicted behavior**: we run tests, modify build outputs and then run tests again. This results with behavior like:
  - tests are passing for the first time, but not for the second time ([source](https://buildkite.com/automattic/woocommerce-android/builds/28776/steps?jid=01967d1d-d029-4ebf-8995-e9b92312f1dd#01967d1d-d029-4ebf-8995-e9b92312f1dd/354-370))
  - different tests are failing on first and second run ([source](https://buildkite.com/automattic/woocommerce-android/builds/28794/steps?jid=01968140-dd82-4c02-819e-34f1b818b541))

#### Solution

Run `jacocoTestReport` as one of the tasks during tests tasks execution. 
- this will allow the whole script to finish, even if `jacocoTestReport` fails
- this also runs `jacocoTestReport` before any other operations related to reporting, making sure, that the build can safely reuse output of previous tasks.

### Testing information
<!-- This is your opportunity to break out individual scenarios that need testing (when necessary) and/or include a checklist for the reviewer to go through. Consider documenting the following from your own completed testing: devices used, alternate workflows, edge cases, affected areas, critical flows, areas not tested, and any remaining unknowns. Provide feedback on this new section of the PR template through Sept 30, 2024 to Apps Quality; additional context here: https://woomobilep2.wordpress.com/2024/05/06/woocommerce-mobile-quality-report-march-april/#comment-12036 -->

- For "**unpredicted behavior**" and "unnecessary **longer job time**" see [build](https://buildkite.com/automattic/woocommerce-android/builds/28800/steps?jid=0196815e-1d87-4db3-9d06-8abe41bbb621) of #13982 . After cherry-picking commits from this branch, unit tests are just fine.
- For  "**not working Buildkite Test Collector collection** " see: [build](https://buildkite.com/automattic/woocommerce-android/builds/28812/steps?jid=019681a3-565a-4f0c-a4fa-8dbeade308f4) of #13988. The tests _are_ collected even that the tests task failed.

### Images/gif
<!-- Include before and after images or gifs when appropriate. -->
<img width="814" alt="Screenshot 2025-04-29 at 16 44 14" src="https://github.com/user-attachments/assets/e4b8c390-0b7c-449d-8b9f-6175d6e89aa4" />


- [ ] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.

## Reviewer (or Author, in the case of optional code reviews):

Please make sure these conditions are met before approving the PR, or request changes if the PR needs improvement:

- [ ] The PR is small and has a clear, single focus, or a valid explanation is provided in the description. If needed, please request to split it into smaller PRs.
- [ ] Ensure Adequate Unit Test Coverage: The changes are reasonably covered by unit tests or an explanation is provided in the PR description.
- [ ] Manual Testing: The author listed all the tests they ran, including smoke tests when needed (e.g., for refactorings). The reviewer confirmed that the PR works as expected on big (tablet) and small (phone) in case of UI changes, and no regressions are added.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
