### PR TITLE
[Shipping Labels] Handle reading permissions and emailReceipts options from the network + other changes

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/ShippingLabelSampleData.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/ShippingLabelSampleData.kt
@@ -57,7 +57,8 @@ object ShippingLabelSampleData {
     fun getPaymentOptions(countOfPaymentMethods: Int = 3) = PaymentMethodOptions(
         selectedPaymentId = if (countOfPaymentMethods > 0) 1 else null,
         paymentMethods = List(countOfPaymentMethods) { getPaymentMethod(it) },
-        addPaymentMethodUrl = "https://example.com/add-payment-method"
+        addPaymentMethodUrl = "https://example.com/add-payment-method",
+        emailReceipts = true
     )
 
     fun getPaymentMethod(index: Int = 0) = PaymentMethodModel(

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/models/AccountSettingsModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/models/AccountSettingsModel.kt
@@ -9,7 +9,6 @@ data class AccountSettingsModel(
     val paymentMethodOptions: PaymentMethodOptions,
     val canManagePayments: Boolean,
     val canEditSettings: Boolean,
-    val isEmailReceiptEnabled: Boolean,
     val storeOwnerName: String,
     val storeOwnerUsername: String
 )
@@ -34,7 +33,8 @@ data class StoreOptionsModel(
 data class PaymentMethodOptions(
     val selectedPaymentId: Int?,
     val paymentMethods: List<PaymentMethodModel>,
-    val addPaymentMethodUrl: String
+    val addPaymentMethodUrl: String,
+    val emailReceipts: Boolean
 ) {
     val selectedPaymentMethod: PaymentMethodModel?
         get() = paymentMethods.find { it.paymentMethodId == selectedPaymentId }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/models/AccountSettingsModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/models/AccountSettingsModel.kt
@@ -6,7 +6,12 @@ import kotlinx.parcelize.Parcelize
 
 data class AccountSettingsModel(
     val storeOptions: StoreOptionsModel,
-    val paymentMethodOptions: PaymentMethodOptions
+    val paymentMethodOptions: PaymentMethodOptions,
+    val canManagePayments: Boolean,
+    val canEditSettings: Boolean,
+    val isEmailReceiptEnabled: Boolean,
+    val storeOwnerName: String,
+    val storeOwnerUsername: String
 )
 
 @Parcelize

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/networking/DTOs.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/networking/DTOs.kt
@@ -16,7 +16,7 @@ import java.math.BigDecimal
 data class AccountSettingsDTO(
     val storeOptions: StoreOptionsDTO,
     val formData: FormDataDTO,
-    val formMeta: FormMetaDTO,
+    val formMeta: FormMetaDTO
 )
 
 data class StoreOptionsDTO(
@@ -28,11 +28,16 @@ data class StoreOptionsDTO(
 
 data class FormDataDTO(
     @SerializedName("selected_payment_method_id") val selectedPaymentId: Int?,
+    @SerializedName("email_receipts") val emailReceipts: Boolean = false
 )
 
 data class FormMetaDTO(
     @SerializedName("payment_methods") val paymentMethods: List<PaymentMethodDTO>,
     @SerializedName("add_payment_method_url") val addPaymentMethodUrl: String,
+    @SerializedName("can_manage_payments") val canManagePayments: Boolean = false,
+    @SerializedName("can_edit_settings") val canEditSettings: Boolean = true,
+    @SerializedName("master_user_name") val masterUserName: String = "",
+    @SerializedName("master_user_wpcom_login") val masterUserWpcomLogin: String = ""
 )
 
 data class PaymentMethodDTO(

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/networking/WooShippingNetworkingMapper.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/networking/WooShippingNetworkingMapper.kt
@@ -47,11 +47,11 @@ class WooShippingNetworkingMapper @Inject constructor(
                             expiry = paymentMethod.expiry
                         )
                     },
-                    addPaymentMethodUrl = formMeta.addPaymentMethodUrl
+                    addPaymentMethodUrl = formMeta.addPaymentMethodUrl,
+                    emailReceipts = formData.emailReceipts
                 ),
                 canManagePayments = formMeta.canManagePayments,
                 canEditSettings = formMeta.canEditSettings,
-                isEmailReceiptEnabled = formData.emailReceipts,
                 storeOwnerName = formMeta.masterUserName,
                 storeOwnerUsername = formMeta.masterUserWpcomLogin
             )

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/networking/WooShippingNetworkingMapper.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/networking/WooShippingNetworkingMapper.kt
@@ -48,7 +48,12 @@ class WooShippingNetworkingMapper @Inject constructor(
                         )
                     },
                     addPaymentMethodUrl = formMeta.addPaymentMethodUrl
-                )
+                ),
+                canManagePayments = formMeta.canManagePayments,
+                canEditSettings = formMeta.canEditSettings,
+                isEmailReceiptEnabled = formData.emailReceipts,
+                storeOwnerName = formMeta.masterUserName,
+                storeOwnerUsername = formMeta.masterUserWpcomLogin
             )
         }
     }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/payment/WooShippingEditPaymentScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/payment/WooShippingEditPaymentScreen.kt
