### PR TITLE
Fix application passwords crash when `uuid` is missing + race condition fixes

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/config/FirebaseRemoteConfigRepository.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/config/FirebaseRemoteConfigRepository.kt
@@ -22,7 +22,7 @@ class FirebaseRemoteConfigRepository @Inject constructor(
         private const val DEBUG_INTERVAL = 10L
         private const val RELEASE_INTERVAL = 31200L
 
-        const val KEY_ENABLE_JETPACK_APP_PASSWORDS_EXPERIMENT = "wcandroid_enable_jetpack_app_passwords_experiment"
+        const val KEY_ENABLE_JETPACK_APP_PASSWORDS_EXPERIMENT = "wcandroid_enable_jetpack_app_passwords_experiment_2"
     }
 
     private val minimumFetchIntervalInSeconds =

--- a/libs/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpapi/applicationpasswords/ApplicationPasswordsApiResponses.kt
+++ b/libs/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpapi/applicationpasswords/ApplicationPasswordsApiResponses.kt
@@ -3,7 +3,7 @@ package org.wordpress.android.fluxc.network.rest.wpapi.applicationpasswords
 import com.google.gson.annotations.SerializedName
 
 internal data class ApplicationPasswordCreationResponse(
-    @SerializedName("uuid") val uuid: ApplicationPasswordUUID,
+    @SerializedName("uuid") val uuid: ApplicationPasswordUUID?,
     @SerializedName("name") val name: String,
     @SerializedName("password") val password: String
 )

--- a/libs/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpapi/applicationpasswords/ApplicationPasswordsManager.kt
+++ b/libs/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpapi/applicationpasswords/ApplicationPasswordsManager.kt
@@ -2,6 +2,8 @@ package org.wordpress.android.fluxc.network.rest.wpapi.applicationpasswords
 
 import com.android.volley.NetworkResponse
 import com.android.volley.VolleyError
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
 import org.wordpress.android.fluxc.model.SiteModel
 import org.wordpress.android.fluxc.network.BaseRequest.BaseNetworkError
 import org.wordpress.android.fluxc.network.BaseRequest.GenericErrorType
@@ -11,12 +13,14 @@ import org.wordpress.android.fluxc.utils.AppLogWrapper
 import org.wordpress.android.util.AppLog
 import org.wordpress.android.util.AppLog.T.MAIN
 import javax.inject.Inject
+import javax.inject.Singleton
 
 private const val UNAUTHORIZED = 401
 private const val CONFLICT = 409
 private const val NOT_FOUND = 404
 private const val APPLICATION_PASSWORDS_DISABLED_ERROR_CODE = "application_passwords_disabled"
 
