### PR TITLE
[WOOMOB-496] Replace activity toolbar with fragment toolbar in SimpleTextEditor

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/common/texteditor/SimpleTextEditorFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/common/texteditor/SimpleTextEditorFragment.kt
@@ -2,27 +2,18 @@ package com.woocommerce.android.ui.common.texteditor
 
 import android.os.Bundle
 import android.view.LayoutInflater
-import android.view.Menu
-import android.view.MenuInflater
-import android.view.MenuItem
 import android.view.View
 import android.view.ViewGroup
 import androidx.compose.ui.platform.ComposeView
 import androidx.compose.ui.platform.ViewCompositionStrategy
-import androidx.core.view.MenuProvider
 import androidx.fragment.app.viewModels
 import androidx.navigation.fragment.findNavController
-import androidx.navigation.fragment.navArgs
-import com.woocommerce.android.R
 import com.woocommerce.android.extensions.navigateBackWithResult
 import com.woocommerce.android.ui.base.BaseFragment
 import com.woocommerce.android.ui.common.texteditor.SimpleTextEditorFragment.Companion.SIMPLE_TEXT_EDITOR_RESULT
-import com.woocommerce.android.ui.common.texteditor.SimpleTextEditorStrategy.SEND_RESULT_ON_CONFIRMATION
-import com.woocommerce.android.ui.common.texteditor.SimpleTextEditorStrategy.SEND_RESULT_ON_NAVIGATE_BACK
 import com.woocommerce.android.ui.common.texteditor.SimpleTextEditorViewModel.SimpleTextEditorResult
 import com.woocommerce.android.ui.compose.theme.WooThemeWithBackground
 import com.woocommerce.android.ui.main.AppBarStatus
-import com.woocommerce.android.ui.main.MainActivity.Companion.BackPressListener
 import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.Exit
 import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.ExitWithResult
 import dagger.hilt.android.AndroidEntryPoint
@@ -36,21 +27,15 @@ import dagger.hilt.android.AndroidEntryPoint
  *   "{[SIMPLE_TEXT_EDITOR_RESULT]}{[SimpleTextEditorFragmentArgs.requestCode] if present}".
  */
 @AndroidEntryPoint
