### PR TITLE
UI glitch in reader connection dialog

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -7,6 +7,7 @@
 - [*] POS: for WooCommerce version 10.0.0 and higher (betas available in June), a new check for POS feature switch value (in wp-admin WooCommerce Settings > Advanced > Features) was added for the POS entry point. [https://github.com/woocommerce/woocommerce-android/pull/14113]
 - [*] POS: for WooCommerce version 10.0.0 and higher (betas available in June) and stores eligible for POS, sending email from the payment success screen sends out POS specific email receipts with product unit price, additional cash/card payment details, and customizable store details from POS settings in wp-admin WooCommerce Settings > Point of Sale. [https://github.com/woocommerce/woocommerce-android/pull/14116]
 - [*] Fixed an issue with taxes not being correctly included during refunds [https://github.com/woocommerce/woocommerce-android/pull/14064]
+- [*] Improved payments UI in accessibility screen mode (increased screen size) [https://github.com/woocommerce/woocommerce-android/pull/14148]
 
 22.5
 -----

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/cardreader/connect/CardReaderConnectDialogFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/cardreader/connect/CardReaderConnectDialogFragment.kt
@@ -49,7 +49,7 @@ import com.woocommerce.android.ui.woopos.cardreader.WooPosCardReaderActivity
 import com.woocommerce.android.util.ChromeCustomTabUtils
 import com.woocommerce.android.util.LocationUtils
 import com.woocommerce.android.util.UiHelpers
-import com.woocommerce.android.util.UiHelpers.getIllustrationVisibilityForFontScale
+import com.woocommerce.android.util.UiHelpers.getIllustrationVisibilityForAccessibility
 import com.woocommerce.android.util.WooAnimUtils
 import com.woocommerce.android.util.WooLog
 import com.woocommerce.android.util.WooPermissionUtils
@@ -169,7 +169,7 @@ class CardReaderConnectDialogFragment : PaymentsBaseDialogFragment(R.layout.card
             .also {
                 if (binding.illustration.isVisible) {
                     binding.illustration.visibility =
-                        getIllustrationVisibilityForFontScale(resources.configuration.fontScale)
+                        requireContext().getIllustrationVisibilityForAccessibility(resources.configuration.fontScale)
                 }
             }
         UiHelpers.setTextOrHide(binding.hintLabel, viewState.hintLabel)

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/cardreader/payment/CardReaderPaymentDialogFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/cardreader/payment/CardReaderPaymentDialogFragment.kt
@@ -34,7 +34,7 @@ import com.woocommerce.android.ui.payments.cardreader.payment.ViewState.External
 import com.woocommerce.android.ui.payments.refunds.RefundSummaryFragment.Companion.KEY_INTERAC_SUCCESS
 import com.woocommerce.android.util.PrintHtmlHelper
 import com.woocommerce.android.util.UiHelpers
-import com.woocommerce.android.util.UiHelpers.getIllustrationVisibilityForFontScale
+import com.woocommerce.android.util.UiHelpers.getIllustrationVisibilityForAccessibility
 import com.woocommerce.android.util.UiHelpers.getTextOfUiString
 import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.Exit
 import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.ShowSnackbar
@@ -112,7 +112,7 @@ class CardReaderPaymentDialogFragment : PaymentsBaseDialogFragment(R.layout.card
             ).also {
                 if (binding.illustration.isVisible) {
                     binding.illustration.visibility =
-                        getIllustrationVisibilityForFontScale(resources.configuration.fontScale)
+                        requireContext().getIllustrationVisibilityForAccessibility(resources.configuration.fontScale)
                 }
             }
             UiHelpers.setTextOrHide(binding.paymentStateLabel, viewState.paymentStateLabel)

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/util/UiHelpers.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/util/UiHelpers.kt
@@ -5,6 +5,7 @@ import android.graphics.drawable.Drawable
 import android.text.SpannableStringBuilder
 import android.text.Spanned
 import android.text.style.ClickableSpan
+import android.util.DisplayMetrics
 import android.view.View
 import android.widget.ImageView
 import android.widget.TextView
@@ -107,10 +108,16 @@ object UiHelpers {
     }
 
     @Suppress("MagicNumber")
-    fun getIllustrationVisibilityForFontScale(fontScale: Float): Int = if (fontScale > 1.5f) {
-        View.GONE
-    } else {
-        View.VISIBLE
+    private fun isFontScaleIncreased(fontScale: Float): Boolean = fontScale > 1.5f
+
+    private fun Context.isDisplaySizeScaleIncreased(): Boolean =
+        resources.displayMetrics.densityDpi > DisplayMetrics.DENSITY_DEVICE_STABLE
+
+    /**
+     * Returns View.GONE if either the font scale is large or the accessibility display size is changed, otherwise View.VISIBLE.
+     */
+    fun Context.getIllustrationVisibilityForAccessibility(fontScale: Float): Int {
+        return if (isFontScaleIncreased(fontScale) || isDisplaySizeScaleIncreased()) View.GONE else View.VISIBLE
     }
 }
 


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->
## UI glitch in reader connection dialog #14148

<!-- Id number of the Linear issue this PR addresses, e.g., WOOMOB-373. -->
WOOMOB-401

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
This PR fixes the UI glitch - overlapping button and image in case the screen size is scaled up in accessibility settings

### Steps to reproduce
<!-- Step-by-step testing instructions. For new user flows, consider instead stating the goal of the workflow and see if your PR reviewer can accomplish the workflow without specific steps! -->
1. Try connecting to a reader, e.g. from Order Creation flow
2. While the connection dialog is visible, experiment with different screen size scale factors. The easy way of doing it is with "device UI shortcuts" in AS (see video).

### Testing information
<!-- This is your opportunity to break out individual scenarios that need testing (when necessary) and/or include a checklist for the reviewer to go through. Consider documenting the following from your own completed testing: devices used, alternate workflows, edge cases, affected areas, critical flows, areas not tested, and any remaining unknowns. Provide feedback on this new section of the PR template through Sept 30, 2024 to Apps Quality; additional context here: p91TBi-b8z-p2#comment-12036 -->
Test different scale factors for both font size and screen size (see the video attached below)

### The tests that have been performed
<!-- To give the reviewer an idea of what could be missed in terms of testing -->
I verified that image and buttons are not overlapping in different font and screen scale settings.

### Images/gif
<!-- Include before and after images or gifs when appropriate. -->

https://github.com/user-attachments/assets/f4a6377a-9b46-46be-a374-2fd9e9ac9760

- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->