### PR TITLE
Issue/wooprd 557 woo posbarcodes implement tracking

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/cart/WooPosCartViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/cart/WooPosCartViewModel.kt
@@ -140,15 +140,7 @@ class WooPosCartViewModel @Inject constructor(
         }
         viewModelScope.launch {
             items.forEach { item ->
-                when (item) {
-                    is WooPosCartItemViewState.Product,
-                    is WooPosCartItemViewState.Coupon -> {
-                        analyticsTracker.track(ItemRemovedFromCart(item = item, source = source))
-                    }
-
-                    is WooPosCartItemViewState.Loading,
-                    is WooPosCartItemViewState.Error -> Unit
-                }
+                analyticsTracker.track(ItemRemovedFromCart(item = item, source = source))
             }
         }
     }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/cart/WooPosCartViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/cart/WooPosCartViewModel.kt
@@ -27,6 +27,7 @@ import com.woocommerce.android.ui.woopos.home.cart.WooPosCartStatus.EMPTY
 import com.woocommerce.android.ui.woopos.home.items.WooPosItemsViewModel
 import com.woocommerce.android.ui.woopos.home.items.variations.getNameForPOS
 import com.woocommerce.android.ui.woopos.util.WooPosGetCachedStoreCurrency
+import com.woocommerce.android.ui.woopos.util.analytics.WooPosAnalyticsEvent
 import com.woocommerce.android.ui.woopos.util.analytics.WooPosAnalyticsEvent.Event.BackToCartTapped
 import com.woocommerce.android.ui.woopos.util.analytics.WooPosAnalyticsEvent.Event.CheckoutTapped
 import com.woocommerce.android.ui.woopos.util.analytics.WooPosAnalyticsEvent.Event.ClearCartTapped
@@ -354,13 +355,18 @@ class WooPosCartViewModel @Inject constructor(
             }
             val itemNumber = getItemNumber()
 
-            updateCartItem(WooPosCartItemViewState.Loading(itemNumber = itemNumber, name = barcode))
+            WooPosCartItemViewState.Loading(itemNumber = itemNumber, name = barcode).let { loadingItem ->
+                analyticsTracker.track(WooPosAnalyticsEvent.Event.ItemAddedToCart(item = loadingItem))
+                updateCartItem(loadingItem)
+            }
 
             val searchResult = searchByIdentifier(barcode)
             val cartItem = searchResult.mapToCartItem(identifier = barcode, itemNumber = itemNumber)
             if (cartItem is WooPosCartItemViewState.Error) {
                 soundHelper.playBarcodeScanFailure()
             }
+
+            analyticsTracker.track(WooPosAnalyticsEvent.Event.ItemAddedToCart(item = cartItem))
             updateCartItem(cartItem)
         }
     }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/util/analytics/WooPosAnalyticsEvent.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/util/analytics/WooPosAnalyticsEvent.kt
@@ -179,7 +179,6 @@ sealed class WooPosAnalyticsEvent : IAnalyticsEvent {
                     is WooPosCartItemViewState.Coupon,
                     is WooPosCartItemViewState.Error,
                     is WooPosCartItemViewState.Loading -> null
-
                     is WooPosCartItemViewState.Product.Simple -> ItemsListProductType.SIMPLE
                     is WooPosCartItemViewState.Product.Variation -> ItemsListProductType.VARIATION
                 }
