### PR TITLE
[Shipping Labels] Improvements to the UI shipment details for purchased labels

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/ShipmentDetails.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/ShipmentDetails.kt
@@ -79,7 +79,7 @@ fun ShipmentDetails(
     onMarkOrderCompleteChange: (Boolean) -> Unit,
     onEditPaymentMethodClicked: () -> Unit,
     handlerModifier: Modifier = Modifier,
-    isReadOnly: Boolean = false
+    shipmentPurchased: Boolean
 ) {
     Column {
         Column(
@@ -134,7 +134,7 @@ fun ShipmentDetails(
                 shippingRateSummary = shippingRateSummary,
                 paymentsSectionUI = paymentsSectionUI,
                 modifier = modifier.padding(top = dimensionResource(R.dimen.major_100)),
-                isReadOnly = isReadOnly,
+                shipmentPurchased = shipmentPurchased,
                 onEditDestinationAddress = onEditDestinationAddress,
                 onEditOriginAddress = onEditOriginAddress,
                 onOriginAddressSelected = onOriginAddressSelected,
@@ -151,7 +151,7 @@ fun ShipmentDetails(
                 shippingRateSummary = shippingRateSummary,
                 paymentsSectionUI = paymentsSectionUI,
                 modifier = modifier.padding(top = dimensionResource(R.dimen.minor_100)),
-                isReadOnly = isReadOnly,
+                shipmentPurchased = shipmentPurchased,
                 onMarkOrderCompleteChange = onMarkOrderCompleteChange,
                 onEditDestinationAddress = onEditDestinationAddress,
                 onEditOriginAddress = onEditOriginAddress,
@@ -179,7 +179,7 @@ private fun ShipmentDetailsPortrait(
     onEditPaymentMethodClicked: () -> Unit,
     destinationStatus: AddressStatus,
     modifier: Modifier = Modifier,
-    isReadOnly: Boolean = false
+    shipmentPurchased: Boolean
 ) {
     Column(modifier) {
         Column(
@@ -193,25 +193,27 @@ private fun ShipmentDetailsPortrait(
                 totalItems = totalItems,
                 totalItemsCost = totalItemsCost,
                 shippingLines = shippingLines,
-                isReadOnly = isReadOnly,
+                isReadOnly = shipmentPurchased,
                 onEditDestinationAddress = onEditDestinationAddress,
                 onEditOriginAddress = onEditOriginAddress,
                 onOriginAddressSelected = onOriginAddressSelected,
                 destinationStatus = destinationStatus
             )
             Divider(modifier = Modifier.padding(horizontal = 16.dp))
-            PaymentSection(
-                paymentsSectionUI = paymentsSectionUI,
-                onEditPaymentMethodClicked = onEditPaymentMethodClicked,
-                modifier = Modifier.padding(16.dp)
-            )
+            if (!shipmentPurchased) {
+                PaymentSection(
+                    paymentsSectionUI = paymentsSectionUI,
+                    onEditPaymentMethodClicked = onEditPaymentMethodClicked,
+                    modifier = Modifier.padding(16.dp)
+                )
+            }
             Divider(modifier = Modifier.padding(horizontal = 16.dp))
             ShipmentCostSection(
                 shippingRateSummary = shippingRateSummary,
                 modifier = Modifier.padding(16.dp)
             )
         }
-        if (isReadOnly.not()) {
+        if (shipmentPurchased.not()) {
             Divider()
             MarkComplete(
                 markOrderComplete = markOrderComplete,
@@ -235,7 +237,7 @@ private fun ShipmentDetailsLandscape(
     onEditPaymentMethodClicked: () -> Unit,
     destinationStatus: AddressStatus,
     modifier: Modifier = Modifier,
-    isReadOnly: Boolean = false
+    shipmentPurchased: Boolean = false
 ) {
     Column(modifier) {
         Column(
@@ -247,7 +249,7 @@ private fun ShipmentDetailsLandscape(
             AddressSectionLandscape(
                 shippingAddresses = shippingAddresses,
                 modifier = Modifier.padding(horizontal = 16.dp),
-                isReadOnly = isReadOnly,
+                isReadOnly = shipmentPurchased,
                 onEditDestinationAddress = onEditDestinationAddress,
                 onEditOriginAddress = onEditOriginAddress,
                 onOriginAddressSelected = onOriginAddressSelected,
@@ -266,11 +268,13 @@ private fun ShipmentDetailsLandscape(
                 )
                 VerticalDivider(modifier = Modifier.padding(top = 16.dp))
                 Column(modifier = Modifier.weight(1f)) {
-                    PaymentSection(
-                        paymentsSectionUI = paymentsSectionUI,
-                        onEditPaymentMethodClicked = onEditPaymentMethodClicked,
-                        modifier = Modifier.padding(16.dp)
-                    )
+                    if (!shipmentPurchased) {
+                        PaymentSection(
+                            paymentsSectionUI = paymentsSectionUI,
+                            onEditPaymentMethodClicked = onEditPaymentMethodClicked,
+                            modifier = Modifier.padding(16.dp)
+                        )
+                    }
                     Divider()
                     ShipmentCostSection(
                         shippingRateSummary = shippingRateSummary,
@@ -609,7 +613,7 @@ fun ShipmentDetailsLandscapePreview() {
                 onMarkOrderCompleteChange = {},
                 onEditPaymentMethodClicked = {},
                 handlerModifier = Modifier,
-                isReadOnly = false
+                shipmentPurchased = false
             )
         }
     }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/ShippingLabelSampleData.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/ShippingLabelSampleData.kt
@@ -19,7 +19,7 @@ object ShippingLabelSampleData {
         city = "City",
         postcode = "",
         email = "email",
-        country = "USA",
+        country = "US",
         state = "California",
         id = "id_1",
         isDefault = true,

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/WooShippingLabelCreationScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/WooShippingLabelCreationScreen.kt
@@ -390,7 +390,7 @@ private fun LabelCreationScreenWithBottomSheet(
                 onOriginAddressSelected = onOriginAddressSelected,
                 destinationStatus = destinationStatus,
                 noticeBannerUiState = uiState.noticeBannerUiState,
-                isReadOnly = selectedShipment.purchased,
+                shipmentPurchased = selectedShipment.purchased,
                 onEditPaymentMethodClicked = onEditPaymentMethodClicked,
             )
         },

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/WooShippingLabelCreationViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/WooShippingLabelCreationViewModel.kt
@@ -63,6 +63,7 @@ import com.woocommerce.android.viewmodel.ScopedViewModel
 import com.woocommerce.android.viewmodel.navArgs
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.FlowPreview
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableSharedFlow
@@ -76,6 +77,8 @@ import kotlinx.coroutines.flow.drop
 import kotlinx.coroutines.flow.filter
 import kotlinx.coroutines.flow.filterNotNull
 import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.flatMapLatest
+import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.onEach
@@ -91,6 +94,7 @@ import java.util.Date
 import java.util.Locale
 import javax.inject.Inject
 
+@OptIn(ExperimentalCoroutinesApi::class)
 @SuppressWarnings("LargeClass")
 @HiltViewModel
 class WooShippingLabelCreationViewModel @Inject constructor(
@@ -190,37 +194,57 @@ class WooShippingLabelCreationViewModel @Inject constructor(
         }
     }
 
-    private suspend fun observeNotices() = observeShippingLabelNotice(
-        shippingAddresses,
-        customsStatesFlow.filter { it.isNotEmpty() },
-        uiState.map { it.selectedIndex }.distinctUntilChanged(),
-        viewModelScope
-    ).onStart { delay(NOTIFICATIONS_DELAY) }
-        .collectLatest { noticeBanner ->
-            uiState.update {
-                it.copy(
-                    noticeBannerUiState = noticeBanner?.copy(
-                        onTapped = {
-                            when (noticeBanner.type) {
-                                NoticeType.UNVERIFIED_ORIGIN_ADDRESS -> {
-                                    shippingAddresses.value?.shipFrom?.let { shipFrom -> onEditOriginAddress(shipFrom) }
-                                }
-
-                                NoticeType.MISSING_DESTINATION_ADDRESS, NoticeType.UNVERIFIED_DESTINATION_ADDRESS -> {
-                                    shippingAddresses.value?.shipTo?.let { shipTo -> onEditDestinationAddress(shipTo) }
-                                }
-
-                                NoticeType.MISSING_ITN -> {
-                                    onEditCustomsClick()
-                                }
-
-                                else -> {}
-                            }
-                        }
-                    )
+    private suspend fun observeNotices() =
+        combine(
+            shipments,
+            uiState.map { it.selectedIndex }.distinctUntilChanged()
+        ) { shipments, selectedShipmentIndex ->
+            shipments[selectedShipmentIndex]
+        }.flatMapLatest { shipment ->
+            if (shipment.purchased) {
+                flowOf(null)
+            } else {
+                observeShippingLabelNotice(
+                    shippingAddresses,
+                    customsStatesFlow.filter { it.isNotEmpty() },
+                    uiState.map { it.selectedIndex }.distinctUntilChanged(),
+                    viewModelScope
                 )
             }
-        }
+        }.onStart { delay(NOTIFICATIONS_DELAY) }
+            .collectLatest { noticeBanner ->
+                uiState.update {
+                    it.copy(
+                        noticeBannerUiState = noticeBanner?.copy(
+                            onTapped = {
+                                when (noticeBanner.type) {
+                                    NoticeType.UNVERIFIED_ORIGIN_ADDRESS -> {
+                                        shippingAddresses.value?.shipFrom?.let { shipFrom ->
+                                            onEditOriginAddress(
+                                                shipFrom
+                                            )
+                                        }
+                                    }
+
+                                    NoticeType.MISSING_DESTINATION_ADDRESS, NoticeType.UNVERIFIED_DESTINATION_ADDRESS -> {
+                                        shippingAddresses.value?.shipTo?.let { shipTo ->
+                                            onEditDestinationAddress(
+                                                shipTo
+                                            )
+                                        }
+                                    }
+
+                                    NoticeType.MISSING_ITN -> {
+                                        onEditCustomsClick()
+                                    }
+
+                                    else -> {}
+                                }
+                            }
+                        )
+                    )
+                }
+            }
 
     private fun observeShippingLabelPurchaseStatus(shipmentId: Int) {
         launch {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/WooShippingLabelCreationViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/WooShippingLabelCreationViewModel.kt
@@ -226,7 +226,8 @@ class WooShippingLabelCreationViewModel @Inject constructor(
                                         }
                                     }
 
-                                    NoticeType.MISSING_DESTINATION_ADDRESS, NoticeType.UNVERIFIED_DESTINATION_ADDRESS -> {
+                                    NoticeType.MISSING_DESTINATION_ADDRESS,
+                                    NoticeType.UNVERIFIED_DESTINATION_ADDRESS -> {
                                         shippingAddresses.value?.shipTo?.let { shipTo ->
                                             onEditDestinationAddress(
                                                 shipTo

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/address/AddressSection.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/address/AddressSection.kt
@@ -39,7 +39,6 @@ import androidx.compose.ui.unit.dp
 import androidx.constraintlayout.compose.ConstraintLayout
 import androidx.constraintlayout.compose.Dimension
 import com.woocommerce.android.R
-import com.woocommerce.android.extensions.appendWithIfNotEmpty
 import com.woocommerce.android.ui.compose.theme.WooThemeWithBackground
 import com.woocommerce.android.ui.orders.wooshippinglabels.RoundedCornerBoxWithBorder
 import com.woocommerce.android.ui.orders.wooshippinglabels.ShippingLabelSampleData
@@ -112,7 +111,7 @@ internal fun AddressSectionPortrait(
 
             )
             Text(
-                text = shippingAddresses.shipFrom.toShippingFromString().uppercase(),
+                text = shippingAddresses.shipFrom.format(singleLine = !isReadOnly).uppercase(),
                 maxLines = if (isReadOnly) Int.MAX_VALUE else 1,
                 overflow = TextOverflow.Ellipsis,
                 color = if (isReadOnly) LocalContentColor.current else MaterialTheme.colors.primary,
@@ -343,7 +342,7 @@ private fun ShipFromSelection(
                 )
         )
         Text(
-            text = shipFrom.toShippingFromString().uppercase(),
+            text = shipFrom.format(singleLine = !isReadOnly).uppercase(),
             maxLines = if (isReadOnly) Int.MAX_VALUE else 1,
             overflow = TextOverflow.Ellipsis,
             color = if (isReadOnly) LocalContentColor.current else MaterialTheme.colors.primary,
@@ -414,7 +413,7 @@ fun OriginAddressSelectionItem(
                     modifier = Modifier
                 )
                 Text(
-                    text = address.toShippingFromString(),
+                    text = address.format(singleLine = true),
                     modifier = Modifier.padding(top = dimensionResource(id = R.dimen.minor_100))
                 )
             }
@@ -483,14 +482,6 @@ private fun OriginShippingAddress.getFormattedName(context: Context): String {
     }
 }
 
-private fun OriginShippingAddress.toShippingFromString() = StringBuilder()
-    .appendWithIfNotEmpty(this.address1)
-    .appendWithIfNotEmpty(this.address2)
-    .appendWithIfNotEmpty(this.city)
-    .appendWithIfNotEmpty(this.state)
-    .appendWithIfNotEmpty(this.postcode)
-    .toString()
-
 @Preview
 @Composable
 private fun AddressSectionPortraitPreview() {
@@ -505,7 +496,7 @@ private fun AddressSectionPortraitPreview() {
                 onEditDestinationAddress = {},
                 onEditOriginAddress = {},
                 onOriginAddressSelected = {},
-                isReadOnly = false,
+                isReadOnly = true,
                 destinationStatus = AddressStatus.VERIFIED
             )
         }
@@ -544,7 +535,7 @@ private fun AddressSectionLandscapePreview() {
                     shipTo = ShippingLabelSampleData.getShipTo(),
                     originAddresses = listOf(ShippingLabelSampleData.getShipFrom())
                 ),
-                isReadOnly = false,
+                isReadOnly = true,
                 onEditDestinationAddress = {},
                 onEditOriginAddress = {},
                 onOriginAddressSelected = {},

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/address/AddressSection.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/address/AddressSection.kt
@@ -186,11 +186,12 @@ internal fun AddressSectionPortrait(
                         ),
                 )
             }
-            AddressStatusIndicator(
-                addressStatus = destinationStatus,
-                modifier = destinationStatusModifier
-            )
             if (isReadOnly.not()) {
+                AddressStatusIndicator(
+                    addressStatus = destinationStatus,
+                    modifier = destinationStatusModifier
+                )
+
                 IconButton(
                     onClick = { onEditDestinationAddress(shippingAddresses.shipTo) },
                     modifier = Modifier
@@ -283,10 +284,12 @@ internal fun AddressSectionLandscape(
                                 )
                         )
                     }
-                    AddressStatusIndicator(
-                        addressStatus = destinationStatus,
-                        modifier = destinationAddressStatusModifier
-                    )
+                    if (!isReadOnly) {
+                        AddressStatusIndicator(
+                            addressStatus = destinationStatus,
+                            modifier = destinationAddressStatusModifier
+                        )
+                    }
                 }
 
                 if (isReadOnly.not()) {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/address/AddressSection.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/address/AddressSection.kt
@@ -13,6 +13,7 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.material.Divider
 import androidx.compose.material.Icon
 import androidx.compose.material.IconButton
+import androidx.compose.material.LocalContentColor
 import androidx.compose.material.MaterialTheme
 import androidx.compose.material.Text
 import androidx.compose.material.icons.Icons
@@ -112,9 +113,9 @@ internal fun AddressSectionPortrait(
             )
             Text(
                 text = shippingAddresses.shipFrom.toShippingFromString().uppercase(),
-                maxLines = 1,
+                maxLines = if (isReadOnly) Int.MAX_VALUE else 1,
                 overflow = TextOverflow.Ellipsis,
-                color = MaterialTheme.colors.primary,
+                color = if (isReadOnly) LocalContentColor.current else MaterialTheme.colors.primary,
                 modifier = Modifier
                     .constrainAs(shipFromValue) {
                         top.linkTo(shipFromLabel.top)
@@ -151,7 +152,7 @@ internal fun AddressSectionPortrait(
             }
             Divider(
                 modifier = Modifier.constrainAs(divider) {
-                    top.linkTo(shipFromLabel.bottom)
+                    top.linkTo(shipFromValue.bottom)
                     start.linkTo(parent.start)
                 }
             )
@@ -343,9 +344,9 @@ private fun ShipFromSelection(
         )
         Text(
             text = shipFrom.toShippingFromString().uppercase(),
-            maxLines = 1,
+            maxLines = if (isReadOnly) Int.MAX_VALUE else 1,
             overflow = TextOverflow.Ellipsis,
-            color = MaterialTheme.colors.primary,
+            color = if (isReadOnly) LocalContentColor.current else MaterialTheme.colors.primary,
             modifier = Modifier
                 .padding(
                     top = dimensionResource(R.dimen.major_100),

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/models/OriginShippingAddress.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/models/OriginShippingAddress.kt
@@ -1,6 +1,7 @@
 package com.woocommerce.android.ui.orders.wooshippinglabels.models
 
 import android.os.Parcelable
+import com.woocommerce.android.extensions.appendWithIfNotEmpty
 import kotlinx.parcelize.Parcelize
 
 @Parcelize
@@ -37,5 +38,18 @@ data class OriginShippingAddress(
             isDefault = false,
             isVerified = false
         )
+    }
+
+    fun format(singleLine: Boolean): String {
+        val separator = if (singleLine) ", " else "\n"
+
+        return buildString {
+            appendWithIfNotEmpty(address1, separator)
+            appendWithIfNotEmpty(address2, separator)
+            appendWithIfNotEmpty(city, separator = " ")
+            appendWithIfNotEmpty(state, separator = " ")
+            appendWithIfNotEmpty(postcode, separator = " ")
+            appendWithIfNotEmpty(country, separator = separator)
+        }
     }
 }

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/WooShippingLabelCreationViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/WooShippingLabelCreationViewModelTest.kt
@@ -810,6 +810,31 @@ class WooShippingLabelCreationViewModelTest : BaseUnitTest() {
     }
 
     @Test
+    fun `when current label is purchased, then do not display notices`() = testBlocking {
+        val order = OrderTestUtils.generateTestOrder(orderId = orderId)
+        val notice = NoticeBannerUiState(
+            message = R.string.woo_shipping_address_notification_destination_missing,
+            type = NoticeType.MISSING_DESTINATION_ADDRESS,
+            error = true,
+        )
+        whenever(orderDetailRepository.getOrderById(any())) doReturn order
+        whenever(getShipments(any())) doReturn listOf(
+            ShipmentUIModel(
+                localId = "0",
+                items = defaultShippableItems,
+                purchased = true
+            )
+        )
+
+        createViewModel()
+
+        advanceUntilIdle()
+
+        val dataState = sut.viewState.value as DataState
+        assertThat(dataState.uiState.noticeBannerUiState).isNull()
+    }
+
+    @Test
     fun `when the destination address is missing then verify endpoint should not be called`() = testBlocking {
         val order = OrderTestUtils.generateTestOrder(orderId = orderId)
 


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

<!-- Id number of the Linear issue this PR addresses, e.g., WOOMOB-373. -->
Closes WOOMOB-642
Part of WOOMOB-668

### Description
This PR updates the UI to purchased labels with the following changes:
- Hide the payment section.
- Hide the address validation status.
- Hide all the notices.
- Update the address formatting to match the other platforms.

> [!NOTE]
> WOOMOB-668 is not closed yet because we need to display the price of the label, but I couldn't implement it yet.

### Steps to reproduce
1. Open an order with a purchased shipping label.
2. Tap on "Create shipping labels"
3. Expand the shipment details bottom sheet.

### Testing information
- Confirm the payment section is hidden for purchased labels and shown for non-purchased labels.
- Confirm that the address section matches the other platforms behavior.
- Confirm that no notices are shown for purchased labels.

### The tests that have been performed
- The above

### Images/gif
| Before | After |
| --- | --- |
|![Screenshot_20250623_193134](https://github.com/user-attachments/assets/0d2ca9c5-7127-4429-8c12-ec59a4fd4dfd) | ![Screenshot_20250623_193340](https://github.com/user-attachments/assets/ba46adc3-1ac3-4bfb-92af-9d4efaec2b8d) |
| ![Screenshot_20250623_193142](https://github.com/user-attachments/assets/fc87d7db-dcae-4374-a370-21d9ade510ef) | ![Screenshot_20250623_203350](https://github.com/user-attachments/assets/4a39f343-e1d2-453d-8f5c-a705ed922d38) |

- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->