### PR TITLE
[WOOPRD-508][Woo POS][Product search] A crash when a product was deleted on the backend and then selected again after checkout

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/WooPosHomeChildToParentCommunication.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/WooPosHomeChildToParentCommunication.kt
@@ -46,6 +46,8 @@ sealed class ChildToParentEvent {
     ) : ChildToParentEvent()
 
     data class ToastMessageDisplayed(val message: String) : ChildToParentEvent()
+    data object RefreshProductList : ChildToParentEvent()
+
     sealed class NavigationEvent : ChildToParentEvent() {
         data class ToCashPayment(val orderId: Long) : NavigationEvent()
         data class ToEmailReceipt(val orderId: Long) : NavigationEvent()

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/WooPosHomeParentToChildCommunication.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/WooPosHomeParentToChildCommunication.kt
@@ -24,6 +24,7 @@ sealed class ParentToChildrenEvent {
     data object BackFromCheckoutToCartClicked : ParentToChildrenEvent()
     data object CouponsValidationFailed : ParentToChildrenEvent()
     data object RemoveCouponsClicked : ParentToChildrenEvent()
+    data object RefreshProductList : ParentToChildrenEvent()
     data class CouponsRemoved(
         val cartDataList: List<WooPosItemsViewModel.ItemClickedData>
     ) : ParentToChildrenEvent()

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/WooPosHomeViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/WooPosHomeViewModel.kt
@@ -6,6 +6,7 @@ import androidx.lifecycle.viewModelScope
 import com.woocommerce.android.ui.woopos.common.util.WooPosSoundHelper
 import com.woocommerce.android.ui.woopos.home.ChildToParentEvent.NavigationEvent
 import com.woocommerce.android.ui.woopos.home.ParentToChildrenEvent.CheckoutClicked
+import com.woocommerce.android.ui.woopos.home.ParentToChildrenEvent.CouponsRemoved
 import com.woocommerce.android.ui.woopos.home.ParentToChildrenEvent.ItemClickedInProductSelector
 import com.woocommerce.android.ui.woopos.home.ParentToChildrenEvent.OrderCreated
 import com.woocommerce.android.ui.woopos.home.ParentToChildrenEvent.OrderSuccessfullyPaid.PaymentMethod
@@ -202,7 +203,11 @@ class WooPosHomeViewModel @Inject constructor(
                         sendEventToChildren(ParentToChildrenEvent.RemoveCouponsClicked)
                     }
                     is ChildToParentEvent.CouponsRemoved -> {
-                        sendEventToChildren(ParentToChildrenEvent.CouponsRemoved(event.cartDataList))
+                        sendEventToChildren(CouponsRemoved(event.cartDataList))
+                    }
+
+                    ChildToParentEvent.RefreshProductList -> {
+                        sendEventToChildren(ParentToChildrenEvent.RefreshProductList)
                     }
                 }
             }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/cart/WooPosCartItemsUpdater.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/cart/WooPosCartItemsUpdater.kt
@@ -1,21 +1,15 @@
 package com.woocommerce.android.ui.woopos.home.cart
 
 import com.automattic.android.tracks.crashlogging.CrashLogging
-import com.woocommerce.android.R
 import com.woocommerce.android.ui.woopos.common.data.WooPosProductsCache
-import com.woocommerce.android.ui.woopos.home.ChildToParentEvent
 import com.woocommerce.android.ui.woopos.home.ParentToChildrenEvent
-import com.woocommerce.android.ui.woopos.home.WooPosChildrenToParentEventSender
 import com.woocommerce.android.ui.woopos.home.cart.WooPosCartItemViewState.Coupon.CouponValidationState
 import com.woocommerce.android.ui.woopos.util.format.WooPosFormatPrice
 import com.woocommerce.android.util.WooLog.T
 import com.woocommerce.android.util.WooLogWrapper
