### PR TITLE
[WOOMOB-442][Crash] Can't represent a width of {N} on the dashboard

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/DashboardContainer.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/DashboardContainer.kt
@@ -117,7 +117,13 @@ private fun DashboardWidgets(
 ) {
     val nestedScrollInterop = rememberNestedScrollInteropConnection()
 
+    WooLog.d(
+        WooLog.T.DASHBOARD,
+        "DashboardWidgets: numberOfColumns=$numberOfColumns, visibleWidgets=${widgetUiModels.count { it.isVisible }}"
+    )
+
     if (numberOfColumns == 1) {
+        WooLog.d(WooLog.T.DASHBOARD, "Using single-column layout with Column + verticalScroll")
         Column(
             modifier = modifier
                 .nestedScroll(nestedScrollInterop)
@@ -139,17 +145,20 @@ private fun DashboardWidgets(
             Spacer(modifier = Modifier)
         }
     } else {
+        WooLog.d(WooLog.T.DASHBOARD, "Using multi-column layout with Row (NO verticalScroll)")
         val widgetColumns = splitWidgetsIntoColumns(
             numberOfColumns = numberOfColumns,
             visibleUiWidgets = widgetUiModels.filter { it.isVisible }
         )
+        WooLog.d(WooLog.T.DASHBOARD, "Split widgets into ${widgetColumns.size} columns")
         Row(
             modifier = modifier
                 .nestedScroll(nestedScrollInterop),
             horizontalArrangement = Arrangement.spacedBy(16.dp)
         ) {
             Spacer(modifier = Modifier)
-            widgetColumns.forEach { columnWidgets ->
+            widgetColumns.forEachIndexed { columnIndex, columnWidgets ->
+                WooLog.d(WooLog.T.DASHBOARD, "Rendering column $columnIndex with ${columnWidgets.size} widgets")
                 Column(
                     modifier = Modifier.weight(1f),
                     verticalArrangement = Arrangement.spacedBy(16.dp)

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/DashboardContainer.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/DashboardContainer.kt
@@ -145,8 +145,7 @@ private fun DashboardWidgets(
         )
         Row(
             modifier = modifier
-                .nestedScroll(nestedScrollInterop)
-                .verticalScroll(rememberScrollState()),
+                .nestedScroll(nestedScrollInterop),
             horizontalArrangement = Arrangement.spacedBy(16.dp)
         ) {
             Spacer(modifier = Modifier)

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/DashboardContainer.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/DashboardContainer.kt
@@ -161,7 +161,6 @@ private fun DashboardWidgets(
             Row(
                 horizontalArrangement = Arrangement.spacedBy(16.dp)
             ) {
-                Spacer(modifier = Modifier)
                 widgetColumns.forEachIndexed { columnIndex, columnWidgets ->
                     WooLog.d(WooLog.T.DASHBOARD, "Rendering column $columnIndex with ${columnWidgets.size} widgets")
                     Column(
@@ -179,7 +178,6 @@ private fun DashboardWidgets(
                         }
                     }
                 }
-                Spacer(modifier = Modifier)
             }
         }
     }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/DashboardContainer.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/DashboardContainer.kt
@@ -5,6 +5,7 @@ import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
 import androidx.compose.foundation.border
 import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.BoxWithConstraints
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
@@ -145,36 +146,41 @@ private fun DashboardWidgets(
             Spacer(modifier = Modifier)
         }
     } else {
-        WooLog.d(WooLog.T.DASHBOARD, "Using multi-column layout with Row (NO verticalScroll)")
+        WooLog.d(WooLog.T.DASHBOARD, "Using multi-column layout with Box + verticalScroll")
         val widgetColumns = splitWidgetsIntoColumns(
             numberOfColumns = numberOfColumns,
             visibleUiWidgets = widgetUiModels.filter { it.isVisible }
         )
         WooLog.d(WooLog.T.DASHBOARD, "Split widgets into ${widgetColumns.size} columns")
-        Row(
+        Box(
             modifier = modifier
-                .nestedScroll(nestedScrollInterop),
-            horizontalArrangement = Arrangement.spacedBy(16.dp)
+                .nestedScroll(nestedScrollInterop)
+                .verticalScroll(rememberScrollState())
+                .padding(bottom = 16.dp)
         ) {
-            Spacer(modifier = Modifier)
-            widgetColumns.forEachIndexed { columnIndex, columnWidgets ->
-                WooLog.d(WooLog.T.DASHBOARD, "Rendering column $columnIndex with ${columnWidgets.size} widgets")
-                Column(
-                    modifier = Modifier.weight(1f),
-                    verticalArrangement = Arrangement.spacedBy(16.dp)
-                ) {
-                    columnWidgets.forEach { widget ->
-                        DashboardWidgetCard(
-                            widget,
-                            mainActivityViewModel,
-                            dashboardViewModel,
-                            blazeCampaignCreationDispatcher,
-                            Modifier.fillMaxWidth()
-                        )
+            Row(
+                horizontalArrangement = Arrangement.spacedBy(16.dp)
+            ) {
+                Spacer(modifier = Modifier)
+                widgetColumns.forEachIndexed { columnIndex, columnWidgets ->
+                    WooLog.d(WooLog.T.DASHBOARD, "Rendering column $columnIndex with ${columnWidgets.size} widgets")
+                    Column(
+                        modifier = Modifier.weight(1f),
+                        verticalArrangement = Arrangement.spacedBy(16.dp)
+                    ) {
+                        columnWidgets.forEach { widget ->
+                            DashboardWidgetCard(
+                                widget,
+                                mainActivityViewModel,
+                                dashboardViewModel,
+                                blazeCampaignCreationDispatcher,
+                                Modifier.fillMaxWidth()
+                            )
+                        }
                     }
                 }
+                Spacer(modifier = Modifier)
             }
-            Spacer(modifier = Modifier)
         }
     }
 }


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Another attempt of fixing WOOMOB-442
<!-- Id number of the Linear issue this PR addresses, e.g., WOOMOB-373. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
We added logs last time and they appeared right before the crash; therefore, I make the conclusion that most probably the issue is in the `DashboardContainer` file.

The logs:

```
[May-20 13:00:07:414 DASHBOARD d] BoxWithConstraints: maxWidth=908.1905, maxHeight=254.4762
[May-20 13:00:07:414 DASHBOARD d] calculateColumnNumber: availableWidthInDp=908.1905.dp, columns=2, visibleWidgetsCount=3
```

I still have no idea what may be the reason, but using the logs, stack trace and Claude code:

```
  The Issue Chain:

  1. Landscape rotation → BoxWithConstraints reports maxWidth=908.1905, 
  maxHeight=254.4762
  2. 2-column layout → Code switches to Row with verticalScroll (lines 146-149)
  3. The problematic combination:
  Row(
      modifier = modifier
          .nestedScroll(nestedScrollInterop)
          .verticalScroll(rememberScrollState()),  // ← This is the culprit
  4. Why verticalScroll on a Row breaks:
    - Row arranges children horizontally
    - verticalScroll tells Compose "I need infinite height"
    - But Row tries to measure its children with horizontal constraints
  5. The constraint math explosion:
    - verticalScroll requests infinite height: Constraints.Infinity = 2147483647
    - When combined with Row's horizontal measurement + the small available height
    - Integer overflow/underflow occurs: 254.4762dp → 1073741677 (suspicious number!)
    - Width calculation fails: → 0

  The Real Problem: verticalScroll on a Row is conceptually wrong. Row layouts
  horizontally, but verticalScroll assumes vertical layout.

  Why it works in 1-column mode:
  - Uses Column + verticalScroll (correct pairing)
  - Column arranges vertically, verticalScroll scrolls vertically ✓

  Why it breaks in 2-column mode:
  - Uses Row + verticalScroll (wrong pairing)
  - Row arranges horizontally, verticalScroll scrolls vertically ✗

  The fix should be to remove verticalScroll from the Row and instead wrap each
  individual Column inside the Row with scrolling, or use a different layout approach
  entirely.

```

I added more logs so maybe we will close if this doesn't fix the issue
 

### Steps to reproduce
<!-- Step-by-step testing instructions. For new user flows, consider instead stating the goal of the workflow and see if your PR reviewer can accomplish the workflow without specific steps! -->
I don't know

### The tests that have been performed
<!-- To give the reviewer an idea of what could be missed in terms of testing -->
Just regression testing

- [ ] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->