### PR TITLE
[Dependabot] Replace Reviewers Configuration with `CODEOWNERS`

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,8 +7,6 @@ updates:
       interval: "daily"
     labels:
       - "bot: dependencies update"
-    reviewers:
-      - "woocommerce/android-developers"
     groups:
       kotlin-ksp:
         applies-to: version-updates

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,1 +1,4 @@
 /WooCommerce/src/androidTest/ @woocommerce/mobile-ui-testing-squad
+
+# Dependabot
+/gradle/libs.versions.toml @woocommerce/android-developers


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

<!-- Id number of the Linear issue this PR addresses, e.g., WOOMOB-373. -->

Closes: [AINFRA-488](https://linear.app/a8c/issue/AINFRA-488)

---

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

This PR replaces the (now) retired Dependabot's `reviewers` configuration with `CODEOWNERS`.

For more info see: [Dependabot reviewers configuration option being replaced by code owners](https://github.blog/changelog/2025-04-29-dependabot-reviewers-configuration-option-being-replaced-by-code-owners/)

---

### Testing information
<!-- This is your opportunity to break out individual scenarios that need testing (when necessary) and/or include a checklist for the reviewer to go through. Consider documenting the following from your own completed testing: devices used, alternate workflows, edge cases, affected areas, critical flows, areas not tested, and any remaining unknowns. Provide feedback on this new section of the PR template through Sept 30, 2024 to Apps Quality; additional context here: p91TBi-b8z-p2#comment-12036 -->

Confirm that the `CODEOWNERS` file/config is valid.

---

- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->