### PR TITLE
[WOOMOB-192] Update Empty Coupon Screen

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/items/WooPosItemsList.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/items/WooPosItemsList.kt
@@ -489,6 +489,7 @@ fun WooPosItemsEmptyList(
         onActionClicked = null
     )
 }
+
 @Composable
 fun WooPosItemsEmptyList(
     modifier: Modifier = Modifier,

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/items/WooPosItemsList.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/items/WooPosItemsList.kt
@@ -50,6 +50,7 @@ import coil.request.ImageRequest
 import com.woocommerce.android.R
 import com.woocommerce.android.ui.woopos.common.composeui.WooPosPreview
 import com.woocommerce.android.ui.woopos.common.composeui.component.ShadowType
+import com.woocommerce.android.ui.woopos.common.composeui.component.WooPosButton
 import com.woocommerce.android.ui.woopos.common.composeui.component.WooPosCard
 import com.woocommerce.android.ui.woopos.common.composeui.component.WooPosLazyColumn
 import com.woocommerce.android.ui.woopos.common.composeui.component.WooPosShimmerBox
@@ -479,6 +480,43 @@ fun WooPosItemsEmptyList(
     message: String,
     contentDescription: String,
 ) {
+    WooPosItemsEmptyListInternal(
+        modifier = modifier,
+        title = title,
+        message = message,
+        contentDescription = contentDescription,
+        actionLabel = null,
+        onActionClicked = null
+    )
+}
+@Composable
+fun WooPosItemsEmptyList(
+    modifier: Modifier = Modifier,
+    title: String,
+    message: String,
+    contentDescription: String,
+    actionLabel: String,
+    onActionClicked: (() -> Unit),
+) {
+    WooPosItemsEmptyListInternal(
+        modifier = modifier,
+        title = title,
+        message = message,
+        contentDescription = contentDescription,
+        actionLabel = actionLabel,
+        onActionClicked = onActionClicked
+    )
+}
+
+@Composable
+private fun WooPosItemsEmptyListInternal(
+    modifier: Modifier = Modifier,
+    title: String,
+    message: String,
+    contentDescription: String,
+    actionLabel: String?,
+    onActionClicked: (() -> Unit)? = null,
+) {
     Box(
         modifier = modifier.verticalScroll(rememberScrollState()),
         contentAlignment = Alignment.Center
@@ -510,7 +548,17 @@ fun WooPosItemsEmptyList(
                 textAlign = TextAlign.Center
             )
 
-            Spacer(modifier = Modifier.height(WooPosSpacing.Medium.value.toAdaptivePadding()))
+            Spacer(modifier = Modifier.height(WooPosSpacing.XLarge.value.toAdaptivePadding()))
+
+            if (onActionClicked != null && actionLabel != null) {
+                WooPosButton(
+                    text = actionLabel,
+                    onClick = onActionClicked,
+                    modifier = Modifier
+                        .fillMaxWidth(0.5f)
+                        .height(80.dp)
+                )
+            }
         }
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/items/coupons/WooPosCouponsScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/items/coupons/WooPosCouponsScreen.kt
@@ -95,6 +95,8 @@ private fun WooPosCouponsScreen(
                 title = stringResource(id = R.string.woopos_coupons_empty_list_title),
                 message = stringResource(id = R.string.woopos_coupons_empty_list_message),
                 contentDescription = stringResource(id = R.string.woopos_coupons_empty_list_image_description),
+                actionLabel = stringResource(id = R.string.woopos_coupons_empty_list_create_coupon_label),
+                onActionClicked = { onUIEvent(WooPosCouponsUIEvent.CreateCouponClicked) }
             )
 
             is WooPosCouponsViewState.Error -> CouponsError { onUIEvent(WooPosCouponsUIEvent.RetryTriggered) }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/items/coupons/WooPosCouponsScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/items/coupons/WooPosCouponsScreen.kt
@@ -91,6 +91,7 @@ private fun WooPosCouponsScreen(
             )
 
             is WooPosCouponsViewState.Empty -> WooPosItemsEmptyList(
+                modifier = Modifier.fillMaxSize(),
                 title = stringResource(id = R.string.woopos_coupons_empty_list_title),
                 message = stringResource(id = R.string.woopos_coupons_empty_list_message),
                 contentDescription = stringResource(id = R.string.woopos_coupons_empty_list_image_description),

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/items/coupons/WooPosCouponsUIEvent.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/items/coupons/WooPosCouponsUIEvent.kt
@@ -6,5 +6,6 @@ sealed class WooPosCouponsUIEvent {
     data object RetryLoadMoreTriggered : WooPosCouponsUIEvent()
     data object RetryTriggered : WooPosCouponsUIEvent()
     data class CouponClicked(val couponId: Long) : WooPosCouponsUIEvent()
+    data object CreateCouponClicked : WooPosCouponsUIEvent()
     data object BackButtonClicked : WooPosCouponsUIEvent()
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/items/coupons/WooPosCouponsViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/items/coupons/WooPosCouponsViewModel.kt
@@ -69,6 +69,10 @@ class WooPosCouponsViewModel @Inject constructor(
             }
 
             RetryTriggered -> fetchCoupons()
+
+            is WooPosCouponsUIEvent.CreateCouponClicked -> {
+                error("Create coupon clicked event not implemented yet")
+            }
         }
     }
 

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -4333,6 +4333,7 @@
     <string name="woopos_coupons_empty_list_image_description">No coupons</string>
     <string name="woopos_coupons_empty_list_title">No coupons found</string>
     <string name="woopos_coupons_empty_list_message">Boost your business by sending customers special offers and discounts.</string>
+    <string name="woopos_coupons_empty_list_create_coupon_label">Create coupon</string>
     <string name="woopos_coupons_loading_error_title">Error loading coupons</string>
     <string name="woopos_coupons_loading_error_message">Give it another go?</string>
     <string name="woopos_coupons_loading_error_retry_button">Retry</string>


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #WOOMOB-192
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

This PR updates the `Empty Coupons screen`
- Adds CTA - the action itself is not implemented in this PR
- Aligns the content of the empty screen vertically

### Testing information
<!-- This is your opportunity to break out individual scenarios that need testing (when necessary) and/or include a checklist for the reviewer to go through. Consider documenting the following from your own completed testing: devices used, alternate workflows, edge cases, affected areas, critical flows, areas not tested, and any remaining unknowns. Provide feedback on this new section of the PR template through Sept 30, 2024 to Apps Quality; additional context here: p91TBi-b8z-p2#comment-12036 -->

1. Open POS on a store without coupons
2. Tap on Coupons tab
3. Notice the empty screen

1. Open POS on a store with coupons
2. Tap on Coupons tab
3. Verify coupons are listed as expected

### The tests that have been performed
<!-- To give the reviewer an idea of what could be missed in terms of testing -->

The above.

### Images/gif

| Before | After |
|--------|-------|
| <img src="https://github.com/user-attachments/assets/c8540ca3-155d-4289-b798-a1f013385d50" width="300px"> | <img src="https://github.com/user-attachments/assets/75899b92-d835-4690-b078-8e4cacc9e895" width="300px"> |


- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.

## Reviewer (or Author, in the case of optional code reviews):

Please make sure these conditions are met before approving the PR, or request changes if the PR needs improvement:

- [ ] The PR is small and has a clear, single focus, or a valid explanation is provided in the description. If needed, please request to split it into smaller PRs.
- [ ] Ensure Adequate Unit Test Coverage: The changes are reasonably covered by unit tests or an explanation is provided in the PR description.
- [ ] Manual Testing: The author listed all the tests they ran, including smoke tests when needed (e.g., for refactorings). The reviewer confirmed that the PR works as expected on big (tablet) and small (phone) in case of UI changes, and no regressions are added.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->2