### PR TITLE
[Shipping labels] Integrating Split Shipments API

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/extensions/FlowExtensions.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/extensions/FlowExtensions.kt
@@ -122,3 +122,45 @@ inline fun <T1, T2, T3, T4, T5, T6, T7, T8, T9, R> combine(
         )
     }
 }
+
+@Suppress("LongParameterList")
+inline fun <T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, R> combine(
+    flow: Flow<T1>,
+    flow2: Flow<T2>,
+    flow3: Flow<T3>,
+    flow4: Flow<T4>,
+    flow5: Flow<T5>,
+    flow6: Flow<T6>,
+    flow7: Flow<T7>,
+    flow8: Flow<T8>,
+    flow9: Flow<T9>,
+    flow10: Flow<T10>,
+    crossinline transform: suspend (T1, T2, T3, T4, T5, T6, T7, T8, T9, T10) -> R
+): Flow<R> {
+    return kotlinx.coroutines.flow.combine(
+        flow,
+        flow2,
+        flow3,
+        flow4,
+        flow5,
+        flow6,
+        flow7,
+        flow8,
+        flow9,
+        flow10
+    ) { args: Array<*> ->
+        @Suppress("UNCHECKED_CAST", "MagicNumber")
+        transform(
+            args[0] as T1,
+            args[1] as T2,
+            args[2] as T3,
+            args[3] as T4,
+            args[4] as T5,
+            args[5] as T6,
+            args[6] as T7,
+            args[7] as T8,
+            args[8] as T9,
+            args[9] as T10,
+        )
+    }
+}

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/SplitShipment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/SplitShipment.kt
@@ -1,0 +1,61 @@
+package com.woocommerce.android.ui.orders.wooshippinglabels
+
+import com.woocommerce.android.tools.SelectedSite
+import com.woocommerce.android.ui.orders.wooshippinglabels.datasource.WooShippingConfigDataStore
+import com.woocommerce.android.ui.orders.wooshippinglabels.models.ShipmentUIModel
+import com.woocommerce.android.ui.orders.wooshippinglabels.models.ShippableItemModel
+import com.woocommerce.android.ui.orders.wooshippinglabels.networking.Item
+import com.woocommerce.android.ui.orders.wooshippinglabels.networking.ShipmentMap
+import com.woocommerce.android.ui.orders.wooshippinglabels.networking.WooShippingLabelRepository
+import kotlinx.coroutines.flow.first
+import javax.inject.Inject
+
+class SplitShipment @Inject constructor(
+    private val selectedSite: SelectedSite,
+    private val wooShippingLabelRepository: WooShippingLabelRepository,
+    private val configDataStore: WooShippingConfigDataStore,
+) {
+
+    suspend operator fun invoke(orderId: Long, shipments: List<ShipmentUIModel>): Result<Unit> {
+        return selectedSite.getOrNull()?.let {
+            val shipmentMap = shipments.toShipmentMap() ?: return Result.failure(Exception("Shipment with null id"))
+
+            val response = wooShippingLabelRepository.updateShipments(
+                site = it,
+                orderId = orderId,
+                shipments = shipmentMap,
+            )
+            val result = response.model
+            if (response.isError || result == null) {
+                Result.failure(Exception("Split shipment failed"))
+            } else {
+                updateCachedShipments(orderId, result.data)
+                Result.success(Unit)
+            }
+        } ?: Result.failure(Exception("No site selected"))
+    }
+
+    private fun List<ShipmentUIModel>.toShipmentMap(): ShipmentMap? {
+        if (any { it.id == null }) {
+            return null
+        }
+        return associate { it.id!! to it.items.map { item -> Item(id = item.itemId, subItems = item.subItems()) } }
+    }
+
+    /**
+     * The endpoint expects subItems in the format:
+     * if quantity is greater than 1, list of subItems e.g: ["6230-sub-0", "6230-sub-1"]
+     * if quantity is 1, an empty list
+     */
+    private fun ShippableItemModel.subItems() = if (quantity > 1) {
+        List(quantity.toInt()) { index -> "$itemId-sub-$index" }
+    } else {
+        emptyList()
+    }
+
+    private suspend fun updateCachedShipments(orderId: Long, newShipments: ShipmentMap) {
+        configDataStore.observeConfig(orderId).first()?.let {
+            configDataStore.saveConfig(orderId, it.copy(shipments = newShipments))
+        }
+    }
+}

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/WooShippingLabelCreationFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/WooShippingLabelCreationFragment.kt
@@ -26,8 +26,10 @@ import com.woocommerce.android.ui.orders.wooshippinglabels.customs.CustomsData
 import com.woocommerce.android.ui.orders.wooshippinglabels.customs.WooShippingCustomsFormFragment.Companion.CUSTOMS_DATA_RESULT
 import com.woocommerce.android.ui.orders.wooshippinglabels.hazmat.WooShippingLabelHazmatFormViewModel.Companion.HAZMAT_CATEGORY_RESULT
 import com.woocommerce.android.ui.orders.wooshippinglabels.models.DestinationShippingAddress
