### PR TITLE
[WOOMOB-479] Cancel create draft job on back/up press

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/totals/WooPosTotalsViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/totals/WooPosTotalsViewModel.kt
@@ -40,6 +40,7 @@ import com.woocommerce.android.util.WooLogWrapper
 import com.woocommerce.android.viewmodel.ResourceProvider
 import com.woocommerce.android.viewmodel.getStateFlow
 import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.Job
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
@@ -81,6 +82,8 @@ class WooPosTotalsViewModel @Inject constructor(
         )
 
     val state: StateFlow<WooPosTotalsViewState> = uiState
+
+    private var createDraftOrderJob: Job? = null
 
     private val dataState: MutableStateFlow<TotalsDataState> = savedState.getStateFlow(
         scope = viewModelScope,
@@ -139,6 +142,10 @@ class WooPosTotalsViewModel @Inject constructor(
     private fun cancelPaymentAction() {
         cardReaderPaymentController?.onBackPressed()
         cardReaderPaymentController?.stop()
+    }
+
+    private fun cancelCreateOrderDraftAction() {
+        createDraftOrderJob?.cancel()
     }
 
     fun onUIEvent(event: WooPosTotalsUIEvent) {
@@ -226,7 +233,10 @@ class WooPosTotalsViewModel @Inject constructor(
                     retryPaymentCollectionFromScratch()
                 }
 
-                else -> childrenToParentEventSender.sendToParent(ChildToParentEvent.BackFromCheckoutToCartClicked)
+                else -> {
+                    cancelCreateOrderDraftAction()
+                    childrenToParentEventSender.sendToParent(ChildToParentEvent.BackFromCheckoutToCartClicked)
+                }
             }
         }
     }
