### PR TITLE
Issue/woomob 535 accessibility leftover issues from running accessibility

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/blaze/creation/ad/BlazeCampaignCreationEditAdScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/blaze/creation/ad/BlazeCampaignCreationEditAdScreen.kt
@@ -43,6 +43,7 @@ import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import coil.compose.SubcomposeAsyncImage
 import coil.request.ImageRequest.Builder
+import com.woocommerce.android.R
 import com.woocommerce.android.R.color
 import com.woocommerce.android.R.dimen
 import com.woocommerce.android.R.drawable
@@ -218,12 +219,14 @@ private fun AdDataSection(
                 SuggestionButton(
                     onClick = onPreviousSuggestionTapped,
                     isEnabled = viewState.isPreviousSuggestionButtonEnabled,
-                    icon = Icons.AutoMirrored.Filled.ArrowBackIos
+                    icon = Icons.AutoMirrored.Filled.ArrowBackIos,
+                    contentDescription = stringResource(id = R.string.blaze_campaign_edit_ad_arrow_forward_description),
                 )
                 SuggestionButton(
                     onClick = onNextSuggestionTapped,
                     isEnabled = viewState.isNextSuggestionButtonEnabled,
                     icon = Icons.AutoMirrored.Filled.ArrowForwardIos,
+                    contentDescription = stringResource(id = R.string.blaze_campaign_edit_ad_arrow_back_description),
                     modifier = Modifier.padding(start = dimensionResource(id = dimen.major_150))
                 )
             }
