### PR TITLE
[WOOMOB-615] Remove mentions of GTIN in code

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/common/data/WooPosProductsCache.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/common/data/WooPosProductsCache.kt
@@ -13,7 +13,7 @@ interface WooPosProductsCache {
 
     suspend fun getProductById(productId: Long): Product?
 
-    suspend fun getProductByGtin(gtin: String): Product?
+    suspend fun getProductByGlobalUniqueIdentifier(globalUniqueIdentifier: String): Product?
 
     suspend fun updateProduct(product: Product)
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/common/data/WooPosProductsInMemoryCache.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/common/data/WooPosProductsInMemoryCache.kt
@@ -40,8 +40,8 @@ class WooPosProductsInMemoryCache @Inject constructor() : WooPosProductsCache {
         return productsCache[productId]
     }
 
-    override suspend fun getProductByGtin(gtin: String): Product? {
-        return productsCache.values.find { it.globalUniqueId == gtin }
+    override suspend fun getProductByGlobalUniqueIdentifier(globalUniqueIdentifier: String): Product? {
+        return productsCache.values.find { it.globalUniqueId == globalUniqueIdentifier }
     }
 
     override suspend fun clear() = mutex.withLock {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/common/data/searchbyidentifier/WooPosSearchByIdentifierRemote.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/common/data/searchbyidentifier/WooPosSearchByIdentifierRemote.kt
@@ -50,7 +50,7 @@ class WooPosSearchByIdentifierRemote @Inject constructor(
         identifier: String,
         format: WooPosBarcodeFormat
     ): WooPosSearchByIdentifierResult = coroutineScope {
-        val gtinSearchDeferred = async {
+        val globalUniqueIdentifierSearchDeferred = async {
             searchAndConvertResult { searchProductsByGlobalUniqueId(identifier) }
         }
 
@@ -58,11 +58,11 @@ class WooPosSearchByIdentifierRemote @Inject constructor(
             searchAndConvertResult { searchProductsBySku(identifier) }
         }
 
-        val gtinResult = gtinSearchDeferred.await()
+        val globalUniqueIdentifierResult = globalUniqueIdentifierSearchDeferred.await()
 
-        if (gtinResult.isSuccess) {
+        if (globalUniqueIdentifierResult.isSuccess) {
             skuSearchDeferred.cancel()
-            return@coroutineScope gtinResult
+            return@coroutineScope globalUniqueIdentifierResult
         }
 
         val identifierResult = skuSearchDeferred.await()
@@ -73,17 +73,17 @@ class WooPosSearchByIdentifierRemote @Inject constructor(
 
         val identifierWithoutCheckDigit = checkDigitRemover(identifier, format)
         if (identifierWithoutCheckDigit != identifier) {
-            val gtinFallbackDeferred = async {
+            val globalUniqueIdentifierFallbackDeferred = async {
                 searchAndConvertResult { searchProductsByGlobalUniqueId(identifierWithoutCheckDigit) }
             }
             val identifierFallbackDeferred = async {
                 searchAndConvertResult { searchProductsBySku(identifierWithoutCheckDigit) }
             }
 
-            val gtinFallbackResult = gtinFallbackDeferred.await()
-            if (gtinFallbackResult.isSuccess) {
+            val globalUniqueIdentifierFallbackResult = globalUniqueIdentifierFallbackDeferred.await()
+            if (globalUniqueIdentifierFallbackResult.isSuccess) {
                 identifierFallbackDeferred.cancel()
-                return@coroutineScope gtinFallbackResult
+                return@coroutineScope globalUniqueIdentifierFallbackResult
             }
 
             val identifierFallbackResult = identifierFallbackDeferred.await()
@@ -91,9 +91,9 @@ class WooPosSearchByIdentifierRemote @Inject constructor(
                 return@coroutineScope identifierFallbackResult
             }
 
-            prioritizeError(gtinFallbackResult, identifierFallbackResult, gtinResult, identifierResult)
+            prioritizeError(globalUniqueIdentifierFallbackResult, identifierFallbackResult, globalUniqueIdentifierResult, identifierResult)
         } else {
-            prioritizeError(gtinResult, identifierResult)
+            prioritizeError(globalUniqueIdentifierResult, identifierResult)
         }
     }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/common/data/searchbyidentifier/WooPosSearchByIdentifierRemote.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/common/data/searchbyidentifier/WooPosSearchByIdentifierRemote.kt
@@ -91,7 +91,12 @@ class WooPosSearchByIdentifierRemote @Inject constructor(
                 return@coroutineScope identifierFallbackResult
             }
 
-            prioritizeError(globalUniqueIdentifierFallbackResult, identifierFallbackResult, globalUniqueIdentifierResult, identifierResult)
+            prioritizeError(
+                globalUniqueIdentifierFallbackResult,
+                identifierFallbackResult,
+                globalUniqueIdentifierResult,
+                identifierResult
+            )
         } else {
             prioritizeError(globalUniqueIdentifierResult, identifierResult)
         }

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/common/data/searchbyidentifier/WooPosSearchByIdentifierRemoteTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/common/data/searchbyidentifier/WooPosSearchByIdentifierRemoteTest.kt
@@ -586,7 +586,7 @@ class WooPosSearchByIdentifierRemoteTest {
             )
         }
 
-        val gtinErrorEvent = WCProductStore.OnProductsSearched(
+        val globalUniqueIdentifierErrorEvent = WCProductStore.OnProductsSearched(
             globalUniqueIdSearchQuery = identifier,
             searchQuery = null,
             searchResults = emptyList(),
@@ -611,8 +611,8 @@ class WooPosSearchByIdentifierRemoteTest {
 
         advanceTimeBy(1)
 
-        // Send error responses for both GTIN and SKU searches
-        sut.onProductsSearched(gtinErrorEvent)
+        // Send error responses for both Global Unique Identifier and SKU searches
+        sut.onProductsSearched(globalUniqueIdentifierErrorEvent)
         sut.onProductsSearched(skuErrorEvent)
 
         advanceTimeBy(1)


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

<!-- Id number of the Linear issue this PR addresses, e.g., WOOMOB-373. -->
WOOMOB-615

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

This PR renames all mentions of gtin to GlobalUniqueIdentifier, since gtin is just one of the standards which can be put into the `GlobalUniqueIdentifier` field. Calling it GTIN can be misleading, as one might think the value follows the format of GTIN even when it doens't.


### Testing information
<!-- This is your opportunity to break out individual scenarios that need testing (when necessary) and/or include a checklist for the reviewer to go through. Consider documenting the following from your own completed testing: devices used, alternate workflows, edge cases, affected areas, critical flows, areas not tested, and any remaining unknowns. Provide feedback on this new section of the PR template through Sept 30, 2024 to Apps Quality; additional context here: p91TBi-b8z-p2#comment-12036 -->

Green CI is enough.

### Images/gif
<!-- Include before and after images or gifs when appropriate. -->

No user facing changes.

- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->