### PR TITLE
[WOOMOB-601] Make Barcode info dialog scrollable

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/WooPosBarcodeInfoDialog.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/WooPosBarcodeInfoDialog.kt
@@ -5,7 +5,9 @@ import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
@@ -27,6 +29,7 @@ import androidx.compose.ui.unit.dp
 import androidx.constraintlayout.compose.ConstraintLayout
 import androidx.constraintlayout.compose.Dimension
 import com.woocommerce.android.R
+import com.woocommerce.android.ui.compose.preview.FontScalePreviews
 import com.woocommerce.android.ui.woopos.common.composeui.WooPosPreview
 import com.woocommerce.android.ui.woopos.common.composeui.component.WooPosDialogWrapper
 import com.woocommerce.android.ui.woopos.common.composeui.component.WooPosOutlinedButton
@@ -46,6 +49,7 @@ fun WooPosBarcodeInfoDialog(
     onDismissRequest: () -> Unit,
 ) {
     val context = LocalContext.current
+    val scrollState = rememberScrollState()
     val dialogContentDescription = getCombinedContentDescription(state = state)
     val primaryButtonContentDescription = stringResource(
         id = R.string.woopos_banner_simple_products_dialog_primary_button_content_description
@@ -70,7 +74,9 @@ fun WooPosBarcodeInfoDialog(
         ) {
             @Suppress("DestructuringDeclarationWithTooManyEntries")
             ConstraintLayout(
-                modifier = Modifier.fillMaxWidth()
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .verticalScroll(scrollState)
             ) {
                 val (
                     header,
@@ -265,6 +271,7 @@ private fun getCombinedContentDescription(state: WooPosHomeState.BarcodeInfoDial
         "\n${stringResource(id = state.quaternaryMessage)}\n${stringResource(id = state.quinaryMessage)}"
 }
 
+@FontScalePreviews
 @WooPosPreview
 @Composable
 fun BarcodeInfoDialogPreview() {


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

<!-- Id number of the Linear issue this PR addresses, e.g., WOOMOB-373. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

Makes the barcode info dialog scrollable so it works even with increased font size.

### Testing information
<!-- This is your opportunity to break out individual scenarios that need testing (when necessary) and/or include a checklist for the reviewer to go through. Consider documenting the following from your own completed testing: devices used, alternate workflows, edge cases, affected areas, critical flows, areas not tested, and any remaining unknowns. Provide feedback on this new section of the PR template through Sept 30, 2024 to Apps Quality; additional context here: p91TBi-b8z-p2#comment-12036 -->

1. Open POS
2. Tap on More menu
3. Tap on Barcode scanning
4. Increase font size
5. Notice the dialog is scrollable

### The tests that have been performed
<!-- To give the reviewer an idea of what could be missed in terms of testing -->

The above

### Images/gif
<!-- Include before and after images or gifs when appropriate. -->

https://github.com/user-attachments/assets/adff904a-4ab6-47c1-984b-50777df8f0b1


- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->