### PR TITLE
[WOOMOB-503] Fix retry behavior in order creation

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -5,6 +5,7 @@
 22.5
 -----
 - [**] Improved local search algorithms in POS [https://github.com/woocommerce/woocommerce-android/pull/14068]
+- [*] Fix a rare dead-end in the order creation flow. [https://github.com/woocommerce/woocommerce-android/pull/14133]
 
 22.4
 -----

--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -1,11 +1,13 @@
 *** PLEASE FOLLOW THIS FORMAT: [<priority indicator, more stars = higher priority>] <description> [<PR URL>]
 *** Use [*****] to indicate smoke tests of all critical flows should be run on the final APK before release (e.g. major library or targetSdk updates).
 *** For entries which are touching the Android Wear app's, start entry with `[WEAR]` too.
+22.6
+-----
+- [*] Fix a rare dead-end in the order creation flow. [https://github.com/woocommerce/woocommerce-android/pull/14133]
 
 22.5
 -----
 - [**] Improved local search algorithms in POS [https://github.com/woocommerce/woocommerce-android/pull/14068]
-- [*] Fix a rare dead-end in the order creation flow. [https://github.com/woocommerce/woocommerce-android/pull/14133]
 
 22.4
 -----

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/OrderCreateEditFormFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/OrderCreateEditFormFragment.kt
@@ -1225,7 +1225,7 @@ class OrderCreateEditFormFragment :
             val orderUpdateFailureSnackBar = orderUpdateFailureSnackBar ?: uiMessageResolver.getIndefiniteActionSnack(
                 message = getString(R.string.order_sync_failed),
                 actionText = getString(R.string.retry),
-                actionListener = { viewModel.onRetryPaymentsClicked() }
+                actionListener = { viewModel.onRetryClicked() }
             ).also {
                 orderUpdateFailureSnackBar = it
             }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/OrderCreateEditFormFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/OrderCreateEditFormFragment.kt
@@ -31,6 +31,7 @@ import androidx.navigation.fragment.navArgs
 import androidx.recyclerview.widget.DefaultItemAnimator
 import androidx.recyclerview.widget.LinearLayoutManager
 import androidx.recyclerview.widget.RecyclerView
+import com.google.android.material.snackbar.BaseTransientBottomBar
 import com.google.android.material.snackbar.Snackbar
 import com.woocommerce.android.NavGraphMainDirections
 import com.woocommerce.android.R
@@ -1226,7 +1227,11 @@ class OrderCreateEditFormFragment :
                 message = getString(R.string.order_sync_failed),
                 actionText = getString(R.string.retry),
                 actionListener = { viewModel.onRetryClicked() }
-            ).also {
+            ).apply {
+                behavior = object : BaseTransientBottomBar.Behavior() {
+                    override fun canSwipeDismissView(child: View): Boolean = false
+                }
+            }.also {
                 orderUpdateFailureSnackBar = it
             }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/OrderCreateEditViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/OrderCreateEditViewModel.kt
@@ -1204,8 +1204,8 @@ class OrderCreateEditViewModel @Inject constructor(
         )
     }
 
-    fun onRetryPaymentsClicked() {
-        retryOrderDraftUpdateTrigger.tryEmit(Unit)
+    fun onRetryClicked() {
+            retryOrderDraftUpdateTrigger.tryEmit(Unit)
     }
 
     fun onFeeButtonClicked() {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/OrderCreateEditViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/OrderCreateEditViewModel.kt
@@ -1442,7 +1442,11 @@ class OrderCreateEditViewModel @Inject constructor(
                             viewState = viewState.copy(willUpdateOrderDraft = true, showOrderUpdateSnackbar = false)
 
                         OrderUpdateStatus.Ongoing ->
-                            viewState = viewState.copy(willUpdateOrderDraft = false, isUpdatingOrderDraft = true)
+                            viewState = viewState.copy(
+                                willUpdateOrderDraft = false,
+                                isUpdatingOrderDraft = true,
+                                showOrderUpdateSnackbar = false
+                            )
 
                         is OrderUpdateStatus.Failed -> {
                             if (updateStatus.isInvalidCouponFailure()) {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/OrderCreateEditViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/OrderCreateEditViewModel.kt
@@ -1205,7 +1205,7 @@ class OrderCreateEditViewModel @Inject constructor(
     }
 
     fun onRetryClicked() {
-            retryOrderDraftUpdateTrigger.tryEmit(Unit)
+        retryOrderDraftUpdateTrigger.tryEmit(Unit)
     }
 
     fun onFeeButtonClicked() {

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/creation/CreationFocusedOrderCreateEditViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/creation/CreationFocusedOrderCreateEditViewModelTest.kt
@@ -31,6 +31,7 @@ import com.woocommerce.android.model.Address
 import com.woocommerce.android.model.Order
 import com.woocommerce.android.ui.orders.CustomAmountUIModel
 import com.woocommerce.android.ui.orders.OrderNavigationTarget.ViewOrderStatusSelector
+import com.woocommerce.android.ui.orders.creation.CreateUpdateOrder.OrderUpdateStatus
 import com.woocommerce.android.ui.orders.creation.CreateUpdateOrder.OrderUpdateStatus.Failed
 import com.woocommerce.android.ui.orders.creation.CreateUpdateOrder.OrderUpdateStatus.Ongoing
 import com.woocommerce.android.ui.orders.creation.CreateUpdateOrder.OrderUpdateStatus.PendingDebounce
@@ -60,9 +61,11 @@ import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.ShowDialog
 import junit.framework.TestCase.assertTrue
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.test.StandardTestDispatcher
 import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.runTest
 import kotlinx.coroutines.test.setMain
 import org.assertj.core.api.Assertions.assertThat
 import org.assertj.core.api.Assertions.fail
@@ -1126,6 +1129,35 @@ class CreationFocusedOrderCreateEditViewModelTest : UnifiedOrderEditViewModelTes
     }
 
     @Test
+    fun `given order failed, when user retries, then adjust view state to reflect the loading`() = runTest {
+        val myFlow: MutableStateFlow<OrderUpdateStatus> =
+            MutableStateFlow(Failed(throwable = Throwable(message = "fail")))
+        createUpdateOrderUseCase = mock {
+            onBlocking { invoke(any(), any()) } doReturn myFlow
+        }
+
+        createSut()
+
+        var viewState: ViewState? = null
+
+        sut.viewStateData.observeForever { _, new ->
+            viewState = new
+        }
+
+        assertThat(viewState).isNotNull
+        assertThat(viewState?.willUpdateOrderDraft).isFalse
+        assertThat(viewState?.isUpdatingOrderDraft).isFalse
+        assertThat(viewState?.showOrderUpdateSnackbar).isTrue
+
+        myFlow.emit(Ongoing) // simulation of retry action
+        advanceUntilIdle()
+
+        assertThat(viewState?.willUpdateOrderDraft).isFalse
+        assertThat(viewState?.isUpdatingOrderDraft).isTrue
+        assertThat(viewState?.showOrderUpdateSnackbar).isFalse
+    }
+
+    @Test
     fun `when viewState is under the order draft sync state, then canCreateOrder must be false`() {
         var viewState = ViewState(
             willUpdateOrderDraft = true,
@@ -1564,7 +1596,7 @@ class CreationFocusedOrderCreateEditViewModelTest : UnifiedOrderEditViewModelTes
 
     @Test
     fun `when custom amount added, then disable the custom amount section until the operation is complete`() {
-        var viewState: MutableList<ViewState> = mutableListOf()
+        val viewState: MutableList<ViewState> = mutableListOf()
         sut.viewStateData.liveData.observeForever {
             viewState.add(it)
         }
@@ -1583,7 +1615,7 @@ class CreationFocusedOrderCreateEditViewModelTest : UnifiedOrderEditViewModelTes
 
     @Test
     fun `when custom amount added, then enable the custom amount section after the operation is complete`() {
-        var viewState: MutableList<ViewState> = mutableListOf()
+        val viewState: MutableList<ViewState> = mutableListOf()
         sut.viewStateData.liveData.observeForever {
             viewState.add(it)
         }
@@ -1899,7 +1931,7 @@ class CreationFocusedOrderCreateEditViewModelTest : UnifiedOrderEditViewModelTes
 
     @Test
     fun `when custom amount removed, then disable the custom amount section until the operation is complete`() {
-        var viewState: MutableList<ViewState> = mutableListOf()
+        val viewState: MutableList<ViewState> = mutableListOf()
         sut.viewStateData.liveData.observeForever {
             viewState.add(it)
         }
@@ -1925,7 +1957,7 @@ class CreationFocusedOrderCreateEditViewModelTest : UnifiedOrderEditViewModelTes
 
     @Test
     fun `when custom amount removed, then enable the custom amount section after the operation is complete`() {
-        var viewState: MutableList<ViewState> = mutableListOf()
+        val viewState: MutableList<ViewState> = mutableListOf()
         sut.viewStateData.liveData.observeForever {
             viewState.add(it)
         }


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

<!-- Id number of the Linear issue this PR addresses, e.g., WOOMOB-373. -->

WOOMOB-503

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

This PR allows users to retry the recalculate operation as many times as they need.

### Steps to reproduce
<!-- Step-by-step testing instructions. For new user flows, consider instead stating the goal of the workflow and see if your PR reviewer can accomplish the workflow without specific steps! -->

1. Open Order Creation
2. Select a product
3. Turn on airplane mode
4. Tap on Recalculate
5. Tap on Retry
6. Notice the button is disabled and the only way to recover is to start over

### Testing information
<!-- This is your opportunity to break out individual scenarios that need testing (when necessary) and/or include a checklist for the reviewer to go through. Consider documenting the following from your own completed testing: devices used, alternate workflows, edge cases, affected areas, critical flows, areas not tested, and any remaining unknowns. Provide feedback on this new section of the PR template through Sept 30, 2024 to Apps Quality; additional context here: p91TBi-b8z-p2#comment-12036 -->

1. Open Order Creation
2. Select a product
3. Turn on airplane mode
4. Tap on Recalculate
5. Tap on Retry
6. Notice the snackbar appears again when the operation fails
7. Tap on retry
8. Notice the snackbar appears again when the operation fails
9. Turn off airplane mode
10. Tap on retry
11. Notice the operation succeeds

### The tests that have been performed
<!-- To give the reviewer an idea of what could be missed in terms of testing -->

- The above. I also tested that if I select different products inbetween retries, the app forces me to use `Recalculate` again before I can proceed with the order.

### Images/gif
<!-- Include before and after images or gifs when appropriate. -->


https://github.com/user-attachments/assets/a5f7ac21-1a3a-4edf-a2eb-16a026f1386c



- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->