### PR TITLE
Issue/woomob 507 no speakable text present

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/blaze/creation/destination/BlazeCampaignCreationAdDestinationScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/blaze/creation/destination/BlazeCampaignCreationAdDestinationScreen.kt
@@ -104,8 +104,7 @@ fun AdDestinationScreen(
 @Composable
 fun AdDestinationProperty(title: String, value: String, onPropertyTapped: () -> Unit) {
     Column(
-        modifier =
-        Modifier
+        modifier = Modifier
             .clickable { onPropertyTapped() }
             .padding(dimensionResource(id = R.dimen.major_100))
             .fillMaxWidth(1f)

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/blaze/creation/preview/BlazeCampaignCreationPreviewScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/blaze/creation/preview/BlazeCampaignCreationPreviewScreen.kt
@@ -239,7 +239,9 @@ fun AdPreview(
                     fallback = painterResource(R.drawable.blaze_campaign_product_placeholder),
                     placeholder = painterResource(R.drawable.blaze_campaign_product_placeholder),
                     error = painterResource(R.drawable.blaze_campaign_product_placeholder),
-                    contentDescription = "",
+                    contentDescription = stringResource(
+                        R.string.blaze_campaign_preview_product_image_content_description
+                    ),
                     contentScale = ContentScale.Crop,
                     modifier = Modifier
                         .fillMaxWidth()

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/compose/component/Feedback.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/compose/component/Feedback.kt
@@ -3,10 +3,8 @@ package com.woocommerce.android.ui.compose.component
 import androidx.annotation.StringRes
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Row
-import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
-import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.Icon
 import androidx.compose.material.IconButton
@@ -18,6 +16,7 @@ import androidx.compose.ui.res.colorResource
 import androidx.compose.ui.res.dimensionResource
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.unit.dp
 import com.woocommerce.android.R
 
 @Composable
@@ -42,7 +41,7 @@ fun FeedbackRequest(
         )
         IconButton(
             onClick = { onFeedbackReceived(true) },
-            modifier = Modifier.size(dimensionResource(id = R.dimen.major_200))
+            modifier = Modifier.size(48.dp)
         ) {
             Icon(
                 painter = painterResource(id = R.drawable.ic_thumb_up),
@@ -51,11 +50,9 @@ fun FeedbackRequest(
             )
         }
 
-        Spacer(modifier = Modifier.width(dimensionResource(id = R.dimen.minor_100)))
-
         IconButton(
             onClick = { onFeedbackReceived(false) },
-            modifier = Modifier.size(dimensionResource(id = R.dimen.major_200))
+            modifier = Modifier.size(48.dp)
         ) {
             Icon(
                 painter = painterResource(id = R.drawable.ic_thumb_down),

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -3961,6 +3961,7 @@
     <string name="blaze_campaign_preview_edit_ad">Edit ad</string>
     <string name="blaze_campaign_preview_details_section_title">Details</string>
     <string name="blaze_campaign_preview_audience_section_title">Audience</string>
+    <string name="blaze_campaign_preview_product_image_content_description">Product image used for the ad</string>
     <string name="blaze_campaign_preview_details_budget">Budget</string>
     <string name="blaze_campaign_preview_details_objective">Campaign objective</string>
     <string name="blaze_campaign_preview_details_choose_objective">Choose campaign objective</string>


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes WOOMOB-507

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
Adds very minor changes to properly support screen readers, adding content description where it was missing. 
Additionally, it makes the feedback buttons a clickable area bigger. 

### Testing information
Not much to test. Just verify for the Blaze screen Compsable previews (using AS UI check mode) that there aren't any accessibility issues like the following: 
- "No speakable text preset". Beware of false positives, things like decorativei mages should not have content description. 
- "Touch target size too small" 

- [ ] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->