### PR TITLE
[WOOMOB-474] Fix Status Bar Color in POS Coupon Creation

### DIFF
--- a/WooCommerce/src/main/AndroidManifest.xml
+++ b/WooCommerce/src/main/AndroidManifest.xml
@@ -168,7 +168,7 @@
 
         <activity
             android:name="com.woocommerce.android.ui.woopos.home.items.coupons.creation.WooPosCouponCreationActivity"
-            android:theme="@style/Theme.WooPos.Transparent"
+            android:theme="@style/Theme.WooPos.DayNight.Transparent"
             android:windowSoftInputMode="adjustResize" />
 
         <!-- Stats today app widget -->

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/items/coupons/creation/WooPosCouponCreationActivity.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/items/coupons/creation/WooPosCouponCreationActivity.kt
@@ -18,7 +18,6 @@ import com.woocommerce.android.R
 import com.woocommerce.android.extensions.adjustActivityTransition
 import com.woocommerce.android.extensions.getColorCompat
 import com.woocommerce.android.ui.coupons.create.CouponTypePickerFragmentArgs
-import com.woocommerce.android.ui.main.MainActivity.Companion.BackPressListener
 import com.woocommerce.android.ui.woopos.util.ext.isGestureNavigation
 import com.woocommerce.android.util.WooLog
 import dagger.hilt.android.AndroidEntryPoint