+import com.woocommerce.android.ui.orders.wooshippinglabels.models.ShipmentUIModel
 import com.woocommerce.android.ui.orders.wooshippinglabels.packages.WooShippingLabelPackageCreationFragment.Companion.PACKAGE_SELECTION_RESULT
 import com.woocommerce.android.ui.orders.wooshippinglabels.packages.ui.PackageData
+import com.woocommerce.android.ui.orders.wooshippinglabels.split.WooShippingSplitShipmentFragment
 import com.woocommerce.android.viewmodel.MultiLiveEvent
 import dagger.hilt.android.AndroidEntryPoint
 import javax.inject.Inject
@@ -101,12 +103,14 @@ class WooShippingLabelCreationFragment : BaseFragment(), BackPressListener {
                             customsData = event.customData
                         ).let { findNavController().navigateSafely(it) }
                 }
+
                 is MultiLiveEvent.Event.ShowSnackbar -> uiMessageResolver.showSnack(event.message)
                 is MultiLiveEvent.Event.ShowActionSnackbar -> uiMessageResolver.showActionSnack(
                     event.message,
                     event.actionText,
                     event.action
                 )
+
                 is MultiLiveEvent.Event.Exit -> findNavController().navigateUp()
                 is WooShippingLabelCreationViewModel.StartSplitShipment -> {
                     WooShippingLabelCreationFragmentDirections
@@ -142,6 +146,9 @@ class WooShippingLabelCreationFragment : BaseFragment(), BackPressListener {
         handleResult<String>(HAZMAT_CATEGORY_RESULT) {
             val selectedCategory = runCatching { ShippingLabelHazmatCategory.valueOf(it) }.getOrNull()
             viewModel.onHazmatCategorySelected(selectedCategory)
+        }
+        handleResult<List<ShipmentUIModel>>(WooShippingSplitShipmentFragment.SPLIT_SHIPMENT_RESULT) {
+            viewModel.onShipmentSplit(it)
         }
     }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/WooShippingLabelCreationViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/WooShippingLabelCreationViewModel.kt
@@ -142,6 +142,7 @@ class WooShippingLabelCreationViewModel @Inject constructor(
         launch { observeShippingLabelInformation() }
         launch { getStoreOptions() }
         launch { getDestinationAddress() }
+        launch { getSavedShipments() }
         launch { getShippingAddresses() }
         launch { getOrderInformation() }
         launch { observePackageWeight() }
@@ -211,6 +212,10 @@ class WooShippingLabelCreationViewModel @Inject constructor(
                 )
             }
         }
+    }
+
+    private suspend fun getSavedShipments() {
+        order.drop(1).collectLatest { order -> shipments.value = getShipments(order) }
     }
 
     @Suppress("ComplexCondition")
