### PR TITLE
[Shipping Labels] Handle adding new payment methods in the WebView

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/compose/component/Buttons.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/compose/component/Buttons.kt
@@ -4,6 +4,7 @@ import android.content.res.Configuration
 import androidx.compose.foundation.BorderStroke
 import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
@@ -20,8 +21,10 @@ import androidx.compose.material.Button
 import androidx.compose.material.ButtonColors
 import androidx.compose.material.ButtonDefaults
 import androidx.compose.material.ButtonElevation
+import androidx.compose.material.CircularProgressIndicator
 import androidx.compose.material.ExperimentalMaterialApi
 import androidx.compose.material.Icon
+import androidx.compose.material.LocalContentColor
 import androidx.compose.material.LocalRippleConfiguration
 import androidx.compose.material.MaterialTheme
 import androidx.compose.material.OutlinedButton
@@ -38,6 +41,7 @@ import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.alpha
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.Shape
 import androidx.compose.ui.graphics.vector.ImageVector
@@ -100,6 +104,7 @@ fun WCColoredButton(
     trailingIcon: @Composable (() -> Unit)? = null,
     interactionSource: MutableInteractionSource = remember { MutableInteractionSource() },
     enabled: Boolean = true,
+    loading: Boolean = false,
     contentPadding: PaddingValues = ButtonDefaults.ContentPadding,
     colors: ButtonColors = ButtonDefaults.buttonColors(
         contentColor = colorResource(id = R.color.woo_white),
@@ -109,21 +114,36 @@ fun WCColoredButton(
     ),
 ) {
     WCColoredButton(
-        onClick = onClick,
+        onClick = { if (!loading) onClick() },
         modifier = modifier,
         enabled = enabled,
         contentPadding = contentPadding,
         interactionSource = interactionSource,
         colors = colors
     ) {
-        if (leadingIcon != null) {
-            leadingIcon()
-            Spacer(modifier = Modifier.width(dimensionResource(id = R.dimen.minor_100)))
-        }
-        Text(text = text)
-        if (trailingIcon != null) {
-            Spacer(modifier = Modifier.width(dimensionResource(id = R.dimen.minor_100)))
-            trailingIcon()
+        Box {
+            if (loading) {
+                CircularProgressIndicator(
+                    color = LocalContentColor.current,
+                    modifier = Modifier
+                        .size(24.dp)
+                        .align(Alignment.Center)
+                )
+            }
+            Row(
+                verticalAlignment = Alignment.CenterVertically,
+                modifier = Modifier.alpha(if (loading) 0f else 1f)
+            ) {
+                if (leadingIcon != null) {
+                    leadingIcon()
+                    Spacer(modifier = Modifier.width(dimensionResource(id = R.dimen.minor_100)))
+                }
+                Text(text = text)
+                if (trailingIcon != null) {
+                    Spacer(modifier = Modifier.width(dimensionResource(id = R.dimen.minor_100)))
+                    trailingIcon()
+                }
+            }
         }
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/ShippingLabelSampleData.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/ShippingLabelSampleData.kt
@@ -56,7 +56,8 @@ object ShippingLabelSampleData {
 
     fun getPaymentOptions(countOfPaymentMethods: Int = 3) = PaymentMethodOptions(
         selectedPaymentId = if (countOfPaymentMethods > 0) 1 else null,
-        paymentMethods = List(countOfPaymentMethods) { getPaymentMethod(it) }
+        paymentMethods = List(countOfPaymentMethods) { getPaymentMethod(it) },
+        addPaymentMethodUrl = "https://example.com/add-payment-method"
     )
 
     fun getPaymentMethod(index: Int = 0) = PaymentMethodModel(

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/models/AccountSettingsModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/models/AccountSettingsModel.kt
@@ -28,7 +28,8 @@ data class StoreOptionsModel(
 
 data class PaymentMethodOptions(
     val selectedPaymentId: Int?,
-    val paymentMethods: List<PaymentMethodModel>
+    val paymentMethods: List<PaymentMethodModel>,
+    val addPaymentMethodUrl: String
 ) {
     val selectedPaymentMethod: PaymentMethodModel?
         get() = paymentMethods.find { it.paymentMethodId == selectedPaymentId }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/networking/DTOs.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/networking/DTOs.kt
@@ -31,7 +31,8 @@ data class FormDataDTO(
 )
 
 data class FormMetaDTO(
-    @SerializedName("payment_methods") val paymentMethods: List<PaymentMethodDTO>
+    @SerializedName("payment_methods") val paymentMethods: List<PaymentMethodDTO>,
+    @SerializedName("add_payment_method_url") val addPaymentMethodUrl: String,
 )
 
 data class PaymentMethodDTO(

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/networking/WooShippingNetworkingMapper.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/networking/WooShippingNetworkingMapper.kt
@@ -46,7 +46,8 @@ class WooShippingNetworkingMapper @Inject constructor(
                             cardDigits = paymentMethod.cardDigits,
                             expiry = paymentMethod.expiry
                         )
-                    }
+                    },
+                    addPaymentMethodUrl = formMeta.addPaymentMethodUrl
                 )
             )
         }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/payment/WooShippingEditPaymentDialogFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/payment/WooShippingEditPaymentDialogFragment.kt
@@ -7,6 +7,9 @@ import android.view.ViewGroup
 import androidx.compose.ui.platform.ComposeView
 import androidx.compose.ui.platform.ViewCompositionStrategy
 import androidx.fragment.app.viewModels
+import androidx.navigation.fragment.findNavController
+import com.woocommerce.android.NavGraphMainDirections
+import com.woocommerce.android.ui.common.webview.AuthenticatedWebViewViewModel
 import com.woocommerce.android.ui.compose.theme.WooTheme
 import com.woocommerce.android.widgets.WCBottomSheetDialogFragment
 import dagger.hilt.android.AndroidEntryPoint
@@ -27,5 +30,30 @@ class WooShippingEditPaymentDialogFragment : WCBottomSheetDialogFragment() {
                 }
             }
         }
+    }
+
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
+        handleEvents()
+    }
+
+    private fun handleEvents() {
+        viewModel.event.observe(viewLifecycleOwner) { event ->
+            when (event) {
+                is WooShippingEditPaymentViewModel.ShowPaymentMethodAddWebView -> {
+                    showWebView(event.url, event.successUrl)
+                }
+            }
+        }
+    }
+
+    private fun showWebView(url: String, exitUrl: String) {
+        findNavController(R.id.nav_host_fragment_main).navigate(
+            NavGraphMainDirections.actionGlobalAuthenticatedWebViewFragment(
+                urlToLoad = url,
+                urlsToTriggerExit = arrayOf(exitUrl),
+                urlComparisonMode = AuthenticatedWebViewViewModel.UrlComparisonMode.PARTIAL
+            )
+        )
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/payment/WooShippingEditPaymentDialogFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/payment/WooShippingEditPaymentDialogFragment.kt
@@ -7,8 +7,11 @@ import android.view.ViewGroup
 import androidx.compose.ui.platform.ComposeView
 import androidx.compose.ui.platform.ViewCompositionStrategy
 import androidx.fragment.app.viewModels
-import androidx.navigation.fragment.findNavController
 import com.woocommerce.android.NavGraphMainDirections
+import com.woocommerce.android.R
+import com.woocommerce.android.extensions.findNavController
+import com.woocommerce.android.extensions.handleNotice
+import com.woocommerce.android.ui.common.webview.AuthenticatedWebViewFragment
 import com.woocommerce.android.ui.common.webview.AuthenticatedWebViewViewModel
 import com.woocommerce.android.ui.compose.theme.WooTheme
 import com.woocommerce.android.widgets.WCBottomSheetDialogFragment
@@ -35,6 +38,7 @@ class WooShippingEditPaymentDialogFragment : WCBottomSheetDialogFragment() {
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
         handleEvents()
+        handleResults()
     }
 
     private fun handleEvents() {
@@ -44,6 +48,12 @@ class WooShippingEditPaymentDialogFragment : WCBottomSheetDialogFragment() {
                     showWebView(event.url, event.successUrl)
                 }
             }
+        }
+    }
+
+    private fun handleResults() {
+        handleNotice(AuthenticatedWebViewFragment.WEBVIEW_RESULT, navHostId = R.id.nav_host_fragment_main) {
+            viewModel.onPaymentMethodAdded()
         }
     }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/payment/WooShippingEditPaymentDialogFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/payment/WooShippingEditPaymentDialogFragment.kt
