### PR TITLE
Add shipments tab to the creation screen

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/ShipmentDetails.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/ShipmentDetails.kt
@@ -64,7 +64,7 @@ import kotlinx.parcelize.Parcelize
 fun ShipmentDetails(
     scaffoldState: BottomSheetScaffoldState,
     shipFromSelectionBottomSheetState: ModalBottomSheetState,
-    shippableItems: ShippableItemsUI,
+    shipmentUI: ShipmentUI,
     shippingLines: List<ShippingLineSummaryUI>,
     shippingAddresses: WooShippingAddresses,
     shippingRateSummary: ShippingRateSummaryUI?,
@@ -125,7 +125,7 @@ fun ShipmentDetails(
         }
         if (LocalConfiguration.current.orientation == Configuration.ORIENTATION_LANDSCAPE) {
             ShipmentDetailsLandscape(
-                shippableItems = shippableItems,
+                shipmentUI = shipmentUI,
                 shippingLines = shippingLines,
                 shippingAddresses = shippingAddresses,
                 shippingRateSummary = shippingRateSummary,
@@ -137,7 +137,7 @@ fun ShipmentDetails(
             )
         } else {
             ShipmentDetailsPortrait(
-                shippableItems = shippableItems,
+                shipmentUI = shipmentUI,
                 shippingLines = shippingLines,
                 markOrderComplete = markOrderComplete,
                 onMarkOrderCompleteChange = onMarkOrderCompleteChange,
@@ -155,7 +155,7 @@ fun ShipmentDetails(
 
 @Composable
 private fun ShipmentDetailsPortrait(
-    shippableItems: ShippableItemsUI,
+    shipmentUI: ShipmentUI,
     shippingLines: List<ShippingLineSummaryUI>,
     shippingAddresses: WooShippingAddresses,
     markOrderComplete: Boolean,
@@ -177,8 +177,8 @@ private fun ShipmentDetailsPortrait(
         ) {
             OrderDetailsSection(
                 shippingAddresses = shippingAddresses,
-                totalItems = shippableItems.shippableItems.size,
-                totalItemsCost = shippableItems.formattedTotalPrice,
+                totalItems = shipmentUI.shippableItems.size,
+                totalItemsCost = shipmentUI.formattedTotalPrice,
                 shippingLines = shippingLines,
                 isReadOnly = isReadOnly,
                 shipFromSelectionBottomSheetState = shipFromSelectionBottomSheetState,
@@ -203,7 +203,7 @@ private fun ShipmentDetailsPortrait(
 
 @Composable
 private fun ShipmentDetailsLandscape(
-    shippableItems: ShippableItemsUI,
+    shipmentUI: ShipmentUI,
     shippingLines: List<ShippingLineSummaryUI>,
     shippingAddresses: WooShippingAddresses,
     shippingRateSummary: ShippingRateSummaryUI?,
@@ -235,8 +235,8 @@ private fun ShipmentDetailsLandscape(
                     .fillMaxWidth()
             ) {
                 OrderDetailsSectionLandscape(
-                    totalItems = shippableItems.shippableItems.size,
-                    totalItemsCost = shippableItems.formattedTotalPrice,
+                    totalItems = shipmentUI.shippableItems.size,
+                    totalItemsCost = shipmentUI.formattedTotalPrice,
                     shippingLines = shippingLines,
                     modifier = Modifier.weight(1f)
                 )
@@ -338,7 +338,7 @@ fun ShipmentDetailsLandscapePreview() {
     WooThemeWithBackground {
         Surface {
             ShipmentDetailsLandscape(
-                shippableItems = ShippableItemsUI(
+                shipmentUI = ShipmentUI(
                     shippableItems = generateItems(6),
                     formattedTotalWeight = "8.5kg",
                     formattedTotalPrice = "$92.78"

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/ShipmentDetails.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/ShipmentDetails.kt
@@ -344,7 +344,7 @@ fun ShipmentDetailsLandscapePreview() {
         Surface {
             ShipmentDetailsLandscape(
                 totalItems = 6,
-                totalItemsCost = "8.5kg",
+                totalItemsCost = "$92.78",
                 shippingLines = getShippingLines(),
                 shippingAddresses = WooShippingAddresses(
                     shipFrom = getShipFrom(),

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/ShipmentDetails.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/ShipmentDetails.kt
@@ -64,7 +64,8 @@ import kotlinx.parcelize.Parcelize
 fun ShipmentDetails(
     scaffoldState: BottomSheetScaffoldState,
     shipFromSelectionBottomSheetState: ModalBottomSheetState,
-    shipmentUI: ShipmentUI,
+    totalItems: Int,
+    totalItemsCost: String,
     shippingLines: List<ShippingLineSummaryUI>,
     shippingAddresses: WooShippingAddresses,
     shippingRateSummary: ShippingRateSummaryUI?,
@@ -125,7 +126,8 @@ fun ShipmentDetails(
         }
         if (LocalConfiguration.current.orientation == Configuration.ORIENTATION_LANDSCAPE) {
             ShipmentDetailsLandscape(
-                shipmentUI = shipmentUI,
+                totalItems = totalItems,
+                totalItemsCost = totalItemsCost,
                 shippingLines = shippingLines,
                 shippingAddresses = shippingAddresses,
                 shippingRateSummary = shippingRateSummary,
@@ -137,7 +139,8 @@ fun ShipmentDetails(
             )
         } else {
             ShipmentDetailsPortrait(
-                shipmentUI = shipmentUI,
+                totalItems = totalItems,
+                totalItemsCost = totalItemsCost,
                 shippingLines = shippingLines,
                 markOrderComplete = markOrderComplete,
                 onMarkOrderCompleteChange = onMarkOrderCompleteChange,
@@ -155,7 +158,8 @@ fun ShipmentDetails(
 
 @Composable
 private fun ShipmentDetailsPortrait(
-    shipmentUI: ShipmentUI,
+    totalItems: Int,
+    totalItemsCost: String,
     shippingLines: List<ShippingLineSummaryUI>,
     shippingAddresses: WooShippingAddresses,
     markOrderComplete: Boolean,
@@ -177,8 +181,8 @@ private fun ShipmentDetailsPortrait(
         ) {
             OrderDetailsSection(
                 shippingAddresses = shippingAddresses,
-                totalItems = shipmentUI.shippableItems.size,
-                totalItemsCost = shipmentUI.formattedTotalPrice,
+                totalItems = totalItems,
+                totalItemsCost = totalItemsCost,
                 shippingLines = shippingLines,
                 isReadOnly = isReadOnly,
                 shipFromSelectionBottomSheetState = shipFromSelectionBottomSheetState,
@@ -203,7 +207,8 @@ private fun ShipmentDetailsPortrait(
 
 @Composable
 private fun ShipmentDetailsLandscape(
-    shipmentUI: ShipmentUI,
+    totalItems: Int,
+    totalItemsCost: String,
     shippingLines: List<ShippingLineSummaryUI>,
     shippingAddresses: WooShippingAddresses,
     shippingRateSummary: ShippingRateSummaryUI?,
@@ -235,8 +240,8 @@ private fun ShipmentDetailsLandscape(
                     .fillMaxWidth()
             ) {
                 OrderDetailsSectionLandscape(
-                    totalItems = shipmentUI.shippableItems.size,
-                    totalItemsCost = shipmentUI.formattedTotalPrice,
+                    totalItems = totalItems,
+                    totalItemsCost = totalItemsCost,
                     shippingLines = shippingLines,
                     modifier = Modifier.weight(1f)
                 )
@@ -338,11 +343,8 @@ fun ShipmentDetailsLandscapePreview() {
     WooThemeWithBackground {
         Surface {
             ShipmentDetailsLandscape(
-                shipmentUI = ShipmentUI(
-                    shippableItems = generateItems(6),
-                    formattedTotalWeight = "8.5kg",
-                    formattedTotalPrice = "$92.78"
-                ),
+                totalItems = 6,
+                totalItemsCost = "8.5kg",
                 shippingLines = getShippingLines(),
                 shippingAddresses = WooShippingAddresses(
                     shipFrom = getShipFrom(),

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/ShippableItemsMapper.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/ShippableItemsMapper.kt
@@ -30,7 +30,8 @@ fun ShippableItemModel.toUIModel(
 fun List<ShippableItemModel>.toUIModel(
     currencyFormatter: CurrencyFormatter,
     dimensionUnit: String,
-    weightUnit: String
+    weightUnit: String,
+    purchased: Boolean
 ): ShipmentUI {
     val shippableItemsUI = map { item -> item.toUIModel(currencyFormatter, dimensionUnit, weightUnit) }
     val formattedTotalPrice = getFormattedTotalPrice(currencyFormatter)
@@ -39,7 +40,8 @@ fun List<ShippableItemModel>.toUIModel(
     return ShipmentUI(
         shippableItems = shippableItemsUI,
         formattedTotalWeight = formattedTotalWeight,
-        formattedTotalPrice = formattedTotalPrice
+        formattedTotalPrice = formattedTotalPrice,
+        purchased = purchased
     )
 }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/ShippableItemsMapper.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/ShippableItemsMapper.kt
@@ -31,12 +31,12 @@ fun List<ShippableItemModel>.toUIModel(
     currencyFormatter: CurrencyFormatter,
     dimensionUnit: String,
     weightUnit: String
-): ShippableItemsUI {
+): ShipmentUI {
     val shippableItemsUI = map { item -> item.toUIModel(currencyFormatter, dimensionUnit, weightUnit) }
     val formattedTotalPrice = getFormattedTotalPrice(currencyFormatter)
     val formattedTotalWeight = getFormattedTotalWeight(weightUnit)
 
-    return ShippableItemsUI(
+    return ShipmentUI(
         shippableItems = shippableItemsUI,
         formattedTotalWeight = formattedTotalWeight,
         formattedTotalPrice = formattedTotalPrice

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/WooShippingLabelCreationFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/WooShippingLabelCreationFragment.kt
@@ -72,7 +72,9 @@ class WooShippingLabelCreationFragment : BaseFragment(), BackPressListener {
                 is WooShippingLabelCreationViewModel.LabelPurchased -> {
                     WooShippingLabelCreationFragmentDirections
                         .actionWooShippingLabelCreationFragmentToWooShippingLabelPurchasedFragment(
-                            purchaseData = event.purchaseData
+                            purchaseData = event.purchaseData,
+                            totalItems = event.totalItems,
+                            totalItemsCost = event.totalItemsCost
                         ).let { findNavController().navigateSafely(it) }
                 }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/WooShippingLabelCreationFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/WooShippingLabelCreationFragment.kt
@@ -60,7 +60,7 @@ class WooShippingLabelCreationFragment : BaseFragment(), BackPressListener {
 
     override val activityAppBarStatus: AppBarStatus = AppBarStatus.Hidden
 
-    @Suppress("CyclomaticComplexMethod")
+    @Suppress("CyclomaticComplexMethod", "LongMethod")
     private fun setupObservers() {
         viewModel.event.observe(viewLifecycleOwner) { event ->
             when (event) {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/WooShippingLabelCreationScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/WooShippingLabelCreationScreen.kt
@@ -13,7 +13,6 @@ import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.pager.HorizontalPager
 import androidx.compose.foundation.pager.rememberPagerState
 import androidx.compose.foundation.rememberScrollState
@@ -34,9 +33,7 @@ import androidx.compose.material.ModalBottomSheetDefaults
 import androidx.compose.material.ModalBottomSheetState
 import androidx.compose.material.ModalBottomSheetValue
 import androidx.compose.material.Scaffold
-import androidx.compose.material.ScrollableTabRow
 import androidx.compose.material.Surface
-import androidx.compose.material.Tab
 import androidx.compose.material.Text
 import androidx.compose.material.TopAppBar
 import androidx.compose.material.icons.Icons
@@ -59,7 +56,6 @@ import androidx.compose.ui.platform.LocalConfiguration
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.res.colorResource
 import androidx.compose.ui.res.dimensionResource
-import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.input.KeyboardType
@@ -85,6 +81,8 @@ import com.woocommerce.android.ui.orders.wooshippinglabels.address.AddressSelect
 import com.woocommerce.android.ui.orders.wooshippinglabels.address.AddressStatus
 import com.woocommerce.android.ui.orders.wooshippinglabels.address.getShipFrom
 import com.woocommerce.android.ui.orders.wooshippinglabels.address.getShipTo
+import com.woocommerce.android.ui.orders.wooshippinglabels.components.ShipmentTabData
+import com.woocommerce.android.ui.orders.wooshippinglabels.components.ShipmentsTabRow
 import com.woocommerce.android.ui.orders.wooshippinglabels.components.ShippingLabelsSnackbarData
 import com.woocommerce.android.ui.orders.wooshippinglabels.components.SuccessSnackbarHost
 import com.woocommerce.android.ui.orders.wooshippinglabels.hazmat.HazmatCard
@@ -437,59 +435,23 @@ private fun LabelCreationScreenWithBottomSheet(
                         )
                     }
                 } else {
-                    val selectedIndex = if (pagerState.currentPage < pagerState.pageCount) pagerState.currentPage else 0
                     Row(
                         modifier = Modifier
                             .fillMaxWidth()
                             .padding(bottom = 16.dp)
                     ) {
-                        ScrollableTabRow(
-                            selectedTabIndex = selectedIndex,
-                            backgroundColor = MaterialTheme.colors.surface,
-                            contentColor = MaterialTheme.colors.primary,
-                            divider = {},
-                            edgePadding = 0.dp,
+                        ShipmentsTabRow(
+                            shipmentTabs = shipmentUIList.mapIndexed { index, shipment ->
+                                ShipmentTabData(shipmentIndex = index + 1, isPurchased = shipment.purchased)
+                            },
+                            selectedTabIndex = if (pagerState.currentPage < pagerState.pageCount) {
+                                pagerState.currentPage
+                            } else {
+                                0
+                            },
+                            onTabSelected = { index -> scope.launch { pagerState.animateScrollToPage(index) } },
                             modifier = modifier.weight(1f)
-                        ) {
-                            shipmentUIList.forEachIndexed { index, _ ->
-                                val textColor = if (index == pagerState.currentPage) {
-                                    MaterialTheme.colors.primary
-                                } else {
-                                    colorResource(id = R.color.color_on_surface_medium)
-                                }
-                                Tab(
-                                    text = {
-                                        Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
-                                            Text(
-                                                text = stringResource(
-                                                    R.string.woo_shipping_split_shipment_shipment_name,
-                                                    index + 1 // Use 1-based indexing for the shipments
-                                                ),
-                                                color = textColor,
-                                                style = MaterialTheme.typography.subtitle1,
-                                                fontWeight = FontWeight.SemiBold
-                                            )
-                                            if (shipmentUIList[index].purchased) {
-                                                Icon(
-                                                    modifier = Modifier.size(16.dp),
-                                                    painter = painterResource(R.drawable.ic_progress_circle_complete),
-                                                    contentDescription = stringResource(
-                                                        R.string.purchased_shipment_content_description
-                                                    ),
-                                                    tint = colorResource(id = R.color.woo_green_70)
-                                                )
-                                            }
-                                        }
-                                    },
-                                    selected = pagerState.currentPage == index,
-                                    onClick = {
-                                        scope.launch {
-                                            pagerState.animateScrollToPage(index)
-                                        }
-                                    }
-                                )
-                            }
-                        }
+                        )
                         IconButton(
                             onClick = onSplitShipment,
                             modifier = Modifier.align(Alignment.CenterVertically)

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/WooShippingLabelCreationScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/WooShippingLabelCreationScreen.kt
@@ -414,7 +414,6 @@ private fun LabelCreationScreenWithBottomSheet(
                 val scope = rememberCoroutineScope()
                 val pagerState = rememberPagerState { shipmentUIList.size }
 
-
                 LaunchedEffect(pagerState.targetPage) {
                     onSelectedShipmentChanged(pagerState.targetPage)
                 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/WooShippingLabelCreationScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/WooShippingLabelCreationScreen.kt
@@ -491,6 +491,16 @@ private fun LabelCreationScreenWithBottomSheet(
                                 )
                             }
                         }
+                        IconButton(
+                            onClick = onSplitShipment,
+                            modifier = Modifier.align(Alignment.CenterVertically)
+                        ) {
+                            Icon(
+                                imageVector = Icons.Filled.Edit,
+                                tint = colorResource(id = R.color.color_icon_menu),
+                                contentDescription = stringResource(id = R.string.woo_shipping_split_shipment)
+                            )
+                        }
                     }
                 }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/WooShippingLabelCreationScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/WooShippingLabelCreationScreen.kt
@@ -13,6 +13,9 @@ import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.pager.HorizontalPager
+import androidx.compose.foundation.pager.rememberPagerState
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.text.BasicTextField
@@ -31,7 +34,9 @@ import androidx.compose.material.ModalBottomSheetDefaults
 import androidx.compose.material.ModalBottomSheetState
 import androidx.compose.material.ModalBottomSheetValue
 import androidx.compose.material.Scaffold
+import androidx.compose.material.ScrollableTabRow
 import androidx.compose.material.Surface
+import androidx.compose.material.Tab
 import androidx.compose.material.Text
 import androidx.compose.material.TopAppBar
 import androidx.compose.material.icons.Icons
@@ -47,12 +52,14 @@ import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalConfiguration
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.res.colorResource
 import androidx.compose.ui.res.dimensionResource
+import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.input.KeyboardType
@@ -88,6 +95,7 @@ import com.woocommerce.android.ui.orders.wooshippinglabels.packages.ui.PackageDa
 import com.woocommerce.android.ui.orders.wooshippinglabels.rates.ui.ShippingRateUI
 import com.woocommerce.android.ui.orders.wooshippinglabels.rates.ui.ShippingRatesSection
 import com.woocommerce.android.ui.orders.wooshippinglabels.rates.ui.ShippingSortOption
+import kotlinx.coroutines.launch
 
 @Composable
 fun WooShippingLabelCreationScreen(viewModel: WooShippingLabelCreationViewModel) {
@@ -105,6 +113,7 @@ fun WooShippingLabelCreationScreen(viewModel: WooShippingLabelCreationViewModel)
                 totalItemsCost = viewState.totalItemsCost,
                 shippingLines = viewState.shippingLines,
                 shippingAddresses = viewState.shippingAddresses,
+                onSelectedShipmentChanged = viewModel::onSelectedShipmentChanged,
                 shippingRatesState = viewState.shippingRates,
                 packageSelectionState = viewState.packageSelection,
                 customsState = viewState.customsState,
@@ -151,6 +160,7 @@ fun WooShippingLabelCreationScreen(
     shippingRatesState: WooShippingLabelCreationViewModel.ShippingRatesState,
     packageSelectionState: PackageSelectionState,
     shippingAddresses: WooShippingAddresses,
+    onSelectedShipmentChanged: (index: Int) -> Unit,
     customsState: CustomsState,
     hazmatState: HazmatState,
     onShippingFromAddressChange: (OriginShippingAddress) -> Unit,
@@ -221,6 +231,7 @@ fun WooShippingLabelCreationScreen(
             scaffoldState = scaffoldState,
             shippingLines = shippingLines,
             shippingAddresses = shippingAddresses,
+            onSelectedShipmentChanged = onSelectedShipmentChanged,
             customsState = customsState,
             hazmatState = hazmatState,
             shippingRatesState = shippingRatesState,
@@ -231,7 +242,7 @@ fun WooShippingLabelCreationScreen(
             onRefreshShippingRates = onRefreshShippingRates,
             customWeight = customWeight,
             onCustomWeightChange = onCustomWeightChange,
-            onSelectedSippingRateChanged = onSelectedSippingRateChanged,
+            onSelectedShippingRateChanged = onSelectedSippingRateChanged,
             uiState = uiState,
             onNavigateBack = onNavigateBack,
             onMarkOrderCompleteChange = onMarkOrderCompleteChange,
@@ -306,13 +317,14 @@ private fun LabelCreationScreenWithBottomSheet(
     hazmatState: HazmatState,
     onSelectPackageClick: () -> Unit,
     shippingAddresses: WooShippingAddresses,
+    onSelectedShipmentChanged: (index: Int) -> Unit,
     onEditOriginAddress: (OriginShippingAddress) -> Unit,
     onShippingFromAddressChange: (OriginShippingAddress) -> Unit,
     onSelectedRateSortOrderChanged: (ShippingSortOption) -> Unit,
     onRefreshShippingRates: () -> Unit,
     customWeight: String,
     onCustomWeightChange: (String) -> Unit,
-    onSelectedSippingRateChanged: (rate: ShippingRateUI) -> Unit,
+    onSelectedShippingRateChanged: (rate: ShippingRateUI) -> Unit,
     uiState: WooShippingLabelCreationViewModel.UIControlsState,
     scaffoldState: BottomSheetScaffoldState,
     shipFromSelectionBottomSheetState: ModalBottomSheetState,
@@ -397,29 +409,89 @@ private fun LabelCreationScreenWithBottomSheet(
             Column(
                 modifier
                     .verticalScroll(rememberScrollState())
-                    .padding(vertical = 16.dp)
+                    .padding(bottom = 16.dp)
             ) {
-                val isExpanded = remember { mutableStateOf(false) }
-                Row(
-                    modifier = Modifier.padding(
-                        start = dimensionResource(R.dimen.major_100),
-                        end = dimensionResource(R.dimen.major_100),
-                        bottom = dimensionResource(R.dimen.minor_100)
-                    ),
-                    verticalAlignment = Alignment.CenterVertically
-                ) {
-                    Text(
-                        text = stringResource(R.string.products),
-                        style = MaterialTheme.typography.h6,
-                        modifier = Modifier.weight(1f)
-                    )
-                    Text(
-                        text = stringResource(R.string.woo_shipping_split_shipment),
-                        color = MaterialTheme.colors.primary,
+                val scope = rememberCoroutineScope()
+                val pagerState = rememberPagerState { shipmentUIList.size }
+
+
+                LaunchedEffect(pagerState.targetPage) {
+                    onSelectedShipmentChanged(pagerState.targetPage)
+                }
+
+                if (shipmentUIList.size == 1) {
+                    Row(
+                        modifier = Modifier.padding(16.dp),
+                        verticalAlignment = Alignment.CenterVertically
+                    ) {
+                        Text(
+                            text = stringResource(R.string.products),
+                            style = MaterialTheme.typography.h6,
+                            modifier = Modifier.weight(1f)
+                        )
+                        Text(
+                            text = stringResource(R.string.woo_shipping_split_shipment),
+                            color = MaterialTheme.colors.primary,
+                            modifier = Modifier
+                                .clickable { onSplitShipment() }
+                                .padding(dimensionResource(R.dimen.minor_100))
+                        )
+                    }
+                } else {
+                    val selectedIndex = if (pagerState.currentPage < pagerState.pageCount) pagerState.currentPage else 0
+                    Row(
                         modifier = Modifier
-                            .clickable { onSplitShipment() }
-                            .padding(dimensionResource(R.dimen.minor_100))
-                    )
+                            .fillMaxWidth()
+                            .padding(bottom = 16.dp)
+                    ) {
+                        ScrollableTabRow(
+                            selectedTabIndex = selectedIndex,
+                            backgroundColor = MaterialTheme.colors.surface,
+                            contentColor = MaterialTheme.colors.primary,
+                            divider = {},
+                            edgePadding = 0.dp,
+                            modifier = modifier.weight(1f)
+                        ) {
+                            shipmentUIList.forEachIndexed { index, _ ->
+                                val textColor = if (index == pagerState.currentPage) {
+                                    MaterialTheme.colors.primary
+                                } else {
+                                    colorResource(id = R.color.color_on_surface_medium)
+                                }
+                                Tab(
+                                    text = {
+                                        Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+                                            Text(
+                                                text = stringResource(
+                                                    R.string.woo_shipping_split_shipment_shipment_name,
+                                                    index + 1 // Use 1-based indexing for the shipments
+                                                ),
+                                                color = textColor,
+                                                style = MaterialTheme.typography.subtitle1,
+                                                fontWeight = FontWeight.SemiBold
+                                            )
+                                            if (shipmentUIList[index].purchased) {
+                                                Icon(
+                                                    modifier = Modifier.size(16.dp),
+                                                    painter = painterResource(R.drawable.ic_progress_circle_complete),
+                                                    contentDescription = stringResource(
+                                                        R.string.purchased_shipment_content_description
+                                                    ),
+                                                    tint = colorResource(id = R.color.woo_green_70)
+                                                )
+                                            }
+                                        }
+                                    },
+                                    selected = pagerState.currentPage == index,
+                                    onClick = {
+                                        scope.launch {
+                                            pagerState.animateScrollToPage(index)
+                                        }
+                                    }
+                                )
+                            }
+                        }
+                    }
                 }
 
                 ShippingProductsCard(
@@ -809,7 +881,8 @@ private fun WooShippingLabelCreationScreenPreview() {
                 ShipmentUI(
                     shippableItems = generateItems(6),
                     formattedTotalWeight = "8.5kg",
-                    formattedTotalPrice = "$92.78"
+                    formattedTotalPrice = "$92.78",
+                    purchased = false
                 )
             ),
             totalItems = 6,
@@ -823,6 +896,7 @@ private fun WooShippingLabelCreationScreenPreview() {
                 shipTo = getShipTo(),
                 originAddresses = listOf(getShipFrom())
             ),
+            onSelectedShipmentChanged = {},
             shippingRatesState = WooShippingLabelCreationViewModel.ShippingRatesState.NoAvailable,
             packageSelectionState = NotSelected,
             customsState = Unavailable,

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/WooShippingLabelCreationScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/WooShippingLabelCreationScreen.kt
@@ -100,7 +100,7 @@ fun WooShippingLabelCreationScreen(viewModel: WooShippingLabelCreationViewModel)
             WooShippingLabelCreationScreen(
                 onSelectPackageClick = viewModel::onSelectPackageClicked,
                 onPurchaseShippingLabel = viewModel::onPurchaseShippingLabel,
-                shipmentUI = viewState.shipmentUI,
+                shipmentUIList = viewState.shipmentUIList,
                 shippingLines = viewState.shippingLines,
                 shippingAddresses = viewState.shippingAddresses,
                 shippingRatesState = viewState.shippingRates,
@@ -142,7 +142,7 @@ fun WooShippingLabelCreationScreen(viewModel: WooShippingLabelCreationViewModel)
 
 @Composable
 fun WooShippingLabelCreationScreen(
-    shipmentUI: ShipmentUI,
+    shipmentUIList: List<ShipmentUI>,
     shippingLines: List<ShippingLineSummaryUI>,
     shippingRatesState: WooShippingLabelCreationViewModel.ShippingRatesState,
     packageSelectionState: PackageSelectionState,
@@ -209,7 +209,7 @@ fun WooShippingLabelCreationScreen(
 
     Box(modifier = Modifier.fillMaxSize()) {
         LabelCreationScreenWithBottomSheet(
-            shipmentUI = shipmentUI,
+            shipmentUIList = shipmentUIList,
             modifier = modifier,
             onSelectPackageClick = onSelectPackageClick,
             scaffoldState = scaffoldState,
@@ -290,7 +290,7 @@ fun WooShippingLabelCreationScreen(
 @Suppress("CyclomaticComplexMethod")
 @Composable
 private fun LabelCreationScreenWithBottomSheet(
-    shipmentUI: ShipmentUI,
+    shipmentUIList: List<ShipmentUI>,
     shippingLines: List<ShippingLineSummaryUI>,
     shippingRatesState: WooShippingLabelCreationViewModel.ShippingRatesState,
     packageSelectionState: PackageSelectionState,
@@ -796,10 +796,12 @@ internal fun ErrorScreen(
 private fun WooShippingLabelCreationScreenPreview() {
     WooThemeWithBackground {
         WooShippingLabelCreationScreen(
-            shipmentUI = ShipmentUI(
-                shippableItems = generateItems(6),
-                formattedTotalWeight = "8.5kg",
-                formattedTotalPrice = "$92.78"
+            shipmentUIList = listOf(
+                ShipmentUI(
+                    shippableItems = generateItems(6),
+                    formattedTotalWeight = "8.5kg",
+                    formattedTotalPrice = "$92.78"
+                )
             ),
             shippingLines = getShippingLines(),
             modifier = Modifier.fillMaxSize(),

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/WooShippingLabelCreationScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/WooShippingLabelCreationScreen.kt
@@ -100,7 +100,7 @@ fun WooShippingLabelCreationScreen(viewModel: WooShippingLabelCreationViewModel)
             WooShippingLabelCreationScreen(
                 onSelectPackageClick = viewModel::onSelectPackageClicked,
                 onPurchaseShippingLabel = viewModel::onPurchaseShippingLabel,
-                shippableItems = viewState.shippableItems,
+                shipmentUI = viewState.shipmentUI,
                 shippingLines = viewState.shippingLines,
                 shippingAddresses = viewState.shippingAddresses,
                 shippingRatesState = viewState.shippingRates,
@@ -142,7 +142,7 @@ fun WooShippingLabelCreationScreen(viewModel: WooShippingLabelCreationViewModel)
 
 @Composable
 fun WooShippingLabelCreationScreen(
-    shippableItems: ShippableItemsUI,
+    shipmentUI: ShipmentUI,
     shippingLines: List<ShippingLineSummaryUI>,
     shippingRatesState: WooShippingLabelCreationViewModel.ShippingRatesState,
     packageSelectionState: PackageSelectionState,
@@ -209,7 +209,7 @@ fun WooShippingLabelCreationScreen(
 
     Box(modifier = Modifier.fillMaxSize()) {
         LabelCreationScreenWithBottomSheet(
-            shippableItems = shippableItems,
+            shipmentUI = shipmentUI,
             modifier = modifier,
             onSelectPackageClick = onSelectPackageClick,
             scaffoldState = scaffoldState,
@@ -290,7 +290,7 @@ fun WooShippingLabelCreationScreen(
 @Suppress("CyclomaticComplexMethod")
 @Composable
 private fun LabelCreationScreenWithBottomSheet(
-    shippableItems: ShippableItemsUI,
+    shipmentUI: ShipmentUI,
     shippingLines: List<ShippingLineSummaryUI>,
     shippingRatesState: WooShippingLabelCreationViewModel.ShippingRatesState,
     packageSelectionState: PackageSelectionState,
@@ -358,7 +358,7 @@ private fun LabelCreationScreenWithBottomSheet(
                 onEditOriginAddress = onEditOriginAddress
             ) {
                 ShipmentDetails(
-                    shippableItems = shippableItems,
+                    shipmentUI = shipmentUI,
                     shippingLines = shippingLines,
                     shipFromSelectionBottomSheetState = shipFromSelectionBottomSheetState,
                     onMarkOrderCompleteChange = onMarkOrderCompleteChange,
@@ -414,7 +414,7 @@ private fun LabelCreationScreenWithBottomSheet(
                 }
 
                 ShippingProductsCard(
-                    shippableItems = shippableItems,
+                    shippableItems = shipmentUI,
                     modifier = Modifier
                         .fillMaxWidth()
                         .padding(
@@ -796,7 +796,7 @@ internal fun ErrorScreen(
 private fun WooShippingLabelCreationScreenPreview() {
     WooThemeWithBackground {
         WooShippingLabelCreationScreen(
-            shippableItems = ShippableItemsUI(
+            shipmentUI = ShipmentUI(
                 shippableItems = generateItems(6),
                 formattedTotalWeight = "8.5kg",
                 formattedTotalPrice = "$92.78"

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/WooShippingLabelCreationScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/WooShippingLabelCreationScreen.kt
@@ -504,45 +504,27 @@ private fun LabelCreationScreenWithBottomSheet(
                     }
                 }
 
-                ShippingProductsCard(
-                    shippableItems = shipmentUI,
-                    modifier = Modifier
-                        .fillMaxWidth()
-                        .padding(
-                            start = dimensionResource(R.dimen.major_100),
-                            end = dimensionResource(R.dimen.major_100),
-                            bottom = dimensionResource(R.dimen.major_100)
-                        ),
-                    isExpanded = isExpanded.value,
-                    onExpand = { isExpanded.value = it }
-                )
-                HazmatCard(
-                    onClick = onHazmatNoticeClick,
-                    selectedCategory = hazmatState.hazmatSelection,
-                    modifier = Modifier
-                        .fillMaxWidth()
-                        .padding(start = 4.dp, end = 8.dp)
-                )
-                CustomsCard(
-                    customsState = customsState,
-                    onEditCustomsClick = onEditCustomsClick,
-                    modifier = Modifier
-                        .fillMaxWidth()
-                        .padding(16.dp)
-                )
-                PackageCard(
-                    modifier = Modifier.padding(16.dp),
-                    packageSelectionState = packageSelectionState,
-                    onSelectPackageClick = onSelectPackageClick,
-                    customWeight = customWeight,
-                    onCustomWeightChange = onCustomWeightChange
-                )
-                ShippingRatesSection(
-                    shippingRatesState = shippingRatesState,
-                    onSelectedRateSortOrderChanged = onSelectedRateSortOrderChanged,
-                    onRefreshShippingRates = onRefreshShippingRates,
-                    onSelectedSippingRateChanged = onSelectedSippingRateChanged
-                )
+                HorizontalPager(
+                    state = pagerState,
+                    modifier = modifier.fillMaxSize(),
+                    verticalAlignment = Alignment.Top,
+                ) { page ->
+                    CreateShippingCards(
+                        shipmentUI = shipmentUIList[page],
+                        onHazmatNoticeClick = onHazmatNoticeClick,
+                        hazmatState = hazmatState,
+                        customsState = customsState,
+                        onEditCustomsClick = onEditCustomsClick,
+                        packageSelectionState = packageSelectionState,
+                        onSelectPackageClick = onSelectPackageClick,
+                        customWeight = customWeight,
+                        onCustomWeightChange = onCustomWeightChange,
+                        shippingRatesState = shippingRatesState,
+                        onSelectedRateSortOrderChanged = onSelectedRateSortOrderChanged,
+                        onRefreshShippingRates = onRefreshShippingRates,
+                        onSelectedShippingRateChanged = onSelectedShippingRateChanged,
+                    )
+                }
             }
 
             val actionSnackbarMessage = snackbarData?.let { stringResource(it.message) }
@@ -562,6 +544,67 @@ private fun LabelCreationScreenWithBottomSheet(
                 } ?: snackbarHostState.currentSnackbarData?.dismiss()
             }
         }
+    }
+}
+
+@Composable
+private fun CreateShippingCards(
+    shipmentUI: ShipmentUI,
+    onHazmatNoticeClick: () -> Unit = {},
+    hazmatState: HazmatState,
+    customsState: CustomsState,
+    onEditCustomsClick: () -> Unit,
+    packageSelectionState: PackageSelectionState,
+    onSelectPackageClick: () -> Unit,
+    customWeight: String,
+    onCustomWeightChange: (String) -> Unit,
+    shippingRatesState: WooShippingLabelCreationViewModel.ShippingRatesState,
+    onSelectedRateSortOrderChanged: (ShippingSortOption) -> Unit,
+    onRefreshShippingRates: () -> Unit,
+    onSelectedShippingRateChanged: (rate: ShippingRateUI) -> Unit,
+) {
+    Column {
+        val isExpanded = remember { mutableStateOf(false) }
+
+        ShippingProductsCard(
+            shippableItems = shipmentUI,
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(
+                    start = dimensionResource(R.dimen.major_100),
+                    end = dimensionResource(R.dimen.major_100),
+                    bottom = dimensionResource(R.dimen.major_100)
+                ),
+            isExpanded = isExpanded.value,
+            onExpand = { isExpanded.value = it }
+        )
+        HazmatCard(
+            onClick = onHazmatNoticeClick,
+            selectedCategory = hazmatState.hazmatSelection,
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(start = 4.dp, end = 8.dp)
+        )
+        CustomsCard(
+            customsState = customsState,
+            onEditCustomsClick = onEditCustomsClick,
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(16.dp)
+        )
+        PackageCard(
+            modifier = Modifier.padding(16.dp),
+            packageSelectionState = packageSelectionState,
+            onSelectPackageClick = onSelectPackageClick,
+            customWeight = customWeight,
+            onCustomWeightChange = onCustomWeightChange
+        )
+        ShippingRatesSection(
+            shippingRatesState = shippingRatesState,
+            onSelectedRateSortOrderChanged = onSelectedRateSortOrderChanged,
+            onRefreshShippingRates = onRefreshShippingRates,
+            onSelectedSippingRateChanged = onSelectedShippingRateChanged
+        )
     }
 }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/WooShippingLabelCreationScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/WooShippingLabelCreationScreen.kt
@@ -101,6 +101,8 @@ fun WooShippingLabelCreationScreen(viewModel: WooShippingLabelCreationViewModel)
                 onSelectPackageClick = viewModel::onSelectPackageClicked,
                 onPurchaseShippingLabel = viewModel::onPurchaseShippingLabel,
                 shipmentUIList = viewState.shipmentUIList,
+                totalItems = viewState.totalItems,
+                totalItemsCost = viewState.totalItemsCost,
                 shippingLines = viewState.shippingLines,
                 shippingAddresses = viewState.shippingAddresses,
                 shippingRatesState = viewState.shippingRates,
@@ -143,6 +145,8 @@ fun WooShippingLabelCreationScreen(viewModel: WooShippingLabelCreationViewModel)
 @Composable
 fun WooShippingLabelCreationScreen(
     shipmentUIList: List<ShipmentUI>,
+    totalItems: Int,
+    totalItemsCost: String,
     shippingLines: List<ShippingLineSummaryUI>,
     shippingRatesState: WooShippingLabelCreationViewModel.ShippingRatesState,
     packageSelectionState: PackageSelectionState,
@@ -210,6 +214,8 @@ fun WooShippingLabelCreationScreen(
     Box(modifier = Modifier.fillMaxSize()) {
         LabelCreationScreenWithBottomSheet(
             shipmentUIList = shipmentUIList,
+            totalItems = totalItems,
+            totalItemsCost = totalItemsCost,
             modifier = modifier,
             onSelectPackageClick = onSelectPackageClick,
             scaffoldState = scaffoldState,
@@ -291,6 +297,8 @@ fun WooShippingLabelCreationScreen(
 @Composable
 private fun LabelCreationScreenWithBottomSheet(
     shipmentUIList: List<ShipmentUI>,
+    totalItems: Int,
+    totalItemsCost: String,
     shippingLines: List<ShippingLineSummaryUI>,
     shippingRatesState: WooShippingLabelCreationViewModel.ShippingRatesState,
     packageSelectionState: PackageSelectionState,
@@ -358,7 +366,8 @@ private fun LabelCreationScreenWithBottomSheet(
                 onEditOriginAddress = onEditOriginAddress
             ) {
                 ShipmentDetails(
-                    shipmentUI = shipmentUI,
+                    totalItems = totalItems,
+                    totalItemsCost = totalItemsCost,
                     shippingLines = shippingLines,
                     shipFromSelectionBottomSheetState = shipFromSelectionBottomSheetState,
                     onMarkOrderCompleteChange = onMarkOrderCompleteChange,
@@ -803,6 +812,8 @@ private fun WooShippingLabelCreationScreenPreview() {
                     formattedTotalPrice = "$92.78"
                 )
             ),
+            totalItems = 6,
+            totalItemsCost = "$92.78",
             shippingLines = getShippingLines(),
             modifier = Modifier.fillMaxSize(),
             onSelectPackageClick = {},

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/WooShippingLabelCreationViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/WooShippingLabelCreationViewModel.kt
@@ -421,6 +421,8 @@ class WooShippingLabelCreationViewModel @Inject constructor(
 
             return@combine WooShippingViewState.DataState(
                 shipmentUIList = shipmentUIList,
+                totalItems = shipmentItems.value.flatten().sumByFloat { it.quantity }.toInt(),
+                totalItemsCost = shipmentItems.value.flatten().getFormattedTotalPrice(currencyFormatter),
                 shippingLines = shippingLineSummary,
                 shippingAddresses = addresses,
                 shippingRates = shippingRates,
@@ -746,6 +748,8 @@ class WooShippingLabelCreationViewModel @Inject constructor(
         data object Loading : WooShippingViewState()
         data class DataState(
             val shipmentUIList: List<ShipmentUI>,
+            val totalItems: Int,
+            val totalItemsCost: String,
             val shippingLines: List<ShippingLineSummaryUI>,
             val shippingAddresses: WooShippingAddresses,
             val shippingRates: ShippingRatesState,

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/WooShippingLabelCreationViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/WooShippingLabelCreationViewModel.kt
@@ -446,6 +446,10 @@ class WooShippingLabelCreationViewModel @Inject constructor(
         } ?: originAddresses.first()
     }
 
+    fun onSelectedShipmentChanged(index: Int) {
+        selectedShipmentIndex.value = index
+    }
+
     fun onShippingFromAddressChange(address: OriginShippingAddress) {
         shippingAddresses.value?.let {
             shippingAddresses.value = it.copy(shipFrom = address)

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/WooShippingLabelCreationViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/WooShippingLabelCreationViewModel.kt
@@ -415,8 +415,13 @@ class WooShippingLabelCreationViewModel @Inject constructor(
             shipmentItems.value = shipments.value.map { it.items }
 
             val shippingLineSummary = order.getShippingLinesSummary(currencyFormatter)
-            val shipmentUIList = shipmentItems.value.map {
-                it.toUIModel(currencyFormatter, storeOptions.dimensionUnit, storeOptions.weightUnit)
+            val shipmentUIList = shipmentItems.value.mapIndexed { index, shippableItemModels ->
+                shippableItemModels.toUIModel(
+                    currencyFormatter,
+                    storeOptions.dimensionUnit,
+                    storeOptions.weightUnit,
+                    shipments.value[index].purchased
+                )
             }
 
             return@combine WooShippingViewState.DataState(
@@ -897,7 +902,8 @@ data class ShippableItemUI(
 data class ShipmentUI(
     val shippableItems: List<ShippableItemUI>,
     val formattedTotalWeight: String,
-    val formattedTotalPrice: String
+    val formattedTotalPrice: String,
+    val purchased: Boolean
 ) : Parcelable {
     val totalItemQuantity
         get() = shippableItems.sumByFloat { it.quantity }.toInt()

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/WooShippingLabelCreationViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/WooShippingLabelCreationViewModel.kt
@@ -561,7 +561,15 @@ class WooShippingLabelCreationViewModel @Inject constructor(
                         rateSummary = selectedRate.summary,
                         shippingLines = currentViewState.shippingLines,
                         hazmatSelection = hazmatSelection
-                    ).let { triggerEvent(LabelPurchased(purchaseData = it)) }
+                    ).let {
+                        triggerEvent(
+                            LabelPurchased(
+                                purchaseData = it,
+                                totalItems = currentViewState.totalItems,
+                                totalItemsCost = currentViewState.totalItemsCost
+                            )
+                        )
+                    }
                 }
             }
     }
@@ -719,7 +727,12 @@ class WooShippingLabelCreationViewModel @Inject constructor(
     }
 
     data object StartPackageSelection : Event()
-    data class LabelPurchased(val purchaseData: PurchasedShippingLabelData) : Event()
+    data class LabelPurchased(
+        val purchaseData: PurchasedShippingLabelData,
+        val totalItems: Int,
+        val totalItemsCost: String
+    ) : Event()
+
     data class StartOriginAddressEdit(val originAddress: OriginShippingAddress) : Event()
     data class StartDestinationAddressEdit(
         val destinationAddress: DestinationShippingAddress,

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/WooShippingLabelCreationViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/WooShippingLabelCreationViewModel.kt
@@ -130,6 +130,7 @@ class WooShippingLabelCreationViewModel @Inject constructor(
         r1.defaultRate.rate.deliveryDays.compareTo(r2.defaultRate.rate.deliveryDays)
     }
 
+    private val selectedShipmentIndex = MutableStateFlow<Int>(0)
     private val selectedRate = MutableStateFlow<ShippingRateUI?>(null)
     private val shippingRates = MutableStateFlow<Map<CarrierUI, List<ShippingRateUI>>>(emptyMap())
     private val shippingRatesState = MutableStateFlow<ShippingRatesState>(ShippingRatesState.NoAvailable)

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/WooShippingLabelCreationViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/WooShippingLabelCreationViewModel.kt
@@ -412,7 +412,7 @@ class WooShippingLabelCreationViewModel @Inject constructor(
             shippableItems.value = shipments.value.map { it.items }.flatten()
 
             val shippingLineSummary = order.getShippingLinesSummary(currencyFormatter)
-            val shippableItemsUI = shippableItems.value.toUIModel(
+            val shipmentUI = shippableItems.value.toUIModel(
                 currencyFormatter,
                 storeOptions.dimensionUnit,
                 storeOptions.weightUnit
@@ -420,7 +420,7 @@ class WooShippingLabelCreationViewModel @Inject constructor(
             )
 
             return@combine WooShippingViewState.DataState(
-                shippableItems = shippableItemsUI,
+                shipmentUI = shipmentUI,
                 shippingLines = shippingLineSummary,
                 shippingAddresses = addresses,
                 shippingRates = shippingRates,
@@ -554,7 +554,7 @@ class WooShippingLabelCreationViewModel @Inject constructor(
                         carrierId = purchasedLabel.carrierId,
                         trackingNumber = purchasedLabel.tracking,
                         addresses = currentViewState.shippingAddresses,
-                        items = currentViewState.shippableItems,
+                        items = currentViewState.shipmentUI,
                         rateSummary = selectedRate.summary,
                         shippingLines = currentViewState.shippingLines,
                         hazmatSelection = hazmatSelection
@@ -744,7 +744,7 @@ class WooShippingLabelCreationViewModel @Inject constructor(
         data object Error : WooShippingViewState()
         data object Loading : WooShippingViewState()
         data class DataState(
-            val shippableItems: ShippableItemsUI,
+            val shipmentUI: ShipmentUI,
             val shippingLines: List<ShippingLineSummaryUI>,
             val shippingAddresses: WooShippingAddresses,
             val shippingRates: ShippingRatesState,
@@ -872,7 +872,7 @@ data class ShippableItemUI(
 ) : Parcelable
 
 @Parcelize
-data class ShippableItemsUI(
+data class ShipmentUI(
     val shippableItems: List<ShippableItemUI>,
     val formattedTotalWeight: String,
     val formattedTotalPrice: String

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/WooShippingLabelCreationViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/WooShippingLabelCreationViewModel.kt
@@ -60,6 +60,7 @@ import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.debounce
 import kotlinx.coroutines.flow.drop
+import kotlinx.coroutines.flow.filter
 import kotlinx.coroutines.flow.onStart
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.joinAll
@@ -309,7 +310,7 @@ class WooShippingLabelCreationViewModel @Inject constructor(
         combine(
             shippingAddresses,
             customsFormData,
-            shipmentItems
+            shipmentItems.filter { it.isNotEmpty() }
         ) { addresses, customsData, shipmentItems ->
             val customsRequired = addresses != null && shouldRequireCustoms(addresses)
             val itnMissing = customsFormData.value?.itn.isNullOrEmpty() &&

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/WooShippingLabelCreationViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/WooShippingLabelCreationViewModel.kt
@@ -269,7 +269,7 @@ class WooShippingLabelCreationViewModel @Inject constructor(
     @OptIn(FlowPreview::class)
     private suspend fun observePackageWeight() {
         combine(
-            shipmentItems,
+            shipmentItems.filter { it.isNotEmpty() },
             packageSelected,
             snapshotFlow { customWeight }.debounce(TYPING_DELAY)
         ) { shipmentItems, selectedPackage, customWeightString ->

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/WooShippingLabelCreationViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/WooShippingLabelCreationViewModel.kt
@@ -99,7 +99,7 @@ class WooShippingLabelCreationViewModel @Inject constructor(
     private val storeOptions = MutableStateFlow<StoreOptionsModel?>(StoreOptionsModel.EMPTY)
 
     private val shipments = MutableStateFlow<List<ShipmentUIModel>>(emptyList())
-    private val shippableItems = MutableStateFlow<List<ShippableItemModel>>(emptyList())
+    private val shipmentItems = MutableStateFlow<List<List<ShippableItemModel>>>(emptyList())
 
     private val packageSelected = MutableStateFlow<PackageData?>(null)
     private val customsFormData = MutableStateFlow<CustomsData?>(null)
@@ -268,11 +268,11 @@ class WooShippingLabelCreationViewModel @Inject constructor(
     @OptIn(FlowPreview::class)
     private suspend fun observePackageWeight() {
         combine(
-            shippableItems,
+            shipmentItems,
             packageSelected,
             snapshotFlow { customWeight }.debounce(TYPING_DELAY)
-        ) { shippableItems, selectedPackage, customWeightString ->
-            val itemsWeight = shippableItems.sumByFloat { it.weight }
+        ) { shipmentItems, selectedPackage, customWeightString ->
+            val itemsWeight = shipmentItems[selectedShipmentIndex.value].sumByFloat { it.weight }
             val packageWeight = selectedPackage?.weight?.toFloatOrNull()
             PackageWeight(
                 itemsWeight = itemsWeight,
@@ -309,10 +309,11 @@ class WooShippingLabelCreationViewModel @Inject constructor(
         combine(
             shippingAddresses,
             customsFormData,
-            shippableItems
-        ) { addresses, customsData, shippableItems ->
+            shipmentItems
+        ) { addresses, customsData, shipmentItems ->
             val customsRequired = addresses != null && shouldRequireCustoms(addresses)
-            val itnMissing = customsFormData.value?.itn.isNullOrEmpty() && shippableItems.isItnRequired()
+            val itnMissing = customsFormData.value?.itn.isNullOrEmpty() &&
+                shipmentItems[selectedShipmentIndex.value].isItnRequired()
 
             when {
                 customsRequired && itnMissing -> ItnMissing
@@ -410,18 +411,15 @@ class WooShippingLabelCreationViewModel @Inject constructor(
                 else -> AddressStatus.UNVERIFIED
             }
 
-            shippableItems.value = shipments.value.map { it.items }.flatten()
+            shipmentItems.value = shipments.value.map { it.items }
 
             val shippingLineSummary = order.getShippingLinesSummary(currencyFormatter)
-            val shipmentUI = shippableItems.value.toUIModel(
-                currencyFormatter,
-                storeOptions.dimensionUnit,
-                storeOptions.weightUnit
-
-            )
+            val shipmentUIList = shipmentItems.value.map {
+                it.toUIModel(currencyFormatter, storeOptions.dimensionUnit, storeOptions.weightUnit)
+            }
 
             return@combine WooShippingViewState.DataState(
-                shipmentUI = shipmentUI,
+                shipmentUIList = shipmentUIList,
                 shippingLines = shippingLineSummary,
                 shippingAddresses = addresses,
                 shippingRates = shippingRates,
@@ -505,7 +503,7 @@ class WooShippingLabelCreationViewModel @Inject constructor(
 
         val orderId = navArgs.orderId
         val lastOrderComplete = uiState.value.markOrderComplete
-        val shippableItemsIdList = shippableItems.value.map { it.productId }
+        val shippableItemsIdList = shipmentItems.value[selectedShipmentIndex.value].map { it.productId }
         val hazmatSelection = hazmatState.value.hazmatSelection
 
         val backupPurchaseState = purchaseState.value
@@ -547,15 +545,16 @@ class WooShippingLabelCreationViewModel @Inject constructor(
             ?.let { purchasedLabel ->
                 val currentViewState = (viewState.value as? WooShippingViewState.DataState)
                 val selectedRate = selectedRate.value
-                val hazmatSelection = hazmatState.value.hazmatSelection
                 if (currentViewState != null && selectedRate != null) {
+                    val items = currentViewState.shipmentUIList[selectedShipmentIndex.value]
+                    val hazmatSelection = hazmatState.value.hazmatSelection
                     PurchasedShippingLabelData(
                         labelId = purchasedLabel.labelId,
                         orderId = navArgs.orderId,
                         carrierId = purchasedLabel.carrierId,
                         trackingNumber = purchasedLabel.tracking,
                         addresses = currentViewState.shippingAddresses,
-                        items = currentViewState.shipmentUI,
+                        items = items,
                         rateSummary = selectedRate.summary,
                         shippingLines = currentViewState.shippingLines,
                         hazmatSelection = hazmatSelection
@@ -574,8 +573,8 @@ class WooShippingLabelCreationViewModel @Inject constructor(
 
     fun onSplitShipment() {
         val currentStoreOptions = storeOptions.value
-        val currentShippableItems = shippableItems.value
-        if (currentStoreOptions != null && currentShippableItems.isNotEmpty()) {
+        val currentShipmentItems = shipmentItems.value
+        if (currentStoreOptions != null && currentShipmentItems.isNotEmpty()) {
             triggerEvent(
                 StartSplitShipment(
                     SplitShipmentArgs(
@@ -621,7 +620,7 @@ class WooShippingLabelCreationViewModel @Inject constructor(
             ?.shipTo?.address?.country?.code.orEmpty()
 
         val event = StartCustomsFormEdit(
-            shippableItems = shippableItems.value,
+            shippableItems = shipmentItems.value[selectedShipmentIndex.value],
             destinationCountryCode = destinationCountryCode,
             customData = customsFormData.value
         )
@@ -745,7 +744,7 @@ class WooShippingLabelCreationViewModel @Inject constructor(
         data object Error : WooShippingViewState()
         data object Loading : WooShippingViewState()
         data class DataState(
-            val shipmentUI: ShipmentUI,
+            val shipmentUIList: List<ShipmentUI>,
             val shippingLines: List<ShippingLineSummaryUI>,
             val shippingAddresses: WooShippingAddresses,
             val shippingRates: ShippingRatesState,

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/WooShippingProductsCard.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/WooShippingProductsCard.kt
@@ -55,7 +55,7 @@ import com.woocommerce.android.util.StringUtils
 
 @Composable
 fun ShippingProductsCard(
-    shippableItems: ShippableItemsUI,
+    shippableItems: ShipmentUI,
     modifier: Modifier = Modifier,
     iconColor: Color = MaterialTheme.colors.primary,
     isExpanded: Boolean = false,
@@ -92,7 +92,7 @@ private fun ShippingProductsCardPreview(@PreviewParameter(IsExpandedProvider::cl
     WooThemeWithBackground {
         Box(modifier = Modifier.padding(dimensionResource(R.dimen.major_100))) {
             ShippingProductsCard(
-                shippableItems = ShippableItemsUI(
+                shippableItems = ShipmentUI(
                     shippableItems = generateItems(6),
                     formattedTotalWeight = "8.5kg",
                     formattedTotalPrice = "$92.78"
@@ -105,7 +105,7 @@ private fun ShippingProductsCardPreview(@PreviewParameter(IsExpandedProvider::cl
 
 @Composable
 private fun ShippingProductsCardHeader(
-    shippableItems: ShippableItemsUI,
+    shippableItems: ShipmentUI,
     iconColor: Color,
     modifier: Modifier = Modifier,
     isExpanded: Boolean = false
@@ -162,7 +162,7 @@ private fun ShippingProductsCardHeader(
 @Preview
 @Composable
 private fun ShippingProductsCardHeaderPreview() {
-    val shippableItems = ShippableItemsUI(
+    val shippableItems = ShipmentUI(
         shippableItems = generateItems(4),
         formattedTotalWeight = "8.5kg",
         formattedTotalPrice = "$92.78"

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/WooShippingProductsCard.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/WooShippingProductsCard.kt
@@ -95,7 +95,8 @@ private fun ShippingProductsCardPreview(@PreviewParameter(IsExpandedProvider::cl
                 shippableItems = ShipmentUI(
                     shippableItems = generateItems(6),
                     formattedTotalWeight = "8.5kg",
-                    formattedTotalPrice = "$92.78"
+                    formattedTotalPrice = "$92.78",
+                    purchased = false
                 ),
                 isExpanded = isExpanded
             )
@@ -165,7 +166,8 @@ private fun ShippingProductsCardHeaderPreview() {
     val shippableItems = ShipmentUI(
         shippableItems = generateItems(4),
         formattedTotalWeight = "8.5kg",
-        formattedTotalPrice = "$92.78"
+        formattedTotalPrice = "$92.78",
+        purchased = false
     )
     val isExpanded = remember { mutableStateOf(false) }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/components/ShipmentsTabRow.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/components/ShipmentsTabRow.kt
@@ -1,0 +1,73 @@
+package com.woocommerce.android.ui.orders.wooshippinglabels.components
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.size
+import androidx.compose.material.Icon
+import androidx.compose.material.MaterialTheme
+import androidx.compose.material.ScrollableTabRow
+import androidx.compose.material.Tab
+import androidx.compose.material.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.colorResource
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import com.woocommerce.android.R
+import kotlinx.coroutines.launch
+
+@Composable
+fun ShipmentsTabRow(
+    shipmentTabs: List<ShipmentTabData>,
+    selectedTabIndex: Int,
+    onTabSelected: (Int) -> Unit,
+    modifier: Modifier = Modifier
+) {
+    val scope = rememberCoroutineScope()
+    ScrollableTabRow(
+        selectedTabIndex = selectedTabIndex,
+        backgroundColor = MaterialTheme.colors.surface,
+        contentColor = MaterialTheme.colors.primary,
+        divider = {},
+        edgePadding = 0.dp,
+        modifier = modifier
+    ) {
+        shipmentTabs.forEachIndexed { index, tabData ->
+            val textColor = if (index == selectedTabIndex) {
+                MaterialTheme.colors.primary
+            } else {
+                colorResource(id = R.color.color_on_surface_medium)
+            }
+            Tab(
+                text = {
+                    Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+                        Text(
+                            text = stringResource(
+                                R.string.woo_shipping_split_shipment_shipment_name,
+                                tabData.shipmentIndex // Use 1-based indexing for the shipments
+                            ),
+                            color = textColor,
+                            style = MaterialTheme.typography.subtitle1,
+                            fontWeight = FontWeight.SemiBold
+                        )
+                        if (tabData.isPurchased) {
+                            Icon(
+                                modifier = Modifier.size(16.dp),
+                                painter = painterResource(R.drawable.ic_progress_circle_complete),
+                                contentDescription = stringResource(R.string.purchased_shipment_content_description),
+                                tint = colorResource(id = R.color.woo_green_70)
+                            )
+                        }
+                    }
+                },
+                selected = selectedTabIndex == index,
+                onClick = { scope.launch { onTabSelected(index) } }
+            )
+        }
+    }
+}
+
+data class ShipmentTabData(val shipmentIndex: Int, val isPurchased: Boolean)

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/purchased/PurchasedShippingLabelData.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/purchased/PurchasedShippingLabelData.kt
@@ -2,7 +2,7 @@ package com.woocommerce.android.ui.orders.wooshippinglabels.purchased
 
 import android.os.Parcelable
 import com.woocommerce.android.ui.orders.shippinglabels.creation.ShippingLabelHazmatCategory
-import com.woocommerce.android.ui.orders.wooshippinglabels.ShippableItemsUI
+import com.woocommerce.android.ui.orders.wooshippinglabels.ShipmentUI
 import com.woocommerce.android.ui.orders.wooshippinglabels.ShippingLineSummaryUI
 import com.woocommerce.android.ui.orders.wooshippinglabels.ShippingRateSummaryUI
 import com.woocommerce.android.ui.orders.wooshippinglabels.WooShippingAddresses
@@ -14,7 +14,7 @@ data class PurchasedShippingLabelData(
     val orderId: Long,
     val carrierId: String,
     val trackingNumber: String,
-    val items: ShippableItemsUI,
+    val items: ShipmentUI,
     val addresses: WooShippingAddresses,
     val rateSummary: ShippingRateSummaryUI,
     val shippingLines: List<ShippingLineSummaryUI>,

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/purchased/WooShippingLabelPurchasedScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/purchased/WooShippingLabelPurchasedScreen.kt
@@ -53,7 +53,7 @@ import com.woocommerce.android.ui.compose.component.WCColoredButton
 import com.woocommerce.android.ui.compose.theme.WooThemeWithBackground
 import com.woocommerce.android.ui.orders.wooshippinglabels.RoundedCornerBoxWithBorder
 import com.woocommerce.android.ui.orders.wooshippinglabels.ShipmentDetails
-import com.woocommerce.android.ui.orders.wooshippinglabels.ShippableItemsUI
+import com.woocommerce.android.ui.orders.wooshippinglabels.ShipmentUI
 import com.woocommerce.android.ui.orders.wooshippinglabels.ShippingProductsCard
 import com.woocommerce.android.ui.orders.wooshippinglabels.ShippingRateSummaryUI
 import com.woocommerce.android.ui.orders.wooshippinglabels.WooShippingAddresses
@@ -99,7 +99,7 @@ internal fun WooShippingLabelPurchasedScreen(
         sheetContent = {
             shippingData?.let {
                 ShipmentDetails(
-                    shippableItems = shippingData.items,
+                    shipmentUI = shippingData.items,
                     shippingLines = shippingData.shippingLines,
                     shippingAddresses = shippingData.addresses,
                     shippingRateSummary = shippingData.rateSummary,
@@ -394,7 +394,7 @@ internal fun WooShippingLabelPurchasedScreenPreview() {
                     orderId = 0,
                     carrierId = "",
                     trackingNumber = "",
-                    items = ShippableItemsUI(
+                    items = ShipmentUI(
                         shippableItems = generateItems(6),
                         formattedTotalWeight = "8.5kg",
                         formattedTotalPrice = "$92.78"

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/purchased/WooShippingLabelPurchasedScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/purchased/WooShippingLabelPurchasedScreen.kt
@@ -402,7 +402,8 @@ internal fun WooShippingLabelPurchasedScreenPreview() {
                     items = ShipmentUI(
                         shippableItems = generateItems(6),
                         formattedTotalWeight = "8.5kg",
-                        formattedTotalPrice = "$92.78"
+                        formattedTotalPrice = "$92.78",
+                        purchased = false
                     ),
                     addresses = WooShippingAddresses.EMPTY,
                     rateSummary = ShippingRateSummaryUI(serviceName = "", total = ""),

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/purchased/WooShippingLabelPurchasedScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/purchased/WooShippingLabelPurchasedScreen.kt
@@ -69,6 +69,8 @@ fun WooShippingLabelPurchasedScreen(viewModel: WooShippingLabelPurchasedViewMode
         isLoading = viewState.value?.isLoadingData == true,
         isPurchaseFinished = viewState.value?.isPurchaseFinished,
         shippingData = viewState.value?.shippingLabelData,
+        totalItems = viewState.value?.totalItems ?: 0,
+        totalItemsCost = viewState.value?.totalItemsCost ?: "",
         selectedLabelPaperSizeOption = viewState.value?.paperSizeOption ?: WooShippingLabelPaperSize.LEGAL,
         onLabelPaperSizeOptionSelected = { viewModel.onLabelPaperSizeOptionSelected(it) },
         onPrintShippingLabelClicked = { viewModel.onPrintShippingLabelClicked() },
@@ -84,6 +86,8 @@ internal fun WooShippingLabelPurchasedScreen(
     isLoading: Boolean,
     isPurchaseFinished: Boolean?,
     shippingData: PurchasedShippingLabelData?,
+    totalItems: Int,
+    totalItemsCost: String,
     selectedLabelPaperSizeOption: WooShippingLabelPaperSize,
     onLabelPaperSizeOptionSelected: (WooShippingLabelPaperSize) -> Unit,
     onPrintShippingLabelClicked: () -> Unit,
@@ -99,7 +103,8 @@ internal fun WooShippingLabelPurchasedScreen(
         sheetContent = {
             shippingData?.let {
                 ShipmentDetails(
-                    shipmentUI = shippingData.items,
+                    totalItems = totalItems,
+                    totalItemsCost = totalItemsCost,
                     shippingLines = shippingData.shippingLines,
                     shippingAddresses = shippingData.addresses,
                     shippingRateSummary = shippingData.rateSummary,
@@ -404,6 +409,8 @@ internal fun WooShippingLabelPurchasedScreenPreview() {
                     shippingLines = emptyList(),
                     hazmatSelection = null
                 ),
+                totalItems = 6,
+                totalItemsCost = "#92.78",
                 selectedLabelPaperSizeOption = selectedLabelPaperSizeOption.value,
                 onLabelPaperSizeOptionSelected = { selectedLabelPaperSizeOption.value = it },
                 onPrintShippingLabelClicked = {},

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/purchased/WooShippingLabelPurchasedViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/purchased/WooShippingLabelPurchasedViewModel.kt
@@ -89,9 +89,13 @@ class WooShippingLabelPurchasedViewModel @Inject constructor(
         } ?: triggerEvent(ShowError(R.string.shipping_label_purchased_pickup_error))
     }
 
-    fun onRefundClicked() { triggerEvent(StartRefundRequest) }
+    fun onRefundClicked() {
+        triggerEvent(StartRefundRequest)
+    }
 
-    fun onLearnMoreClicked() { triggerEvent(OpenLearnMoreScreen) }
+    fun onLearnMoreClicked() {
+        triggerEvent(OpenLearnMoreScreen)
+    }
 
     private fun observeShippingLabelPurchaseStatus() {
         launch {
@@ -103,9 +107,11 @@ class WooShippingLabelPurchasedViewModel @Inject constructor(
                     PurchaseInProgress -> {
                         _viewState.update { it.copy(isPurchaseFinished = false) }
                     }
+
                     Purchased -> {
                         _viewState.update { it.copy(isPurchaseFinished = true) }
                     }
+
                     else -> {
                         _viewState.update { it.copy(isPurchaseFinished = null) }
                     }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/purchased/WooShippingLabelPurchasedViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/purchased/WooShippingLabelPurchasedViewModel.kt
@@ -32,6 +32,8 @@ class WooShippingLabelPurchasedViewModel @Inject constructor(
 ) : ScopedViewModel(savedState) {
     private val navArgs by savedState.navArgs<WooShippingLabelPurchasedFragmentArgs>()
     private val purchaseData = navArgs.purchaseData
+    private val totalItems = navArgs.totalItems
+    private val totalItemsCost = navArgs.totalItemsCost
 
     private val trackingLink: String?
         get() = ShipmentTrackingUrls.fromCarrier(
@@ -44,6 +46,8 @@ class WooShippingLabelPurchasedViewModel @Inject constructor(
         initialValue = ViewState(
             paperSizeOption = LABEL,
             shippingLabelData = purchaseData,
+            totalItems = totalItems,
+            totalItemsCost = totalItemsCost
         )
     )
     val viewState = _viewState.asLiveData()
@@ -114,6 +118,8 @@ class WooShippingLabelPurchasedViewModel @Inject constructor(
     data class ViewState(
         val paperSizeOption: WooShippingLabelPaperSize,
         val shippingLabelData: PurchasedShippingLabelData? = null,
+        val totalItems: Int,
+        val totalItemsCost: String,
         val isLoadingData: Boolean = false,
         val isPurchaseFinished: Boolean? = false
     ) : Parcelable

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/split/WooShippingSplitShipmentScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/split/WooShippingSplitShipmentScreen.kt
@@ -3,7 +3,6 @@ package com.woocommerce.android.ui.orders.wooshippinglabels.split
 import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.animation.slideInVertically
 import androidx.compose.foundation.clickable
-import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
@@ -11,7 +10,6 @@ import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.sizeIn
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.itemsIndexed
@@ -25,9 +23,7 @@ import androidx.compose.material.DropdownMenuItem
 import androidx.compose.material.Icon
 import androidx.compose.material.IconButton
 import androidx.compose.material.MaterialTheme
-import androidx.compose.material.ScrollableTabRow
 import androidx.compose.material.Surface
-import androidx.compose.material.Tab
 import androidx.compose.material.Text
 import androidx.compose.material.TopAppBar
 import androidx.compose.material.icons.Icons
@@ -48,7 +44,6 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.colorResource
-import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.AnnotatedString
 import androidx.compose.ui.text.font.FontWeight
@@ -65,6 +60,8 @@ import com.woocommerce.android.ui.compose.theme.WooThemeWithBackground
 import com.woocommerce.android.ui.orders.wooshippinglabels.ExpandableSelectableShippingProduct
 import com.woocommerce.android.ui.orders.wooshippinglabels.ProductsSummary
 import com.woocommerce.android.ui.orders.wooshippinglabels.SelectableShippingProduct
+import com.woocommerce.android.ui.orders.wooshippinglabels.components.ShipmentTabData
+import com.woocommerce.android.ui.orders.wooshippinglabels.components.ShipmentsTabRow
 import com.woocommerce.android.ui.orders.wooshippinglabels.components.SuccessSnackbarHost
 import com.woocommerce.android.ui.orders.wooshippinglabels.split.WooShippingSplitShipmentViewModel.SplitShipmentViewState
 import kotlinx.coroutines.launch
@@ -244,61 +241,23 @@ private fun MultipleShipments(
 
         LaunchedEffect(viewState.shipmentSelected) {
             val viewStateCurrentPage = shipments.indexOf(viewState.shipmentSelected)
-            if (pagerState.currentPage != viewStateCurrentPage) {
+            if (pagerState.currentPage != viewStateCurrentPage && viewStateCurrentPage != -1) {
                 pagerState.animateScrollToPage(viewStateCurrentPage)
             }
         }
 
-        Row(modifier = modifier.fillMaxWidth()) {
-            ScrollableTabRow(
-                selectedTabIndex = if (pagerState.currentPage < pagerState.pageCount) pagerState.currentPage else 0,
-                backgroundColor = MaterialTheme.colors.surface,
-                contentColor = MaterialTheme.colors.primary,
-                divider = {},
-                edgePadding = 0.dp,
-                modifier = modifier
-                    .weight(1f)
-                    .padding(top = 8.dp)
-            ) {
-                shipments.forEachIndexed { index, _ ->
-                    val textColor = if (index == pagerState.currentPage) {
-                        MaterialTheme.colors.primary
-                    } else {
-                        colorResource(id = R.color.color_on_surface_medium)
-                    }
-                    Tab(
-                        text = {
-                            Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
-                                Text(
-                                    text = stringResource(
-                                        R.string.woo_shipping_split_shipment_shipment_name,
-                                        index + 1 // Use 1-based indexing for the shipments
-                                    ),
-                                    color = textColor,
-                                    style = MaterialTheme.typography.subtitle1,
-                                    fontWeight = FontWeight.SemiBold
-                                )
-                                if (viewState.selectableItems[index]?.purchased == true) {
-                                    Icon(
-                                        modifier = Modifier.size(16.dp),
-                                        painter = painterResource(R.drawable.ic_progress_circle_complete),
-                                        contentDescription = stringResource(
-                                            R.string.purchased_shipment_content_description
-                                        ),
-                                        tint = colorResource(id = R.color.woo_shipping_label_purchased_color)
-                                    )
-                                }
-                            }
-                        },
-                        selected = pagerState.currentPage == index,
-                        onClick = {
-                            scope.launch {
-                                pagerState.animateScrollToPage(index)
-                            }
-                        }
+        Row(modifier = Modifier.fillMaxWidth()) {
+            ShipmentsTabRow(
+                shipmentTabs = shipments.mapIndexed { index, shipmentKey ->
+                    ShipmentTabData(
+                        shipmentIndex = index + 1,
+                        isPurchased = viewState.selectableItems[index]?.purchased == true
                     )
-                }
-            }
+                },
+                selectedTabIndex = if (pagerState.currentPage < pagerState.pageCount) pagerState.currentPage else 0,
+                onTabSelected = { index -> scope.launch { pagerState.animateScrollToPage(index) } },
+                modifier = Modifier.weight(1f)
+            )
             if (viewState.overflowMenuItems.isNotEmpty()) {
                 WCOverflowMenu(
                     items = viewState.overflowMenuItems,

--- a/WooCommerce/src/main/res/navigation/nav_graph_orders.xml
+++ b/WooCommerce/src/main/res/navigation/nav_graph_orders.xml
@@ -166,13 +166,13 @@
         tools:layout="@layout/fragment_order_detail">
         <argument
             android:name="orderId"
-            app:argType="long"
-            android:defaultValue="-1L"/>
+            android:defaultValue="-1L"
+            app:argType="long" />
         <argument
             android:name="allOrderIds"
             android:defaultValue="@null"
-            app:nullable="true"
-            app:argType="long[]" />
+            app:argType="long[]"
+            app:nullable="true" />
         <argument
             android:name="remoteNoteId"
             android:defaultValue="0L"
@@ -273,19 +273,19 @@
             <argument
                 android:name="sku"
                 app:argType="string"
-                app:nullable="true"/>
+                app:nullable="true" />
             <argument
                 android:name="barcodeFormat"
                 app:argType="com.woocommerce.android.ui.orders.creation.GoogleBarcodeFormatMapper$BarcodeFormat"
-                app:nullable="true"/>
+                app:nullable="true" />
             <argument
                 android:name="giftCardCode"
                 app:argType="string"
-                app:nullable="true"/>
+                app:nullable="true" />
             <argument
                 android:name="giftCardAmount"
                 app:argType="java.math.BigDecimal"
-                app:nullable="true"/>
+                app:nullable="true" />
         </action>
 
         <action
@@ -296,14 +296,14 @@
             app:destination="@id/AIThankYouNoteBottomSheetFragment" />
         <action
             android:id="@+id/action_orderDetailFragment_to_customFieldsFragment"
-            app:destination="@id/nav_graph_custom_fields" >
+            app:destination="@id/nav_graph_custom_fields">
             <argument
                 android:name="parentItemId"
                 app:argType="long" />
             <argument
                 android:name="parentItemType"
-                app:argType="org.wordpress.android.fluxc.model.metadata.MetaDataParentItemType"
-                android:defaultValue="ORDER" />
+                android:defaultValue="ORDER"
+                app:argType="org.wordpress.android.fluxc.model.metadata.MetaDataParentItemType" />
         </action>
         <action
             android:id="@+id/action_orderDetailFragment_to_wooShippingLabelCreationFragment"
@@ -484,8 +484,7 @@
         android:id="@+id/editShippingLabelPaymentFragment"
         android:name="com.woocommerce.android.ui.orders.shippinglabels.creation.EditShippingLabelPaymentFragment"
         android:label="EditShippingLabelPaymentFragment"
-        tools:layout="@layout/fragment_edit_shipping_label_payment">
-    </fragment>
+        tools:layout="@layout/fragment_edit_shipping_label_payment"></fragment>
     <fragment
         android:id="@+id/shippingCarrierRatesFragment"
         android:name="com.woocommerce.android.ui.orders.shippinglabels.creation.ShippingCarrierRatesFragment"
@@ -607,7 +606,7 @@
         android:id="@+id/shippingAddressEditingFragment"
         android:name="com.woocommerce.android.ui.orders.details.editing.address.ShippingAddressEditingFragment"
         android:label="ShippingAddressEditingFragment"
-        tools:layout="@layout/fragment_base_edit_address" >
+        tools:layout="@layout/fragment_base_edit_address">
         <argument
             android:name="storedAddress"
             app:argType="com.woocommerce.android.model.Address" />
@@ -616,7 +615,7 @@
         android:id="@+id/billingAddressEditingFragment"
         android:name="com.woocommerce.android.ui.orders.details.editing.address.BillingAddressEditingFragment"
         android:label="BillingAddressEditingFragment"
-        tools:layout="@layout/fragment_base_edit_address" >
+        tools:layout="@layout/fragment_base_edit_address">
         <argument
             android:name="storedAddress"
             app:argType="com.woocommerce.android.model.Address" />
@@ -695,7 +694,7 @@
     <fragment
         android:id="@+id/wooShippingLabelCreationFragment"
         android:name="com.woocommerce.android.ui.orders.wooshippinglabels.WooShippingLabelCreationFragment"
-        android:label="WooShippingLabelCreationFragment" >
+        android:label="WooShippingLabelCreationFragment">
         <argument
             android:name="orderId"
             app:argType="long" />
@@ -723,7 +722,7 @@
     <fragment
         android:id="@+id/wooShippingLabelPackageCreationFragment"
         android:name="com.woocommerce.android.ui.orders.wooshippinglabels.packages.WooShippingLabelPackageCreationFragment"
-        android:label="WooShippingLabelPackageCreationFragment" >
+        android:label="WooShippingLabelPackageCreationFragment">
 
         <action
             android:id="@+id/action_wooShippingLabelPackageCreationFragment_to_itemSelectorDialog"
@@ -745,7 +744,7 @@
     <fragment
         android:id="@+id/wooShippingEditOriginAddressFragment"
         android:name="com.woocommerce.android.ui.orders.wooshippinglabels.address.WooShippingEditAddressFragment"
-        android:label="WooShippingEditOriginAddressFragment" >
+        android:label="WooShippingEditOriginAddressFragment">
         <argument
             android:name="flow"
             app:argType="com.woocommerce.android.ui.orders.wooshippinglabels.address.EditAddressFlow" />
@@ -756,7 +755,7 @@
     <fragment
         android:id="@+id/wooShippingLabelCustomsFormFragment"
         android:name="com.woocommerce.android.ui.orders.wooshippinglabels.customs.WooShippingCustomsFormFragment"
-        android:label="WooShippingLabelCustomsFormFragment" >
+        android:label="WooShippingLabelCustomsFormFragment">
         <argument
             android:name="shippableItems"
             app:argType="com.woocommerce.android.ui.orders.wooshippinglabels.models.ShippableItemModel[]" />
@@ -768,7 +767,7 @@
         <argument
             android:name="customsData"
             app:argType="com.woocommerce.android.ui.orders.wooshippinglabels.customs.CustomsData"
-            app:nullable="true"/>
+            app:nullable="true" />
 
         <action
             android:id="@+id/action_wooShippingLabelCustomsFormFragment_to_itemSelectorDialog"
@@ -781,7 +780,7 @@
     <fragment
         android:id="@+id/wooShippingSplitShipmentFragment"
         android:name="com.woocommerce.android.ui.orders.wooshippinglabels.split.WooShippingSplitShipmentFragment"
-        android:label="WooShippingSplitShipmentFragment" >
+        android:label="WooShippingSplitShipmentFragment">
         <argument
             android:name="shipmentArgs"
             app:argType="com.woocommerce.android.ui.orders.wooshippinglabels.WooShippingLabelCreationViewModel$SplitShipmentArgs" />
@@ -789,7 +788,7 @@
     <fragment
         android:id="@+id/wooShippingLabelHazmatFormFragment"
         android:name="com.woocommerce.android.ui.orders.wooshippinglabels.hazmat.WooShippingLabelHazmatFormFragment"
-        android:label="WooShippingLabelHazmatFormFragment" >
+        android:label="WooShippingLabelHazmatFormFragment">
         <argument
             android:name="selectedCategoryName"
             app:argType="string"

--- a/WooCommerce/src/main/res/navigation/nav_graph_orders.xml
+++ b/WooCommerce/src/main/res/navigation/nav_graph_orders.xml
@@ -737,6 +737,14 @@
             android:name="purchaseData"
             app:argType="com.woocommerce.android.ui.orders.wooshippinglabels.purchased.PurchasedShippingLabelData" />
 
+        <argument
+            android:name="totalItems"
+            app:argType="integer" />
+
+        <argument
+            android:name="totalItemsCost"
+            app:argType="string" />
+
         <action
             android:id="@+id/action_wooShippingLabelPurchasedFragment_to_printShippingLabelInfoFragment"
             app:destination="@id/printShippingLabelInfoFragment" />

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/WooShippingLabelCreationViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/WooShippingLabelCreationViewModelTest.kt
@@ -1143,6 +1143,6 @@ class WooShippingLabelCreationViewModelTest : BaseUnitTest() {
         val currentViewState = sut.viewState.value
         assert(currentViewState is DataState)
         val dataState = currentViewState as DataState
-        assertThat(dataState.shipmentUI.totalItemQuantity).isEqualTo(expectedItemQuantity)
+        assertThat(dataState.totalItems).isEqualTo(expectedItemQuantity)
     }
 }

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/WooShippingLabelCreationViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/WooShippingLabelCreationViewModelTest.kt
@@ -1143,6 +1143,6 @@ class WooShippingLabelCreationViewModelTest : BaseUnitTest() {
         val currentViewState = sut.viewState.value
         assert(currentViewState is DataState)
         val dataState = currentViewState as DataState
-        assertThat(dataState.shippableItems.totalItemQuantity).isEqualTo(expectedItemQuantity)
+        assertThat(dataState.shipmentUI.totalItemQuantity).isEqualTo(expectedItemQuantity)
     }
 }

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/WooShippingLabelCreationViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/WooShippingLabelCreationViewModelTest.kt
@@ -497,10 +497,12 @@ class WooShippingLabelCreationViewModelTest : BaseUnitTest() {
         )
         whenever(shouldRequireCustomsForm.invoke(any())) doReturn false
         whenever(orderDetailRepository.getOrderById(any())) doReturn order
+        whenever(getShipments(any())) doReturn defaultShipments
         whenever(observeOriginAddresses()) doReturn flowOf(defaultOriginAddresses)
         whenever(
             getShippingRates(any(), any(), any(), any(), any(), any(), isNull(), isNull())
         ) doReturn Result.success(defaultShippingRates)
+        whenever(observeStoreOptions()) doReturn flowOf(defaultStoreOptions)
 
         createViewModel()
 
@@ -512,8 +514,7 @@ class WooShippingLabelCreationViewModelTest : BaseUnitTest() {
 
         advanceUntilIdle()
 
-        verify(getShippingRates, times(2))
-            .invoke(any(), any(), any(), any(), any(), any(), isNull(), isNull())
+        verify(getShippingRates, times(2)).invoke(any(), any(), any(), any(), any(), any(), isNull(), isNull())
     }
 
     @Test
@@ -527,10 +528,12 @@ class WooShippingLabelCreationViewModelTest : BaseUnitTest() {
         )
         whenever(shouldRequireCustomsForm.invoke(any())) doReturn false
         whenever(orderDetailRepository.getOrderById(any())) doReturn order
+        whenever(getShipments(any())) doReturn defaultShipments
         whenever(observeOriginAddresses()) doReturn flowOf(defaultOriginAddresses)
         whenever(
             getShippingRates(any(), any(), any(), any(), any(), any(), isNull(), isNull())
         ) doReturn Result.success(defaultShippingRates)
+        whenever(observeStoreOptions()) doReturn flowOf(defaultStoreOptions)
 
         createViewModel()
 
@@ -557,10 +560,12 @@ class WooShippingLabelCreationViewModelTest : BaseUnitTest() {
         )
         whenever(shouldRequireCustomsForm.invoke(any())) doReturn false
         whenever(orderDetailRepository.getOrderById(any())) doReturn order
+        whenever(getShipments(any())) doReturn defaultShipments
         whenever(observeOriginAddresses()) doReturn flowOf(defaultOriginAddresses)
         whenever(
             getShippingRates(any(), any(), any(), any(), any(), any(), isNull(), isNull())
         ) doReturn Result.success(defaultShippingRates)
+        whenever(observeStoreOptions()) doReturn flowOf(defaultStoreOptions)
 
         createViewModel()
 

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/purchased/WooShippingLabelPurchasedViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/purchased/WooShippingLabelPurchasedViewModelTest.kt
@@ -44,7 +44,9 @@ class WooShippingLabelPurchasedViewModelTest : BaseUnitTest() {
     )
 
     private val navArgs = WooShippingLabelPurchasedFragmentArgs(
-        purchaseData = mockPurchaseData
+        purchaseData = mockPurchaseData,
+        totalItems = mock(),
+        totalItemsCost = mock()
     )
 
     @Test

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/purchased/WooShippingLabelPurchasedViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/purchased/WooShippingLabelPurchasedViewModelTest.kt
@@ -45,8 +45,8 @@ class WooShippingLabelPurchasedViewModelTest : BaseUnitTest() {
 
     private val navArgs = WooShippingLabelPurchasedFragmentArgs(
         purchaseData = mockPurchaseData,
-        totalItems = mock(),
-        totalItemsCost = mock()
+        totalItems = 6,
+        totalItemsCost = "$92.78"
     )
 
     @Test


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Part of: WOOMOB-284
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
This adds a Shipments tab to the shipping label creation screen.

Handling of purchased shipments and separation of customs/package data per shipment are not included in this PR and will be addressed in subsequent PRs.

### Steps to reproduce
<!-- Step-by-step testing instructions. For new user flows, consider instead stating the goal of the workflow and see if your PR reviewer can accomplish the workflow without specific steps! -->
1. Open the Orders tab.
2. Tap an order with shipping labels. If you don't have one yet, create an order and purchase some shipments from the web.
3. Tap on Create shipping label.

### Testing information
<!-- This is your opportunity to break out individual scenarios that need testing (when necessary) and/or include a checklist for the reviewer to go through. Consider documenting the following from your own completed testing: devices used, alternate workflows, edge cases, affected areas, critical flows, areas not tested, and any remaining unknowns. Provide feedback on this new section of the PR template through Sept 30, 2024 to Apps Quality; additional context here: p91TBi-b8z-p2#comment-12036 -->
- [ ] Test an order without any shipment
- [ ] Test an order with both purchased shipment an unfulfilled shipment.
- [ ] Test tapping edit button at the end of the shipments tab.
- [ ] Verify item counts and costs for each shipment.

### The tests that have been performed
<!-- To give the reviewer an idea of what could be missed in terms of testing -->
Steps above.

### Images/gif
<!-- Include before and after images or gifs when appropriate. -->

<img src="https://github.com/user-attachments/assets/3893b3ea-9c86-4c5c-8baa-89c328edceb2" width=350>

- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.

## Reviewer (or Author, in the case of optional code reviews):

Please make sure these conditions are met before approving the PR, or request changes if the PR needs improvement:

- [ ] The PR is small and has a clear, single focus, or a valid explanation is provided in the description. If needed, please request to split it into smaller PRs.
- [ ] Ensure Adequate Unit Test Coverage: The changes are reasonably covered by unit tests or an explanation is provided in the PR description.
- [ ] Manual Testing: The author listed all the tests they ran, including smoke tests when needed (e.g., for refactorings). The reviewer confirmed that the PR works as expected on big (tablet) and small (phone) in case of UI changes, and no regressions are added.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->