### PR TITLE
[WOOMOB-497] Replace Activity Toolbar With Fragment Toolbar in ProductCategoryFragment

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/categories/selector/ProductCategorySelectorFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/categories/selector/ProductCategorySelectorFragment.kt
@@ -7,12 +7,13 @@ import android.view.ViewGroup
 import androidx.compose.ui.platform.ComposeView
 import androidx.compose.ui.platform.ViewCompositionStrategy
 import androidx.fragment.app.viewModels
-import com.woocommerce.android.R
+import androidx.navigation.fragment.findNavController
 import com.woocommerce.android.extensions.navigateBackWithResult
 import com.woocommerce.android.ui.base.BaseFragment
 import com.woocommerce.android.ui.base.UIMessageResolver
 import com.woocommerce.android.ui.compose.theme.WooThemeWithBackground
 import com.woocommerce.android.ui.main.AppBarStatus
+import com.woocommerce.android.viewmodel.MultiLiveEvent
 import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.ExitWithResult
 import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.ShowSnackbar
 import dagger.hilt.android.AndroidEntryPoint
@@ -29,10 +30,7 @@ class ProductCategorySelectorFragment : BaseFragment() {
     @Inject lateinit var uiMessageResolver: UIMessageResolver
 
     override val activityAppBarStatus: AppBarStatus
-        get() = AppBarStatus.Visible(
-            navigationIcon = R.drawable.ic_gridicons_cross_24dp,
-            hasShadow = false
-        )
+        get() = AppBarStatus.Hidden
 
     override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View? {
         return ComposeView(requireContext()).apply {
@@ -56,9 +54,8 @@ class ProductCategorySelectorFragment : BaseFragment() {
             when (event) {
                 is ShowSnackbar -> uiMessageResolver.showSnack(event.message)
                 is ExitWithResult<*> -> navigateBackWithResult(PRODUCT_CATEGORY_SELECTOR_RESULT, event.data)
+                is MultiLiveEvent.Event.Exit -> findNavController().navigateUp()
             }
         }
     }
-
-    override fun getFragmentTitle(): String = getString(R.string.product_category_selector_title)
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/categories/selector/ProductCategorySelectorScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/categories/selector/ProductCategorySelectorScreen.kt
@@ -1,5 +1,6 @@
 package com.woocommerce.android.ui.products.categories.selector
 
+import androidx.activity.compose.BackHandler
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
@@ -21,9 +22,11 @@ import androidx.compose.material.CircularProgressIndicator
 import androidx.compose.material.Divider
 import androidx.compose.material.Icon
 import androidx.compose.material.MaterialTheme
+import androidx.compose.material.Scaffold
 import androidx.compose.material.Text
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Check
+import androidx.compose.material.icons.filled.Clear
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.livedata.observeAsState
@@ -41,6 +44,7 @@ import androidx.compose.ui.tooling.preview.Preview
 import com.woocommerce.android.R
 import com.woocommerce.android.ui.compose.animations.SkeletonView
 import com.woocommerce.android.ui.compose.component.InfiniteListHandler
+import com.woocommerce.android.ui.compose.component.Toolbar
 import com.woocommerce.android.ui.compose.component.WCColoredButton
 import com.woocommerce.android.ui.compose.component.WCSearchField
 import com.woocommerce.android.ui.compose.component.WCTextButton
@@ -58,7 +62,8 @@ fun ProductCategorySelectorScreen(viewModel: ProductCategorySelectorViewModel) {
             onLoadMore = viewModel::onLoadMore,
             onClearSelectionClick = viewModel::onClearSelectionClick,
             onSearchQueryChanged = viewModel::onSearchQueryChanged,
-            onDoneClick = viewModel::onDoneClick
+            onDoneClick = viewModel::onDoneClick,
+            onBackPressed = viewModel::onBackPressed
         )
     }
 }
