### PR TITLE
[WOOMOB-600] Fix talkback on barcode info dialog

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/WooPosBarcodeInfoDialog.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/WooPosBarcodeInfoDialog.kt
@@ -14,6 +14,7 @@ import androidx.compose.ui.draw.clip
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.semantics.contentDescription
+import androidx.compose.ui.semantics.disabled
 import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.text.LinkAnnotation
 import androidx.compose.ui.text.SpanStyle
@@ -54,10 +55,12 @@ fun WooPosBarcodeInfoDialog(
         id = R.string.woopos_dialog_barcode_info_background_content_description
     )
     WooPosDialogWrapper(
-        modifier = Modifier,
+        modifier = Modifier.semantics {
+            disabled()
+        },
         isVisible = state.isVisible,
         dialogBackgroundContentDescription = dialogBackgroundContentDescription,
-        onDismissRequest = onDismissRequest
+        onDismissRequest = onDismissRequest,
     ) {
         Box(
             modifier = Modifier

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/WooPosBarcodeInfoDialog.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/WooPosBarcodeInfoDialog.kt
@@ -56,7 +56,7 @@ fun WooPosBarcodeInfoDialog(
     )
     WooPosDialogWrapper(
         modifier = Modifier.semantics {
-            disabled()
+            disabled() // enforce talkback to read dialog content first while allowing to dismiss the dialog
         },
         isVisible = state.isVisible,
         dialogBackgroundContentDescription = dialogBackgroundContentDescription,
@@ -66,7 +66,7 @@ fun WooPosBarcodeInfoDialog(
             modifier = Modifier
                 .background(MaterialTheme.colorScheme.surfaceBright)
                 .padding(WooPosSpacing.XLarge.value.toAdaptivePadding())
-                .semantics(mergeDescendants = true) {
+                .semantics {
                     contentDescription = dialogContentDescription
                 },
             contentAlignment = Alignment.Center


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

<!-- Id number of the Linear issue this PR addresses, e.g., WOOMOB-373. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

This PR improves the accessibility for the barcode info dialog
- The dialog's content is read upon opening
- The dialog content is not merged allowing users to use their fingers to read the dialog content one line at a time without having to listen to the whole dialog if they want to re-listen to a part of the content


### Testing information
<!-- This is your opportunity to break out individual scenarios that need testing (when necessary) and/or include a checklist for the reviewer to go through. Consider documenting the following from your own completed testing: devices used, alternate workflows, edge cases, affected areas, critical flows, areas not tested, and any remaining unknowns. Provide feedback on this new section of the PR template through Sept 30, 2024 to Apps Quality; additional context here: p91TBi-b8z-p2#comment-12036 -->

1. Enable talkback
2. Open POS
3. Open the barcode information dialog
4. Notice the content is read upon opening, but you can still read each line separately and you can still focus the dimmed background.

### The tests that have been performed
<!-- To give the reviewer an idea of what could be missed in terms of testing -->

The above 

### Images/gif
<!-- Include before and after images or gifs when appropriate. -->

https://github.com/user-attachments/assets/58474440-2fa0-431c-9189-742c11dd75e6


- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->