### PR TITLE
[Better Tablet Products] Fix keyboard hiding unexpectedly on product tablet search

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/list/ProductListViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/list/ProductListViewModel.kt
@@ -224,12 +224,12 @@ class ProductListViewModel @Inject constructor(
     }
 
     fun onSearchOpened() {
-        _productList.value = emptyList()
         viewState = viewState.copy(
             isSearchActive = true,
             displaySortAndFilterCard = false,
             isAddProductButtonVisible = false
         )
+        _productList.value = emptyList()
     }
 
     fun onSearchClosed() {
@@ -452,7 +452,10 @@ class ProductListViewModel @Inject constructor(
                     onOpenProduct(selectedProductIdOnBigScreen!!, null)
                 }
             } else {
-                triggerEvent(ProductListEvent.OpenEmptyProduct)
+                // Opening an empty product causes the search input to lose focus
+                if (!isSearching()) {
+                    triggerEvent(ProductListEvent.OpenEmptyProduct)
+                }
             }
         }
     }


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

<!-- Id number of the Linear issue this PR addresses, e.g., WOOMOB-373. -->
Closes WOOMOB-540

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
#### Summary
This PR addresses an issue where the keyboard would unexpectedly hide when searching for products on a tablet. The root cause was that navigating to an empty product detail view was triggered whenever the user typed characters and the query was shorter than 3 characters.

#### Fix
To resolve this, we prevent navigation to an empty product detail view while a search is active. This aligns with the existing behavior in the Orders screen. Supporting navigation during search would require more complex logic, which we deem unnecessary at this point.

#### Changes
- Prevent `OpenEmptyProduct` during search:
The `ProductListViewModel` no longer triggers the `ProductListEvent.OpenEmptyProduct` event if a search is in progress.
- Adjust execution order in `onSearchOpened`:
We now update the viewStatus before resetting the product list. Previously, the keyboard would hide immediately because `isSearching` was still false during the navigation trigger.

### Steps to reproduce
<!-- Step-by-step testing instructions. For new user flows, consider instead stating the goal of the workflow and see if your PR reviewer can accomplish the workflow without specific steps! -->

On a tablet

1. Go to the Products tab
2. Start searching for a product
3. See that the keyboard is not hidden whenever we type the first characters

### Testing information
<!-- This is your opportunity to break out individual scenarios that need testing (when necessary) and/or include a checklist for the reviewer to go through. Consider documenting the following from your own completed testing: devices used, alternate workflows, edge cases, affected areas, critical flows, areas not tested, and any remaining unknowns. Provide feedback on this new section of the PR template through Sept 30, 2024 to Apps Quality; additional context here: https://woomobilep2.wordpress.com/2024/05/06/woocommerce-mobile-quality-report-march-april/#comment-12036 -->

### The tests that have been performed
<!-- To give the reviewer an idea of what could be missed in terms of testing -->
Tablet portrait, phone.

### Images/gif
<!-- Include before and after images or gifs when appropriate. -->

#### Before


https://github.com/user-attachments/assets/95ccb0d1-4e31-439a-aaa4-2d06e14d4719

#### After

https://github.com/user-attachments/assets/962c164c-cbb8-481b-8627-8d537f8dab5e




- [X] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
