### PR TITLE
[Shipping labels] Handle hazmat selection for each shipment

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/ShippableItemsMapper.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/ShippableItemsMapper.kt
@@ -3,6 +3,7 @@ package com.woocommerce.android.ui.orders.wooshippinglabels
 import com.woocommerce.android.extensions.formatToString
 import com.woocommerce.android.extensions.sumByFloat
 import com.woocommerce.android.model.Order
+import com.woocommerce.android.ui.orders.shippinglabels.creation.ShippingLabelHazmatCategory
 import com.woocommerce.android.ui.orders.wooshippinglabels.models.ShipmentUIModel
 import com.woocommerce.android.ui.orders.wooshippinglabels.models.ShippableItemModel
 import com.woocommerce.android.ui.orders.wooshippinglabels.models.ShippableItemModel.Companion.SINGLE_QUANTITY
@@ -31,7 +32,8 @@ fun List<ShippableItemModel>.toUIModel(
     currencyFormatter: CurrencyFormatter,
     dimensionUnit: String,
     weightUnit: String,
-    purchased: Boolean
+    purchased: Boolean,
+    hazmatCategory: ShippingLabelHazmatCategory?
 ): ShipmentUI {
     val shippableItemsUI = map { item -> item.toUIModel(currencyFormatter, dimensionUnit, weightUnit) }
     val formattedTotalPrice = getFormattedTotalPrice(currencyFormatter)
@@ -41,7 +43,9 @@ fun List<ShippableItemModel>.toUIModel(
         shippableItems = shippableItemsUI,
         formattedTotalWeight = formattedTotalWeight,
         formattedTotalPrice = formattedTotalPrice,
-        purchased = purchased
+        purchased = purchased,
+        hazmatState = hazmatCategory?.let { WooShippingLabelCreationViewModel.HazmatState.Declared(it) }
+            ?: WooShippingLabelCreationViewModel.HazmatState.NoSelection
     )
 }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/WooShippingLabelCreationScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/WooShippingLabelCreationScreen.kt
@@ -72,7 +72,6 @@ import com.woocommerce.android.ui.orders.wooshippinglabels.WooShippingLabelCreat
 import com.woocommerce.android.ui.orders.wooshippinglabels.WooShippingLabelCreationViewModel.CustomsState.ItnMissing
 import com.woocommerce.android.ui.orders.wooshippinglabels.WooShippingLabelCreationViewModel.CustomsState.NotRequired
 import com.woocommerce.android.ui.orders.wooshippinglabels.WooShippingLabelCreationViewModel.CustomsState.Unavailable
-import com.woocommerce.android.ui.orders.wooshippinglabels.WooShippingLabelCreationViewModel.HazmatState
 import com.woocommerce.android.ui.orders.wooshippinglabels.WooShippingLabelCreationViewModel.HazmatState.Declared
 import com.woocommerce.android.ui.orders.wooshippinglabels.WooShippingLabelCreationViewModel.PackageSelectionState
 import com.woocommerce.android.ui.orders.wooshippinglabels.WooShippingLabelCreationViewModel.PackageSelectionState.DataAvailable
@@ -115,7 +114,6 @@ fun WooShippingLabelCreationScreen(viewModel: WooShippingLabelCreationViewModel)
                 shippingRatesState = viewState.shippingRates,
                 packageSelectionState = viewState.packageSelection,
                 customsState = viewState.customsState,
-                hazmatState = viewState.hazmatState,
                 onShippingFromAddressChange = viewModel::onShippingFromAddressChange,
                 onEditOriginAddress = viewModel::onEditOriginAddress,
                 onSelectedRateSortOrderChanged = viewModel::onSelectedRateSortOrderChanged,
