### PR TITLE
[WOOPRD-589] Update the user facing string for RequestCancelled state

### DIFF
--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -4294,7 +4294,7 @@
     <string name="woopos_cart_barcode_scan_result_product_not_found">Unknown scanned item</string>
     <string name="woopos_cart_barcode_scan_result_unsupported_product">Unsupported item – %s</string>
     <string name="woopos_cart_barcode_scan_result_network_error">No internet connection</string>
-    <string name="woopos_cart_barcode_scan_result_request_cancelled">Request cancelled</string>
+    <string name="woopos_cart_barcode_scan_result_request_cancelled">Unexpected error</string>
     <string name="woopos_clear_cart_button">Clear</string>
 
     <string name="woopos_banner_simple_products_dialog_content_description">Simple, variable and virtual products only dialog</string>


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

<!-- Id number of the Linear issue this PR addresses, e.g., WOOMOB-373. -->

WOOPRD-589

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

Updates the user facing string of `request cancelled` state to `Unexpected error`.

### Testing information
<!-- This is your opportunity to break out individual scenarios that need testing (when necessary) and/or include a checklist for the reviewer to go through. Consider documenting the following from your own completed testing: devices used, alternate workflows, edge cases, affected areas, critical flows, areas not tested, and any remaining unknowns. Provide feedback on this new section of the PR template through Sept 30, 2024 to Apps Quality; additional context here: p91TBi-b8z-p2#comment-12036 -->

I'm not aware of any flow which ends up in the `Request cancelled` state. Previously, it was possible to reproduce it due to a bug in the FluxC layer which was fixed. Either way, I believe displaying `Unexpected error` is a better user-facing text than `Request cancelled` which can be quite confusing:
1. User has no idea what request or cancellation means in this context, those feel more like developer facing words
2. User didn't request any cancellation

While displaying Unexpected error doesn't help the user much, they will at least understand they didn't do anything wrong, the app just entered an unexpected state.

### The tests that have been performed
<!-- To give the reviewer an idea of what could be missed in terms of testing -->

### Images/gif
<!-- Include before and after images or gifs when appropriate. -->

- [ ] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->