### PR TITLE
[WOOMOB-598] This PR fixes back gesture in the POS

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/common/composeui/modifier/BarcodeScannerModifier.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/common/composeui/modifier/BarcodeScannerModifier.kt
@@ -10,12 +10,11 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.composed
 import androidx.compose.ui.focus.FocusRequester
 import androidx.compose.ui.focus.focusRequester
-import androidx.compose.ui.input.key.Key
 import androidx.compose.ui.input.key.KeyEventType
-import androidx.compose.ui.input.key.key
 import androidx.compose.ui.input.key.onKeyEvent
 import androidx.compose.ui.input.key.type
 import androidx.compose.ui.input.key.utf16CodePoint
+import com.woocommerce.android.ui.woopos.common.composeui.modifier.BarcodeInputDetector.Companion.FIRST_PRINTABLE_CHAR_CODE
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.delay
@@ -49,16 +48,14 @@ fun Modifier.listenForBarcodes(
             if (!enabled) return@onKeyEvent false
 
             if (keyEvent.type == KeyEventType.KeyDown) {
-                val isSystemKey = when (keyEvent.key) {
-                    Key.Escape, Key.Back,
-                    Key.DirectionCenter, Key.DirectionUp, Key.DirectionDown,
-                    Key.DirectionLeft, Key.DirectionRight,
-                    Key.SystemNavigationUp, Key.SystemNavigationDown,
-                    Key.SystemNavigationLeft, Key.SystemNavigationRight -> true
-                    else -> false
-                }
-                if (!isSystemKey) {
-                    val pressedKey = keyEvent.utf16CodePoint.toChar()
+                val charCode = keyEvent.utf16CodePoint
+                val isValidChar = charCode > 0
+                val isPrintableOrNewline = charCode == '\n'.code ||
+                    charCode == '\r'.code ||
+                    charCode >= FIRST_PRINTABLE_CHAR_CODE
+
+                if (isValidChar && isPrintableOrNewline) {
+                    val pressedKey = charCode.toChar()
                     return@onKeyEvent detector.handleKeyInput(pressedKey)
                 }
             }
@@ -77,6 +74,7 @@ class BarcodeInputDetector(
     companion object {
         const val MAX_SCANNER_TOTAL_SCAN_TIMEOUT_MS = 1500L
         const val MAX_SCANNER_INTER_CHAR_DELAY_MS = 100L
+        const val FIRST_PRINTABLE_CHAR_CODE = 32
         const val MIN_BARCODE_LENGTH = 4
     }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/common/composeui/modifier/BarcodeScannerModifier.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/common/composeui/modifier/BarcodeScannerModifier.kt
@@ -10,7 +10,9 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.composed
 import androidx.compose.ui.focus.FocusRequester
 import androidx.compose.ui.focus.focusRequester
+import androidx.compose.ui.input.key.Key
 import androidx.compose.ui.input.key.KeyEventType
+import androidx.compose.ui.input.key.key
 import androidx.compose.ui.input.key.onKeyEvent
 import androidx.compose.ui.input.key.type
 import androidx.compose.ui.input.key.utf16CodePoint
@@ -47,8 +49,18 @@ fun Modifier.listenForBarcodes(
             if (!enabled) return@onKeyEvent false
 
             if (keyEvent.type == KeyEventType.KeyDown) {
-                val pressedKey = keyEvent.utf16CodePoint.toChar()
-                return@onKeyEvent detector.handleKeyInput(pressedKey)
+                val isSystemKey = when (keyEvent.key) {
+                    Key.Escape, Key.Back,
+                    Key.DirectionCenter, Key.DirectionUp, Key.DirectionDown,
+                    Key.DirectionLeft, Key.DirectionRight,
+                    Key.SystemNavigationUp, Key.SystemNavigationDown,
+                    Key.SystemNavigationLeft, Key.SystemNavigationRight -> true
+                    else -> false
+                }
+                if (!isSystemKey) {
+                    val pressedKey = keyEvent.utf16CodePoint.toChar()
+                    return@onKeyEvent detector.handleKeyInput(pressedKey)
+                }
             }
 
             false


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

<!-- Id number of the Linear issue this PR addresses, e.g., WOOMOB-373. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

I removed the list of accepted characters in the barcode detector yesterday but I didn't realize the code would start consuming even system keys, such as back button. This PR checks if the character is printable and within unicode set, which should cover all barcodes.

### Testing information
<!-- This is your opportunity to break out individual scenarios that need testing (when necessary) and/or include a checklist for the reviewer to go through. Consider documenting the following from your own completed testing: devices used, alternate workflows, edge cases, affected areas, critical flows, areas not tested, and any remaining unknowns. Provide feedback on this new section of the PR template through Sept 30, 2024 to Apps Quality; additional context here: p91TBi-b8z-p2#comment-12036 -->

1. Open the POS
2. Press the back button or do the back gesture
3. Notice it is handled properly

### The tests that have been performed
<!-- To give the reviewer an idea of what could be missed in terms of testing -->

The above
+ I tested talkback navigation works as expected.

### Images/gif
<!-- Include before and after images or gifs when appropriate. -->

- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->