### PR TITLE
[Shipping Labels] Handle saving payment settings

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/ShippingLabelSampleData.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/ShippingLabelSampleData.kt
@@ -62,7 +62,7 @@ object ShippingLabelSampleData {
     )
 
     fun getPaymentMethod(index: Int = 0) = PaymentMethodModel(
-        paymentMethodId = index,
+        paymentMethodId = index.toLong(),
         name = "John Doe",
         cardType = "VISA",
         cardDigits = "${index}234",

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/datasource/WooShippingAccountSettingsDataStore.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/datasource/WooShippingAccountSettingsDataStore.kt
@@ -9,6 +9,7 @@ import com.woocommerce.android.datastore.DataStoreQualifier
 import com.woocommerce.android.datastore.DataStoreType
 import com.woocommerce.android.tools.SelectedSite
 import com.woocommerce.android.ui.orders.wooshippinglabels.models.AccountSettingsModel
+import com.woocommerce.android.util.WooLog
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.map
@@ -23,10 +24,7 @@ class WooShippingAccountSettingsDataStore @Inject constructor(
 
     fun observeAccountSettings(): Flow<AccountSettingsModel?> {
         return dataStore.data.map { prefs ->
-            val accountSettings = prefs[stringPreferencesKey(getPrefKey())]
-            runCatching {
-                gson.fromJson(accountSettings, AccountSettingsModel::class.java)
-            }.getOrNull()
+            prefs.getAccountSettings()
         }.distinctUntilChanged()
     }
 
@@ -34,5 +32,25 @@ class WooShippingAccountSettingsDataStore @Inject constructor(
         dataStore.edit { preferences ->
             preferences[stringPreferencesKey(getPrefKey())] = gson.toJson(accountSettings)
         }
+    }
+
+    suspend fun updateAccountSettings(update: (AccountSettingsModel) -> AccountSettingsModel) {
+        dataStore.edit { preferences ->
+            val accountSettings = preferences.getAccountSettings()
+            if (accountSettings == null) {
+                WooLog.w(WooLog.T.SHIPPING_LABELS, "Account settings not found while trying to update local copy")
+                return@edit
+            }
+
+            val updatedAccountSettings = update(accountSettings)
+            preferences[stringPreferencesKey(getPrefKey())] = gson.toJson(updatedAccountSettings)
+        }
+    }
+
+    private fun Preferences.getAccountSettings(): AccountSettingsModel? {
+        return runCatching {
+            val accountSettings = get(stringPreferencesKey(getPrefKey()))
+            gson.fromJson(accountSettings, AccountSettingsModel::class.java)
+        }.getOrNull()
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/models/AccountSettingsModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/models/AccountSettingsModel.kt
@@ -31,7 +31,7 @@ data class StoreOptionsModel(
 }
 
 data class PaymentMethodOptions(
-    val selectedPaymentId: Int?,
+    val selectedPaymentId: Long?,
     val paymentMethods: List<PaymentMethodModel>,
     val addPaymentMethodUrl: String,
     val emailReceipts: Boolean
@@ -41,7 +41,7 @@ data class PaymentMethodOptions(
 }
 
 data class PaymentMethodModel(
-    val paymentMethodId: Int,
+    val paymentMethodId: Long,
     val name: String,
     val cardType: String,
     val cardDigits: String,

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/networking/DTOs.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/networking/DTOs.kt
@@ -27,7 +27,7 @@ data class StoreOptionsDTO(
 )
 
 data class FormDataDTO(
-    @SerializedName("selected_payment_method_id") val selectedPaymentId: Int?,
+    @SerializedName("selected_payment_method_id") val selectedPaymentId: Long?,
     @SerializedName("email_receipts") val emailReceipts: Boolean = false
 )
 
@@ -42,7 +42,7 @@ data class FormMetaDTO(
 
 data class PaymentMethodDTO(
     @SerializedName("payment_method_id")
-    val paymentMethodId: Int,
+    val paymentMethodId: Long,
     @SerializedName("name")
     val name: String,
     @SerializedName("card_type")

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/networking/WooShippingLabelRepository.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/networking/WooShippingLabelRepository.kt
@@ -49,6 +49,26 @@ class WooShippingLabelRepository @Inject constructor(
                 }
         }
 
+    suspend fun updateAccountSettings(
+        site: SiteModel,
+        selectedPaymentMethodId: Long?,
+        emailReceipts: Boolean,
+    ): WooResult<Unit> {
+        return restClient.updateAccountSettings(site, selectedPaymentMethodId, emailReceipts).asWooResult()
+            .also { result ->
+                if (!result.isError) {
+                    accountSettingsDataStore.updateAccountSettings {
+                        it.copy(
+                            paymentMethodOptions = it.paymentMethodOptions.copy(
+                                selectedPaymentId = selectedPaymentMethodId,
+                                emailReceipts = emailReceipts
+                            )
+                        )
+                    }
+                }
+            }
+    }
+
     suspend fun fetchConfig(site: SiteModel, orderId: Long): WooResult<ConfigResponse> =
         restClient.fetchConfig(site, orderId)
             .asWooResult()

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/networking/WooShippingLabelRestClient.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/networking/WooShippingLabelRestClient.kt
@@ -1,10 +1,17 @@
 package com.woocommerce.android.ui.orders.wooshippinglabels.networking
 
+import com.google.gson.JsonObject
+import com.woocommerce.android.extensions.filterNotNull
 import com.woocommerce.android.ui.orders.wooshippinglabels.purchased.printing.ShippingLabelPrintingResponse
 import com.woocommerce.android.ui.orders.wooshippinglabels.rates.networking.DestinationAddressDTO
 import org.wordpress.android.fluxc.model.SiteModel
+import org.wordpress.android.fluxc.network.BaseRequest
+import org.wordpress.android.fluxc.network.rest.wpapi.WPAPIResponse
+import org.wordpress.android.fluxc.network.rest.wpcom.wc.WooError
+import org.wordpress.android.fluxc.network.rest.wpcom.wc.WooErrorType
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.WooNetwork
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.WooPayload
+import org.wordpress.android.fluxc.network.rest.wpcom.wc.toWooError
 import org.wordpress.android.fluxc.utils.toWooPayload
 import javax.inject.Inject
 
@@ -41,6 +48,38 @@ class WooShippingLabelRestClient @Inject constructor(
         )
 
         return result.toWooPayload()
+    }
+
+    suspend fun updateAccountSettings(
+        site: SiteModel,
+        selectedPaymentMethodId: Long?,
+        emailReceipts: Boolean
+    ): WooPayload<Unit> {
+        val url = "/wcshipping/v1/account/settings/"
+
+        val result = wooNetwork.executePostGsonRequest(
+            site = site,
+            path = url,
+            clazz = JsonObject::class.java,
+            body = mapOf(
+                "selected_payment_method_id" to selectedPaymentMethodId,
+                "email_receipts" to emailReceipts
+            ).filterNotNull()
+        )
+
+        val success = (result as? WPAPIResponse.Success<JsonObject>)?.data?.get("success")?.asBoolean ?: false
+
+        return when {
+            result is WPAPIResponse.Error -> WooPayload(error = result.error.toWooError())
+            !success -> WooPayload(
+                error = WooError(
+                    type = WooErrorType.API_ERROR,
+                    original = BaseRequest.GenericErrorType.UNKNOWN,
+                    message = "Something went wrong"
+                )
+            )
+            else -> WooPayload(Unit)
+        }
     }
 
     suspend fun fetchConfig(site: SiteModel, orderId: Long): WooPayload<ConfigResponse> {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/networking/WooShippingLabelRestClient.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/networking/WooShippingLabelRestClient.kt
@@ -63,7 +63,8 @@ class WooShippingLabelRestClient @Inject constructor(
             clazz = JsonObject::class.java,
             body = mapOf(
                 "selected_payment_method_id" to selectedPaymentMethodId,
-                "email_receipts" to emailReceipts
+                "email_receipts" to emailReceipts,
+                "enabled" to true // See WOOSHIP-1410
             ).filterNotNull()
         )
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/payment/UpdatePaymentOptions.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/payment/UpdatePaymentOptions.kt
@@ -1,0 +1,27 @@
+package com.woocommerce.android.ui.orders.wooshippinglabels.payment
+
+import com.woocommerce.android.WooException
+import com.woocommerce.android.tools.SelectedSite
+import com.woocommerce.android.ui.orders.wooshippinglabels.networking.WooShippingLabelRepository
+import jakarta.inject.Inject
+
+class UpdatePaymentOptions @Inject constructor(
+    private val selectedSite: SelectedSite,
+    private val repository: WooShippingLabelRepository
+) {
+    suspend operator fun invoke(
+        selectedPaymentMethodId: Long?,
+        emailReceipts: Boolean,
+    ): Result<Unit> {
+        val result = repository.updateAccountSettings(
+            site = selectedSite.get(),
+            selectedPaymentMethodId = selectedPaymentMethodId,
+            emailReceipts = emailReceipts
+        )
+
+        return when {
+            result.isError -> Result.failure(WooException(result.error))
+            else -> Result.success(Unit)
+        }
+    }
+}

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/payment/WooShippingEditPaymentDialogFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/payment/WooShippingEditPaymentDialogFragment.kt
@@ -4,26 +4,26 @@ import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
+import androidx.compose.material.SnackbarHostState
 import androidx.compose.ui.platform.ComposeView
 import androidx.compose.ui.platform.ViewCompositionStrategy
 import androidx.fragment.app.viewModels
 import androidx.lifecycle.distinctUntilChanged
+import androidx.lifecycle.lifecycleScope
 import androidx.lifecycle.map
 import androidx.navigation.fragment.findNavController
 import com.google.android.material.bottomsheet.BottomSheetDialog
-import com.woocommerce.android.ui.base.UIMessageResolver
 import com.woocommerce.android.ui.compose.theme.WooTheme
 import com.woocommerce.android.viewmodel.MultiLiveEvent
 import com.woocommerce.android.widgets.WCBottomSheetDialogFragment
 import dagger.hilt.android.AndroidEntryPoint
-import javax.inject.Inject
+import kotlinx.coroutines.launch
 
 @AndroidEntryPoint
 class WooShippingEditPaymentDialogFragment : WCBottomSheetDialogFragment() {
     private val viewModel: WooShippingEditPaymentViewModel by viewModels()
 
-    @Inject
-    lateinit var uiMessageResolver: UIMessageResolver
+    private val snackbarHostState = SnackbarHostState()
 
     override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View {
         return ComposeView(requireContext()).apply {
@@ -32,7 +32,8 @@ class WooShippingEditPaymentDialogFragment : WCBottomSheetDialogFragment() {
 
                 WooTheme {
                     WooShippingEditPaymentScreen(
-                        viewModel = viewModel
+                        viewModel = viewModel,
+                        snackbarHostState = snackbarHostState,
                     )
                 }
             }
@@ -48,10 +49,14 @@ class WooShippingEditPaymentDialogFragment : WCBottomSheetDialogFragment() {
     private fun handleEvents() {
         viewModel.event.observe(viewLifecycleOwner) { event ->
             when (event) {
-                is MultiLiveEvent.Event.ShowSnackbar -> uiMessageResolver.showSnack(event.message)
+                is MultiLiveEvent.Event.ShowSnackbar -> showSnackbar(getString(event.message))
                 is MultiLiveEvent.Event.Exit -> findNavController().navigateUp()
             }
         }
+    }
+
+    private fun showSnackbar(message: String) {
+        viewLifecycleOwner.lifecycleScope.launch { snackbarHostState.showSnackbar(message) }
     }
 
     private fun disableDraggingOnWebViewState() {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/payment/WooShippingEditPaymentDialogFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/payment/WooShippingEditPaymentDialogFragment.kt
@@ -9,6 +9,7 @@ import androidx.compose.ui.platform.ViewCompositionStrategy
 import androidx.fragment.app.viewModels
 import androidx.lifecycle.distinctUntilChanged
 import androidx.lifecycle.map
+import androidx.navigation.fragment.findNavController
 import com.google.android.material.bottomsheet.BottomSheetDialog
 import com.woocommerce.android.ui.base.UIMessageResolver
 import com.woocommerce.android.ui.compose.theme.WooTheme
@@ -48,6 +49,7 @@ class WooShippingEditPaymentDialogFragment : WCBottomSheetDialogFragment() {
         viewModel.event.observe(viewLifecycleOwner) { event ->
             when (event) {
                 is MultiLiveEvent.Event.ShowSnackbar -> uiMessageResolver.showSnack(event.message)
+                is MultiLiveEvent.Event.Exit -> findNavController().navigateUp()
             }
         }
     }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/payment/WooShippingEditPaymentScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/payment/WooShippingEditPaymentScreen.kt
@@ -5,6 +5,7 @@ import androidx.compose.foundation.background
 import androidx.compose.foundation.border
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
@@ -27,6 +28,8 @@ import androidx.compose.material.IconButton
 import androidx.compose.material.LocalContentAlpha
 import androidx.compose.material.LocalContentColor
 import androidx.compose.material.MaterialTheme
+import androidx.compose.material.SnackbarHost
+import androidx.compose.material.SnackbarHostState
 import androidx.compose.material.Surface
 import androidx.compose.material.Text
 import androidx.compose.material.icons.Icons
@@ -65,11 +68,13 @@ import com.woocommerce.android.ui.orders.wooshippinglabels.models.PaymentMethodM
 
 @Composable
 fun WooShippingEditPaymentScreen(
-    viewModel: WooShippingEditPaymentViewModel
+    viewModel: WooShippingEditPaymentViewModel,
+    snackbarHostState: SnackbarHostState,
 ) {
     viewModel.viewState.observeAsState().value?.let {
         WooShippingEditPaymentScreen(
-            viewState = it
+            viewState = it,
+            snackbarHostState = snackbarHostState,
         )
     }
 }
@@ -77,40 +82,50 @@ fun WooShippingEditPaymentScreen(
 @Composable
 private fun WooShippingEditPaymentScreen(
     viewState: WooShippingEditPaymentViewModel.ViewState,
+    snackbarHostState: SnackbarHostState = SnackbarHostState(),
 ) {
-    Surface(
-        shape = RoundedCornerShape(
-            topStart = dimensionResource(id = R.dimen.minor_100),
-            topEnd = dimensionResource(id = R.dimen.minor_100)
-        )
-    ) {
-        Column(
-            modifier = Modifier
-                .fillMaxWidth()
+    Box {
+        Surface(
+            shape = RoundedCornerShape(
+                topStart = dimensionResource(id = R.dimen.minor_100),
+                topEnd = dimensionResource(id = R.dimen.minor_100)
+            )
         ) {
-            when (viewState) {
-                is WooShippingEditPaymentViewModel.ViewState.Loading -> {
-                    LoadingScreen(
-                        modifier = Modifier
-                            .fillMaxWidth()
-                    )
-                }
+            Column(
+                modifier = Modifier
+                    .fillMaxWidth()
+            ) {
+                when (viewState) {
+                    is WooShippingEditPaymentViewModel.ViewState.Loading -> {
+                        LoadingScreen(
+                            modifier = Modifier
+                                .fillMaxWidth()
+                        )
+                    }
 
-                is WooShippingEditPaymentViewModel.ViewState.Content -> {
-                    WooShippingEditPaymentContent(
-                        viewState = viewState
-                    )
-                }
+                    is WooShippingEditPaymentViewModel.ViewState.Content -> {
+                        WooShippingEditPaymentContent(
+                            viewState = viewState
+                        )
+                    }
 
-                is WooShippingEditPaymentViewModel.ViewState.AddPaymentMethodWebView -> {
-                    WooShippingEditPaymentWebView(
-                        viewState = viewState,
-                        modifier = Modifier
-                            .fillMaxSize()
-                    )
+                    is WooShippingEditPaymentViewModel.ViewState.AddPaymentMethodWebView -> {
+                        WooShippingEditPaymentWebView(
+                            viewState = viewState,
+                            modifier = Modifier
+                                .fillMaxSize()
+                        )
+                    }
                 }
             }
         }
+
+        SnackbarHost(
+            snackbarHostState,
+            modifier = Modifier
+                .align(Alignment.BottomCenter)
+                .padding(bottom = 24.dp)
+        )
     }
 }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/payment/WooShippingEditPaymentScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/payment/WooShippingEditPaymentScreen.kt
@@ -385,6 +385,7 @@ private fun PaymentMethodsList(
                     R.string.save
                 }
             ),
+            loading = viewState.loadingState == WooShippingEditPaymentViewModel.LoadingState.Saving,
             modifier = Modifier.fillMaxWidth()
         )
     }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/payment/WooShippingEditPaymentViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/payment/WooShippingEditPaymentViewModel.kt
@@ -10,6 +10,7 @@ import com.woocommerce.android.ui.orders.wooshippinglabels.FetchAccountSettings
 import com.woocommerce.android.ui.orders.wooshippinglabels.ObserveAccountSettings
 import com.woocommerce.android.ui.orders.wooshippinglabels.models.AccountSettingsModel
 import com.woocommerce.android.ui.orders.wooshippinglabels.models.PaymentMethodOptions
+import com.woocommerce.android.viewmodel.MultiLiveEvent
 import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.ShowSnackbar
 import com.woocommerce.android.viewmodel.ScopedViewModel
 import com.woocommerce.android.viewmodel.getNullableStateFlow
@@ -33,6 +34,7 @@ class WooShippingEditPaymentViewModel @Inject constructor(
     savedStateHandle: SavedStateHandle,
     observeAccountSettings: ObserveAccountSettings,
     private val fetchAccountSettings: FetchAccountSettings,
+    private val updatePaymentOptions: UpdatePaymentOptions,
     private val webViewAuthenticator: WebViewAuthenticator,
     private val userAgent: UserAgent
 ) : ScopedViewModel(savedStateHandle) {
@@ -138,12 +140,38 @@ class WooShippingEditPaymentViewModel @Inject constructor(
         selectedPaymentMethod.value = paymentMethodId
     }
 
-    private fun onSaveClicked() {
-        TODO()
-    }
-
     private fun onEmailReceiptsChanged(value: Boolean) {
         emailReceipts.value = value
+    }
+
+    private fun onSaveClicked() {
+        val currentPaymentOptions = accountSettings.value?.paymentMethodOptions ?: return
+        val selectedPaymentMethod = selectedPaymentMethod.value ?: currentPaymentOptions.selectedPaymentId
+        val emailReceipts = emailReceipts.value ?: currentPaymentOptions.emailReceipts
+
+        if (selectedPaymentMethod == currentPaymentOptions.selectedPaymentId &&
+            emailReceipts == currentPaymentOptions.emailReceipts
+        ) {
+            // No changes were made, return right away
+            triggerEvent(MultiLiveEvent.Event.Exit)
+            return
+        }
+
+        launch {
+            loadingState.value = LoadingState.Saving
+            updatePaymentOptions(
+                selectedPaymentMethodId = selectedPaymentMethod,
+                emailReceipts = emailReceipts
+            ).fold(
+                onSuccess = {
+                    triggerEvent(MultiLiveEvent.Event.Exit)
+                },
+                onFailure = {
+                    triggerEvent(ShowSnackbar(R.string.error_generic))
+                }
+            )
+            loadingState.value = LoadingState.Idle
+        }
     }
 
     private fun onPaymentMethodAdded() {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/payment/WooShippingEditPaymentViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/payment/WooShippingEditPaymentViewModel.kt
@@ -43,7 +43,7 @@ class WooShippingEditPaymentViewModel @Inject constructor(
     private val selectedPaymentMethod = savedStateHandle.getNullableStateFlow(
         scope = viewModelScope,
         initialValue = null,
-        clazz = Int::class.java,
+        clazz = Long::class.java,
         key = "selectedPaymentMethod",
     )
 
@@ -134,7 +134,7 @@ class WooShippingEditPaymentViewModel @Inject constructor(
         isAddPaymentMethodWebViewVisible.value = true
     }
 
-    private fun onPaymentMethodSelected(paymentMethodId: Int?) {
+    private fun onPaymentMethodSelected(paymentMethodId: Long?) {
         selectedPaymentMethod.value = paymentMethodId
     }
 
@@ -193,12 +193,12 @@ class WooShippingEditPaymentViewModel @Inject constructor(
             val canManagePaymentMethods: Boolean,
             val canEditSettings: Boolean,
             val emailReceipts: Boolean,
-            val selectedPaymentMethodId: Int?,
+            val selectedPaymentMethodId: Long?,
             val storeOwnerName: String,
             val storeOwnerUsername: String,
             val currentPaymentOptions: PaymentMethodOptions,
             val onAddNewPaymentMethod: () -> Unit,
-            val onPaymentMethodSelected: (Int) -> Unit,
+            val onPaymentMethodSelected: (Long) -> Unit,
             val onEmailReceiptsChanged: (Boolean) -> Unit,
             val onSaveClicked: () -> Unit
         ) : ViewState {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/util/WooLog.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/util/WooLog.kt
@@ -43,7 +43,8 @@ object WooLog {
         BLAZE,
         GOOGLE_ADS,
         POS,
-        CUSTOM_FIELDS
+        CUSTOM_FIELDS,
+        SHIPPING_LABELS
     }
 
     // Breaking convention to be consistent with org.wordpress.android.util.AppLog

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/payment/WooShippingEditPaymentViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/payment/WooShippingEditPaymentViewModelTest.kt
@@ -13,6 +13,7 @@ import com.woocommerce.android.util.captureValues
 import com.woocommerce.android.util.getOrAwaitValue
 import com.woocommerce.android.util.runAndCaptureValues
 import com.woocommerce.android.viewmodel.BaseUnitTest
+import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.Exit
 import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.ShowSnackbar
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.flowOf
@@ -66,6 +67,7 @@ class WooShippingEditPaymentViewModelTest : BaseUnitTest() {
     private val fetchAccountSettings: FetchAccountSettings = mock {
         onBlocking { invoke() } doReturn Result.success(defaultAccountSettings)
     }
+    private val updatePaymentOptions: UpdatePaymentOptions = mock()
     private val webViewAuthenticator: WebViewAuthenticator = mock()
     private val userAgent: UserAgent = mock()
     private val savedStateHandle = SavedStateHandle()
@@ -78,6 +80,7 @@ class WooShippingEditPaymentViewModelTest : BaseUnitTest() {
             savedStateHandle = savedStateHandle,
             observeAccountSettings = observeAccountSettings,
             fetchAccountSettings = fetchAccountSettings,
+            updatePaymentOptions = updatePaymentOptions,
             webViewAuthenticator = webViewAuthenticator,
             userAgent = userAgent
         )
@@ -178,11 +181,10 @@ class WooShippingEditPaymentViewModelTest : BaseUnitTest() {
         }.last() as WooShippingEditPaymentViewModel.ViewState.AddPaymentMethodWebView
 
         // Simulate successful URL load with payment method success URL
-        val events = mutableListOf<Any>()
-        viewModel.event.observeForever { events.add(it) }
-
-        webViewState.onUrlLoaded("https://wordpress.com/me/payment-methods")
-        advanceUntilIdle()
+        val events = viewModel.event.runAndCaptureValues {
+            webViewState.onUrlLoaded("https://wordpress.com/me/payment-methods")
+            advanceUntilIdle()
+        }
 
         // Verify that the snackbar is shown
         assertThat(events).anyMatch { it is ShowSnackbar && it.message == R.string.woo_shipping_payment_method_added }
@@ -250,4 +252,95 @@ class WooShippingEditPaymentViewModelTest : BaseUnitTest() {
 
         assertThat(newState.emailReceipts).isEqualTo(!defaultAccountSettings.paymentMethodOptions.emailReceipts)
     }
+
+    @Test
+    fun `when save is clicked with no changes, then exit without calling updatePaymentOptions`() = testBlocking {
+        setup()
+
+        // Get the content state and call onSaveClicked
+        val contentState =
+            viewModel.viewState.captureValues().last() as WooShippingEditPaymentViewModel.ViewState.Content
+
+        // Capture events
+        val events = viewModel.event.runAndCaptureValues {
+            contentState.onSaveClicked()
+            advanceUntilIdle()
+        }
+
+        // Verify that Exit event is triggered and updatePaymentOptions is not called
+        assertThat(events).anyMatch { it is Exit }
+        org.mockito.kotlin.verify(updatePaymentOptions, org.mockito.kotlin.never()).invoke(
+            org.mockito.kotlin.any(),
+            org.mockito.kotlin.any()
+        )
+    }
+
+    @Test
+    fun `when save is clicked with changes and save is successful, then call updatePaymentOptions and exit`() =
+        testBlocking {
+            // Setup with successful update
+            whenever(updatePaymentOptions.invoke(org.mockito.kotlin.any(), org.mockito.kotlin.any()))
+                .thenReturn(Result.success(Unit))
+
+            setup()
+
+            // Get the content state, make changes, and call onSaveClicked
+            val contentState =
+                viewModel.viewState.captureValues().last() as WooShippingEditPaymentViewModel.ViewState.Content
+
+            // Change payment method
+            val newPaymentMethodId = 2L
+            contentState.onPaymentMethodSelected(newPaymentMethodId)
+
+            // Change email receipts
+            contentState.onEmailReceiptsChanged(!defaultAccountSettings.paymentMethodOptions.emailReceipts)
+
+            // Capture events and save changes
+            val events = viewModel.event.runAndCaptureValues {
+                contentState.onSaveClicked()
+                advanceUntilIdle()
+            }
+
+            // Verify that updatePaymentOptions is called with the correct parameters
+            org.mockito.kotlin.verify(updatePaymentOptions).invoke(
+                selectedPaymentMethodId = newPaymentMethodId,
+                emailReceipts = !defaultAccountSettings.paymentMethodOptions.emailReceipts
+            )
+
+            // Verify that Exit event is triggered
+            assertThat(events).anyMatch { it is Exit }
+        }
+
+    @Test
+    fun `when save is clicked with changes and save fails, then call updatePaymentOptions and show error`() =
+        testBlocking {
+            // Setup with failed update
+            whenever(updatePaymentOptions.invoke(org.mockito.kotlin.any(), org.mockito.kotlin.any()))
+                .thenReturn(Result.failure(Exception("Failed to update payment options")))
+
+            setup()
+
+            // Get the content state, make changes, and call onSaveClicked
+            val contentState =
+                viewModel.viewState.captureValues().last() as WooShippingEditPaymentViewModel.ViewState.Content
+
+            // Change payment method
+            val newPaymentMethodId = 2L
+            contentState.onPaymentMethodSelected(newPaymentMethodId)
+
+            // Capture events and save changes
+            val events = viewModel.event.runAndCaptureValues {
+                contentState.onSaveClicked()
+                advanceUntilIdle()
+            }
+
+            // Verify that updatePaymentOptions is called with the correct parameters
+            org.mockito.kotlin.verify(updatePaymentOptions).invoke(
+                selectedPaymentMethodId = newPaymentMethodId,
+                emailReceipts = defaultAccountSettings.paymentMethodOptions.emailReceipts
+            )
+
+            // Verify that ShowSnackbar event is triggered with error message
+            assertThat(events).anyMatch { it is ShowSnackbar && it.message == R.string.error_generic }
+        }
 }

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/payment/WooShippingEditPaymentViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/payment/WooShippingEditPaymentViewModelTest.kt
@@ -19,8 +19,11 @@ import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.test.advanceUntilIdle
 import org.assertj.core.api.Assertions.assertThat
+import org.mockito.kotlin.any
 import org.mockito.kotlin.doReturn
 import org.mockito.kotlin.mock
+import org.mockito.kotlin.never
+import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
 import org.wordpress.android.fluxc.network.UserAgent
 import kotlin.test.Test
@@ -269,9 +272,9 @@ class WooShippingEditPaymentViewModelTest : BaseUnitTest() {
 
         // Verify that Exit event is triggered and updatePaymentOptions is not called
         assertThat(events).anyMatch { it is Exit }
-        org.mockito.kotlin.verify(updatePaymentOptions, org.mockito.kotlin.never()).invoke(
-            org.mockito.kotlin.any(),
-            org.mockito.kotlin.any()
+        verify(updatePaymentOptions, never()).invoke(
+            any(),
+            any()
         )
     }
 
@@ -279,7 +282,7 @@ class WooShippingEditPaymentViewModelTest : BaseUnitTest() {
     fun `when save is clicked with changes and save is successful, then call updatePaymentOptions and exit`() =
         testBlocking {
             // Setup with successful update
-            whenever(updatePaymentOptions.invoke(org.mockito.kotlin.any(), org.mockito.kotlin.any()))
+            whenever(updatePaymentOptions.invoke(any(), any()))
                 .thenReturn(Result.success(Unit))
 
             setup()
@@ -302,7 +305,7 @@ class WooShippingEditPaymentViewModelTest : BaseUnitTest() {
             }
 
             // Verify that updatePaymentOptions is called with the correct parameters
-            org.mockito.kotlin.verify(updatePaymentOptions).invoke(
+            verify(updatePaymentOptions).invoke(
                 selectedPaymentMethodId = newPaymentMethodId,
                 emailReceipts = !defaultAccountSettings.paymentMethodOptions.emailReceipts
             )
@@ -315,7 +318,7 @@ class WooShippingEditPaymentViewModelTest : BaseUnitTest() {
     fun `when save is clicked with changes and save fails, then call updatePaymentOptions and show error`() =
         testBlocking {
             // Setup with failed update
-            whenever(updatePaymentOptions.invoke(org.mockito.kotlin.any(), org.mockito.kotlin.any()))
+            whenever(updatePaymentOptions.invoke(any(), any()))
                 .thenReturn(Result.failure(Exception("Failed to update payment options")))
 
             setup()
@@ -335,7 +338,7 @@ class WooShippingEditPaymentViewModelTest : BaseUnitTest() {
             }
 
             // Verify that updatePaymentOptions is called with the correct parameters
-            org.mockito.kotlin.verify(updatePaymentOptions).invoke(
+            verify(updatePaymentOptions).invoke(
                 selectedPaymentMethodId = newPaymentMethodId,
                 emailReceipts = defaultAccountSettings.paymentMethodOptions.emailReceipts
             )

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/payment/WooShippingEditPaymentViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/payment/WooShippingEditPaymentViewModelTest.kt
@@ -140,7 +140,7 @@ class WooShippingEditPaymentViewModelTest : BaseUnitTest() {
     fun `when payment method is selected, then update selected payment method`() = testBlocking {
         setup()
 
-        val newPaymentMethodId = 2
+        val newPaymentMethodId = 2L
         val initialState = viewModel.viewState.captureValues().last()
             as WooShippingEditPaymentViewModel.ViewState.Content
         val states = viewModel.viewState.runAndCaptureValues {


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

<!-- Id number of the Linear issue this PR addresses, e.g., WOOMOB-373. -->
Closes WOOMOB-662

### Description
This PR adds handling of the saving logic for the payment bottom sheet.

### Steps to reproduce
##### Success
- Open the shipping labels creation form.
- Open the payment options.
- Make some changes.
- Tap on "Use this card"

##### Failure
- Import this API Faker options:
```
[
  {
    "request": {
      "httpMethod": "POST",
      "id": 0,
      "path": "/wcshipping/v1/account/settings",
      "queryParameters": [],
      "type": {
        "type": "wp-api"
      }
    },
    "response": {
      "body": "",
      "endpointId": 0,
      "statusCode": 403
    }
  }
]
```
- Open the shipping labels creation form.
- Open the payment options.
- Make some changes.
- Tap on "Use this card"

### Testing information
- Confirm that both the happy path and unhappy path works.
- Optional: test using both store owner and non-owner.

### The tests that have been performed
The above

### Images/gif
##### Success
[Screen_recording_20250623_122446.webm](https://github.com/user-attachments/assets/4d2409dd-c54a-47ea-8a88-1ac838a1963f)

##### Failure
[Screen_recording_20250623_123642.webm](https://github.com/user-attachments/assets/30b82d90-fab0-41cf-b57d-b8da17a0c5d8)


- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->