### PR TITLE
Issue/woomob 551 blaze compliance for ftc negative option rule

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/AppUrls.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/AppUrls.kt
@@ -118,6 +118,7 @@ object AppUrls {
         "https://woocommerce.com/documentation/woocommerce/getting-started/sell-products/core-payment-options/"
     const val ADVERTISING_POLICY = "https://automattic.com/advertising-policy/"
     const val BLAZE_SUPPORT = "https://wordpress.com/support/promote-a-post/"
+    const val BLAZE_CANCEL_INSTRUCTIONS = BLAZE_SUPPORT + "manage-your-blaze-ad-campaign/#stop-an-ad-campaign"
 
     fun getScreenshotUrl(themeDemoUrl: String) =
         "https://s0.wp.com/mshots/v1/$themeDemoUrl?demo=true/?w=1200&h=2400&vpw=400&vph=800"

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/blaze/BlazeRepository.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/blaze/BlazeRepository.kt
@@ -194,7 +194,8 @@ class BlazeRepository @Inject constructor(
                 parameters = emptyMap()
             ),
             objectiveId = appPrefsWrapper.blazeCampaignSelectedObjective,
-            ctaText = ""
+            ctaText = "",
+            acceptedTos = false
         )
     }
 
@@ -401,7 +402,8 @@ class BlazeRepository @Inject constructor(
         val budget: Budget,
         val targetingParameters: TargetingParameters,
         val destinationParameters: DestinationParameters,
-        val objectiveId: String
+        val objectiveId: String,
+        val acceptedTos: Boolean
     ) : Parcelable
 
     sealed interface BlazeCampaignImage : Parcelable {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/blaze/BlazeRepository.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/blaze/BlazeRepository.kt
@@ -325,7 +325,8 @@ class BlazeRepository @Inject constructor(
                     )
                 },
                 isEndlessCampaign = campaignDetails.budget.isEndlessCampaign,
-                objectiveId = campaignDetails.objectiveId
+                objectiveId = campaignDetails.objectiveId,
+                acceptedTos = campaignDetails.acceptedTos,
             )
         )
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/blaze/creation/preview/BlazeCampaignCreationPreviewScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/blaze/creation/preview/BlazeCampaignCreationPreviewScreen.kt
@@ -33,8 +33,6 @@ import androidx.compose.material.icons.automirrored.filled.ArrowForwardIos
 import androidx.compose.material3.Checkbox
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.livedata.observeAsState
-import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
@@ -78,7 +76,8 @@ fun BlazeCampaignCreationPreviewScreen(viewModel: BlazeCampaignCreationPreviewVi
             onBackPressed = viewModel::onBackPressed,
             onEditAdClicked = viewModel::onEditAdClicked,
             onConfirmDetailsClicked = viewModel::onConfirmClicked,
-            onHelpTapped = viewModel::onHelpTapped
+            onHelpTapped = viewModel::onHelpTapped,
+            onTosAccepted = viewModel::onTosAccepted
         )
     }
 }
@@ -89,7 +88,8 @@ private fun BlazeCampaignCreationPreviewScreen(
     onBackPressed: () -> Unit,
     onEditAdClicked: () -> Unit,
     onConfirmDetailsClicked: () -> Unit,
-    onHelpTapped: () -> Unit
+    onHelpTapped: () -> Unit,
+    onTosAccepted: (Boolean) -> Unit
 ) {
     Scaffold(
         topBar = {
@@ -124,7 +124,11 @@ private fun BlazeCampaignCreationPreviewScreen(
                     .padding(16.dp)
             )
             Spacer(modifier = Modifier.height(16.dp))
-            ConfirmationFooter(onConfirmDetailsClicked, previewState)
+            ConfirmationFooter(
+                previewState,
+                onConfirmDetailsClicked,
+                onTosAccepted
+            )
         }
     }
 
@@ -133,12 +137,11 @@ private fun BlazeCampaignCreationPreviewScreen(
 
 @Composable
 private fun ConfirmationFooter(
-    onConfirmDetailsClicked: () -> Unit,
     previewState: CampaignPreviewUiState,
+    onConfirmDetailsClicked: () -> Unit,
+    onTosAccepted: (Boolean) -> Unit
 ) {
     val context = LocalContext.current
-    val checked = remember { mutableStateOf(false) }
-
     val campaignTosText = annotatedStringRes(
         stringResId = previewState.campaignDetails.campaignTosText.stringRes,
         onUrlClick = { ChromeCustomTabUtils.launchUrl(context, AppUrls.BLAZE_CANCEL_INSTRUCTIONS) },
@@ -151,8 +154,8 @@ private fun ConfirmationFooter(
             verticalAlignment = Alignment.CenterVertically,
         ) {
             Checkbox(
-                checked = checked.value,
-                onCheckedChange = { checked.value = it }
+                checked = previewState.campaignDetails.campaignTosAccepted,
+                onCheckedChange = onTosAccepted
             )
             Text(
                 modifier = Modifier.padding(start = 4.dp),
@@ -168,7 +171,7 @@ private fun ConfirmationFooter(
                 .padding(vertical = 16.dp),
             text = stringResource(id = R.string.blaze_campaign_preview_details_confirm_details_button),
             onClick = onConfirmDetailsClicked,
-            enabled = previewState.adDetails != Loading && checked.value
+            enabled = previewState.adDetails != Loading && previewState.campaignDetails.campaignTosAccepted
         )
     }
 }
@@ -536,13 +539,15 @@ fun CampaignScreenPreview() {
                     params = listOf(
                         UiStringText("35$"), UiStringText("July 15, 2025")
                     )
-                )
+                ),
+                campaignTosAccepted = false
             )
         ),
         onBackPressed = { },
         onEditAdClicked = { },
         onConfirmDetailsClicked = { },
-        onHelpTapped = { }
+        onHelpTapped = { },
+        onTosAccepted = {}
     )
 }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/blaze/creation/preview/BlazeCampaignCreationPreviewScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/blaze/creation/preview/BlazeCampaignCreationPreviewScreen.kt
