### PR TITLE
[WOOPRD-509][Woo POS][Products Search] Perform only remote request when retry button clicked

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/items/search/WooPosItemsSearchViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/items/search/WooPosItemsSearchViewModel.kt
@@ -75,10 +75,7 @@ class WooPosItemsSearchViewModel @Inject constructor(
         when (event) {
             WooPosItemsSearchUiEvent.OnNextPageRequested -> onEndOfListReached()
             is WooPosItemsSearchUiEvent.OnItemClicked -> handleItemClicked(event.item, WooPosItemSource.SEARCH_RESULT)
-            WooPosItemsSearchUiEvent.LoadingErrorRetryButtonClicked -> {
-                val currentState = _viewState.value as? WooPosItemsSearchViewState.Error ?: return
-                performSearch(currentState.searchQuery)
-            }
+            WooPosItemsSearchUiEvent.LoadingErrorRetryButtonClicked -> handleLoadingErrorRetryClick()
 
             is WooPosItemsSearchUiEvent.OnRecentSearchClicked -> {
                 viewModelScope.launch {
@@ -98,6 +95,13 @@ class WooPosItemsSearchViewModel @Inject constructor(
                 }
             }
         }
+    }
+
+    private fun handleLoadingErrorRetryClick() {
+        val currentState = _viewState.value as? WooPosItemsSearchViewState.Error ?: return
+
+        _viewState.value = WooPosItemsSearchViewState.Loading
+        performRemoteSearch(currentState.searchQuery)
     }
 
     private fun performSearch(query: String) {


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #WOOPRD-509
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
The PR fixes a bug where the cached data is displayed instead of a loading screen when the "retry" button is clicked in the search error state.

### Steps to reproduce
<!-- Step-by-step testing instructions. For new user flows, consider instead stating the goal of the workflow and see if your PR reviewer can accomplish the workflow without specific steps! -->
* Open POS
* Open Search
* Disable internet
* Try to search
* Click on retry
* Notice the cached data visible for a second

### The tests that have been performed
<!-- To give the reviewer an idea of what could be missed in terms of testing -->
above

### Images/gif
<!-- Include before and after images or gifs when appropriate. -->

https://github.com/user-attachments/assets/8afc8797-6470-4d31-9dc5-4fb554901444


- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.

## Reviewer (or Author, in the case of optional code reviews):

Please make sure these conditions are met before approving the PR, or request changes if the PR needs improvement:

- [ ] The PR is small and has a clear, single focus, or a valid explanation is provided in the description. If needed, please request to split it into smaller PRs.
- [ ] Ensure Adequate Unit Test Coverage: The changes are reasonably covered by unit tests or an explanation is provided in the PR description.
- [ ] Manual Testing: The author listed all the tests they ran, including smoke tests when needed (e.g., for refactorings). The reviewer confirmed that the PR works as expected on big (tablet) and small (phone) in case of UI changes, and no regressions are added.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->