+@Singleton
 internal class ApplicationPasswordsManager @Inject constructor(
     private val applicationPasswordsStore: ApplicationPasswordsStore,
     private val jetpackApplicationPasswordsRestClient: JetpackApplicationPasswordsRestClient,
@@ -24,6 +28,8 @@ internal class ApplicationPasswordsManager @Inject constructor(
     private val configuration: ApplicationPasswordsConfiguration,
     private val appLogWrapper: AppLogWrapper
 ) {
+    private val mutexLock = Mutex()
+
     private val applicationName
         get() = configuration.applicationName
 
@@ -41,7 +47,7 @@ internal class ApplicationPasswordsManager @Inject constructor(
     @Suppress("ReturnCount")
     suspend fun getApplicationCredentials(
         site: SiteModel
-    ): ApplicationPasswordCreationResult {
+    ): ApplicationPasswordCreationResult = mutexLock.withLock {
         if (site.isWPCom) return ApplicationPasswordCreationResult.NotSupported(
             WPAPINetworkError(
                 BaseNetworkError(

--- a/libs/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpapi/applicationpasswords/ApplicationPasswordsManager.kt
+++ b/libs/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpapi/applicationpasswords/ApplicationPasswordsManager.kt
@@ -213,7 +213,7 @@ internal class ApplicationPasswordsManager @Inject constructor(
             !payload.isError -> {
                 if (payload.isDeleted) {
                     appLogWrapper.d(AppLog.T.MAIN, "Application password deleted")
-                    deleteLocalApplicationPassword(site)
+                    applicationPasswordsStore.deleteCredentials(site)
                     ApplicationPasswordDeletionResult.Success
                 } else {
                     appLogWrapper.w(AppLog.T.MAIN, "Application password deletion failed")
@@ -248,7 +248,9 @@ internal class ApplicationPasswordsManager @Inject constructor(
         }
     }
 
-    fun deleteLocalApplicationPassword(site: SiteModel) {
-        applicationPasswordsStore.deleteCredentials(site)
+    fun deleteLocalApplicationPassword(site: SiteModel, credentials: ApplicationPasswordCredentials) {
+        if (applicationPasswordsStore.getCredentials(site) == credentials) {
+            applicationPasswordsStore.deleteCredentials(site)
+        }
     }
 }

--- a/libs/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpapi/applicationpasswords/ApplicationPasswordsNetwork.kt
+++ b/libs/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpapi/applicationpasswords/ApplicationPasswordsNetwork.kt
@@ -135,7 +135,7 @@ class ApplicationPasswordsNetwork @Inject constructor(
                 "Authentication failure using application password, maybe revoked?" +
                     " Delete the saved one then retry"
             )
-            mApplicationPasswordsManager.deleteLocalApplicationPassword(site)
+            mApplicationPasswordsManager.deleteLocalApplicationPassword(site, credentials)
             executeGsonRequest(site, method, path, clazz, params, body, isRegeneratingApplicationPassword = true)
         } else {
             response

--- a/libs/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpapi/applicationpasswords/ApplicationPasswordsPayloads.kt
+++ b/libs/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpapi/applicationpasswords/ApplicationPasswordsPayloads.kt
@@ -5,7 +5,7 @@ import org.wordpress.android.fluxc.network.BaseRequest.BaseNetworkError
 
 internal data class ApplicationPasswordCreationPayload(
     val password: String,
-    val uuid: String
+    val uuid: String?
 ) : Payload<BaseNetworkError>() {
     constructor(error: BaseNetworkError) : this("", "") {
         this.error = error

--- a/libs/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpapi/applicationpasswords/JetpackApplicationPasswordsRestClient.kt
+++ b/libs/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpapi/applicationpasswords/JetpackApplicationPasswordsRestClient.kt
@@ -76,8 +76,8 @@ internal class JetpackApplicationPasswordsRestClient @Inject constructor(
 
         return when (response) {
             is JetpackSuccess -> {
-                response.data?.firstOrNull { it.name == applicationName }?.let {
-                    ApplicationPasswordUUIDFetchPayload(it.uuid)
+                response.data?.firstOrNull { it.name == applicationName }?.uuid?.let {
+                    ApplicationPasswordUUIDFetchPayload(it)
                 } ?: ApplicationPasswordUUIDFetchPayload(
                     BaseNetworkError(
                         GenericErrorType.UNKNOWN,

--- a/libs/fluxc/src/test/java/org/wordpress/android/fluxc/network/rest/wpapi/applicationpasswords/ApplicationPasswordsNetworkTests.kt
+++ b/libs/fluxc/src/test/java/org/wordpress/android/fluxc/network/rest/wpapi/applicationpasswords/ApplicationPasswordsNetworkTests.kt
@@ -75,7 +75,7 @@ class ApplicationPasswordsNetworkTests {
 
         network.executeGetGsonRequest(testSite, "path", TestResponse::class.java)
 
-        verify(mApplicationPasswordsManager).deleteLocalApplicationPassword(testSite)
+        verify(mApplicationPasswordsManager).deleteLocalApplicationPassword(testSite, testCredentials)
         verify(mApplicationPasswordsManager, times(2)).getApplicationCredentials(testSite)
     }
 


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: WOOMOB-454
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
This PR has three changes:
1. It fixes the crash of the linked issue, the crash happens when the backend doesn't include the `uuid` field in the response, I made the field nullable now.
This seems like a bug in WordPress Core, I managed to reproduce it by sending 20 parallel requests to create app passwords, some of them were returned without the `uuid`. I'll make sure to create a bug report about it.
2. Fixes a race condition that could lead to creating multiple application passwords, this happens because as shared in (WOOMOB-475) WordPress stopped enforcing unique app names, which means that instead of deleting and creating new ones, we keep adding new ones now.
This issue is potentially a factor in increasing the chances of the above crash.
4. Updates the flag of the Jetpack performance experiment.

### Steps to reproduce
1. Open the app and sign in.
2. Open the orders screen and keep the app open.
3. Open wp-admin, and revoke the application password that the app created.
5. Clear logcat.
6. Go back to the app, and create an order.
7. Check logcat, and confirm there is a single line saying: `Create an application password using Jetpack Tunnel`

**Remark:** The app seems to making multiple order fetches after creating an order, this seems like a bug which we need to investigate, but for now it's useful for testing this flow.

### Testing information
- Confirm that a single request was sent to create the app password by checking logcat.
- Check wp-admin and confirm a single app password was created.

### The tests that have been performed
^

- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.

## Reviewer (or Author, in the case of optional code reviews):

Please make sure these conditions are met before approving the PR, or request changes if the PR needs improvement:

- [ ] The PR is small and has a clear, single focus, or a valid explanation is provided in the description. If needed, please request to split it into smaller PRs.
- [ ] Ensure Adequate Unit Test Coverage: The changes are reasonably covered by unit tests or an explanation is provided in the PR description.
- [ ] Manual Testing: The author listed all the tests they ran, including smoke tests when needed (e.g., for refactorings). The reviewer confirmed that the PR works as expected on big (tablet) and small (phone) in case of UI changes, and no regressions are added.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->