### PR TITLE
[Woo POS] BetaFix: Update coupon cart items on checkout screen

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/cart/WooPosCartItemsUpdater.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/cart/WooPosCartItemsUpdater.kt
@@ -22,6 +22,7 @@ class WooPosCartItemsUpdater @Inject constructor(
     ): CartItemsUpdaterResult {
         val mutableCurrentBodyList = itemsInCart.toMutableList()
         var productsChanged = false
+        var couponsChanged = false
 
         val availableProductsMap = createAvailableProductsMap(updatedProducts)
 
@@ -61,6 +62,7 @@ class WooPosCartItemsUpdater @Inject constructor(
                 }
 
                 is WooPosCartItemViewState.Coupon -> {
+                    couponsChanged = true
                     mutableCurrentBodyList[index] = updateCouponsWithFormattedDiscount(updatedCoupons, item)
                 }
             }
@@ -69,6 +71,7 @@ class WooPosCartItemsUpdater @Inject constructor(
         return CartItemsUpdaterResult(
             updatedItems = mutableCurrentBodyList,
             productsChanged = productsChanged,
+            couponsChanged = couponsChanged,
         )
     }
 
@@ -189,5 +192,6 @@ class WooPosCartItemsUpdater @Inject constructor(
     data class CartItemsUpdaterResult(
         val updatedItems: List<WooPosCartItemViewState>,
         val productsChanged: Boolean,
+        val couponsChanged: Boolean,
     )
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/cart/WooPosCartViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/cart/WooPosCartViewModel.kt
@@ -193,17 +193,19 @@ class WooPosCartViewModel @Inject constructor(
 
     private suspend fun onOrderCreated(event: ParentToChildrenEvent.OrderCreated) {
         val body = _state.value.body as? WooPosCartState.Body.WithItems ?: return
-        val updateCartItemsResult = updateCartItemsWithChanges(
+        val result = updateCartItemsWithChanges(
             itemsInCart = body.itemsInCart,
             updatedProducts = event.updatedProducts,
             updatedCoupons = event.updatedCoupons,
         )
-        if (updateCartItemsResult.productsChanged) {
+        if(result.productsChanged || result.couponsChanged) {
             _state.value = _state.value.copy(
                 body = body.copy(
-                    itemsInCart = updateCartItemsResult.updatedItems,
+                    itemsInCart = result.updatedItems,
                 ),
             )
+        }
+        if (result.productsChanged) {
             childrenToParentEventSender.sendToParent(
                 ChildToParentEvent.ToastMessageDisplayed(
                     message = resourceProvider.getString(R.string.woopos_cart_changes_in_the_cart)

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/cart/WooPosCartViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/cart/WooPosCartViewModel.kt
@@ -198,7 +198,7 @@ class WooPosCartViewModel @Inject constructor(
             updatedProducts = event.updatedProducts,
             updatedCoupons = event.updatedCoupons,
         )
-        if(result.productsChanged || result.couponsChanged) {
+        if (result.productsChanged || result.couponsChanged) {
             _state.value = _state.value.copy(
                 body = body.copy(
                     itemsInCart = result.updatedItems,

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/home/cart/WooPosCartItemsUpdaterTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/home/cart/WooPosCartItemsUpdaterTest.kt
@@ -252,33 +252,34 @@ class WooPosCartItemsUpdaterTest {
     }
 
     @Test
-    fun `given no changes in product info, when called, then cache is not updated and products not changed`() = runTest {
-        // GIVEN
-        val simpleProduct = WooPosCartItemViewState.Product.Simple(
-            itemNumber = 1,
-            id = 1L,
-            name = "Product",
-            price = "10.0$",
-            imageUrl = "url",
-            description = null
-        )
-        val itemsInCart = listOf(simpleProduct)
-        val updatedInfo = ParentToChildrenEvent.OrderCreated.ProductInfo.Simple(
-            id = 1L,
-            name = "Product",
-            finalPrice = BigDecimal("10.0"),
-            basePrice = BigDecimal("10.0"),
-            quantity = 1f
-        )
+    fun `given no changes in product info, when called, then cache is not updated and products not changed`() =
+        runTest {
+            // GIVEN
+            val simpleProduct = WooPosCartItemViewState.Product.Simple(
+                itemNumber = 1,
+                id = 1L,
+                name = "Product",
+                price = "10.0$",
+                imageUrl = "url",
+                description = null
+            )
+            val itemsInCart = listOf(simpleProduct)
+            val updatedInfo = ParentToChildrenEvent.OrderCreated.ProductInfo.Simple(
+                id = 1L,
+                name = "Product",
+                finalPrice = BigDecimal("10.0"),
+                basePrice = BigDecimal("10.0"),
+                quantity = 1f
+            )
 
-        // WHEN
-        val result = updater.invoke(itemsInCart, listOf(updatedInfo), emptyList())
+            // WHEN
+            val result = updater.invoke(itemsInCart, listOf(updatedInfo), emptyList())
 
-        // THEN
-        assertThat(result.updatedItems).hasSize(1)
-        verify(productsCache, never()).updateProduct(any())
-        assertThat(result.productsChanged).isFalse()
-    }
+            // THEN
+            assertThat(result.updatedItems).hasSize(1)
+            verify(productsCache, never()).updateProduct(any())
+            assertThat(result.productsChanged).isFalse()
+        }
 
     @Test
     fun `given product deleted, when called, then cache is updated correctly`() = runTest {
@@ -412,6 +413,49 @@ class WooPosCartItemsUpdaterTest {
             val updatedCoupon2 = result.updatedItems[1] as WooPosCartItemViewState.Coupon
             assertThat(updatedCoupon2.validationState).isEqualTo(CouponValidationState.Valid("-10.0$"))
         }
+
+    @Test
+    fun `given cart with coupon, when called, then couponsChanged is true`() = runTest {
+        // GIVEN
+        val coupon = generateCoupon(code = "COUPON1")
+        val itemsInCart = listOf(coupon)
+        val updatedCoupons = listOf(
+            generateCouponLine(
+                code = "COUPON1",
+                discountAmount = "5.0"
+            )
+        )
+
+        // WHEN
+        val result = updater.invoke(itemsInCart, emptyList(), updatedCoupons)
+
+        // THEN
+        assertThat(result.couponsChanged).isTrue()
+    }
+
+    @Test
+    fun `given cart without coupon, when called, then couponsChanged is false`() = runTest {
+        // GIVEN
+
+        // WHEN
+        val result = updater.invoke(emptyList(), emptyList(), emptyList())
+
+        // THEN
+        assertThat(result.couponsChanged).isFalse()
+    }
+
+    @Test
+    fun `given empty cart, when called, then productsChanged and couponsChanged flags are false`() = runTest {
+        // GIVEN
+        val itemsInCart = emptyList<WooPosCartItemViewState>()
+
+        // WHEN
+        val result = updater.invoke(itemsInCart, emptyList(), emptyList())
+
+        // THEN
+        assertThat(result.productsChanged).isFalse()
+        assertThat(result.couponsChanged).isFalse()
+    }
 
     private fun generateCoupon(
         code: String = "COUPON1",


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #WOOMOB-499
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

This PR fixes issue introduced in https://github.com/woocommerce/woocommerce-android/pull/14066 where we stopped updating **coupon** cart items with the discounted price as the user moves to checkout, unless the cart also contains a product with price changed. The desired behavior is to update the cart whenever any of the cart items changes.

Note: This PR will require spinning up a new beta. Let me know, I can take care of it if needed.

### Steps to reproduce
<!-- Step-by-step testing instructions. For new user flows, consider instead stating the goal of the workflow and see if your PR reviewer can accomplish the workflow without specific steps! -->
1. Open POS
2. Add a product to the cart
3. Add a coupon to the cart
4. Tap on checkout
5. Notice the coupon cart item doesn't display discount when the order is created.

### Testing information
<!-- This is your opportunity to break out individual scenarios that need testing (when necessary) and/or include a checklist for the reviewer to go through. Consider documenting the following from your own completed testing: devices used, alternate workflows, edge cases, affected areas, critical flows, areas not tested, and any remaining unknowns. Provide feedback on this new section of the PR template through Sept 30, 2024 to Apps Quality; additional context here: p91TBi-b8z-p2#comment-12036 -->

1. Open POS
2. Add a product to the cart
3. Add a coupon to the cart
4. Tap on checkout
5. Notice the coupon cart item turns green and has a discount displayed.

### The tests that have been performed
<!-- To give the reviewer an idea of what could be missed in terms of testing -->

- Valid coupon
- Invalid coupon
- Removing coupons

### Images/gif
<!-- Include before and after images or gifs when appropriate. -->


https://github.com/user-attachments/assets/f5cc25fa-34bf-40e8-a0c6-3300da8129bf



- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.

## Reviewer (or Author, in the case of optional code reviews):

Please make sure these conditions are met before approving the PR, or request changes if the PR needs improvement:

- [ ] The PR is small and has a clear, single focus, or a valid explanation is provided in the description. If needed, please request to split it into smaller PRs.
- [ ] Ensure Adequate Unit Test Coverage: The changes are reasonably covered by unit tests or an explanation is provided in the PR description.
- [ ] Manual Testing: The author listed all the tests they ran, including smoke tests when needed (e.g., for refactorings). The reviewer confirmed that the PR works as expected on big (tablet) and small (phone) in case of UI changes, and no regressions are added.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->499