### PR TITLE
Move MediaPicker's `source-wordpress` to WooCommerce codebase

### DIFF
--- a/WooCommerce/build.gradle
+++ b/WooCommerce/build.gradle
@@ -395,10 +395,6 @@ dependencies {
         exclude group: "org.wordpress", module: "utils"
     }
     implementation("${gradle.ext.mediaPickerSourceCameraBinaryPath}:${libs.versions.wordpress.mediapicker.get()}")
-    implementation("${gradle.ext.mediaPickerSourceWordPressBinaryPath}:${libs.versions.wordpress.mediapicker.get()}") {
-        exclude group: "org.wordpress", module: "utils"
-        exclude group: "org.wordpress", module: "fluxc"
-    }
 
     // Jetpack Compose
     implementation(platform(libs.androidx.compose.bom))

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/mediapicker/MediaPickerLoaderFactory.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/mediapicker/MediaPickerLoaderFactory.kt
@@ -1,9 +1,9 @@
 package com.woocommerce.android.mediapicker
 
+import com.woocommerce.android.mediapicker.medialibrary.MediaLibrarySource
 import org.wordpress.android.mediapicker.api.MediaPickerSetup
 import org.wordpress.android.mediapicker.loader.MediaLoader
 import org.wordpress.android.mediapicker.loader.MediaLoaderFactory
-import org.wordpress.android.mediapicker.source.wordpress.MediaLibrarySource
 import javax.inject.Inject
 
 // A factory class responsible for building an image-loader class, which is specific to a source.

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/mediapicker/MediaPickerModule.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/mediapicker/MediaPickerModule.kt
@@ -1,5 +1,7 @@
 package com.woocommerce.android.mediapicker
 
+import com.woocommerce.android.mediapicker.medialibrary.MediaLibrarySource
+import com.woocommerce.android.tools.NetworkStatus
 import com.woocommerce.android.tools.SelectedSite
 import dagger.Binds
 import dagger.Module
@@ -16,8 +18,6 @@ import org.wordpress.android.mediapicker.api.MediaPickerSetup
 import org.wordpress.android.mediapicker.api.MimeTypeProvider
 import org.wordpress.android.mediapicker.api.Tracker
 import org.wordpress.android.mediapicker.loader.MediaLoaderFactory
