### PR TITLE
[Shipping labels] Hide "SHOW SHIPMENT DETAILS" button for refunded packages

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/OrderDetailFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/OrderDetailFragment.kt
@@ -446,7 +446,7 @@ class OrderDetailFragment :
         }
         viewModel.shippingLabels.observe(viewLifecycleOwner) {
             lifecycleScope.launch {
-                showShippingLabels(it, viewModel.awaitOrder().currency)
+                showShippingLabels(it, viewModel.awaitOrder().currency, viewModel.isRevampWooShippingEnabled)
             }
         }
         viewModel.subscriptions.observe(viewLifecycleOwner) {
@@ -799,7 +799,11 @@ class OrderDetailFragment :
         )
     }
 
-    private fun showShippingLabels(shippingLabels: List<ShippingLabel>, currency: String) {
+    private fun showShippingLabels(
+        shippingLabels: List<ShippingLabel>,
+        currency: String,
+        isRevampWooShippingEnabled: Boolean
+    ) {
         shippingLabels.whenNotNullNorEmpty {
             with(binding.orderDetailShippingLabelList) {
                 show()
@@ -807,6 +811,7 @@ class OrderDetailFragment :
                     shippingLabels = shippingLabels,
                     productImageMap = productImageMap,
                     formatCurrencyForDisplay = currencyFormatter.buildBigDecimalFormatter(currency),
+                    isRevampWooShippingEnabled = isRevampWooShippingEnabled,
                     productClickListener = this@OrderDetailFragment,
                     shippingLabelClickListener = object : OnShippingLabelClickListener {
                         override fun onRefundRequested(shippingLabel: ShippingLabel) {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/OrderDetailViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/OrderDetailViewModel.kt
@@ -211,7 +211,7 @@ class OrderDetailViewModel @Inject constructor(
 
     private var pluginsInformation: Map<String, WooPlugin> = HashMap()
 
-    private val isRevampWooShippingEnabled: Boolean
+    val isRevampWooShippingEnabled: Boolean
         get() = FeatureFlag.REVAMP_WOO_SHIPPING.isEnabled() &&
             shippingLabelOnboardingRepository.shippingPluginSupport.isWooShippingSupported()
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/adapter/OrderDetailShippingLabelsAdapter.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/adapter/OrderDetailShippingLabelsAdapter.kt
@@ -20,7 +20,6 @@ import com.woocommerce.android.tools.ProductImageMap
 import com.woocommerce.android.ui.orders.OrderProductActionListener
 import com.woocommerce.android.ui.orders.OrderShipmentTrackingHelper
 import com.woocommerce.android.ui.orders.details.adapter.OrderDetailShippingLabelsAdapter.ShippingLabelsViewHolder
-import com.woocommerce.android.util.FeatureFlag
 import com.woocommerce.android.util.StringUtils
 import com.woocommerce.android.widgets.AlignedDividerDecoration
 import java.math.BigDecimal
@@ -29,7 +28,8 @@ class OrderDetailShippingLabelsAdapter(
     private val formatCurrencyForDisplay: (BigDecimal) -> String,
     private val productImageMap: ProductImageMap,
     private val listener: OnShippingLabelClickListener,
-    private val productClickListener: OrderProductActionListener
+    private val productClickListener: OrderProductActionListener,
+    private val isRevampWooShippingEnabled: Boolean
 ) : RecyclerView.Adapter<ShippingLabelsViewHolder>() {
     private val viewPool = RecyclerView.RecycledViewPool()
 
@@ -64,6 +64,7 @@ class OrderDetailShippingLabelsAdapter(
             viewPool,
             productImageMap,
             formatCurrencyForDisplay,
+            isRevampWooShippingEnabled,
             listener,
             productClickListener
         )
@@ -80,6 +81,7 @@ class OrderDetailShippingLabelsAdapter(
         private val viewPool: RecyclerView.RecycledViewPool,
         private val productImageMap: ProductImageMap,
         private val formatCurrencyForDisplay: (BigDecimal) -> String,
+        private val isRevampWooShippingEnabled: Boolean,
         private val listener: OnShippingLabelClickListener,
         private val productClickListener: OrderProductActionListener
     ) : RecyclerView.ViewHolder(
@@ -190,7 +192,7 @@ class OrderDetailShippingLabelsAdapter(
                 }
             }
 
-            if (FeatureFlag.REVAMP_WOO_SHIPPING.isEnabled() && shippingLabel.refund != null) {
+            if (isRevampWooShippingEnabled && shippingLabel.refund != null) {
                 viewBinding.shippingLabelItemViewMore.isVisible = false
             } else {
                 viewBinding.shippingLabelItemViewMore.isVisible = true

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/adapter/OrderDetailShippingLabelsAdapter.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/adapter/OrderDetailShippingLabelsAdapter.kt
@@ -76,6 +76,7 @@ class OrderDetailShippingLabelsAdapter(
 
     override fun getItemCount(): Int = shippingLabels.size
 
+    @Suppress("LongParameterList")
     class ShippingLabelsViewHolder(
         private var viewBinding: OrderDetailShippingLabelListItemBinding,
         private val viewPool: RecyclerView.RecycledViewPool,
@@ -84,9 +85,7 @@ class OrderDetailShippingLabelsAdapter(
         private val isRevampWooShippingEnabled: Boolean,
         private val listener: OnShippingLabelClickListener,
         private val productClickListener: OrderProductActionListener
-    ) : RecyclerView.ViewHolder(
-        viewBinding.root
-    ) {
+    ) : RecyclerView.ViewHolder(viewBinding.root) {
         fun bind(shippingLabel: ShippingLabel) {
             // display product list if product list is not empty
             if (shippingLabel.products.isNotEmpty()) {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/adapter/OrderDetailShippingLabelsAdapter.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/adapter/OrderDetailShippingLabelsAdapter.kt
@@ -20,6 +20,7 @@ import com.woocommerce.android.tools.ProductImageMap
 import com.woocommerce.android.ui.orders.OrderProductActionListener
 import com.woocommerce.android.ui.orders.OrderShipmentTrackingHelper
 import com.woocommerce.android.ui.orders.details.adapter.OrderDetailShippingLabelsAdapter.ShippingLabelsViewHolder
+import com.woocommerce.android.util.FeatureFlag
 import com.woocommerce.android.util.StringUtils
 import com.woocommerce.android.widgets.AlignedDividerDecoration
 import java.math.BigDecimal
@@ -189,20 +190,26 @@ class OrderDetailShippingLabelsAdapter(
                 }
             }
 
-            // click on view more details section
-            viewBinding.shippingLabelItemViewMore.setOnClickListener {
-                val isChecked = viewBinding.shippingLabelItemViewMoreButtonImage.rotation == 0F
-                if (isChecked) {
-                    viewBinding.shippingLabelItemMorePanel.expand()
-                    viewBinding.shippingLabelItemViewMoreButtonImage.animate().rotation(180F).setDuration(200).start()
-                    with(viewBinding.shippingLabelItemViewMoreButtonTitle) {
-                        text = context.getString(R.string.orderdetail_shipping_label_item_hide_shipping)
-                    }
-                } else {
-                    viewBinding.shippingLabelItemMorePanel.collapse()
-                    viewBinding.shippingLabelItemViewMoreButtonImage.animate().rotation(0F).setDuration(200).start()
-                    with(viewBinding.shippingLabelItemViewMoreButtonTitle) {
-                        text = context.getString(R.string.orderdetail_shipping_label_item_show_shipping)
+            if (FeatureFlag.REVAMP_WOO_SHIPPING.isEnabled() && shippingLabel.refund != null) {
+                viewBinding.shippingLabelItemViewMore.isVisible = false
+            } else {
+                viewBinding.shippingLabelItemViewMore.isVisible = true
+                // click on view more details section
+                viewBinding.shippingLabelItemViewMore.setOnClickListener {
+                    val isChecked = viewBinding.shippingLabelItemViewMoreButtonImage.rotation == 0F
+                    if (isChecked) {
+                        viewBinding.shippingLabelItemMorePanel.expand()
+                        viewBinding.shippingLabelItemViewMoreButtonImage.animate().rotation(180F).setDuration(200)
+                            .start()
+                        with(viewBinding.shippingLabelItemViewMoreButtonTitle) {
+                            text = context.getString(R.string.orderdetail_shipping_label_item_hide_shipping)
+                        }
+                    } else {
+                        viewBinding.shippingLabelItemMorePanel.collapse()
+                        viewBinding.shippingLabelItemViewMoreButtonImage.animate().rotation(0F).setDuration(200).start()
+                        with(viewBinding.shippingLabelItemViewMoreButtonTitle) {
+                            text = context.getString(R.string.orderdetail_shipping_label_item_show_shipping)
+                        }
                     }
                 }
             }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/views/OrderDetailShippingLabelsView.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/views/OrderDetailShippingLabelsView.kt
@@ -21,6 +21,7 @@ class OrderDetailShippingLabelsView @JvmOverloads constructor(
 ) : ConstraintLayout(ctx, attrs, defStyleAttr) {
     private val binding = OrderDetailShippingLabelListBinding.inflate(LayoutInflater.from(ctx), this, true)
 
+    @Suppress("LongParameterList")
     fun updateShippingLabels(
         shippingLabels: List<ShippingLabel>,
         productImageMap: ProductImageMap,

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/views/OrderDetailShippingLabelsView.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/views/OrderDetailShippingLabelsView.kt
@@ -25,6 +25,7 @@ class OrderDetailShippingLabelsView @JvmOverloads constructor(
         shippingLabels: List<ShippingLabel>,
         productImageMap: ProductImageMap,
         formatCurrencyForDisplay: (BigDecimal) -> String,
+        isRevampWooShippingEnabled: Boolean,
         productClickListener: OrderProductActionListener,
         shippingLabelClickListener: OnShippingLabelClickListener
     ) {
@@ -33,7 +34,8 @@ class OrderDetailShippingLabelsView @JvmOverloads constructor(
                 formatCurrencyForDisplay = formatCurrencyForDisplay,
                 productImageMap = productImageMap,
                 listener = shippingLabelClickListener,
-                productClickListener = productClickListener
+                productClickListener = productClickListener,
+                isRevampWooShippingEnabled = isRevampWooShippingEnabled
             )
         binding.shippingLabelList.apply {
             setHasFixedSize(true)

--- a/WooCommerce/src/main/res/layout/order_detail_shipping_label_list_item.xml
+++ b/WooCommerce/src/main/res/layout/order_detail_shipping_label_list_item.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<com.google.android.material.card.MaterialCardView
-    xmlns:android="http://schemas.android.com/apk/res/android"
+<com.google.android.material.card.MaterialCardView xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
     style="@style/Woo.Card"
@@ -34,10 +33,10 @@
                 style="@style/Woo.ImageButton.More"
                 android:contentDescription="@string/orderdetail_shipping_label_item_menu"
                 android:scaleType="centerInside"
+                android:visibility="gone"
                 app:layout_constraintBottom_toBottomOf="parent"
                 app:layout_constraintEnd_toEndOf="parent"
                 app:layout_constraintTop_toTopOf="parent"
-                android:visibility="gone"
                 tools:visibility="visible" />
         </androidx.constraintlayout.widget.ConstraintLayout>
 
@@ -51,6 +50,7 @@
             android:contentDescription="@string/orderdetail_shipping_label_item_show_shipping"
             android:focusable="true"
             android:orientation="horizontal">
+
             <com.google.android.material.textview.MaterialTextView
                 android:id="@+id/shippingLabelList_countButtonTitle"
                 style="@style/Woo.Button.TextButton.Expander"
@@ -62,12 +62,13 @@
                 android:importantForAccessibility="no"
                 android:paddingStart="@dimen/major_100"
                 android:paddingEnd="@dimen/major_100"
-                tools:text="@string/shipping_label_items_count_placeholder"
                 android:textAlignment="textStart"
                 app:layout_constraintBottom_toBottomOf="parent"
                 app:layout_constraintEnd_toStartOf="@+id/shippingLabelList_countButtonImage"
                 app:layout_constraintStart_toStartOf="parent"
-                app:layout_constraintTop_toTopOf="parent" />
+                app:layout_constraintTop_toTopOf="parent"
+                tools:text="@string/shipping_label_items_count_placeholder" />
+
             <ImageView
                 android:id="@+id/shippingLabelList_countButtonImage"
                 android:layout_width="@dimen/min_tap_target"
@@ -78,10 +79,10 @@
                 android:importantForAccessibility="no"
                 android:padding="@dimen/minor_100"
                 android:src="@drawable/ic_arrow_down"
-                app:tint="@color/color_on_surface_disabled"
                 app:layout_constraintBottom_toBottomOf="parent"
                 app:layout_constraintEnd_toEndOf="parent"
-                app:layout_constraintTop_toTopOf="parent" />
+                app:layout_constraintTop_toTopOf="parent"
+                app:tint="@color/color_on_surface_disabled" />
         </androidx.constraintlayout.widget.ConstraintLayout>
 
         <!-- Product List -->
@@ -90,9 +91,9 @@
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:nestedScrollingEnabled="false"
+            android:visibility="gone"
             tools:itemCount="3"
             tools:listitem="@layout/order_detail_product_list_item"
-            android:visibility="gone"
             tools:visibility="visible" />
 
         <!-- Print shipping label -->
@@ -101,11 +102,11 @@
             style="@style/Woo.Button.Outlined"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:text="@string/orderdetail_shipping_label_print"
-            android:layout_marginTop="@dimen/minor_100"
-            android:layout_marginBottom="@dimen/minor_100"
             android:layout_marginStart="@dimen/major_125"
+            android:layout_marginTop="@dimen/minor_100"
             android:layout_marginEnd="@dimen/major_125"
+            android:layout_marginBottom="@dimen/minor_100"
+            android:text="@string/orderdetail_shipping_label_print"
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintTop_toTopOf="parent" />


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

<!-- Id number of the Linear issue this PR addresses, e.g., WOOMOB-373. -->
Closes WOOMOB-370

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
This hides "SHOW SHIPMENT DETAILS" button on the order detail screen for the refunded labels. This case works only when revamp shipping label feature flag is enabled.

Decision: p1747276768022719/1747218047.842929-slack-C03L1NF1EA3

### Steps to reproduce
<!-- Step-by-step testing instructions. For new user flows, consider instead stating the goal of the workflow and see if your PR reviewer can accomplish the workflow without specific steps! -->
1. You need an order that has some packages refunded and some not refunded. If you don't have one, create it.
2. Open the order detail screen.
3. You can disable `FeatureFlag.REVAMP_WOO_SHIPPING` in the code, but it's not necessary. When it's disabled, the button should be visible for refunded packages. I've already tested this case.

### The tests that have been performed
<!-- To give the reviewer an idea of what could be missed in terms of testing -->
Screens below.

### Images/gif
<!-- Include before and after images or gifs when appropriate. -->
|Before|After|
|-|-|
|<img src="https://github.com/user-attachments/assets/bde82e5f-fe7e-4c29-b4db-44af6c56ed1d" width=350>|<img src="https://github.com/user-attachments/assets/e00b66a2-9612-4710-ab85-78afb86a5b10" width=350>|

- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->