### PR TITLE
Fix issue with retaining DashboardRepository in memory too long

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/data/DashboardRepository.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/data/DashboardRepository.kt
@@ -9,14 +9,14 @@ import com.woocommerce.android.tools.SelectedSite
 import com.woocommerce.android.ui.mystore.data.DashboardDataModel
 import com.woocommerce.android.ui.mystore.data.DashboardWidgetDataModel
 import dagger.hilt.EntryPoints
-import dagger.hilt.android.scopes.ActivityRetainedScoped
+import dagger.hilt.android.scopes.ViewModelScoped
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.stateIn
 import javax.inject.Inject
 
-@ActivityRetainedScoped
+@ViewModelScoped
 @Suppress("LongParameterList")
 class DashboardRepository @Inject constructor(
     selectedSite: SelectedSite,


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Fixes: #WOOMOB-451
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs, try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
Tricky bug to figure out what was happening, given there wasn't any noticeable crash or logged error. When opening the edit dashboard widget screen, @kidinov reported that an empty screen was shown:


https://github.com/user-attachments/assets/8a9817a8-79c1-4cc3-bb7f-cd1a135a2bc8

The change that caused this bug [was the fix we merged](https://github.com/woocommerce/woocommerce-android/pull/13949) a few days ago. Refreshing the in-memory instance of `SiteModel` messed up with  `DashboardRepository -> DashboardDataStore  -> selectedSite.siteComponent!!`. Because `DashboardRepository` had a `@ActivityRetainedScoped` lifespan, and because it is instantiated before [Appinitializer -> selectedSite.set(it)](https://github.com/woocommerce/woocommerce-android/pull/13949/files#diff-382495f533cb26e13cb937a8bf65d7e96bc9d04fa582e8618ed0b25c9974c4d3R185), by the time we need to make use again of `DashboardDataStore.kt`, this is messed up because it hold an outdated reference to `selectedSite.siteComponent!!` (possible a GC one). This makes any use of `dashboardDataStore.widgets` inside `DashboardRepository` throw an exception. 

The solution I proposed is to reduce the lifespan of `DashboardRepository` and use `@ViewModelScoped` so that a new `DashboardDataStore` is instantiated when navigating to `DashboardWidgetEditorFragment`.  However, there's a tradeoff with this approach: `DashboardRepository` is destroyed when navigating away from `DashboardFragment`, so when we navigate back to it, a new repository instance is created, triggering a data refresh and UI refresh, causing a small flickering effect (see above screen recording).  

I'm open to hearing other alternatives to fix this while keeping the `@ActivityRetainedScoped` to avoid the flickering. A potential alternative would be to avoid updating `siteComponent` when setting a new site. But I'm unsure about what unwanted side effects it could have. It feels riskier: 
```Kotlin
    @Suppress("DEPRECATION")
    @Synchronized
    fun set(siteModel: SiteModel) {
        wasReset = false
        state.value = siteModel
        PreferenceUtils.setInt(getPreferences(), SELECTED_SITE_LOCAL_ID, siteModel.id)

        // Notify listeners
        getEventBus().post(SelectedSiteChangedEvent(siteModel))

        // Create a new site component tied to the lifecycle of the selected site
        // REMOVE THE CODE BELOW
        siteComponent = siteComponentProvider.get()
            .setSite(get())
            .setCoroutineScope(createSiteCoroutineScope())
            .build()
    }
```

### Testing information
<!-- This is your opportunity to break out individual scenarios that need testing (when necessary) and/or include a checklist for the reviewer to go through. Consider documenting the following from your own completed testing: devices used, alternate workflows, edge cases, affected areas, critical flows, areas not tested, and any remaining unknowns. Provide feedback on this new section of the PR template through Sept 30, 2024 to Apps Quality; additional context here: p91TBi-b8z-p2#comment-12036 -->
1. Launch the app 
2. Tap on the top right "Edit" button to add or remove dashboard cards. 
3. Check that the available widgets are displayed correctly


https://github.com/user-attachments/assets/3fb087b0-d438-4d04-a951-ff2431df7b4a



- [ ] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.

## Reviewer (or Author, in the case of optional code reviews):

Please make sure these conditions are met before approving the PR, or request changes if the PR needs improvement:

- [ ] The PR is small and has a clear, single focus, or a valid explanation is provided in the description. If needed, please request to split it into smaller PRs.
- [ ] Ensure Adequate Unit Test Coverage: The changes are reasonably covered by unit tests or an explanation is provided in the PR description.
- [ ] Manual Testing: The author listed all the tests they ran, including smoke tests when needed (e.g., for refactorings). The reviewer confirmed that the PR works as expected on big (tablet) and small (phone) in case of UI changes, and no regressions are added.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->