-import org.wordpress.android.mediapicker.source.wordpress.MediaLibrarySource
-import org.wordpress.android.mediapicker.source.wordpress.util.NetworkUtilsWrapper
 
 @InstallIn(SingletonComponent::class)
 @Module(
@@ -33,14 +33,14 @@ abstract class MediaPickerModule {
             mediaStore: MediaStore,
             dispatcher: Dispatcher,
             bgDispatcher: CoroutineDispatcher,
-            networkUtilsWrapper: NetworkUtilsWrapper,
+            networkStatus: NetworkStatus,
             site: SelectedSite
         ): MediaLibrarySource.Factory {
             return MediaLibrarySource.Factory(
                 mediaStore,
                 dispatcher,
                 bgDispatcher,
-                networkUtilsWrapper,
+                networkStatus,
                 site.get()
             )
         }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/mediapicker/MediaPickerSetupFactory.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/mediapicker/MediaPickerSetupFactory.kt
@@ -1,5 +1,6 @@
 package com.woocommerce.android.mediapicker
 
+import com.woocommerce.android.mediapicker.medialibrary.MediaLibraryPickerSetup
 import org.wordpress.android.mediapicker.api.MediaPickerSetup
 import org.wordpress.android.mediapicker.api.MediaPickerSetup.DataSource
 import org.wordpress.android.mediapicker.api.MediaPickerSetup.DataSource.CAMERA
@@ -8,7 +9,6 @@ import org.wordpress.android.mediapicker.api.MediaPickerSetup.DataSource.WP_MEDI
 import org.wordpress.android.mediapicker.model.MediaTypes
 import org.wordpress.android.mediapicker.setup.SystemMediaPickerSetup
 import org.wordpress.android.mediapicker.source.camera.CameraMediaPickerSetup
-import org.wordpress.android.mediapicker.source.wordpress.MediaLibraryPickerSetup
 import java.security.InvalidParameterException
 import javax.inject.Inject
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/mediapicker/medialibrary/MediaLibraryPickerSetup.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/mediapicker/medialibrary/MediaLibraryPickerSetup.kt
@@ -1,0 +1,20 @@
+package com.woocommerce.android.mediapicker.medialibrary
+
+import com.woocommerce.android.R
+import org.wordpress.android.mediapicker.api.MediaPickerSetup
+import org.wordpress.android.mediapicker.api.MediaPickerSetup.DataSource.WP_MEDIA_LIBRARY
+import org.wordpress.android.mediapicker.api.MediaPickerSetup.SearchMode.HIDDEN
+import org.wordpress.android.mediapicker.model.MediaTypes
+
+object MediaLibraryPickerSetup {
+    fun build(mediaTypes: MediaTypes, canMultiSelect: Boolean): MediaPickerSetup {
+        return MediaPickerSetup(
+            primaryDataSource = WP_MEDIA_LIBRARY,
+            isMultiSelectEnabled = canMultiSelect,
+            allowedTypes = mediaTypes.allowedTypes,
+            areResultsQueued = false,
+            searchMode = HIDDEN,
+            title = R.string.media_library_title
+        )
+    }
+}

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/mediapicker/medialibrary/MediaLibrarySource.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/mediapicker/medialibrary/MediaLibrarySource.kt
@@ -1,0 +1,211 @@
+package com.woocommerce.android.mediapicker.medialibrary
+
+import com.woocommerce.android.R
+import com.woocommerce.android.tools.NetworkStatus
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.async
+import kotlinx.coroutines.awaitAll
+import kotlinx.coroutines.withContext
+import org.greenrobot.eventbus.Subscribe
+import org.greenrobot.eventbus.ThreadMode.MAIN
+import org.wordpress.android.fluxc.Dispatcher
+import org.wordpress.android.fluxc.generated.MediaActionBuilder
+import org.wordpress.android.fluxc.model.MediaModel
+import org.wordpress.android.fluxc.model.SiteModel
+import org.wordpress.android.fluxc.store.MediaStore
+import org.wordpress.android.fluxc.store.MediaStore.FetchMediaListPayload
+import org.wordpress.android.fluxc.store.MediaStore.OnMediaListFetched
+import org.wordpress.android.fluxc.utils.MimeType
+import org.wordpress.android.mediapicker.api.MediaSource
+import org.wordpress.android.mediapicker.api.MediaSource.MediaLoadingResult
+import org.wordpress.android.mediapicker.api.MediaSource.MediaLoadingResult.Empty
+import org.wordpress.android.mediapicker.api.MediaSource.MediaLoadingResult.Failure
+import org.wordpress.android.mediapicker.model.MediaItem
+import org.wordpress.android.mediapicker.model.MediaItem.Identifier.RemoteMedia
+import org.wordpress.android.mediapicker.model.MediaType
+import org.wordpress.android.mediapicker.model.MediaType.AUDIO
+import org.wordpress.android.mediapicker.model.MediaType.DOCUMENT
+import org.wordpress.android.mediapicker.model.MediaType.IMAGE
+import org.wordpress.android.mediapicker.model.MediaType.VIDEO
+import org.wordpress.android.mediapicker.model.UiString.UiStringRes
+import org.wordpress.android.mediapicker.model.UiString.UiStringText
+import org.wordpress.android.util.DateTimeUtils
+import javax.inject.Inject
+import kotlin.coroutines.Continuation
+import kotlin.coroutines.resume
+import kotlin.coroutines.suspendCoroutine
+import org.wordpress.android.mediapicker.api.R as MPApiR
+
+class MediaLibrarySource(
+    private val mediaStore: MediaStore,
+    private val dispatcher: Dispatcher,
+    private val bgDispatcher: CoroutineDispatcher,
+    private val networkStatus: NetworkStatus,
+    private val siteModel: SiteModel,
+    private val mediaTypes: Set<MediaType>
+) : MediaSource {
+    private var loadContinuations = mutableMapOf<MimeType.Type, Continuation<OnMediaListFetched>>()
+
+    init {
+        dispatcher.register(this)
+    }
+
+    override suspend fun load(
+        forced: Boolean,
+        loadMore: Boolean,
+        filter: String?
+    ): MediaLoadingResult {
+        if (!networkStatus.isConnected()) {
+            return Failure(
+                UiStringRes(MPApiR.string.no_network_title),
+                htmlSubtitle = UiStringRes(R.string.no_network_message),
+                image = MPApiR.drawable.img_illustration_cloud_off_152dp,
+                data = if (loadMore) get(mediaTypes, filter) else listOf()
+            )
+        }
+        return withContext(bgDispatcher) {
+            val loadingResults = mediaTypes.map { mediaType ->
+                async {
+                    loadPage(
+                        siteModel,
+                        loadMore,
+                        mediaType.toMimeType()
+                    )
+                }
+            }.awaitAll()
+
+            var error: String? = null
+            var hasMore = false
+            for (loadingResult in loadingResults) {
+                if (loadingResult.isError) {
+                    error = loadingResult.error.message
+                    break
+                } else {
+                    hasMore = hasMore || loadingResult.canLoadMore
+                }
+            }
+            if (error != null) {
+                Failure(
+                    UiStringRes(R.string.media_loading_failed),
+                    htmlSubtitle = UiStringText(error),
+                    image = MPApiR.drawable.img_illustration_cloud_off_152dp,
+                    data = if (loadMore) get(mediaTypes, filter) else listOf()
+                )
+            } else {
+                val data = get(mediaTypes, filter)
+                if (filter.isNullOrEmpty() || data.isNotEmpty()) {
+                    MediaLoadingResult.Success(data, hasMore)
+                } else {
+                    Empty(
+                        UiStringRes(MPApiR.string.media_empty_search_list),
+                        image = MPApiR.drawable.img_illustration_empty_results_216dp
+                    )
+                }
+            }
+        }
+    }
+
+    private suspend fun get(mediaTypes: Set<MediaType>, filter: String?): List<MediaItem> {
+        return withContext(bgDispatcher) {
+            mediaTypes.map { mediaType ->
+                async {
+                    if (filter == null) {
+                        getFromDatabase(mediaType)
+                    } else {
+                        searchInDatabase(mediaType, filter)
+                    }
+                }
+            }.fold(mutableListOf<MediaItem>()) { result, databaseItems ->
+                result.addAll(databaseItems.await())
+                result
+            }.sortedByDescending { it.dataModified }
+        }
+    }
+
+    private fun List<MediaModel>.toMediaItems(mediaType: MediaType): List<MediaItem> {
+        return this.map { mediaModel ->
+            MediaItem(
+                RemoteMedia(
+                    mediaModel.mediaId,
+                    mediaModel.title,
+                    mediaModel.url,
+                    mediaModel.uploadDate
+                ),
+                mediaModel.url,
+                mediaModel.title,
+                mediaType,
+                mediaModel.mimeType,
+                DateTimeUtils.dateFromIso8601(mediaModel.uploadDate).time
+            )
+        }
+    }
+
+    private fun getFromDatabase(mediaType: MediaType): List<MediaItem> {
+        return when (mediaType) {
+            IMAGE -> mediaStore.getSiteImages(siteModel)
+            VIDEO -> mediaStore.getSiteVideos(siteModel)
+            AUDIO -> mediaStore.getSiteAudio(siteModel)
+            DOCUMENT -> mediaStore.getSiteDocuments(siteModel)
+        }.toMediaItems(mediaType)
+    }
+
+    private fun searchInDatabase(mediaType: MediaType, filter: String): List<MediaItem> {
+        return when (mediaType) {
+            IMAGE -> mediaStore.searchSiteImages(siteModel, filter)
+            VIDEO -> mediaStore.searchSiteVideos(siteModel, filter)
+            AUDIO -> mediaStore.searchSiteAudio(siteModel, filter)
+            DOCUMENT -> mediaStore.searchSiteDocuments(siteModel, filter)
+        }.toMediaItems(mediaType)
+    }
+
+    private suspend fun loadPage(siteModel: SiteModel, loadMore: Boolean, filter: MimeType.Type): OnMediaListFetched =
+        suspendCoroutine { cont ->
+            loadContinuations[filter] = cont
+            val payload = FetchMediaListPayload(
+                siteModel,
+                NUM_MEDIA_PER_FETCH,
+                loadMore,
+                filter
+            )
+            dispatcher.dispatch(MediaActionBuilder.newFetchMediaListAction(payload))
+        }
+
+    private fun MediaType.toMimeType(): MimeType.Type {
+        return when (this) {
+            IMAGE -> MimeType.Type.IMAGE
+            VIDEO -> MimeType.Type.VIDEO
+            AUDIO -> MimeType.Type.AUDIO
+            DOCUMENT -> MimeType.Type.APPLICATION
+        }
+    }
+
+    @Suppress("Unused")
+    @Subscribe(threadMode = MAIN)
+    fun onMediaListFetched(event: OnMediaListFetched) {
+        loadContinuations[event.mimeType]?.resume(event)
+        loadContinuations.remove(event.mimeType)
+    }
+
+    companion object {
+        const val NUM_MEDIA_PER_FETCH = 24
+    }
+
+    class Factory
+    @Inject constructor(
+        private val mediaStore: MediaStore,
+        private val dispatcher: Dispatcher,
+        private val bgDispatcher: CoroutineDispatcher,
+        private val networkStatus: NetworkStatus,
+        private val siteModel: SiteModel
+    ) {
+        fun build(mediaTypes: Set<MediaType>) =
+            MediaLibrarySource(
+                mediaStore,
+                dispatcher,
+                bgDispatcher,
+                networkStatus,
+                siteModel,
+                mediaTypes
+            )
+    }
+}

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -4634,4 +4634,8 @@
     <string name="woo_shipping_split_shipment_merge_unfulfilled_desc">This will remove all unfulfilled split shipments and move all items into one shipment.</string>
     <string name="woo_shipping_split_shipment_merge_unfulfilled_button">Merge all shipments</string>
     <string name="purchased_shipment_content_description">Purchased</string>
+
+    <string name="media_library_title">WordPress Media Library</string>
+    <string name="media_loading_failed">Media loading failed</string>
+    <string name="no_network_message">There is no network available</string>
 </resources>

--- a/config/gradle/include_builds.gradle
+++ b/config/gradle/include_builds.gradle
@@ -20,7 +20,6 @@ if (localBuilds.exists()) {
                 substitute module("$gradle.ext.mediaPickerDomainBinaryPath") using project(':mediapicker:domain')
                 substitute module("$gradle.ext.mediaPickerSourceDeviceBinaryPath") using project(':mediapicker:source-device')
                 substitute module("$gradle.ext.mediaPickerSourceGifBinaryPath") using project(':mediapicker:source-gif')
-                substitute module("$gradle.ext.mediaPickerSourceWordPressBinaryPath") using project(':mediapicker:source-wordpress')
             }
         }
     }