@@ -288,6 +298,7 @@ class WooPosTotalsViewModel @Inject constructor(
 
                     is ParentToChildrenEvent.BackFromCheckoutToCartClicked -> {
                         cancelPaymentAction()
+                        cancelCreateOrderDraftAction()
                         uiState.value = InitialState
                     }
 
@@ -442,7 +453,8 @@ class WooPosTotalsViewModel @Inject constructor(
     }
 
     private fun createOrderDraft(itemClickedDataList: List<WooPosItemsViewModel.ItemClickedData>) {
-        viewModelScope.launch {
+        createDraftOrderJob?.cancel()
+        createDraftOrderJob = viewModelScope.launch {
             uiState.value = WooPosTotalsViewState.Loading
 
             totalsRepository.createOrderFromCartItems(itemClickedDataList = itemClickedDataList)
@@ -452,6 +464,7 @@ class WooPosTotalsViewModel @Inject constructor(
                         onCreateOrderDraftFails(error)
                     }
                 )
+            createDraftOrderJob = null
         }
     }
 

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/home/totals/WooPosTotalsViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/home/totals/WooPosTotalsViewModelTest.kt
@@ -57,9 +57,11 @@ import com.woocommerce.android.util.WooLogWrapper
 import com.woocommerce.android.viewmodel.ResourceProvider
 import junit.framework.TestCase.assertTrue
 import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.flow
+import kotlinx.coroutines.test.advanceTimeBy
 import kotlinx.coroutines.test.advanceUntilIdle
 import kotlinx.coroutines.test.runTest
 import org.assertj.core.api.Assertions.assertThat
@@ -69,6 +71,7 @@ import org.mockito.kotlin.any
 import org.mockito.kotlin.argThat
 import org.mockito.kotlin.argumentCaptor
 import org.mockito.kotlin.clearInvocations
+import org.mockito.kotlin.doSuspendableAnswer
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.never
 import org.mockito.kotlin.verify
@@ -1452,16 +1455,17 @@ class WooPosTotalsViewModelTest {
         }
 
     @Test
-    fun `when GoBackToCheckoutAfterFailedCouponValidation clicked, then should send BackFromCheckoutToCartClicked event`() = runTest {
-        // GIVEN
-        val viewModel = createViewModelAndSetupForSuccessfulOrderCreation(couponLines = emptyList())
+    fun `when GoBackToCheckoutAfterFailedCouponValidation clicked, then should send BackFromCheckoutToCartClicked event`() =
+        runTest {
+            // GIVEN
+            val viewModel = createViewModelAndSetupForSuccessfulOrderCreation(couponLines = emptyList())
 
-        // WHEN
-        viewModel.onUIEvent(WooPosTotalsUIEvent.GoBackToCheckoutAfterFailedCouponValidation)
+            // WHEN
+            viewModel.onUIEvent(WooPosTotalsUIEvent.GoBackToCheckoutAfterFailedCouponValidation)
 
-        // THEN
-        verify(childrenToParentEventSender).sendToParent(BackFromCheckoutToCartClicked)
-    }
+            // THEN
+            verify(childrenToParentEventSender).sendToParent(BackFromCheckoutToCartClicked)
+        }
 
     @Test
     fun `when OnRemoveCouponsClicked is triggered, then should send RemoveCouponsClicked event`() = runTest {
@@ -1532,6 +1536,39 @@ class WooPosTotalsViewModelTest {
         // THEN
         assertThat(viewModel.state.value).isInstanceOf(WooPosTotalsViewState.InvalidCouponError::class.java)
     }
+
+    @Test
+    fun `given order draft creation in progress, when back clicked, then order draft job should be canceled`() =
+        runTest {
+            // GIVEN
+            val itemClickedData = listOf(
+                WooPosItemsViewModel.ItemClickedData.Product.Simple(id = 1L)
+            )
+            val parentToChildrenEventFlow = MutableStateFlow(ParentToChildrenEvent.CheckoutClicked(itemClickedData))
+            val parentToChildrenEventReceiver: WooPosParentToChildrenEventReceiver = mock {
+                on { events }.thenReturn(parentToChildrenEventFlow)
+            }
+
+            val totalsRepository: WooPosTotalsRepository = mock {
+                onBlocking { createOrderFromCartItems(itemClickedData) }.doSuspendableAnswer {
+                    delay(2000)
+                    Result.success(createNonEmptyOrder())
+                }
+            }
+            val viewModel = createViewModel(
+                parentToChildrenEventReceiver = parentToChildrenEventReceiver,
+                totalsRepository = totalsRepository,
+            )
+
+            // WHEN
+            // Wait a bit to ensure order creation started but hasn't completed yet
+            advanceTimeBy(100)
+            viewModel.onUIEvent(OnBackClicked)
+
+            // THEN
+            advanceUntilIdle()
+            verify(childrenToParentEventSender, never()).sendToParent(argThat { this is OrderCreated })
+        }
 
     private fun mockPaymentFailedTexts() {
         whenever(resourceProvider.getString(R.string.woopos_success_totals_payment_processing_title))


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #WOOMOB-479
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

This PR fixes a bug which was causing coupon items in the cart to change state upon arrival of the `create order` request, even if the user was no longer on the checkout screen. The fix cancels the `create order` job when the user moves back to Item selection screen - saving some resources and fixing this issue.

### Steps to reproduce
<!-- Step-by-step testing instructions. For new user flows, consider instead stating the goal of the workflow and see if your PR reviewer can accomplish the workflow without specific steps! -->

1. Open POS
2. Add product to the cart
3. Add coupon to the cart
4. Tap on checkout
5. Tap on Up or press the back button
6. Wait for a bit - notice the coupon in the cart is marked as valid/invalid even though we are on the item selection screen

### Testing information
<!-- This is your opportunity to break out individual scenarios that need testing (when necessary) and/or include a checklist for the reviewer to go through. Consider documenting the following from your own completed testing: devices used, alternate workflows, edge cases, affected areas, critical flows, areas not tested, and any remaining unknowns. Provide feedback on this new section of the PR template through Sept 30, 2024 to Apps Quality; additional context here: p91TBi-b8z-p2#comment-12036 -->

1. Open POS
2. Add product to the cart
3. Add coupon to the cart
4. Tap on checkout
5. Tap on Up or press the back button
6. Wait for a bit - notice the coupon remains generic - it's not green or red.

### The tests that have been performed
<!-- To give the reviewer an idea of what could be missed in terms of testing -->

I have tested this flow works with both back and up buttons. I also tested the checkout works as expected if I don't press the back button or if I press it and then go to checkout again.

### Images/gif
<!-- Include before and after images or gifs when appropriate. -->
Before 

https://github.com/user-attachments/assets/30828a45-57ff-404c-bdec-85d0edc8b8a7

After

https://github.com/user-attachments/assets/b87a65a9-70ed-4025-831b-2c8a29a1e578

- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.

## Reviewer (or Author, in the case of optional code reviews):

Please make sure these conditions are met before approving the PR, or request changes if the PR needs improvement:

- [ ] The PR is small and has a clear, single focus, or a valid explanation is provided in the description. If needed, please request to split it into smaller PRs.
- [ ] Ensure Adequate Unit Test Coverage: The changes are reasonably covered by unit tests or an explanation is provided in the PR description.
- [ ] Manual Testing: The author listed all the tests they ran, including smoke tests when needed (e.g., for refactorings). The reviewer confirmed that the PR works as expected on big (tablet) and small (phone) in case of UI changes, and no regressions are added.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->