### PR TITLE
[Refunds] Fix taxes handling

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -6,6 +6,7 @@
 -----
 - [*] POS: for WooCommerce version 10.0.0 and higher (betas available in June), a new check for POS feature switch value (in wp-admin WooCommerce Settings > Advanced > Features) was added for the POS entry point. [https://github.com/woocommerce/woocommerce-android/pull/14113]
 - [*] POS: for WooCommerce version 10.0.0 and higher (betas available in June) and stores eligible for POS, sending email from the payment success screen sends out POS specific email receipts with product unit price, additional cash/card payment details, and customizable store details from POS settings in wp-admin WooCommerce Settings > Point of Sale. [https://github.com/woocommerce/woocommerce-android/pull/14116]
+- [*] Fixed an issue with taxes not being correctly included during refunds [https://github.com/woocommerce/woocommerce-android/pull/14064]
 
 22.5
 -----

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/model/Order.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/model/Order.kt
@@ -116,7 +116,8 @@ data class Order(
         val parent: Long? = null,
         val configuration: ProductConfiguration? = null,
         val configurationKey: Long? = null,
-        val containsMetadata: Boolean = false
+        val containsMetadata: Boolean = false,
+        val taxes: List<LineTaxEntry> = emptyList(),
     ) : Parcelable {
         @IgnoredOnParcel
         val uniqueId: Long = ProductHelper.productOrVariationId(productId, variationId)
@@ -205,10 +206,11 @@ data class Order(
         val methodId: String?,
         val methodTitle: String,
         val totalTax: BigDecimal,
-        val total: BigDecimal
+        val total: BigDecimal,
+        val taxes: List<LineTaxEntry>
     ) : Parcelable {
         constructor(methodId: String, methodTitle: String, total: BigDecimal) :
-            this(0L, methodId, methodTitle, BigDecimal.ZERO, total)
+            this(0L, methodId, methodTitle, BigDecimal.ZERO, total, emptyList())
     }
 
     @Parcelize
@@ -228,6 +230,7 @@ data class Order(
         val total: BigDecimal,
         val totalTax: BigDecimal,
         var taxStatus: FeeLineTaxStatus,
+        val taxes: List<LineTaxEntry>
     ) : Parcelable {
         fun getTotalValue(): BigDecimal = total + totalTax
 
@@ -238,6 +241,7 @@ data class Order(
                 total = BigDecimal.ZERO,
                 totalTax = BigDecimal.ZERO,
                 taxStatus = FeeLineTaxStatus.UNKNOWN,
+                taxes = emptyList()
             )
         }
 
@@ -274,6 +278,12 @@ data class Order(
             )
         }
     }
+
+    @Parcelize
+    data class LineTaxEntry(
+        val rateId: Long,
+        val taxAmount: BigDecimal
+    ) : Parcelable
 
     fun getBillingName(defaultValue: String): String {
         return when {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/model/OrderMapper.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/model/OrderMapper.kt
@@ -10,6 +10,7 @@ import org.wordpress.android.fluxc.model.metadata.get
 import org.wordpress.android.fluxc.model.order.FeeLineTaxStatus
 import org.wordpress.android.fluxc.model.order.OrderAddress
 import org.wordpress.android.fluxc.model.order.TaxLine
+import org.wordpress.android.fluxc.model.order.WCLineTaxEntry
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.order.OrderMappingConst.CHARGE_ID_KEY
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.order.OrderMappingConst.SHIPPING_PHONE_KEY
 import org.wordpress.android.fluxc.persistence.entity.OrderEntity
@@ -84,7 +85,8 @@ class OrderMapper @Inject constructor(
                 FeeLineTaxStatus.Taxable -> Order.FeeLine.FeeLineTaxStatus.TAXABLE
                 FeeLineTaxStatus.None -> Order.FeeLine.FeeLineTaxStatus.NONE
                 else -> Order.FeeLine.FeeLineTaxStatus.UNKNOWN
-            }
+            },
+            taxes = it.taxes?.mapLineTaxes() ?: emptyList()
         )
     }
 
@@ -105,7 +107,8 @@ class OrderMapper @Inject constructor(
             methodId = it.methodId,
             methodTitle = it.methodTitle ?: StringUtils.EMPTY,
             totalTax = it.totalTax?.toBigDecimalOrNull() ?: BigDecimal.ZERO,
-            total = it.total?.toBigDecimalOrNull() ?: BigDecimal.ZERO
+            total = it.total?.toBigDecimalOrNull() ?: BigDecimal.ZERO,
+            taxes = it.taxes?.mapLineTaxes() ?: emptyList(),
         )
     }
 
@@ -129,7 +132,8 @@ class OrderMapper @Inject constructor(
                     },
                     it.bundledBy?.toLongOrNull() ?: it.compositeParent?.toLongOrNull(),
                     configurationKey = it.configurationKey,
-                    containsMetadata = it.metaData?.isNotEmpty() ?: false
+                    containsMetadata = it.metaData?.isNotEmpty() ?: false,
+                    taxes = it.taxes?.mapLineTaxes() ?: emptyList()
                 )
             }
 
@@ -169,6 +173,13 @@ class OrderMapper @Inject constructor(
             code = it.code,
             id = it.id,
             discount = it.discount,
+        )
+    }
+
+    private fun List<WCLineTaxEntry>.mapLineTaxes(): List<Order.LineTaxEntry> = map {
+        Order.LineTaxEntry(
+            rateId = it.rateId ?: 0L,
+            taxAmount = it.total ?: BigDecimal.ZERO,
         )
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/model/OrderMapper.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/model/OrderMapper.kt
@@ -112,6 +112,7 @@ class OrderMapper @Inject constructor(
         )
     }
 
