### PR TITLE
[Shipping labels] Display purchased screen for purchased shipments

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/WooShippingLabelCreationScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/WooShippingLabelCreationScreen.kt
@@ -517,32 +517,34 @@ private fun CreateShippingCards(
             onExpand = { isExpanded.value = it }
         )
         HazmatCard(
-            onClick = onHazmatNoticeClick,
+            onClick = if (shipmentUI.purchased) null else onHazmatNoticeClick,
             selectedCategory = shipmentUI.hazmatState.hazmatSelection,
             modifier = Modifier
                 .fillMaxWidth()
                 .padding(start = 4.dp, end = 8.dp)
         )
-        CustomsCard(
-            customsState = shipmentUI.customsState,
-            onEditCustomsClick = onEditCustomsClick,
-            modifier = Modifier
-                .fillMaxWidth()
-                .padding(16.dp)
-        )
-        PackageCard(
-            modifier = Modifier.padding(16.dp),
-            packageSelectionState = shipmentUI.packageSelectionState,
-            onSelectPackageClick = onSelectPackageClick,
-            customWeight = customWeight,
-            onCustomWeightChange = onCustomWeightChange
-        )
-        ShippingRatesSection(
-            shippingRatesState = shipmentUI.shippingRatesState,
-            onSelectedRateSortOrderChanged = onSelectedRateSortOrderChanged,
-            onRefreshShippingRates = onRefreshShippingRates,
-            onSelectedSippingRateChanged = onSelectedShippingRateChanged
-        )
+        if (!shipmentUI.purchased) {
+            CustomsCard(
+                customsState = shipmentUI.customsState,
+                onEditCustomsClick = onEditCustomsClick,
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(16.dp)
+            )
+            PackageCard(
+                modifier = Modifier.padding(16.dp),
+                packageSelectionState = shipmentUI.packageSelectionState,
+                onSelectPackageClick = onSelectPackageClick,
+                customWeight = customWeight,
+                onCustomWeightChange = onCustomWeightChange
+            )
+            ShippingRatesSection(
+                shippingRatesState = shipmentUI.shippingRatesState,
+                onSelectedRateSortOrderChanged = onSelectedRateSortOrderChanged,
+                onRefreshShippingRates = onRefreshShippingRates,
+                onSelectedSippingRateChanged = onSelectedShippingRateChanged
+            )
+        }
     }
 }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/WooShippingLabelCreationScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/WooShippingLabelCreationScreen.kt
@@ -381,7 +381,7 @@ private fun LabelCreationScreenWithBottomSheet(
         sheetPeekHeight = bottomSheetPeekHeight,
         scaffoldState = scaffoldState,
         topBar = {
-            TopBar(onNavigateBack)
+            TopBar(onNavigateBack, shipmentUIList[uiState.selectedIndex].purchased)
         },
     ) { innerPadding ->
         Surface(
@@ -549,8 +549,18 @@ private fun CreateShippingCards(
 }
 
 @Composable
-private fun TopBar(onNavigateBack: () -> Unit) = TopAppBar(
-    title = { Text(stringResource(id = R.string.shipping_label_create_title)) },
+private fun TopBar(onNavigateBack: () -> Unit, purchased: Boolean = false) = TopAppBar(
+    title = {
+        Text(
+            stringResource(
+                id = if (purchased) {
+                    R.string.shipping_label_print_screen_title
+                } else {
+                    R.string.shipping_label_create_title
+                }
+            )
+        )
+    },
     navigationIcon = {
         IconButton(onNavigateBack) {
             Icon(


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

<!-- Id number of the Linear issue this PR addresses, e.g., WOOMOB-373. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
This PR adds the purchased view state for purchased shipments. It makes purchased shipments non-interactive and displays the item summary and hazmat selection. The Green print shipping card will be added in a following PR.

> [!WARNING]  
> Do not merge: #14131 must be merged first.

### Steps to reproduce
<!-- Step-by-step testing instructions. For new user flows, consider instead stating the goal of the workflow and see if your PR reviewer can accomplish the workflow without specific steps! -->
1. Go to the Orders tab and select an order.
2. Tap an order with shipping labels.
3. Tap on Create shipping label.
4. Tap the Split shipment button.
5. Create new shipments.
6. Tap the DONE button.
7. Purchase one of the shipments. Alternatively, you can open an order that already has a purchased shipment.

### The tests that have been performed
<!-- To give the reviewer an idea of what could be missed in terms of testing -->
Steps above

### Images/gif
<!-- Include before and after images or gifs when appropriate. -->

- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->