-import com.woocommerce.android.viewmodel.ResourceProvider
 import javax.inject.Inject
 
 class WooPosCartItemsUpdater @Inject constructor(
-    private val childrenToParentEventSender: WooPosChildrenToParentEventSender,
-    private val resourceProvider: ResourceProvider,
     private val formatPrice: WooPosFormatPrice,
     private val productsCache: WooPosProductsCache,
     private val wooLogWrapper: WooLogWrapper,
@@ -25,7 +19,7 @@ class WooPosCartItemsUpdater @Inject constructor(
         itemsInCart: List<WooPosCartItemViewState>,
         updatedProducts: List<ParentToChildrenEvent.OrderCreated.ProductInfo>,
         updatedCoupons: List<ParentToChildrenEvent.OrderCreated.CouponInfo>,
-    ): List<WooPosCartItemViewState> {
+    ): CartItemsUpdaterResult {
         val mutableCurrentBodyList = itemsInCart.toMutableList()
         var productsChanged = false
 
@@ -72,11 +66,10 @@ class WooPosCartItemsUpdater @Inject constructor(
             }
         }
 
-        if (productsChanged) {
-            notifyParentAboutChanges()
-        }
-
-        return mutableCurrentBodyList
+        return CartItemsUpdaterResult(
+            updatedItems = mutableCurrentBodyList,
+            productsChanged = productsChanged,
+        )
     }
 
     private suspend fun updateCouponsWithFormattedDiscount(
@@ -88,14 +81,6 @@ class WooPosCartItemsUpdater @Inject constructor(
         val message = "Coupon not found in the cart"
         wooLogWrapper.e(T.POS, message)
         crashLogger.sendReport(IllegalStateException(message))
-    }
-
-    private suspend fun notifyParentAboutChanges() {
-        childrenToParentEventSender.sendToParent(
-            ChildToParentEvent.ToastMessageDisplayed(
-                message = resourceProvider.getString(R.string.woopos_cart_changes_in_the_cart)
-            )
-        )
     }
 
     private suspend fun updateProductInCache(
@@ -200,4 +185,9 @@ class WooPosCartItemsUpdater @Inject constructor(
 
     private fun ParentToChildrenEvent.OrderCreated.ProductInfo.subtotalPricePerItem() =
         basePrice.div(quantity.toBigDecimal())
+
+    data class CartItemsUpdaterResult(
+        val updatedItems: List<WooPosCartItemViewState>,
+        val productsChanged: Boolean,
+    )
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/cart/WooPosCartViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/cart/WooPosCartViewModel.kt
@@ -172,6 +172,7 @@ class WooPosCartViewModel @Inject constructor(
                     is ParentToChildrenEvent.SearchEvent.ChangedQuery,
                     ParentToChildrenEvent.SearchEvent.Finished,
                     ParentToChildrenEvent.SearchEvent.Started,
+                    ParentToChildrenEvent.RefreshProductList,
                     is ParentToChildrenEvent.CouponsRemoved -> Unit
                     is ParentToChildrenEvent.CouponsValidationFailed -> {
                         onCouponsValidationFails()

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/cart/WooPosCartViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/cart/WooPosCartViewModel.kt
@@ -165,19 +165,7 @@ class WooPosCartViewModel @Inject constructor(
 
                     is ParentToChildrenEvent.OrderSuccessfullyPaid -> clearCart()
 
-                    is ParentToChildrenEvent.OrderCreated -> {
-                        val body = _state.value.body as? WooPosCartState.Body.WithItems ?: return@collect
-                        val updateCartItems = updateCartItemsWithChanges(
-                            itemsInCart = body.itemsInCart,
-                            updatedProducts = event.updatedProducts,
-                            updatedCoupons = event.updatedCoupons,
-                        )
-                        _state.value = _state.value.copy(
-                            body = body.copy(
-                                itemsInCart = updateCartItems,
-                            ),
-                        )
-                    }
+                    is ParentToChildrenEvent.OrderCreated -> onOrderCreated(event)
 
                     is ParentToChildrenEvent.SearchEvent.RecentSearchSelected,
                     is ParentToChildrenEvent.CheckoutClicked,
@@ -193,6 +181,27 @@ class WooPosCartViewModel @Inject constructor(
                     }
                 }
             }
+        }
+    }
+
+    private suspend fun onOrderCreated(event: ParentToChildrenEvent.OrderCreated) {
+        val body = _state.value.body as? WooPosCartState.Body.WithItems ?: return
+        val updateCartItemsResult = updateCartItemsWithChanges(
+            itemsInCart = body.itemsInCart,
+            updatedProducts = event.updatedProducts,
+            updatedCoupons = event.updatedCoupons,
+        )
+        if (updateCartItemsResult.productsChanged) {
+            _state.value = _state.value.copy(
+                body = body.copy(
+                    itemsInCart = updateCartItemsResult.updatedItems,
+                ),
+            )
+            childrenToParentEventSender.sendToParent(
+                ChildToParentEvent.ToastMessageDisplayed(
+                    message = resourceProvider.getString(R.string.woopos_cart_changes_in_the_cart)
+                )
+            )
         }
     }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/cart/WooPosCartViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/cart/WooPosCartViewModel.kt
@@ -203,6 +203,9 @@ class WooPosCartViewModel @Inject constructor(
                     message = resourceProvider.getString(R.string.woopos_cart_changes_in_the_cart)
                 )
             )
+            childrenToParentEventSender.sendToParent(
+                ChildToParentEvent.RefreshProductList
+            )
         }
     }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/items/WooPosItemsSearchHelper.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/items/WooPosItemsSearchHelper.kt
