### PR TITLE
[Shipping Labels] Catch purchase error about UPSDAP and TOS bottom sheet

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/PurchaseShippingLabel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/PurchaseShippingLabel.kt
@@ -1,5 +1,6 @@
 package com.woocommerce.android.ui.orders.wooshippinglabels
 
+import com.woocommerce.android.WooException
 import com.woocommerce.android.model.Address
 import com.woocommerce.android.tools.SelectedSite
 import com.woocommerce.android.ui.orders.shippinglabels.creation.ShippingLabelHazmatCategory
@@ -29,27 +30,29 @@ class PurchaseShippingLabel @Inject constructor(
         customsData: List<CustomsData>? = null,
         hazmatSelection: ShippingLabelHazmatCategory? = null
     ): Result<PurchasedLabelData> {
-        return selectedSite.getOrNull()?.let {
-            val response = wooShippingLabelRepository.purchaseShippingLabel(
-                orderId = orderId,
-                shippableItems = shippableItems,
-                selectedPackage = selectedPackage,
-                shipmentId = shipmentId.toString(),
-                shipTo = shipTo,
-                shipFrom = shipFrom,
-                selectedRate = shippingRate,
-                weight = weight,
-                lastOrderComplete = lastOrderComplete,
-                customsData = customsData,
-                hazmatSelection = hazmatSelection,
-                site = it
-            )
-            val result = response.model
-            if (response.isError || result == null) {
-                Result.failure(Exception("Purchase failed"))
-            } else {
-                Result.success(result)
-            }
-        } ?: Result.failure(Exception("No site selected"))
+        val response = wooShippingLabelRepository.purchaseShippingLabel(
+            orderId = orderId,
+            shippableItems = shippableItems,
+            selectedPackage = selectedPackage,
+            shipmentId = shipmentId.toString(),
+            shipTo = shipTo,
+            shipFrom = shipFrom,
+            selectedRate = shippingRate,
+            weight = weight,
+            lastOrderComplete = lastOrderComplete,
+            customsData = customsData,
+            hazmatSelection = hazmatSelection,
+            site = selectedSite.get()
+        )
+
+        val result = response.model
+
+        return if (response.isError) {
+            Result.failure(WooException(response.error))
+        } else if (result == null) {
+            Result.failure(Exception("Unknown error occurred while purchasing shipping label"))
+        } else {
+            Result.success(result)
+        }
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/WooShippingLabelCreationFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/WooShippingLabelCreationFragment.kt
@@ -10,6 +10,7 @@ import androidx.compose.ui.platform.ViewCompositionStrategy
 import androidx.fragment.app.viewModels
 import androidx.navigation.fragment.findNavController
 import com.woocommerce.android.R
+import com.woocommerce.android.extensions.handleDialogNotice
 import com.woocommerce.android.extensions.handleResult
 import com.woocommerce.android.extensions.navigateSafely
 import com.woocommerce.android.ui.base.BaseFragment
@@ -28,11 +29,13 @@ import com.woocommerce.android.ui.orders.wooshippinglabels.customs.CustomsData
 import com.woocommerce.android.ui.orders.wooshippinglabels.customs.WooShippingCustomsFormFragment.Companion.CUSTOMS_DATA_RESULT
 import com.woocommerce.android.ui.orders.wooshippinglabels.hazmat.WooShippingLabelHazmatFormViewModel.Companion.HAZMAT_CATEGORY_RESULT
 import com.woocommerce.android.ui.orders.wooshippinglabels.models.DestinationShippingAddress
+import com.woocommerce.android.ui.orders.wooshippinglabels.models.OriginShippingAddress
 import com.woocommerce.android.ui.orders.wooshippinglabels.models.ShipmentUIModel
 import com.woocommerce.android.ui.orders.wooshippinglabels.packages.WooShippingLabelPackageCreationFragment.Companion.PACKAGE_SELECTION_RESULT
 import com.woocommerce.android.ui.orders.wooshippinglabels.packages.ui.PackageData
 import com.woocommerce.android.ui.orders.wooshippinglabels.refund.WooShippingLabelRefundFragment
 import com.woocommerce.android.ui.orders.wooshippinglabels.split.WooShippingSplitShipmentFragment
+import com.woocommerce.android.ui.orders.wooshippinglabels.upsdap.UPSDAPTermsOfServiceBottomSheetFragment
 import com.woocommerce.android.util.ActivityUtils
 import com.woocommerce.android.util.ChromeCustomTabUtils
 import com.woocommerce.android.viewmodel.MultiLiveEvent
@@ -131,10 +134,14 @@ class WooShippingLabelCreationFragment : BaseFragment(), BackPressListener {
                     event.orderId,
                     event.labelId
                 )
+
                 is WooShippingLabelCreationViewModel.NavigateToPaymentMethodEdit -> navigateToPaymentMethodEdit()
 
                 is WooShippingLabelCreationViewModel.OpenUrl -> openUrl(event.url)
                 is WooShippingLabelCreationViewModel.ShowError -> showErrorDialog(event.errorResId)
+                is WooShippingLabelCreationViewModel.NavigateToUPSDAPTermsOfService -> navigateToUPSDAPTermsOfService(
+                    event.originAddress
+                )
             }
         }
     }
@@ -161,6 +168,13 @@ class WooShippingLabelCreationFragment : BaseFragment(), BackPressListener {
 
         handleResult<Long>(WooShippingLabelRefundFragment.KEY_REFUND_SHIPPING_LABEL_RESULT) {
             viewModel.onShippingLabelRefunded(it)
+        }
+
+        handleDialogNotice(
+            UPSDAPTermsOfServiceBottomSheetFragment.TOS_ACCEPTED_NOTICE_KEY,
+            entryId = R.id.wooShippingLabelCreationFragment
+        ) {
+            viewModel.onPurchaseShippingLabel()
         }
     }
 
