### PR TITLE
[WOOMOB-497] Replace Activity Toolbar With Fragment Toolbar in CouponRestrictionFragment

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/coupons/edit/CouponRestrictionsFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/coupons/edit/CouponRestrictionsFragment.kt
@@ -8,7 +8,6 @@ import androidx.compose.ui.platform.ComposeView
 import androidx.compose.ui.platform.ViewCompositionStrategy
 import androidx.fragment.app.viewModels
 import androidx.navigation.fragment.findNavController
-import com.woocommerce.android.R
 import com.woocommerce.android.extensions.handleResult
 import com.woocommerce.android.extensions.navigateBackWithResult
 import com.woocommerce.android.extensions.navigateSafely
@@ -17,7 +16,6 @@ import com.woocommerce.android.ui.base.BaseFragment
 import com.woocommerce.android.ui.compose.theme.WooThemeWithBackground
 import com.woocommerce.android.ui.coupons.edit.CouponRestrictionsViewModel.OpenAllowedEmailsEditor
 import com.woocommerce.android.ui.main.AppBarStatus
-import com.woocommerce.android.ui.main.MainActivity.Companion.BackPressListener
 import com.woocommerce.android.ui.products.categories.selector.ProductCategorySelectorFragment
 import com.woocommerce.android.ui.products.selector.ProductSelectorFragment
 import com.woocommerce.android.ui.products.selector.ProductSelectorViewModel.SelectedItem
@@ -26,7 +24,7 @@ import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.ExitWithResult
 import dagger.hilt.android.AndroidEntryPoint
 
 @AndroidEntryPoint
