### PR TITLE
Fix coroutines test deprecations

### DIFF
--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/reviews/ReviewModerationHandlerTests.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/reviews/ReviewModerationHandlerTests.kt
@@ -1,4 +1,4 @@
-@file:Suppress("DEPRECATION", "ForbiddenComment")
+@file:Suppress("DEPRECATION_ERROR", "ForbiddenComment")
 // TODO: @malinajirka Issue: https://github.com/woocommerce/woocommerce-android/issues/6899
 
 package com.woocommerce.android.ui.reviews

--- a/libs/fluxc-plugin/src/test/java/org/wordpress/android/fluxc/network/rest/wpcom/wc/product/ProductRestClientTest.kt
+++ b/libs/fluxc-plugin/src/test/java/org/wordpress/android/fluxc/network/rest/wpcom/wc/product/ProductRestClientTest.kt
@@ -1,7 +1,7 @@
 package org.wordpress.android.fluxc.network.rest.wpcom.wc.product
 
 import kotlinx.coroutines.ExperimentalCoroutinesApi
-import kotlinx.coroutines.test.runBlockingTest
+import kotlinx.coroutines.test.runTest
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.Before
 import org.junit.Test
@@ -43,7 +43,7 @@ class ProductRestClientTest {
     }
 
     @Test
