### PR TITLE
[Bug] Missing toolbar in EditVariationAttributesFragment in tablet layout

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -3,7 +3,7 @@
 *** For entries which are touching the Android Wear app's, start entry with `[WEAR]` too.
 22.5
 -----
-
+- [*] Added missing toolbar in tablet layout to Variation Attributes screen [https://github.com/woocommerce/woocommerce-android/pull/14097]
 
 22.4
 -----

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/variations/attributes/edit/EditVariationAttributesFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/variations/attributes/edit/EditVariationAttributesFragment.kt
@@ -14,6 +14,7 @@ import com.woocommerce.android.databinding.FragmentEditVariationAttributesBindin
 import com.woocommerce.android.extensions.navigateBackWithResult
 import com.woocommerce.android.extensions.takeIfNotEqualTo
 import com.woocommerce.android.ui.base.BaseFragment
+import com.woocommerce.android.ui.main.AppBarStatus
 import com.woocommerce.android.ui.main.MainActivity.Companion.BackPressListener
 import com.woocommerce.android.ui.products.variations.attributes.edit.EditVariationAttributesViewModel.ViewState
 import com.woocommerce.android.viewmodel.MultiLiveEvent
@@ -39,6 +40,9 @@ class EditVariationAttributesFragment :
 
     private val skeletonView = SkeletonView()
 
+    override val activityAppBarStatus: AppBarStatus
+        get() = AppBarStatus.Hidden
+
     private var isLoadingSkeletonVisible: Boolean = false
         set(show) {
             field = show
@@ -61,6 +65,7 @@ class EditVariationAttributesFragment :
         _binding = FragmentEditVariationAttributesBinding.bind(view)
         setupObservers()
         setupViews()
+        setupToolbar()
         viewModel.start(navArgs.remoteProductId, navArgs.remoteVariationId)
     }
 
@@ -76,6 +81,15 @@ class EditVariationAttributesFragment :
     }
 
     override fun getFragmentTitle() = getString(R.string.product_attributes)
+
+    private fun setupToolbar() {
+        val toolbar = binding.toolbar
+        toolbar.title = getString(R.string.product_attributes)
+
+        toolbar.setNavigationOnClickListener {
+            viewModel.exit()
+        }
+    }
 
     private fun setupObservers() = viewModel.apply {
         viewStateLiveData.observe(viewLifecycleOwner, ::handleViewStateChanges)

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/variations/attributes/edit/EditVariationAttributesFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/variations/attributes/edit/EditVariationAttributesFragment.kt
@@ -17,6 +17,7 @@ import com.woocommerce.android.ui.base.BaseFragment
 import com.woocommerce.android.ui.main.AppBarStatus
 import com.woocommerce.android.ui.main.MainActivity.Companion.BackPressListener
 import com.woocommerce.android.ui.products.variations.attributes.edit.EditVariationAttributesViewModel.ViewState
+import com.woocommerce.android.util.setupTabletSecondPaneToolbar
 import com.woocommerce.android.viewmodel.MultiLiveEvent
 import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.Exit
 import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.ExitWithResult
@@ -65,7 +66,13 @@ class EditVariationAttributesFragment :
         _binding = FragmentEditVariationAttributesBinding.bind(view)
         setupObservers()
         setupViews()
-        setupToolbar()
+        setupTabletSecondPaneToolbar(
+            title = getString(R.string.product_attributes),
+            onMenuItemSelected = { _ -> false },
+            onCreateMenu = { toolbar ->
+                toolbar.setNavigationOnClickListener { viewModel.exit() }
+            }
+        )
         viewModel.start(navArgs.remoteProductId, navArgs.remoteVariationId)
     }
 
@@ -81,15 +88,6 @@ class EditVariationAttributesFragment :
     }
 
     override fun getFragmentTitle() = getString(R.string.product_attributes)
-
-    private fun setupToolbar() {
-        val toolbar = binding.toolbar
-        toolbar.title = getString(R.string.product_attributes)
-
-        toolbar.setNavigationOnClickListener {
-            viewModel.exit()
-        }
-    }
 
     private fun setupObservers() = viewModel.apply {
         viewStateLiveData.observe(viewLifecycleOwner, ::handleViewStateChanges)

--- a/WooCommerce/src/main/res/layout/fragment_edit_variation_attributes.xml
+++ b/WooCommerce/src/main/res/layout/fragment_edit_variation_attributes.xml
@@ -5,15 +5,27 @@
     xmlns:app="http://schemas.android.com/apk/res-auto"
     android:layout_height="match_parent">
 
+    <com.google.android.material.appbar.MaterialToolbar
+        android:id="@+id/toolbar"
+        style="@style/Widget.Woo.Toolbar"
+        android:layout_width="match_parent"
+        android:layout_height="@dimen/toolbar_height"
+        android:elevation="@dimen/appbar_elevation"
+        app:layout_constraintTop_toTopOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        tools:title="@string/product_attributes" />
+
     <androidx.recyclerview.widget.RecyclerView
         android:id="@+id/attribute_selection_group_list"
         android:layout_width="match_parent"
-        android:layout_height="match_parent"
+        android:layout_height="0dp"
+        app:layout_constraintTop_toBottomOf="@id/toolbar"
+        app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
         android:background="?attr/colorSurface"
         tools:itemCount="3"
-        app:layout_constraintBaseline_toBaselineOf="parent"
         tools:listitem="@layout/attribute_term_selection_list_item"/>
 
 </androidx.constraintlayout.widget.ConstraintLayout>


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->
## Add toolbar to EditVariationAttributesFragment

<!-- Id number of the Linear issue this PR addresses, e.g., WOOMOB-373. -->
WOOMOB-481

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
This PR adds a toolbar to `EditVariationAttributesFragment` that was missing in the dual-pane layout (e.g. on tablet).

### Steps to reproduce
<!-- Step-by-step testing instructions. For new user flows, consider instead stating the goal of the workflow and see if your PR reviewer can accomplish the workflow without specific steps! -->
On tablet device:
1. Go to Products and select variable product
2. Click Variations, and select a variation
3. Click Attributes
4. Notice the toolbar is missing

### Testing information
<!-- This is your opportunity to break out individual scenarios that need testing (when necessary) and/or include a checklist for the reviewer to go through. Consider documenting the following from your own completed testing: devices used, alternate workflows, edge cases, affected areas, critical flows, areas not tested, and any remaining unknowns. Provide feedback on this new section of the PR template through Sept 30, 2024 to Apps Quality; additional context here: p91TBi-b8z-p2#comment-12036 -->
Verify that the toolbar is shown both in dual pane and single pane layout.

### The tests that have been performed
<!-- To give the reviewer an idea of what could be missed in terms of testing -->
Above.

### Images/gif
<!-- Include before and after images or gifs when appropriate. -->
![image](https://github.com/user-attachments/assets/9387c3c0-9ed2-4542-ae99-4499854a5874)

- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->