### PR TITLE
[WOOMOB-480] Order Items in POS Cart - coupons first

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/cart/WooPosCartViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/cart/WooPosCartViewModel.kt
@@ -324,7 +324,7 @@ class WooPosCartViewModel @Inject constructor(
         val updatedItems = if (newItem is WooPosCartItemViewState.Coupon) {
             listOf(newItem) + existingCoupons + existingProducts
         } else {
-            existingCoupons + listOf(newItem) + existingProducts.filterNot { it == newItem }
+            existingCoupons + listOf(newItem) + existingProducts
         }
         return updatedItems
     }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/cart/WooPosCartViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/cart/WooPosCartViewModel.kt
@@ -306,10 +306,26 @@ class WooPosCartViewModel @Inject constructor(
     private fun updateStateWithNewItem(newItem: WooPosCartItemViewState): WooPosCartState {
         return when (val currentState = _state.value.body) {
             is WooPosCartState.Body.Empty -> _state.value.copy(body = WooPosCartState.Body.WithItems(listOf(newItem)))
-            is WooPosCartState.Body.WithItems -> _state.value.copy(
-                body = currentState.copy(itemsInCart = listOf(newItem) + currentState.itemsInCart)
-            )
+            is WooPosCartState.Body.WithItems -> {
+                val updatedItemsList = placeItemInList(currentState, newItem)
+
+                _state.value.copy(body = currentState.copy(itemsInCart = updatedItemsList))
+            }
         }
+    }
+
+    private fun placeItemInList(
+        currentState: WooPosCartState.Body.WithItems,
+        newItem: WooPosCartItemViewState
+    ): List<WooPosCartItemViewState> {
+        val (existingCoupons, existingProducts) = currentState.itemsInCart.partition { it is WooPosCartItemViewState.Coupon }
+
+        val updatedItems = if (newItem is WooPosCartItemViewState.Coupon) {
+            listOf(newItem) + existingCoupons + existingProducts
+        } else {
+            existingCoupons + listOf(newItem) + existingProducts.filterNot { it == newItem }
+        }
+        return updatedItems
     }
 
     private fun updateToolbarState(newState: WooPosCartState): WooPosCartState {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/cart/WooPosCartViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/cart/WooPosCartViewModel.kt
@@ -322,7 +322,15 @@ class WooPosCartViewModel @Inject constructor(
             .partition { it is WooPosCartItemViewState.Coupon }
 
         return if (newItem is WooPosCartItemViewState.Coupon) {
-            listOf(newItem) + existingCoupons + existingProducts
+            val couponAlreadyInCart = existingCoupons.any {
+                (it as WooPosCartItemViewState.Coupon).id == newItem.id
+            }
+
+            if (couponAlreadyInCart) {
+                currentState.itemsInCart
+            } else {
+                listOf(newItem) + existingCoupons + existingProducts
+            }
         } else {
             existingCoupons + listOf(newItem) + existingProducts
         }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/cart/WooPosCartViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/cart/WooPosCartViewModel.kt
@@ -321,12 +321,11 @@ class WooPosCartViewModel @Inject constructor(
         val (existingCoupons, existingProducts) = currentState.itemsInCart
             .partition { it is WooPosCartItemViewState.Coupon }
 
-        val updatedItems = if (newItem is WooPosCartItemViewState.Coupon) {
+        return if (newItem is WooPosCartItemViewState.Coupon) {
             listOf(newItem) + existingCoupons + existingProducts
         } else {
             existingCoupons + listOf(newItem) + existingProducts
         }
-        return updatedItems
     }
 
     private fun updateToolbarState(newState: WooPosCartState): WooPosCartState {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/cart/WooPosCartViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/cart/WooPosCartViewModel.kt
@@ -318,7 +318,8 @@ class WooPosCartViewModel @Inject constructor(
         currentState: WooPosCartState.Body.WithItems,
         newItem: WooPosCartItemViewState
     ): List<WooPosCartItemViewState> {
-        val (existingCoupons, existingProducts) = currentState.itemsInCart.partition { it is WooPosCartItemViewState.Coupon }
+        val (existingCoupons, existingProducts) = currentState.itemsInCart
+            .partition { it is WooPosCartItemViewState.Coupon }
 
         val updatedItems = if (newItem is WooPosCartItemViewState.Coupon) {
             listOf(newItem) + existingCoupons + existingProducts

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/home/cart/WooPosCartViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/home/cart/WooPosCartViewModelTest.kt
@@ -1104,8 +1104,7 @@ class WooPosCartViewModelTest {
                 itemData = WooPosItemsViewModel.ItemClickedData.Coupon(id = couponId, couponCode = ""),
                 source = WooPosItemSource.COUPON_LIST
             ),
-
-            )
+        )
     }
 
     private suspend fun simulateProductClicked(productId: Long = 1L) {

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/home/cart/WooPosCartViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/home/cart/WooPosCartViewModelTest.kt
@@ -987,16 +987,6 @@ class WooPosCartViewModelTest {
         assertThat(finalState.isCheckoutButtonVisible).isFalse()
     }
 
-    private suspend fun simulateCouponClicked(couponId: Long = 1L) {
-        parentToChildrenMutableSharedFlow.emit(
-            ParentToChildrenEvent.ItemClickedInProductSelector(
-                itemData = WooPosItemsViewModel.ItemClickedData.Coupon(id = couponId),
-                source = WooPosItemSource.COUPON_LIST
-            ),
-
-        )
-    }
-
     @Test
     fun `given cart with products, when navigated to checkout, then checkout button not visible`() = runTest {
         // GIVEN
@@ -1026,6 +1016,67 @@ class WooPosCartViewModelTest {
         assertThat(finalState.isCheckoutButtonVisible).isTrue()
     }
 
+    @Test
+    fun `given cart with products, when coupon added, then coupon added to the beginning`() = runTest {
+        // GIVEN
+        val sut = createSut()
+        val states = sut.state.captureValues()
+        simulateProductClicked(23L)
+
+        // WHEN
+        simulateCouponClicked()
+
+        // THEN
+        val itemsInCart = (states.last().body as WooPosCartState.Body.WithItems).itemsInCart
+        assertThat(itemsInCart).hasSize(2)
+        assertThat(itemsInCart[0]).isInstanceOf(WooPosCartItemViewState.Coupon::class.java)
+        assertThat(itemsInCart[1]).isInstanceOf(WooPosCartItemViewState.Product.Simple::class.java)
+    }
+
+    @Test
+    fun `given cart with coupons, when new coupon added, then new coupon added to the beginning`() =
+        runTest {
+            // GIVEN
+            val sut = createSut()
+            val states = sut.state.captureValues()
+
+            simulateCouponClicked(couponId = 1L)
+
+            // WHEN
+            simulateCouponClicked(couponId = 2L)
+
+            // THEN
+            val itemsInCart = (states.last().body as WooPosCartState.Body.WithItems).itemsInCart
+            assertThat(itemsInCart).hasSize(2)
+            assertThat(itemsInCart[0]).isInstanceOf(WooPosCartItemViewState.Coupon::class.java)
+            assertThat(itemsInCart[1]).isInstanceOf(WooPosCartItemViewState.Coupon::class.java)
+            assertThat((itemsInCart[0] as WooPosCartItemViewState.Coupon).id).isEqualTo(2L)
+            assertThat((itemsInCart[1] as WooPosCartItemViewState.Coupon).id).isEqualTo(1L)
+        }
+
+    @Test
+    fun `given cart with coupons and products, when new product added, then added after coupons before products`() =
+        runTest {
+            // GIVEN
+            val sut = createSut()
+            val states = sut.state.captureValues()
+
+            simulateCouponClicked()
+            simulateProductClicked(999L)
+
+            // WHEN
+            simulateProductClicked(1L)
+
+            // THEN
+            val itemsInCart = (states.last().body as WooPosCartState.Body.WithItems).itemsInCart
+            assertThat(itemsInCart).hasSize(3)
+            assertThat(itemsInCart[0]).isInstanceOf(WooPosCartItemViewState.Coupon::class.java)
+            assertThat(itemsInCart[1]).isInstanceOf(WooPosCartItemViewState.Product.Simple::class.java)
+            assertThat(itemsInCart[2]).isInstanceOf(WooPosCartItemViewState.Product.Simple::class.java)
+            assertThat((itemsInCart[1] as WooPosCartItemViewState.Product.Simple).id).isEqualTo(1L)
+            assertThat((itemsInCart[2] as WooPosCartItemViewState.Product.Simple).id).isEqualTo(999L)
+        }
+
     private suspend fun createSutWithItemsInCart(): Pair<WooPosCartViewModel, List<WooPosCartState>> {
         val product = ProductTestUtils.generateProduct(
             productId = 23L,
@@ -1045,6 +1096,35 @@ class WooPosCartViewModelTest {
             )
         )
         return Pair(sut, states)
+    }
+
+    private suspend fun simulateCouponClicked(couponId: Long = 1L) {
+        parentToChildrenMutableSharedFlow.emit(
+            ParentToChildrenEvent.ItemClickedInProductSelector(
+                itemData = WooPosItemsViewModel.ItemClickedData.Coupon(id = couponId),
+                source = WooPosItemSource.COUPON_LIST
+            ),
+
+            )
+    }
+
+    private suspend fun simulateProductClicked(productId: Long = 1L) {
+        val product = ProductTestUtils.generateProduct(
+            productId = productId,
+            productName = "title",
+            amount = "10.0"
+        ).copy(firstImageUrl = "url")
+
+        whenever(getProductById(eq(product.remoteId))).thenReturn(product)
+
+        parentToChildrenMutableSharedFlow.emit(
+            ParentToChildrenEvent.ItemClickedInProductSelector(
+                WooPosItemsViewModel.ItemClickedData.Product.Simple(
+                    id = productId
+                ),
+                source = WooPosItemSource.PRODUCT_LIST
+            )
+        )
     }
 
     private fun createSut(): WooPosCartViewModel {

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/home/cart/WooPosCartViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/home/cart/WooPosCartViewModelTest.kt
@@ -1077,6 +1077,24 @@ class WooPosCartViewModelTest {
             assertThat((itemsInCart[2] as WooPosCartItemViewState.Product.Simple).id).isEqualTo(999L)
         }
 
+    @Test
+    fun `given coupon in cart, when same coupon clicked again, then coupon not duplicated`() = runTest {
+        // GIVEN
+        val sut = createSut()
+        val states = sut.state.captureValues()
+
+        simulateCouponClicked(couponId = 1L)
+
+        // WHEN
+        simulateCouponClicked(couponId = 1L)
+
+        // THEN
+        val itemsAfterSecondAdd = (states.last().body as WooPosCartState.Body.WithItems).itemsInCart
+        assertThat(itemsAfterSecondAdd).hasSize(1)
+        assertThat(itemsAfterSecondAdd[0]).isInstanceOf(WooPosCartItemViewState.Coupon::class.java)
+        assertThat((itemsAfterSecondAdd[0] as WooPosCartItemViewState.Coupon).id).isEqualTo(1L)
+    }
+
     private suspend fun createSutWithItemsInCart(): Pair<WooPosCartViewModel, List<WooPosCartState>> {
         val product = ProductTestUtils.generateProduct(
             productId = 23L,


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #WOOMOB-480
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

This PR changes order of items in the list.
- Coupons are added to the very top
- Products are added after coupons (new products as close to the top of the list as possible, but after coupons)

It also prevents adding duplicated coupons to the cart - clicks are ignored, which isn't an optimal UX, but that's what we landed on after a discussion with the designer.


Note: When there are many coupons in the cart, added products might not be even visible as they are being added. Considering this is likely a temporary UX solution and it's very unlikely users would add so many coupons to the cart, we intentionally decided to not solve this edge-case.

### Testing information
<!-- This is your opportunity to break out individual scenarios that need testing (when necessary) and/or include a checklist for the reviewer to go through. Consider documenting the following from your own completed testing: devices used, alternate workflows, edge cases, affected areas, critical flows, areas not tested, and any remaining unknowns. Provide feedback on this new section of the PR template through Sept 30, 2024 to Apps Quality; additional context here: p91TBi-b8z-p2#comment-12036 -->


- Test adding and removing items from the cart - both coupons and products and ensure the above conditions are met at all times.

### The tests that have been performed
<!-- To give the reviewer an idea of what could be missed in terms of testing -->

I've tested the above + I tested checking out.

### Images/gif
<!-- Include before and after images or gifs when appropriate. -->


https://github.com/user-attachments/assets/43d37571-a1e4-4172-9c03-108ffc9fb6a1



- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.

## Reviewer (or Author, in the case of optional code reviews):

Please make sure these conditions are met before approving the PR, or request changes if the PR needs improvement:

- [ ] The PR is small and has a clear, single focus, or a valid explanation is provided in the description. If needed, please request to split it into smaller PRs.
- [ ] Ensure Adequate Unit Test Coverage: The changes are reasonably covered by unit tests or an explanation is provided in the PR description.
- [ ] Manual Testing: The author listed all the tests they ran, including smoke tests when needed (e.g., for refactorings). The reviewer confirmed that the PR works as expected on big (tablet) and small (phone) in case of UI changes, and no regressions are added.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->