### PR TITLE
[Shipping labels] Refund request UI

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/GetShipments.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/GetShipments.kt
@@ -9,6 +9,8 @@ import com.woocommerce.android.ui.orders.wooshippinglabels.models.ShippableItemM
 import com.woocommerce.android.ui.orders.wooshippinglabels.networking.ShippingLabelDTO
 import com.woocommerce.android.ui.products.details.ProductDetailRepository
 import kotlinx.coroutines.flow.first
+import java.math.BigDecimal
+import java.util.Date
 import javax.inject.Inject
 
 class GetShipments @Inject constructor(
@@ -79,6 +81,8 @@ class GetShipments @Inject constructor(
                 carrierId = labelForShipment.carrierId,
                 trackingNumber = labelForShipment.tracking,
                 status = labelForShipment.status,
+                refundableAmount = labelForShipment.refundableAmount ?: BigDecimal.ZERO,
+                purchaseDate = labelForShipment.createdDate?.let { Date(it) },
             )
         }
     }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/WooShippingLabelCreationFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/WooShippingLabelCreationFragment.kt
@@ -108,7 +108,7 @@ class WooShippingLabelCreationFragment : BaseFragment(), BackPressListener {
                 )
 
                 is MultiLiveEvent.Event.Exit -> findNavController().navigateUp()