@@ -392,7 +392,7 @@ private fun PaymentMethodsList(
             text = stringResource(R.string.woo_shipping_payment_email_receipt_toggle),
             checked = viewState.emailReceipts,
             enabled = viewState.canEditSettings,
-            onCheckedChange = { TODO() },
+            onCheckedChange = viewState.onEmailReceiptsChanged,
             modifier = Modifier.fillMaxWidth()
         )
         Spacer(Modifier.height(16.dp))
@@ -506,7 +506,8 @@ private fun ContentScreenEmptyPreview() {
                 storeOwnerName = "John Doe",
                 storeOwnerUsername = "johndoe",
                 selectedPaymentMethodId = null,
-                currentPaymentOptions = ShippingLabelSampleData.getPaymentOptions(countOfPaymentMethods = 0)
+                currentPaymentOptions = ShippingLabelSampleData.getPaymentOptions(countOfPaymentMethods = 0),
+                onEmailReceiptsChanged = {}
             ),
             onAddNewPaymentMethod = {},
             onPaymentMethodSelected = {},
@@ -527,7 +528,8 @@ private fun ContentScreenWithPaymentMethodsPreview() {
                 storeOwnerName = "John Doe",
                 storeOwnerUsername = "johndoe",
                 selectedPaymentMethodId = 1,
-                currentPaymentOptions = ShippingLabelSampleData.getPaymentOptions()
+                currentPaymentOptions = ShippingLabelSampleData.getPaymentOptions(),
+                onEmailReceiptsChanged = {}
             ),
             onAddNewPaymentMethod = {},
             onPaymentMethodSelected = {},

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/payment/WooShippingEditPaymentScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/payment/WooShippingEditPaymentScreen.kt
@@ -69,10 +69,7 @@ fun WooShippingEditPaymentScreen(
 ) {
     viewModel.viewState.observeAsState().value?.let {
         WooShippingEditPaymentScreen(
-            viewState = it,
-            onAddNewPaymentMethod = viewModel::onAddNewPaymentMethod,
-            onPaymentMethodSelected = viewModel::onPaymentMethodSelected,
-            onSaveClicked = viewModel::onSaveClicked
+            viewState = it
         )
     }
 }
