### PR TITLE
[AINFRA-435] Test Setup to Validate Android Agent (`mac-metal`)

### DIFF
--- a/.buildkite/commands/run-instrumented-tests-emulator.sh
+++ b/.buildkite/commands/run-instrumented-tests-emulator.sh
@@ -53,6 +53,20 @@ echo "adb devices"
 adb devices
 echo ""
 
+echo "ps auxw | grep emulator"
+ps auxw | grep emulator
+echo ""
+echo "pgrep -f emulator"
+pgrep -f emulator || true
+echo ""
+
+echo "ps auxw | grep qemu"
+ps auxw | grep qemu
+echo ""
+echo "pgrep -f qemu"
+pgrep -f qemu || true
+echo ""
+
 # echo "--- 🤖 Stopping Emulator(s)"
 # echo "adb -s emulator-5554 emu kill"
 # adb -s emulator-5554 emu kill

--- a/.buildkite/commands/run-instrumented-tests-emulator.sh
+++ b/.buildkite/commands/run-instrumented-tests-emulator.sh
@@ -1,0 +1,57 @@
+#!/bin/bash -u
+
+echo "--- 📋 Checking Android SDK"
+echo "adb --version"
+adb --version
+echo "emulator -list-avds"
+emulator -list-avds
+echo ""
+
+echo "--- 🤖 Launching Emulator(s)"
+echo "emulator -avd pixel5api34 -no-snapshot -no-boot-anim -no-audio &"
+emulator -avd pixel5api34 -no-snapshot -no-boot-anim -no-audio &
+echo ""
+
+echo "--- 🤖 Waiting for Emulator(s) to Start"
+echo "adb wait-for-device"
+adb wait-for-device
+echo "while [ "$(adb shell getprop sys.boot_completed | tr -d '\r')" != "1" ]; do"
+echo "  sleep 1"
+echo "done"
+while [ "$(adb shell getprop sys.boot_completed | tr -d '\r')" != "1" ]; do
+  sleep 1
+done
+echo ""
+
+echo "--- 🤖 Unlock Emulator(s)"
+echo "adb shell dumpsys window | grep mDreamingLockscreen"
+adb shell dumpsys window | grep mDreamingLockscreen
+echo "adb -s emulator-5554 shell input keyevent 82"
+adb -s emulator-5554 shell input keyevent 82
+echo ""
+
+echo "--- 🤖 Checking Emulator(s)"
+echo "adb devices"
+adb devices
+echo "adb shell dumpsys window | grep mDreamingLockscreen"
+adb shell dumpsys window | grep mDreamingLockscreen
+echo ""
+
+echo "--- 🧪 Testing"
+./gradlew :WooCommerce:connectedVanillaDebugAndroidTest -Pandroid.testInstrumentationRunnerArguments.class=com.woocommerce.android.e2e.tests.ui.ReviewsUITest
+ui_test_exit_code=$?
+echo ""
+
+echo "--- 🤖 Checking Emulator(s)"
+echo "adb devices"
+adb devices
+echo ""
+
+echo "--- 🤖 Stopping Emulator(s)"
+echo "adb -s emulator-5554 emu kill"
+adb -s emulator-5554 emu kill
+echo "adb devices"
+while adb devices | grep -q emulator-5554; do sleep 1; done
+echo ""
+
+exit $ui_test_exit_code

--- a/.buildkite/commands/run-instrumented-tests-emulator.sh
+++ b/.buildkite/commands/run-instrumented-tests-emulator.sh
@@ -14,8 +14,8 @@ emulator -list-avds
 echo ""
 
 echo "--- 🤖 Launching Emulator(s)"
-echo "emulator -avd pixel5api34 -no-snapshot -no-boot-anim -no-audio &"
-emulator -avd pixel5api34 -no-snapshot -no-boot-anim -no-audio &
+echo "emulator -avd pixel5api34 -no-snapshot -wipe-data -no-boot-anim -no-audio &"
+emulator -avd pixel5api34 -no-snapshot -wipe-data -no-boot-anim -no-audio &
 echo ""
 
 echo "--- 🤖 Waiting for Emulator(s) to Start"

