### PR TITLE
[WOOMOB-483] Fetch coupons if not available in cache

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/cart/WooPosCartViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/cart/WooPosCartViewModel.kt
@@ -143,7 +143,7 @@ class WooPosCartViewModel @Inject constructor(
                     id = it.variationId
                 )
 
-                is WooPosCartItemViewState.Coupon -> WooPosItemsViewModel.ItemClickedData.Coupon(it.id)
+                is WooPosCartItemViewState.Coupon -> WooPosItemsViewModel.ItemClickedData.Coupon(it.id, it.name)
             }
         }
         return itemClickedDataList

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/items/WooPosItemsViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/items/WooPosItemsViewModel.kt
@@ -116,11 +116,11 @@ class WooPosItemsViewModel @Inject constructor(
 
     private fun createAndAddCoupon() {
         viewModelScope.launch {
-            val couponId = couponCreationFacade.createCoupon()
-            if (couponId != null) {
+            val coupon = couponCreationFacade.createCoupon()
+            if (coupon != null) {
                 fromChildToParentEventSender.sendToParent(
                     ChildToParentEvent.ItemClickedInProductSelector(
-                        itemData = ItemClickedData.Coupon(couponId),
+                        itemData = ItemClickedData.Coupon(coupon.id, coupon.code ?: ""),
                         source = WooPosItemSource.COUPON_LIST
                     )
                 )
@@ -140,6 +140,6 @@ class WooPosItemsViewModel @Inject constructor(
         }
 
         @Parcelize
-        data class Coupon(override val id: Long) : ItemClickedData(id), Parcelable
+        data class Coupon(override val id: Long, val couponCode: String) : ItemClickedData(id), Parcelable
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/items/coupons/WooPosCouponsScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/items/coupons/WooPosCouponsScreen.kt
@@ -76,7 +76,7 @@ private fun WooPosCouponsScreen(
                     modifier = Modifier.padding(top = WooPosSpacing.Large.value),
                     state = itemsState,
                     listState = listState,
-                    onItemClicked = { item -> onUIEvent(WooPosCouponsUIEvent.CouponClicked(item.id)) },
+                    onItemClicked = { item -> onUIEvent(WooPosCouponsUIEvent.CouponClicked(item.id, item.name)) },
                     onEndOfProductsListReached = { onUIEvent(WooPosCouponsUIEvent.EndOfListReached) },
                 ) {
                     CouponsPaginationError(

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/items/coupons/WooPosCouponsUIEvent.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/items/coupons/WooPosCouponsUIEvent.kt
@@ -5,7 +5,7 @@ sealed class WooPosCouponsUIEvent {
     data object PullToRefreshTriggered : WooPosCouponsUIEvent()
     data object RetryLoadMoreTriggered : WooPosCouponsUIEvent()
     data object RetryTriggered : WooPosCouponsUIEvent()
-    data class CouponClicked(val couponId: Long) : WooPosCouponsUIEvent()
+    data class CouponClicked(val couponId: Long, val couponCode: String) : WooPosCouponsUIEvent()
     data object CreateCouponClicked : WooPosCouponsUIEvent()
     data object BackButtonClicked : WooPosCouponsUIEvent()
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/items/coupons/WooPosCouponsViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/items/coupons/WooPosCouponsViewModel.kt
@@ -103,7 +103,7 @@ class WooPosCouponsViewModel @Inject constructor(
             fromChildToParentEventSender.sendToParent(
                 // CouponsProject: rename ItemClickedInProductSelector to ItemClicked
                 ChildToParentEvent.ItemClickedInProductSelector(
-                    itemData = ItemClickedData.Coupon(event.couponId),
+                    itemData = ItemClickedData.Coupon(event.couponId, event.couponCode),
                     source = WooPosItemSource.COUPON_LIST
                 )
             )
@@ -112,11 +112,11 @@ class WooPosCouponsViewModel @Inject constructor(
 
     private fun createAndAddCoupon() {
         viewModelScope.launch {
-            val couponId = couponCreationFacade.createCoupon()
-            if (couponId != null) {
+            val coupon = couponCreationFacade.createCoupon()
+            if (coupon != null) {
                 fromChildToParentEventSender.sendToParent(
                     ChildToParentEvent.ItemClickedInProductSelector(
-                        itemData = ItemClickedData.Coupon(couponId),
+                        itemData = ItemClickedData.Coupon(coupon.id, coupon.code ?: ""),
                         source = WooPosItemSource.COUPON_LIST
                     )
                 )

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/items/coupons/creation/WooPosCouponCreationFacade.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/items/coupons/creation/WooPosCouponCreationFacade.kt
@@ -7,6 +7,8 @@ import androidx.appcompat.app.AppCompatActivity
 import androidx.core.app.ActivityOptionsCompat
 import androidx.lifecycle.DefaultLifecycleObserver
 import androidx.lifecycle.LifecycleOwner
+import com.woocommerce.android.model.Coupon
+import com.woocommerce.android.ui.woopos.common.data.WooPosGetCouponById
 import dagger.hilt.android.scopes.ActivityRetainedScoped
 import kotlinx.coroutines.CancellableContinuation
 import kotlinx.coroutines.Dispatchers
@@ -25,7 +27,9 @@ import kotlin.coroutines.resume
  * landscape and not receiving result of the newly created coupon isn't critical.
  */
 @ActivityRetainedScoped
-class WooPosCouponCreationFacade @Inject constructor() : DefaultLifecycleObserver {
+class WooPosCouponCreationFacade @Inject constructor(
+    private val getCouponById: WooPosGetCouponById,
+) : DefaultLifecycleObserver {
     private var activityWR: WeakReference<AppCompatActivity>? = null
 
     private var couponCreationLauncher: ActivityResultLauncher<Intent>? = null
@@ -50,12 +54,14 @@ class WooPosCouponCreationFacade @Inject constructor() : DefaultLifecycleObserve
         activityWR = null
     }
 
-    suspend fun createCoupon(): Long? = withContext(Dispatchers.Main) {
+    suspend fun createCoupon(): Coupon? = withContext(Dispatchers.Main) {
         val currentActivityWR = activityWR ?: return@withContext null
 
         suspendCancellableCoroutine { continuation ->
             cancellableContinuation = continuation
             currentActivityWR.get()?.let { launchCouponCreationActivity(it) } ?: continuation.resume(null)
+        }?.let { couponId ->
+            getCouponById(couponId)
         }
     }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/totals/WooPosTotalsRepository.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/totals/WooPosTotalsRepository.kt
@@ -4,7 +4,6 @@ import com.woocommerce.android.model.Order
 import com.woocommerce.android.model.OrderMapper
 import com.woocommerce.android.tools.SelectedSite
 import com.woocommerce.android.ui.orders.creation.OrderCreateEditRepository
-import com.woocommerce.android.ui.woopos.common.data.WooPosGetCouponById
 import com.woocommerce.android.ui.woopos.common.data.WooPosGetProductById
 import com.woocommerce.android.ui.woopos.common.data.WooPosGetVariationById
 import com.woocommerce.android.ui.woopos.home.items.WooPosItemsViewModel
@@ -23,7 +22,6 @@ class WooPosTotalsRepository @Inject constructor(
     private val orderCreateEditRepository: OrderCreateEditRepository,
     private val dateUtils: DateUtils,
     private val getProductById: WooPosGetProductById,
-    private val getCouponById: WooPosGetCouponById,
     private val getVariationById: WooPosGetVariationById,
     private val orderStore: WCOrderStore,
     private val selectedSite: SelectedSite,
@@ -83,19 +81,13 @@ class WooPosTotalsRepository @Inject constructor(
             }
     }
 
-    private suspend fun createCouponLines(coupons: List<WooPosItemsViewModel.ItemClickedData.Coupon>):
-        List<Order.CouponLine> {
-        return coupons.map { (id) ->
-            createCouponOrderItem(id)
+    private fun createCouponLines(coupons: List<WooPosItemsViewModel.ItemClickedData.Coupon>): List<Order.CouponLine> {
+        return coupons.map { item ->
+            Order.CouponLine(
+                id = item.id,
+                code = item.couponCode,
+            )
         }
-    }
-
-    private suspend fun createCouponOrderItem(id: Long): Order.CouponLine {
-        val couponResult = getCouponById(id)!!
-        return Order.CouponLine(
-            id = id,
-            code = couponResult.code ?: "",
-        )
     }
 
     private suspend fun createSimpleProductOrderItem(

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/totals/WooPosTotalsRepository.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/totals/WooPosTotalsRepository.kt
@@ -4,17 +4,19 @@ import com.woocommerce.android.model.Order
 import com.woocommerce.android.model.OrderMapper
 import com.woocommerce.android.tools.SelectedSite
 import com.woocommerce.android.ui.orders.creation.OrderCreateEditRepository
-import com.woocommerce.android.ui.woopos.common.data.WooPosGetCouponById
 import com.woocommerce.android.ui.woopos.common.data.WooPosGetProductById
 import com.woocommerce.android.ui.woopos.common.data.WooPosGetVariationById
 import com.woocommerce.android.ui.woopos.home.items.WooPosItemsViewModel
 import com.woocommerce.android.ui.woopos.home.items.variations.getNameForPOS
 import com.woocommerce.android.util.DateUtils
+import com.woocommerce.android.util.WooLog
+import com.woocommerce.android.util.WooLogWrapper
 import com.woocommerce.android.viewmodel.ResourceProvider
 import kotlinx.coroutines.Deferred
 import kotlinx.coroutines.Dispatchers.IO
 import kotlinx.coroutines.async
 import kotlinx.coroutines.withContext
+import org.wordpress.android.fluxc.store.CouponStore
 import org.wordpress.android.fluxc.store.WCOrderStore
 import java.util.Date
 import javax.inject.Inject
@@ -23,12 +25,13 @@ class WooPosTotalsRepository @Inject constructor(
     private val orderCreateEditRepository: OrderCreateEditRepository,
     private val dateUtils: DateUtils,
     private val getProductById: WooPosGetProductById,
-    private val getCouponById: WooPosGetCouponById,
+    private val couponStore: CouponStore,
     private val getVariationById: WooPosGetVariationById,
     private val orderStore: WCOrderStore,
     private val selectedSite: SelectedSite,
     private val orderMapper: OrderMapper,
     private val resourceProvider: ResourceProvider,
+    private val logWrapper: WooLogWrapper,
 ) {
     private var orderCreationJob: Deferred<Result<Order>>? = null
 
@@ -42,7 +45,12 @@ class WooPosTotalsRepository @Inject constructor(
         return withContext(IO) {
             check(itemClickedDataList.all { it.id >= 0 }) { "Invalid item ID" }
             orderCreationJob = async {
-                val order = createOrder(itemClickedDataList)
+                val order = try {
+                    createOrder(itemClickedDataList)
+                } catch (e: CouponNotFoundException) {
+                    logWrapper.e(WooLog.T.POS, e.message)
+                    return@async Result.failure(e)
+                }
                 orderCreateEditRepository.createOrUpdateOrder(order)
             }
             orderCreationJob!!.await()
@@ -91,10 +99,15 @@ class WooPosTotalsRepository @Inject constructor(
     }
 
     private suspend fun createCouponOrderItem(id: Long): Order.CouponLine {
-        val couponResult = getCouponById(id)!!
+        val result = couponStore.getCoupon(selectedSite.get(), id)
+            ?: run {
+                couponStore.fetchCoupon(selectedSite.get(), id)
+                couponStore.getCoupon(selectedSite.get(), id)
+                    ?: throw CouponNotFoundException("Coupon with ID $id not found in database")
+            }
         return Order.CouponLine(
             id = id,
-            code = couponResult.code ?: "",
+            code = result.coupon.code ?: "",
         )
     }
 
@@ -144,6 +157,8 @@ class WooPosTotalsRepository @Inject constructor(
             orderMapper.toAppModel(it)
         }
     }
+
+    private class CouponNotFoundException(override val message: String) : Throwable()
 
     private companion object {
         /**

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/totals/WooPosTotalsRepository.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/totals/WooPosTotalsRepository.kt
@@ -4,19 +4,17 @@ import com.woocommerce.android.model.Order
 import com.woocommerce.android.model.OrderMapper
 import com.woocommerce.android.tools.SelectedSite
 import com.woocommerce.android.ui.orders.creation.OrderCreateEditRepository
+import com.woocommerce.android.ui.woopos.common.data.WooPosGetCouponById
 import com.woocommerce.android.ui.woopos.common.data.WooPosGetProductById
 import com.woocommerce.android.ui.woopos.common.data.WooPosGetVariationById
 import com.woocommerce.android.ui.woopos.home.items.WooPosItemsViewModel
 import com.woocommerce.android.ui.woopos.home.items.variations.getNameForPOS
 import com.woocommerce.android.util.DateUtils
-import com.woocommerce.android.util.WooLog
-import com.woocommerce.android.util.WooLogWrapper
 import com.woocommerce.android.viewmodel.ResourceProvider
 import kotlinx.coroutines.Deferred
 import kotlinx.coroutines.Dispatchers.IO
 import kotlinx.coroutines.async
 import kotlinx.coroutines.withContext
-import org.wordpress.android.fluxc.store.CouponStore
 import org.wordpress.android.fluxc.store.WCOrderStore
 import java.util.Date
 import javax.inject.Inject
@@ -25,13 +23,12 @@ class WooPosTotalsRepository @Inject constructor(
     private val orderCreateEditRepository: OrderCreateEditRepository,
     private val dateUtils: DateUtils,
     private val getProductById: WooPosGetProductById,
-    private val couponStore: CouponStore,
+    private val getCouponById: WooPosGetCouponById,
     private val getVariationById: WooPosGetVariationById,
     private val orderStore: WCOrderStore,
     private val selectedSite: SelectedSite,
     private val orderMapper: OrderMapper,
     private val resourceProvider: ResourceProvider,
-    private val logWrapper: WooLogWrapper,
 ) {
     private var orderCreationJob: Deferred<Result<Order>>? = null
 
@@ -45,12 +42,7 @@ class WooPosTotalsRepository @Inject constructor(
         return withContext(IO) {
             check(itemClickedDataList.all { it.id >= 0 }) { "Invalid item ID" }
             orderCreationJob = async {
-                val order = try {
-                    createOrder(itemClickedDataList)
-                } catch (e: CouponNotFoundException) {
-                    logWrapper.e(WooLog.T.POS, e.message)
-                    return@async Result.failure(e)
-                }
+                val order = createOrder(itemClickedDataList)
                 orderCreateEditRepository.createOrUpdateOrder(order)
             }
             orderCreationJob!!.await()
@@ -99,15 +91,10 @@ class WooPosTotalsRepository @Inject constructor(
     }
 
     private suspend fun createCouponOrderItem(id: Long): Order.CouponLine {
-        val result = couponStore.getCoupon(selectedSite.get(), id)
-            ?: run {
-                couponStore.fetchCoupon(selectedSite.get(), id)
-                couponStore.getCoupon(selectedSite.get(), id)
-                    ?: throw CouponNotFoundException("Coupon with ID $id not found in database")
-            }
+        val couponResult = getCouponById(id)!!
         return Order.CouponLine(
             id = id,
-            code = result.coupon.code ?: "",
+            code = couponResult.code ?: "",
         )
     }
 
@@ -157,8 +144,6 @@ class WooPosTotalsRepository @Inject constructor(
             orderMapper.toAppModel(it)
         }
     }
-
-    private class CouponNotFoundException(override val message: String) : Throwable()
 
     private companion object {
         /**

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/coupons/CouponTestUtils.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/coupons/CouponTestUtils.kt
@@ -7,10 +7,10 @@ import java.math.BigDecimal
 import java.util.Date
 
 object CouponTestUtils {
-    fun generateTestCoupon(couponId: Long): Coupon {
+    fun generateTestCoupon(couponId: Long, code: String = "code1337"): Coupon {
         return Coupon(
             id = couponId,
-            code = "code1337",
+            code = code,
             amount = BigDecimal.TEN,
             dateCreatedGmt = Date(),
             type = Coupon.Type.FixedCart,

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/home/cart/WooPosCartViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/home/cart/WooPosCartViewModelTest.kt
@@ -752,7 +752,7 @@ class WooPosCartViewModelTest {
         val states = sut.state.captureValues()
         parentToChildrenEventsMutableFlow.emit(
             ParentToChildrenEvent.ItemClickedInProductSelector(
-                itemData = WooPosItemsViewModel.ItemClickedData.Coupon(id = 1L),
+                itemData = WooPosItemsViewModel.ItemClickedData.Coupon(id = 1L, couponCode = ""),
                 source = WooPosItemSource.COUPON_LIST,
             )
         )
@@ -777,13 +777,13 @@ class WooPosCartViewModelTest {
         val states = sut.state.captureValues()
         parentToChildrenEventsMutableFlow.emit(
             ParentToChildrenEvent.ItemClickedInProductSelector(
-                itemData = WooPosItemsViewModel.ItemClickedData.Coupon(id = 1L),
+                itemData = WooPosItemsViewModel.ItemClickedData.Coupon(id = 1L, couponCode = ""),
                 source = WooPosItemSource.COUPON_LIST
             )
         )
         parentToChildrenEventsMutableFlow.emit(
             ParentToChildrenEvent.ItemClickedInProductSelector(
-                itemData = WooPosItemsViewModel.ItemClickedData.Coupon(id = 2L),
+                itemData = WooPosItemsViewModel.ItemClickedData.Coupon(id = 2L, couponCode = ""),
                 source = WooPosItemSource.COUPON_LIST
             )
         )
@@ -823,7 +823,7 @@ class WooPosCartViewModelTest {
         createSut()
         parentToChildrenEventsMutableFlow.emit(
             ParentToChildrenEvent.ItemClickedInProductSelector(
-                itemData = WooPosItemsViewModel.ItemClickedData.Coupon(id = 2L),
+                itemData = WooPosItemsViewModel.ItemClickedData.Coupon(id = 2L, couponCode = ""),
                 source = WooPosItemSource.COUPON_LIST
             )
         )
@@ -857,7 +857,7 @@ class WooPosCartViewModelTest {
         val states = sut.state.captureValues()
         parentToChildrenEventsMutableFlow.emit(
             ParentToChildrenEvent.ItemClickedInProductSelector(
-                itemData = WooPosItemsViewModel.ItemClickedData.Coupon(id = 1L),
+                itemData = WooPosItemsViewModel.ItemClickedData.Coupon(id = 1L, couponCode = ""),
                 source = WooPosItemSource.COUPON_LIST
             )
         )
@@ -990,7 +990,7 @@ class WooPosCartViewModelTest {
     private suspend fun simulateCouponClicked(couponId: Long = 1L) {
         parentToChildrenMutableSharedFlow.emit(
             ParentToChildrenEvent.ItemClickedInProductSelector(
-                itemData = WooPosItemsViewModel.ItemClickedData.Coupon(id = couponId),
+                itemData = WooPosItemsViewModel.ItemClickedData.Coupon(id = couponId, couponCode = ""),
                 source = WooPosItemSource.COUPON_LIST
             ),
 

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/home/items/WooPosItemsViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/home/items/WooPosItemsViewModelTest.kt
@@ -2,6 +2,7 @@ package com.woocommerce.android.ui.woopos.home.items
 
 import app.cash.turbine.test
 import com.woocommerce.android.R
+import com.woocommerce.android.ui.coupons.CouponTestUtils
 import com.woocommerce.android.ui.woopos.common.composeui.component.WooPosSearchInputState
 import com.woocommerce.android.ui.woopos.home.ChildToParentEvent
 import com.woocommerce.android.ui.woopos.home.WooPosChildrenToParentEventSender
@@ -186,7 +187,7 @@ class WooPosItemsViewModelTest {
     @Test
     fun `when add coupon icon is tapped, then newly created coupon added to cart`() = runTest {
         // GIVEN
-        whenever(couponCreationFacade.createCoupon()).thenReturn(1L)
+        whenever(couponCreationFacade.createCoupon()).thenReturn(CouponTestUtils.generateTestCoupon(1L, "test"))
         val viewModel = createViewModel()
 
         // WHEN
@@ -195,7 +196,7 @@ class WooPosItemsViewModelTest {
         // THEN
         verify(fromChildToParentEventSender).sendToParent(
             ChildToParentEvent.ItemClickedInProductSelector(
-                itemData = ItemClickedData.Coupon(1L),
+                itemData = ItemClickedData.Coupon(1L, "test"),
                 source = WooPosItemSource.COUPON_LIST
             )
         )

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/home/items/coupons/WooPosCouponsViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/home/items/coupons/WooPosCouponsViewModelTest.kt
@@ -1,5 +1,6 @@
 package com.woocommerce.android.ui.woopos.home.items.coupons
 
+import com.woocommerce.android.ui.coupons.CouponTestUtils
 import com.woocommerce.android.ui.woopos.home.ChildToParentEvent
 import com.woocommerce.android.ui.woopos.home.WooPosChildrenToParentEventSender
 import com.woocommerce.android.ui.woopos.home.items.WooPosCouponsViewState
@@ -52,14 +53,15 @@ class WooPosCouponsViewModelTest {
     fun `when coupon clicked, then send item clicked event`() = runTest {
         // GIVEN
         val couponId = 123L
+        val couponCode = "test coupon"
 
         // WHEN
-        viewModel.onUIEvent(CouponClicked(couponId))
+        viewModel.onUIEvent(CouponClicked(couponId, couponCode))
 
         // THEN
         verify(fromChildToParentEventSender).sendToParent(
             ChildToParentEvent.ItemClickedInProductSelector(
-                itemData = ItemClickedData.Coupon(couponId),
+                itemData = ItemClickedData.Coupon(couponId, couponCode),
                 source = WooPosItemSource.COUPON_LIST
             )
         )
@@ -130,7 +132,8 @@ class WooPosCouponsViewModelTest {
     @Test
     fun `when add coupon icon is tapped, then newly created coupon added to cart`() = runTest {
         // GIVEN
-        whenever(couponCreationFacade.createCoupon()).thenReturn(1L)
+        whenever(couponCreationFacade.createCoupon())
+            .thenReturn(CouponTestUtils.generateTestCoupon(1L, "test coupon"))
         val viewModel = createViewModel()
 
         // WHEN
@@ -139,7 +142,7 @@ class WooPosCouponsViewModelTest {
         // THEN
         verify(fromChildToParentEventSender).sendToParent(
             ChildToParentEvent.ItemClickedInProductSelector(
-                itemData = ItemClickedData.Coupon(1L),
+                itemData = ItemClickedData.Coupon(1L, "test coupon"),
                 source = WooPosItemSource.COUPON_LIST
             )
         )

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/home/totals/WooPosTotalsRepositoryTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/home/totals/WooPosTotalsRepositoryTest.kt
@@ -23,6 +23,8 @@ import org.mockito.kotlin.mock
 import org.mockito.kotlin.never
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
+import org.wordpress.android.fluxc.network.rest.wpcom.wc.WooError
+import org.wordpress.android.fluxc.network.rest.wpcom.wc.WooResult
 import org.wordpress.android.fluxc.persistence.entity.CouponWithEmails
 import org.wordpress.android.fluxc.store.CouponStore
 import org.wordpress.android.fluxc.store.WCOrderStore
@@ -218,6 +220,58 @@ class WooPosTotalsRepositoryTest {
 
         assertThat(orderCapture.lastValue.couponLines.size).isEqualTo(1)
     }
+
+    @Test
+    fun `given coupon not in database, when createOrderFromCartItems, then coupon fetched and order created`() =
+        runTest {
+            // GIVEN
+            repository = createRepository()
+            val couponId = 1L
+
+            // First return null, then return the fetched coupon
+            whenever(couponStore.getCoupon(any(), eq(couponId)))
+                .thenReturn(null)
+                .thenReturn(CouponWithEmails(mock(), emptyList()))
+
+            val itemClickedData = listOf(
+                WooPosItemsViewModel.ItemClickedData.Coupon(id = couponId)
+            )
+
+            // WHEN
+            repository.createOrderFromCartItems(itemClickedData)
+
+            // THEN
+            verify(couponStore).fetchCoupon(any(), eq(couponId))
+            val orderCapture = argumentCaptor<Order>()
+            verify(orderCreateEditRepository).createOrUpdateOrder(
+                orderCapture.capture(),
+                eq("")
+            )
+            assertThat(orderCapture.lastValue.couponLines.size).isEqualTo(1)
+            assertThat(orderCapture.lastValue.couponLines[0].id).isEqualTo(1L)
+        }
+
+    @Test
+    fun `given coupon not in database and fetch fails, when createOrderFromCartItems, then order creation fails`() =
+        runTest {
+            // GIVEN
+            repository = createRepository()
+            val couponId = 1L
+
+            whenever(couponStore.getCoupon(any(), eq(couponId))).thenReturn(null)
+
+            whenever(couponStore.fetchCoupon(any(), eq(couponId))).thenReturn(WooResult(mock<WooError>()))
+
+            val itemClickedData = listOf(
+                WooPosItemsViewModel.ItemClickedData.Coupon(id = couponId)
+            )
+
+            // WHEN
+            val result = repository.createOrderFromCartItems(itemClickedData)
+
+            // THEN
+            assertThat(result.isFailure).isTrue()
+        }
 
     private fun createRepository() = WooPosTotalsRepository(
         orderCreateEditRepository,

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/home/totals/WooPosTotalsRepositoryTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/home/totals/WooPosTotalsRepositoryTest.kt
@@ -6,34 +6,40 @@ import com.woocommerce.android.tools.SelectedSite
 import com.woocommerce.android.ui.orders.creation.OrderCreateEditRepository
 import com.woocommerce.android.ui.products.ProductHelper
 import com.woocommerce.android.ui.products.ProductType
-import com.woocommerce.android.ui.woopos.common.data.WooPosGetCouponById
 import com.woocommerce.android.ui.woopos.common.data.WooPosGetProductById
 import com.woocommerce.android.ui.woopos.common.data.WooPosGetVariationById
 import com.woocommerce.android.ui.woopos.home.items.WooPosItemsViewModel
 import com.woocommerce.android.util.DateUtils
+import com.woocommerce.android.util.WooLogWrapper
 import com.woocommerce.android.viewmodel.ResourceProvider
 import kotlinx.coroutines.test.runTest
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.Test
 import org.mockito.kotlin.any
 import org.mockito.kotlin.argumentCaptor
+import org.mockito.kotlin.doReturn
 import org.mockito.kotlin.eq
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.never
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
+import org.wordpress.android.fluxc.persistence.entity.CouponWithEmails
+import org.wordpress.android.fluxc.store.CouponStore
 import org.wordpress.android.fluxc.store.WCOrderStore
 
 class WooPosTotalsRepositoryTest {
     private val orderCreateEditRepository: OrderCreateEditRepository = mock()
     private val getProductById: WooPosGetProductById = mock()
-    private val getCouponById: WooPosGetCouponById = mock()
+    private val couponStore: CouponStore = mock()
     private val getVariationById: WooPosGetVariationById = mock()
     private val dateUtils: DateUtils = mock()
     private val orderStore: WCOrderStore = mock()
-    private val selectedSite: SelectedSite = mock()
+    private val selectedSite: SelectedSite = mock {
+        on { get() } doReturn mock()
+    }
     private val orderMapper: OrderMapper = mock()
     private val resourceProvider: ResourceProvider = mock()
+    private val logWrapper: WooLogWrapper = mock()
 
     private lateinit var repository: WooPosTotalsRepository
 
@@ -191,8 +197,8 @@ class WooPosTotalsRepositoryTest {
     fun `given item list contains coupon, when createOrderFromCartItems, then coupon lines present`() = runTest {
         // GIVEN
         repository = createRepository()
-        whenever(getCouponById.invoke(1L)).thenReturn(
-            mock()
+        whenever(couponStore.getCoupon(any(), any())).thenReturn(
+            CouponWithEmails(mock(), emptyList())
         )
         val itemClickedData = listOf(
             WooPosItemsViewModel.ItemClickedData.Coupon(
@@ -217,11 +223,12 @@ class WooPosTotalsRepositoryTest {
         orderCreateEditRepository,
         dateUtils,
         getProductById,
-        getCouponById,
+        couponStore,
         getVariationById,
         orderStore,
         selectedSite,
         orderMapper,
         resourceProvider,
+        logWrapper
     )
 }

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/home/totals/WooPosTotalsRepositoryTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/home/totals/WooPosTotalsRepositoryTest.kt
@@ -6,7 +6,6 @@ import com.woocommerce.android.tools.SelectedSite
 import com.woocommerce.android.ui.orders.creation.OrderCreateEditRepository
 import com.woocommerce.android.ui.products.ProductHelper
 import com.woocommerce.android.ui.products.ProductType
-import com.woocommerce.android.ui.woopos.common.data.WooPosGetCouponById
 import com.woocommerce.android.ui.woopos.common.data.WooPosGetProductById
 import com.woocommerce.android.ui.woopos.common.data.WooPosGetVariationById
 import com.woocommerce.android.ui.woopos.home.items.WooPosItemsViewModel
@@ -27,7 +26,6 @@ import org.wordpress.android.fluxc.store.WCOrderStore
 class WooPosTotalsRepositoryTest {
     private val orderCreateEditRepository: OrderCreateEditRepository = mock()
     private val getProductById: WooPosGetProductById = mock()
-    private val getCouponById: WooPosGetCouponById = mock()
     private val getVariationById: WooPosGetVariationById = mock()
     private val dateUtils: DateUtils = mock()
     private val orderStore: WCOrderStore = mock()
@@ -191,12 +189,10 @@ class WooPosTotalsRepositoryTest {
     fun `given item list contains coupon, when createOrderFromCartItems, then coupon lines present`() = runTest {
         // GIVEN
         repository = createRepository()
-        whenever(getCouponById.invoke(1L)).thenReturn(
-            mock()
-        )
         val itemClickedData = listOf(
             WooPosItemsViewModel.ItemClickedData.Coupon(
                 id = 1L,
+                couponCode = "TEST_COUPON"
             )
         )
 
@@ -217,7 +213,6 @@ class WooPosTotalsRepositoryTest {
         orderCreateEditRepository,
         dateUtils,
         getProductById,
-        getCouponById,
         getVariationById,
         orderStore,
         selectedSite,

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/home/totals/WooPosTotalsRepositoryTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/home/totals/WooPosTotalsRepositoryTest.kt
@@ -6,40 +6,34 @@ import com.woocommerce.android.tools.SelectedSite
 import com.woocommerce.android.ui.orders.creation.OrderCreateEditRepository
 import com.woocommerce.android.ui.products.ProductHelper
 import com.woocommerce.android.ui.products.ProductType
+import com.woocommerce.android.ui.woopos.common.data.WooPosGetCouponById
 import com.woocommerce.android.ui.woopos.common.data.WooPosGetProductById
 import com.woocommerce.android.ui.woopos.common.data.WooPosGetVariationById
 import com.woocommerce.android.ui.woopos.home.items.WooPosItemsViewModel
 import com.woocommerce.android.util.DateUtils
-import com.woocommerce.android.util.WooLogWrapper
 import com.woocommerce.android.viewmodel.ResourceProvider
 import kotlinx.coroutines.test.runTest
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.Test
 import org.mockito.kotlin.any
 import org.mockito.kotlin.argumentCaptor
-import org.mockito.kotlin.doReturn
 import org.mockito.kotlin.eq
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.never
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
-import org.wordpress.android.fluxc.persistence.entity.CouponWithEmails
-import org.wordpress.android.fluxc.store.CouponStore
 import org.wordpress.android.fluxc.store.WCOrderStore
 
 class WooPosTotalsRepositoryTest {
     private val orderCreateEditRepository: OrderCreateEditRepository = mock()
     private val getProductById: WooPosGetProductById = mock()
-    private val couponStore: CouponStore = mock()
+    private val getCouponById: WooPosGetCouponById = mock()
     private val getVariationById: WooPosGetVariationById = mock()
     private val dateUtils: DateUtils = mock()
     private val orderStore: WCOrderStore = mock()
-    private val selectedSite: SelectedSite = mock {
-        on { get() } doReturn mock()
-    }
+    private val selectedSite: SelectedSite = mock()
     private val orderMapper: OrderMapper = mock()
     private val resourceProvider: ResourceProvider = mock()
-    private val logWrapper: WooLogWrapper = mock()
 
     private lateinit var repository: WooPosTotalsRepository
 
@@ -197,8 +191,8 @@ class WooPosTotalsRepositoryTest {
     fun `given item list contains coupon, when createOrderFromCartItems, then coupon lines present`() = runTest {
         // GIVEN
         repository = createRepository()
-        whenever(couponStore.getCoupon(any(), any())).thenReturn(
-            CouponWithEmails(mock(), emptyList())
+        whenever(getCouponById.invoke(1L)).thenReturn(
+            mock()
         )
         val itemClickedData = listOf(
             WooPosItemsViewModel.ItemClickedData.Coupon(
@@ -223,12 +217,11 @@ class WooPosTotalsRepositoryTest {
         orderCreateEditRepository,
         dateUtils,
         getProductById,
-        couponStore,
+        getCouponById,
         getVariationById,
         orderStore,
         selectedSite,
         orderMapper,
         resourceProvider,
-        logWrapper
     )
 }

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/home/totals/WooPosTotalsRepositoryTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/home/totals/WooPosTotalsRepositoryTest.kt
@@ -23,8 +23,6 @@ import org.mockito.kotlin.mock
 import org.mockito.kotlin.never
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
-import org.wordpress.android.fluxc.network.rest.wpcom.wc.WooError
-import org.wordpress.android.fluxc.network.rest.wpcom.wc.WooResult
 import org.wordpress.android.fluxc.persistence.entity.CouponWithEmails
 import org.wordpress.android.fluxc.store.CouponStore
 import org.wordpress.android.fluxc.store.WCOrderStore
@@ -220,58 +218,6 @@ class WooPosTotalsRepositoryTest {
 
         assertThat(orderCapture.lastValue.couponLines.size).isEqualTo(1)
     }
-
-    @Test
-    fun `given coupon not in database, when createOrderFromCartItems, then coupon fetched and order created`() =
-        runTest {
-            // GIVEN
-            repository = createRepository()
-            val couponId = 1L
-
-            // First return null, then return the fetched coupon
-            whenever(couponStore.getCoupon(any(), eq(couponId)))
-                .thenReturn(null)
-                .thenReturn(CouponWithEmails(mock(), emptyList()))
-
-            val itemClickedData = listOf(
-                WooPosItemsViewModel.ItemClickedData.Coupon(id = couponId)
-            )
-
-            // WHEN
-            repository.createOrderFromCartItems(itemClickedData)
-
-            // THEN
-            verify(couponStore).fetchCoupon(any(), eq(couponId))
-            val orderCapture = argumentCaptor<Order>()
-            verify(orderCreateEditRepository).createOrUpdateOrder(
-                orderCapture.capture(),
-                eq("")
-            )
-            assertThat(orderCapture.lastValue.couponLines.size).isEqualTo(1)
-            assertThat(orderCapture.lastValue.couponLines[0].id).isEqualTo(1L)
-        }
-
-    @Test
-    fun `given coupon not in database and fetch fails, when createOrderFromCartItems, then order creation fails`() =
-        runTest {
-            // GIVEN
-            repository = createRepository()
-            val couponId = 1L
-
-            whenever(couponStore.getCoupon(any(), eq(couponId))).thenReturn(null)
-
-            whenever(couponStore.fetchCoupon(any(), eq(couponId))).thenReturn(WooResult(mock<WooError>()))
-
-            val itemClickedData = listOf(
-                WooPosItemsViewModel.ItemClickedData.Coupon(id = couponId)
-            )
-
-            // WHEN
-            val result = repository.createOrderFromCartItems(itemClickedData)
-
-            // THEN
-            assertThat(result.isFailure).isTrue()
-        }
 
     private fun createRepository() = WooPosTotalsRepository(
         orderCreateEditRepository,


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #WOOMOB-483
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

This PR fixes a crash when user moves to checkout, but coupons that are present in the cart are no longer available in local cache.

The solution attempts to fetch the coupons and store them in cache - if the request fails or for whatever reason the coupon is still not present in cache, the order creation request fails and an error `Failed to create order` is shown to the user.

Theoretically, we could completely avoid loading coupons from cache on the totals screen, since the order creation request should get away with only `couponId`. However, due to a bug on the API, the server returns `coupondId is read only` error when we try to pass it - even when we pass it in a read-only manner. (This approach would work for products, since the order creation endpoint works fine if only ID is provided. Having said that, this crash was solved for products in [this PR using a different approach](https://github.com/woocommerce/woocommerce-android/pull/14052).)

Update: We decided to go with an approach that adds couponCode to the events that are used in communication between viewModels => we don't need to load coupon from database or fetch it from the server at all now, since we have all the data necessary for the order creation request.

### Testing information
<!-- This is your opportunity to break out individual scenarios that need testing (when necessary) and/or include a checklist for the reviewer to go through. Consider documenting the following from your own completed testing: devices used, alternate workflows, edge cases, affected areas, critical flows, areas not tested, and any remaining unknowns. Provide feedback on this new section of the PR template through Sept 30, 2024 to Apps Quality; additional context here: p91TBi-b8z-p2#comment-12036 -->

1. Open POS
2. Add a product to the cart
3. Tap on Coupons
4. Scroll down
5. Select a coupon from any page but the first page
6. Pull to refresh - don't scroll after that
7. Tap on checkout - observe, the app doesn't crash and the coupon is successfully applied

### The tests that have been performed
<!-- To give the reviewer an idea of what could be missed in terms of testing -->

I have tested the above. I also tested manually changing the code to not find the product after the fetch completes to simulate that case - error creating order screen was shown as expected.

### Images/gif
<!-- Include before and after images or gifs when appropriate. -->

- The video first shows the bug in pre-alpha build of the app, then shows what happens if the coupon is not found in database after we fetch it, and then displays what happens if the coupon is found in database after retry.

https://github.com/user-attachments/assets/b2bc04bc-1bb4-43c3-a0c1-90dedf2e6f43


- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.

## Reviewer (or Author, in the case of optional code reviews):

Please make sure these conditions are met before approving the PR, or request changes if the PR needs improvement:

- [x] The PR is small and has a clear, single focus, or a valid explanation is provided in the description. If needed, please request to split it into smaller PRs.
- [x] Ensure Adequate Unit Test Coverage: The changes are reasonably covered by unit tests or an explanation is provided in the PR description.
- [x] Manual Testing: The author listed all the tests they ran, including smoke tests when needed (e.g., for refactorings). The reviewer confirmed that the PR works as expected on big (tablet) and small (phone) in case of UI changes, and no regressions are added.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->