### PR TITLE
[Tooling] Skip build / validation jobs depending on the PR changes

### DIFF
--- a/.buildkite/commands/diff-merged-manifest.sh
+++ b/.buildkite/commands/diff-merged-manifest.sh
@@ -4,9 +4,6 @@ set -euo pipefail
 
 # Check if we can skip this job based on PR changes
 if .buildkite/commands/should-skip-job.sh --job-type validation; then
-  message="Skipping Diff Merged Manifest - no relevant files changed"
-  echo "$message" | buildkite-agent annotate --style "info" --context "skip-diff-merged-manifest"
-  echo "$message"
   exit 0
 fi
 

--- a/.buildkite/commands/diff-merged-manifest.sh
+++ b/.buildkite/commands/diff-merged-manifest.sh
@@ -2,6 +2,14 @@
 
 set -euo pipefail
 
+# Check if we can skip this job based on PR changes
+if .buildkite/commands/should-skip-job.sh --validation; then
+  message="Skipping Diff Merged Manifest - no relevant files changed"
+  echo "$message" | buildkite-agent annotate --style "info" --context "skip-diff-merged-manifest"
+  echo "$message"
+  exit 0
+fi
+
 "$(dirname "${BASH_SOURCE[0]}")/restore-cache.sh"
 
 BUILD_VARIANT=$1

--- a/.buildkite/commands/diff-merged-manifest.sh
+++ b/.buildkite/commands/diff-merged-manifest.sh
@@ -3,7 +3,7 @@
 set -euo pipefail
 
 # Check if we can skip this job based on PR changes
-if .buildkite/commands/should-skip-job.sh --validation; then
+if .buildkite/commands/should-skip-job.sh --job-type validation; then
   message="Skipping Diff Merged Manifest - no relevant files changed"
   echo "$message" | buildkite-agent annotate --style "info" --context "skip-diff-merged-manifest"
   echo "$message"

--- a/.buildkite/commands/gradle-cache-build.sh
+++ b/.buildkite/commands/gradle-cache-build.sh
@@ -1,7 +1,7 @@
 #!/bin/bash -eu
 
 # Check if we can skip this job based on PR changes
-if .buildkite/commands/should-skip-job.sh --build; then
+if .buildkite/commands/should-skip-job.sh --job-type build; then
   message="Skipping Gradle Cache Build - no relevant files changed"
   echo "$message" | buildkite-agent annotate --style "info" --context "skip-gradle-cache"
   echo "$message"

--- a/.buildkite/commands/gradle-cache-build.sh
+++ b/.buildkite/commands/gradle-cache-build.sh
@@ -1,5 +1,13 @@
 #!/bin/bash -eu
 
+# Check if we can skip this job based on PR changes
+if .buildkite/commands/should-skip-job.sh --build; then
+  message="Skipping Gradle Cache Build - no relevant files changed"
+  echo "$message" | buildkite-agent annotate --style "info" --context "skip-gradle-cache"
+  echo "$message"
+  exit 0
+fi
+
 # This script is used to populate Gradle's build cache with task outputs that can be reused
 # by the local machine.
 

--- a/.buildkite/commands/gradle-cache-build.sh
+++ b/.buildkite/commands/gradle-cache-build.sh
@@ -2,9 +2,6 @@
 
 # Check if we can skip this job based on PR changes
 if .buildkite/commands/should-skip-job.sh --job-type build; then
-  message="Skipping Gradle Cache Build - no relevant files changed"
-  echo "$message" | buildkite-agent annotate --style "info" --context "skip-gradle-cache"
-  echo "$message"
   exit 0
 fi
 

--- a/.buildkite/commands/lint.sh
+++ b/.buildkite/commands/lint.sh
@@ -2,9 +2,6 @@
 
 # Check if we can skip this job based on PR changes
 if .buildkite/commands/should-skip-job.sh --job-type lint; then
-  message="Skipping Lint - no relevant files changed"
-  echo "$message" | buildkite-agent annotate --style "info" --context "skip-lint"
-  echo "$message"
   exit 0
 fi
 

--- a/.buildkite/commands/lint.sh
+++ b/.buildkite/commands/lint.sh
@@ -1,7 +1,7 @@
 #!/bin/bash -u
 
 # Check if we can skip this job based on PR changes
