### PR TITLE
[Shipping labels] Update shipment status after refunding

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/ShippingLabelRefundViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/ShippingLabelRefundViewModel.kt
@@ -28,7 +28,7 @@ class ShippingLabelRefundViewModel @Inject constructor(
 ) : ScopedViewModel(savedState) {
     private var refundJob: Job? = null
     val isRefundInProgress: Boolean
-        get() = refundJob?.isActive ?: false
+        get() = refundJob?.isActive == true
 
     private val arguments: ShippingLabelRefundFragmentArgs by savedState.navArgs()
 
@@ -79,6 +79,6 @@ class ShippingLabelRefundViewModel @Inject constructor(
         @IgnoredOnParcel
         val isRefundExpired: Boolean
             get() = shippingLabel?.isAnonymized == true ||
-                shippingLabel?.refundExpiryDate?.let { Date().after(it) } ?: false
+                shippingLabel?.refundExpiryDate?.let { Date().after(it) } == true
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/WooShippingLabelCreationFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/WooShippingLabelCreationFragment.kt
@@ -31,6 +31,7 @@ import com.woocommerce.android.ui.orders.wooshippinglabels.models.DestinationShi
 import com.woocommerce.android.ui.orders.wooshippinglabels.models.ShipmentUIModel
 import com.woocommerce.android.ui.orders.wooshippinglabels.packages.WooShippingLabelPackageCreationFragment.Companion.PACKAGE_SELECTION_RESULT
 import com.woocommerce.android.ui.orders.wooshippinglabels.packages.ui.PackageData
+import com.woocommerce.android.ui.orders.wooshippinglabels.refund.WooShippingLabelRefundFragment
 import com.woocommerce.android.ui.orders.wooshippinglabels.split.WooShippingSplitShipmentFragment
 import com.woocommerce.android.util.ActivityUtils
 import com.woocommerce.android.util.ChromeCustomTabUtils
@@ -155,6 +156,10 @@ class WooShippingLabelCreationFragment : BaseFragment(), BackPressListener {
         }
         handleResult<List<ShipmentUIModel>>(WooShippingSplitShipmentFragment.SPLIT_SHIPMENT_RESULT) {
             viewModel.onShipmentSplit(it)
+        }
+
+        handleResult<Long>(WooShippingLabelRefundFragment.KEY_REFUND_SHIPPING_LABEL_RESULT) {
+            viewModel.onShippingLabelRefunded(it)
         }
     }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/WooShippingLabelCreationViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/WooShippingLabelCreationViewModel.kt
@@ -110,7 +110,7 @@ class WooShippingLabelCreationViewModel @Inject constructor(
     private val shouldRequireCustoms: ShouldRequireCustomsForm,
     private val shouldRequireITN: ShouldRequireITN,
     private val fetchShippingLabelFile: FetchShippingLabelFile,
-    private val observeShippingLabelStatus: ObserveShippingLabelStatus
+    private val observeShippingLabelStatus: ObserveShippingLabelStatus,
 ) : ScopedViewModel(savedState) {
     private val navArgs: WooShippingLabelCreationFragmentArgs by savedState.navArgs()
 
@@ -565,6 +565,26 @@ class WooShippingLabelCreationViewModel @Inject constructor(
             }
         }
         shipments.value = newShipments
+    }
+
+    fun onShippingLabelRefunded(labelId: Long) {
+        // Find the shipment with the given labelId
+        val shipmentIndex = shipments.value.indexOfFirst { it.labelId == labelId }
+
+        // If the shipment is found, reset its purchased state
+        if (shipmentIndex != -1) {
+            updateShipment(
+                shipmentIndex,
+                shipments.value[shipmentIndex].copy(
+                    purchased = false,
+                    labelId = null,
+                    carrierId = null,
+                    trackingNumber = null,
+                    purchaseState = PurchaseState.NoStarted,
+                    status = ShippingLabelStatus.UNKNOWN
+                )
+            )
+        }
     }
 
     private fun getSelectedOriginAddress(originAddresses: List<OriginShippingAddress>): OriginShippingAddress {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/refund/WooShippingLabelRefundFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/refund/WooShippingLabelRefundFragment.kt
@@ -8,12 +8,14 @@ import androidx.compose.material.Surface
 import androidx.compose.ui.platform.ComposeView
 import androidx.compose.ui.platform.ViewCompositionStrategy
 import androidx.fragment.app.viewModels
+import androidx.navigation.fragment.findNavController
 import com.woocommerce.android.extensions.navigateBackWithResult
 import com.woocommerce.android.ui.base.BaseFragment
 import com.woocommerce.android.ui.base.UIMessageResolver
 import com.woocommerce.android.ui.compose.theme.WooThemeWithBackground
 import com.woocommerce.android.ui.main.MainActivity.Companion.BackPressListener
 import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.Exit
+import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.ExitWithResult
 import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.ShowSnackbar
 import dagger.hilt.android.AndroidEntryPoint
 import javax.inject.Inject
@@ -62,7 +64,8 @@ class WooShippingLabelRefundFragment : BaseFragment(), BackPressListener {
                     uiMessageResolver.getSnack(event.message, *event.args).show()
                 }
 
-                is Exit -> navigateBackWithResult(KEY_REFUND_SHIPPING_LABEL_RESULT, true)
+                is Exit -> findNavController().popBackStack()
+                is ExitWithResult<*> -> navigateBackWithResult(KEY_REFUND_SHIPPING_LABEL_RESULT, event.data)
                 else -> event.isHandled = false
             }
         }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/refund/WooShippingLabelRefundViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/refund/WooShippingLabelRefundViewModel.kt
