### PR TITLE
[Shipping labels] Prevent Label Config Endpoint Call in Release Variant

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/OrderDetailViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/OrderDetailViewModel.kt
@@ -211,6 +211,10 @@ class OrderDetailViewModel @Inject constructor(
 
     private var pluginsInformation: Map<String, WooPlugin> = HashMap()
 
+    private val isRevampWooShippingEnabled: Boolean
+        get() = FeatureFlag.REVAMP_WOO_SHIPPING.isEnabled() &&
+            shippingLabelOnboardingRepository.shippingPluginSupport.isWooShippingSupported()
+
     init {
         productImageMap.subscribeToOnProductFetchedEvents(this)
         launch {
@@ -680,10 +684,7 @@ class OrderDetailViewModel @Inject constructor(
     fun onCreateShippingLabelButtonTapped() {
         tracker.trackShippinhLabelTapped()
         launch {
-            if (
-                FeatureFlag.REVAMP_WOO_SHIPPING.isEnabled() &&
-                shippingLabelOnboardingRepository.shippingPluginSupport.isWooShippingSupported()
-            ) {
+            if (isRevampWooShippingEnabled) {
                 triggerEvent(StartWooShippingLabelCreationFlow(awaitOrder().id))
             } else {
                 triggerEvent(StartShippingLabelCreationFlow(awaitOrder().id))
@@ -837,7 +838,7 @@ class OrderDetailViewModel @Inject constructor(
     }
 
     private fun fetchShipmentsAsync() = async {
-        if (shippingLabelOnboardingRepository.shippingPluginSupport.isSupported()) {
+        if (isRevampWooShippingEnabled) {
             shippingLabelRepository.fetchConfig(selectedSite.get(), navArgs.orderId)
         }
         orderDetailsTransactionLauncher.onShipmentsFetchingCompleted()

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/OrderDetailViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/OrderDetailViewModelTest.kt
@@ -2524,7 +2524,7 @@ class OrderDetailViewModelTest : BaseUnitTest() {
 
         // THEN
         assertThat(observedViewState!!.orderInfo!!.order).isEqualTo(newOrder)
-        assertThat(observedViewState!!.orderInfo!!.isPaymentCollectableWithCardReader).isFalse()
+        assertThat(observedViewState.orderInfo!!.isPaymentCollectableWithCardReader).isFalse()
     }
 
     @Test

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/OrderDetailViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/OrderDetailViewModelTest.kt
@@ -2531,6 +2531,6 @@ class OrderDetailViewModelTest : BaseUnitTest() {
     fun `when view model is initialized then fetchConfig is called`() = testBlocking {
         viewModel.start()
 
-        verify(shippingLabelRepository).fetchConfig(selectedSite.get(), ORDER_ID)
+        verify(shippingLabelRepository, never()).fetchConfig(selectedSite.get(), ORDER_ID)
     }
 }


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

<!-- Id number of the Linear issue this PR addresses, e.g., WOOMOB-373. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
`/wcshipping/v1/config/label-purchase/` shouldn’t be called from the release variant. This PR adds a condition to prevent that by using the same condition applied to the Create shipping label button, which opens the new flow.

Since this only results in an error and we don’t use the response of this endpoint anywhere, there’s no need to fix it in the beta.

### Steps to reproduce
<!-- Step-by-step testing instructions. For new user flows, consider instead stating the goal of the workflow and see if your PR reviewer can accomplish the workflow without specific steps! -->

Opening the Create shipping screen should be sufficient.

### The tests that have been performed
<!-- To give the reviewer an idea of what could be missed in terms of testing -->
I opened the Create shipping screen for both cases, when the feature flag is enabled and disabled.

### Images/gif
<!-- Include before and after images or gifs when appropriate. -->

- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->