+    @Suppress("CyclomaticComplexMethod")
     private fun List<WCLineItem>.mapLineItems(): List<Item> =
         this.filter { it.productId != null && it.id != null }
             .map {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/refunds/IssueRefundViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/refunds/IssueRefundViewModel.kt
@@ -539,7 +539,7 @@ class IssueRefundViewModel @Inject constructor(
 
                 // Update the subtotal and taxes based on the new quantity
                 val subtotal = newItem.calculateTotalSubtotal()
-                val taxes = listOf(TaxRefund(0L, newItem.calculateTotalTaxes()))
+                val taxes = newItem.calculateTotalTaxes()
                 newItem = newItem.copy(subtotal = subtotal, taxes = taxes)
 
                 newItems.add(newItem)

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/refunds/IssueRefundViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/refunds/IssueRefundViewModel.kt
@@ -228,8 +228,8 @@ class IssueRefundViewModel @Inject constructor(
                 orderItem = it,
                 maxQuantity = maxQuantity,
                 quantity = selectedQuantity,
-                subtotal = formatCurrency(BigDecimal.ZERO),
-                taxes = formatCurrency(BigDecimal.ZERO)
+                subtotal = BigDecimal.ZERO,
+                taxes = emptyList()
             )
         }
         updateRefundItems(items)
@@ -538,8 +538,8 @@ class IssueRefundViewModel @Inject constructor(
                 var newItem = it.copy(quantity = newQuantity, maxQuantity = maxQuantities[uniqueId] ?: 0f)
 
                 // Update the subtotal and taxes based on the new quantity
-                val subtotal = formatCurrency(newItem.calculateTotalSubtotal())
-                val taxes = formatCurrency(newItem.calculateTotalTaxes())
+                val subtotal = newItem.calculateTotalSubtotal()
+                val taxes = listOf(TaxRefund(0L, newItem.calculateTotalTaxes()))
                 newItem = newItem.copy(subtotal = subtotal, taxes = taxes)
 
                 newItems.add(newItem)

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/refunds/IssueRefundViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/refunds/IssueRefundViewModel.kt
@@ -204,8 +204,6 @@ class IssueRefundViewModel @Inject constructor(
         if (refundByItemsStateLiveData.hasInitialValue) {
             refundByItemsState = refundByItemsState.copy(
                 currency = order.currency,
-                subtotal = formatCurrency(BigDecimal.ZERO),
-                taxes = formatCurrency(BigDecimal.ZERO),
                 shippingSubtotal = formatCurrency(order.shippingTotal),
                 shippingTaxes = formatCurrency(order.shippingLines.sumByBigDecimal { it.totalTax }),
                 feesSubtotal = formatCurrency(order.feesTotal),
@@ -510,13 +508,6 @@ class IssueRefundViewModel @Inject constructor(
         refundSummaryState = refundSummaryState.copy(isSummaryTextTooLong = currLength > maxLength)
     }
 
-    fun onProductsRefundAmountChanged(newAmount: BigDecimal) {
-        refundByItemsState = refundByItemsState.copy(
-            productsRefund = newAmount,
-            formattedProductsRefund = formatCurrency(newAmount)
-        )
-    }
-
     fun onRefundQuantityChanged(uniqueId: Long, newQuantity: Int) {
         val newItems = getUpdatedItemList(uniqueId, newQuantity)
         updateRefundItems(newItems)
@@ -535,8 +526,6 @@ class IssueRefundViewModel @Inject constructor(
         refundByItemsState = refundByItemsState.copy(
             productsRefund = productsRefund,
             formattedProductsRefund = formatCurrency(productsRefund),
-            taxes = formatCurrency(taxes),
-            subtotal = formatCurrency(subtotal),
             selectButtonTitle = selectButtonTitle
         )
     }
@@ -786,8 +775,6 @@ class IssueRefundViewModel @Inject constructor(
         val currency: String? = null,
         val productsRefund: BigDecimal = BigDecimal.ZERO,
         val formattedProductsRefund: String? = null,
-        val subtotal: String? = null,
-        val taxes: String? = null,
         val feesSubtotal: String? = null,
         val feesTaxes: String? = null,
         val feesRefund: BigDecimal = BigDecimal.ZERO,

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/refunds/IssueRefundViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/refunds/IssueRefundViewModel.kt
@@ -541,7 +541,7 @@ class IssueRefundViewModel @Inject constructor(
 
                 // Update the subtotal and taxes based on the new quantity
                 val subtotal = newItem.calculateTotalSubtotal()
-                val taxes = newItem.calculateTotalTaxes()
+                val taxes = newItem.calculateTaxesList()
                 newItem = newItem.copy(subtotal = subtotal, taxes = taxes)
 
                 newItems.add(newItem)

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/refunds/IssueRefundViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/refunds/IssueRefundViewModel.kt
@@ -303,7 +303,8 @@ class IssueRefundViewModel @Inject constructor(
         refundSummaryState = refundSummaryState.copy(
             isFormEnabled = true,
             previouslyRefunded = formatCurrency(order.refundTotal),
-            refundAmount = formatCurrency(commonState.refundTotal)
+            refundAmount = commonState.refundTotal,
+            refundAmountFormatted = formatCurrency(commonState.refundTotal)
         )
 
         triggerEvent(ShowRefundSummary)
@@ -399,11 +400,12 @@ class IssueRefundViewModel @Inject constructor(
         selectedFees?.forEach { allItems.add(it.toDataModel()) }
 
         return refundStore.createItemsRefund(
-            selectedSite.get(),
-            order.id,
-            refundSummaryState.refundReason ?: "",
-            true,
-            gateway.supportsRefunds,
+            site = selectedSite.get(),
+            orderId = order.id,
+            amount = refundSummaryState.refundAmount,
+            reason = refundSummaryState.refundReason ?: "",
+            restockItems = true,
+            autoRefund = gateway.supportsRefunds,
             items = allItems
         )
     }
@@ -808,7 +810,8 @@ class IssueRefundViewModel @Inject constructor(
     data class RefundSummaryViewState(
         val isFormEnabled: Boolean? = null,
         val previouslyRefunded: String? = null,
-        val refundAmount: String? = null,
+        val refundAmount: BigDecimal? = null,
+        val refundAmountFormatted: String? = null,
         val refundMethod: String? = null,
         val refundReason: String? = null,
         val isMethodDescriptionVisible: Boolean? = null,

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/refunds/RefundProductListAdapter.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/refunds/RefundProductListAdapter.kt
@@ -164,9 +164,8 @@ class RefundProductListAdapter(
                     .into(productImageView)
             } ?: productImageView.setImageResource(R.drawable.ic_product)
 
-            subtotalTextView.text = item.subtotal
-
-            taxesTextView.text = item.taxes
+            subtotalTextView.text = formatCurrency(item.subtotal)
+            taxesTextView.text = formatCurrency(item.taxesTotal)
         }
     }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/refunds/RefundSummaryFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/refunds/RefundSummaryFragment.kt
@@ -100,7 +100,7 @@ class RefundSummaryFragment : BaseFragment(R.layout.fragment_refund_summary), Ba
             new.isSubmitButtonEnabled.takeIfNotEqualTo(old?.isSubmitButtonEnabled) {
                 binding.refundSummaryBtnRefund.isEnabled = new.isSubmitButtonEnabled
             }
-            new.refundAmount?.takeIfNotEqualTo(old?.refundAmount) {
+            new.refundAmountFormatted?.takeIfNotEqualTo(old?.refundAmountFormatted) {
                 binding.refundSummaryRefundAmount.text = it
                 binding.toolbar.title = resources.getString(
                     R.string.order_refunds_title_with_amount, it

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/refunds/RefundsExt.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/refunds/RefundsExt.kt
@@ -1,5 +1,6 @@
 package com.woocommerce.android.ui.payments.refunds
 
+import org.wordpress.android.fluxc.utils.sumBy
 import java.math.BigDecimal
 import java.math.RoundingMode.HALF_UP
 
@@ -8,7 +9,7 @@ fun List<ProductRefundListItem>.calculateTotals(): Pair<BigDecimal, BigDecimal> 
     var subtotal = BigDecimal.ZERO
     this.forEach { item ->
         subtotal += item.calculateTotalSubtotal()
-        taxes += item.calculateTotalTaxes()
+        taxes += item.calculateTotalTaxes().sumBy { it.tax }
     }
     return Pair(subtotal, taxes)
 }
@@ -18,9 +19,12 @@ fun ProductRefundListItem.calculateTotalSubtotal(): BigDecimal {
     return quantity.times(orderItem.price)
 }
 
-fun ProductRefundListItem.calculateTotalTaxes(): BigDecimal {
+fun ProductRefundListItem.calculateTotalTaxes(): List<TaxRefund> {
     val quantity = quantity.toBigDecimal()
+    val taxes = orderItem.taxes
 
-    val singleItemTax = orderItem.totalTax.divide(orderItem.quantity.toBigDecimal(), 2, HALF_UP)
-    return quantity.times(singleItemTax)
+    return taxes.map {
+        val tax = it.taxAmount.divide(orderItem.quantity.toBigDecimal(), 2, HALF_UP)
+        TaxRefund(it.rateId, quantity.times(tax))
+    }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/refunds/RefundsExt.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/refunds/RefundsExt.kt
@@ -1,6 +1,5 @@
 package com.woocommerce.android.ui.payments.refunds
 
-import org.wordpress.android.fluxc.utils.sumBy
 import java.math.BigDecimal
 import java.math.RoundingMode.HALF_UP
 
@@ -9,7 +8,7 @@ fun List<ProductRefundListItem>.calculateTotals(): Pair<BigDecimal, BigDecimal> 
     var subtotal = BigDecimal.ZERO
     this.forEach { item ->
         subtotal += item.calculateTotalSubtotal()
-        taxes += item.calculateTotalTaxes().sumBy { it.tax }
+        taxes += item.calculateTotalTaxes()
     }
     return Pair(subtotal, taxes)
 }
@@ -19,7 +18,14 @@ fun ProductRefundListItem.calculateTotalSubtotal(): BigDecimal {
     return quantity.times(orderItem.price)
 }
 
-fun ProductRefundListItem.calculateTotalTaxes(): List<TaxRefund> {
+fun ProductRefundListItem.calculateTotalTaxes(): BigDecimal {
+    val quantity = quantity.toBigDecimal()
+
+    val singleItemTax = orderItem.totalTax.divide(orderItem.quantity.toBigDecimal(), 2, HALF_UP)
+    return quantity.times(singleItemTax)
+}
+
+fun ProductRefundListItem.calculateTaxesList(): List<TaxRefund> {
     val quantity = quantity.toBigDecimal()
     val taxes = orderItem.taxes
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/refunds/RefundsUiModels.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/refunds/RefundsUiModels.kt
@@ -5,69 +5,87 @@ import com.woocommerce.android.model.Order
 import kotlinx.parcelize.Parcelize
 import org.wordpress.android.fluxc.model.refunds.RefundRequestItem
 import org.wordpress.android.fluxc.model.refunds.RefundRequestTax
-import java.math.RoundingMode.HALF_UP
+import java.math.BigDecimal
+
+sealed class RefundItem : Parcelable {
+    abstract val itemId: Long
+    abstract val quantity: Int?
+    abstract val subtotal: BigDecimal
+    abstract val taxes: List<TaxRefund>
+
+    fun toDataModel(): RefundRequestItem {
+        return RefundRequestItem(
+            itemId = itemId,
+            quantity = quantity,
+            refundTotal = subtotal,
+            refundTax = taxes.map {
+                RefundRequestTax(
+                    taxRateId = it.rateId,
+                    refundTotal = it.tax
+                )
+            }
+        )
+    }
+}
+
+@Parcelize
+data class TaxRefund(
+    val rateId: Long,
+    val tax: BigDecimal,
+) : Parcelable
 
 @Parcelize
 data class ProductRefundListItem(
     val orderItem: Order.Item,
     val maxQuantity: Float = 0f,
-    val quantity: Int = 0,
-    val subtotal: String? = null,
-    val taxes: String? = null
-) : Parcelable {
+    override val quantity: Int = 0,
+    override val subtotal: BigDecimal = BigDecimal.ZERO,
+    override val taxes: List<TaxRefund> = emptyList()
+) : RefundItem() {
+    override val itemId: Long
+        get() = orderItem.itemId
+
     val availableRefundQuantity
         get() = maxQuantity.toInt()
 
-    fun toDataModel(): RefundRequestItem {
-        return RefundRequestItem(
-            itemId = orderItem.itemId,
-            quantity = quantity,
-            refundTotal = quantity.toBigDecimal().times(orderItem.price),
-            refundTax = listOf(
-                RefundRequestTax(
-                    taxRateId = 0L,
-                    refundTotal = orderItem.totalTax.divide(orderItem.quantity.toBigDecimal(), 2, HALF_UP)
-                        .times(quantity.toBigDecimal())
-                )
-            )
-        )
-    }
+    val taxesTotal: BigDecimal
+        get() = taxes.sumOf { it.tax }
 }
 
 @Parcelize
 data class ShippingRefundListItem(
     val shippingLine: Order.ShippingLine
-) : Parcelable {
-    fun toDataModel(): RefundRequestItem {
-        return RefundRequestItem(
-            shippingLine.itemId,
-            quantity = 1, // Hardcoded because a shipping line always has a quantity of 1
-            refundTotal = shippingLine.total,
-            refundTax = listOf(
-                RefundRequestTax(
-                    taxRateId = 0L,
-                    refundTotal = shippingLine.totalTax
-                )
+) : RefundItem() {
+    override val itemId: Long
+        get() = shippingLine.itemId
+    override val quantity: Int?
+        get() = null
+    override val subtotal: BigDecimal
+        get() = shippingLine.total
+    override val taxes: List<TaxRefund>
+        get() = listOf(
+            TaxRefund(
+                rateId = 0L,
+                tax = shippingLine.totalTax
             )
         )
-    }
 }
 
 @Parcelize
 data class FeeRefundListItem(
     val feeLine: Order.FeeLine
-) : Parcelable {
-    fun toDataModel(): RefundRequestItem {
-        return RefundRequestItem(
-            feeLine.id,
-            quantity = 1, // Hardcoded because a fee line always has a quantity of 1
-            refundTotal = feeLine.total,
-            refundTax = listOf(
-                RefundRequestTax(
-                    taxRateId = 0L,
-                    refundTotal = feeLine.totalTax,
-                )
+) : RefundItem() {
+    override val itemId: Long
+        get() = feeLine.id
+    override val quantity: Int?
+        get() = null
+    override val subtotal: BigDecimal
+        get() = feeLine.total
+    override val taxes: List<TaxRefund>
+        get() = listOf(
+            TaxRefund(
+                rateId = 0L,
+                tax = feeLine.totalTax
             )
         )
-    }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/refunds/RefundsUiModels.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/refunds/RefundsUiModels.kt
@@ -63,12 +63,12 @@ data class ShippingRefundListItem(
     override val subtotal: BigDecimal
         get() = shippingLine.total
     override val taxes: List<TaxRefund>
-        get() = listOf(
+        get() = shippingLine.taxes.map {
             TaxRefund(
-                rateId = 0L,
-                tax = shippingLine.totalTax
+                rateId = it.rateId,
+                tax = it.taxAmount
             )
-        )
+        }
 }
 
 @Parcelize
@@ -82,10 +82,10 @@ data class FeeRefundListItem(
     override val subtotal: BigDecimal
         get() = feeLine.total
     override val taxes: List<TaxRefund>
-        get() = listOf(
+        get() = feeLine.taxes.map {
             TaxRefund(
-                rateId = 0L,
-                tax = feeLine.totalTax
+                rateId = it.rateId,
+                tax = it.taxAmount
             )
-        )
+        }
 }

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/model/ShippingLineDetailsTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/model/ShippingLineDetailsTest.kt
@@ -22,7 +22,8 @@ class ShippingLineDetailsTest {
             methodId = "method$i",
             methodTitle = "shippingLineTitle$i",
             totalTax = BigDecimal.TEN * i.toBigDecimal(),
-            total = BigDecimal.ZERO
+            total = BigDecimal.ZERO,
+            taxes = emptyList()
         )
     }
 
@@ -55,7 +56,8 @@ class ShippingLineDetailsTest {
                 methodId = null,
                 methodTitle = "shippingLineDiscarded",
                 totalTax = BigDecimal.TEN,
-                total = BigDecimal.ZERO
+                total = BigDecimal.ZERO,
+                taxes = emptyList()
             )
         )
         val result = shippingLines.toShippingLineDetails(defaultShippingMethods)

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/OrderDetailViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/OrderDetailViewModelTest.kt
@@ -2215,14 +2215,16 @@ class OrderDetailViewModelTest : BaseUnitTest() {
                     methodTitle = "Free",
                     methodId = shippingMethod.id,
                     total = BigDecimal.ZERO,
-                    totalTax = BigDecimal.ZERO
+                    totalTax = BigDecimal.ZERO,
+                    taxes = emptyList()
                 ),
                 Order.ShippingLine(
                     itemId = 2L,
                     methodTitle = "Another shipping",
                     methodId = "",
                     total = BigDecimal.TEN,
-                    totalTax = BigDecimal.ZERO
+                    totalTax = BigDecimal.ZERO,
+                    taxes = emptyList()
                 ),
             )
             val testOrder = order.copy(shippingLines = orderShippingLines)
@@ -2265,14 +2267,16 @@ class OrderDetailViewModelTest : BaseUnitTest() {
                     methodTitle = "Free",
                     methodId = "free_shipping",
                     total = BigDecimal.ZERO,
-                    totalTax = BigDecimal.ZERO
+                    totalTax = BigDecimal.ZERO,
+                    taxes = emptyList()
                 ),
                 Order.ShippingLine(
                     itemId = 2L,
                     methodTitle = "Another shipping",
                     methodId = "",
                     total = BigDecimal.TEN,
-                    totalTax = BigDecimal.ZERO
+                    totalTax = BigDecimal.ZERO,
+                    taxes = emptyList()
                 ),
             )
             val testOrder = order.copy(shippingLines = orderShippingLines)
@@ -2313,14 +2317,16 @@ class OrderDetailViewModelTest : BaseUnitTest() {
                     methodTitle = "Free",
                     methodId = "free_shipping",
                     total = BigDecimal.ZERO,
-                    totalTax = BigDecimal.ZERO
+                    totalTax = BigDecimal.ZERO,
+                    taxes = emptyList()
                 ),
                 Order.ShippingLine(
                     itemId = 2L,
                     methodTitle = "Another shipping",
                     methodId = "",
                     total = BigDecimal.TEN,
-                    totalTax = BigDecimal.ZERO
+                    totalTax = BigDecimal.ZERO,
+                    taxes = emptyList()
                 ),
             )
             val testOrder = order.copy(shippingLines = orderShippingLines)

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/OrderTestUtils.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/OrderTestUtils.kt
@@ -213,7 +213,7 @@ object OrderTestUtils {
             "    \"subtotal_tax\":\"0.00\",\n" +
             "    \"total\":\"10.00\",\n" +
             "    \"total_tax\":\"0.00\",\n" +
-            "    \"taxes\":[],\n" +
+            "    \"taxes\":[{\"id\":1, \"total\":2}, {\"id\":2, \"total\":5}],\n" +
             "    \"meta_data\":[],\n" +
             "    \"sku\":null,\n" +
             "    \"price\":10\n" +
@@ -241,7 +241,7 @@ object OrderTestUtils {
                 "   \"instance_id\":\"0\",\n" +
                 "   \"total\":\"30.00\",\n" +
                 "   \"total_tax\":\"0.00\",\n" +
-                "   \"taxes\":[],\n" +
+                "   \"taxes\":[{\"id\":1, \"total\":2}, {\"id\":2, \"total\":5}],\n" +
                 "   \"meta_data\":[]}]",
         )
     }
@@ -258,7 +258,7 @@ object OrderTestUtils {
                 "    \"subtotal_tax\":\"0.00\",\n" +
                 "    \"total\":\"10.00\",\n" +
                 "    \"total_tax\":\"0.00\",\n" +
-                "    \"taxes\":[],\n" +
+                "    \"taxes\":[{\"id\":1, \"total\":2}, {\"id\":2, \"total\":5}],\n" +
                 "    \"meta_data\":[],\n" +
                 "    \"sku\":null,\n" +
                 "    \"price\":10\n" +
@@ -305,7 +305,7 @@ object OrderTestUtils {
                 "    \"subtotal_tax\":\"0.00\",\n" +
                 "    \"total\":\"10.00\",\n" +
                 "    \"total_tax\":\"0.00\",\n" +
-                "    \"taxes\":[],\n" +
+                "    \"taxes\":[{\"id\":1, \"total\":2}, {\"id\":2, \"total\":5}],\n" +
                 "    \"meta_data\":[],\n" +
                 "    \"sku\":null,\n" +
                 "    \"price\":10\n" +
@@ -319,7 +319,7 @@ object OrderTestUtils {
                 "   \"instance_id\":\"0\",\n" +
                 "   \"total\":\"30.00\",\n" +
                 "   \"total_tax\":\"0.00\",\n" +
-                "   \"taxes\":[],\n" +
+                "   \"taxes\":[{\"id\":1, \"total\":2}, {\"id\":2, \"total\":5}],\n" +
                 "   \"meta_data\":[]},\n" +
                 "{  " +
                 "\"id\":120,\n" +
@@ -328,7 +328,7 @@ object OrderTestUtils {
                 "   \"instance_id\":\"0\",\n" +
                 "   \"total\":\"20.00\",\n" +
                 "   \"total_tax\":\"0.00\",\n" +
-                "   \"taxes\":[],\n" +
+                "   \"taxes\":[{\"id\":1, \"total\":3}, {\"id\":2, \"total\":4}],\n" +
                 "   \"meta_data\":[]\n" +
                 "}]",
         )
@@ -377,7 +377,8 @@ object OrderTestUtils {
     fun generateTestOrderItems(
         count: Int = 1,
         productId: Long = -1,
-        quantity: Float = 1F
+        quantity: Float = 1F,
+        taxes: (Int) -> List<Order.LineTaxEntry> = { emptyList() }
     ): List<Item> {
         val list = mutableListOf<Item>()
         for (i in 1..count) {
@@ -394,7 +395,8 @@ object OrderTestUtils {
                     totalTax = BigDecimal.ZERO,
                     total = BigDecimal("10"),
                     variationId = 0,
-                    attributesList = emptyList()
+                    attributesList = emptyList(),
+                    taxes = taxes(i),
                 )
             )
         }

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/creation/CreationFocusedOrderCreateEditViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/creation/CreationFocusedOrderCreateEditViewModelTest.kt
@@ -914,7 +914,7 @@ class CreationFocusedOrderCreateEditViewModelTest : UnifiedOrderEditViewModelTes
                 Succeeded(
                     Order.getEmptyOrder(Date(), Date()).copy(
                         shippingLines = listOf(
-                            Order.ShippingLine(itemId, "first", "first", BigDecimal(1), BigDecimal.ZERO),
+                            Order.ShippingLine(itemId, "first", "first", BigDecimal(1), BigDecimal.ZERO, emptyList()),
                             Order.ShippingLine("second", "second", BigDecimal(2)),
                             Order.ShippingLine("third", "third", BigDecimal(3)),
                         )
@@ -954,7 +954,7 @@ class CreationFocusedOrderCreateEditViewModelTest : UnifiedOrderEditViewModelTes
                 Succeeded(
                     Order.getEmptyOrder(Date(), Date()).copy(
                         shippingLines = listOf(
-                            Order.ShippingLine(itemId, "first", "first", BigDecimal(1), BigDecimal.ZERO),
+                            Order.ShippingLine(itemId, "first", "first", BigDecimal(1), BigDecimal.ZERO, emptyList()),
                             Order.ShippingLine("second", "second", BigDecimal(2)),
                             Order.ShippingLine("third", "third", BigDecimal(3)),
                         )
@@ -1016,9 +1016,9 @@ class CreationFocusedOrderCreateEditViewModelTest : UnifiedOrderEditViewModelTes
                 Succeeded(
                     Order.getEmptyOrder(Date(), Date()).copy(
                         shippingLines = listOf(
-                            Order.ShippingLine(itemId, "first", "first", BigDecimal(1), BigDecimal.ZERO),
-                            Order.ShippingLine(2L, "second", "second", BigDecimal(2), BigDecimal.ZERO),
-                            Order.ShippingLine(3L, "third", "third", BigDecimal(3), BigDecimal.ZERO),
+                            Order.ShippingLine(itemId, "first", "first", BigDecimal(1), BigDecimal.ZERO, emptyList()),
+                            Order.ShippingLine(2L, "second", "second", BigDecimal(2), BigDecimal.ZERO, emptyList()),
+                            Order.ShippingLine(3L, "third", "third", BigDecimal(3), BigDecimal.ZERO, emptyList()),
                         )
                     )
                 )

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/creation/MapFeeLineToCustomAmountUIModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/creation/MapFeeLineToCustomAmountUIModelTest.kt
@@ -20,7 +20,8 @@ class MapFeeLineToCustomAmountUIModelTest : BaseUnitTest() {
             name = "Test Amount",
             total = BigDecimal.TEN,
             totalTax = BigDecimal.ZERO,
-            taxStatus = Order.FeeLine.FeeLineTaxStatus.UNKNOWN
+            taxStatus = Order.FeeLine.FeeLineTaxStatus.UNKNOWN,
+            taxes = emptyList()
         )
         val expectedResult = CustomAmountUIModel(
             id = 1,
@@ -43,7 +44,8 @@ class MapFeeLineToCustomAmountUIModelTest : BaseUnitTest() {
             name = "Test Amount",
             total = BigDecimal.TEN,
             totalTax = BigDecimal.ZERO,
-            taxStatus = Order.FeeLine.FeeLineTaxStatus.NONE
+            taxStatus = Order.FeeLine.FeeLineTaxStatus.NONE,
+            taxes = emptyList()
         )
         val expectedResult = CustomAmountUIModel(
             id = 1,
@@ -66,7 +68,8 @@ class MapFeeLineToCustomAmountUIModelTest : BaseUnitTest() {
             name = "Test Amount",
             total = BigDecimal.TEN,
             totalTax = BigDecimal.ZERO,
-            taxStatus = Order.FeeLine.FeeLineTaxStatus.TAXABLE
+            taxStatus = Order.FeeLine.FeeLineTaxStatus.TAXABLE,
+            taxes = emptyList()
         )
         val expectedResult = CustomAmountUIModel(
             id = 1,

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/creation/UnifiedOrderEditViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/creation/UnifiedOrderEditViewModelTest.kt
@@ -484,7 +484,8 @@ abstract class UnifiedOrderEditViewModelTest : BaseUnitTest() {
                 methodId = "other",
                 total = BigDecimal(10),
                 totalTax = BigDecimal.ZERO,
-                methodTitle = "name"
+                methodTitle = "name",
+                taxes = emptyList()
             )
         )
         val order = defaultOrderValue.copy(shippingLines = shippingLines)
@@ -1968,7 +1969,8 @@ abstract class UnifiedOrderEditViewModelTest : BaseUnitTest() {
                 methodId = shippingMethodId,
                 total = BigDecimal.TEN,
                 methodTitle = "Random name",
-                totalTax = BigDecimal.ZERO
+                totalTax = BigDecimal.ZERO,
+                taxes = emptyList()
             )
         )
         val getShippingMethodsResult = flowOf(
@@ -2027,7 +2029,8 @@ abstract class UnifiedOrderEditViewModelTest : BaseUnitTest() {
                     methodId = shippingMethodId,
                     total = BigDecimal.TEN,
                     methodTitle = "Random name",
-                    totalTax = BigDecimal.ZERO
+                    totalTax = BigDecimal.ZERO,
+                    taxes = emptyList()
                 )
             )
             val getShippingMethodsResult = flowOf(
@@ -2087,7 +2090,8 @@ abstract class UnifiedOrderEditViewModelTest : BaseUnitTest() {
                     methodId = shippingMethodId,
                     total = BigDecimal.TEN,
                     methodTitle = "Random name",
-                    totalTax = BigDecimal.ZERO
+                    totalTax = BigDecimal.ZERO,
+                    taxes = emptyList()
                 )
             )
             val getShippingMethodsResult = flowOf(

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/WooShippingLabelCreationViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/WooShippingLabelCreationViewModelTest.kt
@@ -93,6 +93,7 @@ class WooShippingLabelCreationViewModelTest : BaseUnitTest() {
             methodId = it.toString(),
             itemId = it.toLong(),
             totalTax = BigDecimal.ZERO,
+            taxes = emptyList()
         )
     }
     private val defaultOriginAddresses = listOf(

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/payments/refunds/IssueRefundViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/payments/refunds/IssueRefundViewModelTest.kt
@@ -15,6 +15,7 @@ import com.woocommerce.android.ui.orders.OrderTestUtils
 import com.woocommerce.android.ui.orders.details.OrderDetailRepository
 import com.woocommerce.android.ui.payments.refunds.IssueRefundViewModel.RefundByItemsViewState
 import com.woocommerce.android.util.CurrencyFormatter
+import com.woocommerce.android.util.getOrAwaitValue
 import com.woocommerce.android.viewmodel.BaseUnitTest
 import com.woocommerce.android.viewmodel.MultiLiveEvent
 import com.woocommerce.android.viewmodel.ResourceProvider
@@ -1206,4 +1207,67 @@ class IssueRefundViewModelTest : BaseUnitTest() {
             assertThat(viewModel.refundItems.value!![1].maxQuantity).isEqualTo(2.0F)
             assertThat(viewModel.refundItems.value!![2].maxQuantity).isEqualTo(2.0F)
         }
+
+    @Test
+    fun `when preparing refund for products, then pass correct tax rates`() {
+        testBlocking {
+            val order = OrderTestUtils.generateOrderWithOneShipping()
+            whenever(orderStore.getOrderByIdAndSite(any(), any())).thenReturn(order)
+
+            initViewModel()
+            viewModel.onSelectButtonTapped()
+
+            val items = viewModel.refundItems.getOrAwaitValue()
+            items.map { it.toDataModel() }.forEach { refundItem ->
+                val item = order.getLineItemList().first { it.id == refundItem.itemId }
+                assertThat(refundItem.refundTax).allMatch { refundTaxItem ->
+                    val tax = item.taxes!!.first { it.rateId == refundTaxItem.taxRateId }
+                    tax.rateId == refundTaxItem.taxRateId &&
+                        tax.total.isEqualTo(refundTaxItem.refundTotal)
+                }
+            }
+        }
+    }
+
+    @Test
+    fun `when preparing refund for shipping, then pass correct tax rates`() {
+        testBlocking {
+            val order = OrderTestUtils.generateOrderWithOneShipping()
+            whenever(orderStore.getOrderByIdAndSite(any(), any())).thenReturn(order)
+
+            initViewModel()
+            viewModel.onSelectButtonTapped()
+
+            val shippingLines = viewModel.refundShippingLines.getOrAwaitValue()
+            shippingLines.map { it.toDataModel() }.forEach { refundItem ->
+                val shippingLine = order.getShippingLineList().first { it.id == refundItem.itemId }
+                assertThat(refundItem.refundTax).allMatch { refundTaxItem ->
+                    val tax = shippingLine.taxes!!.first { it.rateId == refundTaxItem.taxRateId }
+                    tax.rateId == refundTaxItem.taxRateId &&
+                        tax.total.isEqualTo(refundTaxItem.refundTotal)
+                }
+            }
+        }
+    }
+
+    @Test
+    fun `when preparing refund for fees, then pass correct tax rates`() {
+        testBlocking {
+            val order = OrderTestUtils.generateOrderWithOneShipping()
+            whenever(orderStore.getOrderByIdAndSite(any(), any())).thenReturn(order)
+
+            initViewModel()
+            viewModel.onSelectButtonTapped()
+
+            val feeLines = viewModel.refundFeeLines.getOrAwaitValue()
+            feeLines.map { it.toDataModel() }.forEach { refundItem ->
+                val feeLine = order.getFeeLineList().first { it.id == refundItem.itemId }
+                assertThat(refundItem.refundTax).allMatch { refundTaxItem ->
+                    val tax = feeLine.taxes!!.first { it.rateId == refundTaxItem.taxRateId }
+                    tax.rateId == refundTaxItem.taxRateId &&
+                        tax.total.isEqualTo(refundTaxItem.refundTotal)
+                }
+            }
+        }
+    }
 }

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/payments/refunds/IssueRefundViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/payments/refunds/IssueRefundViewModelTest.kt
@@ -23,6 +23,7 @@ import kotlinx.coroutines.ExperimentalCoroutinesApi
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.Test
 import org.mockito.kotlin.any
+import org.mockito.kotlin.anyOrNull
 import org.mockito.kotlin.doReturn
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.never
@@ -384,6 +385,7 @@ class IssueRefundViewModelTest : BaseUnitTest() {
                 refundStore.createItemsRefund(
                     site = any(),
                     orderId = any(),
+                    amount = anyOrNull(),
                     reason = any(),
                     restockItems = any(),
                     autoRefund = any(),
@@ -435,6 +437,7 @@ class IssueRefundViewModelTest : BaseUnitTest() {
                 refundStore.createItemsRefund(
                     site = any(),
                     orderId = any(),
+                    amount = anyOrNull(),
                     reason = any(),
                     restockItems = any(),
                     autoRefund = any(),
@@ -486,6 +489,7 @@ class IssueRefundViewModelTest : BaseUnitTest() {
                 refundStore.createItemsRefund(
                     site = any(),
                     orderId = any(),
+                    amount = anyOrNull(),
                     reason = any(),
                     restockItems = any(),
                     autoRefund = any(),
@@ -778,6 +782,7 @@ class IssueRefundViewModelTest : BaseUnitTest() {
                 refundStore.createItemsRefund(
                     site = any(),
                     orderId = any(),
+                    amount = anyOrNull(),
                     reason = any(),
                     restockItems = any(),
                     autoRefund = any(),
@@ -833,6 +838,7 @@ class IssueRefundViewModelTest : BaseUnitTest() {
                 refundStore.createItemsRefund(
                     site = any(),
                     orderId = any(),
+                    amount = anyOrNull(),
                     reason = any(),
                     restockItems = any(),
                     autoRefund = any(),

--- a/libs/fluxc-plugin/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/refunds/RefundRestClient.kt
+++ b/libs/fluxc-plugin/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/refunds/RefundRestClient.kt
@@ -9,8 +9,9 @@ import org.wordpress.android.fluxc.model.refunds.WCRefundModel.WCRefundFeeLine
 import org.wordpress.android.fluxc.model.refunds.WCRefundModel.WCRefundShippingLine
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.WooNetwork
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.WooPayload
-import org.wordpress.android.fluxc.utils.sumBy
+import org.wordpress.android.fluxc.utils.extensions.filterNotNull
 import org.wordpress.android.fluxc.utils.toWooPayload
+import java.math.BigDecimal
 import javax.inject.Inject
 
 class RefundRestClient @Inject constructor(private val wooNetwork: WooNetwork) {
@@ -33,6 +34,7 @@ class RefundRestClient @Inject constructor(private val wooNetwork: WooNetwork) {
     suspend fun createRefundByItems(
         site: SiteModel,
         orderId: Long,
+        amount: BigDecimal?,
         reason: String,
         automaticRefund: Boolean,
         items: List<RefundRequestItem>,
@@ -40,11 +42,12 @@ class RefundRestClient @Inject constructor(private val wooNetwork: WooNetwork) {
     ): WooPayload<RefundResponse> {
         val body = mapOf(
                 "reason" to reason,
-                "amount" to items.sumBy { it.total }.toString(),
+                "amount" to amount?.toString(),
                 "api_refund" to automaticRefund.toString(),
                 "line_items" to items,
                 "restock_items" to restockItems
-        )
+        ).filterNotNull()
+
         return createRefund(site, orderId, body)
     }
 

--- a/libs/fluxc-plugin/src/main/kotlin/org/wordpress/android/fluxc/store/WCRefundStore.kt
+++ b/libs/fluxc-plugin/src/main/kotlin/org/wordpress/android/fluxc/store/WCRefundStore.kt
@@ -54,6 +54,7 @@ class WCRefundStore @Inject constructor(
     suspend fun createItemsRefund(
         site: SiteModel,
         orderId: Long,
+        amount: BigDecimal?,
         reason: String = "",
         restockItems: Boolean = true,
         autoRefund: Boolean = false,
@@ -61,12 +62,13 @@ class WCRefundStore @Inject constructor(
     ): WooResult<WCRefundModel> {
         return coroutineEngine.withDefaultContext(AppLog.T.API, this, "createItemsRefund") {
             val response = restClient.createRefundByItems(
-                    site,
-                    orderId,
-                    reason,
-                    autoRefund,
-                    items,
-                    restockItems
+                site = site,
+                orderId = orderId,
+                amount = amount,
+                reason = reason,
+                automaticRefund = autoRefund,
+                items = items,
+                restockItems = restockItems
             )
             return@withDefaultContext when {
                 response.isError -> WooResult(response.error)


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: WOOMOB-395
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
This PR builds on top of the previous [PR](https://github.com/woocommerce/woocommerce-android/pull/14002) to fix the issue of tax refunding, as for now, we weren't handling it correctly.
This PR updates the logic of the refunding to handle splitting the taxes refund according to each item taxes.

**Important:** There is a discrepancy between the `taxes` array that each order line returns, and the `total_tax`, the `total_tax` is rounded, while the values in the array are raw. Initially, I wanted to avoid making any calculations on client side, and drop the `amount` argument from the API call, but I noticed an issue where the refunds could have less amount that the total order amount, so for now, we'll still send the `amount`, and its value will still use the `total_tax` for calculation (this matches iOS behavior too).
This issue will become problematic when we try to add support for partial refunds, I asked about it here p1747301522966739-slack-C07JJG089M0, and depending on the response, I'll document the next steps.

### Steps to reproduce
1. Enable tax calculation on your store.
2. Add multiple tax rates (make sure to assign different priorities so that they all get used for calculation).
3. Create an order.
4. Go to the app and refund the order.

### Testing information
- Confirm refunding works as expected.
- Check wp-admin and confirm taxes were correctly refunded (as shown in the screenshots below)

### The tests that have been performed
^

### Images/gif
| Before | After |
| --- | --- |
| <img width="972" alt="Screenshot 2025-05-15 at 14 50 23" src="https://github.com/user-attachments/assets/01b7e699-6cb0-453f-832c-8cf85e1b990c" /> | <img width="972" alt="Screenshot 2025-05-15 at 14 51 01" src="https://github.com/user-attachments/assets/50815edc-020e-428b-a50b-1ae4a0feef07" /> |

- [ ] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.

## Reviewer (or Author, in the case of optional code reviews):

Please make sure these conditions are met before approving the PR, or request changes if the PR needs improvement:

- [ ] The PR is small and has a clear, single focus, or a valid explanation is provided in the description. If needed, please request to split it into smaller PRs.
- [ ] Ensure Adequate Unit Test Coverage: The changes are reasonably covered by unit tests or an explanation is provided in the PR description.
- [ ] Manual Testing: The author listed all the tests they ran, including smoke tests when needed (e.g., for refactorings). The reviewer confirmed that the PR works as expected on big (tablet) and small (phone) in case of UI changes, and no regressions are added.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->