### PR TITLE
[WOOMOB-577] Propagate barcodes only in cart state

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/WooPosHomeViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/WooPosHomeViewModel.kt
@@ -106,6 +106,7 @@ class WooPosHomeViewModel @Inject constructor(
             WooPosHomeUIEvent.OnPaymentCompletedViaCash -> onOrderSuccessfullyPaid(
                 PaymentMethod.CASH
             )
+
             WooPosHomeUIEvent.ExitPosClicked -> {
                 viewModelScope.launch {
                     _navigationEvent.emit(NavigationEvent.ExitPos)
@@ -158,6 +159,7 @@ class WooPosHomeViewModel @Inject constructor(
                             screenPositionState = ScreenPositionState.Checkout.CartWithTotals
                         )
                     }
+
                     is ChildToParentEvent.PaymentInProgress,
                     is ChildToParentEvent.PaymentFailed -> {
                         _state.value = _state.value.copy(
@@ -200,12 +202,15 @@ class WooPosHomeViewModel @Inject constructor(
                     is ChildToParentEvent.SearchEvent.QueryChanged -> {
                         sendEventToChildren(ChangedQuery(event.query))
                     }
+
                     ChildToParentEvent.SearchEvent.Finished -> {
                         sendEventToChildren(ParentToChildrenEvent.SearchEvent.Finished)
                     }
+
                     ChildToParentEvent.SearchEvent.Started -> {
                         sendEventToChildren(ParentToChildrenEvent.SearchEvent.Started)
                     }
+
                     is ChildToParentEvent.SearchEvent.RecentSearchSelected -> {
                         sendEventToChildren(RecentSearchSelected(event.query))
                     }
@@ -214,9 +219,11 @@ class WooPosHomeViewModel @Inject constructor(
                     is ChildToParentEvent.CouponsValidationFailed -> {
                         sendEventToChildren(ParentToChildrenEvent.CouponsValidationFailed)
                     }
+
                     is ChildToParentEvent.RemoveCouponsClicked -> {
                         sendEventToChildren(ParentToChildrenEvent.RemoveCouponsClicked)
                     }
+
                     is ChildToParentEvent.CouponsRemoved -> {
                         sendEventToChildren(CouponsRemoved(event.cartDataList))
                     }
@@ -225,9 +232,13 @@ class WooPosHomeViewModel @Inject constructor(
                         sendEventToChildren(ParentToChildrenEvent.RefreshProductList)
                     }
 
-                    is ChildToParentEvent.BarcodeScanned -> sendEventToChildren(
-                        ParentToChildrenEvent.BarcodeScanned(event.barcode)
-                    )
+                    is ChildToParentEvent.BarcodeScanned -> {
+                        if (state.value.screenPositionState is ScreenPositionState.Cart) {
+                            sendEventToChildren(
+                                ParentToChildrenEvent.BarcodeScanned(event.barcode)
+                            )
+                        }
+                    }
                 }
             }
         }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/cart/WooPosCartViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/cart/WooPosCartViewModel.kt
@@ -342,9 +342,6 @@ class WooPosCartViewModel @Inject constructor(
     }
 
     private fun onBarcodeScanned(barcode: String) {
-        if (_state.value.cartStatus !in listOf(EDITABLE, EMPTY)) {
-            return
-        }
         viewModelScope.launch {
             if (_state.value.body == WooPosCartState.Body.Empty) {
                 analyticsTracker.track(InteractionWithCustomerStarted)

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/home/WooPosHomeViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/home/WooPosHomeViewModelTest.kt
@@ -58,25 +58,68 @@ class WooPosHomeViewModelTest {
             )
         }
 
-    @Test
-    fun `when barcode scanned, then pass event to children`() =
-        runTest {
-            // GIVEN
-            whenever(childrenToParentEventReceiver.events).thenReturn(
-                flowOf(ChildToParentEvent.BarcodeScanned("123456789"))
-            )
-
-            // WHEN
-            createViewModel()
-
-            // THEN
-            verify(parentToChildrenEventSender).sendToChildren(
-                argThat {
-                    this is ParentToChildrenEvent.BarcodeScanned &&
-                        barcode == "123456789"
-                }
-            )
-        }
+//    @Test
+//    fun `given screen state Cart, when barcode scanned, then pass event to children`() = runTest {
+//        // GIVEN
+//        val events = MutableSharedFlow<ChildToParentEvent>()
+//        whenever(childrenToParentEventReceiver.events).thenReturn(events)
+//        createViewModel()
+//
+//        // WHEN
+//        events.emit(ChildToParentEvent.BarcodeScanned("123456789"))
+//
+//        // THEN
+//        verify(parentToChildrenEventSender).sendToChildren(
+//            argThat {
+//                this is ParentToChildrenEvent.BarcodeScanned &&
+//                    barcode == "123456789"
+//            }
+//        )
+//    }
+//
+//    @Test
+//    fun `given payment completed state, when barcode scanned, then don't pass event to children`() = runTest {
+//        // GIVEN
+//        val events = MutableSharedFlow<ChildToParentEvent>()
+//        whenever(childrenToParentEventReceiver.events).thenReturn(events)
+//
+//        val viewModel = createViewModel()
+//        events.emit(ChildToParentEvent.CheckoutClicked(listOf(ItemClickedData.Product.Simple(1))))
+//
+//        assertThat(viewModel.state.value.screenPositionState)
+//            .isEqualTo(WooPosHomeState.ScreenPositionState.Checkout.CartWithTotals)
+//
+//        // WHEN
+//        events.emit(ChildToParentEvent.BarcodeScanned("123456789"))
+//
+//        // THEN
+//        verify(parentToChildrenEventSender, never()).sendToChildren(
+//            argThat {
+//                this is ParentToChildrenEvent.BarcodeScanned &&
+//                    barcode == "123456789"
+//            }
+//        )
+//    }
+//
+//    @Test
+//    fun `given checkout state, when barcode scanned, then don't pass event to children`() =
+//        runTest {
+//            // GIVEN
+//            val events = MutableSharedFlow<ChildToParentEvent>()
+//            whenever(childrenToParentEventReceiver.events).thenReturn(events)
+//            createViewModel().onUIEvent(WooPosHomeUIEvent.OnPaymentCompletedViaCash)
+//
+//            // WHEN
+//            events.emit(ChildToParentEvent.BarcodeScanned("123456789"))
+//
+//            // THEN
+//            verify(parentToChildrenEventSender, never()).sendToChildren(
+//                argThat {
+//                    this is ParentToChildrenEvent.BarcodeScanned &&
+//                        barcode == "123456789"
+//                }
+//            )
+//        }
 
     @Test
     fun `given state checkout, when SystemBackClicked passed, then BackFromCheckoutToCartClicked event should be sent`() =

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/home/WooPosHomeViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/home/WooPosHomeViewModelTest.kt
@@ -79,7 +79,7 @@ class WooPosHomeViewModelTest {
     }
 
     @Test
-    fun `given payment completed state, when barcode scanned, then don't pass event to children`() = runTest {
+    fun `given checkout state, when barcode scanned, then don't pass event to children`() = runTest {
         // GIVEN
         val events = MutableSharedFlow<ChildToParentEvent>()
         whenever(childrenToParentEventReceiver.events).thenReturn(events)
@@ -103,7 +103,7 @@ class WooPosHomeViewModelTest {
     }
 
     @Test
-    fun `given checkout state, when barcode scanned, then don't pass event to children`() =
+    fun `given payment completed state, when barcode scanned, then don't pass event to children`() =
         runTest {
             // GIVEN
             val events = MutableSharedFlow<ChildToParentEvent>()

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/home/WooPosHomeViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/home/WooPosHomeViewModelTest.kt
@@ -20,6 +20,7 @@ import org.assertj.core.api.Assertions.assertThat
 import org.junit.Rule
 import org.mockito.kotlin.argThat
 import org.mockito.kotlin.mock
+import org.mockito.kotlin.never
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
 import kotlin.test.Test
@@ -58,68 +59,68 @@ class WooPosHomeViewModelTest {
             )
         }
 
-//    @Test
-//    fun `given screen state Cart, when barcode scanned, then pass event to children`() = runTest {
-//        // GIVEN
-//        val events = MutableSharedFlow<ChildToParentEvent>()
-//        whenever(childrenToParentEventReceiver.events).thenReturn(events)
-//        createViewModel()
-//
-//        // WHEN
-//        events.emit(ChildToParentEvent.BarcodeScanned("123456789"))
-//
-//        // THEN
-//        verify(parentToChildrenEventSender).sendToChildren(
-//            argThat {
-//                this is ParentToChildrenEvent.BarcodeScanned &&
-//                    barcode == "123456789"
-//            }
-//        )
-//    }
-//
-//    @Test
-//    fun `given payment completed state, when barcode scanned, then don't pass event to children`() = runTest {
-//        // GIVEN
-//        val events = MutableSharedFlow<ChildToParentEvent>()
-//        whenever(childrenToParentEventReceiver.events).thenReturn(events)
-//
-//        val viewModel = createViewModel()
-//        events.emit(ChildToParentEvent.CheckoutClicked(listOf(ItemClickedData.Product.Simple(1))))
-//
-//        assertThat(viewModel.state.value.screenPositionState)
-//            .isEqualTo(WooPosHomeState.ScreenPositionState.Checkout.CartWithTotals)
-//
-//        // WHEN
-//        events.emit(ChildToParentEvent.BarcodeScanned("123456789"))
-//
-//        // THEN
-//        verify(parentToChildrenEventSender, never()).sendToChildren(
-//            argThat {
-//                this is ParentToChildrenEvent.BarcodeScanned &&
-//                    barcode == "123456789"
-//            }
-//        )
-//    }
-//
-//    @Test
-//    fun `given checkout state, when barcode scanned, then don't pass event to children`() =
-//        runTest {
-//            // GIVEN
-//            val events = MutableSharedFlow<ChildToParentEvent>()
-//            whenever(childrenToParentEventReceiver.events).thenReturn(events)
-//            createViewModel().onUIEvent(WooPosHomeUIEvent.OnPaymentCompletedViaCash)
-//
-//            // WHEN
-//            events.emit(ChildToParentEvent.BarcodeScanned("123456789"))
-//
-//            // THEN
-//            verify(parentToChildrenEventSender, never()).sendToChildren(
-//                argThat {
-//                    this is ParentToChildrenEvent.BarcodeScanned &&
-//                        barcode == "123456789"
-//                }
-//            )
-//        }
+    @Test
+    fun `given screen state Cart, when barcode scanned, then pass event to children`() = runTest {
+        // GIVEN
+        val events = MutableSharedFlow<ChildToParentEvent>()
+        whenever(childrenToParentEventReceiver.events).thenReturn(events)
+        createViewModel()
+
+        // WHEN
+        events.emit(ChildToParentEvent.BarcodeScanned("123456789"))
+
+        // THEN
+        verify(parentToChildrenEventSender).sendToChildren(
+            argThat {
+                this is ParentToChildrenEvent.BarcodeScanned &&
+                    barcode == "123456789"
+            }
+        )
+    }
+
+    @Test
+    fun `given payment completed state, when barcode scanned, then don't pass event to children`() = runTest {
+        // GIVEN
+        val events = MutableSharedFlow<ChildToParentEvent>()
+        whenever(childrenToParentEventReceiver.events).thenReturn(events)
+
+        val viewModel = createViewModel()
+        events.emit(ChildToParentEvent.CheckoutClicked(listOf(ItemClickedData.Product.Simple(1))))
+
+        assertThat(viewModel.state.value.screenPositionState)
+            .isEqualTo(WooPosHomeState.ScreenPositionState.Checkout.CartWithTotals)
+
+        // WHEN
+        events.emit(ChildToParentEvent.BarcodeScanned("123456789"))
+
+        // THEN
+        verify(parentToChildrenEventSender, never()).sendToChildren(
+            argThat {
+                this is ParentToChildrenEvent.BarcodeScanned &&
+                    barcode == "123456789"
+            }
+        )
+    }
+
+    @Test
+    fun `given checkout state, when barcode scanned, then don't pass event to children`() =
+        runTest {
+            // GIVEN
+            val events = MutableSharedFlow<ChildToParentEvent>()
+            whenever(childrenToParentEventReceiver.events).thenReturn(events)
+            createViewModel().onUIEvent(WooPosHomeUIEvent.OnPaymentCompletedViaCash)
+
+            // WHEN
+            events.emit(ChildToParentEvent.BarcodeScanned("123456789"))
+
+            // THEN
+            verify(parentToChildrenEventSender, never()).sendToChildren(
+                argThat {
+                    this is ParentToChildrenEvent.BarcodeScanned &&
+                        barcode == "123456789"
+                }
+            )
+        }
 
     @Test
     fun `given state checkout, when SystemBackClicked passed, then BackFromCheckoutToCartClicked event should be sent`() =


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

<!-- Id number of the Linear issue this PR addresses, e.g., WOOMOB-373. -->

WOOMOB-577


### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

This PR ensures barcode scan results are processed only on the Cart screen/state.

### Testing information
<!-- This is your opportunity to break out individual scenarios that need testing (when necessary) and/or include a checklist for the reviewer to go through. Consider documenting the following from your own completed testing: devices used, alternate workflows, edge cases, affected areas, critical flows, areas not tested, and any remaining unknowns. Provide feedback on this new section of the PR template through Sept 30, 2024 to Apps Quality; additional context here: p91TBi-b8z-p2#comment-12036 -->

1. Scan barcode on the cart screen and verify it works
2. Tap on checkout
3. Scan barcode and verify the result is ignored
4. Collect a payment
5. Scan barcode on the success screen and verify the barcode is ignored
6. Tap on New Order
7. Scan barcode on the cart screen and verify it works

### The tests that have been performed
<!-- To give the reviewer an idea of what could be missed in terms of testing -->
The above.

### Images/gif
<!-- Include before and after images or gifs when appropriate. -->



- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->