@@ -80,9 +77,6 @@ fun WooShippingEditPaymentScreen(
 @Composable
 private fun WooShippingEditPaymentScreen(
     viewState: WooShippingEditPaymentViewModel.ViewState,
-    onAddNewPaymentMethod: () -> Unit,
-    onPaymentMethodSelected: (Int) -> Unit,
-    onSaveClicked: () -> Unit,
 ) {
     Surface(
         shape = RoundedCornerShape(
@@ -104,10 +98,7 @@ private fun WooShippingEditPaymentScreen(
 
                 is WooShippingEditPaymentViewModel.ViewState.Content -> {
                     WooShippingEditPaymentContent(
-                        viewState = viewState,
-                        onAddNewPaymentClicked = onAddNewPaymentMethod,
-                        onSaveClicked = onSaveClicked,
-                        onPaymentMethodSelected = onPaymentMethodSelected
+                        viewState = viewState
                     )
                 }
 
@@ -165,9 +156,6 @@ private fun LoadingScreen(
 @Composable
 private fun WooShippingEditPaymentContent(
     viewState: WooShippingEditPaymentViewModel.ViewState.Content,
-    onAddNewPaymentClicked: () -> Unit,
-    onPaymentMethodSelected: (Int) -> Unit,
-    onSaveClicked: () -> Unit,
     modifier: Modifier = Modifier
 ) {
     Column(
@@ -195,17 +183,12 @@ private fun WooShippingEditPaymentContent(
                     storeOwnerUsername = viewState.storeOwnerUsername,
                     loadingAddedPaymentMethod = viewState.loadingState ==
                         WooShippingEditPaymentViewModel.LoadingState.LoadingAddedPaymentMethod,
-                    onAddNewPaymentMethod = onAddNewPaymentClicked,
+                    onAddNewPaymentMethod = viewState.onAddNewPaymentMethod,
                 )
             }
 
             else -> {
-                PaymentMethodsList(
-                    viewState = viewState,
-                    onAddNewPaymentClicked = onAddNewPaymentClicked,
-                    onPaymentMethodSelected = onPaymentMethodSelected,
-                    onSaveClicked = onSaveClicked
-                )
+                PaymentMethodsList(viewState = viewState)
             }
         }
     }
@@ -324,9 +307,6 @@ fun EmptyPaymentMethodsView(
 @Composable
 private fun PaymentMethodsList(
     viewState: WooShippingEditPaymentViewModel.ViewState.Content,
-    onAddNewPaymentClicked: () -> Unit,
-    onPaymentMethodSelected: (Int) -> Unit,
-    onSaveClicked: () -> Unit,
     modifier: Modifier = Modifier
 ) {
     Column(
@@ -338,13 +318,13 @@ private fun PaymentMethodsList(
                 paymentMethod = paymentMethod,
                 isSelected = paymentMethod.paymentMethodId == viewState.selectedPaymentMethodId,
                 enabled = viewState.canManagePaymentMethods,
-                onClick = { onPaymentMethodSelected(paymentMethod.paymentMethodId) },
+                onClick = { viewState.onPaymentMethodSelected(paymentMethod.paymentMethodId) },
                 modifier = Modifier.fillMaxWidth()
             )
             Spacer(Modifier.height(8.dp))
         }
         WCOutlinedButton(
-            onClick = onAddNewPaymentClicked,
+            onClick = viewState.onAddNewPaymentMethod,
             colors = ButtonDefaults.outlinedButtonColors(contentColor = MaterialTheme.colors.onSurface),
             enabled = viewState.canManagePaymentMethods,
             modifier = Modifier.fillMaxWidth()
@@ -397,7 +377,7 @@ private fun PaymentMethodsList(
         )
         Spacer(Modifier.height(16.dp))
         WCColoredButton(
-            onClick = onSaveClicked,
+            onClick = viewState.onSaveClicked,
             text = stringResource(
                 if (viewState.canManagePaymentMethods) {
                     R.string.woo_shipping_payment_use_card_button
@@ -486,10 +466,7 @@ private fun EditDisabledWarning(
 private fun LoadingScreenPreview() {
     WooThemeWithBackground {
         WooShippingEditPaymentScreen(
-            viewState = WooShippingEditPaymentViewModel.ViewState.Loading,
-            onAddNewPaymentMethod = {},
-            onPaymentMethodSelected = {},
-            onSaveClicked = {}
+            viewState = WooShippingEditPaymentViewModel.ViewState.Loading
         )
     }
 }
@@ -503,15 +480,14 @@ private fun ContentScreenEmptyPreview() {
                 canManagePaymentMethods = false,
                 canEditSettings = true,
                 emailReceipts = true,
+                selectedPaymentMethodId = null,
                 storeOwnerName = "John Doe",
                 storeOwnerUsername = "johndoe",
-                selectedPaymentMethodId = null,
                 currentPaymentOptions = ShippingLabelSampleData.getPaymentOptions(countOfPaymentMethods = 0),
+                onAddNewPaymentMethod = {},
+                onPaymentMethodSelected = {},
                 onEmailReceiptsChanged = {}
-            ),
-            onAddNewPaymentMethod = {},
-            onPaymentMethodSelected = {},
-            onSaveClicked = {}
+            ) {}
         )
     }
 }
@@ -525,15 +501,14 @@ private fun ContentScreenWithPaymentMethodsPreview() {
                 canManagePaymentMethods = true,
                 canEditSettings = true,
                 emailReceipts = true,
+                selectedPaymentMethodId = 1,
                 storeOwnerName = "John Doe",
                 storeOwnerUsername = "johndoe",
-                selectedPaymentMethodId = 1,
                 currentPaymentOptions = ShippingLabelSampleData.getPaymentOptions(),
+                onAddNewPaymentMethod = {},
+                onPaymentMethodSelected = {},
                 onEmailReceiptsChanged = {}
-            ),
-            onAddNewPaymentMethod = {},
-            onPaymentMethodSelected = {},
-            onSaveClicked = {}
+            ) {}
         )
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/payment/WooShippingEditPaymentScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/payment/WooShippingEditPaymentScreen.kt
@@ -390,7 +390,7 @@ private fun PaymentMethodsList(
         Spacer(Modifier.height(16.dp))
         WCSwitch(
             text = stringResource(R.string.woo_shipping_payment_email_receipt_toggle),
-            checked = viewState.emailTheReceipt,
+            checked = viewState.emailReceipts,
             enabled = viewState.canEditSettings,
             onCheckedChange = { TODO() },
             modifier = Modifier.fillMaxWidth()
@@ -502,7 +502,7 @@ private fun ContentScreenEmptyPreview() {
             viewState = WooShippingEditPaymentViewModel.ViewState.Content(
                 canManagePaymentMethods = false,
                 canEditSettings = true,
-                emailTheReceipt = true,
+                emailReceipts = true,
                 storeOwnerName = "John Doe",
                 storeOwnerUsername = "johndoe",
                 selectedPaymentMethodId = null,
@@ -523,7 +523,7 @@ private fun ContentScreenWithPaymentMethodsPreview() {
             viewState = WooShippingEditPaymentViewModel.ViewState.Content(
                 canManagePaymentMethods = true,
                 canEditSettings = true,
-                emailTheReceipt = true,
+                emailReceipts = true,
                 storeOwnerName = "John Doe",
                 storeOwnerUsername = "johndoe",
                 selectedPaymentMethodId = 1,

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/payment/WooShippingEditPaymentScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/payment/WooShippingEditPaymentScreen.kt
@@ -398,7 +398,13 @@ private fun PaymentMethodsList(
         Spacer(Modifier.height(16.dp))
         WCColoredButton(
             onClick = onSaveClicked,
-            text = stringResource(R.string.woo_shipping_payment_use_card_button),
+            text = stringResource(
+                if (viewState.canManagePaymentMethods) {
+                    R.string.woo_shipping_payment_use_card_button
+                } else {
+                    R.string.save
+                }
+            ),
             modifier = Modifier.fillMaxWidth()
         )
     }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/payment/WooShippingEditPaymentViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/payment/WooShippingEditPaymentViewModel.kt
@@ -104,7 +104,7 @@ class WooShippingEditPaymentViewModel @Inject constructor(
                 dialogState = dialogState,
                 canManagePaymentMethods = accountSettings.canManagePayments,
                 canEditSettings = accountSettings.canEditSettings,
-                emailTheReceipt = accountSettings.paymentMethodOptions.emailReceipts,
+                emailReceipts = accountSettings.paymentMethodOptions.emailReceipts,
                 storeOwnerName = accountSettings.storeOwnerName,
                 storeOwnerUsername = accountSettings.storeOwnerUsername,
                 selectedPaymentMethodId = selectedPaymentMethod
@@ -172,7 +172,7 @@ class WooShippingEditPaymentViewModel @Inject constructor(
             val dialogState: DialogState? = null,
             val canManagePaymentMethods: Boolean,
             val canEditSettings: Boolean,
-            val emailTheReceipt: Boolean,
+            val emailReceipts: Boolean,
             val selectedPaymentMethodId: Int?,
             val storeOwnerName: String,
             val storeOwnerUsername: String,

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/payment/WooShippingEditPaymentViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/payment/WooShippingEditPaymentViewModel.kt
@@ -102,11 +102,11 @@ class WooShippingEditPaymentViewModel @Inject constructor(
             ViewState.Content(
                 loadingState = loadingState,
                 dialogState = dialogState,
-                canManagePaymentMethods = true, // TODO
-                canEditSettings = true, // TODO
-                emailTheReceipt = true, // TODO
-                storeOwnerName = "John Doe", // TODO
-                storeOwnerUsername = "johndoe", // TODO
+                canManagePaymentMethods = accountSettings.canManagePayments,
+                canEditSettings = accountSettings.canEditSettings,
+                emailTheReceipt = accountSettings.isEmailReceiptEnabled,
+                storeOwnerName = accountSettings.storeOwnerName,
+                storeOwnerUsername = accountSettings.storeOwnerUsername,
                 selectedPaymentMethodId = selectedPaymentMethod
                     ?: accountSettings.paymentMethodOptions.selectedPaymentId,
                 currentPaymentOptions = accountSettings.paymentMethodOptions

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/payment/WooShippingEditPaymentViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/payment/WooShippingEditPaymentViewModel.kt
@@ -104,7 +104,7 @@ class WooShippingEditPaymentViewModel @Inject constructor(
                 dialogState = dialogState,
                 canManagePaymentMethods = accountSettings.canManagePayments,
                 canEditSettings = accountSettings.canEditSettings,
-                emailTheReceipt = accountSettings.isEmailReceiptEnabled,
+                emailTheReceipt = accountSettings.paymentMethodOptions.emailReceipts,
                 storeOwnerName = accountSettings.storeOwnerName,
                 storeOwnerUsername = accountSettings.storeOwnerUsername,
                 selectedPaymentMethodId = selectedPaymentMethod

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/payment/WooShippingEditPaymentViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/payment/WooShippingEditPaymentViewModel.kt
@@ -117,12 +117,15 @@ class WooShippingEditPaymentViewModel @Inject constructor(
                 canManagePaymentMethods = accountSettings.canManagePayments,
                 canEditSettings = accountSettings.canEditSettings,
                 emailReceipts = emailReceipts ?: accountSettings.paymentMethodOptions.emailReceipts,
-                storeOwnerName = accountSettings.storeOwnerName,
-                storeOwnerUsername = accountSettings.storeOwnerUsername,
                 selectedPaymentMethodId = selectedPaymentMethod
                     ?: accountSettings.paymentMethodOptions.selectedPaymentId,
+                storeOwnerName = accountSettings.storeOwnerName,
+                storeOwnerUsername = accountSettings.storeOwnerUsername,
                 currentPaymentOptions = accountSettings.paymentMethodOptions,
-                onEmailReceiptsChanged = ::onEmailReceiptsChanged
+                onAddNewPaymentMethod = ::onAddNewPaymentMethod,
+                onPaymentMethodSelected = ::onPaymentMethodSelected,
+                onEmailReceiptsChanged = ::onEmailReceiptsChanged,
+                onSaveClicked = ::onSaveClicked
             )
         }.let { emitAll(it) }
     }
@@ -131,11 +134,11 @@ class WooShippingEditPaymentViewModel @Inject constructor(
         isAddPaymentMethodWebViewVisible.value = true
     }
 
-    fun onPaymentMethodSelected(paymentMethodId: Int?) {
+    private fun onPaymentMethodSelected(paymentMethodId: Int?) {
         selectedPaymentMethod.value = paymentMethodId
     }
 
-    fun onSaveClicked() {
+    private fun onSaveClicked() {
         TODO()
     }
 
@@ -194,7 +197,10 @@ class WooShippingEditPaymentViewModel @Inject constructor(
             val storeOwnerName: String,
             val storeOwnerUsername: String,
             val currentPaymentOptions: PaymentMethodOptions,
+            val onAddNewPaymentMethod: () -> Unit,
+            val onPaymentMethodSelected: (Int) -> Unit,
             val onEmailReceiptsChanged: (Boolean) -> Unit,
+            val onSaveClicked: () -> Unit
         ) : ViewState {
             val paymentMethods get() = currentPaymentOptions.paymentMethods
         }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/payment/WooShippingEditPaymentViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/payment/WooShippingEditPaymentViewModel.kt
@@ -47,6 +47,13 @@ class WooShippingEditPaymentViewModel @Inject constructor(
         key = "selectedPaymentMethod",
     )
 
+    private val emailReceipts = savedStateHandle.getNullableStateFlow(
+        scope = viewModelScope,
+        initialValue = null,
+        clazz = Boolean::class.java,
+        key = "emailReceipts",
+    )
+
     private val isAddPaymentMethodWebViewVisible = savedStateHandle.getStateFlow(
         scope = viewModelScope,
         initialValue = false,
@@ -98,18 +105,24 @@ class WooShippingEditPaymentViewModel @Inject constructor(
     }
 
     private suspend fun FlowCollector<ViewState>.initContentViewState(accountSettings: AccountSettingsModel) {
-        combine(selectedPaymentMethod, loadingState, dialogState) { selectedPaymentMethod, loadingState, dialogState ->
+        combine(
+            selectedPaymentMethod,
+            emailReceipts,
+            loadingState,
+            dialogState
+        ) { selectedPaymentMethod, emailReceipts, loadingState, dialogState ->
             ViewState.Content(
                 loadingState = loadingState,
                 dialogState = dialogState,
                 canManagePaymentMethods = accountSettings.canManagePayments,
                 canEditSettings = accountSettings.canEditSettings,
-                emailReceipts = accountSettings.paymentMethodOptions.emailReceipts,
+                emailReceipts = emailReceipts ?: accountSettings.paymentMethodOptions.emailReceipts,
                 storeOwnerName = accountSettings.storeOwnerName,
                 storeOwnerUsername = accountSettings.storeOwnerUsername,
                 selectedPaymentMethodId = selectedPaymentMethod
                     ?: accountSettings.paymentMethodOptions.selectedPaymentId,
-                currentPaymentOptions = accountSettings.paymentMethodOptions
+                currentPaymentOptions = accountSettings.paymentMethodOptions,
+                onEmailReceiptsChanged = ::onEmailReceiptsChanged
             )
         }.let { emitAll(it) }
     }
@@ -124,6 +137,10 @@ class WooShippingEditPaymentViewModel @Inject constructor(
 
     fun onSaveClicked() {
         TODO()
+    }
+
+    private fun onEmailReceiptsChanged(value: Boolean) {
+        emailReceipts.value = value
     }
 
     private fun onPaymentMethodAdded() {
@@ -176,7 +193,8 @@ class WooShippingEditPaymentViewModel @Inject constructor(
             val selectedPaymentMethodId: Int?,
             val storeOwnerName: String,
             val storeOwnerUsername: String,
-            val currentPaymentOptions: PaymentMethodOptions
+            val currentPaymentOptions: PaymentMethodOptions,
+            val onEmailReceiptsChanged: (Boolean) -> Unit,
         ) : ViewState {
             val paymentMethods get() = currentPaymentOptions.paymentMethods
         }

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/FetchAccountSettingsTests.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/FetchAccountSettingsTests.kt
@@ -37,11 +37,11 @@ class FetchAccountSettingsTests : BaseUnitTest() {
         paymentMethodOptions = PaymentMethodOptions(
             selectedPaymentId = null,
             paymentMethods = emptyList(),
-            addPaymentMethodUrl = "https://example.com/add-payment-method"
+            addPaymentMethodUrl = "https://example.com/add-payment-method",
+            emailReceipts = false
         ),
         canManagePayments = false,
         canEditSettings = true,
-        isEmailReceiptEnabled = false,
         storeOwnerName = "",
         storeOwnerUsername = ""
     )

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/FetchAccountSettingsTests.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/FetchAccountSettingsTests.kt
@@ -38,7 +38,12 @@ class FetchAccountSettingsTests : BaseUnitTest() {
             selectedPaymentId = null,
             paymentMethods = emptyList(),
             addPaymentMethodUrl = "https://example.com/add-payment-method"
-        )
+        ),
+        canManagePayments = false,
+        canEditSettings = true,
+        isEmailReceiptEnabled = false,
+        storeOwnerName = "",
+        storeOwnerUsername = ""
     )
 
     val sut = FetchAccountSettings(

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/ObserveAccountSettingsTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/ObserveAccountSettingsTest.kt
@@ -29,11 +29,11 @@ class ObserveAccountSettingsTest : BaseUnitTest() {
         paymentMethodOptions = PaymentMethodOptions(
             selectedPaymentId = null,
             paymentMethods = emptyList(),
-            addPaymentMethodUrl = "https://example.com/add-payment-method"
+            addPaymentMethodUrl = "https://example.com/add-payment-method",
+            emailReceipts = false
         ),
         canManagePayments = false,
         canEditSettings = true,
-        isEmailReceiptEnabled = false,
         storeOwnerName = "",
         storeOwnerUsername = ""
     )

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/ObserveAccountSettingsTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/ObserveAccountSettingsTest.kt
@@ -30,7 +30,12 @@ class ObserveAccountSettingsTest : BaseUnitTest() {
             selectedPaymentId = null,
             paymentMethods = emptyList(),
             addPaymentMethodUrl = "https://example.com/add-payment-method"
-        )
+        ),
+        canManagePayments = false,
+        canEditSettings = true,
+        isEmailReceiptEnabled = false,
+        storeOwnerName = "",
+        storeOwnerUsername = ""
     )
 
     val sut = ObserveAccountSettings(

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/WooShippingLabelCreationViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/WooShippingLabelCreationViewModelTest.kt
@@ -139,11 +139,11 @@ class WooShippingLabelCreationViewModelTest : BaseUnitTest() {
         paymentMethodOptions = PaymentMethodOptions(
             selectedPaymentId = null,
             paymentMethods = emptyList(),
-            addPaymentMethodUrl = "https://example.com/add-payment-method"
+            addPaymentMethodUrl = "https://example.com/add-payment-method",
+            emailReceipts = false
         ),
         canManagePayments = false,
         canEditSettings = true,
-        isEmailReceiptEnabled = false,
         storeOwnerName = "",
         storeOwnerUsername = ""
     )
@@ -1079,7 +1079,8 @@ class WooShippingLabelCreationViewModelTest : BaseUnitTest() {
                         expiry = "12/25"
                     )
                 ),
-                addPaymentMethodUrl = "https://example.com/add-payment-method"
+                addPaymentMethodUrl = "https://example.com/add-payment-method",
+                emailReceipts = false
             )
         )
         given(observeAccountSettings()).willReturn(flowOf(accountSettings))
@@ -1099,7 +1100,8 @@ class WooShippingLabelCreationViewModelTest : BaseUnitTest() {
             paymentMethodOptions = PaymentMethodOptions(
                 selectedPaymentId = null,
                 paymentMethods = emptyList(),
-                addPaymentMethodUrl = "https://example.com/add-payment-method"
+                addPaymentMethodUrl = "https://example.com/add-payment-method",
+                emailReceipts = false
             )
         )
         given(observeAccountSettings()).willReturn(flowOf(accountSettings))

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/WooShippingLabelCreationViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/WooShippingLabelCreationViewModelTest.kt
@@ -140,7 +140,12 @@ class WooShippingLabelCreationViewModelTest : BaseUnitTest() {
             selectedPaymentId = null,
             paymentMethods = emptyList(),
             addPaymentMethodUrl = "https://example.com/add-payment-method"
-        )
+        ),
+        canManagePayments = false,
+        canEditSettings = true,
+        isEmailReceiptEnabled = false,
+        storeOwnerName = "",
+        storeOwnerUsername = ""
     )
 
     private val defaultPackageData = PackageData(

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/payment/WooShippingEditPaymentViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/payment/WooShippingEditPaymentViewModelTest.kt
@@ -51,7 +51,12 @@ class WooShippingEditPaymentViewModelTest : BaseUnitTest() {
                 )
             ),
             addPaymentMethodUrl = "https://example.com/add-payment-method"
-        )
+        ),
+        canManagePayments = true,
+        canEditSettings = true,
+        isEmailReceiptEnabled = true,
+        storeOwnerName = "John Doe",
+        storeOwnerUsername = "johndoe"
     )
 
     private val observeAccountSettings: ObserveAccountSettings = mock {
@@ -104,6 +109,11 @@ class WooShippingEditPaymentViewModelTest : BaseUnitTest() {
         assertThat(contentState.selectedPaymentMethodId)
             .isEqualTo(defaultAccountSettings.paymentMethodOptions.selectedPaymentId)
         assertThat(contentState.paymentMethods).isEqualTo(defaultAccountSettings.paymentMethodOptions.paymentMethods)
+        assertThat(contentState.canManagePaymentMethods).isEqualTo(defaultAccountSettings.canManagePayments)
+        assertThat(contentState.canEditSettings).isEqualTo(defaultAccountSettings.canEditSettings)
+        assertThat(contentState.emailTheReceipt).isEqualTo(defaultAccountSettings.isEmailReceiptEnabled)
+        assertThat(contentState.storeOwnerName).isEqualTo(defaultAccountSettings.storeOwnerName)
+        assertThat(contentState.storeOwnerUsername).isEqualTo(defaultAccountSettings.storeOwnerUsername)
     }
 
     @Test

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/payment/WooShippingEditPaymentViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/payment/WooShippingEditPaymentViewModelTest.kt
@@ -9,6 +9,7 @@ import com.woocommerce.android.ui.orders.wooshippinglabels.models.AccountSetting
 import com.woocommerce.android.ui.orders.wooshippinglabels.models.PaymentMethodModel
 import com.woocommerce.android.ui.orders.wooshippinglabels.models.PaymentMethodOptions
 import com.woocommerce.android.ui.orders.wooshippinglabels.models.StoreOptionsModel
+import com.woocommerce.android.util.captureValues
 import com.woocommerce.android.util.getOrAwaitValue
 import com.woocommerce.android.util.runAndCaptureValues
 import com.woocommerce.android.viewmodel.BaseUnitTest
@@ -227,5 +228,17 @@ class WooShippingEditPaymentViewModelTest : BaseUnitTest() {
         }
 
         assertThat(states.last()).isInstanceOf(WooShippingEditPaymentViewModel.ViewState.Content::class.java)
+    }
+
+    @Test
+    fun `when email receipts is toggled, then update email receipts state`() = testBlocking {
+        setup()
+
+        val initialState = viewModel.viewState.captureValues().last()
+            as WooShippingEditPaymentViewModel.ViewState.Content
+        initialState.onEmailReceiptsChanged(!defaultAccountSettings.paymentMethodOptions.emailReceipts)
+        val newState = viewModel.viewState.getOrAwaitValue() as WooShippingEditPaymentViewModel.ViewState.Content
+
+        assertThat(newState.emailReceipts).isEqualTo(!defaultAccountSettings.paymentMethodOptions.emailReceipts)
     }
 }

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/payment/WooShippingEditPaymentViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/payment/WooShippingEditPaymentViewModelTest.kt
@@ -50,11 +50,11 @@ class WooShippingEditPaymentViewModelTest : BaseUnitTest() {
                     name = "Mastercard *5678"
                 )
             ),
-            addPaymentMethodUrl = "https://example.com/add-payment-method"
+            addPaymentMethodUrl = "https://example.com/add-payment-method",
+            emailReceipts = true
         ),
         canManagePayments = true,
         canEditSettings = true,
-        isEmailReceiptEnabled = true,
         storeOwnerName = "John Doe",
         storeOwnerUsername = "johndoe"
     )
@@ -111,7 +111,7 @@ class WooShippingEditPaymentViewModelTest : BaseUnitTest() {
         assertThat(contentState.paymentMethods).isEqualTo(defaultAccountSettings.paymentMethodOptions.paymentMethods)
         assertThat(contentState.canManagePaymentMethods).isEqualTo(defaultAccountSettings.canManagePayments)
         assertThat(contentState.canEditSettings).isEqualTo(defaultAccountSettings.canEditSettings)
-        assertThat(contentState.emailTheReceipt).isEqualTo(defaultAccountSettings.isEmailReceiptEnabled)
+        assertThat(contentState.emailTheReceipt).isEqualTo(defaultAccountSettings.paymentMethodOptions.emailReceipts)
         assertThat(contentState.storeOwnerName).isEqualTo(defaultAccountSettings.storeOwnerName)
         assertThat(contentState.storeOwnerUsername).isEqualTo(defaultAccountSettings.storeOwnerUsername)
     }

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/payment/WooShippingEditPaymentViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/payment/WooShippingEditPaymentViewModelTest.kt
@@ -141,7 +141,8 @@ class WooShippingEditPaymentViewModelTest : BaseUnitTest() {
         setup()
 
         val newPaymentMethodId = 2
-        val initialState = viewModel.viewState.captureValues().last() as WooShippingEditPaymentViewModel.ViewState.Content
+        val initialState = viewModel.viewState.captureValues().last()
+            as WooShippingEditPaymentViewModel.ViewState.Content
         val states = viewModel.viewState.runAndCaptureValues {
             initialState.onPaymentMethodSelected(newPaymentMethodId)
         }

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/payment/WooShippingEditPaymentViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/payment/WooShippingEditPaymentViewModelTest.kt
@@ -121,8 +121,10 @@ class WooShippingEditPaymentViewModelTest : BaseUnitTest() {
     fun `when add new payment method is clicked, then show add payment method web view`() = testBlocking {
         setup()
 
+        val initialState = viewModel.viewState.captureValues().last()
+            as WooShippingEditPaymentViewModel.ViewState.Content
         val states = viewModel.viewState.runAndCaptureValues {
-            viewModel.onAddNewPaymentMethod()
+            initialState.onAddNewPaymentMethod()
         }
 
         assertThat(states.last())
@@ -139,8 +141,9 @@ class WooShippingEditPaymentViewModelTest : BaseUnitTest() {
         setup()
 
         val newPaymentMethodId = 2
+        val initialState = viewModel.viewState.captureValues().last() as WooShippingEditPaymentViewModel.ViewState.Content
         val states = viewModel.viewState.runAndCaptureValues {
-            viewModel.onPaymentMethodSelected(newPaymentMethodId)
+            initialState.onPaymentMethodSelected(newPaymentMethodId)
         }
 
         val contentState = states.last() as WooShippingEditPaymentViewModel.ViewState.Content
@@ -167,8 +170,10 @@ class WooShippingEditPaymentViewModelTest : BaseUnitTest() {
         setup()
 
         // Simulate adding a payment method
+        val initialState = viewModel.viewState.captureValues().last()
+            as WooShippingEditPaymentViewModel.ViewState.Content
         val webViewState = viewModel.viewState.runAndCaptureValues {
-            viewModel.onAddNewPaymentMethod()
+            initialState.onAddNewPaymentMethod()
         }.last() as WooShippingEditPaymentViewModel.ViewState.AddPaymentMethodWebView
 
         // Simulate successful URL load with payment method success URL
@@ -194,8 +199,10 @@ class WooShippingEditPaymentViewModelTest : BaseUnitTest() {
         setup()
 
         // Simulate adding a payment method
+        val initialState = viewModel.viewState.captureValues().last()
+            as WooShippingEditPaymentViewModel.ViewState.Content
         val webViewState = viewModel.viewState.runAndCaptureValues {
-            viewModel.onAddNewPaymentMethod()
+            initialState.onAddNewPaymentMethod()
         }.last() as WooShippingEditPaymentViewModel.ViewState.AddPaymentMethodWebView
 
         // Simulate successful URL load with payment method success URL
@@ -236,8 +243,9 @@ class WooShippingEditPaymentViewModelTest : BaseUnitTest() {
 
         val initialState = viewModel.viewState.captureValues().last()
             as WooShippingEditPaymentViewModel.ViewState.Content
-        initialState.onEmailReceiptsChanged(!defaultAccountSettings.paymentMethodOptions.emailReceipts)
-        val newState = viewModel.viewState.getOrAwaitValue() as WooShippingEditPaymentViewModel.ViewState.Content
+        val newState = viewModel.viewState.runAndCaptureValues {
+            initialState.onEmailReceiptsChanged(!defaultAccountSettings.paymentMethodOptions.emailReceipts)
+        }.last() as WooShippingEditPaymentViewModel.ViewState.Content
 
         assertThat(newState.emailReceipts).isEqualTo(!defaultAccountSettings.paymentMethodOptions.emailReceipts)
     }

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/payment/WooShippingEditPaymentViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/payment/WooShippingEditPaymentViewModelTest.kt
@@ -111,7 +111,7 @@ class WooShippingEditPaymentViewModelTest : BaseUnitTest() {
         assertThat(contentState.paymentMethods).isEqualTo(defaultAccountSettings.paymentMethodOptions.paymentMethods)
         assertThat(contentState.canManagePaymentMethods).isEqualTo(defaultAccountSettings.canManagePayments)
         assertThat(contentState.canEditSettings).isEqualTo(defaultAccountSettings.canEditSettings)
-        assertThat(contentState.emailTheReceipt).isEqualTo(defaultAccountSettings.paymentMethodOptions.emailReceipts)
+        assertThat(contentState.emailReceipts).isEqualTo(defaultAccountSettings.paymentMethodOptions.emailReceipts)
         assertThat(contentState.storeOwnerName).isEqualTo(defaultAccountSettings.storeOwnerName)
         assertThat(contentState.storeOwnerUsername).isEqualTo(defaultAccountSettings.storeOwnerUsername)
     }


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

<!-- Id number of the Linear issue this PR addresses, e.g., WOOMOB-373. -->
Closes WOOMOB-436

### Description
This PR has two main changes:
- Exposes more fields from the `/account/settings` response to handle in the ViewMode, those include the permissions settings, and the store owner details and the `emailReceipts` option.
- Add logic for the `emailReceipts` toggle.

I also did some refactoring which I'll explain below in the comments.

> [!NOTE]
> Saving is still not implemented. 

### Steps to reproduce
1. Open the shipping label creation form.
2. Open payment bottom sheet.

### Testing information
- Confirm that the payment options are enabled for store owner, and disabled for other users.
- Confirm that the footer caption mentions the correct store owner name and WPCom username.
- Toggle the emailReceipts and confirm it works.

### The tests that have been performed
The above.

- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->