### PR TITLE
[WOOMOB-541][Bug] Wrong start padding in the main activity toolbar on tablet

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -7,6 +7,7 @@
 - [*] POS: for WooCommerce version 10.0.0 and higher (betas available in June), a new check for POS feature switch value (in wp-admin WooCommerce Settings > Advanced > Features) was added for the POS entry point. [https://github.com/woocommerce/woocommerce-android/pull/14113]
 - [*] POS: for WooCommerce version 10.0.0 and higher (betas available in June) and stores eligible for POS, sending email from the payment success screen sends out POS specific email receipts with product unit price, additional cash/card payment details, and customizable store details from POS settings in wp-admin WooCommerce Settings > Point of Sale. [https://github.com/woocommerce/woocommerce-android/pull/14116]
 - [*] Fixed an issue with taxes not being correctly included during refunds [https://github.com/woocommerce/woocommerce-android/pull/14064]
+- [*] Fixed start padding for the back navigation icon in the toolbars [https://github.com/woocommerce/woocommerce-android/pull/14151]
 
 22.5
 -----

--- a/WooCommerce/src/main/res/values/styles_base.xml
+++ b/WooCommerce/src/main/res/values/styles_base.xml
@@ -18,6 +18,8 @@ theme across the entire app. Overridden versions should be added to the styles.x
         <item name="navigationIcon">@drawable/ic_back_24dp</item>
         <item name="android:theme">@style/Widget.Woo.Toolbar.Surface</item>
         <item name="android:background">@color/color_toolbar</item>
+        <item name="android:paddingStart">0dp</item>
+        <item name="android:paddingLeft">0dp</item>
     </style>
     <style name="Widget.Woo.Toolbar.Surface" parent="ThemeOverlay.MaterialComponents.Toolbar.Surface">
         <item name="actionMenuTextColor">@color/color_primary_selector</item>

--- a/WooCommerce/src/main/res/values/styles_base.xml
+++ b/WooCommerce/src/main/res/values/styles_base.xml
@@ -31,7 +31,7 @@ theme across the entire app. Overridden versions should be added to the styles.x
         <item name="android:textColor">@color/color_on_surface</item>
         <item name="android:layout_height">@dimen/toolbar_height</item>
     </style>
-    <style name="Woo.CollapsedToolbarLayout" parent="Widget.MaterialComponents.Toolbar.Surface">
+    <style name="Woo.CollapsedToolbarLayout" parent="@style/Widget.Design.CollapsingToolbar">
         <item name="layout_scrollFlags">scroll|exitUntilCollapsed</item>
         <item name="android:background">@color/color_toolbar</item>
         <item name="statusBarScrim">@android:color/transparent</item>


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

<!-- Id number of the Linear issue this PR addresses, e.g., WOOMOB-373. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
The PR:
* Uses correct parent style for CollapsedToolbarLayout
* Sets to 0 padding to the toolbar, otherwise apparently by default it large on tablets, therefore it doesn't match for the cases where we use compose toolbar

### Steps to reproduce
<!-- Step-by-step testing instructions. For new user flows, consider instead stating the goal of the workflow and see if your PR reviewer can accomplish the workflow without specific steps! -->
* Use both tablet and a phone
* Notice that the start padding for the back navigation icon is consistent across the app, for instant on the more -> coupons

### Images/gif
<!-- Include before and after images or gifs when appropriate. -->
### Before

<img width="432" alt="image" src="https://github.com/user-attachments/assets/a5cc7e34-d3f6-423b-831c-18842b19aa7c" />
<img width="675" alt="image" src="https://github.com/user-attachments/assets/3f5fa3d1-4e13-46ff-a4fa-c5cb543f3a28" />

### After
<img width="436" alt="image" src="https://github.com/user-attachments/assets/b036effa-7e81-4e13-9eee-fa6505411bcc" />

<img width="677" alt="image" src="https://github.com/user-attachments/assets/f368a124-fd0b-4986-87e4-94f305bf6f33" />


- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->