### PR TITLE
[WOOMOB-515] POS Remember coupon list scroll position

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/items/WooPosItemsScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/items/WooPosItemsScreen.kt
@@ -34,13 +34,15 @@ import kotlinx.coroutines.flow.StateFlow
 @Composable
 fun WooPosItemsScreen(
     modifier: Modifier = Modifier,
-    listState: LazyListState,
+    productsViewState: LazyListState,
+    couponsListState: LazyListState,
 ) {
     val productsViewModel: WooPosItemsViewModel = hiltViewModel()
     WooPosItemsScreen(
         modifier = modifier,
         itemsStateFlow = productsViewModel.viewState,
-        listState = listState,
+        productsViewState = productsViewState,
+        couponsListState = couponsListState,
         onUIEvent = { productsViewModel.onUIEvent(it) },
     )
 }
@@ -50,7 +52,8 @@ fun WooPosItemsScreen(
 private fun WooPosItemsScreen(
     modifier: Modifier = Modifier,
     itemsStateFlow: StateFlow<WooPosItemsViewState>,
-    listState: LazyListState,
+    productsViewState: LazyListState,
+    couponsListState: LazyListState,
     onUIEvent: (WooPosItemsUIEvent) -> Unit,
 ) {
     val state = itemsStateFlow.collectAsState()
@@ -58,7 +61,8 @@ private fun WooPosItemsScreen(
     MainItemsList(
         modifier = modifier,
         state = state,
-        listState = listState,
+        productsViewState = productsViewState,
+        couponsListState = couponsListState,
         onSearchEvent = {
             when (it) {
                 WooPosSearchUIEvent.Clear -> onUIEvent(WooPosItemsUIEvent.ClearSearchClicked)
@@ -89,7 +93,8 @@ private fun WooPosItemsScreen(
 private fun MainItemsList(
     modifier: Modifier,
     state: State<WooPosItemsViewState>,
-    listState: LazyListState,
+    productsViewState: LazyListState,
+    couponsListState: LazyListState,
     onSearchEvent: (WooPosSearchUIEvent) -> Unit,
     onTabClicked: (WooPosItemsViewState.Tab) -> Unit,
     onAddCouponEvent: () -> Unit,
@@ -127,13 +132,15 @@ private fun MainItemsList(
                         modifier = Modifier.padding(
                             horizontal = WooPosSpacing.Medium.value.toAdaptivePadding(),
                         ),
-                        listState = listState
+                        listState = productsViewState
                     )
+
                     ScreenState.PRODUCTS_SEARCH -> WooPosItemsSearchScreen()
                     ScreenState.COUPONS -> WooPosCouponsScreen(
                         modifier = Modifier.padding(
                             horizontal = WooPosSpacing.Medium.value.toAdaptivePadding(),
-                        )
+                        ),
+                        listState = couponsListState,
                     )
                 }
             }
@@ -182,7 +189,8 @@ fun WooPosItemsScreenSearchVisiblePreview(modifier: Modifier = Modifier) {
         WooPosItemsScreen(
             modifier = modifier,
             itemsStateFlow = productState,
-            listState = rememberLazyListState(),
+            productsViewState = rememberLazyListState(),
+            couponsListState = rememberLazyListState(),
             onUIEvent = {},
         )
     }
@@ -207,7 +215,8 @@ fun WooPosItemsScreenSearchHiddenPreview(modifier: Modifier = Modifier) {
         WooPosItemsScreen(
             modifier = modifier,
             itemsStateFlow = productState,
-            listState = rememberLazyListState(),
+            productsViewState = rememberLazyListState(),
+            couponsListState = rememberLazyListState(),
             onUIEvent = {},
         )
     }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/items/coupons/WooPosCouponsScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/items/coupons/WooPosCouponsScreen.kt
@@ -36,9 +36,9 @@ import kotlinx.coroutines.flow.StateFlow
 @Composable
 fun WooPosCouponsScreen(
     modifier: Modifier = Modifier,
+    listState: LazyListState,
 ) {
     val vm: WooPosCouponsViewModel = hiltViewModel()
-    val listState = rememberLazyListState()
     WooPosCouponsScreen(
         modifier = modifier,
         listState = listState,

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/items/navigation/WooPosItemsScreens.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/items/navigation/WooPosItemsScreens.kt
@@ -27,12 +27,13 @@ fun WooPosItemsScreens(
     onNavigateToItemsListScreen: () -> Unit
 ) {
     val currentNavigationState = itemsScreens.collectAsState()
-    val listState = rememberLazyListState()
+    val productListState = rememberLazyListState()
+    val couponsListState = rememberLazyListState()
     Box(modifier = modifier.fillMaxSize()) {
         Crossfade(targetState = currentNavigationState.value, label = "LeftPaneScreen") { navigationState ->
             when (navigationState) {
                 is WooPosItemsScreenViewModel.ItemsScreens.ItemListScreen -> {
-                    WooPosItemsScreen(modifier = modifier, listState)
+                    WooPosItemsScreen(modifier = modifier, productListState, couponsListState)
                 }
 
                 is WooPosItemsScreenViewModel.ItemsScreens.VariationsScreen -> {


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #WOOMOB-515
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

This PR adds logic to remember coupon's list scroll position. I tried three different approaches, but this one is the only one that worked without issues/side-effects/performance-impact.

AFAICT the listState needs to live outside the cross-fade animations as it completely removes the composables from the tree => if the remembered state is inside, it'll be lost as the screen is completely re-rendered during the next cross-fade. I even tried replacing cross-fade with animatedVisibility, which doesn't remove the compostables from the tree - it somewhat worked, but I was worried about the potential performance impact.

This current solution feels relatively clean and easy to follow.

### Testing information
<!-- This is your opportunity to break out individual scenarios that need testing (when necessary) and/or include a checklist for the reviewer to go through. Consider documenting the following from your own completed testing: devices used, alternate workflows, edge cases, affected areas, critical flows, areas not tested, and any remaining unknowns. Provide feedback on this new section of the PR template through Sept 30, 2024 to Apps Quality; additional context here: p91TBi-b8z-p2#comment-12036 -->

1. Open POS
2. Scroll on product list
3. Switch to coupons
4. Scroll on coupons
5. Switch back to product list and ensure the previous scrolling position was remembered
6. Tap on a variable product
7. Tap back
8. Notice the scroll position of product list is retained
9. Tap on search
10. Tap back
11. Notice the scroll position of both product and coupons list is retained

### The tests that have been performed
<!-- To give the reviewer an idea of what could be missed in terms of testing -->

The above

### Images/gif
<!-- Include before and after images or gifs when appropriate. -->

https://github.com/user-attachments/assets/58527ea4-e428-4015-8c03-98aa8b98c56e


- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.

## Reviewer (or Author, in the case of optional code reviews):

Please make sure these conditions are met before approving the PR, or request changes if the PR needs improvement:

- [x] The PR is small and has a clear, single focus, or a valid explanation is provided in the description. If needed, please request to split it into smaller PRs.
- [x] Ensure Adequate Unit Test Coverage: The changes are reasonably covered by unit tests or an explanation is provided in the PR description.
- [x] Manual Testing: The author listed all the tests they ran, including smoke tests when needed (e.g., for refactorings). The reviewer confirmed that the PR works as expected on big (tablet) and small (phone) in case of UI changes, and no regressions are added.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->