### PR TITLE
[Shipping labels] Fix inconsistent currency in shipping labels flow

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/GetShipments.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/GetShipments.kt
@@ -9,8 +9,6 @@ import com.woocommerce.android.ui.orders.wooshippinglabels.models.ShippableItemM
 import com.woocommerce.android.ui.orders.wooshippinglabels.networking.ShippingLabelDTO
 import com.woocommerce.android.ui.products.details.ProductDetailRepository
 import kotlinx.coroutines.flow.first
-import java.math.BigDecimal
-import java.util.Date
 import javax.inject.Inject
 
 class GetShipments @Inject constructor(
@@ -83,8 +81,6 @@ class GetShipments @Inject constructor(
                 carrierId = noRefundedLabelForShipment.carrierId,
                 trackingNumber = noRefundedLabelForShipment.tracking,
                 status = noRefundedLabelForShipment.status,
-                refundableAmount = noRefundedLabelForShipment.refundableAmount ?: BigDecimal.ZERO,
-                purchaseDate = noRefundedLabelForShipment.createdDate?.let { Date(it) },
             )
         }
     }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/WooShippingLabelCreationFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/WooShippingLabelCreationFragment.kt
@@ -128,7 +128,7 @@ class WooShippingLabelCreationFragment : BaseFragment(), BackPressListener {
                 is WooShippingLabelCreationViewModel.OpenLearnMoreScreen -> openLearnMoreView()
                 is WooShippingLabelCreationViewModel.NavigateToRefundRequest -> navigateToRefundRequest(
                     event.orderId,
-                    event.shipment
+                    event.labelId
                 )
 
                 is WooShippingLabelCreationViewModel.OpenUrl -> openUrl(event.url)
@@ -171,10 +171,10 @@ class WooShippingLabelCreationFragment : BaseFragment(), BackPressListener {
         )
     }
 
