### PR TITLE
[POS as a Tab] Remove POS entry point from Menu

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/moremenu/MoreMenuViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/moremenu/MoreMenuViewModel.kt
@@ -35,6 +35,7 @@ import com.woocommerce.android.ui.payments.taptopay.isAvailable
 import com.woocommerce.android.ui.plans.domain.SitePlan
 import com.woocommerce.android.ui.plans.repository.SitePlanRepository
 import com.woocommerce.android.ui.woopos.WooPosIsEnabled
+import com.woocommerce.android.ui.woopos.tab.WooPosIsPOSAsATabEnabled
 import com.woocommerce.android.util.WooLog
 import com.woocommerce.android.viewmodel.ResourceProvider
 import com.woocommerce.android.viewmodel.ScopedViewModel
@@ -71,7 +72,8 @@ class MoreMenuViewModel @Inject constructor(
     private val isGoogleForWooEnabled: IsGoogleForWooEnabled,
     private val hasGoogleAdsCampaigns: HasGoogleAdsCampaigns,
     private val isWooPosEnabled: WooPosIsEnabled,
-    private val analyticsTrackerWrapper: AnalyticsTrackerWrapper
+    private val analyticsTrackerWrapper: AnalyticsTrackerWrapper,
+    private val isPOSAsATabEnabled: WooPosIsPOSAsATabEnabled
 ) : ScopedViewModel(savedState) {
     private var storeHasGoogleAdsCampaigns = false
 
@@ -469,7 +471,7 @@ class MoreMenuViewModel @Inject constructor(
             doCheckAvailability(MoreMenuItemButton.Type.GoogleForWoo) { isGoogleForWooEnabled() },
             doCheckAvailability(MoreMenuItemButton.Type.Inbox) { moreMenuRepository.isInboxEnabled() },
             doCheckAvailability(MoreMenuItemButton.Type.Settings) { moreMenuRepository.isUpgradesEnabled() },
-            doCheckAvailability(MoreMenuItemButton.Type.WooPos) { isWooPosEnabled() }
+            doCheckAvailability(MoreMenuItemButton.Type.WooPos) { isWooPosEnabled() && !isPOSAsATabEnabled() }
         ).merge()
             .map { update ->
                 initialState[update.first] = update.second

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/moremenu/MoreMenuViewModelTests.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/moremenu/MoreMenuViewModelTests.kt
@@ -14,6 +14,7 @@ import com.woocommerce.android.ui.payments.taptopay.TapToPayAvailabilityStatus
 import com.woocommerce.android.ui.plans.domain.SitePlan
 import com.woocommerce.android.ui.plans.repository.SitePlanRepository
 import com.woocommerce.android.ui.woopos.WooPosIsEnabled
+import com.woocommerce.android.ui.woopos.tab.WooPosIsPOSAsATabEnabled
 import com.woocommerce.android.util.captureValues
 import com.woocommerce.android.util.runAndCaptureValues
 import com.woocommerce.android.viewmodel.BaseUnitTest
@@ -92,6 +93,8 @@ class MoreMenuViewModelTests : BaseUnitTest() {
 
     private val blazeCampaignsStore: BlazeCampaignsStore = mock()
 
+    private val isPOSAsATabEnabled: WooPosIsPOSAsATabEnabled = mock()
+
     private lateinit var viewModel: MoreMenuViewModel
     private val tapToPayAvailabilityStatus: TapToPayAvailabilityStatus = mock()
 
@@ -113,6 +116,7 @@ class MoreMenuViewModelTests : BaseUnitTest() {
             hasGoogleAdsCampaigns = hasGoogleAdsCampaigns,
             isWooPosEnabled = isWooPosEnabled,
             analyticsTrackerWrapper = analyticsTrackerWrapper,
+            isPOSAsATabEnabled = isPOSAsATabEnabled
         )
     }
 
@@ -450,10 +454,30 @@ class MoreMenuViewModelTests : BaseUnitTest() {
         }
 
     @Test
-    fun `given isWooPosEnabled returns true, when building state, then WooPOS section is displayed`() = testBlocking {
+    fun `given isWooPosEnabled returns true, but isPOSAsATabEnabled returns true, when building state, then WooPOS section is not displayed`() =
+        testBlocking {
+            // GIVEN
+            setup {
+                whenever(isWooPosEnabled.invoke()).thenReturn(true)
+                whenever(isPOSAsATabEnabled.invoke()).thenReturn(true)
+            }
+
+            // WHEN
+            val states = viewModel.moreMenuViewState.captureValues()
+
+            // THEN
+            assertThat(
+                states.last().menuSections.flatMap { it.items }
+                    .firstOrNull { it.title == R.string.more_menu_button_woo_pos }
+            ).isNull()
+        }
+
+    @Test
+    fun `given isWooPosEnabled returns true, and isPOSAsATabEnabled returns false, when building state, then WooPOS section is displayed`() = testBlocking {
         // GIVEN
         setup {
             whenever(isWooPosEnabled.invoke()).thenReturn(true)
+            whenever(isPOSAsATabEnabled.invoke()).thenReturn(false)
         }
 
         // WHEN


### PR DESCRIPTION
**~Do not merge label - the parent PR https://github.com/woocommerce/woocommerce-android/pull/14183 needs to be merged first.~**

…re flag is enabled.

<!-- Remember about a good descriptive title. -->

<!-- Id number of the Linear issue this PR addresses, e.g., WOOMOB-373. -->
Closes WOOMOB-596

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
With this PR we hide the POS entry point in the menu if the POS as a Tab is Feature Flag is enabled, as we won't be needing that anymore: the POS can accessed through a tab.

### Steps to reproduce
<!-- Step-by-step testing instructions. For new user flows, consider instead stating the goal of the workflow and see if your PR reviewer can accomplish the workflow without specific steps! -->
With the `WOO_POS_AS_A_TAB_I1` feature flag enabled, and a site eligible for POS, go to menu and check that the POS entry point is not displayed. Check also that when the `WOO_POS_AS_A_TAB_I1` feature flag is disabled we show the entry point as before.

- [X] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
