### PR TITLE
[Shipping Labels] Remove green checkmark icon from error

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/WooShippingLabelCreationScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/WooShippingLabelCreationScreen.kt
@@ -39,6 +39,7 @@ import androidx.compose.material.icons.filled.Edit
 import androidx.compose.material.icons.filled.Star
 import androidx.compose.material.icons.outlined.Star
 import androidx.compose.material.rememberBottomSheetScaffoldState
+import androidx.compose.material3.SnackbarHost
 import androidx.compose.material3.SnackbarHostState
 import androidx.compose.material3.SnackbarResult
 import androidx.compose.runtime.Composable
@@ -367,10 +368,14 @@ private fun LabelCreationScreenWithBottomSheet(
 
     BottomSheetScaffold(
         snackbarHost = {
-            SuccessSnackbarHost(
-                snackbarHostState,
-                modifier = Modifier.padding(bottom = snackbarPaddingBottom)
-            )
+            if (snackbarData?.isSuccessSnackbar == true) {
+                SuccessSnackbarHost(
+                    snackbarHostState,
+                    modifier = Modifier.padding(bottom = snackbarPaddingBottom)
+                )
+            } else {
+                SnackbarHost(snackbarHostState)
+            }
         },
         sheetContent = {
             ShipmentDetails(

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/WooShippingLabelCreationScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/WooShippingLabelCreationScreen.kt
@@ -39,6 +39,7 @@ import androidx.compose.material.icons.filled.Edit
 import androidx.compose.material.icons.filled.Star
 import androidx.compose.material.icons.outlined.Star
 import androidx.compose.material.rememberBottomSheetScaffoldState
+import androidx.compose.material3.Snackbar
 import androidx.compose.material3.SnackbarHost
 import androidx.compose.material3.SnackbarHostState
 import androidx.compose.material3.SnackbarResult
@@ -80,7 +81,8 @@ import com.woocommerce.android.ui.orders.wooshippinglabels.components.PrintShipp
 import com.woocommerce.android.ui.orders.wooshippinglabels.components.ShipmentTabData
 import com.woocommerce.android.ui.orders.wooshippinglabels.components.ShipmentsTabRow
 import com.woocommerce.android.ui.orders.wooshippinglabels.components.ShippingLabelsSnackbarData
-import com.woocommerce.android.ui.orders.wooshippinglabels.components.SuccessSnackbarHost
+import com.woocommerce.android.ui.orders.wooshippinglabels.components.ShippingLabelsSnackbarVisuals
+import com.woocommerce.android.ui.orders.wooshippinglabels.components.SuccessSnackbar
 import com.woocommerce.android.ui.orders.wooshippinglabels.components.WooShippingLabelPaperSize
 import com.woocommerce.android.ui.orders.wooshippinglabels.hazmat.HazmatCard
 import com.woocommerce.android.ui.orders.wooshippinglabels.models.DestinationShippingAddress
@@ -368,13 +370,20 @@ private fun LabelCreationScreenWithBottomSheet(
 
     BottomSheetScaffold(
         snackbarHost = {
-            if (snackbarData?.isSuccessSnackbar == true) {
-                SuccessSnackbarHost(
-                    snackbarHostState,
-                    modifier = Modifier.padding(bottom = snackbarPaddingBottom)
-                )
-            } else {
-                SnackbarHost(snackbarHostState)
+            SnackbarHost(
+                snackbarHostState,
+                modifier = Modifier.padding(bottom = snackbarPaddingBottom)
+            ) { data ->
+                val visuals = data.visuals as ShippingLabelsSnackbarVisuals
+                if (visuals.isSuccessSnackbar) {
+                    SuccessSnackbar(
+                        content = visuals.message,
+                        actionLabel = visuals.actionLabel,
+                        action = { data.performAction() }
+                    )
+                } else {
+                    Snackbar(data)
+                }
             }
         },
         sheetContent = {
@@ -502,9 +511,12 @@ private fun LabelCreationScreenWithBottomSheet(
             LaunchedEffect(snackbarData) {
                 snackbarData?.let {
                     val result = snackbarHostState.showSnackbar(
-                        message = actionSnackbarMessage ?: "",
-                        actionLabel = actionSnackbarActionLabel,
-                        duration = snackbarData.duration,
+                        visuals = ShippingLabelsSnackbarVisuals(
+                            message = actionSnackbarMessage.orEmpty(),
+                            actionLabel = actionSnackbarActionLabel,
+                            duration = snackbarData.duration,
+                            isSuccessSnackbar = it.isSuccessSnackbar
+                        )
                     )
                     when (result) {
                         SnackbarResult.ActionPerformed -> snackbarData.action()

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/WooShippingLabelCreationScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/WooShippingLabelCreationScreen.kt
@@ -39,7 +39,6 @@ import androidx.compose.material.icons.filled.Edit
 import androidx.compose.material.icons.filled.Star
 import androidx.compose.material.icons.outlined.Star
 import androidx.compose.material.rememberBottomSheetScaffoldState
-import androidx.compose.material3.Snackbar
 import androidx.compose.material3.SnackbarHost
 import androidx.compose.material3.SnackbarHostState
 import androidx.compose.material3.SnackbarResult
@@ -80,9 +79,9 @@ import com.woocommerce.android.ui.orders.wooshippinglabels.address.AddressStatus
 import com.woocommerce.android.ui.orders.wooshippinglabels.components.PrintShippingLabelSection
 import com.woocommerce.android.ui.orders.wooshippinglabels.components.ShipmentTabData
 import com.woocommerce.android.ui.orders.wooshippinglabels.components.ShipmentsTabRow
+import com.woocommerce.android.ui.orders.wooshippinglabels.components.ShippingLabelsSnackbar
 import com.woocommerce.android.ui.orders.wooshippinglabels.components.ShippingLabelsSnackbarData
 import com.woocommerce.android.ui.orders.wooshippinglabels.components.ShippingLabelsSnackbarVisuals
-import com.woocommerce.android.ui.orders.wooshippinglabels.components.SuccessSnackbar
 import com.woocommerce.android.ui.orders.wooshippinglabels.components.WooShippingLabelPaperSize
 import com.woocommerce.android.ui.orders.wooshippinglabels.hazmat.HazmatCard
 import com.woocommerce.android.ui.orders.wooshippinglabels.models.DestinationShippingAddress
@@ -375,15 +374,7 @@ private fun LabelCreationScreenWithBottomSheet(
                 modifier = Modifier.padding(bottom = snackbarPaddingBottom)
             ) { data ->
                 val visuals = data.visuals as ShippingLabelsSnackbarVisuals
-                if (visuals.isSuccessSnackbar) {
-                    SuccessSnackbar(
-                        content = visuals.message,
-                        actionLabel = visuals.actionLabel,
-                        action = { data.performAction() }
-                    )
-                } else {
-                    Snackbar(data)
-                }
+                ShippingLabelsSnackbar(visuals = visuals, action = { data.performAction() })
             }
         },
         sheetContent = {
@@ -515,7 +506,7 @@ private fun LabelCreationScreenWithBottomSheet(
                             message = actionSnackbarMessage.orEmpty(),
                             actionLabel = actionSnackbarActionLabel,
                             duration = snackbarData.duration,
-                            isSuccessSnackbar = it.isSuccessSnackbar
+                            hasIcon = it.hasIcon
                         )
                     )
                     when (result) {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/WooShippingLabelCreationScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/WooShippingLabelCreationScreen.kt
@@ -506,7 +506,7 @@ private fun LabelCreationScreenWithBottomSheet(
                             message = actionSnackbarMessage.orEmpty(),
                             actionLabel = actionSnackbarActionLabel,
                             duration = snackbarData.duration,
-                            hasIcon = it.hasIcon
+                            hasSuccessCheckmark = it.hasIcon
                         )
                     )
                     when (result) {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/WooShippingLabelCreationViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/WooShippingLabelCreationViewModel.kt
@@ -815,6 +815,7 @@ class WooShippingLabelCreationViewModel @Inject constructor(
         snackbarData = ShippingLabelsSnackbarData(
             message = snackbarMessage,
             actionLabel = R.string.undo,
+            isSuccessSnackbar = true,
             dismissAction = { snackbarData = null }
         ) {
             hazmatStatesFlow.value = previousStates

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/WooShippingLabelCreationViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/WooShippingLabelCreationViewModel.kt
@@ -815,7 +815,7 @@ class WooShippingLabelCreationViewModel @Inject constructor(
         snackbarData = ShippingLabelsSnackbarData(
             message = snackbarMessage,
             actionLabel = R.string.undo,
-            isSuccessSnackbar = true,
+            hasIcon = true,
             dismissAction = { snackbarData = null }
         ) {
             hazmatStatesFlow.value = previousStates

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/components/ShippingLabelsSnackbar.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/components/ShippingLabelsSnackbar.kt
@@ -32,7 +32,7 @@ fun ShippingLabelsSnackbar(visuals: ShippingLabelsSnackbarVisuals, action: () ->
             verticalAlignment = Alignment.CenterVertically,
             horizontalArrangement = Arrangement.spacedBy(8.dp)
         ) {
-            if (visuals.hasIcon) {
+            if (visuals.hasSuccessCheckmark) {
                 Icon(
                     imageVector = Icons.Filled.CheckCircle,
                     contentDescription = null,

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/components/ShippingLabelsSnackbar.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/components/ShippingLabelsSnackbar.kt
@@ -21,11 +21,7 @@ import androidx.compose.ui.unit.dp
 import com.woocommerce.android.R
 
 @Composable
-fun SuccessSnackbar(
-    content: String,
-    actionLabel: String?,
-    action: () -> Unit
-) {
+fun ShippingLabelsSnackbar(visuals: ShippingLabelsSnackbarVisuals, action: () -> Unit) {
     Surface(
         color = SnackbarDefaults.color,
         shape = SnackbarDefaults.shape,
@@ -36,14 +32,16 @@ fun SuccessSnackbar(
             verticalAlignment = Alignment.CenterVertically,
             horizontalArrangement = Arrangement.spacedBy(8.dp)
         ) {
-            Icon(
-                imageVector = Icons.Filled.CheckCircle,
-                contentDescription = null,
-                tint = colorResource(R.color.woo_green_20),
-            )
+            if (visuals.hasIcon) {
+                Icon(
+                    imageVector = Icons.Filled.CheckCircle,
+                    contentDescription = null,
+                    tint = colorResource(R.color.woo_green_20),
+                )
+            }
 
             Text(
-                text = content,
+                text = visuals.message,
                 modifier = Modifier
                     .weight(1f)
                     .padding(vertical = 16.dp),
@@ -51,7 +49,7 @@ fun SuccessSnackbar(
                 color = SnackbarDefaults.contentColor
             )
 
-            actionLabel?.let { label ->
+            visuals.actionLabel?.let { label ->
                 TextButton(
                     onClick = action,
                     colors = ButtonDefaults.textButtonColors(contentColor = SnackbarDefaults.actionContentColor)
@@ -65,20 +63,21 @@ fun SuccessSnackbar(
 
 @Preview(name = "Standard snackbar")
 @Composable
-fun SuccessSnackbarHostPreview() {
-    SuccessSnackbar(
-        content = "Shipping label created successfully",
-        actionLabel = "View",
+fun ShippingLabelsSnackbarHostPreview() {
+    ShippingLabelsSnackbar(
+        visuals = ShippingLabelsSnackbarVisuals(message = "Shipping label created successfully"),
         action = {}
     )
 }
 
 @Preview(name = "Snackbar with long message")
 @Composable
-fun SuccessSnackbarHostWithLongMessagePreview() {
-    SuccessSnackbar(
-        content = "Shipping label created successfully in a long long long long long message",
-        actionLabel = "View",
+fun ShippingLabelsSnackbarHostWithLongMessagePreview() {
+    ShippingLabelsSnackbar(
+        visuals = ShippingLabelsSnackbarVisuals(
+            message = "Shipping label created successfully in a long long long long long message",
+            actionLabel = "View",
+        ),
         action = {}
     )
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/components/ShippingLabelsSnackbarData.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/components/ShippingLabelsSnackbarData.kt
@@ -9,15 +9,15 @@ data class ShippingLabelsSnackbarData(
     val messageParameters: List<Int> = emptyList(),
     val duration: SnackbarDuration = SnackbarDuration.Short,
     val actionLabel: Int,
-    val isSuccessSnackbar: Boolean = false,
+    val hasIcon: Boolean = false,
     val dismissAction: () -> Unit = {},
     val action: () -> Unit
 )
 
 data class ShippingLabelsSnackbarVisuals(
     override val message: String,
-    override val actionLabel: String?,
+    override val actionLabel: String? = null,
     override val duration: SnackbarDuration = SnackbarDuration.Short,
     override val withDismissAction: Boolean = false,
-    val isSuccessSnackbar: Boolean
+    val hasIcon: Boolean = false
 ) : SnackbarVisuals

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/components/ShippingLabelsSnackbarData.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/components/ShippingLabelsSnackbarData.kt
@@ -4,7 +4,8 @@ import androidx.annotation.StringRes
 import androidx.compose.material3.SnackbarDuration
 import androidx.compose.material3.SnackbarVisuals
 
-data class ShippingLabelsSnackbarData(
+data class
+ShippingLabelsSnackbarData(
     @StringRes val message: Int,
     val messageParameters: List<Int> = emptyList(),
     val duration: SnackbarDuration = SnackbarDuration.Short,
@@ -19,5 +20,5 @@ data class ShippingLabelsSnackbarVisuals(
     override val actionLabel: String? = null,
     override val duration: SnackbarDuration = SnackbarDuration.Short,
     override val withDismissAction: Boolean = false,
-    val hasIcon: Boolean = false
+    val hasSuccessCheckmark: Boolean = false
 ) : SnackbarVisuals

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/components/ShippingLabelsSnackbarData.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/components/ShippingLabelsSnackbarData.kt
@@ -2,6 +2,7 @@ package com.woocommerce.android.ui.orders.wooshippinglabels.components
 
 import androidx.annotation.StringRes
 import androidx.compose.material3.SnackbarDuration
+import androidx.compose.material3.SnackbarVisuals
 
 data class ShippingLabelsSnackbarData(
     @StringRes val message: Int,
@@ -12,3 +13,11 @@ data class ShippingLabelsSnackbarData(
     val dismissAction: () -> Unit = {},
     val action: () -> Unit
 )
+
+data class ShippingLabelsSnackbarVisuals(
+    override val message: String,
+    override val actionLabel: String?,
+    override val duration: SnackbarDuration = SnackbarDuration.Short,
+    override val withDismissAction: Boolean = false,
+    val isSuccessSnackbar: Boolean
+) : SnackbarVisuals

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/components/ShippingLabelsSnackbarData.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/components/ShippingLabelsSnackbarData.kt
@@ -8,6 +8,7 @@ data class ShippingLabelsSnackbarData(
     val messageParameters: List<Int> = emptyList(),
     val duration: SnackbarDuration = SnackbarDuration.Short,
     val actionLabel: Int,
+    val isSuccessSnackbar: Boolean = false,
     val dismissAction: () -> Unit = {},
     val action: () -> Unit
 )

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/components/SuccessSnackbar.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/components/SuccessSnackbar.kt
@@ -9,8 +9,6 @@ import androidx.compose.material3.ButtonDefaults
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.SnackbarDefaults
-import androidx.compose.material3.SnackbarHost
-import androidx.compose.material3.SnackbarHostState
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
@@ -23,27 +21,7 @@ import androidx.compose.ui.unit.dp
 import com.woocommerce.android.R
 
 @Composable
-fun SuccessSnackbarHost(
-    hostState: SnackbarHostState,
-    modifier: Modifier = Modifier
-) {
-    SnackbarHost(
-        hostState = hostState,
-        modifier = modifier,
-        snackbar = { snackbarData ->
-            val actionLabel = snackbarData.visuals.actionLabel
-
-            SuccessSnackbar(
-                content = snackbarData.visuals.message,
-                actionLabel = actionLabel,
-                action = { snackbarData.performAction() }
-            )
-        }
-    )
-}
-
-@Composable
-private fun SuccessSnackbar(
+fun SuccessSnackbar(
     content: String,
     actionLabel: String?,
     action: () -> Unit

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/split/WooShippingSplitShipmentScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/split/WooShippingSplitShipmentScreen.kt
@@ -31,6 +31,7 @@ import androidx.compose.material.icons.filled.ArrowDropDown
 import androidx.compose.material.icons.filled.Close
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.Scaffold
+import androidx.compose.material3.SnackbarHost
 import androidx.compose.material3.SnackbarHostState
 import androidx.compose.material3.SnackbarResult
 import androidx.compose.runtime.Composable
@@ -63,7 +64,6 @@ import com.woocommerce.android.ui.orders.wooshippinglabels.ProductsSummary
 import com.woocommerce.android.ui.orders.wooshippinglabels.SelectableShippingProduct
 import com.woocommerce.android.ui.orders.wooshippinglabels.components.ShipmentTabData
 import com.woocommerce.android.ui.orders.wooshippinglabels.components.ShipmentsTabRow
-import com.woocommerce.android.ui.orders.wooshippinglabels.components.ShippingLabelsSnackbarData
 import com.woocommerce.android.ui.orders.wooshippinglabels.components.SuccessSnackbarHost
 import com.woocommerce.android.ui.orders.wooshippinglabels.split.WooShippingSplitShipmentViewModel.SplitShipmentViewState
 import kotlinx.coroutines.launch
@@ -87,7 +87,6 @@ fun WooShippingSplitShipmentScreen(
                 onUpdateSelectedShipment = viewModel::onUpdateSelectedShipment,
                 onRemoveShipmentMenuTapped = viewModel::onRemoveShipmentMenuTapped,
                 onDismissRemoveSheet = viewModel::onDismissRemoveSheet,
-                snackbarData = viewModel.snackbarData,
                 modifier = modifier
             )
         }
@@ -108,13 +107,18 @@ fun WooShippingSplitShipmentScreen(
     onRemoveShipmentMenuTapped: (shipmentKeys: List<Int>) -> Unit,
     onDismissRemoveSheet: () -> Unit,
     modifier: Modifier = Modifier,
-    snackbarData: ShippingLabelsSnackbarData? = null,
 ) {
     val snackbarHostState = remember { SnackbarHostState() }
 
     Scaffold(
         topBar = { TopBar(onBack, onDone) },
-        snackbarHost = { SuccessSnackbarHost(snackbarHostState) }
+        snackbarHost = {
+            if (viewState.splitMessage is SplitShipmentMessage.Success) {
+                SuccessSnackbarHost(snackbarHostState)
+            } else {
+                SnackbarHost(snackbarHostState)
+            }
+        }
     ) { padding ->
         Surface(
             modifier = modifier
@@ -190,40 +194,32 @@ fun WooShippingSplitShipmentScreen(
         }
     }
 
-    val actionSnackbarMessage = snackbarData?.let { stringResource(it.message) }
-    val actionSnackbarActionLabel = snackbarData?.let { stringResource(it.actionLabel) }
-    LaunchedEffect(snackbarData) {
-        snackbarData?.let {
-            val result = snackbarHostState.showSnackbar(
-                message = actionSnackbarMessage ?: "",
-                actionLabel = actionSnackbarActionLabel,
-                duration = snackbarData.duration,
-            )
-            when (result) {
-                SnackbarResult.ActionPerformed -> snackbarData.action()
-                SnackbarResult.Dismissed -> snackbarData.dismissAction()
-            }
-        } ?: snackbarHostState.currentSnackbarData?.dismiss()
-    }
-
     val context = LocalContext.current
     LaunchedEffect(viewState.splitMessage) {
-        if (viewState.splitMessage is SplitShipmentMessage.Success) {
-            val snackbarData = viewState.splitMessage.snackbarData
+        val snackbarData = if (viewState.splitMessage is SplitShipmentMessage.Success) {
+            viewState.splitMessage.snackbarData
+        } else if (viewState.splitMessage is SplitShipmentMessage.Error) {
+            viewState.splitMessage.snackbarData
+        } else {
+            return@LaunchedEffect
+        }
 
-            @Suppress("SpreadOperator")
-            val result = snackbarHostState.showSnackbar(
-                message = context.getString(
+        @Suppress("SpreadOperator")
+        val result = snackbarHostState.showSnackbar(
+            message = if (snackbarData.messageParameters.isEmpty()) {
+                context.getString(snackbarData.message)
+            } else {
+                context.getString(
                     snackbarData.message,
                     *snackbarData.messageParameters.toTypedArray()
-                ),
-                actionLabel = context.getString(R.string.undo),
-                duration = snackbarData.duration
-            )
-            when (result) {
-                SnackbarResult.ActionPerformed -> snackbarData.action()
-                SnackbarResult.Dismissed -> snackbarData.dismissAction()
-            }
+                )
+            },
+            actionLabel = context.getString(snackbarData.actionLabel),
+            duration = snackbarData.duration
+        )
+        when (result) {
+            SnackbarResult.ActionPerformed -> snackbarData.action()
+            SnackbarResult.Dismissed -> snackbarData.dismissAction()
         }
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/split/WooShippingSplitShipmentScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/split/WooShippingSplitShipmentScreen.kt
@@ -31,6 +31,7 @@ import androidx.compose.material.icons.filled.ArrowDropDown
 import androidx.compose.material.icons.filled.Close
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Snackbar
 import androidx.compose.material3.SnackbarHost
 import androidx.compose.material3.SnackbarHostState
 import androidx.compose.material3.SnackbarResult
@@ -64,7 +65,8 @@ import com.woocommerce.android.ui.orders.wooshippinglabels.ProductsSummary
 import com.woocommerce.android.ui.orders.wooshippinglabels.SelectableShippingProduct
 import com.woocommerce.android.ui.orders.wooshippinglabels.components.ShipmentTabData
 import com.woocommerce.android.ui.orders.wooshippinglabels.components.ShipmentsTabRow
-import com.woocommerce.android.ui.orders.wooshippinglabels.components.SuccessSnackbarHost
+import com.woocommerce.android.ui.orders.wooshippinglabels.components.ShippingLabelsSnackbarVisuals
+import com.woocommerce.android.ui.orders.wooshippinglabels.components.SuccessSnackbar
 import com.woocommerce.android.ui.orders.wooshippinglabels.split.WooShippingSplitShipmentViewModel.SplitShipmentViewState
 import kotlinx.coroutines.launch
 
@@ -113,10 +115,17 @@ fun WooShippingSplitShipmentScreen(
     Scaffold(
         topBar = { TopBar(onBack, onDone) },
         snackbarHost = {
-            if (viewState.splitMessage is SplitShipmentMessage.Success) {
-                SuccessSnackbarHost(snackbarHostState)
-            } else {
-                SnackbarHost(snackbarHostState)
+            SnackbarHost(snackbarHostState) { data ->
+                val visuals = data.visuals as ShippingLabelsSnackbarVisuals
+                if (visuals.isSuccessSnackbar) {
+                    SuccessSnackbar(
+                        content = visuals.message,
+                        actionLabel = visuals.actionLabel,
+                        action = { data.performAction() }
+                    )
+                } else {
+                    Snackbar(data)
+                }
             }
         }
     ) { padding ->
@@ -206,16 +215,19 @@ fun WooShippingSplitShipmentScreen(
 
         @Suppress("SpreadOperator")
         val result = snackbarHostState.showSnackbar(
-            message = if (snackbarData.messageParameters.isEmpty()) {
-                context.getString(snackbarData.message)
-            } else {
-                context.getString(
-                    snackbarData.message,
-                    *snackbarData.messageParameters.toTypedArray()
-                )
-            },
-            actionLabel = context.getString(snackbarData.actionLabel),
-            duration = snackbarData.duration
+            visuals = ShippingLabelsSnackbarVisuals(
+                message = if (snackbarData.messageParameters.isEmpty()) {
+                    context.getString(snackbarData.message)
+                } else {
+                    context.getString(
+                        snackbarData.message,
+                        *snackbarData.messageParameters.toTypedArray()
+                    )
+                },
+                actionLabel = context.getString(snackbarData.actionLabel),
+                duration = snackbarData.duration,
+                isSuccessSnackbar = viewState.splitMessage is SplitShipmentMessage.Success
+            )
         )
         when (result) {
             SnackbarResult.ActionPerformed -> snackbarData.action()

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/split/WooShippingSplitShipmentScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/split/WooShippingSplitShipmentScreen.kt
@@ -217,7 +217,7 @@ fun WooShippingSplitShipmentScreen(
                 },
                 actionLabel = context.getString(snackbarData.actionLabel),
                 duration = snackbarData.duration,
-                hasIcon = viewState.splitMessage is SplitShipmentMessage.Success
+                hasSuccessCheckmark = viewState.splitMessage is SplitShipmentMessage.Success
             )
         )
         when (result) {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/split/WooShippingSplitShipmentScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/split/WooShippingSplitShipmentScreen.kt
@@ -31,7 +31,6 @@ import androidx.compose.material.icons.filled.ArrowDropDown
 import androidx.compose.material.icons.filled.Close
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.Scaffold
-import androidx.compose.material3.Snackbar
 import androidx.compose.material3.SnackbarHost
 import androidx.compose.material3.SnackbarHostState
 import androidx.compose.material3.SnackbarResult
@@ -65,8 +64,8 @@ import com.woocommerce.android.ui.orders.wooshippinglabels.ProductsSummary
 import com.woocommerce.android.ui.orders.wooshippinglabels.SelectableShippingProduct
 import com.woocommerce.android.ui.orders.wooshippinglabels.components.ShipmentTabData
 import com.woocommerce.android.ui.orders.wooshippinglabels.components.ShipmentsTabRow
+import com.woocommerce.android.ui.orders.wooshippinglabels.components.ShippingLabelsSnackbar
 import com.woocommerce.android.ui.orders.wooshippinglabels.components.ShippingLabelsSnackbarVisuals
-import com.woocommerce.android.ui.orders.wooshippinglabels.components.SuccessSnackbar
 import com.woocommerce.android.ui.orders.wooshippinglabels.split.WooShippingSplitShipmentViewModel.SplitShipmentViewState
 import kotlinx.coroutines.launch
 
@@ -117,15 +116,7 @@ fun WooShippingSplitShipmentScreen(
         snackbarHost = {
             SnackbarHost(snackbarHostState) { data ->
                 val visuals = data.visuals as ShippingLabelsSnackbarVisuals
-                if (visuals.isSuccessSnackbar) {
-                    SuccessSnackbar(
-                        content = visuals.message,
-                        actionLabel = visuals.actionLabel,
-                        action = { data.performAction() }
-                    )
-                } else {
-                    Snackbar(data)
-                }
+                ShippingLabelsSnackbar(visuals = visuals, action = { data.performAction() })
             }
         }
     ) { padding ->
@@ -226,7 +217,7 @@ fun WooShippingSplitShipmentScreen(
                 },
                 actionLabel = context.getString(snackbarData.actionLabel),
                 duration = snackbarData.duration,
-                isSuccessSnackbar = viewState.splitMessage is SplitShipmentMessage.Success
+                hasIcon = viewState.splitMessage is SplitShipmentMessage.Success
             )
         )
         when (result) {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/split/WooShippingSplitShipmentViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/split/WooShippingSplitShipmentViewModel.kt
@@ -1,8 +1,5 @@
 package com.woocommerce.android.ui.orders.wooshippinglabels.split
 
-import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.setValue
 import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.asLiveData
 import com.woocommerce.android.R
@@ -35,7 +32,6 @@ class WooShippingSplitShipmentViewModel @Inject constructor(
     private val splitShipment: SplitShipment,
 ) : ScopedViewModel(savedState) {
     private val navArgs: WooShippingSplitShipmentFragmentArgs by savedState.navArgs()
-    var snackbarData by mutableStateOf<ShippingLabelsSnackbarData?>(null)
     private val storeOptions = navArgs.shipmentArgs.storeOptions
 
     private val currentShipments = MutableStateFlow(
@@ -126,10 +122,12 @@ class WooShippingSplitShipmentViewModel @Inject constructor(
                     triggerEvent(MultiLiveEvent.Event.ExitWithResult(result.getOrThrow()))
                 } else {
                     isLoading.value = false
-                    snackbarData = ShippingLabelsSnackbarData(
-                        message = R.string.woo_shipping_split_shipment_error,
-                        actionLabel = R.string.retry,
-                    ) { onDoneTapped() }
+                    splitMessage.value = SplitShipmentMessage.Error(
+                        ShippingLabelsSnackbarData(
+                            message = R.string.woo_shipping_split_shipment_error,
+                            actionLabel = R.string.retry,
+                        ) { onDoneTapped() }
+                    )
                 }
             }
         } else {
@@ -278,6 +276,7 @@ class WooShippingSplitShipmentViewModel @Inject constructor(
                     splitMovement.destinationShipmentKey + 1
                 ),
                 actionLabel = R.string.undo,
+                isSuccessSnackbar = true,
                 dismissAction = { splitMessage.value = null },
                 action = undoAction
             )
@@ -333,6 +332,7 @@ sealed interface SelectableShippableItemUI {
 sealed class SplitShipmentMessage {
     data object Instructions : SplitShipmentMessage()
     data class Success(val snackbarData: ShippingLabelsSnackbarData) : SplitShipmentMessage()
+    data class Error(val snackbarData: ShippingLabelsSnackbarData) : SplitShipmentMessage()
 }
 
 data class RemoveShipmentSheet(

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/split/WooShippingSplitShipmentViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/split/WooShippingSplitShipmentViewModel.kt
@@ -276,7 +276,7 @@ class WooShippingSplitShipmentViewModel @Inject constructor(
                     splitMovement.destinationShipmentKey + 1
                 ),
                 actionLabel = R.string.undo,
-                isSuccessSnackbar = true,
+                hasIcon = true,
                 dismissAction = { splitMessage.value = null },
                 action = undoAction
             )


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

<!-- Id number of the Linear issue this PR addresses, e.g., WOOMOB-373. -->
WOOMOB-555

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
On shipment flow, error messages had ✅ icon. This PR removes the icon from only error messages but keep it for success messages.

### Steps to reproduce
<!-- Step-by-step testing instructions. For new user flows, consider instead stating the goal of the workflow and see if your PR reviewer can accomplish the workflow without specific steps! -->
#### Purchase error
1. To create fake endpoint response for error, add this to API faker
```
[
  {
    "request": {
      "id": 0,
      "path": "/wcshipping/v1/label/purchase/%",
      "queryParameters": [],
      "type": {
        "type": "wp-api"
      }
    },
    "response": {
      "body": "",
      "endpointId": 0,
      "statusCode": 500
    }
  }
]
```
2. Go to order and select and order.
3. Tap Create shipping labels button.
4. Fill the fields and tap Purchase label button.

#### Split shipment error
1. To create fake endpoint response for error, add this to API faker
```
[
  {
    "request": {
      "id": 0,
      "path": "/wcshipping/v1/shipments/%",
      "queryParameters": [],
      "type": {
        "type": "wp-api"
      }
    },
    "response": {
      "body": "",
      "endpointId": 0,
      "statusCode": 500
    }
  }
]
```
2. Go to order and select and order.
3. Tap Create shipping labels button.
4. Tap Split Shipment button.
5. Make some changes and tap DONE button.

### The tests that have been performed
<!-- To give the reviewer an idea of what could be missed in terms of testing -->
Steps above

### Images/gif
<!-- Include before and after images or gifs when appropriate. -->
|Before|After|
|-|-|
|<img src="https://github.com/user-attachments/assets/b25ef3b2-8599-457e-a749-0e2d73d8c09a" width=350>|<img src="https://github.com/user-attachments/assets/420a05a2-48a9-4ac7-abee-3bade9a44e80" width=350>|
|<img src="https://github.com/user-attachments/assets/0b582cc2-baa5-4176-a2e1-7271149006fd" width=350>|<img src="https://github.com/user-attachments/assets/d3a49243-bdab-4ae0-b49a-c74923a3a690" width=350>|

- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->