### PR TITLE
[Woo POS][Coupons] Separate coupon list and coupon search list states

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/items/WooPosItemsSearchHelper.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/items/WooPosItemsSearchHelper.kt
@@ -88,9 +88,6 @@ class WooPosItemsSearchHelper @Inject constructor(
     }
 
     fun onCloseSearchClicked() {
-        coroutineScope.launch {
-            childToParentEventSender.sendToParent(ChildToParentEvent.SearchEvent.QueryChanged(query = ""))
-        }
         wasLastStateClosed = true
         viewStateFlow.value = viewStateFlow.value.copy(
             search = SearchState.Visible(

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/items/coupons/WooPosCouponsDataSource.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/items/coupons/WooPosCouponsDataSource.kt
@@ -4,10 +4,8 @@ import com.woocommerce.android.model.Coupon
 import com.woocommerce.android.ui.coupons.CouponListHandler
 import kotlinx.coroutines.flow.Flow
 import javax.inject.Inject
-import javax.inject.Singleton
 import kotlin.Boolean as CanLoadMore
 
-@Singleton
 class WooPosCouponsDataSource @Inject constructor(private val handler: CouponListHandler) {
     val couponsFlow: Flow<List<Coupon>> = handler.couponsFlow
 


### PR DESCRIPTION
### Fix for Coupons list reload after coming back from search

<!-- Remember about a good descriptive title. -->

<!-- Id number of the Linear issue this PR addresses, e.g., WOOMOB-373. -->
WOOMOB-533

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
This PR fixes a bug – the coupon list was reset after returning to the coupon list from search (previously loaded pages were lost). The problem was due to the fact that the same (singleton) instance of `WooPosCouponsDataSource` was used for both Coupons main list and Coupons Search list.

### Steps to reproduce
<!-- Step-by-step testing instructions. For new user flows, consider instead stating the goal of the workflow and see if your PR reviewer can accomplish the workflow without specific steps! -->
1. Open POS
2. Open Coupons and scroll to load next page
3. Open Coupons Search
4. Go back to Coupons
5. Observe Coupons list being reloaded, next page of results being lost

### Testing information
<!-- This is your opportunity to break out individual scenarios that need testing (when necessary) and/or include a checklist for the reviewer to go through. Consider documenting the following from your own completed testing: devices used, alternate workflows, edge cases, affected areas, critical flows, areas not tested, and any remaining unknowns. Provide feedback on this new section of the PR template through Sept 30, 2024 to Apps Quality; additional context here: p91TBi-b8z-p2#comment-12036 -->
Switching between search and coupons should not result in any state loss.

### The tests that have been performed
<!-- To give the reviewer an idea of what could be missed in terms of testing -->
Tested switching between Coupons and Search in different scenarios.

### Images/gif
<!-- Include before and after images or gifs when appropriate. -->
N/A 

- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->