### PR TITLE
[Shipping labels] Purchased shipments UI on the split shipments screen

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/GetShipments.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/GetShipments.kt
@@ -54,7 +54,7 @@ class GetShipments @Inject constructor(
                     orderItems.firstOrNull { it.itemId == id }
                         ?.copy(quantity = if (subItems.isNullOrEmpty()) 1f else subItems.size.toFloat())
                 }
-                val purchased = purchasedLabels?.map { it.toString() }?.contains(shipmentId) == true
+                val purchased = purchasedLabels?.map { it.id.toString() }?.contains(shipmentId) == true
                 ShipmentUIModel(shipmentId, items, purchased)
             }
         }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/ShippableItemsMapper.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/ShippableItemsMapper.kt
@@ -77,7 +77,8 @@ fun ShippableItemModel.toSelectableUIModel(
 fun List<ShippableItemModel>.toSelectableUIModel(
     currencyFormatter: CurrencyFormatter,
     dimensionUnit: String,
-    weightUnit: String
+    weightUnit: String,
+    purchased: Boolean
 ): SelectableShippableItemsUI {
     val shippableItemsUI = map { item -> item.toSelectableUIModel(currencyFormatter, dimensionUnit, weightUnit) }
     val formattedTotalPrice = getFormattedTotalPrice(currencyFormatter)
@@ -86,7 +87,8 @@ fun List<ShippableItemModel>.toSelectableUIModel(
     return SelectableShippableItemsUI(
         shippableItems = shippableItemsUI,
         formattedTotalWeight = formattedTotalWeight,
-        formattedTotalPrice = formattedTotalPrice
+        formattedTotalPrice = formattedTotalPrice,
+        purchased = purchased
     )
 }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/ShippableItemsMapper.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/ShippableItemsMapper.kt
@@ -3,6 +3,7 @@ package com.woocommerce.android.ui.orders.wooshippinglabels
 import com.woocommerce.android.extensions.formatToString
 import com.woocommerce.android.extensions.sumByFloat
 import com.woocommerce.android.model.Order
+import com.woocommerce.android.ui.orders.wooshippinglabels.models.ShipmentUIModel
 import com.woocommerce.android.ui.orders.wooshippinglabels.models.ShippableItemModel
 import com.woocommerce.android.ui.orders.wooshippinglabels.models.ShippableItemModel.Companion.SINGLE_QUANTITY
 import com.woocommerce.android.ui.orders.wooshippinglabels.split.SelectableShippableItemUI
@@ -74,15 +75,15 @@ fun ShippableItemModel.toSelectableUIModel(
     }
 }
 
-fun List<ShippableItemModel>.toSelectableUIModel(
+fun ShipmentUIModel.toSelectableUIModel(
     currencyFormatter: CurrencyFormatter,
     dimensionUnit: String,
     weightUnit: String,
     purchased: Boolean
 ): SelectableShippableItemsUI {
-    val shippableItemsUI = map { item -> item.toSelectableUIModel(currencyFormatter, dimensionUnit, weightUnit) }
-    val formattedTotalPrice = getFormattedTotalPrice(currencyFormatter)
-    val formattedTotalWeight = getFormattedTotalWeight(weightUnit)
+    val shippableItemsUI = items.map { item -> item.toSelectableUIModel(currencyFormatter, dimensionUnit, weightUnit) }
+    val formattedTotalPrice = items.getFormattedTotalPrice(currencyFormatter)
+    val formattedTotalWeight = items.getFormattedTotalWeight(weightUnit)
 
     return SelectableShippableItemsUI(
         shippableItems = shippableItemsUI,

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/WooShippingProductsCard.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/WooShippingProductsCard.kt
@@ -148,8 +148,9 @@ private fun ShippingProductsCardHeader(
             Icon(
                 painter = painterResource(R.drawable.ic_arrow_down),
                 tint = iconColor,
-                contentDescription =
-                stringResource(id = R.string.shipping_label_package_details_items_expand_content_description),
+                contentDescription = stringResource(
+                    id = R.string.shipping_label_package_details_items_expand_content_description
+                ),
                 modifier = Modifier
                     .size(dimensionResource(R.dimen.image_minor_100))
                     .rotate(rotationAnimation.value)
@@ -461,14 +462,14 @@ fun SelectableShippingProduct(
     price: String,
     quantity: Float,
     isSelected: Boolean,
-    onSelectionChange: (Boolean) -> Unit,
+    onSelectionChange: ((Boolean) -> Unit)?,
     modifier: Modifier = Modifier,
     imageUrl: String? = null,
 ) {
     RoundedCornerBoxWithBorder(
         modifier = modifier,
         innerModifier = Modifier
-            .clickable { onSelectionChange(!isSelected) }
+            .clickable(enabled = onSelectionChange != null, onClick = { onSelectionChange?.invoke(!isSelected) })
             .padding(
                 top = 16.dp,
                 start = 8.dp,
@@ -497,8 +498,8 @@ fun ExpandableSelectableShippingProduct(
     price: String,
     quantity: Float,
     isSelected: Boolean,
-    onSelectionChange: (Boolean) -> Unit,
-    onInnerSelectionChange: (Boolean, Int) -> Unit,
+    onSelectionChange: ((Boolean) -> Unit)?,
+    onInnerSelectionChange: ((Boolean, Int) -> Unit)?,
     selectedIndexes: Set<Int>,
     isExpanded: Boolean,
     onExpand: (Boolean) -> Unit,
@@ -510,7 +511,10 @@ fun ExpandableSelectableShippingProduct(
     val rotationAnimation = animateFloatAsState(targetValue = if (isExpanded) 180f else 0f, label = "rotationAnimation")
     RoundedCornerBoxWithBorder(
         modifier = modifier,
-        innerModifier = Modifier.clickable { onSelectionChange(!isSelected) }
+        innerModifier = Modifier.clickable(
+            enabled = onSelectionChange != null,
+            onClick = { onSelectionChange?.invoke(!isSelected) }
+        )
     ) {
         Column(modifier = Modifier.animateContentSize()) {
             Row(
@@ -577,11 +581,14 @@ fun ExpandableSelectableShippingProduct(
                         quantity = quantity,
                         isSelected = isInnerItemSelected,
                         onSelectionChange = {
-                            onInnerSelectionChange(isInnerItemSelected, index)
+                            onInnerSelectionChange?.invoke(isInnerItemSelected, index)
                         },
                         imageUrl = imageUrl,
                         modifier = Modifier
-                            .clickable { onInnerSelectionChange(isInnerItemSelected, index) }
+                            .clickable(
+                                enabled = onInnerSelectionChange != null,
+                                onClick = { onInnerSelectionChange?.invoke(isInnerItemSelected, index) }
+                            )
                             .padding(start = 24.dp, top = 16.dp, end = 16.dp, bottom = 16.dp),
                         imageSize = dimensionResource(R.dimen.image_minor_100),
                         displayQuantity = false
@@ -600,7 +607,7 @@ fun SelectableShippingProductDetails(
     price: String,
     quantity: Float,
     isSelected: Boolean,
-    onSelectionChange: (Boolean) -> Unit,
+    onSelectionChange: ((Boolean) -> Unit)?,
     modifier: Modifier = Modifier,
     imageUrl: String? = null,
     imageSize: Dp = dimensionResource(R.dimen.image_major_50),

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/models/ShipmentUIModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/models/ShipmentUIModel.kt
@@ -8,5 +8,5 @@ data class ShipmentUIModel(
     // If id is null, it indicates that no shipment has been fetched from the backend.
     val id: String?,
     val items: List<ShippableItemModel>,
-    val purchased: Boolean
+    val purchased: Boolean = false
 ) : Parcelable

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/split/GetSplitMovements.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/split/GetSplitMovements.kt
@@ -45,7 +45,7 @@ class GetSplitMovements @Inject constructor() {
         }
 
         return if (nextShipmentItems.isNotEmpty()) {
-            getPossibleKeys(
+            getPossibleDestinationKeys(
                 sourceShipmentKey = sourceShipmentKey,
                 items = shipments,
                 isRemoveMovement = sourceShipmentItems.isEmpty()
@@ -62,17 +62,18 @@ class GetSplitMovements @Inject constructor() {
         }
     }
 
-    private fun getPossibleKeys(
+    private fun getPossibleDestinationKeys(
         sourceShipmentKey: Int,
         items: Map<Int, ShipmentUIModel>,
         isRemoveMovement: Boolean
     ): List<Int> {
-        val otherKeys = items.keys.filter { it != sourceShipmentKey }
-        if (isRemoveMovement) return otherKeys
+        val otherUnfulfilledKeys = items.filterNot { it.key == sourceShipmentKey || it.value.purchased }.keys.toList()
+        if (isRemoveMovement) return otherUnfulfilledKeys
 
+        val otherKeys = items.keys.filter { it != sourceShipmentKey }
         var nextKey = (otherKeys.maxOrNull() ?: sourceShipmentKey) + 1
         if (nextKey == sourceShipmentKey) nextKey++
-        return otherKeys + nextKey
+        return otherUnfulfilledKeys + nextKey
     }
 }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/split/GetSplitMovements.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/split/GetSplitMovements.kt
@@ -1,13 +1,14 @@
 package com.woocommerce.android.ui.orders.wooshippinglabels.split
 
 import com.woocommerce.android.extensions.sumByFloat
+import com.woocommerce.android.ui.orders.wooshippinglabels.models.ShipmentUIModel
 import com.woocommerce.android.ui.orders.wooshippinglabels.models.ShippableItemModel
 import javax.inject.Inject
 
 class GetSplitMovements @Inject constructor() {
     operator fun invoke(
         sourceShipmentKey: Int,
-        shipments: Map<Int, List<ShippableItemModel>>,
+        shipments: Map<Int, ShipmentUIModel>,
         selection: Map<Int, SelectableShippableItemsUI>
     ): List<SplitMovement> {
         val sourceShipmentItems = mutableListOf<ShippableItemModel>()
@@ -16,29 +17,29 @@ class GetSplitMovements @Inject constructor() {
         selection[sourceShipmentKey]?.shippableItems?.forEachIndexed { index, item ->
             when {
                 item is SelectableShippableItemUI.SingleSelectableShippableItemUI && item.isSelected -> {
-                    nextShipmentItems.add(shipments.getValue(sourceShipmentKey)[index])
+                    nextShipmentItems.add(shipments.getValue(sourceShipmentKey).items[index])
                 }
 
                 item is SelectableShippableItemUI.SingleSelectableShippableItemUI && !item.isSelected -> {
-                    sourceShipmentItems.add(shipments.getValue(sourceShipmentKey)[index])
+                    sourceShipmentItems.add(shipments.getValue(sourceShipmentKey).items[index])
                 }
 
                 item is SelectableShippableItemUI.ExpandableSelectableShippableItemUI && item.isSelected -> {
-                    nextShipmentItems.add(shipments.getValue(sourceShipmentKey)[index])
+                    nextShipmentItems.add(shipments.getValue(sourceShipmentKey).items[index])
                 }
 
                 item is SelectableShippableItemUI.ExpandableSelectableShippableItemUI &&
                     !item.isSelected &&
                     item.selectedIndexes.isNotEmpty() -> {
                     val selected = item.selectedIndexes.size
-                    val sourceItem = shipments.getValue(sourceShipmentKey)[index]
+                    val sourceItem = shipments.getValue(sourceShipmentKey).items[index]
 
                     sourceShipmentItems.add(sourceItem.copy(quantity = sourceItem.quantity - selected))
                     nextShipmentItems.add(sourceItem.copy(quantity = selected.toFloat()))
                 }
 
                 else -> {
-                    sourceShipmentItems.add(shipments.getValue(sourceShipmentKey)[index])
+                    sourceShipmentItems.add(shipments.getValue(sourceShipmentKey).items[index])
                 }
             }
         }
@@ -63,7 +64,7 @@ class GetSplitMovements @Inject constructor() {
 
     private fun getPossibleKeys(
         sourceShipmentKey: Int,
-        items: Map<Int, List<ShippableItemModel>>,
+        items: Map<Int, ShipmentUIModel>,
         isRemoveMovement: Boolean
     ): List<Int> {
         val otherKeys = items.keys.filter { it != sourceShipmentKey }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/split/RemoveShipmentBottomSheet.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/split/RemoveShipmentBottomSheet.kt
@@ -237,8 +237,9 @@ private fun ShipmentCardPreview() = ShipmentCard(
     shipment = mapOf(
         3 to SelectableShippableItemsUI(
             shippableItems = emptyList(),
-            "550g",
-            "$50.00"
+            formattedTotalWeight = "550g",
+            formattedTotalPrice = "$50.00",
+            purchased = false
         )
     ).entries.first()
 )
@@ -250,8 +251,9 @@ private fun ShipmentCardSelectedPreview() = ShipmentCard(
     shipment = mapOf(
         2 to SelectableShippableItemsUI(
             shippableItems = emptyList(),
-            "825g",
-            "$75.00"
+            formattedTotalWeight = "825g",
+            formattedTotalPrice = "$75.00",
+            purchased = false
         )
     ).entries.first(),
     isSelected = true

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/split/WooShippingSplitShipmentScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/split/WooShippingSplitShipmentScreen.kt
@@ -285,7 +285,7 @@ private fun MultipleShipments(
                                         contentDescription = stringResource(
                                             R.string.purchased_shipment_content_description
                                         ),
-                                        tint = colorResource(id = R.color.woo_green_70)
+                                        tint = colorResource(id = R.color.woo_shipping_label_purchased_color)
                                     )
                                 }
                             }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/split/WooShippingSplitShipmentScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/split/WooShippingSplitShipmentScreen.kt
@@ -299,25 +299,27 @@ private fun MultipleShipments(
                     )
                 }
             }
-            WCOverflowMenu(
-                items = viewState.overflowMenuItems,
-                mapper = { shipmentIndexList ->
-                    if (shipmentIndexList.size == 1) {
-                        // Example: "Remove shipment 1"
-                        stringResource(
-                            R.string.woo_shipping_split_shipment_shipment_remove,
+            if (viewState.overflowMenuItems.isNotEmpty()) {
+                WCOverflowMenu(
+                    items = viewState.overflowMenuItems,
+                    mapper = { shipmentIndexList ->
+                        if (shipmentIndexList.size == 1) {
+                            // Example: "Remove shipment 1"
                             stringResource(
-                                R.string.woo_shipping_split_shipment_shipment_name,
-                                shipmentIndexList.first() + 1
-                            ).toLowerCase(Locale.current)
-                        )
-                    } else {
-                        stringResource(R.string.woo_shipping_split_shipment_merge_unfulfilled_menu)
-                    }
-                },
-                onSelected = onRemoveShipmentMenuTapped,
-                modifier = modifier.align(Alignment.CenterVertically)
-            )
+                                R.string.woo_shipping_split_shipment_shipment_remove,
+                                stringResource(
+                                    R.string.woo_shipping_split_shipment_shipment_name,
+                                    shipmentIndexList.first() + 1
+                                ).toLowerCase(Locale.current)
+                            )
+                        } else {
+                            stringResource(R.string.woo_shipping_split_shipment_merge_unfulfilled_menu)
+                        }
+                    },
+                    onSelected = onRemoveShipmentMenuTapped,
+                    modifier = modifier.align(Alignment.CenterVertically)
+                )
+            }
         }
 
         HorizontalPager(

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/split/WooShippingSplitShipmentScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/split/WooShippingSplitShipmentScreen.kt
@@ -518,7 +518,11 @@ fun SelectableProductsSection(
                             quantity = shippableItem.shippableItem.quantity,
                             imageUrl = shippableItem.shippableItem.imageUrl,
                             isSelected = shippableItem.isSelected,
-                            onSelectionChange = { onUpdateSelection(index, null) },
+                            onSelectionChange = if (shipment.purchased) {
+                                null
+                            } else {
+                                { onUpdateSelection(index, null) }
+                            },
                             modifier = Modifier.padding(vertical = 8.dp)
                         )
                     }
@@ -533,17 +537,25 @@ fun SelectableProductsSection(
                             quantity = shippableItem.shippableItem.quantity,
                             imageUrl = shippableItem.shippableItem.imageUrl,
                             isSelected = shippableItem.isSelected,
-                            onSelectionChange = { onUpdateSelection(index, null) },
+                            onSelectionChange = if (shipment.purchased) {
+                                null
+                            } else {
+                                { onUpdateSelection(index, null) }
+                            },
                             isExpanded = expanded,
                             onExpand = { expanded = !expanded },
                             singleWeight = shippableItem.innerShippableItem.formattedWeight,
                             singlePrice = shippableItem.innerShippableItem.formattedPrice,
                             selectedIndexes = shippableItem.selectedIndexes,
-                            onInnerSelectionChange = { isSelected, innerIndex ->
-                                val indexes = shippableItem.selectedIndexes.toMutableSet()
-                                if (isSelected) indexes.remove(innerIndex) else indexes.add(innerIndex)
+                            onInnerSelectionChange = if (shipment.purchased) {
+                                null
+                            } else {
+                                { isSelected, innerIndex ->
+                                    val indexes = shippableItem.selectedIndexes.toMutableSet()
+                                    if (isSelected) indexes.remove(innerIndex) else indexes.add(innerIndex)
 
-                                onUpdateSelection(index, indexes)
+                                    onUpdateSelection(index, indexes)
+                                }
                             },
                             modifier = Modifier.padding(vertical = 8.dp)
                         )

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/split/WooShippingSplitShipmentScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/split/WooShippingSplitShipmentScreen.kt
@@ -3,6 +3,7 @@ package com.woocommerce.android.ui.orders.wooshippinglabels.split
 import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.animation.slideInVertically
 import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
@@ -10,6 +11,7 @@ import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.sizeIn
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.itemsIndexed
@@ -46,6 +48,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.colorResource
+import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.AnnotatedString
 import androidx.compose.ui.text.font.FontWeight
@@ -265,15 +268,27 @@ private fun MultipleShipments(
                     }
                     Tab(
                         text = {
-                            Text(
-                                text = stringResource(
-                                    R.string.woo_shipping_split_shipment_shipment_name,
-                                    index + 1 // Use 1-based indexing for the shipments
-                                ),
-                                color = textColor,
-                                style = MaterialTheme.typography.subtitle1,
-                                fontWeight = FontWeight.SemiBold
-                            )
+                            Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+                                Text(
+                                    text = stringResource(
+                                        R.string.woo_shipping_split_shipment_shipment_name,
+                                        index + 1 // Use 1-based indexing for the shipments
+                                    ),
+                                    color = textColor,
+                                    style = MaterialTheme.typography.subtitle1,
+                                    fontWeight = FontWeight.SemiBold
+                                )
+                                if (viewState.selectableItems[index]?.purchased == true) {
+                                    Icon(
+                                        modifier = Modifier.size(16.dp),
+                                        painter = painterResource(R.drawable.ic_progress_circle_complete),
+                                        contentDescription = stringResource(
+                                            R.string.purchased_shipment_content_description
+                                        ),
+                                        tint = colorResource(id = R.color.woo_green_70)
+                                    )
+                                }
+                            }
                         },
                         selected = pagerState.currentPage == index,
                         onClick = {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/split/WooShippingSplitShipmentScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/split/WooShippingSplitShipmentScreen.kt
@@ -554,12 +554,14 @@ private fun WooShippingSplitShipmentScreenPreview() = WooThemeWithBackground {
                 0 to SelectableShippableItemsUI(
                     shippableItems = emptyList(),
                     formattedTotalWeight = "",
-                    formattedTotalPrice = ""
+                    formattedTotalPrice = "",
+                    purchased = false
                 ),
                 1 to SelectableShippableItemsUI(
                     shippableItems = emptyList(),
                     formattedTotalWeight = "",
-                    formattedTotalPrice = ""
+                    formattedTotalPrice = "",
+                    purchased = false
                 )
             )
         ),

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/split/WooShippingSplitShipmentViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/split/WooShippingSplitShipmentViewModel.kt
@@ -72,10 +72,11 @@ class WooShippingSplitShipmentViewModel @Inject constructor(
         removeShipmentSheet,
         splitMessage
     ) { shipmentSelected, selectableItems, sheet, message ->
+        val unfulfilledShipmentKeys = selectableItems.keys.filterNot { selectableItems.getValue(it).purchased }
         SplitShipmentViewState(
             shipmentSelected = shipmentSelected,
             selectableItems = selectableItems,
-            overflowMenuItems = getOverflowMenuItems(selectableItems.keys.toList()),
+            overflowMenuItems = getOverflowMenuItems(unfulfilledShipmentKeys),
             splitMovements = getSplitMovements(
                 sourceShipmentKey = shipmentSelected,
                 shipments = currentShipments.value,

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/split/WooShippingSplitShipmentViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/split/WooShippingSplitShipmentViewModel.kt
@@ -6,6 +6,7 @@ import com.woocommerce.android.R
 import com.woocommerce.android.extensions.sumByFloat
 import com.woocommerce.android.ui.orders.wooshippinglabels.ShippableItemUI
 import com.woocommerce.android.ui.orders.wooshippinglabels.components.ShippingLabelsSnackbarData
+import com.woocommerce.android.ui.orders.wooshippinglabels.models.ShipmentUIModel
 import com.woocommerce.android.ui.orders.wooshippinglabels.models.ShippableItemModel
 import com.woocommerce.android.ui.orders.wooshippinglabels.toSelectableUIModel
 import com.woocommerce.android.util.CurrencyFormatter
@@ -32,7 +33,7 @@ class WooShippingSplitShipmentViewModel @Inject constructor(
     private val storeOptions = navArgs.shipmentArgs.storeOptions
 
     private val currentShipments = MutableStateFlow(
-        navArgs.shipmentArgs.shipments.withIndex().associate { (index, shipment) -> index to shipment.items }
+        navArgs.shipmentArgs.shipments.withIndex().associate { (index, shipment) -> index to shipment }
     )
     private val shipmentsUIMap: MutableStateFlow<Map<Int, SelectableShippableItemsUI>?> = MutableStateFlow(null)
 
@@ -206,7 +207,7 @@ class WooShippingSplitShipmentViewModel @Inject constructor(
      * as "Shipment 0, Shipment 1".
      */
     private fun reindexShipments(
-        shipments: Map<Int, List<ShippableItemModel>>
+        shipments: Map<Int, ShipmentUIModel>
     ) = shipments.values.mapIndexed { index, items -> index to items }.toMap()
 
     private fun showUndoSnackbar(splitMovement: SplitMovement, undoAction: () -> Unit) {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/split/WooShippingSplitShipmentViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/split/WooShippingSplitShipmentViewModel.kt
@@ -139,11 +139,14 @@ class WooShippingSplitShipmentViewModel @Inject constructor(
     }
 
     private fun mergeUnfulfilledShipments() {
-        currentShipments.value = currentShipments.value.run {
-            // TODO Once the purchasing shipments feature is implemented, exclude purchased shipments from the merging
-            //  action.
-            mapOf(keys.first() to values.reduce(List<ShippableItemModel>::combine))
-        }
+        val fulfilledShipments = currentShipments.value.filter { it.value.purchased }
+        val unfulfilledShipments = currentShipments.value.filterNot { it.value.purchased }
+        val firstUnfulfilledShipmentKey = unfulfilledShipments.keys.first()
+        val firstUnfulfilledShipmentValue = unfulfilledShipments.values.first()
+        val mergedShipmentUIModel = firstUnfulfilledShipmentValue.copy(
+            items = unfulfilledShipments.values.map { it.items }.reduce(List<ShippableItemModel>::combine)
+        )
+        currentShipments.value = fulfilledShipments + mapOf(firstUnfulfilledShipmentKey to mergedShipmentUIModel)
     }
 
     fun onDismissRemoveSheet() {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/split/WooShippingSplitShipmentViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/split/WooShippingSplitShipmentViewModel.kt
@@ -116,14 +116,14 @@ class WooShippingSplitShipmentViewModel @Inject constructor(
         val shipmentsMap = shipmentsUIMap.value ?: return
         removeShipmentSheet.value = RemoveShipmentSheet(
             removingShipments = shipmentsMap.filter { it.key in shipmentKeys },
-            otherShipments = shipmentsMap.filter { it.key !in shipmentKeys },
+            otherShipments = shipmentsMap.filter { it.key !in shipmentKeys && !it.value.purchased },
         )
     }
 
     fun onRemoveShipments(removingShipmentKeys: List<Int>, destinationShipmentKey: Int?) {
         if (destinationShipmentKey != null && removingShipmentKeys.size == 1) {
             val removingShipmentKey = removingShipmentKeys.first()
-            val movingShipmentItems = currentShipments.value[removingShipmentKey] ?: return
+            val movingShipmentItems = currentShipments.value[removingShipmentKey]?.items ?: return
             onUpdateShipment(
                 SplitMovement(
                     sourceShipmentKey = removingShipmentKey,

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/split/WooShippingSplitShipmentViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/split/WooShippingSplitShipmentViewModel.kt
@@ -51,7 +51,8 @@ class WooShippingSplitShipmentViewModel @Inject constructor(
                     it.value.toSelectableUIModel(
                         currencyFormatter = currencyFormatter,
                         dimensionUnit = storeOptions.dimensionUnit,
-                        weightUnit = storeOptions.weightUnit
+                        weightUnit = storeOptions.weightUnit,
+                        purchased = it.value.purchased
                     )
                 }
 
@@ -246,7 +247,8 @@ class WooShippingSplitShipmentViewModel @Inject constructor(
 data class SelectableShippableItemsUI(
     val shippableItems: List<SelectableShippableItemUI>,
     val formattedTotalWeight: String,
-    val formattedTotalPrice: String
+    val formattedTotalPrice: String,
+    val purchased: Boolean
 ) {
     val totalItemQuantity: Int
         get() = shippableItems.sumByFloat { it.shippableItem.quantity }.toInt()

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/split/WooShippingSplitShipmentViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/split/WooShippingSplitShipmentViewModel.kt
@@ -181,15 +181,27 @@ class WooShippingSplitShipmentViewModel @Inject constructor(
         val currentShipmentBackup = currentShipments.value
         currentShipments.update {
             val shipments = it.toMutableMap()
+
+            // Update the source shipment
             if (splitMovement.updatedSourceShipmentItems.isEmpty()) {
                 shipments.remove(splitMovement.sourceShipmentKey)
             } else {
-                shipments[splitMovement.sourceShipmentKey] = splitMovement.updatedSourceShipmentItems
+                shipments[splitMovement.sourceShipmentKey] = shipments[splitMovement.sourceShipmentKey]?.copy(
+                    items = splitMovement.updatedSourceShipmentItems
+                ) ?: return
             }
-            shipments[splitMovement.destinationShipmentKey] = shipments[splitMovement.destinationShipmentKey]
-                ?.takeIf { it.isNotEmpty() }
-                ?.combine(splitMovement.movingShipmentItems)
-                ?: splitMovement.movingShipmentItems
+
+            // Update the destination shipment
+            shipments[splitMovement.destinationShipmentKey] = shipments[splitMovement.destinationShipmentKey]?.copy(
+                items = shipments[splitMovement.destinationShipmentKey]?.items
+                    ?.takeIf { it.isNotEmpty() }
+                    ?.combine(splitMovement.movingShipmentItems)
+                    ?: splitMovement.movingShipmentItems
+            ) ?: ShipmentUIModel(
+                id = splitMovement.destinationShipmentKey.toString(),
+                items = splitMovement.movingShipmentItems
+            )
+
             reindexShipments(shipments)
         }
 

--- a/WooCommerce/src/main/res/values-night/colors_base.xml
+++ b/WooCommerce/src/main/res/values-night/colors_base.xml
@@ -244,6 +244,7 @@
     <!-- Shipping labels -->
     <color name="woo_shipping_label_success">@color/woo_green_50</color>
     <color name="woo_shipping_label_success_surface">@color/woo_green_100</color>
+    <color name="woo_shipping_label_purchased_color">@color/woo_green_20</color>
     <!--
     Custom Message Color
     -->

--- a/WooCommerce/src/main/res/values/colors_base.xml
+++ b/WooCommerce/src/main/res/values/colors_base.xml
@@ -336,6 +336,7 @@
     <color name="woo_shipping_label_success_surface">@color/woo_green_0</color>
     <color name="woo_shipping_label_error">@color/woo_red_60</color>
     <color name="woo_shipping_label_error_surface">@color/woo_red_0</color>
+    <color name="woo_shipping_label_purchased_color">@color/woo_green_70</color>
 
     <!--
         Custom Message Color

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -4627,4 +4627,5 @@
     <string name="woo_shipping_split_shipment_merge_unfulfilled_title">Merge all unfulfilled shipments</string>
     <string name="woo_shipping_split_shipment_merge_unfulfilled_desc">This will remove all unfulfilled split shipments and move all items into one shipment.</string>
     <string name="woo_shipping_split_shipment_merge_unfulfilled_button">Merge all shipments</string>
+    <string name="purchased_shipment_content_description">Purchased</string>
 </resources>

--- a/WooCommerce/src/main/res/values/wc_colors_base.xml
+++ b/WooCommerce/src/main/res/values/wc_colors_base.xml
@@ -57,6 +57,7 @@
     <color name="woo_green_20">#1ED15A</color>
     <color name="woo_green_50">#008A20</color>
     <color name="woo_green_60">#007017</color>
+    <color name="woo_green_70">#005C12</color>
     <color name="woo_green_100">#001C05</color>
 
     <color name="woo_white">#FFFFFF</color>

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/WooShippingLabelCreationViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/WooShippingLabelCreationViewModelTest.kt
@@ -85,7 +85,7 @@ class WooShippingLabelCreationViewModelTest : BaseUnitTest() {
             length = it.toFloat()
         )
     }
-    private val defaultShipments = listOf(ShipmentUIModel(id = "0", items = defaultShippableItems, purchased = false))
+    private val defaultShipments = listOf(ShipmentUIModel(id = "0", items = defaultShippableItems))
     private val defaultShippingLines = List(3) {
         Order.ShippingLine(
             methodTitle = "Shipping Line $it",

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/split/GetSplitMovementsTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/split/GetSplitMovementsTest.kt
@@ -151,6 +151,35 @@ class GetSplitMovementsTest : BaseUnitTest() {
         assertThat(hasNewKey).isTrue
     }
 
+    @Test
+    fun `when the selection is a remove movement, then do NOT include purchased keys`() {
+        val allItemsSelected = twoShipmentsSelection.getValue(0).shippableItems.map {
+            when (it) {
+                is SelectableShippableItemUI.SingleSelectableShippableItemUI -> {
+                    it.copy(isSelected = true)
+                }
+
+                is SelectableShippableItemUI.ExpandableSelectableShippableItemUI -> {
+                    it.copy(
+                        selectedIndexes = List(it.shippableItem.quantity.toInt()) { it }.toSet()
+                    )
+                }
+            }
+        }
+        val selection = twoShipmentsSelection.toMutableMap()
+        selection[0] = defaultSelection.getValue(0).copy(shippableItems = allItemsSelected)
+
+        val result = sut.invoke(
+            sourceShipmentKey = 0,
+            shipments = purchasedShipment + twoShipments,
+            selection = selection
+        )
+
+        assertThat(result.size).isEqualTo(1)
+        val isAnExistingKey = result.first().destinationShipmentKey in twoShipments.keys
+        assertThat(isAnExistingKey).isTrue
+    }
+
     private val defaultShippableItems = List(3) {
         ShippableItemModel(
             itemId = it.toLong(),
@@ -189,4 +218,8 @@ class GetSplitMovementsTest : BaseUnitTest() {
             purchased = false
         )
     }
+
+    private val purchasedShipment = mapOf(
+        10 to ShipmentUIModel(id = null, items = defaultShippableItems, purchased = true)
+    )
 }

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/split/GetSplitMovementsTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/split/GetSplitMovementsTest.kt
@@ -1,5 +1,6 @@
 package com.woocommerce.android.ui.orders.wooshippinglabels.split
 
+import com.woocommerce.android.ui.orders.wooshippinglabels.models.ShipmentUIModel
 import com.woocommerce.android.ui.orders.wooshippinglabels.models.ShippableItemModel
 import com.woocommerce.android.ui.orders.wooshippinglabels.toSelectableUIModel
 import com.woocommerce.android.util.CurrencyFormatter
@@ -166,24 +167,26 @@ class GetSplitMovementsTest : BaseUnitTest() {
         )
     }
 
-    private val defaultShipments = mapOf(0 to defaultShippableItems)
+    private val defaultShipments = mapOf(0 to ShipmentUIModel(id = null, items = defaultShippableItems))
     val defaultSelection = defaultShipments.mapValues {
         it.value.toSelectableUIModel(
             currencyFormatter = currencyFormatter,
             dimensionUnit = "cm",
-            weightUnit = "kg"
+            weightUnit = "kg",
+            purchased = false
         )
     }
 
     private val twoShipments = mapOf(
-        0 to defaultShippableItems,
-        1 to defaultShippableItems
+        0 to ShipmentUIModel(id = null, items = defaultShippableItems),
+        1 to ShipmentUIModel(id = null, items = defaultShippableItems)
     )
     val twoShipmentsSelection = twoShipments.mapValues {
         it.value.toSelectableUIModel(
             currencyFormatter = currencyFormatter,
             dimensionUnit = "cm",
-            weightUnit = "kg"
+            weightUnit = "kg",
+            purchased = false
         )
     }
 }

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/split/WooShippingSplitShipmentViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/split/WooShippingSplitShipmentViewModelTest.kt
@@ -354,6 +354,24 @@ class WooShippingSplitShipmentViewModelTest : BaseUnitTest() {
     }
 
     @Test
+    fun `when there are 2 shipments and 1 purchased shipment, then do not display the Merge all unfulfilled option`() =
+        testBlocking {
+            val shipmentArgs = SplitShipmentArgs(
+                orderId = 1L,
+                storeOptions = StoreOptionsModel.EMPTY,
+                shipments = twoShipments + purchasedShipmentUIModel
+            )
+
+            createViewModel(shipmentArgs)
+
+            sut.viewState.observeForTesting { }
+
+            val state = sut.viewState.value!!
+
+            assertThat(state.overflowMenuItems.size).isEqualTo(2)
+        }
+
+    @Test
     fun `when there are 3 shipments, then display the Merge all unfulfilled option`() = testBlocking {
         val shipmentArgs = SplitShipmentArgs(
             orderId = 1L,
@@ -403,6 +421,35 @@ class WooShippingSplitShipmentViewModelTest : BaseUnitTest() {
 
         assertThat(currentShipments.values.first().totalItemQuantity).isEqualTo(expectedItemQuantity)
     }
+
+    @Test
+    fun `when merging unfulfilled shipments, do not merge purchased shipments`() =
+        testBlocking {
+            val shipmentArgs = SplitShipmentArgs(
+                orderId = 1L,
+                storeOptions = StoreOptionsModel.EMPTY,
+                shipments = listOf(purchasedShipmentUIModel) + threeShipments
+            )
+
+            createViewModel(shipmentArgs)
+
+            // Trigger merging all shipments
+            sut.onRemoveShipments(
+                removingShipmentKeys = (0 until shipmentArgs.shipments.size).toList(),
+                destinationShipmentKey = null
+            )
+
+            sut.viewState.observeForTesting { }
+
+            val state = sut.viewState.value!!
+            val currentShipments = state.selectableItems
+            val expectedItemQuantity = 10 // All items from `threeShipments`
+
+            // Verify there are two shipments
+            assertThat(currentShipments.size).isEqualTo(2)
+
+            assertThat(currentShipments.values.toList()[1].totalItemQuantity).isEqualTo(expectedItemQuantity)
+        }
 
     private val defaultShipments = listOf(
         ShipmentUIModel(
@@ -571,5 +618,25 @@ class WooShippingSplitShipmentViewModelTest : BaseUnitTest() {
                 )
             )
         )
+    )
+
+    val purchasedShipmentUIModel = ShipmentUIModel(
+        id = "10",
+        items = listOf(
+            ShippableItemModel(
+                itemId = 1L,
+                productId = 1L,
+                title = "A product with quantity 1",
+                price = BigDecimal(30),
+                quantity = 1f,
+                imageUrl = null,
+                currency = "USD",
+                length = 3f,
+                width = 3f,
+                height = 3f,
+                weight = 8f
+            )
+        ),
+        purchased = true
     )
 }

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/split/WooShippingSplitShipmentViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/split/WooShippingSplitShipmentViewModelTest.kt
@@ -447,8 +447,7 @@ class WooShippingSplitShipmentViewModelTest : BaseUnitTest() {
                     height = 3f,
                     weight = 8f
                 )
-            ),
-            purchased = false
+            )
         )
     )
 
@@ -482,8 +481,7 @@ class WooShippingSplitShipmentViewModelTest : BaseUnitTest() {
                     height = 3f,
                     weight = 8f
                 )
-            ),
-            purchased = false
+            )
         ),
         ShipmentUIModel(
             id = "1",
@@ -501,8 +499,7 @@ class WooShippingSplitShipmentViewModelTest : BaseUnitTest() {
                     height = 3f,
                     weight = 8f
                 )
-            ),
-            purchased = false
+            )
         )
     )
 
@@ -536,8 +533,7 @@ class WooShippingSplitShipmentViewModelTest : BaseUnitTest() {
                     height = 3f,
                     weight = 8f
                 )
-            ),
-            purchased = false
+            )
         ),
         ShipmentUIModel(
             id = "1",
@@ -555,8 +551,7 @@ class WooShippingSplitShipmentViewModelTest : BaseUnitTest() {
                     height = 3f,
                     weight = 8f
                 )
-            ),
-            purchased = false
+            )
         ),
         ShipmentUIModel(
             id = "2",
@@ -574,8 +569,7 @@ class WooShippingSplitShipmentViewModelTest : BaseUnitTest() {
                     height = 3f,
                     weight = 8f
                 )
-            ),
-            purchased = false
+            )
         )
     )
 }


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
This adds ✅ icon to the purchased shipments on the split shipments screen and also handles logic for item movement actions.

### Steps to reproduce
<!-- Step-by-step testing instructions. For new user flows, consider instead stating the goal of the workflow and see if your PR reviewer can accomplish the workflow without specific steps! -->
1. Open the Orders tab.
2. Tap an order with shipping labels. If you don't have one yet, create an order and purchase some shipments from the web.
3. Tap on Create shipping label.
4. Tap Split shipment.

### Testing information
<!-- This is your opportunity to break out individual scenarios that need testing (when necessary) and/or include a checklist for the reviewer to go through. Consider documenting the following from your own completed testing: devices used, alternate workflows, edge cases, affected areas, critical flows, areas not tested, and any remaining unknowns. Provide feedback on this new section of the PR template through Sept 30, 2024 to Apps Quality; additional context here: p91TBi-b8z-p2#comment-12036 -->
Here are some rules to use during testing:
- Purchased shipments shouldn’t be modified when removing or merging shipments.
- To see the “Merge unfulfilled shipments” button, there must be at least three unfulfilled shipments.
- Items in purchased shipments should not be clickable.
- When selecting an item, the UI should exclude purchased shipments from the list of destination shipments.

### The tests that have been performed
<!-- To give the reviewer an idea of what could be missed in terms of testing -->

### Images/gif
<!-- Include before and after images or gifs when appropriate. -->
<img src="https://github.com/user-attachments/assets/7b3874dd-f902-4544-87ed-93a3d4ad48e2" width=360> <img src="https://github.com/user-attachments/assets/006b1b77-dcc6-440f-8502-1925333e427c" width=360>

- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.

## Reviewer (or Author, in the case of optional code reviews):

Please make sure these conditions are met before approving the PR, or request changes if the PR needs improvement:

- [ ] The PR is small and has a clear, single focus, or a valid explanation is provided in the description. If needed, please request to split it into smaller PRs.
- [ ] Ensure Adequate Unit Test Coverage: The changes are reasonably covered by unit tests or an explanation is provided in the PR description.
- [ ] Manual Testing: The author listed all the tests they ran, including smoke tests when needed (e.g., for refactorings). The reviewer confirmed that the PR works as expected on big (tablet) and small (phone) in case of UI changes, and no regressions are added.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->