--- a/.buildkite/commands/run-instrumented-tests-emulator.sh
+++ b/.buildkite/commands/run-instrumented-tests-emulator.sh
@@ -53,11 +53,11 @@ echo "adb devices"
 adb devices
 echo ""
 
-echo "--- 🤖 Stopping Emulator(s)"
-echo "adb -s emulator-5554 emu kill"
-adb -s emulator-5554 emu kill
-echo "adb devices"
-while adb devices | grep -q emulator-5554; do sleep 1; done
-echo ""
+# echo "--- 🤖 Stopping Emulator(s)"
+# echo "adb -s emulator-5554 emu kill"
+# adb -s emulator-5554 emu kill
+# echo "adb devices"
+# while adb devices | grep -q emulator-5554; do sleep 1; done
+# echo ""
 
 exit $ui_test_exit_code

--- a/.buildkite/commands/run-instrumented-tests-emulator.sh
+++ b/.buildkite/commands/run-instrumented-tests-emulator.sh
@@ -1,5 +1,11 @@
 #!/bin/bash -u
 
+echo "--- :rubygems: Setting up Gems"
+install_gems
+
+echo "--- :closed_lock_with_key: Installing Secrets"
+bundle exec fastlane run configure_apply
+
 echo "--- 📋 Checking Android SDK"
 echo "adb --version"
 adb --version

--- a/.buildkite/commands/run-instrumented-tests-emulator.sh
+++ b/.buildkite/commands/run-instrumented-tests-emulator.sh
@@ -53,17 +53,22 @@ echo "adb devices"
 adb devices
 echo ""
 
-echo "ps auxw | grep emulator"
-ps auxw | grep emulator
+echo "--- 🤖 Debug running processes"
+echo "~~~ ps -xw -o ppid,pid,command"
+ps -xw -o ppid,pid,command
 echo ""
-echo "pgrep -f emulator"
+
+echo "~~~ ps auxw -o ppid,pid,user,command | grep emulator"
+ps auxw -o ppid,pid,user,command | grep emulator
+echo ""
+echo "~~~ pgrep -f emulator"
 pgrep -f emulator || true
 echo ""
 
-echo "ps auxw | grep qemu"
-ps auxw | grep qemu
+echo "~~~ ps auxw -o ppid,pid,user,command | grep qemu"
+ps auxw -o ppid,pid,user,command | grep qemu
 echo ""
-echo "pgrep -f qemu"
+echo "~~~ pgrep -f qemu"
 pgrep -f qemu || true
 echo ""
 

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -1,108 +1,13 @@
 # yaml-language-server: $schema=https://raw.githubusercontent.com/buildkite/pipeline-schema/main/schema.json
 ---
 
-# Nodes with values to reuse in the pipeline.
-common_params:
-  # Common plugin settings to use with the `plugins` key.
-  - &test_collector_common_params
-      files: "WooCommerce/build/buildkite-test-analytics/*.xml"
-      format: "junit"
-
-agents:
-  queue: "android"
-
 steps:
