### PR TITLE
[Shipping labels] Label refund button visibility logic

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/GetShipments.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/GetShipments.kt
@@ -7,6 +7,7 @@ import com.woocommerce.android.ui.orders.wooshippinglabels.datasource.WooShippin
 import com.woocommerce.android.ui.orders.wooshippinglabels.models.ShipmentUIModel
 import com.woocommerce.android.ui.orders.wooshippinglabels.models.ShippableItemModel
 import com.woocommerce.android.ui.orders.wooshippinglabels.networking.ShippingLabelDTO
+import com.woocommerce.android.ui.orders.wooshippinglabels.networking.WooShippingNetworkingMapper
 import com.woocommerce.android.ui.products.details.ProductDetailRepository
 import kotlinx.coroutines.flow.first
 import javax.inject.Inject
@@ -15,6 +16,7 @@ class GetShipments @Inject constructor(
     private val orderDetailRepository: OrderDetailRepository,
     private val productDetailRepository: ProductDetailRepository,
     private val configDataStore: WooShippingConfigDataStore,
+    private val mapper: WooShippingNetworkingMapper,
 ) {
     suspend operator fun invoke(order: Order): List<ShipmentUIModel> {
         val refunds = orderDetailRepository.getOrderRefunds(order.id)
@@ -75,13 +77,7 @@ class GetShipments @Inject constructor(
         if (noRefundedLabelForShipment == null) {
             shipmentUIModel
         } else {
-            shipmentUIModel.copy(
-                purchased = true,
-                labelId = noRefundedLabelForShipment.labelId,
-                carrierId = noRefundedLabelForShipment.carrierId,
-                trackingNumber = noRefundedLabelForShipment.tracking,
-                status = noRefundedLabelForShipment.status,
-            )
+            shipmentUIModel.copy(purchased = true, label = mapper.invoke(noRefundedLabelForShipment))
         }
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/ShippableItemsMapper.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/ShippableItemsMapper.kt
@@ -10,6 +10,7 @@ import com.woocommerce.android.ui.orders.wooshippinglabels.WooShippingLabelCreat
 import com.woocommerce.android.ui.orders.wooshippinglabels.models.ShipmentUIModel
 import com.woocommerce.android.ui.orders.wooshippinglabels.models.ShippableItemModel
 import com.woocommerce.android.ui.orders.wooshippinglabels.models.ShippableItemModel.Companion.SINGLE_QUANTITY
+import com.woocommerce.android.ui.orders.wooshippinglabels.models.ShippingLabelStatus
 import com.woocommerce.android.ui.orders.wooshippinglabels.split.SelectableShippableItemUI
 import com.woocommerce.android.ui.orders.wooshippinglabels.split.SelectableShippableItemsUI
 import com.woocommerce.android.util.CurrencyFormatter
@@ -57,7 +58,8 @@ fun List<ShippableItemModel>.toUIModel(
             ?: WooShippingLabelCreationViewModel.HazmatState.NoSelection,
         shippingRatesState = shippingRates,
         purchaseState = shipmentUIModel.purchaseState,
-        status = shipmentUIModel.status
+        status = shipmentUIModel.label?.status ?: ShippingLabelStatus.UNKNOWN,
+        isRefundAvailable = shipmentUIModel.label?.isRefundAvailable == true
     )
 }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/WooShippingLabelCreationScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/WooShippingLabelCreationScreen.kt
@@ -536,6 +536,7 @@ private fun CreateShippingCards(
         if (shipmentUI.purchased) {
             PrintShippingLabelSection(
                 status = shipmentUI.status,
+                isRefundAvailable = shipmentUI.isRefundAvailable,
                 selectedLabelPaperSizeOption = uiState.paperSizeOption,
                 onLabelPaperSizeOptionSelected = onLabelPaperSizeOptionSelected,
                 onPrintShippingLabelClicked = onPrintShippingLabelClicked,

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/WooShippingLabelCreationViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/WooShippingLabelCreationViewModel.kt
@@ -1116,6 +1116,7 @@ data class ShipmentUI(
     val shippingRatesState: ShippingRatesState,
     val purchaseState: PurchaseState = PurchaseState.NoStarted,
     val status: ShippingLabelStatus = ShippingLabelStatus.UNKNOWN,
+    val isRefundAvailable: Boolean = false,
 ) : Parcelable {
     val totalItemQuantity
         get() = shippableItems.sumByFloat { it.quantity }.toInt()

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/WooShippingLabelCreationViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/WooShippingLabelCreationViewModel.kt
@@ -224,12 +224,12 @@ class WooShippingLabelCreationViewModel @Inject constructor(
 
     private fun observeShippingLabelPurchaseStatus(shipmentId: Int) {
         launch {
-            val labelId = shipments.value[shipmentId].labelId ?: return@launch
+            val shipment = shipments.value[shipmentId]
+            val labelId = shipment.label?.labelId ?: return@launch
             observeShippingLabelStatus(orderId = navArgs.orderId, labelId = labelId).onEach { result ->
-                updateShipment(
-                    shipmentId,
-                    shipments.value[shipmentId].copy(status = result.status)
-                )
+                // If result has a label model update the label with it. Otherwise, just update the status.
+                val newLabel = result.shippingLabelModel ?: shipment.label.copy(status = result.status)
+                updateShipment(shipmentId, shipment.copy(label = newLabel))
             }.launchIn(this)
         }
     }
@@ -569,21 +569,11 @@ class WooShippingLabelCreationViewModel @Inject constructor(
 
     fun onShippingLabelRefunded(labelId: Long) {
         // Find the shipment with the given labelId
-        val shipmentIndex = shipments.value.indexOfFirst { it.labelId == labelId }
+        val shipmentIndex = shipments.value.indexOfFirst { it.label?.labelId == labelId }
 
         // If the shipment is found, reset its purchased state
         if (shipmentIndex != -1) {
-            updateShipment(
-                shipmentIndex,
-                shipments.value[shipmentIndex].copy(
-                    purchased = false,
-                    labelId = null,
-                    carrierId = null,
-                    trackingNumber = null,
-                    purchaseState = PurchaseState.NoStarted,
-                    status = ShippingLabelStatus.UNKNOWN
-                )
-            )
+            updateShipment(shipmentIndex, shipments.value[shipmentIndex].copy(purchased = false, label = null))
         }
     }
 
@@ -696,15 +686,7 @@ class WooShippingLabelCreationViewModel @Inject constructor(
             ?.labels
             ?.firstOrNull()
             ?.let { purchasedLabel ->
-                updateShipment(
-                    shipmentId,
-                    shipments.value[shipmentId].copy(
-                        purchased = true,
-                        labelId = purchasedLabel.labelId,
-                        carrierId = purchasedLabel.carrierId,
-                        trackingNumber = purchasedLabel.tracking,
-                    )
-                )
+                updateShipment(shipmentId, shipments.value[shipmentId].copy(purchased = true, label = purchasedLabel))
                 observeShippingLabelPurchaseStatus(shipmentId)
             }
     }
@@ -829,7 +811,7 @@ class WooShippingLabelCreationViewModel @Inject constructor(
         val fallbackViewState = viewState.value
         viewState.value = WooShippingViewState.Loading(R.string.shipping_label_print_screen_title)
         launch {
-            val labelId = shipments.value[selectedShipmentIndex].labelId ?: return@launch
+            val labelId = shipments.value[selectedShipmentIndex].label?.labelId ?: return@launch
             val paperSize = uiState.value.paperSizeOption
             val labelFile = fetchShippingLabelFile(
                 labelIds = listOf(labelId),
@@ -845,22 +827,22 @@ class WooShippingLabelCreationViewModel @Inject constructor(
     }
 
     fun onTrackShipmentClicked() {
-        val carrierId = shipments.value[selectedShipmentIndex].carrierId ?: return
-        val trackingNumber = shipments.value[selectedShipmentIndex].trackingNumber ?: return
+        val carrierId = shipments.value[selectedShipmentIndex].label?.carrierId ?: return
+        val trackingNumber = shipments.value[selectedShipmentIndex].label?.tracking ?: return
         ShipmentTrackingUrls.fromCarrier(carrierId, trackingNumber)
             ?.let { triggerEvent(OpenUrl(it)) }
             ?: triggerEvent(ShowError(R.string.shipping_label_purchased_tracking_error))
     }
 
     fun onSchedulePickUpClicked() {
-        val carrierId = shipments.value[selectedShipmentIndex].carrierId ?: return
+        val carrierId = shipments.value[selectedShipmentIndex].label?.carrierId ?: return
         Carrier.fromCarrierId(carrierId)?.let {
             triggerEvent(OpenUrl(it.pickupUrl))
         } ?: triggerEvent(ShowError(R.string.shipping_label_purchased_pickup_error))
     }
 
     fun onRefundClicked() {
-        shipments.value[selectedShipmentIndex].labelId?.let { labelId ->
+        shipments.value[selectedShipmentIndex].label?.labelId?.let { labelId ->
             triggerEvent(NavigateToRefundRequest(navArgs.orderId, labelId))
         }
     }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/components/PrintShippingLabelSection.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/components/PrintShippingLabelSection.kt
@@ -50,6 +50,7 @@ import com.woocommerce.android.ui.orders.wooshippinglabels.models.ShippingLabelS
 @Composable
 fun PrintShippingLabelSection(
     status: ShippingLabelStatus,
+    isRefundAvailable: Boolean,
     selectedLabelPaperSizeOption: WooShippingLabelPaperSize,
     onLabelPaperSizeOptionSelected: (WooShippingLabelPaperSize) -> Unit,
     onPrintShippingLabelClicked: () -> Unit,
@@ -92,6 +93,7 @@ fun PrintShippingLabelSection(
         Spacer(modifier = Modifier.padding(top = 16.dp))
         PrintShippingLabelCard(
             isPrintButtonEnabled = status == PURCHASED,
+            isRefundAvailable = isRefundAvailable,
             selectedLabelPaperSizeOption = selectedLabelPaperSizeOption,
             onLabelPaperSizeOptionSelected = onLabelPaperSizeOptionSelected,
             onPrintShippingLabelClicked = onPrintShippingLabelClicked,
@@ -113,6 +115,7 @@ fun PrintShippingLabelSection(
 @Composable
 private fun PrintShippingLabelCard(
     isPrintButtonEnabled: Boolean,
+    isRefundAvailable: Boolean,
     selectedLabelPaperSizeOption: WooShippingLabelPaperSize,
     onLabelPaperSizeOptionSelected: (WooShippingLabelPaperSize) -> Unit,
     onPrintShippingLabelClicked: () -> Unit,
@@ -189,14 +192,16 @@ private fun PrintShippingLabelCard(
             showIcon = true,
             modifier = Modifier.padding(vertical = 8.dp)
         )
-        ShippingLabelLink(
-            text = stringResource(id = R.string.shipping_label_purchased_request_refund),
-            onClick = {
-                onRefundClicked()
-            },
-            showIcon = false,
-            modifier = Modifier.padding(vertical = 8.dp)
-        )
+        if (isRefundAvailable) {
+            ShippingLabelLink(
+                text = stringResource(id = R.string.shipping_label_purchased_request_refund),
+                onClick = {
+                    onRefundClicked()
+                },
+                showIcon = false,
+                modifier = Modifier.padding(vertical = 8.dp)
+            )
+        }
     }
 }
 
@@ -302,6 +307,7 @@ internal fun PrintShippingLabelSectionPreview() {
                 remember { mutableStateOf(WooShippingLabelPaperSize.LEGAL) }
             PrintShippingLabelSection(
                 status = PURCHASED,
+                isRefundAvailable = true,
                 selectedLabelPaperSizeOption = selectedLabelPaperSizeOption.value,
                 onLabelPaperSizeOptionSelected = { selectedLabelPaperSizeOption.value = it },
                 onPrintShippingLabelClicked = {},

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/datasource/WooShippingConfigDataStore.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/datasource/WooShippingConfigDataStore.kt
@@ -9,6 +9,7 @@ import com.woocommerce.android.datastore.DataStoreQualifier
 import com.woocommerce.android.datastore.DataStoreType
 import com.woocommerce.android.tools.SelectedSite
 import com.woocommerce.android.ui.orders.wooshippinglabels.networking.ConfigDTO
+import com.woocommerce.android.ui.orders.wooshippinglabels.networking.WooShippingNetworkingMapper
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.map
@@ -17,7 +18,8 @@ import javax.inject.Inject
 class WooShippingConfigDataStore @Inject constructor(
     @DataStoreQualifier(DataStoreType.SHIPPING_LABELS_DATA) private val dataStore: DataStore<Preferences>,
     private val gson: Gson,
-    private val selectedSite: SelectedSite
+    private val selectedSite: SelectedSite,
+    private val mapper: WooShippingNetworkingMapper,
 ) {
     private fun getConfigKey(orderId: Long) = "${selectedSite.get().id}:${orderId}Config"
 
@@ -25,6 +27,12 @@ class WooShippingConfigDataStore @Inject constructor(
         val config = prefs[stringPreferencesKey(getConfigKey(orderId))]
         runCatching { gson.fromJson(config, ConfigDTO::class.java) }.getOrNull()
     }.distinctUntilChanged()
+
+    fun getShippingLabel(orderId: Long, labelId: Long) = observeConfig(orderId).map { config ->
+        config?.shippingLabelData?.currentOrderLabels
+            ?.find { it.labelId == labelId }
+            ?.let { mapper(it) }
+    }
 
     suspend fun saveConfig(orderId: Long, config: ConfigDTO) {
         dataStore.edit { preferences ->

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/models/ShipmentUIModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/models/ShipmentUIModel.kt
@@ -9,11 +9,8 @@ data class ShipmentUIModel(
     val remoteId: String? = null,
     val items: List<ShippableItemModel>,
     val purchased: Boolean = false,
-    val labelId: Long? = null,
-    val carrierId: String? = null,
-    val trackingNumber: String? = null,
     val purchaseState: PurchaseState = PurchaseState.NoStarted,
-    val status: ShippingLabelStatus = ShippingLabelStatus.UNKNOWN,
+    val label: ShippingLabelModel? = null,
 ) : Parcelable
 
 @Parcelize

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/models/ShippingLabelModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/models/ShippingLabelModel.kt
@@ -5,6 +5,7 @@ import com.google.gson.annotations.SerializedName
 import kotlinx.parcelize.Parcelize
 import java.math.BigDecimal
 import java.util.Date
+import java.util.concurrent.TimeUnit
 
 @Parcelize
 data class ShippingLabelModel(
@@ -29,6 +30,13 @@ data class ShippingLabelModel(
     val currency: String,
     val expiryDate: Long,
 ) : Parcelable {
+    val isRefundAvailable: Boolean
+        get() {
+            val createdTime = createdDate?.time ?: return true
+            return status != ShippingLabelStatus.ANONYMIZED &&
+                Date().before(Date(createdTime + TimeUnit.DAYS.toMillis(REFUND_EXPIRY_DAYS))) == true
+        }
+
     companion object {
         private const val REFUND_EXPIRY_DAYS = 30L
     }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/models/ShippingLabelModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/models/ShippingLabelModel.kt
@@ -29,6 +29,9 @@ data class ShippingLabelModel(
     val currency: String,
     val expiryDate: Long,
 ) : Parcelable {
+    companion object {
+        private const val REFUND_EXPIRY_DAYS = 30L
+    }
 }
 
 enum class ShippingLabelStatus {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/models/ShippingLabelModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/models/ShippingLabelModel.kt
@@ -55,8 +55,8 @@ data class ShippingLabelModel(
 
     companion object {
         private const val REFUND_EXPIRY_DAYS = 30L
-        private const val REFUND_DURATION_DHL_EXPRESS = 14
-        const val REFUND_DURATION_DEFAULT = 31
+        private const val REFUND_DURATION_DHL_EXPRESS = 31
+        const val REFUND_DURATION_DEFAULT = 14
     }
 }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/models/ShippingLabelModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/models/ShippingLabelModel.kt
@@ -32,6 +32,13 @@ data class ShippingLabelModel(
     val expiryDate: Long,
     val usedDate: Long?,
 ) : Parcelable {
+    val refundDuration: Int
+        get() = if (carrierId == CARRIER_DHL_EXPRESS_KEY) {
+            REFUND_DURATION_DHL_EXPRESS
+        } else {
+            REFUND_DURATION_DEFAULT
+        }
+
     val isRefundAvailable: Boolean
         get() {
             val createdDate = createdDate?.time ?: return true
@@ -48,6 +55,8 @@ data class ShippingLabelModel(
 
     companion object {
         private const val REFUND_EXPIRY_DAYS = 30L
+        private const val REFUND_DURATION_DHL_EXPRESS = 14
+        const val REFUND_DURATION_DEFAULT = 31
     }
 }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/models/ShippingLabelModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/models/ShippingLabelModel.kt
@@ -2,6 +2,7 @@ package com.woocommerce.android.ui.orders.wooshippinglabels.models
 
 import android.os.Parcelable
 import com.google.gson.annotations.SerializedName
+import com.woocommerce.android.ui.orders.wooshippinglabels.rates.datasource.WooShippingRatesDatasourceMapper.Companion.CARRIER_DHL_EXPRESS_KEY
 import kotlinx.parcelize.Parcelize
 import java.math.BigDecimal
 import java.util.Date
@@ -29,13 +30,21 @@ data class ShippingLabelModel(
     val rate: BigDecimal,
     val currency: String,
     val expiryDate: Long,
+    val usedDate: Long?,
 ) : Parcelable {
     val isRefundAvailable: Boolean
         get() {
-            val createdTime = createdDate?.time ?: return true
-            return status != ShippingLabelStatus.ANONYMIZED &&
-                Date().before(Date(createdTime + TimeUnit.DAYS.toMillis(REFUND_EXPIRY_DAYS))) == true
+            val createdDate = createdDate?.time ?: return true
+            val thirtyDaysAgo = System.currentTimeMillis() - TimeUnit.DAYS.toMillis(REFUND_EXPIRY_DAYS)
+
+            return createdDate >= thirtyDaysAgo &&
+                !hasLabelExpired &&
+                carrierId != CARRIER_DHL_EXPRESS_KEY &&
+                tracking.isNotEmpty()
         }
+
+    private val hasLabelExpired: Boolean
+        get() = status == ShippingLabelStatus.ANONYMIZED || usedDate != null || expiryDate < System.currentTimeMillis()
 
     companion object {
         private const val REFUND_EXPIRY_DAYS = 30L

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/models/ShippingLabelModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/models/ShippingLabelModel.kt
@@ -1,9 +1,12 @@
 package com.woocommerce.android.ui.orders.wooshippinglabels.models
 
+import android.os.Parcelable
 import com.google.gson.annotations.SerializedName
+import kotlinx.parcelize.Parcelize
 import java.math.BigDecimal
 import java.util.Date
 
+@Parcelize
 data class ShippingLabelModel(
     val labelId: Long,
     val tracking: String,
@@ -25,7 +28,8 @@ data class ShippingLabelModel(
     val rate: BigDecimal,
     val currency: String,
     val expiryDate: Long,
-)
+) : Parcelable {
+}
 
 enum class ShippingLabelStatus {
     @SerializedName("UNKNOWN")

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/networking/DTOs.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/networking/DTOs.kt
@@ -109,6 +109,7 @@ data class ShippingLabelDTO(
     @SerializedName("rate") val rate: BigDecimal? = null,
     @SerializedName("currency") val currency: String? = null,
     @SerializedName("expiry_date") val expiryDate: Long? = null,
+    @SerializedName("used_date") val usedDate: Long? = null,
     @SerializedName("refund") val refund: LabelRefund? = null
 )
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/networking/WooShippingNetworkingMapper.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/networking/WooShippingNetworkingMapper.kt
@@ -74,7 +74,8 @@ class WooShippingNetworkingMapper @Inject constructor(
             mainReceiptId = shippingLabelDTO.mainReceiptId ?: 0,
             rate = shippingLabelDTO.rate ?: BigDecimal.ZERO,
             currency = shippingLabelDTO.currency.orEmpty(),
-            expiryDate = shippingLabelDTO.expiryDate ?: 0
+            expiryDate = shippingLabelDTO.expiryDate ?: 0,
+            usedDate = shippingLabelDTO.usedDate
         )
     }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/purchased/ObserveShippingLabelStatus.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/purchased/ObserveShippingLabelStatus.kt
@@ -1,6 +1,7 @@
 package com.woocommerce.android.ui.orders.wooshippinglabels.purchased
 
 import com.woocommerce.android.tools.SelectedSite
+import com.woocommerce.android.ui.orders.wooshippinglabels.models.ShippingLabelModel
 import com.woocommerce.android.ui.orders.wooshippinglabels.models.ShippingLabelStatus
 import com.woocommerce.android.ui.orders.wooshippinglabels.models.ShippingLabelStatus.PURCHASE_IN_PROGRESS
 import com.woocommerce.android.ui.orders.wooshippinglabels.models.ShippingLabelStatus.UNKNOWN
@@ -8,7 +9,6 @@ import com.woocommerce.android.ui.orders.wooshippinglabels.networking.WooShippin
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.flow
-import java.math.BigDecimal
 import javax.inject.Inject
 
 class ObserveShippingLabelStatus @Inject constructor(
@@ -18,7 +18,7 @@ class ObserveShippingLabelStatus @Inject constructor(
     operator fun invoke(orderId: Long, labelId: Long): Flow<ObserveShippingLabelStatusResult> {
         return flow {
             var latestStatus = PURCHASE_IN_PROGRESS
-            emit(ObserveShippingLabelStatusResult(latestStatus, null))
+            emit(ObserveShippingLabelStatusResult(latestStatus))
 
             do {
                 val response = labelRepository.fetchShippingLabelStatus(
@@ -27,13 +27,16 @@ class ObserveShippingLabelStatus @Inject constructor(
                     labelId = labelId
                 ).takeIf { it.isError.not() }?.model
                 latestStatus = response?.status ?: UNKNOWN
-                emit(ObserveShippingLabelStatusResult(latestStatus, response?.refundableAmount))
+                emit(ObserveShippingLabelStatusResult(latestStatus, response))
                 delay(DELAY_BETWEEN_STATUS_CHECKS)
             } while (latestStatus == PURCHASE_IN_PROGRESS)
         }
     }
 
-    data class ObserveShippingLabelStatusResult(val status: ShippingLabelStatus, val refundableAmount: BigDecimal?)
+    data class ObserveShippingLabelStatusResult(
+        val status: ShippingLabelStatus,
+        val shippingLabelModel: ShippingLabelModel? = null
+    )
 
     companion object {
         private const val DELAY_BETWEEN_STATUS_CHECKS = 2000L

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/rates/datasource/WooShippingRatesDatasourceMapper.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/rates/datasource/WooShippingRatesDatasourceMapper.kt
@@ -18,7 +18,7 @@ class WooShippingRatesDatasourceMapper @Inject constructor() {
         private const val CARRIER_USPS_KEY = "usps"
         private const val CARRIER_UPS_KEY = "ups"
         private const val CARRIER_FEDEX_KEY = "fedex"
-        private const val CARRIER_DHL_EXPRESS_KEY = "dhlexpress"
+        const val CARRIER_DHL_EXPRESS_KEY = "dhlexpress"
         private const val CARRIER_DHL_ECOMMERCE_KEY = "dhlecommerce"
         private const val CARRIER_DHL_ECOMMERCE_ASIA_KEY = "dhlecommerceasia"
     }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/refund/WooShippingLabelRefundScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/refund/WooShippingLabelRefundScreen.kt
@@ -39,6 +39,7 @@ fun WooShippingLabelRefundScreen(viewModel: WooShippingLabelRefundViewModel) {
             is WooShippingLabelRefundViewModel.ViewState.DataState -> WooShippingLabelRefundScreen(
                 purchaseDate = it.purchaseDate,
                 refundableAmount = it.refundableAmount,
+                refundDuration = it.refundDuration,
                 onRefundLabelClick = viewModel::onRefundShippingLabelButtonClicked,
             )
         }
@@ -49,6 +50,7 @@ fun WooShippingLabelRefundScreen(viewModel: WooShippingLabelRefundViewModel) {
 fun WooShippingLabelRefundScreen(
     purchaseDate: String?,
     refundableAmount: String?,
+    refundDuration: Int,
     onRefundLabelClick: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
@@ -68,7 +70,7 @@ fun WooShippingLabelRefundScreen(
             )
 
             Text(
-                text = stringResource(R.string.woo_shipping_refund_description),
+                text = stringResource(R.string.woo_shipping_refund_description, refundDuration),
                 style = MaterialTheme.typography.bodyMedium,
                 color = colorResource(id = R.color.color_on_surface),
                 modifier = Modifier.padding(top = 16.dp)
@@ -142,6 +144,7 @@ fun WooShippingLabelRefundScreenPreview() {
         WooShippingLabelRefundScreen(
             purchaseDate = "Feb 19, 2025",
             refundableAmount = "$11.33",
+            refundDuration = 14,
             onRefundLabelClick = {},
         )
     }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/refund/WooShippingLabelRefundViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/refund/WooShippingLabelRefundViewModel.kt
@@ -9,6 +9,7 @@ import com.woocommerce.android.extensions.formatToLocalizedMedium
 import com.woocommerce.android.tools.NetworkStatus
 import com.woocommerce.android.tools.SelectedSite
 import com.woocommerce.android.ui.orders.wooshippinglabels.datasource.WooShippingConfigDataStore
+import com.woocommerce.android.ui.orders.wooshippinglabels.models.ShippingLabelModel
 import com.woocommerce.android.ui.orders.wooshippinglabels.networking.WooShippingLabelRepository
 import com.woocommerce.android.util.CurrencyFormatter
 import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.Exit
@@ -20,11 +21,9 @@ import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.combine
-import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.shareIn
 import kotlinx.coroutines.launch
 import kotlinx.parcelize.Parcelize
-import java.util.Date
 import javax.inject.Inject
 
 @HiltViewModel
@@ -39,8 +38,7 @@ class WooShippingLabelRefundViewModel @Inject constructor(
     private val arguments: WooShippingLabelRefundFragmentArgs by savedState.navArgs()
 
     // Finding the shipping label from cached config data
-    private val shippingLabelFlow = configDataStore.observeConfig(arguments.orderId)
-        .map { it?.shippingLabelData?.currentOrderLabels?.find { it.labelId == arguments.labelId } }
+    private val shippingLabelFlow = configDataStore.getShippingLabel(arguments.orderId, arguments.labelId)
         .shareIn(viewModelScope, started = SharingStarted.Lazily, replay = 1)
 
     private val isLoadingFlow = MutableStateFlow(false)
@@ -49,11 +47,15 @@ class WooShippingLabelRefundViewModel @Inject constructor(
         if (isLoading) {
             ViewState.Loading
         } else {
-            val purchaseDate = label?.createdDate?.let { date -> Date(date) }?.formatToLocalizedMedium()
+            val purchaseDate = label?.createdDate?.formatToLocalizedMedium().orEmpty()
             val refundableAmount = label?.refundableAmount?.let { amount ->
-                label.currency?.let { currency -> currencyFormatter.formatCurrency(amount, currency) }
-            }
-            ViewState.DataState(purchaseDate, refundableAmount)
+                currencyFormatter.formatCurrency(amount, label.currency)
+            }.orEmpty()
+            ViewState.DataState(
+                purchaseDate,
+                refundableAmount,
+                label?.refundDuration ?: ShippingLabelModel.REFUND_DURATION_DEFAULT
+            )
         }
     }.asLiveData()
 
@@ -88,7 +90,8 @@ class WooShippingLabelRefundViewModel @Inject constructor(
         data object Loading : ViewState()
         data class DataState(
             val purchaseDate: String? = null,
-            val refundableAmount: String? = null
+            val refundableAmount: String? = null,
+            val refundDuration: Int
         ) : ViewState()
     }
 }

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -4669,7 +4669,7 @@
     <string name="purchased_shipment_content_description">Purchased</string>
 
     <string name="woo_shipping_refund_title">Request a shipping label refund</string>
-    <string name="woo_shipping_refund_description">Request a refund for your unused shipping label. The refund process for the shipping label will begin immediately and is typically completed within 14 business days.</string>
+    <string name="woo_shipping_refund_description">Request a refund for your unused shipping label. The refund process for the shipping label will begin immediately and is typically completed within %d business days.</string>
     <string name="woo_shipping_refund_purchase_date"><![CDATA[<b>Purchase date:</b> %s]]></string>
     <string name="woo_shipping_refund_amount_eligible_for_refund"><![CDATA[<b>Amount eligible for refund:</b> %s]]></string>
     <string name="woo_shipping_refund_note">Please note that this refund request applies only to the unused shipping label and will not affect the order itself.</string>

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/GetShipmentsTests.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/GetShipmentsTests.kt
@@ -35,7 +35,7 @@ class GetShipmentsTests : BaseUnitTest() {
         doReturn(flowOf(null)).whenever(it).observeConfig(any())
     }
 
-    private val sut = GetShipments(orderDetailRepository, productDetailRepository, configDataStore)
+    private val sut = GetShipments(orderDetailRepository, productDetailRepository, configDataStore, mock())
 
     @Test
     fun `when order only contains refunded products then should return empty list`() = testBlocking {

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/WooShippingLabelCreationViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/WooShippingLabelCreationViewModelTest.kt
@@ -35,6 +35,8 @@ import com.woocommerce.android.ui.orders.wooshippinglabels.models.PaymentMethodM
 import com.woocommerce.android.ui.orders.wooshippinglabels.models.PaymentMethodOptions
 import com.woocommerce.android.ui.orders.wooshippinglabels.models.ShipmentUIModel
 import com.woocommerce.android.ui.orders.wooshippinglabels.models.ShippableItemModel
+import com.woocommerce.android.ui.orders.wooshippinglabels.models.ShippingLabelModel
+import com.woocommerce.android.ui.orders.wooshippinglabels.models.ShippingLabelStatus.UNKNOWN
 import com.woocommerce.android.ui.orders.wooshippinglabels.models.StoreOptionsModel
 import com.woocommerce.android.ui.orders.wooshippinglabels.models.WooShippingCarrier
 import com.woocommerce.android.ui.orders.wooshippinglabels.packages.ui.PackageData
@@ -188,6 +190,29 @@ class WooShippingLabelCreationViewModelTest : BaseUnitTest() {
         rate = defaultShippingRate,
         feeDescription = "fee description",
         formattedOptionName = Option.DEFAULT.name
+    )
+
+    private val shippingLabelModel = ShippingLabelModel(
+        labelId = 1,
+        tracking = "",
+        refundableAmount = BigDecimal.ZERO,
+        status = UNKNOWN,
+        created = null,
+        carrierId = "",
+        serviceName = "",
+        commercialInvoiceUrl = "",
+        isCommercialInvoiceSubmittedElectronically = false,
+        packageName = "",
+        isLetter = false,
+        productNames = emptyList(),
+        productIds = emptyList(),
+        shipmentId = "0",
+        receiptItemId = 0L,
+        createdDate = null,
+        mainReceiptId = 0L,
+        rate = BigDecimal.ZERO,
+        currency = "",
+        expiryDate = 0L
     )
 
     private val defaultShippingRates = mapOf(
@@ -912,7 +937,11 @@ class WooShippingLabelCreationViewModelTest : BaseUnitTest() {
     @Test
     fun `onPrintShippingLabelClicked triggers OpenShippingLabelFile event`() = testBlocking {
         whenever(getShipments(any())) doReturn listOf(
-            ShipmentUIModel(localId = "0", items = defaultShippableItems, labelId = 123)
+            ShipmentUIModel(
+                localId = "0",
+                items = defaultShippableItems,
+                label = shippingLabelModel.copy(labelId = 123L)
+            )
         )
         whenever(fetchShippingLabelFile(eq(listOf(123)), any())).thenReturn(file)
 
@@ -961,8 +990,7 @@ class WooShippingLabelCreationViewModelTest : BaseUnitTest() {
             ShipmentUIModel(
                 localId = "0",
                 items = defaultShippableItems,
-                carrierId = "usps",
-                trackingNumber = "123456"
+                label = shippingLabelModel.copy(carrierId = "usps", tracking = "123456"),
             )
         )
 
@@ -979,7 +1007,11 @@ class WooShippingLabelCreationViewModelTest : BaseUnitTest() {
     @Test
     fun `onSchedulePickUpClicked triggers OpenUrl event`() = testBlocking {
         whenever(getShipments(any())) doReturn listOf(
-            ShipmentUIModel(localId = "0", items = defaultShippableItems, carrierId = "usps")
+            ShipmentUIModel(
+                localId = "0",
+                items = defaultShippableItems,
+                label = shippingLabelModel.copy(carrierId = "usps")
+            )
         )
 
         createViewModel()
@@ -996,7 +1028,7 @@ class WooShippingLabelCreationViewModelTest : BaseUnitTest() {
     fun `onRefundClicked triggers NavigateToRefundRequest event`() = testBlocking {
         val labelId = 123L
         whenever(getShipments(any())) doReturn defaultShipments.toMutableList().apply {
-            set(0, defaultShipments.first().copy(labelId = labelId))
+            set(0, defaultShipments.first().copy(label = shippingLabelModel.copy(labelId = labelId)))
         }
 
         createViewModel()

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/WooShippingLabelCreationViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/WooShippingLabelCreationViewModelTest.kt
@@ -212,7 +212,8 @@ class WooShippingLabelCreationViewModelTest : BaseUnitTest() {
         mainReceiptId = 0L,
         rate = BigDecimal.ZERO,
         currency = "",
-        expiryDate = 0L
+        expiryDate = 0L,
+        usedDate = 0L
     )
 
     private val defaultShippingRates = mapOf(

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/models/ShippingLabelModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/models/ShippingLabelModelTest.kt
@@ -1,0 +1,93 @@
+package com.woocommerce.android.ui.orders.wooshippinglabels.models
+
+import com.woocommerce.android.ui.orders.wooshippinglabels.models.ShippingLabelStatus.UNKNOWN
+import com.woocommerce.android.viewmodel.BaseUnitTest
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import org.junit.Test
+import java.math.BigDecimal
+import java.util.Date
+import java.util.concurrent.TimeUnit
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class ShippingLabelModelTest : BaseUnitTest() {
+    private val model = ShippingLabelModel(
+        labelId = 1,
+        tracking = "tracking",
+        refundableAmount = BigDecimal(1),
+        status = UNKNOWN,
+        created = Date(0),
+        carrierId = "fedex",
+        serviceName = "serviceName",
+        commercialInvoiceUrl = "commercialInvoiceUrl",
+        isCommercialInvoiceSubmittedElectronically = false,
+        packageName = "packageName",
+        isLetter = false,
+        productNames = emptyList(),
+        productIds = emptyList(),
+        shipmentId = "0",
+        receiptItemId = 0L,
+        createdDate = Date(0),
+        mainReceiptId = 0L,
+        rate = BigDecimal(1),
+        currency = "USD",
+        expiryDate = 32503680000000, // far future date
+        usedDate = null
+    )
+
+    @Test
+    fun `when anonymized, refund should be unavailable`() = testBlocking {
+        val sut = model.copy(status = ShippingLabelStatus.ANONYMIZED)
+
+        assertFalse(sut.isRefundAvailable)
+    }
+
+    @Test
+    fun `when created a week ago, refund should be available`() = testBlocking {
+        val now = System.currentTimeMillis()
+        val weekAgo = now - TimeUnit.DAYS.toMillis(7)
+        val sut = model.copy(createdDate = Date(weekAgo))
+
+        assertTrue(sut.isRefundAvailable)
+    }
+
+    @Test
+    fun `when created two months ago, refund should be unavailable`() = testBlocking {
+        val now = System.currentTimeMillis()
+        val twoMonthsAgo = now - TimeUnit.DAYS.toMillis(60)
+        val sut = model.copy(createdDate = Date(twoMonthsAgo))
+
+        assertFalse(sut.isRefundAvailable)
+    }
+
+    @Test
+    fun `when used, refund should be unavailable`() = testBlocking {
+        val sut = model.copy(usedDate = null)
+
+        assertFalse(sut.isRefundAvailable)
+    }
+
+    @Test
+    fun `when expired, refund should be unavailable`() = testBlocking {
+        val now = System.currentTimeMillis()
+        val dayAgo = now - TimeUnit.DAYS.toMillis(1)
+        val sut = model.copy(expiryDate = dayAgo)
+
+        assertFalse(sut.isRefundAvailable)
+    }
+
+    @Test
+    fun `when usps, refund should be unavailable`() = testBlocking {
+        val sut = model.copy(carrierId = "usps")
+
+        assertFalse(sut.isRefundAvailable)
+    }
+
+    @Test
+    fun `when no tracking, refund should be unavailable`() = testBlocking {
+        val sut = model.copy(tracking = "")
+
+        assertFalse(sut.isRefundAvailable)
+    }
+}

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/purchased/ObserveShippingLabelStatusTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/purchased/ObserveShippingLabelStatusTest.kt
@@ -53,7 +53,8 @@ class ObserveShippingLabelStatusTest : BaseUnitTest() {
         mainReceiptId = 0L,
         rate = BigDecimal.ZERO,
         currency = "",
-        expiryDate = 0L
+        expiryDate = 0L,
+        usedDate = null
     )
 
     @Before


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

<!-- Id number of the Linear issue this PR addresses, e.g., WOOMOB-373. -->
Closes WOOMOB-370

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
This PR adds additional logic for the visibility of the “Request refund” button. The logic was copied from the old flow.

### Steps to reproduce
<!-- Step-by-step testing instructions. For new user flows, consider instead stating the goal of the workflow and see if your PR reviewer can accomplish the workflow without specific steps! -->
Open purchased shipments. For shipments purchased more than 30 days ago, the “Request refund” button should not be displayed.
I couldn't find a way to test ANONYMIZED labels, but I copied the condition from the old flow, so it should be safe.

### The tests that have been performed
<!-- To give the reviewer an idea of what could be missed in terms of testing -->
Steps above.

### Images/gif
<!-- Include before and after images or gifs when appropriate. -->
|Before|After|
|-|-|
|<img src="https://github.com/user-attachments/assets/ec2af655-2d86-4011-89f7-106cf1e3633d" width=340>|<img src="https://github.com/user-attachments/assets/a484271c-43b9-4977-b337-f074a251222f" width=340>|

- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->