### PR TITLE
[WOOPRD-567][Woo POS][Barcodes] Implement removing of the loading and error items from the cart

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/cart/WooPosCartViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/cart/WooPosCartViewModel.kt
@@ -126,7 +126,14 @@ class WooPosCartViewModel @Inject constructor(
         }
         viewModelScope.launch {
             items.forEach { item ->
-                analyticsTracker.track(ItemRemovedFromCart(item = item, source = source))
+                when (item) {
+                    is WooPosCartItemViewState.Product,
+                    is WooPosCartItemViewState.Coupon -> {
+                        analyticsTracker.track(ItemRemovedFromCart(item = item, source = source))
+                    }
+                    is WooPosCartItemViewState.Loading,
+                    is WooPosCartItemViewState.Error -> Unit
+                }
             }
         }
     }


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

<!-- Id number of the Linear issue this PR addresses, e.g., WOOMOB-373. -->
WOOPRD-567

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
Implements the removal of the loading and error items. It was actually implemented already but was crashing due to tracking. This PR fixes it

### Steps to reproduce
<!-- Step-by-step testing instructions. For new user flows, consider instead stating the goal of the workflow and see if your PR reviewer can accomplish the workflow without specific steps! -->
* Open POS
* Add a few products
* Remove items in loading and error state

### The tests that have been performed
<!-- To give the reviewer an idea of what could be missed in terms of testing -->
Above

### Images/gif
<!-- Include before and after images or gifs when appropriate. -->

https://github.com/user-attachments/assets/bad0ebcc-41b1-4253-92c0-4ad332257eed


- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->