### PR TITLE
[WOOMOB-626] Simplify Barcode Detection Logic

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/common/composeui/modifier/BarcodeScannerModifier.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/common/composeui/modifier/BarcodeScannerModifier.kt
@@ -5,7 +5,6 @@ import androidx.compose.foundation.focusable
 import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.remember
-import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.composed
 import androidx.compose.ui.focus.FocusRequester
@@ -16,19 +15,14 @@ import androidx.compose.ui.input.key.type
 import androidx.compose.ui.input.key.utf16CodePoint
 import com.woocommerce.android.ui.woopos.common.composeui.modifier.BarcodeInputDetector.Companion.FIRST_PRINTABLE_CHAR_CODE
 import com.woocommerce.android.ui.woopos.common.util.WooPosLogWrapper
-import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.Job
-import kotlinx.coroutines.delay
-import kotlinx.coroutines.launch
 import org.wordpress.android.fluxc.utils.CurrentTimeProvider
 
 fun Modifier.listenForBarcodes(
     onBarcodeScanned: (String) -> Unit,
     enabled: Boolean = true
 ): Modifier = composed {
-    val scope = rememberCoroutineScope()
     val focusRequester = remember { FocusRequester() }
-    val detector = remember { BarcodeInputDetector(onBarcodeScanned, scope, CurrentTimeProvider()) }
+    val detector = remember { BarcodeInputDetector(onBarcodeScanned, CurrentTimeProvider()) }
 
     LaunchedEffect(enabled) {
         if (enabled) {
@@ -68,76 +62,36 @@ fun Modifier.listenForBarcodes(
 @VisibleForTesting(otherwise = VisibleForTesting.PRIVATE)
 class BarcodeInputDetector(
     private val onBarcodeScanned: (String) -> Unit,
-    private val coroutineScope: CoroutineScope,
     private val currentTimeProvider: CurrentTimeProvider,
 ) {
     @VisibleForTesting(otherwise = VisibleForTesting.PRIVATE)
     companion object {
-        const val MAX_SCANNER_TOTAL_SCAN_TIMEOUT_MS = 1500L
-        const val MAX_SCANNER_INTER_CHAR_DELAY_MS = 100L
+        const val MAX_SCANNER_INTER_CHAR_DELAY_MS = 200L
         const val FIRST_PRINTABLE_CHAR_CODE = 32
         const val MIN_BARCODE_LENGTH = 4
     }
 
     private val barcodeBuffer = StringBuilder()
-    private var scanStartTime: Long = -1L
     private var lastCharTime: Long = -1L
-    private var timeoutJob: Job? = null
 
     fun handleKeyInput(char: Char): Boolean {
         val currentTime = currentTimeProvider.currentDate().time
 
+        if (lastCharTime != -1L && currentTime - lastCharTime > MAX_SCANNER_INTER_CHAR_DELAY_MS) {
+            clear()
+        }
+
         when (char) {
             '\n', '\r' -> {
-                cancelTimeout()
-                val isLikelyScanner = (currentTime - scanStartTime <= MAX_SCANNER_TOTAL_SCAN_TIMEOUT_MS) &&
-                    (currentTime - lastCharTime <= MAX_SCANNER_INTER_CHAR_DELAY_MS)
-                if (isLikelyScanner) processBarcodeBuffer()
-                clear()
+                processBarcodeBuffer()
             }
 
             else -> {
-                cancelTimeout()
-
-                if (scanStartTime == -1L) {
-                    startNewScan(char, currentTime)
-                } else {
-                    handleContinuedScan(char, currentTime)
-                }
+                lastCharTime = currentTime
+                barcodeBuffer.append(char)
             }
         }
         return true
-    }
-
-    private fun startNewScan(char: Char, currentTime: Long) {
-        scanStartTime = currentTime
-        lastCharTime = currentTime
-        barcodeBuffer.append(char)
-    }
-
-    private fun handleContinuedScan(char: Char, currentTime: Long) {
-        val totalElapsedTime = currentTime - scanStartTime
-        val timeSinceLastChar = currentTime - lastCharTime
-        val humanInputDetected = totalElapsedTime > MAX_SCANNER_TOTAL_SCAN_TIMEOUT_MS ||
-            timeSinceLastChar > MAX_SCANNER_INTER_CHAR_DELAY_MS
-
-        if (humanInputDetected) {
-            clear()
-            startNewScan(char, currentTime)
-        } else {
-            lastCharTime = currentTime
-            barcodeBuffer.append(char)
-
-            val remainingTime = MAX_SCANNER_TOTAL_SCAN_TIMEOUT_MS - totalElapsedTime
-            if (remainingTime > 0) {
-                timeoutJob = coroutineScope.launch {
-                    delay(remainingTime)
-                    processBarcodeBuffer()
-                }
-            } else {
-                clear()
-            }
-        }
     }
 
     private fun processBarcodeBuffer() {
@@ -152,14 +106,7 @@ class BarcodeInputDetector(
     }
 
     fun clear() {
-        cancelTimeout()
         barcodeBuffer.clear()
-        scanStartTime = -1
         lastCharTime = -1
-    }
-
-    private fun cancelTimeout() {
-        timeoutJob?.cancel()
-        timeoutJob = null
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/common/composeui/modifier/BarcodeScannerModifier.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/common/composeui/modifier/BarcodeScannerModifier.kt
@@ -13,9 +13,10 @@ import androidx.compose.ui.input.key.KeyEventType
 import androidx.compose.ui.input.key.onKeyEvent
 import androidx.compose.ui.input.key.type
 import androidx.compose.ui.input.key.utf16CodePoint
-import com.woocommerce.android.ui.woopos.common.composeui.modifier.BarcodeInputDetector.Companion.FIRST_PRINTABLE_CHAR_CODE
 import com.woocommerce.android.ui.woopos.common.util.WooPosLogWrapper
 import org.wordpress.android.fluxc.utils.CurrentTimeProvider
+
+private const val FIRST_PRINTABLE_CHAR_CODE = 32
 
 fun Modifier.listenForBarcodes(
     onBarcodeScanned: (String) -> Unit,
@@ -64,10 +65,8 @@ class BarcodeInputDetector(
     private val onBarcodeScanned: (String) -> Unit,
     private val currentTimeProvider: CurrentTimeProvider,
 ) {
-    @VisibleForTesting(otherwise = VisibleForTesting.PRIVATE)
-    companion object {
+    private companion object {
         const val MAX_SCANNER_INTER_CHAR_DELAY_MS = 200L
-        const val FIRST_PRINTABLE_CHAR_CODE = 32
         const val MIN_BARCODE_LENGTH = 4
     }
 

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/common/composeui/modifier/BarcodeInputDetectorTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/common/composeui/modifier/BarcodeInputDetectorTest.kt
@@ -1,13 +1,7 @@
 package com.woocommerce.android.ui.woopos.common.composeui.modifier
 
-import com.woocommerce.android.ui.woopos.util.WooPosCoroutineTestRule
-import kotlinx.coroutines.ExperimentalCoroutinesApi
-import kotlinx.coroutines.test.TestScope
-import kotlinx.coroutines.test.advanceTimeBy
 import kotlinx.coroutines.test.runTest
-import org.junit.Rule
 import org.junit.Test
-import org.mockito.kotlin.any
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.never
 import org.mockito.kotlin.verify
@@ -15,32 +9,27 @@ import org.mockito.kotlin.whenever
 import org.wordpress.android.fluxc.utils.CurrentTimeProvider
 import java.util.Date
 
-@ExperimentalCoroutinesApi
 class BarcodeInputDetectorTest {
-    @Rule
-    @JvmField
-    val coroutineTestRule = WooPosCoroutineTestRule()
 
     private var onBarcodeScanned: (String) -> Unit = mock()
     private var timeProvider: CurrentTimeProvider = mock()
     private var currentTime = 10000L
 
-    private fun setupDetector(testScope: TestScope): BarcodeInputDetector {
+    private fun setupDetector(): BarcodeInputDetector {
         currentTime = 10000L
         whenever(timeProvider.currentDate()).thenReturn(Date(currentTime))
-        return BarcodeInputDetector(onBarcodeScanned, testScope, timeProvider)
+        return BarcodeInputDetector(onBarcodeScanned, timeProvider)
     }
 
-    private fun TestScope.advanceTestTimeBy(milliseconds: Long) {
+    private fun advanceTestTimeBy(milliseconds: Long) {
         currentTime += milliseconds
         whenever(timeProvider.currentDate()).thenReturn(Date(currentTime))
-        advanceTimeBy(milliseconds)
     }
 
     @Test
     fun `given fast keyboard input, when enter key pressed, then barcode scan is triggered`() = runTest {
         // GIVEN
-        val detector = setupDetector(this)
+        val detector = setupDetector()
         val barcode = "12345678"
 
         // WHEN
@@ -55,32 +44,15 @@ class BarcodeInputDetectorTest {
     }
 
     @Test
-    fun `given valid barcode input, when timeout elapses, then barcode scan is triggered`() = runTest {
-        // GIVEN
-        val detector = setupDetector(this)
-        val barcode = "1234567"
-
-        // WHEN
-        for (char in barcode) {
-            detector.handleKeyInput(char)
-            advanceTestTimeBy(10)
-        }
-        advanceTestTimeBy(BarcodeInputDetector.MAX_SCANNER_TOTAL_SCAN_TIMEOUT_MS)
-
-        // THEN
-        verify(onBarcodeScanned).invoke(barcode)
-    }
-
-    @Test
     fun `given slow keyboard input, when enter key pressed, then barcode scan is not triggered`() = runTest {
         // GIVEN
-        val detector = setupDetector(this)
+        val detector = setupDetector()
         val barcode = "12345678"
 
         // WHEN
         for (char in barcode) {
             detector.handleKeyInput(char)
-            advanceTestTimeBy(200)
+            advanceTestTimeBy(250) // More than MAX_SCANNER_INTER_CHAR_DELAY_MS (200ms)
         }
         detector.handleKeyInput('\n')
 
@@ -91,7 +63,7 @@ class BarcodeInputDetectorTest {
     @Test
     fun `given input shorter than minimum length, when enter pressed, then barcode scan is not triggered`() = runTest {
         // GIVEN
-        val detector = setupDetector(this)
+        val detector = setupDetector()
         detector.handleKeyInput('1')
         detector.handleKeyInput('2')
         detector.handleKeyInput('3')
@@ -104,28 +76,9 @@ class BarcodeInputDetectorTest {
     }
 
     @Test
-    fun `given started scan, when total timeout exceeded, then new scan is started`() = runTest {
-        // GIVEN
-        val detector = setupDetector(this)
-        detector.handleKeyInput('1')
-        advanceTestTimeBy(10)
-        detector.handleKeyInput('2')
-        advanceTestTimeBy(10)
-
-        // WHEN
-        currentTime += BarcodeInputDetector.MAX_SCANNER_TOTAL_SCAN_TIMEOUT_MS + 1
-        whenever(timeProvider.currentDate()).thenReturn(Date(currentTime))
-        detector.handleKeyInput('3')
-        detector.handleKeyInput('\n')
-
-        // THEN
-        verify(onBarcodeScanned, never()).invoke(any())
-    }
-
-    @Test
     fun `given two consecutive valid barcodes, when both scanned, then both are detected`() = runTest {
         // GIVEN
-        val detector = setupDetector(this)
+        val detector = setupDetector()
         val barcode1 = "12345678"
         val barcode2 = "87654321"
 
@@ -145,5 +98,60 @@ class BarcodeInputDetectorTest {
         // THEN
         verify(onBarcodeScanned).invoke(barcode1)
         verify(onBarcodeScanned).invoke(barcode2)
+    }
+
+    @Test
+    fun `given partial input with timeout, when new input starts, then buffer is cleared and new scan detected`() = runTest {
+        // GIVEN
+        val detector = setupDetector()
+
+        // WHEN - start typing a barcode but don't finish
+        detector.handleKeyInput('1')
+        detector.handleKeyInput('2')
+        advanceTestTimeBy(10)
+
+        // Wait more than the inter-char delay
+        advanceTestTimeBy(250)
+
+        // Then start a new barcode
+        val barcode = "87654321"
+        for (char in barcode) {
+            detector.handleKeyInput(char)
+            advanceTestTimeBy(10)
+        }
+        detector.handleKeyInput('\n')
+
+        // THEN - only the complete barcode should be detected
+        verify(onBarcodeScanned).invoke(barcode)
+        verify(onBarcodeScanned, never()).invoke("12")
+    }
+
+    @Test
+    fun `given carriage return terminator, when valid barcode scanned, then barcode is detected`() = runTest {
+        // GIVEN
+        val detector = setupDetector()
+        val barcode = "12345678"
+
+        // WHEN - use \r instead of \n as terminator
+        for (char in barcode) {
+            detector.handleKeyInput(char)
+            advanceTestTimeBy(10)
+        }
+        detector.handleKeyInput('\r')
+
+        // THEN
+        verify(onBarcodeScanned).invoke(barcode)
+    }
+
+    @Test
+    fun `given empty buffer, when terminator pressed, then no barcode is scanned`() = runTest {
+        // GIVEN
+        val detector = setupDetector()
+
+        // WHEN
+        detector.handleKeyInput('\n')
+
+        // THEN
+        verify(onBarcodeScanned, never()).invoke("")
     }
 }


### PR DESCRIPTION
 WOOMOB-626

  ### Description
  Simplified the BarcodeInputDetector implementation to remove unnecessary complexity. The changes implement the agreed-upon requirements:
  - Remove the 1.5s timeout for barcode scanning
  - Only process scans with \r or \n terminator characters
  - Allow maximum 200ms between keystrokes (increased from 100ms)

  The logic is now much cleaner and easier to understand - instead of complex state management with multiple helper methods, we simply check at the beginning of each input if too much time has passed and clear the buffer
  if needed.

  ### Testing information
  Smoke test barcode scanning

  ### The tests that have been performed
I have smoked tested barcode scanning. I also tested entering characters using a hardware keyboard - with 200ms delay and without, all worked fine.

  ### Images/gif
  N/A - Internal code simplification

  - [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.