@@ -7,13 +7,10 @@ import android.view.ViewGroup
 import androidx.compose.ui.platform.ComposeView
 import androidx.compose.ui.platform.ViewCompositionStrategy
 import androidx.fragment.app.viewModels
-import com.woocommerce.android.NavGraphMainDirections
-import com.woocommerce.android.R
-import com.woocommerce.android.extensions.findNavController
-import com.woocommerce.android.extensions.handleNotice
+import androidx.lifecycle.distinctUntilChanged
+import androidx.lifecycle.map
+import com.google.android.material.bottomsheet.BottomSheetDialog
 import com.woocommerce.android.ui.base.UIMessageResolver
-import com.woocommerce.android.ui.common.webview.AuthenticatedWebViewFragment
-import com.woocommerce.android.ui.common.webview.AuthenticatedWebViewViewModel
 import com.woocommerce.android.ui.compose.theme.WooTheme
 import com.woocommerce.android.viewmodel.MultiLiveEvent
 import com.woocommerce.android.widgets.WCBottomSheetDialogFragment
@@ -44,33 +41,24 @@ class WooShippingEditPaymentDialogFragment : WCBottomSheetDialogFragment() {
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
         handleEvents()
-        handleResults()
+        disableDraggingOnWebViewState()
     }
 
     private fun handleEvents() {
         viewModel.event.observe(viewLifecycleOwner) { event ->
             when (event) {
-                is WooShippingEditPaymentViewModel.ShowPaymentMethodAddWebView -> {
-                    showWebView(event.url, event.successUrl)
-                }
                 is MultiLiveEvent.Event.ShowSnackbar -> uiMessageResolver.showSnack(event.message)
             }
         }
     }
 
-    private fun handleResults() {
-        handleNotice(AuthenticatedWebViewFragment.WEBVIEW_RESULT, navHostId = R.id.nav_host_fragment_main) {
-            viewModel.onPaymentMethodAdded()
-        }
-    }
-
-    private fun showWebView(url: String, exitUrl: String) {
-        findNavController(R.id.nav_host_fragment_main).navigate(
-            NavGraphMainDirections.actionGlobalAuthenticatedWebViewFragment(
-                urlToLoad = url,
-                urlsToTriggerExit = arrayOf(exitUrl),
-                urlComparisonMode = AuthenticatedWebViewViewModel.UrlComparisonMode.PARTIAL
-            )
-        )
+    private fun disableDraggingOnWebViewState() {
+        viewModel.viewState.map { it.javaClass }
+            .distinctUntilChanged()
+            .observe(viewLifecycleOwner) {
+                val dialog = requireDialog() as BottomSheetDialog
+                dialog.behavior.isDraggable =
+                    it != WooShippingEditPaymentViewModel.ViewState.AddPaymentMethodWebView::class.java
+            }
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/payment/WooShippingEditPaymentDialogFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/payment/WooShippingEditPaymentDialogFragment.kt
@@ -11,15 +11,21 @@ import com.woocommerce.android.NavGraphMainDirections
 import com.woocommerce.android.R
 import com.woocommerce.android.extensions.findNavController
 import com.woocommerce.android.extensions.handleNotice
+import com.woocommerce.android.ui.base.UIMessageResolver
 import com.woocommerce.android.ui.common.webview.AuthenticatedWebViewFragment
 import com.woocommerce.android.ui.common.webview.AuthenticatedWebViewViewModel
 import com.woocommerce.android.ui.compose.theme.WooTheme
+import com.woocommerce.android.viewmodel.MultiLiveEvent
 import com.woocommerce.android.widgets.WCBottomSheetDialogFragment
 import dagger.hilt.android.AndroidEntryPoint
+import javax.inject.Inject
 
 @AndroidEntryPoint
 class WooShippingEditPaymentDialogFragment : WCBottomSheetDialogFragment() {
     private val viewModel: WooShippingEditPaymentViewModel by viewModels()
+
+    @Inject
+    lateinit var uiMessageResolver: UIMessageResolver
 
     override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View {
         return ComposeView(requireContext()).apply {
@@ -47,6 +53,7 @@ class WooShippingEditPaymentDialogFragment : WCBottomSheetDialogFragment() {
                 is WooShippingEditPaymentViewModel.ShowPaymentMethodAddWebView -> {
                     showWebView(event.url, event.successUrl)
                 }
+                is MultiLiveEvent.Event.ShowSnackbar -> uiMessageResolver.showSnack(event.message)
             }
         }
     }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/payment/WooShippingEditPaymentScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/payment/WooShippingEditPaymentScreen.kt
@@ -52,6 +52,7 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import com.woocommerce.android.R
+import com.woocommerce.android.ui.compose.Render
 import com.woocommerce.android.ui.compose.component.BottomSheetHandle
 import com.woocommerce.android.ui.compose.component.WCColoredButton
 import com.woocommerce.android.ui.compose.component.WCOutlinedButton
@@ -205,6 +206,10 @@ private fun WooShippingEditPaymentContent(
                 )
             }
         }
+    }
+
+    viewState.dialogState?.let {
+        it.Render()
     }
 }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/payment/WooShippingEditPaymentScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/payment/WooShippingEditPaymentScreen.kt
@@ -12,6 +12,7 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.layout.wrapContentSize
 import androidx.compose.foundation.rememberScrollState