-    fun `send only updated parameters with id if products differ`() = runBlockingTest {
+    fun `send only updated parameters with id if products differ`() = runTest {
         // given
         val product = WCProductModel().copy(
             remoteId = RemoteId(productId),
@@ -79,7 +79,7 @@ class ProductRestClientTest {
     }
 
     @Test
-    fun `do not send any properties if entities do not differ`() = runBlockingTest {
+    fun `do not send any properties if entities do not differ`() = runTest {
         // given
         val productA = WCProductModel().copy(
             remoteId = RemoteId(2),
@@ -111,7 +111,7 @@ class ProductRestClientTest {
 
     @Test
     fun `when fetch products called with exact sku search, then correct params is used for network call`() {
-        runBlockingTest {
+        runTest {
             whenever(wooNetwork.executeGetGsonRequest(any(), any(), eq(Array<ProductApiResponse>::class.java), any(), any(), any(), any(), any(), any())).thenReturn(WPAPIResponse.Success(null))
             sut.fetchProducts(
                 site = site,
@@ -140,7 +140,7 @@ class ProductRestClientTest {
 
     @Test
     fun `when fetch products called with partial sku search, then correct params is used for network call`() {
-        runBlockingTest {
+        runTest {
             whenever(wooNetwork.executeGetGsonRequest(any(), any(), eq(Array<ProductApiResponse>::class.java), any(), any(), any(), any(), any(), any())).thenReturn(WPAPIResponse.Success(null))
             sut.fetchProducts(
                 site = site,
@@ -168,7 +168,7 @@ class ProductRestClientTest {
 
     @Test
     fun `when fetch products called with the global unique id, then correct params is used for network call`() {
-        runBlockingTest {
+        runTest {
             whenever(wooNetwork.executeGetGsonRequest(any(), any(), eq(Array<ProductApiResponse>::class.java), any(), any(), any(), any(), any(), any())).thenReturn(WPAPIResponse.Success(null))
             val globalUniqueIdSearchQuery = "test global unique id"
             sut.fetchProducts(

--- a/libs/fluxc-plugin/src/test/java/org/wordpress/android/fluxc/store/WCGoogleStoreTest.kt
+++ b/libs/fluxc-plugin/src/test/java/org/wordpress/android/fluxc/store/WCGoogleStoreTest.kt
@@ -1,7 +1,7 @@
 package org.wordpress.android.fluxc.store
 
 import kotlinx.coroutines.ExperimentalCoroutinesApi
-import kotlinx.coroutines.test.runBlockingTest
+import kotlinx.coroutines.test.runTest
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertNotNull
@@ -47,7 +47,7 @@ class WCGoogleStoreTest {
     }
 
     @Test
-    fun `when programs response is a single page, then return the data directly`() = runBlockingTest {
+    fun `when programs response is a single page, then return the data directly`() = runTest {
         // Given
         val mockPrograms = createProgramsPage()
         val expectedModel = WCGoogleAdsProgramsMapper().mapToModel(mockPrograms)
@@ -76,7 +76,7 @@ class WCGoogleStoreTest {
     }
 
     @Test
-    fun `when programs response is paginated, requested everything and return the sum`() = runBlockingTest {
+    fun `when programs response is paginated, requested everything and return the sum`() = runTest {
         // Given
         val mapper = WCGoogleAdsProgramsMapper()
         val firstPage = createProgramsPage(pageNumber = 1, hasNextPage = true)

--- a/libs/fluxc-plugin/src/test/java/org/wordpress/android/fluxc/store/WCShippingMethodsStoreTest.kt
+++ b/libs/fluxc-plugin/src/test/java/org/wordpress/android/fluxc/store/WCShippingMethodsStoreTest.kt
@@ -1,7 +1,7 @@
 package org.wordpress.android.fluxc.store
 
 import kotlinx.coroutines.ExperimentalCoroutinesApi
-import kotlinx.coroutines.test.runBlockingTest
+import kotlinx.coroutines.test.runTest
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.Before
 import org.junit.Test
@@ -41,7 +41,7 @@ class WCShippingMethodsStoreTest {
 
     @Test
     fun `when shipping method id is not empty, then the shipping method can be updated`() =
-        runBlockingTest {
+        runTest {
             val shippingMethod = WCShippingMethod(id = "methodId", title = "methodTitle")
 
             sut.updateShippingMethod(defaultSiteModel, shippingMethod)
@@ -51,7 +51,7 @@ class WCShippingMethodsStoreTest {
 
     @Test
     fun `when shipping method id is empty, then the shipping method CAN'T be updated`() =
-        runBlockingTest {
+        runTest {
             val shippingMethod = WCShippingMethod(id = "", title = "methodTitle")
 
             sut.updateShippingMethod(defaultSiteModel, shippingMethod)
@@ -60,7 +60,7 @@ class WCShippingMethodsStoreTest {
         }
 
     @Test
-    fun `when fetch shipping method success, then response is expected`() = runBlockingTest {
+    fun `when fetch shipping method success, then response is expected`() = runTest {
         val methodId = "methodId"
         val methodTitle = "Random Title"
         val expected = WCShippingMethod(methodId, methodTitle)
@@ -77,7 +77,7 @@ class WCShippingMethodsStoreTest {
     }
 
     @Test
-    fun `when fetch shipping method is null, then response is error`() = runBlockingTest {
+    fun `when fetch shipping method is null, then response is error`() = runTest {
         val methodId = "methodId"
         whenever(shippingMethodsRestClient.fetchShippingMethodsById(defaultSiteModel, methodId))
             .doReturn(WooPayload(null))
@@ -89,7 +89,7 @@ class WCShippingMethodsStoreTest {
     }
 
     @Test
-    fun `when fetch shipping method fails, then response is error`() = runBlockingTest {
+    fun `when fetch shipping method fails, then response is error`() = runTest {
         val methodId = "methodId"
         val error = WooError(EMPTY_RESPONSE, NOT_FOUND)
         whenever(shippingMethodsRestClient.fetchShippingMethodsById(defaultSiteModel, methodId))
@@ -102,7 +102,7 @@ class WCShippingMethodsStoreTest {
     }
 
     @Test
-    fun `when fetch shipping methods success, then response is expected`() = runBlockingTest {
+    fun `when fetch shipping methods success, then response is expected`() = runTest {
         val methodId = "methodId"
         val methodTitle = "Random Title"
         val expected = listOf(WCShippingMethod(methodId, methodTitle))
@@ -119,7 +119,7 @@ class WCShippingMethodsStoreTest {
     }
 
     @Test
-    fun `when fetch shipping methods is null, then response is error`() = runBlockingTest {
+    fun `when fetch shipping methods is null, then response is error`() = runTest {
         whenever(shippingMethodsRestClient.fetchShippingMethods(defaultSiteModel))
             .doReturn(WooPayload(null))
 
@@ -130,7 +130,7 @@ class WCShippingMethodsStoreTest {
     }
 
     @Test
-    fun `when fetch shipping methods fails, then response is error`() = runBlockingTest {
+    fun `when fetch shipping methods fails, then response is error`() = runTest {
         val error = WooError(EMPTY_RESPONSE, NOT_FOUND)
         whenever(shippingMethodsRestClient.fetchShippingMethods(defaultSiteModel))
             .doReturn(WooPayload(error))

--- a/libs/fluxc/src/test/java/org/wordpress/android/fluxc/network/rest/wpapi/applicationpasswords/ApplicationPasswordManagerTests.kt
+++ b/libs/fluxc/src/test/java/org/wordpress/android/fluxc/network/rest/wpapi/applicationpasswords/ApplicationPasswordManagerTests.kt
@@ -3,7 +3,7 @@ package org.wordpress.android.fluxc.network.rest.wpapi.applicationpasswords
 import com.android.volley.NetworkResponse
 import com.android.volley.VolleyError
 import kotlinx.coroutines.ExperimentalCoroutinesApi
-import kotlinx.coroutines.test.runBlockingTest
+import kotlinx.coroutines.test.runTest
 import org.junit.Assert
 import org.junit.Before
 import org.junit.Test
@@ -14,7 +14,7 @@ import org.wordpress.android.fluxc.model.SiteModel
 import org.wordpress.android.fluxc.network.BaseRequest.BaseNetworkError
 import org.wordpress.android.fluxc.network.BaseRequest.GenericErrorType
 import org.wordpress.android.fluxc.network.rest.wpcom.WPComGsonRequest.WPComGsonNetworkError
-import java.util.Optional
+import java.util.*
 import kotlin.test.assertEquals
 
 @ExperimentalCoroutinesApi
@@ -50,7 +50,7 @@ class ApplicationPasswordManagerTests {
     }
 
     @Test
-    fun `given a local password exists, when we ask for a password, then return it`() = runBlockingTest {
+    fun `given a local password exists, when we ask for a password, then return it`() = runTest {
         whenever(applicationPasswordsStore.getCredentials(testSite)).thenReturn(testCredentials)
         val result = mApplicationPasswordsManager.getApplicationCredentials(
             testSite
@@ -61,7 +61,7 @@ class ApplicationPasswordManagerTests {
 
     @Test
     fun `given no local password is saved, when we ask for a password for a jetpack site, then create it`() =
-        runBlockingTest {
+        runTest {
             val site = testSite.apply {
                 origin = SiteModel.ORIGIN_WPCOM_REST
             }
@@ -92,7 +92,7 @@ class ApplicationPasswordManagerTests {
 
     @Test
     fun `given no local password is saved, when we ask for a password for a non-jetpack site, then create it`() =
-        runBlockingTest {
+        runTest {
             val site = testSite.apply {
                 origin = SiteModel.ORIGIN_XMLRPC
                 username = testCredentials.userName
@@ -122,7 +122,7 @@ class ApplicationPasswordManagerTests {
 
     @Test
     fun `when a jetpack site returns 404, then return feature not available`() =
-        runBlockingTest {
+        runTest {
             val site = testSite.apply {
                 origin = SiteModel.ORIGIN_WPCOM_REST
             }
@@ -143,7 +143,7 @@ class ApplicationPasswordManagerTests {
 
     @Test
     fun `when a jetpack site returns application_passwords_disabled, then return feature not available`() =
-        runBlockingTest {
+        runTest {
             val site = testSite.apply {
                 origin = SiteModel.ORIGIN_WPCOM_REST
             }
@@ -166,7 +166,7 @@ class ApplicationPasswordManagerTests {
 
     @Test
     fun `when a non-jetpack site returns 404, then return feature not available`() =
-        runBlockingTest {
+        runTest {
             val site = testSite.apply {
                 origin = SiteModel.ORIGIN_XMLRPC
                 username = testCredentials.userName
@@ -187,7 +187,7 @@ class ApplicationPasswordManagerTests {
 
     @Test
     fun `when a non-jetpack site returns application_passwords_disabled, then return feature not available`() =
-        runBlockingTest {
+        runTest {
             val site = testSite.apply {
                 origin = SiteModel.ORIGIN_XMLRPC
                 username = testCredentials.userName
@@ -210,7 +210,7 @@ class ApplicationPasswordManagerTests {
 
     @Test
     fun `given a duplicate password already exists, when creating a new password, then delete the previous one`() =
-        runBlockingTest {
+        runTest {
             val site = testSite.apply {
                 origin = SiteModel.ORIGIN_XMLRPC
                 username = testCredentials.userName
@@ -235,7 +235,7 @@ class ApplicationPasswordManagerTests {
 
     @Test
     fun `given application password doesn't exist locally, when deleting a password, then fetch the UUID`() =
-        runBlockingTest {
+        runTest {
             val site = testSite.apply {
                 origin = SiteModel.ORIGIN_XMLRPC
                 username = testCredentials.userName
@@ -255,7 +255,7 @@ class ApplicationPasswordManagerTests {
 
     @Test
     fun `given application password exists locally, when deleting a password, then delete it using it itself`() =
-        runBlockingTest {
+        runTest {
             val site = testSite.apply {
                 origin = SiteModel.ORIGIN_XMLRPC
                 username = testCredentials.userName

--- a/libs/fluxc/src/test/java/org/wordpress/android/fluxc/network/rest/wpapi/applicationpasswords/ApplicationPasswordsNetworkTests.kt
+++ b/libs/fluxc/src/test/java/org/wordpress/android/fluxc/network/rest/wpapi/applicationpasswords/ApplicationPasswordsNetworkTests.kt
@@ -5,7 +5,7 @@ import com.android.volley.Request
 import com.android.volley.RequestQueue
 import com.android.volley.VolleyError
 import kotlinx.coroutines.ExperimentalCoroutinesApi
-import kotlinx.coroutines.test.runBlockingTest
+import kotlinx.coroutines.test.runTest
 import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -21,7 +21,7 @@ import org.wordpress.android.fluxc.network.BaseRequest.BaseNetworkError
 import org.wordpress.android.fluxc.network.UserAgent
 import org.wordpress.android.fluxc.network.rest.wpapi.WPAPIGsonRequest
 import org.wordpress.android.fluxc.network.rest.wpapi.WPAPIResponse
-import java.util.Optional
+import java.util.*
 import kotlin.test.assertEquals
 import kotlin.test.assertIs
 
@@ -55,7 +55,7 @@ class ApplicationPasswordsNetworkTests {
     }
 
     @Test
-    fun `when sending a new request, then fetch the application password`() = runBlockingTest {
+    fun `when sending a new request, then fetch the application password`() = runTest {
         givenSuccessResponse()
         whenever(mApplicationPasswordsManager.getApplicationCredentials(testSite))
             .thenReturn(ApplicationPasswordCreationResult.Created(testCredentials))
@@ -66,7 +66,7 @@ class ApplicationPasswordsNetworkTests {
     }
 
     @Test
-    fun `given a locally existing password, when password is revoked, then regenerate a new one`() = runBlockingTest {
+    fun `given a locally existing password, when password is revoked, then regenerate a new one`() = runTest {
         whenever(mApplicationPasswordsManager.getApplicationCredentials(testSite))
             .thenReturn(ApplicationPasswordCreationResult.Existing(testCredentials))
             .thenReturn(ApplicationPasswordCreationResult.Created(testCredentials))
@@ -80,7 +80,7 @@ class ApplicationPasswordsNetworkTests {
     }
 
     @Test
-    fun `given request succeeds, when request is executed, then return the response`() = runBlockingTest {
+    fun `given request succeeds, when request is executed, then return the response`() = runTest {
         val expectedResponse = TestResponse("value")
         givenSuccessResponse(expectedResponse)
         whenever(mApplicationPasswordsManager.getApplicationCredentials(testSite))
@@ -93,7 +93,7 @@ class ApplicationPasswordsNetworkTests {
     }
 
     @Test
-    fun `given request fails, when request is executed, then return the error`() = runBlockingTest {
+    fun `given request fails, when request is executed, then return the error`() = runTest {
         val networkError = VolleyError(NetworkResponse(500, byteArrayOf(), true, 0, emptyList()))
         givenErrorResponse(networkError)
         whenever(mApplicationPasswordsManager.getApplicationCredentials(testSite))
@@ -107,7 +107,7 @@ class ApplicationPasswordsNetworkTests {
 
     @Test
     fun `given site doesn't support application passwords, when a new request, then notify listener`() =
-        runBlockingTest {
+        runTest {
             val networkError = BaseNetworkError(VolleyError(NetworkResponse(501, byteArrayOf(), true, 0, emptyList())))
             whenever(mApplicationPasswordsManager.getApplicationCredentials(testSite))
                 .thenReturn(ApplicationPasswordCreationResult.NotSupported(BaseNetworkError(networkError)))
@@ -119,7 +119,7 @@ class ApplicationPasswordsNetworkTests {
 
     @Test
     fun `when a new password is created, then notify listener`() =
-        runBlockingTest {
+        runTest {
             givenSuccessResponse()
             whenever(mApplicationPasswordsManager.getApplicationCredentials(testSite))
                 .thenReturn(ApplicationPasswordCreationResult.Created(testCredentials))
@@ -131,7 +131,7 @@ class ApplicationPasswordsNetworkTests {
 
     @Test
     fun `given a revoked local password, when a new password is created, then notify listener`() =
-        runBlockingTest {
+        runTest {
             whenever(mApplicationPasswordsManager.getApplicationCredentials(testSite))
                 .thenReturn(ApplicationPasswordCreationResult.Existing(testCredentials))
                 .thenReturn(ApplicationPasswordCreationResult.Created(testCredentials))


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

<!-- Id number of the Linear issue this PR addresses, e.g., WOOMOB-373. -->

### Description
After updating coroutines-test library in #14087, a bunch of warnings about using deprecated functions is thrown in fluxc unit tests and breaking the [CI](https://buildkite.com/automattic/woocommerce-android/builds/29749#019756bf-1bb4-4277-87b5-a0735a457e3b), this PR fixes those deprecations.

- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->