### PR TITLE
Shipping Labels: introduce logic to retain state when splitting shipments

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/WooShippingLabelCreationViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/WooShippingLabelCreationViewModel.kt
@@ -460,6 +460,7 @@ class WooShippingLabelCreationViewModel @Inject constructor(
 
     @Suppress("ComplexCondition")
     private suspend fun observeShippingLabelInformation() {
+
         combine(
             storeOptions.drop(1),
             order.drop(1),
@@ -521,38 +522,28 @@ class WooShippingLabelCreationViewModel @Inject constructor(
     }
 
     private fun initFlows(shipmentSize: Int) {
-        if (selectedPackagesFlow.value.size != shipmentSize) {
-            selectedPackagesFlow.value = List(shipmentSize) { null }
+        fun <T> MutableStateFlow<List<T>>.updateSize(defaultValue: T) = this.update { currentList ->
+            if (currentList.size < shipmentSize) {
+                currentList + List(shipmentSize - currentList.size) { defaultValue }
+            } else {
+                currentList.take(shipmentSize)
+            }
         }
-        if (customsFormDataFlow.value.size != shipmentSize) {
-            customsFormDataFlow.value = List(shipmentSize) { null }
-        }
-        if (packageWeightsFlow.value.size != shipmentSize) {
-            packageWeightsFlow.value = List(shipmentSize) { null }
-        }
-        if (packageSelectionsFlow.value.size != shipmentSize) {
-            packageSelectionsFlow.value = List(shipmentSize) { NotSelected }
-        }
-        if (customsStatesFlow.value.size != shipmentSize) {
-            customsStatesFlow.value = List(shipmentSize) { NotRequired }
-        }
-        if (hazmatStatesFlow.value.size != shipmentSize) {
-            hazmatStatesFlow.value = List(shipmentSize) { NoSelection }
-        }
-        if (selectedRatesSortOrdersFlow.value.size != shipmentSize) {
-            selectedRatesSortOrdersFlow.value = List(shipmentSize) { ShippingSortOption.FASTEST }
-        }
-        if (selectedRatesFlow.value.size != shipmentSize) {
-            selectedRatesFlow.value = List(shipmentSize) { null }
-        }
-        if (shippingRatesListFlow.value.size != shipmentSize) {
-            shippingRatesListFlow.value = List(shipmentSize) { emptyMap() }
-        }
-        if (shippingRatesStatesFlow.value.size != shipmentSize) {
-            shippingRatesStatesFlow.value = List(shipmentSize) { ShippingRatesState.NoAvailable }
-        }
-        if (customWeight.size != shipmentSize) {
-            customWeight = List(shipmentSize) { "" }
+        selectedPackagesFlow.updateSize(null)
+        customsFormDataFlow.updateSize(null)
+        packageWeightsFlow.updateSize(null)
+        packageSelectionsFlow.updateSize(NotSelected)
+        customsStatesFlow.updateSize(NotRequired)
+        hazmatStatesFlow.updateSize(NoSelection)
+        selectedRatesSortOrdersFlow.updateSize(ShippingSortOption.FASTEST)
+        selectedRatesFlow.updateSize(null)
+        shippingRatesListFlow.updateSize(emptyMap())
+        shippingRatesStatesFlow.updateSize(ShippingRatesState.NoAvailable)
+
+        customWeight = if (customWeight.size < shipmentSize) {
+            customWeight + List(shipmentSize - customWeight.size) { "" }
+        } else {
+            customWeight.take(shipmentSize)
         }
     }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/WooShippingLabelCreationViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/WooShippingLabelCreationViewModel.kt
@@ -529,8 +529,6 @@ class WooShippingLabelCreationViewModel @Inject constructor(
             }
         }
 
-        selectedShipmentIndexFlow.update { it.coerceAtMost(shipmentSize - 1) }
-
         selectedPackagesFlow.updateSize(null)
         customsFormDataFlow.updateSize(null)
         packageWeightsFlow.updateSize(null)
@@ -554,6 +552,10 @@ class WooShippingLabelCreationViewModel @Inject constructor(
     }
 
     fun onShipmentSplit(newShipments: List<ShipmentUIModel>) {
+        if (selectedShipmentIndexFlow.value >= newShipments.size) {
+            selectedShipmentIndexFlow.update { it.coerceAtMost(newShipments.size - 1) }
+            uiState.update { it.copy(selectedIndex = selectedShipmentIndexFlow.value) }
+        }
         shipments.value = newShipments
     }
 
@@ -564,6 +566,8 @@ class WooShippingLabelCreationViewModel @Inject constructor(
     }
 
     fun onSelectedShipmentChanged(index: Int) {
+        if (index >= shipments.value.size) return // This can happen after shipment split when the UI is not updated yet
+
         selectedShipmentIndexFlow.value = index
         uiState.value = uiState.value.copy(selectedIndex = index)
     }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/WooShippingLabelCreationViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/WooShippingLabelCreationViewModel.kt
@@ -522,10 +522,10 @@ class WooShippingLabelCreationViewModel @Inject constructor(
 
     private fun initFlows(shipmentSize: Int) {
         fun <T> MutableStateFlow<List<T>>.updateSize(defaultValue: T) = this.update { currentList ->
-            if (currentList.size < shipmentSize) {
+            if (currentList.size <= shipmentSize) {
                 currentList + List(shipmentSize - currentList.size) { defaultValue }
             } else {
-                currentList.take(shipmentSize)
+                List(shipmentSize) { defaultValue }
             }
         }
 
@@ -542,10 +542,10 @@ class WooShippingLabelCreationViewModel @Inject constructor(
         shippingRatesListFlow.updateSize(emptyMap())
         shippingRatesStatesFlow.updateSize(ShippingRatesState.NoAvailable)
 
-        customWeight = if (customWeight.size < shipmentSize) {
+        customWeight = if (customWeight.size <= shipmentSize) {
             customWeight + List(shipmentSize - customWeight.size) { "" }
         } else {
-            customWeight.take(shipmentSize)
+            List(shipmentSize) { "" }
         }
     }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/WooShippingLabelCreationViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/WooShippingLabelCreationViewModel.kt
@@ -69,10 +69,12 @@ import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.debounce
+import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.drop
 import kotlinx.coroutines.flow.filter
 import kotlinx.coroutines.flow.filterNotNull
 import kotlinx.coroutines.flow.launchIn
+import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.flow.onStart
 import kotlinx.coroutines.flow.update
@@ -149,10 +151,12 @@ class WooShippingLabelCreationViewModel @Inject constructor(
         r1.defaultRate.rate.deliveryDays.compareTo(r2.defaultRate.rate.deliveryDays)
     }
 
-    private val selectedShipmentIndexFlow = MutableStateFlow<Int>(0)
     private val selectedRatesFlow = MutableStateFlow<List<ShippingRateUI?>>(emptyList())
     private val shippingRatesListFlow = MutableStateFlow<List<Map<CarrierUI, List<ShippingRateUI>>>>(emptyList())
     private val shippingRatesStatesFlow = MutableStateFlow<List<ShippingRatesState>>(emptyList())
+
+    private val selectedShipmentIndex: Int
+        get() = uiState.value.selectedIndex
 
     val viewState: MutableStateFlow<WooShippingViewState> = MutableStateFlow(
         WooShippingViewState.Loading(R.string.shipping_label_create_title)
@@ -185,7 +189,7 @@ class WooShippingLabelCreationViewModel @Inject constructor(
     private suspend fun observeNotices() = observeShippingLabelNotice(
         shippingAddresses,
         customsStatesFlow.filter { it.isNotEmpty() },
-        selectedShipmentIndexFlow,
+        uiState.map { it.selectedIndex }.distinctUntilChanged(),
         viewModelScope
     ).onStart { delay(NOTIFICATIONS_DELAY) }
         .collectLatest { noticeBanner ->
@@ -262,25 +266,25 @@ class WooShippingLabelCreationViewModel @Inject constructor(
             hazmatStatesFlow.filter { it.isNotEmpty() },
             refreshShippingRates.onStart { emit(Unit) },
         ) { selectedPackages, addresses, packageWeight, customState, hazmatStates, _ ->
-            val customsFulfilled = customState[selectedShipmentIndexFlow.value] is CustomsState.DataAvailable ||
-                customState[selectedShipmentIndexFlow.value] is NotRequired
-            val selectedPackage = selectedPackages[selectedShipmentIndexFlow.value]
+            val customsFulfilled = customState[selectedShipmentIndex] is CustomsState.DataAvailable ||
+                customState[selectedShipmentIndex] is NotRequired
+            val selectedPackage = selectedPackages[selectedShipmentIndex]
             if (selectedPackage != null && addresses != null && customsFulfilled) {
                 ShippingRatesInfo(
                     orderId = navArgs.orderId,
                     packageSelected = selectedPackage,
                     shipFrom = addresses.shipFrom,
                     shipTo = addresses.shipTo.address,
-                    weight = packageWeight[selectedShipmentIndexFlow.value]?.totalWeight,
+                    weight = packageWeight[selectedShipmentIndex]?.totalWeight,
                     currencyCode = order.value.currency,
-                    customsData = customsFormDataFlow.value[selectedShipmentIndexFlow.value],
-                    hazmatSelection = hazmatStates[selectedShipmentIndexFlow.value].hazmatSelection
+                    customsData = customsFormDataFlow.value[selectedShipmentIndex],
+                    hazmatSelection = hazmatStates[selectedShipmentIndex].hazmatSelection
                 )
             } else {
                 null
             }
         }.debounce(MULTIPLE_CALLS_DELAY)
-            .collectLatest { updateShippingRates(selectedShipmentIndexFlow.value, it) }
+            .collectLatest { updateShippingRates(selectedShipmentIndex, it) }
     }
 
     private suspend fun observeShippingRatesState() {
@@ -308,7 +312,7 @@ class WooShippingLabelCreationViewModel @Inject constructor(
     @OptIn(FlowPreview::class)
     private suspend fun observePackageWeight() {
         combine(
-            shipmentItems.filter { it.isNotEmpty() && it.size > selectedShipmentIndexFlow.value },
+            shipmentItems.filter { it.isNotEmpty() && it.size > selectedShipmentIndex },
             selectedPackagesFlow.filter { it.isNotEmpty() && it.size == shipments.value.size },
             snapshotFlow { customWeight }
                 .filter { it.isNotEmpty() && it.size == shipments.value.size }
@@ -552,9 +556,10 @@ class WooShippingLabelCreationViewModel @Inject constructor(
     }
 
     fun onShipmentSplit(newShipments: List<ShipmentUIModel>) {
-        if (selectedShipmentIndexFlow.value >= newShipments.size) {
-            selectedShipmentIndexFlow.update { it.coerceAtMost(newShipments.size - 1) }
-            uiState.update { it.copy(selectedIndex = selectedShipmentIndexFlow.value) }
+        if (selectedShipmentIndex >= newShipments.size) {
+            uiState.update {
+                it.copy(selectedIndex = it.selectedIndex.coerceAtMost(newShipments.size - 1))
+            }
         }
         shipments.value = newShipments
     }
@@ -568,7 +573,6 @@ class WooShippingLabelCreationViewModel @Inject constructor(
     fun onSelectedShipmentChanged(index: Int) {
         if (index >= shipments.value.size) return // This can happen after shipment split when the UI is not updated yet
 
-        selectedShipmentIndexFlow.value = index
         uiState.value = uiState.value.copy(selectedIndex = index)
     }
 
@@ -623,7 +627,7 @@ class WooShippingLabelCreationViewModel @Inject constructor(
 
     @Suppress("ComplexCondition")
     fun onPurchaseShippingLabel() {
-        val selectedShipmentIndex = selectedShipmentIndexFlow.value
+        val selectedShipmentIndex = selectedShipmentIndex
         val selectedPackage = selectedPackagesFlow.value[selectedShipmentIndex]
         val addresses = shippingAddresses.value
         val shippingRate = selectedRatesFlow.value[selectedShipmentIndex]?.selectedOption?.rate
@@ -694,13 +698,13 @@ class WooShippingLabelCreationViewModel @Inject constructor(
 
     fun onSelectedRateSortOrderChanged(option: ShippingSortOption) {
         selectedRatesSortOrdersFlow.value = selectedRatesSortOrdersFlow.value.toMutableList().apply {
-            set(selectedShipmentIndexFlow.value, option)
+            set(selectedShipmentIndex, option)
         }
     }
 
     fun onSelectedSippingRateChanged(rate: ShippingRateUI) {
         selectedRatesFlow.update {
-            selectedRatesFlow.value.toMutableList().apply { set(selectedShipmentIndexFlow.value, rate) }
+            selectedRatesFlow.value.toMutableList().apply { set(selectedShipmentIndex, rate) }
         }
     }
 
@@ -738,18 +742,18 @@ class WooShippingLabelCreationViewModel @Inject constructor(
 
     fun onPackageSelected(packageData: PackageData) {
         selectedPackagesFlow.value = selectedPackagesFlow.value.toMutableList().apply {
-            set(selectedShipmentIndexFlow.value, packageData)
+            set(selectedShipmentIndex, packageData)
         }
     }
 
     fun onCustomsDataAvailable(customsData: CustomsData) {
         customsFormDataFlow.value = customsFormDataFlow.value.toMutableList().apply {
-            set(selectedShipmentIndexFlow.value, customsData)
+            set(selectedShipmentIndex, customsData)
         }
     }
 
     fun onCustomWeightChange(input: String) {
-        customWeight = customWeight.toMutableList().apply { set(selectedShipmentIndexFlow.value, input) }
+        customWeight = customWeight.toMutableList().apply { set(selectedShipmentIndex, input) }
     }
 
     fun onEditCustomsClick() {
@@ -757,15 +761,15 @@ class WooShippingLabelCreationViewModel @Inject constructor(
             ?.shipTo?.address?.country?.code.orEmpty()
 
         val event = StartCustomsFormEdit(
-            shippableItems = shipmentItems.value[selectedShipmentIndexFlow.value],
+            shippableItems = shipmentItems.value[selectedShipmentIndex],
             destinationCountryCode = destinationCountryCode,
-            customData = customsFormDataFlow.value[selectedShipmentIndexFlow.value]
+            customData = customsFormDataFlow.value[selectedShipmentIndex]
         )
         triggerEvent(event)
     }
 
     fun onHazmatNoticeClick() {
-        val selectedCategory = hazmatStatesFlow.value[selectedShipmentIndexFlow.value]
+        val selectedCategory = hazmatStatesFlow.value[selectedShipmentIndex]
             .run { this as? Declared }
             ?.hazmatCategory
 
@@ -781,10 +785,10 @@ class WooShippingLabelCreationViewModel @Inject constructor(
             null -> NoSelection
             else -> Declared(selectedCategory)
         }
-        if (newState == previousStates[selectedShipmentIndexFlow.value]) return
+        if (newState == previousStates[selectedShipmentIndex]) return
 
         hazmatStatesFlow.value = previousStates.toMutableList().apply {
-            this[selectedShipmentIndexFlow.value] = newState
+            this[selectedShipmentIndex] = newState
         }.toList()
 
         val snackbarMessage = if (selectedCategory != null) {
@@ -810,7 +814,7 @@ class WooShippingLabelCreationViewModel @Inject constructor(
         val fallbackViewState = viewState.value
         viewState.value = WooShippingViewState.Loading(R.string.shipping_label_print_screen_title)
         launch {
-            val labelId = shipments.value[selectedShipmentIndexFlow.value].labelId ?: return@launch
+            val labelId = shipments.value[selectedShipmentIndex].labelId ?: return@launch
             val paperSize = uiState.value.paperSizeOption
             val labelFile = fetchShippingLabelFile(
                 labelIds = listOf(labelId),
@@ -826,15 +830,15 @@ class WooShippingLabelCreationViewModel @Inject constructor(
     }
 
     fun onTrackShipmentClicked() {
-        val carrierId = shipments.value[selectedShipmentIndexFlow.value].carrierId ?: return
-        val trackingNumber = shipments.value[selectedShipmentIndexFlow.value].trackingNumber ?: return
+        val carrierId = shipments.value[selectedShipmentIndex].carrierId ?: return
+        val trackingNumber = shipments.value[selectedShipmentIndex].trackingNumber ?: return
         ShipmentTrackingUrls.fromCarrier(carrierId, trackingNumber)
             ?.let { triggerEvent(OpenUrl(it)) }
             ?: triggerEvent(ShowError(R.string.shipping_label_purchased_tracking_error))
     }
 
     fun onSchedulePickUpClicked() {
-        val carrierId = shipments.value[selectedShipmentIndexFlow.value].carrierId ?: return
+        val carrierId = shipments.value[selectedShipmentIndex].carrierId ?: return
         Carrier.fromCarrierId(carrierId)?.let {
             triggerEvent(OpenUrl(it.pickupUrl))
         } ?: triggerEvent(ShowError(R.string.shipping_label_purchased_pickup_error))

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/WooShippingLabelCreationViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/WooShippingLabelCreationViewModel.kt
@@ -488,7 +488,7 @@ class WooShippingLabelCreationViewModel @Inject constructor(
             }
 
             shipmentItems.value = shipments.map { it.items }
-            initFlows(shipments.size)
+            adjustFlowSizesToShipmentCount(shipments.size)
 
             val shippingLineSummary = order.getShippingLinesSummary(currencyFormatter)
             val shipmentUIList = shipmentItems.value.mapIndexed { index, shippableItemModels ->
@@ -520,7 +520,7 @@ class WooShippingLabelCreationViewModel @Inject constructor(
         }
     }
 
-    private fun initFlows(shipmentSize: Int) {
+    private fun adjustFlowSizesToShipmentCount(shipmentSize: Int) {
         fun <T> MutableStateFlow<List<T>>.updateSize(defaultValue: T) = this.update { currentList ->
             if (currentList.size <= shipmentSize) {
                 currentList + List(shipmentSize - currentList.size) { defaultValue }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/WooShippingLabelCreationViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/WooShippingLabelCreationViewModel.kt
@@ -460,7 +460,6 @@ class WooShippingLabelCreationViewModel @Inject constructor(
 
     @Suppress("ComplexCondition")
     private suspend fun observeShippingLabelInformation() {
-
         combine(
             storeOptions.drop(1),
             order.drop(1),
@@ -529,6 +528,9 @@ class WooShippingLabelCreationViewModel @Inject constructor(
                 currentList.take(shipmentSize)
             }
         }
+
+        selectedShipmentIndexFlow.update { it.coerceAtMost(shipmentSize - 1) }
+
         selectedPackagesFlow.updateSize(null)
         customsFormDataFlow.updateSize(null)
         packageWeightsFlow.updateSize(null)

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/address/ObserveShippingLabelNotice.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/address/ObserveShippingLabelNotice.kt
@@ -36,8 +36,7 @@ class ObserveShippingLabelNotice @Inject constructor(private val addressValidati
         selectedIndexFlow,
         isDismissedFlow
     ) { addresses, customs, selectedIndex, isDismissed ->
-        val custom = customs.getOrNull(selectedIndex) ?: return@combine null
-        val noticeType = getNoticeType(addresses, custom, isDismissed) ?: return@combine null
+        val noticeType = getNoticeType(addresses, customs[selectedIndex], isDismissed) ?: return@combine null
         getNoticeBannerUiState(noticeType).also { state ->
             previousNotice = state.type
             if (state.autoDismiss) {

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/WooShippingLabelCreationViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/WooShippingLabelCreationViewModelTest.kt
@@ -15,7 +15,7 @@ import com.woocommerce.android.ui.orders.wooshippinglabels.WooShippingLabelCreat
 import com.woocommerce.android.ui.orders.wooshippinglabels.WooShippingLabelCreationViewModel.OpenLearnMoreScreen
 import com.woocommerce.android.ui.orders.wooshippinglabels.WooShippingLabelCreationViewModel.OpenShippingLabelFile
 import com.woocommerce.android.ui.orders.wooshippinglabels.WooShippingLabelCreationViewModel.OpenUrl
-import com.woocommerce.android.ui.orders.wooshippinglabels.WooShippingLabelCreationViewModel.PackageSelectionState.DataAvailable
+import com.woocommerce.android.ui.orders.wooshippinglabels.WooShippingLabelCreationViewModel.PackageSelectionState
 import com.woocommerce.android.ui.orders.wooshippinglabels.WooShippingLabelCreationViewModel.StartHazmatFormEdit
 import com.woocommerce.android.ui.orders.wooshippinglabels.WooShippingLabelCreationViewModel.StartRefundRequest
 import com.woocommerce.android.ui.orders.wooshippinglabels.WooShippingLabelCreationViewModel.WooShippingViewState
@@ -599,8 +599,8 @@ class WooShippingLabelCreationViewModelTest : BaseUnitTest() {
         assertThat(currentViewState).isInstanceOf(DataState::class.java)
         val dataState = currentViewState as DataState
 
-        assertThat(dataState.shipmentUIList[0].packageSelectionState).isInstanceOf(DataAvailable::class.java)
-        val dataAvailable = dataState.shipmentUIList[0].packageSelectionState as DataAvailable
+        assertThat(dataState.shipmentUIList[0].packageSelectionState).isInstanceOf(PackageSelectionState.DataAvailable::class.java)
+        val dataAvailable = dataState.shipmentUIList[0].packageSelectionState as PackageSelectionState.DataAvailable
         assertThat(dataAvailable.selectedPackage).isEqualTo(initialPackageData)
     }
 
@@ -652,8 +652,8 @@ class WooShippingLabelCreationViewModelTest : BaseUnitTest() {
         assertThat(currentViewState).isInstanceOf(DataState::class.java)
         val dataState = currentViewState as DataState
 
-        assertThat(dataState.shipmentUIList[0].packageSelectionState).isInstanceOf(DataAvailable::class.java)
-        val dataAvailable = dataState.shipmentUIList[0].packageSelectionState as DataAvailable
+        assertThat(dataState.shipmentUIList[0].packageSelectionState).isInstanceOf(PackageSelectionState.DataAvailable::class.java)
+        val dataAvailable = dataState.shipmentUIList[0].packageSelectionState as PackageSelectionState.DataAvailable
         assertThat(dataAvailable.selectedPackage).isEqualTo(newPackageData)
     }
 
@@ -1238,5 +1238,57 @@ class WooShippingLabelCreationViewModelTest : BaseUnitTest() {
         sut.onLearnMoreClicked()
 
         assertThat(event).isEqualTo(OpenLearnMoreScreen)
+    }
+
+    @Test
+    fun `after splitting a shipment, then retain the state of previous shipments`() = testBlocking {
+        val order = OrderTestUtils.generateTestOrder(orderId = orderId).copy(
+            shippingLines = defaultShippingLines
+        )
+        whenever(orderDetailRepository.getOrderById(any())) doReturn order
+        whenever(getShipments(any())) doReturn defaultShipments
+        whenever(observeOriginAddresses()) doReturn flowOf(defaultOriginAddresses)
+        whenever(observeStoreOptions()) doReturn flowOf(defaultStoreOptions)
+
+        createViewModel()
+        advanceUntilIdle()
+
+        sut.onPackageSelected(defaultPackageData)
+        sut.onShipmentSplit(
+            listOf(
+                ShipmentUIModel("0", items = defaultShippableItems.take(2)),
+                ShipmentUIModel("1", items = defaultShippableItems.takeLast(1)),
+            )
+        )
+
+        val afterSplitState = sut.viewState.value as DataState
+        assertThat(afterSplitState.shipmentUIList.first().packageSelectionState)
+            .matches { it is PackageSelectionState.DataAvailable && it.selectedPackage == defaultPackageData }
+        assertThat(afterSplitState.shipmentUIList.last().packageSelectionState)
+            .isEqualTo(PackageSelectionState.NotSelected)
+    }
+
+    @Test
+    fun `after merging shipments, then reset state to default values`() = testBlocking {
+        val order = OrderTestUtils.generateTestOrder(orderId = orderId).copy(
+            shippingLines = defaultShippingLines
+        )
+        whenever(orderDetailRepository.getOrderById(any())) doReturn order
+        whenever(getShipments(any())) doReturn listOf(
+            ShipmentUIModel("0", items = defaultShippableItems.take(2)),
+            ShipmentUIModel("1", items = defaultShippableItems.takeLast(1)),
+        )
+        whenever(observeOriginAddresses()) doReturn flowOf(defaultOriginAddresses)
+        whenever(observeStoreOptions()) doReturn flowOf(defaultStoreOptions)
+
+        createViewModel()
+        advanceUntilIdle()
+
+        sut.onPackageSelected(defaultPackageData)
+        sut.onShipmentSplit(defaultShipments)
+
+        val afterSplitState = sut.viewState.value as DataState
+        assertThat(afterSplitState.shipmentUIList.first().packageSelectionState)
+            .isEqualTo(PackageSelectionState.NotSelected)
     }
 }

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/WooShippingLabelCreationViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/WooShippingLabelCreationViewModelTest.kt
@@ -599,7 +599,8 @@ class WooShippingLabelCreationViewModelTest : BaseUnitTest() {
         assertThat(currentViewState).isInstanceOf(DataState::class.java)
         val dataState = currentViewState as DataState
 
-        assertThat(dataState.shipmentUIList[0].packageSelectionState).isInstanceOf(PackageSelectionState.DataAvailable::class.java)
+        assertThat(dataState.shipmentUIList[0].packageSelectionState)
+            .isInstanceOf(PackageSelectionState.DataAvailable::class.java)
         val dataAvailable = dataState.shipmentUIList[0].packageSelectionState as PackageSelectionState.DataAvailable
         assertThat(dataAvailable.selectedPackage).isEqualTo(initialPackageData)
     }
@@ -652,7 +653,8 @@ class WooShippingLabelCreationViewModelTest : BaseUnitTest() {
         assertThat(currentViewState).isInstanceOf(DataState::class.java)
         val dataState = currentViewState as DataState
 
-        assertThat(dataState.shipmentUIList[0].packageSelectionState).isInstanceOf(PackageSelectionState.DataAvailable::class.java)
+        assertThat(dataState.shipmentUIList[0].packageSelectionState)
+            .isInstanceOf(PackageSelectionState.DataAvailable::class.java)
         val dataAvailable = dataState.shipmentUIList[0].packageSelectionState as PackageSelectionState.DataAvailable
         assertThat(dataAvailable.selectedPackage).isEqualTo(newPackageData)
     }


### PR DESCRIPTION
### Description
This PR introduces the logic that was discussed before to retain state when splitting shipments, the idea is that we'll retain state when splitting, but we reset the state when removing shipments, check here for more context: p1749116297102689-slack-C03L1NF1EA3

The PR also fixes a cause of some crashes that happen when removing shipments, the crashes are caused by the fact that the `selectedIndex` could hold a value higher than the size of the new shipments list, and it was happening at different spots.

### Steps to reproduce
1. Start shipping label creation for an order with multiple products.
1. Make some changes (e.g select a package or change customs form)
1. Split the shipment.
1. When back at the main form, select the last package.
1. Now, open the split screen and remove the last shipment.

### Testing information
- Confirm that after splitting the state is retained.
- Confirm that after removing the last shipment, the state was reset, and the app didn't crash.

### The tests that have been performed
The above.

- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->