### PR TITLE
[WOOMOB-576] Improve accessibility for adding items to cart

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -4,6 +4,7 @@
 22.6
 -----
 - [*] Fix a rare dead-end in the order creation flow. [https://github.com/woocommerce/woocommerce-android/pull/14133]
+- [*] Improve talkback support in the POS list of items. [https://github.com/woocommerce/woocommerce-android/pull/14173]
 
 22.6
 -----

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/cart/WooPosCartScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/cart/WooPosCartScreen.kt
@@ -329,7 +329,6 @@ private fun AnnounceCartItemChangesForAccessibility(
 
                 is WooPosCartItemViewState.Loading ->
                     localView.context.getString(R.string.woopos_cart_searching_for_item)
-
             }
 
             localView.announceForAccessibility(message)

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/cart/WooPosCartScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/cart/WooPosCartScreen.kt
@@ -43,6 +43,7 @@ import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.livedata.observeAsState
 import androidx.compose.runtime.mutableIntStateOf
+import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -53,6 +54,7 @@ import androidx.compose.ui.graphics.ColorFilter
 import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.platform.LocalView
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.res.vectorResource
 import androidx.compose.ui.semantics.clearAndSetSemantics
@@ -237,6 +239,8 @@ private fun CartBodyWithItems(
         label = "cart list height animation"
     )
 
+    AnnounceCartItemChangesForAccessibility(items)
+
     WooPosLazyColumn(
         modifier = modifier
             .padding(horizontal = WooPosSpacing.Medium.value.toAdaptivePadding())
@@ -275,6 +279,7 @@ private fun CartBodyWithItems(
                     canRemoveItems = areItemsRemovable,
                     onUIEvent = onUIEvent,
                 )
+
                 is WooPosCartItemViewState.Loading -> LoadingItem(
                     modifier = Modifier.animateItem(),
                     item = item,
@@ -286,6 +291,50 @@ private fun CartBodyWithItems(
         item {
             Spacer(modifier = Modifier.height(spacerHeight))
         }
+    }
+}
+
+@Composable
+private fun AnnounceCartItemChangesForAccessibility(
+    items: List<WooPosCartItemViewState>,
+) {
+    val localView = LocalView.current
+    val previousItems = remember { mutableStateOf<List<WooPosCartItemViewState>>(emptyList()) }
+    LaunchedEffect(items) {
+        val changedItem = items.firstOrNull { currentItem ->
+            val previousItem = previousItems.value.find { it.itemNumber == currentItem.itemNumber }
+            previousItem == null || currentItem::class != previousItem::class
+        }
+
+        changedItem?.let { currentItem ->
+            val message = when (currentItem) {
+                is WooPosCartItemViewState.Product ->
+                    localView.context.getString(
+                        R.string.woopos_cart_product_added_to_cart_accessibility,
+                        currentItem.name,
+                        currentItem.price
+                    )
+
+                is WooPosCartItemViewState.Coupon ->
+                    localView.context.getString(
+                        R.string.woopos_cart_coupon_added_to_cart_accessibility,
+                        currentItem.name
+                    )
+
+                is WooPosCartItemViewState.Error ->
+                    localView.context.getString(
+                        R.string.woopos_cart_adding_item_to_cart_failed,
+                        currentItem.message
+                    )
+
+                is WooPosCartItemViewState.Loading ->
+                    localView.context.getString(R.string.woopos_cart_searching_for_item)
+
+            }
+
+            localView.announceForAccessibility(message)
+        }
+        previousItems.value = items
     }
 }
 
@@ -637,6 +686,7 @@ private fun CouponItem(
                             modifier = Modifier.clearAndSetSemantics { }
                         )
                     }
+
                     is CouponValidationState.Valid -> {
                         Spacer(modifier = Modifier.height(WooPosSpacing.XSmall.value.toAdaptivePadding()))
                         WooPosText(

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/items/WooPosItemsList.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/items/WooPosItemsList.kt
@@ -216,6 +216,7 @@ private fun CouponItem(
     val itemContentDescription = stringResource(
         id = R.string.woopos_coupon_item_content_description,
         item.name,
+        item.summary
     )
     WooPosCouponCard(modifier, itemContentDescription, onItemClicked, item)
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/items/WooPosItemsList.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/items/WooPosItemsList.kt
@@ -177,8 +177,7 @@ private fun VariableProductItem(
 ) {
     val itemContentDescription = stringResource(
         id = R.string.woopos_variable_product_item_content_description,
-        item.name,
-        item.price
+        item.name
     )
     WooPosProductCard(
         modifier = modifier,

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/items/WooPosItemsList.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/items/WooPosItemsList.kt
@@ -43,8 +43,8 @@ import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.res.vectorResource
+import androidx.compose.ui.semantics.clearAndSetSemantics
 import androidx.compose.ui.semantics.contentDescription
-import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.text.style.TextOverflow
@@ -161,7 +161,12 @@ private fun ProductItem(
         item.name,
         item.price
     )
-    WooPosProductCard(modifier, itemContentDescription, onItemClicked, item)
+    WooPosProductCard(
+        modifier = modifier,
+        itemContentDescription = itemContentDescription,
+        onItemClicked = onItemClicked,
+        item = item
+    )
 }
 
 @Composable
@@ -175,7 +180,13 @@ private fun VariableProductItem(
         item.name,
         item.price
     )
-    WooPosProductCard(modifier, itemContentDescription, onItemClicked, item)
+    WooPosProductCard(
+        modifier = modifier,
+        itemContentDescription = itemContentDescription,
+        clickLabelForAccessibility = stringResource(R.string.woopos_add_variable_product_to_cart_accessibility_label),
+        onItemClicked = onItemClicked,
+        item = item
+    )
 }
 
 @Composable
@@ -189,7 +200,12 @@ private fun VariationItem(
         item.name,
         item.price
     )
-    WooPosProductCard(modifier, itemContentDescription, onItemClicked, item)
+    WooPosProductCard(
+        modifier = modifier,
+        itemContentDescription = itemContentDescription,
+        onItemClicked = onItemClicked,
+        item = item
+    )
 }
 
 @Composable
@@ -209,13 +225,13 @@ private fun CouponItem(
 fun WooPosProductCard(
     modifier: Modifier,
     itemContentDescription: String,
+    clickLabelForAccessibility: String = stringResource(R.string.woopos_add_product_to_cart_accessibility_label),
     onItemClicked: (item: WooPosItemSelectionViewState) -> Unit,
     item: Product
 ) {
     WooPosCard(
         modifier = modifier
-            .wrapContentHeight()
-            .semantics { contentDescription = itemContentDescription },
+            .wrapContentHeight(),
         shape = RoundedCornerShape(WooPosCornerRadius.Medium.value),
         backgroundColor = MaterialTheme.colorScheme.surfaceContainerLowest,
         elevation = WooPosElevation.Medium,
@@ -223,9 +239,12 @@ fun WooPosProductCard(
     ) {
         Row(
             modifier = Modifier
-                .clickable { onItemClicked(item) }
+                .clickable(
+                    onClickLabel = clickLabelForAccessibility,
+                ) { onItemClicked(item) }
                 .height(IntrinsicSize.Min)
                 .heightIn(min = 112.dp)
+                .clearAndSetSemantics { contentDescription = itemContentDescription }
                 .fillMaxWidth(),
             verticalAlignment = Alignment.CenterVertically
         ) {
@@ -313,8 +332,7 @@ fun WooPosCouponCard(
 ) {
     WooPosCard(
         modifier = modifier
-            .wrapContentHeight()
-            .semantics { contentDescription = itemContentDescription },
+            .wrapContentHeight(),
         shape = RoundedCornerShape(WooPosCornerRadius.Medium.value),
         backgroundColor = if (item.expiredState is Coupon.ExpiredState.Expired) {
             WooPosTheme.colors.disabledContainer
@@ -326,7 +344,11 @@ fun WooPosCouponCard(
     ) {
         Row(
             modifier = Modifier
-                .clickable(enabled = item.expiredState is Coupon.ExpiredState.NotExpired) { onItemClicked(item) }
+                .clickable(
+                    enabled = item.expiredState is Coupon.ExpiredState.NotExpired,
+                    onClickLabel = stringResource(R.string.woopos_add_coupon_to_cart_accessibility_label)
+                ) { onItemClicked(item) }
+                .clearAndSetSemantics { contentDescription = itemContentDescription }
                 .height(IntrinsicSize.Min)
                 .fillMaxWidth(),
             verticalAlignment = Alignment.CenterVertically

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/items/WooPosItemsList.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/items/WooPosItemsList.kt
@@ -176,7 +176,7 @@ private fun VariableProductItem(
     onItemClicked: (item: WooPosItemSelectionViewState) -> Unit
 ) {
     val itemContentDescription = stringResource(
-        id = R.string.woopos_variable_product_item_content_description,
+        id = R.string.woopos_variable_product_item_content_description_v2,
         item.name
     )
     WooPosProductCard(
@@ -214,7 +214,7 @@ private fun CouponItem(
     onItemClicked: (item: WooPosItemSelectionViewState) -> Unit
 ) {
     val itemContentDescription = stringResource(
-        id = R.string.woopos_coupon_item_content_description,
+        id = R.string.woopos_coupon_item_content_description_v2,
         item.name,
         item.summary
     )

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -4271,12 +4271,12 @@
     <string name="woopos_checkout_button">Check out</string>
     <string name="woopos_remove_item_button_from_cart_content_description">Remove %s from cart</string>
     <string name="woopos_product_item_content_description">Product %s, Price %s</string>
-    <string name="woopos_variable_product_item_content_description">Variable Product %s, Price %s</string>
+    <string name="woopos_variable_product_item_content_description">Variable Product %s</string>
     <string name="woopos_variation_item_content_description">Variation %s, Price %s</string>
     <string name="woopos_cart_item_product_content_description">Product in cart %s, Price %s</string>
     <string name="woopos_cart_item_loading_content_description">Loading item %s</string>
     <string name="woopos_cart_item_error_content_description">Error loading item %s</string>
-    <string name="woopos_coupon_item_content_description">Coupon %s</string>
+    <string name="woopos_coupon_item_content_description">Coupon %s, %s</string>
     <string name="woopos_coupon_item_expired_label">Expired on %s</string>
     <string name="woopos_add_product_to_cart_accessibility_label">Add product to cart</string>
     <string name="woopos_add_variable_product_to_cart_accessibility_label">Open list of variations</string>
@@ -4353,6 +4353,10 @@
     <string name="woopos_products_empty_list_message_two">POS currently only supports simple products</string>
     <string name="woopos_products_loading_error_title">Unable to load products</string>
     <string name="woopos_products_loading_error_message">Please try again.</string>
+    <string name="woopos_cart_product_added_to_cart_accessibility">Product %1$s added to cart, price %2$s</string>
+    <string name="woopos_cart_coupon_added_to_cart_accessibility">Coupon %1$s added to cart</string>
+    <string name="woopos_cart_adding_item_to_cart_failed">Adding item to cart failed, %s.</string>
+    <string name="woopos_cart_searching_for_item">Searching</string>
 
     <string name="woopos_coupons_empty_list_image_description">No coupons</string>
     <string name="woopos_coupons_empty_list_title">No coupons found</string>

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -4278,6 +4278,9 @@
     <string name="woopos_cart_item_error_content_description">Error loading item %s</string>
     <string name="woopos_coupon_item_content_description">Coupon %s</string>
     <string name="woopos_coupon_item_expired_label">Expired on %s</string>
+    <string name="woopos_add_product_to_cart_accessibility_label">Add product to cart</string>
+    <string name="woopos_add_variable_product_to_cart_accessibility_label">Open list of variations</string>
+    <string name="woopos_add_coupon_to_cart_accessibility_label">Add coupon to cart</string>
     <string name="woopos_cart_item_coupon_content_description">Coupon in cart %s</string>
     <string name="woopos_cart_title">Cart</string>
     <string name="woopos_cart_changes_in_the_cart">There are changes in the cart</string>

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -4271,12 +4271,12 @@
     <string name="woopos_checkout_button">Check out</string>
     <string name="woopos_remove_item_button_from_cart_content_description">Remove %s from cart</string>
     <string name="woopos_product_item_content_description">Product %s, Price %s</string>
-    <string name="woopos_variable_product_item_content_description">Variable Product %s</string>
+    <string name="woopos_variable_product_item_content_description_v2">Variable Product %s</string>
     <string name="woopos_variation_item_content_description">Variation %s, Price %s</string>
     <string name="woopos_cart_item_product_content_description">Product in cart %s, Price %s</string>
     <string name="woopos_cart_item_loading_content_description">Loading item %s</string>
     <string name="woopos_cart_item_error_content_description">Error loading item %s</string>
-    <string name="woopos_coupon_item_content_description">Coupon %s, %s</string>
+    <string name="woopos_coupon_item_content_description_v2">Coupon %s, %s</string>
     <string name="woopos_coupon_item_expired_label">Expired on %s</string>
     <string name="woopos_add_product_to_cart_accessibility_label">Add product to cart</string>
     <string name="woopos_add_variable_product_to_cart_accessibility_label">Open list of variations</string>


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

<!-- Id number of the Linear issue this PR addresses, e.g., WOOMOB-373. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

This PR updates talkback announcements for the item list, cart, and barcode scanning.
- Announces "Double tap to add product/coupon to cart" upon selecting an item or "Double tap to open list of variations" on variable products.
- Fixes Product/Coupon announcements => reads name + price/summary.
- Reads "Searching" when the app fetches item after barcode scan.
- Reads "Product/Coupon added to cart" along with it's name.

### Testing information
<!-- This is your opportunity to break out individual scenarios that need testing (when necessary) and/or include a checklist for the reviewer to go through. Consider documenting the following from your own completed testing: devices used, alternate workflows, edge cases, affected areas, critical flows, areas not tested, and any remaining unknowns. Provide feedback on this new section of the PR template through Sept 30, 2024 to Apps Quality; additional context here: p91TBi-b8z-p2#comment-12036 -->

1. Enable talkback.
2. Play with selecting items in the list.
3. Try adding items to the cart.
4. Try adding items to the cart by scanning a barcode.


### Images/gif
<!-- Include before and after images or gifs when appropriate. -->

https://github.com/user-attachments/assets/ec440916-001b-43a5-8f87-3ff0f4851932

- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->