@@ -160,7 +158,6 @@ fun WooShippingLabelCreationScreen(
     shippingAddresses: WooShippingAddresses,
     onSelectedShipmentChanged: (index: Int) -> Unit,
     customsState: CustomsState,
-    hazmatState: HazmatState,
     onShippingFromAddressChange: (OriginShippingAddress) -> Unit,
     onEditOriginAddress: (OriginShippingAddress) -> Unit,
     onSelectPackageClick: () -> Unit,
@@ -231,7 +228,6 @@ fun WooShippingLabelCreationScreen(
             shippingAddresses = shippingAddresses,
             onSelectedShipmentChanged = onSelectedShipmentChanged,
             customsState = customsState,
-            hazmatState = hazmatState,
             shippingRatesState = shippingRatesState,
             packageSelectionState = packageSelectionState,
             onShippingFromAddressChange = onShippingFromAddressChange,
@@ -312,7 +308,6 @@ private fun LabelCreationScreenWithBottomSheet(
     shippingRatesState: WooShippingLabelCreationViewModel.ShippingRatesState,
     packageSelectionState: PackageSelectionState,
     customsState: CustomsState,
-    hazmatState: HazmatState,
     onSelectPackageClick: () -> Unit,
     shippingAddresses: WooShippingAddresses,
     onSelectedShipmentChanged: (index: Int) -> Unit,
@@ -473,7 +468,6 @@ private fun LabelCreationScreenWithBottomSheet(
                     CreateShippingCards(
                         shipmentUI = shipmentUIList[page],
                         onHazmatNoticeClick = onHazmatNoticeClick,
-                        hazmatState = hazmatState,
                         customsState = customsState,
                         onEditCustomsClick = onEditCustomsClick,
                         packageSelectionState = packageSelectionState,
@@ -512,7 +506,6 @@ private fun LabelCreationScreenWithBottomSheet(
 private fun CreateShippingCards(
     shipmentUI: ShipmentUI,
     onHazmatNoticeClick: () -> Unit = {},
-    hazmatState: HazmatState,
     customsState: CustomsState,
     onEditCustomsClick: () -> Unit,
     packageSelectionState: PackageSelectionState,
@@ -541,7 +534,7 @@ private fun CreateShippingCards(
         )
         HazmatCard(
             onClick = onHazmatNoticeClick,
-            selectedCategory = hazmatState.hazmatSelection,
+            selectedCategory = shipmentUI.hazmatState.hazmatSelection,
             modifier = Modifier
                 .fillMaxWidth()
                 .padding(start = 4.dp, end = 8.dp)
@@ -896,7 +889,8 @@ private fun WooShippingLabelCreationScreenPreview() {
                     shippableItems = generateItems(6),
                     formattedTotalWeight = "8.5kg",
                     formattedTotalPrice = "$92.78",
-                    purchased = false
+                    purchased = false,
+                    hazmatState = Declared(ShippingLabelHazmatCategory.CLASS_1)
                 )
             ),
             totalItems = 6,
@@ -914,7 +908,6 @@ private fun WooShippingLabelCreationScreenPreview() {
             shippingRatesState = WooShippingLabelCreationViewModel.ShippingRatesState.NoAvailable,
             packageSelectionState = NotSelected,
             customsState = Unavailable,
-            hazmatState = Declared(ShippingLabelHazmatCategory.CLASS_1),
             onShippingFromAddressChange = {},
             onRefreshShippingRates = {},
             onSelectedRateSortOrderChanged = {},

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/WooShippingLabelCreationViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/WooShippingLabelCreationViewModel.kt
@@ -428,7 +428,8 @@ class WooShippingLabelCreationViewModel @Inject constructor(
                     currencyFormatter,
                     storeOptions.dimensionUnit,
                     storeOptions.weightUnit,
-                    shipments[index].purchased
+                    shipments[index].purchased,
+                    hazmatStatesFlow.value[index].hazmatSelection,
                 )
             }
 
@@ -443,7 +444,6 @@ class WooShippingLabelCreationViewModel @Inject constructor(
                 uiState = uiState,
                 purchaseState = purchaseState,
                 customsState = customsState,
-                hazmatState = hazmatState,
                 destinationStatus = destinationStatus
             )
         }.combine(loadTrigger.onStart { emit(Unit) }) { viewState, _ ->
@@ -528,7 +528,7 @@ class WooShippingLabelCreationViewModel @Inject constructor(
         val orderId = navArgs.orderId
         val lastOrderComplete = uiState.value.markOrderComplete
         val shippableItemsIdList = shipmentItems.value[selectedShipmentIndex.value].map { it.productId }
-        val hazmatSelection = hazmatState.value.hazmatSelection
+        val hazmatSelection = hazmatStatesFlow.value[selectedShipmentIndex.value].hazmatSelection
 
         val backupPurchaseState = purchaseState.value
         purchaseState.value = PurchaseState.InProgress
@@ -793,7 +793,6 @@ class WooShippingLabelCreationViewModel @Inject constructor(
             val uiState: UIControlsState,
             val purchaseState: PurchaseState,
             val customsState: CustomsState,
-            val hazmatState: HazmatState,
             val destinationStatus: AddressStatus
         ) : WooShippingViewState()
     }
@@ -870,7 +869,8 @@ class WooShippingLabelCreationViewModel @Inject constructor(
         data class DataAvailable(val customsData: CustomsData) : CustomsState()
     }
 
-    sealed class HazmatState {
+    @Parcelize
+    sealed class HazmatState : Parcelable {
         data object NoSelection : HazmatState()
         data class Declared(val hazmatCategory: ShippingLabelHazmatCategory) : HazmatState()
 
@@ -917,7 +917,8 @@ data class ShipmentUI(
     val shippableItems: List<ShippableItemUI>,
     val formattedTotalWeight: String,
     val formattedTotalPrice: String,
-    val purchased: Boolean
+    val purchased: Boolean,
+    val hazmatState: HazmatState
 ) : Parcelable {
     val totalItemQuantity
         get() = shippableItems.sumByFloat { it.quantity }.toInt()

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/WooShippingLabelCreationViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/WooShippingLabelCreationViewModel.kt
@@ -17,6 +17,7 @@ import com.woocommerce.android.ui.orders.shippinglabels.creation.ShippingLabelHa
 import com.woocommerce.android.ui.orders.wooshippinglabels.WooShippingLabelCreationViewModel.CustomsState.ItnMissing
 import com.woocommerce.android.ui.orders.wooshippinglabels.WooShippingLabelCreationViewModel.CustomsState.NotRequired
 import com.woocommerce.android.ui.orders.wooshippinglabels.WooShippingLabelCreationViewModel.CustomsState.Unavailable
+import com.woocommerce.android.ui.orders.wooshippinglabels.WooShippingLabelCreationViewModel.HazmatState
 import com.woocommerce.android.ui.orders.wooshippinglabels.WooShippingLabelCreationViewModel.HazmatState.Declared
 import com.woocommerce.android.ui.orders.wooshippinglabels.WooShippingLabelCreationViewModel.HazmatState.NoSelection
 import com.woocommerce.android.ui.orders.wooshippinglabels.WooShippingLabelCreationViewModel.PackageSelectionState.DataAvailable
@@ -107,7 +108,7 @@ class WooShippingLabelCreationViewModel @Inject constructor(
     private val packageWeight = MutableStateFlow<PackageWeight?>(null)
     private val packageSelection = MutableStateFlow<PackageSelectionState>(NotSelected)
     private val customsState = MutableStateFlow<CustomsState>(NotRequired)
-    private val hazmatState = MutableStateFlow<HazmatState>(NoSelection)
+    private val hazmatStatesFlow = MutableStateFlow<List<HazmatState>>(emptyList())
 
     private val uiState = MutableStateFlow(
         UIControlsState(
@@ -226,9 +227,9 @@ class WooShippingLabelCreationViewModel @Inject constructor(
             shippingAddresses,
             packageWeight,
             customsState,
-            hazmatState,
+            hazmatStatesFlow,
             refreshShippingRates.onStart { emit(Unit) }
-        ) { selectedPackage, addresses, packageWeight, customState, hazmatState, _ ->
+        ) { selectedPackage, addresses, packageWeight, customState, hazmatStates, _ ->
             val customsFulfilled = customState is CustomsState.DataAvailable || customState is NotRequired
             if (selectedPackage != null && addresses != null && customsFulfilled) {
                 ShippingRatesInfo(
@@ -239,7 +240,7 @@ class WooShippingLabelCreationViewModel @Inject constructor(
                     weight = packageWeight?.totalWeight,
                     currencyCode = order.value.currency,
                     customsData = customsFormData.value,
-                    hazmatSelection = (hazmatState as? Declared)?.hazmatCategory
+                    hazmatSelection = hazmatStates[selectedShipmentIndex.value].hazmatSelection
                 )
             } else {
                 null
@@ -400,9 +401,9 @@ class WooShippingLabelCreationViewModel @Inject constructor(
             uiState,
             purchaseState,
             customsState,
-            hazmatState
+            hazmatStatesFlow
         ) { storeOptions, order, shipments, addresses, shippingRates,
-            packageSelection, uiState, purchaseState, customsState, hazmatState ->
+            packageSelection, uiState, purchaseState, customsState, hazmatStates ->
             if (storeOptions == null || addresses == null || purchaseState is PurchaseState.Error) {
                 return@combine WooShippingViewState.Error
             }
@@ -417,6 +418,9 @@ class WooShippingLabelCreationViewModel @Inject constructor(
             }
 
             shipmentItems.value = shipments.map { it.items }
+            if (hazmatStates.isEmpty()) {
+                hazmatStatesFlow.value = List(shipments.size) { NoSelection }
+            }
 
             val shippingLineSummary = order.getShippingLinesSummary(currencyFormatter)
             val shipmentUIList = shipmentItems.value.mapIndexed { index, shippableItemModels ->
@@ -567,7 +571,7 @@ class WooShippingLabelCreationViewModel @Inject constructor(
                 val selectedRate = selectedRate.value
                 if (currentViewState != null && selectedRate != null) {
                     val items = currentViewState.shipmentUIList[selectedShipmentIndex.value]
-                    val hazmatSelection = hazmatState.value.hazmatSelection
+                    val hazmatSelection = hazmatStatesFlow.value[selectedShipmentIndex.value].hazmatSelection
                     PurchasedShippingLabelData(
                         labelId = purchasedLabel.labelId,
                         orderId = navArgs.orderId,
@@ -656,7 +660,7 @@ class WooShippingLabelCreationViewModel @Inject constructor(
     }
 
     fun onHazmatNoticeClick() {
-        val selectedCategory = hazmatState.value
+        val selectedCategory = hazmatStatesFlow.value[selectedShipmentIndex.value]
             .run { this as? Declared }
             ?.hazmatCategory
 
@@ -667,14 +671,16 @@ class WooShippingLabelCreationViewModel @Inject constructor(
     }
 
     fun onHazmatCategorySelected(selectedCategory: ShippingLabelHazmatCategory?) {
-        val previousState = hazmatState.value
+        val previousStates = hazmatStatesFlow.value
         val newState = when (selectedCategory) {
             null -> NoSelection
             else -> Declared(selectedCategory)
         }
-        if (newState == previousState) return
+        if (newState == previousStates[selectedShipmentIndex.value]) return
 
-        hazmatState.value = newState
+        hazmatStatesFlow.value = previousStates.toMutableList().apply {
+            this[selectedShipmentIndex.value] = newState
+        }.toList()
 
         val snackbarMessage = if (selectedCategory != null) {
             R.string.woo_shipping_labels_hazmat_selection_set
@@ -687,7 +693,7 @@ class WooShippingLabelCreationViewModel @Inject constructor(
             actionLabel = R.string.undo,
             dismissAction = { snackbarData = null }
         ) {
-            hazmatState.value = previousState
+            hazmatStatesFlow.value = previousStates
         }
     }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/WooShippingProductsCard.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/WooShippingProductsCard.kt
@@ -96,7 +96,8 @@ private fun ShippingProductsCardPreview(@PreviewParameter(IsExpandedProvider::cl
                     shippableItems = generateItems(6),
                     formattedTotalWeight = "8.5kg",
                     formattedTotalPrice = "$92.78",
-                    purchased = false
+                    purchased = false,
+                    hazmatState = WooShippingLabelCreationViewModel.HazmatState.NoSelection
                 ),
                 isExpanded = isExpanded
             )
@@ -167,7 +168,8 @@ private fun ShippingProductsCardHeaderPreview() {
         shippableItems = generateItems(4),
         formattedTotalWeight = "8.5kg",
         formattedTotalPrice = "$92.78",
-        purchased = false
+        purchased = false,
+        hazmatState = WooShippingLabelCreationViewModel.HazmatState.NoSelection
     )
     val isExpanded = remember { mutableStateOf(false) }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/purchased/WooShippingLabelPurchasedScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/purchased/WooShippingLabelPurchasedScreen.kt
@@ -57,6 +57,7 @@ import com.woocommerce.android.ui.orders.wooshippinglabels.ShipmentUI
 import com.woocommerce.android.ui.orders.wooshippinglabels.ShippingProductsCard
 import com.woocommerce.android.ui.orders.wooshippinglabels.ShippingRateSummaryUI
 import com.woocommerce.android.ui.orders.wooshippinglabels.WooShippingAddresses
+import com.woocommerce.android.ui.orders.wooshippinglabels.WooShippingLabelCreationViewModel
 import com.woocommerce.android.ui.orders.wooshippinglabels.address.AddressStatus
 import com.woocommerce.android.ui.orders.wooshippinglabels.generateItems
 import com.woocommerce.android.ui.orders.wooshippinglabels.hazmat.HazmatCard
@@ -403,7 +404,8 @@ internal fun WooShippingLabelPurchasedScreenPreview() {
                         shippableItems = generateItems(6),
                         formattedTotalWeight = "8.5kg",
                         formattedTotalPrice = "$92.78",
-                        purchased = false
+                        purchased = false,
+                        hazmatState = WooShippingLabelCreationViewModel.HazmatState.NoSelection
                     ),
                     addresses = WooShippingAddresses.EMPTY,
                     rateSummary = ShippingRateSummaryUI(serviceName = "", total = ""),

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/WooShippingLabelCreationViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/WooShippingLabelCreationViewModelTest.kt
@@ -1084,7 +1084,7 @@ class WooShippingLabelCreationViewModelTest : BaseUnitTest() {
         assertThat(currentViewState).isInstanceOf(DataState::class.java)
         val dataState = currentViewState as DataState
 
-        assertThat(dataState.hazmatState).isEqualTo(HazmatState.NoSelection)
+        assertThat(dataState.shipmentUIList[0].hazmatState).isEqualTo(HazmatState.NoSelection)
     }
 
     @Test
@@ -1109,14 +1109,16 @@ class WooShippingLabelCreationViewModelTest : BaseUnitTest() {
         assertThat(currentViewState).isInstanceOf(DataState::class.java)
         val dataState = currentViewState as DataState
 
-        assertThat(dataState.hazmatState).isEqualTo(HazmatState.Declared(ShippingLabelHazmatCategory.CLASS_1))
+        assertThat(dataState.shipmentUIList[0].hazmatState).isEqualTo(HazmatState.Declared(ShippingLabelHazmatCategory.CLASS_1))
     }
 
     @Test
     fun `when StartHazmatFormEdit is triggered with a selected category, the event contains the expected category value`() =
         testBlocking {
             var event: MultiLiveEvent.Event? = null
-            whenever(orderDetailRepository.getOrderById(any())) doReturn null
+            val order = OrderTestUtils.generateTestOrder(orderId = orderId)
+            whenever(orderDetailRepository.getOrderById(any())) doReturn order
+            whenever(getShipments(any())) doReturn defaultShipments
             whenever(observeOriginAddresses()) doReturn flowOf(defaultOriginAddresses)
             whenever(observeStoreOptions()) doReturn flowOf(defaultStoreOptions)
 

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/WooShippingLabelCreationViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/WooShippingLabelCreationViewModelTest.kt
@@ -1109,7 +1109,8 @@ class WooShippingLabelCreationViewModelTest : BaseUnitTest() {
         assertThat(currentViewState).isInstanceOf(DataState::class.java)
         val dataState = currentViewState as DataState
 
-        assertThat(dataState.shipmentUIList[0].hazmatState).isEqualTo(HazmatState.Declared(ShippingLabelHazmatCategory.CLASS_1))
+        assertThat(dataState.shipmentUIList[0].hazmatState)
+            .isEqualTo(HazmatState.Declared(ShippingLabelHazmatCategory.CLASS_1))
     }
 
     @Test


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

<!-- Id number of the Linear issue this PR addresses, e.g., WOOMOB-373. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
Hazmat selection was originally designed for a single shipment. This PR adds support for selecting hazmat separately for each shipment.

> [!WARNING]  
> Known issues:
> - Hazmat selection for purchased shipments is still available. This will be disabled in upcoming PRs.
> - Hazmat selection handling in the purchase flow has not been tested yet.

> [!WARNING]  
> Review #14110 first.

### Steps to reproduce
<!-- Step-by-step testing instructions. For new user flows, consider instead stating the goal of the workflow and see if your PR reviewer can accomplish the workflow without specific steps! -->
1. Open the Orders tab. Ideally, select an order with multiple shipments.
2. Tap an order with shipping labels.
3. Tap on Create shipping label.
4. Update Hazmat selection for a shipment.
5. Change selected shipment.

### The tests that have been performed
<!-- To give the reviewer an idea of what could be missed in terms of testing -->
The video below

### Images/gif
<!-- Include before and after images or gifs when appropriate. -->

[Screen_recording_20250529_031532.webm](https://github.com/user-attachments/assets/490bae8f-748e-47c5-9fae-812d915e6144)

- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->