### PR TITLE
Use API response to star/unstar carrier packages

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/packages/UpdateSavedCarrierPackages.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/packages/UpdateSavedCarrierPackages.kt
@@ -1,12 +1,14 @@
 package com.woocommerce.android.ui.orders.wooshippinglabels.packages
 
+import com.woocommerce.android.tools.SelectedSite
 import com.woocommerce.android.ui.orders.wooshippinglabels.packages.datasource.WooShippingLabelPackageRepository
 import com.woocommerce.android.ui.orders.wooshippinglabels.packages.ui.Carrier
 import com.woocommerce.android.ui.orders.wooshippinglabels.packages.ui.CarrierPackageGroup
 import javax.inject.Inject
 
 class UpdateSavedCarrierPackages @Inject constructor(
-    private val repository: WooShippingLabelPackageRepository
+    private val repository: WooShippingLabelPackageRepository,
+    private val selectedSite: SelectedSite
 ) {
     suspend operator fun invoke(
         savePackage: Boolean,
@@ -15,10 +17,15 @@ class UpdateSavedCarrierPackages @Inject constructor(
     ) {
         if (savePackage) {
             repository.saveCarrierPackage(
-                packageId, findCarrierIdForPackageId(packageId, carrierPackages)
+                packageId,
+                findCarrierIdForPackageId(packageId, carrierPackages),
+                selectedSite.get()
             )
         } else {
-            repository.deleteSavedCarrierPackage(packageId = packageId)
+            repository.deleteSavedCarrierPackage(
+                packageId,
+                selectedSite.get()
+            )
         }
     }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/packages/UpdateSavedCarrierPackages.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/packages/UpdateSavedCarrierPackages.kt
@@ -1,0 +1,38 @@
+package com.woocommerce.android.ui.orders.wooshippinglabels.packages
+
+import com.woocommerce.android.ui.orders.wooshippinglabels.packages.datasource.WooShippingLabelPackageRepository
+import com.woocommerce.android.ui.orders.wooshippinglabels.packages.ui.Carrier
+import com.woocommerce.android.ui.orders.wooshippinglabels.packages.ui.CarrierPackageGroup
+import javax.inject.Inject
+
+class UpdateSavedCarrierPackages @Inject constructor(
+    private val repository: WooShippingLabelPackageRepository
+) {
+    suspend operator fun invoke(
+        savePackage: Boolean,
+        packageId: String,
+        carrierPackages: Map<Carrier, List<CarrierPackageGroup>>
+    ) {
+        if (savePackage) {
+            repository.saveCarrierPackage(
+                packageId, findCarrierIdForPackageId(packageId, carrierPackages)
+            )
+        } else {
+            repository.deleteSavedCarrierPackage(packageId = packageId)
+        }
+    }
+
+    private fun findCarrierIdForPackageId(
+        packageId: String,
+        carrierPackages: Map<Carrier, List<CarrierPackageGroup>>?
+    ): String {
+        return carrierPackages
+            ?.entries
+            ?.firstNotNullOfOrNull { (carrier, packageGroupList) ->
+                packageGroupList
+                    .flatMap { it.packages }
+                    .find { it.id == packageId }
+                    ?.let { carrier.id }
+            } ?: ""
+    }
+}

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/packages/WooShippingLabelPackageCreationViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/packages/WooShippingLabelPackageCreationViewModel.kt
@@ -32,6 +32,7 @@ class WooShippingLabelPackageCreationViewModel @Inject constructor(
     private val selectedSite: SelectedSite,
     private val resourceProvider: ResourceProvider,
     private val fetchPredefinedPackages: FetchPredefinedPackagesFromStore,
+    private val updateSavedCarrierPackages: UpdateSavedCarrierPackages,
     private val packageRepository: WooShippingLabelPackageRepository
 ) : ScopedViewModel(savedState) {
 
@@ -272,24 +273,12 @@ class WooShippingLabelPackageCreationViewModel @Inject constructor(
             )
         }
         launch {
-            if (isStarred) {
-                packageRepository.saveCarrierPackage(packageData.id, findCarrierIdForPackageId(packageData.id) ?: "")
-            } else {
-                packageRepository.deleteSavedCarrierPackage(packageId = packageData.id)
-            }
+            updateSavedCarrierPackages(
+                savePackage = isStarred,
+                packageId = packageData.id,
+                carrierPackages = _viewState.value.predefinedPackagesData?.carrierPackages ?: emptyMap()
+            )
         }
-    }
-
-    private fun findCarrierIdForPackageId(packageId: String): String? {
-        return _viewState.value.predefinedPackagesData
-            ?.carrierPackages
-            ?.entries
-            ?.firstNotNullOfOrNull { (carrier, packageGroupList) ->
-                packageGroupList
-                    .flatMap { it.packages }
-                    .find { it.id == packageId }
-                    ?.let { carrier.id }
-            }
     }
 
     @Parcelize

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/packages/WooShippingLabelPackageCreationViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/packages/WooShippingLabelPackageCreationViewModel.kt
@@ -273,20 +273,23 @@ class WooShippingLabelPackageCreationViewModel @Inject constructor(
         }
         launch {
             if (isStarred) {
-                packageRepository.saveCarrierPackage(
-                    carrierSelectedPackages =
-                        _viewState.value.predefinedPackagesData?.carrierPackages?.entries?.associate { entry ->
-                            entry.key.id to entry.value.flatMap { carrierPackageGroup ->
-                                carrierPackageGroup.packages
-                                    .filter { it.isStarred }
-                                    .map { it.id }
-                            }
-                        } ?: emptyMap(),
-                )
+                packageRepository.saveCarrierPackage(packageData.id, findCarrierIdForPackageId(packageData.id) ?: "")
             } else {
-                //TODO REMOVE STARRED CARRIER PACKAGE
+                packageRepository.deleteSavedCarrierPackage(packageId = packageData.id)
             }
         }
+    }
+
+    private fun findCarrierIdForPackageId(packageId: String): String? {
+        return _viewState.value.predefinedPackagesData
+            ?.carrierPackages
+            ?.entries
+            ?.firstNotNullOfOrNull { (carrier, packageGroupList) ->
+                packageGroupList
+                    .flatMap { it.packages }
+                    .find { it.id == packageId }
+                    ?.let { carrier.id }
+            }
     }
 
     @Parcelize

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/packages/WooShippingLabelPackageCreationViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/packages/WooShippingLabelPackageCreationViewModel.kt
@@ -271,6 +271,22 @@ class WooShippingLabelPackageCreationViewModel @Inject constructor(
                 predefinedPackagesState = predefinedPackages.copy(carrierPackages = updatedCarrierPackages)
             )
         }
