### PR TITLE
[WOOMOB-623] Make filter dialogs on tablets for orders and products

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -3,7 +3,7 @@
 *** For entries which are touching the Android Wear app's, start entry with `[WEAR]` too.
 22.7
 -----
-
+- [*] Improved filtering UI in the order's screen [https://github.com/woocommerce/woocommerce-android/pull/14212]
 
 22.6
 -----

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/filters/OrderFilterCategoriesFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/filters/OrderFilterCategoriesFragment.kt
@@ -15,7 +15,6 @@ import com.woocommerce.android.R
 import com.woocommerce.android.databinding.FragmentOrderFilterListBinding
 import com.woocommerce.android.extensions.edgeToEdgeHandlingForNavigationAndStatusBar
 import com.woocommerce.android.extensions.handleResult
-import com.woocommerce.android.extensions.isTwoPanesShouldBeUsed
 import com.woocommerce.android.extensions.navigateBackWithNotice
 import com.woocommerce.android.extensions.navigateSafely
 import com.woocommerce.android.model.Order
@@ -36,7 +35,6 @@ import com.woocommerce.android.ui.products.selector.ProductSelectorViewModel.Sel
 import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.Exit
 import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.ShowDialog
 import dagger.hilt.android.AndroidEntryPoint
-import org.wordpress.android.util.DisplayUtils
 
 @AndroidEntryPoint
 class OrderFilterCategoriesFragment :
@@ -47,8 +45,6 @@ class OrderFilterCategoriesFragment :
     private val binding get() = _binding!!
     companion object {
         const val KEY_UPDATED_FILTER_OPTIONS = "key_updated_filter_options"
-        const val TABLET_LANDSCAPE_WIDTH_RATIO = 0.55f
-        const val TABLET_LANDSCAPE_HEIGHT_RATIO = 0.6f
     }
 
     private val viewModel: OrderFilterCategoriesViewModel by viewModels()
@@ -125,24 +121,11 @@ class OrderFilterCategoriesFragment :
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-
-        if (requireContext().isTwoPanesShouldBeUsed) {
-            setStyle(STYLE_NO_TITLE, R.style.Theme_Woo_Dialog_RoundedCorners_NoMinWidth)
-        } else {
-            /* This draws the dialog as full screen */
-            setStyle(STYLE_NO_TITLE, R.style.Theme_Woo)
-        }
+        setStyle(STYLE_NO_TITLE, R.style.Theme_Woo)
     }
 
     override fun onStart() {
         super.onStart()
-        if (requireContext().isTwoPanesShouldBeUsed) {
-            dialog?.window?.setLayout(
-                (DisplayUtils.getWindowPixelWidth(requireContext()) * TABLET_LANDSCAPE_WIDTH_RATIO).toInt(),
-                (DisplayUtils.getWindowPixelHeight(requireContext()) * TABLET_LANDSCAPE_HEIGHT_RATIO).toInt()
-            )
-        }
-
         dialog?.window?.let {
             WindowCompat.setDecorFitsSystemWindows(it, false)
         }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/selector/ProductSelectorScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/selector/ProductSelectorScreen.kt
@@ -33,7 +33,6 @@ import androidx.compose.material.Scaffold
 import androidx.compose.material.Text
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
-import androidx.compose.material.icons.filled.Close
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.livedata.observeAsState
@@ -96,11 +95,7 @@ fun ProductSelectorScreen(
                 Toolbar(
                     title = state.screenTitleOverride
                         ?: stringResource(id = string.coupon_conditions_products_select_products_title),
-                    navigationIcon = if (state.searchState.isActive) {
-                        Icons.AutoMirrored.Filled.ArrowBack
-                    } else {
-                        Icons.Filled.Close
-                    },
+                    navigationIcon = Icons.AutoMirrored.Filled.ArrowBack,
                     onNavigationButtonClick = viewModel::onNavigateBack,
                     windowInsets = if (handleInsets) AppBarDefaults.topAppBarWindowInsets else WindowInsets(0),
                 )

--- a/WooCommerce/src/main/res/layout/fragment_order_filter_list.xml
+++ b/WooCommerce/src/main/res/layout/fragment_order_filter_list.xml
@@ -2,6 +2,7 @@
 <androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
+    android:background="?attr/colorSurface"
     android:layout_width="match_parent"
     android:layout_height="match_parent">
 


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

<!-- Id number of the Linear issue this PR addresses, e.g., WOOMOB-373. -->
WOOMOB-623
### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

The PR makes filtering of the product and orders more consistent between each other.

Also, it fixes the white space in the dark mode

Initially I thought that it should be dialogs on both places but as there is a whole flow with navigation then it should be full screen both on tablet and phones

As on orders we still use dialogs for inner filtering screens I created an issue on that

### Steps to reproduce
<!-- Step-by-step testing instructions. For new user flows, consider instead stating the goal of the workflow and see if your PR reviewer can accomplish the workflow without specific steps! -->
* Order -> Filters
* Products -> Filters

Notice that at least the "parent" filter screen is fullscreen in both places. 

### Testing information
<!-- This is your opportunity to break out individual scenarios that need testing (when necessary) and/or include a checklist for the reviewer to go through. Consider documenting the following from your own completed testing: devices used, alternate workflows, edge cases, affected areas, critical flows, areas not tested, and any remaining unknowns. Provide feedback on this new section of the PR template through Sept 30, 2024 to Apps Quality; additional context here: p91TBi-b8z-p2#comment-12036 -->
Validate that on the phones there is no regression or changes

### The tests that have been performed
<!-- To give the reviewer an idea of what could be missed in terms of testing -->
Above

### Images/gif
<!-- Include before and after images or gifs when appropriate. -->
Before:
<img width="1265" alt="image" src="https://github.com/user-attachments/assets/a4714ec4-f975-4829-adca-9d6455fc2e2a" />

After
<img width="678" alt="image" src="https://github.com/user-attachments/assets/9331ee89-023e-4e43-b3e2-48a6695de892" />


- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->