@@ -70,32 +75,48 @@ fun ProductCategorySelectorScreen(
     onClearSelectionClick: () -> Unit = {},
     onSearchQueryChanged: (String) -> Unit = {},
     onDoneClick: () -> Unit = {},
+    onBackPressed: () -> Unit = {},
 ) {
-    Column(
-        modifier = Modifier
-            .fillMaxSize()
-            .background(MaterialTheme.colors.surface)
-    ) {
-        WCSearchField(
-            value = viewState.searchQuery,
-            onValueChange = onSearchQueryChanged,
-            hint = stringResource(id = R.string.product_category_selector_search_hint),
-            modifier = Modifier
-                .fillMaxWidth()
-                .padding(
-                    horizontal = dimensionResource(id = R.dimen.major_100),
-                    vertical = dimensionResource(id = R.dimen.minor_100)
-                )
-        )
-        when {
-            viewState.categories.isNotEmpty() -> CategoriesList(
-                viewState = viewState,
-                onLoadMore = onLoadMore,
-                onClearSelectionClick = onClearSelectionClick,
-                onDoneClick = onDoneClick
+    BackHandler {
+        onBackPressed()
+    }
+    Scaffold(
+        topBar = {
+            Toolbar(
+                title = stringResource(id = R.string.product_category_selector_title),
+                navigationIcon = Icons.Default.Clear,
+                onNavigationButtonClick = onBackPressed
             )
-            viewState.loadingState == LoadingState.Loading -> CategoriesSkeleton()
-            else -> EmptyCategoriesList(viewState.searchQuery)
+        }
+    ) { contentPadding ->
+        Column(
+            modifier = Modifier
+                .padding(contentPadding)
+                .fillMaxSize()
+                .background(MaterialTheme.colors.surface)
+        ) {
+            WCSearchField(
+                value = viewState.searchQuery,
+                onValueChange = onSearchQueryChanged,
+                hint = stringResource(id = R.string.product_category_selector_search_hint),
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(
+                        horizontal = dimensionResource(id = R.dimen.major_100),
+                        vertical = dimensionResource(id = R.dimen.minor_100)
+                    )
+            )
+            when {
+                viewState.categories.isNotEmpty() -> CategoriesList(
+                    viewState = viewState,
+                    onLoadMore = onLoadMore,
+                    onClearSelectionClick = onClearSelectionClick,
+                    onDoneClick = onDoneClick
+                )
+
+                viewState.loadingState == LoadingState.Loading -> CategoriesSkeleton()
+                else -> EmptyCategoriesList(viewState.searchQuery)
+            }
         }
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/categories/selector/ProductCategorySelectorViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/categories/selector/ProductCategorySelectorViewModel.kt
@@ -5,6 +5,7 @@ import androidx.lifecycle.asLiveData
 import androidx.lifecycle.viewModelScope
 import com.woocommerce.android.AppConstants
 import com.woocommerce.android.R
+import com.woocommerce.android.viewmodel.MultiLiveEvent
 import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.ExitWithResult
 import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.ShowSnackbar
 import com.woocommerce.android.viewmodel.ScopedViewModel
@@ -93,6 +94,10 @@ class ProductCategorySelectorViewModel @Inject constructor(
 
     fun onDoneClick() {
         triggerEvent(ExitWithResult(selectedCategories.value))
+    }
+
+    fun onBackPressed() {
+        triggerEvent(MultiLiveEvent.Event.Exit)
     }
 
     private fun monitorSearchQuery() {

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/products/categories/selector/ProductCategorySelectorViewModelTests.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/products/categories/selector/ProductCategorySelectorViewModelTests.kt
@@ -44,6 +44,7 @@ class ProductCategorySelectorViewModelTests : BaseUnitTest() {
 
     @Test
     fun `when screen is loaded, then fetch product categories`() = testBlocking {
+        // GIVEN
         setup {
             whenever(productCategoryListHandler.fetchCategories(true)).doSuspendableAnswer {
                 delay(1L)
@@ -51,25 +52,31 @@ class ProductCategorySelectorViewModelTests : BaseUnitTest() {
             }
         }
 
+        // WHEN
         val fetchingState = viewModel.viewState.captureValues().last()
 
         verify(productCategoryListHandler).fetchCategories(forceRefresh = true)
         assertThat(fetchingState.loadingState).isEqualTo(LoadingState.Loading)
 
         advanceUntilIdle()
+
+        // THEN
         val idleState = viewModel.viewState.captureValues().last()
         assertThat(idleState.loadingState).isEqualTo(LoadingState.Idle)
     }
 
     @Test
     fun `when screen is loaded, then load saved categories`() = testBlocking {
+        // GIVEN
         setup()
 
+        // WHEN
         val state = viewModel.viewState.runAndCaptureValues {
             categoriesStateFlow.value = defaultProductCategoriesList
             advanceUntilIdle()
         }.last()
 
+        // THEN
         assertThat(state.categories.map { it.id })
             .isEqualTo(defaultProductCategoriesList.map { it.productCategory.remoteCategoryId })
         assertThat(state.loadingState).isEqualTo(LoadingState.Idle)
@@ -77,28 +84,35 @@ class ProductCategorySelectorViewModelTests : BaseUnitTest() {
 
     @Test
     fun `when search query is entered, then search for categories`() = testBlocking {
+        // GIVEN
         setup()
 
+        // WHEN
         val state = viewModel.viewState.runAndCaptureValues {
             viewModel.onSearchQueryChanged("Search")
             advanceUntilIdle()
         }.last()
 
+        // THEN
         assertThat(state.searchQuery).isEqualTo("Search")
         verify(productCategoryListHandler).fetchCategories(searchQuery = "Search")
     }
 
     @Test
     fun `when load more is requested, then load next page`() = testBlocking {
+        // GIVEN
         setup()
 
+        // WHEN
         viewModel.onLoadMore()
 
+        // THEN
         verify(productCategoryListHandler).loadMore()
     }
 
     @Test
     fun `when fetching coupons fails, then show an error`() = testBlocking {
+        // GIVEN
         setup {
             whenever(productCategoryListHandler.fetchCategories(forceRefresh = true)).thenReturn(
                 Result.failure(
@@ -107,36 +121,118 @@ class ProductCategorySelectorViewModelTests : BaseUnitTest() {
             )
         }
 
+        // WHEN
         val event = viewModel.event.captureValues().filterIsInstance<MultiLiveEvent.Event.ShowSnackbar>().last()
 
+        // THEN
         assertThat(event.message).isEqualTo(R.string.product_category_selector_loading_failed)
     }
 
     @Test
     fun `when searching coupons fails, then show an error`() = testBlocking {
+        // GIVEN
         setup {
             whenever(
                 productCategoryListHandler.fetchCategories(searchQuery = "Search")
             ).thenReturn(Result.failure(Exception()))
         }
 
+        // WHEN
         viewModel.onSearchQueryChanged("Search")
         advanceUntilIdle()
         val event = viewModel.event.captureValues().filterIsInstance<MultiLiveEvent.Event.ShowSnackbar>().last()
 
+        // THEN
         assertThat(event.message).isEqualTo(R.string.product_category_selector_search_failed)
     }
 
     @Test
     fun `when loading next page, then show an error`() = testBlocking {
+        // GIVEN
         setup {
             whenever(productCategoryListHandler.loadMore()).thenReturn(Result.failure(Exception()))
         }
 
+        // WHEN
         viewModel.onLoadMore()
         advanceUntilIdle()
         val event = viewModel.event.captureValues().filterIsInstance<MultiLiveEvent.Event.ShowSnackbar>().last()
 
+        // THEN
         assertThat(event.message).isEqualTo(R.string.product_category_selector_loading_failed)
+    }
+
+    @Test
+    fun `when done is clicked, then exit with selected categories`() = testBlocking {
+        // GIVEN
+        val selectedCategories = longArrayOf(1L, 3L)
+        setup(selectedCategories = selectedCategories)
+        // WHEN
+        viewModel.onDoneClick()
+        val event = viewModel.event.captureValues()
+            .filterIsInstance<MultiLiveEvent.Event.ExitWithResult<*>>()
+            .last()
+
+        // THEN
+        val returnedCategories = event.data as Set<*>
+        assertThat(returnedCategories).containsExactlyInAnyOrder(1L, 3L)
+    }
+
+    @Test
+    fun `when back is pressed, then exit without result`() = testBlocking {
+        // GIVEN
+        setup()
+
+        // WHEN
+        viewModel.onBackPressed()
+
+        // THEN
+        val event = viewModel.event.captureValues()
+            .filterIsInstance<MultiLiveEvent.Event.Exit>()
+            .last()
+
+        assertThat(event).isNotNull
+    }
+
+    @Test
+    fun `when category is selected, then add to selection`() = testBlocking {
+        // GIVEN
+        setup()
+
+        val initialState = viewModel.viewState.runAndCaptureValues {
+            categoriesStateFlow.value = defaultProductCategoriesList
+            advanceUntilIdle()
+        }.last()
+
+        // WHEN
+        initialState.categories.first().onItemClick()
+
+        // THEN
+        val updatedState = viewModel.viewState.captureValues().last()
+        defaultProductCategoriesList.first().productCategory.remoteCategoryId
+        assertThat(updatedState.selectedCategoriesCount).isEqualTo(1)
+        assertThat(updatedState.categories.first().isSelected).isTrue()
+    }
+
+    @Test
+    fun `when clear selection is clicked, then remove all selected categories`() = testBlocking {
+        // GIVEN
+        val selectedCategories = longArrayOf(1L, 3L)
+        setup(selectedCategories = selectedCategories)
+
+        val initialState = viewModel.viewState.runAndCaptureValues {
+            categoriesStateFlow.value = defaultProductCategoriesList
+            advanceUntilIdle()
+        }.last()
+
+        assertThat(initialState.selectedCategoriesCount).isEqualTo(2)
+
+        // WHEN
+        viewModel.onClearSelectionClick()
+
+        // THEN
+        val updatedState = viewModel.viewState.captureValues().last()
+        assertThat(updatedState.selectedCategoriesCount).isEqualTo(0)
+        assertThat(updatedState.categories.all { !it.isSelected }).isTrue()
     }
 }


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->
\
Closes: #WOOPOS-497
<!-- Id number of the GitHub issue this PR addresses. -->

**Do not merge until https://github.com/woocommerce/woocommerce-android/pull/14038 is merged.**

Series of PRs with Toolbar fixes for coupons creation flow
1. https://github.com/woocommerce/woocommerce-android/pull/14036
2. https://github.com/woocommerce/woocommerce-android/pull/14038
3. **THIS PR** https://github.com/woocommerce/woocommerce-android/pull/14039
4. https://github.com/woocommerce/woocommerce-android/pull/14040
5. https://github.com/woocommerce/woocommerce-android/pull/14041

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

Goal of this PR is to replace the MainActivity toolbar with fragment specific toolbar on the ProductCategorySelectorFragment.

Known issues
- The status bar on CouponEditScreen within POS has dark overlay - not related to this PR.
- Enter/exit animation for coupons flow is not consistent within POS.
- Toolbars are missing on some of the other screens.


### Steps to reproduce
<!-- Step-by-step testing instructions. For new user flows, consider instead stating the goal of the workflow and see if your PR reviewer can accomplish the workflow without specific steps! -->

1. Open POS
2. Tap on coupons tab
3. Tap on Plus button
4. Select a coupon type
5. Tap on Include Product Category
6. Notice a toolbar is missing

### Testing information
<!-- This is your opportunity to break out individual scenarios that need testing (when necessary) and/or include a checklist for the reviewer to go through. Consider documenting the following from your own completed testing: devices used, alternate workflows, edge cases, affected areas, critical flows, areas not tested, and any remaining unknowns. Provide feedback on this new section of the PR template through Sept 30, 2024 to Apps Quality; additional context here: p91TBi-b8z-p2#comment-12036 -->

**POS**
1. Open POS
2. Tap on coupons tab
3. Tap on Plus button
4. Select a coupon type
5. Tap on Include Product Category
6. Notice a toolbar is present
7. Verify both back button and up/clear buttons don't save changes.
8. Verify the confirmation button saves changes.
9. Open coupon restrictions
10. Tap on `Exclude product categories` and verify it works there too.

**Regression Coupons**
-Repeat the above steps but not within the POS but in More Menu -> Coupons -> Plus FAB icon.


### The tests that have been performed
<!-- To give the reviewer an idea of what could be missed in terms of testing -->

The above.

All of the above

### Images/gif
<!-- Include before and after images or gifs when appropriate. -->

|                | Before   | After   |
|----------------|---------------|---------------|
| POS   | ![Screenshot_1747046974](https://github.com/user-attachments/assets/e13f2659-0084-4150-860f-03ed43829eb4) | ![Screenshot_1747047028](https://github.com/user-attachments/assets/38ede0d9-43c7-4c96-b19b-35790ccba619) |
| Coupons   | ![Screenshot_1747047009](https://github.com/user-attachments/assets/1d428a93-acf0-40f0-bd3f-5b684f35a3ac) | ![Screenshot_1747047040](https://github.com/user-attachments/assets/ac6c28c6-ccd4-4c71-aa6e-66e8037b9d8f) |


All of the above.

- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.

## Reviewer (or Author, in the case of optional code reviews):

Please make sure these conditions are met before approving the PR, or request changes if the PR needs improvement:

- [x] The PR is small and has a clear, single focus, or a valid explanation is provided in the description. If needed, please request to split it into smaller PRs.
- [x] Ensure Adequate Unit Test Coverage: The changes are reasonably covered by unit tests or an explanation is provided in the PR description.
- [x] Manual Testing: The author listed all the tests they ran, including smoke tests when needed (e.g., for refactorings). The reviewer confirmed that the PR works as expected on big (tablet) and small (phone) in case of UI changes, and no regressions are added.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->