--- a/settings.gradle
+++ b/settings.gradle
@@ -186,7 +186,6 @@ gradle.ext.mediaPickerDomainBinaryPath = "org.wordpress.mediapicker:domain"
 gradle.ext.mediaPickerSourceCameraBinaryPath = "org.wordpress.mediapicker:source-camera"
 gradle.ext.mediaPickerSourceDeviceBinaryPath = "org.wordpress.mediapicker:source-device"
 gradle.ext.mediaPickerSourceGifBinaryPath = "org.wordpress.mediapicker:source-gif"
-gradle.ext.mediaPickerSourceWordPressBinaryPath = "org.wordpress.mediapicker:source-wordpress"
 
 gradle.ext {
     compileSdkVersion = 35


### PR DESCRIPTION
Closes: AINFRA-659
<!-- Remember about a good descriptive title. -->

<!-- Id number of the Linear issue this PR addresses, e.g., WOOMOB-373. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

Because `source-wordpress` depends on external FluxC, it conflicts with locally vendored FluxC. See https://github.com/woocommerce/woocommerce-android/pull/14098

`MediaLibraryPicketSetup` source: https://github.com/wordpress-mobile/WordPress-MediaPicker-Android/blob/0e275be05341678996dc1b9abfc8608f331d2540/mediapicker/source-wordpress/src/main/java/org/wordpress/android/mediapicker/source/wordpress/MediaLibraryPickerSetup.kt

`MediaLibrarySource` source: https://github.com/wordpress-mobile/WordPress-MediaPicker-Android/blob/0e275be05341678996dc1b9abfc8608f331d2540/mediapicker/source-wordpress/src/main/java/org/wordpress/android/mediapicker/source/wordpress/MediaLibrarySource.kt

### Steps to reproduce
<!-- Step-by-step testing instructions. For new user flows, consider instead stating the goal of the workflow and see if your PR reviewer can accomplish the workflow without specific steps! -->

Smoke test WordPress Media Library picker (e.g. when adding product images).


- [ ] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
