### PR TITLE
[Shipping labels] Parse purchased labels from config endpoint

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/GetShipments.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/GetShipments.kt
@@ -40,10 +40,12 @@ class GetShipments @Inject constructor(
             }
         }
 
-        val shipments = configDataStore.observeConfig(order.id).first()?.shipments
+        val config = configDataStore.observeConfig(order.id).first()
+        val purchasedLabels = config?.shippingLabelData?.currentOrderLabels
+        val shipments = config?.shipments
 
         return if (shipments.isNullOrEmpty()) {
-            listOf(ShipmentUIModel(id = null, items = orderItems))
+            listOf(ShipmentUIModel(id = null, items = orderItems, purchased = !purchasedLabels.isNullOrEmpty()))
         } else {
             shipments.map { (shipmentId, shipmentItems) ->
                 val items = shipmentItems.mapNotNull { (id, subItems) ->
@@ -52,7 +54,8 @@ class GetShipments @Inject constructor(
                     orderItems.firstOrNull { it.itemId == id }
                         ?.copy(quantity = if (subItems.isNullOrEmpty()) 1f else subItems.size.toFloat())
                 }
-                ShipmentUIModel(shipmentId, items)
+                val purchased = purchasedLabels?.map { it.toString() }?.contains(shipmentId) == true
+                ShipmentUIModel(shipmentId, items, purchased)
             }
         }
     }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/models/ShipmentUIModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/models/ShipmentUIModel.kt
@@ -7,5 +7,6 @@ import kotlinx.parcelize.Parcelize
 data class ShipmentUIModel(
     // If id is null, it indicates that no shipment has been fetched from the backend.
     val id: String?,
-    val items: List<ShippableItemModel>
+    val items: List<ShippableItemModel>,
+    val purchased: Boolean
 ) : Parcelable

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/networking/DTOs.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/networking/DTOs.kt
@@ -36,7 +36,8 @@ typealias ShipmentMap = Map<String, List<Item>>
 data class ConfigDTO(
     @SerializedName("shipments")
     @JsonAdapter(ShipmentMapDeserializer::class)
-    val shipments: ShipmentMap? = null
+    val shipments: ShipmentMap? = null,
+    @SerializedName("shippingLabelData") val shippingLabelData: ShippingLabelDTO,
 )
 
 data class Item(@SerializedName("id") val id: Long?, @SerializedName("subItems") val subItems: List<String>?)
@@ -72,7 +73,10 @@ data class ShippingLabelDTO(
     @SerializedName("rate") val rate: BigDecimal? = null,
     @SerializedName("currency") val currency: String? = null,
     @SerializedName("expiry_date") val expiryDate: Long? = null,
+    @SerializedName("currentOrderLabels") val currentOrderLabels: List<OrderLabel>? = null,
 )
+
+data class OrderLabel(@SerializedName("id") val id: Long)
 
 data class PurchasedShippingLabelResponseDTO(
     val success: Boolean,

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/OrderDetailViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/OrderDetailViewModelTest.kt
@@ -47,6 +47,7 @@ import com.woocommerce.android.ui.orders.details.ShippingLabelOnboardingReposito
 import com.woocommerce.android.ui.orders.wooshippinglabels.datasource.WooShippingConfigDataStore
 import com.woocommerce.android.ui.orders.wooshippinglabels.networking.ConfigDTO
 import com.woocommerce.android.ui.orders.wooshippinglabels.networking.Item
+import com.woocommerce.android.ui.orders.wooshippinglabels.networking.ShippingLabelDTO
 import com.woocommerce.android.ui.orders.wooshippinglabels.networking.WooShippingLabelRepository
 import com.woocommerce.android.ui.payments.cardreader.payment.CardReaderPaymentCollectibilityChecker
 import com.woocommerce.android.ui.payments.receipt.PaymentReceiptHelper
@@ -644,7 +645,8 @@ class OrderDetailViewModelTest : BaseUnitTest() {
             doReturn(false).whenever(addonsRepository).containsAddonsFrom(any())
 
             doReturn(true).whenever(orderDetailRepository).isOrderEligibleForSLCreation(order.id)
-            doReturn(flowOf(ConfigDTO(emptyMap()))).whenever(configDataStore).observeConfig(order.id)
+            doReturn(flowOf(ConfigDTO(emptyMap(), ShippingLabelDTO()))).whenever(configDataStore)
+                .observeConfig(order.id)
 
             var isCreateShippingLabelButtonVisible: Boolean? = null
             viewModel.viewStateData.observeForever { _, new ->
@@ -683,7 +685,8 @@ class OrderDetailViewModelTest : BaseUnitTest() {
                             "2" to emptyList<Item>(),
                             "3" to emptyList<Item>(),
                             "4" to emptyList<Item>()
-                        )
+                        ),
+                        ShippingLabelDTO()
                     )
                 )
             ).whenever(configDataStore).observeConfig(order.id)

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/GetShipmentsTests.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/GetShipmentsTests.kt
@@ -6,6 +6,7 @@ import com.woocommerce.android.ui.orders.details.OrderDetailRepository
 import com.woocommerce.android.ui.orders.wooshippinglabels.datasource.WooShippingConfigDataStore
 import com.woocommerce.android.ui.orders.wooshippinglabels.networking.ConfigDTO
 import com.woocommerce.android.ui.orders.wooshippinglabels.networking.Item