-if .buildkite/commands/should-skip-job.sh --job-type validation; then
+if .buildkite/commands/should-skip-job.sh --job-type lint; then
   message="Skipping Lint - no relevant files changed"
   echo "$message" | buildkite-agent annotate --style "info" --context "skip-lint"
   echo "$message"

--- a/.buildkite/commands/lint.sh
+++ b/.buildkite/commands/lint.sh
@@ -1,5 +1,13 @@
 #!/bin/bash -u
 
+# Check if we can skip this job based on PR changes
+if .buildkite/commands/should-skip-job.sh --validation; then
+  message="Skipping Lint - no relevant files changed"
+  echo "$message" | buildkite-agent annotate --style "info" --context "skip-lint"
+  echo "$message"
+  exit 0
+fi
+
 "$(dirname "${BASH_SOURCE[0]}")/restore-cache.sh"
 
 echo "--- 🧹 Linting"

--- a/.buildkite/commands/lint.sh
+++ b/.buildkite/commands/lint.sh
@@ -1,7 +1,7 @@
 #!/bin/bash -u
 
 # Check if we can skip this job based on PR changes
-if .buildkite/commands/should-skip-job.sh --validation; then
+if .buildkite/commands/should-skip-job.sh --job-type validation; then
   message="Skipping Lint - no relevant files changed"
   echo "$message" | buildkite-agent annotate --style "info" --context "skip-lint"
   echo "$message"

--- a/.buildkite/commands/prototype-build.sh
+++ b/.buildkite/commands/prototype-build.sh
@@ -1,5 +1,13 @@
 #!/bin/bash -eu
 
+# Check if we can skip this job based on PR changes
+if .buildkite/commands/should-skip-job.sh --build; then
+  message="Skipping Build - no relevant files changed"
+  echo "$message" | buildkite-agent annotate --style "info" --context "skip-build"
+  echo "$message"
+  exit 0
+fi
+
 "$(dirname "${BASH_SOURCE[0]}")/restore-cache.sh"
 
 APP_TO_BUILD="${1?You need to specify the app to build, WooCommerce or WooCommerce-Wear}"

--- a/.buildkite/commands/prototype-build.sh
+++ b/.buildkite/commands/prototype-build.sh
@@ -1,7 +1,7 @@
 #!/bin/bash -eu
 
 # Check if we can skip this job based on PR changes
-if .buildkite/commands/should-skip-job.sh --build; then
+if .buildkite/commands/should-skip-job.sh --job-type build; then
   message="Skipping Build - no relevant files changed"
   echo "$message" | buildkite-agent annotate --style "info" --context "skip-build"
   echo "$message"

--- a/.buildkite/commands/prototype-build.sh
+++ b/.buildkite/commands/prototype-build.sh
@@ -2,9 +2,6 @@
 
 # Check if we can skip this job based on PR changes
 if .buildkite/commands/should-skip-job.sh --job-type build; then
-  message="Skipping Build - no relevant files changed"
-  echo "$message" | buildkite-agent annotate --style "info" --context "skip-build"
-  echo "$message"
   exit 0
 fi
 

--- a/.buildkite/commands/run-instrumented-tests.sh
+++ b/.buildkite/commands/run-instrumented-tests.sh
@@ -1,7 +1,7 @@
 #!/bin/bash -eu
 
 # Check if we can skip this job based on PR changes
-if .buildkite/commands/should-skip-job.sh --validation; then
+if .buildkite/commands/should-skip-job.sh --job-type validation; then
   message="Skipping Instrumented Tests - no relevant files changed"
   echo "$message" | buildkite-agent annotate --style "info" --context "skip-instrumented-tests"
   echo "$message"

--- a/.buildkite/commands/run-instrumented-tests.sh
+++ b/.buildkite/commands/run-instrumented-tests.sh
@@ -5,6 +5,7 @@ if .buildkite/commands/should-skip-job.sh --validation; then
   message="Skipping Instrumented Tests - no relevant files changed"
   echo "$message" | buildkite-agent annotate --style "info" --context "skip-instrumented-tests"
   echo "$message"
