### PR TITLE
[WOOPRD-553][Woo POS][Barcodes] Implement UI states for scanned items in the cart

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/common/composeui/component/WooPosRecentSearchesChips.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/common/composeui/component/WooPosRecentSearchesChips.kt
@@ -23,7 +23,7 @@ import com.woocommerce.android.ui.woopos.common.composeui.designsystem.WooPosTyp
 import com.woocommerce.android.ui.woopos.common.composeui.designsystem.toAdaptivePadding
 
 @Composable
-fun RecentSearchesChips(
+fun WooPosRecentSearchesChips(
     recentSearches: List<String>,
     onRecentSearchClicked: (String) -> Unit,
 ) {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/cart/WooPosBarcodeLoadingSimulator.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/cart/WooPosBarcodeLoadingSimulator.kt
@@ -39,10 +39,12 @@ class WooPosBarcodeLoadingSimulator @Inject constructor(
                     }
 
                     is WooPosCartState.Body.WithItems -> {
-                        currentBody.itemsInCart + WooPosCartItemViewState.Loading(
-                            itemNumber = itemNumber,
-                            name = loadingItemName
-                        )
+                        listOf(
+                            WooPosCartItemViewState.Loading(
+                                itemNumber = itemNumber,
+                                name = loadingItemName
+                            )
+                        ) + currentBody.itemsInCart
                     }
                 }
                 currentState.copy(

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/cart/WooPosBarcodeLoadingSimulator.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/cart/WooPosBarcodeLoadingSimulator.kt
@@ -15,6 +15,7 @@ class WooPosBarcodeLoadingSimulator @Inject constructor(
 ) {
     private val itemNumberCounter = AtomicInteger(1000)
 
+    @Suppress("MagicNumber", "LongMethod")
     fun maybeSimulateLoadingItem(
         state: MutableStateFlow<WooPosCartState>,
         scope: CoroutineScope
@@ -29,11 +30,14 @@ class WooPosBarcodeLoadingSimulator @Inject constructor(
                 val currentBody = currentState.body
                 val newItems = when (currentBody) {
                     is WooPosCartState.Body.Empty -> {
-                        listOf(WooPosCartItemViewState.Loading(
-                            itemNumber = itemNumber,
-                            name = loadingItemName
-                        ))
+                        listOf(
+                            WooPosCartItemViewState.Loading(
+                                itemNumber = itemNumber,
+                                name = loadingItemName
+                            )
+                        )
                     }
+
                     is WooPosCartState.Body.WithItems -> {
                         currentBody.itemsInCart + WooPosCartItemViewState.Loading(
                             itemNumber = itemNumber,

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/cart/WooPosBarcodeLoadingSimulator.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/cart/WooPosBarcodeLoadingSimulator.kt
@@ -1,0 +1,96 @@
+package com.woocommerce.android.ui.woopos.home.cart
+
+import com.woocommerce.android.ui.woopos.featureflags.WooPosIsBarcodesScanningFeatureFlagEnabled
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.launch
+import java.util.concurrent.atomic.AtomicInteger
+import javax.inject.Inject
+import kotlin.random.Random
+
+class WooPosBarcodeLoadingSimulator @Inject constructor(
+    private val scanningFeatureFlagEnabled: WooPosIsBarcodesScanningFeatureFlagEnabled
+) {
+    private val itemNumberCounter = AtomicInteger(1000)
+
+    fun maybeSimulateLoadingItem(
+        state: MutableStateFlow<WooPosCartState>,
+        scope: CoroutineScope
+    ) {
+        if (!scanningFeatureFlagEnabled()) return
+
+        if (Random.nextBoolean()) {
+            val itemNumber = itemNumberCounter.getAndIncrement()
+            val loadingItemName = "00${Random.nextInt(10000000, 99999999)}${Random.nextInt(10000, 99999)}"
+
+            state.update { currentState ->
+                val currentBody = currentState.body
+                val newItems = when (currentBody) {
+                    is WooPosCartState.Body.Empty -> {
+                        listOf(WooPosCartItemViewState.Loading(
+                            itemNumber = itemNumber,
+                            name = loadingItemName
+                        ))
+                    }
+                    is WooPosCartState.Body.WithItems -> {
+                        currentBody.itemsInCart + WooPosCartItemViewState.Loading(
+                            itemNumber = itemNumber,
+                            name = loadingItemName
+                        )
+                    }
+                }
+                currentState.copy(
+                    body = WooPosCartState.Body.WithItems(newItems)
+                )
+            }
+
+            scope.launch {
+                delay(3000)
+
+                state.update { currentState ->
+                    val body = currentState.body
+                    if (body is WooPosCartState.Body.WithItems) {
+                        val updatedItems = body.itemsInCart.map { item ->
+                            if (item is WooPosCartItemViewState.Loading && item.itemNumber == itemNumber) {
+                                WooPosCartItemViewState.Error(
+                                    itemNumber = item.itemNumber,
+                                    name = item.name,
+                                    message = "Product not found"
+                                )
+                            } else {
+                                item
+                            }
+                        }
+                        currentState.copy(
+                            body = WooPosCartState.Body.WithItems(updatedItems)
+                        )
+                    } else {
+                        currentState
+                    }
+                }
+
+                delay(3000)
+
+                state.update { currentState ->
+                    val body = currentState.body
+                    if (body is WooPosCartState.Body.WithItems) {
+                        val remainingItems = body.itemsInCart.filter { item ->
+                            !(item is WooPosCartItemViewState.Error && item.itemNumber == itemNumber)
+                        }
+                        if (remainingItems.isEmpty()) {
+                            currentState.copy(body = WooPosCartState.Body.Empty)
+                        } else {
+                            currentState.copy(
+                                body = WooPosCartState.Body.WithItems(remainingItems)
+                            )
+                        }
+                    } else {
+                        currentState
+                    }
+                }
+            }
+        }
+    }
+}

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/cart/WooPosCartItemsUpdater.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/cart/WooPosCartItemsUpdater.kt
@@ -65,6 +65,9 @@ class WooPosCartItemsUpdater @Inject constructor(
                     couponsChanged = true
                     mutableCurrentBodyList[index] = updateCouponsWithFormattedDiscount(updatedCoupons, item)
                 }
+
+                is WooPosCartItemViewState.Error -> error("unsupported item $item")
+                is WooPosCartItemViewState.Loading -> error("unsupported item $item")
             }
         }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/cart/WooPosCartItemsUpdater.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/cart/WooPosCartItemsUpdater.kt
@@ -29,36 +29,9 @@ class WooPosCartItemsUpdater @Inject constructor(
         itemsInCart.forEachIndexed { index, item ->
             when (item) {
                 is WooPosCartItemViewState.Product -> {
-                    val productKey = getProductKey(item)
-                    val availableQuantity = availableProductsMap[productKey] ?: 0
-
-                    if (availableQuantity > 0) {
-                        availableProductsMap[productKey] = availableQuantity - 1
-                        val updatedProduct = findMatchingProduct(item, updatedProducts)
-
-                        updatedProduct?.let {
-                            val updatedItem = updateProductWithNewInfo(item, it)
-                            val itemChanged = updatedItem.name != item.name || updatedItem.price != item.price
-
-                            if (itemChanged) {
-                                updateProductInCache(updatedItem, updatedProduct)
-                            }
-
-                            mutableCurrentBodyList[index] = updatedItem
-                            productsChanged = productsChanged || itemChanged
-                        }
-                    } else {
-                        val updatedItem = markProductAsNotExisting(item)
-                        mutableCurrentBodyList[index] = updatedItem
-                        val itemChanged = updatedItem.name != item.name ||
-                            updatedItem.price != item.price ||
-                            updatedItem.productDoesNotExist != item.productDoesNotExist
-
-                        if (itemChanged) {
-                            deleteProductFromCache(updatedItem.id)
-                        }
-                        productsChanged = productsChanged || itemChanged
-                    }
+                    val result = processProduct(item, availableProductsMap, updatedProducts)
+                    mutableCurrentBodyList[index] = result.updatedItem
+                    productsChanged = productsChanged || result.changed
                 }
 
                 is WooPosCartItemViewState.Coupon -> {
@@ -76,6 +49,49 @@ class WooPosCartItemsUpdater @Inject constructor(
             productsChanged = productsChanged,
             couponsChanged = couponsChanged,
         )
+    }
+
+    private suspend fun processProduct(
+        item: WooPosCartItemViewState.Product,
+        availableProductsMap: MutableMap<String, Int>,
+        updatedProducts: List<ParentToChildrenEvent.OrderCreated.ProductInfo>
+    ): ProductProcessResult {
+        val productKey = getProductKey(item)
+        val availableQuantity = availableProductsMap[productKey] ?: 0
+        var changed = false
+
+        val updatedItem = if (availableQuantity > 0) {
+            availableProductsMap[productKey] = availableQuantity - 1
+            val updatedProduct = findMatchingProduct(item, updatedProducts)
+
+            if (updatedProduct != null) {
+                val newItem = updateProductWithNewInfo(item, updatedProduct)
+                val itemChanged = newItem.name != item.name || newItem.price != item.price
+
+                if (itemChanged) {
+                    updateProductInCache(newItem, updatedProduct)
+                }
+
+                changed = itemChanged
+                newItem
+            } else {
+                item
+            }
+        } else {
+            val newItem = markProductAsNotExisting(item)
+            val itemChanged = newItem.name != item.name ||
+                newItem.price != item.price ||
+                newItem.productDoesNotExist != item.productDoesNotExist
+
+            if (itemChanged) {
+                deleteProductFromCache(newItem.id)
+            }
+
+            changed = itemChanged
+            newItem
+        }
+
+        return ProductProcessResult(updatedItem, changed)
     }
 
     private suspend fun updateCouponsWithFormattedDiscount(
@@ -196,5 +212,10 @@ class WooPosCartItemsUpdater @Inject constructor(
         val updatedItems: List<WooPosCartItemViewState>,
         val productsChanged: Boolean,
         val couponsChanged: Boolean,
+    )
+
+    private data class ProductProcessResult(
+        val updatedItem: WooPosCartItemViewState.Product,
+        val changed: Boolean
     )
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/cart/WooPosCartScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/cart/WooPosCartScreen.kt
@@ -76,6 +76,7 @@ import com.woocommerce.android.ui.woopos.common.composeui.component.WooPosButton
 import com.woocommerce.android.ui.woopos.common.composeui.component.WooPosCard
 import com.woocommerce.android.ui.woopos.common.composeui.component.WooPosLazyColumn
 import com.woocommerce.android.ui.woopos.common.composeui.component.WooPosOutlinedButtonSmall
+import com.woocommerce.android.ui.woopos.common.composeui.component.WooPosShimmerBox
 import com.woocommerce.android.ui.woopos.common.composeui.component.WooPosText
 import com.woocommerce.android.ui.woopos.common.composeui.designsystem.WooPosCornerRadius
 import com.woocommerce.android.ui.woopos.common.composeui.designsystem.WooPosElevation
@@ -258,6 +259,9 @@ private fun CartBodyWithItems(
                     canRemoveItems = areItemsRemovable,
                     onUIEvent = onUIEvent,
                 )
+
+                is WooPosCartItemViewState.Error -> TODO()
+                is WooPosCartItemViewState.Loading -> LoadingItem(item)
             }
         }
         item {
@@ -637,6 +641,76 @@ private fun CouponItem(
 }
 
 @Composable
+private fun LoadingItem(
+    item: WooPosCartItemViewState.Loading,
+    modifier: Modifier = Modifier
+) {
+    var itemContentDescription = stringResource(
+        id = R.string.woopos_cart_item_loading_content_description,
+        item.name
+    )
+    WooPosCard(
+        modifier = modifier
+            .height(96.dp)
+            .semantics { contentDescription = itemContentDescription },
+        backgroundColor = MaterialTheme.colorScheme.surfaceContainerLowest,
+        elevation = WooPosElevation.Medium,
+        shadowType = ShadowType.Soft,
+        shape = RoundedCornerShape(WooPosCornerRadius.Medium.value),
+    ) {
+        Row(
+            horizontalArrangement = Arrangement.SpaceBetween,
+            verticalAlignment = Alignment.CenterVertically
+        ) {
+            Box(
+                modifier = Modifier
+                    .size(96.dp)
+            ) {
+                WooPosShimmerBox(
+                    modifier = Modifier.fillMaxSize()
+                )
+            }
+
+            Spacer(modifier = Modifier.width(WooPosSpacing.Medium.value.toAdaptivePadding()))
+
+            Column(
+                modifier = Modifier
+                    .weight(1f)
+                    .padding(end = WooPosSpacing.Medium.value.toAdaptivePadding())
+            ) {
+                WooPosText(
+                    text = item.name,
+                    maxLines = 1,
+                    style = WooPosTypography.BodySmall,
+                    fontWeight = FontWeight.Bold,
+                    overflow = TextOverflow.Ellipsis,
+                    color = MaterialTheme.colorScheme.onSurface,
+                    modifier = Modifier.clearAndSetSemantics { }
+                )
+
+                Spacer(modifier = Modifier.height(WooPosSpacing.XSmall.value.toAdaptivePadding()))
+
+                WooPosShimmerBox(
+                    modifier = Modifier
+                        .height(14.dp)
+                        .fillMaxWidth(0.9f)
+                )
+
+                Spacer(modifier = Modifier.height(WooPosSpacing.XSmall.value.toAdaptivePadding()))
+
+                WooPosShimmerBox(
+                    modifier = Modifier
+                        .height(14.dp)
+                        .fillMaxWidth(0.4f)
+                )
+            }
+
+            Spacer(modifier = Modifier.width(WooPosSpacing.Medium.value.toAdaptivePadding()))
+        }
+    }
+}
+
+@Composable
 private fun RemoveItemFromCartButton(
     item: WooPosCartItemViewState,
     onUIEvent: (WooPosCartUIEvent) -> Unit
@@ -803,6 +877,37 @@ fun WooPosCartScreenEmptyPreview(modifier: Modifier = Modifier) {
                 body = WooPosCartState.Body.Empty,
                 areItemsRemovable = false,
                 isCheckoutButtonVisible = false
+            )
+        ) {}
+    }
+}
+
+@Composable
+@WooPosPreview
+fun WooPosCartScreenLoadingPreview(modifier: Modifier = Modifier) {
+    WooPosTheme {
+        WooPosCartScreen(
+            modifier = modifier,
+            state = WooPosCartState(
+                toolbar = WooPosCartState.Toolbar(
+                    backIconVisible = false,
+                    itemsCount = "3 items",
+                    isClearAllButtonVisible = true
+                ),
+                body = WooPosCartState.Body.WithItems(
+                    itemsInCart = listOf(
+                        WooPosCartItemViewState.Loading(
+                            itemNumber = 1,
+                            name = "VW California"
+                        ),
+                        WooPosCartItemViewState.Loading(
+                            itemNumber = 2,
+                            name = "ADAXS1313XDVZX"
+                        )
+                    )
+                ),
+                areItemsRemovable = false,
+                isCheckoutButtonVisible = true
             )
         ) {}
     }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/cart/WooPosCartScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/cart/WooPosCartScreen.kt
@@ -33,6 +33,7 @@ import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material.icons.outlined.Delete
+import androidx.compose.material.icons.outlined.Inventory2
 import androidx.compose.material.icons.outlined.LocalOffer
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
@@ -51,7 +52,6 @@ import androidx.compose.ui.graphics.ColorFilter
 import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.platform.LocalContext
-import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.res.vectorResource
 import androidx.compose.ui.semantics.clearAndSetSemantics
@@ -260,8 +260,14 @@ private fun CartBodyWithItems(
                     onUIEvent = onUIEvent,
                 )
 
-                is WooPosCartItemViewState.Error -> TODO()
-                is WooPosCartItemViewState.Loading -> LoadingItem(item)
+                is WooPosCartItemViewState.Error -> ErrorItem(
+                    modifier = Modifier.animateItem(),
+                    item = item,
+                )
+                is WooPosCartItemViewState.Loading -> LoadingItem(
+                    modifier = Modifier.animateItem(),
+                    item = item,
+                )
             }
         }
         item {
@@ -445,7 +451,7 @@ private fun ProductItem(
 
                 if (isNotLoaded) {
                     Image(
-                        painter = painterResource(R.drawable.ic_box),
+                        imageVector = Icons.Outlined.Inventory2,
                         contentDescription = null,
                         colorFilter = if (item.productDoesNotExist) {
                             ColorFilter.tint(WooPosTheme.colors.onSurfaceVariantLowest)
@@ -575,7 +581,7 @@ private fun CouponItem(
                             is CouponValidationState.Valid -> WooPosTheme.colors.onSuccess
                         }
                     ),
-                    modifier = Modifier.size(36.dp, 36.dp)
+                    modifier = Modifier.size(36.dp)
                 )
             }
 
@@ -642,8 +648,8 @@ private fun CouponItem(
 
 @Composable
 private fun LoadingItem(
+    modifier: Modifier = Modifier,
     item: WooPosCartItemViewState.Loading,
-    modifier: Modifier = Modifier
 ) {
     val itemContentDescription = stringResource(
         id = R.string.woopos_cart_item_loading_content_description,
@@ -706,6 +712,82 @@ private fun LoadingItem(
             }
 
             Spacer(modifier = Modifier.width(WooPosSpacing.Medium.value.toAdaptivePadding()))
+        }
+    }
+}
+
+@Composable
+private fun ErrorItem(
+    modifier: Modifier = Modifier,
+    item: WooPosCartItemViewState.Error,
+) {
+    val itemContentDescription = stringResource(
+        id = R.string.woopos_cart_item_error_content_description,
+        item.name
+    )
+
+    WooPosCard(
+        modifier = modifier
+            .wrapContentHeight()
+            .semantics { contentDescription = itemContentDescription },
+        backgroundColor = MaterialTheme.colorScheme.surfaceContainerLowest,
+        elevation = WooPosElevation.Medium,
+        shadowType = ShadowType.Soft,
+        shape = RoundedCornerShape(WooPosCornerRadius.Medium.value),
+    ) {
+        Row(
+            modifier = Modifier.height(IntrinsicSize.Min),
+            horizontalArrangement = Arrangement.SpaceBetween,
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+            Box(
+                modifier = Modifier
+                    .background(MaterialTheme.colorScheme.error)
+                    .width(96.dp)
+                    .fillMaxHeight()
+                    .heightIn(min = 96.dp),
+                contentAlignment = Alignment.Center
+            ) {
+                Image(
+                    imageVector = Icons.Outlined.Inventory2,
+                    contentDescription = null,
+                    colorFilter = ColorFilter.tint(MaterialTheme.colorScheme.onError),
+                    modifier = Modifier.size(36.dp)
+                )
+            }
+
+            Spacer(modifier = Modifier.width(WooPosSpacing.Medium.value.toAdaptivePadding()))
+
+            Column(
+                modifier = Modifier
+                    .weight(1f)
+                    .padding(end = WooPosSpacing.Medium.value.toAdaptivePadding())
+                    .padding(vertical = WooPosSpacing.Medium.value.toAdaptivePadding())
+            ) {
+                WooPosText(
+                    text = item.name,
+                    maxLines = 1,
+                    style = WooPosTypography.BodySmall,
+                    fontWeight = FontWeight.Bold,
+                    overflow = TextOverflow.Ellipsis,
+                    color = MaterialTheme.colorScheme.onSurface,
+                    modifier = Modifier.clearAndSetSemantics { }
+                )
+
+                Spacer(modifier = Modifier.height(WooPosSpacing.XSmall.value.toAdaptivePadding()))
+
+                WooPosText(
+                    text = item.message,
+                    style = WooPosTypography.BodySmall,
+                    fontWeight = FontWeight.Medium,
+                    color = MaterialTheme.colorScheme.error,
+                    maxLines = 2,
+                    overflow = TextOverflow.Ellipsis,
+                    modifier = Modifier.clearAndSetSemantics { }
+                )
+            }
+
+            Spacer(modifier = Modifier.width(WooPosSpacing.Small.value.toAdaptivePadding()))
         }
     }
 }
@@ -884,7 +966,7 @@ fun WooPosCartScreenEmptyPreview(modifier: Modifier = Modifier) {
 
 @Composable
 @WooPosPreview
-fun WooPosCartScreenLoadingPreview(modifier: Modifier = Modifier) {
+fun WooPosCartScreenErrorLoadingPreview(modifier: Modifier = Modifier) {
     WooPosTheme {
         WooPosCartScreen(
             modifier = modifier,
@@ -898,12 +980,17 @@ fun WooPosCartScreenLoadingPreview(modifier: Modifier = Modifier) {
                     itemsInCart = listOf(
                         WooPosCartItemViewState.Loading(
                             itemNumber = 1,
-                            name = "VW California"
+                            name = "ADS@#DXASDDZA"
                         ),
                         WooPosCartItemViewState.Loading(
                             itemNumber = 2,
                             name = "ADAXS1313XDVZX"
-                        )
+                        ),
+                        WooPosCartItemViewState.Error(
+                            itemNumber = 3,
+                            name = "ADAXS1313XDVZX",
+                            message = "Product does not exist"
+                        ),
                     )
                 ),
                 areItemsRemovable = false,

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/cart/WooPosCartScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/cart/WooPosCartScreen.kt
@@ -645,7 +645,7 @@ private fun LoadingItem(
     item: WooPosCartItemViewState.Loading,
     modifier: Modifier = Modifier
 ) {
-    var itemContentDescription = stringResource(
+    val itemContentDescription = stringResource(
         id = R.string.woopos_cart_item_loading_content_description,
         item.name
     )
@@ -684,7 +684,7 @@ private fun LoadingItem(
                     style = WooPosTypography.BodySmall,
                     fontWeight = FontWeight.Bold,
                     overflow = TextOverflow.Ellipsis,
-                    color = MaterialTheme.colorScheme.onSurface,
+                    color = WooPosTheme.colors.onSurfaceVariantLowest,
                     modifier = Modifier.clearAndSetSemantics { }
                 )
 
@@ -693,7 +693,7 @@ private fun LoadingItem(
                 WooPosShimmerBox(
                     modifier = Modifier
                         .height(14.dp)
-                        .fillMaxWidth(0.9f)
+                        .fillMaxWidth(0.6f)
                 )
 
                 Spacer(modifier = Modifier.height(WooPosSpacing.XSmall.value.toAdaptivePadding()))
@@ -701,7 +701,7 @@ private fun LoadingItem(
                 WooPosShimmerBox(
                     modifier = Modifier
                         .height(14.dp)
-                        .fillMaxWidth(0.4f)
+                        .fillMaxWidth(0.3f)
                 )
             }
 
@@ -785,7 +785,7 @@ fun WooPosCartScreenProductsPreview(modifier: Modifier = Modifier) {
                             id = 3L,
                             imageUrl = "",
                             name = "VW California",
-                            description = "",
+                            description = "description bla",
                             price = "€250,000",
                         )
                     )

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/cart/WooPosCartScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/cart/WooPosCartScreen.kt
@@ -47,6 +47,7 @@ import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.alpha
+import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.BlendMode
 import androidx.compose.ui.graphics.ColorFilter
 import androidx.compose.ui.graphics.vector.ImageVector
@@ -263,10 +264,14 @@ private fun CartBodyWithItems(
                 is WooPosCartItemViewState.Error -> ErrorItem(
                     modifier = Modifier.animateItem(),
                     item = item,
+                    canRemoveItems = areItemsRemovable,
+                    onUIEvent = onUIEvent,
                 )
                 is WooPosCartItemViewState.Loading -> LoadingItem(
                     modifier = Modifier.animateItem(),
                     item = item,
+                    canRemoveItems = areItemsRemovable,
+                    onUIEvent = onUIEvent,
                 )
             }
         }
@@ -650,6 +655,8 @@ private fun CouponItem(
 private fun LoadingItem(
     modifier: Modifier = Modifier,
     item: WooPosCartItemViewState.Loading,
+    canRemoveItems: Boolean,
+    onUIEvent: (WooPosCartUIEvent) -> Unit,
 ) {
     val itemContentDescription = stringResource(
         id = R.string.woopos_cart_item_loading_content_description,
@@ -684,34 +691,27 @@ private fun LoadingItem(
                     .weight(1f)
                     .padding(end = WooPosSpacing.Medium.value.toAdaptivePadding())
             ) {
-                WooPosText(
-                    text = item.name,
-                    maxLines = 1,
-                    style = WooPosTypography.BodySmall,
-                    fontWeight = FontWeight.Bold,
-                    overflow = TextOverflow.Ellipsis,
-                    color = WooPosTheme.colors.onSurfaceVariantLowest,
-                    modifier = Modifier.clearAndSetSemantics { }
+                WooPosShimmerBox(
+                    modifier = Modifier
+                        .height(22.dp)
+                        .fillMaxWidth(0.95f)
+                        .clip(RoundedCornerShape(WooPosCornerRadius.Medium.value))
                 )
 
                 Spacer(modifier = Modifier.height(WooPosSpacing.XSmall.value.toAdaptivePadding()))
 
                 WooPosShimmerBox(
                     modifier = Modifier
-                        .height(14.dp)
-                        .fillMaxWidth(0.6f)
-                )
-
-                Spacer(modifier = Modifier.height(WooPosSpacing.XSmall.value.toAdaptivePadding()))
-
-                WooPosShimmerBox(
-                    modifier = Modifier
-                        .height(14.dp)
-                        .fillMaxWidth(0.3f)
+                        .height(22.dp)
+                        .fillMaxWidth(0.25f)
+                        .clip(RoundedCornerShape(WooPosCornerRadius.Medium.value))
                 )
             }
 
-            Spacer(modifier = Modifier.width(WooPosSpacing.Medium.value.toAdaptivePadding()))
+            if (canRemoveItems) {
+                RemoveItemFromCartButton(item, onUIEvent)
+            }
+            Spacer(modifier = Modifier.width(WooPosSpacing.Small.value.toAdaptivePadding()))
         }
     }
 }
@@ -720,6 +720,8 @@ private fun LoadingItem(
 private fun ErrorItem(
     modifier: Modifier = Modifier,
     item: WooPosCartItemViewState.Error,
+    canRemoveItems: Boolean,
+    onUIEvent: (WooPosCartUIEvent) -> Unit,
 ) {
     val itemContentDescription = stringResource(
         id = R.string.woopos_cart_item_error_content_description,
@@ -779,7 +781,6 @@ private fun ErrorItem(
                 WooPosText(
                     text = item.message,
                     style = WooPosTypography.BodySmall,
-                    fontWeight = FontWeight.Medium,
                     color = MaterialTheme.colorScheme.error,
                     maxLines = 2,
                     overflow = TextOverflow.Ellipsis,
@@ -787,6 +788,9 @@ private fun ErrorItem(
                 )
             }
 
+            if (canRemoveItems) {
+                RemoveItemFromCartButton(item, onUIEvent)
+            }
             Spacer(modifier = Modifier.width(WooPosSpacing.Small.value.toAdaptivePadding()))
         }
     }
@@ -993,7 +997,7 @@ fun WooPosCartScreenErrorLoadingPreview(modifier: Modifier = Modifier) {
                         ),
                     )
                 ),
-                areItemsRemovable = false,
+                areItemsRemovable = true,
                 isCheckoutButtonVisible = true
             )
         ) {}

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/cart/WooPosCartScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/cart/WooPosCartScreen.kt
@@ -755,14 +755,14 @@ fun WooPosCartScreenProductsPreview(modifier: Modifier = Modifier) {
                             validationState = CouponValidationState.Valid("-$10")
                         ),
                         WooPosCartItemViewState.Coupon(
-                            itemNumber = 1,
+                            itemNumber = 2,
                             name = "Test Coupon",
                             summary = "10$ off * All Products",
                             id = 1L,
                             validationState = CouponValidationState.Invalid
                         ),
                         WooPosCartItemViewState.Product.Simple(
-                            itemNumber = 2,
+                            itemNumber = 3,
                             id = 1L,
                             imageUrl = "",
                             name = "VW California, VW California VW California, VW California VW California, " +
@@ -771,7 +771,7 @@ fun WooPosCartScreenProductsPreview(modifier: Modifier = Modifier) {
                             price = "€50,000",
                         ),
                         WooPosCartItemViewState.Product.Simple(
-                            itemNumber = 3,
+                            itemNumber = 4,
                             id = 2L,
                             imageUrl = "",
                             name = "VW California",
@@ -781,7 +781,7 @@ fun WooPosCartScreenProductsPreview(modifier: Modifier = Modifier) {
                             productDoesNotExist = true,
                         ),
                         WooPosCartItemViewState.Product.Simple(
-                            itemNumber = 4,
+                            itemNumber = 5,
                             id = 3L,
                             imageUrl = "",
                             name = "VW California",
@@ -822,14 +822,14 @@ fun WooPosCartScreenCheckoutPreview(modifier: Modifier = Modifier) {
                             validationState = CouponValidationState.Valid("-$10")
                         ),
                         WooPosCartItemViewState.Coupon(
-                            itemNumber = 1,
+                            itemNumber = 2,
                             name = "Test Coupon",
                             summary = "10$ off * All Products",
                             id = 1L,
                             validationState = CouponValidationState.Invalid
                         ),
                         WooPosCartItemViewState.Product.Simple(
-                            itemNumber = 2,
+                            itemNumber = 3,
                             id = 1L,
                             imageUrl = "",
                             name = "VW California",
@@ -837,7 +837,7 @@ fun WooPosCartScreenCheckoutPreview(modifier: Modifier = Modifier) {
                             price = "€50,000",
                         ),
                         WooPosCartItemViewState.Product.Simple(
-                            itemNumber = 3,
+                            itemNumber = 4,
                             id = 2L,
                             imageUrl = "",
                             name = "VW California",
@@ -845,7 +845,7 @@ fun WooPosCartScreenCheckoutPreview(modifier: Modifier = Modifier) {
                             price = "$150,000",
                         ),
                         WooPosCartItemViewState.Product.Simple(
-                            itemNumber = 4,
+                            itemNumber = 5,
                             id = 3L,
                             imageUrl = "",
                             name = "VW California",

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/cart/WooPosCartState.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/cart/WooPosCartState.kt
@@ -97,4 +97,17 @@ sealed class WooPosCartItemViewState(open val itemNumber: Int, open val name: St
             data object Unknown : CouponValidationState()
         }
     }
+
+    @Parcelize
+    data class Loading(
+        override val itemNumber: Int,
+        override val name: String,
+    ) : WooPosCartItemViewState(itemNumber, name)
+
+    @Parcelize
+    data class Error(
+        override val itemNumber: Int,
+        override val name: String,
+        val message: String,
+    ) : WooPosCartItemViewState(itemNumber, name)
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/cart/WooPosCartViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/cart/WooPosCartViewModel.kt
@@ -56,6 +56,7 @@ class WooPosCartViewModel @Inject constructor(
     private val analyticsTrackingDataKeeper: WooPosAnalyticsTrackingDataKeeper,
     private val updateCartItemsWithChanges: WooPosCartItemsUpdater,
     private val getCachedStoreCurrency: WooPosGetCachedStoreCurrency,
+    private val barcodeLoadingSimulator: WooPosBarcodeLoadingSimulator,
     savedState: SavedStateHandle,
 ) : ViewModel() {
     private val _state = savedState.getStateFlow(
@@ -284,6 +285,7 @@ class WooPosCartViewModel @Inject constructor(
 
             itemClicked.await()?.let {
                 _state.value = updateStateWithNewItem(it)
+                barcodeLoadingSimulator.maybeSimulateLoadingItem(_state, viewModelScope)
             }
             event.eventForTracking?.let {
                 analyticsTracker.track(it)

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/cart/WooPosCartViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/cart/WooPosCartViewModel.kt
@@ -141,7 +141,7 @@ class WooPosCartViewModel @Inject constructor(
     }
 
     private fun getCartItemsDataList(): List<WooPosItemsViewModel.ItemClickedData> {
-        val itemClickedDataList = (_state.value.body as WooPosCartState.Body.WithItems).itemsInCart.map {
+        val itemClickedDataList = (_state.value.body as WooPosCartState.Body.WithItems).itemsInCart.mapNotNull {
             when (it) {
                 is WooPosCartItemViewState.Product.Simple -> WooPosItemsViewModel.ItemClickedData.Product.Simple(it.id)
                 is WooPosCartItemViewState.Product.Variation -> WooPosItemsViewModel.ItemClickedData.Product.Variation(
@@ -150,6 +150,8 @@ class WooPosCartViewModel @Inject constructor(
                 )
 
                 is WooPosCartItemViewState.Coupon -> WooPosItemsViewModel.ItemClickedData.Coupon(it.id, it.name)
+                is WooPosCartItemViewState.Loading -> null
+                is WooPosCartItemViewState.Error -> null
             }
         }
         return itemClickedDataList
@@ -434,6 +436,8 @@ class WooPosCartViewModel @Inject constructor(
             when (item) {
                 is WooPosCartItemViewState.Coupon -> item.copy(validationState = CouponValidationState.Unknown)
                 is WooPosCartItemViewState.Product -> item
+                is WooPosCartItemViewState.Error -> item
+                is WooPosCartItemViewState.Loading -> item
             }
         }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/items/coupons/search/WooPosCouponsEmptySearchQueryStateScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/items/coupons/search/WooPosCouponsEmptySearchQueryStateScreen.kt
@@ -16,7 +16,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalFocusManager
 import androidx.compose.ui.unit.dp
 import com.woocommerce.android.ui.woopos.common.composeui.WooPosPreview
-import com.woocommerce.android.ui.woopos.common.composeui.component.RecentSearchesChips
+import com.woocommerce.android.ui.woopos.common.composeui.component.WooPosRecentSearchesChips
 import com.woocommerce.android.ui.woopos.common.composeui.designsystem.WooPosSpacing
 import com.woocommerce.android.ui.woopos.common.composeui.designsystem.WooPosTheme
 import com.woocommerce.android.ui.woopos.common.composeui.designsystem.toAdaptivePadding
@@ -41,7 +41,7 @@ fun WooPosCouponsEmptySearchQueryStateScreen(
             .verticalScroll(scrollState)
     ) {
         if (state.recentSearches.isNotEmpty()) {
-            RecentSearchesChips(
+            WooPosRecentSearchesChips(
                 recentSearches = state.recentSearches,
                 onRecentSearchClicked = { recentSearch ->
                     onUIEvent(WooPosCouponsSearchUiEvent.OnRecentSearchClicked(recentSearch))
@@ -82,7 +82,7 @@ fun WooPosCouponsRecentSearchesChipsPreview() {
                 .fillMaxWidth()
                 .padding(WooPosSpacing.Medium.value)
         ) {
-            RecentSearchesChips(
+            WooPosRecentSearchesChips(
                 recentSearches = listOf("SUMMER", "DISCOUNT", "SALE", "WINTER", "PROMO"),
                 onRecentSearchClicked = {}
             )

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/items/search/WooPosItemsEmptySearchQueryStateScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/items/search/WooPosItemsEmptySearchQueryStateScreen.kt
@@ -18,7 +18,7 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import com.woocommerce.android.R
 import com.woocommerce.android.ui.woopos.common.composeui.WooPosPreview
-import com.woocommerce.android.ui.woopos.common.composeui.component.RecentSearchesChips
+import com.woocommerce.android.ui.woopos.common.composeui.component.WooPosRecentSearchesChips
 import com.woocommerce.android.ui.woopos.common.composeui.component.SectionHeader
 import com.woocommerce.android.ui.woopos.common.composeui.designsystem.WooPosSpacing
 import com.woocommerce.android.ui.woopos.common.composeui.designsystem.WooPosTheme
@@ -46,7 +46,7 @@ fun WooPosItemsEmptySearchQueryStateScreen(
             .verticalScroll(scrollState)
     ) {
         if (state.recentSearches.isNotEmpty()) {
-            RecentSearchesChips(
+            WooPosRecentSearchesChips(
                 recentSearches = state.recentSearches,
                 onRecentSearchClicked = { recentSearch ->
                     onUIEvent(WooPosItemsSearchUiEvent.OnRecentSearchClicked(recentSearch))
@@ -197,7 +197,7 @@ fun WooPosRecentSearchesChipsPreview() {
                 .fillMaxWidth()
                 .padding(WooPosSpacing.Medium.value)
         ) {
-            RecentSearchesChips(
+            WooPosRecentSearchesChips(
                 recentSearches = listOf("Chocolate", "Mug", "Hario", "Coffee", "Prezzetti"),
                 onRecentSearchClicked = {}
             )

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/items/search/WooPosItemsEmptySearchQueryStateScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/items/search/WooPosItemsEmptySearchQueryStateScreen.kt
@@ -18,8 +18,8 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import com.woocommerce.android.R
 import com.woocommerce.android.ui.woopos.common.composeui.WooPosPreview
-import com.woocommerce.android.ui.woopos.common.composeui.component.WooPosRecentSearchesChips
 import com.woocommerce.android.ui.woopos.common.composeui.component.SectionHeader
+import com.woocommerce.android.ui.woopos.common.composeui.component.WooPosRecentSearchesChips
 import com.woocommerce.android.ui.woopos.common.composeui.designsystem.WooPosSpacing
 import com.woocommerce.android.ui.woopos.common.composeui.designsystem.WooPosTheme
 import com.woocommerce.android.ui.woopos.common.composeui.designsystem.toAdaptivePadding

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/util/analytics/WooPosAnalyticsEvent.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/util/analytics/WooPosAnalyticsEvent.kt
@@ -193,11 +193,15 @@ sealed class WooPosAnalyticsEvent : IAnalyticsEvent {
                 itemType = when (item) {
                     is WooPosCartItemViewState.Product -> ItemsListItemType.PRODUCT
                     is WooPosCartItemViewState.Coupon -> ItemsListItemType.COUPON
+                    is WooPosCartItemViewState.Error -> error("Error item is not a valid item type")
+                    is WooPosCartItemViewState.Loading -> error("Loading item is not a valid item type")
                 },
                 productType = when (item) {
                     is WooPosCartItemViewState.Product.Simple -> ItemsListProductType.SIMPLE
                     is WooPosCartItemViewState.Product.Variation -> ItemsListProductType.VARIATION
                     is WooPosCartItemViewState.Coupon -> null
+                    is WooPosCartItemViewState.Error -> error("Error item is not a valid item type")
+                    is WooPosCartItemViewState.Loading -> error("Loading item is not a valid item type")
                 }
             )
 

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -4273,6 +4273,7 @@
     <string name="woopos_variable_product_item_content_description">Variable Product %s, Price %s</string>
     <string name="woopos_variation_item_content_description">Variation %s, Price %s</string>
     <string name="woopos_cart_item_product_content_description">Product in cart %s, Price %s</string>
+    <string name="woopos_cart_item_loading_content_description">Loading %s</string>
     <string name="woopos_coupon_item_content_description">Coupon %s</string>
     <string name="woopos_coupon_item_expired_label">Expired on %s</string>
     <string name="woopos_cart_item_coupon_content_description">Coupon in cart %s</string>

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -4273,7 +4273,8 @@
     <string name="woopos_variable_product_item_content_description">Variable Product %s, Price %s</string>
     <string name="woopos_variation_item_content_description">Variation %s, Price %s</string>
     <string name="woopos_cart_item_product_content_description">Product in cart %s, Price %s</string>
-    <string name="woopos_cart_item_loading_content_description">Loading %s</string>
+    <string name="woopos_cart_item_loading_content_description">Loading item %s</string>
+    <string name="woopos_cart_item_error_content_description">Error loading item %s</string>
     <string name="woopos_coupon_item_content_description">Coupon %s</string>
     <string name="woopos_coupon_item_expired_label">Expired on %s</string>
     <string name="woopos_cart_item_coupon_content_description">Coupon in cart %s</string>

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/home/cart/WooPosCartViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/home/cart/WooPosCartViewModelTest.kt
@@ -99,6 +99,7 @@ class WooPosCartViewModelTest {
     private val savedState: SavedStateHandle = SavedStateHandle()
     private val trackerData: WooPosAnalyticsTrackingDataKeeper = WooPosAnalyticsTrackingDataKeeper()
     private val cartItemsUpdater: WooPosCartItemsUpdater = mock()
+    private val barcodeLoadingSimulator: WooPosBarcodeLoadingSimulator = mock()
 
     @Test
     fun `given empty cart, when product clicked in product selector, then should add product to cart`() = runTest {
@@ -1056,6 +1057,7 @@ class WooPosCartViewModelTest {
             trackerData,
             cartItemsUpdater,
             getCachedStoreCurrency,
+            barcodeLoadingSimulator,
             savedState
         )
     }


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->
WOOPRD-553
<!-- Id number of the Linear issue this PR addresses, e.g., WOOMOB-373. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

Implements the UI for error and loading. ~~The design is not final.~~

There is a first iteration so I am implementing this based on it
pdfdoF-7lQ-p2
so validate the design

It has also behind FF code that randomly adds those states for testing

### Steps to reproduce
<!-- Step-by-step testing instructions. For new user flows, consider instead stating the goal of the workflow and see if your PR reviewer can accomplish the workflow without specific steps! -->
* Open the POS
* Add a few items 
* Notice Loading and error states

Validate that there is nothing extra added when FF is OFF

### The tests that have been performed
<!-- To give the reviewer an idea of what could be missed in terms of testing -->
above

### Images/gif
<!-- Include before and after images or gifs when appropriate. -->

https://github.com/user-attachments/assets/77455dbf-4944-46ab-8677-a6813760b148

- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->