+        launch {
+            if (isStarred) {
+                packageRepository.saveCarrierPackage(
+                    carrierSelectedPackages =
+                        _viewState.value.predefinedPackagesData?.carrierPackages?.entries?.associate { entry ->
+                            entry.key.id to entry.value.flatMap { carrierPackageGroup ->
+                                carrierPackageGroup.packages
+                                    .filter { it.isStarred }
+                                    .map { it.id }
+                            }
+                        } ?: emptyMap(),
+                )
+            } else {
+                //TODO REMOVE STARRED CARRIER PACKAGE
+            }
+        }
     }
 
     @Parcelize

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/packages/datasource/PackageDAOs.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/packages/datasource/PackageDAOs.kt
@@ -14,7 +14,8 @@ data class PackageDAO(
     val isLetter: Boolean,
     val dimensionUnit: String,
     val weightUnit: String,
-    val groupName: String? = null
+    val groupName: String? = null,
+    val saved: Boolean,
 )
 
 data class CarrierDAO(

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/packages/datasource/PackageDAOs.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/packages/datasource/PackageDAOs.kt
@@ -34,7 +34,7 @@ data class StoreOptionsDAO(
     val originCountry: String
 )
 
-enum class CarrierType {
-    USPS,
-    DHL
+enum class CarrierType(val id: String) {
+    USPS(id = "usps"),
+    DHL(id = "dhlexpress")
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/packages/datasource/WooShippingLabelPackageMapper.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/packages/datasource/WooShippingLabelPackageMapper.kt
@@ -8,6 +8,7 @@ import com.woocommerce.android.ui.orders.wooshippinglabels.packages.networking.C
 import com.woocommerce.android.ui.orders.wooshippinglabels.packages.networking.CustomPackageDTO
 import com.woocommerce.android.ui.orders.wooshippinglabels.packages.networking.PackageResponse
 import com.woocommerce.android.ui.orders.wooshippinglabels.packages.networking.PackageStoreOptionsDTO
+import com.woocommerce.android.ui.orders.wooshippinglabels.packages.networking.PredefinedSavedPackageIdsDTO
 import javax.inject.Inject
 
 class WooShippingLabelPackageMapper @Inject constructor() {
@@ -18,7 +19,11 @@ class WooShippingLabelPackageMapper @Inject constructor() {
         return StorePackagesDAO(
             storeOptions = mapStoreOptions(storeOptionsResponse),
             savedPackages = mapSavedPackages(savedPackagesResponse, response.storeOptions),
-            carrierPackages = mapCarrierPackages(response.packages?.predefined, response.storeOptions)
+            carrierPackages = mapCarrierPackages(
+                response.storeOptions,
+                response.packages?.predefined,
+                response.packages?.saved?.predefined
+            )
         )
     }
 
@@ -33,7 +38,8 @@ class WooShippingLabelPackageMapper @Inject constructor() {
                 weight = it.boxWeight?.toString().orEmpty(),
                 isLetter = it.isLetter ?: false,
                 dimensionUnit = "",
-                weightUnit = ""
+                weightUnit = "",
+                saved = true
             )
         } ?: emptyList()
     }
@@ -50,27 +56,31 @@ class WooShippingLabelPackageMapper @Inject constructor() {
                 weight = it.boxWeight?.toString().orEmpty(),
                 isLetter = it.isLetter ?: false,
                 dimensionUnit = storeOptions?.dimensionUnit.orEmpty(),
-                weightUnit = storeOptions?.weightUnit.orEmpty()
+                weightUnit = storeOptions?.weightUnit.orEmpty(),
+                saved = true
             )
         }
     }
 
     private fun mapCarrierPackages(
+        storeOptions: PackageStoreOptionsDTO?,
         carrierPackagesResponse: CarrierPredefinedPackagesDTO?,
-        storeOptions: PackageStoreOptionsDTO?
+        savedCarrierPackageIds: PredefinedSavedPackageIdsDTO?,
     ): Map<CarrierType, CarrierDAO> {
         val uspsPackages = mutableListOf<CarrierPackageGroupDAO>().apply {
             carrierPackagesResponse?.usps?.let { usps ->
-                usps.flatBoxes?.toCarrierGroup(storeOptions)?.let { add(it) }
-                usps.boxes?.toCarrierGroup(storeOptions)?.let { add(it) }
-                usps.expressBoxes?.toCarrierGroup(storeOptions)?.let { add(it) }
-                usps.envelopes?.toCarrierGroup(storeOptions)?.let { add(it) }
+                usps.flatBoxes?.toCarrierGroup(storeOptions, savedCarrierPackageIds?.usps)?.let { add(it) }
+                usps.boxes?.toCarrierGroup(storeOptions, savedCarrierPackageIds?.usps)?.let { add(it) }
+                usps.expressBoxes?.toCarrierGroup(storeOptions, savedCarrierPackageIds?.usps)?.let { add(it) }
+                usps.envelopes?.toCarrierGroup(storeOptions, savedCarrierPackageIds?.usps)?.let { add(it) }
             }
         }.let { CarrierDAO(it) }
 
         val dhlPackages = mutableListOf<CarrierPackageGroupDAO>().apply {
             carrierPackagesResponse?.dhlExpress?.let { dhl ->
-                dhl.domesticAndInternationalPackages?.toCarrierGroup(storeOptions)?.let { add(it) }
+                dhl.domesticAndInternationalPackages
+                    ?.toCarrierGroup(storeOptions, savedCarrierPackageIds?.dhlexpress)
+                    ?.let { add(it) }
             }
         }.let { CarrierDAO(it) }
 
@@ -85,7 +95,8 @@ class WooShippingLabelPackageMapper @Inject constructor() {
     }
 
     private fun CarrierPackageGroupDTO.toCarrierGroup(
-        storeOptions: PackageStoreOptionsDTO?
+        storeOptions: PackageStoreOptionsDTO?,
+        savedCarrierPackages: List<String>?
     ) = CarrierPackageGroupDAO(
         description = title.orEmpty(),
         packages = definitions?.map {
@@ -97,7 +108,8 @@ class WooShippingLabelPackageMapper @Inject constructor() {
                 isLetter = it.isLetter ?: false,
                 dimensionUnit = storeOptions?.dimensionUnit.orEmpty(),
                 weightUnit = storeOptions?.weightUnit.orEmpty(),
-                groupName = title
+                groupName = title,
+                saved = savedCarrierPackages?.contains(it.id.orEmpty()) ?: false
             )
         } ?: emptyList()
     )

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/packages/datasource/WooShippingLabelPackageMapper.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/packages/datasource/WooShippingLabelPackageMapper.kt
@@ -4,11 +4,10 @@ import com.woocommerce.android.ui.orders.wooshippinglabels.packages.datasource.C
 import com.woocommerce.android.ui.orders.wooshippinglabels.packages.datasource.CarrierType.USPS
 import com.woocommerce.android.ui.orders.wooshippinglabels.packages.networking.CarrierPackageGroupDTO
 import com.woocommerce.android.ui.orders.wooshippinglabels.packages.networking.CarrierPredefinedPackagesDTO
-import com.woocommerce.android.ui.orders.wooshippinglabels.packages.networking.CustomPackageCreationResponse
 import com.woocommerce.android.ui.orders.wooshippinglabels.packages.networking.CustomPackageDTO
+import com.woocommerce.android.ui.orders.wooshippinglabels.packages.networking.PackageCreationResponse
 import com.woocommerce.android.ui.orders.wooshippinglabels.packages.networking.PackageResponse
 import com.woocommerce.android.ui.orders.wooshippinglabels.packages.networking.PackageStoreOptionsDTO
-import com.woocommerce.android.ui.orders.wooshippinglabels.packages.networking.PredefinedSavedPackageIdsDTO
 import javax.inject.Inject
 
 class WooShippingLabelPackageMapper @Inject constructor() {
@@ -28,7 +27,7 @@ class WooShippingLabelPackageMapper @Inject constructor() {
     }
 
     operator fun invoke(
-        response: CustomPackageCreationResponse
+        response: PackageCreationResponse
     ): List<PackageDAO> {
         return response.custom?.map {
             PackageDAO(
@@ -65,21 +64,21 @@ class WooShippingLabelPackageMapper @Inject constructor() {
     private fun mapCarrierPackages(
         storeOptions: PackageStoreOptionsDTO?,
         carrierPackagesResponse: CarrierPredefinedPackagesDTO?,
-        savedCarrierPackageIds: PredefinedSavedPackageIdsDTO?,
+        savedCarrierPackageIds: Map<String, List<String>>?,
     ): Map<CarrierType, CarrierDAO> {
         val uspsPackages = mutableListOf<CarrierPackageGroupDAO>().apply {
             carrierPackagesResponse?.usps?.let { usps ->
-                usps.flatBoxes?.toCarrierGroup(storeOptions, savedCarrierPackageIds?.usps)?.let { add(it) }
-                usps.boxes?.toCarrierGroup(storeOptions, savedCarrierPackageIds?.usps)?.let { add(it) }
-                usps.expressBoxes?.toCarrierGroup(storeOptions, savedCarrierPackageIds?.usps)?.let { add(it) }
-                usps.envelopes?.toCarrierGroup(storeOptions, savedCarrierPackageIds?.usps)?.let { add(it) }
+                usps.flatBoxes?.toCarrierGroup(storeOptions, savedCarrierPackageIds?.get(USPS.id))?.let { add(it) }
+                usps.boxes?.toCarrierGroup(storeOptions, savedCarrierPackageIds?.get(USPS.id))?.let { add(it) }
+                usps.expressBoxes?.toCarrierGroup(storeOptions, savedCarrierPackageIds?.get(USPS.id))?.let { add(it) }
+                usps.envelopes?.toCarrierGroup(storeOptions, savedCarrierPackageIds?.get(USPS.id))?.let { add(it) }
             }
         }.let { CarrierDAO(it) }
 
         val dhlPackages = mutableListOf<CarrierPackageGroupDAO>().apply {
             carrierPackagesResponse?.dhlExpress?.let { dhl ->
                 dhl.domesticAndInternationalPackages
-                    ?.toCarrierGroup(storeOptions, savedCarrierPackageIds?.dhlexpress)
+                    ?.toCarrierGroup(storeOptions, savedCarrierPackageIds?.get(DHL.id))
                     ?.let { add(it) }
             }
         }.let { CarrierDAO(it) }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/packages/datasource/WooShippingLabelPackageRepository.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/packages/datasource/WooShippingLabelPackageRepository.kt
@@ -24,8 +24,8 @@ class WooShippingLabelPackageRepository @Inject constructor(
     }
 
     suspend fun createCustomPackage(
+        requestData: List<CustomPackageCreationRequestData>,
         site: SiteModel = selectedSite.get(),
-        requestData: List<CustomPackageCreationRequestData>
     ) = with(packageRestClient.postNewCustomPackage(site, requestData)) {
         result.takeIf { isError.not() }
             ?.let { packageMapper(it) }
@@ -34,9 +34,24 @@ class WooShippingLabelPackageRepository @Inject constructor(
     }
 
     suspend fun saveCarrierPackage(
+        savedPackageId: String,
+        parentCarrierId: String,
         site: SiteModel = selectedSite.get(),
-        carrierSelectedPackages: Map<String, List<String>>
-    ) = with(packageRestClient.postPredefinedPackages(site, carrierSelectedPackages)) {
+    ) = with(
+        packageRestClient.postPredefinedPackages(
+            site, mapOf(parentCarrierId to listOf(savedPackageId))
+        )
+    ) {
+        result.takeIf { isError.not() }
+            ?.let { packageMapper(it) }
+            ?.let { WooResult(it) }
+            ?: WooResult(error)
+    }
+
+    suspend fun deleteSavedCarrierPackage(
+        packageId: String,
+        site: SiteModel = selectedSite.get(),
+    ) = with(packageRestClient.deleteSavedCarrierPackage(site, packageId)) {
         result.takeIf { isError.not() }
             ?.let { packageMapper(it) }
             ?.let { WooResult(it) }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/packages/datasource/WooShippingLabelPackageRepository.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/packages/datasource/WooShippingLabelPackageRepository.kt
@@ -32,4 +32,14 @@ class WooShippingLabelPackageRepository @Inject constructor(
             ?.let { WooResult(it) }
             ?: WooResult(error)
     }
+
+    suspend fun saveCarrierPackage(
+        site: SiteModel = selectedSite.get(),
+        carrierSelectedPackages: Map<String, List<String>>
+    ) = with(packageRestClient.postPredefinedPackages(site, carrierSelectedPackages)) {
+        result.takeIf { isError.not() }
+            ?.let { packageMapper(it) }
+            ?.let { WooResult(it) }
+            ?: WooResult(error)
+    }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/packages/datasource/WooShippingLabelPackageRepository.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/packages/datasource/WooShippingLabelPackageRepository.kt
@@ -36,7 +36,7 @@ class WooShippingLabelPackageRepository @Inject constructor(
     suspend fun saveCarrierPackage(
         savedPackageId: String,
         parentCarrierId: String,
-        site: SiteModel = selectedSite.get(),
+        site: SiteModel,
     ) = with(
         packageRestClient.postPredefinedPackages(
             site, mapOf(parentCarrierId to listOf(savedPackageId))
@@ -50,7 +50,7 @@ class WooShippingLabelPackageRepository @Inject constructor(
 
     suspend fun deleteSavedCarrierPackage(
         packageId: String,
-        site: SiteModel = selectedSite.get(),
+        site: SiteModel,
     ) = with(packageRestClient.deleteSavedCarrierPackage(site, packageId)) {
         result.takeIf { isError.not() }
             ?.let { packageMapper(it) }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/packages/datasource/WooShippingLabelPackageRepository.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/packages/datasource/WooShippingLabelPackageRepository.kt
@@ -39,7 +39,8 @@ class WooShippingLabelPackageRepository @Inject constructor(
         site: SiteModel,
     ) = with(
         packageRestClient.postPredefinedPackages(
-            site, mapOf(parentCarrierId to listOf(savedPackageId))
+            site,
+            mapOf(parentCarrierId to listOf(savedPackageId))
         )
     ) {
         result.takeIf { isError.not() }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/packages/networking/PackageResponseDTOs.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/packages/networking/PackageResponseDTOs.kt
@@ -2,8 +2,9 @@ package com.woocommerce.android.ui.orders.wooshippinglabels.packages.networking
 
 import com.google.gson.annotations.SerializedName
 
-class CustomPackageCreationResponse {
+class PackageCreationResponse {
     val custom: List<CustomPackageDTO>? = null
+    val predefined: Map<String, List<String>>? = null
 }
 
 data class CustomPackageCreationRequestData(

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/packages/networking/StorePackageDTOs.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/packages/networking/StorePackageDTOs.kt
@@ -4,7 +4,7 @@ import com.google.gson.annotations.SerializedName
 
 class SavedPackageInfoDTO {
     val custom: List<CustomPackageDTO>? = null
-    val predefined: PredefinedSavedPackageIdsDTO? = null
+    val predefined: Map<String, List<String>>? = null // Carrier -> List of Package IDs
 }
 
 class CustomPackageDTO {
@@ -24,10 +24,4 @@ class CustomPackageDTO {
 
     @SerializedName("is_user_defined")
     val isUserDefined: Boolean? = null
-}
-
-class PredefinedSavedPackageIdsDTO {
-    val usps: List<String>? = null
-    val dhlexpress: List<String>? = null
-    val upsdap: List<String>? = null
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/packages/networking/StorePackageDTOs.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/packages/networking/StorePackageDTOs.kt
@@ -4,6 +4,7 @@ import com.google.gson.annotations.SerializedName
 
 class SavedPackageInfoDTO {
     val custom: List<CustomPackageDTO>? = null
+    val predefined: PredefinedSavedPackageIdsDTO? = null
 }
 
 class CustomPackageDTO {
@@ -23,4 +24,10 @@ class CustomPackageDTO {
 
     @SerializedName("is_user_defined")
     val isUserDefined: Boolean? = null
+}
+
+class PredefinedSavedPackageIdsDTO {
+    val usps: List<String>? = null
+    val dhlexpress: List<String>? = null
+    val upsdap: List<String>? = null
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/packages/networking/WooShippingLabelPackageRestClient.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/packages/networking/WooShippingLabelPackageRestClient.kt
@@ -19,17 +19,36 @@ class WooShippingLabelPackageRestClient @Inject constructor(
         ).toWooPayload()
     }
 
+    /**
+     * Creates a new custom package.
+     */
     suspend fun postNewCustomPackage(
         site: SiteModel,
         requestData: List<CustomPackageCreationRequestData>
-    ): WooPayload<CustomPackageCreationResponse> {
+    ): WooPayload<PackageCreationResponse> {
         return wooNetwork.executePostGsonRequest(
             site = site,
             path = URL,
             body = mapOf("custom" to requestData),
-            clazz = CustomPackageCreationResponse::class.java,
+            clazz = PackageCreationResponse::class.java,
         ).toWooPayload()
     }
+
+    /**
+     * Updates the saved carrier packages.
+     */
+    suspend fun postPredefinedPackages(
+        site: SiteModel,
+        requestData: Map<String, List<String>>
+    ): WooPayload<PackageCreationResponse> {
+        return wooNetwork.executePostGsonRequest(
+            site = site,
+            path = URL,
+            body = mapOf("predefined" to requestData),
+            clazz = PackageCreationResponse::class.java,
+        ).toWooPayload()
+    }
+
 
     companion object {
         private const val URL = "/wcshipping/v1/packages"

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/packages/networking/WooShippingLabelPackageRestClient.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/packages/networking/WooShippingLabelPackageRestClient.kt
@@ -49,6 +49,17 @@ class WooShippingLabelPackageRestClient @Inject constructor(
         ).toWooPayload()
     }
 
+    suspend fun deleteSavedCarrierPackage(
+        site: SiteModel,
+        packageId: String
+    ): WooPayload<PackageCreationResponse> {
+        return wooNetwork.executeDeleteGsonRequest(
+            site = site,
+            path = "$URL/predefined/$packageId",
+            clazz = PackageCreationResponse::class.java,
+        ).toWooPayload()
+    }
+
 
     companion object {
         private const val URL = "/wcshipping/v1/packages"

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/packages/networking/WooShippingLabelPackageRestClient.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/packages/networking/WooShippingLabelPackageRestClient.kt
@@ -60,7 +60,6 @@ class WooShippingLabelPackageRestClient @Inject constructor(
         ).toWooPayload()
     }
 
-
     companion object {
         private const val URL = "/wcshipping/v1/packages"
     }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/packages/ui/UIModels.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/packages/ui/UIModels.kt
@@ -75,7 +75,8 @@ data class PackageData(
             isLetter = dao.isLetter,
             dimensionUnit = dao.dimensionUnit,
             weightUnit = dao.weightUnit,
-            groupName = dao.groupName
+            groupName = dao.groupName,
+            isStarred = dao.saved
         )
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/packages/ui/UIModels.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/packages/ui/UIModels.kt
@@ -4,6 +4,7 @@ import android.os.Parcelable
 import com.woocommerce.android.R
 import com.woocommerce.android.extensions.isNotNullOrEmpty
 import com.woocommerce.android.ui.orders.wooshippinglabels.packages.WooShippingLabelPackageCreationViewModel.PackageType
+import com.woocommerce.android.ui.orders.wooshippinglabels.packages.datasource.CarrierType
 import com.woocommerce.android.ui.orders.wooshippinglabels.packages.datasource.PackageDAO
 import kotlinx.parcelize.IgnoredOnParcel
 import kotlinx.parcelize.Parcelize
@@ -140,13 +141,13 @@ sealed class Carrier(
     val logoRes: Int? = null,
 ) : Parcelable {
     data object USPS : Carrier(
-        id = "usps",
+        id = CarrierType.USPS.id,
         name = "USPS",
         logoRes = R.drawable.usps_logo
     )
 
     data object DHL : Carrier(
-        id = "dhl",
+        id = CarrierType.DHL.id,
         name = "DHL",
         logoRes = R.drawable.dhl_logo
     )

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/packages/UpdateSavedCarrierPackagesTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/packages/UpdateSavedCarrierPackagesTest.kt
@@ -1,0 +1,113 @@
+package com.woocommerce.android.ui.orders.wooshippinglabels.packages
+
+import com.woocommerce.android.tools.SelectedSite
+import com.woocommerce.android.ui.orders.wooshippinglabels.packages.datasource.WooShippingLabelPackageRepository
+import com.woocommerce.android.ui.orders.wooshippinglabels.packages.ui.Carrier
+import com.woocommerce.android.ui.orders.wooshippinglabels.packages.ui.Carrier.DHL
+import com.woocommerce.android.ui.orders.wooshippinglabels.packages.ui.CarrierPackageGroup
+import com.woocommerce.android.ui.orders.wooshippinglabels.packages.ui.PackageData
+import com.woocommerce.android.viewmodel.BaseUnitTest
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.runTest
+import org.junit.Test
+import org.mockito.Mockito.mock
+import org.mockito.Mockito.never
+import org.mockito.Mockito.times
+import org.mockito.kotlin.any
+import org.mockito.kotlin.doReturn
+import org.mockito.kotlin.verifyBlocking
+import org.wordpress.android.fluxc.model.SiteModel
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class UpdateSavedCarrierPackagesTest : BaseUnitTest() {
+    private val repository: WooShippingLabelPackageRepository = mock()
+    private val selectedSite: SelectedSite = org.mockito.kotlin.mock {
+        on { get() } doReturn SiteModel().apply {
+            url = "https://example.com"
+        }
+    }
+    private val useCase = UpdateSavedCarrierPackages(repository, selectedSite)
+
+    @Test
+    fun `When starring a package, then call saveCarrierPackage with correct carrierId`() = runTest {
+        // Given
+        val packageIdToSave = "usps_package_123"
+        val expectedCarrier = Carrier.USPS
+        val carrierPackages = createDummyCarrierPackages(packageIdToSave, expectedCarrier)
+
+        // When
+        useCase(
+            savePackage = true,
+            packageId = packageIdToSave,
+            carrierPackages = carrierPackages,
+        )
+
+        // Then
+        verifyBlocking(repository, times(1)) {
+            saveCarrierPackage(packageIdToSave, expectedCarrier.id, selectedSite.get())
+        }
+        verifyBlocking(repository, never()) {
+            deleteSavedCarrierPackage(any(), any())
+        }
+    }
+
+    @Test
+    fun `When un-starring a package, then call deleteSavedCarrierPackage with correct carrierId`() = runTest {
+        // Given
+        val packageIdToDelete = "usps_package_123"
+        val expectedCarrier = Carrier.USPS
+        val carrierPackages = createDummyCarrierPackages(packageIdToDelete, expectedCarrier)
+
+        // When
+        useCase(
+            savePackage = false,
+            packageId = packageIdToDelete,
+            carrierPackages = carrierPackages,
+        )
+
+        // Then
+        verifyBlocking(repository, times(1)) {
+            deleteSavedCarrierPackage(packageIdToDelete, selectedSite.get())
+        }
+        verifyBlocking(repository, never()) {
+            saveCarrierPackage(any(), any(), any())
+        }
+    }
+
+    private fun createDummyCarrierPackages(
+        targetPackageId: String,
+        targetCarrier: Carrier
+    ): Map<Carrier, List<CarrierPackageGroup>> {
+        val packageData = PackageData(
+            id = targetPackageId,
+            name = "Test Package",
+            dimensions = "1x1x1",
+            weight = "1kg",
+            isSelected = false,
+            isLetter = false,
+        )
+        return mapOf(
+            targetCarrier to listOf(
+                CarrierPackageGroup(
+                    groupName = "Test Group",
+                    packages = listOf(packageData)
+                )
+            ),
+            DHL to listOf(
+                CarrierPackageGroup(
+                    groupName = "DHL Express",
+                    packages = listOf(
+                        PackageData(
+                            id = "dhl_pkg",
+                            name = "DHL Pkg",
+                            dimensions = "",
+                            weight = "",
+                            isSelected = false,
+                            isLetter = false,
+                        )
+                    )
+                )
+            )
+        )
+    }
+}

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/packages/WooShippingLabelPackageCreationViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/packages/WooShippingLabelPackageCreationViewModelTest.kt
@@ -4,19 +4,21 @@ import androidx.lifecycle.SavedStateHandle
 import com.woocommerce.android.R
 import com.woocommerce.android.tools.SelectedSite
 import com.woocommerce.android.ui.orders.wooshippinglabels.packages.WooShippingLabelPackageCreationViewModel.PackageSelected
-import com.woocommerce.android.ui.orders.wooshippinglabels.packages.WooShippingLabelPackageCreationViewModel.PackageType
-import com.woocommerce.android.ui.orders.wooshippinglabels.packages.WooShippingLabelPackageCreationViewModel.PredefinedPackagesState
+import com.woocommerce.android.ui.orders.wooshippinglabels.packages.WooShippingLabelPackageCreationViewModel.PackageType.ENVELOPE
+import com.woocommerce.android.ui.orders.wooshippinglabels.packages.WooShippingLabelPackageCreationViewModel.PredefinedPackagesState.Data
 import com.woocommerce.android.ui.orders.wooshippinglabels.packages.WooShippingLabelPackageCreationViewModel.ShowPackageTypeDialog
 import com.woocommerce.android.ui.orders.wooshippinglabels.packages.WooShippingLabelPackageCreationViewModel.ViewState
 import com.woocommerce.android.ui.orders.wooshippinglabels.packages.datasource.FetchPredefinedPackagesFromStore
 import com.woocommerce.android.ui.orders.wooshippinglabels.packages.datasource.WooShippingLabelPackageRepository
 import com.woocommerce.android.ui.orders.wooshippinglabels.packages.ui.Carrier
+import com.woocommerce.android.ui.orders.wooshippinglabels.packages.ui.Carrier.DHL
+import com.woocommerce.android.ui.orders.wooshippinglabels.packages.ui.Carrier.USPS
 import com.woocommerce.android.ui.orders.wooshippinglabels.packages.ui.CarrierPackageGroup
 import com.woocommerce.android.ui.orders.wooshippinglabels.packages.ui.CustomPackageCreationData
 import com.woocommerce.android.ui.orders.wooshippinglabels.packages.ui.PackageData
 import com.woocommerce.android.ui.orders.wooshippinglabels.packages.ui.StoreOptionsForPackages
 import com.woocommerce.android.viewmodel.BaseUnitTest
-import com.woocommerce.android.viewmodel.MultiLiveEvent
+import com.woocommerce.android.viewmodel.MultiLiveEvent.Event
 import com.woocommerce.android.viewmodel.ResourceProvider
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.advanceUntilIdle
@@ -67,11 +69,11 @@ class WooShippingLabelPackageCreationViewModelTest : BaseUnitTest() {
 
     @Test
     fun `onAddPackageClick triggers PackageSelected event`() = testBlocking {
-        var lastEvent: MultiLiveEvent.Event? = null
+        var lastEvent: Event? = null
         sut.event.observeForever { lastEvent = it }
 
         val customPackageData = CustomPackageCreationData(
-            type = PackageType.ENVELOPE,
+            type = ENVELOPE,
             length = "10",
             width = "10",
             height = "10",
@@ -86,7 +88,7 @@ class WooShippingLabelPackageCreationViewModelTest : BaseUnitTest() {
         sut.onWeightChange("20")
         sut.onPackageNameChange("Test Package")
         sut.onSavePackageChanged(true)
-        sut.onPackageTypeSelected(PackageType.ENVELOPE)
+        sut.onPackageTypeSelected(ENVELOPE)
 
         sut.onAddCustomPackageClick(savePackageAsTemplate = false)
 
@@ -110,22 +112,22 @@ class WooShippingLabelPackageCreationViewModelTest : BaseUnitTest() {
 
     @Test
     fun `onPackageTypeSpinnerClick triggers ShowPackageTypeDialog event`() = testBlocking {
-        var lastEvent: MultiLiveEvent.Event? = null
+        var lastEvent: Event? = null
         sut.event.observeForever { lastEvent = it }
-        sut.onPackageTypeSelected(PackageType.ENVELOPE)
+        sut.onPackageTypeSelected(ENVELOPE)
 
         sut.onPackageTypeSpinnerClick()
 
         assertThat(
             lastEvent
-        ).isEqualTo(ShowPackageTypeDialog(PackageType.ENVELOPE))
+        ).isEqualTo(ShowPackageTypeDialog(ENVELOPE))
     }
 
     @Test
     fun `onPackageTypeSelected updates viewState with new type`() = testBlocking {
         var lastViewState: ViewState? = null
         sut.viewState.observeForever { lastViewState = it }
-        val newType = PackageType.ENVELOPE
+        val newType = ENVELOPE
         sut.onPackageTypeSelected(newType)
 
         assertThat(lastViewState?.customPackageCreationData?.type).isEqualTo(newType)
@@ -191,7 +193,7 @@ class WooShippingLabelPackageCreationViewModelTest : BaseUnitTest() {
             isLetter = true,
         )
         whenever(fetchPredefinedPackages()).thenReturn(
-            PredefinedPackagesState.Data(
+            Data(
                 storeOptions = StoreOptionsForPackages.DEFAULT,
                 carrierPackages = emptyMap(),
                 savedPackages = listOf(package1, package2)
@@ -218,7 +220,7 @@ class WooShippingLabelPackageCreationViewModelTest : BaseUnitTest() {
     @Test
     fun `onCarrierPackageSelected selects only one package at a time`() = testBlocking {
         var lastViewState: ViewState? = null
-        val carrier: Carrier = Carrier.DHL
+        val carrier: Carrier = DHL
         val package1 = PackageData(
             id = "1",
             name = "Package 1",
@@ -244,7 +246,7 @@ class WooShippingLabelPackageCreationViewModelTest : BaseUnitTest() {
             )
         )
         whenever(fetchPredefinedPackages()).thenReturn(
-            PredefinedPackagesState.Data(
+            Data(
                 storeOptions = StoreOptionsForPackages.DEFAULT,
                 carrierPackages = carrierPackages,
                 savedPackages = emptyList()
@@ -279,8 +281,8 @@ class WooShippingLabelPackageCreationViewModelTest : BaseUnitTest() {
     @Suppress("LongMethod")
     fun `onCarrierPackageSelected selects only one package at a time with multiple carriers`() = testBlocking {
         var lastViewState: ViewState? = null
-        val carrier1: Carrier = Carrier.DHL
-        val carrier2: Carrier = Carrier.USPS
+        val carrier1: Carrier = DHL
+        val carrier2: Carrier = USPS
         val package1 = PackageData(
             id = "1",
             name = "Package 1 - Carrier 1",
@@ -328,7 +330,7 @@ class WooShippingLabelPackageCreationViewModelTest : BaseUnitTest() {
             )
         )
         whenever(fetchPredefinedPackages()).thenReturn(
-            PredefinedPackagesState.Data(
+            Data(
                 storeOptions = StoreOptionsForPackages.DEFAULT,
                 carrierPackages = carrierPackages,
                 savedPackages = emptyList()
@@ -361,4 +363,68 @@ class WooShippingLabelPackageCreationViewModelTest : BaseUnitTest() {
         assertThat(selectedPackages).size().isEqualTo(1)
         assertThat(selectedPackages?.first()).isEqualTo(package2.copy(isSelected = true))
     }
+
+    @Test
+    fun `When starring a carrier package, update UI status and invoke updateSavedCarrierPackages use case`() =
+        testBlocking {
+            val carrier: Carrier = USPS
+            val packageToStar = PackageData(
+                id = "1",
+                name = "Package 1 - Carrier 1",
+                dimensions = "10 x 10 x 10",
+                weight = "10",
+                isSelected = false,
+                isLetter = false,
+                isStarred = false // Initially not starred
+            )
+            val initialCarrierPackages = mapOf(
+                carrier to listOf(
+                    CarrierPackageGroup(
+                        groupName = "Group A",
+                        packages = listOf(packageToStar)
+                    )
+                )
+            )
+            whenever(fetchPredefinedPackages()).thenReturn(
+                Data(
+                    storeOptions = StoreOptionsForPackages.DEFAULT,
+                    carrierPackages = initialCarrierPackages,
+                    savedPackages = emptyList()
+                )
+            )
+
+            sut = WooShippingLabelPackageCreationViewModel(
+                SavedStateHandle(),
+                selectedSite,
+                resourceProvider,
+                fetchPredefinedPackages,
+                updateSavedCarrierPackages,
+                packageRepository
+            )
+            advanceUntilIdle()
+
+            var lastViewState: ViewState? = null
+            sut.viewState.observeForever { lastViewState = it }
+            // When
+            sut.onCarrierPackageStarred(packageToStar, true)
+            advanceUntilIdle()
+
+            // Then
+            verify(updateSavedCarrierPackages, times(1)).invoke(
+                true,
+                packageToStar.id,
+                lastViewState?.predefinedPackagesData?.carrierPackages!!
+            )
+
+            // Verify viewState is updated
+            val updatedPackage = lastViewState
+                ?.predefinedPackagesData
+                ?.carrierPackages
+                ?.get(carrier)
+                ?.flatMap { it.packages }
+                ?.find { it.id == packageToStar.id }
+
+            assertThat(updatedPackage).isNotNull
+            assertThat(updatedPackage?.isStarred).isTrue
+        }
 }

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/packages/WooShippingLabelPackageCreationViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/packages/WooShippingLabelPackageCreationViewModelTest.kt
@@ -41,6 +41,7 @@ class WooShippingLabelPackageCreationViewModelTest : BaseUnitTest() {
     private val selectedSite: SelectedSite = mock {
         on { getOrNull() } doReturn SiteModel().apply { siteId = 123 }
     }
+    private val updateSavedCarrierPackages: UpdateSavedCarrierPackages = mock()
 
     @Before
     fun setUp() {
@@ -59,6 +60,7 @@ class WooShippingLabelPackageCreationViewModelTest : BaseUnitTest() {
             selectedSite,
             resourceProvider,
             fetchPredefinedPackages,
+            updateSavedCarrierPackages,
             packageRepository
         )
     }
@@ -201,6 +203,7 @@ class WooShippingLabelPackageCreationViewModelTest : BaseUnitTest() {
             selectedSite,
             resourceProvider,
             fetchPredefinedPackages,
+            updateSavedCarrierPackages,
             packageRepository
         )
         sut.viewState.observeForever { lastViewState = it }
@@ -253,6 +256,7 @@ class WooShippingLabelPackageCreationViewModelTest : BaseUnitTest() {
             selectedSite,
             resourceProvider,
             fetchPredefinedPackages,
+            updateSavedCarrierPackages,
             packageRepository
         )
         sut.viewState.observeForever { lastViewState = it }
@@ -336,6 +340,7 @@ class WooShippingLabelPackageCreationViewModelTest : BaseUnitTest() {
             selectedSite,
             resourceProvider,
             fetchPredefinedPackages,
+            updateSavedCarrierPackages,
             packageRepository
         )
 

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/packages/datasource/FetchPredefinedPackagesFromStoreTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/packages/datasource/FetchPredefinedPackagesFromStoreTest.kt
@@ -54,6 +54,7 @@ class FetchPredefinedPackagesFromStoreTest : BaseUnitTest() {
                 isSelected = false,
                 isLetter = false,
                 isPredefined = true,
+                isStarred = true,
             )
         )
         assertThat(result.carrierPackages[Carrier.USPS]).containsExactly(
@@ -110,7 +111,8 @@ class FetchPredefinedPackagesFromStoreTest : BaseUnitTest() {
                 weight = "weight",
                 isLetter = false,
                 dimensionUnit = "cm",
-                weightUnit = "kg"
+                weightUnit = "kg",
+                saved = false
             ),
             PackageDAO(
                 id = "2",
@@ -119,7 +121,8 @@ class FetchPredefinedPackagesFromStoreTest : BaseUnitTest() {
                 weight = "weight",
                 isLetter = false,
                 dimensionUnit = "cm",
-                weightUnit = "kg"
+                weightUnit = "kg",
+                saved = true
             )
         ),
         carrierPackages = mapOf(
@@ -135,7 +138,8 @@ class FetchPredefinedPackagesFromStoreTest : BaseUnitTest() {
                                 weight = "weight",
                                 isLetter = false,
                                 dimensionUnit = "cm",
-                                weightUnit = "kg"
+                                weightUnit = "kg",
+                                saved = false
                             )
                         )
                     )


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: WOOMOB-428

<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
Adds logic to star/un-star any carrier package and sync it with the API.
This PR does not include: 
- Error handling
- Updating the list of saved packages on the `Saved` tab. 

### Testing information
<!-- This is your opportunity to break out individual scenarios that need testing (when necessary) and/or include a checklist for the reviewer to go through. Consider documenting the following from your own completed testing: devices used, alternate workflows, edge cases, affected areas, critical flows, areas not tested, and any remaining unknowns. Provide feedback on this new section of the PR template through Sept 30, 2024 to Apps Quality; additional context here: p91TBi-b8z-p2#comment-12036 -->
1. Log into a site with shipping labels enabled
2. Open an order and tap "Create shipping label"
3. Tap "Select package"
4. Navigate to "Carrier" tab 
5. Check that the start status is correct and synced with the server. 
6. Star a package. Open the site on the web or another device and check that is synced. 
7. Unstar the package and check that it is synced with the web or other device where you are logged in. 

https://github.com/user-attachments/assets/48a5ae96-2808-4228-818a-f2e311fbc7fb

### The tests that have been performed
<!-- To give the reviewer an idea of what could be missed in terms of testing -->
The above ☝🏼 

- [ ] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.

## Reviewer (or Author, in the case of optional code reviews):

Please make sure these conditions are met before approving the PR, or request changes if the PR needs improvement:

- [x] The PR is small and has a clear, single focus, or a valid explanation is provided in the description. If needed, please request to split it into smaller PRs.
- [x] Ensure Adequate Unit Test Coverage: The changes are reasonably covered by unit tests or an explanation is provided in the PR description.
- [x] Manual Testing: The author listed all the tests they ran, including smoke tests when needed (e.g., for refactorings). The reviewer confirmed that the PR works as expected on big (tablet) and small (phone) in case of UI changes, and no regressions are added.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->