### PR TITLE
[WOOMOB-538] Fix duplicated requests in order creation flow

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/OrderCreateEditFormFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/OrderCreateEditFormFragment.kt
@@ -565,14 +565,12 @@ class OrderCreateEditFormFragment :
             }
             new.isUpdatingOrderDraft.takeIfNotEqualTo(old?.isUpdatingOrderDraft) { isUpdatingOrderDraft ->
                 if (isUpdatingOrderDraft) {
-                    // Show overlay with fade in animation
                     binding.orderUpdateOverlay.isVisible = true
                     binding.orderUpdateOverlay.animate()
                         .alpha(1f)
                         .setDuration(ANIMATION_DURATION)
                         .start()
                 } else {
-                    // Hide overlay with fade out animation
                     binding.orderUpdateOverlay.animate()
                         .alpha(0f)
                         .setDuration(ANIMATION_DURATION)

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/OrderCreateEditFormFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/OrderCreateEditFormFragment.kt
@@ -561,6 +561,25 @@ class OrderCreateEditFormFragment :
                 binding.taxRateSelectorSection.isVisible = it.isShown
                 binding.setTaxRateButton.text = it.label
             }
+            new.isUpdatingOrderDraft.takeIfNotEqualTo(old?.isUpdatingOrderDraft) { isUpdatingOrderDraft ->
+                if (isUpdatingOrderDraft) {
+                    // Show overlay with fade in animation
+                    binding.orderUpdateOverlay.isVisible = true
+                    binding.orderUpdateOverlay.animate()
+                        .alpha(1f)
+                        .setDuration(200)
+                        .start()
+                } else {
+                    // Hide overlay with fade out animation
+                    binding.orderUpdateOverlay.animate()
+                        .alpha(0f)
+                        .setDuration(200)
+                        .withEndAction {
+                            binding.orderUpdateOverlay.isVisible = false
+                        }
+                        .start()
+                }
+            }
         }
     }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/OrderCreateEditFormFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/OrderCreateEditFormFragment.kt
@@ -109,6 +109,8 @@ import kotlinx.coroutines.launch
 import org.wordpress.android.util.ToastUtils
 import javax.inject.Inject
 
+private const val ANIMATION_DURATION = 200L
+
 @Suppress("LargeClass")
 @AndroidEntryPoint
 class OrderCreateEditFormFragment :
@@ -567,13 +569,13 @@ class OrderCreateEditFormFragment :
                     binding.orderUpdateOverlay.isVisible = true
                     binding.orderUpdateOverlay.animate()
                         .alpha(1f)
