### PR TITLE
Update release notes 22.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 <!--
 Contains editorialized release notes. Raw release notes should go into `RELEASE-NOTES.txt`.
 -->
+## 22.6
+This release brings smoother order creation, better UI on tablets, and enhanced accessibility. POS now supports HID barcode scanners, sends detailed receipts, and checks feature availability for WooCommerce 10.0+. We've also improved refunds, payments UI, and large screen support.
+
 ## 22.5
 We've enhanced your WooCommerce experience with this update! Enjoy smoother order creation with our improved custom amount editing form, better tablet navigation with the added toolbar for Variation Attributes, faster product searches with our enhanced POS algorithms, and a new Coupons search feature to help you find discounts quickly. Happy selling!
 

--- a/fastlane/metadata/android/en-US/changelogs/default.txt
+++ b/fastlane/metadata/android/en-US/changelogs/default.txt
@@ -1,10 +1,1 @@
-- [*] Fix a rare dead-end in the order creation flow. [https://github.com/woocommerce/woocommerce-android/pull/14133]
-- [***] POS: Supports of the HID barcode scanners [https://github.com/woocommerce/woocommerce-android/pull/14178]
-- [**] Fix UI glitches in Orders screen on small tablets. [https://github.com/woocommerce/woocommerce-android/pull/14152]
-- [*] Improve talkback support in the POS list of items. [https://github.com/woocommerce/woocommerce-android/pull/14173]
-- [*] POS: for WooCommerce version 10.0.0 and higher (betas available in June), a new check for POS feature switch value (in wp-admin WooCommerce Settings > Advanced > Features) was added for the POS entry point. [https://github.com/woocommerce/woocommerce-android/pull/14113]
-- [*] POS: for WooCommerce version 10.0.0 and higher (betas available in June) and stores eligible for POS, sending email from the payment success screen sends out POS specific email receipts with product unit price, additional cash/card payment details, and customizable store details from POS settings in wp-admin WooCommerce Settings > Point of Sale. [https://github.com/woocommerce/woocommerce-android/pull/14116]
-- [*] Fixed an issue with taxes not being correctly included during refunds [https://github.com/woocommerce/woocommerce-android/pull/14064]
-- [*] Fixed start padding for the back navigation icon in the toolbars [https://github.com/woocommerce/woocommerce-android/pull/14151]
-- [*] Improved payments UI in accessibility screen mode (increased screen size) [https://github.com/woocommerce/woocommerce-android/pull/14148]
-- [**] Improved large screen detection logic to better handle devices with large screens [https://github.com/woocommerce/woocommerce-android/pull/14160]
+This release brings smoother order creation, better UI on tablets, and enhanced accessibility. POS now supports HID barcode scanners, sends detailed receipts, and checks feature availability for WooCommerce 10.0+. We've also improved refunds, payments UI, and large screen support.

--- a/fastlane/metadata/wear/en-US/changelogs/default.txt
+++ b/fastlane/metadata/wear/en-US/changelogs/default.txt
@@ -1,1 +1,1 @@
-This update brings product search and coupon support to Woo POS, making in-person selling smoother than ever. We've also polished the coupon creation flow and improved the "Custom amount" UI. Plus, a pesky crash caused by malformed tax data is now fixed for a more stable experience.
+Our latest update brings a refreshed look and feel, aligning the app with the new WooCommerce branding. Enjoy a fresh, modern design!


### PR DESCRIPTION
### Description
This PR updates the release notes for the version 22.6.

I also updates the Wear's `default.txt` to restore the correct release notes of the Wear app, as we accidentally modified it in the two last releases.

- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->