### PR TITLE
[WOOMOB-472] Replace Activity Toolbar With Fragment Toolbar in EditCouponFragment

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/coupons/edit/EditCouponFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/coupons/edit/EditCouponFragment.kt
@@ -9,7 +9,6 @@ import androidx.compose.ui.platform.ViewCompositionStrategy
 import androidx.fragment.app.setFragmentResult
 import androidx.fragment.app.viewModels
 import androidx.navigation.fragment.findNavController
-import com.woocommerce.android.R
 import com.woocommerce.android.extensions.handleResult
 import com.woocommerce.android.model.Coupon
 import com.woocommerce.android.ui.base.BaseFragment
@@ -25,7 +24,6 @@ import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.Exit
 import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.ShowUiStringSnackbar
 import dagger.hilt.android.AndroidEntryPoint
 import javax.inject.Inject
-import kotlin.properties.Delegates.observable
 
 @AndroidEntryPoint
 class EditCouponFragment : BaseFragment() {
@@ -34,15 +32,7 @@ class EditCouponFragment : BaseFragment() {
     @Inject lateinit var uiMessageResolver: UIMessageResolver
 
     override val activityAppBarStatus: AppBarStatus
-        get() = AppBarStatus.Visible(
-            navigationIcon = R.drawable.ic_gridicons_cross_24dp
-        )
-
-    private var screenTitle: String by observable("") { _, oldValue, newValue ->
-        if (oldValue != newValue) {
-            updateActivityTitle()
-        }
-    }
+        get() = AppBarStatus.Hidden
 
     override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View {
         return ComposeView(requireContext()).apply {
@@ -62,10 +52,6 @@ class EditCouponFragment : BaseFragment() {
     }
 
     private fun setupObservers() {
-        viewModel.viewState.observe(viewLifecycleOwner) {
-            screenTitle = it.screenTitle
-        }
-
         viewModel.event.observe(viewLifecycleOwner) { event ->
             when (event) {
                 is EditCouponNavigationTarget -> EditCouponNavigator.navigate(this, event)
@@ -95,8 +81,6 @@ class EditCouponFragment : BaseFragment() {
             viewModel.onIncludedCategoriesChanged(it)
         }
     }
-
-    override fun getFragmentTitle() = screenTitle
 
     private fun setNewCouponIdAsResultIfAvailable(event: EditCouponViewModel.NavigateBackToPOS) {
         val bundle = event.couponId?.let {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/coupons/edit/EditCouponScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/coupons/edit/EditCouponScreen.kt
@@ -100,11 +100,13 @@ fun EditCouponScreen(
 ) {
     val scrollState = rememberScrollState()
     Scaffold(
-        topBar = { Toolbar(
-            title = viewState.screenTitle,
-            onNavigationButtonClick = { onBackPressed() },
-            navigationIcon = Icons.Default.Clear
-        ) }
+        topBar = {
+            Toolbar(
+                title = viewState.screenTitle,
+                onNavigationButtonClick = { onBackPressed() },
+                navigationIcon = Icons.Default.Clear
+            )
+        }
     ) { paddingValues ->
         Column(
             verticalArrangement = Arrangement.spacedBy(dimensionResource(id = R.dimen.major_100)),

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/coupons/edit/EditCouponScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/coupons/edit/EditCouponScreen.kt
@@ -113,6 +113,7 @@ fun EditCouponScreen(
                 .fillMaxSize()
                 .background(color = MaterialTheme.colors.surface)
                 .verticalScroll(scrollState)
+                .padding(vertical = dimensionResource(id = R.dimen.major_100))
         ) {
             DetailsSection(
                 viewState = viewState,

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/coupons/edit/EditCouponScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/coupons/edit/EditCouponScreen.kt
@@ -16,10 +16,12 @@ import androidx.compose.material.ButtonDefaults
 import androidx.compose.material.Divider
 import androidx.compose.material.Icon
 import androidx.compose.material.MaterialTheme
+import androidx.compose.material.Scaffold
 import androidx.compose.material.Text
 import androidx.compose.material.TextButton
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Add
+import androidx.compose.material.icons.filled.Clear
 import androidx.compose.material.icons.filled.Edit
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
@@ -47,6 +49,7 @@ import com.woocommerce.android.model.Coupon.Type.Percent
 import com.woocommerce.android.ui.compose.component.BigDecimalTextFieldValueMapper
 import com.woocommerce.android.ui.compose.component.DatePickerDialog
 import com.woocommerce.android.ui.compose.component.ProgressDialog
+import com.woocommerce.android.ui.compose.component.Toolbar
 import com.woocommerce.android.ui.compose.component.WCColoredButton
 import com.woocommerce.android.ui.compose.component.WCOutlinedButton
 import com.woocommerce.android.ui.compose.component.WCOutlinedSpinner
@@ -74,7 +77,8 @@ fun EditCouponScreen(viewModel: EditCouponViewModel) {
             onUsageRestrictionsClick = viewModel::onUsageRestrictionsClick,
             onSelectProductsButtonClick = viewModel::onSelectProductsButtonClick,
             onSelectCategoriesButtonClick = viewModel::onSelectCategoriesButtonClick,
-            onSaveClick = viewModel::onSaveClick
+            onSaveClick = viewModel::onSaveClick,
+            onBackPressed = viewModel::onBackPressed,
         )
     }
 }
@@ -91,36 +95,45 @@ fun EditCouponScreen(
     onUsageRestrictionsClick: () -> Unit = {},
     onSelectProductsButtonClick: () -> Unit = {},
     onSelectCategoriesButtonClick: () -> Unit = {},
-    onSaveClick: () -> Unit = {}
+    onSaveClick: () -> Unit = {},
+    onBackPressed: () -> Unit = {},
 ) {
     val scrollState = rememberScrollState()
-    Column(
-        verticalArrangement = Arrangement.spacedBy(dimensionResource(id = R.dimen.major_100)),
-        modifier = Modifier
-            .background(color = MaterialTheme.colors.surface)
-            .verticalScroll(scrollState)
-            .padding(vertical = dimensionResource(id = R.dimen.major_100))
-            .fillMaxSize()
-    ) {
-        DetailsSection(
-            viewState = viewState,
-            onAmountChanged = onAmountChanged,
-            onCouponCodeChanged = onCouponCodeChanged,
-            onRegenerateCodeClick = onRegenerateCodeClick,
-            onDescriptionButtonClick = onDescriptionButtonClick,
-            onExpiryDateChanged = onExpiryDateChanged,
-            onFreeShippingChanged = onFreeShippingChanged
-        )
-        ConditionsSection(viewState, onSelectProductsButtonClick, onSelectCategoriesButtonClick)
-        UsageRestrictionsSection(onUsageRestrictionsClick)
-        WCColoredButton(
-            onClick = onSaveClick,
-            text = stringResource(id = viewState.saveButtonText),
+    Scaffold(
+        topBar = { Toolbar(
+            title = viewState.screenTitle,
+            onNavigationButtonClick = { onBackPressed() },
+            navigationIcon = Icons.Default.Clear
+        ) }
+    ) { paddingValues ->
+        Column(
+            verticalArrangement = Arrangement.spacedBy(dimensionResource(id = R.dimen.major_100)),
             modifier = Modifier
-                .padding(horizontal = dimensionResource(id = R.dimen.major_100))
-                .fillMaxWidth(),
-            enabled = viewState.hasChanges
-        )
+                .padding(paddingValues)
+                .fillMaxSize()
+                .background(color = MaterialTheme.colors.surface)
+                .verticalScroll(scrollState)
+        ) {
+            DetailsSection(
+                viewState = viewState,
+                onAmountChanged = onAmountChanged,
+                onCouponCodeChanged = onCouponCodeChanged,
+                onRegenerateCodeClick = onRegenerateCodeClick,
+                onDescriptionButtonClick = onDescriptionButtonClick,
+                onExpiryDateChanged = onExpiryDateChanged,
+                onFreeShippingChanged = onFreeShippingChanged
+            )
+            ConditionsSection(viewState, onSelectProductsButtonClick, onSelectCategoriesButtonClick)
+            UsageRestrictionsSection(onUsageRestrictionsClick)
+            WCColoredButton(
+                onClick = onSaveClick,
+                text = stringResource(id = viewState.saveButtonText),
+                modifier = Modifier
+                    .padding(horizontal = dimensionResource(id = R.dimen.major_100))
+                    .fillMaxWidth(),
+                enabled = viewState.hasChanges
+            )
+        }
     }
 
     if (viewState.isSaving) {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/coupons/edit/EditCouponViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/coupons/edit/EditCouponViewModel.kt
@@ -258,6 +258,10 @@ class EditCouponViewModel @Inject constructor(
         isSaving.value = false
     }
 
+    fun onBackPressed() {
+        exitFlow()
+    }
+
     private fun getSaveButtonText(): Int = when (mode.value) {
         is Mode.Edit -> R.string.coupon_edit_save_button
         is Mode.Create -> R.string.coupon_create_save_button


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->
Closes: #WOOMOB-472
<!-- Id number of the GitHub issue this PR addresses. -->

Do not merge - https://github.com/woocommerce/woocommerce-android/pull/14031 needs to be merged first.

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

Series of PRs with Toolbar fixes for coupons creation flow
1. **THIS PR** https://github.com/woocommerce/woocommerce-android/pull/14036
2. https://github.com/woocommerce/woocommerce-android/pull/14038
3. https://github.com/woocommerce/woocommerce-android/pull/14039
4. https://github.com/woocommerce/woocommerce-android/pull/14040
5. https://github.com/woocommerce/woocommerce-android/pull/14041


Goal of this PR is to replace the MainActivity toolbar with fragment specific toolbar on the EditCouponFragment.

Known issues
- The status bar on CouponEditScreen within POS has dark overlay - not related to this PR.


### Steps to reproduce
<!-- Step-by-step testing instructions. For new user flows, consider instead stating the goal of the workflow and see if your PR reviewer can accomplish the workflow without specific steps! -->

1. Open POS
2. Tap on coupons tab
4. Tap on plus icon
5. Select one of the coupon types
6. Notice the Toolbar is not visible


### Testing information
<!-- This is your opportunity to break out individual scenarios that need testing (when necessary) and/or include a checklist for the reviewer to go through. Consider documenting the following from your own completed testing: devices used, alternate workflows, edge cases, affected areas, critical flows, areas not tested, and any remaining unknowns. Provide feedback on this new section of the PR template through Sept 30, 2024 to Apps Quality; additional context here: p91TBi-b8z-p2#comment-12036 -->

**POS testing**
1. Open POS
2. Tap on coupons tab
3. Tap on plus icon
4. Select one of the coupon types
5. Notice the Toolbar is visible
------------
**Regression testing**
1. Open More menu
2. Tap on Coupons
3. Tap on plus FAB
4. Select one of the coupon types
5. Notice the Toolbar is visible

### The tests that have been performed
<!-- To give the reviewer an idea of what could be missed in terms of testing -->
I've tested the above on tablet and phone.

### Images/gif
<!-- Include before and after images or gifs when appropriate. -->
| Coupons (300px)                                | POS (300px)                                   |
|-----------------------------------------------|-----------------------------------------------|
| **Before**                                     | **Before**                                    |
| <img src="https://github.com/user-attachments/assets/acd29c97-6b22-4357-9323-1274222dc4ce" width="300"> | <img src="https://github.com/user-attachments/assets/0e8f84c0-4a4d-45ef-b61c-ef3848660a2d" width="300"> |
| **After**                                      | **After**                                     |
| <img src="https://github.com/user-attachments/assets/bb4c5089-814f-4f94-9d44-078ee1f69e95" width="300"> | <img src="https://github.com/user-attachments/assets/38481f6f-6b9a-4eb0-b2a2-4110e439078f" width="300"> |

- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.

## Reviewer (or Author, in the case of optional code reviews):

Please make sure these conditions are met before approving the PR, or request changes if the PR needs improvement:

- [x] The PR is small and has a clear, single focus, or a valid explanation is provided in the description. If needed, please request to split it into smaller PRs.
- [x] Ensure Adequate Unit Test Coverage: The changes are reasonably covered by unit tests or an explanation is provided in the PR description.
- [x] Manual Testing: The author listed all the tests they ran, including smoke tests when needed (e.g., for refactorings). The reviewer confirmed that the PR works as expected on big (tablet) and small (phone) in case of UI changes, and no regressions are added.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->