### PR TITLE
[WOOMOB-499] Replace Activity Toolbar With Fragment Toolbar in EmailRestrictionsFragment

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/coupons/edit/EmailRestrictionFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/coupons/edit/EmailRestrictionFragment.kt
@@ -8,13 +8,11 @@ import androidx.compose.ui.platform.ComposeView
 import androidx.compose.ui.platform.ViewCompositionStrategy
 import androidx.fragment.app.viewModels
 import androidx.navigation.fragment.findNavController
-import com.woocommerce.android.R
 import com.woocommerce.android.extensions.navigateBackWithResult
 import com.woocommerce.android.ui.base.BaseFragment
 import com.woocommerce.android.ui.base.UIMessageResolver
 import com.woocommerce.android.ui.compose.theme.WooThemeWithBackground
 import com.woocommerce.android.ui.main.AppBarStatus
-import com.woocommerce.android.ui.main.MainActivity.Companion.BackPressListener
 import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.Exit
 import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.ExitWithResult
 import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.ShowSnackbar
@@ -22,7 +20,7 @@ import dagger.hilt.android.AndroidEntryPoint
 import javax.inject.Inject
 
 @AndroidEntryPoint
-class EmailRestrictionFragment : BaseFragment(), BackPressListener {
+class EmailRestrictionFragment : BaseFragment() {
     companion object {
         const val ALLOWED_EMAILS = "allowed-emails"
     }
@@ -32,9 +30,7 @@ class EmailRestrictionFragment : BaseFragment(), BackPressListener {
     @Inject lateinit var uiMessageResolver: UIMessageResolver
 
     override val activityAppBarStatus: AppBarStatus
-        get() = AppBarStatus.Visible(
-            navigationIcon = R.drawable.ic_gridicons_cross_24dp
-        )
+        get() = AppBarStatus.Hidden
 
     override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View {
         return ComposeView(requireContext()).apply {
@@ -63,12 +59,5 @@ class EmailRestrictionFragment : BaseFragment(), BackPressListener {
                 is ShowSnackbar -> uiMessageResolver.showSnack(event.message)
             }
         }
-    }
-
-    override fun getFragmentTitle() = getString(R.string.coupon_restrictions_allowed_emails)
-
-    override fun onRequestAllowBackPress(): Boolean {
-        viewModel.onBackPressed()
-        return false
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/coupons/edit/EmailRestrictionScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/coupons/edit/EmailRestrictionScreen.kt
@@ -1,5 +1,6 @@
 package com.woocommerce.android.ui.coupons.edit
 
+import androidx.activity.compose.BackHandler
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
@@ -9,12 +10,16 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.MaterialTheme
+import androidx.compose.material.Scaffold
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Clear
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.livedata.observeAsState
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.dimensionResource
 import androidx.compose.ui.res.stringResource
 import com.woocommerce.android.R
+import com.woocommerce.android.ui.compose.component.Toolbar
 import com.woocommerce.android.ui.compose.component.WCOutlinedTextField
 
 @Composable
@@ -22,7 +27,8 @@ fun EmailRestrictionScreen(viewModel: EmailRestrictionViewModel) {
     viewModel.viewState.observeAsState().value?.let {
         EmailRestrictionScreen(
             viewState = it,
-            onAllowedEmailsChanged = viewModel::onAllowedEmailsChanged
+            onAllowedEmailsChanged = viewModel::onAllowedEmailsChanged,
+            onBackPressed = viewModel::onBackPressed,
         )
     }
 }
@@ -30,25 +36,39 @@ fun EmailRestrictionScreen(viewModel: EmailRestrictionViewModel) {
 @Composable
 fun EmailRestrictionScreen(
     viewState: EmailRestrictionViewModel.ViewState,
-    onAllowedEmailsChanged: (String) -> Unit
+    onAllowedEmailsChanged: (String) -> Unit,
+    onBackPressed: () -> Unit,
 ) {
     val scrollState = rememberScrollState()
-    Column(
-        verticalArrangement = Arrangement.spacedBy(dimensionResource(id = R.dimen.major_100)),
-        modifier = Modifier
-            .background(color = MaterialTheme.colors.surface)
-            .verticalScroll(scrollState)
-            .padding(vertical = dimensionResource(id = R.dimen.major_100))
-            .fillMaxSize()
-    ) {
-        WCOutlinedTextField(
-            value = viewState.allowedEmails,
-            label = stringResource(id = R.string.coupon_restrictions_allowed_emails),
-            onValueChange = onAllowedEmailsChanged,
-            helperText = stringResource(id = R.string.coupon_restrictions_allowed_emails_hint),
+    BackHandler { onBackPressed() }
+
+    Scaffold(
+        topBar = {
+            Toolbar(
+                title = stringResource(id = R.string.coupon_restrictions_allowed_emails),
+                navigationIcon = Icons.Default.Clear,
+                onNavigationButtonClick = onBackPressed
+            )
+        }
+    ) { paddingValues ->
+        Column(
+            verticalArrangement = Arrangement.spacedBy(dimensionResource(id = R.dimen.major_100)),
             modifier = Modifier
-                .fillMaxWidth()
-                .padding(horizontal = dimensionResource(id = R.dimen.major_100))
-        )
+                .padding(paddingValues)
+                .background(color = MaterialTheme.colors.surface)
+                .fillMaxSize()
+                .verticalScroll(scrollState)
+                .padding(vertical = dimensionResource(id = R.dimen.major_100))
+        ) {
+            WCOutlinedTextField(
+                value = viewState.allowedEmails,
+                label = stringResource(id = R.string.coupon_restrictions_allowed_emails),
+                onValueChange = onAllowedEmailsChanged,
+                helperText = stringResource(id = R.string.coupon_restrictions_allowed_emails_hint),
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(horizontal = dimensionResource(id = R.dimen.major_100))
+            )
+        }
     }
 }


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #WOOMOB-499
<!-- Id number of the GitHub issue this PR addresses. -->
<!-- Remember about a good descriptive title. -->

**Do not merge until https://github.com/woocommerce/woocommerce-android/pull/14040 is merged.**

Series of PRs with Toolbar fixes for coupons creation flow
1. https://github.com/woocommerce/woocommerce-android/pull/14036
2. https://github.com/woocommerce/woocommerce-android/pull/14038
3. https://github.com/woocommerce/woocommerce-android/pull/14039
4. https://github.com/woocommerce/woocommerce-android/pull/14040
5. **THIS PR** https://github.com/woocommerce/woocommerce-android/pull/14041

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

Goal of this PR is to replace the MainActivity toolbar with fragment specific toolbar on the EmailRestrictionsFragment.

Known issues
- The status bar on CouponEditScreen within POS has dark overlay - not related to this PR.
- Enter/exit animation for coupons flow is not consistent within POS.
- Toolbars are missing on some of the other screens.


### Steps to reproduce
<!-- Step-by-step testing instructions. For new user flows, consider instead stating the goal of the workflow and see if your PR reviewer can accomplish the workflow without specific steps! -->

1. Open POS
2. Tap on coupons tab
3. Tap on Plus button
7. Select a coupon type
8. Tap on Usage Restrictions
9. Tap on Allowed Emails
10. Notice toolbar is missing

### Testing information
<!-- This is your opportunity to break out individual scenarios that need testing (when necessary) and/or include a checklist for the reviewer to go through. Consider documenting the following from your own completed testing: devices used, alternate workflows, edge cases, affected areas, critical flows, areas not tested, and any remaining unknowns. Provide feedback on this new section of the PR template through Sept 30, 2024 to Apps Quality; additional context here: p91TBi-b8z-p2#comment-12036 -->

**POS**
1. Open POS
2. Tap on coupons tab
3. Tap on Plus button
6. Select a coupon type
7. Tap on Usage Restrictions
8. Tap on Allowed Emails
9. Notice toolbar is present
11. Enter email and verify both up and back buttons persist the changes


**Regression Coupons**
-Repeat the above steps but not within the POS but in More Menu -> Coupons -> Plus FAB icon.


### The tests that have been performed
<!-- To give the reviewer an idea of what could be missed in terms of testing -->

The above.

All of the above

### Images/gif
<!-- Include before and after images or gifs when appropriate. -->

|                | Before   | After   |
|----------------|---------------|---------------|
| POS | ![Screenshot_1747050827](https://github.com/user-attachments/assets/aa3feecf-bf0b-49c8-81c8-65a8b4f590e3) | ![Screenshot_1747050850](https://github.com/user-attachments/assets/bb9fd15f-1457-42a1-9e2a-7e306ea41728) |
| Coupons | ![Screenshot_1747050844](https://github.com/user-attachments/assets/00d0fd59-312a-432c-9f24-380c0d310451) | ![Screenshot_1747050861](https://github.com/user-attachments/assets/59de61e9-79bf-4ee8-8139-3ca044048961) |




All of the above.

- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.

## Reviewer (or Author, in the case of optional code reviews):

Please make sure these conditions are met before approving the PR, or request changes if the PR needs improvement:

- [x] The PR is small and has a clear, single focus, or a valid explanation is provided in the description. If needed, please request to split it into smaller PRs.
- [x] Ensure Adequate Unit Test Coverage: The changes are reasonably covered by unit tests or an explanation is provided in the PR description.
- [x] Manual Testing: The author listed all the tests they ran, including smoke tests when needed (e.g., for refactorings). The reviewer confirmed that the PR works as expected on big (tablet) and small (phone) in case of UI changes, and no regressions are added.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->