+  mkdir -p WooCommerce/build/buildkite-test-analytics && touch WooCommerce/build/buildkite-test-analytics/empty.xml
   exit 0
 fi
 

--- a/.buildkite/commands/run-instrumented-tests.sh
+++ b/.buildkite/commands/run-instrumented-tests.sh
@@ -1,5 +1,13 @@
 #!/bin/bash -eu
 
+# Check if we can skip this job based on PR changes
+if .buildkite/commands/should-skip-job.sh --validation; then
+  message="Skipping Instrumented Tests - no relevant files changed"
+  echo "$message" | buildkite-agent annotate --style "info" --context "skip-instrumented-tests"
+  echo "$message"
+  exit 0
+fi
+
 "$(dirname "${BASH_SOURCE[0]}")/restore-cache.sh"
 
 echo "--- :rubygems: Setting up Gems"

--- a/.buildkite/commands/run-instrumented-tests.sh
+++ b/.buildkite/commands/run-instrumented-tests.sh
@@ -2,9 +2,6 @@
 
 # Check if we can skip this job based on PR changes
 if .buildkite/commands/should-skip-job.sh --job-type validation; then
-  message="Skipping Instrumented Tests - no relevant files changed"
-  echo "$message" | buildkite-agent annotate --style "info" --context "skip-instrumented-tests"
-  echo "$message"
   mkdir -p WooCommerce/build/buildkite-test-analytics && touch WooCommerce/build/buildkite-test-analytics/empty.xml
   exit 0
 fi

--- a/.buildkite/commands/run-unit-tests.sh
+++ b/.buildkite/commands/run-unit-tests.sh
@@ -1,5 +1,13 @@
 #!/bin/bash -eu
 
+# Check if we can skip this job based on PR changes
+if .buildkite/commands/should-skip-job.sh --validation; then
+  message="Skipping Unit Tests - no relevant files changed"
+  echo "$message" | buildkite-agent annotate --style "info" --context "skip-unit-tests"
+  echo "$message"
+  exit 0
+fi
+
 "$(dirname "${BASH_SOURCE[0]}")/restore-cache.sh"
 
 echo "--- :rubygems: Setting up Gems"

--- a/.buildkite/commands/run-unit-tests.sh
+++ b/.buildkite/commands/run-unit-tests.sh
@@ -5,6 +5,7 @@ if .buildkite/commands/should-skip-job.sh --validation; then
   message="Skipping Unit Tests - no relevant files changed"
   echo "$message" | buildkite-agent annotate --style "info" --context "skip-unit-tests"
   echo "$message"
+  mkdir -p WooCommerce/build/buildkite-test-analytics && touch WooCommerce/build/buildkite-test-analytics/empty.xml
   exit 0
 fi
 

--- a/.buildkite/commands/run-unit-tests.sh
+++ b/.buildkite/commands/run-unit-tests.sh
@@ -1,7 +1,7 @@
 #!/bin/bash -eu
 
 # Check if we can skip this job based on PR changes
-if .buildkite/commands/should-skip-job.sh --validation; then
+if .buildkite/commands/should-skip-job.sh --job-type validation; then
   message="Skipping Unit Tests - no relevant files changed"
   echo "$message" | buildkite-agent annotate --style "info" --context "skip-unit-tests"
   echo "$message"

--- a/.buildkite/commands/run-unit-tests.sh
+++ b/.buildkite/commands/run-unit-tests.sh
@@ -2,9 +2,6 @@
 
 # Check if we can skip this job based on PR changes
 if .buildkite/commands/should-skip-job.sh --job-type validation; then
-  message="Skipping Unit Tests - no relevant files changed"
-  echo "$message" | buildkite-agent annotate --style "info" --context "skip-unit-tests"
-  echo "$message"
   mkdir -p WooCommerce/build/buildkite-test-analytics && touch WooCommerce/build/buildkite-test-analytics/empty.xml
   exit 0
 fi

--- a/.buildkite/commands/should-skip-job.sh
+++ b/.buildkite/commands/should-skip-job.sh
@@ -41,6 +41,6 @@ case "$2" in
   *)
     echo "Error: Job type must be either 'validation', 'build', or 'lint'"
     buildkite-agent step cancel
-    exit 1
+    exit 15
     ;;
 esac

