### PR TITLE
[WOOMOB-500] Improve Coupon Creation Exit Animation in POS

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/items/coupons/creation/WooPosCouponCreationActivity.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/items/coupons/creation/WooPosCouponCreationActivity.kt
@@ -78,9 +78,9 @@ class WooPosCouponCreationActivity : AppCompatActivity(R.layout.activity_woo_pos
     override fun finish() {
         super.finish()
         adjustActivityTransition(
-            overrideTransitionOpen = true,
-            enterAnim = android.R.anim.fade_in,
-            exitAnim = android.R.anim.fade_out,
+            overrideTransitionOpen = false,
+            enterAnim = R.anim.woopos_slide_in_left,
+            exitAnim = R.anim.woopos_slide_out_right
         )
     }
 


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #WOOMOB-500
<!-- Id number of the GitHub issue this PR addresses. -->

**Do not merge - https://github.com/woocommerce/woocommerce-android/pull/14031 needs to be merged first.**

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

This PR adjusts the exit animation of the EditCouponsFragment to slide out to the right, making it more consistent with other POS flows. While it still doesn't fully replicate the "push-away" animation due to architectural constraints (the flow starts in a separate activity with a bottom sheet), this change improves visual consistency and helps reduce jarring transitions.

### Testing information
<!-- This is your opportunity to break out individual scenarios that need testing (when necessary) and/or include a checklist for the reviewer to go through. Consider documenting the following from your own completed testing: devices used, alternate workflows, edge cases, affected areas, critical flows, areas not tested, and any remaining unknowns. Provide feedback on this new section of the PR template through Sept 30, 2024 to Apps Quality; additional context here: p91TBi-b8z-p2#comment-12036 -->

1. Open POS.
2. Tap on Coupons tab.
3. Tap on 'Creation coupon` button.
4. Go through the coupon creation flow and notice the exit animation.
5. Repeat the above steps but leave the flow by pressing back button and observe the animation.

### The tests that have been performed
<!-- To give the reviewer an idea of what could be missed in terms of testing -->

The above.

### Images/gif
<!-- Include before and after images or gifs when appropriate. -->

| Before | After |
|--------|-------|
| <video src="https://github.com/user-attachments/assets/f9b03d8f-b599-424e-92c5-866a5fb87a43" controls width="300"></video> | <video src="https://github.com/user-attachments/assets/522f2703-db4a-4b74-ac5f-704547ea26cc" controls width="300"></video> |




- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.

## Reviewer (or Author, in the case of optional code reviews):

Please make sure these conditions are met before approving the PR, or request changes if the PR needs improvement:

- [x] The PR is small and has a clear, single focus, or a valid explanation is provided in the description. If needed, please request to split it into smaller PRs.
- [x] Ensure Adequate Unit Test Coverage: The changes are reasonably covered by unit tests or an explanation is provided in the PR description.
- [x] Manual Testing: The author listed all the tests they ran, including smoke tests when needed (e.g., for refactorings). The reviewer confirmed that the PR works as expected on big (tablet) and small (phone) in case of UI changes, and no regressions are added.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->