### PR TITLE
Remove unused field to avoid nullpointer crash

### DIFF
--- a/libs/fluxc-plugin/src/main/kotlin/org/wordpress/android/fluxc/model/shippinglabels/WCShippingAccountSettings.kt
+++ b/libs/fluxc-plugin/src/main/kotlin/org/wordpress/android/fluxc/model/shippinglabels/WCShippingAccountSettings.kt
@@ -10,7 +10,7 @@ data class WCShippingAccountSettings(
     val canManagePayments: Boolean,
     val storeOwnerName: String,
     val storeOwnerUserName: String,
-    val storeOwnerWpcomUserName: String,
+    val storeOwnerWpcomUserName: String?,
     val storeOwnerWpcomEmail: String,
     val selectedPaymentMethodId: Int?,
     val paymentMethods: List<WCPaymentMethod>,

--- a/libs/fluxc-plugin/src/main/kotlin/org/wordpress/android/fluxc/model/shippinglabels/WCShippingAccountSettings.kt
+++ b/libs/fluxc-plugin/src/main/kotlin/org/wordpress/android/fluxc/model/shippinglabels/WCShippingAccountSettings.kt
@@ -10,7 +10,6 @@ data class WCShippingAccountSettings(
     val canManagePayments: Boolean,
     val storeOwnerName: String,
     val storeOwnerUserName: String,
-    val storeOwnerWpcomUserName: String?,
     val storeOwnerWpcomEmail: String,
     val selectedPaymentMethodId: Int?,
     val paymentMethods: List<WCPaymentMethod>,

--- a/libs/fluxc-plugin/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/shippinglabels/AccountSettingsApiResponse.kt
+++ b/libs/fluxc-plugin/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/shippinglabels/AccountSettingsApiResponse.kt
@@ -21,7 +21,7 @@ data class AccountSettingsApiResponse(
         @SerializedName("can_manage_payments") val canManagePayments: Boolean,
         @SerializedName("master_user_name") val storeOwnerName: String,
         @SerializedName("master_user_login") val storeOwnerUserName: String,
-        @SerializedName("master_user_wpcom_login") val storeOwnerWpcomUserName: String,
+        @SerializedName("master_user_wpcom_login") val storeOwnerWpcomUserName: String?,
         @SerializedName("master_user_email") val storeOwnerWpcomEmail: String,
         @SerializedName("payment_methods") val paymentMethods: List<WCPaymentMethod>?
     )

--- a/libs/fluxc-plugin/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/shippinglabels/AccountSettingsApiResponse.kt
+++ b/libs/fluxc-plugin/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/shippinglabels/AccountSettingsApiResponse.kt
@@ -21,7 +21,6 @@ data class AccountSettingsApiResponse(
         @SerializedName("can_manage_payments") val canManagePayments: Boolean,
         @SerializedName("master_user_name") val storeOwnerName: String,
         @SerializedName("master_user_login") val storeOwnerUserName: String,
-        @SerializedName("master_user_wpcom_login") val storeOwnerWpcomUserName: String?,
         @SerializedName("master_user_email") val storeOwnerWpcomEmail: String,
         @SerializedName("payment_methods") val paymentMethods: List<WCPaymentMethod>?
     )

--- a/libs/fluxc-plugin/src/main/kotlin/org/wordpress/android/fluxc/store/WCShippingLabelStore.kt
+++ b/libs/fluxc-plugin/src/main/kotlin/org/wordpress/android/fluxc/store/WCShippingLabelStore.kt
@@ -375,7 +375,6 @@ class WCShippingLabelStore @Inject constructor(
                                     canManagePayments = response.result.formMeta.canManagePayments,
                                     storeOwnerName = response.result.formMeta.storeOwnerName,
                                     storeOwnerUserName = response.result.formMeta.storeOwnerUserName,
-                                    storeOwnerWpcomUserName = response.result.formMeta.storeOwnerWpcomUserName,
                                     storeOwnerWpcomEmail = response.result.formMeta.storeOwnerWpcomEmail,
                                     selectedPaymentMethodId = response.result.formData.selectedPaymentId,
                                     paymentMethods = response.result.formMeta.paymentMethods.orEmpty(),


### PR DESCRIPTION

Fixes WOOMOB-594  

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
In WooShipping labels legacy flow there's an unused field `storeOwnerWpcomUserName` that is causing a nullpointer exception. This PR simply removes it to fix the crash. 

### Testing information
Compiling the app should be enough. 

- [ ] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->