-    private fun navigateToRefundRequest(orderId: Long, shipment: ShipmentUIModel) {
+    private fun navigateToRefundRequest(orderId: Long, labelId: Long) {
         findNavController().navigate(
             WooShippingLabelCreationFragmentDirections
-                .actionWooShippingLabelCreationFragmentToWooShippingLabelRefundRequestFragment(orderId, shipment)
+                .actionWooShippingLabelCreationFragmentToWooShippingLabelRefundRequestFragment(orderId, labelId)
         )
     }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/WooShippingLabelCreationViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/WooShippingLabelCreationViewModel.kt
@@ -102,7 +102,7 @@ class WooShippingLabelCreationViewModel @Inject constructor(
     private val fetchOriginAddresses: FetchOriginAddresses,
     private val getShippingRates: GetShippingRates,
     private val purchaseShippingLabel: PurchaseShippingLabel,
-    private val observeAccountSettings: ObserveAccountSettings,
+    observeAccountSettings: ObserveAccountSettings,
     private val fetchAccountSettings: FetchAccountSettings,
     private val addressValidationHelper: AddressValidationHelper,
     private val verifyDestinationAddress: VerifyDestinationAddress,

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/WooShippingLabelCreationViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/WooShippingLabelCreationViewModel.kt
@@ -839,8 +839,9 @@ class WooShippingLabelCreationViewModel @Inject constructor(
     }
 
     fun onRefundClicked() {
-        val selectedShipment = shipments.value[selectedShipmentIndex]
-        triggerEvent(NavigateToRefundRequest(navArgs.orderId, selectedShipment))
+        shipments.value[selectedShipmentIndex].labelId?.let { labelId ->
+            triggerEvent(NavigateToRefundRequest(navArgs.orderId, labelId))
+        }
     }
 
     fun onLearnMoreClicked() {
@@ -1026,7 +1027,7 @@ class WooShippingLabelCreationViewModel @Inject constructor(
     data class OpenShippingLabelFile(val file: File) : Event()
     data class OpenUrl(val url: String) : Event()
     data class ShowError(val errorResId: Int) : Event()
-    data class NavigateToRefundRequest(val orderId: Long, val shipment: ShipmentUIModel) : Event()
+    data class NavigateToRefundRequest(val orderId: Long, val labelId: Long) : Event()
 
     object OpenLearnMoreScreen : Event()
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/WooShippingLabelCreationViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/WooShippingLabelCreationViewModel.kt
@@ -228,10 +228,7 @@ class WooShippingLabelCreationViewModel @Inject constructor(
             observeShippingLabelStatus(orderId = navArgs.orderId, labelId = labelId).onEach { result ->
                 updateShipment(
                     shipmentId,
-                    shipments.value[shipmentId].copy(
-                        status = result.status,
-                        refundableAmount = result.refundableAmount ?: BigDecimal.ZERO
-                    )
+                    shipments.value[shipmentId].copy(status = result.status)
                 )
             }.launchIn(this)
         }
@@ -685,8 +682,6 @@ class WooShippingLabelCreationViewModel @Inject constructor(
                         labelId = purchasedLabel.labelId,
                         carrierId = purchasedLabel.carrierId,
                         trackingNumber = purchasedLabel.tracking,
-                        refundableAmount = purchasedLabel.refundableAmount,
-                        purchaseDate = purchasedLabel.created
                     )
                 )
                 observeShippingLabelPurchaseStatus(shipmentId)

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/WooShippingLabelCreationViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/WooShippingLabelCreationViewModel.kt
@@ -260,13 +260,14 @@ class WooShippingLabelCreationViewModel @Inject constructor(
     @OptIn(FlowPreview::class)
     private suspend fun observeShippingRates() {
         combine(
+            accountSettings,
             selectedPackagesFlow.filter { it.isNotEmpty() },
             shippingAddresses,
             packageWeightsFlow.filter { it.isNotEmpty() },
             customsStatesFlow.filter { it.isNotEmpty() },
             hazmatStatesFlow.filter { it.isNotEmpty() },
             refreshShippingRates.onStart { emit(Unit) },
-        ) { selectedPackages, addresses, packageWeight, customState, hazmatStates, _ ->
+        ) { accountSettings, selectedPackages, addresses, packageWeight, customState, hazmatStates, _ ->
             val customsFulfilled = customState[selectedShipmentIndex] is CustomsState.DataAvailable ||
                 customState[selectedShipmentIndex] is NotRequired
             val selectedPackage = selectedPackages[selectedShipmentIndex]
@@ -277,7 +278,7 @@ class WooShippingLabelCreationViewModel @Inject constructor(
                     shipFrom = addresses.shipFrom,
                     shipTo = addresses.shipTo.address,
                     weight = packageWeight[selectedShipmentIndex]?.totalWeight,
-                    currencyCode = order.value.currency,
+                    currencyCode = accountSettings?.storeOptions?.currencySymbol,
                     customsData = customsFormDataFlow.value[selectedShipmentIndex],
                     hazmatSelection = hazmatStates[selectedShipmentIndex].hazmatSelection
                 )

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/models/ShipmentUIModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/models/ShipmentUIModel.kt
@@ -2,8 +2,6 @@ package com.woocommerce.android.ui.orders.wooshippinglabels.models
 
 import android.os.Parcelable
 import kotlinx.parcelize.Parcelize
-import java.math.BigDecimal
-import java.util.Date
 
 @Parcelize
 data class ShipmentUIModel(
@@ -16,8 +14,6 @@ data class ShipmentUIModel(
     val trackingNumber: String? = null,
     val purchaseState: PurchaseState = PurchaseState.NoStarted,
     val status: ShippingLabelStatus = ShippingLabelStatus.UNKNOWN,
-    val refundableAmount: BigDecimal = BigDecimal.ZERO,
-    val purchaseDate: Date? = null,
 ) : Parcelable
 
 @Parcelize

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/refund/WooShippingLabelRefundViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/refund/WooShippingLabelRefundViewModel.kt
@@ -8,18 +8,22 @@ import com.woocommerce.android.R
 import com.woocommerce.android.extensions.formatToLocalizedMedium
 import com.woocommerce.android.tools.NetworkStatus
 import com.woocommerce.android.tools.SelectedSite
+import com.woocommerce.android.ui.orders.wooshippinglabels.datasource.WooShippingConfigDataStore
 import com.woocommerce.android.ui.orders.wooshippinglabels.networking.WooShippingLabelRepository
 import com.woocommerce.android.util.CurrencyFormatter
 import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.Exit
 import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.ShowSnackbar
 import com.woocommerce.android.viewmodel.ScopedViewModel
-import com.woocommerce.android.viewmodel.getStateFlow
 import com.woocommerce.android.viewmodel.navArgs
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.MutableStateFlow
-import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.flow.SharingStarted
+import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.shareIn
 import kotlinx.coroutines.launch
 import kotlinx.parcelize.Parcelize
+import java.util.Date
 import javax.inject.Inject
 
 @HiltViewModel
@@ -27,49 +31,42 @@ class WooShippingLabelRefundViewModel @Inject constructor(
     savedState: SavedStateHandle,
     private val selectedSite: SelectedSite,
     private val repository: WooShippingLabelRepository,
+    configDataStore: WooShippingConfigDataStore,
     private val networkStatus: NetworkStatus,
     private val currencyFormatter: CurrencyFormatter,
 ) : ScopedViewModel(savedState) {
     private val arguments: WooShippingLabelRefundFragmentArgs by savedState.navArgs()
 
-    private val _viewState: MutableStateFlow<ViewState> = savedState.getStateFlow(
-        scope = viewModelScope,
-        initialValue = ViewState.Loading
-    )
-    val viewState = _viewState.asLiveData()
+    // Finding the shipping label from cached config data
+    private val shippingLabelFlow = configDataStore.observeConfig(arguments.orderId)
+        .map { it?.shippingLabelData?.currentOrderLabels?.find { it.labelId == arguments.labelId } }
+        .shareIn(viewModelScope, started = SharingStarted.Lazily, replay = 1)
 
-    init {
-        loadDataState()
-    }
+    private val isLoadingFlow = MutableStateFlow(false)
 
-    private fun loadDataState() {
-        _viewState.update { viewState ->
-            val currency = arguments.shipment.items.firstOrNull()?.currency
-                ?: return@update viewState
-            ViewState.DataState(
-                purchaseDate = arguments.shipment.purchaseDate?.formatToLocalizedMedium(),
-                refundableAmount = currencyFormatter.formatCurrency(
-                    arguments.shipment.refundableAmount,
-                    currency
-                )
-            )
+    val viewState = combine(shippingLabelFlow, isLoadingFlow) { label, isLoading ->
+        if (isLoading) {
+            ViewState.Loading
+        } else {
+            val purchaseDate = label?.createdDate?.let { date -> Date(date) }?.formatToLocalizedMedium()
+            val refundableAmount = label?.refundableAmount?.let { amount ->
+                label.currency?.let { currency -> currencyFormatter.formatCurrency(amount, currency) }
+            }
+            ViewState.DataState(purchaseDate, refundableAmount)
         }
-    }
+    }.asLiveData()
 
     fun onRefundShippingLabelButtonClicked() {
         if (networkStatus.isConnected()) {
-            _viewState.update { ViewState.Loading }
+            isLoadingFlow.value = true
             launch {
-                repository.refundLabel(
-                    selectedSite.get(),
-                    arguments.orderId,
-                    arguments.shipment.labelId ?: return@launch
-                ).takeIf { it.isError.not() }?.let {
-                    triggerEvent(ShowSnackbar(R.string.shipping_label_refund_success))
-                    triggerEvent(Exit)
-                } ?: run {
+                repository.refundLabel(selectedSite.get(), arguments.orderId, arguments.labelId)
+                    .takeIf { it.isError.not() }?.let {
+                        triggerEvent(ShowSnackbar(R.string.shipping_label_refund_success))
+                        triggerEvent(Exit)
+                    } ?: run {
                     triggerEvent(ShowSnackbar(R.string.order_refunds_amount_refund_error))
-                    loadDataState()
+                    isLoadingFlow.value = false
                 }
             }
         } else {
@@ -78,7 +75,7 @@ class WooShippingLabelRefundViewModel @Inject constructor(
     }
 
     fun onBackPressed() {
-        if (_viewState.value is ViewState.Loading) {
+        if (isLoadingFlow.value) {
             triggerEvent(ShowSnackbar(R.string.order_refunds_refund_in_progress))
         } else {
             triggerEvent(Exit)

--- a/WooCommerce/src/main/res/navigation/nav_graph_orders.xml
+++ b/WooCommerce/src/main/res/navigation/nav_graph_orders.xml
@@ -796,7 +796,7 @@
             android:name="orderId"
             app:argType="long" />
         <argument
-            android:name="shipment"
-            app:argType="com.woocommerce.android.ui.orders.wooshippinglabels.models.ShipmentUIModel" />
+            android:name="labelId"
+            app:argType="long" />
     </fragment>
 </navigation>

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/WooShippingLabelCreationViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/WooShippingLabelCreationViewModelTest.kt
@@ -994,6 +994,11 @@ class WooShippingLabelCreationViewModelTest : BaseUnitTest() {
 
     @Test
     fun `onRefundClicked triggers NavigateToRefundRequest event`() = testBlocking {
+        val labelId = 123L
+        whenever(getShipments(any())) doReturn defaultShipments.toMutableList().apply {
+            set(0, defaultShipments.first().copy(labelId = labelId))
+        }
+
         createViewModel()
 
         var event: NavigateToRefundRequest? = null
@@ -1001,7 +1006,7 @@ class WooShippingLabelCreationViewModelTest : BaseUnitTest() {
 
         sut.onRefundClicked()
 
-        assertThat(event).isEqualTo(NavigateToRefundRequest(orderId, defaultShipments.first()))
+        assertThat(event).isEqualTo(NavigateToRefundRequest(orderId, labelId))
     }
 
     @Test

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/refund/WooShippingLabelRefundViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/refund/WooShippingLabelRefundViewModelTest.kt
@@ -37,6 +37,7 @@ class WooShippingLabelRefundViewModelTest : BaseUnitTest() {
             ).toSavedStateHandle(),
             selectedSite = selectedSite,
             repository = repository,
+            configDataStore = mock(),
             networkStatus = networkStatus,
             currencyFormatter = mock()
         )

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/refund/WooShippingLabelRefundViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/refund/WooShippingLabelRefundViewModelTest.kt
@@ -3,7 +3,6 @@ package com.woocommerce.android.ui.orders.wooshippinglabels.refund
 import com.woocommerce.android.R
 import com.woocommerce.android.tools.NetworkStatus
 import com.woocommerce.android.tools.SelectedSite
-import com.woocommerce.android.ui.orders.wooshippinglabels.models.ShipmentUIModel
 import com.woocommerce.android.ui.orders.wooshippinglabels.networking.RefundLabelResponseDTO
 import com.woocommerce.android.ui.orders.wooshippinglabels.networking.WooShippingLabelRepository
 import com.woocommerce.android.viewmodel.BaseUnitTest
@@ -34,11 +33,7 @@ class WooShippingLabelRefundViewModelTest : BaseUnitTest() {
         viewModel = WooShippingLabelRefundViewModel(
             WooShippingLabelRefundFragmentArgs(
                 orderId = mockOrderId,
-                shipment = ShipmentUIModel(
-                    localId = "0",
-                    items = emptyList(),
-                    labelId = mockLabelId
-                )
+                labelId = mockLabelId
             ).toSavedStateHandle(),
             selectedSite = selectedSite,
             repository = repository,


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

<!-- Id number of the Linear issue this PR addresses, e.g., WOOMOB-373. -->
Closes WOOMOB-609

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
This makes following chages:
- Removes the `ShipmentUIModel` parameter from `WooShippingLabelRefundFragment` arguments. The fragment is now initialized with only `labelId` and `orderId`.
- Uses the currency from shipping label data on the refund screen. This value comes`shippingLabelData` parameter in the `config` endpoint response. Before, the screen incorrectly used the order’s currency.
- Displays shipping rates using the currency defined in store options. Before, the rates were shown using the order’s currency, which was incorrect.

### Steps to reproduce
<!-- Step-by-step testing instructions. For new user flows, consider instead stating the goal of the workflow and see if your PR reviewer can accomplish the workflow without specific steps! -->

1. Open the Orders screen.
2. Select an order that includes a purchased shipment.
3. Tap the "Request refund" button.
4. Tap the "Refund label" button.
5. Confirm that the amount is displayed using the currency from the label purchase.
6. Navigate back.
7. Fill in the address, package, and other necessary fields to display shipping rates.
8. Confirm that the shipping rates are listed using the store’s currency.

### The tests that have been performed
<!-- To give the reviewer an idea of what could be missed in terms of testing -->
Steps above

### Images/gif
<!-- Include before and after images or gifs when appropriate. -->

- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->