-class SimpleTextEditorFragment : BaseFragment(), BackPressListener, MenuProvider {
+class SimpleTextEditorFragment : BaseFragment() {
     companion object {
         const val SIMPLE_TEXT_EDITOR_RESULT = "text-editor-result"
     }
 
     private val viewModel: SimpleTextEditorViewModel by viewModels()
-    private val navArgs: SimpleTextEditorFragmentArgs by navArgs()
 
     override val activityAppBarStatus: AppBarStatus
-        get() = AppBarStatus.Visible(
-            when (navArgs.strategy) {
-                SEND_RESULT_ON_NAVIGATE_BACK -> R.drawable.ic_back_24dp
-                SEND_RESULT_ON_CONFIRMATION -> R.drawable.ic_gridicons_cross_24dp
-            }
-        )
+        get() = AppBarStatus.Hidden
 
     override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View {
         return ComposeView(requireContext()).apply {
@@ -66,7 +51,6 @@ class SimpleTextEditorFragment : BaseFragment(), BackPressListener, MenuProvider
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
-        requireActivity().addMenuProvider(this, viewLifecycleOwner)
         setupObservers()
     }
 
@@ -80,28 +64,6 @@ class SimpleTextEditorFragment : BaseFragment(), BackPressListener, MenuProvider
                 }
                 is Exit -> findNavController().navigateUp()
             }
-        }
-    }
-
-    override fun getFragmentTitle(): String = navArgs.screenTitle
-
-    override fun onRequestAllowBackPress(): Boolean {
-        viewModel.onBackPressed()
-        return false
-    }
-
-    override fun onCreateMenu(menu: Menu, menuInflater: MenuInflater) {
-        if (navArgs.strategy == SEND_RESULT_ON_CONFIRMATION) {
-            menuInflater.inflate(R.menu.menu_done, menu)
-        }
-    }
-
-    override fun onMenuItemSelected(menuItem: MenuItem): Boolean {
-        return if (menuItem.itemId == R.id.menu_done) {
-            viewModel.onDonePressed()
-            true
-        } else {
-            false
         }
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/common/texteditor/SimpleTextEditorScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/common/texteditor/SimpleTextEditorScreen.kt
@@ -23,23 +23,25 @@ import com.woocommerce.android.ui.compose.component.Toolbar
 @Composable
 fun SimpleTextEditorScreen(viewModel: SimpleTextEditorViewModel) {
     val viewState by viewModel.viewState.observeAsState()
-    SimpleTextEditorScreen(
-        screenTitle = viewState?.screenTitle,
-        text = viewState?.text,
-        hint = viewState?.hint,
-        strategy = viewState?.strategy,
-        viewModel::onTextChanged,
-        viewModel::onDonePressed,
-        viewModel::onBackPressed,
-    )
+    viewState?.let { state ->
+        SimpleTextEditorScreen(
+            screenTitle = state.screenTitle,
+            text = state.text,
+            hint = state.hint,
+            strategy = state.strategy,
+            viewModel::onTextChanged,
+            viewModel::onDonePressed,
+            viewModel::onBackPressed,
+        )
+    }
 }
 
 @Composable
 fun SimpleTextEditorScreen(
-    screenTitle: String?,
-    text: String?,
-    hint: String?,
-    strategy: SimpleTextEditorStrategy?,
+    screenTitle: String,
+    text: String,
+    hint: String,
+    strategy: SimpleTextEditorStrategy,
     onTextChanged: (String) -> Unit,
     onDonePressed: () -> Unit,
     onBackPressed: () -> Unit,
@@ -50,11 +52,11 @@ fun SimpleTextEditorScreen(
     Scaffold(
         topBar = {
             Toolbar(
-                title = screenTitle.orEmpty(),
+                title = screenTitle,
                 onNavigationButtonClick = onBackPressed,
                 navigationIcon = when (strategy) {
                     SimpleTextEditorStrategy.SEND_RESULT_ON_CONFIRMATION -> Icons.Default.Clear
-                    SimpleTextEditorStrategy.SEND_RESULT_ON_NAVIGATE_BACK, null -> Icons.AutoMirrored.Filled.ArrowBack
+                    SimpleTextEditorStrategy.SEND_RESULT_ON_NAVIGATE_BACK -> Icons.AutoMirrored.Filled.ArrowBack
                 },
                 actions = {
                     if (strategy == SimpleTextEditorStrategy.SEND_RESULT_ON_CONFIRMATION) {
@@ -67,10 +69,10 @@ fun SimpleTextEditorScreen(
         }
     ) { paddingValues ->
         TextField(
-            value = text.orEmpty(),
+            value = text,
             onValueChange = onTextChanged,
             placeholder = {
-                Text(hint.orEmpty())
+                Text(hint)
             },
             colors = TextFieldDefaults.textFieldColors(backgroundColor = MaterialTheme.colors.surface),
             modifier = Modifier

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/common/texteditor/SimpleTextEditorScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/common/texteditor/SimpleTextEditorScreen.kt
@@ -1,30 +1,81 @@
 package com.woocommerce.android.ui.common.texteditor
 
+import androidx.activity.compose.BackHandler
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.padding
 import androidx.compose.material.MaterialTheme
+import androidx.compose.material.Scaffold
 import androidx.compose.material.Text
+import androidx.compose.material.TextButton
 import androidx.compose.material.TextField
 import androidx.compose.material.TextFieldDefaults
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material.icons.filled.Clear
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.livedata.observeAsState
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import com.woocommerce.android.R
+import com.woocommerce.android.ui.compose.component.Toolbar
 
 @Composable
 fun SimpleTextEditorScreen(viewModel: SimpleTextEditorViewModel) {
     val viewState by viewModel.viewState.observeAsState()
-    SimpleTextEditorScreen(viewState?.text, viewState?.hint, viewModel::onTextChanged)
+    SimpleTextEditorScreen(
+        screenTitle = viewState?.screenTitle,
+        text = viewState?.text,
+        hint = viewState?.hint,
+        strategy = viewState?.strategy,
+        viewModel::onTextChanged,
+        viewModel::onDonePressed,
+        viewModel::onBackPressed,
+    )
 }
 
 @Composable
-fun SimpleTextEditorScreen(text: String?, hint: String?, onTextChanged: (String) -> Unit) {
-    TextField(
-        value = text.orEmpty(),
-        onValueChange = onTextChanged,
-        placeholder = {
-            Text(hint.orEmpty())
-        },
-        colors = TextFieldDefaults.textFieldColors(backgroundColor = MaterialTheme.colors.surface),
-        modifier = Modifier.fillMaxSize()
-    )
+fun SimpleTextEditorScreen(
+    screenTitle: String?,
+    text: String?,
+    hint: String?,
+    strategy: SimpleTextEditorStrategy?,
+    onTextChanged: (String) -> Unit,
+    onDonePressed: () -> Unit,
+    onBackPressed: () -> Unit,
+) {
+    BackHandler {
+        onBackPressed()
+    }
+    Scaffold(
+        topBar = {
+            Toolbar(
+                title = screenTitle.orEmpty(),
+                onNavigationButtonClick = onBackPressed,
+                navigationIcon = when (strategy) {
+                    SimpleTextEditorStrategy.SEND_RESULT_ON_CONFIRMATION -> Icons.Default.Clear
+                    SimpleTextEditorStrategy.SEND_RESULT_ON_NAVIGATE_BACK, null -> Icons.AutoMirrored.Filled.ArrowBack
+                },
+                actions = {
+                    if (strategy == SimpleTextEditorStrategy.SEND_RESULT_ON_CONFIRMATION) {
+                        TextButton(onClick = onDonePressed) {
+                            Text(text = stringResource(id = R.string.done))
+                        }
+                    }
+                }
+            )
+        }
+    ) { paddingValues ->
+        TextField(
+            value = text.orEmpty(),
+            onValueChange = onTextChanged,
+            placeholder = {
+                Text(hint.orEmpty())
+            },
+            colors = TextFieldDefaults.textFieldColors(backgroundColor = MaterialTheme.colors.surface),
+            modifier = Modifier
+                .padding(paddingValues)
+                .fillMaxSize()
+        )
+    }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/common/texteditor/SimpleTextEditorViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/common/texteditor/SimpleTextEditorViewModel.kt
@@ -21,7 +21,7 @@ class SimpleTextEditorViewModel @Inject constructor(savedState: SavedStateHandle
     private val textLiveData = savedState.getLiveData(TEXT_KEY, navArgs.currentText)
     val viewState = textLiveData.map {
         ViewState(
-            text = it,
+            text = it.orEmpty(),
             hint = navArgs.hint,
             hasChanges = it != navArgs.currentText,
             screenTitle = navArgs.screenTitle,
@@ -66,7 +66,7 @@ class SimpleTextEditorViewModel @Inject constructor(savedState: SavedStateHandle
     }
 
     data class ViewState(
-        val text: String?,
+        val text: String,
         val hint: String,
         val hasChanges: Boolean,
         val screenTitle: String,

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/common/texteditor/SimpleTextEditorViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/common/texteditor/SimpleTextEditorViewModel.kt
@@ -23,7 +23,9 @@ class SimpleTextEditorViewModel @Inject constructor(savedState: SavedStateHandle
         ViewState(
             text = it,
             hint = navArgs.hint,
-            hasChanges = it != navArgs.currentText
+            hasChanges = it != navArgs.currentText,
+            screenTitle = navArgs.screenTitle,
+            strategy = navArgs.strategy,
         )
     }
 
@@ -66,7 +68,9 @@ class SimpleTextEditorViewModel @Inject constructor(savedState: SavedStateHandle
     data class ViewState(
         val text: String?,
         val hint: String,
-        val hasChanges: Boolean
+        val hasChanges: Boolean,
+        val screenTitle: String,
+        val strategy: SimpleTextEditorStrategy,
     )
 
     data class SimpleTextEditorResult(


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->
\
Closes: #WOOPRD-496
<!-- Id number of the GitHub issue this PR addresses. -->

**Do not merge until https://github.com/woocommerce/woocommerce-android/pull/14036 is merged.**

Series of PRs with Toolbar fixes for coupons creation flow
1. https://github.com/woocommerce/woocommerce-android/pull/14036
2. **THIS PR** https://github.com/woocommerce/woocommerce-android/pull/14038
3. https://github.com/woocommerce/woocommerce-android/pull/14039
4. https://github.com/woocommerce/woocommerce-android/pull/14040
5. https://github.com/woocommerce/woocommerce-android/pull/14041

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

Goal of this PR is to replace the MainActivity toolbar with fragment specific toolbar on the SimpleTextEditorFragment.

Known issues
- The status bar on CouponEditScreen within POS has dark overlay - not related to this PR.
- Enter/exit animation for coupons flow is not consistent within POS.
- Toolbars are missing on some of the other screens.


### Steps to reproduce
<!-- Step-by-step testing instructions. For new user flows, consider instead stating the goal of the workflow and see if your PR reviewer can accomplish the workflow without specific steps! -->

1. Open POS
2. Tap on coupons tab
3. Tap on Plus button
4. Select a coupon type
5. Tap on Add Description
6. Notice a toolbar is missing

### Testing information
<!-- This is your opportunity to break out individual scenarios that need testing (when necessary) and/or include a checklist for the reviewer to go through. Consider documenting the following from your own completed testing: devices used, alternate workflows, edge cases, affected areas, critical flows, areas not tested, and any remaining unknowns. Provide feedback on this new section of the PR template through Sept 30, 2024 to Apps Quality; additional context here: p91TBi-b8z-p2#comment-12036 -->

**POS**
1. Open POS
2. Tap on coupons tab
3. Tap on Plus button
4. Select a coupon type
5. Tap on Add Description
6. Notice a toolbar is present
7. Enter text
8. Press back
9. Tap on Add Description
10. Verify the text you added is persisted
11. Edit it again
12. Press the up arrow
13. Verify the text you edited is persisted

**Regression Coupons**
-Repeat the above steps but not within the POS but in More Menu -> Coupons -> Plus FAB icon.

**Regression Review**
1. Tap on More menu
2. Tap on Reviews
3. Open a review
4. Tap on reply
5. Verify toolbar is present and has `cross` instead of `back arrow` and `Done` action.
6. Verify the changes are published only when you explicitly tap on `Done` and are NOT published when you tap on the `cross/up` or when you press back.


### The tests that have been performed
<!-- To give the reviewer an idea of what could be missed in terms of testing -->

All of the above

### Images/gif
<!-- Include before and after images or gifs when appropriate. -->

| POS (300px)                                    | Coupons (300px)                               | Reviews (300px)                               |
|-----------------------------------------------|-----------------------------------------------|-----------------------------------------------|
| **Before**                                     | **Before**                                    | **Before**                                    |
| <img src="https://github.com/user-attachments/assets/6c2f7ed2-2827-40a0-8bba-576f2bb66470" width="300"> | <img src="https://github.com/user-attachments/assets/07717881-71f6-4d3e-a701-8532057d62cc" width="300"> | <img src="https://github.com/user-attachments/assets/ab6b1756-f859-43e4-bd0f-e56a0671232c" width="300"> |
| **After**                                      | **After**                                     | **After**                                     |
| <img src="https://github.com/user-attachments/assets/2dee7c8c-31de-4fdf-aead-4cac87595f3a" width="300"> | <img src="https://github.com/user-attachments/assets/5825fc58-c584-4fc6-b874-8f9b37dacf9c" width="300"> | <img src="https://github.com/user-attachments/assets/46553347-99ae-44a1-8464-f2e500170921" width="300"> |

All of the above.

- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.

## Reviewer (or Author, in the case of optional code reviews):

Please make sure these conditions are met before approving the PR, or request changes if the PR needs improvement:

- [x] The PR is small and has a clear, single focus, or a valid explanation is provided in the description. If needed, please request to split it into smaller PRs.
- [x] Ensure Adequate Unit Test Coverage: The changes are reasonably covered by unit tests or an explanation is provided in the PR description.
- [x] Manual Testing: The author listed all the tests they ran, including smoke tests when needed (e.g., for refactorings). The reviewer confirmed that the PR works as expected on big (tablet) and small (phone) in case of UI changes, and no regressions are added.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->