### PR TITLE
[WOOMOB-470] Crash on parsing taxlines JSON 

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -4,6 +4,7 @@
 22.4
 -----
 - [*] UI improvements for the "Custom amount" section on the order details screen [https://github.com/woocommerce/woocommerce-android/pull/13999]
+- [*] Fixes for the crash when tax lines JSON is malformed [https://github.com/woocommerce/woocommerce-android/pull/14049]
 
 22.3
 -----

--- a/libs/fluxc-plugin/src/main/kotlin/org/wordpress/android/fluxc/persistence/entity/OrderEntity.kt
+++ b/libs/fluxc-plugin/src/main/kotlin/org/wordpress/android/fluxc/persistence/entity/OrderEntity.kt
@@ -156,11 +156,15 @@ data class OrderEntity(
 
     /**
      * Deserializes the JSON contained in [taxLines] into a list of [TaxLine] objects.
+     * Returns an empty list if deserialization fails.
      */
     fun getTaxLineList(): List<TaxLine> {
-        val responseType = object : TypeToken<List<TaxLine>>() {}.type
-        return gson.fromJson(taxLines, responseType) as? List<TaxLine> ?: emptyList()
+        return try {
+            val responseType = object : TypeToken<List<TaxLine>>() {}.type
+            gson.fromJson(taxLines, responseType) as? List<TaxLine> ?: emptyList()
+        } catch (e: Exception) {
+            e.printStackTrace()
+            emptyList()
+        }
     }
-
-    fun isMultiShippingLinesAvailable() = getShippingLineList().size > 1
 }

--- a/libs/fluxc-plugin/src/main/kotlin/org/wordpress/android/fluxc/persistence/entity/OrderEntity.kt
+++ b/libs/fluxc-plugin/src/main/kotlin/org/wordpress/android/fluxc/persistence/entity/OrderEntity.kt
@@ -5,6 +5,7 @@ import androidx.room.Entity
 import androidx.room.Index
 import androidx.room.TypeConverters
 import com.google.gson.Gson
+import com.google.gson.JsonSyntaxException
 import com.google.gson.reflect.TypeToken
 import org.wordpress.android.fluxc.model.LocalOrRemoteId.LocalId
 import org.wordpress.android.fluxc.model.metadata.WCMetaData
@@ -162,7 +163,8 @@ data class OrderEntity(
         return try {
             val responseType = object : TypeToken<List<TaxLine>>() {}.type
             gson.fromJson(taxLines, responseType) as? List<TaxLine> ?: emptyList()
-        } catch (e: Exception) {
+        } catch (e: JsonSyntaxException) {
+            @Suppress("PrintStackTrace")
             e.printStackTrace()
             emptyList()
         }

--- a/libs/fluxc-tests/src/test/java/org/wordpress/android/fluxc/wc/order/OrderEntityTest.kt
+++ b/libs/fluxc-tests/src/test/java/org/wordpress/android/fluxc/wc/order/OrderEntityTest.kt
@@ -143,4 +143,25 @@ class OrderEntityTest {
         assertEquals("Flat Rate Shipping", shippingLinesList[0].methodTitle)
         assertEquals("Local Pickup Shipping", shippingLinesList[1].methodTitle)
     }
+
+    @Test
+    fun testGetTaxLinesHandlesInvalidJson() {
+        // GIVEN
+        val model = OrderTestUtils.generateSampleOrder(61).copy(
+            taxLines = """[{
+            "id": 1,
+            "rate_id": "stripe_tax_for_woocommerce__shipping_tax__0__Shipping Tax",
+            "code": "TAX",
+            "title": "Shipping Tax",
+            "total": "5.00",
+            "compound": false
+        }]"""
+        )
+
+        // WHEN
+        val taxLines = model.getTaxLineList()
+
+        // THEN
+        assertEquals(0, taxLines.size, "Should return empty list when tax lines contains invalid values")
+    }
 }

--- a/libs/fluxc-tests/src/test/java/org/wordpress/android/fluxc/wc/order/OrderEntityTest.kt
+++ b/libs/fluxc-tests/src/test/java/org/wordpress/android/fluxc/wc/order/OrderEntityTest.kt
@@ -164,4 +164,57 @@ class OrderEntityTest {
         // THEN
         assertEquals(0, taxLines.size, "Should return empty list when tax lines contains invalid values")
     }
+
+    @Test
+    fun testGetTaxLinesValidJson() {
+        val model = OrderTestUtils.generateSampleOrder(61).copy(
+            taxLines = """[{
+            "id": 1,
+            "rate_id": 5,
+            "rate_code": "TAX-1",
+            "rate_percent": 7.5,
+            "label": "State Tax",
+            "compound": false,
+            "tax_total": "5.50",
+            "shipping_tax_total": "0.75"
+        }, {
+            "id": 2,
+            "rate_id": 6,
+            "rate_code": "TAX-2",
+            "rate_percent": 2.0,
+            "label": "County Tax",
+            "compound": true,
+            "tax_total": "2.30",
+            "shipping_tax_total": "0.25"
+        }]"""
+        )
+
+        // WHEN
+        val taxLines = model.getTaxLineList()
+
+        // THEN
+        assertEquals(2, taxLines.size)
+
+        with(taxLines[0]) {
+            assertEquals(1, id)
+            assertEquals(5, rateId)
+            assertEquals("TAX-1", rateCode)
+            assertEquals(7.5f, ratePercent)
+            assertEquals("State Tax", label)
+            assertEquals(false, compound)
+            assertEquals("5.50", taxTotal)
+            assertEquals("0.75", shippingTaxTotal)
+        }
+
+        with(taxLines[1]) {
+            assertEquals(2, id)
+            assertEquals(6, rateId)
+            assertEquals("TAX-2", rateCode)
+            assertEquals(2.0f, ratePercent)
+            assertEquals("County Tax", label)
+            assertEquals(true, compound)
+            assertEquals("2.30", taxTotal)
+            assertEquals("0.25", shippingTaxTotal)
+        }
+    }
 }


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #WOOMOB-470
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
The PR catches the exception when JSON with tax lines is malformed and returns empty tax lines in this case.

### Steps to reproduce
<!-- Step-by-step testing instructions. For new user flows, consider instead stating the goal of the workflow and see if your PR reviewer can accomplish the workflow without specific steps! -->
I don't know how to reproduce this, but I added a unit test on this case

### The tests that have been performed
<!-- To give the reviewer an idea of what could be missed in terms of testing -->
Unit test

### Images/gif
<!-- Include before and after images or gifs when appropriate. -->

- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.

## Reviewer (or Author, in the case of optional code reviews):

Please make sure these conditions are met before approving the PR, or request changes if the PR needs improvement:

- [ ] The PR is small and has a clear, single focus, or a valid explanation is provided in the description. If needed, please request to split it into smaller PRs.
- [ ] Ensure Adequate Unit Test Coverage: The changes are reasonably covered by unit tests or an explanation is provided in the PR description.
- [ ] Manual Testing: The author listed all the tests they ran, including smoke tests when needed (e.g., for refactorings). The reviewer confirmed that the PR works as expected on big (tablet) and small (phone) in case of UI changes, and no regressions are added.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->