### PR TITLE
[WOOPRD-559][Woo POS][Barcodes] Disable checkout button when loading or error item in the cart

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/cart/WooPosCartScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/cart/WooPosCartScreen.kt
@@ -74,6 +74,7 @@ import com.woocommerce.android.extensions.isNotNullOrEmpty
 import com.woocommerce.android.ui.woopos.common.composeui.WooPosPreview
 import com.woocommerce.android.ui.woopos.common.composeui.component.ShadowType
 import com.woocommerce.android.ui.woopos.common.composeui.component.WooPosButton
+import com.woocommerce.android.ui.woopos.common.composeui.component.WooPosButtonState
 import com.woocommerce.android.ui.woopos.common.composeui.component.WooPosCard
 import com.woocommerce.android.ui.woopos.common.composeui.component.WooPosLazyColumn
 import com.woocommerce.android.ui.woopos.common.composeui.component.WooPosOutlinedButtonSmall
@@ -158,14 +159,14 @@ private fun WooPosCartScreen(
                     },
                     items = state.body.itemsInCart,
                     areItemsRemovable = state.areItemsRemovable,
-                    isCheckoutButtonVisible = state.isCheckoutButtonVisible,
+                    checkoutButtonState = state.checkoutButtonState,
                     onUIEvent = onUIEvent
                 )
             }
         }
 
         AnimatedVisibility(
-            visible = state.isCheckoutButtonVisible,
+            visible = state.checkoutButtonState != WooPosCartState.CheckoutButtonState.Invisible,
             enter = fadeIn(animationSpec = tween(300)),
             exit = fadeOut(animationSpec = tween(300)),
             modifier = Modifier
@@ -180,7 +181,14 @@ private fun WooPosCartScreen(
         ) {
             WooPosButton(
                 text = stringResource(R.string.woopos_checkout_button),
-                onClick = { onUIEvent(WooPosCartUIEvent.CheckoutClicked) }
+                onClick = { onUIEvent(WooPosCartUIEvent.CheckoutClicked) },
+                state = when (state.checkoutButtonState) {
+                    WooPosCartState.CheckoutButtonState.Enabled -> WooPosButtonState.ENABLED
+                    WooPosCartState.CheckoutButtonState.Disabled -> WooPosButtonState.DISABLED
+
+                    // To be displayed during animation
+                    WooPosCartState.CheckoutButtonState.Invisible -> WooPosButtonState.ENABLED
+                }
             )
         }
     }
@@ -218,14 +226,14 @@ private fun CartBodyWithItems(
     modifier: Modifier = Modifier,
     items: List<WooPosCartItemViewState>,
     areItemsRemovable: Boolean,
-    isCheckoutButtonVisible: Boolean,
+    checkoutButtonState: WooPosCartState.CheckoutButtonState,
     onUIEvent: (WooPosCartUIEvent) -> Unit,
 ) {
     val listState = rememberLazyListState()
     ScrollToTopHandler(items, listState)
 
     val spacerHeight by animateDpAsState(
-        targetValue = if (!isCheckoutButtonVisible) 212.dp else 0.dp,
+        targetValue = if (checkoutButtonState == WooPosCartState.CheckoutButtonState.Invisible) 212.dp else 0.dp,
         label = "cart list height animation"
     )
 
@@ -877,7 +885,7 @@ fun WooPosCartScreenProductsPreview(modifier: Modifier = Modifier) {
                     )
                 ),
                 areItemsRemovable = true,
-                isCheckoutButtonVisible = true
+                checkoutButtonState = WooPosCartState.CheckoutButtonState.Enabled
             )
         ) {}
     }
@@ -942,7 +950,7 @@ fun WooPosCartScreenCheckoutPreview(modifier: Modifier = Modifier) {
                     )
                 ),
                 areItemsRemovable = false,
-                isCheckoutButtonVisible = true
+                checkoutButtonState = WooPosCartState.CheckoutButtonState.Enabled
             )
         ) {}
     }