@@ -391,6 +394,7 @@ private fun SuggestionButton(
     onClick: () -> Unit,
     isEnabled: Boolean,
     icon: ImageVector,
+    contentDescription: String,
     modifier: Modifier = Modifier
 ) {
     Box(
@@ -405,7 +409,7 @@ private fun SuggestionButton(
     ) {
         Icon(
             imageVector = icon,
-            contentDescription = null,
+            contentDescription = contentDescription,
             tint = if (isEnabled) {
                 MaterialTheme.colors.primary
             } else {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/blaze/creation/budget/BlazeCampaignBudgetScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/blaze/creation/budget/BlazeCampaignBudgetScreen.kt
@@ -17,6 +17,7 @@ import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.text.InlineTextContent
 import androidx.compose.foundation.text.appendInlineContent
 import androidx.compose.foundation.verticalScroll
+import androidx.compose.material.ButtonDefaults
 import androidx.compose.material.Divider
 import androidx.compose.material.Icon
 import androidx.compose.material.MaterialTheme
@@ -500,7 +501,10 @@ private fun EditDurationBottomSheet(
                         delay(400)
                         onCancelTapped()
                     }
-                }
+                },
+                colors = ButtonDefaults.textButtonColors(
+                    contentColor = colorResource(id = R.color.text_button_over_bottom_sheet)
+                )
             ) {
                 Text(
                     text = stringResource(id = R.string.blaze_campaign_budget_duration_cancel_button),

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/compose/component/Buttons.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/compose/component/Buttons.kt
@@ -273,7 +273,9 @@ fun WCTextButton(
     enabled: Boolean = true,
     interactionSource: MutableInteractionSource = remember { MutableInteractionSource() },
     contentPadding: PaddingValues = ButtonDefaults.TextButtonContentPadding,
-    colors: ButtonColors = ButtonDefaults.textButtonColors(),
+    colors: ButtonColors = ButtonDefaults.textButtonColors(
+        disabledContentColor = colorResource(id = R.color.color_on_surface_medium),
+    ),
     content: @Composable RowScope.() -> Unit
 ) {
     TextButton(
@@ -322,7 +324,9 @@ fun WCTextButton(
     allCaps: Boolean = true,
     interactionSource: MutableInteractionSource = remember { MutableInteractionSource() },
     contentPadding: PaddingValues = ButtonDefaults.TextButtonContentPadding,
-    colors: ButtonColors = ButtonDefaults.textButtonColors(),
+    colors: ButtonColors = ButtonDefaults.textButtonColors(
+        disabledContentColor = colorResource(id = R.color.color_on_surface_medium),
+    ),
 ) {
     TextButton(
         onClick = onClick,

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/compose/component/Buttons.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/compose/component/Buttons.kt
@@ -135,7 +135,9 @@ fun WCOutlinedButton(
     enabled: Boolean = true,
     interactionSource: MutableInteractionSource = remember { MutableInteractionSource() },
     contentPadding: PaddingValues = ButtonDefaults.ContentPadding,
-    colors: ButtonColors = ButtonDefaults.outlinedButtonColors(),
+    colors: ButtonColors = ButtonDefaults.outlinedButtonColors(
+        disabledContentColor = colorResource(id = R.color.color_on_surface_medium)
+    ),
     border: BorderStroke? = ButtonDefaults.outlinedBorder,
     content: @Composable RowScope.() -> Unit
 ) {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/compose/component/Buttons.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/compose/component/Buttons.kt
@@ -60,7 +60,9 @@ fun WCColoredButton(
     contentPadding: PaddingValues = ButtonDefaults.ContentPadding,
     colors: ButtonColors = ButtonDefaults.buttonColors(
         contentColor = colorResource(id = R.color.woo_white),
-        backgroundColor = colorResource(id = R.color.primary_colored_button_background)
+        backgroundColor = colorResource(id = R.color.primary_colored_button_background),
+        disabledBackgroundColor = MaterialTheme.colors.onSurface.copy(alpha = 0.06f),
+        disabledContentColor = colorResource(id = R.color.color_on_surface_medium)
     ),
     rippleColor: Color = MaterialTheme.colors.primaryVariant,
     elevation: ButtonElevation? = null,
@@ -101,7 +103,9 @@ fun WCColoredButton(
     contentPadding: PaddingValues = ButtonDefaults.ContentPadding,
     colors: ButtonColors = ButtonDefaults.buttonColors(
         contentColor = colorResource(id = R.color.woo_white),
-        backgroundColor = colorResource(id = R.color.primary_colored_button_background)
+        backgroundColor = colorResource(id = R.color.primary_colored_button_background),
+        disabledBackgroundColor = MaterialTheme.colors.onSurface.copy(alpha = 0.06f),
+        disabledContentColor = colorResource(id = R.color.color_on_surface_medium)
     ),
 ) {
     WCColoredButton(

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/compose/component/DatePickerDialog.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/compose/component/DatePickerDialog.kt
@@ -252,12 +252,10 @@ private fun CalendarView(
 ) {
     AndroidView(
         modifier = modifier.wrapContentSize(),
-            factory = { context ->
-                // Apply your custom theme overlay here
-                val themedContext =
-                    ContextThemeWrapper(context, R.style.Woo_Theme_CalendarView)
-                AndroidCalendarView(themedContext) // Use the themedContext
-            },
+        factory = { context ->
+            val themedContext = ContextThemeWrapper(context, R.style.Woo_Theme_CalendarView)
+            AndroidCalendarView(themedContext)
+        },
         update = { view ->
             if (minDate != null) {
                 view.minDate = minDate.timeInMillis

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/compose/component/DatePickerDialog.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/compose/component/DatePickerDialog.kt
@@ -3,6 +3,7 @@
 package com.woocommerce.android.ui.compose.component
 
 import android.content.res.Configuration
+import androidx.appcompat.view.ContextThemeWrapper
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Box
@@ -251,9 +252,12 @@ private fun CalendarView(
 ) {
     AndroidView(
         modifier = modifier.wrapContentSize(),
-        factory = { context ->
-            AndroidCalendarView(context)
-        },
+            factory = { context ->
+                // Apply your custom theme overlay here
+                val themedContext =
+                    ContextThemeWrapper(context, R.style.Woo_Theme_CalendarView)
+                AndroidCalendarView(themedContext) // Use the themedContext
+            },
         update = { view ->
             if (minDate != null) {
                 view.minDate = minDate.timeInMillis

--- a/WooCommerce/src/main/res/values-night/colors_base.xml
+++ b/WooCommerce/src/main/res/values-night/colors_base.xml
@@ -165,6 +165,7 @@
     <color name="light_colored_button_text">@color/color_primary</color>
     <color name="light_colored_button_background">@color/woo_black_80</color>
     <color name="light_colored_button_text_secondary">@color/white</color>
+    <color name="text_button_over_bottom_sheet">@color/woo_purple_20</color>
 
     <!--
     Analytics

--- a/WooCommerce/src/main/res/values/colors_base.xml
+++ b/WooCommerce/src/main/res/values/colors_base.xml
@@ -237,6 +237,7 @@
     <color name="light_colored_button_background">@color/woo_gray_6</color>
     <color name="light_colored_button_text_secondary">@color/color_primary</color>
     <color name="primary_colored_button_background">@color/woo_purple_40</color>
+    <color name="text_button_over_bottom_sheet">@color/color_primary</color>
 
     <!--
     Analytics

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -4037,6 +4037,8 @@
     <string name="blaze_campaign_product_photo_picker_title">Product Photos</string>
     <string name="blaze_campaign_product_photo_picker_empty">No photos found</string>
     <string name="blaze_campaign_product_photo_picker_photo_content_description">Product photo</string>
+    <string name="blaze_campaign_edit_ad_arrow_forward_description">Next suggestion</string>
+    <string name="blaze_campaign_edit_ad_arrow_back_description">Previous suggestion</string>
 
     <!--
     Blaze campaign payment

--- a/WooCommerce/src/main/res/values/styles_base.xml
+++ b/WooCommerce/src/main/res/values/styles_base.xml
@@ -808,4 +808,8 @@ theme across the entire app. Overridden versions should be added to the styles.x
     <style name="Woo.Theme.BottomSheetDialog.Resizeable" parent="Woo.Theme.BottomSheetDialog">
         <item name="android:windowSoftInputMode">adjustResize</item>
     </style>
+
+    <style name="Woo.Theme.CalendarView" parent="android:Widget.CalendarView">
+        <item name="android:textColorPrimary">@color/color_on_surface_medium</item>
+    </style>
 </resources>


### PR DESCRIPTION
Closes WOOMOB-535

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
Fixes some leftover accessibility issues that I was able to detect using Android [Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor&hl=en)

### Testing information
Run the Accessibility Scanner app over the Blaze campaign creation flow and check that the following errors are gone: 

<img width="300"  src="https://github.com/user-attachments/assets/df21acc8-d569-412b-9097-5d2cec2ad0e0"> 
<img width="300"  src="https://github.com/user-attachments/assets/585efaa1-5c7e-4bf5-bd06-9ebbadc25db1"> 
<img width="300"  src="https://github.com/user-attachments/assets/292eb7cf-dd25-4c01-a023-ff434c443c16"> 
<img width="300"  src="https://github.com/user-attachments/assets/ccec265e-df6b-468f-a27d-5a6e1d7b201d"> 

### The tests that have been performed
Checked the above are fixed using [Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor&hl=en)


- [ ] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->