### PR TITLE
[WOOPRD-502][Woo POS][Product search] Large fonts support

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/common/composeui/component/WooPosSearchInput.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/common/composeui/component/WooPosSearchInput.kt
@@ -13,7 +13,7 @@ import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.heightIn
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
@@ -59,10 +59,9 @@ import com.woocommerce.android.ui.woopos.common.composeui.designsystem.WooPosSpa
 import com.woocommerce.android.ui.woopos.common.composeui.designsystem.WooPosTheme
 import com.woocommerce.android.ui.woopos.common.composeui.designsystem.WooPosTypography
 import com.woocommerce.android.ui.woopos.common.composeui.designsystem.toAdaptivePadding
+import com.woocommerce.android.ui.woopos.home.items.WOO_POS_ITEMS_TOOLBAR_HEIGHT
 import kotlinx.coroutines.delay
 import kotlinx.parcelize.Parcelize
-
-private val INPUT_FIELD_HEIGHT = 56.dp
 
 @Composable
 fun WooPosSearchInput(
@@ -92,8 +91,7 @@ fun WooPosSearchInput(
 
     Box(
         modifier = modifier
-            .fillMaxWidth()
-            .height(INPUT_FIELD_HEIGHT),
+            .fillMaxWidth(),
         contentAlignment = Alignment.CenterEnd
     ) {
         AnimatedVisibility(
@@ -221,7 +219,7 @@ private fun SearchInput(
             },
             modifier = Modifier
                 .weight(1f)
-                .height(INPUT_FIELD_HEIGHT)
+                .heightIn(min = WOO_POS_ITEMS_TOOLBAR_HEIGHT)
                 .focusRequester(focusRequester)
                 .onFocusChanged { focusState ->
                     isFocused = focusState.isFocused

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/items/WooPosItemsList.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/items/WooPosItemsList.kt
@@ -213,6 +213,7 @@ fun WooPosProductCard(
 ) {
     WooPosCard(
         modifier = modifier
+            .wrapContentHeight()
             .semantics { contentDescription = itemContentDescription },
         shape = RoundedCornerShape(WooPosCornerRadius.Medium.value),
         backgroundColor = MaterialTheme.colorScheme.surfaceContainerLowest,
@@ -222,7 +223,8 @@ fun WooPosProductCard(
         Row(
             modifier = Modifier
                 .clickable { onItemClicked(item) }
-                .height(112.dp)
+                .height(IntrinsicSize.Min)
+                .heightIn(min = 112.dp)
                 .fillMaxWidth(),
             verticalAlignment = Alignment.CenterVertically
         ) {
@@ -278,7 +280,9 @@ private fun ProductInfo(modifier: Modifier, item: Product) {
 private fun ProductImage(item: Product) {
     Box(
         modifier = Modifier
-            .size(112.dp)
+            .width(112.dp)
+            .fillMaxHeight()
+            .heightIn(min = 112.dp)
             .background(MaterialTheme.colorScheme.surfaceDim),
         contentAlignment = Alignment.Center
     ) {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/items/WooPosItemsToolbar.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/items/WooPosItemsToolbar.kt
@@ -11,7 +11,7 @@ import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.heightIn
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.lazy.LazyRow
@@ -43,6 +43,7 @@ import com.woocommerce.android.ui.woopos.home.items.WooPosItemsViewState.Tab.Hig
 import com.woocommerce.android.ui.woopos.home.items.WooPosItemsViewState.Tab.HighlightLevel.Normal
 
 private const val ANIMATION_DURATION = 300
+val WOO_POS_ITEMS_TOOLBAR_HEIGHT = 56.dp
 
 @Composable
 fun WooPosItemsToolbar(
@@ -59,7 +60,7 @@ fun WooPosItemsToolbar(
     Box(
         modifier = modifier
             .fillMaxWidth()
-            .height(56.dp),
+            .heightIn(min = WOO_POS_ITEMS_TOOLBAR_HEIGHT),
         contentAlignment = Alignment.CenterStart
     ) {
         AnimatedVisibility(


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: WOOPRD-502
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
The PR improves large fonts support on:
* Products items
* Search input component + toolbar

### Testing information
<!-- This is your opportunity to break out individual scenarios that need testing (when necessary) and/or include a checklist for the reviewer to go through. Consider documenting the following from your own completed testing: devices used, alternate workflows, edge cases, affected areas, critical flows, areas not tested, and any remaining unknowns. Provide feedback on this new section of the PR template through Sept 30, 2024 to Apps Quality; additional context here: p91TBi-b8z-p2#comment-12036 -->

* Open POS
* Change font size in the settings
* Validate that there is no regression when the standard font size is used
* Validate that all look decent when a large font size is used

### Images/gif
<!-- Include before and after images or gifs when appropriate. -->
<img width="805" alt="image" src="https://github.com/user-attachments/assets/da2f211d-98ea-40b2-9a65-feba4d2a8b3d" />
<img width="799" alt="image" src="https://github.com/user-attachments/assets/e0d6a9c3-bef3-4e00-9bc4-7eb2ae7ffe8f" />


<img width="800" alt="image" src="https://github.com/user-attachments/assets/5e71c16f-e84d-4c86-ab63-31dbbb92100c" />
<img width="800" alt="image" src="https://github.com/user-attachments/assets/53daf912-f451-45b7-ba35-d68627aa3aa7" />


- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.

## Reviewer (or Author, in the case of optional code reviews):

Please make sure these conditions are met before approving the PR, or request changes if the PR needs improvement:

- [ ] The PR is small and has a clear, single focus, or a valid explanation is provided in the description. If needed, please request to split it into smaller PRs.
- [ ] Ensure Adequate Unit Test Coverage: The changes are reasonably covered by unit tests or an explanation is provided in the PR description.
- [ ] Manual Testing: The author listed all the tests they ran, including smoke tests when needed (e.g., for refactorings). The reviewer confirmed that the PR works as expected on big (tablet) and small (phone) in case of UI changes, and no regressions are added.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->