### PR TITLE
[Shipping labels] Use fetched shipments in split shipment screen

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/GetShipments.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/GetShipments.kt
@@ -4,6 +4,7 @@ import com.woocommerce.android.model.Order
 import com.woocommerce.android.model.getNonRefundedProducts
 import com.woocommerce.android.ui.orders.details.OrderDetailRepository
 import com.woocommerce.android.ui.orders.wooshippinglabels.datasource.WooShippingConfigDataStore
+import com.woocommerce.android.ui.orders.wooshippinglabels.models.ShipmentUIModel
 import com.woocommerce.android.ui.orders.wooshippinglabels.models.ShippableItemModel
 import com.woocommerce.android.ui.products.details.ProductDetailRepository
 import kotlinx.coroutines.flow.first
@@ -14,11 +15,9 @@ class GetShipments @Inject constructor(
     private val productDetailRepository: ProductDetailRepository,
     private val configDataStore: WooShippingConfigDataStore,
 ) {
-    suspend operator fun invoke(order: Order): Map<String, List<ShippableItemModel>> {
+    suspend operator fun invoke(order: Order): List<ShipmentUIModel> {
         val refunds = orderDetailRepository.getOrderRefunds(order.id)
         val noRefundedProducts = refunds.getNonRefundedProducts(order.items)
-
-        val shipments = configDataStore.observeConfig(order.id).first()?.shipments ?: emptyMap()
 
         val orderItems = noRefundedProducts.mapNotNull { item ->
             val product = productDetailRepository.getProductAsync(item.productId)
@@ -41,13 +40,19 @@ class GetShipments @Inject constructor(
             }
         }
 
-        // Return a map by matching each shipment key to its corresponding items in orderItems and adjusting quantity by
-        // subItems count
-        return shipments.mapValues { (_, shipmentItems) ->
-            shipmentItems.mapNotNull { (id, subItems) ->
-                orderItems.firstOrNull { it.itemId == id }?.let { item ->
-                    if (subItems.isNullOrEmpty()) item else item.copy(quantity = subItems.size.toFloat())
+        val shipments = configDataStore.observeConfig(order.id).first()?.shipments
+
+        return if (shipments.isNullOrEmpty()) {
+            listOf(ShipmentUIModel(id = null, items = orderItems))
+        } else {
+            shipments.map { (shipmentId, shipmentItems) ->
+                val items = shipmentItems.mapNotNull { (id, subItems) ->
+                    // orderItems contains the total quantity for each product in the order.
+                    // We update the quantity per shipment based on the number of subItems in each shipment.
+                    orderItems.firstOrNull { it.itemId == id }
+                        ?.copy(quantity = if (subItems.isNullOrEmpty()) 1f else subItems.size.toFloat())
                 }
+                ShipmentUIModel(shipmentId, items)
             }
         }
     }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/GetShipments.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/GetShipments.kt
@@ -9,7 +9,7 @@ import com.woocommerce.android.ui.products.details.ProductDetailRepository
 import kotlinx.coroutines.flow.first
 import javax.inject.Inject
 
-class GetShippableItems @Inject constructor(
+class GetShipments @Inject constructor(
     private val orderDetailRepository: OrderDetailRepository,
     private val productDetailRepository: ProductDetailRepository,
     private val configDataStore: WooShippingConfigDataStore,

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/GetShipments.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/GetShipments.kt
@@ -14,13 +14,13 @@ class GetShipments @Inject constructor(
     private val productDetailRepository: ProductDetailRepository,
     private val configDataStore: WooShippingConfigDataStore,
 ) {
-    suspend operator fun invoke(order: Order): List<ShippableItemModel> {
+    suspend operator fun invoke(order: Order): Map<String, List<ShippableItemModel>> {
         val refunds = orderDetailRepository.getOrderRefunds(order.id)
         val noRefundedProducts = refunds.getNonRefundedProducts(order.items)
 
-        val shipments = configDataStore.observeConfig(order.id).first()?.shipments
+        val shipments = configDataStore.observeConfig(order.id).first()?.shipments ?: emptyMap()
 
-        return noRefundedProducts.mapNotNull { item ->
+        val orderItems = noRefundedProducts.mapNotNull { item ->
             val product = productDetailRepository.getProductAsync(item.productId)
             if (product != null && !product.isSampleProduct && !product.isVirtual) {
                 ShippableItemModel(
@@ -38,6 +38,16 @@ class GetShipments @Inject constructor(
                 )
             } else {
                 null
+            }
+        }
+
+        // Return a map by matching each shipment key to its corresponding items in orderItems and adjusting quantity by
+        // subItems count
+        return shipments.mapValues { (_, shipmentItems) ->
+            shipmentItems.mapNotNull { (id, subItems) ->
+                orderItems.firstOrNull { it.itemId == id }?.let { item ->
+                    if (subItems.isNullOrEmpty()) item else item.copy(quantity = subItems.size.toFloat())
+                }
             }
         }
     }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/GetShippableItems.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/GetShippableItems.kt
@@ -18,7 +18,7 @@ class GetShippableItems @Inject constructor(
         val refunds = orderDetailRepository.getOrderRefunds(order.id)
         val noRefundedProducts = refunds.getNonRefundedProducts(order.items)
 
-        val shipments = configDataStore.observeConfig(order.id).first()?.shipments // TODO Use this in the UI
+        val shipments = configDataStore.observeConfig(order.id).first()?.shipments
 
         return noRefundedProducts.mapNotNull { item ->
             productDetailRepository.getProductAsync(item.productId)?.let {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/GetShippableItems.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/GetShippableItems.kt
@@ -21,26 +21,24 @@ class GetShippableItems @Inject constructor(
         val shipments = configDataStore.observeConfig(order.id).first()?.shipments
 
         return noRefundedProducts.mapNotNull { item ->
-            productDetailRepository.getProductAsync(item.productId)?.let {
-                Pair(it, item)
+            val product = productDetailRepository.getProductAsync(item.productId)
+            if (product != null && !product.isSampleProduct && !product.isVirtual) {
+                ShippableItemModel(
+                    itemId = item.itemId,
+                    productId = product.remoteId,
+                    height = product.height,
+                    width = product.width,
+                    length = product.length,
+                    weight = product.weight,
+                    title = product.name,
+                    imageUrl = product.firstImageUrl,
+                    quantity = item.quantity,
+                    price = item.price,
+                    currency = order.currency
+                )
+            } else {
+                null
             }
-        }.filter { product ->
-            product.first.isSampleProduct.not() && product.first.isVirtual.not()
-        }.map {
-            val (product, item) = it
-            ShippableItemModel(
-                itemId = item.itemId,
-                productId = product.remoteId,
-                height = product.height,
-                width = product.width,
-                length = product.length,
-                weight = product.weight,
-                title = product.name,
-                imageUrl = product.firstImageUrl,
-                quantity = item.quantity,
-                price = item.price,
-                currency = order.currency
-            )
         }
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/WooShippingLabelCreationViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/WooShippingLabelCreationViewModel.kt
@@ -36,6 +36,7 @@ import com.woocommerce.android.ui.orders.wooshippinglabels.customs.domain.Should
 import com.woocommerce.android.ui.orders.wooshippinglabels.models.DestinationShippingAddress
 import com.woocommerce.android.ui.orders.wooshippinglabels.models.OriginShippingAddress
 import com.woocommerce.android.ui.orders.wooshippinglabels.models.PurchasedLabelData
+import com.woocommerce.android.ui.orders.wooshippinglabels.models.ShipmentUIModel
 import com.woocommerce.android.ui.orders.wooshippinglabels.models.ShippableItemModel
 import com.woocommerce.android.ui.orders.wooshippinglabels.models.StoreOptionsModel
 import com.woocommerce.android.ui.orders.wooshippinglabels.packages.ui.PackageData
@@ -97,6 +98,7 @@ class WooShippingLabelCreationViewModel @Inject constructor(
     private val loadTrigger = MutableSharedFlow<Unit>()
     private val storeOptions = MutableStateFlow<StoreOptionsModel?>(StoreOptionsModel.EMPTY)
 
+    private val shipments = MutableStateFlow<List<ShipmentUIModel>>(emptyList())
     private val shippableItems = MutableStateFlow<List<ShippableItemModel>>(emptyList())
 
     private val packageSelected = MutableStateFlow<PackageData?>(null)
@@ -396,7 +398,7 @@ class WooShippingLabelCreationViewModel @Inject constructor(
                 return@combine WooShippingViewState.Error
             }
 
-            val items = getShipments(order).values.flatten() // TODO add support for multiple shipments
+            shipments.value = getShipments(order)
 
             val destinationStatus = when {
                 addressValidationHelper.isMissingDestinationAddress(addresses.shipTo.address) -> {
@@ -407,10 +409,10 @@ class WooShippingLabelCreationViewModel @Inject constructor(
                 else -> AddressStatus.UNVERIFIED
             }
 
-            shippableItems.value = items
+            shippableItems.value = shipments.value.map { it.items }.flatten()
 
             val shippingLineSummary = order.getShippingLinesSummary(currencyFormatter)
-            val shippableItemsUI = items.toUIModel(
+            val shippableItemsUI = shippableItems.value.toUIModel(
                 currencyFormatter,
                 storeOptions.dimensionUnit,
                 storeOptions.weightUnit
@@ -578,7 +580,7 @@ class WooShippingLabelCreationViewModel @Inject constructor(
                     SplitShipmentArgs(
                         orderId = navArgs.orderId,
                         storeOptions = currentStoreOptions,
-                        shipments = mapOf(0 to currentShippableItems)
+                        shipments = shipments.value
                     )
                 )
             )
@@ -726,7 +728,7 @@ class WooShippingLabelCreationViewModel @Inject constructor(
     @Parcelize
     data class SplitShipmentArgs(
         val orderId: Long,
-        val shipments: Map<Int, List<ShippableItemModel>>,
+        val shipments: List<ShipmentUIModel>,
         val storeOptions: StoreOptionsModel
     ) : Parcelable
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/WooShippingLabelCreationViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/WooShippingLabelCreationViewModel.kt
@@ -72,7 +72,7 @@ import javax.inject.Inject
 class WooShippingLabelCreationViewModel @Inject constructor(
     savedState: SavedStateHandle,
     private val orderDetailRepository: OrderDetailRepository,
-    private val getShippableItems: GetShippableItems,
+    private val getShipments: GetShipments,
     private val currencyFormatter: CurrencyFormatter,
     private val observeOriginAddresses: ObserveOriginAddresses,
     private val fetchOriginAddresses: FetchOriginAddresses,
@@ -396,7 +396,7 @@ class WooShippingLabelCreationViewModel @Inject constructor(
                 return@combine WooShippingViewState.Error
             }
 
-            val items = getShippableItems(order)
+            val items = getShipments(order)
 
             val destinationStatus = when {
                 addressValidationHelper.isMissingDestinationAddress(addresses.shipTo.address) -> {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/WooShippingLabelCreationViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/WooShippingLabelCreationViewModel.kt
@@ -396,7 +396,7 @@ class WooShippingLabelCreationViewModel @Inject constructor(
                 return@combine WooShippingViewState.Error
             }
 
-            val items = getShipments(order)
+            val items = getShipments(order).values.flatten() // TODO add support for multiple shipments
 
             val destinationStatus = when {
                 addressValidationHelper.isMissingDestinationAddress(addresses.shipTo.address) -> {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/models/ShipmentUIModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/models/ShipmentUIModel.kt
@@ -1,0 +1,11 @@
+package com.woocommerce.android.ui.orders.wooshippinglabels.models
+
+import android.os.Parcelable
+import kotlinx.parcelize.Parcelize
+
+@Parcelize
+data class ShipmentUIModel(
+    // If id is null, it indicates that no shipment has been fetched from the backend.
+    val id: String?,
+    val items: List<ShippableItemModel>
+) : Parcelable

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/split/WooShippingSplitShipmentViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/split/WooShippingSplitShipmentViewModel.kt
@@ -31,10 +31,12 @@ class WooShippingSplitShipmentViewModel @Inject constructor(
     private val navArgs: WooShippingSplitShipmentFragmentArgs by savedState.navArgs()
     private val storeOptions = navArgs.shipmentArgs.storeOptions
 
-    private val currentShipments = MutableStateFlow(navArgs.shipmentArgs.shipments)
+    private val currentShipments = MutableStateFlow(
+        navArgs.shipmentArgs.shipments.withIndex().associate { (index, shipment) -> index to shipment.items }
+    )
     private val shipmentsUIMap: MutableStateFlow<Map<Int, SelectableShippableItemsUI>?> = MutableStateFlow(null)
 
-    private val shipmentSelected = MutableStateFlow(navArgs.shipmentArgs.shipments.keys.first())
+    private val shipmentSelected = MutableStateFlow(0)
     private val removeShipmentSheet: MutableStateFlow<RemoveShipmentSheet?> = MutableStateFlow(null)
     private val splitMessage: MutableStateFlow<SplitShipmentMessage?> = MutableStateFlow(null)
 

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/GetShipmentsTests.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/GetShipmentsTests.kt
@@ -45,8 +45,9 @@ class GetShipmentsTests : BaseUnitTest() {
         whenever(orderDetailRepository.getOrderRefunds(eq(order.id))) doReturn refunds
 
         val result = sut.invoke(order)
+        val items = result.first().items
 
-        assertTrue(result.isEmpty())
+        assertTrue(items.isEmpty())
         verify(productDetailRepository, never()).getProductAsync(any())
     }
 

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/GetShipmentsTests.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/GetShipmentsTests.kt
@@ -4,6 +4,8 @@ import com.woocommerce.android.model.Refund
 import com.woocommerce.android.ui.orders.OrderTestUtils
 import com.woocommerce.android.ui.orders.details.OrderDetailRepository
 import com.woocommerce.android.ui.orders.wooshippinglabels.datasource.WooShippingConfigDataStore
+import com.woocommerce.android.ui.orders.wooshippinglabels.networking.ConfigDTO
+import com.woocommerce.android.ui.orders.wooshippinglabels.networking.Item
 import com.woocommerce.android.ui.products.ProductTestUtils
 import com.woocommerce.android.ui.products.details.ProductDetailRepository
 import com.woocommerce.android.viewmodel.BaseUnitTest
@@ -123,5 +125,56 @@ class GetShipmentsTests : BaseUnitTest() {
             it.productId == virtualProductId || it.productId == sampleProductId
         }
         assertTrue(expectedFilteredProducts.isEmpty())
+    }
+
+    @Test
+    fun `when there are multiple shipments, then should return shipments with correct quantities`() = testBlocking {
+        val itemsSize = 1
+        val quantity = 10f
+        val refunds = emptyList<Refund>()
+        val item = OrderTestUtils.generateTestOrderItems(count = itemsSize, quantity = quantity).first()
+
+        val order = OrderTestUtils.generateTestOrder().copy(items = listOf(item))
+        whenever(orderDetailRepository.getOrderRefunds(eq(order.id))) doReturn refunds
+        whenever(productDetailRepository.getProductAsync(any())).thenAnswer { invocation ->
+            val productId = invocation.arguments[0] as Long
+            ProductTestUtils.generateProduct(productId = productId, productName = "Product $productId")
+        }
+
+        // When total order quantity is 10 and each shipment has 5 items
+        val shipments = mapOf(
+            "0" to listOf(
+                Item(
+                    id = item.itemId,
+                    subItems = listOf(
+                        "${item.itemId}-sub-0",
+                        "${item.itemId}-sub-1",
+                        "${item.itemId}-sub-2",
+                        "${item.itemId}-sub-3",
+                        "${item.itemId}-sub-4"
+                    )
+                )
+            ),
+            "1" to listOf(
+                Item(
+                    id = item.itemId,
+                    subItems = listOf(
+                        "${item.itemId}-sub-0",
+                        "${item.itemId}-sub-1",
+                        "${item.itemId}-sub-2",
+                        "${item.itemId}-sub-3",
+                        "${item.itemId}-sub-4"
+                    )
+                )
+            )
+        )
+        whenever(configDataStore.observeConfig(eq(order.id))) doReturn flowOf(ConfigDTO(shipments))
+
+        val result = sut.invoke(order)
+        val shipment1 = result.first()
+        val shipment2 = result[1]
+
+        assertEquals(shipment1.items.first().quantity, 5f)
+        assertEquals(shipment2.items.first().quantity, 5f)
     }
 }

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/GetShipmentsTests.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/GetShipmentsTests.kt
@@ -22,14 +22,14 @@ import org.mockito.kotlin.whenever
 import kotlin.test.assertEquals
 
 @OptIn(ExperimentalCoroutinesApi::class)
-class GetShippableItemsTests : BaseUnitTest() {
+class GetShipmentsTests : BaseUnitTest() {
     private val orderDetailRepository: OrderDetailRepository = mock()
     private val productDetailRepository: ProductDetailRepository = mock()
     private val configDataStore: WooShippingConfigDataStore = mock {
         doReturn(flowOf(null)).whenever(it).observeConfig(any())
     }
 
-    private val sut = GetShippableItems(orderDetailRepository, productDetailRepository, configDataStore)
+    private val sut = GetShipments(orderDetailRepository, productDetailRepository, configDataStore)
 
     @Test
     fun `when order only contains refunded products then should return empty list`() = testBlocking {

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/GetShipmentsTests.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/GetShipmentsTests.kt
@@ -35,14 +35,9 @@ class GetShipmentsTests : BaseUnitTest() {
     fun `when order only contains refunded products then should return empty list`() = testBlocking {
         val productId = 18L
         val quantity = 2F
-        val refunds = OrderTestUtils.generateItemsRefunds(
-            listOf(Pair(productId, quantity.toInt()))
-        )
+        val refunds = OrderTestUtils.generateItemsRefunds(listOf(Pair(productId, quantity.toInt())))
         val order = OrderTestUtils.generateTestOrder().copy(
-            items = OrderTestUtils.generateTestOrderItems(
-                productId = productId,
-                quantity = quantity
-            )
+            items = OrderTestUtils.generateTestOrderItems(productId = productId, quantity = quantity)
         )
 
         whenever(orderDetailRepository.getOrderRefunds(eq(order.id))) doReturn refunds
@@ -58,9 +53,7 @@ class GetShipmentsTests : BaseUnitTest() {
         val itemsSize = 5
         val refunds = emptyList<Refund>()
         val order = OrderTestUtils.generateTestOrder().copy(
-            items = OrderTestUtils.generateTestOrderItems(
-                count = itemsSize,
-            )
+            items = OrderTestUtils.generateTestOrderItems(count = itemsSize)
         )
         whenever(orderDetailRepository.getOrderRefunds(eq(order.id))) doReturn refunds
         whenever(productDetailRepository.getProductAsync(any())).thenAnswer { invocation ->
@@ -69,9 +62,10 @@ class GetShipmentsTests : BaseUnitTest() {
         }
 
         val result = sut.invoke(order)
+        val items = result.first().items
 
-        assertTrue(result.isNotEmpty())
-        assertEquals(result.size, itemsSize)
+        assertTrue(items.isNotEmpty())
+        assertEquals(items.size, itemsSize)
     }
 
     @Test
@@ -79,15 +73,9 @@ class GetShipmentsTests : BaseUnitTest() {
         val productId = 18L
         val quantity = 2F
         val itemsSize = 1
-        val refunds = OrderTestUtils.generateItemsRefunds(
-            listOf(Pair(productId, quantity.toInt() - 1))
-        )
+        val refunds = OrderTestUtils.generateItemsRefunds(listOf(Pair(productId, quantity.toInt() - 1)))
         val order = OrderTestUtils.generateTestOrder().copy(
-            items = OrderTestUtils.generateTestOrderItems(
-                count = itemsSize,
-                productId = productId,
-                quantity = quantity
-            )
+            items = OrderTestUtils.generateTestOrderItems(count = itemsSize, productId = productId, quantity = quantity)
         )
 
         whenever(orderDetailRepository.getOrderRefunds(eq(order.id))) doReturn refunds
@@ -97,9 +85,10 @@ class GetShipmentsTests : BaseUnitTest() {
         }
 
         val result = sut.invoke(order)
+        val items = result.first().items
 
-        assertTrue(result.isNotEmpty())
-        assertEquals(result.size, itemsSize)
+        assertTrue(items.isNotEmpty())
+        assertEquals(items.size, itemsSize)
     }
 
     @Test
@@ -107,9 +96,9 @@ class GetShipmentsTests : BaseUnitTest() {
         val itemsSize = 5
         val virtualProductId = 1L
         val sampleProductId = 2L
-        val items = OrderTestUtils.generateTestOrderItems(count = itemsSize)
+        val orderItems = OrderTestUtils.generateTestOrderItems(count = itemsSize)
         val refunds = emptyList<Refund>()
-        val order = OrderTestUtils.generateTestOrder().copy(items = items)
+        val order = OrderTestUtils.generateTestOrder().copy(items = orderItems)
 
         whenever(orderDetailRepository.getOrderRefunds(eq(order.id))) doReturn refunds
         whenever(productDetailRepository.getProductAsync(any())).thenAnswer { invocation ->
@@ -124,12 +113,13 @@ class GetShipmentsTests : BaseUnitTest() {
         }
 
         val result = sut.invoke(order)
+        val items = result.first().items
 
-        assertTrue(result.isNotEmpty())
+        assertTrue(items.isNotEmpty())
         // result without a virtual product and a sample product should be total - 2
-        assertNotEquals(result.size, itemsSize)
-        assertEquals(result.size, itemsSize - 2)
-        val expectedFilteredProducts = result.filter {
+        assertNotEquals(items.size, itemsSize)
+        assertEquals(items.size, itemsSize - 2)
+        val expectedFilteredProducts = items.filter {
             it.productId == virtualProductId || it.productId == sampleProductId
         }
         assertTrue(expectedFilteredProducts.isEmpty())

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/WooShippingLabelCreationViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/WooShippingLabelCreationViewModelTest.kt
@@ -217,7 +217,7 @@ class WooShippingLabelCreationViewModelTest : BaseUnitTest() {
     )
 
     private val orderDetailRepository: OrderDetailRepository = mock()
-    private val getShippableItems: GetShippableItems = mock()
+    private val getShipments: GetShipments = mock()
     private val currencyFormatter: CurrencyFormatter = mock {
         on { formatCurrency(any<BigDecimal>(), any(), any()) } doAnswer {
             val amount = it.getArgument(0) as BigDecimal
@@ -250,7 +250,7 @@ class WooShippingLabelCreationViewModelTest : BaseUnitTest() {
     fun createViewModel() {
         sut = WooShippingLabelCreationViewModel(
             orderDetailRepository = orderDetailRepository,
-            getShippableItems = getShippableItems,
+            getShipments = getShipments,
             currencyFormatter = currencyFormatter,
             observeOriginAddresses = observeOriginAddresses,
             fetchOriginAddresses = mock(),
@@ -277,7 +277,7 @@ class WooShippingLabelCreationViewModelTest : BaseUnitTest() {
             )
         )
         whenever(orderDetailRepository.getOrderById(any())) doReturn order
-        whenever(getShippableItems(any())) doReturn defaultShippableItems
+        whenever(getShipments(any())) doReturn defaultShippableItems
         whenever(observeOriginAddresses()) doReturn flowOf(defaultOriginAddresses)
         whenever(observeStoreOptions()) doReturn flowOf(defaultStoreOptions)
 
@@ -301,7 +301,7 @@ class WooShippingLabelCreationViewModelTest : BaseUnitTest() {
             )
         )
         whenever(orderDetailRepository.getOrderById(any())) doReturn order
-        whenever(getShippableItems(any())) doReturn defaultShippableItems
+        whenever(getShipments(any())) doReturn defaultShippableItems
         whenever(observeOriginAddresses()) doReturn flowOf(defaultOriginAddresses)
         whenever(observeStoreOptions()) doReturn flowOf(defaultStoreOptions)
 
@@ -354,7 +354,7 @@ class WooShippingLabelCreationViewModelTest : BaseUnitTest() {
             shippingLines = defaultShippingLines
         )
         whenever(orderDetailRepository.getOrderById(any())) doReturn order
-        whenever(getShippableItems(any())) doReturn defaultShippableItems
+        whenever(getShipments(any())) doReturn defaultShippableItems
         whenever(observeOriginAddresses()) doReturn flowOf(defaultOriginAddresses)
         whenever(observeStoreOptions()) doReturn flowOf(defaultStoreOptions)
 
@@ -381,7 +381,7 @@ class WooShippingLabelCreationViewModelTest : BaseUnitTest() {
         )
         whenever(shouldRequireCustomsForm.invoke(any())) doReturn false
         whenever(orderDetailRepository.getOrderById(any())) doReturn order
-        whenever(getShippableItems(any())) doReturn defaultShippableItems
+        whenever(getShipments(any())) doReturn defaultShippableItems
         whenever(observeOriginAddresses()) doReturn flowOf(defaultOriginAddresses)
         whenever(
             getShippingRates(any(), any(), any(), any(), any(), any(), isNull(), isNull())
@@ -410,7 +410,7 @@ class WooShippingLabelCreationViewModelTest : BaseUnitTest() {
             )
         )
         whenever(orderDetailRepository.getOrderById(any())) doReturn order
-        whenever(getShippableItems(any())) doReturn defaultShippableItems
+        whenever(getShipments(any())) doReturn defaultShippableItems
         whenever(observeOriginAddresses()) doReturn flowOf(defaultOriginAddresses)
         whenever(addressValidationHelper.canFetchShippingRates(any())) doReturn false
         whenever(observeStoreOptions()) doReturn flowOf(defaultStoreOptions)
@@ -437,7 +437,7 @@ class WooShippingLabelCreationViewModelTest : BaseUnitTest() {
             )
         )
         whenever(orderDetailRepository.getOrderById(any())) doReturn order
-        whenever(getShippableItems(any())) doReturn defaultShippableItems.map { it.copy(weight = 0f) }
+        whenever(getShipments(any())) doReturn defaultShippableItems.map { it.copy(weight = 0f) }
         whenever(observeOriginAddresses()) doReturn flowOf(defaultOriginAddresses)
         whenever(observeStoreOptions()) doReturn flowOf(defaultStoreOptions)
         whenever(shouldRequireCustomsForm.invoke(any())) doReturn false
@@ -464,7 +464,7 @@ class WooShippingLabelCreationViewModelTest : BaseUnitTest() {
         )
         whenever(shouldRequireCustomsForm.invoke(any())) doReturn false
         whenever(orderDetailRepository.getOrderById(any())) doReturn order
-        whenever(getShippableItems(any())) doReturn defaultShippableItems
+        whenever(getShipments(any())) doReturn defaultShippableItems
         whenever(observeOriginAddresses()) doReturn flowOf(defaultOriginAddresses)
         whenever(
             getShippingRates(any(), any(), any(), any(), any(), any(), isNull(), isNull())
@@ -579,7 +579,7 @@ class WooShippingLabelCreationViewModelTest : BaseUnitTest() {
             shippingLines = defaultShippingLines
         )
         whenever(orderDetailRepository.getOrderById(any())) doReturn order
-        whenever(getShippableItems(any())) doReturn defaultShippableItems
+        whenever(getShipments(any())) doReturn defaultShippableItems
         whenever(observeOriginAddresses()) doReturn flowOf(defaultOriginAddresses)
         whenever(observeStoreOptions()) doReturn flowOf(defaultStoreOptions)
 
@@ -619,7 +619,7 @@ class WooShippingLabelCreationViewModelTest : BaseUnitTest() {
             shippingLines = defaultShippingLines
         )
         whenever(orderDetailRepository.getOrderById(any())) doReturn order
-        whenever(getShippableItems(any())) doReturn defaultShippableItems
+        whenever(getShipments(any())) doReturn defaultShippableItems
         whenever(observeOriginAddresses()) doReturn flowOf(defaultOriginAddresses)
         whenever(observeStoreOptions()) doReturn flowOf(defaultStoreOptions)
 
@@ -672,7 +672,7 @@ class WooShippingLabelCreationViewModelTest : BaseUnitTest() {
             shippingLines = defaultShippingLines
         )
         whenever(orderDetailRepository.getOrderById(any())) doReturn order
-        whenever(getShippableItems(any())) doReturn defaultShippableItems
+        whenever(getShipments(any())) doReturn defaultShippableItems
         whenever(observeOriginAddresses()) doReturn flowOf(defaultOriginAddresses)
         whenever(observeStoreOptions()) doReturn flowOf(defaultStoreOptions)
         whenever(shouldRequireCustomsForm.invoke(any())) doReturn false
@@ -698,7 +698,7 @@ class WooShippingLabelCreationViewModelTest : BaseUnitTest() {
             shippingLines = defaultShippingLines
         )
         whenever(orderDetailRepository.getOrderById(any())) doReturn order
-        whenever(getShippableItems(any())) doReturn defaultShippableItems
+        whenever(getShipments(any())) doReturn defaultShippableItems
         whenever(observeOriginAddresses()) doReturn flowOf(defaultOriginAddresses)
         whenever(observeStoreOptions()) doReturn flowOf(defaultStoreOptions)
         whenever(shouldRequireCustomsForm.invoke(any())) doReturn false
@@ -729,7 +729,7 @@ class WooShippingLabelCreationViewModelTest : BaseUnitTest() {
             whenever(observeStoreOptions()) doReturn flowOf(defaultStoreOptions)
             whenever(shouldRequireCustomsForm.invoke(any())) doReturn true
             whenever(shouldRequireITN.invoke(any(), any())) doReturn true
-            whenever(getShippableItems(any())) doReturn defaultShippableItems.map { it.copy(price = BigDecimal(10000)) }
+            whenever(getShipments(any())) doReturn defaultShippableItems.map { it.copy(price = BigDecimal(10000)) }
 
             createViewModel()
 
@@ -751,7 +751,7 @@ class WooShippingLabelCreationViewModelTest : BaseUnitTest() {
             shippingLines = defaultShippingLines
         )
         whenever(orderDetailRepository.getOrderById(any())) doReturn order
-        whenever(getShippableItems(any())) doReturn defaultShippableItems
+        whenever(getShipments(any())) doReturn defaultShippableItems
         whenever(observeOriginAddresses()) doReturn flowOf(defaultOriginAddresses)
         whenever(observeStoreOptions()) doReturn flowOf(defaultStoreOptions)
         whenever(
@@ -804,7 +804,7 @@ class WooShippingLabelCreationViewModelTest : BaseUnitTest() {
         val order = OrderTestUtils.generateTestOrder(orderId = orderId)
 
         whenever(orderDetailRepository.getOrderById(any())) doReturn order
-        whenever(getShippableItems(any())) doReturn defaultShippableItems
+        whenever(getShipments(any())) doReturn defaultShippableItems
         whenever(observeOriginAddresses()) doReturn flowOf(defaultOriginAddresses)
         whenever(observeStoreOptions()) doReturn flowOf(defaultStoreOptions)
         whenever(
@@ -831,7 +831,7 @@ class WooShippingLabelCreationViewModelTest : BaseUnitTest() {
             val order = OrderTestUtils.generateTestOrder(orderId = orderId)
 
             whenever(orderDetailRepository.getOrderById(any())) doReturn order
-            whenever(getShippableItems(any())) doReturn defaultShippableItems
+            whenever(getShipments(any())) doReturn defaultShippableItems
             whenever(observeOriginAddresses()) doReturn flowOf(defaultOriginAddresses)
             whenever(observeStoreOptions()) doReturn flowOf(null, defaultStoreOptions)
 
@@ -984,7 +984,7 @@ class WooShippingLabelCreationViewModelTest : BaseUnitTest() {
         )
 
         whenever(orderDetailRepository.getOrderById(any())) doReturn order
-        whenever(getShippableItems(any())) doReturn defaultShippableItems
+        whenever(getShipments(any())) doReturn defaultShippableItems
         whenever(observeOriginAddresses()) doReturn flowOf(defaultOriginAddresses)
         whenever(observeStoreOptions()) doReturn flowOf(defaultStoreOptions)
         whenever(observeShippingLabelNotice(any(), any(), any())) doReturn flowOf(notice)
@@ -1003,7 +1003,7 @@ class WooShippingLabelCreationViewModelTest : BaseUnitTest() {
         val notice = null
 
         whenever(orderDetailRepository.getOrderById(any())) doReturn order
-        whenever(getShippableItems(any())) doReturn defaultShippableItems
+        whenever(getShipments(any())) doReturn defaultShippableItems
         whenever(observeOriginAddresses()) doReturn flowOf(defaultOriginAddresses)
         whenever(observeStoreOptions()) doReturn flowOf(defaultStoreOptions)
         whenever(observeShippingLabelNotice(any(), any(), any())) doReturn flowOf(notice)
@@ -1021,7 +1021,7 @@ class WooShippingLabelCreationViewModelTest : BaseUnitTest() {
         val order = OrderTestUtils.generateTestOrder(orderId = orderId)
 
         whenever(orderDetailRepository.getOrderById(any())) doReturn order
-        whenever(getShippableItems(any())) doReturn defaultShippableItems
+        whenever(getShipments(any())) doReturn defaultShippableItems
         whenever(observeOriginAddresses()) doReturn flowOf(defaultOriginAddresses)
         whenever(observeStoreOptions()) doReturn flowOf(defaultStoreOptions)
         whenever(addressValidationHelper.isMissingDestinationAddress(any())) doReturn true
@@ -1038,7 +1038,7 @@ class WooShippingLabelCreationViewModelTest : BaseUnitTest() {
         val order = OrderTestUtils.generateTestOrder(orderId = orderId)
 
         whenever(orderDetailRepository.getOrderById(any())) doReturn order
-        whenever(getShippableItems(any())) doReturn defaultShippableItems
+        whenever(getShipments(any())) doReturn defaultShippableItems
         whenever(observeOriginAddresses()) doReturn flowOf(defaultOriginAddresses)
         whenever(observeStoreOptions()) doReturn flowOf(defaultStoreOptions)
         whenever(addressValidationHelper.isMissingDestinationAddress(any())) doReturn false
@@ -1057,7 +1057,7 @@ class WooShippingLabelCreationViewModelTest : BaseUnitTest() {
             shippingLines = defaultShippingLines
         )
         whenever(orderDetailRepository.getOrderById(any())) doReturn order
-        whenever(getShippableItems(any())) doReturn defaultShippableItems
+        whenever(getShipments(any())) doReturn defaultShippableItems
         whenever(observeOriginAddresses()) doReturn flowOf(defaultOriginAddresses)
         whenever(observeStoreOptions()) doReturn flowOf(defaultStoreOptions)
         whenever(shouldRequireCustomsForm.invoke(any())) doReturn false
@@ -1083,7 +1083,7 @@ class WooShippingLabelCreationViewModelTest : BaseUnitTest() {
             shippingLines = defaultShippingLines
         )
         whenever(orderDetailRepository.getOrderById(any())) doReturn order
-        whenever(getShippableItems(any())) doReturn defaultShippableItems
+        whenever(getShipments(any())) doReturn defaultShippableItems
         whenever(observeOriginAddresses()) doReturn flowOf(defaultOriginAddresses)
         whenever(observeStoreOptions()) doReturn flowOf(defaultStoreOptions)
         whenever(shouldRequireCustomsForm.invoke(any())) doReturn false
@@ -1123,7 +1123,7 @@ class WooShippingLabelCreationViewModelTest : BaseUnitTest() {
     fun `when initialized, show expected item quantity`() = testBlocking {
         val order = OrderTestUtils.generateTestOrder(orderId = orderId)
         whenever(orderDetailRepository.getOrderById(any())) doReturn order
-        whenever(getShippableItems(any())) doReturn defaultShippableItems
+        whenever(getShipments(any())) doReturn defaultShippableItems
         whenever(observeOriginAddresses()) doReturn flowOf(defaultOriginAddresses)
         whenever(observeStoreOptions()) doReturn flowOf(defaultStoreOptions)
         whenever(shouldRequireCustomsForm.invoke(any())) doReturn false

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/WooShippingLabelCreationViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/WooShippingLabelCreationViewModelTest.kt
@@ -28,6 +28,7 @@ import com.woocommerce.android.ui.orders.wooshippinglabels.customs.domain.Should
 import com.woocommerce.android.ui.orders.wooshippinglabels.customs.domain.ShouldRequireITN
 import com.woocommerce.android.ui.orders.wooshippinglabels.models.OriginShippingAddress
 import com.woocommerce.android.ui.orders.wooshippinglabels.models.PurchasedLabelData
+import com.woocommerce.android.ui.orders.wooshippinglabels.models.ShipmentUIModel
 import com.woocommerce.android.ui.orders.wooshippinglabels.models.ShippableItemModel
 import com.woocommerce.android.ui.orders.wooshippinglabels.models.ShippingLabelModel
 import com.woocommerce.android.ui.orders.wooshippinglabels.models.ShippingLabelStatus
@@ -84,6 +85,7 @@ class WooShippingLabelCreationViewModelTest : BaseUnitTest() {
             length = it.toFloat()
         )
     }
+    private val defaultShipments = listOf(ShipmentUIModel("0", defaultShippableItems))
     private val defaultShippingLines = List(3) {
         Order.ShippingLine(
             methodTitle = "Shipping Line $it",
@@ -277,7 +279,7 @@ class WooShippingLabelCreationViewModelTest : BaseUnitTest() {
             )
         )
         whenever(orderDetailRepository.getOrderById(any())) doReturn order
-        whenever(getShipments(any())) doReturn defaultShippableItems
+        whenever(getShipments(any())) doReturn defaultShipments
         whenever(observeOriginAddresses()) doReturn flowOf(defaultOriginAddresses)
         whenever(observeStoreOptions()) doReturn flowOf(defaultStoreOptions)
 
@@ -301,7 +303,7 @@ class WooShippingLabelCreationViewModelTest : BaseUnitTest() {
             )
         )
         whenever(orderDetailRepository.getOrderById(any())) doReturn order
-        whenever(getShipments(any())) doReturn defaultShippableItems
+        whenever(getShipments(any())) doReturn defaultShipments
         whenever(observeOriginAddresses()) doReturn flowOf(defaultOriginAddresses)
         whenever(observeStoreOptions()) doReturn flowOf(defaultStoreOptions)
 
@@ -354,7 +356,7 @@ class WooShippingLabelCreationViewModelTest : BaseUnitTest() {
             shippingLines = defaultShippingLines
         )
         whenever(orderDetailRepository.getOrderById(any())) doReturn order
-        whenever(getShipments(any())) doReturn defaultShippableItems
+        whenever(getShipments(any())) doReturn defaultShipments
         whenever(observeOriginAddresses()) doReturn flowOf(defaultOriginAddresses)
         whenever(observeStoreOptions()) doReturn flowOf(defaultStoreOptions)
 
@@ -381,7 +383,7 @@ class WooShippingLabelCreationViewModelTest : BaseUnitTest() {
         )
         whenever(shouldRequireCustomsForm.invoke(any())) doReturn false
         whenever(orderDetailRepository.getOrderById(any())) doReturn order
-        whenever(getShipments(any())) doReturn defaultShippableItems
+        whenever(getShipments(any())) doReturn defaultShipments
         whenever(observeOriginAddresses()) doReturn flowOf(defaultOriginAddresses)
         whenever(
             getShippingRates(any(), any(), any(), any(), any(), any(), isNull(), isNull())
@@ -410,7 +412,7 @@ class WooShippingLabelCreationViewModelTest : BaseUnitTest() {
             )
         )
         whenever(orderDetailRepository.getOrderById(any())) doReturn order
-        whenever(getShipments(any())) doReturn defaultShippableItems
+        whenever(getShipments(any())) doReturn defaultShipments
         whenever(observeOriginAddresses()) doReturn flowOf(defaultOriginAddresses)
         whenever(addressValidationHelper.canFetchShippingRates(any())) doReturn false
         whenever(observeStoreOptions()) doReturn flowOf(defaultStoreOptions)
@@ -437,7 +439,9 @@ class WooShippingLabelCreationViewModelTest : BaseUnitTest() {
             )
         )
         whenever(orderDetailRepository.getOrderById(any())) doReturn order
-        whenever(getShipments(any())) doReturn defaultShippableItems.map { it.copy(weight = 0f) }
+        whenever(getShipments(any())) doReturn defaultShipments.map {
+            it.copy(items = defaultShippableItems.map { it.copy(weight = 0f) })
+        }
         whenever(observeOriginAddresses()) doReturn flowOf(defaultOriginAddresses)
         whenever(observeStoreOptions()) doReturn flowOf(defaultStoreOptions)
         whenever(shouldRequireCustomsForm.invoke(any())) doReturn false
@@ -464,7 +468,7 @@ class WooShippingLabelCreationViewModelTest : BaseUnitTest() {
         )
         whenever(shouldRequireCustomsForm.invoke(any())) doReturn false
         whenever(orderDetailRepository.getOrderById(any())) doReturn order
-        whenever(getShipments(any())) doReturn defaultShippableItems
+        whenever(getShipments(any())) doReturn defaultShipments
         whenever(observeOriginAddresses()) doReturn flowOf(defaultOriginAddresses)
         whenever(
             getShippingRates(any(), any(), any(), any(), any(), any(), isNull(), isNull())
@@ -579,7 +583,7 @@ class WooShippingLabelCreationViewModelTest : BaseUnitTest() {
             shippingLines = defaultShippingLines
         )
         whenever(orderDetailRepository.getOrderById(any())) doReturn order
-        whenever(getShipments(any())) doReturn defaultShippableItems
+        whenever(getShipments(any())) doReturn defaultShipments
         whenever(observeOriginAddresses()) doReturn flowOf(defaultOriginAddresses)
         whenever(observeStoreOptions()) doReturn flowOf(defaultStoreOptions)
 
@@ -619,7 +623,7 @@ class WooShippingLabelCreationViewModelTest : BaseUnitTest() {
             shippingLines = defaultShippingLines
         )
         whenever(orderDetailRepository.getOrderById(any())) doReturn order
-        whenever(getShipments(any())) doReturn defaultShippableItems
+        whenever(getShipments(any())) doReturn defaultShipments
         whenever(observeOriginAddresses()) doReturn flowOf(defaultOriginAddresses)
         whenever(observeStoreOptions()) doReturn flowOf(defaultStoreOptions)
 
@@ -672,7 +676,7 @@ class WooShippingLabelCreationViewModelTest : BaseUnitTest() {
             shippingLines = defaultShippingLines
         )
         whenever(orderDetailRepository.getOrderById(any())) doReturn order
-        whenever(getShipments(any())) doReturn defaultShippableItems
+        whenever(getShipments(any())) doReturn defaultShipments
         whenever(observeOriginAddresses()) doReturn flowOf(defaultOriginAddresses)
         whenever(observeStoreOptions()) doReturn flowOf(defaultStoreOptions)
         whenever(shouldRequireCustomsForm.invoke(any())) doReturn false
@@ -698,7 +702,7 @@ class WooShippingLabelCreationViewModelTest : BaseUnitTest() {
             shippingLines = defaultShippingLines
         )
         whenever(orderDetailRepository.getOrderById(any())) doReturn order
-        whenever(getShipments(any())) doReturn defaultShippableItems
+        whenever(getShipments(any())) doReturn defaultShipments
         whenever(observeOriginAddresses()) doReturn flowOf(defaultOriginAddresses)
         whenever(observeStoreOptions()) doReturn flowOf(defaultStoreOptions)
         whenever(shouldRequireCustomsForm.invoke(any())) doReturn false
@@ -729,7 +733,9 @@ class WooShippingLabelCreationViewModelTest : BaseUnitTest() {
             whenever(observeStoreOptions()) doReturn flowOf(defaultStoreOptions)
             whenever(shouldRequireCustomsForm.invoke(any())) doReturn true
             whenever(shouldRequireITN.invoke(any(), any())) doReturn true
-            whenever(getShipments(any())) doReturn defaultShippableItems.map { it.copy(price = BigDecimal(10000)) }
+            whenever(getShipments(any())) doReturn defaultShipments.map {
+                it.copy(items = defaultShippableItems.map { it.copy(price = BigDecimal(10000)) })
+            }
 
             createViewModel()
 
@@ -751,7 +757,7 @@ class WooShippingLabelCreationViewModelTest : BaseUnitTest() {
             shippingLines = defaultShippingLines
         )
         whenever(orderDetailRepository.getOrderById(any())) doReturn order
-        whenever(getShipments(any())) doReturn defaultShippableItems
+        whenever(getShipments(any())) doReturn defaultShipments
         whenever(observeOriginAddresses()) doReturn flowOf(defaultOriginAddresses)
         whenever(observeStoreOptions()) doReturn flowOf(defaultStoreOptions)
         whenever(
@@ -804,7 +810,7 @@ class WooShippingLabelCreationViewModelTest : BaseUnitTest() {
         val order = OrderTestUtils.generateTestOrder(orderId = orderId)
 
         whenever(orderDetailRepository.getOrderById(any())) doReturn order
-        whenever(getShipments(any())) doReturn defaultShippableItems
+        whenever(getShipments(any())) doReturn defaultShipments
         whenever(observeOriginAddresses()) doReturn flowOf(defaultOriginAddresses)
         whenever(observeStoreOptions()) doReturn flowOf(defaultStoreOptions)
         whenever(
@@ -831,7 +837,7 @@ class WooShippingLabelCreationViewModelTest : BaseUnitTest() {
             val order = OrderTestUtils.generateTestOrder(orderId = orderId)
 
             whenever(orderDetailRepository.getOrderById(any())) doReturn order
-            whenever(getShipments(any())) doReturn defaultShippableItems
+            whenever(getShipments(any())) doReturn defaultShipments
             whenever(observeOriginAddresses()) doReturn flowOf(defaultOriginAddresses)
             whenever(observeStoreOptions()) doReturn flowOf(null, defaultStoreOptions)
 
@@ -984,7 +990,7 @@ class WooShippingLabelCreationViewModelTest : BaseUnitTest() {
         )
 
         whenever(orderDetailRepository.getOrderById(any())) doReturn order
-        whenever(getShipments(any())) doReturn defaultShippableItems
+        whenever(getShipments(any())) doReturn defaultShipments
         whenever(observeOriginAddresses()) doReturn flowOf(defaultOriginAddresses)
         whenever(observeStoreOptions()) doReturn flowOf(defaultStoreOptions)
         whenever(observeShippingLabelNotice(any(), any(), any())) doReturn flowOf(notice)
@@ -1003,7 +1009,7 @@ class WooShippingLabelCreationViewModelTest : BaseUnitTest() {
         val notice = null
 
         whenever(orderDetailRepository.getOrderById(any())) doReturn order
-        whenever(getShipments(any())) doReturn defaultShippableItems
+        whenever(getShipments(any())) doReturn defaultShipments
         whenever(observeOriginAddresses()) doReturn flowOf(defaultOriginAddresses)
         whenever(observeStoreOptions()) doReturn flowOf(defaultStoreOptions)
         whenever(observeShippingLabelNotice(any(), any(), any())) doReturn flowOf(notice)
@@ -1021,7 +1027,7 @@ class WooShippingLabelCreationViewModelTest : BaseUnitTest() {
         val order = OrderTestUtils.generateTestOrder(orderId = orderId)
 
         whenever(orderDetailRepository.getOrderById(any())) doReturn order
-        whenever(getShipments(any())) doReturn defaultShippableItems
+        whenever(getShipments(any())) doReturn defaultShipments
         whenever(observeOriginAddresses()) doReturn flowOf(defaultOriginAddresses)
         whenever(observeStoreOptions()) doReturn flowOf(defaultStoreOptions)
         whenever(addressValidationHelper.isMissingDestinationAddress(any())) doReturn true
@@ -1038,7 +1044,7 @@ class WooShippingLabelCreationViewModelTest : BaseUnitTest() {
         val order = OrderTestUtils.generateTestOrder(orderId = orderId)
 
         whenever(orderDetailRepository.getOrderById(any())) doReturn order
-        whenever(getShipments(any())) doReturn defaultShippableItems
+        whenever(getShipments(any())) doReturn defaultShipments
         whenever(observeOriginAddresses()) doReturn flowOf(defaultOriginAddresses)
         whenever(observeStoreOptions()) doReturn flowOf(defaultStoreOptions)
         whenever(addressValidationHelper.isMissingDestinationAddress(any())) doReturn false
@@ -1057,7 +1063,7 @@ class WooShippingLabelCreationViewModelTest : BaseUnitTest() {
             shippingLines = defaultShippingLines
         )
         whenever(orderDetailRepository.getOrderById(any())) doReturn order
-        whenever(getShipments(any())) doReturn defaultShippableItems
+        whenever(getShipments(any())) doReturn defaultShipments
         whenever(observeOriginAddresses()) doReturn flowOf(defaultOriginAddresses)
         whenever(observeStoreOptions()) doReturn flowOf(defaultStoreOptions)
         whenever(shouldRequireCustomsForm.invoke(any())) doReturn false
@@ -1083,7 +1089,7 @@ class WooShippingLabelCreationViewModelTest : BaseUnitTest() {
             shippingLines = defaultShippingLines
         )
         whenever(orderDetailRepository.getOrderById(any())) doReturn order
-        whenever(getShipments(any())) doReturn defaultShippableItems
+        whenever(getShipments(any())) doReturn defaultShipments
         whenever(observeOriginAddresses()) doReturn flowOf(defaultOriginAddresses)
         whenever(observeStoreOptions()) doReturn flowOf(defaultStoreOptions)
         whenever(shouldRequireCustomsForm.invoke(any())) doReturn false
@@ -1123,7 +1129,7 @@ class WooShippingLabelCreationViewModelTest : BaseUnitTest() {
     fun `when initialized, show expected item quantity`() = testBlocking {
         val order = OrderTestUtils.generateTestOrder(orderId = orderId)
         whenever(orderDetailRepository.getOrderById(any())) doReturn order
-        whenever(getShipments(any())) doReturn defaultShippableItems
+        whenever(getShipments(any())) doReturn defaultShipments
         whenever(observeOriginAddresses()) doReturn flowOf(defaultOriginAddresses)
         whenever(observeStoreOptions()) doReturn flowOf(defaultStoreOptions)
         whenever(shouldRequireCustomsForm.invoke(any())) doReturn false

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/split/WooShippingSplitShipmentViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/split/WooShippingSplitShipmentViewModelTest.kt
@@ -2,6 +2,7 @@ package com.woocommerce.android.ui.orders.wooshippinglabels.split
 
 import com.woocommerce.android.R
 import com.woocommerce.android.ui.orders.wooshippinglabels.WooShippingLabelCreationViewModel.SplitShipmentArgs
+import com.woocommerce.android.ui.orders.wooshippinglabels.models.ShipmentUIModel
 import com.woocommerce.android.ui.orders.wooshippinglabels.models.ShippableItemModel
 import com.woocommerce.android.ui.orders.wooshippinglabels.models.StoreOptionsModel
 import com.woocommerce.android.util.CurrencyFormatter
@@ -27,7 +28,7 @@ class WooShippingSplitShipmentViewModelTest : BaseUnitTest() {
         shipmentArgs: SplitShipmentArgs = SplitShipmentArgs(
             orderId = 1L,
             storeOptions = StoreOptionsModel.EMPTY,
-            shipments = defaultShipment
+            shipments = defaultShipments
         )
     ) {
         val savedState = WooShippingSplitShipmentFragmentArgs(shipmentArgs).toSavedStateHandle()
@@ -58,7 +59,7 @@ class WooShippingSplitShipmentViewModelTest : BaseUnitTest() {
             val shipmentArgs = SplitShipmentArgs(
                 orderId = 1L,
                 storeOptions = StoreOptionsModel.EMPTY,
-                shipments = defaultShipment
+                shipments = defaultShipments
             )
 
             createViewModel(shipmentArgs)
@@ -135,8 +136,8 @@ class WooShippingSplitShipmentViewModelTest : BaseUnitTest() {
 
     @Test
     fun `when moving a shippable item to a new shipment, then a new shipment is created`() = testBlocking {
-        val updatedCurrentShipmentItems = defaultShipment[0]!!.subList(fromIndex = 1, toIndex = 3)
-        val updatedShipmentItems = defaultShipment[0]!!.subList(fromIndex = 0, toIndex = 1)
+        val updatedCurrentShipmentItems = defaultShipments[0].items.subList(fromIndex = 1, toIndex = 3)
+        val updatedShipmentItems = defaultShipments[0].items.subList(fromIndex = 0, toIndex = 1)
 
         val movement = SplitMovement(
             sourceShipmentKey = 0,
@@ -167,7 +168,7 @@ class WooShippingSplitShipmentViewModelTest : BaseUnitTest() {
                 storeOptions = StoreOptionsModel.EMPTY,
                 shipments = twoShipments
             )
-            val updatedCurrentShipmentItems = defaultShipment[0]!!
+            val updatedCurrentShipmentItems = defaultShipments[0].items
             val updatedShipmentItems = listOf(
                 ShippableItemModel(
                     itemId = 3L,
@@ -210,8 +211,8 @@ class WooShippingSplitShipmentViewModelTest : BaseUnitTest() {
 
     @Test
     fun `when moving a shippable item to new shipment, then show singular snackbar`() = testBlocking {
-        val updatedCurrentShipmentItems = defaultShipment[0]!!.subList(fromIndex = 1, toIndex = 3)
-        val updatedShipmentItems = defaultShipment[0]!!.subList(fromIndex = 0, toIndex = 1)
+        val updatedCurrentShipmentItems = defaultShipments[0].items.subList(fromIndex = 1, toIndex = 3)
+        val updatedShipmentItems = defaultShipments[0].items.subList(fromIndex = 0, toIndex = 1)
 
         val movement = SplitMovement(
             sourceShipmentKey = 0,
@@ -237,8 +238,8 @@ class WooShippingSplitShipmentViewModelTest : BaseUnitTest() {
 
     @Test
     fun `when moving shippable items to new shipment, then show plural snackbar`() = testBlocking {
-        val updatedCurrentShipmentItems = defaultShipment[0]!!.subList(fromIndex = 0, toIndex = 1)
-        val updatedShipmentItems = defaultShipment[0]!!.subList(fromIndex = 1, toIndex = 2)
+        val updatedCurrentShipmentItems = defaultShipments[0].items.subList(fromIndex = 0, toIndex = 1)
+        val updatedShipmentItems = defaultShipments[0].items.subList(fromIndex = 1, toIndex = 2)
 
         val movement = SplitMovement(
             sourceShipmentKey = 0,
@@ -284,7 +285,7 @@ class WooShippingSplitShipmentViewModelTest : BaseUnitTest() {
 
     @Test
     fun `when removing a shipment, then the total shipment count is reduced by 1`() = testBlocking {
-        val movingItems = twoShipments[1]!!
+        val movingItems = twoShipments[1].items
 
         // Removing "Shipment 2"
         val movement = SplitMovement(
@@ -312,7 +313,7 @@ class WooShippingSplitShipmentViewModelTest : BaseUnitTest() {
             storeOptions = StoreOptionsModel.EMPTY,
             shipments = twoShipments
         )
-        val movingItems = twoShipments[1]!!
+        val movingItems = twoShipments[1].items
 
         // Removing "Shipment 2"
         val movement = SplitMovement(
@@ -321,7 +322,7 @@ class WooShippingSplitShipmentViewModelTest : BaseUnitTest() {
             destinationShipmentKey = 0,
             movingShipmentItems = movingItems
         )
-        val expectedItemCount = twoShipments[0]!!.size + twoShipments[1]!!.size
+        val expectedItemCount = twoShipments[0].items.size + twoShipments[1].items.size
 
         createViewModel(shipmentArgs)
 
@@ -386,7 +387,10 @@ class WooShippingSplitShipmentViewModelTest : BaseUnitTest() {
         createViewModel(shipmentArgs)
 
         // Trigger merging all shipments
-        sut.onRemoveShipments(removingShipmentKeys = threeShipments.keys.toList(), destinationShipmentKey = null)
+        sut.onRemoveShipments(
+            removingShipmentKeys = (0 until threeShipments.size).toList(),
+            destinationShipmentKey = null
+        )
 
         sut.viewState.observeForTesting { }
 
@@ -400,151 +404,171 @@ class WooShippingSplitShipmentViewModelTest : BaseUnitTest() {
         assertThat(currentShipments.values.first().totalItemQuantity).isEqualTo(expectedItemQuantity)
     }
 
-    private val defaultShipment = mapOf(
-        0 to listOf(
-            ShippableItemModel(
-                itemId = 1L,
-                productId = 1L,
-                title = "A product with quantity 1",
-                price = BigDecimal(30),
-                quantity = 1f,
-                imageUrl = null,
-                currency = "USD",
-                length = 3f,
-                width = 3f,
-                height = 3f,
-                weight = 8f
-            ),
-            ShippableItemModel(
-                itemId = 2L,
-                productId = 2L,
-                title = "A product with quantity 5",
-                price = BigDecimal(10),
-                quantity = 5f,
-                imageUrl = null,
-                currency = "USD",
-                length = 3f,
-                width = 3f,
-                height = 3f,
-                weight = 8f
-            ),
-            ShippableItemModel(
-                itemId = 3L,
-                productId = 3L,
-                title = "Another product with quantity 3",
-                price = BigDecimal(10),
-                quantity = 3f,
-                imageUrl = null,
-                currency = "USD",
-                length = 3f,
-                width = 3f,
-                height = 3f,
-                weight = 8f
+    private val defaultShipments = listOf(
+        ShipmentUIModel(
+            id = "0",
+            items = listOf(
+                ShippableItemModel(
+                    itemId = 1L,
+                    productId = 1L,
+                    title = "A product with quantity 1",
+                    price = BigDecimal(30),
+                    quantity = 1f,
+                    imageUrl = null,
+                    currency = "USD",
+                    length = 3f,
+                    width = 3f,
+                    height = 3f,
+                    weight = 8f
+                ),
+                ShippableItemModel(
+                    itemId = 2L,
+                    productId = 2L,
+                    title = "A product with quantity 5",
+                    price = BigDecimal(10),
+                    quantity = 5f,
+                    imageUrl = null,
+                    currency = "USD",
+                    length = 3f,
+                    width = 3f,
+                    height = 3f,
+                    weight = 8f
+                ),
+                ShippableItemModel(
+                    itemId = 3L,
+                    productId = 3L,
+                    title = "Another product with quantity 3",
+                    price = BigDecimal(10),
+                    quantity = 3f,
+                    imageUrl = null,
+                    currency = "USD",
+                    length = 3f,
+                    width = 3f,
+                    height = 3f,
+                    weight = 8f
+                )
             )
         )
     )
-    private val twoShipments = mapOf(
-        0 to listOf(
-            ShippableItemModel(
-                itemId = 1L,
-                productId = 1L,
-                title = "A product with quantity 1",
-                price = BigDecimal(30),
-                quantity = 1f,
-                imageUrl = null,
-                currency = "USD",
-                length = 3f,
-                width = 3f,
-                height = 3f,
-                weight = 8f
-            ),
-            ShippableItemModel(
-                itemId = 2L,
-                productId = 2L,
-                title = "A product with quantity 5",
-                price = BigDecimal(10),
-                quantity = 5f,
-                imageUrl = null,
-                currency = "USD",
-                length = 3f,
-                width = 3f,
-                height = 3f,
-                weight = 8f
+
+    private val twoShipments = listOf(
+        ShipmentUIModel(
+            id = "0",
+            items = listOf(
+                ShippableItemModel(
+                    itemId = 1L,
+                    productId = 1L,
+                    title = "A product with quantity 1",
+                    price = BigDecimal(30),
+                    quantity = 1f,
+                    imageUrl = null,
+                    currency = "USD",
+                    length = 3f,
+                    width = 3f,
+                    height = 3f,
+                    weight = 8f
+                ),
+                ShippableItemModel(
+                    itemId = 2L,
+                    productId = 2L,
+                    title = "A product with quantity 5",
+                    price = BigDecimal(10),
+                    quantity = 5f,
+                    imageUrl = null,
+                    currency = "USD",
+                    length = 3f,
+                    width = 3f,
+                    height = 3f,
+                    weight = 8f
+                )
             )
         ),
-        1 to listOf(
-            ShippableItemModel(
-                itemId = 3L,
-                productId = 3L,
-                title = "Another product with quantity 3",
-                price = BigDecimal(10),
-                quantity = 3f,
-                imageUrl = null,
-                currency = "USD",
-                length = 3f,
-                width = 3f,
-                height = 3f,
-                weight = 8f
+        ShipmentUIModel(
+            id = "1",
+            items = listOf(
+                ShippableItemModel(
+                    itemId = 3L,
+                    productId = 3L,
+                    title = "Another product with quantity 3",
+                    price = BigDecimal(10),
+                    quantity = 3f,
+                    imageUrl = null,
+                    currency = "USD",
+                    length = 3f,
+                    width = 3f,
+                    height = 3f,
+                    weight = 8f
+                )
             )
         )
     )
-    private val threeShipments = mapOf(
-        0 to listOf(
-            ShippableItemModel(
-                itemId = 1L,
-                productId = 1L,
-                title = "A product with quantity 1",
-                price = BigDecimal(30),
-                quantity = 1f,
-                imageUrl = null,
-                currency = "USD",
-                length = 3f,
-                width = 3f,
-                height = 3f,
-                weight = 8f
-            ),
-            ShippableItemModel(
-                itemId = 2L,
-                productId = 2L,
-                title = "A product with quantity 5",
-                price = BigDecimal(10),
-                quantity = 5f,
-                imageUrl = null,
-                currency = "USD",
-                length = 3f,
-                width = 3f,
-                height = 3f,
-                weight = 8f
+
+    private val threeShipments = listOf(
+        ShipmentUIModel(
+            id = "0",
+            items = listOf(
+                ShippableItemModel(
+                    itemId = 1L,
+                    productId = 1L,
+                    title = "A product with quantity 1",
+                    price = BigDecimal(30),
+                    quantity = 1f,
+                    imageUrl = null,
+                    currency = "USD",
+                    length = 3f,
+                    width = 3f,
+                    height = 3f,
+                    weight = 8f
+                ),
+                ShippableItemModel(
+                    itemId = 2L,
+                    productId = 2L,
+                    title = "A product with quantity 5",
+                    price = BigDecimal(10),
+                    quantity = 5f,
+                    imageUrl = null,
+                    currency = "USD",
+                    length = 3f,
+                    width = 3f,
+                    height = 3f,
+                    weight = 8f
+                )
             )
         ),
-        1 to listOf(
-            ShippableItemModel(
-                itemId = 3L,
-                productId = 3L,
-                title = "Another product with quantity 3",
-                price = BigDecimal(10),
-                quantity = 3f,
-                imageUrl = null,
-                currency = "USD",
-                length = 3f,
-                width = 3f,
-                height = 3f,
-                weight = 8f
+        ShipmentUIModel(
+            id = "1",
+            items = listOf(
+                ShippableItemModel(
+                    itemId = 3L,
+                    productId = 3L,
+                    title = "Another product with quantity 3",
+                    price = BigDecimal(10),
+                    quantity = 3f,
+                    imageUrl = null,
+                    currency = "USD",
+                    length = 3f,
+                    width = 3f,
+                    height = 3f,
+                    weight = 8f
+                )
             )
         ),
-        2 to listOf(
-            ShippableItemModel(
-                itemId = 3L,
-                productId = 3L,
-                title = "Another product with quantity 3",
-                price = BigDecimal(10),
-                quantity = 1f,
-                imageUrl = null,
-                currency = "USD",
-                length = 3f,
-                width = 3f,
-                height = 3f,
-                weight = 8f
+        ShipmentUIModel(
+            id = "2",
+            items = listOf(
+                ShippableItemModel(
+                    itemId = 3L,
+                    productId = 3L,
+                    title = "Another product with quantity 3",
+                    price = BigDecimal(10),
+                    quantity = 1f,
+                    imageUrl = null,
+                    currency = "USD",
+                    length = 3f,
+                    width = 3f,
+                    height = 3f,
+                    weight = 8f
+                )
             )
         )
     )


### PR DESCRIPTION
Closes WOOMOB-416

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
This completes the UI parts of fetching shipments from the backend.

> [!WARNING]  
> Review #13995 first.

### Steps to reproduce
<!-- Step-by-step testing instructions. For new user flows, consider instead stating the goal of the workflow and see if your PR reviewer can accomplish the workflow without specific steps! -->
1. On the web, create an order with shipments.
2. In the app, open the Orders tab.
3. Tap the order you created on the web.
4. Tap on Create shipping label.
5. Tap Split shipment.
6. Verify that the shipments match those on the web.

### Testing information
<!-- This is your opportunity to break out individual scenarios that need testing (when necessary) and/or include a checklist for the reviewer to go through. Consider documenting the following from your own completed testing: devices used, alternate workflows, edge cases, affected areas, critical flows, areas not tested, and any remaining unknowns. Provide feedback on this new section of the PR template through Sept 30, 2024 to Apps Quality; additional context here: p91TBi-b8z-p2#comment-12036 -->
- [x] Test an order that has shipments
- [x] Test an order that has shipments with the same product type in separate shipments
- [x] Test a new order that has no shipments
- [x] Remove shipments
- [x] Move items

### The tests that have been performed
<!-- To give the reviewer an idea of what could be missed in terms of testing -->
Steps above

### Images/gif
<!-- Include before and after images or gifs when appropriate. -->
[after.webm](https://github.com/user-attachments/assets/d69be842-141f-47b3-baac-fcf39217781a)

- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.

## Reviewer (or Author, in the case of optional code reviews):

Please make sure these conditions are met before approving the PR, or request changes if the PR needs improvement:

- [ ] The PR is small and has a clear, single focus, or a valid explanation is provided in the description. If needed, please request to split it into smaller PRs.
- [ ] Ensure Adequate Unit Test Coverage: The changes are reasonably covered by unit tests or an explanation is provided in the PR description.
- [ ] Manual Testing: The author listed all the tests they ran, including smoke tests when needed (e.g., for refactorings). The reviewer confirmed that the PR works as expected on big (tablet) and small (phone) in case of UI changes, and no regressions are added.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->