### PR TITLE
Issue/wooprd 552 woo posbarcodes implement scanning send the data to the cart

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/common/composeui/modifier/BarcodeScannerModifier.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/common/composeui/modifier/BarcodeScannerModifier.kt
@@ -43,12 +43,12 @@ fun Modifier.barcodeScanner(
                         onBarcodeScanned(scannedBarcode)
                         barcodeBuffer.clear()
                     }
+                    return@onKeyEvent true
                 } else if (pressedKey in ALLOWED_BARCODE_CHARS) {
                     barcodeBuffer.append(pressedKey)
+                    return@onKeyEvent true
                 }
-                true
-            } else {
-                false
             }
+            return@onKeyEvent false
         }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/common/composeui/modifier/BarcodeScannerModifier.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/common/composeui/modifier/BarcodeScannerModifier.kt
@@ -16,7 +16,7 @@ import androidx.compose.ui.input.key.utf16CodePoint
 private const val ALLOWED_BARCODE_CHARS =
     "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz-._~:/?#[]@!$&'()*+,;="
 
-fun Modifier.barcodeScanner(
+fun Modifier.listenForBarcodes(
     onBarcodeScanned: (String) -> Unit,
     enabled: Boolean = true
 ): Modifier = composed {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/common/composeui/modifier/BarcodeScannerModifier.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/common/composeui/modifier/BarcodeScannerModifier.kt
@@ -1,0 +1,54 @@
+package com.woocommerce.android.ui.woopos.common.composeui.modifier
+
+import androidx.compose.foundation.focusable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.composed
+import androidx.compose.ui.focus.FocusRequester
+import androidx.compose.ui.focus.focusRequester
+import androidx.compose.ui.input.key.KeyEventType
+import androidx.compose.ui.input.key.onKeyEvent
+import androidx.compose.ui.input.key.type
+import androidx.compose.ui.input.key.utf16CodePoint
+
+@Suppress("SpellCheckingInspection")
+private const val ALLOWED_BARCODE_CHARS =
+    "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz-._~:/?#[]@!$&'()*+,;="
+
+fun Modifier.barcodeScanner(
+    onBarcodeScanned: (String) -> Unit,
+    enabled: Boolean = true
+): Modifier = composed {
+    val focusRequester = remember { FocusRequester() }
+    val barcodeBuffer = remember { StringBuilder() }
+
+    LaunchedEffect(enabled) {
+        if (enabled) {
+            focusRequester.requestFocus()
+        }
+    }
+
+    this
+        .focusRequester(focusRequester)
+        .focusable(enabled)
+        .onKeyEvent { keyEvent ->
+            if (!enabled) return@onKeyEvent false
+
+            if (keyEvent.type == KeyEventType.KeyDown) {
+                val pressedKey = keyEvent.utf16CodePoint.toChar()
+                if (pressedKey == '\n' || pressedKey == '\r') {
+                    val scannedBarcode = barcodeBuffer.toString()
+                    if (scannedBarcode.isNotEmpty()) {
+                        onBarcodeScanned(scannedBarcode)
+                        barcodeBuffer.clear()
+                    }
+                } else if (pressedKey in ALLOWED_BARCODE_CHARS) {
+                    barcodeBuffer.append(pressedKey)
+                }
+                true
+            } else {
+                false
+            }
+        }
+}

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/common/data/WooPosGetProductByGtinOrSku.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/common/data/WooPosGetProductByGtinOrSku.kt
@@ -16,4 +16,3 @@ class WooPosGetProductByGtinOrSku @Inject constructor(
         throw NotImplementedError("Fetching product by GTIN is not implemented yet.")
     }
 }
-

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/common/data/WooPosGetProductByGtinOrSku.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/common/data/WooPosGetProductByGtinOrSku.kt
@@ -1,0 +1,19 @@
+package com.woocommerce.android.ui.woopos.common.data
+
+import com.woocommerce.android.model.Product
+import kotlinx.coroutines.Dispatchers.IO
+import kotlinx.coroutines.withContext
+import javax.inject.Inject
+
+class WooPosGetProductByGtinOrSku @Inject constructor(
+    private val cache: WooPosProductsCache,
+) {
+    suspend operator fun invoke(gtin: String): Product = withContext(IO) {
+        val cachedProduct = cache.getProductByGtin(gtin)
+        if (cachedProduct != null) {
+            return@withContext cachedProduct
+        }
+        throw NotImplementedError("Fetching product by GTIN is not implemented yet.")
+    }
+}
+

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/common/data/WooPosProductsCache.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/common/data/WooPosProductsCache.kt
@@ -13,6 +13,8 @@ interface WooPosProductsCache {
 
     suspend fun getProductById(productId: Long): Product?
 
+    suspend fun getProductByGtin(gtin: String): Product?
+
     suspend fun updateProduct(product: Product)
 
     suspend fun deleteProduct(productId: Long)

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/common/data/WooPosProductsInMemoryCache.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/common/data/WooPosProductsInMemoryCache.kt
@@ -40,6 +40,10 @@ class WooPosProductsInMemoryCache @Inject constructor() : WooPosProductsCache {
         return productsCache[productId]
     }
 
+    override suspend fun getProductByGtin(gtin: String): Product? {
+        return productsCache.values.find { it.globalUniqueId == gtin }
+    }
+
     override suspend fun clear() = mutex.withLock {
         productsCache.clear()
     }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/WooPosHomeChildToParentCommunication.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/WooPosHomeChildToParentCommunication.kt
@@ -48,6 +48,8 @@ sealed class ChildToParentEvent {
     data class ToastMessageDisplayed(val message: String) : ChildToParentEvent()
     data object RefreshProductList : ChildToParentEvent()
 
+    data class BarcodeScanned(val barcode: String) : ChildToParentEvent()
+
     sealed class NavigationEvent : ChildToParentEvent() {
         data class ToCashPayment(val orderId: Long) : NavigationEvent()
         data class ToEmailReceipt(val orderId: Long) : NavigationEvent()

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/WooPosHomeParentToChildCommunication.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/WooPosHomeParentToChildCommunication.kt
@@ -37,6 +37,8 @@ sealed class ParentToChildrenEvent {
         val itemClickedDataList: List<WooPosItemsViewModel.ItemClickedData>
     ) : ParentToChildrenEvent()
 
+    data class BarcodeScanned(val barcode: String) : ParentToChildrenEvent()
+
     data class OrderSuccessfullyPaid(val paymentMethod: PaymentMethod) : ParentToChildrenEvent() {
         enum class PaymentMethod {
             CARD,

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/WooPosHomeViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/WooPosHomeViewModel.kt
@@ -210,6 +210,10 @@ class WooPosHomeViewModel @Inject constructor(
                     ChildToParentEvent.RefreshProductList -> {
                         sendEventToChildren(ParentToChildrenEvent.RefreshProductList)
                     }
+
+                    is ChildToParentEvent.BarcodeScanned -> sendEventToChildren(
+                        ParentToChildrenEvent.BarcodeScanned(event.barcode)
+                    )
                 }
             }
         }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/cart/WooPosCartViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/cart/WooPosCartViewModel.kt
@@ -186,6 +186,10 @@ class WooPosCartViewModel @Inject constructor(
                     is ParentToChildrenEvent.RemoveCouponsClicked -> {
                         removeCouponsFromCart()
                     }
+
+                    is ParentToChildrenEvent.BarcodeScanned -> {
+                        onBarcodeScanned(event.barcode)
+                    }
                 }
             }
         }
@@ -315,6 +319,14 @@ class WooPosCartViewModel @Inject constructor(
 
     private fun clearCart() {
         _state.value = WooPosCartState()
+    }
+
+    private fun onBarcodeScanned(barcode: String) {
+        viewModelScope.launch {
+            val product = getProductByGtinOrSku.invoke(barcode)
+            val itemNumber = getItemNumber()
+            product.toCartListItem(itemNumber)
+        }
     }
 
     private fun getItemNumber(): Int {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/cart/WooPosCartViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/cart/WooPosCartViewModel.kt
@@ -324,6 +324,9 @@ class WooPosCartViewModel @Inject constructor(
     }
 
     private fun onBarcodeScanned(barcode: String) {
+        if (_state.value.cartStatus == CHECKOUT) {
+            return
+        }
         viewModelScope.launch {
             if (_state.value.body == WooPosCartState.Body.Empty) {
                 analyticsTracker.track(InteractionWithCustomerStarted)

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/cart/WooPosCartViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/cart/WooPosCartViewModel.kt
@@ -325,9 +325,16 @@ class WooPosCartViewModel @Inject constructor(
 
     private fun onBarcodeScanned(barcode: String) {
         viewModelScope.launch {
+            if (_state.value.body == WooPosCartState.Body.Empty) {
+                analyticsTracker.track(InteractionWithCustomerStarted)
+            }
+            // TBD display a loading state when searching for a product
             val product = getProductByGtinOrSku.invoke(barcode)
+            // TBD handle cases when the barcode is not found
+            // TBD handle cases when the product is a variation
             val itemNumber = getItemNumber()
-            product.toCartListItem(itemNumber)
+            val cartListItem = product.toCartListItem(itemNumber)
+            _state.value = updateStateWithNewItem(cartListItem)
         }
     }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/cart/WooPosCartViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/cart/WooPosCartViewModel.kt
@@ -10,6 +10,7 @@ import com.woocommerce.android.R
 import com.woocommerce.android.model.Product
 import com.woocommerce.android.model.ProductVariation
 import com.woocommerce.android.ui.woopos.common.data.WooPosGetCouponById
+import com.woocommerce.android.ui.woopos.common.data.WooPosGetProductByGtinOrSku
 import com.woocommerce.android.ui.woopos.common.data.WooPosGetProductById
 import com.woocommerce.android.ui.woopos.common.data.WooPosGetVariationById
 import com.woocommerce.android.ui.woopos.home.ChildToParentEvent
@@ -56,6 +57,7 @@ class WooPosCartViewModel @Inject constructor(
     private val analyticsTrackingDataKeeper: WooPosAnalyticsTrackingDataKeeper,
     private val updateCartItemsWithChanges: WooPosCartItemsUpdater,
     private val getCachedStoreCurrency: WooPosGetCachedStoreCurrency,
+    private val getProductByGtinOrSku: WooPosGetProductByGtinOrSku,
     savedState: SavedStateHandle,
 ) : ViewModel() {
     private val _state = savedState.getStateFlow(

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/cart/WooPosCartViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/cart/WooPosCartViewModel.kt
@@ -324,7 +324,7 @@ class WooPosCartViewModel @Inject constructor(
     }
 
     private fun onBarcodeScanned(barcode: String) {
-        if (_state.value.cartStatus == CHECKOUT) {
+        if (_state.value.cartStatus !in listOf(EDITABLE, EMPTY)) {
             return
         }
         viewModelScope.launch {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/items/WooPosItemsScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/items/WooPosItemsScreen.kt
@@ -22,6 +22,7 @@ import com.woocommerce.android.ui.woopos.common.composeui.component.WooPosSearch
 import com.woocommerce.android.ui.woopos.common.composeui.designsystem.WooPosSpacing
 import com.woocommerce.android.ui.woopos.common.composeui.designsystem.WooPosTheme
 import com.woocommerce.android.ui.woopos.common.composeui.designsystem.toAdaptivePadding
+import com.woocommerce.android.ui.woopos.common.composeui.modifier.barcodeScanner
 import com.woocommerce.android.ui.woopos.home.items.WooPosItemsToolbarViewState.Tab.Coupons
 import com.woocommerce.android.ui.woopos.home.items.WooPosItemsToolbarViewState.Tab.HighlightLevel
 import com.woocommerce.android.ui.woopos.home.items.WooPosItemsToolbarViewState.Tab.Products
@@ -84,6 +85,9 @@ private fun WooPosItemsScreen(
             onUIEvent(WooPosItemsUIEvent.AddCouponIconClicked)
         },
         onTabClicked = { onUIEvent(WooPosItemsUIEvent.OnTabClicked(it)) },
+        onBarcodeScanned = { barcode ->
+            onUIEvent(WooPosItemsUIEvent.BarcodeScanned(barcode))
+        },
         onBackClicked = { onUIEvent(WooPosItemsUIEvent.BackFromVariationsClicked) },
     )
 }
@@ -98,11 +102,16 @@ private fun MainItemsList(
     onSearchEvent: (WooPosSearchUIEvent) -> Unit,
     onTabClicked: (WooPosItemsToolbarViewState.Tab) -> Unit,
     onAddCouponEvent: () -> Unit,
+    onBarcodeScanned: (String) -> Unit,
     onBackClicked: () -> Unit,
 ) {
     Box(
         modifier = modifier
             .fillMaxSize()
+            .barcodeScanner(
+                enabled = state.value.barcodeScanningEnabled,
+                onBarcodeScanned = onBarcodeScanned
+            )
     ) {
         Column(
             modifier.fillMaxHeight()

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/items/WooPosItemsScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/items/WooPosItemsScreen.kt
@@ -22,7 +22,7 @@ import com.woocommerce.android.ui.woopos.common.composeui.component.WooPosSearch
 import com.woocommerce.android.ui.woopos.common.composeui.designsystem.WooPosSpacing
 import com.woocommerce.android.ui.woopos.common.composeui.designsystem.WooPosTheme
 import com.woocommerce.android.ui.woopos.common.composeui.designsystem.toAdaptivePadding
-import com.woocommerce.android.ui.woopos.common.composeui.modifier.barcodeScanner
+import com.woocommerce.android.ui.woopos.common.composeui.modifier.listenForBarcodes
 import com.woocommerce.android.ui.woopos.home.items.WooPosItemsToolbarViewState.Tab.Coupons
 import com.woocommerce.android.ui.woopos.home.items.WooPosItemsToolbarViewState.Tab.HighlightLevel
 import com.woocommerce.android.ui.woopos.home.items.WooPosItemsToolbarViewState.Tab.Products
@@ -108,7 +108,7 @@ private fun MainItemsList(
     Box(
         modifier = modifier
             .fillMaxSize()
-            .barcodeScanner(
+            .listenForBarcodes(
                 enabled = state.value.barcodeScanningEnabled,
                 onBarcodeScanned = onBarcodeScanned
             )

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/items/WooPosItemsSearchHelper.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/items/WooPosItemsSearchHelper.kt
@@ -68,6 +68,7 @@ class WooPosItemsSearchHelper @Inject constructor(
                     is ParentToChildrenEvent.CouponsRemoved -> Unit
                     is ParentToChildrenEvent.RemoveCouponsClicked -> Unit
                     is ParentToChildrenEvent.CouponsValidationFailed -> Unit
+                    is ParentToChildrenEvent.BarcodeScanned -> Unit
                 }
             }
         }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/items/WooPosItemsToolbarViewState.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/items/WooPosItemsToolbarViewState.kt
@@ -2,11 +2,13 @@ package com.woocommerce.android.ui.woopos.home.items
 
 import com.woocommerce.android.ui.woopos.common.composeui.component.WooPosSearchInputState
 import com.woocommerce.android.ui.woopos.home.items.variations.WooPosVariationsNavigationData
+import com.woocommerce.android.util.FeatureFlag
 
 sealed class WooPosItemsToolbarViewState(
     open val tabs: List<Tab>,
     open val search: SearchState,
     open val backNavigation: Boolean = false,
+    open val barcodeScanningEnabled: Boolean = FeatureFlag.WOO_POS_BARCODES_SCANNING.isEnabled(),
 ) {
     data class ProductList(
         override val tabs: List<Tab>,

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/items/WooPosItemsUIEvent.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/items/WooPosItemsUIEvent.kt
@@ -12,4 +12,5 @@ sealed class WooPosItemsUIEvent {
     data object CloseSearchClicked : WooPosItemsUIEvent()
     data object SearchIconClicked : WooPosItemsUIEvent()
     data object AddCouponIconClicked : WooPosItemsUIEvent()
+    data class BarcodeScanned(val barcode: String) : WooPosItemsUIEvent()
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/items/WooPosItemsViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/items/WooPosItemsViewModel.kt
@@ -71,6 +71,9 @@ class WooPosItemsViewModel @Inject constructor(
             }
 
             is WooPosItemsUIEvent.AddCouponIconClicked -> createAndAddCoupon()
+            is WooPosItemsUIEvent.BarcodeScanned -> {
+                handleBarcodeScannedEvent(event)
+            }
         }
     }
 
@@ -88,6 +91,7 @@ class WooPosItemsViewModel @Inject constructor(
                     is ParentToChildrenEvent.SearchEvent.ChangedQuery,
                     ParentToChildrenEvent.SearchEvent.Finished,
                     is ParentToChildrenEvent.SearchEvent.RecentSearchSelected,
+                    is ParentToChildrenEvent.BarcodeScanned,
                     ParentToChildrenEvent.SearchEvent.Started -> Unit
 
                     is ParentToChildrenEvent.OrderSuccessfullyPaid -> _viewState.value = initialState()
@@ -208,6 +212,12 @@ class WooPosItemsViewModel @Inject constructor(
                     )
                 )
             }
+        }
+    }
+
+    private fun handleBarcodeScannedEvent(event: WooPosItemsUIEvent.BarcodeScanned) {
+        viewModelScope.launch {
+            fromChildToParentEventSender.sendToParent(ChildToParentEvent.BarcodeScanned(event.barcode))
         }
     }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/items/products/WooPosProductsViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/items/products/WooPosProductsViewModel.kt
@@ -80,7 +80,8 @@ class WooPosProductsViewModel @Inject constructor(
                     is ParentToChildrenEvent.SearchEvent.ChangedQuery,
                     ParentToChildrenEvent.SearchEvent.Finished,
                     is ParentToChildrenEvent.SearchEvent.RecentSearchSelected,
-                    ParentToChildrenEvent.SearchEvent.Started -> Unit
+                    ParentToChildrenEvent.SearchEvent.Started,
+                    is ParentToChildrenEvent.BarcodeScanned -> Unit
                 }
             }
         }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/items/search/WooPosItemsSearchViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/items/search/WooPosItemsSearchViewModel.kt
@@ -193,6 +193,7 @@ class WooPosItemsSearchViewModel @Inject constructor(
                     is ParentToChildrenEvent.CouponsRemoved -> Unit
                     is ParentToChildrenEvent.RefreshProductList -> Unit
                     is ParentToChildrenEvent.CouponsValidationFailed -> Unit
+                    is ParentToChildrenEvent.BarcodeScanned -> Unit
                     is ParentToChildrenEvent.ItemClickedInItemsList -> {
                         if (event.itemData is ItemClickedData.Product.Variation && searchHelper.isSearchOpen()) {
                             storeRecentSearch()

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/totals/WooPosTotalsViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/totals/WooPosTotalsViewModel.kt
@@ -320,7 +320,8 @@ class WooPosTotalsViewModel @Inject constructor(
                     ParentToChildrenEvent.SearchEvent.Started,
                     ParentToChildrenEvent.RemoveCouponsClicked,
                     ParentToChildrenEvent.RefreshProductList,
-                    ParentToChildrenEvent.CouponsValidationFailed -> Unit
+                    ParentToChildrenEvent.CouponsValidationFailed,
+                    is ParentToChildrenEvent.BarcodeScanned -> Unit
                 }
             }
         }

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/common/data/WooPosGetProductByGtinOrSkuTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/common/data/WooPosGetProductByGtinOrSkuTest.kt
@@ -1,0 +1,49 @@
+package com.woocommerce.android.ui.woopos.common.data
+
+import com.woocommerce.android.model.Product
+import com.woocommerce.android.ui.woopos.util.WooPosCoroutineTestRule
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.runTest
+import org.junit.Rule
+import org.junit.Test
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.whenever
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class WooPosGetProductByGtinOrSkuTest {
+
+    @Rule
+    @JvmField
+    val coroutinesTestRule = WooPosCoroutineTestRule()
+
+    private val productsCache: WooPosProductsCache = mock()
+    private val getProductByGtinOrSku = WooPosGetProductByGtinOrSku(productsCache)
+
+    @Test
+    fun `when product exists in cache, then return it`() = runTest {
+        // GIVEN
+        val gtin = "123456789"
+        val expectedProduct: Product = mock()
+        whenever(productsCache.getProductByGtin(gtin)).thenReturn(expectedProduct)
+
+        // WHEN
+        val result = getProductByGtinOrSku(gtin)
+
+        // THEN
+        assertEquals(expectedProduct, result)
+    }
+
+    @Test
+    fun `when product does not exist in cache, then throw not implemented error`() = runTest {
+        // GIVEN
+        val gtin = "123456789"
+        whenever(productsCache.getProductByGtin(gtin)).thenReturn(null)
+
+        // WHEN/THEN
+        assertFailsWith<NotImplementedError> {
+            getProductByGtinOrSku(gtin)
+        }
+    }
+}

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/home/WooPosHomeViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/home/WooPosHomeViewModelTest.kt
@@ -59,6 +59,26 @@ class WooPosHomeViewModelTest {
         }
 
     @Test
+    fun `when barcode scanned, then pass event to children`() =
+        runTest {
+            // GIVEN
+            whenever(childrenToParentEventReceiver.events).thenReturn(
+                flowOf(ChildToParentEvent.BarcodeScanned("123456789"))
+            )
+
+            // WHEN
+            createViewModel()
+
+            // THEN
+            verify(parentToChildrenEventSender).sendToChildren(
+                argThat {
+                    this is ParentToChildrenEvent.BarcodeScanned &&
+                        barcode == "123456789"
+                }
+            )
+        }
+
+    @Test
     fun `given state checkout, when SystemBackClicked passed, then BackFromCheckoutToCartClicked event should be sent`() =
         runTest {
             // GIVEN

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/home/cart/WooPosCartViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/home/cart/WooPosCartViewModelTest.kt
@@ -6,6 +6,7 @@ import com.woocommerce.android.R
 import com.woocommerce.android.model.Coupon
 import com.woocommerce.android.ui.products.ProductTestUtils
 import com.woocommerce.android.ui.woopos.common.data.WooPosGetCouponById
+import com.woocommerce.android.ui.woopos.common.data.WooPosGetProductByGtinOrSku
 import com.woocommerce.android.ui.woopos.common.data.WooPosGetProductById
 import com.woocommerce.android.ui.woopos.common.data.WooPosGetVariationById
 import com.woocommerce.android.ui.woopos.home.ChildToParentEvent
@@ -99,6 +100,7 @@ class WooPosCartViewModelTest {
     private val savedState: SavedStateHandle = SavedStateHandle()
     private val trackerData: WooPosAnalyticsTrackingDataKeeper = WooPosAnalyticsTrackingDataKeeper()
     private val cartItemsUpdater: WooPosCartItemsUpdater = mock()
+    private val getProductByGtinOrSku: WooPosGetProductByGtinOrSku = mock()
 
     @Test
     fun `given empty cart, when product clicked in product selector, then should add product to cart`() = runTest {
@@ -1056,6 +1058,7 @@ class WooPosCartViewModelTest {
             trackerData,
             cartItemsUpdater,
             getCachedStoreCurrency,
+            getProductByGtinOrSku,
             savedState
         )
     }

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/home/items/WooPosItemsViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/home/items/WooPosItemsViewModelTest.kt
@@ -405,6 +405,22 @@ class WooPosItemsViewModelTest {
         }
     }
 
+    @Test
+    fun `when barcode scanned, then event passed to parent`() = runTest {
+        // GIVEN
+        val viewModel = createViewModel()
+
+        // WHEN
+        viewModel.onUIEvent(WooPosItemsUIEvent.BarcodeScanned("1234567890"))
+
+        // THEN
+        verify(fromChildToParentEventSender).sendToParent(
+            eq(
+                ChildToParentEvent.BarcodeScanned("1234567890")
+            )
+        )
+    }
+
     private fun createViewModel() =
         WooPosItemsViewModel(
             searchHelper,

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/home/items/WooPosItemsViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/home/items/WooPosItemsViewModelTest.kt
@@ -405,7 +405,6 @@ class WooPosItemsViewModelTest {
         }
     }
 
-
     @Test
     fun `when barcode scanned, then event passed to parent`() = runTest {
         // GIVEN


### PR DESCRIPTION
<!-- Remember about a good descriptive title. --->

<!-- Id number of the Linear issue this PR addresses, e.g., WOOMOB-373. -->
WOOMOB-552

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

This PR adds a naive implementation of barcode scanner support to the POS. 

It adds a custom modifier to PosItemsScreen that listens for keyboard inputs and passes them back to the ItemsVM when the input ends with `\n or \r`. Better detection of barcode inputs will be implemented in a separate task.

The ItemsVM passes the scanned barcode to HomeVM which passes it to CartVM. The CartVM takes care of searching the item and adding it into the cart.

The implementation in the CartVM is naive too
- Works only if the product is in the cache.
- Doesn't display any loading indicator when the search is in progress

Proper implementation will be implemented as part of a different task.

---------------

I considered listening for the key inputs in the WooPosActivity instead of adding the custom modifier. I like that the modifier is closer to the state/screen when we want to enable barcode scanning. However, I'm a bit worried it might cause troubles with TalkBack - we'll see, moving it to the Activity will be pretty simple if needed.


### Testing information
<!-- This is your opportunity to break out individual scenarios that need testing (when necessary) and/or include a checklist for the reviewer to go through. Consider documenting the following from your own completed testing: devices used, alternate workflows, edge cases, affected areas, critical flows, areas not tested, and any remaining unknowns. Provide feedback on this new section of the PR template through Sept 30, 2024 to Apps Quality; additional context here: p91TBi-b8z-p2#comment-12036 -->

1. Open POS.
2. Scan a barcode - make sure the barcode is assigned as GTIN on one of the products in the cache.
3. Notice the item is added to the cart.
4. Open search.
5. Notice a software keyboard is visible or the OS displays a button to display it.
6. Check that you can search for items - scanning at this moment, enters the code into the search field instead of automatically adding the product into the cart as long as the search input has focus. I think this behavior is fine and might be even desired, especially considering we can't reliable differentiate between barcode scanner and keyboard. Wdyt?

### The tests that have been performed
<!-- To give the reviewer an idea of what could be missed in terms of testing -->

I also tested
- scanning is disabled on checkout
- scanning is disabled when the FF is off
- back gesture/button works as expected

### Images/gif
<!-- Include before and after images or gifs when appropriate. -->

https://github.com/user-attachments/assets/c86b3a96-ee16-45bc-85ac-5a6288923820

- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->