@@ -12,6 +12,7 @@ import com.woocommerce.android.ui.orders.wooshippinglabels.datasource.WooShippin
 import com.woocommerce.android.ui.orders.wooshippinglabels.networking.WooShippingLabelRepository
 import com.woocommerce.android.util.CurrencyFormatter
 import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.Exit
+import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.ExitWithResult
 import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.ShowSnackbar
 import com.woocommerce.android.viewmodel.ScopedViewModel
 import com.woocommerce.android.viewmodel.navArgs
@@ -63,7 +64,7 @@ class WooShippingLabelRefundViewModel @Inject constructor(
                 repository.refundLabel(selectedSite.get(), arguments.orderId, arguments.labelId)
                     .takeIf { it.isError.not() }?.let {
                         triggerEvent(ShowSnackbar(R.string.shipping_label_refund_success))
-                        triggerEvent(Exit)
+                        triggerEvent(ExitWithResult(arguments.labelId))
                     } ?: run {
                     triggerEvent(ShowSnackbar(R.string.order_refunds_amount_refund_error))
                     isLoadingFlow.value = false

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/refund/WooShippingLabelRefundViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/refund/WooShippingLabelRefundViewModelTest.kt
@@ -59,7 +59,7 @@ class WooShippingLabelRefundViewModelTest : BaseUnitTest() {
         assertThat(capturedEvents.first()).isInstanceOf(Event.ShowSnackbar::class.java)
         assertThat((capturedEvents.first() as Event.ShowSnackbar).message)
             .isEqualTo(R.string.shipping_label_refund_success)
-        assertThat(capturedEvents.last()).isEqualTo(Event.Exit)
+        assertThat(capturedEvents.last()).isEqualTo(Event.ExitWithResult(mockLabelId))
     }
 
     @Test

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/refund/WooShippingLabelRefundViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/refund/WooShippingLabelRefundViewModelTest.kt
@@ -14,6 +14,9 @@ import org.mockito.kotlin.doReturn
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.whenever
 import org.wordpress.android.fluxc.model.SiteModel
+import org.wordpress.android.fluxc.network.BaseRequest
+import org.wordpress.android.fluxc.network.rest.wpcom.wc.WooError
+import org.wordpress.android.fluxc.network.rest.wpcom.wc.WooErrorType
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.WooResult
 import kotlin.test.Test
 
@@ -65,16 +68,22 @@ class WooShippingLabelRefundViewModelTest : BaseUnitTest() {
     @Test
     fun `when refund fails, show error message`() = testBlocking {
         // Given
-        var capturedEvent: Event.Exit? = null
-        viewModel.event.observeForever { capturedEvent = it as? Event.Exit }
+        var capturedEvent: Event.ShowSnackbar? = null
+        viewModel.event.observeForever { capturedEvent = it as? Event.ShowSnackbar }
         whenever(
             repository.refundLabel(site = mockSite, orderId = mockOrderId, labelId = mockLabelId)
-        ) doReturn WooResult(RefundLabelResponseDTO(false))
+        ) doReturn WooResult(
+            WooError(
+                type = WooErrorType.API_ERROR,
+                original = BaseRequest.GenericErrorType.PARSE_ERROR,
+                message = "Error"
+            )
+        )
 
         // When
         viewModel.onRefundShippingLabelButtonClicked()
 
         // Then
-        assertThat(capturedEvent).isNotNull()
+        assertThat(capturedEvent).isEqualTo(Event.ShowSnackbar(R.string.order_refunds_amount_refund_error))
     }
 }


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

<!-- Id number of the Linear issue this PR addresses, e.g., WOOMOB-373. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
This PR fixes the behavior after refunding a label. Previously, when a purchased shipment was refunded and the user returned to the main creation screen, the shipment was still incorrectly displayed as purchased.

### Steps to reproduce
<!-- Step-by-step testing instructions. For new user flows, consider instead stating the goal of the workflow and see if your PR reviewer can accomplish the workflow without specific steps! -->
1. Open the Orders screen.
2. Select an order that includes a purchased shipment.
3. Tap the "Request refund" button.
4. Tap the "Refund label" button.

### The tests that have been performed
<!-- To give the reviewer an idea of what could be missed in terms of testing -->
Video below

### Images/gif
<!-- Include before and after images or gifs when appropriate. -->
[after.webm](https://github.com/user-attachments/assets/f82b8920-265c-4da1-91f7-8cce6b8ed4e4)

- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->