-                        .setDuration(200)
+                        .setDuration(ANIMATION_DURATION)
                         .start()
                 } else {
                     // Hide overlay with fade out animation
                     binding.orderUpdateOverlay.animate()
                         .alpha(0f)
-                        .setDuration(200)
+                        .setDuration(ANIMATION_DURATION)
                         .withEndAction {
                             binding.orderUpdateOverlay.isVisible = false
                         }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/OrderCreateEditViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/OrderCreateEditViewModel.kt
@@ -1421,10 +1421,10 @@ class OrderCreateEditViewModel @Inject constructor(
     /**
      * Monitor order changes, and update the remote draft to update price totals
      */
+    @Suppress("LongMethod")
     private fun monitorOrderChanges() {
         viewModelScope.launch {
-            var orderUpdatedFromRemote = false
-
+            var ignoreIfOrderJustUpdatedFromRemote = false
             val changes =
                 if (mode is Mode.Edit) {
                     _orderDraft.drop(1)
@@ -1439,7 +1439,7 @@ class OrderCreateEditViewModel @Inject constructor(
                     }
                     .filter {
                         // We don't need to sync changes with the remote when the order we just received is from remote.
-                        !orderUpdatedFromRemote
+                        !ignoreIfOrderJustUpdatedFromRemote
                     }
             syncStrategy.syncOrderChanges(changes, retryOrderDraftUpdateTrigger)
                 .collect { updateStatus ->
@@ -1474,8 +1474,8 @@ class OrderCreateEditViewModel @Inject constructor(
                                 showOrderUpdateSnackbar = false,
                                 isEditable = isOrderEditable(updateStatus)
                             )
-                            orderUpdatedFromRemote = true
                             try {
+                                ignoreIfOrderJustUpdatedFromRemote = true
                                 _orderDraft.updateAndGet { currentDraft ->
                                     if (mode is Mode.Creation) {
                                         // Once the order is synced, revert the auto-draft status and keep
@@ -1490,7 +1490,7 @@ class OrderCreateEditViewModel @Inject constructor(
                                     updateAddGiftCardButtonVisibility(it)
                                 }
                             } finally {
-                                orderUpdatedFromRemote = false
+                                ignoreIfOrderJustUpdatedFromRemote = false
                             }
                         }
                     }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/OrderCreateEditViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/OrderCreateEditViewModel.kt
@@ -1423,6 +1423,8 @@ class OrderCreateEditViewModel @Inject constructor(
      */
     private fun monitorOrderChanges() {
         viewModelScope.launch {
+            var orderUpdatedFromRemote = false
+
             val changes =
                 if (mode is Mode.Edit) {
                     _orderDraft.drop(1)
@@ -1434,6 +1436,10 @@ class OrderCreateEditViewModel @Inject constructor(
                 }
                     .map {
                         sanitizeUnsyncedOrderItemsData(it)
+                    }
+                    .filter {
+                        // We don't need to sync changes with the remote when the order we just received is from remote.
+                        !orderUpdatedFromRemote
                     }
             syncStrategy.syncOrderChanges(changes, retryOrderDraftUpdateTrigger)
                 .collect { updateStatus ->
@@ -1468,18 +1474,23 @@ class OrderCreateEditViewModel @Inject constructor(
                                 showOrderUpdateSnackbar = false,
                                 isEditable = isOrderEditable(updateStatus)
                             )
-                            _orderDraft.updateAndGet { currentDraft ->
-                                if (mode is Mode.Creation) {
-                                    // Once the order is synced, revert the auto-draft status and keep
-                                    // the user's selected one
-                                    updateStatus.order.copy(status = currentDraft.status)
-                                } else {
-                                    updateStatus.order
+                            orderUpdatedFromRemote = true
+                            try {
+                                _orderDraft.updateAndGet { currentDraft ->
+                                    if (mode is Mode.Creation) {
+                                        // Once the order is synced, revert the auto-draft status and keep
+                                        // the user's selected one
+                                        updateStatus.order.copy(status = currentDraft.status)
+                                    } else {
+                                        updateStatus.order
+                                    }
+                                }.also {
+                                    updateCouponAndDiscountButtonsState(it)
+                                    updateAddShippingButtonVisibility(it)
+                                    updateAddGiftCardButtonVisibility(it)
                                 }
-                            }.also {
-                                updateCouponAndDiscountButtonsState(it)
-                                updateAddShippingButtonVisibility(it)
-                                updateAddGiftCardButtonVisibility(it)
+                            } finally {
+                                orderUpdatedFromRemote = false
                             }
                         }
                     }
@@ -2013,6 +2024,7 @@ class OrderCreateEditViewModel @Inject constructor(
             !isEditingExistingCustomAmount && orderContainsProductsOrCustomAmounts() -> {
                 triggerEvent(ShowCustomAmountBottomSheet)
             }
+
             else -> {
                 triggerEvent(
                     ShowCustomAmountDialog(

--- a/WooCommerce/src/main/res/layout/fragment_order_create_edit_form.xml
+++ b/WooCommerce/src/main/res/layout/fragment_order_create_edit_form.xml
@@ -190,6 +190,7 @@
         android:background="@color/order_update_overlay_background"
         android:clickable="true"
         android:focusable="true"
+        android:focusableInTouchMode="true"
         app:layout_constraintBottom_toTopOf="@+id/feedback_section"
         app:layout_constraintEnd_toEndOf="@+id/scrollView"
         app:layout_constraintStart_toStartOf="@+id/scrollView"

--- a/WooCommerce/src/main/res/layout/fragment_order_create_edit_form.xml
+++ b/WooCommerce/src/main/res/layout/fragment_order_create_edit_form.xml
@@ -182,4 +182,17 @@
         app:layout_constraintStart_toEndOf="@+id/product_selector_nav_container"
         app:layout_constraintTop_toBottomOf="@id/two_pane_mode_toolbar" />
 
+    <View
+        android:id="@+id/order_update_overlay"
+        android:layout_width="0dp"
+        android:layout_height="0dp"
+        android:visibility="gone"
+        android:background="@color/order_update_overlay_background"
+        android:clickable="true"
+        android:focusable="true"
+        app:layout_constraintBottom_toTopOf="@+id/feedback_section"
+        app:layout_constraintEnd_toEndOf="@+id/scrollView"
+        app:layout_constraintStart_toStartOf="@+id/scrollView"
+        app:layout_constraintTop_toBottomOf="@+id/loadingProgress" />
+
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/WooCommerce/src/main/res/values-night/colors_base.xml
+++ b/WooCommerce/src/main/res/values-night/colors_base.xml
@@ -252,4 +252,9 @@
     <color name="woo_message_surface">@color/woo_purple_20</color>
     <color name="woo_message_on_surface">@color/woo_black</color>
 
+    <!--
+        Order Creation
+    -->
+    <color name="order_update_overlay_background">@color/woo_black_90_alpha_060</color>
+
 </resources>

--- a/WooCommerce/src/main/res/values/colors_base.xml
+++ b/WooCommerce/src/main/res/values/colors_base.xml
@@ -346,4 +346,9 @@
     <color name="woo_message_surface">#1C1C1E</color>
     <color name="woo_message_on_surface">@color/woo_purple_30</color>
 
+    <!--
+        Order Creation
+    -->
+    <color name="order_update_overlay_background">@color/woo_white_alpha_060</color>
+
 </resources>


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

<!-- Id number of the Linear issue this PR addresses, e.g., WOOMOB-373. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

This PR makes two main changes
1. It removes unnecessary requests in the order creation flow in order to speed it up.
- The app pushes all changes to the order model to the remote. However, it does so even when the changes are coming from the backend. When the user creates a new order in the app, the app creates a draft-order send syncs with the backend which is desired. However, when a result comes back, the app identifies an ID was assigned to the order and totals/subtotals/... was assigned => it considers it as a change and pushes the changes to the backend, ignoring the fact that the changes came from backend and the backend knows about them. This PR improves this behavior by not sending this unnecessary request.

2. It adds an unclickable overlay in the order creatino when a remote request is in progress to prevent users from editing the order.
- We have been disabling buttons which aren't supposed to be editable when a request is in progress. However, this solution is extremely prone to error as we often forget to disable newly added buttons. This PR adds an unclickable overlay over the whole section to ensure the order is not editable when it's being synced.

Note: The overlay is added with 500ms delay, since there is a debounce implemented to ensure users can increase quantity of items in the cart by clicking repeatedly on the plus button.


### Testing information
<!-- This is your opportunity to break out individual scenarios that need testing (when necessary) and/or include a checklist for the reviewer to go through. Consider documenting the following from your own completed testing: devices used, alternate workflows, edge cases, affected areas, critical flows, areas not tested, and any remaining unknowns. Provide feedback on this new section of the PR template through Sept 30, 2024 to Apps Quality; additional context here: p91TBi-b8z-p2#comment-12036 -->

- Verify the order is sent to the backend just once after each change - eg. using network inspector.
- Verify the overlay is displayed when the order is being synced.
- Verify the overlay is unclickable - clicks are ignored.
- Verify the overlay disappears when the sync finishes - in both error and success.

Test the above on both a tablet and a phone.

### The tests that have been performed
<!-- To give the reviewer an idea of what could be missed in terms of testing -->

- I've tested the above + I tested order editing mode + dark and light mode.

### Images/gif

https://github.com/user-attachments/assets/c0112681-3131-4cec-9c8c-e536f14744a8


<!-- Include before and after images or gifs when appropriate. -->



- [ ] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->