--- a/.buildkite/commands/should-skip-job.sh
+++ b/.buildkite/commands/should-skip-job.sh
@@ -23,15 +23,16 @@ COMMON_PATTERNS=(
 if [ -z "${1:-}" ] || [ "$1" != "--job-type" ] || [ -z "${2:-}" ]; then
   echo "Error: Must specify --job-type [validation|build|lint]"
   buildkite-agent step cancel
-  exit 1
+  exit 15
 fi
 
 if [ "$2" = "validation" ]; then
-  # Check if changes are limited to documentation, tooling, non-code files, and localization files
+  # We should skip if changes are limited to documentation, tooling, non-code files, and localization files
   PATTERNS=("${COMMON_PATTERNS[@]}" "**/strings.xml")
   pr_changed_files --all-match "${PATTERNS[@]}"
 elif [ "$2" = "build" ] || [ "$2" = "lint" ]; then
-  # Check if changes are limited to documentation, tooling, and non-code files (NOT localization files)
+  # We should if changes are limited to documentation, tooling, and non-code files
+  # We'll let the job run (won't skip) if PR includes changes in localization files though
   PATTERNS=("${COMMON_PATTERNS[@]}")
   pr_changed_files --all-match "${PATTERNS[@]}"
 else

--- a/.buildkite/commands/should-skip-job.sh
+++ b/.buildkite/commands/should-skip-job.sh
@@ -24,7 +24,7 @@ if [ "$1" = "--validation" ]; then
   pr_changed_files --all-match "${PATTERNS[@]}"
 elif [ "$1" = "--build" ]; then
   # Check if changes are limited to documentation, tooling, and non-code files (NOT localization files)
-  PATTERNS=("${COMMON_PATTERNS[@]}" "app/metadata/**")
+  PATTERNS=("${COMMON_PATTERNS[@]}")
   pr_changed_files --all-match "${PATTERNS[@]}"
 else
   echo "Error: Must specify either --validation or --build"

--- a/.buildkite/commands/should-skip-job.sh
+++ b/.buildkite/commands/should-skip-job.sh
@@ -1,8 +1,8 @@
 #!/bin/bash -eu
 
-# Usage: should-skip-job.sh [--validation|--build]
-# --validation: Skip when changes are limited to documentation, tooling, non-code files, and localization files
-# --build: Skip when changes are limited to documentation, tooling, and non-code files
+# Usage: should-skip-job.sh --job-type [validation|build]
+# --job-type validation: Skip when changes are limited to documentation, tooling, non-code files, and localization files
+# --job-type build: Skip when changes are limited to documentation, tooling, and non-code files
 
 COMMON_PATTERNS=(
   "*.md"
@@ -18,15 +18,22 @@ COMMON_PATTERNS=(
   "version.properties"
 )
 
-if [ "$1" = "--validation" ]; then
+if [ "$1" != "--job-type" ]; then
+  echo "Error: Must specify --job-type [validation|build]"
+  buildkite-agent step cancel
+  exit 1
+fi
+
+if [ "$2" = "validation" ]; then
   # Check if changes are limited to documentation, tooling, non-code files, and localization files
   PATTERNS=("${COMMON_PATTERNS[@]}" "**/strings.xml")
   pr_changed_files --all-match "${PATTERNS[@]}"
-elif [ "$1" = "--build" ]; then
+elif [ "$2" = "build" ]; then
   # Check if changes are limited to documentation, tooling, and non-code files (NOT localization files)
   PATTERNS=("${COMMON_PATTERNS[@]}")
   pr_changed_files --all-match "${PATTERNS[@]}"
 else
-  echo "Error: Must specify either --validation or --build"
+  echo "Error: Job type must be either 'validation' or 'build'"
+  buildkite-agent step cancel
   exit 1
 fi

--- a/.buildkite/commands/should-skip-job.sh
+++ b/.buildkite/commands/should-skip-job.sh
@@ -1,9 +1,18 @@
 #!/bin/bash -eu
 
 # Usage: should-skip-job.sh --job-type [validation|build|lint]
-# --job-type validation: Skip when changes are limited to documentation, tooling, non-code files, and localization files
-# --job-type build: Skip when changes are limited to documentation, tooling, and non-code files
-# --job-type lint: Skip when changes are limited to documentation, tooling, and non-code files
+# --job-type validation: For jobs like unit/instrumented tests, manifest validation…
+#     Skip when changes are limited to documentation, tooling, non-code files, and localization files
+# --job-type lint: For jobs doing linting, especially ones that might include linting of localization files
+#     Skip when changes are limited to documentation, tooling, and non-code files.
+#     Does not skip if localization files changed (so that linter can run to report translation inconsistencies)
+# --job-type build: For jobs building an apk binary, e.g. Assemble, Prototype Builds…
+#     Skip when changes are limited to documentation, tooling, and non-code files
+#
+# Return codes:
+# 0 - Job should be skipped (script also handles displaying the message and annotation)
+# 1 - Job should not be skipped
+# 15 - Error in script parameters
 
 COMMON_PATTERNS=(
   "*.md"
@@ -26,17 +35,36 @@ if [ -z "${1:-}" ] || [ "$1" != "--job-type" ] || [ -z "${2:-}" ]; then
   exit 15
 fi
 
-case "$2" in
+# Function to display skip message and create annotation
+show_skip_message() {
+  local job_type=$1
+  local message="Skipping ${BUILDKITE_LABEL:-Job} - no relevant files changed"
+  local context="skip-$(echo "${BUILDKITE_LABEL:-$job_type}" | sed -E -e 's/[^[:alnum:]]+/-/g' | tr A-Z a-z)"
+  
+  echo "$message" | buildkite-agent annotate --style "info" --context "$context"
+  echo "$message"
+}
+
+job_type="$2"
+case "$job_type" in
   "validation")
     # We should skip if changes are limited to documentation, tooling, non-code files, and localization files
     PATTERNS=("${COMMON_PATTERNS[@]}" "**/strings.xml")
-    pr_changed_files --all-match "${PATTERNS[@]}"
+    if pr_changed_files --all-match "${PATTERNS[@]}"; then
+      show_skip_message "$job_type"
+      exit 0
+    fi
+    exit 1
     ;;
   "build"|"lint")
-    # We should if changes are limited to documentation, tooling, and non-code files
+    # We should skip if changes are limited to documentation, tooling, and non-code files
     # We'll let the job run (won't skip) if PR includes changes in localization files though
     PATTERNS=("${COMMON_PATTERNS[@]}")
-    pr_changed_files --all-match "${PATTERNS[@]}"
+    if pr_changed_files --all-match "${PATTERNS[@]}"; then
+      show_skip_message "$job_type"
+      exit 0
+    fi
+    exit 1
     ;;
   *)
     echo "Error: Job type must be either 'validation', 'build', or 'lint'"

