### PR TITLE
[POS as a Tab] Update icon for the POS in the tab bar.

### DIFF
--- a/WooCommerce/src/main/res/drawable/as_menu_pos.xml
+++ b/WooCommerce/src/main/res/drawable/as_menu_pos.xml
@@ -1,0 +1,5 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android" android:height="24dp" android:tint="#000000" android:viewportHeight="24" android:viewportWidth="24" android:width="24dp">
+      
+    <path android:fillColor="@android:color/white" android:pathData="M7,18c-1.1,0 -1.99,0.9 -1.99,2S5.9,22 7,22s2,-0.9 2,-2 -0.9,-2 -2,-2zM1,2v2h2l3.6,7.59 -1.35,2.45c-0.16,0.28 -0.25,0.61 -0.25,0.96 0,1.1 0.9,2 2,2h12v-2L7.42,15c-0.14,0 -0.25,-0.11 -0.25,-0.25l0.03,-0.12 0.9,-1.63h7.45c0.75,0 1.41,-0.41 1.75,-1.03l3.58,-6.49c0.08,-0.14 0.12,-0.31 0.12,-0.48 0,-0.55 -0.45,-1 -1,-1L5.21,4l-0.94,-2L1,2zM17,18c-1.1,0 -1.99,0.9 -1.99,2s0.89,2 1.99,2 2,-0.9 2,-2 -0.9,-2 -2,-2z"/>
+    
+</vector>

--- a/WooCommerce/src/main/res/menu/menu_bottom_bar.xml
+++ b/WooCommerce/src/main/res/menu/menu_bottom_bar.xml
@@ -17,7 +17,7 @@
 
     <item
         android:id="@+id/point_of_sale"
-        android:icon="@drawable/ic_gridicons_credit_card"
+        android:icon="@drawable/as_menu_pos"
         android:title="@string/point_of_sale" />
 
     <item


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

<!-- Id number of the Linear issue this PR addresses, e.g., WOOMOB-373. -->

Closes WOOMOB-667

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
With this PR we replace the icon on the tab bar for the POS tab.

### Steps to reproduce
<!-- Step-by-step testing instructions. For new user flows, consider instead stating the goal of the workflow and see if your PR reviewer can accomplish the workflow without specific steps! -->
Open the app with a POS eligible store and check the new icon.

### Images/gif
<!-- Include before and after images or gifs when appropriate. -->
![Screenshot_20250624_105656_Woo (Pre-Alpha)](https://github.com/user-attachments/assets/1cdd2914-0043-41a1-9dba-3cd1d971c3e5)


- [X] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