@@ -36,22 +35,6 @@ class WooPosCouponCreationActivity : AppCompatActivity(R.layout.activity_woo_pos
 
         setupNavGraph(navHostFragment)
         observeResult(navHostFragment)
-    }
-
-    // Copied from MainActivity. Ensures SimpleTextEditorFragment handles backpresses as expected.
-    @Deprecated("Deprecated in Java")
-    override fun onBackPressed() {
-        val navHostFragment = supportFragmentManager.primaryNavigationFragment
-        if (navHostFragment?.childFragmentManager?.fragments?.isNotEmpty() == true) {
-            navHostFragment.childFragmentManager.fragments[0]?.let { fragment ->
-                if (fragment is BackPressListener && !(fragment as BackPressListener).onRequestAllowBackPress()) {
-                    return
-                }
-            }
-        }
-
-        @Suppress("DEPRECATION")
-        super.onBackPressed()
     }
 
     private fun setupTopAndBottomInsets() {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/items/coupons/creation/WooPosCouponCreationActivity.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/items/coupons/creation/WooPosCouponCreationActivity.kt
@@ -3,17 +3,20 @@ package com.woocommerce.android.ui.woopos.home.items.coupons.creation
 import android.content.Context
 import android.content.Intent
 import android.content.pm.ActivityInfo
+import android.content.res.Configuration
 import android.os.Bundle
 import android.view.View
+import androidx.activity.SystemBarStyle
+import androidx.activity.enableEdgeToEdge
 import androidx.appcompat.app.AppCompatActivity
 import androidx.core.view.ViewCompat
-import androidx.core.view.WindowCompat
 import androidx.core.view.WindowInsetsCompat
 import androidx.core.view.updatePadding
 import androidx.navigation.NavGraph
 import androidx.navigation.fragment.NavHostFragment
 import com.woocommerce.android.R
 import com.woocommerce.android.extensions.adjustActivityTransition
+import com.woocommerce.android.extensions.getColorCompat
 import com.woocommerce.android.ui.coupons.create.CouponTypePickerFragmentArgs
 import com.woocommerce.android.ui.main.MainActivity.Companion.BackPressListener
 import com.woocommerce.android.ui.woopos.util.ext.isGestureNavigation
@@ -52,7 +55,7 @@ class WooPosCouponCreationActivity : AppCompatActivity(R.layout.activity_woo_pos
     }
 
     private fun setupTopAndBottomInsets() {
-        WindowCompat.setDecorFitsSystemWindows(window, false)
+        applyFixForStatusBarColor()
         val rootView = findViewById<View>(R.id.snack_root)
         ViewCompat.setOnApplyWindowInsetsListener(rootView) { view, insets ->
             insets.toWindowInsets()?.let { windowInsets ->
@@ -73,6 +76,18 @@ class WooPosCouponCreationActivity : AppCompatActivity(R.layout.activity_woo_pos
 
             insets
         }
+    }
+
+    private fun applyFixForStatusBarColor() {
+        val isDark =
+            (resources.configuration.uiMode and Configuration.UI_MODE_NIGHT_MASK) == Configuration.UI_MODE_NIGHT_YES
+        val statusBarColor = getColorCompat(R.color.color_toolbar)
+        val statusBarStyle = if (isDark) {
+            SystemBarStyle.dark(statusBarColor)
+        } else {
+            SystemBarStyle.light(statusBarColor, statusBarColor)
+        }
+        enableEdgeToEdge(statusBarStyle = statusBarStyle)
     }
 
     override fun finish() {

--- a/WooCommerce/src/main/res/values/themes.xml
+++ b/WooCommerce/src/main/res/values/themes.xml
@@ -160,4 +160,12 @@
         <item name="android:windowIsFloating">false</item>
         <item name="android:backgroundDimEnabled">true</item>
     </style>
+
+    <style name="Theme.WooPos.DayNight.Transparent" parent="Theme.Woo.DayNight">
+        <item name="android:windowIsTranslucent">true</item>
+        <item name="android:windowBackground">@android:color/transparent</item>
+        <item name="android:windowNoTitle">true</item>
+        <item name="android:windowIsFloating">false</item>
+        <item name="android:backgroundDimEnabled">true</item>
+    </style>
 </resources>


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #WOOMOB-474
<!-- Id number of the GitHub issue this PR addresses. -->



### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

This PR adds two improvements:
- Fixes status bar color of the coupons creation flow in the POS.
- Removes obsolete back-press-handler, since SimpleTextEditorFragment now handles back presses using Compose's BacHandler.


Related slack convo p1747122988815869-slack-CGPNUU63E. Hattip to @hichamboushaba for coming up with the solution!


### Testing information
<!-- This is your opportunity to break out individual scenarios that need testing (when necessary) and/or include a checklist for the reviewer to go through. Consider documenting the following from your own completed testing: devices used, alternate workflows, edge cases, affected areas, critical flows, areas not tested, and any remaining unknowns. Provide feedback on this new section of the PR template through Sept 30, 2024 to Apps Quality; additional context here: p91TBi-b8z-p2#comment-12036 -->

1. Open POS
2. Tap on Coupons
3. Tap on Plus icon
4. Select a type
5. Notice the status bar looks fine
6. Tap on Add Description
7. Type something
8. Press back
9. Notice the description was saved
----------------
Test the above in dark mode

### The tests that have been performed
<!-- To give the reviewer an idea of what could be missed in terms of testing -->

I have smoke tested the coupon creation flow in both dark and light modes.

### Images/gif
<!-- Include before and after images or gifs when appropriate. -->

| Before | After |
| -- | -- |
| <img src="https://github.com/user-attachments/assets/83642035-50a6-4476-9d8f-15d3b177b2bd" width="300px" /> | <img src="https://github.com/user-attachments/assets/c5c8c5a5-886f-4ba8-b5d6-f1f5a1c744a7" width="300px" /> |

- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.

## Reviewer (or Author, in the case of optional code reviews):

Please make sure these conditions are met before approving the PR, or request changes if the PR needs improvement:

- [x] The PR is small and has a clear, single focus, or a valid explanation is provided in the description. If needed, please request to split it into smaller PRs.
- [x] Ensure Adequate Unit Test Coverage: The changes are reasonably covered by unit tests or an explanation is provided in the PR description.
- [x] Manual Testing: The author listed all the tests they ran, including smoke tests when needed (e.g., for refactorings). The reviewer confirmed that the PR works as expected on big (tablet) and small (phone) in case of UI changes, and no regressions are added.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->