--- a/.buildkite/commands/should-skip-job.sh
+++ b/.buildkite/commands/should-skip-job.sh
@@ -1,6 +1,6 @@
 #!/bin/bash -eu
 
-# Usage: should-skip-job.sh --job-type [validation|build|lint]
+# Usage: should-skip-job.sh --job-type [validation|lint|build]
 # --job-type validation: For jobs like unit/instrumented tests, manifest validation…
 #     Skip when changes are limited to documentation, tooling, non-code files, and localization files
 # --job-type lint: For jobs doing linting, especially ones that might include linting of localization files

--- a/.buildkite/commands/should-skip-job.sh
+++ b/.buildkite/commands/should-skip-job.sh
@@ -1,8 +1,9 @@
 #!/bin/bash -eu
 
-# Usage: should-skip-job.sh --job-type [validation|build]
+# Usage: should-skip-job.sh --job-type [validation|build|lint]
 # --job-type validation: Skip when changes are limited to documentation, tooling, non-code files, and localization files
 # --job-type build: Skip when changes are limited to documentation, tooling, and non-code files
+# --job-type lint: Skip when changes are limited to documentation, tooling, and non-code files
 
 COMMON_PATTERNS=(
   "*.md"
@@ -19,7 +20,7 @@ COMMON_PATTERNS=(
 )
 
 if [ "$1" != "--job-type" ]; then
-  echo "Error: Must specify --job-type [validation|build]"
+  echo "Error: Must specify --job-type [validation|build|lint]"
   buildkite-agent step cancel
   exit 1
 fi
@@ -28,12 +29,12 @@ if [ "$2" = "validation" ]; then
   # Check if changes are limited to documentation, tooling, non-code files, and localization files
   PATTERNS=("${COMMON_PATTERNS[@]}" "**/strings.xml")
   pr_changed_files --all-match "${PATTERNS[@]}"
-elif [ "$2" = "build" ]; then
+elif [ "$2" = "build" ] || [ "$2" = "lint" ]; then
   # Check if changes are limited to documentation, tooling, and non-code files (NOT localization files)
   PATTERNS=("${COMMON_PATTERNS[@]}")
   pr_changed_files --all-match "${PATTERNS[@]}"
 else
-  echo "Error: Job type must be either 'validation' or 'build'"
+  echo "Error: Job type must be either 'validation', 'build', or 'lint'"
   buildkite-agent step cancel
   exit 1
 fi

--- a/.buildkite/commands/should-skip-job.sh
+++ b/.buildkite/commands/should-skip-job.sh
@@ -26,17 +26,21 @@ if [ -z "${1:-}" ] || [ "$1" != "--job-type" ] || [ -z "${2:-}" ]; then
   exit 15
 fi
 
-if [ "$2" = "validation" ]; then
-  # We should skip if changes are limited to documentation, tooling, non-code files, and localization files
-  PATTERNS=("${COMMON_PATTERNS[@]}" "**/strings.xml")
-  pr_changed_files --all-match "${PATTERNS[@]}"
-elif [ "$2" = "build" ] || [ "$2" = "lint" ]; then
-  # We should if changes are limited to documentation, tooling, and non-code files
-  # We'll let the job run (won't skip) if PR includes changes in localization files though
-  PATTERNS=("${COMMON_PATTERNS[@]}")
-  pr_changed_files --all-match "${PATTERNS[@]}"
-else
-  echo "Error: Job type must be either 'validation', 'build', or 'lint'"
-  buildkite-agent step cancel
-  exit 1
-fi
+case "$2" in
+  "validation")
+    # We should skip if changes are limited to documentation, tooling, non-code files, and localization files
+    PATTERNS=("${COMMON_PATTERNS[@]}" "**/strings.xml")
+    pr_changed_files --all-match "${PATTERNS[@]}"
+    ;;
+  "build"|"lint")
+    # We should if changes are limited to documentation, tooling, and non-code files
+    # We'll let the job run (won't skip) if PR includes changes in localization files though
+    PATTERNS=("${COMMON_PATTERNS[@]}")
+    pr_changed_files --all-match "${PATTERNS[@]}"
+    ;;
+  *)
+    echo "Error: Job type must be either 'validation', 'build', or 'lint'"
+    buildkite-agent step cancel
+    exit 1
+    ;;
+esac

