### PR TITLE
[WOOMOB-417] Fix large fonts in POS for coupons (and buttons across the POS)

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/common/composeui/component/WooPosButtons.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/common/composeui/component/WooPosButtons.kt
@@ -203,7 +203,7 @@ private fun Button(
         border = border,
         colors = colors,
         modifier = modifier
-            .heightIn(min = height),
+            .heightIn(min = height, max = height * 3),
         elevation = ButtonDefaults.buttonElevation(
             defaultElevation = WooPosSpacing.None.value,
             pressedElevation = WooPosSpacing.None.value,

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/common/composeui/component/WooPosButtons.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/common/composeui/component/WooPosButtons.kt
@@ -357,9 +357,6 @@ fun WooPosSmallButtonsPreview() {
 
             Spacer(modifier = Modifier.height(WooPosSpacing.Medium.value))
 
-
-            Spacer(modifier = Modifier.height(WooPosSpacing.Medium.value))
-
             WooPosOutlinedButtonSmall(
                 text = "Button Outlined Small",
                 state = WooPosButtonState.LOADING,

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/common/composeui/component/WooPosButtons.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/common/composeui/component/WooPosButtons.kt
@@ -203,7 +203,7 @@ private fun Button(
         border = border,
         colors = colors,
         modifier = modifier
-            .heightIn(min = height, max = height * 2),
+            .heightIn(min = height),
         elevation = ButtonDefaults.buttonElevation(
             defaultElevation = WooPosSpacing.None.value,
             pressedElevation = WooPosSpacing.None.value,

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/common/composeui/component/WooPosButtons.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/common/composeui/component/WooPosButtons.kt
@@ -7,7 +7,6 @@ import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
@@ -40,7 +39,6 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.tooling.preview.PreviewFontScale
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
-import com.woocommerce.android.ui.woopos.common.composeui.WooPosPreview
 import com.woocommerce.android.ui.woopos.common.composeui.designsystem.WooPosCornerRadius
 import com.woocommerce.android.ui.woopos.common.composeui.designsystem.WooPosSpacing
 import com.woocommerce.android.ui.woopos.common.composeui.designsystem.WooPosTheme
@@ -246,7 +244,6 @@ private fun ButtonsLoadingIndicator(size: Dp) {
 }
 
 @Composable
-@WooPosPreview
 @PreviewFontScale
 fun WooPosButtonsPreview() {
     WooPosTheme {
@@ -298,55 +295,76 @@ fun WooPosButtonsPreview() {
                 modifier = Modifier.fillMaxWidth(),
                 onClick = {}
             )
+        }
+    }
+}
+
+@Composable
+@PreviewFontScale
+fun WooPosSmallButtonsPreview() {
+    WooPosTheme {
+        Column(
+            modifier = Modifier
+                .padding(WooPosSpacing.Medium.value)
+                .width(600.dp)
+                .verticalScroll(rememberScrollState()),
+            verticalArrangement = Arrangement.spacedBy(8.dp),
+        ) {
+            WooPosButtonSmall(
+                text = "Button Small",
+                state = WooPosButtonState.ENABLED,
+                onClick = {}
+            )
 
             Spacer(modifier = Modifier.height(WooPosSpacing.Medium.value))
 
-            Row(
-                horizontalArrangement = Arrangement.spacedBy(WooPosSpacing.Small.value),
-                verticalAlignment = Alignment.CenterVertically,
-            ) {
-                WooPosButtonSmall(
-                    text = "Button Small",
-                    state = WooPosButtonState.ENABLED,
-                    onClick = {}
-                )
-
-                WooPosButtonSmall(
-                    text = "Button Small",
-                    onClick = {},
-                    state = WooPosButtonState.DISABLED,
-                )
-
-                WooPosButtonSmall(
-                    text = "Button Small",
-                    state = WooPosButtonState.LOADING,
-                    onClick = {}
-                )
-                WooPosCircularIconButton(
-                    icon = Icons.Default.Search,
-                    onClick = {}
-                )
-            }
+            WooPosButtonSmall(
+                text = "Button Small",
+                onClick = {},
+                state = WooPosButtonState.DISABLED,
+            )
 
             Spacer(modifier = Modifier.height(WooPosSpacing.Medium.value))
 
-            Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
-                WooPosOutlinedButtonSmall(
-                    text = "Button Outlined Small",
-                    state = WooPosButtonState.ENABLED,
-                    onClick = {}
-                )
-                WooPosOutlinedButtonSmall(
-                    text = "Button Outlined Small",
-                    state = WooPosButtonState.DISABLED,
-                    onClick = {}
-                )
-                WooPosOutlinedButtonSmall(
-                    text = "Button Outlined Small",
-                    state = WooPosButtonState.LOADING,
-                    onClick = {}
-                )
-            }
+            WooPosButtonSmall(
+                text = "Button Small",
+                state = WooPosButtonState.LOADING,
+                onClick = {}
+            )
+
+            Spacer(modifier = Modifier.height(WooPosSpacing.Medium.value))
+
+            WooPosCircularIconButton(
+                icon = Icons.Default.Search,
+                onClick = {}
+            )
+
+            Spacer(modifier = Modifier.height(WooPosSpacing.Medium.value))
+
+            WooPosOutlinedButtonSmall(
+                text = "Button Outlined Small",
+                state = WooPosButtonState.ENABLED,
+                onClick = {}
+            )
+
+            Spacer(modifier = Modifier.height(WooPosSpacing.Medium.value))
+
+            WooPosOutlinedButtonSmall(
+                text = "Button Outlined Small",
+                state = WooPosButtonState.DISABLED,
+                onClick = {}
+            )
+
+            Spacer(modifier = Modifier.height(WooPosSpacing.Medium.value))
+
+
+            Spacer(modifier = Modifier.height(WooPosSpacing.Medium.value))
+
+            WooPosOutlinedButtonSmall(
+                text = "Button Outlined Small",
+                state = WooPosButtonState.LOADING,
+                onClick = {}
+            )
         }
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/common/composeui/component/WooPosButtons.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/common/composeui/component/WooPosButtons.kt
@@ -12,6 +12,7 @@ import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.heightIn
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
@@ -36,6 +37,7 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.compositeOver
 import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.tooling.preview.PreviewFontScale
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import com.woocommerce.android.ui.woopos.common.composeui.WooPosPreview
@@ -203,7 +205,7 @@ private fun Button(
         border = border,
         colors = colors,
         modifier = modifier
-            .height(height),
+            .heightIn(min = height, max = height * 2),
         elevation = ButtonDefaults.buttonElevation(
             defaultElevation = WooPosSpacing.None.value,
             pressedElevation = WooPosSpacing.None.value,
@@ -245,6 +247,7 @@ private fun ButtonsLoadingIndicator(size: Dp) {
 
 @Composable
 @WooPosPreview
+@PreviewFontScale
 fun WooPosButtonsPreview() {
     WooPosTheme {
         Column(

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/cart/WooPosCartScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/cart/WooPosCartScreen.kt
@@ -12,16 +12,20 @@ import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.IntrinsicSize
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.heightIn
 import androidx.compose.foundation.layout.offset
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.layout.wrapContentHeight
 import androidx.compose.foundation.lazy.LazyListState
 import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.lazy.rememberLazyListState
@@ -531,7 +535,7 @@ private fun CouponItem(
 
     WooPosCard(
         modifier = modifier
-            .height(96.dp)
+            .wrapContentHeight()
             .semantics { contentDescription = itemContentDescription },
         backgroundColor = MaterialTheme.colorScheme.surfaceContainerLowest,
         elevation = WooPosElevation.Medium,
@@ -539,8 +543,9 @@ private fun CouponItem(
         shape = RoundedCornerShape(WooPosCornerRadius.Medium.value),
     ) {
         Row(
+            modifier = Modifier.height(IntrinsicSize.Min),
             horizontalArrangement = Arrangement.SpaceBetween,
-            verticalAlignment = Alignment.CenterVertically
+            verticalAlignment = Alignment.CenterVertically,
         ) {
             Box(
                 modifier = Modifier
@@ -551,7 +556,9 @@ private fun CouponItem(
                             is CouponValidationState.Valid -> WooPosTheme.colors.success
                         }
                     )
-                    .size(96.dp),
+                    .width(96.dp)
+                    .fillMaxHeight()
+                    .heightIn(min = 96.dp),
                 contentAlignment = Alignment.Center
             ) {
                 Image(
@@ -574,6 +581,7 @@ private fun CouponItem(
                 modifier = Modifier
                     .weight(1f)
                     .padding(end = WooPosSpacing.Medium.value.toAdaptivePadding())
+                    .padding(vertical = WooPosSpacing.Small.value.toAdaptivePadding())
             ) {
                 WooPosText(
                     text = item.name,
@@ -589,7 +597,7 @@ private fun CouponItem(
                     text = item.summary,
                     style = WooPosTypography.BodySmall,
                     color = WooPosTheme.colors.onSurfaceVariantHighest,
-                    maxLines = 1,
+                    maxLines = 2,
                     overflow = TextOverflow.Ellipsis,
                     modifier = Modifier.clearAndSetSemantics { }
                 )
@@ -600,6 +608,8 @@ private fun CouponItem(
                         WooPosText(
                             text = stringResource(R.string.woopos_cart_coupon_invalid_subtitle),
                             style = WooPosTypography.BodySmall,
+                            maxLines = 2,
+                            overflow = TextOverflow.Ellipsis,
                             color = MaterialTheme.colorScheme.error,
                             modifier = Modifier.clearAndSetSemantics { }
                         )
@@ -609,6 +619,8 @@ private fun CouponItem(
                         WooPosText(
                             text = item.validationState.formattedDiscount,
                             style = WooPosTypography.BodySmall,
+                            maxLines = 2,
+                            overflow = TextOverflow.Ellipsis,
                             color = WooPosTheme.colors.success,
                             modifier = Modifier.clearAndSetSemantics { }
                         )

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/items/WooPosItemsList.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/items/WooPosItemsList.kt
@@ -6,6 +6,7 @@ import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.IntrinsicSize
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
@@ -13,9 +14,11 @@ import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.heightIn
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.layout.wrapContentHeight
 import androidx.compose.foundation.lazy.LazyListState
 import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.rememberScrollState
@@ -302,6 +305,7 @@ fun WooPosCouponCard(
 ) {
     WooPosCard(
         modifier = modifier
+            .wrapContentHeight()
             .semantics { contentDescription = itemContentDescription },
         shape = RoundedCornerShape(WooPosCornerRadius.Medium.value),
         backgroundColor = if (item.expiredState is Coupon.ExpiredState.Expired) {
@@ -315,7 +319,7 @@ fun WooPosCouponCard(
         Row(
             modifier = Modifier
                 .clickable(enabled = item.expiredState is Coupon.ExpiredState.NotExpired) { onItemClicked(item) }
-                .height(112.dp)
+                .height(IntrinsicSize.Min)
                 .fillMaxWidth(),
             verticalAlignment = Alignment.CenterVertically
         ) {
@@ -334,8 +338,9 @@ private fun CouponInfo(name: String, summary: String, expiredState: Coupon.Expir
         modifier = Modifier
             .fillMaxHeight()
             .padding(
-                end = WooPosSpacing.Medium.value
-            ),
+                end = WooPosSpacing.Medium.value,
+            )
+            .padding(vertical = WooPosSpacing.Small.value.toAdaptivePadding()),
         verticalArrangement = Arrangement.Center
     ) {
         WooPosText(
@@ -380,7 +385,9 @@ private fun CouponInfo(name: String, summary: String, expiredState: Coupon.Expir
 private fun CouponImage(expiredState: Coupon.ExpiredState) {
     Box(
         modifier = Modifier
-            .size(112.dp)
+            .width(112.dp)
+            .fillMaxHeight()
+            .heightIn(min = 112.dp)
             .background(MaterialTheme.colorScheme.surfaceDim),
         contentAlignment = Alignment.Center
     ) {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/items/WooPosItemsList.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/items/WooPosItemsList.kt
@@ -361,6 +361,7 @@ private fun CouponInfo(name: String, summary: String, expiredState: Coupon.Expir
         WooPosText(
             text = summary,
             maxLines = 1,
+            overflow = TextOverflow.Ellipsis,
             style = WooPosTypography.BodyLarge,
             color = if (expiredState is Coupon.ExpiredState.Expired) {
                 WooPosTheme.colors.onDisabledContainer


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #WOOMOB-417
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

This PR adjust layouts to accommodate bigger font sizes after the introduction of coupons into the POS. It also updates size restrictions for buttons in the POS.

### Testing information
<!-- This is your opportunity to break out individual scenarios that need testing (when necessary) and/or include a checklist for the reviewer to go through. Consider documenting the following from your own completed testing: devices used, alternate workflows, edge cases, affected areas, critical flows, areas not tested, and any remaining unknowns. Provide feedback on this new section of the PR template through Sept 30, 2024 to Apps Quality; additional context here: p91TBi-b8z-p2#comment-12036 -->

Test coupon flows with increased font sizes as well as with default ones to make sure it doesn't cause regressions.

### The tests that have been performed
<!-- To give the reviewer an idea of what could be missed in terms of testing -->
- Adding coupon
- Removing coupon
- Valid coupon
- Invalid coupon
- Expired coupon

### Images/gif
<!-- Include before and after images or gifs when appropriate. -->

### Default Font
| Before | After |
| -- | -- |
| ![Screenshot_20250513_145123](https://github.com/user-attachments/assets/ce188969-9a33-4e31-8b17-c214ea4354cb) | ![Screenshot_20250513_135614](https://github.com/user-attachments/assets/12396754-dd97-4448-8c3a-1687fbeb9ce1) |
| ![Screenshot_20250513_145044](https://github.com/user-attachments/assets/78c902e1-9585-4476-993a-aa389e1ee6f3) | ![Screenshot_20250513_133913](https://github.com/user-attachments/assets/659404ed-ae08-4b61-b99b-00296d839078) |
| ![Screenshot_20250513_145059](https://github.com/user-attachments/assets/4e970640-c974-46f8-b603-95f5ee515ba5) | ![Screenshot_20250513_133929](https://github.com/user-attachments/assets/ec3b5643-dbd7-471d-83ed-690a399a9447) |

### Increased Font Size
| Before | After |
| -- | -- |
| ![Screenshot_20250513_145155](https://github.com/user-attachments/assets/b61e1dbf-6ffe-4a65-8cbe-0069f69211a4) | ![Screenshot_20250513_135438](https://github.com/user-attachments/assets/fe2fccdb-0c9b-455c-9bdc-49cc6e8a3d7b) |
| ![Screenshot_20250513_145203](https://github.com/user-attachments/assets/a114cd4a-979e-4c61-812a-d69a9adc0e71) | ![Screenshot_20250513_135449](https://github.com/user-attachments/assets/1b72fae4-65e1-4ba5-9078-772710a607bd) |
| ![Screenshot_20250513_145218](https://github.com/user-attachments/assets/07e59a09-1a35-489c-bcd2-b15dee9b31d9) | ![Screenshot_20250513_135513](https://github.com/user-attachments/assets/6622ae76-44b8-48c3-b314-0a6ad15cd0f3) |






- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.

## Reviewer (or Author, in the case of optional code reviews):

Please make sure these conditions are met before approving the PR, or request changes if the PR needs improvement:

- [x] The PR is small and has a clear, single focus, or a valid explanation is provided in the description. If needed, please request to split it into smaller PRs.
- [x] Ensure Adequate Unit Test Coverage: The changes are reasonably covered by unit tests or an explanation is provided in the PR description.
- [x] Manual Testing: The author listed all the tests they ran, including smoke tests when needed (e.g., for refactorings). The reviewer confirmed that the PR works as expected on big (tablet) and small (phone) in case of UI changes, and no regressions are added.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->