### PR TITLE
[WOOMOB-468] Update designs of coupons type selector bottom sheet

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -4,6 +4,7 @@
 22.4
 -----
 - [*] UI improvements for the "Custom amount" section on the order details screen [https://github.com/woocommerce/woocommerce-android/pull/13999]
+- [*] Minor design adjustments of the coupon creation flow.
 
 22.3
 -----

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/coupons/create/CouponTypePickerFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/coupons/create/CouponTypePickerFragment.kt
@@ -10,7 +10,7 @@ import androidx.compose.ui.platform.ViewCompositionStrategy
 import androidx.fragment.app.setFragmentResult
 import androidx.fragment.app.viewModels
 import androidx.navigation.fragment.findNavController
-import com.woocommerce.android.ui.compose.theme.WooThemeWithBackground
+import com.woocommerce.android.ui.compose.theme.WooTheme
 import com.woocommerce.android.ui.woopos.home.items.coupons.creation.WooPosCouponCreationActivity
 import com.woocommerce.android.widgets.WCBottomSheetDialogFragment
 import dagger.hilt.android.AndroidEntryPoint
@@ -27,7 +27,7 @@ class CouponTypePickerFragment : WCBottomSheetDialogFragment() {
         return ComposeView(requireContext()).apply {
             setViewCompositionStrategy(ViewCompositionStrategy.DisposeOnViewTreeLifecycleDestroyed)
             setContent {
-                WooThemeWithBackground {
+                WooTheme {
                     CouponTypePickerScreen(
                         viewModel::onPercentageDiscountClicked,
                         viewModel::onFixedCartDiscountClicked,

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/coupons/create/CouponTypePickerScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/coupons/create/CouponTypePickerScreen.kt
@@ -8,19 +8,21 @@ import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.MaterialTheme
+import androidx.compose.material.Surface
 import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.colorResource
 import androidx.compose.ui.res.dimensionResource
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
-import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.tooling.preview.Preview
-import androidx.compose.ui.unit.dp
 import androidx.constraintlayout.compose.ConstraintLayout
 import com.woocommerce.android.R
+import com.woocommerce.android.ui.compose.component.BottomSheetHandle
 
 @Composable
 fun CouponTypePickerScreen(
@@ -28,39 +30,41 @@ fun CouponTypePickerScreen(
     onFixedCartDiscountClicked: () -> Unit,
     onFixedProductDiscountClicked: () -> Unit
 ) {
-    Column(modifier = Modifier.padding(dimensionResource(id = R.dimen.major_100))) {
-        Text(
-            text = stringResource(R.string.coupon_type_picker_title),
-            style = MaterialTheme.typography.subtitle1,
-            fontWeight = FontWeight.Bold,
-            modifier = Modifier.padding(
-                start = 0.dp,
-                top = dimensionResource(id = R.dimen.major_125),
-                end = 0.dp,
-                bottom = dimensionResource(id = R.dimen.major_75)
+    Surface(
+        shape = RoundedCornerShape(
+            topStart = dimensionResource(id = R.dimen.minor_100),
+            topEnd = dimensionResource(id = R.dimen.minor_100)
+        )
+    ) {
+        Column(modifier = Modifier.padding(dimensionResource(id = R.dimen.major_100))) {
+            BottomSheetHandle(Modifier.align(Alignment.CenterHorizontally))
+            Text(
+                text = stringResource(id = R.string.coupon_type_picker_title),
+                color = colorResource(id = R.color.color_on_surface_medium),
+                modifier = Modifier.padding(vertical = dimensionResource(id = R.dimen.major_100))
             )
-        )
-        CouponType(
-            typeNameTitle = stringResource(R.string.coupon_type_picker_percentage_discount_title),
-            subtitle = stringResource(R.string.coupon_type_picker_percentage_discount_subtitle),
-            iconRes = R.drawable.ic_coupon_percentage,
-            contentDescription = R.string.coupon_type_picker_percentage_content_description,
-            onClick = onPercentageDiscountClicked
-        )
-        CouponType(
-            typeNameTitle = stringResource(R.string.coupon_type_picker_fixed_cart_discount_title),
-            subtitle = stringResource(R.string.coupon_type_picker_fixed_cart_discount_subtitle),
-            iconRes = R.drawable.ic_coupon_fixed_cart,
-            contentDescription = R.string.coupon_type_picker_fixed_cart_content_description,
-            onClick = onFixedCartDiscountClicked
-        )
-        CouponType(
-            typeNameTitle = stringResource(R.string.coupon_type_picker_fixed_product_discount_title),
-            subtitle = stringResource(R.string.coupon_type_picker_fixed_product_discount_subtitle),
-            iconRes = R.drawable.ic_coupon_fixed_product,
-            contentDescription = R.string.coupon_type_picker_fixed_product_content_description,
-            onClick = onFixedProductDiscountClicked
-        )
+            CouponType(
+                typeNameTitle = stringResource(R.string.coupon_type_picker_percentage_discount_title),
+                subtitle = stringResource(R.string.coupon_type_picker_percentage_discount_subtitle),
+                iconRes = R.drawable.ic_coupon_percentage,
+                contentDescription = R.string.coupon_type_picker_percentage_content_description,
+                onClick = onPercentageDiscountClicked
+            )
+            CouponType(
+                typeNameTitle = stringResource(R.string.coupon_type_picker_fixed_cart_discount_title),
+                subtitle = stringResource(R.string.coupon_type_picker_fixed_cart_discount_subtitle),
+                iconRes = R.drawable.ic_coupon_fixed_cart,
+                contentDescription = R.string.coupon_type_picker_fixed_cart_content_description,
+                onClick = onFixedCartDiscountClicked
+            )
+            CouponType(
+                typeNameTitle = stringResource(R.string.coupon_type_picker_fixed_product_discount_title),
+                subtitle = stringResource(R.string.coupon_type_picker_fixed_product_discount_subtitle),
+                iconRes = R.drawable.ic_coupon_fixed_product,
+                contentDescription = R.string.coupon_type_picker_fixed_product_content_description,
+                onClick = onFixedProductDiscountClicked
+            )
+        }
     }
 }
 


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #WOOMOB-468
<!-- Id number of the GitHub issue this PR addresses. -->

Do not marge label - https://github.com/woocommerce/woocommerce-android/pull/14031 needs to be merged first.

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

This PR updates designs of coupon type selector bottom sheet.

### Testing information
<!-- This is your opportunity to break out individual scenarios that need testing (when necessary) and/or include a checklist for the reviewer to go through. Consider documenting the following from your own completed testing: devices used, alternate workflows, edge cases, affected areas, critical flows, areas not tested, and any remaining unknowns. Provide feedback on this new section of the PR template through Sept 30, 2024 to Apps Quality; additional context here: p91TBi-b8z-p2#comment-12036 -->

1. Tap on More menu
2. Tap on Coupons
3. Tap on Plus FAB
4. Notice the bottom sheet
------------
1. Tap on More menu
2. Open POS
3. Tap on Coupons tab
4. Tap on plus icon
5. Notice the bottom sheet

### The tests that have been performed
<!-- To give the reviewer an idea of what could be missed in terms of testing -->

I've tested the above.

### Images/gif
<!-- Include before and after images or gifs when appropriate. -->

| Light | Dark |
| -- | -- |
| ![Screenshot_1747119971](https://github.com/user-attachments/assets/1462072d-033e-4ab5-8937-a2afa9d79492) | ![Screenshot_1747120031](https://github.com/user-attachments/assets/aed0e650-1aec-403a-b6d5-d714a641b7dc) |



- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.

## Reviewer (or Author, in the case of optional code reviews):

Please make sure these conditions are met before approving the PR, or request changes if the PR needs improvement:

- [x] The PR is small and has a clear, single focus, or a valid explanation is provided in the description. If needed, please request to split it into smaller PRs.
- [x] Ensure Adequate Unit Test Coverage: The changes are reasonably covered by unit tests or an explanation is provided in the PR description.
- [x] Manual Testing: The author listed all the tests they ran, including smoke tests when needed (e.g., for refactorings). The reviewer confirmed that the PR works as expected on big (tablet) and small (phone) in case of UI changes, and no regressions are added.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->