### PR TITLE
[WOOMOB-625][Order List] Order and product filtering is not consistent on the tablets

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/customerlist/CustomerListDialogFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/customerlist/CustomerListDialogFragment.kt
@@ -13,33 +13,23 @@ import androidx.navigation.fragment.findNavController
 import com.woocommerce.android.R
 import com.woocommerce.android.analytics.AnalyticsTracker
 import com.woocommerce.android.extensions.edgeToEdgeForInLandscape
-import com.woocommerce.android.extensions.isTwoPanesShouldBeUsed
 import com.woocommerce.android.extensions.navigateBackWithResult
 import com.woocommerce.android.extensions.navigateSafely
 import com.woocommerce.android.ui.compose.theme.WooThemeWithBackground
 import com.woocommerce.android.viewmodel.MultiLiveEvent
 import dagger.hilt.android.AndroidEntryPoint
-import org.wordpress.android.util.DisplayUtils
 
 @AndroidEntryPoint
 class CustomerListDialogFragment : DialogFragment() {
     companion object {
         const val KEY_CUSTOMER_RESULT = "customer_model"
-        private const val TABLET_LANDSCAPE_WIDTH_RATIO = 0.55f
-        private const val TABLET_LANDSCAPE_HEIGHT_RATIO = 0.6f
     }
 
     private val viewModel by viewModels<CustomerListSelectionViewModel>()
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-
-        if (requireContext().isTwoPanesShouldBeUsed) {
-            setStyle(STYLE_NO_TITLE, R.style.Theme_Woo_Dialog_RoundedCorners_NoMinWidth)
-        } else {
-            /* This draws the dialog as full screen */
-            setStyle(STYLE_NO_TITLE, R.style.Theme_Woo)
-        }
+        setStyle(STYLE_NO_TITLE, R.style.Theme_Woo)
     }
 
     override fun onCreateView(
@@ -89,12 +79,6 @@ class CustomerListDialogFragment : DialogFragment() {
 
     override fun onStart() {
         super.onStart()
-        if (requireContext().isTwoPanesShouldBeUsed) {
-            dialog?.window?.setLayout(
-                (DisplayUtils.getWindowPixelWidth(requireContext()) * TABLET_LANDSCAPE_WIDTH_RATIO).toInt(),
-                (DisplayUtils.getWindowPixelHeight(requireContext()) * TABLET_LANDSCAPE_HEIGHT_RATIO).toInt()
-            )
-        }
         dialog?.window?.let {
             WindowCompat.setDecorFitsSystemWindows(it, false)
         }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/filters/OrderFilterOptionsFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/filters/OrderFilterOptionsFragment.kt
@@ -11,7 +11,6 @@ import androidx.recyclerview.widget.LinearLayoutManager
 import com.woocommerce.android.R
 import com.woocommerce.android.databinding.FragmentOrderFilterListBinding
 import com.woocommerce.android.extensions.edgeToEdgeHandlingForNavigationAndStatusBar
-import com.woocommerce.android.extensions.isTwoPanesShouldBeUsed
 import com.woocommerce.android.extensions.navigateBackWithNotice
 import com.woocommerce.android.extensions.navigateBackWithResult
 import com.woocommerce.android.extensions.showDateRangePicker
@@ -24,7 +23,6 @@ import com.woocommerce.android.ui.orders.filters.model.OrderFilterEvent.ShowCust
 import com.woocommerce.android.ui.orders.filters.model.OrderFilterOptionUiModel
 import com.woocommerce.android.ui.orders.list.OrderListFragment
 import dagger.hilt.android.AndroidEntryPoint
-import org.wordpress.android.util.DisplayUtils
 
 @AndroidEntryPoint
 class OrderFilterOptionsFragment :
@@ -33,23 +31,13 @@ class OrderFilterOptionsFragment :
 
     private var _binding: FragmentOrderFilterListBinding? = null
     private val binding get() = _binding!!
-    private companion object {
-        const val TABLET_LANDSCAPE_WIDTH_RATIO = 0.55f
-        const val TABLET_LANDSCAPE_HEIGHT_RATIO = 0.6f
-    }
 
     private val viewModel: OrderFilterOptionsViewModel by viewModels()
     lateinit var orderFilterOptionAdapter: OrderFilterOptionAdapter
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-
-        if (requireContext().isTwoPanesShouldBeUsed) {
-            setStyle(STYLE_NO_TITLE, R.style.Theme_Woo_Dialog_RoundedCorners_NoMinWidth)
-        } else {
-            /* This draws the dialog as full screen */
-            setStyle(STYLE_NO_TITLE, R.style.Theme_Woo)
-        }
+        setStyle(STYLE_NO_TITLE, R.style.Theme_Woo)
     }
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
@@ -67,12 +55,6 @@ class OrderFilterOptionsFragment :
 
     override fun onStart() {
         super.onStart()
-        if (requireContext().isTwoPanesShouldBeUsed) {
-            dialog?.window?.setLayout(
-                (DisplayUtils.getWindowPixelWidth(requireContext()) * TABLET_LANDSCAPE_WIDTH_RATIO).toInt(),
-                (DisplayUtils.getWindowPixelHeight(requireContext()) * TABLET_LANDSCAPE_HEIGHT_RATIO).toInt()
-            )
-        }
         dialog?.window?.let {
             WindowCompat.setDecorFitsSystemWindows(it, false)
         }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/selector/ProductSelectorDialogFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/selector/ProductSelectorDialogFragment.kt
@@ -13,7 +13,6 @@ import androidx.navigation.fragment.findNavController
 import androidx.navigation.fragment.navArgs
 import com.woocommerce.android.R
 import com.woocommerce.android.extensions.edgeToEdgeForInLandscape
-import com.woocommerce.android.extensions.isTwoPanesShouldBeUsed
 import com.woocommerce.android.extensions.navigateBackWithResult
 import com.woocommerce.android.ui.compose.theme.WooThemeWithBackground
 import com.woocommerce.android.ui.products.ProductNavigationTarget
@@ -22,15 +21,12 @@ import com.woocommerce.android.ui.products.selector.ProductSelectorViewModel.Sel
 import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.Exit
 import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.ExitWithResult
 import dagger.hilt.android.AndroidEntryPoint
-import org.wordpress.android.util.DisplayUtils
 import javax.inject.Inject
 
 @AndroidEntryPoint
 class ProductSelectorDialogFragment : DialogFragment() {
     companion object {
         const val PRODUCT_SELECTOR_RESULT = "product-selector-result"
-        private const val TABLET_LANDSCAPE_WIDTH_RATIO = 0.55f
-        private const val TABLET_LANDSCAPE_HEIGHT_RATIO = 0.6f
     }
 
     @Inject
@@ -42,13 +38,7 @@ class ProductSelectorDialogFragment : DialogFragment() {
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-
-        if (requireContext().isTwoPanesShouldBeUsed) {
-            setStyle(STYLE_NO_TITLE, R.style.Theme_Woo_Dialog_RoundedCorners_NoMinWidth)
-        } else {
-            /* This draws the dialog as full screen */
-            setStyle(STYLE_NO_TITLE, R.style.Theme_Woo)
-        }
+        setStyle(STYLE_NO_TITLE, R.style.Theme_Woo)
 
         if (args.selectionHandling != ProductSelectorViewModel.SelectionHandling.SIMPLE) {
             // If we want to support the other handling, we need to make all of the destinations as dialogs
@@ -79,12 +69,6 @@ class ProductSelectorDialogFragment : DialogFragment() {
 
     override fun onStart() {
         super.onStart()
-        if (requireContext().isTwoPanesShouldBeUsed) {
-            dialog?.window?.setLayout(
-                (DisplayUtils.getWindowPixelWidth(requireContext()) * TABLET_LANDSCAPE_WIDTH_RATIO).toInt(),
-                (DisplayUtils.getWindowPixelHeight(requireContext()) * TABLET_LANDSCAPE_HEIGHT_RATIO).toInt()
-            )
-        }
         dialog?.window?.let {
             WindowCompat.setDecorFitsSystemWindows(it, false)
         }


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

<!-- Id number of the Linear issue this PR addresses, e.g., WOOMOB-373. -->

WOOMOB-625

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

The PR makes the filter options be full screen to match the products filters on tablets

### Steps to reproduce
<!-- Step-by-step testing instructions. For new user flows, consider instead stating the goal of the workflow and see if your PR reviewer can accomplish the workflow without specific steps! -->
* Order list -> filters -> select all the filters

### Testing information
<!-- This is your opportunity to break out individual scenarios that need testing (when necessary) and/or include a checklist for the reviewer to go through. Consider documenting the following from your own completed testing: devices used, alternate workflows, edge cases, affected areas, critical flows, areas not tested, and any remaining unknowns. Provide feedback on this new section of the PR template through Sept 30, 2024 to Apps Quality; additional context here: p91TBi-b8z-p2#comment-12036 -->
Test both on tablets and phones

### The tests that have been performed
<!-- To give the reviewer an idea of what could be missed in terms of testing -->
Above

### Images/gif
<!-- Include before and after images or gifs when appropriate. -->



https://github.com/user-attachments/assets/3c40e922-cf49-4a96-a4ae-f220266d1420



- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->