@@ -21,6 +21,7 @@ import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.ButtonDefaults
 import androidx.compose.material.Card
+import androidx.compose.material.ContentAlpha
 import androidx.compose.material.Divider
 import androidx.compose.material.Icon
 import androidx.compose.material.MaterialTheme
@@ -31,7 +32,6 @@ import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material.icons.automirrored.filled.ArrowForwardIos
 import androidx.compose.material3.Checkbox
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.MutableState
 import androidx.compose.runtime.livedata.observeAsState
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
@@ -46,6 +46,7 @@ import androidx.compose.ui.res.dimensionResource
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import coil.compose.AsyncImage
@@ -58,6 +59,7 @@ import com.woocommerce.android.ui.blaze.creation.preview.BlazeCampaignCreationPr
 import com.woocommerce.android.ui.blaze.creation.preview.BlazeCampaignCreationPreviewViewModel.CampaignPreviewUiState
 import com.woocommerce.android.ui.compose.Render
 import com.woocommerce.android.ui.compose.animations.SkeletonView
+import com.woocommerce.android.ui.compose.annotatedStringRes
 import com.woocommerce.android.ui.compose.component.ToolbarWithHelpButton
 import com.woocommerce.android.ui.compose.component.WCColoredButton
 import com.woocommerce.android.ui.compose.component.WCTextButton
@@ -117,9 +119,7 @@ private fun BlazeCampaignCreationPreviewScreen(
                     .padding(16.dp)
             )
             Spacer(modifier = Modifier.height(16.dp))
-            Divider()
-            val checked = remember { mutableStateOf(false) }
-            ConfirmationFooter(onConfirmDetailsClicked, previewState, checked)
+            ConfirmationFooter(onConfirmDetailsClicked, previewState)
         }
     }
 
