### PR TITLE
[WellSQL Migration] Fix `FetchMediaListPayload` Crash on Upload Method

### DIFF
--- a/libs/fluxc/src/main/java/org/wordpress/android/fluxc/store/MediaStore.java
+++ b/libs/fluxc/src/main/java/org/wordpress/android/fluxc/store/MediaStore.java
@@ -106,6 +106,19 @@ public class MediaStore extends Store {
         public FetchMediaListPayload(@NonNull SiteModel site) {
             this.site = site;
         }
+
+        // WARN: This constructor is used within WordPress-MediaPicker-Android, do not remove!
+        @SuppressWarnings("unused")
+        public FetchMediaListPayload(
+                @NonNull SiteModel site,
+                int number,
+                boolean loadMore,
+                @NonNull MimeType.Type mimeType) {
+            this.site = site;
+            this.loadMore = loadMore;
+            this.mimeType = mimeType;
+            this.number = number;
+        }
     }
 
     /**


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

<!-- Id number of the Linear issue this PR addresses, e.g., WOOMOB-373. -->
Closes: [AINFRA-583](https://linear.app/a8c/issue/AINFRA-583)

See also: p1747758362791519/1747757747.775429-slack-CGPNUU63E (Cc @wzieba )

---

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

This PR fixes the `java.lang.NoSuchMethodError` on `MediaStore$FetchMediaListPayload` for when a user tries to add a new product photo using the `WordPress media library` option.

FYI: This crash occurs because of the [WordPress-MediaPicker-Android](https://github.com/wordpress-mobile/WordPress-MediaPicker-Android) library, which is using an [older version](https://github.com/wordpress-mobile/WordPress-MediaPicker-Android/blob/trunk/build.gradle#L61) of the [WordPress-FluxC-Android](https://github.com/wordpress-mobile/WordPress-MediaPicker-Android/blob/trunk/mediapicker/source-wordpress/build.gradle#L41-L44) library, that depends on this specific [FetchMediaListPayload](https://github.com/wordpress-mobile/WordPress-MediaPicker-Android/blob/0e275be05341678996dc1b9abfc8608f331d2540/mediapicker/source-wordpress/src/main/java/org/wordpress/android/mediapicker/source/wordpress/MediaLibrarySource.kt#L163-L168) constructor.

PS: #14084 PR and more specifically this [commit](https://github.com/woocommerce/woocommerce-android/commit/40c17bd3e34cb5ea87faf366423b0c49539ba685)/[change](https://github.com/woocommerce/woocommerce-android/commit/40c17bd3e34cb5ea87faf366423b0c49539ba685#diff-16cc99d2e9e1f7a34b9076c9407dba6169e3ed7f6ff72ea987eb8865846d15f9L122-L141) introduced this crash.

---

### Steps to reproduce
<!-- Step-by-step testing instructions. For new user flows, consider instead stating the goal of the workflow and see if your PR reviewer can accomplish the workflow without specific steps! -->

1. Go to `Products` screen.
2. Find any product and click on it.
3. Go to `Photos` screen.
4. Click on `Add photos`.
5. Chose `WordPress media library`.
6. App crashes with the below stack trace:

<details>
    <summary>Crash Stack Trace</summary>

```
E  FATAL EXCEPTION: main
   Process: com.woocommerce.android.prealpha, PID: 6723
   java.lang.NoSuchMethodError: No direct method <init>(Lorg/wordpress/android/fluxc/model/SiteModel;IZLorg/wordpress/android/fluxc/utils/MimeType$Type;)V in class Lorg/wordpress/android/fluxc/store/MediaStore$FetchMediaListPayload; or its super classes (declaration of 'org.wordpress.android.fluxc.store.MediaStore$FetchMediaListPayload' appears in /data/app/~~1YIwTZviZ5TXiToMdyID8Q==/com.woocommerce.android.prealpha-o7KtlXVY8Ty8z3IKDgrc_Q==/base.apk!classes5.dex)
   	at org.wordpress.android.mediapicker.source.wordpress.MediaLibrarySource.loadPage(MediaLibrarySource.kt:163)
   	at org.wordpress.android.mediapicker.source.wordpress.MediaLibrarySource.access$loadPage(MediaLibrarySource.kt:38)
   	at org.wordpress.android.mediapicker.source.wordpress.MediaLibrarySource$load$2$loadingResults$1$1.invokeSuspend(MediaLibrarySource.kt:68)
   	at kotlin.coroutines.jvm.internal.BaseContinuationImpl.resumeWith(ContinuationImpl.kt:33)
   	at kotlinx.coroutines.DispatchedTask.run(DispatchedTask.kt:104)
   	at kotlinx.coroutines.scheduling.CoroutineScheduler.runSafely(CoroutineScheduler.kt:584)
   	at kotlinx.coroutines.scheduling.CoroutineScheduler$Worker.executeTask(CoroutineScheduler.kt:811)
   	at kotlinx.coroutines.scheduling.CoroutineScheduler$Worker.runWorker(CoroutineScheduler.kt:715)
   	at kotlinx.coroutines.scheduling.CoroutineScheduler$Worker.run(CoroutineScheduler.kt:702)
   	Suppressed: kotlinx.coroutines.internal.DiagnosticCoroutineContextException: [StandaloneCoroutine{Cancelling}@354c86a, Dispatchers.Main.immediate]
```

</details>

---

### Testing information
<!-- This is your opportunity to break out individual scenarios that need testing (when necessary) and/or include a checklist for the reviewer to go through. Consider documenting the following from your own completed testing: devices used, alternate workflows, edge cases, affected areas, critical flows, areas not tested, and any remaining unknowns. Provide feedback on this new section of the PR template through Sept 30, 2024 to Apps Quality; additional context here: p91TBi-b8z-p2#comment-12036 -->

Same as above, verify this fix resolves the above crash.

---

- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->