### PR TITLE
[Shipping labels] Add missing parameter for split shipments and error handling

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/GetShipments.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/GetShipments.kt
@@ -45,7 +45,7 @@ class GetShipments @Inject constructor(
         val shipments = config?.shipments
 
         return if (shipments.isNullOrEmpty()) {
-            listOf(ShipmentUIModel(id = null, items = orderItems, purchased = !purchasedLabels.isNullOrEmpty()))
+            listOf(ShipmentUIModel(id = "0", items = orderItems, purchased = !purchasedLabels.isNullOrEmpty()))
         } else {
             shipments.map { (shipmentId, shipmentItems) ->
                 val items = shipmentItems.mapNotNull { (id, subItems) ->
@@ -55,7 +55,7 @@ class GetShipments @Inject constructor(
                         ?.copy(quantity = if (subItems.isNullOrEmpty()) 1f else subItems.size.toFloat())
                 }
                 val purchased = purchasedLabels?.map { it.id.toString() }?.contains(shipmentId) == true
-                ShipmentUIModel(shipmentId, items, purchased)
+                ShipmentUIModel(id = shipmentId, remoteId = shipmentId, items = items, purchased = purchased)
             }
         }
     }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/SplitShipment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/SplitShipment.kt
@@ -16,7 +16,7 @@ class SplitShipment @Inject constructor(
     private val configDataStore: WooShippingConfigDataStore,
 ) {
 
-    suspend operator fun invoke(orderId: Long, shipments: List<ShipmentUIModel>): Result<Unit> {
+    suspend operator fun invoke(orderId: Long, shipments: List<ShipmentUIModel>): Result<List<ShipmentUIModel>> {
         return selectedSite.getOrNull()?.let {
             val shipmentMap = shipments.toShipmentMap()
 
@@ -24,16 +24,23 @@ class SplitShipment @Inject constructor(
                 site = it,
                 orderId = orderId,
                 shipments = shipmentMap,
+                shipmentIdsToUpdate = getShipmentsToUpdate(shipments)
             )
             val result = response.model
             if (response.isError || result == null) {
                 Result.failure(Exception("Split shipment failed"))
             } else {
                 updateCachedShipments(orderId, result.data)
-                Result.success(Unit)
+                // Update remote ids
+                val newShipments = shipments.map { it.copy(remoteId = it.id) }
+                Result.success(newShipments)
             }
         } ?: Result.failure(Exception("No site selected"))
     }
+
+    private fun getShipmentsToUpdate(shipments: List<ShipmentUIModel>): Map<String, Int> = shipments.filter {
+        it.remoteId != null && it.id != it.remoteId
+    }.associate { it.remoteId!! to it.id.toInt() }
 
     private fun List<ShipmentUIModel>.toShipmentMap() = associate {
         it.id to it.items.map { item -> Item(id = item.itemId, subItems = item.subItems()) }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/SplitShipment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/SplitShipment.kt
@@ -18,7 +18,7 @@ class SplitShipment @Inject constructor(
 
     suspend operator fun invoke(orderId: Long, shipments: List<ShipmentUIModel>): Result<Unit> {
         return selectedSite.getOrNull()?.let {
-            val shipmentMap = shipments.toShipmentMap() ?: return Result.failure(Exception("Shipment with null id"))
+            val shipmentMap = shipments.toShipmentMap()
 
             val response = wooShippingLabelRepository.updateShipments(
                 site = it,
@@ -35,11 +35,8 @@ class SplitShipment @Inject constructor(
         } ?: Result.failure(Exception("No site selected"))
     }
 
-    private fun List<ShipmentUIModel>.toShipmentMap(): ShipmentMap? {
-        if (any { it.id == null }) {
-            return null
-        }
-        return associate { it.id!! to it.items.map { item -> Item(id = item.itemId, subItems = item.subItems()) } }
+    private fun List<ShipmentUIModel>.toShipmentMap() = associate {
+        it.id to it.items.map { item -> Item(id = item.itemId, subItems = item.subItems()) }
     }
 
     /**

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/SplitShipment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/SplitShipment.kt
@@ -38,6 +38,15 @@ class SplitShipment @Inject constructor(
         } ?: Result.failure(Exception("No site selected"))
     }
 
+    /**
+     * Returns a map of remote shipment IDs to their updated local shipment IDs.
+     *
+     * This is used to inform the backend which existing shipments (identified by `remoteId`)
+     * have been modified (and now have a different local `id`). Only shipments that already exist
+     * remotely (`remoteId != null`) and whose local ID has changed are included in this map.
+     *
+     * This mapping helps the backend update the correct shipment mapping during a split operation.
+     */
     private fun getShipmentsToUpdate(shipments: List<ShipmentUIModel>): Map<String, Int> = shipments.filter {
         it.remoteId != null && it.id != it.remoteId
     }.associate { it.remoteId!! to it.id.toInt() }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/WooShippingLabelCreationScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/WooShippingLabelCreationScreen.kt
@@ -517,32 +517,34 @@ private fun CreateShippingCards(
             onExpand = { isExpanded.value = it }
         )
         HazmatCard(
-            onClick = onHazmatNoticeClick,
+            onClick = if (shipmentUI.purchased) null else onHazmatNoticeClick,
             selectedCategory = shipmentUI.hazmatState.hazmatSelection,
             modifier = Modifier
                 .fillMaxWidth()
                 .padding(start = 4.dp, end = 8.dp)
         )
-        CustomsCard(
-            customsState = shipmentUI.customsState,
-            onEditCustomsClick = onEditCustomsClick,
-            modifier = Modifier
-                .fillMaxWidth()
-                .padding(16.dp)
-        )
-        PackageCard(
-            modifier = Modifier.padding(16.dp),
-            packageSelectionState = shipmentUI.packageSelectionState,
-            onSelectPackageClick = onSelectPackageClick,
-            customWeight = customWeight,
-            onCustomWeightChange = onCustomWeightChange
-        )
-        ShippingRatesSection(
-            shippingRatesState = shipmentUI.shippingRatesState,
-            onSelectedRateSortOrderChanged = onSelectedRateSortOrderChanged,
-            onRefreshShippingRates = onRefreshShippingRates,
-            onSelectedSippingRateChanged = onSelectedShippingRateChanged
-        )
+        if (!shipmentUI.purchased) {
+            CustomsCard(
+                customsState = shipmentUI.customsState,
+                onEditCustomsClick = onEditCustomsClick,
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(16.dp)
+            )
+            PackageCard(
+                modifier = Modifier.padding(16.dp),
+                packageSelectionState = shipmentUI.packageSelectionState,
+                onSelectPackageClick = onSelectPackageClick,
+                customWeight = customWeight,
+                onCustomWeightChange = onCustomWeightChange
+            )
+            ShippingRatesSection(
+                shippingRatesState = shipmentUI.shippingRatesState,
+                onSelectedRateSortOrderChanged = onSelectedRateSortOrderChanged,
+                onRefreshShippingRates = onRefreshShippingRates,
+                onSelectedSippingRateChanged = onSelectedShippingRateChanged
+            )
+        }
     }
 }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/WooShippingLabelCreationScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/WooShippingLabelCreationScreen.kt
@@ -381,7 +381,7 @@ private fun LabelCreationScreenWithBottomSheet(
         sheetPeekHeight = bottomSheetPeekHeight,
         scaffoldState = scaffoldState,
         topBar = {
-            TopBar(onNavigateBack)
+            TopBar(onNavigateBack, shipmentUIList[uiState.selectedIndex].purchased)
         },
     ) { innerPadding ->
         Surface(
@@ -549,8 +549,18 @@ private fun CreateShippingCards(
 }
 
 @Composable
-private fun TopBar(onNavigateBack: () -> Unit) = TopAppBar(
-    title = { Text(stringResource(id = R.string.shipping_label_create_title)) },
+private fun TopBar(onNavigateBack: () -> Unit, purchased: Boolean = false) = TopAppBar(
+    title = {
+        Text(
+            stringResource(
+                id = if (purchased) {
+                    R.string.shipping_label_print_screen_title
+                } else {
+                    R.string.shipping_label_create_title
+                }
+            )
+        )
+    },
     navigationIcon = {
         IconButton(onNavigateBack) {
             Icon(

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/address/ObserveShippingLabelNotice.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/address/ObserveShippingLabelNotice.kt
@@ -36,7 +36,8 @@ class ObserveShippingLabelNotice @Inject constructor(private val addressValidati
         selectedIndexFlow,
         isDismissedFlow
     ) { addresses, customs, selectedIndex, isDismissed ->
-        val noticeType = getNoticeType(addresses, customs[selectedIndex], isDismissed) ?: return@combine null
+        val custom = customs.getOrNull(selectedIndex) ?: return@combine null
+        val noticeType = getNoticeType(addresses, custom, isDismissed) ?: return@combine null
         getNoticeBannerUiState(noticeType).also { state ->
             previousNotice = state.type
             if (state.autoDismiss) {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/models/ShipmentUIModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/models/ShipmentUIModel.kt
@@ -5,8 +5,8 @@ import kotlinx.parcelize.Parcelize
 
 @Parcelize
 data class ShipmentUIModel(
-    // If id is null, it indicates that no shipment has been fetched from the backend.
-    val id: String?,
+    val id: String, // Local id
+    val remoteId: String? = null,
     val items: List<ShippableItemModel>,
     val purchased: Boolean = false
 ) : Parcelable

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/networking/WooShippingLabelRepository.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/networking/WooShippingLabelRepository.kt
@@ -242,6 +242,12 @@ class WooShippingLabelRepository @Inject constructor(
     suspend fun updateShipments(
         site: SiteModel,
         orderId: Long,
-        shipments: ShipmentMap
-    ) = restClient.updateShipments(site = site, orderId = orderId, shipments = shipments).asWooResult()
+        shipments: ShipmentMap,
+        shipmentIdsToUpdate: Map<String, Int>
+    ) = restClient.updateShipments(
+        site = site,
+        orderId = orderId,
+        shipments = shipments,
+        shipmentIdsToUpdate = shipmentIdsToUpdate
+    ).asWooResult()
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/networking/WooShippingLabelRestClient.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/networking/WooShippingLabelRestClient.kt
@@ -209,13 +209,14 @@ class WooShippingLabelRestClient @Inject constructor(
         site: SiteModel,
         orderId: Long,
         shipments: ShipmentMap,
+        shipmentIdsToUpdate: Map<String, Int>
     ): WooPayload<UpdateShipmentsResponse> {
         val url = "/wcshipping/v1/shipments/$orderId"
 
         val result = wooNetwork.executePostGsonRequest(
             site = site,
             path = url,
-            body = mapOf("shipments" to shipments, "shipmentIdsToUpdate" to emptyMap()),
+            body = mapOf("shipments" to shipments, "shipmentIdsToUpdate" to shipmentIdsToUpdate),
             clazz = UpdateShipmentsResponse::class.java,
         )
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/split/WooShippingSplitShipmentScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/split/WooShippingSplitShipmentScreen.kt
@@ -90,7 +90,7 @@ fun WooShippingSplitShipmentScreen(
 
 @Composable
 fun WooShippingSplitShipmentScreen(
-    viewState: SplitShipmentViewState,
+    viewState: SplitShipmentViewState.DataState,
     onBack: () -> Unit,
     onDone: () -> Unit,
     onDismissInstructions: () -> Unit,
@@ -225,7 +225,7 @@ fun WooShippingSplitShipmentScreen(
 
 @Composable
 private fun MultipleShipments(
-    viewState: SplitShipmentViewState,
+    viewState: SplitShipmentViewState.DataState,
     shipments: List<Int>,
     productsExtraPadding: Dp,
     onUpdateSelectedShipment: (shipmentKey: Int) -> Unit,
@@ -538,7 +538,7 @@ fun SelectableProductsSection(
 @Composable
 private fun WooShippingSplitShipmentScreenPreview() = WooThemeWithBackground {
     WooShippingSplitShipmentScreen(
-        viewState = SplitShipmentViewState(
+        viewState = SplitShipmentViewState.DataState(
             shipmentSelected = 0,
             selectableItems = mapOf(
                 0 to SelectableShippableItemsUI(

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/split/WooShippingSplitShipmentScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/split/WooShippingSplitShipmentScreen.kt
@@ -105,26 +105,7 @@ fun WooShippingSplitShipmentScreen(
     val snackbarHostState = remember { SnackbarHostState() }
 
     Scaffold(
-        topBar = {
-            TopAppBar(
-                title = { Text(stringResource(R.string.woo_shipping_split_shipment)) },
-                navigationIcon = {
-                    IconButton(onBack) {
-                        Icon(
-                            imageVector = Icons.Filled.Close,
-                            contentDescription = stringResource(id = R.string.close)
-                        )
-                    }
-                },
-                backgroundColor = colorResource(id = R.color.color_toolbar),
-                actions = {
-                    WCTextButton(
-                        onClick = onDone,
-                        text = stringResource(id = R.string.done)
-                    )
-                }
-            )
-        },
+        topBar = { TopBar(onBack, onDone) },
         snackbarHost = { SuccessSnackbarHost(snackbarHostState) }
     ) { padding ->
         Surface(
@@ -221,6 +202,29 @@ fun WooShippingSplitShipmentScreen(
             }
         }
     }
+}
+
+@Composable
+private fun TopBar(onBack: (() -> Unit)? = null, onDone: (() -> Unit)? = null) {
+    TopAppBar(
+        title = { Text(stringResource(R.string.woo_shipping_split_shipment)) },
+        navigationIcon = {
+            IconButton(onBack ?: {}) {
+                Icon(
+                    imageVector = Icons.Filled.Close,
+                    contentDescription = stringResource(id = R.string.close)
+                )
+            }
+        },
+        backgroundColor = colorResource(id = R.color.color_toolbar),
+        actions = {
+            WCTextButton(
+                enabled = onDone != null,
+                onClick = onDone ?: {},
+                text = stringResource(id = R.string.done)
+            )
+        }
+    )
 }
 
 @Composable

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/split/WooShippingSplitShipmentScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/split/WooShippingSplitShipmentScreen.kt
@@ -18,6 +18,7 @@ import androidx.compose.foundation.pager.rememberPagerState
 import androidx.compose.foundation.shape.CornerSize
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.Card
+import androidx.compose.material.CircularProgressIndicator
 import androidx.compose.material.DropdownMenu
 import androidx.compose.material.DropdownMenuItem
 import androidx.compose.material.Icon
@@ -534,6 +535,20 @@ fun SelectableProductsSection(
                     Spacer(modifier = Modifier.padding(bottom = extraBottomPadding))
                 }
             }
+        }
+    }
+}
+
+@Composable
+private fun LoadingScreen() {
+    Scaffold(topBar = { TopBar() }) { padding ->
+        Box(
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(padding),
+            contentAlignment = Alignment.Center
+        ) {
+            CircularProgressIndicator()
         }
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/split/WooShippingSplitShipmentScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/split/WooShippingSplitShipmentScreen.kt
@@ -63,6 +63,7 @@ import com.woocommerce.android.ui.orders.wooshippinglabels.ProductsSummary
 import com.woocommerce.android.ui.orders.wooshippinglabels.SelectableShippingProduct
 import com.woocommerce.android.ui.orders.wooshippinglabels.components.ShipmentTabData
 import com.woocommerce.android.ui.orders.wooshippinglabels.components.ShipmentsTabRow
+import com.woocommerce.android.ui.orders.wooshippinglabels.components.ShippingLabelsSnackbarData
 import com.woocommerce.android.ui.orders.wooshippinglabels.components.SuccessSnackbarHost
 import com.woocommerce.android.ui.orders.wooshippinglabels.split.WooShippingSplitShipmentViewModel.SplitShipmentViewState
 import kotlinx.coroutines.launch
@@ -85,6 +86,7 @@ fun WooShippingSplitShipmentScreen(
             onUpdateSelectedShipment = viewModel::onUpdateSelectedShipment,
             onRemoveShipmentMenuTapped = viewModel::onRemoveShipmentMenuTapped,
             onDismissRemoveSheet = viewModel::onDismissRemoveSheet,
+            snackbarData = viewModel.snackbarData,
             modifier = modifier
         )
     }
@@ -102,7 +104,8 @@ fun WooShippingSplitShipmentScreen(
     onUpdateSelectedShipment: (shipmentKey: Int) -> Unit,
     onRemoveShipmentMenuTapped: (shipmentKeys: List<Int>) -> Unit,
     onDismissRemoveSheet: () -> Unit,
-    modifier: Modifier = Modifier
+    modifier: Modifier = Modifier,
+    snackbarData: ShippingLabelsSnackbarData? = null,
 ) {
     val snackbarHostState = remember { SnackbarHostState() }
 
@@ -182,6 +185,22 @@ fun WooShippingSplitShipmentScreen(
         viewState.removeShipmentSheet?.let { removeShipmentSheet ->
             RemoveShipmentBottomSheet(removeShipmentSheet, onDismissRemoveSheet, onRemoveShipments)
         }
+    }
+
+    val actionSnackbarMessage = snackbarData?.let { stringResource(it.message) }
+    val actionSnackbarActionLabel = snackbarData?.let { stringResource(it.actionLabel) }
+    LaunchedEffect(snackbarData) {
+        snackbarData?.let {
+            val result = snackbarHostState.showSnackbar(
+                message = actionSnackbarMessage ?: "",
+                actionLabel = actionSnackbarActionLabel,
+                duration = snackbarData.duration,
+            )
+            when (result) {
+                SnackbarResult.ActionPerformed -> snackbarData.action()
+                SnackbarResult.Dismissed -> snackbarData.dismissAction()
+            }
+        } ?: snackbarHostState.currentSnackbarData?.dismiss()
     }
 
     val context = LocalContext.current

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/split/WooShippingSplitShipmentScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/split/WooShippingSplitShipmentScreen.kt
@@ -92,6 +92,7 @@ fun WooShippingSplitShipmentScreen(
     }
 }
 
+@Suppress("CyclomaticComplexMethod")
 @Composable
 fun WooShippingSplitShipmentScreen(
     viewState: SplitShipmentViewState.DataState,

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/split/WooShippingSplitShipmentScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/split/WooShippingSplitShipmentScreen.kt
@@ -35,8 +35,8 @@ import androidx.compose.material3.SnackbarHostState
 import androidx.compose.material3.SnackbarResult
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
-import androidx.compose.runtime.livedata.observeAsState
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
@@ -72,9 +72,10 @@ fun WooShippingSplitShipmentScreen(
     viewModel: WooShippingSplitShipmentViewModel,
     modifier: Modifier = Modifier
 ) {
-    viewModel.viewState.observeAsState().value?.let {
-        WooShippingSplitShipmentScreen(
-            viewState = it,
+    when (val viewState = viewModel.viewState.collectAsState().value) {
+        is SplitShipmentViewState.Loading -> LoadingScreen()
+        is SplitShipmentViewState.DataState -> WooShippingSplitShipmentScreen(
+            viewState = viewState,
             onBack = viewModel::onNavigateBack,
             onDone = viewModel::onDoneTapped,
             onDismissInstructions = viewModel::onDismissInstructions,

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/split/WooShippingSplitShipmentScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/split/WooShippingSplitShipmentScreen.kt
@@ -35,8 +35,8 @@ import androidx.compose.material3.SnackbarHostState
 import androidx.compose.material3.SnackbarResult
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
-import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.livedata.observeAsState
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
@@ -73,22 +73,24 @@ fun WooShippingSplitShipmentScreen(
     viewModel: WooShippingSplitShipmentViewModel,
     modifier: Modifier = Modifier
 ) {
-    when (val viewState = viewModel.viewState.collectAsState().value) {
-        is SplitShipmentViewState.Loading -> LoadingScreen()
-        is SplitShipmentViewState.DataState -> WooShippingSplitShipmentScreen(
-            viewState = viewState,
-            onBack = viewModel::onNavigateBack,
-            onDone = viewModel::onDoneTapped,
-            onDismissInstructions = viewModel::onDismissInstructions,
-            onUpdateSelection = viewModel::onUpdateSelection,
-            onUpdateShipment = viewModel::onUpdateShipment,
-            onRemoveShipments = viewModel::onRemoveShipments,
-            onUpdateSelectedShipment = viewModel::onUpdateSelectedShipment,
-            onRemoveShipmentMenuTapped = viewModel::onRemoveShipmentMenuTapped,
-            onDismissRemoveSheet = viewModel::onDismissRemoveSheet,
-            snackbarData = viewModel.snackbarData,
-            modifier = modifier
-        )
+    viewModel.viewState.observeAsState().value?.let {
+        when (it) {
+            is SplitShipmentViewState.Loading -> LoadingScreen()
+            is SplitShipmentViewState.DataState -> WooShippingSplitShipmentScreen(
+                viewState = it,
+                onBack = viewModel::onNavigateBack,
+                onDone = viewModel::onDoneTapped,
+                onDismissInstructions = viewModel::onDismissInstructions,
+                onUpdateSelection = viewModel::onUpdateSelection,
+                onUpdateShipment = viewModel::onUpdateShipment,
+                onRemoveShipments = viewModel::onRemoveShipments,
+                onUpdateSelectedShipment = viewModel::onUpdateSelectedShipment,
+                onRemoveShipmentMenuTapped = viewModel::onRemoveShipmentMenuTapped,
+                onDismissRemoveSheet = viewModel::onDismissRemoveSheet,
+                snackbarData = viewModel.snackbarData,
+                modifier = modifier
+            )
+        }
     }
 }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/split/WooShippingSplitShipmentViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/split/WooShippingSplitShipmentViewModel.kt
@@ -1,7 +1,9 @@
 package com.woocommerce.android.ui.orders.wooshippinglabels.split
 
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.setValue
 import androidx.lifecycle.SavedStateHandle
-import androidx.lifecycle.asLiveData
 import com.woocommerce.android.R
 import com.woocommerce.android.di.AppCoroutineScope
 import com.woocommerce.android.extensions.sumByFloat
@@ -46,10 +48,15 @@ class WooShippingSplitShipmentViewModel @Inject constructor(
     private val removeShipmentSheet: MutableStateFlow<RemoveShipmentSheet?> = MutableStateFlow(null)
     private val splitMessage: MutableStateFlow<SplitShipmentMessage?> = MutableStateFlow(null)
 
+    val viewState: MutableStateFlow<SplitShipmentViewState> = MutableStateFlow(SplitShipmentViewState.Loading)
+
     init {
         launch {
             delay(TOOLTIP_DELAY)
             splitMessage.value = SplitShipmentMessage.Instructions
+        }
+        launch {
+            observeShipments()
         }
         launch {
             currentShipments.collectLatest { shipments ->
@@ -71,26 +78,28 @@ class WooShippingSplitShipmentViewModel @Inject constructor(
         }
     }
 
-    val viewState = combine(
-        shipmentSelected,
-        shipmentsUIMap.filterNotNull(),
-        removeShipmentSheet,
-        splitMessage
-    ) { shipmentSelected, selectableItems, sheet, message ->
-        val unfulfilledShipmentKeys = selectableItems.keys.filterNot { selectableItems.getValue(it).purchased }
-        SplitShipmentViewState(
-            shipmentSelected = shipmentSelected,
-            selectableItems = selectableItems,
-            overflowMenuItems = getOverflowMenuItems(unfulfilledShipmentKeys),
-            splitMovements = getSplitMovements(
-                sourceShipmentKey = shipmentSelected,
-                shipments = currentShipments.value,
-                selection = selectableItems
-            ),
-            removeShipmentSheet = sheet,
-            splitMessage = message
-        )
-    }.asLiveData()
+    private suspend fun observeShipments() {
+        combine(
+            shipmentSelected,
+            shipmentsUIMap.filterNotNull(),
+            removeShipmentSheet,
+            splitMessage
+        ) { shipmentSelected, selectableItems, sheet, message ->
+            val unfulfilledShipmentKeys = selectableItems.keys.filterNot { selectableItems.getValue(it).purchased }
+            SplitShipmentViewState.DataState(
+                shipmentSelected = shipmentSelected,
+                selectableItems = selectableItems,
+                overflowMenuItems = getOverflowMenuItems(unfulfilledShipmentKeys),
+                splitMovements = getSplitMovements(
+                    sourceShipmentKey = shipmentSelected,
+                    shipments = currentShipments.value,
+                    selection = selectableItems
+                ),
+                removeShipmentSheet = sheet,
+                splitMessage = message
+            )
+        }.collectLatest { viewState.value = it }
+    }
 
     private fun getOverflowMenuItems(shipmentKeys: List<Int>) = buildList {
         if (shipmentKeys.size >= 2) {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/split/WooShippingSplitShipmentViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/split/WooShippingSplitShipmentViewModel.kt
@@ -253,7 +253,9 @@ class WooShippingSplitShipmentViewModel @Inject constructor(
      */
     private fun reindexShipments(
         shipments: Map<Int, ShipmentUIModel>
-    ) = shipments.values.mapIndexed { index, items -> index to items }.toMap()
+    ) = shipments.values.mapIndexed { index, shipmentUIModel ->
+        index to shipmentUIModel.copy(id = index.toString())
+    }.toMap()
 
     private fun showUndoSnackbar(splitMovement: SplitMovement, undoAction: () -> Unit) {
         val snackbarMessage = if (splitMovement.totalItemsToMove > 1) {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/split/WooShippingSplitShipmentViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/split/WooShippingSplitShipmentViewModel.kt
@@ -3,9 +3,8 @@ package com.woocommerce.android.ui.orders.wooshippinglabels.split
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.setValue
-import androidx.lifecycle.LiveData
-import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.SavedStateHandle
+import androidx.lifecycle.asLiveData
 import com.woocommerce.android.R
 import com.woocommerce.android.extensions.sumByFloat
 import com.woocommerce.android.ui.orders.wooshippinglabels.ShippableItemUI
@@ -47,17 +46,12 @@ class WooShippingSplitShipmentViewModel @Inject constructor(
     private val shipmentSelected = MutableStateFlow(0)
     private val removeShipmentSheet: MutableStateFlow<RemoveShipmentSheet?> = MutableStateFlow(null)
     private val splitMessage: MutableStateFlow<SplitShipmentMessage?> = MutableStateFlow(null)
-
-    private val _viewState = MutableLiveData<SplitShipmentViewState>(SplitShipmentViewState.Loading)
-    val viewState: LiveData<SplitShipmentViewState> = _viewState
+    private val isLoading: MutableStateFlow<Boolean> = MutableStateFlow(false)
 
     init {
         launch {
             delay(TOOLTIP_DELAY)
             splitMessage.value = SplitShipmentMessage.Instructions
-        }
-        launch {
-            observeShipments()
         }
         launch {
             currentShipments.collectLatest { shipments ->
@@ -79,13 +73,16 @@ class WooShippingSplitShipmentViewModel @Inject constructor(
         }
     }
 
-    private suspend fun observeShipments() {
-        combine(
-            shipmentSelected,
-            shipmentsUIMap.filterNotNull(),
-            removeShipmentSheet,
-            splitMessage
-        ) { shipmentSelected, selectableItems, sheet, message ->
+    val viewState = combine(
+        shipmentSelected,
+        shipmentsUIMap.filterNotNull(),
+        removeShipmentSheet,
+        splitMessage,
+        isLoading
+    ) { shipmentSelected, selectableItems, sheet, message, loading ->
+        if (loading) {
+            SplitShipmentViewState.Loading
+        } else {
             val unfulfilledShipmentKeys = selectableItems.keys.filterNot { selectableItems.getValue(it).purchased }
             SplitShipmentViewState.DataState(
                 shipmentSelected = shipmentSelected,
@@ -99,8 +96,8 @@ class WooShippingSplitShipmentViewModel @Inject constructor(
                 removeShipmentSheet = sheet,
                 splitMessage = message
             )
-        }.collectLatest { _viewState.value = it }
-    }
+        }
+    }.asLiveData()
 
     private fun getOverflowMenuItems(shipmentKeys: List<Int>) = buildList {
         if (shipmentKeys.size >= 2) {
@@ -121,15 +118,14 @@ class WooShippingSplitShipmentViewModel @Inject constructor(
 
     fun onDoneTapped() {
         if (hasShipmentChange()) {
-            val fallbackViewState = _viewState.value
-            _viewState.value = SplitShipmentViewState.Loading
+            isLoading.value = true
             launch {
                 val currentShipmentList = currentShipments.value.values.toList()
                 val result = splitShipment(navArgs.shipmentArgs.orderId, currentShipmentList)
                 if (result.isSuccess) {
                     triggerEvent(MultiLiveEvent.Event.ExitWithResult(result.getOrThrow()))
                 } else {
-                    fallbackViewState?.let { _viewState.value = it }
+                    isLoading.value = false
                     snackbarData = ShippingLabelsSnackbarData(
                         message = R.string.woo_shipping_split_shipment_error,
                         actionLabel = R.string.retry,

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/split/WooShippingSplitShipmentViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/split/WooShippingSplitShipmentViewModel.kt
@@ -5,7 +5,6 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.setValue
 import androidx.lifecycle.SavedStateHandle
 import com.woocommerce.android.R
-import com.woocommerce.android.di.AppCoroutineScope
 import com.woocommerce.android.extensions.sumByFloat
 import com.woocommerce.android.ui.orders.wooshippinglabels.ShippableItemUI
 import com.woocommerce.android.ui.orders.wooshippinglabels.SplitShipment
@@ -18,7 +17,6 @@ import com.woocommerce.android.viewmodel.MultiLiveEvent
 import com.woocommerce.android.viewmodel.ScopedViewModel
 import com.woocommerce.android.viewmodel.navArgs
 import dagger.hilt.android.lifecycle.HiltViewModel
-import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.collectLatest
@@ -34,7 +32,6 @@ class WooShippingSplitShipmentViewModel @Inject constructor(
     private val currencyFormatter: CurrencyFormatter,
     private val getSplitMovements: GetSplitMovements,
     private val splitShipment: SplitShipment,
-    @AppCoroutineScope private val appCoroutineScope: CoroutineScope
 ) : ScopedViewModel(savedState) {
     private val navArgs: WooShippingSplitShipmentFragmentArgs by savedState.navArgs()
     var snackbarData by mutableStateOf<ShippingLabelsSnackbarData?>(null)
@@ -121,11 +118,21 @@ class WooShippingSplitShipmentViewModel @Inject constructor(
 
     fun onDoneTapped() {
         if (hasShipmentChange()) {
-            val currentShipmentList = currentShipments.value.values.toList()
-            // Launch splitShipment in the application-level scope
-            appCoroutineScope.launch { splitShipment(navArgs.shipmentArgs.orderId, currentShipmentList) }
-            // Trigger event immediately after starting the task
-            triggerEvent(MultiLiveEvent.Event.ExitWithResult(currentShipmentList))
+            val fallbackViewState = viewState.value
+            viewState.value = SplitShipmentViewState.Loading
+            launch {
+                val currentShipmentList = currentShipments.value.values.toList()
+                val result = splitShipment(navArgs.shipmentArgs.orderId, currentShipmentList)
+                if (result.isSuccess) {
+                    triggerEvent(MultiLiveEvent.Event.ExitWithResult(result.getOrThrow()))
+                } else {
+                    viewState.value = fallbackViewState
+                    snackbarData = ShippingLabelsSnackbarData(
+                        message = R.string.woo_shipping_split_shipment_error,
+                        actionLabel = R.string.retry,
+                    ) { onDoneTapped() }
+                }
+            }
         } else {
             triggerEvent(MultiLiveEvent.Event.Exit)
         }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/split/WooShippingSplitShipmentViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/split/WooShippingSplitShipmentViewModel.kt
@@ -3,6 +3,8 @@ package com.woocommerce.android.ui.orders.wooshippinglabels.split
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.setValue
+import androidx.lifecycle.LiveData
+import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.SavedStateHandle
 import com.woocommerce.android.R
 import com.woocommerce.android.extensions.sumByFloat
@@ -46,7 +48,8 @@ class WooShippingSplitShipmentViewModel @Inject constructor(
     private val removeShipmentSheet: MutableStateFlow<RemoveShipmentSheet?> = MutableStateFlow(null)
     private val splitMessage: MutableStateFlow<SplitShipmentMessage?> = MutableStateFlow(null)
 
-    val viewState: MutableStateFlow<SplitShipmentViewState> = MutableStateFlow(SplitShipmentViewState.Loading)
+    private val _viewState = MutableLiveData<SplitShipmentViewState>(SplitShipmentViewState.Loading)
+    val viewState: LiveData<SplitShipmentViewState> = _viewState
 
     init {
         launch {
@@ -96,7 +99,7 @@ class WooShippingSplitShipmentViewModel @Inject constructor(
                 removeShipmentSheet = sheet,
                 splitMessage = message
             )
-        }.collectLatest { viewState.value = it }
+        }.collectLatest { _viewState.value = it }
     }
 
     private fun getOverflowMenuItems(shipmentKeys: List<Int>) = buildList {
@@ -118,15 +121,15 @@ class WooShippingSplitShipmentViewModel @Inject constructor(
 
     fun onDoneTapped() {
         if (hasShipmentChange()) {
-            val fallbackViewState = viewState.value
-            viewState.value = SplitShipmentViewState.Loading
+            val fallbackViewState = _viewState.value
+            _viewState.value = SplitShipmentViewState.Loading
             launch {
                 val currentShipmentList = currentShipments.value.values.toList()
                 val result = splitShipment(navArgs.shipmentArgs.orderId, currentShipmentList)
                 if (result.isSuccess) {
                     triggerEvent(MultiLiveEvent.Event.ExitWithResult(result.getOrThrow()))
                 } else {
-                    viewState.value = fallbackViewState
+                    fallbackViewState?.let { _viewState.value = it }
                     snackbarData = ShippingLabelsSnackbarData(
                         message = R.string.woo_shipping_split_shipment_error,
                         actionLabel = R.string.retry,

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/split/WooShippingSplitShipmentViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/split/WooShippingSplitShipmentViewModel.kt
@@ -37,6 +37,7 @@ class WooShippingSplitShipmentViewModel @Inject constructor(
     @AppCoroutineScope private val appCoroutineScope: CoroutineScope
 ) : ScopedViewModel(savedState) {
     private val navArgs: WooShippingSplitShipmentFragmentArgs by savedState.navArgs()
+    var snackbarData by mutableStateOf<ShippingLabelsSnackbarData?>(null)
     private val storeOptions = navArgs.shipmentArgs.storeOptions
 
     private val currentShipments = MutableStateFlow(

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/split/WooShippingSplitShipmentViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/split/WooShippingSplitShipmentViewModel.kt
@@ -266,14 +266,17 @@ class WooShippingSplitShipmentViewModel @Inject constructor(
         )
     }
 
-    data class SplitShipmentViewState(
-        val shipmentSelected: Int,
-        val selectableItems: Map<Int, SelectableShippableItemsUI>,
-        val overflowMenuItems: List<List<Int>> = emptyList(), // Each item represents shipments to be removed.
-        val splitMovements: List<SplitMovement> = emptyList(),
-        val removeShipmentSheet: RemoveShipmentSheet? = null,
-        val splitMessage: SplitShipmentMessage? = null
-    )
+    sealed class SplitShipmentViewState {
+        data object Loading : SplitShipmentViewState()
+        data class DataState(
+            val shipmentSelected: Int,
+            val selectableItems: Map<Int, SelectableShippableItemsUI>,
+            val overflowMenuItems: List<List<Int>> = emptyList(), // Each item represents shipments to be removed.
+            val splitMovements: List<SplitMovement> = emptyList(),
+            val removeShipmentSheet: RemoveShipmentSheet? = null,
+            val splitMessage: SplitShipmentMessage? = null
+        ) : SplitShipmentViewState()
+    }
 
     companion object {
         private const val TOOLTIP_DELAY = 800L

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -4593,6 +4593,7 @@
     <string name="woo_shipping_address_missing_info_hint">Add missing information</string>
     <string name="woo_shipping_labels_loading_order_error">Unable to load the order</string>
     <string name="woo_shipping_labels_purchase_error">We are unable to purchase the shipping label. Please try again.</string>
+    <string name="woo_shipping_split_shipment_error">We were unable to split the shipments. Please try again.</string>
     <string name="woo_shipping_labels_loading_error">Unable to load data</string>
     <string name="woo_shipping_address_save_changes">Save changes</string>
 

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/SplitShipmentTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/SplitShipmentTest.kt
@@ -35,20 +35,20 @@ class SplitShipmentTest : BaseUnitTest() {
     @Test
     fun `when shipment has single quantity, endpoint should be called with empty subItems`() = testBlocking {
         val order = OrderTestUtils.generateTestOrder()
-        whenever(wooShippingLabelRepository.updateShipments(any(), eq(order.id), any())).doReturn(
+        whenever(wooShippingLabelRepository.updateShipments(any(), eq(order.id), any(), any())).doReturn(
             WooResult(UpdateShipmentsResponse(true, emptyMap()))
         )
 
         sut.invoke(order.id, listOf(ShipmentUIModel(id = "0", items = listOf(singleItem))))
 
         val expectedShipmentMap = mapOf("0" to listOf(Item(singleItem.itemId, emptyList())))
-        verify(wooShippingLabelRepository).updateShipments(any(), eq(order.id), eq(expectedShipmentMap))
+        verify(wooShippingLabelRepository).updateShipments(any(), eq(order.id), eq(expectedShipmentMap), any())
     }
 
     @Test
     fun `when shipment has multiple quantity, endpoint should be called with valid format`() = testBlocking {
         val order = OrderTestUtils.generateTestOrder()
-        whenever(wooShippingLabelRepository.updateShipments(any(), eq(order.id), any())).doReturn(
+        whenever(wooShippingLabelRepository.updateShipments(any(), eq(order.id), any(), any())).doReturn(
             WooResult(UpdateShipmentsResponse(true, emptyMap()))
         )
 
@@ -56,7 +56,7 @@ class SplitShipmentTest : BaseUnitTest() {
 
         val expectedSubItems = listOf("1000-sub-0", "1000-sub-1", "1000-sub-2")
         val expectedShipmentMap = mapOf("0" to listOf(Item(multipleQuantityItem.itemId, expectedSubItems)))
-        verify(wooShippingLabelRepository).updateShipments(any(), eq(order.id), eq(expectedShipmentMap))
+        verify(wooShippingLabelRepository).updateShipments(any(), eq(order.id), eq(expectedShipmentMap), any())
     }
 
     private val singleItem = ShippableItemModel(

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/SplitShipmentTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/SplitShipmentTest.kt
@@ -39,7 +39,7 @@ class SplitShipmentTest : BaseUnitTest() {
             WooResult(UpdateShipmentsResponse(true, emptyMap()))
         )
 
-        sut.invoke(order.id, listOf(ShipmentUIModel("0", listOf(singleItem))))
+        sut.invoke(order.id, listOf(ShipmentUIModel(id = "0", items = listOf(singleItem))))
 
         val expectedShipmentMap = mapOf("0" to listOf(Item(singleItem.itemId, emptyList())))
         verify(wooShippingLabelRepository).updateShipments(any(), eq(order.id), eq(expectedShipmentMap))
@@ -52,7 +52,7 @@ class SplitShipmentTest : BaseUnitTest() {
             WooResult(UpdateShipmentsResponse(true, emptyMap()))
         )
 
-        sut.invoke(order.id, listOf(ShipmentUIModel("0", listOf(multipleQuantityItem))))
+        sut.invoke(order.id, listOf(ShipmentUIModel(id = "0", items = listOf(multipleQuantityItem))))
 
         val expectedSubItems = listOf("1000-sub-0", "1000-sub-1", "1000-sub-2")
         val expectedShipmentMap = mapOf("0" to listOf(Item(multipleQuantityItem.itemId, expectedSubItems)))

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/split/GetSplitMovementsTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/split/GetSplitMovementsTest.kt
@@ -196,7 +196,7 @@ class GetSplitMovementsTest : BaseUnitTest() {
         )
     }
 
-    private val defaultShipments = mapOf(0 to ShipmentUIModel(id = null, items = defaultShippableItems))
+    private val defaultShipments = mapOf(0 to ShipmentUIModel(id = "0", remoteId = null, items = defaultShippableItems))
     val defaultSelection = defaultShipments.mapValues {
         it.value.toSelectableUIModel(
             currencyFormatter = currencyFormatter,
@@ -207,8 +207,8 @@ class GetSplitMovementsTest : BaseUnitTest() {
     }
 
     private val twoShipments = mapOf(
-        0 to ShipmentUIModel(id = null, items = defaultShippableItems),
-        1 to ShipmentUIModel(id = null, items = defaultShippableItems)
+        0 to ShipmentUIModel(id = "0", remoteId = null, items = defaultShippableItems),
+        1 to ShipmentUIModel(id = "0", remoteId = null, items = defaultShippableItems)
     )
     val twoShipmentsSelection = twoShipments.mapValues {
         it.value.toSelectableUIModel(
@@ -220,6 +220,6 @@ class GetSplitMovementsTest : BaseUnitTest() {
     }
 
     private val purchasedShipment = mapOf(
-        10 to ShipmentUIModel(id = null, items = defaultShippableItems, purchased = true)
+        10 to ShipmentUIModel(id = "0", remoteId = null, items = defaultShippableItems, purchased = true)
     )
 }

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/split/WooShippingSplitShipmentViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/split/WooShippingSplitShipmentViewModelTest.kt
@@ -7,10 +7,8 @@ import com.woocommerce.android.ui.orders.wooshippinglabels.models.ShipmentUIMode
 import com.woocommerce.android.ui.orders.wooshippinglabels.models.ShippableItemModel
 import com.woocommerce.android.ui.orders.wooshippinglabels.models.StoreOptionsModel
 import com.woocommerce.android.util.CurrencyFormatter
-import com.woocommerce.android.util.observeForTesting
 import com.woocommerce.android.viewmodel.BaseUnitTest
 import kotlinx.coroutines.ExperimentalCoroutinesApi
-import kotlinx.coroutines.test.TestScope
 import org.assertj.core.api.Assertions.assertThat
 import org.mockito.kotlin.any
 import org.mockito.kotlin.doAnswer
@@ -35,22 +33,14 @@ class WooShippingSplitShipmentViewModelTest : BaseUnitTest() {
         )
     ) {
         val savedState = WooShippingSplitShipmentFragmentArgs(shipmentArgs).toSavedStateHandle()
-        sut = WooShippingSplitShipmentViewModel(
-            savedState,
-            currencyFormatter,
-            getSplitMovements,
-            splitShipment,
-            TestScope(coroutinesTestRule.testDispatcher)
-        )
+        sut = WooShippingSplitShipmentViewModel(savedState, currencyFormatter, getSplitMovements, splitShipment)
     }
 
     @Test
     fun `when split shipments is opened, then display the correct number of expandable products`() = testBlocking {
         createViewModel()
 
-        sut.viewState.observeForTesting { }
-
-        val state = sut.viewState.value!!
+        val state = sut.viewState.value as WooShippingSplitShipmentViewModel.SplitShipmentViewState.DataState
 
         val selectableItems = state.selectableItems[0]!!
         val expandableProducts = selectableItems.shippableItems
@@ -69,9 +59,7 @@ class WooShippingSplitShipmentViewModelTest : BaseUnitTest() {
 
             createViewModel(shipmentArgs)
 
-            sut.viewState.observeForTesting { }
-
-            val state = sut.viewState.value!!
+            val state = sut.viewState.value as WooShippingSplitShipmentViewModel.SplitShipmentViewState.DataState
 
             val selectableItems = state.selectableItems[0]!!
             val expandableProducts = selectableItems.shippableItems
@@ -87,9 +75,7 @@ class WooShippingSplitShipmentViewModelTest : BaseUnitTest() {
 
         sut.onUpdateSelection(shippableItemIndex, List(3) { it }.toSet())
 
-        sut.viewState.observeForTesting { }
-
-        val state = sut.viewState.value!!
+        val state = sut.viewState.value as WooShippingSplitShipmentViewModel.SplitShipmentViewState.DataState
 
         val selectableItems = state.selectableItems[0]!!
         val expandableProducts = selectableItems.shippableItems.filter {
@@ -107,9 +93,7 @@ class WooShippingSplitShipmentViewModelTest : BaseUnitTest() {
 
         sut.onUpdateSelection(shippableItemIndex, null)
 
-        sut.viewState.observeForTesting { }
-
-        val state = sut.viewState.value!!
+        val state = sut.viewState.value as WooShippingSplitShipmentViewModel.SplitShipmentViewState.DataState
 
         val selectableItems = state.selectableItems[0]!!
         val expandableProducts = selectableItems.shippableItems.filter {
@@ -127,9 +111,7 @@ class WooShippingSplitShipmentViewModelTest : BaseUnitTest() {
 
         sut.onUpdateSelection(shippableItemIndex, null)
 
-        sut.viewState.observeForTesting { }
-
-        val state = sut.viewState.value!!
+        val state = sut.viewState.value as WooShippingSplitShipmentViewModel.SplitShipmentViewState.DataState
 
         val selectableItems = state.selectableItems[0]!!
         val expandableProducts = selectableItems.shippableItems.filter {
@@ -155,9 +137,7 @@ class WooShippingSplitShipmentViewModelTest : BaseUnitTest() {
 
         sut.onUpdateShipment(movement)
 
-        sut.viewState.observeForTesting { }
-
-        val state = sut.viewState.value!!
+        val state = sut.viewState.value as WooShippingSplitShipmentViewModel.SplitShipmentViewState.DataState
 
         val selectableItems = state.selectableItems
         assertThat(selectableItems.size).isEqualTo(2)
@@ -201,9 +181,7 @@ class WooShippingSplitShipmentViewModelTest : BaseUnitTest() {
 
             sut.onUpdateShipment(movement)
 
-            sut.viewState.observeForTesting { }
-
-            val state = sut.viewState.value!!
+            val state = sut.viewState.value as WooShippingSplitShipmentViewModel.SplitShipmentViewState.DataState
 
             val selectableItems = state.selectableItems
             assertThat(selectableItems.size).isEqualTo(2)
@@ -230,9 +208,7 @@ class WooShippingSplitShipmentViewModelTest : BaseUnitTest() {
 
         sut.onUpdateShipment(movement)
 
-        sut.viewState.observeForTesting { }
-
-        val state = sut.viewState.value!!
+        val state = sut.viewState.value as WooShippingSplitShipmentViewModel.SplitShipmentViewState.DataState
 
         val splitMessage = state.splitMessage
         assertThat(splitMessage).isInstanceOf(SplitShipmentMessage.Success::class.java)
@@ -257,9 +233,7 @@ class WooShippingSplitShipmentViewModelTest : BaseUnitTest() {
 
         sut.onUpdateShipment(movement)
 
-        sut.viewState.observeForTesting { }
-
-        val state = sut.viewState.value!!
+        val state = sut.viewState.value as WooShippingSplitShipmentViewModel.SplitShipmentViewState.DataState
 
         val splitMessage = state.splitMessage
         assertThat(splitMessage).isInstanceOf(SplitShipmentMessage.Success::class.java)
@@ -280,9 +254,7 @@ class WooShippingSplitShipmentViewModelTest : BaseUnitTest() {
 
         createViewModel(shipmentArgs)
 
-        sut.viewState.observeForTesting { }
-
-        val state = sut.viewState.value!!
+        val state = sut.viewState.value as WooShippingSplitShipmentViewModel.SplitShipmentViewState.DataState
 
         val selectableItems = state.selectableItems[0]!!
         assertThat(selectableItems.totalItemQuantity).isEqualTo(expectedQuantity)
@@ -304,9 +276,7 @@ class WooShippingSplitShipmentViewModelTest : BaseUnitTest() {
 
         sut.onUpdateShipment(movement)
 
-        sut.viewState.observeForTesting { }
-
-        val state = sut.viewState.value!!
+        val state = sut.viewState.value as WooShippingSplitShipmentViewModel.SplitShipmentViewState.DataState
 
         assertThat(state.selectableItems.size).isEqualTo(1)
     }
@@ -333,9 +303,7 @@ class WooShippingSplitShipmentViewModelTest : BaseUnitTest() {
 
         sut.onUpdateShipment(movement)
 
-        sut.viewState.observeForTesting { }
-
-        val state = sut.viewState.value!!
+        val state = sut.viewState.value as WooShippingSplitShipmentViewModel.SplitShipmentViewState.DataState
 
         val modifiedShipment = state.selectableItems.values.first()
         assertThat(modifiedShipment.shippableItems.size).isEqualTo(expectedItemCount)
@@ -351,9 +319,7 @@ class WooShippingSplitShipmentViewModelTest : BaseUnitTest() {
 
         createViewModel(shipmentArgs)
 
-        sut.viewState.observeForTesting { }
-
-        val state = sut.viewState.value!!
+        val state = sut.viewState.value as WooShippingSplitShipmentViewModel.SplitShipmentViewState.DataState
 
         assertThat(state.overflowMenuItems.size).isEqualTo(2)
     }
@@ -369,9 +335,7 @@ class WooShippingSplitShipmentViewModelTest : BaseUnitTest() {
 
             createViewModel(shipmentArgs)
 
-            sut.viewState.observeForTesting { }
-
-            val state = sut.viewState.value!!
+            val state = sut.viewState.value as WooShippingSplitShipmentViewModel.SplitShipmentViewState.DataState
 
             assertThat(state.overflowMenuItems.size).isEqualTo(2)
         }
@@ -386,9 +350,7 @@ class WooShippingSplitShipmentViewModelTest : BaseUnitTest() {
 
         createViewModel(shipmentArgs)
 
-        sut.viewState.observeForTesting { }
-
-        val state = sut.viewState.value!!
+        val state = sut.viewState.value as WooShippingSplitShipmentViewModel.SplitShipmentViewState.DataState
         val lastMenuItem = state.overflowMenuItems.last()
         val expectedShipmentCountToBeMerged = threeShipments.size
         val expectedMenuItemCount = expectedShipmentCountToBeMerged + 1
@@ -415,9 +377,7 @@ class WooShippingSplitShipmentViewModelTest : BaseUnitTest() {
             destinationShipmentKey = null
         )
 
-        sut.viewState.observeForTesting { }
-
-        val state = sut.viewState.value!!
+        val state = sut.viewState.value as WooShippingSplitShipmentViewModel.SplitShipmentViewState.DataState
         val currentShipments = state.selectableItems
         val expectedItemQuantity = 10 // All items from `threeShipments`
 
@@ -444,9 +404,7 @@ class WooShippingSplitShipmentViewModelTest : BaseUnitTest() {
                 destinationShipmentKey = null
             )
 
-            sut.viewState.observeForTesting { }
-
-            val state = sut.viewState.value!!
+            val state = sut.viewState.value as WooShippingSplitShipmentViewModel.SplitShipmentViewState.DataState
             val currentShipments = state.selectableItems
             val expectedItemQuantity = 10 // All items from `threeShipments`
 

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/split/WooShippingSplitShipmentViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/split/WooShippingSplitShipmentViewModelTest.kt
@@ -7,6 +7,7 @@ import com.woocommerce.android.ui.orders.wooshippinglabels.models.ShipmentUIMode
 import com.woocommerce.android.ui.orders.wooshippinglabels.models.ShippableItemModel
 import com.woocommerce.android.ui.orders.wooshippinglabels.models.StoreOptionsModel
 import com.woocommerce.android.util.CurrencyFormatter
+import com.woocommerce.android.util.observeForTesting
 import com.woocommerce.android.viewmodel.BaseUnitTest
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import org.assertj.core.api.Assertions.assertThat
@@ -40,6 +41,8 @@ class WooShippingSplitShipmentViewModelTest : BaseUnitTest() {
     fun `when split shipments is opened, then display the correct number of expandable products`() = testBlocking {
         createViewModel()
 
+        sut.viewState.observeForTesting { }
+
         val state = sut.viewState.value as WooShippingSplitShipmentViewModel.SplitShipmentViewState.DataState
 
         val selectableItems = state.selectableItems[0]!!
@@ -59,6 +62,8 @@ class WooShippingSplitShipmentViewModelTest : BaseUnitTest() {
 
             createViewModel(shipmentArgs)
 
+            sut.viewState.observeForTesting { }
+
             val state = sut.viewState.value as WooShippingSplitShipmentViewModel.SplitShipmentViewState.DataState
 
             val selectableItems = state.selectableItems[0]!!
@@ -74,6 +79,8 @@ class WooShippingSplitShipmentViewModelTest : BaseUnitTest() {
         createViewModel()
 
         sut.onUpdateSelection(shippableItemIndex, List(3) { it }.toSet())
+
+        sut.viewState.observeForTesting { }
 
         val state = sut.viewState.value as WooShippingSplitShipmentViewModel.SplitShipmentViewState.DataState
 
@@ -93,6 +100,8 @@ class WooShippingSplitShipmentViewModelTest : BaseUnitTest() {
 
         sut.onUpdateSelection(shippableItemIndex, null)
 
+        sut.viewState.observeForTesting { }
+
         val state = sut.viewState.value as WooShippingSplitShipmentViewModel.SplitShipmentViewState.DataState
 
         val selectableItems = state.selectableItems[0]!!
@@ -110,6 +119,8 @@ class WooShippingSplitShipmentViewModelTest : BaseUnitTest() {
         createViewModel()
 
         sut.onUpdateSelection(shippableItemIndex, null)
+
+        sut.viewState.observeForTesting { }
 
         val state = sut.viewState.value as WooShippingSplitShipmentViewModel.SplitShipmentViewState.DataState
 
@@ -136,6 +147,8 @@ class WooShippingSplitShipmentViewModelTest : BaseUnitTest() {
         createViewModel()
 
         sut.onUpdateShipment(movement)
+
+        sut.viewState.observeForTesting { }
 
         val state = sut.viewState.value as WooShippingSplitShipmentViewModel.SplitShipmentViewState.DataState
 
@@ -181,6 +194,8 @@ class WooShippingSplitShipmentViewModelTest : BaseUnitTest() {
 
             sut.onUpdateShipment(movement)
 
+            sut.viewState.observeForTesting { }
+
             val state = sut.viewState.value as WooShippingSplitShipmentViewModel.SplitShipmentViewState.DataState
 
             val selectableItems = state.selectableItems
@@ -208,6 +223,8 @@ class WooShippingSplitShipmentViewModelTest : BaseUnitTest() {
 
         sut.onUpdateShipment(movement)
 
+        sut.viewState.observeForTesting { }
+
         val state = sut.viewState.value as WooShippingSplitShipmentViewModel.SplitShipmentViewState.DataState
 
         val splitMessage = state.splitMessage
@@ -233,6 +250,8 @@ class WooShippingSplitShipmentViewModelTest : BaseUnitTest() {
 
         sut.onUpdateShipment(movement)
 
+        sut.viewState.observeForTesting { }
+
         val state = sut.viewState.value as WooShippingSplitShipmentViewModel.SplitShipmentViewState.DataState
 
         val splitMessage = state.splitMessage
@@ -253,6 +272,8 @@ class WooShippingSplitShipmentViewModelTest : BaseUnitTest() {
         val expectedQuantity = 6 // Total single items in the Shipment 1 from `twoShipment`
 
         createViewModel(shipmentArgs)
+
+        sut.viewState.observeForTesting { }
 
         val state = sut.viewState.value as WooShippingSplitShipmentViewModel.SplitShipmentViewState.DataState
 
@@ -275,6 +296,8 @@ class WooShippingSplitShipmentViewModelTest : BaseUnitTest() {
         createViewModel()
 
         sut.onUpdateShipment(movement)
+
+        sut.viewState.observeForTesting { }
 
         val state = sut.viewState.value as WooShippingSplitShipmentViewModel.SplitShipmentViewState.DataState
 
@@ -303,6 +326,8 @@ class WooShippingSplitShipmentViewModelTest : BaseUnitTest() {
 
         sut.onUpdateShipment(movement)
 
+        sut.viewState.observeForTesting { }
+
         val state = sut.viewState.value as WooShippingSplitShipmentViewModel.SplitShipmentViewState.DataState
 
         val modifiedShipment = state.selectableItems.values.first()
@@ -318,6 +343,8 @@ class WooShippingSplitShipmentViewModelTest : BaseUnitTest() {
         )
 
         createViewModel(shipmentArgs)
+
+        sut.viewState.observeForTesting { }
 
         val state = sut.viewState.value as WooShippingSplitShipmentViewModel.SplitShipmentViewState.DataState
 
@@ -335,6 +362,8 @@ class WooShippingSplitShipmentViewModelTest : BaseUnitTest() {
 
             createViewModel(shipmentArgs)
 
+            sut.viewState.observeForTesting { }
+
             val state = sut.viewState.value as WooShippingSplitShipmentViewModel.SplitShipmentViewState.DataState
 
             assertThat(state.overflowMenuItems.size).isEqualTo(2)
@@ -349,6 +378,8 @@ class WooShippingSplitShipmentViewModelTest : BaseUnitTest() {
         )
 
         createViewModel(shipmentArgs)
+
+        sut.viewState.observeForTesting { }
 
         val state = sut.viewState.value as WooShippingSplitShipmentViewModel.SplitShipmentViewState.DataState
         val lastMenuItem = state.overflowMenuItems.last()
@@ -377,6 +408,8 @@ class WooShippingSplitShipmentViewModelTest : BaseUnitTest() {
             destinationShipmentKey = null
         )
 
+        sut.viewState.observeForTesting { }
+
         val state = sut.viewState.value as WooShippingSplitShipmentViewModel.SplitShipmentViewState.DataState
         val currentShipments = state.selectableItems
         val expectedItemQuantity = 10 // All items from `threeShipments`
@@ -403,6 +436,8 @@ class WooShippingSplitShipmentViewModelTest : BaseUnitTest() {
                 removingShipmentKeys = (0 until shipmentArgs.shipments.size).toList(),
                 destinationShipmentKey = null
             )
+
+            sut.viewState.observeForTesting { }
 
             val state = sut.viewState.value as WooShippingSplitShipmentViewModel.SplitShipmentViewState.DataState
             val currentShipments = state.selectableItems


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

<!-- Id number of the Linear issue this PR addresses, e.g., WOOMOB-373. -->
Part of WOOMOB-284

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
This adds the missing `shipmentIdsToUpdate` parameter to the split shipment endpoint and implements error handling for split shipment failures.

> [!WARNING]  
> Please review #14119 first.

### Steps to reproduce
<!-- Step-by-step testing instructions. For new user flows, consider instead stating the goal of the workflow and see if your PR reviewer can accomplish the workflow without specific steps! -->
#### To test the `shipmentIdsToUpdate` parameter:
You can either debug the `SplitShipment` class or inspect the network requests. For details on the correct usage of `shipmentIdsToUpdate`, refer to pe5sF9-4ft-p2#comment-4574. In short, we include shipment IDs in this map if a shipment’s local id has changed from its remoteId.

#### To test error handling:
1. Go to the Orders tab and select an order.
2. Tap an order with shipping labels.
3. Tap on Create shipping label.
4. Tap the Split shipment button.
5. Make some changes to the shipments.
6. Disconnect your internet connection.
7. Tap the DONE button.

### The tests that have been performed
<!-- To give the reviewer an idea of what could be missed in terms of testing -->
Steps above

### Images/gif
<!-- Include before and after images or gifs when appropriate. -->
<img src="https://github.com/user-attachments/assets/446137e8-16d1-4850-9212-29fcbeffca5d" width=350>

- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->