@@ -51,6 +51,9 @@ class WooPosItemsSearchHelper @Inject constructor(
                     is ParentToChildrenEvent.SearchEvent.RecentSearchSelected -> {
                         onSearchChanged(event.query, event.query.length)
                     }
+                    is ParentToChildrenEvent.RefreshProductList -> {
+                        onSearchChanged("", 0)
+                    }
 
                     is ParentToChildrenEvent.BackFromCheckoutToCartClicked -> Unit
                     is ParentToChildrenEvent.ItemClickedInProductSelector -> Unit

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/items/WooPosItemsSearchHelper.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/items/WooPosItemsSearchHelper.kt
@@ -52,7 +52,9 @@ class WooPosItemsSearchHelper @Inject constructor(
                         onSearchChanged(event.query, event.query.length)
                     }
                     is ParentToChildrenEvent.RefreshProductList -> {
-                        onSearchChanged("", 0)
+                        if (isSearchOpen()) {
+                            onSearchChanged("", 0)
+                        }
                     }
 
                     is ParentToChildrenEvent.BackFromCheckoutToCartClicked -> Unit

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/items/WooPosItemsSearchHelper.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/items/WooPosItemsSearchHelper.kt
@@ -32,6 +32,7 @@ class WooPosItemsSearchHelper @Inject constructor(
         listenEventsFromParent()
     }
 
+    @Suppress("CyclomaticComplexMethod")
     private fun listenEventsFromParent() {
         coroutineScope.launch {
             parentToChildrenEventReceiver.events.collect { event ->

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/items/products/WooPosProductsViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/items/products/WooPosProductsViewModel.kt
@@ -5,7 +5,9 @@ import androidx.lifecycle.viewModelScope
 import com.woocommerce.android.model.Product
 import com.woocommerce.android.ui.products.ProductType
 import com.woocommerce.android.ui.woopos.home.ChildToParentEvent
+import com.woocommerce.android.ui.woopos.home.ParentToChildrenEvent
 import com.woocommerce.android.ui.woopos.home.WooPosChildrenToParentEventSender
+import com.woocommerce.android.ui.woopos.home.WooPosParentToChildrenEventReceiver
 import com.woocommerce.android.ui.woopos.home.items.WooPosItemNavigationData.VariableProductData
 import com.woocommerce.android.ui.woopos.home.items.WooPosItemSelectionViewState
 import com.woocommerce.android.ui.woopos.home.items.WooPosItemsViewModel.ItemClickedData
@@ -31,6 +33,7 @@ import javax.inject.Inject
 class WooPosProductsViewModel @Inject constructor(
     private val productsDataSource: WooPosProductsDataSource,
     private val fromChildToParentEventSender: WooPosChildrenToParentEventSender,
+    private val parentToChildrenEventReceiver: WooPosParentToChildrenEventReceiver,
     private val priceFormat: WooPosFormatPrice,
     private val navigator: WooPosItemsNavigator,
     private val analyticsTracker: WooPosAnalyticsTracker,
@@ -51,10 +54,39 @@ class WooPosProductsViewModel @Inject constructor(
         )
 
     init {
+        listenEventsFromParent()
         loadProducts(
             forceRefreshProducts = false,
             withPullToRefresh = false,
         )
+    }
+
+    private fun listenEventsFromParent() {
+        viewModelScope.launch {
+            parentToChildrenEventReceiver.events.collect { event ->
+                when (event) {
+                    ParentToChildrenEvent.RefreshProductList -> {
+                        loadProducts(
+                            forceRefreshProducts = true,
+                            withPullToRefresh = false,
+                        )
+                    }
+
+                    ParentToChildrenEvent.BackFromCheckoutToCartClicked,
+                    is ParentToChildrenEvent.CheckoutClicked,
+                    is ParentToChildrenEvent.CouponsRemoved,
+                    ParentToChildrenEvent.CouponsValidationFailed,
+                    is ParentToChildrenEvent.ItemClickedInProductSelector,
+                    is ParentToChildrenEvent.OrderCreated,
+                    is ParentToChildrenEvent.OrderSuccessfullyPaid,
+                    ParentToChildrenEvent.RemoveCouponsClicked,
+                    is ParentToChildrenEvent.SearchEvent.ChangedQuery,
+                    ParentToChildrenEvent.SearchEvent.Finished,
+                    is ParentToChildrenEvent.SearchEvent.RecentSearchSelected,
+                    ParentToChildrenEvent.SearchEvent.Started -> Unit
+                }
+            }
+        }
     }
 
     fun onUIEvent(event: WooPosProductsUIEvent) {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/items/search/WooPosItemsSearchViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/items/search/WooPosItemsSearchViewModel.kt
@@ -188,6 +188,7 @@ class WooPosItemsSearchViewModel @Inject constructor(
                     is ParentToChildrenEvent.OrderCreated -> Unit
                     is ParentToChildrenEvent.RemoveCouponsClicked -> Unit
                     is ParentToChildrenEvent.CouponsRemoved -> Unit
+                    is ParentToChildrenEvent.RefreshProductList -> Unit
                     is ParentToChildrenEvent.CouponsValidationFailed -> Unit
                     is ParentToChildrenEvent.ItemClickedInProductSelector -> {
                         if (event.itemData is ItemClickedData.Product.Variation && searchHelper.isSearchOpen()) {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/totals/WooPosTotalsViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/totals/WooPosTotalsViewModel.kt
@@ -310,6 +310,7 @@ class WooPosTotalsViewModel @Inject constructor(
                     is ParentToChildrenEvent.OrderCreated,
                     ParentToChildrenEvent.SearchEvent.Started,
                     ParentToChildrenEvent.RemoveCouponsClicked,
+                    ParentToChildrenEvent.RefreshProductList,
                     ParentToChildrenEvent.CouponsValidationFailed -> Unit
                 }
             }

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/home/cart/WooPosCartItemsUpdaterTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/home/cart/WooPosCartItemsUpdaterTest.kt
@@ -2,17 +2,13 @@ package com.woocommerce.android.ui.woopos.home.cart
 
 import androidx.arch.core.executor.testing.InstantTaskExecutorRule
 import com.automattic.android.tracks.crashlogging.CrashLogging
-import com.woocommerce.android.R
 import com.woocommerce.android.model.Product
 import com.woocommerce.android.ui.woopos.common.data.WooPosProductsCache
-import com.woocommerce.android.ui.woopos.home.ChildToParentEvent
 import com.woocommerce.android.ui.woopos.home.ParentToChildrenEvent
-import com.woocommerce.android.ui.woopos.home.WooPosChildrenToParentEventSender
 import com.woocommerce.android.ui.woopos.home.cart.WooPosCartItemViewState.Coupon.CouponValidationState
 import com.woocommerce.android.ui.woopos.util.WooPosCoroutineTestRule
 import com.woocommerce.android.ui.woopos.util.format.WooPosFormatPrice
 import com.woocommerce.android.util.WooLogWrapper
-import com.woocommerce.android.viewmodel.ResourceProvider
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.runTest
 import org.assertj.core.api.Assertions.assertThat
@@ -20,7 +16,6 @@ import org.junit.Rule
 import org.mockito.kotlin.any
 import org.mockito.kotlin.anyOrNull
 import org.mockito.kotlin.argThat
-import org.mockito.kotlin.eq
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.never
 import org.mockito.kotlin.verify
@@ -38,10 +33,6 @@ class WooPosCartItemsUpdaterTest {
     @JvmField
     val coroutinesTestRule = WooPosCoroutineTestRule()
 
-    private val childrenToParentEventSender: WooPosChildrenToParentEventSender = mock()
-    private val resourceProvider: ResourceProvider = mock {
-        on { getString(eq(R.string.woopos_cart_changes_in_the_cart)) }.thenReturn("Changes made to items in cart")
-    }
     private val formatPrice: WooPosFormatPrice = mock {
         onBlocking { invoke(argThat { this == BigDecimal("10.0") }) }.thenReturn("10.0$")
         onBlocking { invoke(argThat { this == BigDecimal("5.0") }) }.thenReturn("5.0$")
@@ -51,8 +42,6 @@ class WooPosCartItemsUpdaterTest {
     private val logger: WooLogWrapper = mock()
 
     private val updater = WooPosCartItemsUpdater(
-        childrenToParentEventSender = childrenToParentEventSender,
-        resourceProvider = resourceProvider,
         formatPrice = formatPrice,
         productsCache = productsCache,
         wooLogWrapper = logger,
@@ -85,11 +74,11 @@ class WooPosCartItemsUpdaterTest {
         val result = updater.invoke(itemsInCart, listOf(updatedInfo), emptyList())
 
         // THEN
-        assertThat(result).hasSize(1)
-        val updatedItem = result[0] as WooPosCartItemViewState.Product.Simple
+        assertThat(result.updatedItems).hasSize(1)
+        val updatedItem = result.updatedItems[0] as WooPosCartItemViewState.Product.Simple
         assertThat(updatedItem.name).isEqualTo("Updated Name")
         assertThat(updatedItem.price).isEqualTo("10.0$")
-        verify(childrenToParentEventSender).sendToParent(any<ChildToParentEvent.ToastMessageDisplayed>())
+        assertThat(result.productsChanged).isTrue()
         verify(productsCache).updateProduct(
             cachedProduct.copy(
                 name = "Updated Name",
@@ -126,11 +115,11 @@ class WooPosCartItemsUpdaterTest {
         val result = updater.invoke(itemsInCart, listOf(updatedInfo), emptyList())
 
         // THEN
-        assertThat(result).hasSize(1)
-        val updatedItem = result[0] as WooPosCartItemViewState.Product.Variation
+        assertThat(result.updatedItems).hasSize(1)
+        val updatedItem = result.updatedItems[0] as WooPosCartItemViewState.Product.Variation
         assertThat(updatedItem.name).isEqualTo("Updated Variation")
         assertThat(updatedItem.price).isEqualTo("10.0$")
-        verify(childrenToParentEventSender).sendToParent(any<ChildToParentEvent.ToastMessageDisplayed>())
+        assertThat(result.productsChanged).isTrue()
         verify(productsCache).updateProduct(
             cachedProduct.copy(
                 name = "Updated Variation",
@@ -156,10 +145,10 @@ class WooPosCartItemsUpdaterTest {
         val result = updater.invoke(itemsInCart, emptyList(), emptyList())
 
         // THEN
-        assertThat(result).hasSize(1)
-        val updatedItem = result[0] as WooPosCartItemViewState.Product.Simple
+        assertThat(result.updatedItems).hasSize(1)
+        val updatedItem = result.updatedItems[0] as WooPosCartItemViewState.Product.Simple
         assertThat(updatedItem.productDoesNotExist).isTrue()
-        verify(childrenToParentEventSender).sendToParent(any<ChildToParentEvent.ToastMessageDisplayed>())
+        assertThat(result.productsChanged).isTrue()
         verify(productsCache).deleteProduct(1L)
     }
 
@@ -197,16 +186,16 @@ class WooPosCartItemsUpdaterTest {
         val result = updater.invoke(itemsInCart, listOf(updatedInfo), emptyList())
 
         // THEN
-        assertThat(result).hasSize(2)
+        assertThat(result.updatedItems).hasSize(2)
 
-        val updatedItem1 = result[0] as WooPosCartItemViewState.Product.Simple
+        val updatedItem1 = result.updatedItems[0] as WooPosCartItemViewState.Product.Simple
         assertThat(updatedItem1.name).isEqualTo("Updated Product 1")
         assertThat(updatedItem1.price).isEqualTo("10.0$")
 
-        val updatedItem2 = result[1] as WooPosCartItemViewState.Product.Simple
+        val updatedItem2 = result.updatedItems[1] as WooPosCartItemViewState.Product.Simple
         assertThat(updatedItem2.productDoesNotExist).isTrue()
 
-        verify(childrenToParentEventSender).sendToParent(any<ChildToParentEvent.ToastMessageDisplayed>())
+        assertThat(result.productsChanged).isTrue()
         verify(productsCache).updateProduct(
             cachedProduct.copy(
                 name = "Updated Product 1",
@@ -242,17 +231,17 @@ class WooPosCartItemsUpdaterTest {
         val result = updater.invoke(itemsInCart, listOf(updatedInfo), emptyList())
 
         // THEN
-        assertThat(result).hasSize(2)
+        assertThat(result.updatedItems).hasSize(2)
 
-        val firstItem = result[0] as WooPosCartItemViewState.Product.Simple
+        val firstItem = result.updatedItems[0] as WooPosCartItemViewState.Product.Simple
         assertThat(firstItem.name).isEqualTo("Updated Product")
         assertThat(firstItem.price).isEqualTo("10.0$")
         assertThat(firstItem.productDoesNotExist).isFalse()
 
-        val secondItem = result[1] as WooPosCartItemViewState.Product.Simple
+        val secondItem = result.updatedItems[1] as WooPosCartItemViewState.Product.Simple
         assertThat(secondItem.productDoesNotExist).isTrue()
 
-        verify(childrenToParentEventSender).sendToParent(any<ChildToParentEvent.ToastMessageDisplayed>())
+        assertThat(result.productsChanged).isTrue()
         verify(productsCache).updateProduct(
             cachedProduct.copy(
                 name = "Updated Product",
@@ -263,7 +252,7 @@ class WooPosCartItemsUpdaterTest {
     }
 
     @Test
-    fun `given no changes in product info, when called, then cache is not updated and parent is not notified`() = runTest {
+    fun `given no changes in product info, when called, then cache is not updated and products not changed`() = runTest {
         // GIVEN
         val simpleProduct = WooPosCartItemViewState.Product.Simple(
             itemNumber = 1,
@@ -286,9 +275,9 @@ class WooPosCartItemsUpdaterTest {
         val result = updater.invoke(itemsInCart, listOf(updatedInfo), emptyList())
 
         // THEN
-        assertThat(result).hasSize(1)
+        assertThat(result.updatedItems).hasSize(1)
         verify(productsCache, never()).updateProduct(any())
-        verify(childrenToParentEventSender, never()).sendToParent(any<ChildToParentEvent.ToastMessageDisplayed>())
+        assertThat(result.productsChanged).isFalse()
     }
 
     @Test
@@ -362,8 +351,8 @@ class WooPosCartItemsUpdaterTest {
             val result = updater.invoke(itemsInCart, emptyList(), updatedCoupons)
 
             // THEN
-            assertThat(result).hasSize(1)
-            val updatedCoupon = result[0] as WooPosCartItemViewState.Coupon
+            assertThat(result.updatedItems).hasSize(1)
+            val updatedCoupon = result.updatedItems[0] as WooPosCartItemViewState.Coupon
             assertThat(updatedCoupon.validationState).isEqualTo(CouponValidationState.Valid("-5.0$"))
         }
 
@@ -377,8 +366,8 @@ class WooPosCartItemsUpdaterTest {
             val result = updater.invoke(itemsInCart, emptyList(), updatedCoupons = emptyList())
 
             // THEN
-            assertThat(result).hasSize(1)
-            val updatedCoupon = result[0] as WooPosCartItemViewState.Coupon
+            assertThat(result.updatedItems).hasSize(1)
+            val updatedCoupon = result.updatedItems[0] as WooPosCartItemViewState.Coupon
             assertThat(updatedCoupon.validationState).isEqualTo(CouponValidationState.Unknown)
         }
 
@@ -417,10 +406,10 @@ class WooPosCartItemsUpdaterTest {
             val result = updater.invoke(itemsInCart, emptyList(), updatedCoupons)
 
             // THEN
-            assertThat(result).hasSize(2)
-            val updatedCoupon1 = result[0] as WooPosCartItemViewState.Coupon
+            assertThat(result.updatedItems).hasSize(2)
+            val updatedCoupon1 = result.updatedItems[0] as WooPosCartItemViewState.Coupon
             assertThat(updatedCoupon1.validationState).isEqualTo(CouponValidationState.Valid("-5.0$"))
-            val updatedCoupon2 = result[1] as WooPosCartItemViewState.Coupon
+            val updatedCoupon2 = result.updatedItems[1] as WooPosCartItemViewState.Coupon
             assertThat(updatedCoupon2.validationState).isEqualTo(CouponValidationState.Valid("-10.0$"))
         }
 

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/home/items/products/WooPosProductsViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/home/items/products/WooPosProductsViewModelTest.kt
@@ -4,6 +4,7 @@ import app.cash.turbine.test
 import com.woocommerce.android.ui.products.ProductTestUtils
 import com.woocommerce.android.ui.woopos.home.ChildToParentEvent
 import com.woocommerce.android.ui.woopos.home.WooPosChildrenToParentEventSender
+import com.woocommerce.android.ui.woopos.home.WooPosParentToChildrenEventReceiver
 import com.woocommerce.android.ui.woopos.home.items.WooPosContentViewState
 import com.woocommerce.android.ui.woopos.home.items.WooPosItemNavigationData
 import com.woocommerce.android.ui.woopos.home.items.WooPosItemSelectionViewState
@@ -46,6 +47,7 @@ class WooPosProductsViewModelTest {
         onBlocking { invoke(BigDecimal("20.0")) }.thenReturn("$20.0")
     }
     private val fromChildToParentEventSender: WooPosChildrenToParentEventSender = mock()
+    private val parentToChildrenEventReceiver: WooPosParentToChildrenEventReceiver = mock()
     private val analyticsTracker: WooPosAnalyticsTracker = mock()
     private val productsDataSource: WooPosProductsDataSource = mock()
     private val wooPosItemsNavigator: WooPosItemsNavigator = mock()
@@ -502,6 +504,7 @@ class WooPosProductsViewModelTest {
             priceFormat = priceFormat,
             analyticsTracker = analyticsTracker,
             fromChildToParentEventSender = fromChildToParentEventSender,
+            parentToChildrenEventReceiver = parentToChildrenEventReceiver,
             navigator = wooPosItemsNavigator,
         )
     }


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #WOOPRD-508
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
The PR updates the search (if selected) and the products list if there are changes in the cache due to the data received from the order creation response.

### Steps to reproduce
<!-- Step-by-step testing instructions. For new user flows, consider instead stating the goal of the workflow and see if your PR reviewer can accomplish the workflow without specific steps! -->
* Open the POS
* Add a product (via search or from the list)
* Delete the product from the backend (from the bin too!)
* Do the checkout
* Go back
* Select the same product 
* Crash

### Images/gif
<!-- Include before and after images or gifs when appropriate. -->

https://github.com/user-attachments/assets/5ce9da82-7d7d-4b30-b103-0af797881bab

https://github.com/user-attachments/assets/1a3ac40a-3329-4b34-9fdb-c57f8e4afb86

- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.

## Reviewer (or Author, in the case of optional code reviews):

Please make sure these conditions are met before approving the PR, or request changes if the PR needs improvement:

- [x] The PR is small and has a clear, single focus, or a valid explanation is provided in the description. If needed, please request to split it into smaller PRs.
- [x] Ensure Adequate Unit Test Coverage: The changes are reasonably covered by unit tests or an explanation is provided in the PR description.
- [x] Manual Testing: The author listed all the tests they ran, including smoke tests when needed (e.g., for refactorings). The reviewer confirmed that the PR works as expected on big (tablet) and small (phone) in case of UI changes, and no regressions are added.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->