### PR TITLE
[WOOPRD-490][Woo POS][Product Search] Recent searches stored by site

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/util/datastore/WooPosPreferencesRepository.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/util/datastore/WooPosPreferencesRepository.kt
@@ -29,7 +29,7 @@ class WooPosPreferencesRepository @Inject constructor(
 
             val updatedSearches = (listOf(search) + currentSearches)
                 .distinct()
-                .take(MAX_RECENT_SEARCHES)
+                .take(MAX_RECENT_SEARCHES_COUNT)
 
             preferences[recentProductSearchesSiteSpecificKey] = updatedSearches.joinToString(",")
         }
@@ -38,9 +38,9 @@ class WooPosPreferencesRepository @Inject constructor(
     private fun buildSiteSpecificKey(key: String): Preferences.Key<String> =
         stringPreferencesKey("${selectedSite.getOrNull()?.siteId}-$key")
 
-    companion object {
+    private companion object {
         const val RECENT_PRODUCT_SEARCHES_KEY = "recent_product_searches_key"
 
-        const val MAX_RECENT_SEARCHES = 10
+        const val MAX_RECENT_SEARCHES_COUNT = 10
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/util/datastore/WooPosPreferencesRepository.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/util/datastore/WooPosPreferencesRepository.kt
@@ -4,20 +4,26 @@ import androidx.datastore.core.DataStore
 import androidx.datastore.preferences.core.Preferences
 import androidx.datastore.preferences.core.edit
 import androidx.datastore.preferences.core.stringPreferencesKey
+import com.woocommerce.android.tools.SelectedSite
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.map
 import javax.inject.Inject
 
-class WooPosPreferencesRepository @Inject constructor(private val dataStore: DataStore<Preferences>) {
+class WooPosPreferencesRepository @Inject constructor(
+    private val selectedSite: SelectedSite,
+    private val dataStore: DataStore<Preferences>
+) {
+    private val recentProductSearchesSiteSpecificKey = buildSiteSpecificKey(RECENT_PRODUCT_SEARCHES_KEY)
+
     val recentProductSearches: Flow<List<String>> = dataStore.data
         .map { preferences ->
-            val searchesString = preferences[RECENT_PRODUCT_SEARCHES] ?: ""
+            val searchesString = preferences[recentProductSearchesSiteSpecificKey] ?: ""
             if (searchesString.isEmpty()) emptyList() else searchesString.split(",")
         }
 
     suspend fun addRecentProductSearch(search: String) {
         dataStore.edit { preferences ->
-            val currentSearches = preferences[RECENT_PRODUCT_SEARCHES]?.let {
+            val currentSearches = preferences[recentProductSearchesSiteSpecificKey]?.let {
                 if (it.isEmpty()) emptyList() else it.split(",")
             } ?: emptyList()
 
@@ -25,14 +31,15 @@ class WooPosPreferencesRepository @Inject constructor(private val dataStore: Dat
                 .distinct()
                 .take(MAX_RECENT_SEARCHES)
 
-            preferences[RECENT_PRODUCT_SEARCHES] = updatedSearches.joinToString(",")
+            preferences[recentProductSearchesSiteSpecificKey] = updatedSearches.joinToString(",")
         }
     }
 
+    private fun buildSiteSpecificKey(key: String): Preferences.Key<String> =
+        stringPreferencesKey("${selectedSite.getOrNull()?.siteId}-$key")
+
     companion object {
-        val RECENT_PRODUCT_SEARCHES = stringPreferencesKey(
-            "recent_product_searches"
-        )
+        const val RECENT_PRODUCT_SEARCHES_KEY = "recent_product_searches_key"
 
         const val MAX_RECENT_SEARCHES = 10
     }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/util/datastore/WooPosPreferencesRepository.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/util/datastore/WooPosPreferencesRepository.kt
@@ -2,7 +2,6 @@ package com.woocommerce.android.ui.woopos.util.datastore
 
 import androidx.datastore.core.DataStore
 import androidx.datastore.preferences.core.Preferences
-import androidx.datastore.preferences.core.booleanPreferencesKey
 import androidx.datastore.preferences.core.edit
 import androidx.datastore.preferences.core.stringPreferencesKey
 import kotlinx.coroutines.flow.Flow
@@ -31,10 +30,6 @@ class WooPosPreferencesRepository @Inject constructor(private val dataStore: Dat
     }
 
     companion object {
-        val SIMPLE_PRODUCTS_ONLY_BANNER_HIDDEN_BY_USER = booleanPreferencesKey(
-            "is_simple_products_only_banner_hidden_by_user"
-        )
-
         val RECENT_PRODUCT_SEARCHES = stringPreferencesKey(
             "recent_product_searches"
         )


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #WOOPRD-490
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
The PR stores the recent searches based on the site id

### Steps to reproduce
<!-- Step-by-step testing instructions. For new user flows, consider instead stating the goal of the workflow and see if your PR reviewer can accomplish the workflow without specific steps! -->
* POS -> Search -> Select a product
* Notice newly added recent search
* Change store and repeat
* Notice that recent searches are different

@samiuelson I don't clean the recent search. It has the downside that it takes up space, but it keeps them when a user switches the stores back and forth. Wdyt?

### The tests that have been performed
<!-- To give the reviewer an idea of what could be missed in terms of testing -->
Above

### Images/gif
<!-- Include before and after images or gifs when appropriate. -->
https://github.com/user-attachments/assets/622e17c0-7f49-4c8a-b737-c26ab5b94319

- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.


## Reviewer (or Author, in the case of optional code reviews):

Please make sure these conditions are met before approving the PR, or request changes if the PR needs improvement:

- [ ] The PR is small and has a clear, single focus, or a valid explanation is provided in the description. If needed, please request to split it into smaller PRs.
- [ ] Ensure Adequate Unit Test Coverage: The changes are reasonably covered by unit tests or an explanation is provided in the PR description.
- [ ] Manual Testing: The author listed all the tests they ran, including smoke tests when needed (e.g., for refactorings). The reviewer confirmed that the PR works as expected on big (tablet) and small (phone) in case of UI changes, and no regressions are added.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->