@@ -201,6 +215,13 @@ class WooShippingLabelCreationFragment : BaseFragment(), BackPressListener {
             titleId = R.string.error_generic,
             messageId = messageResId,
             positiveButtonId = R.string.dialog_ok
+        )
+    }
+
+    private fun navigateToUPSDAPTermsOfService(originAddress: OriginShippingAddress) {
+        findNavController().navigate(
+            WooShippingLabelCreationFragmentDirections
+                .actionWooShippingLabelCreationFragmentToUpsDapTermsOfServiceBottomSheetFragment(originAddress)
         )
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/WooShippingLabelCreationViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/WooShippingLabelCreationViewModel.kt
@@ -124,7 +124,7 @@ class WooShippingLabelCreationViewModel @Inject constructor(
 
     private val emptyOrder = Order.getEmptyOrder(Date(), Date())
     private val order = MutableStateFlow<Order>(emptyOrder)
-    private val destinationAddress = MutableStateFlow<DestinationShippingAddress>(DestinationShippingAddress.EMPTY)
+    private val destinationAddress = MutableStateFlow(DestinationShippingAddress.EMPTY)
     private val shippingAddresses = MutableStateFlow<WooShippingAddresses?>(WooShippingAddresses.EMPTY)
     private val loadTrigger = MutableSharedFlow<Unit>()
 
@@ -1091,6 +1091,7 @@ class WooShippingLabelCreationViewModel @Inject constructor(
         private const val NOTIFICATIONS_DELAY = 2_000L
         private const val TYPING_DELAY = 800L
         private const val MULTIPLE_CALLS_DELAY = 50L
+
         @VisibleForTesting
         const val UPSDAP_MISSING_TOS_ERROR_CODE = "missing_upsdap_terms_of_service_acceptance"
     }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/WooShippingLabelCreationViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/WooShippingLabelCreationViewModel.kt
@@ -2,6 +2,7 @@ package com.woocommerce.android.ui.orders.wooshippinglabels
 
 import android.os.Parcelable
 import androidx.annotation.StringRes
+import androidx.annotation.VisibleForTesting
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.setValue
@@ -9,6 +10,7 @@ import androidx.compose.runtime.snapshotFlow
 import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.viewModelScope
 import com.woocommerce.android.R
+import com.woocommerce.android.WooException
 import com.woocommerce.android.extensions.combine
 import com.woocommerce.android.extensions.sumByFloat
 import com.woocommerce.android.model.Address
@@ -676,7 +678,7 @@ class WooShippingLabelCreationViewModel @Inject constructor(
         val customsData = customsFormDataFlow.value[selectedShipmentIndex]?.let { listOf(it) }
 
         launch {
-            val result = purchaseShippingLabel(
+            purchaseShippingLabel(
                 orderId,
                 shippableItemsIdList,
                 selectedPackage,
@@ -688,28 +690,32 @@ class WooShippingLabelCreationViewModel @Inject constructor(
                 lastOrderComplete,
                 customsData,
                 hazmatSelection
+            ).fold(
+                onSuccess = {
+                    handlePurchaseSuccess(it, selectedShipmentIndex)
+                },
+                onFailure = { exception ->
+                    updateShipment(
+                        selectedShipmentIndex,
+                        shipments.value[selectedShipmentIndex].copy(purchaseState = fallbackPurchaseState)
+                    )
+                    if (exception is WooException && exception.error.apiErrorCode == UPSDAP_MISSING_TOS_ERROR_CODE) {
+                        TODO("Handle UPSDAP missing TOS error")
+                    } else {
+                        snackbarData = ShippingLabelsSnackbarData(
+                            message = R.string.woo_shipping_labels_purchase_error,
+                            actionLabel = R.string.retry,
+                        ) { onPurchaseShippingLabel() }
+                    }
+                }
             )
-
-            if (result.isSuccess) {
-                handlePurchaseSuccess(result, selectedShipmentIndex)
-            } else {
-                updateShipment(
-                    selectedShipmentIndex,
-                    shipments.value[selectedShipmentIndex].copy(purchaseState = fallbackPurchaseState)
-                )
-                snackbarData = ShippingLabelsSnackbarData(
-                    message = R.string.woo_shipping_labels_purchase_error,
-                    actionLabel = R.string.retry,
-                ) { onPurchaseShippingLabel() }
-            }
         }
     }
 
-    private fun handlePurchaseSuccess(result: Result<PurchasedLabelData>, shipmentId: Int) {
+    private fun handlePurchaseSuccess(result: PurchasedLabelData, shipmentId: Int) {
         updateShipment(shipmentId, shipments.value[shipmentId].copy(purchaseState = PurchaseState.Success))
-        result.getOrNull()
-            ?.labels
-            ?.firstOrNull()
+        result.labels
+            .firstOrNull()
             ?.let { purchasedLabel ->
                 updateShipment(shipmentId, shipments.value[shipmentId].copy(purchased = true, label = purchasedLabel))
                 observeShippingLabelPurchaseStatus(shipmentId)
@@ -1082,6 +1088,8 @@ class WooShippingLabelCreationViewModel @Inject constructor(
         private const val NOTIFICATIONS_DELAY = 2_000L
         private const val TYPING_DELAY = 800L
         private const val MULTIPLE_CALLS_DELAY = 50L
+        @VisibleForTesting
+        const val UPSDAP_MISSING_TOS_ERROR_CODE = "missing_upsdap_terms_of_service_acceptance"
     }
 }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/WooShippingLabelCreationViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/WooShippingLabelCreationViewModel.kt
@@ -700,7 +700,9 @@ class WooShippingLabelCreationViewModel @Inject constructor(
                         shipments.value[selectedShipmentIndex].copy(purchaseState = fallbackPurchaseState)
                     )
                     if (exception is WooException && exception.error.apiErrorCode == UPSDAP_MISSING_TOS_ERROR_CODE) {
-                        TODO("Handle UPSDAP missing TOS error")
+                        shippingAddresses.value?.shipFrom?.let { shipFrom ->
+                            triggerEvent(NavigateToUPSDAPTermsOfService(shipFrom))
+                        }
                     } else {
                         snackbarData = ShippingLabelsSnackbarData(
                             message = R.string.woo_shipping_labels_purchase_error,
@@ -1064,6 +1066,7 @@ class WooShippingLabelCreationViewModel @Inject constructor(
     data class ShowError(val errorResId: Int) : Event()
     data class NavigateToRefundRequest(val orderId: Long, val labelId: Long) : Event()
     data object NavigateToPaymentMethodEdit : Event()
+    data class NavigateToUPSDAPTermsOfService(val originAddress: OriginShippingAddress) : Event()
 
     object OpenLearnMoreScreen : Event()
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/models/OriginShippingAddress.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/models/OriginShippingAddress.kt
@@ -46,7 +46,7 @@ data class OriginShippingAddress(
         return buildString {
             appendWithIfNotEmpty(address1, separator)
             appendWithIfNotEmpty(address2, separator)
-            appendWithIfNotEmpty(city, separator = " ")
+            appendWithIfNotEmpty(city, separator = separator)
             appendWithIfNotEmpty(state, separator = " ")
             appendWithIfNotEmpty(postcode, separator = " ")
             appendWithIfNotEmpty(country, separator = separator)

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/payment/WooShippingEditPaymentScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/payment/WooShippingEditPaymentScreen.kt
@@ -47,7 +47,9 @@ import androidx.compose.ui.geometry.Size
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.PathEffect
 import androidx.compose.ui.graphics.drawscope.Stroke
+import androidx.compose.ui.input.nestedscroll.nestedScroll
 import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.platform.rememberNestedScrollInteropConnection
 import androidx.compose.ui.res.colorResource
 import androidx.compose.ui.res.dimensionResource
 import androidx.compose.ui.res.painterResource
@@ -176,7 +178,8 @@ private fun WooShippingEditPaymentContent(
     Column(
         modifier
             .padding(16.dp)
-            .verticalScroll(rememberScrollState())
+            .nestedScroll(rememberNestedScrollInteropConnection())
+            .verticalScroll(rememberScrollState()),
     ) {
         BottomSheetHandle(modifier = Modifier.align(Alignment.CenterHorizontally))
 
@@ -208,9 +211,7 @@ private fun WooShippingEditPaymentContent(
         }
     }
 
-    viewState.dialogState?.let {
-        it.Render()
-    }
+    viewState.dialogState?.Render()
 }
 
 @Composable

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/upsdap/UPSDAPTermsOfServiceBottomSheet.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/upsdap/UPSDAPTermsOfServiceBottomSheet.kt
@@ -1,6 +1,8 @@
 package com.woocommerce.android.ui.orders.wooshippinglabels.upsdap
 
+import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
@@ -12,11 +14,14 @@ import androidx.compose.material.Divider
 import androidx.compose.material.MaterialTheme
 import androidx.compose.material.Surface
 import androidx.compose.material.Text
+import androidx.compose.material3.Checkbox
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.livedata.observeAsState
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.dimensionResource
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.AnnotatedString
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
@@ -31,12 +36,17 @@ import com.woocommerce.android.ui.orders.wooshippinglabels.models.OriginShipping
 
 @Composable
 fun UPSDAPTermsOfServiceBottomSheet(
-    originAddress: OriginShippingAddress,
-    onAcceptClicked: () -> Unit,
-    onUrlClicked: (String) -> Unit
+    viewModel: UPSDAPTermsOfServiceViewModel
 ) {
-    val scrollState = rememberScrollState()
+    viewModel.viewState.observeAsState().value?.let {
+        UPSDAPTermsOfServiceBottomSheet(it)
+    }
+}
 
+@Composable
+fun UPSDAPTermsOfServiceBottomSheet(
+    viewState: UPSDAPTermsOfServiceViewModel.ViewState
+) {
     Surface(
         shape = RoundedCornerShape(
             topStart = dimensionResource(id = R.dimen.minor_100),
@@ -47,7 +57,7 @@ fun UPSDAPTermsOfServiceBottomSheet(
             modifier = Modifier
                 .fillMaxWidth()
                 .padding(horizontal = 16.dp)
-                .verticalScroll(scrollState),
+                .verticalScroll(rememberScrollState()),
             horizontalAlignment = Alignment.CenterHorizontally
         ) {
             Spacer(modifier = Modifier.height(8.dp))
@@ -60,21 +70,16 @@ fun UPSDAPTermsOfServiceBottomSheet(
                 textAlign = TextAlign.Center
             )
 
-            Spacer(modifier = Modifier.height(16.dp))
+            Spacer(modifier = Modifier.height(24.dp))
 
-            OriginAddressSection(address = originAddress)
-
-            Spacer(modifier = Modifier.height(16.dp))
-
-            // Divider
-            Divider(
-                modifier = Modifier.fillMaxWidth(),
-                color = MaterialTheme.colors.onSurface.copy(alpha = 0.12f)
-            )
+            OriginAddressSection(address = viewState.originShippingAddress)
 
             Spacer(modifier = Modifier.height(16.dp))
 
-            // Description
+            Divider()
+
+            Spacer(modifier = Modifier.height(16.dp))
+
             Text(
                 text = stringResource(id = R.string.wpp_shipping_ups_tos_description),
                 style = MaterialTheme.typography.body1,
@@ -87,13 +92,16 @@ fun UPSDAPTermsOfServiceBottomSheet(
 
             Spacer(modifier = Modifier.height(16.dp))
 
-            Conditions(onUrlClicked)
+            Conditions(
+                conditionsState = viewState.conditionsState,
+                onUrlClicked = viewState.onUrlClicked
+            )
 
             Spacer(modifier = Modifier.height(32.dp))
 
-            // Accept Button
             WCColoredButton(
-                onClick = onAcceptClicked,
+                onClick = viewState.onContinueClicked,
+                enabled = viewState.areAllConditionsAccepted,
                 modifier = Modifier.fillMaxWidth()
             ) {
                 Text(text = stringResource(id = R.string.wpp_shipping_ups_tos_accept))
@@ -129,41 +137,61 @@ private fun OriginAddressSection(address: OriginShippingAddress) {
 }
 
 @Composable
-private fun Conditions(onUrlClicked: (String) -> Unit) {
+private fun Conditions(
+    conditionsState: UPSDAPTermsOfServiceViewModel.ConditionsState,
+    onUrlClicked: (String) -> Unit,
+    modifier: Modifier = Modifier
+) {
     Column(
-        modifier = Modifier
+        verticalArrangement = Arrangement.spacedBy(12.dp),
+        modifier = modifier
             .fillMaxWidth()
-            .padding(horizontal = 8.dp)
     ) {
-        Text(
-            text = annotatedStringRes(
+        CheckboxWithTitle(
+            checked = conditionsState.isTermsOfServiceChecked,
+            title = annotatedStringRes(
                 stringResId = R.string.wpp_shipping_ups_tos_condition_1,
                 onUrlClick = onUrlClicked
             ),
-            style = MaterialTheme.typography.body2,
-            color = MaterialTheme.colors.onSurface
+            onCheckedChange = conditionsState.onTermsOfServiceCheckedChanged
         )
 
-        Spacer(modifier = Modifier.height(12.dp))
-
-        Text(
-            text = annotatedStringRes(
+        CheckboxWithTitle(
+            checked = conditionsState.isProhibitedItemsChecked,
+            title = annotatedStringRes(
                 stringResId = R.string.wpp_shipping_ups_tos_condition_2,
                 onUrlClick = onUrlClicked
             ),
-            style = MaterialTheme.typography.body2,
-            color = MaterialTheme.colors.onSurface
+            onCheckedChange = conditionsState.onProhibitedItemsCheckedChanged
         )
 
-        Spacer(modifier = Modifier.height(12.dp))
-
-        Text(
-            text = annotatedStringRes(
+        CheckboxWithTitle(
+            checked = conditionsState.isTechnologyAgreementChecked,
+            title = annotatedStringRes(
                 stringResId = R.string.wpp_shipping_ups_tos_condition_3,
                 onUrlClick = onUrlClicked
             ),
-            style = MaterialTheme.typography.body2,
-            color = MaterialTheme.colors.onSurface
+            onCheckedChange = conditionsState.onTechnologyAgreementCheckedChanged
+        )
+    }
+}
+
+@Composable
+private fun CheckboxWithTitle(
+    checked: Boolean,
+    title: AnnotatedString,
+    onCheckedChange: (Boolean) -> Unit
+) {
+    Row(
+        verticalAlignment = Alignment.CenterVertically
+    ) {
+        Checkbox(
+            checked = checked,
+            onCheckedChange = onCheckedChange
+        )
+        Text(
+            text = title,
+            style = MaterialTheme.typography.body2
         )
     }
 }
@@ -173,9 +201,19 @@ private fun Conditions(onUrlClicked: (String) -> Unit) {
 fun UPSDAPTermsOfServiceBottomSheetPreview() {
     WooThemeWithBackground {
         UPSDAPTermsOfServiceBottomSheet(
-            originAddress = ShippingLabelSampleData.getShipFrom(),
-            onAcceptClicked = {},
-            onUrlClicked = {}
+            UPSDAPTermsOfServiceViewModel.ViewState(
+                originShippingAddress = ShippingLabelSampleData.getShipFrom(),
+                conditionsState = UPSDAPTermsOfServiceViewModel.ConditionsState(
+                    isTermsOfServiceChecked = true,
+                    isProhibitedItemsChecked = true,
+                    isTechnologyAgreementChecked = true,
+                    onTermsOfServiceCheckedChanged = {},
+                    onProhibitedItemsCheckedChanged = {},
+                    onTechnologyAgreementCheckedChanged = {}
+                ),
+                onUrlClicked = {},
+                onContinueClicked = {}
+            )
         )
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/upsdap/UPSDAPTermsOfServiceBottomSheet.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/upsdap/UPSDAPTermsOfServiceBottomSheet.kt
@@ -19,6 +19,8 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.livedata.observeAsState
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.input.nestedscroll.nestedScroll
+import androidx.compose.ui.platform.rememberNestedScrollInteropConnection
 import androidx.compose.ui.res.dimensionResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.AnnotatedString
@@ -56,57 +58,63 @@ fun UPSDAPTermsOfServiceBottomSheet(
         Column(
             modifier = Modifier
                 .fillMaxWidth()
-                .padding(horizontal = 16.dp)
-                .verticalScroll(rememberScrollState()),
+                .padding(horizontal = 16.dp),
             horizontalAlignment = Alignment.CenterHorizontally
         ) {
             Spacer(modifier = Modifier.height(8.dp))
             BottomSheetHandle(Modifier.align(Alignment.CenterHorizontally))
-            Spacer(modifier = Modifier.height(24.dp))
 
-            Text(
-                text = stringResource(id = R.string.wpp_shipping_ups_tos_title),
-                style = MaterialTheme.typography.h6,
-                textAlign = TextAlign.Center
-            )
-
-            Spacer(modifier = Modifier.height(24.dp))
-
-            OriginAddressSection(address = viewState.originShippingAddress)
-
-            Spacer(modifier = Modifier.height(16.dp))
-
-            Divider()
-
-            Spacer(modifier = Modifier.height(16.dp))
-
-            Text(
-                text = stringResource(id = R.string.wpp_shipping_ups_tos_description),
-                style = MaterialTheme.typography.body1,
-                textAlign = TextAlign.Start,
-                modifier = Modifier
+            Column(
+                Modifier
                     .fillMaxWidth()
-                    .padding(horizontal = 8.dp)
-            )
-
-            Spacer(modifier = Modifier.height(16.dp))
-
-            Conditions(
-                conditionsState = viewState.conditionsState,
-                onUrlClicked = viewState.onUrlClicked
-            )
-
-            Spacer(modifier = Modifier.height(32.dp))
-
-            WCColoredButton(
-                onClick = viewState.onContinueClicked,
-                enabled = viewState.areAllConditionsAccepted,
-                modifier = Modifier.fillMaxWidth()
+                    .nestedScroll(rememberNestedScrollInteropConnection())
+                    .verticalScroll(rememberScrollState()),
             ) {
-                Text(text = stringResource(id = R.string.wpp_shipping_ups_tos_accept))
-            }
+                Spacer(modifier = Modifier.height(24.dp))
+                Text(
+                    text = stringResource(id = R.string.wpp_shipping_ups_tos_title),
+                    style = MaterialTheme.typography.h6,
+                    textAlign = TextAlign.Center
+                )
 
-            Spacer(modifier = Modifier.height(16.dp))
+                Spacer(modifier = Modifier.height(24.dp))
+
+                OriginAddressSection(address = viewState.originShippingAddress)
+
+                Spacer(modifier = Modifier.height(16.dp))
+
+                Divider()
+
+                Spacer(modifier = Modifier.height(16.dp))
+
+                Text(
+                    text = stringResource(id = R.string.wpp_shipping_ups_tos_description),
+                    style = MaterialTheme.typography.body1,
+                    textAlign = TextAlign.Start,
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .padding(horizontal = 8.dp)
+                )
+
+                Spacer(modifier = Modifier.height(16.dp))
+
+                Conditions(
+                    conditionsState = viewState.conditionsState,
+                    onUrlClicked = viewState.onUrlClicked
+                )
+
+                Spacer(modifier = Modifier.height(32.dp))
+
+                WCColoredButton(
+                    onClick = viewState.onContinueClicked,
+                    enabled = viewState.areAllConditionsAccepted,
+                    modifier = Modifier.fillMaxWidth()
+                ) {
+                    Text(text = stringResource(id = R.string.wpp_shipping_ups_tos_accept))
+                }
+
+                Spacer(modifier = Modifier.height(16.dp))
+            }
         }
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/upsdap/UPSDAPTermsOfServiceBottomSheet.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/upsdap/UPSDAPTermsOfServiceBottomSheet.kt
@@ -150,7 +150,7 @@ private fun Conditions(
         CheckboxWithTitle(
             checked = conditionsState.isTermsOfServiceChecked,
             title = annotatedStringRes(
-                stringResId = R.string.wpp_shipping_ups_tos_condition_1,
+                stringResId = R.string.wpp_shipping_ups_tos_condition_terms,
                 onUrlClick = onUrlClicked
             ),
             onCheckedChange = conditionsState.onTermsOfServiceCheckedChanged
@@ -159,7 +159,7 @@ private fun Conditions(
         CheckboxWithTitle(
             checked = conditionsState.isProhibitedItemsChecked,
             title = annotatedStringRes(
-                stringResId = R.string.wpp_shipping_ups_tos_condition_2,
+                stringResId = R.string.wpp_shipping_ups_tos_condition_prohibited_items,
                 onUrlClick = onUrlClicked
             ),
             onCheckedChange = conditionsState.onProhibitedItemsCheckedChanged
@@ -168,7 +168,7 @@ private fun Conditions(
         CheckboxWithTitle(
             checked = conditionsState.isTechnologyAgreementChecked,
             title = annotatedStringRes(
-                stringResId = R.string.wpp_shipping_ups_tos_condition_3,
+                stringResId = R.string.wpp_shipping_ups_tos_condition_technology_agreement,
                 onUrlClick = onUrlClicked
             ),
             onCheckedChange = conditionsState.onTechnologyAgreementCheckedChanged

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/upsdap/UPSDAPTermsOfServiceBottomSheet.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/upsdap/UPSDAPTermsOfServiceBottomSheet.kt
@@ -1,0 +1,181 @@
+package com.woocommerce.android.ui.orders.wooshippinglabels.upsdap
+
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material.Divider
+import androidx.compose.material.MaterialTheme
+import androidx.compose.material.Surface
+import androidx.compose.material.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.dimensionResource
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.dp
+import com.woocommerce.android.R
+import com.woocommerce.android.ui.compose.annotatedStringRes
+import com.woocommerce.android.ui.compose.component.BottomSheetHandle
+import com.woocommerce.android.ui.compose.component.WCColoredButton
+import com.woocommerce.android.ui.compose.preview.LightDarkThemePreviews
+import com.woocommerce.android.ui.compose.theme.WooThemeWithBackground
+import com.woocommerce.android.ui.orders.wooshippinglabels.ShippingLabelSampleData
+import com.woocommerce.android.ui.orders.wooshippinglabels.models.OriginShippingAddress
+
+@Composable
+fun UPSDAPTermsOfServiceBottomSheet(
+    originAddress: OriginShippingAddress,
+    onAcceptClicked: () -> Unit,
+    onUrlClicked: (String) -> Unit
+) {
+    val scrollState = rememberScrollState()
+
+    Surface(
+        shape = RoundedCornerShape(
+            topStart = dimensionResource(id = R.dimen.minor_100),
+            topEnd = dimensionResource(id = R.dimen.minor_100)
+        )
+    ) {
+        Column(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(horizontal = 16.dp)
+                .verticalScroll(scrollState),
+            horizontalAlignment = Alignment.CenterHorizontally
+        ) {
+            Spacer(modifier = Modifier.height(8.dp))
+            BottomSheetHandle(Modifier.align(Alignment.CenterHorizontally))
+            Spacer(modifier = Modifier.height(24.dp))
+
+            Text(
+                text = stringResource(id = R.string.wpp_shipping_ups_tos_title),
+                style = MaterialTheme.typography.h6,
+                textAlign = TextAlign.Center
+            )
+
+            Spacer(modifier = Modifier.height(16.dp))
+
+            OriginAddressSection(address = originAddress)
+
+            Spacer(modifier = Modifier.height(16.dp))
+
+            // Divider
+            Divider(
+                modifier = Modifier.fillMaxWidth(),
+                color = MaterialTheme.colors.onSurface.copy(alpha = 0.12f)
+            )
+
+            Spacer(modifier = Modifier.height(16.dp))
+
+            // Description
+            Text(
+                text = stringResource(id = R.string.wpp_shipping_ups_tos_description),
+                style = MaterialTheme.typography.body1,
+                textAlign = TextAlign.Start,
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(horizontal = 8.dp),
+                color = MaterialTheme.colors.onSurface
+            )
+
+            Spacer(modifier = Modifier.height(16.dp))
+
+            Conditions(onUrlClicked)
+
+            Spacer(modifier = Modifier.height(32.dp))
+
+            // Accept Button
+            WCColoredButton(
+                onClick = onAcceptClicked,
+                modifier = Modifier.fillMaxWidth()
+            ) {
+                Text(text = stringResource(id = R.string.wpp_shipping_ups_tos_accept))
+            }
+
+            Spacer(modifier = Modifier.height(16.dp))
+        }
+    }
+}
+
+@Composable
+private fun OriginAddressSection(address: OriginShippingAddress) {
+    Column(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(horizontal = 8.dp)
+    ) {
+        Text(
+            text = stringResource(id = R.string.wpp_shipping_ups_tos_shipping_from),
+            style = MaterialTheme.typography.subtitle1,
+            color = MaterialTheme.colors.onSurface,
+            fontWeight = FontWeight.SemiBold
+        )
+
+        Spacer(modifier = Modifier.height(4.dp))
+
+        Text(
+            text = address.format(singleLine = false),
+            style = MaterialTheme.typography.body2,
+            color = MaterialTheme.colors.onSurface
+        )
+    }
+}
+
+@Composable
+private fun Conditions(onUrlClicked: (String) -> Unit) {
+    Column(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(horizontal = 8.dp)
+    ) {
+        Text(
+            text = annotatedStringRes(
+                stringResId = R.string.wpp_shipping_ups_tos_condition_1,
+                onUrlClick = onUrlClicked
+            ),
+            style = MaterialTheme.typography.body2,
+            color = MaterialTheme.colors.onSurface
+        )
+
+        Spacer(modifier = Modifier.height(12.dp))
+
+        Text(
+            text = annotatedStringRes(
+                stringResId = R.string.wpp_shipping_ups_tos_condition_2,
+                onUrlClick = onUrlClicked
+            ),
+            style = MaterialTheme.typography.body2,
+            color = MaterialTheme.colors.onSurface
+        )
+
+        Spacer(modifier = Modifier.height(12.dp))
+
+        Text(
+            text = annotatedStringRes(
+                stringResId = R.string.wpp_shipping_ups_tos_condition_3,
+                onUrlClick = onUrlClicked
+            ),
+            style = MaterialTheme.typography.body2,
+            color = MaterialTheme.colors.onSurface
+        )
+    }
+}
+
+@LightDarkThemePreviews
+@Composable
+fun UPSDAPTermsOfServiceBottomSheetPreview() {
+    WooThemeWithBackground {
+        UPSDAPTermsOfServiceBottomSheet(
+            originAddress = ShippingLabelSampleData.getShipFrom(),
+            onAcceptClicked = {},
+            onUrlClicked = {}
+        )
+    }
+}

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/upsdap/UPSDAPTermsOfServiceBottomSheet.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/upsdap/UPSDAPTermsOfServiceBottomSheet.kt
@@ -86,8 +86,7 @@ fun UPSDAPTermsOfServiceBottomSheet(
                 textAlign = TextAlign.Start,
                 modifier = Modifier
                     .fillMaxWidth()
-                    .padding(horizontal = 8.dp),
-                color = MaterialTheme.colors.onSurface
+                    .padding(horizontal = 8.dp)
             )
 
             Spacer(modifier = Modifier.height(16.dp))
@@ -122,7 +121,6 @@ private fun OriginAddressSection(address: OriginShippingAddress) {
         Text(
             text = stringResource(id = R.string.wpp_shipping_ups_tos_shipping_from),
             style = MaterialTheme.typography.subtitle1,
-            color = MaterialTheme.colors.onSurface,
             fontWeight = FontWeight.SemiBold
         )
 
@@ -130,8 +128,7 @@ private fun OriginAddressSection(address: OriginShippingAddress) {
 
         Text(
             text = address.format(singleLine = false),
-            style = MaterialTheme.typography.body2,
-            color = MaterialTheme.colors.onSurface
+            style = MaterialTheme.typography.body2
         )
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/upsdap/UPSDAPTermsOfServiceBottomSheetFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/upsdap/UPSDAPTermsOfServiceBottomSheetFragment.kt
@@ -1,0 +1,39 @@
+package com.woocommerce.android.ui.orders.wooshippinglabels.upsdap
+
+import android.os.Bundle
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import androidx.navigation.fragment.navArgs
+import com.woocommerce.android.extensions.navigateBackWithNotice
+import com.woocommerce.android.ui.compose.composeView
+import com.woocommerce.android.util.ChromeCustomTabUtils
+import com.woocommerce.android.widgets.WCBottomSheetDialogFragment
+import dagger.hilt.android.AndroidEntryPoint
+
+@AndroidEntryPoint
+class UPSDAPTermsOfServiceBottomSheetFragment : WCBottomSheetDialogFragment() {
+    private val args: UPSDAPTermsOfServiceBottomSheetFragmentArgs by navArgs()
+
+    override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View {
+        return composeView {
+            UPSDAPTermsOfServiceBottomSheet(
+                originAddress = args.originAddress,
+                onAcceptClicked = { onAcceptClicked() },
+                onUrlClicked = { onUrlClicked(it) }
+            )
+        }
+    }
+
+    private fun onAcceptClicked() {
+        navigateBackWithNotice(TOS_ACCEPTED_NOTICE_KEY)
+    }
+
+    private fun onUrlClicked(url: String) {
+        ChromeCustomTabUtils.launchUrl(requireContext(), url)
+    }
+
+    companion object {
+        const val TOS_ACCEPTED_NOTICE_KEY = "tos_accepted_notice_key"
+    }
+}

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/upsdap/UPSDAPTermsOfServiceBottomSheetFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/upsdap/UPSDAPTermsOfServiceBottomSheetFragment.kt
@@ -4,36 +4,44 @@ import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
-import androidx.navigation.fragment.navArgs
+import androidx.compose.ui.platform.ComposeView
+import androidx.compose.ui.platform.ViewCompositionStrategy
+import androidx.fragment.app.viewModels
 import com.woocommerce.android.extensions.navigateBackWithNotice
-import com.woocommerce.android.ui.compose.composeView
 import com.woocommerce.android.util.ChromeCustomTabUtils
+import com.woocommerce.android.viewmodel.MultiLiveEvent
 import com.woocommerce.android.widgets.WCBottomSheetDialogFragment
 import dagger.hilt.android.AndroidEntryPoint
 
 @AndroidEntryPoint
 class UPSDAPTermsOfServiceBottomSheetFragment : WCBottomSheetDialogFragment() {
-    private val args: UPSDAPTermsOfServiceBottomSheetFragmentArgs by navArgs()
+    companion object {
+        const val TOS_ACCEPTED_NOTICE_KEY = "tos_accepted_notice_key"
+    }
+
+    private val viewModel: UPSDAPTermsOfServiceViewModel by viewModels()
 
     override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View {
-        return composeView {
-            UPSDAPTermsOfServiceBottomSheet(
-                originAddress = args.originAddress,
-                onAcceptClicked = { onAcceptClicked() },
-                onUrlClicked = { onUrlClicked(it) }
-            )
+        return ComposeView(requireContext()).apply {
+            setViewCompositionStrategy(ViewCompositionStrategy.DisposeOnViewTreeLifecycleDestroyed)
+
+            setContent {
+                UPSDAPTermsOfServiceBottomSheet(viewModel)
+            }
         }
     }
 
-    private fun onAcceptClicked() {
-        navigateBackWithNotice(TOS_ACCEPTED_NOTICE_KEY)
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
+        handleEvents()
     }
 
-    private fun onUrlClicked(url: String) {
-        ChromeCustomTabUtils.launchUrl(requireContext(), url)
-    }
-
-    companion object {
-        const val TOS_ACCEPTED_NOTICE_KEY = "tos_accepted_notice_key"
+    private fun handleEvents() {
+        viewModel.event.observe(viewLifecycleOwner) { event ->
+            when (event) {
+                is MultiLiveEvent.Event.ExitWithResult<*> -> navigateBackWithNotice(TOS_ACCEPTED_NOTICE_KEY)
+                is MultiLiveEvent.Event.OpenUrl -> ChromeCustomTabUtils.launchUrl(requireContext(), event.url)
+            }
+        }
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/upsdap/UPSDAPTermsOfServiceBottomSheetFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/upsdap/UPSDAPTermsOfServiceBottomSheetFragment.kt
@@ -8,6 +8,7 @@ import androidx.compose.ui.platform.ComposeView
 import androidx.compose.ui.platform.ViewCompositionStrategy
 import androidx.fragment.app.viewModels
 import com.woocommerce.android.extensions.navigateBackWithNotice
+import com.woocommerce.android.ui.compose.theme.WooTheme
 import com.woocommerce.android.util.ChromeCustomTabUtils
 import com.woocommerce.android.viewmodel.MultiLiveEvent
 import com.woocommerce.android.widgets.WCBottomSheetDialogFragment
@@ -26,7 +27,9 @@ class UPSDAPTermsOfServiceBottomSheetFragment : WCBottomSheetDialogFragment() {
             setViewCompositionStrategy(ViewCompositionStrategy.DisposeOnViewTreeLifecycleDestroyed)
 
             setContent {
-                UPSDAPTermsOfServiceBottomSheet(viewModel)
+                WooTheme {
+                    UPSDAPTermsOfServiceBottomSheet(viewModel)
+                }
             }
         }
     }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/upsdap/UPSDAPTermsOfServiceViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/upsdap/UPSDAPTermsOfServiceViewModel.kt
@@ -17,6 +17,14 @@ import javax.inject.Inject
 class UPSDAPTermsOfServiceViewModel @Inject constructor(
     savedState: SavedStateHandle
 ) : ScopedViewModel(savedState) {
+    companion object {
+        private const val TERMS_URL = "https://www.ups.com/assets/resources/webcontent/" +
+                "en_US/ups_dap_supplemental_tc.pdf"
+        private const val PROHIBITED_ITEMS_URL = "https://www.ups.com/us/en/support/shipping-support/" +
+                "shipping-special-care-regulated-items/prohibited-items.page"
+        private const val TECHNOLOGY_AGREEMENT_URL = "https://www.ups.com/assets/resources/webcontent/en_US/UTA.pdf"
+    }
+
     private val args: UPSDAPTermsOfServiceBottomSheetFragmentArgs by savedState.navArgs()
 
     private var isTermsOfServiceAccepted = savedState.getStateFlow(
@@ -66,7 +74,13 @@ class UPSDAPTermsOfServiceViewModel @Inject constructor(
     }.asLiveData()
 
     private fun onUrlClicked(url: String) {
-        triggerEvent(MultiLiveEvent.Event.OpenUrl(url))
+        val finalUrl = when (url) {
+            "ups-tos" -> TERMS_URL
+            "ups-prohibited-items" -> PROHIBITED_ITEMS_URL
+            "ups-technology-agreement" -> TECHNOLOGY_AGREEMENT_URL
+            else -> error("Unknown URL: $url")
+        }
+        triggerEvent(MultiLiveEvent.Event.OpenUrl(finalUrl))
     }
 
     private fun onContinueClicked() {
@@ -91,7 +105,7 @@ class UPSDAPTermsOfServiceViewModel @Inject constructor(
     ) {
         val areAllConditionsAccepted: Boolean
             get() = conditionsState.isTermsOfServiceChecked &&
-                conditionsState.isProhibitedItemsChecked &&
-                conditionsState.isTechnologyAgreementChecked
+                    conditionsState.isProhibitedItemsChecked &&
+                    conditionsState.isTechnologyAgreementChecked
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/upsdap/UPSDAPTermsOfServiceViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/upsdap/UPSDAPTermsOfServiceViewModel.kt
@@ -19,9 +19,9 @@ class UPSDAPTermsOfServiceViewModel @Inject constructor(
 ) : ScopedViewModel(savedState) {
     companion object {
         private const val TERMS_URL = "https://www.ups.com/assets/resources/webcontent/" +
-                "en_US/ups_dap_supplemental_tc.pdf"
+            "en_US/ups_dap_supplemental_tc.pdf"
         private const val PROHIBITED_ITEMS_URL = "https://www.ups.com/us/en/support/shipping-support/" +
-                "shipping-special-care-regulated-items/prohibited-items.page"
+            "shipping-special-care-regulated-items/prohibited-items.page"
         private const val TECHNOLOGY_AGREEMENT_URL = "https://www.ups.com/assets/resources/webcontent/en_US/UTA.pdf"
     }
 
@@ -105,7 +105,7 @@ class UPSDAPTermsOfServiceViewModel @Inject constructor(
     ) {
         val areAllConditionsAccepted: Boolean
             get() = conditionsState.isTermsOfServiceChecked &&
-                    conditionsState.isProhibitedItemsChecked &&
-                    conditionsState.isTechnologyAgreementChecked
+                conditionsState.isProhibitedItemsChecked &&
+                conditionsState.isTechnologyAgreementChecked
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/upsdap/UPSDAPTermsOfServiceViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/upsdap/UPSDAPTermsOfServiceViewModel.kt
@@ -1,0 +1,97 @@
+package com.woocommerce.android.ui.orders.wooshippinglabels.upsdap
+
+import androidx.lifecycle.SavedStateHandle
+import androidx.lifecycle.asLiveData
+import androidx.lifecycle.viewModelScope
+import com.woocommerce.android.ui.orders.wooshippinglabels.models.OriginShippingAddress
+import com.woocommerce.android.viewmodel.MultiLiveEvent
+import com.woocommerce.android.viewmodel.ScopedViewModel
+import com.woocommerce.android.viewmodel.getStateFlow
+import com.woocommerce.android.viewmodel.navArgs
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.flow.map
+import javax.inject.Inject
+
+@HiltViewModel
+class UPSDAPTermsOfServiceViewModel @Inject constructor(
+    savedState: SavedStateHandle
+) : ScopedViewModel(savedState) {
+    private val args: UPSDAPTermsOfServiceBottomSheetFragmentArgs by savedState.navArgs()
+
+    private var isTermsOfServiceAccepted = savedState.getStateFlow(
+        scope = viewModelScope,
+        key = "terms_of_service_accepted",
+        initialValue = false
+    )
+    private var isProhibitedItemsChecked = savedState.getStateFlow(
+        scope = viewModelScope,
+        key = "prohibited_items_checked",
+        initialValue = false
+    )
+    private var isTechnologyAgreementChecked = savedState.getStateFlow(
+        scope = viewModelScope,
+        key = "technology_agreement_checked",
+        initialValue = false
+    )
+
+    private val conditionsState = combine(
+        isTermsOfServiceAccepted,
+        isProhibitedItemsChecked,
+        isTechnologyAgreementChecked
+    ) { termsAccepted, prohibitedItemsChecked, technologyAgreementChecked ->
+        ConditionsState(
+            isTermsOfServiceChecked = termsAccepted,
+            isProhibitedItemsChecked = prohibitedItemsChecked,
+            isTechnologyAgreementChecked = technologyAgreementChecked,
+            onTermsOfServiceCheckedChanged = { newValue ->
+                isTermsOfServiceAccepted.value = newValue
+            },
+            onProhibitedItemsCheckedChanged = { newValue ->
+                isProhibitedItemsChecked.value = newValue
+            },
+            onTechnologyAgreementCheckedChanged = { newValue ->
+                isTechnologyAgreementChecked.value = newValue
+            }
+        )
+    }
+
+    val viewState = conditionsState.map { conditionsState ->
+        ViewState(
+            originShippingAddress = args.originAddress,
+            conditionsState = conditionsState,
+            onUrlClicked = ::onUrlClicked,
+            onContinueClicked = ::onContinueClicked
+        )
+    }.asLiveData()
+
+    private fun onUrlClicked(url: String) {
+        triggerEvent(MultiLiveEvent.Event.OpenUrl(url))
+    }
+
+    private fun onContinueClicked() {
+        // TODO handle accepting the terms and conditions
+        triggerEvent(MultiLiveEvent.Event.ExitWithResult(Unit))
+    }
+
+    data class ConditionsState(
+        val isTermsOfServiceChecked: Boolean,
+        val isProhibitedItemsChecked: Boolean,
+        val isTechnologyAgreementChecked: Boolean,
+        val onTermsOfServiceCheckedChanged: (Boolean) -> Unit,
+        val onProhibitedItemsCheckedChanged: (Boolean) -> Unit,
+        val onTechnologyAgreementCheckedChanged: (Boolean) -> Unit
+    )
+
+    data class ViewState(
+        val originShippingAddress: OriginShippingAddress,
+        val conditionsState: ConditionsState,
+        val onUrlClicked: (String) -> Unit,
+        val onContinueClicked: () -> Unit,
+    ) {
+        val areAllConditionsAccepted: Boolean
+            get() = conditionsState.isTermsOfServiceChecked &&
+                conditionsState.isProhibitedItemsChecked &&
+                conditionsState.isTechnologyAgreementChecked
+    }
+}

--- a/WooCommerce/src/main/res/navigation/nav_graph_orders.xml
+++ b/WooCommerce/src/main/res/navigation/nav_graph_orders.xml
@@ -726,6 +726,9 @@
         <action
             android:id="@+id/action_wooShippingLabelCreationFragment_to_wooShippingEditPaymentDialogFragment"
             app:destination="@id/wooShippingEditPaymentDialogFragment" />
+        <action
+            android:id="@+id/action_wooShippingLabelCreationFragment_to_upsDapTermsOfServiceBottomSheetFragment"
+            app:destination="@id/upsDapTermsOfServiceBottomSheetFragment" />
     </fragment>
     <fragment
         android:id="@+id/wooShippingLabelPackageCreationFragment"
@@ -809,4 +812,13 @@
         android:id="@+id/wooShippingEditPaymentDialogFragment"
         android:name="com.woocommerce.android.ui.orders.wooshippinglabels.payment.WooShippingEditPaymentDialogFragment"
         android:label="WooShippingEditPaymentDialogFragment" />
+
+    <dialog
+        android:id="@+id/upsDapTermsOfServiceBottomSheetFragment"
+        android:name="com.woocommerce.android.ui.orders.wooshippinglabels.upsdap.UPSDAPTermsOfServiceBottomSheetFragment"
+        android:label="UPSDAPTermsOfServiceBottomSheetFragment">
+        <argument
+            android:name="originAddress"
+            app:argType="com.woocommerce.android.ui.orders.wooshippinglabels.models.OriginShippingAddress" />
+    </dialog>
 </navigation>

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -4686,6 +4686,14 @@
     <string name="woo_shipping_payment_method_added">Payment method added</string>
     <string name="woo_shipping_payment_fetching_cards_failed">Unable to refresh your payment methods</string>
 
+    <string name="wpp_shipping_ups_tos_title">UPS® Terms and Conditions</string>
+    <string name="wpp_shipping_ups_tos_shipping_from">Shipping from</string>
+    <string name="wpp_shipping_ups_tos_description">To start shipping from this address with UPS®, we need you to agree to the following terms and conditions:</string>
+    <string name="wpp_shipping_ups_tos_condition_1">I agree to the &lt;a href=\"ups-tos\"&gt;UPS® Terms of Service&lt;/a&gt;.</string>
+    <string name="wpp_shipping_ups_tos_condition_2">I will not ship any &lt;a href=\"ups-prohibited-items\"&gt;Prohibited Items&lt;/a&gt; that UPS® disallows, nor any regulated items without the necessary permissions.</string>
+    <string name="wpp_shipping_ups_tos_condition_3">I also agree to the &lt;a href=\"ups-technology-agreement\"&gt;UPS® Technology Agreement&lt;/a&gt;.</string>
+    <string name="wpp_shipping_ups_tos_accept">Confirm and continue</string>
+
     <string name="media_library_title">WordPress Media Library</string>
     <string name="media_loading_failed">Media loading failed</string>
     <string name="no_network_message">There is no network available</string>

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -4689,9 +4689,9 @@
     <string name="wpp_shipping_ups_tos_title">UPS® Terms and Conditions</string>
     <string name="wpp_shipping_ups_tos_shipping_from">Shipping from</string>
     <string name="wpp_shipping_ups_tos_description">To start shipping from this address with UPS®, we need you to agree to the following terms and conditions:</string>
-    <string name="wpp_shipping_ups_tos_condition_1">I agree to the &lt;a href=\"ups-tos\"&gt;UPS® Terms of Service&lt;/a&gt;.</string>
-    <string name="wpp_shipping_ups_tos_condition_2">I will not ship any &lt;a href=\"ups-prohibited-items\"&gt;Prohibited Items&lt;/a&gt; that UPS® disallows, nor any regulated items without the necessary permissions.</string>
-    <string name="wpp_shipping_ups_tos_condition_3">I also agree to the &lt;a href=\"ups-technology-agreement\"&gt;UPS® Technology Agreement&lt;/a&gt;.</string>
+    <string name="wpp_shipping_ups_tos_condition_terms">I agree to the &lt;a href=\"ups-tos\"&gt;UPS® Terms of Service&lt;/a&gt;.</string>
+    <string name="wpp_shipping_ups_tos_condition_prohibited_items">I will not ship any &lt;a href=\"ups-prohibited-items\"&gt;Prohibited Items&lt;/a&gt; that UPS® disallows, nor any regulated items without the necessary permissions.</string>
+    <string name="wpp_shipping_ups_tos_condition_technology_agreement">I also agree to the &lt;a href=\"ups-technology-agreement\"&gt;UPS® Technology Agreement&lt;/a&gt;.</string>
     <string name="wpp_shipping_ups_tos_accept">Confirm and continue</string>
 
     <string name="media_library_title">WordPress Media Library</string>

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/WooShippingLabelCreationViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/WooShippingLabelCreationViewModelTest.kt
@@ -3,6 +3,7 @@ package com.woocommerce.android.ui.orders.wooshippinglabels
 import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.asLiveData
 import com.woocommerce.android.R
+import com.woocommerce.android.WooException
 import com.woocommerce.android.model.Address
 import com.woocommerce.android.model.AmbiguousLocation
 import com.woocommerce.android.model.Location
@@ -14,6 +15,7 @@ import com.woocommerce.android.ui.orders.wooshippinglabels.WooShippingLabelCreat
 import com.woocommerce.android.ui.orders.wooshippinglabels.WooShippingLabelCreationViewModel.HazmatState
 import com.woocommerce.android.ui.orders.wooshippinglabels.WooShippingLabelCreationViewModel.NavigateToHazmatFormEdit
 import com.woocommerce.android.ui.orders.wooshippinglabels.WooShippingLabelCreationViewModel.NavigateToRefundRequest
+import com.woocommerce.android.ui.orders.wooshippinglabels.WooShippingLabelCreationViewModel.NavigateToUPSDAPTermsOfService
 import com.woocommerce.android.ui.orders.wooshippinglabels.WooShippingLabelCreationViewModel.OpenLearnMoreScreen
 import com.woocommerce.android.ui.orders.wooshippinglabels.WooShippingLabelCreationViewModel.OpenShippingLabelFile
 import com.woocommerce.android.ui.orders.wooshippinglabels.WooShippingLabelCreationViewModel.OpenUrl
@@ -68,6 +70,9 @@ import org.mockito.kotlin.times
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.verifyNoInteractions
 import org.mockito.kotlin.whenever
+import org.wordpress.android.fluxc.network.BaseRequest.GenericErrorType
+import org.wordpress.android.fluxc.network.rest.wpcom.wc.WooError
+import org.wordpress.android.fluxc.network.rest.wpcom.wc.WooErrorType
 import java.io.File
 import java.math.BigDecimal
 import kotlin.test.assertEquals
@@ -1169,5 +1174,38 @@ class WooShippingLabelCreationViewModelTest : BaseUnitTest() {
 
         val viewState = sut.viewState.value as DataState
         assertThat(viewState.paymentsSectionUI.selectedPaymentMethod).isNull()
+    }
+
+    @Test
+    fun `when purchase shipping label fails with UPSDAP_MISSING_TOS_ERROR_CODE, then navigate to UPS DAP terms of service`() = testBlocking {
+        val order = OrderTestUtils.generateTestOrder(orderId = orderId)
+        val wooError = WooError(
+            type = WooErrorType.API_ERROR,
+            original = GenericErrorType.UNKNOWN,
+            apiErrorCode = WooShippingLabelCreationViewModel.UPSDAP_MISSING_TOS_ERROR_CODE,
+            message = "Missing UPS DAP terms of service acceptance"
+        )
+        val wooException = WooException(wooError)
+
+        whenever(orderDetailRepository.getOrderById(any())) doReturn order
+        whenever(
+            purchaseShippingLabel(any(), any(), any(), any(), any(), any(), any(), any(), any(), isNull(), isNull())
+        ) doReturn Result.failure(wooException)
+
+        createViewModel()
+
+        val selectedRate = defaultShippingRates.values.first().first()
+        sut.onPackageSelected(defaultPackageData)
+        sut.onSelectedSippingRateChanged(selectedRate)
+
+        advanceUntilIdle()
+
+        var event: NavigateToUPSDAPTermsOfService? = null
+        sut.event.observeForever { if (it is NavigateToUPSDAPTermsOfService) event = it }
+
+        sut.onPurchaseShippingLabel()
+
+        assertThat(event).isNotNull
+        assertThat(event?.originAddress).isEqualTo(defaultOriginAddresses.first())
     }
 }

--- a/libs/fluxc-plugin/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/WooError.kt
+++ b/libs/fluxc-plugin/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/WooError.kt
@@ -18,10 +18,11 @@ import org.wordpress.android.fluxc.network.rest.wpapi.WPAPINetworkError
 import org.wordpress.android.fluxc.network.rest.wpcom.WPComGsonRequest.WPComGsonNetworkError
 import org.wordpress.android.fluxc.store.Store.OnChangedError
 
-class WooError(
-    var type: WooErrorType,
-    var original: GenericErrorType,
-    var message: String? = null
+data class WooError(
+    val type: WooErrorType,
+    val original: GenericErrorType,
+    val message: String? = null,
+    val apiErrorCode: String? = null
 ) : OnChangedError
 
 enum class WooErrorType {
@@ -42,13 +43,15 @@ enum class WooErrorType {
 fun WPComGsonNetworkError.toWooError() = WooError(
     type = type.getWooErrorType(apiError),
     original = type,
-    message = message
+    message = message,
+    apiErrorCode = apiError
 )
 
 fun WPAPINetworkError.toWooError() = WooError(
     type = type.getWooErrorType(errorCode),
     original = type,
-    message = message
+    message = message,
+    apiErrorCode = errorCode
 )
 
 private fun GenericErrorType?.getWooErrorType(apiError: String?) = when (this) {

--- a/libs/fluxc-plugin/src/main/kotlin/org/wordpress/android/fluxc/store/WCShippingLabelStore.kt
+++ b/libs/fluxc-plugin/src/main/kotlin/org/wordpress/android/fluxc/store/WCShippingLabelStore.kt
@@ -199,7 +199,7 @@ class WCShippingLabelStore @Inject constructor(
         return coroutineEngine.withDefaultContext(AppLog.T.API, this, "verifyAddress") {
             val response = restClient.verifyAddress(site, address, type)
             return@withDefaultContext if (response.isError) {
-                WooResult(response.error.apply { message = message ?: "" })
+                WooResult(response.error)
             } else if (response.result?.error != null) {
                 if (!response.result.error.address.isNullOrBlank()) {
                     WooResult(InvalidAddress(response.result.error.address))


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

<!-- Id number of the Linear issue this PR addresses, e.g., WOOMOB-373. -->
Closes WOOMOB-677

### Description
This PR adds logic to show the UPSDAP TOS bottom sheet: the TOS are required when the backend returns the error `missing_upsdap_terms_of_service_acceptance`, and the bottom sheet is shown when we receive it.

### Steps to reproduce
1. Open shipping label creation form.
2. Choose an origin address that was not used before with UPS.
3. Select a UPS package.
4. Select a UPS rate.
5. Tap on purchase. 

### Testing information
- Confirm the bottom sheet lists all the required conditions.
- Test tapping on the links in the conditions.
- Select all conditions, then continue, this should dismiss the bottom sheet, and restart the shipping label creation, but it would result in a second display of the bottom sheet afterwards, because **the acceptance logic is not implemented yet**.

### The tests that have been performed
The above.

### Images/gif
| | |
| - | - |
| ![Screenshot_20250625_155641](https://github.com/user-attachments/assets/a5e495b2-124c-4440-8fa9-7489f98f46f0) | ![Screenshot_20250625_155647](https://github.com/user-attachments/assets/735b1bc4-8d92-48da-b37a-3df0cdd65449) |

- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->