### PR TITLE
[WOOMOB-602] Fix POS variation cart items with increased font size

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/cart/WooPosCartScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/cart/WooPosCartScreen.kt
@@ -478,7 +478,7 @@ private fun ProductItem(
 
     WooPosCard(
         modifier = modifier
-            .height(96.dp)
+            .wrapContentHeight()
             .semantics { contentDescription = itemContentDescription },
         backgroundColor = if (item.productDoesNotExist) {
             WooPosTheme.colors.disabledContainer
@@ -490,13 +490,16 @@ private fun ProductItem(
         shape = RoundedCornerShape(WooPosCornerRadius.Medium.value),
     ) {
         Row(
+            modifier = Modifier.height(IntrinsicSize.Min),
             horizontalArrangement = Arrangement.SpaceBetween,
             verticalAlignment = Alignment.CenterVertically
         ) {
             Box(
                 modifier = Modifier
                     .background(MaterialTheme.colorScheme.surfaceDim)
-                    .size(96.dp),
+                    .width(96.dp)
+                    .fillMaxHeight()
+                    .heightIn(min = 96.dp),
                 contentAlignment = Alignment.Center
             ) {
                 val asyncImagePainter = rememberAsyncImagePainter(
@@ -538,7 +541,8 @@ private fun ProductItem(
             Column(
                 modifier = Modifier
                     .weight(1f)
-                    .padding(end = WooPosSpacing.Medium.value.toAdaptivePadding())
+                    .padding(end = WooPosSpacing.Medium.value.toAdaptivePadding(),)
+                    .padding(vertical = WooPosSpacing.Medium.value.toAdaptivePadding())
             ) {
                 WooPosText(
                     text = item.name,


### PR DESCRIPTION
**This is a nice to have for 22.6, but can be moved to 22.7.**

<!-- Remember about a good descriptive title. -->

<!-- Id number of the Linear issue this PR addresses, e.g., WOOMOB-373. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

This PR updates the variable cart row so it gets properly vertically resized when the content doesn't fit the space. The image doesn't resize as it'd take more horizontal space and that's IMO not desired.

### Testing information
<!-- This is your opportunity to break out individual scenarios that need testing (when necessary) and/or include a checklist for the reviewer to go through. Consider documenting the following from your own completed testing: devices used, alternate workflows, edge cases, affected areas, critical flows, areas not tested, and any remaining unknowns. Provide feedback on this new section of the PR template through Sept 30, 2024 to Apps Quality; additional context here: p91TBi-b8z-p2#comment-12036 -->

1. Add a variation to the cart.
2. Increase font size.
3. Notice the content isn't cut off.

### The tests that have been performed
<!-- To give the reviewer an idea of what could be missed in terms of testing -->

The above + regression testing with both normal font size and increased font size.

### Images/gif
<!-- Include before and after images or gifs when appropriate. -->

| Before | After |
|--|--|
| ![Screenshot_20250613_065100](https://github.com/user-attachments/assets/9260d034-3ca9-46ca-9b86-1fff9cceacd2) | ![Screenshot_20250613_070756](https://github.com/user-attachments/assets/de3069de-6df5-43cf-aa78-cf71dce4ac49) |


- [ ] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->