-  - label: Gradle Wrapper Validation
-    command: validate_gradle_wrapper
-    agents:
-      queue: linter
-
-  # Wait for Gradle Wrapper to be validated before running any other jobs
-  - wait
-
-  ########################################
-  - group: "🕵️ Linters"
-    steps:
-
-      - label: "☢️ Danger - PR Check"
-        command: danger
-        key: danger
-        if: "build.pull_request.id != null"
-        retry:
-          manual:
-            permit_on_passed: true
-        agents:
-          queue: "linter"
-
-      - label: "detekt"
-        command: |
-          if .buildkite/commands/should-skip-job.sh --job-type validation; then
-            exit 0
-          fi
-          ./gradlew detektAll
-        plugins: [$CI_TOOLKIT]
-        artifact_paths:
-          - "**/build/reports/detekt/detekt.html"
-
-      - label: "lint"
-        command: .buildkite/commands/lint.sh
-        plugins: [$CI_TOOLKIT]
-        artifact_paths:
-          - "**/build/reports/lint-results*.*"
-
-      - label: "Dependency Tree Diff"
-        command: comment_with_dependency_diff 'woocommerce' 'vanillaReleaseRuntimeClasspath'
-        if: build.pull_request.id != null
-        plugins: [$CI_TOOLKIT]
-        artifact_paths:
-          - "**/build/reports/diff/*"
-
-      - label: "Merged Manifest Diff"
-        command: ".buildkite/commands/diff-merged-manifest.sh vanillaRelease"
-        if: build.pull_request.id != null
-        plugins: [$CI_TOOLKIT]
-        artifact_paths:
-          - "**/build/reports/diff_manifest/**/**/*"
-
-  ########################################
-  - group: "🛠 Prototype Builds"
-    steps:
-
-      - label: "🛠 Prototype Build: Mobile App"
-        command: ".buildkite/commands/prototype-build.sh WooCommerce"
-        if: build.pull_request.id != null
-        plugins: [$CI_TOOLKIT]
-
-      - label: "🛠 Prototype Build: Wear App"
-        command: ".buildkite/commands/prototype-build.sh WooCommerce-Wear"
-        if: build.pull_request.id != null
-        plugins: [$CI_TOOLKIT]
-
-  ########################################
-  - group: "🔬 Tests"
-    steps:
-
-      - label: "Unit tests"
-        command: .buildkite/commands/run-unit-tests.sh
-        plugins:
-          - $CI_TOOLKIT
-          - $TEST_COLLECTOR :
-              <<: *test_collector_common_params
-              api-token-env-name: "BUILDKITE_ANALYTICS_TOKEN_UNIT_TESTS"
-        artifact_paths:
-          - "**/build/test-results/merged-test-results.xml"
-
-      - label: "Instrumented tests"
-        command: .buildkite/commands/run-instrumented-tests.sh
-        plugins:
-          - $CI_TOOLKIT
-          - $TEST_COLLECTOR :
-              <<: *test_collector_common_params
-              api-token-env-name: "BUILDKITE_ANALYTICS_TOKEN_INSTRUMENTED_TESTS"
-        artifact_paths:
-          - "**/build/instrumented-tests/**/*"
-
-
-  - label: "🐘 Populate Gradle build cache"
-    command: .buildkite/commands/gradle-cache-build.sh
+  - label: "Test mac-metal queue"
+    command: |
+      env
+      echo "Hello, world!"
+      aws --version
     plugins: [$CI_TOOLKIT]
+    agents:
+      queue: "mac-metal"
+

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -13,12 +13,6 @@ steps:
 
   - label: "Instrumented tests (ReviewsUITest)"
     command: |
-      echo "--- :rubygems: Setting up Gems"
-      install_gems
-
-      echo "--- :closed_lock_with_key: Installing Secrets"
-      bundle exec fastlane run configure_apply
-
       echo "--- 🧪 Testing"
       ./gradlew :WooCommerce:connectedVanillaDebugAndroidTest -Pandroid.testInstrumentationRunnerArguments.class=com.woocommerce.android.e2e.tests.ui.ReviewsUITest
     plugins: [ $CI_TOOLKIT ]

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -11,3 +11,18 @@ steps:
     agents:
       queue: "mac-metal"
 
+  - label: "Instrumented tests (ReviewsUITest)"
+    command: |
+      echo "--- :rubygems: Setting up Gems"
+      install_gems
+
+      echo "--- :closed_lock_with_key: Installing Secrets"
+      bundle exec fastlane run configure_apply
+
+      echo "--- 🧪 Testing"
+      ./gradlew :WooCommerce:connectedVanillaDebugAndroidTest -Pandroid.testInstrumentationRunnerArguments.class=com.woocommerce.android.e2e.tests.ui.ReviewsUITest
+    plugins: [ $CI_TOOLKIT ]
+    artifact_paths:
+      - "**/build/reports/androidTests/**/**/**/**/**/*"
+    agents:
+      queue: "mac-metal"

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -21,12 +21,24 @@ steps:
     agents:
       queue: "mac-metal"
 
