### PR TITLE
[WOOPRD-594][Woo POS][Barcodes] Add a link on license for the error sound we use

### DIFF
--- a/WooCommerce/src/main/res/layout/fragment_licenses.xml
+++ b/WooCommerce/src/main/res/layout/fragment_licenses.xml
@@ -1,11 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<FrameLayout
-    xmlns:android="http://schemas.android.com/apk/res/android"
+<WebView xmlns:android="http://schemas.android.com/apk/res/android"
+    android:id="@+id/webView"
     android:layout_width="match_parent"
-    android:layout_height="match_parent">
-
-    <WebView
-        android:id="@+id/webView"
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"/>
-</FrameLayout>
+    android:layout_height="match_parent" />

--- a/WooCommerce/src/main/res/raw/licenses.html
+++ b/WooCommerce/src/main/res/raw/licenses.html
@@ -43,6 +43,7 @@
     <p>Additional credits:</p>
     <ul>
       <li><a href="https://freesound.org/people/Zott820/sounds/209578/">Cash register sound</a> ("cha-ching") by CapsLok remixed for extra depth by Zott820</li>
+      <li><a href="https://pixabay.com/sound-effects/error-message-182475/">Barcode scan error sound</a> by <a href="https://pixabay.com/users/voicebosch-30143949/">VoiceBosch</a> from <a href="https://pixabay.com">Pixabay</a></li>
     </ul>
 
   </body>


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

<!-- Id number of the Linear issue this PR addresses, e.g., WOOMOB-373. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
* Adds a link on license for the error sound we use
* Fixes the layout. Before it was not full screen webview

### Steps to reproduce
<!-- Step-by-step testing instructions. For new user flows, consider instead stating the goal of the workflow and see if your PR reviewer can accomplish the workflow without specific steps! -->
* More -> Settings -> Open Source Licences

### Images/gif
<!-- Include before and after images or gifs when appropriate. -->

https://github.com/user-attachments/assets/d5f87c81-bfd8-4609-b70e-2c368cc0ff45


- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->