@@ -339,23 +340,27 @@ private fun PaymentMethodsList(
             enabled = viewState.canManagePaymentMethods,
             modifier = Modifier.fillMaxWidth()
         ) {
-            Row(
-                horizontalArrangement = Arrangement.spacedBy(16.dp),
-                verticalAlignment = Alignment.CenterVertically,
-                modifier = Modifier.fillMaxWidth()
-            ) {
-                Icon(
-                    imageVector = Icons.Default.Add,
-                    tint = if (viewState.canManagePaymentMethods) {
-                        MaterialTheme.colors.primary
-                    } else {
-                        LocalContentColor.current.copy(LocalContentAlpha.current)
-                    },
-                    contentDescription = null
-                )
-                Text(
-                    text = stringResource(R.string.woo_shipping_payment_add_new_button)
-                )
+            if (viewState.loadingState == WooShippingEditPaymentViewModel.LoadingState.LoadingAddedPaymentMethod) {
+                CircularProgressIndicator(Modifier.size(24.dp))
+            } else {
+                Row(
+                    horizontalArrangement = Arrangement.spacedBy(16.dp),
+                    verticalAlignment = Alignment.CenterVertically,
+                    modifier = Modifier.fillMaxWidth()
+                ) {
+                    Icon(
+                        imageVector = Icons.Default.Add,
+                        tint = if (viewState.canManagePaymentMethods) {
+                            MaterialTheme.colors.primary
+                        } else {
+                            LocalContentColor.current.copy(LocalContentAlpha.current)
+                        },
+                        contentDescription = null
+                    )
+                    Text(
+                        text = stringResource(R.string.woo_shipping_payment_add_new_button)
+                    )
+                }
             }
         }
         Spacer(Modifier.height(16.dp))

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/payment/WooShippingEditPaymentScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/payment/WooShippingEditPaymentScreen.kt
@@ -8,6 +8,7 @@ import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
@@ -21,6 +22,7 @@ import androidx.compose.material.CircularProgressIndicator
 import androidx.compose.material.ContentAlpha
 import androidx.compose.material.Divider
 import androidx.compose.material.Icon
+import androidx.compose.material.IconButton
 import androidx.compose.material.LocalContentAlpha
 import androidx.compose.material.LocalContentColor
 import androidx.compose.material.MaterialTheme
@@ -28,6 +30,7 @@ import androidx.compose.material.Surface
 import androidx.compose.material.Text
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Add
+import androidx.compose.material.icons.filled.Clear
 import androidx.compose.material.icons.outlined.Info
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
@@ -52,6 +55,7 @@ import com.woocommerce.android.ui.compose.component.BottomSheetHandle
 import com.woocommerce.android.ui.compose.component.WCColoredButton
 import com.woocommerce.android.ui.compose.component.WCOutlinedButton
 import com.woocommerce.android.ui.compose.component.WCSwitch
+import com.woocommerce.android.ui.compose.component.web.WCWebView
 import com.woocommerce.android.ui.compose.preview.LightDarkThemePreviews
 import com.woocommerce.android.ui.compose.theme.WooThemeWithBackground
 import com.woocommerce.android.ui.orders.wooshippinglabels.ShippingLabelSampleData
@@ -85,29 +89,14 @@ private fun WooShippingEditPaymentScreen(
         )
     ) {
         Column(
-            verticalArrangement = Arrangement.spacedBy(8.dp),
             modifier = Modifier
                 .fillMaxWidth()
-                .padding(16.dp)
         ) {
-            BottomSheetHandle(modifier = Modifier.align(Alignment.CenterHorizontally))
-
-            Text(
-                text = stringResource(R.string.woo_shipping_payment_screen_title),
-                style = MaterialTheme.typography.h6
-            )
-            Text(
-                text = stringResource(R.string.woo_shipping_payment_screen_description),
-                style = MaterialTheme.typography.body1
-            )
-
             when (viewState) {
                 is WooShippingEditPaymentViewModel.ViewState.Loading -> {
-                    CircularProgressIndicator(
+                    LoadingScreen(
                         modifier = Modifier
-                            .align(Alignment.CenterHorizontally)
-                            .height(200.dp)
-                            .wrapContentSize(align = Alignment.Center)
+                            .fillMaxWidth()
                     )
                 }
 
@@ -116,12 +105,58 @@ private fun WooShippingEditPaymentScreen(
                         viewState = viewState,
                         onAddNewPaymentClicked = onAddNewPaymentMethod,
                         onSaveClicked = onSaveClicked,
-                        onPaymentMethodSelected = onPaymentMethodSelected,
+                        onPaymentMethodSelected = onPaymentMethodSelected
+                    )
+                }
+
+                is WooShippingEditPaymentViewModel.ViewState.AddPaymentMethodWebView -> {
+                    WooShippingEditPaymentWebView(
+                        viewState = viewState,
                         modifier = Modifier
+                            .fillMaxSize()
                     )
                 }
             }
         }
+    }
+}
+
+@Composable
+private fun TitleSection(
+    modifier: Modifier = Modifier
+) {
+    Column(modifier) {
+        Text(
+            text = stringResource(R.string.woo_shipping_payment_screen_title),
+            style = MaterialTheme.typography.h6
+        )
+        Text(
+            text = stringResource(R.string.woo_shipping_payment_screen_description),
+            style = MaterialTheme.typography.body1
+        )
+    }
+}
+
+@Composable
+private fun LoadingScreen(
+    modifier: Modifier = Modifier
+) {
+    Column(
+        verticalArrangement = Arrangement.spacedBy(8.dp),
+        modifier = modifier.padding(16.dp)
+    ) {
+        BottomSheetHandle(modifier = Modifier.align(Alignment.CenterHorizontally))
+
+        Spacer(Modifier)
+
+        TitleSection()
+
+        CircularProgressIndicator(
+            modifier = Modifier
+                .align(Alignment.CenterHorizontally)
+                .height(200.dp)
+                .wrapContentSize(align = Alignment.Center)
+        )
     }
 }
 
@@ -135,9 +170,13 @@ private fun WooShippingEditPaymentContent(
 ) {
     Column(
         modifier
-            .padding(vertical = 16.dp)
+            .padding(16.dp)
             .verticalScroll(rememberScrollState())
     ) {
+        BottomSheetHandle(modifier = Modifier.align(Alignment.CenterHorizontally))
+
+        Spacer(modifier = Modifier.height(16.dp))
+
         if (!viewState.canManagePaymentMethods) {
             EditDisabledWarning(
                 storeOwnerName = viewState.storeOwnerName,
@@ -165,6 +204,32 @@ private fun WooShippingEditPaymentContent(
                 )
             }
         }
+    }
+}
+
+@Composable
+private fun WooShippingEditPaymentWebView(
+    viewState: WooShippingEditPaymentViewModel.ViewState.AddPaymentMethodWebView,
+    modifier: Modifier = Modifier
+) {
+    Column(modifier) {
+        IconButton(
+            onClick = viewState.onDismiss,
+            modifier = Modifier.align(Alignment.End)
+        ) {
+            Icon(
+                imageVector = Icons.Default.Clear,
+                contentDescription = stringResource(R.string.dismiss),
+                tint = MaterialTheme.colors.onSurface
+            )
+        }
+
+        WCWebView(
+            url = viewState.url,
+            userAgent = viewState.userAgent,
+            onUrlLoaded = viewState.onUrlLoaded,
+            authenticator = viewState.authenticator
+        )
     }
 }
 