-  - label: "Instrumented tests (ReviewsUITest)"
+  - label: "Instrumented tests without GMD (ReviewsUITest)"
     command: |
       echo "--- 🧪 Testing"
       ./gradlew :WooCommerce:connectedVanillaDebugAndroidTest -Pandroid.testInstrumentationRunnerArguments.class=com.woocommerce.android.e2e.tests.ui.ReviewsUITest
     plugins: [ $CI_TOOLKIT ]
     artifact_paths:
-      - "**/build/reports/androidTests/**/**/**/**/**/*"
+      - "**/build/reports/androidTests/connected/**/**/**/*"
+      - "**/build/reports/androidTests/connected/**/**/**/**/*"
+    agents:
+      queue: "mac-metal"
+
+  - label: "Instrumented tests with GMD (ReviewsUITest)"
+    command: |
+      echo "--- 🧪 Testing"
+      ./gradlew :WooCommerce:pixel5api34VanillaDebugAndroidTest -Pandroid.testInstrumentationRunnerArguments.class=com.woocommerce.android.e2e.tests.ui.ReviewsUITest
+    plugins: [ $CI_TOOLKIT ]
+    artifact_paths:
+      - "**/build/reports/androidTests/managedDevice/**/**/**/pixel5api34/*"
+      - "**/build/reports/androidTests/managedDevice/**/**/**/pixel5api34/**/*"
     agents:
       queue: "mac-metal"

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -11,6 +11,16 @@ steps:
     agents:
       queue: "mac-metal"
 
+  - label: "Assemble"
+    command: |
+      echo "--- 🛠 Building"
+      ./gradlew :WooCommerce:assembleJalapenoDebug
+    plugins: [ $CI_TOOLKIT ]
+    artifact_paths:
+      - "**/build/outputs/apk/**/**/*"
+    agents:
+      queue: "mac-metal"
+
   - label: "Instrumented tests (ReviewsUITest)"
     command: |
       echo "--- 🧪 Testing"

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -13,6 +13,12 @@ steps:
 
   - label: "Assemble"
     command: |
+      echo "--- :rubygems: Setting up Gems"
+      install_gems
+
+      echo "--- :closed_lock_with_key: Installing Secrets"
+      bundle exec fastlane run configure_apply
+
       echo "--- 🛠 Building"
       ./gradlew :WooCommerce:assembleJalapenoDebug
     plugins: [ $CI_TOOLKIT ]

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -22,9 +22,7 @@ steps:
       queue: "mac-metal"
 
   - label: "Instrumented tests without GMD (ReviewsUITest)"
-    command: |
-      echo "--- 🧪 Testing"
-      ./gradlew :WooCommerce:connectedVanillaDebugAndroidTest -Pandroid.testInstrumentationRunnerArguments.class=com.woocommerce.android.e2e.tests.ui.ReviewsUITest
+    command: .buildkite/commands/run-instrumented-tests-emulator.sh
     plugins: [ $CI_TOOLKIT ]
     artifact_paths:
       - "**/build/reports/androidTests/connected/**/**/**/*"

--- a/WooCommerce/build.gradle
+++ b/WooCommerce/build.gradle
@@ -175,6 +175,15 @@ android {
     testOptions {
         animationsDisabled = true
         execution 'ANDROIDX_TEST_ORCHESTRATOR'
+        managedDevices {
+            localDevices {
+                pixel5api34 {
+                    device = "Pixel 5"
+                    apiLevel = 34
+                    systemImageSource = "google"
+                }
+            }
+        }
     }
 
     signingConfigs {


### PR DESCRIPTION
Related: #14153

> [!IMPORTANT]
> DO NOT MERGE — This PR is used to test CI scenarios only

This is a draft PR that I will use to (primary) run Android UI tests on the new CI agents (based on `mac-metal`), which is part of [this](https://linear.app/a8c/project/provision-new-bare-metal-ci-agents-981ef3d39744) project.

FYI: Currently this will be used to test [AINFRA-433](https://linear.app/a8c/issue/AINFRA-433) but as the project progress I'm expecting I'll continue to use this dummy PR and branch to test more parts/steps/issues of the project (in the context of Android, mostly UI tests, as well as the generation of Baseline Profiles, see #12429).