-                is WooShippingLabelCreationViewModel.StartSplitShipment -> {
+                is WooShippingLabelCreationViewModel.NavigateToSplitShipment -> {
                     WooShippingLabelCreationFragmentDirections
                         .actionWooShippingLabelCreationFragmentToWooShippingSplitShipmentFragment(
                             shipmentArgs = event.shipmentArgs

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/WooShippingLabelCreationFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/WooShippingLabelCreationFragment.kt
@@ -21,7 +21,7 @@ import com.woocommerce.android.ui.main.MainActivity.Companion.BackPressListener
 import com.woocommerce.android.ui.orders.shippinglabels.creation.ShippingLabelHazmatCategory
 import com.woocommerce.android.ui.orders.wooshippinglabels.WooShippingLabelCreationViewModel.NavigatePackageSelection
 import com.woocommerce.android.ui.orders.wooshippinglabels.WooShippingLabelCreationViewModel.NavigateToCustomsFormEdit
-import com.woocommerce.android.ui.orders.wooshippinglabels.WooShippingLabelCreationViewModel.StartHazmatFormEdit
+import com.woocommerce.android.ui.orders.wooshippinglabels.WooShippingLabelCreationViewModel.NavigateToHazmatFormEdit
 import com.woocommerce.android.ui.orders.wooshippinglabels.address.EditAddressFlow
 import com.woocommerce.android.ui.orders.wooshippinglabels.address.WooShippingEditAddressFragment.Companion.DESTINATION_ADDRESS_UPDATE_RESULT
 import com.woocommerce.android.ui.orders.wooshippinglabels.customs.CustomsData
@@ -117,7 +117,7 @@ class WooShippingLabelCreationFragment : BaseFragment(), BackPressListener {
                         }
                 }
 
-                is StartHazmatFormEdit -> {
+                is NavigateToHazmatFormEdit -> {
                     WooShippingLabelCreationFragmentDirections
                         .actionWooShippingLabelCreationFragmentToWooShippingLabelHazmatFormFragment(
                             event.selectedCategory?.name

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/WooShippingLabelCreationFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/WooShippingLabelCreationFragment.kt
@@ -126,6 +126,11 @@ class WooShippingLabelCreationFragment : BaseFragment(), BackPressListener {
 
                 is WooShippingLabelCreationViewModel.OpenShippingLabelFile -> openShippingLabelPreview(event.file)
                 is WooShippingLabelCreationViewModel.OpenLearnMoreScreen -> openLearnMoreView()
+                is WooShippingLabelCreationViewModel.StartRefundRequest -> startRefundRequest(
+                    event.orderId,
+                    event.shipment
+                )
+
                 is WooShippingLabelCreationViewModel.OpenUrl -> openUrl(event.url)
                 is WooShippingLabelCreationViewModel.ShowError -> showErrorDialog(event.errorResId)
             }
@@ -163,6 +168,13 @@ class WooShippingLabelCreationFragment : BaseFragment(), BackPressListener {
         findNavController().navigate(
             WooShippingLabelCreationFragmentDirections
                 .actionWooShippingLabelCreationFragmentToPrintShippingLabelInfoFragment()
+        )
+    }
+
+    private fun startRefundRequest(orderId: Long, shipment: ShipmentUIModel) {
+        findNavController().navigate(
+            WooShippingLabelCreationFragmentDirections
+                .actionWooShippingLabelCreationFragmentToWooShippingLabelRefundRequestFragment(orderId, shipment)
         )
     }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/WooShippingLabelCreationFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/WooShippingLabelCreationFragment.kt
@@ -19,9 +19,9 @@ import com.woocommerce.android.ui.dialog.WooDialog
 import com.woocommerce.android.ui.main.AppBarStatus
 import com.woocommerce.android.ui.main.MainActivity.Companion.BackPressListener
 import com.woocommerce.android.ui.orders.shippinglabels.creation.ShippingLabelHazmatCategory
+import com.woocommerce.android.ui.orders.wooshippinglabels.WooShippingLabelCreationViewModel.NavigatePackageSelection
 import com.woocommerce.android.ui.orders.wooshippinglabels.WooShippingLabelCreationViewModel.StartCustomsFormEdit
 import com.woocommerce.android.ui.orders.wooshippinglabels.WooShippingLabelCreationViewModel.StartHazmatFormEdit
-import com.woocommerce.android.ui.orders.wooshippinglabels.WooShippingLabelCreationViewModel.StartPackageSelection
 import com.woocommerce.android.ui.orders.wooshippinglabels.address.EditAddressFlow
 import com.woocommerce.android.ui.orders.wooshippinglabels.address.WooShippingEditAddressFragment.Companion.DESTINATION_ADDRESS_UPDATE_RESULT
 import com.woocommerce.android.ui.orders.wooshippinglabels.customs.CustomsData
@@ -71,7 +71,7 @@ class WooShippingLabelCreationFragment : BaseFragment(), BackPressListener {
     private fun setupObservers() {
         viewModel.event.observe(viewLifecycleOwner) { event ->
             when (event) {
-                is StartPackageSelection ->
+                is NavigatePackageSelection ->
                     WooShippingLabelCreationFragmentDirections
                         .actionWooShippingLabelCreationFragmentToWooShippingLabelPackageCreationFragment()
                         .let { findNavController().navigateSafely(it) }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/WooShippingLabelCreationFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/WooShippingLabelCreationFragment.kt
@@ -76,7 +76,7 @@ class WooShippingLabelCreationFragment : BaseFragment(), BackPressListener {
                         .actionWooShippingLabelCreationFragmentToWooShippingLabelPackageCreationFragment()
                         .let { findNavController().navigateSafely(it) }
 
-                is WooShippingLabelCreationViewModel.StartOriginAddressEdit ->
+                is WooShippingLabelCreationViewModel.NavigateToOriginAddressEdit ->
                     WooShippingLabelCreationFragmentDirections
                         .actionWooShippingLabelCreationFragmentToWooShippingEditOriginAddressFragment(
                             flow = EditAddressFlow.EditOriginAddress(event.originAddress)

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/WooShippingLabelCreationFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/WooShippingLabelCreationFragment.kt
@@ -20,7 +20,7 @@ import com.woocommerce.android.ui.main.AppBarStatus
 import com.woocommerce.android.ui.main.MainActivity.Companion.BackPressListener
 import com.woocommerce.android.ui.orders.shippinglabels.creation.ShippingLabelHazmatCategory
 import com.woocommerce.android.ui.orders.wooshippinglabels.WooShippingLabelCreationViewModel.NavigatePackageSelection
-import com.woocommerce.android.ui.orders.wooshippinglabels.WooShippingLabelCreationViewModel.StartCustomsFormEdit
+import com.woocommerce.android.ui.orders.wooshippinglabels.WooShippingLabelCreationViewModel.NavigateToCustomsFormEdit
 import com.woocommerce.android.ui.orders.wooshippinglabels.WooShippingLabelCreationViewModel.StartHazmatFormEdit
 import com.woocommerce.android.ui.orders.wooshippinglabels.address.EditAddressFlow
 import com.woocommerce.android.ui.orders.wooshippinglabels.address.WooShippingEditAddressFragment.Companion.DESTINATION_ADDRESS_UPDATE_RESULT
@@ -91,7 +91,7 @@ class WooShippingLabelCreationFragment : BaseFragment(), BackPressListener {
                             )
                         ).let { findNavController().navigateSafely(it) }
 
-                is StartCustomsFormEdit -> {
+                is NavigateToCustomsFormEdit -> {
                     WooShippingLabelCreationFragmentDirections
                         .actionWooShippingLabelCreationFragmentToWooShippingLabelCustomsFormFragment(
                             shippableItems = event.shippableItems.toTypedArray(),

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/WooShippingLabelCreationFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/WooShippingLabelCreationFragment.kt
@@ -126,7 +126,7 @@ class WooShippingLabelCreationFragment : BaseFragment(), BackPressListener {
 
                 is WooShippingLabelCreationViewModel.OpenShippingLabelFile -> openShippingLabelPreview(event.file)
                 is WooShippingLabelCreationViewModel.OpenLearnMoreScreen -> openLearnMoreView()
-                is WooShippingLabelCreationViewModel.StartRefundRequest -> startRefundRequest(
+                is WooShippingLabelCreationViewModel.NavigateToRefundRequest -> navigateToRefundRequest(
                     event.orderId,
                     event.shipment
                 )
@@ -171,7 +171,7 @@ class WooShippingLabelCreationFragment : BaseFragment(), BackPressListener {
         )
     }
 
-    private fun startRefundRequest(orderId: Long, shipment: ShipmentUIModel) {
+    private fun navigateToRefundRequest(orderId: Long, shipment: ShipmentUIModel) {
         findNavController().navigate(
             WooShippingLabelCreationFragmentDirections
                 .actionWooShippingLabelCreationFragmentToWooShippingLabelRefundRequestFragment(orderId, shipment)

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/WooShippingLabelCreationFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/WooShippingLabelCreationFragment.kt
@@ -82,7 +82,7 @@ class WooShippingLabelCreationFragment : BaseFragment(), BackPressListener {
                             flow = EditAddressFlow.EditOriginAddress(event.originAddress)
                         ).let { findNavController().navigateSafely(it) }
 
-                is WooShippingLabelCreationViewModel.StartDestinationAddressEdit ->
+                is WooShippingLabelCreationViewModel.NavigateToDestinationAddressEdit ->
                     WooShippingLabelCreationFragmentDirections
                         .actionWooShippingLabelCreationFragmentToWooShippingEditOriginAddressFragment(
                             flow = EditAddressFlow.EditDestinationAddress(

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/WooShippingLabelCreationViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/WooShippingLabelCreationViewModel.kt
@@ -594,7 +594,7 @@ class WooShippingLabelCreationViewModel @Inject constructor(
 
     fun onEditDestinationAddress(destinationAddress: DestinationShippingAddress) {
         triggerEvent(
-            StartDestinationAddressEdit(
+            NavigateToDestinationAddressEdit(
                 destinationAddress = destinationAddress,
                 orderId = navArgs.orderId
             )
@@ -916,7 +916,7 @@ class WooShippingLabelCreationViewModel @Inject constructor(
     data object NavigatePackageSelection : Event()
 
     data class NavigateToOriginAddressEdit(val originAddress: OriginShippingAddress) : Event()
-    data class StartDestinationAddressEdit(
+    data class NavigateToDestinationAddressEdit(
         val destinationAddress: DestinationShippingAddress,
         val orderId: Long
     ) : Event()

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/WooShippingLabelCreationViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/WooShippingLabelCreationViewModel.kt
@@ -721,7 +721,7 @@ class WooShippingLabelCreationViewModel @Inject constructor(
         val currentShipmentItems = shipmentItems.value
         if (currentStoreOptions != null && currentShipmentItems.isNotEmpty()) {
             triggerEvent(
-                StartSplitShipment(
+                NavigateToSplitShipment(
                     SplitShipmentArgs(
                         orderId = navArgs.orderId,
                         storeOptions = currentStoreOptions,
@@ -921,7 +921,7 @@ class WooShippingLabelCreationViewModel @Inject constructor(
         val orderId: Long
     ) : Event()
 
-    data class StartSplitShipment(val shipmentArgs: SplitShipmentArgs) : Event()
+    data class NavigateToSplitShipment(val shipmentArgs: SplitShipmentArgs) : Event()
 
     @Parcelize
     data class SplitShipmentArgs(

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/WooShippingLabelCreationViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/WooShippingLabelCreationViewModel.kt
@@ -589,7 +589,7 @@ class WooShippingLabelCreationViewModel @Inject constructor(
     }
 
     fun onEditOriginAddress(address: OriginShippingAddress) {
-        triggerEvent(StartOriginAddressEdit(address))
+        triggerEvent(NavigateToOriginAddressEdit(address))
     }
 
     fun onEditDestinationAddress(destinationAddress: DestinationShippingAddress) {
@@ -915,7 +915,7 @@ class WooShippingLabelCreationViewModel @Inject constructor(
 
     data object NavigatePackageSelection : Event()
 
-    data class StartOriginAddressEdit(val originAddress: OriginShippingAddress) : Event()
+    data class NavigateToOriginAddressEdit(val originAddress: OriginShippingAddress) : Event()
     data class StartDestinationAddressEdit(
         val destinationAddress: DestinationShippingAddress,
         val orderId: Long

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/WooShippingLabelCreationViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/WooShippingLabelCreationViewModel.kt
@@ -853,7 +853,7 @@ class WooShippingLabelCreationViewModel @Inject constructor(
     }
 
     fun onRefundClicked() {
-        val selectedShipment = shipments.value[selectedShipmentIndexFlow.value]
+        val selectedShipment = shipments.value[selectedShipmentIndex]
         triggerEvent(StartRefundRequest(navArgs.orderId, selectedShipment))
     }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/WooShippingLabelCreationViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/WooShippingLabelCreationViewModel.kt
@@ -844,7 +844,8 @@ class WooShippingLabelCreationViewModel @Inject constructor(
     }
 
     fun onRefundClicked() {
-        triggerEvent(StartRefundRequest)
+        val selectedShipment = shipments.value[selectedShipmentIndexFlow.value]
+        triggerEvent(StartRefundRequest(navArgs.orderId, selectedShipment))
     }
 
     fun onLearnMoreClicked() {
@@ -1031,7 +1032,8 @@ class WooShippingLabelCreationViewModel @Inject constructor(
     data class OpenShippingLabelFile(val file: File) : Event()
     data class OpenUrl(val url: String) : Event()
     data class ShowError(val errorResId: Int) : Event()
-    object StartRefundRequest : Event()
+    data class StartRefundRequest(val orderId: Long, val shipment: ShipmentUIModel) : Event()
+
     object OpenLearnMoreScreen : Event()
 
     enum class Carrier(val pickupUrl: String) {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/WooShippingLabelCreationViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/WooShippingLabelCreationViewModel.kt
@@ -217,8 +217,14 @@ class WooShippingLabelCreationViewModel @Inject constructor(
     private fun observeShippingLabelPurchaseStatus(shipmentId: Int) {
         launch {
             val labelId = shipments.value[shipmentId].labelId ?: return@launch
-            observeShippingLabelStatus(orderId = navArgs.orderId, labelId = labelId).onEach { status ->
-                updateShipment(shipmentId, shipments.value[shipmentId].copy(status = status))
+            observeShippingLabelStatus(orderId = navArgs.orderId, labelId = labelId).onEach { result ->
+                updateShipment(
+                    shipmentId,
+                    shipments.value[shipmentId].copy(
+                        status = result.status,
+                        refundableAmount = result.refundableAmount ?: BigDecimal.ZERO
+                    )
+                )
             }.launchIn(this)
         }
     }
@@ -688,7 +694,9 @@ class WooShippingLabelCreationViewModel @Inject constructor(
                         purchased = true,
                         labelId = purchasedLabel.labelId,
                         carrierId = purchasedLabel.carrierId,
-                        trackingNumber = purchasedLabel.tracking
+                        trackingNumber = purchasedLabel.tracking,
+                        refundableAmount = purchasedLabel.refundableAmount,
+                        purchaseDate = purchasedLabel.created
                     )
                 )
                 observeShippingLabelPurchaseStatus(shipmentId)

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/WooShippingLabelCreationViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/WooShippingLabelCreationViewModel.kt
@@ -768,7 +768,7 @@ class WooShippingLabelCreationViewModel @Inject constructor(
         val destinationCountryCode = shippingAddresses.value
             ?.shipTo?.address?.country?.code.orEmpty()
 
-        val event = StartCustomsFormEdit(
+        val event = NavigateToCustomsFormEdit(
             shippableItems = shipmentItems.value[selectedShipmentIndex],
             destinationCountryCode = destinationCountryCode,
             customData = customsFormDataFlow.value[selectedShipmentIndex]
@@ -930,7 +930,7 @@ class WooShippingLabelCreationViewModel @Inject constructor(
         val storeOptions: StoreOptionsModel
     ) : Parcelable
 
-    data class StartCustomsFormEdit(
+    data class NavigateToCustomsFormEdit(
         val shippableItems: List<ShippableItemModel>,
         val destinationCountryCode: String,
         val customData: CustomsData?

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/WooShippingLabelCreationViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/WooShippingLabelCreationViewModel.kt
@@ -628,7 +628,7 @@ class WooShippingLabelCreationViewModel @Inject constructor(
     }
 
     fun onSelectPackageClicked() {
-        triggerEvent(StartPackageSelection)
+        triggerEvent(NavigatePackageSelection)
     }
 
     @Suppress("ComplexCondition")
@@ -913,7 +913,7 @@ class WooShippingLabelCreationViewModel @Inject constructor(
         return shouldRequireITN(destinationCountryCode, totalShippingValue)
     }
 
-    data object StartPackageSelection : Event()
+    data object NavigatePackageSelection : Event()
 
     data class StartOriginAddressEdit(val originAddress: OriginShippingAddress) : Event()
     data class StartDestinationAddressEdit(

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/WooShippingLabelCreationViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/WooShippingLabelCreationViewModel.kt
@@ -784,7 +784,7 @@ class WooShippingLabelCreationViewModel @Inject constructor(
         // Disables the current Snackbar before navigation
         // to avoid presentation conflict with the Hazmat selection result
         snackbarData = null
-        triggerEvent(StartHazmatFormEdit(selectedCategory))
+        triggerEvent(NavigateToHazmatFormEdit(selectedCategory))
     }
 
     fun onHazmatCategorySelected(selectedCategory: ShippingLabelHazmatCategory?) {
@@ -936,7 +936,7 @@ class WooShippingLabelCreationViewModel @Inject constructor(
         val customData: CustomsData?
     ) : Event()
 
-    data class StartHazmatFormEdit(val selectedCategory: ShippingLabelHazmatCategory?) : Event()
+    data class NavigateToHazmatFormEdit(val selectedCategory: ShippingLabelHazmatCategory?) : Event()
 
     sealed class WooShippingViewState {
         data object Error : WooShippingViewState()

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/WooShippingLabelCreationViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/WooShippingLabelCreationViewModel.kt
@@ -854,7 +854,7 @@ class WooShippingLabelCreationViewModel @Inject constructor(
 
     fun onRefundClicked() {
         val selectedShipment = shipments.value[selectedShipmentIndex]
-        triggerEvent(StartRefundRequest(navArgs.orderId, selectedShipment))
+        triggerEvent(NavigateToRefundRequest(navArgs.orderId, selectedShipment))
     }
 
     fun onLearnMoreClicked() {
@@ -1041,7 +1041,7 @@ class WooShippingLabelCreationViewModel @Inject constructor(
     data class OpenShippingLabelFile(val file: File) : Event()
     data class OpenUrl(val url: String) : Event()
     data class ShowError(val errorResId: Int) : Event()
-    data class StartRefundRequest(val orderId: Long, val shipment: ShipmentUIModel) : Event()
+    data class NavigateToRefundRequest(val orderId: Long, val shipment: ShipmentUIModel) : Event()
 
     object OpenLearnMoreScreen : Event()
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/models/ShipmentUIModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/models/ShipmentUIModel.kt
@@ -2,6 +2,8 @@ package com.woocommerce.android.ui.orders.wooshippinglabels.models
 
 import android.os.Parcelable
 import kotlinx.parcelize.Parcelize
+import java.math.BigDecimal
+import java.util.Date
 
 @Parcelize
 data class ShipmentUIModel(
@@ -13,7 +15,9 @@ data class ShipmentUIModel(
     val carrierId: String? = null,
     val trackingNumber: String? = null,
     val purchaseState: PurchaseState = PurchaseState.NoStarted,
-    val status: ShippingLabelStatus = ShippingLabelStatus.UNKNOWN
+    val status: ShippingLabelStatus = ShippingLabelStatus.UNKNOWN,
+    val refundableAmount: BigDecimal = BigDecimal.ZERO,
+    val purchaseDate: Date? = null,
 ) : Parcelable
 
 @Parcelize

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/networking/WooShippingLabelRepository.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/networking/WooShippingLabelRepository.kt
@@ -10,7 +10,6 @@ import com.woocommerce.android.ui.orders.wooshippinglabels.models.AddressNormali
 import com.woocommerce.android.ui.orders.wooshippinglabels.models.DestinationShippingAddress
 import com.woocommerce.android.ui.orders.wooshippinglabels.models.OriginShippingAddress
 import com.woocommerce.android.ui.orders.wooshippinglabels.models.PurchasedLabelData
-import com.woocommerce.android.ui.orders.wooshippinglabels.models.ShippingLabelStatus
 import com.woocommerce.android.ui.orders.wooshippinglabels.packages.ui.PackageData
 import com.woocommerce.android.ui.orders.wooshippinglabels.rates.datasource.WooShippingRateModel
 import org.wordpress.android.fluxc.model.SiteModel
@@ -75,11 +74,7 @@ class WooShippingLabelRepository @Inject constructor(
         site = site,
         orderId = orderId,
         labelId = labelId,
-    ).asWooResult { response ->
-        response.shippingLabel?.let {
-            mapper(it).status
-        } ?: ShippingLabelStatus.UNKNOWN
-    }
+    ).asWooResult { response -> response.shippingLabel?.let { mapper(it) } }
 
     @Suppress("LongParameterList")
     suspend fun purchaseShippingLabel(

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/purchased/ObserveShippingLabelStatus.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/purchased/ObserveShippingLabelStatus.kt
@@ -8,28 +8,32 @@ import com.woocommerce.android.ui.orders.wooshippinglabels.networking.WooShippin
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.flow
+import java.math.BigDecimal
 import javax.inject.Inject
 
 class ObserveShippingLabelStatus @Inject constructor(
     private val selectedSite: SelectedSite,
     private val labelRepository: WooShippingLabelRepository
 ) {
-    operator fun invoke(orderId: Long, labelId: Long): Flow<ShippingLabelStatus> {
+    operator fun invoke(orderId: Long, labelId: Long): Flow<ObserveShippingLabelStatusResult> {
         return flow {
             var latestStatus = PURCHASE_IN_PROGRESS
-            emit(latestStatus)
+            emit(ObserveShippingLabelStatusResult(latestStatus, null))
 
             do {
-                latestStatus = labelRepository.fetchShippingLabelStatus(
+                val response = labelRepository.fetchShippingLabelStatus(
                     site = selectedSite.get(),
                     orderId = orderId,
                     labelId = labelId
-                ).takeIf { it.isError.not() }?.model ?: UNKNOWN
-                emit(latestStatus)
+                ).takeIf { it.isError.not() }?.model
+                latestStatus = response?.status ?: UNKNOWN
+                emit(ObserveShippingLabelStatusResult(latestStatus, response?.refundableAmount))
                 delay(DELAY_BETWEEN_STATUS_CHECKS)
             } while (latestStatus == PURCHASE_IN_PROGRESS)
         }
     }
+
+    data class ObserveShippingLabelStatusResult(val status: ShippingLabelStatus, val refundableAmount: BigDecimal?)
 
     companion object {
         private const val DELAY_BETWEEN_STATUS_CHECKS = 2000L

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/refund/WooShippingLabelRefundFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/refund/WooShippingLabelRefundFragment.kt
@@ -1,0 +1,70 @@
+package com.woocommerce.android.ui.orders.wooshippinglabels.refund
+
+import android.os.Bundle
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import androidx.compose.material.Surface
+import androidx.compose.ui.platform.ComposeView
+import androidx.compose.ui.platform.ViewCompositionStrategy
+import androidx.fragment.app.viewModels
+import com.woocommerce.android.extensions.navigateBackWithResult
+import com.woocommerce.android.ui.base.BaseFragment
+import com.woocommerce.android.ui.base.UIMessageResolver
+import com.woocommerce.android.ui.compose.theme.WooThemeWithBackground
+import com.woocommerce.android.ui.main.MainActivity.Companion.BackPressListener
+import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.Exit
+import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.ShowSnackbar
+import dagger.hilt.android.AndroidEntryPoint
+import javax.inject.Inject
+
+@AndroidEntryPoint
+class WooShippingLabelRefundFragment : BaseFragment(), BackPressListener {
+    val viewModel: WooShippingLabelRefundViewModel by viewModels()
+
+    @Inject
+    lateinit var uiMessageResolver: UIMessageResolver
+
+    override fun getFragmentTitle() = ""
+
+    override fun onCreateView(
+        inflater: LayoutInflater,
+        container: ViewGroup?,
+        savedInstanceState: Bundle?
+    ): View? {
+        return ComposeView(requireContext()).apply {
+            setViewCompositionStrategy(ViewCompositionStrategy.DisposeOnViewTreeLifecycleDestroyed)
+            setContent {
+                WooThemeWithBackground {
+                    Surface {
+                        WooShippingLabelRefundScreen(viewModel)
+                    }
+                }
+            }
+        }
+    }
+
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
+        bindEventListener()
+    }
+
+    override fun onRequestAllowBackPress(): Boolean {
+        viewModel.onBackPressed()
+        return false
+    }
+
+    private fun bindEventListener() {
+        viewModel.event.observe(viewLifecycleOwner) { event ->
+            when (event) {
+                is ShowSnackbar -> uiMessageResolver.getSnack(event.message, *event.args).show()
+                is Exit -> navigateBackWithResult(KEY_REFUND_SHIPPING_LABEL_RESULT, true)
+                else -> event.isHandled = false
+            }
+        }
+    }
+
+    companion object {
+        const val KEY_REFUND_SHIPPING_LABEL_RESULT = "key_refund_shipping_label_result"
+    }
+}

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/refund/WooShippingLabelRefundFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/refund/WooShippingLabelRefundFragment.kt
@@ -57,7 +57,11 @@ class WooShippingLabelRefundFragment : BaseFragment(), BackPressListener {
     private fun bindEventListener() {
         viewModel.event.observe(viewLifecycleOwner) { event ->
             when (event) {
-                is ShowSnackbar -> uiMessageResolver.getSnack(event.message, *event.args).show()
+                is ShowSnackbar -> {
+                    @Suppress("SpreadOperator")
+                    uiMessageResolver.getSnack(event.message, *event.args).show()
+                }
+
                 is Exit -> navigateBackWithResult(KEY_REFUND_SHIPPING_LABEL_RESULT, true)
                 else -> event.isHandled = false
             }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/refund/WooShippingLabelRefundScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/refund/WooShippingLabelRefundScreen.kt
@@ -1,0 +1,133 @@
+package com.woocommerce.android.ui.orders.wooshippinglabels.refund
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material.Scaffold
+import androidx.compose.material.Surface
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.livedata.observeAsState
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.colorResource
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.font.FontStyle
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import com.woocommerce.android.R
+import com.woocommerce.android.ui.compose.annotatedStringResLegacy
+import com.woocommerce.android.ui.compose.component.WCColoredButton
+import com.woocommerce.android.ui.compose.theme.WooThemeWithBackground
+
+@Composable
+fun WooShippingLabelRefundScreen(viewModel: WooShippingLabelRefundViewModel) {
+    viewModel.viewState.observeAsState().value?.let {
+        when (it) {
+            is WooShippingLabelRefundViewModel.ViewState.Loading -> LoadingScreen()
+
+            is WooShippingLabelRefundViewModel.ViewState.DataState -> WooShippingLabelRefundScreen(
+                purchaseDate = it.purchaseDate,
+                refundableAmount = it.refundableAmount,
+                onRefundLabelClick = viewModel::onRefundShippingLabelButtonClicked,
+            )
+        }
+    }
+}
+
+@Composable
+fun WooShippingLabelRefundScreen(
+    purchaseDate: String?,
+    refundableAmount: String?,
+    onRefundLabelClick: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    Surface(modifier = modifier.fillMaxSize()) {
+        Column(
+            verticalArrangement = Arrangement.spacedBy(8.dp),
+            modifier = modifier
+                .fillMaxSize()
+                .padding(16.dp)
+                .verticalScroll(rememberScrollState())
+        ) {
+            Text(
+                text = stringResource(R.string.woo_shipping_refund_title),
+                style = MaterialTheme.typography.titleLarge,
+                fontWeight = FontWeight.Bold,
+                color = colorResource(id = R.color.color_on_surface)
+            )
+
+            Text(
+                text = stringResource(R.string.woo_shipping_refund_description),
+                style = MaterialTheme.typography.bodyMedium,
+                color = colorResource(id = R.color.color_on_surface),
+                modifier = Modifier.padding(top = 16.dp)
+            )
+
+            purchaseDate?.let {
+                Text(
+                    text = annotatedStringResLegacy(
+                        stringResId = R.string.woo_shipping_refund_purchase_date,
+                        it
+                    ),
+                    style = MaterialTheme.typography.bodyMedium,
+                    color = colorResource(id = R.color.color_on_surface),
+                )
+            }
+
+            refundableAmount?.let {
+                Text(
+                    text = annotatedStringResLegacy(
+                        stringResId = R.string.woo_shipping_refund_amount_eligible_for_refund,
+                        it
+                    ),
+                    style = MaterialTheme.typography.bodyMedium,
+                    color = colorResource(id = R.color.color_on_surface),
+                )
+            }
+
+            Text(
+                text = stringResource(R.string.woo_shipping_refund_note),
+                style = MaterialTheme.typography.bodyMedium,
+                fontStyle = FontStyle.Italic,
+                color = colorResource(id = R.color.color_on_surface),
+            )
+
+            Spacer(modifier = Modifier.weight(1f))
+
+            refundableAmount?.let {
+                WCColoredButton(
+                    text = stringResource(R.string.shipping_label_refund_button, it),
+                    onClick = onRefundLabelClick,
+                    modifier = modifier.fillMaxWidth()
+                )
+            }
+        }
+    }
+}
+
+@Composable
+private fun LoadingScreen() {
+    Scaffold { padding ->
+        Surface(
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(padding)
+        ) {
+            Box(
+                modifier = Modifier.fillMaxSize(),
+                contentAlignment = Alignment.Center
+            ) {
+                CircularProgressIndicator()
+            }
+        }
+    }
+}

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/refund/WooShippingLabelRefundScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/refund/WooShippingLabelRefundScreen.kt
@@ -1,5 +1,6 @@
 package com.woocommerce.android.ui.orders.wooshippinglabels.refund
 
+import android.content.res.Configuration
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -22,6 +23,7 @@ import androidx.compose.ui.res.colorResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontStyle
 import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import com.woocommerce.android.R
 import com.woocommerce.android.ui.compose.annotatedStringResLegacy
@@ -129,5 +131,18 @@ private fun LoadingScreen() {
                 CircularProgressIndicator()
             }
         }
+    }
+}
+
+@Preview
+@Preview("Dark Theme", uiMode = Configuration.UI_MODE_NIGHT_YES)
+@Composable
+fun WooShippingLabelRefundScreenPreview() {
+    WooThemeWithBackground {
+        WooShippingLabelRefundScreen(
+            purchaseDate = "Feb 19, 2025",
+            refundableAmount = "$11.33",
+            onRefundLabelClick = {},
+        )
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/refund/WooShippingLabelRefundViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/refund/WooShippingLabelRefundViewModel.kt
@@ -1,0 +1,81 @@
+package com.woocommerce.android.ui.orders.wooshippinglabels.refund
+
+import android.os.Parcelable
+import androidx.lifecycle.SavedStateHandle
+import androidx.lifecycle.asLiveData
+import androidx.lifecycle.viewModelScope
+import com.woocommerce.android.R
+import com.woocommerce.android.extensions.formatToLocalizedMedium
+import com.woocommerce.android.tools.NetworkStatus
+import com.woocommerce.android.util.CurrencyFormatter
+import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.Exit
+import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.ShowSnackbar
+import com.woocommerce.android.viewmodel.ScopedViewModel
+import com.woocommerce.android.viewmodel.getStateFlow
+import com.woocommerce.android.viewmodel.navArgs
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.launch
+import kotlinx.parcelize.Parcelize
+import javax.inject.Inject
+
+@HiltViewModel
+class WooShippingLabelRefundViewModel @Inject constructor(
+    savedState: SavedStateHandle,
+    private val networkStatus: NetworkStatus,
+    private val currencyFormatter: CurrencyFormatter,
+) : ScopedViewModel(savedState) {
+    private val arguments: WooShippingLabelRefundFragmentArgs by savedState.navArgs()
+
+    private val _viewState: MutableStateFlow<ViewState> = savedState.getStateFlow(
+        scope = viewModelScope,
+        initialValue = ViewState.Loading
+    )
+    val viewState = _viewState.asLiveData()
+
+    init {
+        loadDataState()
+    }
+
+    private fun loadDataState() {
+        _viewState.update { viewState ->
+            val currency = arguments.shipment.items.firstOrNull()?.currency
+                ?: return@update viewState
+            ViewState.DataState(
+                purchaseDate = arguments.shipment.purchaseDate?.formatToLocalizedMedium(),
+                refundableAmount = currencyFormatter.formatCurrency(
+                    arguments.shipment.refundableAmount,
+                    currency
+                )
+            )
+        }
+    }
+
+    fun onRefundShippingLabelButtonClicked() {
+        if (networkStatus.isConnected()) {
+            _viewState.update { ViewState.Loading }
+            launch {
+            }
+        } else {
+            triggerEvent(ShowSnackbar(R.string.offline_error))
+        }
+    }
+
+    fun onBackPressed() {
+        if (_viewState.value is ViewState.Loading) {
+            triggerEvent(ShowSnackbar(R.string.order_refunds_refund_in_progress))
+        } else {
+            triggerEvent(Exit)
+        }
+    }
+
+    @Parcelize
+    sealed class ViewState : Parcelable {
+        data object Loading : ViewState()
+        data class DataState(
+            val purchaseDate: String? = null,
+            val refundableAmount: String? = null
+        ) : ViewState()
+    }
+}

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/split/WooShippingSplitShipmentScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/split/WooShippingSplitShipmentScreen.kt
@@ -18,7 +18,6 @@ import androidx.compose.foundation.pager.rememberPagerState
 import androidx.compose.foundation.shape.CornerSize
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.Card
-import androidx.compose.material.CircularProgressIndicator
 import androidx.compose.material.DropdownMenu
 import androidx.compose.material.DropdownMenuItem
 import androidx.compose.material.Icon
@@ -30,6 +29,7 @@ import androidx.compose.material.TopAppBar
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.ArrowDropDown
 import androidx.compose.material.icons.filled.Close
+import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.SnackbarHostState
 import androidx.compose.material3.SnackbarResult
@@ -565,13 +565,17 @@ fun SelectableProductsSection(
 @Composable
 private fun LoadingScreen() {
     Scaffold(topBar = { TopBar() }) { padding ->
-        Box(
+        Surface(
             modifier = Modifier
                 .fillMaxSize()
-                .padding(padding),
-            contentAlignment = Alignment.Center
+                .padding(padding)
         ) {
-            CircularProgressIndicator()
+            Box(
+                modifier = Modifier.fillMaxSize(),
+                contentAlignment = Alignment.Center
+            ) {
+                CircularProgressIndicator()
+            }
         }
     }
 }

--- a/WooCommerce/src/main/res/navigation/nav_graph_orders.xml
+++ b/WooCommerce/src/main/res/navigation/nav_graph_orders.xml
@@ -717,6 +717,9 @@
         <action
             android:id="@+id/action_wooShippingLabelCreationFragment_to_printShippingLabelInfoFragment"
             app:destination="@id/printShippingLabelInfoFragment" />
+        <action
+            android:id="@+id/action_wooShippingLabelCreationFragment_to_wooShippingLabelRefundRequestFragment"
+            app:destination="@id/wooShippingLabelRefundRequestFragment" />
     </fragment>
     <fragment
         android:id="@+id/wooShippingLabelPackageCreationFragment"
@@ -784,5 +787,16 @@
         <action
             android:id="@+id/action_wooShippingLabelHazmatFormFragment_to_hazmatCategorySelector"
             app:destination="@id/searchFilterFragment" />
+    </fragment>
+    <fragment
+        android:id="@+id/wooShippingLabelRefundRequestFragment"
+        android:name="com.woocommerce.android.ui.orders.wooshippinglabels.refund.WooShippingLabelRefundFragment"
+        android:label="WooShippingLabelRefundFragment">
+        <argument
+            android:name="orderId"
+            app:argType="long" />
+        <argument
+            android:name="shipment"
+            app:argType="com.woocommerce.android.ui.orders.wooshippinglabels.models.ShipmentUIModel" />
     </fragment>
 </navigation>

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -4574,7 +4574,6 @@
     <string name="woo_shipping_labels_hazmat_selection_set">Hazardous materials category set</string>
     <string name="woo_shipping_labels_hazmat_selection_removed">Removed hazardous materials category</string>
 
-
     <string name="email_not_registered_wpcom">Hmm, we can\'t find a WordPress.com account connected to this email address.</string>
 
     <string name="woo_shipping_edit_origin_address_title">Edit Origin</string>
@@ -4606,7 +4605,6 @@
     <string name="woo_shipping_address_notification_destination_verified">Verified destination address</string>
     <string name="woo_shipping_address_notification_origin_verified">Verified origin address</string>
 
-
     <string name="woo_shipping_address_validate_and_save">Validate &amp; Save</string>
     <string name="woo_shipping_address_missing_info_hint">Add missing information</string>
     <string name="woo_shipping_labels_loading_order_error">Unable to load the order</string>
@@ -4628,7 +4626,6 @@
 
     <string name="woo_shipping_confirm_submit_address_suggested">Confirm Suggested Address</string>
     <string name="woo_shipping_confirm_submit_address_entered">Confirm Entered Address</string>
-
 
     <string name="error_user_username_instead_of_email">Please log in using your WordPress.com username instead of your email address.</string>
     <string name="about_automattic_x_item_title">X</string>
@@ -4653,6 +4650,12 @@
     <string name="woo_shipping_split_shipment_merge_unfulfilled_desc">This will remove all unfulfilled split shipments and move all items into one shipment.</string>
     <string name="woo_shipping_split_shipment_merge_unfulfilled_button">Merge all shipments</string>
     <string name="purchased_shipment_content_description">Purchased</string>
+
+    <string name="woo_shipping_refund_title">Request a shipping label refund</string>
+    <string name="woo_shipping_refund_description">Request a refund for your unused shipping label. The refund process for the shipping label will begin immediately and is typically completed within 14 business days.</string>
+    <string name="woo_shipping_refund_purchase_date"><![CDATA[<b>Purchase date:</b> %s]]></string>
+    <string name="woo_shipping_refund_amount_eligible_for_refund"><![CDATA[<b>Amount eligible for refund:</b> %s]]></string>
+    <string name="woo_shipping_refund_note">Please note that this refund request applies only to the unused shipping label and will not affect the order itself.</string>
 
     <string name="media_library_title">WordPress Media Library</string>
     <string name="media_loading_failed">Media loading failed</string>

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/WooShippingLabelCreationViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/WooShippingLabelCreationViewModelTest.kt
@@ -13,11 +13,11 @@ import com.woocommerce.android.ui.orders.shippinglabels.creation.ShippingLabelHa
 import com.woocommerce.android.ui.orders.wooshippinglabels.WooShippingLabelCreationViewModel.CustomsState
 import com.woocommerce.android.ui.orders.wooshippinglabels.WooShippingLabelCreationViewModel.HazmatState
 import com.woocommerce.android.ui.orders.wooshippinglabels.WooShippingLabelCreationViewModel.NavigateToHazmatFormEdit
+import com.woocommerce.android.ui.orders.wooshippinglabels.WooShippingLabelCreationViewModel.NavigateToRefundRequest
 import com.woocommerce.android.ui.orders.wooshippinglabels.WooShippingLabelCreationViewModel.OpenLearnMoreScreen
 import com.woocommerce.android.ui.orders.wooshippinglabels.WooShippingLabelCreationViewModel.OpenShippingLabelFile
 import com.woocommerce.android.ui.orders.wooshippinglabels.WooShippingLabelCreationViewModel.OpenUrl
 import com.woocommerce.android.ui.orders.wooshippinglabels.WooShippingLabelCreationViewModel.PackageSelectionState
-import com.woocommerce.android.ui.orders.wooshippinglabels.WooShippingLabelCreationViewModel.StartRefundRequest
 import com.woocommerce.android.ui.orders.wooshippinglabels.WooShippingLabelCreationViewModel.WooShippingViewState
 import com.woocommerce.android.ui.orders.wooshippinglabels.WooShippingLabelCreationViewModel.WooShippingViewState.DataState
 import com.woocommerce.android.ui.orders.wooshippinglabels.address.AddressValidationHelper
@@ -1199,7 +1199,7 @@ class WooShippingLabelCreationViewModelTest : BaseUnitTest() {
     }
 
     @Test
-    fun `onRefundClicked triggers StartRefundRequest event`() = testBlocking {
+    fun `onRefundClicked triggers NavigateToRefundRequest event`() = testBlocking {
         val order = OrderTestUtils.generateTestOrder(orderId = orderId).copy(
             shippingLines = defaultShippingLines,
             customer = Order.Customer(
@@ -1212,12 +1212,12 @@ class WooShippingLabelCreationViewModelTest : BaseUnitTest() {
 
         createViewModel()
 
-        var event: StartRefundRequest? = null
-        sut.event.observeForever { if (it is StartRefundRequest) event = it }
+        var event: NavigateToRefundRequest? = null
+        sut.event.observeForever { if (it is NavigateToRefundRequest) event = it }
 
         sut.onRefundClicked()
 
-        assertThat(event).isEqualTo(StartRefundRequest(orderId, defaultShipments.first()))
+        assertThat(event).isEqualTo(NavigateToRefundRequest(orderId, defaultShipments.first()))
     }
 
     @Test

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/WooShippingLabelCreationViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/WooShippingLabelCreationViewModelTest.kt
@@ -12,11 +12,11 @@ import com.woocommerce.android.ui.orders.details.OrderDetailRepository
 import com.woocommerce.android.ui.orders.shippinglabels.creation.ShippingLabelHazmatCategory
 import com.woocommerce.android.ui.orders.wooshippinglabels.WooShippingLabelCreationViewModel.CustomsState
 import com.woocommerce.android.ui.orders.wooshippinglabels.WooShippingLabelCreationViewModel.HazmatState
+import com.woocommerce.android.ui.orders.wooshippinglabels.WooShippingLabelCreationViewModel.NavigateToHazmatFormEdit
 import com.woocommerce.android.ui.orders.wooshippinglabels.WooShippingLabelCreationViewModel.OpenLearnMoreScreen
 import com.woocommerce.android.ui.orders.wooshippinglabels.WooShippingLabelCreationViewModel.OpenShippingLabelFile
 import com.woocommerce.android.ui.orders.wooshippinglabels.WooShippingLabelCreationViewModel.OpenUrl
 import com.woocommerce.android.ui.orders.wooshippinglabels.WooShippingLabelCreationViewModel.PackageSelectionState
-import com.woocommerce.android.ui.orders.wooshippinglabels.WooShippingLabelCreationViewModel.StartHazmatFormEdit
 import com.woocommerce.android.ui.orders.wooshippinglabels.WooShippingLabelCreationViewModel.StartRefundRequest
 import com.woocommerce.android.ui.orders.wooshippinglabels.WooShippingLabelCreationViewModel.WooShippingViewState
 import com.woocommerce.android.ui.orders.wooshippinglabels.WooShippingLabelCreationViewModel.WooShippingViewState.DataState
@@ -1045,7 +1045,7 @@ class WooShippingLabelCreationViewModelTest : BaseUnitTest() {
     }
 
     @Test
-    fun `when StartHazmatFormEdit is triggered with a selected category, the event contains the expected category value`() =
+    fun `when NavigateToHazmatFormEdit is triggered with a selected category, the event contains the expected category value`() =
         testBlocking {
             var event: MultiLiveEvent.Event? = null
             val order = OrderTestUtils.generateTestOrder(orderId = orderId)
@@ -1061,7 +1061,7 @@ class WooShippingLabelCreationViewModelTest : BaseUnitTest() {
 
             sut.event.observeForever { event = it }
 
-            assertThat(event).isEqualTo(StartHazmatFormEdit(ShippingLabelHazmatCategory.CLASS_1))
+            assertThat(event).isEqualTo(NavigateToHazmatFormEdit(ShippingLabelHazmatCategory.CLASS_1))
         }
 
     @Test

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/WooShippingLabelCreationViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/WooShippingLabelCreationViewModelTest.kt
@@ -1215,7 +1215,7 @@ class WooShippingLabelCreationViewModelTest : BaseUnitTest() {
 
         sut.onRefundClicked()
 
-        assertThat(event).isEqualTo(StartRefundRequest)
+        assertThat(event).isEqualTo(StartRefundRequest(orderId, defaultShipments.first()))
     }
 
     @Test

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/purchased/ObserveShippingLabelStatusTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/purchased/ObserveShippingLabelStatusTest.kt
@@ -1,4 +1,5 @@
 import com.woocommerce.android.tools.SelectedSite
+import com.woocommerce.android.ui.orders.wooshippinglabels.models.PurchasedLabelModel
 import com.woocommerce.android.ui.orders.wooshippinglabels.models.ShippingLabelStatus.PURCHASED
 import com.woocommerce.android.ui.orders.wooshippinglabels.models.ShippingLabelStatus.PURCHASE_IN_PROGRESS
 import com.woocommerce.android.ui.orders.wooshippinglabels.models.ShippingLabelStatus.UNKNOWN
@@ -19,11 +20,11 @@ import org.wordpress.android.fluxc.network.BaseRequest
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.WooError
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.WooErrorType
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.WooResult
+import java.math.BigDecimal
 import kotlin.test.assertEquals
 
 @ExperimentalCoroutinesApi
 class ObserveShippingLabelStatusTest : BaseUnitTest() {
-
     private lateinit var observeShippingLabelStatus: ObserveShippingLabelStatus
     private val selectedSite: SelectedSite = mock()
     private val labelRepository: WooShippingLabelRepository = mock()
@@ -31,6 +32,22 @@ class ObserveShippingLabelStatusTest : BaseUnitTest() {
     private val mockSite = SiteModel().apply { id = 123 }
     private val mockOrderId = 456L
     private val mockLabelId = 789L
+
+    private val purchaseLabelModel = PurchasedLabelModel(
+        labelId = 0,
+        tracking = "",
+        refundableAmount = BigDecimal.ZERO,
+        status = UNKNOWN,
+        created = null,
+        carrierId = "",
+        serviceName = "",
+        commercialInvoiceUrl = "",
+        isCommercialInvoiceSubmittedElectronically = false,
+        packageName = "",
+        isLetter = false,
+        productNames = emptyList(),
+        productIds = emptyList()
+    )
 
     @Before
     fun setup() {
@@ -41,13 +58,13 @@ class ObserveShippingLabelStatusTest : BaseUnitTest() {
     @Test
     fun `When status response is unknown, then observation stops`() = testBlocking {
         whenever(labelRepository.fetchShippingLabelStatus(mockSite, mockOrderId, mockLabelId))
-            .thenReturn(WooResult(UNKNOWN))
+            .thenReturn(WooResult(purchaseLabelModel))
 
         val result = observeShippingLabelStatus(mockOrderId, mockLabelId).toList()
         advanceUntilIdle()
 
         verify(labelRepository).fetchShippingLabelStatus(mockSite, mockOrderId, mockLabelId)
-        assertEquals(listOf(PURCHASE_IN_PROGRESS, UNKNOWN), result)
+        assertEquals(listOf(PURCHASE_IN_PROGRESS, UNKNOWN), result.map { it.status })
     }
 
     @Test
@@ -56,9 +73,9 @@ class ObserveShippingLabelStatusTest : BaseUnitTest() {
         whenever(labelRepository.fetchShippingLabelStatus(mockSite, mockOrderId, mockLabelId))
             .then {
                 if (statusCallCount++ == 0) {
-                    WooResult(PURCHASE_IN_PROGRESS)
+                    WooResult(purchaseLabelModel.copy(status = PURCHASE_IN_PROGRESS))
                 } else {
-                    WooResult(PURCHASED)
+                    WooResult(purchaseLabelModel.copy(status = PURCHASED))
                 }
             }
 
@@ -66,7 +83,7 @@ class ObserveShippingLabelStatusTest : BaseUnitTest() {
         advanceUntilIdle()
 
         verify(labelRepository, times(2)).fetchShippingLabelStatus(mockSite, mockOrderId, mockLabelId)
-        assertEquals(listOf(PURCHASE_IN_PROGRESS, PURCHASE_IN_PROGRESS, PURCHASED), result)
+        assertEquals(listOf(PURCHASE_IN_PROGRESS, PURCHASE_IN_PROGRESS, PURCHASED), result.map { it.status })
     }
 
     @Test
@@ -79,6 +96,6 @@ class ObserveShippingLabelStatusTest : BaseUnitTest() {
         advanceUntilIdle()
 
         verify(labelRepository, times(1)).fetchShippingLabelStatus(mockSite, mockOrderId, mockLabelId)
-        assertEquals(listOf(PURCHASE_IN_PROGRESS, UNKNOWN), result)
+        assertEquals(listOf(PURCHASE_IN_PROGRESS, UNKNOWN), result.map { it.status })
     }
 }


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

<!-- Id number of the Linear issue this PR addresses, e.g., WOOMOB-373. -->
Part of WOOMOB-370

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
This adds the UI for the Refund request screen. The design slightly differs from the Figma file, as I aimed to maintain consistency with other screens, such as the Hazmat selection screen.

> [!WARNING]  
> Network integration has not been implemented yet. Tapping the Refund label will result in infinite loading, which is expected at this stage.

### Steps to reproduce
<!-- Step-by-step testing instructions. For new user flows, consider instead stating the goal of the workflow and see if your PR reviewer can accomplish the workflow without specific steps! -->
1. Open the Orders screen.
2. Select an order that includes a purchased shipment. 
3. Tap the "Request refund" button.
4. Tap the "Refund label" button

### The tests that have been performed
<!-- To give the reviewer an idea of what could be missed in terms of testing -->
Steps above

### Images/gif
<!-- Include before and after images or gifs when appropriate. -->
<img src="https://github.com/user-attachments/assets/dc1135ff-ee7f-4059-b5f9-f1967483b7b8" width=350> <img src="https://github.com/user-attachments/assets/2df01f4f-fe9b-4340-a7bc-7ebfd36468dc" width=350>

- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->