### PR TITLE
[Login] Fix a crash during login after Activity or process death

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/sitecredentials/LoginSiteCredentialsViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/sitecredentials/LoginSiteCredentialsViewModel.kt
@@ -126,7 +126,8 @@ class LoginSiteCredentialsViewModel @Inject constructor(
 
     fun onContinueClick() = launch {
         loginAnalyticsListener.trackSubmitClicked()
-        if (fetchedSiteId.value != -1) {
+        val site = fetchedSiteId.value.takeIf { it != -1 }?.let { wpApiSiteRepository.getSiteByLocalId(it) }
+        if (site?.username != null) {
             // The login already succeeded, proceed to fetching user info
             fetchUserInfo()
         } else {


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

WOOMOB-381

### Description
This PR fixes a crash that happens during the site credentials login, the crash happens if a Activity or process death occurred when the Application Passwords tutorial screen was shown, and the user dismissed it and retried login.

> [!IMPORTANT]
> I'm targeting `release/22.4` branch with the fix as this impacted 268 users just in the last month, but if you feel this should go to `trunk`, please let me know. 

### Steps to reproduce
1. Enable "Don't keep activities" in the developer options of your device.
2. Prepare a site that can't use native site credentials login (for example using this [plugin](https://wordpress.org/plugins/captcha-for-contact-form-7/), and enabling captcha for "WordPress login")
3. Open the app and start login.
4. Enter the site address, then credentials, then tap on **Continue**.
5. In the Application Passwords tutorial screen, tap on **Contact support**
6. Go back to the site credentials screen.
7. Tap on **Continue** again.

### Testing information
- Confirm the app doesn't crash.

### The tests that have been performed
Tested on an emulator, and confirmed that the app crashs because of this on `trunk` and `release/22.4` branches, this branch fixes it.

- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->