### PR TITLE
[WOOMOB-450] Fix UI glitch when only coupons in cart

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/cart/WooPosCartScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/cart/WooPosCartScreen.kt
@@ -143,13 +143,7 @@ private fun WooPosCartScreen(
                 CartBodyWithItems(
                     modifier = Modifier.constrainAs(body) {
                         top.linkTo(toolbar.bottom, margin = productsTopMargin)
-                        bottom.linkTo(
-                            if (state.isCheckoutButtonVisible) {
-                                checkoutButton.top
-                            } else {
-                                parent.bottom
-                            }
-                        )
+                        bottom.linkTo(checkoutButton.top)
                         start.linkTo(parent.start)
                         end.linkTo(parent.end)
                         height = Dimension.fillToConstraints
@@ -223,13 +217,14 @@ private fun CartBodyWithItems(
     ScrollToTopHandler(items, listState)
 
     val spacerHeight by animateDpAsState(
-        targetValue = if (!isCheckoutButtonVisible) 100.dp else 0.dp,
+        targetValue = if (!isCheckoutButtonVisible) 212.dp else 0.dp,
         label = "cart list height animation"
     )
 
     WooPosLazyColumn(
         modifier = modifier
-            .padding(horizontal = WooPosSpacing.Medium.value.toAdaptivePadding()),
+            .padding(horizontal = WooPosSpacing.Medium.value.toAdaptivePadding())
+            .fillMaxSize(),
         state = listState,
         verticalArrangement = Arrangement.spacedBy(WooPosSpacing.Small.value.toAdaptivePadding()),
         horizontalAlignment = Alignment.CenterHorizontally,

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/cart/WooPosCartScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/cart/WooPosCartScreen.kt
@@ -223,7 +223,7 @@ private fun CartBodyWithItems(
     ScrollToTopHandler(items, listState)
 
     val spacerHeight by animateDpAsState(
-        targetValue = if (!isCheckoutButtonVisible) 182.dp else 0.dp,
+        targetValue = if (!isCheckoutButtonVisible) 100.dp else 0.dp,
         label = "cart list height animation"
     )
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/cart/WooPosCartScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/cart/WooPosCartScreen.kt
@@ -143,7 +143,13 @@ private fun WooPosCartScreen(
                 CartBodyWithItems(
                     modifier = Modifier.constrainAs(body) {
                         top.linkTo(toolbar.bottom, margin = productsTopMargin)
-                        bottom.linkTo(checkoutButton.top)
+                        bottom.linkTo(
+                            if (state.isCheckoutButtonVisible) {
+                                checkoutButton.top
+                            } else {
+                                parent.bottom
+                            }
+                        )
                         start.linkTo(parent.start)
                         end.linkTo(parent.end)
                         height = Dimension.fillToConstraints


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #WOOMOB-450
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

This PR fixes UI glitch in the POS cart when the cart contains only coupons (aka when the checkout button isn't visible).

https://private-user-images.githubusercontent.com/4923871/440405800-074932b1-47e8-4ea3-bd8d-ebd1499a1793.mp4?jwt=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJnaXRodWIuY29tIiwiYXVkIjoicmF3LmdpdGh1YnVzZXJjb250ZW50LmNvbSIsImtleSI6ImtleTUiLCJleHAiOjE3NDY1MTMxNjAsIm5iZiI6MTc0NjUxMjg2MCwicGF0aCI6Ii80OTIzODcxLzQ0MDQwNTgwMC0wNzQ5MzJiMS00N2U4LTRlYTMtYmQ4ZC1lYmQxNDk5YTE3OTMubXA0P1gtQW16LUFsZ29yaXRobT1BV1M0LUhNQUMtU0hBMjU2JlgtQW16LUNyZWRlbnRpYWw9QUtJQVZDT0RZTFNBNTNQUUs0WkElMkYyMDI1MDUwNiUyRnVzLWVhc3QtMSUyRnMzJTJGYXdzNF9yZXF1ZXN0JlgtQW16LURhdGU9MjAyNTA1MDZUMDYyNzQwWiZYLUFtei1FeHBpcmVzPTMwMCZYLUFtei1TaWduYXR1cmU9NDI1NjBkZGJkN2ZlNmJmN2QyMDA4MDA1N2I3ZGI3ZWYwOTVkMjY0MDc5YmYwNzcwMGI3N2MxNDY2MzA0YTFiYSZYLUFtei1TaWduZWRIZWFkZXJzPWhvc3QifQ.1IHD3ZOBkMMIXewP6BC8RkHvs7D51DHNdj3hsF5OC9w

### Steps to reproduce
<!-- Step-by-step testing instructions. For new user flows, consider instead stating the goal of the workflow and see if your PR reviewer can accomplish the workflow without specific steps! -->

1. Open POS
2. Tap on coupons
3. Add a few coupons into the cart
4. Notice the cart list doesn't expand to full height

### Testing information
<!-- This is your opportunity to break out individual scenarios that need testing (when necessary) and/or include a checklist for the reviewer to go through. Consider documenting the following from your own completed testing: devices used, alternate workflows, edge cases, affected areas, critical flows, areas not tested, and any remaining unknowns. Provide feedback on this new section of the PR template through Sept 30, 2024 to Apps Quality; additional context here: p91TBi-b8z-p2#comment-12036 -->

1. Open POS
2. Tap on coupons
3. Add a few coupons into the cart
4. Notice the cart list expands to full height
5. Add a product into the cart
6. Notice the checkout button appears and the cart is scrollable - all items are reachable

### The tests that have been performed
<!-- To give the reviewer an idea of what could be missed in terms of testing -->

The above

### Images/gif
<!-- Include before and after images or gifs when appropriate. -->

| Before                                                                                  | After                                                                                   |
|-----------------------------------------------------------------------------------------|-----------------------------------------------------------------------------------------|
| <img src="https://github.com/user-attachments/assets/a844a3c5-1784-4635-af53-69ae954e010c" width="300px" /> | <img src="https://github.com/user-attachments/assets/e83a26c6-c16f-48b8-a484-80bf7cc73f6e" width="300px" /> |

- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.

## Reviewer (or Author, in the case of optional code reviews):

Please make sure these conditions are met before approving the PR, or request changes if the PR needs improvement:

- [x] The PR is small and has a clear, single focus, or a valid explanation is provided in the description. If needed, please request to split it into smaller PRs.
- [x] Ensure Adequate Unit Test Coverage: The changes are reasonably covered by unit tests or an explanation is provided in the PR description.
- [x] Manual Testing: The author listed all the tests they ran, including smoke tests when needed (e.g., for refactorings). The reviewer confirmed that the PR works as expected on big (tablet) and small (phone) in case of UI changes, and no regressions are added.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->