### PR TITLE
[Shipping labels] Fix crash on the Create Shipping Label Button

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/OrderDetailViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/OrderDetailViewModel.kt
@@ -211,6 +211,10 @@ class OrderDetailViewModel @Inject constructor(
 
     private var pluginsInformation: Map<String, WooPlugin> = HashMap()
 
+    private val isRevampWooShippingEnabled: Boolean
+        get() = FeatureFlag.REVAMP_WOO_SHIPPING.isEnabled() &&
+            shippingLabelOnboardingRepository.shippingPluginSupport.isWooShippingSupported()
+
     init {
         productImageMap.subscribeToOnProductFetchedEvents(this)
         launch {
@@ -680,10 +684,7 @@ class OrderDetailViewModel @Inject constructor(
     fun onCreateShippingLabelButtonTapped() {
         tracker.trackShippinhLabelTapped()
         launch {
-            if (
-                FeatureFlag.REVAMP_WOO_SHIPPING.isEnabled() &&
-                shippingLabelOnboardingRepository.shippingPluginSupport.isWooShippingSupported()
-            ) {
+            if (isRevampWooShippingEnabled) {
                 triggerEvent(StartWooShippingLabelCreationFlow(awaitOrder().id))
             } else {
                 triggerEvent(StartShippingLabelCreationFlow(awaitOrder().id))
@@ -837,7 +838,7 @@ class OrderDetailViewModel @Inject constructor(
     }
 
     private fun fetchShipmentsAsync() = async {
-        if (shippingLabelOnboardingRepository.shippingPluginSupport.isSupported()) {
+        if (isRevampWooShippingEnabled) {
             shippingLabelRepository.fetchConfig(selectedSite.get(), navArgs.orderId)
         }
         orderDetailsTransactionLauncher.onShipmentsFetchingCompleted()

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/OrderDetailViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/OrderDetailViewModelTest.kt
@@ -2525,6 +2525,6 @@ class OrderDetailViewModelTest : BaseUnitTest() {
     fun `when view model is initialized then fetchConfig is called`() = testBlocking {
         viewModel.start()
 
-        verify(shippingLabelRepository).fetchConfig(selectedSite.get(), ORDER_ID)
+        verify(shippingLabelRepository, never()).fetchConfig(selectedSite.get(), ORDER_ID)
     }
 }

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/OrderDetailViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/OrderDetailViewModelTest.kt
@@ -2518,7 +2518,7 @@ class OrderDetailViewModelTest : BaseUnitTest() {
 
         // THEN
         assertThat(observedViewState!!.orderInfo!!.order).isEqualTo(newOrder)
-        assertThat(observedViewState!!.orderInfo!!.isPaymentCollectableWithCardReader).isFalse()
+        assertThat(observedViewState.orderInfo!!.isPaymentCollectableWithCardReader).isFalse()
     }
 
     @Test


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

<!-- Id number of the Linear issue this PR addresses, e.g., WOOMOB-373. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
In #14158, I added a fix for a parsing error that caused by an endpoint that shouldn't be enabled before shipping label project is ready for production. I initially thought it wasn’t causing a crash, but an A11n experienced a crash when tapping the “Create shipping label” button.

I cherry-picked the commits from #14158 to include in the beta.

### Steps to reproduce
<!-- Step-by-step testing instructions. For new user flows, consider instead stating the goal of the workflow and see if your PR reviewer can accomplish the workflow without specific steps! -->
The code is already tested. Just disable [the REVAMP_WOO_SHIPPING](https://github.com/woocommerce/woocommerce-android/blob/312da4a579531d4ec4cdee2fcdf2ab574f33a649/WooCommerce/src/main/kotlin/com/woocommerce/android/util/FeatureFlag.kt#L28) flag, open the "Create shipping label" screen from the app, and ensure it doesn't crash.

### The tests that have been performed
<!-- To give the reviewer an idea of what could be missed in terms of testing -->
I will also test it on the A11n's testing site.

### Images/gif
<!-- Include before and after images or gifs when appropriate. -->

- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->