@@ -962,7 +970,7 @@ fun WooPosCartScreenEmptyPreview(modifier: Modifier = Modifier) {
                 ),
                 body = WooPosCartState.Body.Empty,
                 areItemsRemovable = false,
-                isCheckoutButtonVisible = false
+                checkoutButtonState = WooPosCartState.CheckoutButtonState.Invisible
             )
         ) {}
     }
@@ -998,7 +1006,7 @@ fun WooPosCartScreenErrorLoadingPreview(modifier: Modifier = Modifier) {
                     )
                 ),
                 areItemsRemovable = true,
-                isCheckoutButtonVisible = true
+                checkoutButtonState = WooPosCartState.CheckoutButtonState.Disabled
             )
         ) {}
     }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/cart/WooPosCartState.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/cart/WooPosCartState.kt
@@ -9,7 +9,7 @@ data class WooPosCartState(
     val toolbar: Toolbar = Toolbar(),
     val body: Body = Body.Empty,
     val areItemsRemovable: Boolean = true,
-    val isCheckoutButtonVisible: Boolean = true,
+    val checkoutButtonState: CheckoutButtonState = CheckoutButtonState.Enabled,
 ) : Parcelable {
     @Parcelize
     sealed class Body : Parcelable {
@@ -34,6 +34,12 @@ data class WooPosCartState(
         val itemsCount: String? = null,
         val isClearAllButtonVisible: Boolean = false,
     ) : Parcelable
+
+    enum class CheckoutButtonState {
+        Enabled,
+        Disabled,
+        Invisible
+    }
 }
 
 enum class WooPosCartStatus {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/cart/WooPosCartViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/cart/WooPosCartViewModel.kt
@@ -399,17 +399,22 @@ class WooPosCartViewModel @Inject constructor(
     private fun updateStateDependingOnCartStatus(newState: WooPosCartState) =
         when (newState.cartStatus) {
             EDITABLE -> {
+                val checkoutButtonState = when {
+                    newState.body !is WooPosCartState.Body.WithItems -> WooPosCartState.CheckoutButtonState.Invisible
+                    cartContainsLoadingOrErrorItems(newState.body) -> WooPosCartState.CheckoutButtonState.Disabled
+                    cartContainsPurchasableItems(newState.body) -> WooPosCartState.CheckoutButtonState.Enabled
+                    else -> WooPosCartState.CheckoutButtonState.Invisible
+                }
                 newState.copy(
                     areItemsRemovable = true,
-                    isCheckoutButtonVisible = newState.body is WooPosCartState.Body.WithItems &&
-                        cartContainsPurchasableItems(newState.body),
+                    checkoutButtonState = checkoutButtonState,
                 )
             }
 
             CHECKOUT, EMPTY -> {
                 newState.copy(
                     areItemsRemovable = false,
-                    isCheckoutButtonVisible = false,
+                    checkoutButtonState = WooPosCartState.CheckoutButtonState.Invisible,
                 )
             }
         }
@@ -471,4 +476,7 @@ class WooPosCartViewModel @Inject constructor(
 
     private fun cartContainsPurchasableItems(body: WooPosCartState.Body.WithItems) =
         body.itemsInCart.filterIsInstance<WooPosCartItemViewState.Product>().isNotEmpty()
+
+    private fun cartContainsLoadingOrErrorItems(body: WooPosCartState.Body.WithItems) =
+        body.itemsInCart.any { it is WooPosCartItemViewState.Loading || it is WooPosCartItemViewState.Error }
 }

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/home/cart/WooPosCartViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/home/cart/WooPosCartViewModelTest.kt
@@ -780,7 +780,7 @@ class WooPosCartViewModelTest {
 
         // THEN
         val state = states.last()
-        assertThat(state.isCheckoutButtonVisible).isFalse()
+        assertThat(state.checkoutButtonState).isEqualTo(WooPosCartState.CheckoutButtonState.Invisible)
     }
 
     @Test
@@ -794,7 +794,7 @@ class WooPosCartViewModelTest {
 
         // THEN
         val finalState = states.last()
-        assertThat(finalState.isCheckoutButtonVisible).isFalse()
+        assertThat(finalState.checkoutButtonState).isEqualTo(WooPosCartState.CheckoutButtonState.Invisible)
     }
 
     @Test
@@ -821,7 +821,7 @@ class WooPosCartViewModelTest {
 
         // THEN
         val finalState = states.last()
-        assertThat(finalState.isCheckoutButtonVisible).isTrue()
+        assertThat(finalState.checkoutButtonState).isEqualTo(WooPosCartState.CheckoutButtonState.Enabled)
     }
 
     @Test
@@ -851,7 +851,7 @@ class WooPosCartViewModelTest {
 
         // THEN
         val finalState = states.last()
-        assertThat(finalState.isCheckoutButtonVisible).isTrue()
+        assertThat(finalState.checkoutButtonState).isEqualTo(WooPosCartState.CheckoutButtonState.Enabled)
     }
 
     @Test
@@ -883,21 +883,21 @@ class WooPosCartViewModelTest {
 
         // THEN
         val finalState = states.last()
-        assertThat(finalState.isCheckoutButtonVisible).isFalse()
+        assertThat(finalState.checkoutButtonState).isEqualTo(WooPosCartState.CheckoutButtonState.Invisible)
     }
 
     @Test
     fun `given cart with products, when navigated to checkout, then checkout button not visible`() = runTest {
         // GIVEN
         val (sut, states) = createSutWithItemsInCart()
-        assertThat(states.last().isCheckoutButtonVisible).isTrue()
+        assertThat(states.last().checkoutButtonState).isEqualTo(WooPosCartState.CheckoutButtonState.Enabled)
 
         // WHEN
         sut.onUIEvent(WooPosCartUIEvent.CheckoutClicked)
 
         // THEN
         val finalState = states.last()
-        assertThat(finalState.isCheckoutButtonVisible).isFalse()
+        assertThat(finalState.checkoutButtonState).isEqualTo(WooPosCartState.CheckoutButtonState.Invisible)
     }
 
     @Test
@@ -905,14 +905,14 @@ class WooPosCartViewModelTest {
         // GIVEN
         val (sut, states) = createSutWithItemsInCart()
         sut.onUIEvent(WooPosCartUIEvent.CheckoutClicked)
-        assertThat(states.last().isCheckoutButtonVisible).isFalse()
+        assertThat(states.last().checkoutButtonState).isEqualTo(WooPosCartState.CheckoutButtonState.Invisible)
 
         // WHEN
         sut.onUIEvent(WooPosCartUIEvent.BackClicked)
 
         // THEN
         val finalState = states.last()
-        assertThat(finalState.isCheckoutButtonVisible).isTrue()
+        assertThat(finalState.checkoutButtonState).isEqualTo(WooPosCartState.CheckoutButtonState.Enabled)
     }
 
     @Test


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->
WOOPRD-559
<!-- Id number of the Linear issue this PR addresses, e.g., WOOMOB-373. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
The PR disables checkout button when a loading or an error item in the cart

### Steps to reproduce
<!-- Step-by-step testing instructions. For new user flows, consider instead stating the goal of the workflow and see if your PR reviewer can accomplish the workflow without specific steps! -->
* Open POS
* Add a few items
* Notice loading and error items in the cart
* Notice the checkout button is disabled when they are there

### The tests that have been performed
<!-- To give the reviewer an idea of what could be missed in terms of testing -->
above

### Images/gif
<!-- Include before and after images or gifs when appropriate. -->

https://github.com/user-attachments/assets/42d122a1-ed7b-4f94-a296-004f3a8a0cae



- [ ] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->