+import com.woocommerce.android.ui.orders.wooshippinglabels.networking.ShippingLabelDTO
 import com.woocommerce.android.ui.products.ProductTestUtils
 import com.woocommerce.android.ui.products.details.ProductDetailRepository
 import com.woocommerce.android.viewmodel.BaseUnitTest
@@ -169,7 +170,9 @@ class GetShipmentsTests : BaseUnitTest() {
                 )
             )
         )
-        whenever(configDataStore.observeConfig(eq(order.id))) doReturn flowOf(ConfigDTO(shipments))
+        whenever(configDataStore.observeConfig(eq(order.id))) doReturn flowOf(
+            ConfigDTO(shipments = shipments, shippingLabelData = ShippingLabelDTO())
+        )
 
         val result = sut.invoke(order)
         val shipment1 = result.first()

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/WooShippingLabelCreationViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/WooShippingLabelCreationViewModelTest.kt
@@ -85,7 +85,7 @@ class WooShippingLabelCreationViewModelTest : BaseUnitTest() {
             length = it.toFloat()
         )
     }
-    private val defaultShipments = listOf(ShipmentUIModel("0", defaultShippableItems))
+    private val defaultShipments = listOf(ShipmentUIModel(id = "0", items = defaultShippableItems, purchased = false))
     private val defaultShippingLines = List(3) {
         Order.ShippingLine(
             methodTitle = "Shipping Line $it",

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/split/WooShippingSplitShipmentViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/split/WooShippingSplitShipmentViewModelTest.kt
@@ -447,7 +447,8 @@ class WooShippingSplitShipmentViewModelTest : BaseUnitTest() {
                     height = 3f,
                     weight = 8f
                 )
-            )
+            ),
+            purchased = false
         )
     )
 
@@ -481,7 +482,8 @@ class WooShippingSplitShipmentViewModelTest : BaseUnitTest() {
                     height = 3f,
                     weight = 8f
                 )
-            )
+            ),
+            purchased = false
         ),
         ShipmentUIModel(
             id = "1",
@@ -499,7 +501,8 @@ class WooShippingSplitShipmentViewModelTest : BaseUnitTest() {
                     height = 3f,
                     weight = 8f
                 )
-            )
+            ),
+            purchased = false
         )
     )
 
@@ -533,7 +536,8 @@ class WooShippingSplitShipmentViewModelTest : BaseUnitTest() {
                     height = 3f,
                     weight = 8f
                 )
-            )
+            ),
+            purchased = false
         ),
         ShipmentUIModel(
             id = "1",
@@ -551,7 +555,8 @@ class WooShippingSplitShipmentViewModelTest : BaseUnitTest() {
                     height = 3f,
                     weight = 8f
                 )
-            )
+            ),
+            purchased = false
         ),
         ShipmentUIModel(
             id = "2",
@@ -569,7 +574,8 @@ class WooShippingSplitShipmentViewModelTest : BaseUnitTest() {
                     height = 3f,
                     weight = 8f
                 )
-            )
+            ),
+            purchased = false
         )
     )
 }


### PR DESCRIPTION
### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
This PR parses purchased label from the config endpoint. The UI part will be added with the following PR.

### Steps to reproduce
<!-- Step-by-step testing instructions. For new user flows, consider instead stating the goal of the workflow and see if your PR reviewer can accomplish the workflow without specific steps! -->
No need to test anything in this PR. We can test the feature in the next PR, where I’ll add the UI part.

### The tests that have been performed
<!-- To give the reviewer an idea of what could be missed in terms of testing -->
Debugged and verified parsed purchased labels in `GetShipments` class.

### Images/gif
<!-- Include before and after images or gifs when appropriate. -->

- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.

## Reviewer (or Author, in the case of optional code reviews):

Please make sure these conditions are met before approving the PR, or request changes if the PR needs improvement:

- [x] The PR is small and has a clear, single focus, or a valid explanation is provided in the description. If needed, please request to split it into smaller PRs.
- [ ] Ensure Adequate Unit Test Coverage: The changes are reasonably covered by unit tests or an explanation is provided in the PR description.
- [x] Manual Testing: The author listed all the tests they ran, including smoke tests when needed (e.g., for refactorings). The reviewer confirmed that the PR works as expected on big (tablet) and small (phone) in case of UI changes, and no regressions are added.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->