### PR TITLE
[WOOPRD-504][Woo POS][Products search] Consider starting the remote search right away if the local is empty

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/items/search/WooPosItemsSearchViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/items/search/WooPosItemsSearchViewModel.kt
@@ -57,7 +57,7 @@ class WooPosItemsSearchViewModel @Inject constructor(
         )
 
     private var loadMoreJob: Job? = null
-    private var localSearchJob: Job? = null
+    private var searchJob: Job? = null
     private var remoteSearchJob: Job? = null
 
     private val currentQuery = AtomicReference("")
@@ -109,7 +109,7 @@ class WooPosItemsSearchViewModel @Inject constructor(
     }
 
     private fun performSearch(query: String) {
-        localSearchJob?.cancel()
+        searchJob?.cancel()
         remoteSearchJob?.cancel()
 
         currentQuery.set(query)
@@ -117,7 +117,7 @@ class WooPosItemsSearchViewModel @Inject constructor(
         if (query.isEmpty()) {
             setEmptySearchQueryState()
         } else {
-            localSearchJob = viewModelScope.launch {
+            searchJob = viewModelScope.launch {
                 val localProducts = dataSource.searchLocalProducts(query)
 
                 if (query != currentQuery.get()) return@launch

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/items/search/WooPosItemsSearchViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/items/search/WooPosItemsSearchViewModel.kt
@@ -78,6 +78,7 @@ class WooPosItemsSearchViewModel @Inject constructor(
                 }
                 handleItemClicked(event.item, source)
             }
+
             WooPosItemsSearchUiEvent.LoadingErrorRetryButtonClicked -> handleLoadingErrorRetryClick()
 
             is WooPosItemsSearchUiEvent.OnRecentSearchClicked -> {
@@ -123,9 +124,9 @@ class WooPosItemsSearchViewModel @Inject constructor(
 
                 analyticsTracker.storedLocalSearchResultIds(localProducts.map { it.remoteId })
 
-            if (localProducts.isEmpty()) {
-                _viewState.value = WooPosItemsSearchViewState.Loading
-            performRemoteSearchImmediately(query)
+                if (localProducts.isEmpty()) {
+                    _viewState.value = WooPosItemsSearchViewState.Loading
+                    performRemoteSearchImmediately(query)
                 } else {
                     _viewState.value = localProducts.toContentState(
                         searchQuery = query,

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/items/search/WooPosItemsSearchViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/items/search/WooPosItemsSearchViewModel.kt
@@ -104,7 +104,7 @@ class WooPosItemsSearchViewModel @Inject constructor(
         val currentState = _viewState.value as? WooPosItemsSearchViewState.Error ?: return
 
         _viewState.value = WooPosItemsSearchViewState.Loading
-        performRemoteSearch(currentState.searchQuery)
+        performRemoteSearchImmediately(currentState.searchQuery)
     }
 
     private fun performSearch(query: String) {
@@ -116,65 +116,68 @@ class WooPosItemsSearchViewModel @Inject constructor(
         if (query.isEmpty()) {
             setEmptySearchQueryState()
         } else {
-            performLocalSearch(query)
-            performRemoteSearch(query)
-        }
-    }
+            localSearchJob = viewModelScope.launch {
+                val localProducts = dataSource.searchLocalProducts(query)
 
-    private fun performLocalSearch(query: String) {
-        localSearchJob?.cancel()
-        localSearchJob = viewModelScope.launch {
-            val localProducts = dataSource.searchLocalProducts(query)
+                if (query != currentQuery.get()) return@launch
 
-            if (query != currentQuery.get()) return@launch
-
-            analyticsTracker.storedLocalSearchResultIds(localProducts.map { it.remoteId })
+                analyticsTracker.storedLocalSearchResultIds(localProducts.map { it.remoteId })
 
             if (localProducts.isEmpty()) {
                 _viewState.value = WooPosItemsSearchViewState.Loading
-            } else {
-                _viewState.value = localProducts.toContentState(
-                    searchQuery = query,
-                )
+            performRemoteSearchImmediately(query)
+                } else {
+                    _viewState.value = localProducts.toContentState(
+                        searchQuery = query,
+                    )
+                    performRemoteSearchWithDebounce(query)
+                }
             }
         }
     }
 
-    private fun performRemoteSearch(query: String) {
+    private fun performRemoteSearchWithDebounce(query: String) {
         remoteSearchJob?.cancel()
         remoteSearchJob = viewModelScope.launch {
             delay(SEARCH_DEBOUNCING_TIME)
-
-            if (query != currentQuery.get()) {
-                return@launch
-            }
-
-            childToParentEventSender.sendToParent(ChildToParentEvent.SearchEvent.Started)
-            var result: Result<List<Product>>
-            val searchTimeMillis = measureTimeMillis {
-                result = dataSource.searchRemoteProducts(query)
-            }
-
-            if (query != currentQuery.get()) {
-                childToParentEventSender.sendToParent(ChildToParentEvent.SearchEvent.Finished)
-                return@launch
-            }
-
-            if (result.isSuccess) {
-                val searchResult = result.getOrThrow()
-                if (searchResult.isEmpty()) {
-                    _viewState.value = WooPosItemsSearchViewState.Empty
-                } else {
-                    _viewState.value = searchResult.toContentState(searchQuery = query)
-                }
-
-                analyticsTracker.trackSearchPerformance(searchTimeMillis)
-            } else {
-                _viewState.value = WooPosItemsSearchViewState.Error(searchQuery = query)
-            }
-
-            childToParentEventSender.sendToParent(ChildToParentEvent.SearchEvent.Finished)
+            if (query != currentQuery.get()) return@launch
+            executeRemoteSearch(query)
         }
+    }
+
+    private fun performRemoteSearchImmediately(query: String) {
+        remoteSearchJob?.cancel()
+        remoteSearchJob = viewModelScope.launch {
+            executeRemoteSearch(query)
+        }
+    }
+
+    private suspend fun executeRemoteSearch(query: String) {
+        childToParentEventSender.sendToParent(ChildToParentEvent.SearchEvent.Started)
+        var result: Result<List<Product>>
+        val searchTimeMillis = measureTimeMillis {
+            result = dataSource.searchRemoteProducts(query)
+        }
+
+        if (query != currentQuery.get()) {
+            childToParentEventSender.sendToParent(ChildToParentEvent.SearchEvent.Finished)
+            return
+        }
+
+        if (result.isSuccess) {
+            val searchResult = result.getOrThrow()
+            if (searchResult.isEmpty()) {
+                _viewState.value = WooPosItemsSearchViewState.Empty
+            } else {
+                _viewState.value = searchResult.toContentState(searchQuery = query)
+            }
+
+            analyticsTracker.trackSearchPerformance(searchTimeMillis)
+        } else {
+            _viewState.value = WooPosItemsSearchViewState.Error(searchQuery = query)
+        }
+
+        childToParentEventSender.sendToParent(ChildToParentEvent.SearchEvent.Finished)
     }
 
     @Suppress("CyclomaticComplexMethod")

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/home/items/search/WooPosItemsSearchViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/home/items/search/WooPosItemsSearchViewModelTest.kt
@@ -464,11 +464,10 @@ class WooPosItemsSearchViewModelTest {
 
         // WHEN
         val viewModel = createViewModel()
-        advanceTimeBy(600)
 
         // THEN
         viewModel.viewState.test {
-            skipItems(1)
+            skipItems(2)
 
             val contentState = awaitItem() as WooPosItemsSearchViewState.Content
             assertThat(contentState.searchQuery).isEqualTo(query2)
@@ -477,7 +476,7 @@ class WooPosItemsSearchViewModelTest {
     }
 
     @Test
-    fun `given empty cached results, when search performed, then show loading state`() = runTest {
+    fun `given empty cached results, when search performed, then do remote search right away`() = runTest {
         // GIVEN
         val query = "test query"
         val products = listOf(
@@ -505,11 +504,10 @@ class WooPosItemsSearchViewModelTest {
 
         // THEN
         viewModel.viewState.test {
-            val loadingState = awaitItem()
-            assertThat(loadingState).isInstanceOf(WooPosItemsSearchViewState.Loading::class.java)
-
             val contentState = awaitItem() as WooPosItemsSearchViewState.Content
+            assertThat(contentState.searchQuery).isEqualTo(query)
             assertThat(contentState.items).hasSize(1)
+            assertThat((contentState.items[0] as Product.Simple).name).isEqualTo("Test Product")
         }
     }
 


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #WOOPRD-504
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
The PR removes the bouncing delay for the remote request if the local returns empty list. I am not sure that the change worth the result, so if you feel the same please do not merge

### Testing information
<!-- This is your opportunity to break out individual scenarios that need testing (when necessary) and/or include a checklist for the reviewer to go through. Consider documenting the following from your own completed testing: devices used, alternate workflows, edge cases, affected areas, critical flows, areas not tested, and any remaining unknowns. Provide feedback on this new section of the PR template through Sept 30, 2024 to Apps Quality; additional context here: p91TBi-b8z-p2#comment-12036 -->
* Open POS
* Saerch
* Enter something that returns empty list locally
* Notice that the remote request indicator is shown right away

Test other cases with search to make sure that there is no regresion

### The tests that have been performed
<!-- To give the reviewer an idea of what could be missed in terms of testing -->
Above

### Images/gif
<!-- Include before and after images or gifs when appropriate. -->

- [ ] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.

## Reviewer (or Author, in the case of optional code reviews):

Please make sure these conditions are met before approving the PR, or request changes if the PR needs improvement:

- [ ] The PR is small and has a clear, single focus, or a valid explanation is provided in the description. If needed, please request to split it into smaller PRs.
- [ ] Ensure Adequate Unit Test Coverage: The changes are reasonably covered by unit tests or an explanation is provided in the PR description.
- [ ] Manual Testing: The author listed all the tests they ran, including smoke tests when needed (e.g., for refactorings). The reviewer confirmed that the PR works as expected on big (tablet) and small (phone) in case of UI changes, and no regressions are added.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->