@@ -130,32 +130,42 @@ private fun BlazeCampaignCreationPreviewScreen(
 private fun ConfirmationFooter(
     onConfirmDetailsClicked: () -> Unit,
     previewState: CampaignPreviewUiState,
-    checked: MutableState<Boolean>
 ) {
-    WCColoredButton(
-        modifier = Modifier
-            .fillMaxWidth()
-            .padding(16.dp),
-        text = stringResource(id = R.string.blaze_campaign_preview_details_confirm_details_button),
-        onClick = onConfirmDetailsClicked,
-        enabled = previewState.adDetails != Loading && checked.value
-    )
-
-    Row(
-        modifier = Modifier
-            .padding(horizontal = 16.dp)
-            .padding(bottom = 16.dp),
-        verticalAlignment = Alignment.CenterVertically,
-    ) {
-        Checkbox(
-            checked = checked.value,
-            onCheckedChange = { checked.value = it }
-        )
-        Text(
-            modifier = Modifier.padding(start = 8.dp),
-            text = stringResource(id = R.string.blaze_campaign_preview_tos_checkbox),
-            style = MaterialTheme.typography.body2,
-            color = colorResource(id = R.color.color_on_surface_medium),
+    val checked = remember { mutableStateOf(false) }
+//    val checkboxLegalText = if(previewState.campaignDetails.budget){
+//        stringResource(id = R.string.blaze_campaign_preview_tos_checkbox_evergreen_campaigns)
+//    } else {
+//        stringResource(id = R.string.blaze_campaign_preview_tos_checkbox_evergreen_campaigns)
+//    }
+    Column(modifier = Modifier.padding(horizontal = 16.dp)) {
+        Divider()
+        Row(
+            modifier = Modifier.padding(top = 16.dp),
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+            Checkbox(
+                checked = checked.value,
+                onCheckedChange = { checked.value = it }
+            )
+            Text(
+                modifier = Modifier.padding(start = 4.dp),
+                text = annotatedStringRes(
+                    stringResId = R.string.blaze_campaign_preview_tos_checkbox_evergreen_campaigns,
+                    onUrlClick = null,
+                    previewState.campaignDetails.budget.displayValue
+                ),
+                textAlign = TextAlign.Justify,
+                style = MaterialTheme.typography.caption,
+                color = MaterialTheme.colors.onSurface.copy(alpha = ContentAlpha.medium),
+            )
+        }
+        WCColoredButton(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(vertical = 16.dp),
+            text = stringResource(id = R.string.blaze_campaign_preview_details_confirm_details_button),
+            onClick = onConfirmDetailsClicked,
+            enabled = previewState.adDetails != Loading && checked.value
         )
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/blaze/creation/preview/BlazeCampaignCreationPreviewScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/blaze/creation/preview/BlazeCampaignCreationPreviewScreen.kt
@@ -536,9 +536,7 @@ fun CampaignScreenPreview() {
                 ),
                 campaignTosText = UiStringRes(
                     stringRes = R.string.blaze_campaign_preview_tos_checkbox_evergreen_campaigns,
-                    params = listOf(
-                        UiStringText("35$"), UiStringText("July 15, 2025")
-                    )
+                    params = listOf(UiStringText("35$"), UiStringText("July 15, 2025"))
                 ),
                 campaignTosAccepted = false
             )

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/blaze/creation/preview/BlazeCampaignCreationPreviewScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/blaze/creation/preview/BlazeCampaignCreationPreviewScreen.kt
@@ -51,7 +51,10 @@ import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import coil.compose.AsyncImage
 import coil.request.ImageRequest
+import com.woocommerce.android.AppUrls
 import com.woocommerce.android.R
+import com.woocommerce.android.model.UiString.UiStringRes
+import com.woocommerce.android.model.UiString.UiStringText
 import com.woocommerce.android.ui.blaze.creation.preview.BlazeCampaignCreationPreviewViewModel.AdDetailsUi.AdDetails
 import com.woocommerce.android.ui.blaze.creation.preview.BlazeCampaignCreationPreviewViewModel.AdDetailsUi.Loading
 import com.woocommerce.android.ui.blaze.creation.preview.BlazeCampaignCreationPreviewViewModel.CampaignDetailItemUi
@@ -63,7 +66,9 @@ import com.woocommerce.android.ui.compose.annotatedStringRes
 import com.woocommerce.android.ui.compose.component.ToolbarWithHelpButton
 import com.woocommerce.android.ui.compose.component.WCColoredButton
 import com.woocommerce.android.ui.compose.component.WCTextButton
+import com.woocommerce.android.ui.compose.component.getText
 import com.woocommerce.android.ui.compose.preview.LightDarkThemePreviews
+import com.woocommerce.android.util.ChromeCustomTabUtils
 
 @Composable
 fun BlazeCampaignCreationPreviewScreen(viewModel: BlazeCampaignCreationPreviewViewModel) {
@@ -131,12 +136,14 @@ private fun ConfirmationFooter(
     onConfirmDetailsClicked: () -> Unit,
     previewState: CampaignPreviewUiState,
 ) {
+    val context = LocalContext.current
     val checked = remember { mutableStateOf(false) }
-//    val checkboxLegalText = if(previewState.campaignDetails.budget){
-//        stringResource(id = R.string.blaze_campaign_preview_tos_checkbox_evergreen_campaigns)
-//    } else {
-//        stringResource(id = R.string.blaze_campaign_preview_tos_checkbox_evergreen_campaigns)
-//    }
+
+    val campaignTosText = annotatedStringRes(
+        stringResId = previewState.campaignDetails.campaignTosText.stringRes,
+        onUrlClick = { ChromeCustomTabUtils.launchUrl(context, AppUrls.BLAZE_CANCEL_INSTRUCTIONS) },
+        args = previewState.campaignDetails.campaignTosText.params.map { it.getText() }.toTypedArray()
+    )
     Column(modifier = Modifier.padding(horizontal = 16.dp)) {
         Divider()
         Row(
@@ -149,11 +156,7 @@ private fun ConfirmationFooter(
             )
             Text(
                 modifier = Modifier.padding(start = 4.dp),
-                text = annotatedStringRes(
-                    stringResId = R.string.blaze_campaign_preview_tos_checkbox_evergreen_campaigns,
-                    onUrlClick = null,
-                    previewState.campaignDetails.budget.displayValue
-                ),
+                text = campaignTosText,
                 textAlign = TextAlign.Justify,
                 style = MaterialTheme.typography.caption,
                 color = MaterialTheme.colors.onSurface.copy(alpha = ContentAlpha.medium),
@@ -528,6 +531,12 @@ fun CampaignScreenPreview() {
                     displayValue = "Sales",
                     onItemSelected = {},
                 ),
+                campaignTosText = UiStringRes(
+                    stringRes = R.string.blaze_campaign_preview_tos_checkbox_evergreen_campaigns,
+                    params = listOf(
+                        UiStringText("35$"), UiStringText("July 15, 2025")
+                    )
+                )
             )
         ),
         onBackPressed = { },

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/blaze/creation/preview/BlazeCampaignCreationPreviewScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/blaze/creation/preview/BlazeCampaignCreationPreviewScreen.kt
@@ -29,8 +29,12 @@ import androidx.compose.material.Text
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material.icons.automirrored.filled.ArrowForwardIos
+import androidx.compose.material3.Checkbox
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.MutableState
 import androidx.compose.runtime.livedata.observeAsState
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
@@ -114,19 +118,46 @@ private fun BlazeCampaignCreationPreviewScreen(
             )
             Spacer(modifier = Modifier.height(16.dp))
             Divider()
-            WCColoredButton(
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .padding(16.dp)
-                    .padding(bottom = 8.dp),
-                text = stringResource(id = R.string.blaze_campaign_preview_details_confirm_details_button),
-                onClick = onConfirmDetailsClicked,
-                enabled = previewState.adDetails != Loading
-            )
+            val checked = remember { mutableStateOf(false) }
+            ConfirmationFooter(onConfirmDetailsClicked, previewState, checked)
         }
     }
 
     previewState.dialogState?.Render()
+}
+
+@Composable
+private fun ConfirmationFooter(
+    onConfirmDetailsClicked: () -> Unit,
+    previewState: CampaignPreviewUiState,
+    checked: MutableState<Boolean>
+) {
+    WCColoredButton(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(16.dp),
+        text = stringResource(id = R.string.blaze_campaign_preview_details_confirm_details_button),
+        onClick = onConfirmDetailsClicked,
+        enabled = previewState.adDetails != Loading && checked.value
+    )
+
+    Row(
+        modifier = Modifier
+            .padding(horizontal = 16.dp)
+            .padding(bottom = 16.dp),
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        Checkbox(
+            checked = checked.value,
+            onCheckedChange = { checked.value = it }
+        )
+        Text(
+            modifier = Modifier.padding(start = 8.dp),
+            text = stringResource(id = R.string.blaze_campaign_preview_tos_checkbox),
+            style = MaterialTheme.typography.body2,
+            color = colorResource(id = R.color.color_on_surface_medium),
+        )
+    }
 }
 
 @Composable

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/blaze/creation/preview/BlazeCampaignCreationPreviewViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/blaze/creation/preview/BlazeCampaignCreationPreviewViewModel.kt
@@ -410,7 +410,9 @@ class BlazeCampaignCreationPreviewViewModel @Inject constructor(
     private fun CampaignDetails.buildCampaignTosText(): UiStringRes {
         val stringRes = when {
             budget.isEndlessCampaign -> R.string.blaze_campaign_preview_tos_checkbox_evergreen_campaigns
-            budget.durationInDays <= 7 -> R.string.blaze_campaign_preview_tos_checkbox_less_than_7_days_campaign
+            budget.durationInDays <= WEEK_LONG_CAMPAIGN_IN_DAYS ->
+                R.string.blaze_campaign_preview_tos_checkbox_less_than_7_days_campaign
+
             else -> R.string.blaze_campaign_preview_tos_checkbox_over_7_days_campaign
         }
         return UiStringRes(
@@ -502,4 +504,8 @@ class BlazeCampaignCreationPreviewViewModel @Inject constructor(
     data class NavigateToPaymentSummary(
         val campaignDetails: CampaignDetails
     ) : MultiLiveEvent.Event()
+
+    companion object {
+        const val WEEK_LONG_CAMPAIGN_IN_DAYS = 7
+    }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/blaze/creation/preview/BlazeCampaignCreationPreviewViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/blaze/creation/preview/BlazeCampaignCreationPreviewViewModel.kt
@@ -407,15 +407,21 @@ class BlazeCampaignCreationPreviewViewModel @Inject constructor(
             currencyCode
         )
 
-    private fun CampaignDetails.buildCampaignTosText() = UiStringRes(
-        stringRes = R.string.blaze_campaign_preview_tos_checkbox_evergreen_campaigns,
-        params = listOf(
-            UiStringText(budget.toDisplayTotalBudget()),
-            UiStringText(budget.startDate.formatToLocalizedMedium())
-        ),
-        containsHtml = true
-    )
-
+    private fun CampaignDetails.buildCampaignTosText(): UiStringRes {
+        val stringRes = when {
+            budget.isEndlessCampaign -> R.string.blaze_campaign_preview_tos_checkbox_evergreen_campaigns
+            budget.durationInDays <= 7 -> R.string.blaze_campaign_preview_tos_checkbox_less_than_7_days_campaign
+            else -> R.string.blaze_campaign_preview_tos_checkbox_over_7_days_campaign
+        }
+        return UiStringRes(
+            stringRes = stringRes,
+            params = listOf(
+                UiStringText(budget.toDisplayTotalBudget()),
+                UiStringText(budget.startDate.formatToLocalizedMedium())
+            ),
+            containsHtml = true
+        )
+    }
 
     data class CampaignPreviewUiState(
         val adDetails: AdDetailsUi,

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/blaze/creation/preview/BlazeCampaignCreationPreviewViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/blaze/creation/preview/BlazeCampaignCreationPreviewViewModel.kt
@@ -13,7 +13,6 @@ import com.woocommerce.android.analytics.AnalyticsTracker
 import com.woocommerce.android.analytics.AnalyticsTrackerWrapper
 import com.woocommerce.android.extensions.formatToLocalizedMedium
 import com.woocommerce.android.extensions.formatToMMMdd
-import com.woocommerce.android.model.UiString
 import com.woocommerce.android.model.UiString.UiStringRes
 import com.woocommerce.android.model.UiString.UiStringText
 import com.woocommerce.android.support.help.HelpOrigin
@@ -299,7 +298,8 @@ class BlazeCampaignCreationPreviewViewModel @Inject constructor(
         ),
         destinationUrl = getTargetDestinationDetails(),
         selectedObjective = getSelectedObjective(campaignObjectives),
-        campaignTosText = buildCampaignTosText()
+        campaignTosText = buildCampaignTosText(),
+        campaignTosAccepted = acceptedTos
     )
 
     private fun getSelectedObjective(objectives: List<Objective>): CampaignDetailItemUi {
@@ -423,6 +423,12 @@ class BlazeCampaignCreationPreviewViewModel @Inject constructor(
         )
     }
 
+    fun onTosAccepted(accepted: Boolean) {
+        campaignDetails.update {
+            it?.copy(acceptedTos = accepted)
+        }
+    }
+
     data class CampaignPreviewUiState(
         val adDetails: AdDetailsUi,
         val campaignDetails: CampaignDetailsUi,
@@ -453,6 +459,7 @@ class BlazeCampaignCreationPreviewViewModel @Inject constructor(
         val destinationUrl: CampaignDetailItemUi,
         val selectedObjective: CampaignDetailItemUi,
         val campaignTosText: UiStringRes,
+        val campaignTosAccepted: Boolean
     )
 
     data class CampaignDetailItemUi(

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/blaze/creation/preview/BlazeCampaignCreationPreviewViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/blaze/creation/preview/BlazeCampaignCreationPreviewViewModel.kt
@@ -13,6 +13,9 @@ import com.woocommerce.android.analytics.AnalyticsTracker
 import com.woocommerce.android.analytics.AnalyticsTrackerWrapper
 import com.woocommerce.android.extensions.formatToLocalizedMedium
 import com.woocommerce.android.extensions.formatToMMMdd
+import com.woocommerce.android.model.UiString
+import com.woocommerce.android.model.UiString.UiStringRes
+import com.woocommerce.android.model.UiString.UiStringText
 import com.woocommerce.android.support.help.HelpOrigin
 import com.woocommerce.android.ui.blaze.BlazeRepository
 import com.woocommerce.android.ui.blaze.BlazeRepository.AiSuggestionForAd
@@ -295,7 +298,8 @@ class BlazeCampaignCreationPreviewViewModel @Inject constructor(
             getTargetInterestsDetails(),
         ),
         destinationUrl = getTargetDestinationDetails(),
-        selectedObjective = getSelectedObjective(campaignObjectives)
+        selectedObjective = getSelectedObjective(campaignObjectives),
+        campaignTosText = buildCampaignTosText()
     )
 
     private fun getSelectedObjective(objectives: List<Objective>): CampaignDetailItemUi {
@@ -380,10 +384,7 @@ class BlazeCampaignCreationPreviewViewModel @Inject constructor(
         )
 
     private fun BlazeRepository.Budget.toDisplayValue(): String {
-        val totalBudgetWithCurrency = currencyFormatter.formatCurrency(
-            totalBudget.toBigDecimal(),
-            currencyCode
-        )
+        val totalBudgetWithCurrency = toDisplayTotalBudget()
         return when {
             isEndlessCampaign -> resourceProvider.getString(
                 R.string.blaze_campaign_preview_days_duration_endless,
@@ -399,6 +400,22 @@ class BlazeCampaignCreationPreviewViewModel @Inject constructor(
                 )
         }
     }
+
+    private fun BlazeRepository.Budget.toDisplayTotalBudget(): String =
+        currencyFormatter.formatCurrency(
+            totalBudget.toBigDecimal(),
+            currencyCode
+        )
+
+    private fun CampaignDetails.buildCampaignTosText() = UiStringRes(
+        stringRes = R.string.blaze_campaign_preview_tos_checkbox_evergreen_campaigns,
+        params = listOf(
+            UiStringText(budget.toDisplayTotalBudget()),
+            UiStringText(budget.startDate.formatToLocalizedMedium())
+        ),
+        containsHtml = true
+    )
+
 
     data class CampaignPreviewUiState(
         val adDetails: AdDetailsUi,
@@ -428,7 +445,8 @@ class BlazeCampaignCreationPreviewViewModel @Inject constructor(
         val budget: CampaignDetailItemUi,
         val targetDetails: List<CampaignDetailItemUi>,
         val destinationUrl: CampaignDetailItemUi,
-        val selectedObjective: CampaignDetailItemUi
+        val selectedObjective: CampaignDetailItemUi,
+        val campaignTosText: UiStringRes,
     )
 
     data class CampaignDetailItemUi(

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -3982,7 +3982,8 @@
     <string name="blaze_campaign_preview_missing_content_dialog_positive_button">Add</string>
     <string name="blaze_campaign_preview_missing_objective_dialog_text">Please select an objective for the Blaze campaign</string>
     <string name="blaze_campaign_preview_missing_objective_dialog_positive_button">Select objective</string>
-    <string name="blaze_campaign_preview_tos_checkbox">I understand that this will create a subscription of 5$ that will be billed daily once the campaign starts</string>
+    <string name="blaze_campaign_preview_tos_checkbox_evergreen_campaigns"><![CDATA[I agree to a recurring charge of <b>%1$s</b> and will continue until I cancel. Campaigns can be cancelled at any time from campaign details screen.]]></string>
+    <string name="blaze_campaign_preview_tos_checkbox_end_date_campaigns"> I agree to a recurring charge of %1$s per week. Billing will start when my campaign launches and will continue until %2$. You can cancel at any time from campaign details screen.</string>
     <!--
     Blaze campaign objective screen
     -->

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -3982,8 +3982,9 @@
     <string name="blaze_campaign_preview_missing_content_dialog_positive_button">Add</string>
     <string name="blaze_campaign_preview_missing_objective_dialog_text">Please select an objective for the Blaze campaign</string>
     <string name="blaze_campaign_preview_missing_objective_dialog_positive_button">Select objective</string>
-    <string name="blaze_campaign_preview_tos_checkbox_evergreen_campaigns"><![CDATA[I agree to a recurring charge of <b>%1$s</b> and will continue until I cancel. Campaigns can be cancelled at any time from campaign details screen.]]></string>
-    <string name="blaze_campaign_preview_tos_checkbox_end_date_campaigns"> I agree to a recurring charge of %1$s per week. Billing will start when my campaign launches and will continue until %2$. You can cancel at any time from campaign details screen.</string>
+    <string name="blaze_campaign_preview_tos_checkbox_evergreen_campaigns">I agree to a recurring weekly charge up to <b>%1$s</b> starting <b>%2$s</b>. Charges may occur at varying times during the campaign. &lt;a href=\'cancelInstructions\'&gt;&lt;u&gt;I can cancel anytime&lt;/u&gt;&lt;/a&gt;; I/’ll only pay for ads delivered up to cancellation.</string>
+<!--    <string name="blaze_campaign_preview_tos_checkbox_end_date_campaigns"> I agree to a recurring charge of %1$s per week. Billing will start when my campaign launches and will continue until %2$. You can cancel at any time from campaign details screen.</string>-->
+<!--    <string name="blaze_campaign_preview_tos_checkbox_end_date_campaigns"> I agree to a recurring charge of %1$s per week. Billing will start when my campaign launches and will continue until %2$. You can cancel at any time from campaign details screen.</string>-->
     <!--
     Blaze campaign objective screen
     -->

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -3982,7 +3982,7 @@
     <string name="blaze_campaign_preview_missing_content_dialog_positive_button">Add</string>
     <string name="blaze_campaign_preview_missing_objective_dialog_text">Please select an objective for the Blaze campaign</string>
     <string name="blaze_campaign_preview_missing_objective_dialog_positive_button">Select objective</string>
-
+    <string name="blaze_campaign_preview_tos_checkbox">I understand that this will create a subscription of 5$ that will be billed daily once the campaign starts</string>
     <!--
     Blaze campaign objective screen
     -->

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -3982,9 +3982,9 @@
     <string name="blaze_campaign_preview_missing_content_dialog_positive_button">Add</string>
     <string name="blaze_campaign_preview_missing_objective_dialog_text">Please select an objective for the Blaze campaign</string>
     <string name="blaze_campaign_preview_missing_objective_dialog_positive_button">Select objective</string>
-    <string name="blaze_campaign_preview_tos_checkbox_evergreen_campaigns">I agree to a recurring weekly charge up to <b>%1$s</b> starting <b>%2$s</b>. Charges may occur at varying times during the campaign. &lt;a href=\'cancelInstructions\'&gt;&lt;u&gt;I can cancel anytime&lt;/u&gt;&lt;/a&gt;; I/’ll only pay for ads delivered up to cancellation.</string>
-<!--    <string name="blaze_campaign_preview_tos_checkbox_end_date_campaigns"> I agree to a recurring charge of %1$s per week. Billing will start when my campaign launches and will continue until %2$. You can cancel at any time from campaign details screen.</string>-->
-<!--    <string name="blaze_campaign_preview_tos_checkbox_end_date_campaigns"> I agree to a recurring charge of %1$s per week. Billing will start when my campaign launches and will continue until %2$. You can cancel at any time from campaign details screen.</string>-->
+    <string name="blaze_campaign_preview_tos_checkbox_less_than_7_days_campaign">I agree to be charged up to %1$s starting %2$s. Charges may occur in one or more payments while the campaign is active. &lt;a href=\'cancelInstructions\'&gt;&lt;u&gt;I can cancel anytime&lt;/u&gt;&lt;/a&gt;; I\’ll only pay for ads delivered up to cancellation.</string>
+    <string name="blaze_campaign_preview_tos_checkbox_over_7_days_campaign">I agree to a recurring charge of up to %1$s weekly, starting %2$s. Charges may occur at varying times during the campaign. &lt;a href=\'cancelInstructions\'&gt;&lt;u&gt;I can cancel anytime&lt;/u&gt;&lt;/a&gt;; I\’ll only pay for ads delivered up to cancellation.</string>
+    <string name="blaze_campaign_preview_tos_checkbox_evergreen_campaigns">I agree to a recurring weekly charge up to %1$s starting %2$s. Charges may occur at varying times during the campaign. &lt;a href=\'cancelInstructions\'&gt;&lt;u&gt;I can cancel anytime&lt;/u&gt;&lt;/a&gt;; I\’ll only pay for ads delivered up to cancellation.</string>
     <!--
     Blaze campaign objective screen
     -->

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/blaze/BlazeRepositoryTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/blaze/BlazeRepositoryTest.kt
@@ -134,6 +134,7 @@ class BlazeRepositoryTest : BaseUnitTest() {
                 targetingParameters = EMPTY_TARGETING_PARAMETERS,
                 destinationParameters = EMPTY_DESTINATION_PARAMETERS,
                 objectiveId = "sales",
+                acceptedTos = false,
             )
         private val ENDLESS_CAMPAIGN_DETAILS = DEFAULT_CAMPAIGN_DETAILS.copy(
             budget = DEFAULT_BUDGET.copy(isEndlessCampaign = true)

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/blaze/creation/payment/BlazeCampaignPaymentSummaryViewModelTests.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/blaze/creation/payment/BlazeCampaignPaymentSummaryViewModelTests.kt
@@ -43,7 +43,8 @@ class BlazeCampaignPaymentSummaryViewModelTests : BaseUnitTest() {
                 targetUrl = "https://test.com",
                 parameters = emptyMap()
             ),
-            objectiveId = "sales"
+            objectiveId = "sales",
+            acceptedTos = false,
         )
     }
 

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/blaze/creation/preview/BlazeCampaignCreationPreviewViewModelTests.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/blaze/creation/preview/BlazeCampaignCreationPreviewViewModelTests.kt
@@ -61,7 +61,8 @@ class BlazeCampaignCreationPreviewViewModelTests : BaseUnitTest() {
                 parameters = emptyMap()
             ),
             targetingParameters = BlazeRepository.TargetingParameters(),
-            objectiveId = "sales"
+            objectiveId = "sales",
+            acceptedTos = false
         )
         private val locations = listOf(Location(1, "Location 1"), Location(2, "Location 2"))
         private val languages = listOf(Language("en", "English"), Language("es", "Spanish"))

--- a/libs/fluxc/src/main/java/org/wordpress/android/fluxc/model/blaze/BlazeCampaignCreationRequest.kt
+++ b/libs/fluxc/src/main/java/org/wordpress/android/fluxc/model/blaze/BlazeCampaignCreationRequest.kt
@@ -22,7 +22,8 @@ data class BlazeCampaignCreationRequest(
     val targetingParameters: BlazeTargetingParameters?,
     val timeZoneId: String = TimeZone.getDefault().id,
     val isEndlessCampaign: Boolean,
-    val objectiveId: String?
+    val objectiveId: String?,
+    val acceptedTos: Boolean,
 )
 
 data class BlazeCampaignCreationRequestBudget(

--- a/libs/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/blaze/BlazeCreationRestClient.kt
+++ b/libs/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/blaze/BlazeCreationRestClient.kt
@@ -250,7 +250,8 @@ class BlazeCreationRestClient @Inject constructor(
                 ).filterNotNull()
             },
             "is_evergreen" to request.isEndlessCampaign,
-            "objective" to request.objectiveId
+            "objective" to request.objectiveId,
+            "accepted_tos" to request.acceptedTos
         ).filterNotNull()
 
         val response = wpComNetwork.executePostGsonRequest(


### PR DESCRIPTION
Closes WOOMOB-551

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
We need to be compliant with 
In order to do that, we must add a checkbox in the Blaze campaign creation flow that explicitly informs the user that they are committing to a "subscription" payment model and that they can cancel at any time. 

### Testing information
<!-- This is your opportunity to break out individual scenarios that need testing (when necessary) and/or include a checklist for the reviewer to go through. Consider documenting the following from your own completed testing: devices used, alternate workflows, edge cases, affected areas, critical flows, areas not tested, and any remaining unknowns. Provide feedback on this new section of the PR template through Sept 30, 2024 to Apps Quality; additional context here: p91TBi-b8z-p2#comment-12036 -->
1. Log into a site with Blaze enabled
2. Trigger Blaze campaign creation flow
3. Check there's a checkbox before the main CTA in Blaze campaign preview screen with the following text variations: 
    - Duration less than 7 days: I agree to be charged up to $35 starting June 11, 2025. Charges may occur in one or more payments while the campaign is active. [I can cancel anytime](https://wordpress.com/support/promote-a-post/manage-your-blaze-ad-campaign/#stop-an-ad-campaign); I’ll only pay for ads delivered up to cancellation.

    - Duration more than 7 days: I agree to a recurring charge of up to $35 weekly starting June 11, 2025. Charges may occur at varying times during the campaign. I can cancel anytime; I’ll only pay for ads delivered up to cancellation.

    - Campaigns running endlessly until stopped: I agree to a recurring weekly charge up to $35.00 starting June 11, 2025. Charges may occur at varying times during the campaign. [I can cancel anytime](https://wordpress.com/support/promote-a-post/manage-your-blaze-ad-campaign/#stop-an-ad-campaign); I only pay for ads delivered up to cancellation.
 
4. Modify campaign duration to check that the text is updated accordingly. 
5. Proceed and create the campaign, check the request `/wpcom/v2/sites/{SiteId}/wordads/dsp/api/v1.1/campaigns/` contains the new field `"accepted_tos": true` in the request body.  

<img width="300"  src="https://github.com/user-attachments/assets/7b663715-92ec-4079-9017-a5d456666fff"> 

### The tests that have been performed
<!-- To give the reviewer an idea of what could be missed in terms of testing -->
The above

### Images/gif
<!-- Include before and after images or gifs when appropriate. -->

- [ ] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->