### PR TITLE
[Shipping labels] Request label refund network

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/networking/DTOs.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/networking/DTOs.kt
@@ -191,6 +191,8 @@ data class CustomsItemDTO(
     @SerializedName("product_id") val productId: Long
 )
 
+data class RefundLabelResponseDTO(val success: Boolean)
+
 private class ShipmentMapDeserializer : JsonDeserializer<ShipmentMap> {
     override fun deserialize(json: JsonElement, typeOfT: Type, context: JsonDeserializationContext): ShipmentMap {
         // Handle string-encoded JSON or direct JSON object

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/networking/WooShippingLabelRepository.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/networking/WooShippingLabelRepository.kt
@@ -245,4 +245,10 @@ class WooShippingLabelRepository @Inject constructor(
         shipments = shipments,
         shipmentIdsToUpdate = shipmentIdsToUpdate
     ).asWooResult()
+
+    suspend fun refundLabel(
+        site: SiteModel,
+        orderId: Long,
+        labelId: Long
+    ): WooResult<RefundLabelResponseDTO> = restClient.refundShippingLabel(orderId, labelId, site).asWooResult()
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/networking/WooShippingLabelRestClient.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/networking/WooShippingLabelRestClient.kt
@@ -222,4 +222,17 @@ class WooShippingLabelRestClient @Inject constructor(
 
         return result.toWooPayload()
     }
+
+    suspend fun refundShippingLabel(
+        orderId: Long,
+        labelId: Long,
+        site: SiteModel
+    ): WooPayload<RefundLabelResponseDTO> {
+        val url = "/wcshipping/v1/label/refund/$orderId/$labelId"
+        return wooNetwork.executePostGsonRequest(
+            site = site,
+            path = url,
+            clazz = RefundLabelResponseDTO::class.java,
+        ).toWooPayload()
+    }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/refund/WooShippingLabelRefundViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/refund/WooShippingLabelRefundViewModel.kt
@@ -60,13 +60,11 @@ class WooShippingLabelRefundViewModel @Inject constructor(
         if (networkStatus.isConnected()) {
             _viewState.update { ViewState.Loading }
             launch {
-                selectedSite.getOrNull()?.let {
-                    repository.refundLabel(
-                        it,
-                        arguments.orderId,
-                        arguments.shipment.labelId ?: return@launch
-                    )
-                }?.takeIf { it.isError.not() }?.let {
+                repository.refundLabel(
+                    selectedSite.get(),
+                    arguments.orderId,
+                    arguments.shipment.labelId ?: return@launch
+                ).takeIf { it.isError.not() }?.let {
                     triggerEvent(ShowSnackbar(R.string.shipping_label_refund_success))
                     triggerEvent(Exit)
                 } ?: run {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/refund/WooShippingLabelRefundViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/refund/WooShippingLabelRefundViewModel.kt
@@ -7,6 +7,8 @@ import androidx.lifecycle.viewModelScope
 import com.woocommerce.android.R
 import com.woocommerce.android.extensions.formatToLocalizedMedium
 import com.woocommerce.android.tools.NetworkStatus
+import com.woocommerce.android.tools.SelectedSite
+import com.woocommerce.android.ui.orders.wooshippinglabels.networking.WooShippingLabelRepository
 import com.woocommerce.android.util.CurrencyFormatter
 import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.Exit
 import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.ShowSnackbar
@@ -23,6 +25,8 @@ import javax.inject.Inject
 @HiltViewModel
 class WooShippingLabelRefundViewModel @Inject constructor(
     savedState: SavedStateHandle,
+    private val selectedSite: SelectedSite,
+    private val repository: WooShippingLabelRepository,
     private val networkStatus: NetworkStatus,
     private val currencyFormatter: CurrencyFormatter,
 ) : ScopedViewModel(savedState) {
@@ -56,6 +60,19 @@ class WooShippingLabelRefundViewModel @Inject constructor(
         if (networkStatus.isConnected()) {
             _viewState.update { ViewState.Loading }
             launch {
+                selectedSite.getOrNull()?.let {
+                    repository.refundLabel(
+                        it,
+                        arguments.orderId,
+                        arguments.shipment.labelId ?: return@launch
+                    )
+                }?.takeIf { it.isError.not() }?.let {
+                    triggerEvent(ShowSnackbar(R.string.shipping_label_refund_success))
+                    triggerEvent(Exit)
+                } ?: run {
+                    triggerEvent(ShowSnackbar(R.string.order_refunds_amount_refund_error))
+                    loadDataState()
+                }
             }
         } else {
             triggerEvent(ShowSnackbar(R.string.offline_error))

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/refund/WooShippingLabelRefundViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/refund/WooShippingLabelRefundViewModelTest.kt
@@ -1,0 +1,80 @@
+package com.woocommerce.android.ui.orders.wooshippinglabels.refund
+
+import com.woocommerce.android.R
+import com.woocommerce.android.tools.NetworkStatus
+import com.woocommerce.android.tools.SelectedSite
+import com.woocommerce.android.ui.orders.wooshippinglabels.models.ShipmentUIModel
+import com.woocommerce.android.ui.orders.wooshippinglabels.networking.RefundLabelResponseDTO
+import com.woocommerce.android.ui.orders.wooshippinglabels.networking.WooShippingLabelRepository
+import com.woocommerce.android.viewmodel.BaseUnitTest
+import com.woocommerce.android.viewmodel.MultiLiveEvent.Event
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.Before
+import org.mockito.kotlin.doReturn
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.whenever
+import org.wordpress.android.fluxc.model.SiteModel
+import org.wordpress.android.fluxc.network.rest.wpcom.wc.WooResult
+import kotlin.test.Test
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class WooShippingLabelRefundViewModelTest : BaseUnitTest() {
+    private lateinit var viewModel: WooShippingLabelRefundViewModel
+    private val mockOrderId = 456L
+    private val mockLabelId = 789L
+    val mockSite = SiteModel().apply { siteId = 123 }
+
+    private val selectedSite: SelectedSite = mock { on { getOrNull() } doReturn mockSite }
+    private val repository: WooShippingLabelRepository = mock()
+    private val networkStatus: NetworkStatus = mock { on { isConnected() } doReturn true }
+
+    @Before
+    fun setup() {
+        viewModel = WooShippingLabelRefundViewModel(
+            WooShippingLabelRefundFragmentArgs(
+                orderId = mockOrderId,
+                shipment = ShipmentUIModel(localId = "0", items = emptyList(), labelId = mockLabelId)
+            ).toSavedStateHandle(),
+            selectedSite = selectedSite,
+            repository = repository,
+            networkStatus = networkStatus,
+            currencyFormatter = mock()
+        )
+    }
+
+    @Test
+    fun `when refund is successful, show success message and exit`() = testBlocking {
+        // Given
+        var capturedEvents = mutableListOf<Event>()
+        viewModel.event.observeForever { capturedEvents.add(it) }
+        whenever(
+            repository.refundLabel(site = mockSite, orderId = mockOrderId, labelId = mockLabelId)
+        ) doReturn WooResult(RefundLabelResponseDTO(true))
+
+        // When
+        viewModel.onRefundShippingLabelButtonClicked()
+
+        // Then
+        assertThat(capturedEvents.first()).isInstanceOf(Event.ShowSnackbar::class.java)
+        assertThat((capturedEvents.first() as Event.ShowSnackbar).message)
+            .isEqualTo(R.string.shipping_label_refund_success)
+        assertThat(capturedEvents.last()).isEqualTo(Event.Exit)
+    }
+
+    @Test
+    fun `when refund fails, show error message`() = testBlocking {
+        // Given
+        var capturedEvent: Event.Exit? = null
+        viewModel.event.observeForever { capturedEvent = it as? Event.Exit }
+        whenever(
+            repository.refundLabel(site = mockSite, orderId = mockOrderId, labelId = mockLabelId)
+        ) doReturn WooResult(RefundLabelResponseDTO(false))
+
+        // When
+        viewModel.onRefundShippingLabelButtonClicked()
+
+        // Then
+        assertThat(capturedEvent).isNotNull()
+    }
+}

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/refund/WooShippingLabelRefundViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/refund/WooShippingLabelRefundViewModelTest.kt
@@ -25,7 +25,7 @@ class WooShippingLabelRefundViewModelTest : BaseUnitTest() {
     private val mockLabelId = 789L
     val mockSite = SiteModel().apply { siteId = 123 }
 
-    private val selectedSite: SelectedSite = mock { on { getOrNull() } doReturn mockSite }
+    private val selectedSite: SelectedSite = mock { on { get() } doReturn mockSite }
     private val repository: WooShippingLabelRepository = mock()
     private val networkStatus: NetworkStatus = mock { on { isConnected() } doReturn true }
 
@@ -34,7 +34,11 @@ class WooShippingLabelRefundViewModelTest : BaseUnitTest() {
         viewModel = WooShippingLabelRefundViewModel(
             WooShippingLabelRefundFragmentArgs(
                 orderId = mockOrderId,
-                shipment = ShipmentUIModel(localId = "0", items = emptyList(), labelId = mockLabelId)
+                shipment = ShipmentUIModel(
+                    localId = "0",
+                    items = emptyList(),
+                    labelId = mockLabelId
+                )
             ).toSavedStateHandle(),
             selectedSite = selectedSite,
             repository = repository,


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

<!-- Id number of the Linear issue this PR addresses, e.g., WOOMOB-373. -->
Part of WOOMOB-370

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
This implements network integration for the Refund Request screen.

> [!WARNING]  
> Known issues:
> - The condition for the visibility of the "Request refund" button will be handled in a separate PR.

### Steps to reproduce
<!-- Step-by-step testing instructions. For new user flows, consider instead stating the goal of the workflow and see if your PR reviewer can accomplish the workflow without specific steps! -->
#### Successful case
1. Open the Orders screen.
2. Select an order that includes a purchased shipment.
3. Tap the "Request refund" button.
4. Tap the "Refund label" button

### Testing information
<!-- This is your opportunity to break out individual scenarios that need testing (when necessary) and/or include a checklist for the reviewer to go through. Consider documenting the following from your own completed testing: devices used, alternate workflows, edge cases, affected areas, critical flows, areas not tested, and any remaining unknowns. Provide feedback on this new section of the PR template through Sept 30, 2024 to Apps Quality; additional context here: p91TBi-b8z-p2#comment-12036 -->
- [ ] Test tapping back while the refund is in progress.
- [ ] Test the failure case. You can do this by attempting to refund a shipment that has already been refunded. Since the visibility condition for the refund button is currently broken, you can take advantage of that to test the failure case.
- [ ] Test refunding a shipment after a successful purchase.

### The tests that have been performed
<!-- To give the reviewer an idea of what could be missed in terms of testing -->
Steps above.

### Images/gif
<!-- Include before and after images or gifs when appropriate. -->
<img src="https://github.com/user-attachments/assets/9961d23f-397c-49cb-bc54-019cf8da2199" width=300>

- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->