### PR TITLE
[Shipping labels] Fix "Create shipping label" button visibility logic

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/OrderDetailViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/OrderDetailViewModel.kt
@@ -58,6 +58,7 @@ import com.woocommerce.android.ui.orders.creation.shipping.GetShippingMethodsWit
 import com.woocommerce.android.ui.orders.creation.shipping.RefreshShippingMethods
 import com.woocommerce.android.ui.orders.creation.shipping.ShippingLineDetails
 import com.woocommerce.android.ui.orders.creation.shipping.ShippingMethodsRepository
+import com.woocommerce.android.ui.orders.wooshippinglabels.datasource.WooShippingConfigDataStore
 import com.woocommerce.android.ui.orders.wooshippinglabels.networking.WooShippingLabelRepository
 import com.woocommerce.android.ui.payments.cardreader.onboarding.CardReaderFlowParam
 import com.woocommerce.android.ui.payments.cardreader.payment.CardReaderPaymentCollectibilityChecker
@@ -102,6 +103,7 @@ class OrderDetailViewModel @Inject constructor(
     private val networkStatus: NetworkStatus,
     private val resourceProvider: ResourceProvider,
     private val orderDetailRepository: OrderDetailRepository,
+    private val configDataStore: WooShippingConfigDataStore,
     private val addonsRepository: AddonRepository,
     private val selectedSite: SelectedSite,
     private val productImageMap: ProductImageMap,
@@ -886,8 +888,12 @@ class OrderDetailViewModel @Inject constructor(
         return ListInfo(isVisible = false)
     }
 
+    private suspend fun loadShippingConfig() = configDataStore.observeConfig(navArgs.orderId).first()?.shipments
+        ?: emptyMap()
+
     private suspend fun displayProductAndShippingDetails() {
         val shippingLabels = loadOrderShippingLabels()
+        val shipments = loadShippingConfig()
         val shipmentTracking = loadShipmentTracking(shippingLabels)
         val orderRefunds = loadOrderRefunds()
         val orderProducts = loadOrderProducts(orderRefunds)
@@ -927,8 +933,10 @@ class OrderDetailViewModel @Inject constructor(
             tracker.trackOrderEligibleForShippingLabelCreation(awaitOrder().status.value)
         }
 
+        val allShipmentsFulfilled = shipments.isNotEmpty() && shipments.size == shippingLabels.list.size
+
         viewState = viewState.copy(
-            isCreateShippingLabelButtonVisible = isOrderEligibleForSLCreation && !shippingLabels.isVisible,
+            isCreateShippingLabelButtonVisible = isOrderEligibleForSLCreation && !allShipmentsFulfilled,
             isProductListMenuVisible = isOrderEligibleForSLCreation && shippingLabels.isVisible,
             isShipmentTrackingAvailable = shipmentTracking.isVisible,
             isProductListVisible = orderProducts.isVisible,
@@ -1034,8 +1042,4 @@ class OrderDetailViewModel @Inject constructor(
 
     data class ListInfo<T>(val isVisible: Boolean = true, val list: List<T> = emptyList())
     data class TrashOrder(val orderId: Long) : MultiLiveEvent.Event()
-
-    private companion object {
-        const val TIME_TO_WAIT_ORDER_MS = 3_000L
-    }
 }

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/OrderDetailViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/OrderDetailViewModelTest.kt
@@ -44,6 +44,9 @@ import com.woocommerce.android.ui.orders.details.OrderProduct
 import com.woocommerce.android.ui.orders.details.OrderProductMapper
 import com.woocommerce.android.ui.orders.details.ShippingLabelOnboardingRepository
 import com.woocommerce.android.ui.orders.details.ShippingLabelOnboardingRepository.ShippingLabelSupport
+import com.woocommerce.android.ui.orders.wooshippinglabels.datasource.WooShippingConfigDataStore
+import com.woocommerce.android.ui.orders.wooshippinglabels.networking.ConfigDTO
+import com.woocommerce.android.ui.orders.wooshippinglabels.networking.Item
 import com.woocommerce.android.ui.orders.wooshippinglabels.networking.WooShippingLabelRepository
 import com.woocommerce.android.ui.payments.cardreader.payment.CardReaderPaymentCollectibilityChecker
 import com.woocommerce.android.ui.payments.receipt.PaymentReceiptHelper
@@ -114,6 +117,9 @@ class OrderDetailViewModelTest : BaseUnitTest() {
     private val pluginsInfo = HashMap<String, WooPlugin>()
     private val orderDetailRepository: OrderDetailRepository = mock {
         onBlocking { getOrderDetailsPluginsInfo() } doReturn pluginsInfo
+    }
+    private val configDataStore: WooShippingConfigDataStore = mock {
+        doReturn(flowOf(null)).whenever(it).observeConfig(any())
     }
     private val addonsRepository: AddonRepository = mock()
     private val paymentsFlowTracker: PaymentsFlowTracker = mock()
@@ -200,6 +206,7 @@ class OrderDetailViewModelTest : BaseUnitTest() {
                 networkStatus,
                 resources,
                 orderDetailRepository,
+                configDataStore,
                 addonsRepository,
                 selectedSite,
                 productImageMap,
@@ -628,16 +635,33 @@ class OrderDetailViewModelTest : BaseUnitTest() {
         }
 
     @Test
-    fun `Hide Create shipping label button and show Products area menu when shipping labels are available`() =
+    fun `Show Create shipping label button when there are unfulfilled shipments`() =
         testBlocking {
-            doReturn(order).whenever(orderDetailRepository).getOrderById(any())
             doReturn(order).whenever(orderDetailRepository).fetchOrderById(any())
 
             doReturn(true).whenever(orderDetailRepository).fetchOrderNotes(any())
-            doReturn(testOrderNotes).whenever(orderDetailRepository).getOrderNotes(any())
 
-            doReturn(emptyList<Refund>()).whenever(orderDetailRepository).fetchOrderRefunds(any())
-            doReturn(emptyList<Refund>()).whenever(orderDetailRepository).getOrderRefunds(any())
+            doReturn(false).whenever(addonsRepository).containsAddonsFrom(any())
+
+            doReturn(true).whenever(orderDetailRepository).isOrderEligibleForSLCreation(order.id)
+            doReturn(flowOf(ConfigDTO(emptyMap()))).whenever(configDataStore).observeConfig(order.id)
+
+            var isCreateShippingLabelButtonVisible: Boolean? = null
+            viewModel.viewStateData.observeForever { _, new ->
+                isCreateShippingLabelButtonVisible = new.isCreateShippingLabelButtonVisible
+            }
+
+            viewModel.start()
+
+            assertThat(isCreateShippingLabelButtonVisible).isTrue
+        }
+
+    @Test
+    fun `Hide Create shipping label button when all shipments fulfilled`() =
+        testBlocking {
+            doReturn(order).whenever(orderDetailRepository).fetchOrderById(any())
+
+            doReturn(true).whenever(orderDetailRepository).fetchOrderNotes(any())
 
             doReturn(RequestResult.SUCCESS).whenever(orderDetailRepository).fetchOrderShipmentTrackingList(any())
             doReturn(testOrderShipmentTrackings).whenever(orderDetailRepository).getOrderShipmentTrackings(any())
@@ -645,69 +669,77 @@ class OrderDetailViewModelTest : BaseUnitTest() {
             doReturn(orderShippingLabels).whenever(orderDetailRepository).getOrderShippingLabels(any())
             doReturn(false).whenever(addonsRepository).containsAddonsFrom(any())
 
-            doReturn(Unit).whenever(orderDetailRepository).fetchSLCreationEligibility(order.id)
             doReturn(true).whenever(orderDetailRepository).isOrderEligibleForSLCreation(order.id)
             doReturn(ShippingLabelSupport.WCS_SUPPORTED)
                 .whenever(shippingLabelOnboardingRepository).shippingPluginSupport
 
-            val shippingLabels = ArrayList<ShippingLabel>()
-            viewModel.shippingLabels.observeForever {
-                it?.let { shippingLabels.addAll(it) }
-            }
+            doReturn(
+                flowOf(
+                    ConfigDTO(
+                        // Creating 5 items map since orderShippingLabels has 5 labels
+                        mapOf(
+                            "0" to emptyList<Item>(),
+                            "1" to emptyList<Item>(),
+                            "2" to emptyList<Item>(),
+                            "3" to emptyList<Item>(),
+                            "4" to emptyList<Item>()
+                        )
+                    )
+                )
+            ).whenever(configDataStore).observeConfig(order.id)
 
             var isCreateShippingLabelButtonVisible: Boolean? = null
-            var isProductListMenuVisible: Boolean? = null
             viewModel.viewStateData.observeForever { _, new ->
                 isCreateShippingLabelButtonVisible = new.isCreateShippingLabelButtonVisible
-                isProductListMenuVisible = new.isProductListMenuVisible
             }
+
+            viewModel.start()
+
+            assertThat(isCreateShippingLabelButtonVisible).isFalse
+        }
+
+    @Test
+    fun `Show Products area menu when shipping labels are available`() =
+        testBlocking {
+            doReturn(order).whenever(orderDetailRepository).fetchOrderById(any())
+
+            doReturn(true).whenever(orderDetailRepository).fetchOrderNotes(any())
+
+            doReturn(orderShippingLabels).whenever(orderDetailRepository).getOrderShippingLabels(any())
+            doReturn(false).whenever(addonsRepository).containsAddonsFrom(any())
+
+            doReturn(true).whenever(orderDetailRepository).isOrderEligibleForSLCreation(order.id)
+
+            val shippingLabels = ArrayList<ShippingLabel>()
+            viewModel.shippingLabels.observeForever { it?.let { shippingLabels.addAll(it) } }
+
+            var isProductListMenuVisible: Boolean? = null
+            viewModel.viewStateData.observeForever { _, new -> isProductListMenuVisible = new.isProductListMenuVisible }
 
             viewModel.start()
 
             assertThat(shippingLabels).isNotEmpty
-            assertThat(isCreateShippingLabelButtonVisible).isFalse
             assertThat(isProductListMenuVisible).isTrue
         }
 
     @Test
-    fun `Show Create shipping label button and hide Products area menu when no shipping labels are available`() =
+    fun `Hide Products area menu when no shipping labels are available`() =
         testBlocking {
-            doReturn(order).whenever(orderDetailRepository).getOrderById(any())
             doReturn(order).whenever(orderDetailRepository).fetchOrderById(any())
 
             doReturn(true).whenever(orderDetailRepository).fetchOrderNotes(any())
-            doReturn(testOrderNotes).whenever(orderDetailRepository).getOrderNotes(any())
 
-            doReturn(emptyList<Refund>()).whenever(orderDetailRepository).fetchOrderRefunds(any())
-            doReturn(emptyList<Refund>()).whenever(orderDetailRepository).getOrderRefunds(any())
-
-            doReturn(RequestResult.SUCCESS).whenever(orderDetailRepository).fetchOrderShipmentTrackingList(any())
-            doReturn(testOrderShipmentTrackings).whenever(orderDetailRepository).getOrderShipmentTrackings(any())
-
-            doReturn(emptyList<ShippingLabel>()).whenever(orderDetailRepository).getOrderShippingLabels(any())
             doReturn(false).whenever(addonsRepository).containsAddonsFrom(any())
 
-            doReturn(Unit).whenever(orderDetailRepository).fetchSLCreationEligibility(order.id)
-            doReturn(true).whenever(orderDetailRepository).isOrderEligibleForSLCreation(order.id)
-            doReturn(ShippingLabelSupport.WCS_SUPPORTED)
-                .whenever(shippingLabelOnboardingRepository).shippingPluginSupport
-
             val shippingLabels = ArrayList<ShippingLabel>()
-            viewModel.shippingLabels.observeForever {
-                it?.let { shippingLabels.addAll(it) }
-            }
+            viewModel.shippingLabels.observeForever { it?.let { shippingLabels.addAll(it) } }
 
-            var isCreateShippingLabelButtonVisible: Boolean? = null
             var isProductListMenuVisible: Boolean? = null
-            viewModel.viewStateData.observeForever { _, new ->
-                isCreateShippingLabelButtonVisible = new.isCreateShippingLabelButtonVisible
-                isProductListMenuVisible = new.isProductListMenuVisible
-            }
+            viewModel.viewStateData.observeForever { _, new -> isProductListMenuVisible = new.isProductListMenuVisible }
 
             viewModel.start()
 
             assertThat(shippingLabels).isEmpty()
-            assertThat(isCreateShippingLabelButtonVisible).isTrue
             assertThat(isProductListMenuVisible).isFalse
         }
 


### PR DESCRIPTION
### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
"Create shipping label" button was incorrectly hidden when there was only one purchased shipment, even though unfulfilled shipments still existed. This PR fixes the visibility logic for the button.

> [!WARNING]  
> Review #13998 first.

### Steps to reproduce
<!-- Step-by-step testing instructions. For new user flows, consider instead stating the goal of the workflow and see if your PR reviewer can accomplish the workflow without specific steps! -->
1. On the web, create an order with shipments and purchase one of the shipments.
2. In the app, open the Orders tab.
3. Tap the order you created on the web.

### Testing information
<!-- This is your opportunity to break out individual scenarios that need testing (when necessary) and/or include a checklist for the reviewer to go through. Consider documenting the following from your own completed testing: devices used, alternate workflows, edge cases, affected areas, critical flows, areas not tested, and any remaining unknowns. Provide feedback on this new section of the PR template through Sept 30, 2024 to Apps Quality; additional context here: p91TBi-b8z-p2#comment-12036 -->

![image](https://github.com/user-attachments/assets/935146f5-0415-41bb-b7c3-c77449ccacc2)
When this button is visible on the web, we should also show the “Create shipping label” button on the order detail screen in the app. So, use these order types and compare the web with the app:
- [x] Order without any shipments
- [x] Order with multiple shipments, all of which are purchased
- [x] Order with multiple shipments, only one of which is purchased

### The tests that have been performed
<!-- To give the reviewer an idea of what could be missed in terms of testing -->
Steps above

- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.

## Reviewer (or Author, in the case of optional code reviews):

Please make sure these conditions are met before approving the PR, or request changes if the PR needs improvement:

- [ ] The PR is small and has a clear, single focus, or a valid explanation is provided in the description. If needed, please request to split it into smaller PRs.
- [ ] Ensure Adequate Unit Test Coverage: The changes are reasonably covered by unit tests or an explanation is provided in the PR description.
- [ ] Manual Testing: The author listed all the tests they ran, including smoke tests when needed (e.g., for refactorings). The reviewer confirmed that the PR works as expected on big (tablet) and small (phone) in case of UI changes, and no regressions are added.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->