@@ -215,15 +214,15 @@ sealed class WooPosAnalyticsEvent : IAnalyticsEvent {
                 itemType = when (item) {
                     is WooPosCartItemViewState.Product -> ItemsListItemType.PRODUCT
                     is WooPosCartItemViewState.Coupon -> ItemsListItemType.COUPON
-                    is WooPosCartItemViewState.Error -> error("Error item is not a valid item type")
-                    is WooPosCartItemViewState.Loading -> error("Loading item is not a valid item type")
+                    is WooPosCartItemViewState.Error -> ItemsListItemType.ERROR
+                    is WooPosCartItemViewState.Loading -> ItemsListItemType.LOADING
                 },
                 productType = when (item) {
                     is WooPosCartItemViewState.Product.Simple -> ItemsListProductType.SIMPLE
                     is WooPosCartItemViewState.Product.Variation -> ItemsListProductType.VARIATION
-                    is WooPosCartItemViewState.Coupon -> null
-                    is WooPosCartItemViewState.Error -> error("Error item is not a valid item type")
-                    is WooPosCartItemViewState.Loading -> error("Loading item is not a valid item type")
+                    is WooPosCartItemViewState.Coupon,
+                    is WooPosCartItemViewState.Error,
+                    is WooPosCartItemViewState.Loading -> null
                 }
             )
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/util/analytics/WooPosAnalyticsEvent.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/util/analytics/WooPosAnalyticsEvent.kt
@@ -134,7 +134,7 @@ sealed class WooPosAnalyticsEvent : IAnalyticsEvent {
 
         @ExposedCopyVisibility
         data class ItemAddedToCart private constructor(
-            val source: ItemsListSource,
+            val source: ItemsListSource?,
             val sourceType: ItemsListSourceType,
             val itemType: ItemsListItemType,
             val productType: ItemsListProductType?
@@ -165,10 +165,32 @@ sealed class WooPosAnalyticsEvent : IAnalyticsEvent {
                 }
             )
 
+            constructor(item: WooPosCartItemViewState) : this(
+                source = null,
+                sourceType = ItemsListSourceType.BARCODE_SCANNER,
+                itemType = when (item) {
+                    is WooPosCartItemViewState.Loading -> ItemsListItemType.LOADING
+                    is WooPosCartItemViewState.Coupon -> ItemsListItemType.COUPON
+                    is WooPosCartItemViewState.Product.Simple -> ItemsListItemType.PRODUCT
+                    is WooPosCartItemViewState.Product.Variation -> ItemsListItemType.PRODUCT
+                    is WooPosCartItemViewState.Error -> ItemsListItemType.ERROR
+                },
+                productType = when (item) {
+                    is WooPosCartItemViewState.Coupon,
+                    is WooPosCartItemViewState.Error,
+                    is WooPosCartItemViewState.Loading -> null
+
+                    is WooPosCartItemViewState.Product.Simple -> ItemsListProductType.SIMPLE
+                    is WooPosCartItemViewState.Product.Variation -> ItemsListProductType.VARIATION
+                }
+            )
+
             init {
                 addProperties(
                     buildMap {
-                        put(ItemsListSource.SOURCE, source.toString())
+                        if (source != null) {
+                            put(ItemsListSource.SOURCE, source.toString())
+                        }
                         put(ItemsListSourceType.SOURCE_TYPE, sourceType.toString())
                         put(ItemsListItemType.ITEM_TYPE, itemType.toString())
                         if (productType != null) {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/util/analytics/WooPosAnalyticsEvent.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/util/analytics/WooPosAnalyticsEvent.kt
@@ -137,7 +137,8 @@ sealed class WooPosAnalyticsEvent : IAnalyticsEvent {
             val source: ItemsListSource?,
             val sourceType: ItemsListSourceType,
             val itemType: ItemsListItemType,
-            val productType: ItemsListProductType?
+            val productType: ItemsListProductType?,
+            val error: String? = null
         ) : Event() {
             override val name: String = "item_added_to_cart"
 
@@ -181,7 +182,8 @@ sealed class WooPosAnalyticsEvent : IAnalyticsEvent {
                     is WooPosCartItemViewState.Loading -> null
                     is WooPosCartItemViewState.Product.Simple -> ItemsListProductType.SIMPLE
                     is WooPosCartItemViewState.Product.Variation -> ItemsListProductType.VARIATION
-                }
+                },
+                error = if (item is WooPosCartItemViewState.Error) item.message else null
             )
 
             init {
@@ -194,6 +196,9 @@ sealed class WooPosAnalyticsEvent : IAnalyticsEvent {
                         put(ItemsListItemType.ITEM_TYPE, itemType.toString())
                         if (productType != null) {
                             put(ItemsListProductType.PRODUCT_TYPE, productType.toString())
+                        }
+                        if (error != null) {
+                            put("error", error)
                         }
                     }
                 )

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/util/analytics/WooPosAnalyticsEventConstant.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/util/analytics/WooPosAnalyticsEventConstant.kt
@@ -16,7 +16,9 @@ object WooPosAnalyticsEventConstant {
 
     enum class ItemsListItemType(val value: String) {
         PRODUCT("product"),
-        COUPON("coupon");
+        COUPON("coupon"),
+        LOADING("loading"),
+        ERROR("error");
 
         override fun toString(): String {
             return value
@@ -44,7 +46,8 @@ object WooPosAnalyticsEventConstant {
         LIST("list"),
         SEARCH_RESULT("search"),
         SEARCH_RESULT_LOCAL("search_result_local"),
-        POPULAR_PRODUCTS("pre_search");
+        POPULAR_PRODUCTS("pre_search"),
+        BARCODE_SCANNER("scanner");
 
         override fun toString(): String {
             return value

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/home/cart/WooPosCartViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/home/cart/WooPosCartViewModelTest.kt
@@ -1031,6 +1031,36 @@ class WooPosCartViewModelTest {
     }
 
     @Test
+    fun `when barcode scanned, then item added to cart event tracked`() = runTest {
+        // GIVEN
+        whenever(
+            searchByIdentifier(any(), any())
+        ).doSuspendableAnswer {
+            delay(1)
+            WooPosSearchByIdentifierResult.Success(
+                ProductTestUtils.generateProduct(
+                    amount = "10.0"
+                )
+            )
+        }
+        createSut()
+
+        // WHEN
+        parentToChildrenMutableSharedFlow.emit(
+            ParentToChildrenEvent.BarcodeScanned("123456789")
+        )
+
+        // THEN
+        verify(analyticsTracker).track(
+            eq(
+                WooPosAnalyticsEvent.Event.ItemAddedToCart(
+                    item = WooPosCartItemViewState.Loading(1, "123456789")
+                )
+            )
+        )
+    }
+
+    @Test
     fun `given empty cart, when barcode scanned and product found, then loading item is replaced with product`() =
         runTest {
             // GIVEN
@@ -1060,6 +1090,45 @@ class WooPosCartViewModelTest {
             val productItem = finalItemsInCart.first() as WooPosCartItemViewState.Product.Simple
             assertThat(productItem.id).isEqualTo(product.remoteId)
             assertThat(productItem.name).isEqualTo(product.name)
+        }
+
+    @Test
+    fun `when barcode scanned and product found, then track item added to cart event`() =
+        runTest {
+            // GIVEN
+            val product = ProductTestUtils.generateProduct(
+                productId = 23L,
+                productName = "Scanned Product",
+                amount = "10.0"
+            ).copy(firstImageUrl = "url")
+
+            whenever(searchByIdentifier(eq("123456789"), any())).thenReturn(
+                WooPosSearchByIdentifierResult.Success(product)
+            )
+
+            createSut()
+
+            // WHEN
+            parentToChildrenMutableSharedFlow.emit(
+                ParentToChildrenEvent.BarcodeScanned("123456789")
+            )
+            advanceUntilIdle()
+
+            // THEN
+           verify(analyticsTracker).track(
+                eq(
+                    WooPosAnalyticsEvent.Event.ItemAddedToCart(
+                        item = WooPosCartItemViewState.Product.Simple(
+                            itemNumber = 1,
+                            id = product.remoteId,
+                            name = product.name,
+                            price = "$10.0",
+                            imageUrl = product.firstImageUrl,
+                            description = product.description,
+                        )
+                    )
+                )
+            )
         }
 
     @Test
@@ -1189,6 +1258,39 @@ class WooPosCartViewModelTest {
         assertThat(finalItemsInCart).hasSize(1)
         val errorItem = finalItemsInCart.first() as WooPosCartItemViewState.Error
         assertThat(errorItem.message).isEqualTo(errorMessage)
+    }
+
+    @Test
+    fun `when barcode scan fails, then item added to cart tracked`() = runTest {
+        // GIVEN
+        val errorMessage = "Network error occurred"
+        whenever(resourceProvider.getString(R.string.woopos_cart_barcode_scan_result_network_error))
+            .thenReturn(errorMessage)
+
+        whenever(searchByIdentifier(eq("123456789"), any())).thenReturn(
+            WooPosSearchByIdentifierResult.Failure(WooPosSearchByIdentifierResult.Error.NetworkError)
+        )
+
+        createSut()
+
+        // WHEN
+        parentToChildrenMutableSharedFlow.emit(
+            ParentToChildrenEvent.BarcodeScanned("123456789")
+        )
+        advanceUntilIdle()
+
+        // THEN
+        verify(analyticsTracker).track(
+            eq(
+                WooPosAnalyticsEvent.Event.ItemAddedToCart(
+                    item = WooPosCartItemViewState.Error(
+                        itemNumber = 1,
+                        name = "123456789",
+                        message = "Network error occurred",
+                    )
+                )
+            )
+        )
     }
 
     @Test

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/home/cart/WooPosCartViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/home/cart/WooPosCartViewModelTest.kt
@@ -1115,7 +1115,7 @@ class WooPosCartViewModelTest {
             advanceUntilIdle()
 
             // THEN
-           verify(analyticsTracker).track(
+            verify(analyticsTracker).track(
                 eq(
                     WooPosAnalyticsEvent.Event.ItemAddedToCart(
                         item = WooPosCartItemViewState.Product.Simple(


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

<!-- Id number of the Linear issue this PR addresses, e.g., WOOMOB-373. -->
WOOMOB-557

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

This PR adds tracking for the barcode scanning project, specifically:
1. Updates existing `woocommerceandroid_pos_item_added_to_cart`
- 'item_type' now supports `loading` and `error` values.
- 'source_type' now supports `scanner` value.
- Newly added `error` attribute containing the error message.
- 'source' is NOT tracked when the item is added using a scanner

2. Update existing `woocommerceandroid_pos_item_removed_from_cart`
- 'item_type' now supports `loading` and `error`values.

### Testing information
<!-- This is your opportunity to break out individual scenarios that need testing (when necessary) and/or include a checklist for the reviewer to go through. Consider documenting the following from your own completed testing: devices used, alternate workflows, edge cases, affected areas, critical flows, areas not tested, and any remaining unknowns. Provide feedback on this new section of the PR template through Sept 30, 2024 to Apps Quality; additional context here: p91TBi-b8z-p2#comment-12036 -->

1. Scan a barcode assigned to a simple product.
2. Notice woocommerceandroid_pos_item_added_to_cart is tracked for the loading item and for the item itself when the search succeeds.
3. Scan a barcode that is NOT assigned to any product.
4. Notice woocommerceandroid_pos_item_added_to_cart is tracked for the loading item and then for the error item.
5. Tap on the delete icon and notice `woocommerceandroid_pos_item_removed_from_cart` with item_type error is tracked 
6. Scan a barcode and before the loading item disappears, tap on `delete` => notice `woocommerceandroid_pos_item_removed_from_cart` with `item_type` loading is tracked.

### The tests that have been performed
<!-- To give the reviewer an idea of what could be missed in terms of testing -->

The above.

### Images/gif
<!-- Include before and after images or gifs when appropriate. -->

- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->