--- a/.buildkite/commands/should-skip-job.sh
+++ b/.buildkite/commands/should-skip-job.sh
@@ -19,7 +19,8 @@ COMMON_PATTERNS=(
   "version.properties"
 )
 
-if [ "$1" != "--job-type" ]; then
+# Check if arguments are valid
+if [ -z "${1:-}" ] || [ "$1" != "--job-type" ] || [ -z "${2:-}" ]; then
   echo "Error: Must specify --job-type [validation|build|lint]"
   buildkite-agent step cancel
   exit 1

--- a/.buildkite/commands/should-skip-job.sh
+++ b/.buildkite/commands/should-skip-job.sh
@@ -1,0 +1,32 @@
+#!/bin/bash -eu
+
+# Usage: should-skip-job.sh [--validation|--build]
+# --validation: Skip when changes are limited to documentation, tooling, non-code files, and localization files
+# --build: Skip when changes are limited to documentation, tooling, and non-code files
+
+COMMON_PATTERNS=(
+  "*.md"
+  "*.pot"
+  "*.txt"
+  ".gitignore"
+  "config/**"
+  "docs/**"
+  "fastlane/**"
+  "Gemfile"
+  "Gemfile.lock"
+  "gradle/**"
+  "version.properties"
+)
+
+if [ "$1" = "--validation" ]; then
+  # Check if changes are limited to documentation, tooling, non-code files, and localization files
+  PATTERNS=("${COMMON_PATTERNS[@]}" "**/strings.xml")
+  pr_changed_files --all-match "${PATTERNS[@]}"
+elif [ "$1" = "--build" ]; then
+  # Check if changes are limited to documentation, tooling, and non-code files (NOT localization files)
+  PATTERNS=("${COMMON_PATTERNS[@]}" "app/metadata/**")
+  pr_changed_files --all-match "${PATTERNS[@]}"
+else
+  echo "Error: Must specify either --validation or --build"
+  exit 1
+fi

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -36,7 +36,7 @@ steps:
 
       - label: "detekt"
         command: |