@@ -388,6 +393,7 @@ class WooShippingLabelCreationViewModel @Inject constructor(
         combine(
             storeOptions.drop(1),
             order.drop(1),
+            shipments.drop(1),
             shippingAddresses.drop(1),
             shippingRatesState,
             packageSelection,
@@ -395,13 +401,11 @@ class WooShippingLabelCreationViewModel @Inject constructor(
             purchaseState,
             customsState,
             hazmatState
-        ) { storeOptions, order, addresses, shippingRates,
+        ) { storeOptions, order, shipments, addresses, shippingRates,
             packageSelection, uiState, purchaseState, customsState, hazmatState ->
             if (storeOptions == null || addresses == null || purchaseState is PurchaseState.Error) {
                 return@combine WooShippingViewState.Error
             }
-
-            shipments.value = getShipments(order)
 
             val destinationStatus = when {
                 addressValidationHelper.isMissingDestinationAddress(addresses.shipTo.address) -> {
@@ -412,7 +416,7 @@ class WooShippingLabelCreationViewModel @Inject constructor(
                 else -> AddressStatus.UNVERIFIED
             }
 
-            shipmentItems.value = shipments.value.map { it.items }
+            shipmentItems.value = shipments.map { it.items }
 
             val shippingLineSummary = order.getShippingLinesSummary(currencyFormatter)
             val shipmentUIList = shipmentItems.value.mapIndexed { index, shippableItemModels ->
@@ -420,7 +424,7 @@ class WooShippingLabelCreationViewModel @Inject constructor(
                     currencyFormatter,
                     storeOptions.dimensionUnit,
                     storeOptions.weightUnit,
-                    shipments.value[index].purchased
+                    shipments[index].purchased
                 )
             }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/WooShippingLabelCreationViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/WooShippingLabelCreationViewModel.kt
@@ -274,7 +274,7 @@ class WooShippingLabelCreationViewModel @Inject constructor(
     @OptIn(FlowPreview::class)
     private suspend fun observePackageWeight() {
         combine(
-            shipmentItems.filter { it.isNotEmpty() },
+            shipmentItems.filter { it.isNotEmpty() && it.size > selectedShipmentIndex.value },
             packageSelected,
             snapshotFlow { customWeight }.debounce(TYPING_DELAY)
         ) { shipmentItems, selectedPackage, customWeightString ->
@@ -447,6 +447,10 @@ class WooShippingLabelCreationViewModel @Inject constructor(
         }.collectLatest {
             viewState.value = it
         }
+    }
+
+    fun onShipmentSplit(newShipments: List<ShipmentUIModel>) {
+        launch { shipments.value = newShipments }
     }
 
     private fun getSelectedOriginAddress(originAddresses: List<OriginShippingAddress>): OriginShippingAddress {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/networking/DTOs.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/networking/DTOs.kt
@@ -28,6 +28,13 @@ data class ConfigResponse(
     @SerializedName("config") val config: ConfigDTO
 )
 
+data class UpdateShipmentsResponse(
+    @SerializedName("success") val success: Boolean? = null,
+    @SerializedName("data")
+    @JsonAdapter(ShipmentMapDeserializer::class)
+    val data: ShipmentMap
+)
+
 /**
  * Alias for a mapping of shipment id (as String) to the list of items contained in each shipment.
  */

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/networking/WooShippingLabelRepository.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/networking/WooShippingLabelRepository.kt
@@ -238,4 +238,10 @@ class WooShippingLabelRepository @Inject constructor(
             )
         }
     }
+
+    suspend fun updateShipments(
+        site: SiteModel,
+        orderId: Long,
+        shipments: ShipmentMap
+    ) = restClient.updateShipments(site = site, orderId = orderId, shipments = shipments).asWooResult()
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/networking/WooShippingLabelRestClient.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/networking/WooShippingLabelRestClient.kt
@@ -201,4 +201,24 @@ class WooShippingLabelRestClient @Inject constructor(
             clazz = VerifyDestinationAddressResponseDTO::class.java,
         ).toWooPayload()
     }
+
+    /**
+     * Update the shipments for a specific order.
+     */
+    suspend fun updateShipments(
+        site: SiteModel,
+        orderId: Long,
+        shipments: ShipmentMap,
+    ): WooPayload<UpdateShipmentsResponse> {
+        val url = "/wcshipping/v1/shipments/$orderId"
+
+        val result = wooNetwork.executePostGsonRequest(
+            site = site,
+            path = url,
+            body = mapOf("shipments" to shipments, "shipmentIdsToUpdate" to emptyMap()),
+            clazz = UpdateShipmentsResponse::class.java,
+        )
+
+        return result.toWooPayload()
+    }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/split/WooShippingSplitShipmentFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/split/WooShippingSplitShipmentFragment.kt
@@ -9,6 +9,7 @@ import androidx.compose.ui.platform.ComposeView
 import androidx.compose.ui.platform.ViewCompositionStrategy.DisposeOnViewTreeLifecycleDestroyed
 import androidx.fragment.app.viewModels
 import androidx.navigation.fragment.findNavController
+import com.woocommerce.android.extensions.navigateBackWithResult
 import com.woocommerce.android.ui.base.BaseFragment
 import com.woocommerce.android.ui.compose.theme.WooThemeWithBackground
 import com.woocommerce.android.ui.main.AppBarStatus
@@ -42,7 +43,12 @@ class WooShippingSplitShipmentFragment : BaseFragment() {
         viewModel.event.observe(viewLifecycleOwner) { event ->
             when (event) {
                 is MultiLiveEvent.Event.Exit -> findNavController().navigateUp()
+                is MultiLiveEvent.Event.ExitWithResult<*> -> navigateBackWithResult(SPLIT_SHIPMENT_RESULT, event.data)
             }
         }
+    }
+
+    companion object {
+        const val SPLIT_SHIPMENT_RESULT = "split_shipment_result"
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/split/WooShippingSplitShipmentScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/split/WooShippingSplitShipmentScreen.kt
@@ -75,6 +75,7 @@ fun WooShippingSplitShipmentScreen(
         WooShippingSplitShipmentScreen(
             viewState = it,
             onBack = viewModel::onNavigateBack,
+            onDone = viewModel::onDoneTapped,
             onDismissInstructions = viewModel::onDismissInstructions,
             onUpdateSelection = viewModel::onUpdateSelection,
             onUpdateShipment = viewModel::onUpdateShipment,
@@ -91,6 +92,7 @@ fun WooShippingSplitShipmentScreen(
 fun WooShippingSplitShipmentScreen(
     viewState: SplitShipmentViewState,
     onBack: () -> Unit,
+    onDone: () -> Unit,
     onDismissInstructions: () -> Unit,
     onUpdateSelection: (index: Int, selectedIndexes: Set<Int>?) -> Unit,
     onUpdateShipment: (splitMovement: SplitMovement) -> Unit,
@@ -117,7 +119,7 @@ fun WooShippingSplitShipmentScreen(
                 backgroundColor = colorResource(id = R.color.color_toolbar),
                 actions = {
                     WCTextButton(
-                        onClick = onBack,
+                        onClick = onDone,
                         text = stringResource(id = R.string.done)
                     )
                 }
@@ -554,6 +556,7 @@ private fun WooShippingSplitShipmentScreenPreview() = WooThemeWithBackground {
             )
         ),
         onBack = {},
+        onDone = {},
         onDismissInstructions = {},
         onUpdateSelection = { _, _ -> },
         onUpdateShipment = {},

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/split/WooShippingSplitShipmentViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/split/WooShippingSplitShipmentViewModel.kt
@@ -3,8 +3,10 @@ package com.woocommerce.android.ui.orders.wooshippinglabels.split
 import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.asLiveData
 import com.woocommerce.android.R
+import com.woocommerce.android.di.AppCoroutineScope
 import com.woocommerce.android.extensions.sumByFloat
 import com.woocommerce.android.ui.orders.wooshippinglabels.ShippableItemUI
+import com.woocommerce.android.ui.orders.wooshippinglabels.SplitShipment
 import com.woocommerce.android.ui.orders.wooshippinglabels.components.ShippingLabelsSnackbarData
 import com.woocommerce.android.ui.orders.wooshippinglabels.models.ShipmentUIModel
 import com.woocommerce.android.ui.orders.wooshippinglabels.models.ShippableItemModel
@@ -14,6 +16,7 @@ import com.woocommerce.android.viewmodel.MultiLiveEvent
 import com.woocommerce.android.viewmodel.ScopedViewModel
 import com.woocommerce.android.viewmodel.navArgs
 import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.collectLatest
@@ -27,7 +30,9 @@ import javax.inject.Inject
 class WooShippingSplitShipmentViewModel @Inject constructor(
     savedState: SavedStateHandle,
     private val currencyFormatter: CurrencyFormatter,
-    private val getSplitMovements: GetSplitMovements
+    private val getSplitMovements: GetSplitMovements,
+    private val splitShipment: SplitShipment,
+    @AppCoroutineScope private val appCoroutineScope: CoroutineScope
 ) : ScopedViewModel(savedState) {
     private val navArgs: WooShippingSplitShipmentFragmentArgs by savedState.navArgs()
     private val storeOptions = navArgs.shipmentArgs.storeOptions
@@ -103,6 +108,20 @@ class WooShippingSplitShipmentViewModel @Inject constructor(
     fun onNavigateBack() {
         triggerEvent(MultiLiveEvent.Event.Exit)
     }
+
+    fun onDoneTapped() {
+        if (hasShipmentChange()) {
+            val currentShipmentList = currentShipments.value.values.toList()
+            // Launch splitShipment in the application-level scope
+            appCoroutineScope.launch { splitShipment(navArgs.shipmentArgs.orderId, currentShipmentList) }
+            // Trigger event immediately after starting the task
+            triggerEvent(MultiLiveEvent.Event.ExitWithResult(currentShipmentList))
+        } else {
+            triggerEvent(MultiLiveEvent.Event.Exit)
+        }
+    }
+
+    private fun hasShipmentChange() = currentShipments.value.values.toList() != navArgs.shipmentArgs.shipments
 
     fun onDismissInstructions() {
         splitMessage.value = null

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/SplitShipmentTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/SplitShipmentTest.kt
@@ -1,0 +1,76 @@
+package com.woocommerce.android.ui.orders.wooshippinglabels
+
+import com.woocommerce.android.tools.SelectedSite
+import com.woocommerce.android.ui.orders.OrderTestUtils
+import com.woocommerce.android.ui.orders.wooshippinglabels.datasource.WooShippingConfigDataStore
+import com.woocommerce.android.ui.orders.wooshippinglabels.models.ShipmentUIModel
+import com.woocommerce.android.ui.orders.wooshippinglabels.models.ShippableItemModel
+import com.woocommerce.android.ui.orders.wooshippinglabels.networking.Item
+import com.woocommerce.android.ui.orders.wooshippinglabels.networking.UpdateShipmentsResponse
+import com.woocommerce.android.ui.orders.wooshippinglabels.networking.WooShippingLabelRepository
+import com.woocommerce.android.viewmodel.BaseUnitTest
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.flowOf
+import org.junit.Test
+import org.mockito.kotlin.any
+import org.mockito.kotlin.doReturn
+import org.mockito.kotlin.eq
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
+import org.wordpress.android.fluxc.model.SiteModel
+import org.wordpress.android.fluxc.network.rest.wpcom.wc.WooResult
+import java.math.BigDecimal
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class SplitShipmentTest : BaseUnitTest() {
+    private val selectedSite: SelectedSite = mock { doReturn(SiteModel().apply { id = 1 }).whenever(it).getOrNull() }
+    private val wooShippingLabelRepository: WooShippingLabelRepository = mock()
+    private val configDataStore: WooShippingConfigDataStore = mock {
+        doReturn(flowOf(null)).whenever(it).observeConfig(any())
+    }
+
+    private val sut = SplitShipment(selectedSite, wooShippingLabelRepository, configDataStore)
+
+    @Test
+    fun `when shipment has single quantity, endpoint should be called with empty subItems`() = testBlocking {
+        val order = OrderTestUtils.generateTestOrder()
+        whenever(wooShippingLabelRepository.updateShipments(any(), eq(order.id), any())).doReturn(
+            WooResult(UpdateShipmentsResponse(true, emptyMap()))
+        )
+
+        sut.invoke(order.id, listOf(ShipmentUIModel("0", listOf(singleItem))))
+
+        val expectedShipmentMap = mapOf("0" to listOf(Item(singleItem.itemId, emptyList())))
+        verify(wooShippingLabelRepository).updateShipments(any(), eq(order.id), eq(expectedShipmentMap))
+    }
+
+    @Test
+    fun `when shipment has multiple quantity, endpoint should be called with valid format`() = testBlocking {
+        val order = OrderTestUtils.generateTestOrder()
+        whenever(wooShippingLabelRepository.updateShipments(any(), eq(order.id), any())).doReturn(
+            WooResult(UpdateShipmentsResponse(true, emptyMap()))
+        )
+
+        sut.invoke(order.id, listOf(ShipmentUIModel("0", listOf(multipleQuantityItem))))
+
+        val expectedSubItems = listOf("1000-sub-0", "1000-sub-1", "1000-sub-2")
+        val expectedShipmentMap = mapOf("0" to listOf(Item(multipleQuantityItem.itemId, expectedSubItems)))
+        verify(wooShippingLabelRepository).updateShipments(any(), eq(order.id), eq(expectedShipmentMap))
+    }
+
+    private val singleItem = ShippableItemModel(
+        itemId = 1000,
+        productId = 10,
+        title = "Product",
+        price = BigDecimal(100),
+        quantity = 1f,
+        weight = 1f,
+        currency = "USD",
+        width = 1f,
+        height = 1f,
+        length = 1f
+    )
+
+    private val multipleQuantityItem = singleItem.copy(quantity = 3f)
+}

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/split/WooShippingSplitShipmentViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/split/WooShippingSplitShipmentViewModelTest.kt
@@ -1,6 +1,7 @@
 package com.woocommerce.android.ui.orders.wooshippinglabels.split
 
 import com.woocommerce.android.R
+import com.woocommerce.android.ui.orders.wooshippinglabels.SplitShipment
 import com.woocommerce.android.ui.orders.wooshippinglabels.WooShippingLabelCreationViewModel.SplitShipmentArgs
 import com.woocommerce.android.ui.orders.wooshippinglabels.models.ShipmentUIModel
 import com.woocommerce.android.ui.orders.wooshippinglabels.models.ShippableItemModel
@@ -9,6 +10,7 @@ import com.woocommerce.android.util.CurrencyFormatter
 import com.woocommerce.android.util.observeForTesting
 import com.woocommerce.android.viewmodel.BaseUnitTest
 import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.TestScope
 import org.assertj.core.api.Assertions.assertThat
 import org.mockito.kotlin.any
 import org.mockito.kotlin.doAnswer
@@ -22,6 +24,7 @@ class WooShippingSplitShipmentViewModelTest : BaseUnitTest() {
         on { formatCurrency(amount = any(), any(), any()) }.doAnswer { it.getArgument<BigDecimal>(0).toString() }
     }
     private val getSplitMovements: GetSplitMovements = mock()
+    private val splitShipment: SplitShipment = mock()
     lateinit var sut: WooShippingSplitShipmentViewModel
 
     private fun createViewModel(
@@ -35,7 +38,9 @@ class WooShippingSplitShipmentViewModelTest : BaseUnitTest() {
         sut = WooShippingSplitShipmentViewModel(
             savedState,
             currencyFormatter,
-            getSplitMovements
+            getSplitMovements,
+            splitShipment,
+            TestScope(coroutinesTestRule.testDispatcher)
         )
     }
 


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

<!-- Id number of the Linear issue this PR addresses, e.g., WOOMOB-373. -->
WOOMOB-284

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
This integrates split shipment API. Now, Done button on the Split shipment screen should send request to the split shipment endpoint.

### Steps to reproduce
<!-- Step-by-step testing instructions. For new user flows, consider instead stating the goal of the workflow and see if your PR reviewer can accomplish the workflow without specific steps! -->
1. Open the Orders tab.
2. Tap an order with shipping labels. If you don't have one yet, create an order and purchase some shipments from the web.
3. Tap on Create shipping label.
4. Tap Split shipment.
5. Make some changes to the shipments.
6. Tap the DONE button.
7. Verify that your changes are saved. 
8. Navigate back to the order detail screen.
9. Open the shipping labels screen again.
10. Verify that your changes are still correct. 

### Testing information
<!-- This is your opportunity to break out individual scenarios that need testing (when necessary) and/or include a checklist for the reviewer to go through. Consider documenting the following from your own completed testing: devices used, alternate workflows, edge cases, affected areas, critical flows, areas not tested, and any remaining unknowns. Provide feedback on this new section of the PR template through Sept 30, 2024 to Apps Quality; additional context here: p91TBi-b8z-p2#comment-12036 -->

### The tests that have been performed
<!-- To give the reviewer an idea of what could be missed in terms of testing -->
Flow in the video below.

### Images/gif
<!-- Include before and after images or gifs when appropriate. -->
[Screen_recording_20250528_031756.webm](https://github.com/user-attachments/assets/e75b21e7-756d-4d43-b9e8-ed5eb423dd6c)

- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->