### PR TITLE
[WOOMOB-461] Display 'Add coupon' button in toolbar on Coupons tab

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/items/WooPosItemsScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/items/WooPosItemsScreen.kt
@@ -77,6 +77,9 @@ private fun WooPosItemsScreen(
                 WooPosSearchUIEvent.SearchIconClicked -> onUIEvent(WooPosItemsUIEvent.SearchIconClicked)
             }
         },
+        onAddCouponEvent = {
+            onUIEvent(WooPosItemsUIEvent.AddCouponIconClicked)
+        },
         onTabClicked = { onUIEvent(WooPosItemsUIEvent.OnTabClicked(it)) },
     )
 }
@@ -89,6 +92,7 @@ private fun MainItemsList(
     listState: LazyListState,
     onSearchEvent: (WooPosSearchUIEvent) -> Unit,
     onTabClicked: (WooPosItemsViewState.Tab) -> Unit,
+    onAddCouponEvent: () -> Unit,
 ) {
     Box(
         modifier = modifier
@@ -107,6 +111,7 @@ private fun MainItemsList(
                 state = state.value,
                 onTabClicked = onTabClicked,
                 onSearchEvent = onSearchEvent,
+                onAddCouponEvent = onAddCouponEvent,
             )
 
             val currentState = state.value

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/items/WooPosItemsToolbar.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/items/WooPosItemsToolbar.kt
@@ -16,7 +16,7 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.lazy.LazyRow
 import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.filled.LocalOffer
+import androidx.compose.material.icons.filled.Add
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.remember
@@ -106,7 +106,7 @@ fun WooPosItemsToolbar(
                 if (state.isAddCouponVisible) {
                     Spacer(modifier = Modifier.width(WooPosSpacing.Medium.value))
                     WooPosCircularIconButton(
-                        icon = Icons.Default.LocalOffer,
+                        icon = Icons.Default.Add,
                         contentDescription = stringResource(
                             id = R.string.woopos_coupons_empty_list_create_coupon_label,
                         ),

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/items/WooPosItemsToolbar.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/items/WooPosItemsToolbar.kt
@@ -82,7 +82,8 @@ fun WooPosItemsToolbar(
                 modifier = Modifier
                     .fillMaxWidth()
                     .padding(start = WooPosSpacing.Medium.value.toAdaptivePadding()),
-                verticalAlignment = Alignment.CenterVertically) {
+                verticalAlignment = Alignment.CenterVertically
+            ) {
                 LazyRow(
                     modifier = Modifier.weight(1f),
                 ) {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/items/WooPosItemsToolbar.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/items/WooPosItemsToolbar.kt
@@ -96,6 +96,7 @@ fun WooPosItemsToolbar(
                     }
                 }
                 if (state.isAddCouponVisible) {
+                    Spacer(modifier = Modifier.width(WooPosSpacing.Medium.value))
                     WooPosCircularIconButton(
                         icon = Icons.Default.LocalOffer,
                         contentDescription = stringResource(

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/items/WooPosItemsToolbar.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/items/WooPosItemsToolbar.kt
@@ -13,6 +13,9 @@ import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.lazy.LazyRow
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.LocalOffer
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.remember
@@ -24,6 +27,7 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import com.woocommerce.android.R
 import com.woocommerce.android.ui.woopos.common.composeui.WooPosPreview
+import com.woocommerce.android.ui.woopos.common.composeui.component.WooPosCircularIconButton
 import com.woocommerce.android.ui.woopos.common.composeui.component.WooPosSearchInput
 import com.woocommerce.android.ui.woopos.common.composeui.component.WooPosSearchInputState
 import com.woocommerce.android.ui.woopos.common.composeui.component.WooPosSearchInputState.Open.Input
@@ -43,6 +47,7 @@ fun WooPosItemsToolbar(
     state: WooPosItemsViewState,
     onTabClicked: (WooPosItemsViewState.Tab) -> Unit,
     onSearchEvent: (WooPosSearchUIEvent) -> Unit,
+    onAddCouponEvent: () -> Unit,
 ) {
     val isSearchOpen = (state.search as? SearchState.Visible)?.let {
         it.state is WooPosSearchInputState.Open
@@ -71,19 +76,33 @@ fun WooPosItemsToolbar(
             ),
         ) {
             Row(verticalAlignment = Alignment.CenterVertically) {
-                state.tabs.forEach { tab ->
-                    WooPosText(
-                        text = stringResource(id = tab.stringId),
-                        style = WooPosTypography.Heading,
-                        fontWeight = FontWeight.Bold,
-                        color = tab.highlightLevel.titleColor(),
-                        modifier = Modifier.clickable(
-                            interactionSource = remember { MutableInteractionSource() },
-                            indication = null,
-                            onClick = { onTabClicked(tab) }
+                LazyRow(
+                    modifier = Modifier.weight(1f),
+                ) {
+                    items(state.tabs.size) { index ->
+                        val tab = state.tabs[index]
+                        WooPosText(
+                            text = stringResource(id = tab.stringId),
+                            style = WooPosTypography.Heading,
+                            fontWeight = FontWeight.Bold,
+                            color = tab.highlightLevel.titleColor(),
+                            modifier = Modifier.clickable(
+                                interactionSource = remember { MutableInteractionSource() },
+                                indication = null,
+                                onClick = { onTabClicked(tab) }
+                            )
                         )
+                        Spacer(modifier = Modifier.width(WooPosSpacing.Large.value))
+                    }
+                }
+                if (state.isAddCouponVisible) {
+                    WooPosCircularIconButton(
+                        icon = Icons.Default.LocalOffer,
+                        contentDescription = stringResource(
+                            id = R.string.woopos_coupons_empty_list_create_coupon_label,
+                        ),
+                        onClick = { onAddCouponEvent() }
                     )
-                    Spacer(modifier = Modifier.width(WooPosSpacing.Large.value))
                 }
             }
         }
@@ -111,7 +130,7 @@ private fun WooPosItemsViewState.Tab.HighlightLevel.titleColor(): Color = when (
 
 @Composable
 @WooPosPreview
-fun WooPosItemsToolbarPreview() {
+fun WooPosProductsToolbarPreview() {
     val tabs = listOf(
         WooPosItemsViewState.Tab(R.string.woopos_products_screen_title, highlightLevel = Full),
         WooPosItemsViewState.Tab(R.string.woopos_coupons_screen_title, highlightLevel = Normal),
@@ -124,7 +143,26 @@ fun WooPosItemsToolbarPreview() {
                 search = SearchState.Hidden,
             ),
             onTabClicked = {},
-            onSearchEvent = {}
+            onSearchEvent = {},
+            onAddCouponEvent = {},
+        )
+    }
+}
+
+@Composable
+@WooPosPreview
+fun WooPosCouponsToolbarPreview() {
+    val tabs = listOf(
+        WooPosItemsViewState.Tab(R.string.woopos_products_screen_title, highlightLevel = Normal),
+        WooPosItemsViewState.Tab(R.string.woopos_coupons_screen_title, highlightLevel = Full),
+    )
+
+    WooPosTheme {
+        WooPosItemsToolbar(
+            state = WooPosItemsViewState.CouponList(tabs = tabs),
+            onTabClicked = {},
+            onSearchEvent = {},
+            onAddCouponEvent = {},
         )
     }
 }
@@ -153,7 +191,8 @@ fun WooPosItemsToolbarWithSearchPreview() {
                 )
             ),
             onTabClicked = {},
-            onSearchEvent = {}
+            onSearchEvent = {},
+            onAddCouponEvent = {},
         )
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/items/WooPosItemsUIEvent.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/items/WooPosItemsUIEvent.kt
@@ -11,5 +11,6 @@ sealed class WooPosItemsUIEvent {
     ) : WooPosItemsUIEvent()
     data object CloseSearchClicked : WooPosItemsUIEvent()
     data object SearchAnimationComplete : WooPosItemsUIEvent()
-    object SearchIconClicked : WooPosItemsUIEvent()
+    data object SearchIconClicked : WooPosItemsUIEvent()
+    data object AddCouponIconClicked : WooPosItemsUIEvent()
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/items/WooPosItemsViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/items/WooPosItemsViewModel.kt
@@ -69,6 +69,8 @@ class WooPosItemsViewModel @Inject constructor(
                 searchHelper.onSearchChanged("", 0)
                 trackSearchIconClicked()
             }
+
+            is WooPosItemsUIEvent.AddCouponIconClicked -> error("Coupon creation flow is not implemented")
         }
     }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/items/WooPosItemsViewState.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/items/WooPosItemsViewState.kt
@@ -6,6 +6,7 @@ import com.woocommerce.android.ui.woopos.common.composeui.component.WooPosSearch
 sealed class WooPosItemsViewState(
     open val tabs: List<Tab>,
     open val search: SearchState,
+    open val isAddCouponVisible: Boolean,
 ) {
     data class ProductList(
         override val tabs: List<Tab>,
@@ -13,6 +14,7 @@ sealed class WooPosItemsViewState(
     ) : WooPosItemsViewState(
         tabs = tabs,
         search = search,
+        isAddCouponVisible = true,
     )
 
     data class CouponList(
@@ -20,6 +22,7 @@ sealed class WooPosItemsViewState(
     ) : WooPosItemsViewState(
         tabs = tabs,
         search = SearchState.Hidden,
+        isAddCouponVisible = true,
     )
 
     data class Tab(@StringRes val stringId: Int, val highlightLevel: HighlightLevel) {


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #WOOMOB-461
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

This PR displays the 'Add coupon' button on the coupons tab -  **the behavior of the button isn't implemented in this PR**.

Note: I've put the `tabs` into a lazy column to ensure the coupons button is always visible and the tabs are scrollable. However, I haven't implemented the same for the search icon - it's more complex since the search composable contains both the icon as well as the expanded input field (+ animations). I didn't want to waste too much time on this considering it might take a 5 minutes to someone who already understands how the search composable works. Let me know if I should look into it in this PR.


### Testing information
<!-- This is your opportunity to break out individual scenarios that need testing (when necessary) and/or include a checklist for the reviewer to go through. Consider documenting the following from your own completed testing: devices used, alternate workflows, edge cases, affected areas, critical flows, areas not tested, and any remaining unknowns. Provide feedback on this new section of the PR template through Sept 30, 2024 to Apps Quality; additional context here: p91TBi-b8z-p2#comment-12036 -->


1. Open POS
2. Tap on Coupons tab
3. Notice coupons button is visible
4. Extra points: Update the code to display more/longer tab names and check the scrolling works (or watch the video below)

### The tests that have been performed
<!-- To give the reviewer an idea of what could be missed in terms of testing -->

The above including the extra points.

### Images/gif
<!-- Include before and after images or gifs when appropriate. -->
<img src="https://github.com/user-attachments/assets/ecde7204-867e-4dd8-b4cc-c64d80e1e026" alt="Screenshot_1746702537" width="300px">

https://github.com/user-attachments/assets/344d4f01-1949-438c-908b-5cb2072c4703


- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.

## Reviewer (or Author, in the case of optional code reviews):

Please make sure these conditions are met before approving the PR, or request changes if the PR needs improvement:

- [ ] The PR is small and has a clear, single focus, or a valid explanation is provided in the description. If needed, please request to split it into smaller PRs.
- [ ] Ensure Adequate Unit Test Coverage: The changes are reasonably covered by unit tests or an explanation is provided in the PR description.
- [ ] Manual Testing: The author listed all the tests they ran, including smoke tests when needed (e.g., for refactorings). The reviewer confirmed that the PR works as expected on big (tablet) and small (phone) in case of UI changes, and no regressions are added.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->