-          if .buildkite/commands/should-skip-job.sh --validation; then
+          if .buildkite/commands/should-skip-job.sh --job-type validation; then
             echo "Skipping Detekt - no relevant files changed" | buildkite-agent annotate --style "info" --context "skip-detekt"
             exit 0
           fi

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -37,7 +37,6 @@ steps:
       - label: "detekt"
         command: |
           if .buildkite/commands/should-skip-job.sh --job-type validation; then
-            echo "Skipping Detekt - no relevant files changed" | buildkite-agent annotate --style "info" --context "skip-detekt"
             exit 0
           fi
           ./gradlew detektAll

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -36,11 +36,8 @@ steps:
 
       - label: "detekt"
         command: |
-          # Check if we can skip this job based on PR changes
           if .buildkite/commands/should-skip-job.sh --validation; then
-            message="Skipping Detekt - no relevant files changed"
-            echo "$message" | buildkite-agent annotate --style "info" --context "skip-detekt"
-            echo "$message"
+            echo "Skipping Detekt - no relevant files changed" | buildkite-agent annotate --style "info" --context "skip-detekt"
             exit 0
           fi
           ./gradlew detektAll

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -35,7 +35,15 @@ steps:
           queue: "linter"
 
       - label: "detekt"
-        command: ./gradlew detektAll
+        command: |
+          # Check if we can skip this job based on PR changes
+          if .buildkite/commands/should-skip-job.sh --validation; then
+            message="Skipping Detekt - no relevant files changed"
+            echo "$message" | buildkite-agent annotate --style "info" --context "skip-detekt"
+            echo "$message"
+            exit 0
+          fi
+          ./gradlew detektAll
         plugins: [$CI_TOOLKIT]
         artifact_paths:
           - "**/build/reports/detekt/detekt.html"
@@ -100,5 +108,5 @@ steps:
 
 
   - label: "🐘 Populate Gradle build cache"
-    command: ".buildkite/commands/gradle-cache-build.sh"
+    command: .buildkite/commands/gradle-cache-build.sh
     plugins: [$CI_TOOLKIT]

--- a/.buildkite/shared-pipeline-vars
+++ b/.buildkite/shared-pipeline-vars
@@ -3,5 +3,5 @@
 # This file is `source`'d before calling `buildkite-agent pipeline upload`, and can be used
 # to set up some variables that will be interpolated in the `.yml` pipeline before uploading it.
 
-export CI_TOOLKIT="automattic/a8c-ci-toolkit#5.1.3"
+export CI_TOOLKIT="automattic/a8c-ci-toolkit#5.3.1"
 export TEST_COLLECTOR="test-collector#v1.10.1"


### PR DESCRIPTION
Internal reference: paaHJt-7Ss-p2

The main goal of this PR is to optimize the wait time for PRs with minor, non-code related changes, specially the ones related to the release process.

I've updated the original script to cover build, validation and localization jobs:
- `should-skip-job.sh --job-type [build|lint]`: skips if the changes are limited to documentation, tooling, metadata, etc
- `should-skip-job.sh --job-type validation`: same as above, but also skip on localization changes. The idea is that it can be valuable to run things as a Prototype build when localization changes

## Testing

I've created the PR https://github.com/woocommerce/woocommerce-android/pull/14035 to run a few tests in CI:
- Version bump https://buildkite.com/automattic/woocommerce-android/builds/29095
- Update release notes https://buildkite.com/automattic/woocommerce-android/builds/29098
- Update localized strings https://buildkite.com/automattic/woocommerce-android/builds/29100
- **Update**: Same as above, but with the latest changes adding `--job-type` https://buildkite.com/automattic/woocommerce-android/builds/29137