### PR TITLE
[WOOMOB-442][Dashboard] IllegalArgumentException: Can't represent a width of 0 and height of 16777069 in Constraints

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/DashboardContainer.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/DashboardContainer.kt
@@ -75,9 +75,11 @@ fun DashboardContainer(
         )
 
         val pullRefreshState = rememberPullRefreshState(state.isRefreshing, dashboardViewModel::onPullToRefresh)
-        BoxWithConstraints(Modifier
-            .pullRefresh(pullRefreshState)
-            .fillMaxSize()) {
+        BoxWithConstraints(
+            modifier = Modifier
+                .pullRefresh(pullRefreshState)
+                .fillMaxSize()
+        ) {
             WooLog.d(
                 WooLog.T.DASHBOARD,
                 "BoxWithConstraints: maxWidth=${maxWidth.value}, maxHeight=${maxHeight.value}"

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/DashboardContainer.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/DashboardContainer.kt
@@ -70,7 +70,7 @@ fun DashboardContainer(
     dashboardViewModel.dashboardCardsState.observeAsState().value?.let { state ->
 
         val pullRefreshState = rememberPullRefreshState(state.isRefreshing, dashboardViewModel::onPullToRefresh)
-        BoxWithConstraints(Modifier.pullRefresh(pullRefreshState)) {
+        BoxWithConstraints(Modifier.pullRefresh(pullRefreshState).fillMaxSize()) {
             val boxWithConstraintsScope = this
             DashboardWidgets(
                 widgetUiModels = state.widgets,
@@ -162,13 +162,16 @@ private fun DashboardWidgets(
 private fun calculateColumnNumber(
     availableWidthInDp: Dp,
     state: DashboardCardsState
-) = when {
-    availableWidthInDp < 600.dp -> 1 // 600dp covers 99.96% of phones in portrait
-    availableWidthInDp < 1000.dp -> 2 // 1000dp should be enough to avoid 3 columns on big phones in landscape
-    else -> 3 // 3 columns should only display on tablets in landscape
-}.coerceAtMost(
-    maximumValue = state.widgets.filter { it.isVisible }.size
-)
+): Int {
+    val columns = when {
+        availableWidthInDp < 600.dp -> 1 // 600dp covers 99.96% of phones in portrait
+        availableWidthInDp < 1000.dp -> 2 // 1000dp should be enough to avoid 3 columns on big phones in landscape
+        else -> 3 // 3 columns should only display on tablets in landscape
+    }
+
+    val visibleWidgetsCount = state.widgets.count { it.isVisible }
+    return columns.coerceAtMost(maximumValue = maxOf(visibleWidgetsCount, 1))
+}
 
 private fun splitWidgetsIntoColumns(
     numberOfColumns: Int,

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/DashboardContainer.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/DashboardContainer.kt
@@ -59,6 +59,7 @@ import com.woocommerce.android.ui.dashboard.stats.DashboardStatsCard
 import com.woocommerce.android.ui.dashboard.stock.DashboardProductStockCard
 import com.woocommerce.android.ui.dashboard.topperformers.DashboardTopPerformersWidgetCard
 import com.woocommerce.android.ui.main.MainActivityViewModel
+import com.woocommerce.android.util.WooLog
 
 @OptIn(ExperimentalMaterialApi::class)
 @Composable
@@ -68,9 +69,17 @@ fun DashboardContainer(
     blazeCampaignCreationDispatcher: BlazeCampaignCreationDispatcher,
 ) {
     dashboardViewModel.dashboardCardsState.observeAsState().value?.let { state ->
+        WooLog.d(
+            WooLog.T.DASHBOARD,
+            "DashboardCardsState observed: widgets=${state.widgets.size}, refreshing=${state.isRefreshing}"
+        )
 
         val pullRefreshState = rememberPullRefreshState(state.isRefreshing, dashboardViewModel::onPullToRefresh)
         BoxWithConstraints(Modifier.pullRefresh(pullRefreshState).fillMaxSize()) {
+            WooLog.d(
+                WooLog.T.DASHBOARD,
+                "BoxWithConstraints: maxWidth=${maxWidth.value}, maxHeight=${maxHeight.value}"
+            )
             val boxWithConstraintsScope = this
             DashboardWidgets(
                 widgetUiModels = state.widgets,

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/DashboardContainer.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/DashboardContainer.kt
@@ -228,7 +228,7 @@ private fun DashboardWidgetCard(
 
 @Composable
 private fun ConfigurableWidgetCard(
-    widgetUiModel: DashboardWidgetUiModel.ConfigurableWidget,
+    widgetUiModel: ConfigurableWidget,
     mainActivityViewModel: MainActivityViewModel,
     dashboardViewModel: DashboardViewModel,
     blazeCampaignCreationDispatcher: BlazeCampaignCreationDispatcher,
@@ -336,7 +336,7 @@ private fun ShareStoreCard(
 
 @Composable
 private fun FeedbackCard(
-    widget: DashboardWidgetUiModel.FeedbackWidget,
+    widget: FeedbackWidget,
     modifier: Modifier
 ) {
     LaunchedEffect(Unit) {
@@ -380,7 +380,7 @@ private fun FeedbackCard(
 
 @Composable
 private fun NewWidgetsCard(
-    state: DashboardWidgetUiModel.NewWidgetsCard,
+    state: NewWidgetsCard,
     modifier: Modifier
 ) {
     Column(

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/DashboardContainer.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/DashboardContainer.kt
@@ -75,7 +75,9 @@ fun DashboardContainer(
         )
 
         val pullRefreshState = rememberPullRefreshState(state.isRefreshing, dashboardViewModel::onPullToRefresh)
-        BoxWithConstraints(Modifier.pullRefresh(pullRefreshState).fillMaxSize()) {
+        BoxWithConstraints(Modifier
+            .pullRefresh(pullRefreshState)
+            .fillMaxSize()) {
             WooLog.d(
                 WooLog.T.DASHBOARD,
                 "BoxWithConstraints: maxWidth=${maxWidth.value}, maxHeight=${maxHeight.value}"
@@ -179,6 +181,12 @@ private fun calculateColumnNumber(
     }
 
     val visibleWidgetsCount = state.widgets.count { it.isVisible }
+    WooLog.d(
+        WooLog.T.DASHBOARD,
+        "calculateColumnNumber: availableWidthInDp=$availableWidthInDp, " +
+            "columns=$columns, " +
+            "visibleWidgetsCount=$visibleWidgetsCount"
+    )
     return columns.coerceAtMost(maximumValue = maxOf(visibleWidgetsCount, 1))
 }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/stats/DashboardStatsCard.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/stats/DashboardStatsCard.kt
@@ -181,7 +181,7 @@ private fun StatsChart(
     }
 
     AndroidView(
-        modifier = modifier,
+        modifier = modifier.fillMaxWidth(),
         factory = {
             statsView.apply {
                 customRangeButton.setOnClickListener { onAddCustomRangeClick() }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/stats/DashboardStatsCard.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/stats/DashboardStatsCard.kt
@@ -1,6 +1,7 @@
 package com.woocommerce.android.ui.dashboard.stats
 
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.defaultMinSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.material.Divider
 import androidx.compose.runtime.Composable
@@ -13,6 +14,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.unit.dp
 import androidx.compose.ui.viewinterop.AndroidView
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.LiveData
@@ -181,7 +183,9 @@ private fun StatsChart(
     }
 
     AndroidView(
-        modifier = modifier.fillMaxWidth(),
+        modifier = modifier
+            .fillMaxWidth()
+            .defaultMinSize(minWidth = 1.dp, minHeight = 1.dp),
         factory = {
             statsView.apply {
                 customRangeButton.setOnClickListener { onAddCustomRangeClick() }


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

#WOOMOB-442
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
* I don't know how to reproduce this
* While in the original CUW it was kinda of implied that it happens in the OrderDetailsFragment, but the vast majority of the logs end with Dashboard in it. It maybe 2 different crashes, but the one from the Dashboard seems much more prominent 
* Both orientations
* All the changes proposed by Claude's code, as I have no idea
* Do you have any ideas on that?

```

Based on the error message and code analysis, here's how you might reproduce the crash:

  1. The issue happens in the Dashboard screen with the stats widget
  2. The crash occurs when Compose is trying to lay out the embedded Android view with invalid constraints (width 0)
  3. This likely happens during specific timing of layout passes

  Ways to potentially reproduce:
  - Rapidly switch between different screens and back to Dashboard
  - Rotate the device while the Dashboard screen is loading stats
  - Try resizing the app window (on tablets or foldables)
  - Navigate to and from the Dashboard fragment during initial loading
  - Put the app in split-screen mode and adjust the split position

  The crash is probably intermittent because it depends on exact timing of when the chart view is measured relative to when the parent container gets
  its final size. The issue is most likely to occur during transitions or when the system is under load, as there might be a momentary state where the
   width is reported as 0 before the final layout dimensions are determined.
```

### Steps to reproduce
<!-- Step-by-step testing instructions. For new user flows, consider stating the goal of the workflow instead and see if your PR reviewer can accomplish the workflow without specific steps! -->
I don't know

### Testing information
<!-- This is your opportunity to break out individual scenarios that need testing (when necessary) and/or include a checklist for the reviewer to go through. Consider documenting the following from your own completed testing: devices used, alternate workflows, edge cases, affected areas, critical flows, areas not tested, and any remaining unknowns. Provide feedback on this new section of the PR template through Sept 30, 2024 to Apps Quality; additional context here: p91TBi-b8z-p2#comment-12036 -->

### The tests that have been performed
<!-- To give the reviewer an idea of what could be missed in terms of testing -->
None, I can not reproduce this

### Images/gif
<!-- Include before and after images or gifs when appropriate. -->

- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.

## Reviewer (or Author, in the case of optional code reviews):

Please make sure these conditions are met before approving the PR, or request changes if the PR needs improvement:

- [ ] The PR is small and has a clear, single focus, or a valid explanation is provided in the description. If needed, please request to split it into smaller PRs.
- [ ] Ensure Adequate Unit Test Coverage: The changes are reasonably covered by unit tests or an explanation is provided in the PR description.
- [ ] Manual Testing: The author listed all the tests they ran, including smoke tests when needed (e.g., for refactorings). The reviewer confirmed that the PR works as expected on big (tablet) and small (phone) in case of UI changes, and no regressions are added.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->