### PR TITLE
[POS Receipts] Anchor button at the bottom with small spacing.

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/emailreceipt/WooPosEmailReceiptScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/emailreceipt/WooPosEmailReceiptScreen.kt
@@ -1,5 +1,6 @@
 package com.woocommerce.android.ui.woopos.emailreceipt
 
+import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
@@ -58,7 +59,7 @@ private fun WooPosEmailReceiptScreen(
     onEmailSent: () -> Unit,
     onBackClicked: () -> Unit,
 ) {
-    Column(modifier = Modifier.fillMaxSize().verticalScroll(rememberScrollState()).imePadding()) {
+    Column(modifier = Modifier.fillMaxSize()) {
         WooPosToolbar(
             titleText = stringResource(R.string.woopos_email_receipt_title),
             onBackClicked = onBackClicked,
@@ -93,36 +94,43 @@ private fun EmailState(
     Column(
         modifier = Modifier
             .fillMaxSize()
+            .verticalScroll(rememberScrollState())
             .imePadding(),
-        horizontalAlignment = Alignment.CenterHorizontally
+        verticalArrangement = Arrangement.SpaceBetween
     ) {
         Spacer(modifier = Modifier.weight(1f))
 
-        WooPosInputField(
-            value = state.email,
-            onValueChange = onEmailAddressChanged,
-            label = stringResource(R.string.woopos_email_receipt_email_label),
-            contentAlignment = Alignment.Center,
-            textStyle = WooPosTypography.Heading,
-            textColor = MaterialTheme.colorScheme.onSurface,
-            keyboardOptions = KeyboardOptions(
-                autoCorrectEnabled = false,
-                keyboardType = KeyboardType.Email
-            ),
-            modifier = Modifier
-                .focusRequester(focusRequester)
-                .padding(horizontal = WooPosSpacing.Medium.value)
-        )
-
-        if (state.errorMessage != null) {
-            Spacer(modifier = Modifier.height(WooPosSpacing.Small.value))
-
-            WooPosText(
-                text = state.errorMessage,
-                color = MaterialTheme.colorScheme.error,
-                style = WooPosTypography.BodyLarge,
-                textAlign = TextAlign.Center,
+        Column(
+            modifier = Modifier.fillMaxWidth(),
+            horizontalAlignment = Alignment.CenterHorizontally
+        ) {
+            WooPosInputField(
+                value = state.email,
+                onValueChange = onEmailAddressChanged,
+                label = stringResource(R.string.woopos_email_receipt_email_label),
+                contentAlignment = Alignment.Center,
+                textStyle = WooPosTypography.Heading,
+                textColor = MaterialTheme.colorScheme.onSurface,
+                keyboardOptions = KeyboardOptions(
+                    autoCorrectEnabled = false,
+                    keyboardType = KeyboardType.Email
+                ),
+                modifier = Modifier
+                    .focusRequester(focusRequester)
+                    .padding(horizontal = WooPosSpacing.Medium.value)
             )
+
+            if (state.errorMessage != null) {
+                Spacer(modifier = Modifier.height(WooPosSpacing.Small.value))
+
+                WooPosText(
+                    text = state.errorMessage,
+                    color = MaterialTheme.colorScheme.error,
+                    style = WooPosTypography.BodyLarge,
+                    textAlign = TextAlign.Center,
+                    modifier = Modifier.padding(horizontal = WooPosSpacing.Medium.value)
+                )
+            }
         }
 
         Spacer(modifier = Modifier.weight(1f))


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

<!-- Id number of the Linear issue this PR addresses, e.g., WOOMOB-373. -->

Closes WOOMOB-512

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
With this PR we fix the UI in the POS Email receipt screen by anchoring the button at the bottom with small spacing.

#### The key changes:

- Removed `verticalScroll` and `imePadding` from the parent `WooPosEmailReceiptScreen` Column
- Added `verticalScroll` and `imePadding` to the `EmailState` Column instead
- This allows the added `Arrangement.SpaceBetween` to work properly

#### What was the issue?

Originally, I added `Arrangement.SpaceBetween` to the parent column to solve the issue, but when we have `verticalScroll` on a `Column` with `Arrangement.SpaceBetween`, the scrolling behavior interferes with the space distribution. By moving the scroll modifiers to the inner Column, the button will now be properly anchored at the bottom with the small spacing we want.

### Steps to reproduce
<!-- Step-by-step testing instructions. For new user flows, consider instead stating the goal of the workflow and see if your PR reviewer can accomplish the workflow without specific steps! -->

- Go to Menu
- Tap on POS
- Collect an order and pay with cash or card.
- When finished, tap on Email receipt.
- Check that the screen shows the button as expected

### Testing information
<!-- This is your opportunity to break out individual scenarios that need testing (when necessary) and/or include a checklist for the reviewer to go through. Consider documenting the following from your own completed testing: devices used, alternate workflows, edge cases, affected areas, critical flows, areas not tested, and any remaining unknowns. Provide feedback on this new section of the PR template through Sept 30, 2024 to Apps Quality; additional context here: https://woomobilep2.wordpress.com/2024/05/06/woocommerce-mobile-quality-report-march-april/#comment-12036 -->

I checked that it works fine with and without showing the keyboard. Also with and without the email filled.

### Images/gif
<!-- Include before and after images or gifs when appropriate. -->
#### Before

<img width="952" alt="image" src="https://github.com/user-attachments/assets/867c0311-f662-4919-8fb6-5ef949ae5983" />


#### After
![Screenshot_20250522_162857_Woo (Dev)](https://github.com/user-attachments/assets/c8ef01cf-9d59-48d5-8368-f54c04284bdc)
![Screenshot_20250522_162906_Woo (Dev)](https://github.com/user-attachments/assets/eb8e97a1-fae6-4af8-8b3b-acc062ff993c)


- [X] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