@@ -436,7 +501,7 @@ private fun ContentScreenWithPaymentMethodsPreview() {
     WooThemeWithBackground {
         WooShippingEditPaymentScreen(
             viewState = WooShippingEditPaymentViewModel.ViewState.Content(
-                canManagePaymentMethods = false,
+                canManagePaymentMethods = true,
                 canEditSettings = true,
                 emailTheReceipt = true,
                 storeOwnerName = "John Doe",

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/payment/WooShippingEditPaymentScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/payment/WooShippingEditPaymentScreen.kt
@@ -193,6 +193,8 @@ private fun WooShippingEditPaymentContent(
                     editEnabled = viewState.canManagePaymentMethods,
                     storeOwnerName = viewState.storeOwnerName,
                     storeOwnerUsername = viewState.storeOwnerUsername,
+                    loadingAddedPaymentMethod = viewState.loadingState ==
+                        WooShippingEditPaymentViewModel.LoadingState.LoadingAddedPaymentMethod,
                     onAddNewPaymentMethod = onAddNewPaymentClicked,
                 )
             }
@@ -244,6 +246,7 @@ fun EmptyPaymentMethodsView(
     editEnabled: Boolean,
     storeOwnerName: String,
     storeOwnerUsername: String,
+    loadingAddedPaymentMethod: Boolean,
     onAddNewPaymentMethod: () -> Unit,
     modifier: Modifier = Modifier
 ) {
@@ -293,6 +296,7 @@ fun EmptyPaymentMethodsView(
             WCColoredButton(
                 onClick = onAddNewPaymentMethod,
                 enabled = editEnabled,
+                loading = loadingAddedPaymentMethod,
                 text = stringResource(R.string.woo_shipping_payment_add_new_button),
                 leadingIcon = {
                     Icon(

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/payment/WooShippingEditPaymentViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/payment/WooShippingEditPaymentViewModel.kt
@@ -5,11 +5,14 @@ import androidx.lifecycle.asLiveData
 import androidx.lifecycle.viewModelScope
 import com.woocommerce.android.ui.orders.wooshippinglabels.ObserveAccountSettings
 import com.woocommerce.android.ui.orders.wooshippinglabels.models.PaymentMethodOptions
+import com.woocommerce.android.viewmodel.MultiLiveEvent
 import com.woocommerce.android.viewmodel.ScopedViewModel
 import com.woocommerce.android.viewmodel.getNullableStateFlow
 import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.onStart
+import kotlinx.coroutines.flow.stateIn
 import javax.inject.Inject
 
 @HiltViewModel
@@ -17,6 +20,10 @@ class WooShippingEditPaymentViewModel @Inject constructor(
     savedStateHandle: SavedStateHandle,
     observeAccountSettings: ObserveAccountSettings
 ) : ScopedViewModel(savedStateHandle) {
+    companion object {
+        private const val PAYMENT_METHOD_SUCCESS_URL = "me/payment-methods"
+    }
+
     private val selectedPaymentMethod = savedStateHandle.getNullableStateFlow(
         scope = viewModelScope,
         initialValue = null,
@@ -24,8 +31,11 @@ class WooShippingEditPaymentViewModel @Inject constructor(
         key = "selectedPaymentMethod",
     )
 
+    private val accountSettings = observeAccountSettings()
+        .stateIn(viewModelScope, initialValue = null, started = SharingStarted.Lazily)
+
     val viewState = combine(
-        observeAccountSettings(),
+        accountSettings,
         selectedPaymentMethod
     ) { accountSettings, selectedPaymentMethod ->
         if (accountSettings == null) return@combine ViewState.Loading
@@ -44,7 +54,14 @@ class WooShippingEditPaymentViewModel @Inject constructor(
         .asLiveData()
 
     fun onAddNewPaymentMethod() {
-        TODO()
+        accountSettings.value?.let {
+            triggerEvent(
+                ShowPaymentMethodAddWebView(
+                    url = it.paymentMethodOptions.addPaymentMethodUrl,
+                    successUrl = PAYMENT_METHOD_SUCCESS_URL
+                )
+            )
+        }
     }
 
     fun onPaymentMethodSelected(paymentMethodId: Int?) {
@@ -69,4 +86,7 @@ class WooShippingEditPaymentViewModel @Inject constructor(
             val paymentMethods get() = currentPaymentOptions.paymentMethods
         }
     }
+
+    data class ShowPaymentMethodAddWebView(val url: String, val successUrl: String) : MultiLiveEvent.Event()
 }
+

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/payment/WooShippingEditPaymentViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/payment/WooShippingEditPaymentViewModel.kt
@@ -14,10 +14,15 @@ import com.woocommerce.android.viewmodel.ScopedViewModel
 import com.woocommerce.android.viewmodel.getNullableStateFlow
 import com.woocommerce.android.viewmodel.getStateFlow
 import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.FlowCollector
+import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.flow.emitAll
 import kotlinx.coroutines.flow.onStart
 import kotlinx.coroutines.flow.stateIn
+import kotlinx.coroutines.flow.transformLatest
 import kotlinx.coroutines.launch
 import org.wordpress.android.fluxc.network.UserAgent
 import javax.inject.Inject
@@ -47,56 +52,63 @@ class WooShippingEditPaymentViewModel @Inject constructor(
         key = "isAddPaymentMethodWebViewVisible"
     )
 
+    private val loadingState = MutableStateFlow(LoadingState.Idle)
+
     private val accountSettings = observeAccountSettings()
         .stateIn(viewModelScope, initialValue = null, started = SharingStarted.Lazily)
 
+    @OptIn(ExperimentalCoroutinesApi::class)
     val viewState = combine(
         isAddPaymentMethodWebViewVisible,
-        accountSettings,
-        selectedPaymentMethod
-    ) { isAddPaymentMethodWebViewVisible, accountSettings, selectedPaymentMethod ->
-        if (accountSettings == null) return@combine ViewState.Loading
-
-        if (isAddPaymentMethodWebViewVisible) {
-            initAddPaymentMethodWebView(accountSettings)
-        } else {
-            initContentViewState(
-                accountSettings = accountSettings,
-                selectedPaymentMethod = selectedPaymentMethod
-            )
-        }
+        accountSettings
+    ) { isAddPaymentMethodWebViewVisible, accountSettings ->
+        Pair(isAddPaymentMethodWebViewVisible, accountSettings)
     }
+        .transformLatest { (isAddPaymentMethodWebViewVisible, accountSettings) ->
+            if (accountSettings == null) {
+                emit(ViewState.Loading)
+                return@transformLatest
+            }
+
+            if (isAddPaymentMethodWebViewVisible) {
+                initAddPaymentMethodWebView(accountSettings)
+            } else {
+                initContentViewState(accountSettings)
+            }
+        }
         .onStart { emit(ViewState.Loading) }
         .asLiveData()
 
-    private fun initAddPaymentMethodWebView(accountSettings: AccountSettingsModel): ViewState.AddPaymentMethodWebView {
-        return ViewState.AddPaymentMethodWebView(
-            url = accountSettings.paymentMethodOptions.addPaymentMethodUrl,
-            userAgent = userAgent,
-            authenticator = webViewAuthenticator,
-            onUrlLoaded = { url ->
-                if (url.contains(PAYMENT_METHOD_SUCCESS_URL)) {
-                    onPaymentMethodAdded()
-                }
-            },
-            onDismiss = { this.isAddPaymentMethodWebViewVisible.value = false }
+    private suspend fun FlowCollector<ViewState>.initAddPaymentMethodWebView(accountSettings: AccountSettingsModel) {
+        emit(
+            ViewState.AddPaymentMethodWebView(
+                url = accountSettings.paymentMethodOptions.addPaymentMethodUrl,
+                userAgent = userAgent,
+                authenticator = webViewAuthenticator,
+                onUrlLoaded = { url ->
+                    if (url.contains(PAYMENT_METHOD_SUCCESS_URL)) {
+                        onPaymentMethodAdded()
+                    }
+                },
+                onDismiss = { isAddPaymentMethodWebViewVisible.value = false }
+            )
         )
     }
 
-    private fun initContentViewState(
-        accountSettings: AccountSettingsModel,
-        selectedPaymentMethod: Int?
-    ): ViewState.Content {
-        return ViewState.Content(
-            canManagePaymentMethods = true, // TODO
-            canEditSettings = true, // TODO
-            emailTheReceipt = true, // TODO
-            storeOwnerName = "John Doe", // TODO
-            storeOwnerUsername = "johndoe", // TODO
-            selectedPaymentMethodId = selectedPaymentMethod
-                ?: accountSettings.paymentMethodOptions.selectedPaymentId,
-            currentPaymentOptions = accountSettings.paymentMethodOptions
-        )
+    private suspend fun FlowCollector<ViewState>.initContentViewState(accountSettings: AccountSettingsModel) {
+        combine(selectedPaymentMethod, loadingState) { selectedPaymentMethod, loadingState ->
+            ViewState.Content(
+                loadingState = loadingState,
+                canManagePaymentMethods = true, // TODO
+                canEditSettings = true, // TODO
+                emailTheReceipt = true, // TODO
+                storeOwnerName = "John Doe", // TODO
+                storeOwnerUsername = "johndoe", // TODO
+                selectedPaymentMethodId = selectedPaymentMethod
+                    ?: accountSettings.paymentMethodOptions.selectedPaymentId,
+                currentPaymentOptions = accountSettings.paymentMethodOptions
+            )
+        }.let { emitAll(it) }
     }
 
     fun onAddNewPaymentMethod() {
@@ -112,8 +124,10 @@ class WooShippingEditPaymentViewModel @Inject constructor(
     }
 
     private fun onPaymentMethodAdded() {
-        isAddPaymentMethodWebViewVisible.value = false
         launch {
+            isAddPaymentMethodWebViewVisible.value = false
+            loadingState.value = LoadingState.LoadingAddedPaymentMethod
+
             val countOfCurrentPaymentMethods = accountSettings.value?.paymentMethodOptions
                 ?.paymentMethods?.size ?: return@launch
 
@@ -127,12 +141,14 @@ class WooShippingEditPaymentViewModel @Inject constructor(
                     TODO()
                 }
             )
+            loadingState.value = LoadingState.Idle
         }
     }
 
     sealed interface ViewState {
         data object Loading : ViewState
         data class Content(
+            val loadingState: LoadingState = LoadingState.Idle,
             val canManagePaymentMethods: Boolean,
             val canEditSettings: Boolean,
             val emailTheReceipt: Boolean,
@@ -151,5 +167,9 @@ class WooShippingEditPaymentViewModel @Inject constructor(
             val onUrlLoaded: (String) -> Unit,
             val onDismiss: () -> Unit
         ) : ViewState
+    }
+
+    enum class LoadingState {
+        Idle, LoadingAddedPaymentMethod, Saving
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/payment/WooShippingEditPaymentViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/payment/WooShippingEditPaymentViewModel.kt
@@ -4,26 +4,30 @@ import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.asLiveData
 import androidx.lifecycle.viewModelScope
 import com.woocommerce.android.R
+import com.woocommerce.android.ui.common.webview.WebViewAuthenticator
 import com.woocommerce.android.ui.orders.wooshippinglabels.FetchAccountSettings
 import com.woocommerce.android.ui.orders.wooshippinglabels.ObserveAccountSettings
 import com.woocommerce.android.ui.orders.wooshippinglabels.models.PaymentMethodOptions
-import com.woocommerce.android.viewmodel.MultiLiveEvent
 import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.ShowSnackbar
 import com.woocommerce.android.viewmodel.ScopedViewModel
 import com.woocommerce.android.viewmodel.getNullableStateFlow
+import com.woocommerce.android.viewmodel.getStateFlow
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.onStart
 import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.launch
+import org.wordpress.android.fluxc.network.UserAgent
 import javax.inject.Inject
 
 @HiltViewModel
 class WooShippingEditPaymentViewModel @Inject constructor(
     savedStateHandle: SavedStateHandle,
     observeAccountSettings: ObserveAccountSettings,
-    private val fetchAccountSettings: FetchAccountSettings
+    private val fetchAccountSettings: FetchAccountSettings,
+    private val webViewAuthenticator: WebViewAuthenticator,
+    private val userAgent: UserAgent
 ) : ScopedViewModel(savedStateHandle) {
     companion object {
         private const val PAYMENT_METHOD_SUCCESS_URL = "me/payment-methods"
@@ -36,37 +40,52 @@ class WooShippingEditPaymentViewModel @Inject constructor(
         key = "selectedPaymentMethod",
     )
 
+    private val isAddPaymentMethodWebViewVisible = savedStateHandle.getStateFlow(
+        scope = viewModelScope,
+        initialValue = false,
+        key = "isAddPaymentMethodWebViewVisible"
+    )
+
     private val accountSettings = observeAccountSettings()
         .stateIn(viewModelScope, initialValue = null, started = SharingStarted.Lazily)
 
     val viewState = combine(
+        isAddPaymentMethodWebViewVisible,
         accountSettings,
         selectedPaymentMethod
-    ) { accountSettings, selectedPaymentMethod ->
+    ) { isAddPaymentMethodWebViewVisible, accountSettings, selectedPaymentMethod ->
         if (accountSettings == null) return@combine ViewState.Loading
 
-        ViewState.Content(
-            canManagePaymentMethods = true, // TODO
-            canEditSettings = true, // TODO
-            emailTheReceipt = true, // TODO
-            storeOwnerName = "John Doe", // TODO
-            storeOwnerUsername = "johndoe", // TODO
-            selectedPaymentMethodId = selectedPaymentMethod ?: accountSettings.paymentMethodOptions.selectedPaymentId,
-            currentPaymentOptions = accountSettings.paymentMethodOptions
-        )
+        if (isAddPaymentMethodWebViewVisible) {
+            ViewState.AddPaymentMethodWebView(
+                url = accountSettings.paymentMethodOptions.addPaymentMethodUrl,
+                userAgent = userAgent,
+                authenticator = webViewAuthenticator,
+                onUrlLoaded = { url ->
+                    if (url.contains(PAYMENT_METHOD_SUCCESS_URL)) {
+                        onPaymentMethodAdded()
+                    }
+                },
+                onDismiss = { this.isAddPaymentMethodWebViewVisible.value = false }
+            )
+        } else {
+            ViewState.Content(
+                canManagePaymentMethods = true, // TODO
+                canEditSettings = true, // TODO
+                emailTheReceipt = true, // TODO
+                storeOwnerName = "John Doe", // TODO
+                storeOwnerUsername = "johndoe", // TODO
+                selectedPaymentMethodId = selectedPaymentMethod
+                    ?: accountSettings.paymentMethodOptions.selectedPaymentId,
+                currentPaymentOptions = accountSettings.paymentMethodOptions
+            )
+        }
     }
         .onStart { emit(ViewState.Loading) }
         .asLiveData()
 
     fun onAddNewPaymentMethod() {
-        accountSettings.value?.let {
-            triggerEvent(
-                ShowPaymentMethodAddWebView(
-                    url = it.paymentMethodOptions.addPaymentMethodUrl,
-                    successUrl = PAYMENT_METHOD_SUCCESS_URL
-                )
-            )
-        }
+        isAddPaymentMethodWebViewVisible.value = true
     }
 
     fun onPaymentMethodSelected(paymentMethodId: Int?) {
@@ -77,7 +96,8 @@ class WooShippingEditPaymentViewModel @Inject constructor(
         TODO()
     }
 
-    fun onPaymentMethodAdded() {
+    private fun onPaymentMethodAdded() {
+        isAddPaymentMethodWebViewVisible.value = false
         launch {
             val countOfCurrentPaymentMethods = accountSettings.value?.paymentMethodOptions
                 ?.paymentMethods?.size ?: return@launch
@@ -108,8 +128,13 @@ class WooShippingEditPaymentViewModel @Inject constructor(
         ) : ViewState {
             val paymentMethods get() = currentPaymentOptions.paymentMethods
         }
+
+        data class AddPaymentMethodWebView(
+            val url: String,
+            val userAgent: UserAgent,
+            val authenticator: WebViewAuthenticator,
+            val onUrlLoaded: (String) -> Unit,
+            val onDismiss: () -> Unit
+        ) : ViewState
     }
-
-    data class ShowPaymentMethodAddWebView(val url: String, val successUrl: String) : MultiLiveEvent.Event()
 }
-

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/payment/WooShippingEditPaymentViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/payment/WooShippingEditPaymentViewModel.kt
@@ -5,6 +5,7 @@ import androidx.lifecycle.asLiveData
 import androidx.lifecycle.viewModelScope
 import com.woocommerce.android.R
 import com.woocommerce.android.ui.common.webview.WebViewAuthenticator
+import com.woocommerce.android.ui.compose.DialogState
 import com.woocommerce.android.ui.orders.wooshippinglabels.FetchAccountSettings
 import com.woocommerce.android.ui.orders.wooshippinglabels.ObserveAccountSettings
 import com.woocommerce.android.ui.orders.wooshippinglabels.models.AccountSettingsModel
@@ -52,10 +53,11 @@ class WooShippingEditPaymentViewModel @Inject constructor(
         key = "isAddPaymentMethodWebViewVisible"
     )
 
-    private val loadingState = MutableStateFlow(LoadingState.Idle)
-
     private val accountSettings = observeAccountSettings()
         .stateIn(viewModelScope, initialValue = null, started = SharingStarted.Lazily)
+
+    private val loadingState = MutableStateFlow(LoadingState.Idle)
+    private val dialogState = MutableStateFlow<DialogState?>(null)
 
     @OptIn(ExperimentalCoroutinesApi::class)
     val viewState = combine(
@@ -96,9 +98,10 @@ class WooShippingEditPaymentViewModel @Inject constructor(
     }
 
     private suspend fun FlowCollector<ViewState>.initContentViewState(accountSettings: AccountSettingsModel) {
-        combine(selectedPaymentMethod, loadingState) { selectedPaymentMethod, loadingState ->
+        combine(selectedPaymentMethod, loadingState, dialogState) { selectedPaymentMethod, loadingState, dialogState ->
             ViewState.Content(
                 loadingState = loadingState,
+                dialogState = dialogState,
                 canManagePaymentMethods = true, // TODO
                 canEditSettings = true, // TODO
                 emailTheReceipt = true, // TODO
@@ -142,7 +145,20 @@ class WooShippingEditPaymentViewModel @Inject constructor(
                     }
                 },
                 onFailure = {
-                    TODO()
+                    dialogState.value = DialogState(
+                        message = R.string.woo_shipping_payment_fetching_cards_failed,
+                        positiveButton = DialogState.DialogButton(
+                            text = R.string.retry,
+                            onClick = {
+                                dialogState.value = null
+                                onPaymentMethodAdded()
+                            }
+                        ),
+                        negativeButton = DialogState.DialogButton(
+                            text = R.string.cancel,
+                            onClick = { dialogState.value = null }
+                        )
+                    )
                 }
             )
             loadingState.value = LoadingState.Idle
@@ -153,6 +169,7 @@ class WooShippingEditPaymentViewModel @Inject constructor(
         data object Loading : ViewState
         data class Content(
             val loadingState: LoadingState = LoadingState.Idle,
+            val dialogState: DialogState? = null,
             val canManagePaymentMethods: Boolean,
             val canEditSettings: Boolean,
             val emailTheReceipt: Boolean,

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/payment/WooShippingEditPaymentViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/payment/WooShippingEditPaymentViewModel.kt
@@ -3,9 +3,12 @@ package com.woocommerce.android.ui.orders.wooshippinglabels.payment
 import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.asLiveData
 import androidx.lifecycle.viewModelScope
+import com.woocommerce.android.R
+import com.woocommerce.android.ui.orders.wooshippinglabels.FetchAccountSettings
 import com.woocommerce.android.ui.orders.wooshippinglabels.ObserveAccountSettings
 import com.woocommerce.android.ui.orders.wooshippinglabels.models.PaymentMethodOptions
 import com.woocommerce.android.viewmodel.MultiLiveEvent
+import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.ShowSnackbar
 import com.woocommerce.android.viewmodel.ScopedViewModel
 import com.woocommerce.android.viewmodel.getNullableStateFlow
 import dagger.hilt.android.lifecycle.HiltViewModel
@@ -13,12 +16,14 @@ import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.onStart
 import kotlinx.coroutines.flow.stateIn
+import kotlinx.coroutines.launch
 import javax.inject.Inject
 
 @HiltViewModel
 class WooShippingEditPaymentViewModel @Inject constructor(
     savedStateHandle: SavedStateHandle,
-    observeAccountSettings: ObserveAccountSettings
+    observeAccountSettings: ObserveAccountSettings,
+    private val fetchAccountSettings: FetchAccountSettings
 ) : ScopedViewModel(savedStateHandle) {
     companion object {
         private const val PAYMENT_METHOD_SUCCESS_URL = "me/payment-methods"
@@ -73,7 +78,21 @@ class WooShippingEditPaymentViewModel @Inject constructor(
     }
 
     fun onPaymentMethodAdded() {
-        TODO()
+        launch {
+            val countOfCurrentPaymentMethods = accountSettings.value?.paymentMethodOptions
+                ?.paymentMethods?.size ?: return@launch
+
+            fetchAccountSettings().fold(
+                onSuccess = {
+                    if (it.paymentMethodOptions.paymentMethods.size == countOfCurrentPaymentMethods + 1) {
+                        triggerEvent(ShowSnackbar(R.string.woo_shipping_payment_method_added))
+                    }
+                },
+                onFailure = {
+                    TODO()
+                }
+            )
+        }
     }
 
     sealed interface ViewState {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/payment/WooShippingEditPaymentViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/payment/WooShippingEditPaymentViewModel.kt
@@ -128,12 +128,16 @@ class WooShippingEditPaymentViewModel @Inject constructor(
             isAddPaymentMethodWebViewVisible.value = false
             loadingState.value = LoadingState.LoadingAddedPaymentMethod
 
-            val countOfCurrentPaymentMethods = accountSettings.value?.paymentMethodOptions
-                ?.paymentMethods?.size ?: return@launch
+            val existingPaymentMethods = accountSettings.value?.paymentMethodOptions
+                ?.paymentMethods ?: return@launch
 
             fetchAccountSettings().fold(
-                onSuccess = {
-                    if (it.paymentMethodOptions.paymentMethods.size == countOfCurrentPaymentMethods + 1) {
+                onSuccess = { accountSettings ->
+                    if (accountSettings.paymentMethodOptions.paymentMethods.size == existingPaymentMethods.size + 1) {
+                        val newPaymentMethod = accountSettings.paymentMethodOptions.paymentMethods.firstOrNull {
+                            it !in existingPaymentMethods
+                        }
+                        selectedPaymentMethod.value = newPaymentMethod?.paymentMethodId
                         triggerEvent(ShowSnackbar(R.string.woo_shipping_payment_method_added))
                     }
                 },

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/payment/WooShippingEditPaymentViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/payment/WooShippingEditPaymentViewModel.kt
@@ -72,6 +72,10 @@ class WooShippingEditPaymentViewModel @Inject constructor(
         TODO()
     }
 
+    fun onPaymentMethodAdded() {
+        TODO()
+    }
+
     sealed interface ViewState {
         data object Loading : ViewState
         data class Content(

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/payment/WooShippingEditPaymentViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/payment/WooShippingEditPaymentViewModel.kt
@@ -7,6 +7,7 @@ import com.woocommerce.android.R
 import com.woocommerce.android.ui.common.webview.WebViewAuthenticator
 import com.woocommerce.android.ui.orders.wooshippinglabels.FetchAccountSettings
 import com.woocommerce.android.ui.orders.wooshippinglabels.ObserveAccountSettings
+import com.woocommerce.android.ui.orders.wooshippinglabels.models.AccountSettingsModel
 import com.woocommerce.android.ui.orders.wooshippinglabels.models.PaymentMethodOptions
 import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.ShowSnackbar
 import com.woocommerce.android.viewmodel.ScopedViewModel
@@ -57,32 +58,46 @@ class WooShippingEditPaymentViewModel @Inject constructor(
         if (accountSettings == null) return@combine ViewState.Loading
 
         if (isAddPaymentMethodWebViewVisible) {
-            ViewState.AddPaymentMethodWebView(
-                url = accountSettings.paymentMethodOptions.addPaymentMethodUrl,
-                userAgent = userAgent,
-                authenticator = webViewAuthenticator,
-                onUrlLoaded = { url ->
-                    if (url.contains(PAYMENT_METHOD_SUCCESS_URL)) {
-                        onPaymentMethodAdded()
-                    }
-                },
-                onDismiss = { this.isAddPaymentMethodWebViewVisible.value = false }
-            )
+            initAddPaymentMethodWebView(accountSettings)
         } else {
-            ViewState.Content(
-                canManagePaymentMethods = true, // TODO
-                canEditSettings = true, // TODO
-                emailTheReceipt = true, // TODO
-                storeOwnerName = "John Doe", // TODO
-                storeOwnerUsername = "johndoe", // TODO
-                selectedPaymentMethodId = selectedPaymentMethod
-                    ?: accountSettings.paymentMethodOptions.selectedPaymentId,
-                currentPaymentOptions = accountSettings.paymentMethodOptions
+            initContentViewState(
+                accountSettings = accountSettings,
+                selectedPaymentMethod = selectedPaymentMethod
             )
         }
     }
         .onStart { emit(ViewState.Loading) }
         .asLiveData()
+
+    private fun initAddPaymentMethodWebView(accountSettings: AccountSettingsModel): ViewState.AddPaymentMethodWebView {
+        return ViewState.AddPaymentMethodWebView(
+            url = accountSettings.paymentMethodOptions.addPaymentMethodUrl,
+            userAgent = userAgent,
+            authenticator = webViewAuthenticator,
+            onUrlLoaded = { url ->
+                if (url.contains(PAYMENT_METHOD_SUCCESS_URL)) {
+                    onPaymentMethodAdded()
+                }
+            },
+            onDismiss = { this.isAddPaymentMethodWebViewVisible.value = false }
+        )
+    }
+
+    private fun initContentViewState(
+        accountSettings: AccountSettingsModel,
+        selectedPaymentMethod: Int?
+    ): ViewState.Content {
+        return ViewState.Content(
+            canManagePaymentMethods = true, // TODO
+            canEditSettings = true, // TODO
+            emailTheReceipt = true, // TODO
+            storeOwnerName = "John Doe", // TODO
+            storeOwnerUsername = "johndoe", // TODO
+            selectedPaymentMethodId = selectedPaymentMethod
+                ?: accountSettings.paymentMethodOptions.selectedPaymentId,
+            currentPaymentOptions = accountSettings.paymentMethodOptions
+        )
+    }
 
     fun onAddNewPaymentMethod() {
         isAddPaymentMethodWebViewVisible.value = true

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -4683,6 +4683,7 @@
     <string name="woo_shipping_payment_email_receipt_toggle">Email the receipt</string>
     <string name="woo_shipping_payment_use_card_button">Use this card</string>
     <string name="woo_shipping_payment_method_added">Payment method added</string>
+    <string name="woo_shipping_payment_fetching_cards_failed">Unable to refresh your payment methods</string>
 
     <string name="media_library_title">WordPress Media Library</string>
     <string name="media_loading_failed">Media loading failed</string>

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -4682,6 +4682,7 @@
     <string name="woo_shipping_payment_methods_info_footer"><![CDATA[Credit cards are retrieved from the following WordPress.com account: %1$s <%2$s>]]></string>
     <string name="woo_shipping_payment_email_receipt_toggle">Email the receipt</string>
     <string name="woo_shipping_payment_use_card_button">Use this card</string>
+    <string name="woo_shipping_payment_method_added">Payment method added</string>
 
     <string name="media_library_title">WordPress Media Library</string>
     <string name="media_loading_failed">Media loading failed</string>

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/FetchAccountSettingsTests.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/FetchAccountSettingsTests.kt
@@ -36,7 +36,8 @@ class FetchAccountSettingsTests : BaseUnitTest() {
         ),
         paymentMethodOptions = PaymentMethodOptions(
             selectedPaymentId = null,
-            paymentMethods = emptyList()
+            paymentMethods = emptyList(),
+            addPaymentMethodUrl = "https://example.com/add-payment-method"
         )
     )
 

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/ObserveAccountSettingsTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/ObserveAccountSettingsTest.kt
@@ -28,7 +28,8 @@ class ObserveAccountSettingsTest : BaseUnitTest() {
         ),
         paymentMethodOptions = PaymentMethodOptions(
             selectedPaymentId = null,
-            paymentMethods = emptyList()
+            paymentMethods = emptyList(),
+            addPaymentMethodUrl = "https://example.com/add-payment-method"
         )
     )
 

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/WooShippingLabelCreationViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/WooShippingLabelCreationViewModelTest.kt
@@ -138,7 +138,8 @@ class WooShippingLabelCreationViewModelTest : BaseUnitTest() {
         ),
         paymentMethodOptions = PaymentMethodOptions(
             selectedPaymentId = null,
-            paymentMethods = emptyList()
+            paymentMethods = emptyList(),
+            addPaymentMethodUrl = "https://example.com/add-payment-method"
         )
     )
 
@@ -1072,7 +1073,8 @@ class WooShippingLabelCreationViewModelTest : BaseUnitTest() {
                         cardDigits = "1234",
                         expiry = "12/25"
                     )
-                )
+                ),
+                addPaymentMethodUrl = "https://example.com/add-payment-method"
             )
         )
         given(observeAccountSettings()).willReturn(flowOf(accountSettings))
@@ -1091,7 +1093,8 @@ class WooShippingLabelCreationViewModelTest : BaseUnitTest() {
         val accountSettings = defaultAccountSettings.copy(
             paymentMethodOptions = PaymentMethodOptions(
                 selectedPaymentId = null,
-                paymentMethods = emptyList()
+                paymentMethods = emptyList(),
+                addPaymentMethodUrl = "https://example.com/add-payment-method"
             )
         )
         given(observeAccountSettings()).willReturn(flowOf(accountSettings))

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/payment/WooShippingEditPaymentViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/payment/WooShippingEditPaymentViewModelTest.kt
@@ -1,0 +1,221 @@
+package com.woocommerce.android.ui.orders.wooshippinglabels.payment
+
+import androidx.lifecycle.SavedStateHandle
+import com.woocommerce.android.R
+import com.woocommerce.android.ui.common.webview.WebViewAuthenticator
+import com.woocommerce.android.ui.orders.wooshippinglabels.FetchAccountSettings
+import com.woocommerce.android.ui.orders.wooshippinglabels.ObserveAccountSettings
+import com.woocommerce.android.ui.orders.wooshippinglabels.models.AccountSettingsModel
+import com.woocommerce.android.ui.orders.wooshippinglabels.models.PaymentMethodModel
+import com.woocommerce.android.ui.orders.wooshippinglabels.models.PaymentMethodOptions
+import com.woocommerce.android.ui.orders.wooshippinglabels.models.StoreOptionsModel
+import com.woocommerce.android.util.getOrAwaitValue
+import com.woocommerce.android.util.runAndCaptureValues
+import com.woocommerce.android.viewmodel.BaseUnitTest
+import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.ShowSnackbar
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.test.advanceUntilIdle
+import org.assertj.core.api.Assertions.assertThat
+import org.mockito.kotlin.doReturn
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.whenever
+import org.wordpress.android.fluxc.network.UserAgent
+import kotlin.test.Test
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class WooShippingEditPaymentViewModelTest : BaseUnitTest() {
+    private val defaultAccountSettings = AccountSettingsModel(
+        storeOptions = StoreOptionsModel(
+            weightUnit = "kg",
+            currencySymbol = "$",
+            dimensionUnit = "cm",
+            originCountry = "US"
+        ),
+        paymentMethodOptions = PaymentMethodOptions(
+            selectedPaymentId = 1,
+            paymentMethods = listOf(
+                PaymentMethodModel(
+                    paymentMethodId = 1,
+                    cardType = "visa",
+                    cardDigits = "1234",
+                    expiry = "12/25",
+                    name = "Visa *1234"
+                ),
+                PaymentMethodModel(
+                    paymentMethodId = 2,
+                    cardType = "mastercard",
+                    cardDigits = "5678",
+                    expiry = "10/24",
+                    name = "Mastercard *5678"
+                )
+            ),
+            addPaymentMethodUrl = "https://example.com/add-payment-method"
+        )
+    )
+
+    private val observeAccountSettings: ObserveAccountSettings = mock {
+        on { invoke() } doReturn flowOf(defaultAccountSettings)
+    }
+    private val fetchAccountSettings: FetchAccountSettings = mock {
+        onBlocking { invoke() } doReturn Result.success(defaultAccountSettings)
+    }
+    private val webViewAuthenticator: WebViewAuthenticator = mock()
+    private val userAgent: UserAgent = mock()
+    private val savedStateHandle = SavedStateHandle()
+
+    private lateinit var viewModel: WooShippingEditPaymentViewModel
+
+    suspend fun setup(prepareMocks: suspend () -> Unit = {}) {
+        prepareMocks()
+        viewModel = WooShippingEditPaymentViewModel(
+            savedStateHandle = savedStateHandle,
+            observeAccountSettings = observeAccountSettings,
+            fetchAccountSettings = fetchAccountSettings,
+            webViewAuthenticator = webViewAuthenticator,
+            userAgent = userAgent
+        )
+    }
+
+    @Test
+    fun `when screen is opened, then show loading state`() = testBlocking {
+        whenever(observeAccountSettings()).doReturn(flowOf(null))
+
+        setup()
+
+        val state = viewModel.viewState.getOrAwaitValue()
+        assertThat(state).isInstanceOf(WooShippingEditPaymentViewModel.ViewState.Loading::class.java)
+    }
+
+    @Test
+    fun `when account settings are loaded, then show content state`() = testBlocking {
+        setup()
+
+        // Capture all states emitted by the viewState LiveData
+        val states = viewModel.viewState.runAndCaptureValues {
+            // Need to advance time to allow the flow transformation to complete
+            advanceUntilIdle()
+        }
+
+        // The first state might be Loading, but the last state should be Content
+        assertThat(states.last()).isInstanceOf(WooShippingEditPaymentViewModel.ViewState.Content::class.java)
+
+        val contentState = states.last() as WooShippingEditPaymentViewModel.ViewState.Content
+        assertThat(contentState.selectedPaymentMethodId)
+            .isEqualTo(defaultAccountSettings.paymentMethodOptions.selectedPaymentId)
+        assertThat(contentState.paymentMethods).isEqualTo(defaultAccountSettings.paymentMethodOptions.paymentMethods)
+    }
+
+    @Test
+    fun `when add new payment method is clicked, then show add payment method web view`() = testBlocking {
+        setup()
+
+        val states = viewModel.viewState.runAndCaptureValues {
+            viewModel.onAddNewPaymentMethod()
+        }
+
+        assertThat(states.last())
+            .isInstanceOf(WooShippingEditPaymentViewModel.ViewState.AddPaymentMethodWebView::class.java)
+
+        val webViewState = states.last() as WooShippingEditPaymentViewModel.ViewState.AddPaymentMethodWebView
+        assertThat(webViewState.url).isEqualTo(defaultAccountSettings.paymentMethodOptions.addPaymentMethodUrl)
+        assertThat(webViewState.userAgent).isEqualTo(userAgent)
+        assertThat(webViewState.authenticator).isEqualTo(webViewAuthenticator)
+    }
+
+    @Test
+    fun `when payment method is selected, then update selected payment method`() = testBlocking {
+        setup()
+
+        val newPaymentMethodId = 2
+        val states = viewModel.viewState.runAndCaptureValues {
+            viewModel.onPaymentMethodSelected(newPaymentMethodId)
+        }
+
+        val contentState = states.last() as WooShippingEditPaymentViewModel.ViewState.Content
+        assertThat(contentState.selectedPaymentMethodId).isEqualTo(newPaymentMethodId)
+    }
+
+    @Test
+    fun `when payment method is added successfully, then update payment methods and show snackbar`() = testBlocking {
+        val initialAccountSettings = defaultAccountSettings.copy(
+            paymentMethodOptions = defaultAccountSettings.paymentMethodOptions.copy(
+                paymentMethods = listOf(defaultAccountSettings.paymentMethodOptions.paymentMethods[0])
+            )
+        )
+
+        val updatedAccountSettings = defaultAccountSettings.copy(
+            paymentMethodOptions = defaultAccountSettings.paymentMethodOptions.copy(
+                paymentMethods = defaultAccountSettings.paymentMethodOptions.paymentMethods
+            )
+        )
+
+        whenever(observeAccountSettings()).doReturn(flowOf(initialAccountSettings))
+        whenever(fetchAccountSettings()).doReturn(Result.success(updatedAccountSettings))
+
+        setup()
+
+        // Simulate adding a payment method
+        val webViewState = viewModel.viewState.runAndCaptureValues {
+            viewModel.onAddNewPaymentMethod()
+        }.last() as WooShippingEditPaymentViewModel.ViewState.AddPaymentMethodWebView
+
+        // Simulate successful URL load with payment method success URL
+        val events = mutableListOf<Any>()
+        viewModel.event.observeForever { events.add(it) }
+
+        webViewState.onUrlLoaded("https://wordpress.com/me/payment-methods")
+        advanceUntilIdle()
+
+        // Verify that the snackbar is shown
+        assertThat(events).anyMatch { it is ShowSnackbar && it.message == R.string.woo_shipping_payment_method_added }
+
+        // Verify that the new payment method is selected
+        val contentState = viewModel.viewState.getOrAwaitValue() as WooShippingEditPaymentViewModel.ViewState.Content
+        assertThat(contentState.selectedPaymentMethodId).isEqualTo(2)
+    }
+
+    @Test
+    fun `when payment method fetch fails, then show error dialog`() = testBlocking {
+        whenever(fetchAccountSettings())
+            .doReturn(Result.failure(Exception("Error fetching payment methods")))
+
+        setup()
+
+        // Simulate adding a payment method
+        val webViewState = viewModel.viewState.runAndCaptureValues {
+            viewModel.onAddNewPaymentMethod()
+        }.last() as WooShippingEditPaymentViewModel.ViewState.AddPaymentMethodWebView
+
+        // Simulate successful URL load with payment method success URL
+        webViewState.onUrlLoaded("https://wordpress.com/me/payment-methods")
+        advanceUntilIdle()
+
+        // Verify that the error dialog is shown
+        val contentState = viewModel.viewState.getOrAwaitValue() as WooShippingEditPaymentViewModel.ViewState.Content
+        assertThat(contentState.dialogState).isNotNull
+
+        // Check that the message is a UiString.UiStringRes with the correct resource ID
+        val message = contentState.dialogState!!.message
+        assertThat(message).isInstanceOf(com.woocommerce.android.model.UiString.UiStringRes::class.java)
+        val uiStringRes = message as com.woocommerce.android.model.UiString.UiStringRes
+        assertThat(uiStringRes.stringRes).isEqualTo(R.string.woo_shipping_payment_fetching_cards_failed)
+    }
+
+    @Test
+    fun `when web view is dismissed, then return to content view`() = testBlocking {
+        setup()
+
+        // Simulate adding a payment method
+        val webViewState = viewModel.viewState.runAndCaptureValues {
+            viewModel.onAddNewPaymentMethod()
+        }.last() as WooShippingEditPaymentViewModel.ViewState.AddPaymentMethodWebView
+
+        // Simulate dismissing the web view
+        val states = viewModel.viewState.runAndCaptureValues {
+            webViewState.onDismiss()
+        }
+
+        assertThat(states.last()).isInstanceOf(WooShippingEditPaymentViewModel.ViewState.Content::class.java)
+    }
+}


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

<!-- Id number of the Linear issue this PR addresses, e.g., WOOMOB-373. -->
Closes WOOMOB-438

### Description
This PR adds logic to handle adding new payment methods in the WebView, the logic is as follows:
- Tapping on the Add button will open the WebView.
- Like the old flow, when we detect redirection to the `/me/payment-methods` URL, we treat it as success.
- When we detect success, we reload the account settings to get the new payment methods.
- In the new flow, I added logic to auto-select the newly added payment method.

> [!IMPORTANT]
> I was planning to use the existing `AuthenticatedWebViewFragment`, but given the screen is shown as a `BottomSheetDialogFragment`, this wasn't possible, as after navigating to another `Fragment`, it gets dismissed automatically (a limitation to being a `DialogFragment`), I tried various solutions, and at the end I opted to use the `WebView` in `Compose`, please feel free to share any thoughts about this topic, or to suggest any other solutions. 

### Steps to reproduce
1. Disable the "WCS staging" plugin on your store to point to production servers (The mobile WebView will always point to the productions server)
2. Open the app, and start creating a new shipping label.
3. Open the payment settings.
4. Tap on "Add new payment method"
5. Add a card.

Make sure to delete the card if you don't need it.

### Testing information
- Confirm that the WebView is correctly opened.
- Confirm that after adding the card, the WebView is automatically dismissed, and we start loading the account settings.
- Confirm that the added card is automatically selected.

### The tests that have been performed
The above.

### Images/gif
##### Adding first payment card

https://github.com/user-attachments/assets/2a4e2527-429e-495a-9b5e-69c8354f17f1

##### Adding additional payment cards

https://github.com/user-attachments/assets/dba643aa-7a1f-4b80-bee5-9407dfd952c5

##### Error
<img src=https://github.com/user-attachments/assets/6182c5e7-6e7a-46fe-96f0-0540738eaca3 width=320 />


- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