-class CouponRestrictionsFragment : BaseFragment(), BackPressListener {
+class CouponRestrictionsFragment : BaseFragment() {
     companion object {
         const val RESTRICTIONS_RESULT = "restrictions-result"
     }
@@ -34,9 +32,7 @@ class CouponRestrictionsFragment : BaseFragment(), BackPressListener {
     private val viewModel: CouponRestrictionsViewModel by viewModels()
 
     override val activityAppBarStatus: AppBarStatus
-        get() = AppBarStatus.Visible(
-            navigationIcon = R.drawable.ic_gridicons_cross_24dp
-        )
+        get() = AppBarStatus.Hidden
 
     override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View {
         return ComposeView(requireContext()).apply {
@@ -85,12 +81,5 @@ class CouponRestrictionsFragment : BaseFragment(), BackPressListener {
         handleResult<Set<Long>>(ProductCategorySelectorFragment.PRODUCT_CATEGORY_SELECTOR_RESULT) {
             viewModel.onExcludedProductCategoriesChanged(it)
         }
-    }
-
-    override fun getFragmentTitle() = getString(R.string.coupon_edit_usage_restrictions)
-
-    override fun onRequestAllowBackPress(): Boolean {
-        viewModel.onBackPressed()
-        return false
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/coupons/edit/CouponRestrictionsScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/coupons/edit/CouponRestrictionsScreen.kt
@@ -21,8 +21,8 @@ import androidx.compose.material.MaterialTheme
 import androidx.compose.material.Scaffold
 import androidx.compose.material.Text
 import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material.icons.filled.Add
-import androidx.compose.material.icons.filled.Clear
 import androidx.compose.material.icons.filled.Edit
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.livedata.observeAsState
@@ -89,7 +89,7 @@ fun CouponRestrictionsScreen(
             Toolbar(
                 title = stringResource(id = R.string.coupon_edit_usage_restrictions),
                 onNavigationButtonClick = onBackPressed,
-                navigationIcon = Icons.Default.Clear,
+                navigationIcon = Icons.AutoMirrored.Filled.ArrowBack,
             )
         }
     ) { paddingValues ->

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/coupons/edit/CouponRestrictionsScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/coupons/edit/CouponRestrictionsScreen.kt
@@ -84,12 +84,14 @@ fun CouponRestrictionsScreen(
     BackHandler {
         onBackPressed()
     }
-    Scaffold (
-        topBar = { Toolbar(
-            title = stringResource(id = R.string.coupon_edit_usage_restrictions),
-            onNavigationButtonClick = onBackPressed,
-            navigationIcon = Icons.Default.Clear,
-        ) }
+    Scaffold(
+        topBar = {
+            Toolbar(
+                title = stringResource(id = R.string.coupon_edit_usage_restrictions),
+                onNavigationButtonClick = onBackPressed,
+                navigationIcon = Icons.Default.Clear,
+            )
+        }
     ) { paddingValues ->
         Column(
             verticalArrangement = Arrangement.spacedBy(dimensionResource(id = R.dimen.major_100)),

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/coupons/edit/CouponRestrictionsScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/coupons/edit/CouponRestrictionsScreen.kt
@@ -1,5 +1,6 @@
 package com.woocommerce.android.ui.coupons.edit
 
+import androidx.activity.compose.BackHandler
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
@@ -17,9 +18,11 @@ import androidx.compose.material.ButtonDefaults
 import androidx.compose.material.Divider
 import androidx.compose.material.Icon
 import androidx.compose.material.MaterialTheme
+import androidx.compose.material.Scaffold
 import androidx.compose.material.Text
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Add
+import androidx.compose.material.icons.filled.Clear
 import androidx.compose.material.icons.filled.Edit
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.livedata.observeAsState
@@ -34,6 +37,7 @@ import androidx.compose.ui.text.toUpperCase
 import com.woocommerce.android.R
 import com.woocommerce.android.ui.compose.component.NullableBigDecimalTextFieldValueMapper
 import com.woocommerce.android.ui.compose.component.NullableIntTextFieldValueMapper
+import com.woocommerce.android.ui.compose.component.Toolbar
 import com.woocommerce.android.ui.compose.component.WCListItemWithInlineSubtitle
 import com.woocommerce.android.ui.compose.component.WCOutlinedButton
 import com.woocommerce.android.ui.compose.component.WCOutlinedTypedTextField
@@ -55,14 +59,15 @@ fun CouponRestrictionsScreen(viewModel: CouponRestrictionsViewModel) {
             onExcludeSaleItemsChanged = viewModel::onExcludeSaleItemsChanged,
             onAllowedEmailsButtonClicked = viewModel::onAllowedEmailsButtonClicked,
             onExcludeProductsButtonClick = viewModel::onExcludeProductsButtonClick,
-            onExcludeCategoriesButtonClick = viewModel::onExcludeCategoriesButtonClick
+            onExcludeCategoriesButtonClick = viewModel::onExcludeCategoriesButtonClick,
+            onBackPressed = viewModel::onBackPressed,
         )
     }
 }
 
 @Composable
 fun CouponRestrictionsScreen(
-    viewState: CouponRestrictionsViewModel.ViewState,
+    viewState: ViewState,
     onMinimumAmountChanged: (BigDecimal?) -> Unit,
     onMaximumAmountChanged: (BigDecimal?) -> Unit,
     onUsageLimitPerCouponChanged: (Int?) -> Unit,
@@ -73,77 +78,90 @@ fun CouponRestrictionsScreen(
     onAllowedEmailsButtonClicked: () -> Unit,
     onExcludeProductsButtonClick: () -> Unit,
     onExcludeCategoriesButtonClick: () -> Unit,
+    onBackPressed: () -> Unit,
 ) {
     val scrollState = rememberScrollState()
-    Column(
-        verticalArrangement = Arrangement.spacedBy(dimensionResource(id = R.dimen.major_100)),
-        modifier = Modifier
-            .background(color = MaterialTheme.colors.surface)
-            .verticalScroll(scrollState)
-            .padding(vertical = dimensionResource(id = R.dimen.major_100))
-            .fillMaxSize()
-    ) {
-        SpendingRestrictionField(
-            value = viewState.restrictions.minimumAmount,
-            onValueChange = onMinimumAmountChanged,
-            label = stringResource(id = R.string.coupon_restrictions_minimum_spend_hint, viewState.currencyCode),
-            modifier = Modifier.padding(horizontal = dimensionResource(id = R.dimen.major_100))
-        )
+    BackHandler {
+        onBackPressed()
+    }
+    Scaffold (
+        topBar = { Toolbar(
+            title = stringResource(id = R.string.coupon_edit_usage_restrictions),
+            onNavigationButtonClick = onBackPressed,
+            navigationIcon = Icons.Default.Clear,
+        ) }
+    ) { paddingValues ->
+        Column(
+            verticalArrangement = Arrangement.spacedBy(dimensionResource(id = R.dimen.major_100)),
+            modifier = Modifier
+                .padding(paddingValues)
+                .background(color = MaterialTheme.colors.surface)
+                .verticalScroll(scrollState)
+                .padding(vertical = dimensionResource(id = R.dimen.major_100))
+                .fillMaxSize()
+        ) {
+            SpendingRestrictionField(
+                value = viewState.restrictions.minimumAmount,
+                onValueChange = onMinimumAmountChanged,
+                label = stringResource(id = R.string.coupon_restrictions_minimum_spend_hint, viewState.currencyCode),
+                modifier = Modifier.padding(horizontal = dimensionResource(id = R.dimen.major_100))
+            )
 
-        SpendingRestrictionField(
-            value = viewState.restrictions.maximumAmount,
-            onValueChange = onMaximumAmountChanged,
-            label = stringResource(id = R.string.coupon_restrictions_maximum_spend_hint, viewState.currencyCode),
-            modifier = Modifier.padding(horizontal = dimensionResource(id = R.dimen.major_100))
-        )
+            SpendingRestrictionField(
+                value = viewState.restrictions.maximumAmount,
+                onValueChange = onMaximumAmountChanged,
+                label = stringResource(id = R.string.coupon_restrictions_maximum_spend_hint, viewState.currencyCode),
+                modifier = Modifier.padding(horizontal = dimensionResource(id = R.dimen.major_100))
+            )
 
-        WCOutlinedTypedTextField(
-            value = viewState.restrictions.usageLimit,
-            onValueChange = onUsageLimitPerCouponChanged,
-            label = stringResource(id = R.string.coupon_restrictions_limit_per_coupon_hint),
-            valueMapper = NullableIntTextFieldValueMapper(supportsNegativeValue = false),
-            modifier = Modifier.padding(horizontal = dimensionResource(id = R.dimen.major_100)),
-            keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Number),
-            placeholderText = stringResource(id = R.string.coupon_restrictions_limit_per_coupon_placeholder)
-        )
-
-        if (viewState.showLimitUsageToXItems) {
             WCOutlinedTypedTextField(
-                value = viewState.restrictions.limitUsageToXItems,
-                onValueChange = onLimitUsageToXItemsChanged,
-                label = stringResource(id = R.string.coupon_restrictions_amount_limit_hint),
+                value = viewState.restrictions.usageLimit,
+                onValueChange = onUsageLimitPerCouponChanged,
+                label = stringResource(id = R.string.coupon_restrictions_limit_per_coupon_hint),
                 valueMapper = NullableIntTextFieldValueMapper(supportsNegativeValue = false),
                 modifier = Modifier.padding(horizontal = dimensionResource(id = R.dimen.major_100)),
                 keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Number),
-                placeholderText = stringResource(id = R.string.coupon_restrictions_amount_limit_placeholder)
+                placeholderText = stringResource(id = R.string.coupon_restrictions_limit_per_coupon_placeholder)
             )
+
+            if (viewState.showLimitUsageToXItems) {
+                WCOutlinedTypedTextField(
+                    value = viewState.restrictions.limitUsageToXItems,
+                    onValueChange = onLimitUsageToXItemsChanged,
+                    label = stringResource(id = R.string.coupon_restrictions_amount_limit_hint),
+                    valueMapper = NullableIntTextFieldValueMapper(supportsNegativeValue = false),
+                    modifier = Modifier.padding(horizontal = dimensionResource(id = R.dimen.major_100)),
+                    keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Number),
+                    placeholderText = stringResource(id = R.string.coupon_restrictions_amount_limit_placeholder)
+                )
+            }
+
+            WCOutlinedTypedTextField(
+                value = viewState.restrictions.usageLimitPerUser,
+                onValueChange = onUsageLimitPerUserChanged,
+                label = stringResource(id = R.string.coupon_restrictions_limit_per_user_hint),
+                valueMapper = NullableIntTextFieldValueMapper(supportsNegativeValue = false),
+                modifier = Modifier.padding(horizontal = dimensionResource(id = R.dimen.major_100)),
+                keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Number),
+                placeholderText = stringResource(id = R.string.coupon_restrictions_limit_per_user_placeholder)
+            )
+
+            AllowedEmailsButton(
+                allowedEmails = viewState.restrictions.restrictedEmails,
+                onClick = onAllowedEmailsButtonClicked
+            )
+
+            IndividualUseSwitch(
+                isForIndividualUse = viewState.restrictions.isForIndividualUse ?: false,
+                onIndividualUseChanged = onIndividualUseChanged
+            )
+            SaleItemsSwitch(
+                areSaleItemsExcluded = viewState.restrictions.areSaleItemsExcluded ?: false,
+                onExcludeSaleItemsChanged = onExcludeSaleItemsChanged
+            )
+            Spacer(modifier = Modifier.height(dimensionResource(id = R.dimen.minor_100)))
+            ExclusionsSection(viewState, onExcludeProductsButtonClick, onExcludeCategoriesButtonClick)
         }
-
-        WCOutlinedTypedTextField(
-            value = viewState.restrictions.usageLimitPerUser,
-            onValueChange = onUsageLimitPerUserChanged,
-            label = stringResource(id = R.string.coupon_restrictions_limit_per_user_hint),
-            valueMapper = NullableIntTextFieldValueMapper(supportsNegativeValue = false),
-            modifier = Modifier.padding(horizontal = dimensionResource(id = R.dimen.major_100)),
-            keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Number),
-            placeholderText = stringResource(id = R.string.coupon_restrictions_limit_per_user_placeholder)
-        )
-
-        AllowedEmailsButton(
-            allowedEmails = viewState.restrictions.restrictedEmails,
-            onClick = onAllowedEmailsButtonClicked
-        )
-
-        IndividualUseSwitch(
-            isForIndividualUse = viewState.restrictions.isForIndividualUse ?: false,
-            onIndividualUseChanged = onIndividualUseChanged
-        )
-        SaleItemsSwitch(
-            areSaleItemsExcluded = viewState.restrictions.areSaleItemsExcluded ?: false,
-            onExcludeSaleItemsChanged = onExcludeSaleItemsChanged
-        )
-        Spacer(modifier = Modifier.height(dimensionResource(id = R.dimen.minor_100)))
-        ExclusionsSection(viewState, onExcludeProductsButtonClick, onExcludeCategoriesButtonClick)
     }
 }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/coupons/edit/CouponRestrictionsScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/coupons/edit/CouponRestrictionsScreen.kt
@@ -95,10 +95,10 @@ fun CouponRestrictionsScreen(
             verticalArrangement = Arrangement.spacedBy(dimensionResource(id = R.dimen.major_100)),
             modifier = Modifier
                 .padding(paddingValues)
+                .fillMaxSize()
                 .background(color = MaterialTheme.colors.surface)
                 .verticalScroll(scrollState)
                 .padding(vertical = dimensionResource(id = R.dimen.major_100))
-                .fillMaxSize()
         ) {
             SpendingRestrictionField(
                 value = viewState.restrictions.minimumAmount,


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->
\
Closes: #WOOPOS-497
<!-- Id number of the GitHub issue this PR addresses. -->

**Do not merge until https://github.com/woocommerce/woocommerce-android/pull/14039 is merged.**

Series of PRs with Toolbar fixes for coupons creation flow
1. https://github.com/woocommerce/woocommerce-android/pull/14036
2. https://github.com/woocommerce/woocommerce-android/pull/14038
3. https://github.com/woocommerce/woocommerce-android/pull/14039
4. **THIS PR** https://github.com/woocommerce/woocommerce-android/pull/14040
5. https://github.com/woocommerce/woocommerce-android/pull/14041

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

Goal of this PR is to replace the MainActivity toolbar with fragment specific toolbar on the CouponRestrictionFragment.

Known issues
- The status bar on CouponEditScreen within POS has dark overlay - not related to this PR.
- Enter/exit animation for coupons flow is not consistent within POS.
- Toolbars are missing on some of the other screens.


### Steps to reproduce
<!-- Step-by-step testing instructions. For new user flows, consider instead stating the goal of the workflow and see if your PR reviewer can accomplish the workflow without specific steps! -->

1. Open POS
2. Tap on coupons tab
3. Tap on Plus button
5. Select a coupon type
6. Tap on Usage Restrictions
7. Notice a toolbar is missing

### Testing information
<!-- This is your opportunity to break out individual scenarios that need testing (when necessary) and/or include a checklist for the reviewer to go through. Consider documenting the following from your own completed testing: devices used, alternate workflows, edge cases, affected areas, critical flows, areas not tested, and any remaining unknowns. Provide feedback on this new section of the PR template through Sept 30, 2024 to Apps Quality; additional context here: p91TBi-b8z-p2#comment-12036 -->

**POS**
1. Open POS
2. Tap on coupons tab
3. Tap on Plus button
4. Select a coupon type
5. Tap on Usage Restrictions
6. Notice a toolbar is present
8. Verify both back button and up/clear buttons DO save changes.

**Regression Coupons**
-Repeat the above steps but not within the POS but in More Menu -> Coupons -> Plus FAB icon.


### The tests that have been performed
<!-- To give the reviewer an idea of what could be missed in terms of testing -->

The above.

All of the above

### Images/gif
<!-- Include before and after images or gifs when appropriate. -->

|                | Before   | After   |
|----------------|---------------|---------------|
| POS   | ![Screenshot_1747049626](https://github.com/user-attachments/assets/953cfdae-2bc8-4a3d-8b34-1ac725dd8e07) | ![Screenshot_1747049589](https://github.com/user-attachments/assets/94681114-3fb2-4b83-8b12-4d84fb488350) |
| Coupons   | ![Screenshot_1747049613](https://github.com/user-attachments/assets/d3b8c246-f654-4220-8746-dcbfc8ef1abc) | ![Screenshot_1747049605](https://github.com/user-attachments/assets/37bc80e4-282a-4c9a-8600-0285bb99a044) |



All of the above.

- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.

## Reviewer (or Author, in the case of optional code reviews):

Please make sure these conditions are met before approving the PR, or request changes if the PR needs improvement:

- [x] The PR is small and has a clear, single focus, or a valid explanation is provided in the description. If needed, please request to split it into smaller PRs.
- [x] Ensure Adequate Unit Test Coverage: The changes are reasonably covered by unit tests or an explanation is provided in the PR description.
- [x] Manual Testing: The author listed all the tests they ran, including smoke tests when needed (e.g., for refactorings). The reviewer confirmed that the PR works as expected on big (tablet) and small (phone) in case of UI changes, and no regressions are added.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->