### PR TITLE
[Shipping Labels] UPSDAP purchase flow (accepting terms + continuing purchase) 

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/WooShippingLabelCreationFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/WooShippingLabelCreationFragment.kt
@@ -174,7 +174,7 @@ class WooShippingLabelCreationFragment : BaseFragment(), BackPressListener {
             UPSDAPTermsOfServiceBottomSheetFragment.TOS_ACCEPTED_NOTICE_KEY,
             entryId = R.id.wooShippingLabelCreationFragment
         ) {
-            viewModel.onPurchaseShippingLabel()
+            viewModel.onUPSTermsAccepted()
         }
     }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/WooShippingLabelCreationViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/WooShippingLabelCreationViewModel.kt
@@ -662,11 +662,7 @@ class WooShippingLabelCreationViewModel @Inject constructor(
             previouslySelectedRate: ShippingRateUI,
             onSelected: () -> Unit
         ) {
-            val carrier = newRates.keys.find {
-                it.carrier.carrierIds.contains(previouslySelectedRate.defaultRate.rate.carrierId)
-            } ?: return
-
-            val newRate = newRates[carrier]?.find {
+            val newRate = newRates.values.flatten().find {
                 it.defaultRate.rate.serviceId == previouslySelectedRate.defaultRate.rate.serviceId
             }?.let {
                 val selectedOption = it.options[previouslySelectedRate.selectedOption.option]

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/WooShippingLabelCreationViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/WooShippingLabelCreationViewModel.kt
@@ -655,6 +655,61 @@ class WooShippingLabelCreationViewModel @Inject constructor(
         triggerEvent(NavigatePackageSelection)
     }
 
+    fun onUPSTermsAccepted() {
+        @Suppress("ReturnCount")
+        fun selectMatchingRate(
+            newRates: Map<CarrierUI, List<ShippingRateUI>>,
+            previouslySelectedRate: ShippingRateUI,
+            onSelected: () -> Unit
+        ) {
+            val carrier = newRates.keys.find {
+                it.carrier.carrierIds.contains(previouslySelectedRate.defaultRate.rate.carrierId)
+            } ?: return
+
+            val newRate = newRates[carrier]?.find {
+                it.defaultRate.rate.serviceId == previouslySelectedRate.defaultRate.rate.serviceId
+            }?.let {
+                val selectedOption = it.options[previouslySelectedRate.selectedOption.option]
+                if (selectedOption != null) {
+                    it.copy(selectedOption = selectedOption)
+                } else {
+                    null
+                }
+            } ?: return
+
+            selectedRatesFlow.update { currentRates ->
+                currentRates.toMutableList().apply {
+                    set(selectedShipmentIndex, newRate)
+                }
+            }
+            onSelected()
+        }
+
+        val selectedRate = selectedRatesFlow.value[selectedShipmentIndex] ?: return
+
+        // Observe the shipping rates state and use the new rates after the refresh
+        launch {
+            val newRatesState = shippingRatesStatesFlow.drop(1)
+                .filter { it[selectedShipmentIndex] !is ShippingRatesState.Loading }
+                .first()
+            if (newRatesState[selectedShipmentIndex] !is ShippingRatesState.DataState) {
+                WooLog.w(WooLog.T.SHIPPING_LABELS, "Refreshing shipping rates failed")
+                return@launch
+            }
+            val newRates = (newRatesState[selectedShipmentIndex] as ShippingRatesState.DataState).shippingRates
+            selectMatchingRate(
+                newRates = newRates,
+                previouslySelectedRate = selectedRate,
+                onSelected = {
+                    onPurchaseShippingLabel()
+                }
+            )
+        }
+
+        // Trigger a refresh of the shipping rates
+        launch { refreshShippingRates.emit(Unit) }
+    }
+
     @Suppress("ComplexCondition")
     fun onPurchaseShippingLabel() {
         val selectedPackage = selectedPackagesFlow.value[selectedShipmentIndex]

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/models/WooShippingCarrier.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/models/WooShippingCarrier.kt
@@ -1,9 +1,15 @@
 package com.woocommerce.android.ui.orders.wooshippinglabels.models
 
-enum class WooShippingCarrier {
-    FEDEX,
-    USPS,
-    UPS,
-    DHL,
-    UNKNOWN
+enum class WooShippingCarrier(val carrierIds: List<String>) {
+    FEDEX(listOf("fedex")),
+    USPS(listOf("usps")),
+    UPS(listOf("upsdap")),
+    DHL(listOf("dhlexpress", "dhlecommerce", "dhlecommerceasia")),
+    UNKNOWN(emptyList());
+
+    companion object {
+        fun fromCarrierId(carrierId: String): WooShippingCarrier {
+            return values().firstOrNull { it.carrierIds.contains(carrierId) } ?: UNKNOWN
+        }
+    }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/models/WooShippingCarrier.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/models/WooShippingCarrier.kt
@@ -9,7 +9,7 @@ enum class WooShippingCarrier(val carrierIds: List<String>) {
 
     companion object {
         fun fromCarrierId(carrierId: String): WooShippingCarrier {
-            return values().firstOrNull { it.carrierIds.contains(carrierId) } ?: UNKNOWN
+            return entries.firstOrNull { it.carrierIds.contains(carrierId) } ?: UNKNOWN
         }
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/networking/WooShippingLabelRestClient.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/networking/WooShippingLabelRestClient.kt
@@ -79,6 +79,7 @@ class WooShippingLabelRestClient @Inject constructor(
                     message = "Something went wrong"
                 )
             )
+
             else -> WooPayload(Unit)
         }
     }
@@ -275,5 +276,40 @@ class WooShippingLabelRestClient @Inject constructor(
             path = url,
             clazz = RefundLabelResponseDTO::class.java,
         ).toWooPayload()
+    }
+
+    suspend fun updateUPSDAPAgreement(
+        site: SiteModel,
+        originAddress: OriginAddressPurchaseDTO,
+        agreementAccepted: Boolean
+    ): WooPayload<Unit> {
+        val url = "/wcshipping/v1/carrier-strategy/upsdap"
+
+        val result = wooNetwork.executePostGsonRequest(
+            site = site,
+            path = url,
+            body = mapOf(
+                "origin" to mapOf(
+                    "address" to originAddress.address,
+                    "address_2" to originAddress.address2,
+                    "city" to originAddress.city,
+                    "company" to originAddress.company,
+                    "country" to originAddress.country,
+                    "name" to originAddress.name,
+                    "phone" to originAddress.phone,
+                    "postcode" to originAddress.postcode,
+                    "state" to originAddress.state,
+                    "email" to originAddress.email
+                ),
+                "confirmed" to agreementAccepted
+            ),
+            clazz = JsonObject::class.java,
+        )
+
+        return if (result is WPAPIResponse.Error) {
+            WooPayload(error = result.error.toWooError())
+        } else {
+            WooPayload(Unit)
+        }
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/networking/WooShippingLabelRestClient.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/networking/WooShippingLabelRestClient.kt
@@ -159,7 +159,8 @@ class WooShippingLabelRestClient @Inject constructor(
                 "selected_rate_options" to "",
                 "hazmat" to mapOf(selectedPackage.boxId to hazmat),
                 "customs" to customs,
-                "user_meta" to mapOf("last_order_completed" to markOrderComplete)
+                "user_meta" to mapOf("last_order_completed" to markOrderComplete),
+                "features_supported_by_client" to listOf("upsdap"),
             ),
             clazz = PurchasedShippingLabelResponseDTO::class.java,
         ).toWooPayload()

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/networking/WooShippingLabelRestClient.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/networking/WooShippingLabelRestClient.kt
@@ -296,7 +296,8 @@ class WooShippingLabelRestClient @Inject constructor(
                     "city" to originAddress.city,
                     "company" to originAddress.company,
                     "country" to originAddress.country,
-                    "name" to originAddress.name,
+                    // The `name` field is required by the API, but it can't be blank
+                    "name" to originAddress.name.orEmpty().ifBlank { "" },
                     "phone" to originAddress.phone,
                     "postcode" to originAddress.postcode,
                     "state" to originAddress.state,

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/networking/WooShippingNetworkingMapper.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/networking/WooShippingNetworkingMapper.kt
@@ -263,7 +263,7 @@ class WooShippingNetworkingMapper @Inject constructor(
             isSelected = selectedRate.isSelected,
             tracking = selectedRate.isTrackingEnabled,
             listRate = selectedRate.listRate,
-            retailRate = selectedRate.discount
+            retailRate = selectedRate.retailRate
         )
     }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/networking/WooShippingNetworkingMapper.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/networking/WooShippingNetworkingMapper.kt
@@ -129,7 +129,9 @@ class WooShippingNetworkingMapper @Inject constructor(
         labels = purchasedShippingLabelResponseDTO.labels.map { invoke(it) },
         destination = purchasedShippingLabelResponseDTO.selectedDestination.mapValues { invoke(it.value) },
         origin = purchasedShippingLabelResponseDTO.selectedOrigin.mapValues { invoke(it.value) },
-        rates = purchasedShippingLabelResponseDTO.selectedRates.mapValues { ratesMapper(it.key, it.value) }
+        rates = purchasedShippingLabelResponseDTO.selectedRates.mapValues {
+            requireNotNull(ratesMapper(it.key, it.value))
+        }
     )
 
     operator fun invoke(addressListDTO: Array<AddressDTO>): List<OriginShippingAddress> {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/rates/datasource/WooShippingRatesDatasourceMapper.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/rates/datasource/WooShippingRatesDatasourceMapper.kt
@@ -4,7 +4,6 @@ import com.woocommerce.android.ui.orders.wooshippinglabels.models.WooShippingCar
 import com.woocommerce.android.ui.orders.wooshippinglabels.networking.ShippingRatePurchaseDTO
 import com.woocommerce.android.ui.orders.wooshippinglabels.networking.ShippingRatePurchaseResponseDTO
 import com.woocommerce.android.ui.orders.wooshippinglabels.rates.datasource.WooShippingRateModel.Option
-import com.woocommerce.android.ui.orders.wooshippinglabels.rates.networking.ShippingRateDTO
 import com.woocommerce.android.ui.orders.wooshippinglabels.rates.networking.WooShippingRatesDTO
 import java.math.BigDecimal
 import javax.inject.Inject
@@ -25,37 +24,10 @@ class WooShippingRatesDatasourceMapper @Inject constructor() {
 
     operator fun invoke(
         packageId: String,
-        shippingRateDTO: ShippingRateDTO,
-        rateOptionId: String
-    ): WooShippingRateModel {
-        return WooShippingRateModel(
-            packageId = packageId,
-            shipmentId = shippingRateDTO.shipmentId.orEmpty(),
-            rateId = shippingRateDTO.rateId,
-            serviceId = shippingRateDTO.serviceId,
-            carrierId = shippingRateDTO.carrierId.orEmpty(),
-            serviceName = shippingRateDTO.title,
-            deliveryDays = shippingRateDTO.deliveryDays,
-            price = shippingRateDTO.rate,
-            discount = shippingRateDTO.retailRate?.minus(shippingRateDTO.rate) ?: BigDecimal.ZERO,
-            option = getOption(rateOptionId),
-            carrier = getCarrier(shippingRateDTO.carrierId.orEmpty()),
-            isTrackingEnabled = shippingRateDTO.tracking,
-            hasFreePickup = shippingRateDTO.freePickup,
-            insurance = shippingRateDTO.insurance?.toBigDecimalOrNull(),
-            deliveryDate = shippingRateDTO.deliveryDate,
-            isDeliveryDateGuaranteed = shippingRateDTO.deliveryDateGuaranteed,
-            isSelected = shippingRateDTO.isSelected,
-            listRate = shippingRateDTO.listRate ?: BigDecimal.ZERO,
-            retailRate = shippingRateDTO.retailRate ?: BigDecimal.ZERO
-        )
-    }
-
-    operator fun invoke(
-        packageId: String,
         shippingRateDTO: ShippingRatePurchaseResponseDTO,
         rateOptionId: String
-    ): WooShippingRateModel {
+    ): WooShippingRateModel? {
+        val rateOption = getOption(rateOptionId) ?: return null
         return WooShippingRateModel(
             packageId = packageId,
             shipmentId = shippingRateDTO.shipmentId.orEmpty(),
@@ -66,7 +38,7 @@ class WooShippingRatesDatasourceMapper @Inject constructor() {
             deliveryDays = shippingRateDTO.deliveryDays,
             price = shippingRateDTO.rate,
             discount = shippingRateDTO.retailRate?.minus(shippingRateDTO.rate) ?: BigDecimal.ZERO,
-            option = getOption(rateOptionId),
+            option = rateOption,
             carrier = getCarrier(shippingRateDTO.carrierId.orEmpty()),
             isTrackingEnabled = shippingRateDTO.tracking,
             hasFreePickup = shippingRateDTO.freePickup,
@@ -82,14 +54,15 @@ class WooShippingRatesDatasourceMapper @Inject constructor() {
     operator fun invoke(
         packageId: String,
         shippingRateDTO: ShippingRatePurchaseDTO
-    ): WooShippingRateModel {
+    ): WooShippingRateModel? {
         return invoke(packageId, shippingRateDTO.rate, DEFAULT_RATE_OPTION)
     }
 
     operator fun invoke(response: Map<String, Map<String, WooShippingRatesDTO>>?): List<WooShippingRateOptionsModel> {
         val optionsMap = mutableMapOf<String, MutableList<WooShippingRateModel>>()
         response?.forEach { (packageId, ratesMap) ->
-            ratesMap.forEach { (rateOptionId, wooShippingRates) ->
+            ratesMap.forEach nestedForEach@ { (rateOptionId, wooShippingRates) ->
+                val rateOption = getOption(rateOptionId) ?: return@nestedForEach
                 wooShippingRates.rates.forEach { rate ->
                     val option = WooShippingRateModel(
                         packageId = packageId,
@@ -101,7 +74,7 @@ class WooShippingRatesDatasourceMapper @Inject constructor() {
                         deliveryDays = rate.deliveryDays,
                         price = rate.rate,
                         discount = rate.retailRate?.minus(rate.rate) ?: BigDecimal.ZERO,
-                        option = getOption(rateOptionId),
+                        option = rateOption,
                         carrier = getCarrier(rate.carrierId.orEmpty()),
                         isTrackingEnabled = rate.tracking,
                         hasFreePickup = rate.freePickup,
@@ -126,12 +99,12 @@ class WooShippingRatesDatasourceMapper @Inject constructor() {
         }
     }
 
-    private fun getOption(rateOptionId: String): Option {
+    private fun getOption(rateOptionId: String): Option? {
         return when (rateOptionId) {
             DEFAULT_RATE_OPTION -> Option.DEFAULT
             SIGNATURE_RATE_OPTION -> Option.SIGNATURE
             ADULT_SIGNATURE_RATE_OPTION -> Option.ADULT_SIGNATURE
-            else -> Option.DEFAULT
+            else -> null
         }
     }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/rates/datasource/WooShippingRatesDatasourceMapper.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/rates/datasource/WooShippingRatesDatasourceMapper.kt
@@ -14,12 +14,7 @@ class WooShippingRatesDatasourceMapper @Inject constructor() {
         private const val SIGNATURE_RATE_OPTION = "signature_required"
         private const val ADULT_SIGNATURE_RATE_OPTION = "adult_signature_required"
 
-        private const val CARRIER_USPS_KEY = "usps"
-        private const val CARRIER_UPS_KEY = "upsdap"
-        private const val CARRIER_FEDEX_KEY = "fedex"
         const val CARRIER_DHL_EXPRESS_KEY = "dhlexpress"
-        private const val CARRIER_DHL_ECOMMERCE_KEY = "dhlecommerce"
-        private const val CARRIER_DHL_ECOMMERCE_ASIA_KEY = "dhlecommerceasia"
     }
 
     operator fun invoke(
@@ -39,7 +34,7 @@ class WooShippingRatesDatasourceMapper @Inject constructor() {
             price = shippingRateDTO.rate,
             discount = shippingRateDTO.retailRate?.minus(shippingRateDTO.rate) ?: BigDecimal.ZERO,
             option = rateOption,
-            carrier = getCarrier(shippingRateDTO.carrierId.orEmpty()),
+            carrier = WooShippingCarrier.fromCarrierId(shippingRateDTO.carrierId.orEmpty()),
             isTrackingEnabled = shippingRateDTO.tracking,
             hasFreePickup = shippingRateDTO.freePickup,
             insurance = shippingRateDTO.insurance?.toBigDecimalOrNull(),
@@ -75,7 +70,7 @@ class WooShippingRatesDatasourceMapper @Inject constructor() {
                         price = rate.rate,
                         discount = rate.retailRate?.minus(rate.rate) ?: BigDecimal.ZERO,
                         option = rateOption,
-                        carrier = getCarrier(rate.carrierId.orEmpty()),
+                        carrier = WooShippingCarrier.fromCarrierId(rate.carrierId.orEmpty()),
                         isTrackingEnabled = rate.tracking,
                         hasFreePickup = rate.freePickup,
                         insurance = rate.insurance?.toBigDecimalOrNull(),
@@ -107,13 +102,4 @@ class WooShippingRatesDatasourceMapper @Inject constructor() {
             else -> null
         }
     }
-
-    private fun getCarrier(carrierId: String) =
-        when (carrierId) {
-            CARRIER_USPS_KEY -> WooShippingCarrier.USPS
-            CARRIER_FEDEX_KEY -> WooShippingCarrier.FEDEX
-            CARRIER_UPS_KEY -> WooShippingCarrier.UPS
-            CARRIER_DHL_EXPRESS_KEY, CARRIER_DHL_ECOMMERCE_KEY, CARRIER_DHL_ECOMMERCE_ASIA_KEY -> WooShippingCarrier.DHL
-            else -> WooShippingCarrier.UNKNOWN
-        }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/rates/datasource/WooShippingRatesDatasourceMapper.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/rates/datasource/WooShippingRatesDatasourceMapper.kt
@@ -56,7 +56,7 @@ class WooShippingRatesDatasourceMapper @Inject constructor() {
     operator fun invoke(response: Map<String, Map<String, WooShippingRatesDTO>>?): List<WooShippingRateOptionsModel> {
         val optionsMap = mutableMapOf<String, MutableList<WooShippingRateModel>>()
         response?.forEach { (packageId, ratesMap) ->
-            ratesMap.forEach nestedForEach@ { (rateOptionId, wooShippingRates) ->
+            ratesMap.forEach nestedForEach@{ (rateOptionId, wooShippingRates) ->
                 val rateOption = getOption(rateOptionId) ?: return@nestedForEach
                 wooShippingRates.rates.forEach { rate ->
                     val option = WooShippingRateModel(

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/rates/networking/ShippingRatesDTOs.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/rates/networking/ShippingRatesDTOs.kt
@@ -50,7 +50,7 @@ data class DestinationAddressDTO(
 )
 
 data class OriginAddressDTO(
-    @SerializedName("address_1") val address: String? = null,
+    @SerializedName("address") val address: String? = null,
     @SerializedName("address_2") val address2: String? = null,
     val city: String? = null,
     val company: String? = null,

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/upsdap/AcceptUPSDAPTerms.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/upsdap/AcceptUPSDAPTerms.kt
@@ -1,0 +1,28 @@
+package com.woocommerce.android.ui.orders.wooshippinglabels.upsdap
+
+import com.woocommerce.android.WooException
+import com.woocommerce.android.tools.SelectedSite
+import com.woocommerce.android.ui.orders.wooshippinglabels.models.OriginShippingAddress
+import com.woocommerce.android.ui.orders.wooshippinglabels.networking.WooShippingLabelRestClient
+import com.woocommerce.android.ui.orders.wooshippinglabels.networking.WooShippingNetworkingMapper
+import javax.inject.Inject
+
+class AcceptUPSDAPTerms @Inject constructor(
+    private val selectedSite: SelectedSite,
+    private val restClient: WooShippingLabelRestClient,
+    private val mapper: WooShippingNetworkingMapper
+) {
+    suspend operator fun invoke(originAddressDTO: OriginShippingAddress): Result<Unit> {
+        val response = restClient.updateUPSDAPAgreement(
+            site = selectedSite.get(),
+            originAddress = mapper.toOriginAddressPurchaseDTO(originAddressDTO),
+            agreementAccepted = true
+        )
+
+        return if (response.isError) {
+            Result.failure(WooException(response.error))
+        } else {
+            Result.success(Unit)
+        }
+    }
+}

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/upsdap/UPSDAPTermsOfServiceBottomSheet.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/upsdap/UPSDAPTermsOfServiceBottomSheet.kt
@@ -1,6 +1,7 @@
 package com.woocommerce.android.ui.orders.wooshippinglabels.upsdap
 
 import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
@@ -15,8 +16,11 @@ import androidx.compose.material.MaterialTheme
 import androidx.compose.material.Surface
 import androidx.compose.material.Text
 import androidx.compose.material3.Checkbox
+import androidx.compose.material3.SnackbarHost
+import androidx.compose.material3.SnackbarHostState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.livedata.observeAsState
+import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.input.nestedscroll.nestedScroll
@@ -38,83 +42,94 @@ import com.woocommerce.android.ui.orders.wooshippinglabels.models.OriginShipping
 
 @Composable
 fun UPSDAPTermsOfServiceBottomSheet(
-    viewModel: UPSDAPTermsOfServiceViewModel
+    viewModel: UPSDAPTermsOfServiceViewModel,
+    snackbarHostState: SnackbarHostState
 ) {
     viewModel.viewState.observeAsState().value?.let {
-        UPSDAPTermsOfServiceBottomSheet(it)
+        UPSDAPTermsOfServiceBottomSheet(it, snackbarHostState)
     }
 }
 
 @Composable
 fun UPSDAPTermsOfServiceBottomSheet(
-    viewState: UPSDAPTermsOfServiceViewModel.ViewState
+    viewState: UPSDAPTermsOfServiceViewModel.ViewState,
+    snackbarHostState: SnackbarHostState
 ) {
-    Surface(
-        shape = RoundedCornerShape(
-            topStart = dimensionResource(id = R.dimen.minor_100),
-            topEnd = dimensionResource(id = R.dimen.minor_100)
-        )
-    ) {
-        Column(
-            modifier = Modifier
-                .fillMaxWidth()
-                .padding(horizontal = 16.dp),
-            horizontalAlignment = Alignment.CenterHorizontally
+    Box {
+        Surface(
+            shape = RoundedCornerShape(
+                topStart = dimensionResource(id = R.dimen.minor_100),
+                topEnd = dimensionResource(id = R.dimen.minor_100)
+            )
         ) {
-            Spacer(modifier = Modifier.height(8.dp))
-            BottomSheetHandle(Modifier.align(Alignment.CenterHorizontally))
-
             Column(
-                Modifier
+                modifier = Modifier
                     .fillMaxWidth()
-                    .nestedScroll(rememberNestedScrollInteropConnection())
-                    .verticalScroll(rememberScrollState()),
+                    .padding(horizontal = 16.dp),
+                horizontalAlignment = Alignment.CenterHorizontally
             ) {
-                Spacer(modifier = Modifier.height(24.dp))
-                Text(
-                    text = stringResource(id = R.string.wpp_shipping_ups_tos_title),
-                    style = MaterialTheme.typography.h6,
-                    textAlign = TextAlign.Center
-                )
+                Spacer(modifier = Modifier.height(8.dp))
+                BottomSheetHandle(Modifier.align(Alignment.CenterHorizontally))
 
-                Spacer(modifier = Modifier.height(24.dp))
-
-                OriginAddressSection(address = viewState.originShippingAddress)
-
-                Spacer(modifier = Modifier.height(16.dp))
-
-                Divider()
-
-                Spacer(modifier = Modifier.height(16.dp))
-
-                Text(
-                    text = stringResource(id = R.string.wpp_shipping_ups_tos_description),
-                    style = MaterialTheme.typography.body1,
-                    textAlign = TextAlign.Start,
-                    modifier = Modifier
+                Column(
+                    Modifier
                         .fillMaxWidth()
-                        .padding(horizontal = 8.dp)
-                )
-
-                Spacer(modifier = Modifier.height(16.dp))
-
-                Conditions(
-                    conditionsState = viewState.conditionsState,
-                    onUrlClicked = viewState.onUrlClicked
-                )
-
-                Spacer(modifier = Modifier.height(32.dp))
-
-                WCColoredButton(
-                    onClick = viewState.onContinueClicked,
-                    enabled = viewState.areAllConditionsAccepted,
-                    modifier = Modifier.fillMaxWidth()
+                        .nestedScroll(rememberNestedScrollInteropConnection())
+                        .verticalScroll(rememberScrollState()),
                 ) {
-                    Text(text = stringResource(id = R.string.wpp_shipping_ups_tos_accept))
-                }
+                    Spacer(modifier = Modifier.height(24.dp))
+                    Text(
+                        text = stringResource(id = R.string.wpp_shipping_ups_tos_title),
+                        style = MaterialTheme.typography.h6,
+                        textAlign = TextAlign.Center
+                    )
 
-                Spacer(modifier = Modifier.height(16.dp))
+                    Spacer(modifier = Modifier.height(24.dp))
+
+                    OriginAddressSection(address = viewState.originShippingAddress)
+
+                    Spacer(modifier = Modifier.height(16.dp))
+
+                    Divider()
+
+                    Spacer(modifier = Modifier.height(16.dp))
+
+                    Text(
+                        text = stringResource(id = R.string.wpp_shipping_ups_tos_description),
+                        style = MaterialTheme.typography.body1,
+                        textAlign = TextAlign.Start,
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .padding(horizontal = 8.dp)
+                    )
+
+                    Spacer(modifier = Modifier.height(16.dp))
+
+                    Conditions(
+                        conditionsState = viewState.conditionsState,
+                        onUrlClicked = viewState.onUrlClicked
+                    )
+
+                    Spacer(modifier = Modifier.height(32.dp))
+
+                    WCColoredButton(
+                        onClick = viewState.onContinueClicked,
+                        text = stringResource(id = R.string.wpp_shipping_ups_tos_accept),
+                        enabled = viewState.areAllConditionsAccepted,
+                        loading = viewState.isLoading,
+                        modifier = Modifier.fillMaxWidth()
+                    )
+
+                    Spacer(modifier = Modifier.height(16.dp))
+                }
             }
+
+            SnackbarHost(
+                snackbarHostState,
+                modifier = Modifier
+                    .align(Alignment.BottomCenter)
+                    .padding(bottom = 24.dp)
+            )
         }
     }
 }
@@ -207,6 +222,7 @@ fun UPSDAPTermsOfServiceBottomSheetPreview() {
     WooThemeWithBackground {
         UPSDAPTermsOfServiceBottomSheet(
             UPSDAPTermsOfServiceViewModel.ViewState(
+                isLoading = false,
                 originShippingAddress = ShippingLabelSampleData.getShipFrom(),
                 conditionsState = UPSDAPTermsOfServiceViewModel.ConditionsState(
                     isTermsOfServiceChecked = true,
@@ -218,7 +234,8 @@ fun UPSDAPTermsOfServiceBottomSheetPreview() {
                 ),
                 onUrlClicked = {},
                 onContinueClicked = {}
-            )
+            ),
+            snackbarHostState = remember { SnackbarHostState() }
         )
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/upsdap/UPSDAPTermsOfServiceBottomSheetFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/upsdap/UPSDAPTermsOfServiceBottomSheetFragment.kt
@@ -4,15 +4,18 @@ import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
+import androidx.compose.material3.SnackbarHostState
 import androidx.compose.ui.platform.ComposeView
 import androidx.compose.ui.platform.ViewCompositionStrategy
 import androidx.fragment.app.viewModels
+import androidx.lifecycle.lifecycleScope
 import com.woocommerce.android.extensions.navigateBackWithNotice
 import com.woocommerce.android.ui.compose.theme.WooTheme
 import com.woocommerce.android.util.ChromeCustomTabUtils
 import com.woocommerce.android.viewmodel.MultiLiveEvent
 import com.woocommerce.android.widgets.WCBottomSheetDialogFragment
 import dagger.hilt.android.AndroidEntryPoint
+import kotlinx.coroutines.launch
 
 @AndroidEntryPoint
 class UPSDAPTermsOfServiceBottomSheetFragment : WCBottomSheetDialogFragment() {
@@ -21,6 +24,7 @@ class UPSDAPTermsOfServiceBottomSheetFragment : WCBottomSheetDialogFragment() {
     }
 
     private val viewModel: UPSDAPTermsOfServiceViewModel by viewModels()
+    private val snackbarHostState = SnackbarHostState()
 
     override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View {
         return ComposeView(requireContext()).apply {
@@ -28,7 +32,7 @@ class UPSDAPTermsOfServiceBottomSheetFragment : WCBottomSheetDialogFragment() {
 
             setContent {
                 WooTheme {
-                    UPSDAPTermsOfServiceBottomSheet(viewModel)
+                    UPSDAPTermsOfServiceBottomSheet(viewModel, snackbarHostState)
                 }
             }
         }
@@ -44,6 +48,11 @@ class UPSDAPTermsOfServiceBottomSheetFragment : WCBottomSheetDialogFragment() {
             when (event) {
                 is MultiLiveEvent.Event.ExitWithResult<*> -> navigateBackWithNotice(TOS_ACCEPTED_NOTICE_KEY)
                 is MultiLiveEvent.Event.OpenUrl -> ChromeCustomTabUtils.launchUrl(requireContext(), event.url)
+                is MultiLiveEvent.Event.ShowSnackbar -> {
+                    viewLifecycleOwner.lifecycleScope.launch {
+                        snackbarHostState.showSnackbar(message = getString(event.message))
+                    }
+                }
             }
         }
     }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/upsdap/UPSDAPTermsOfServiceViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/upsdap/UPSDAPTermsOfServiceViewModel.kt
@@ -3,45 +3,50 @@ package com.woocommerce.android.ui.orders.wooshippinglabels.upsdap
 import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.asLiveData
 import androidx.lifecycle.viewModelScope
+import com.woocommerce.android.R
 import com.woocommerce.android.ui.orders.wooshippinglabels.models.OriginShippingAddress
 import com.woocommerce.android.viewmodel.MultiLiveEvent
 import com.woocommerce.android.viewmodel.ScopedViewModel
 import com.woocommerce.android.viewmodel.getStateFlow
 import com.woocommerce.android.viewmodel.navArgs
 import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.combine
-import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.launch
 import javax.inject.Inject
 
 @HiltViewModel
 class UPSDAPTermsOfServiceViewModel @Inject constructor(
-    savedState: SavedStateHandle
+    savedState: SavedStateHandle,
+    private val acceptUPSDAPTerms: AcceptUPSDAPTerms
 ) : ScopedViewModel(savedState) {
     companion object {
         private const val TERMS_URL = "https://www.ups.com/assets/resources/webcontent/" +
-            "en_US/ups_dap_supplemental_tc.pdf"
+                "en_US/ups_dap_supplemental_tc.pdf"
         private const val PROHIBITED_ITEMS_URL = "https://www.ups.com/us/en/support/shipping-support/" +
-            "shipping-special-care-regulated-items/prohibited-items.page"
+                "shipping-special-care-regulated-items/prohibited-items.page"
         private const val TECHNOLOGY_AGREEMENT_URL = "https://www.ups.com/assets/resources/webcontent/en_US/UTA.pdf"
     }
 
     private val args: UPSDAPTermsOfServiceBottomSheetFragmentArgs by savedState.navArgs()
 
-    private var isTermsOfServiceAccepted = savedState.getStateFlow(
+    private val isTermsOfServiceAccepted = savedState.getStateFlow(
         scope = viewModelScope,
         key = "terms_of_service_accepted",
         initialValue = false
     )
-    private var isProhibitedItemsChecked = savedState.getStateFlow(
+    private val isProhibitedItemsChecked = savedState.getStateFlow(
         scope = viewModelScope,
         key = "prohibited_items_checked",
         initialValue = false
     )
-    private var isTechnologyAgreementChecked = savedState.getStateFlow(
+    private val isTechnologyAgreementChecked = savedState.getStateFlow(
         scope = viewModelScope,
         key = "technology_agreement_checked",
         initialValue = false
     )
+
+    private val isLoading = MutableStateFlow(false)
 
     private val conditionsState = combine(
         isTermsOfServiceAccepted,
@@ -64,8 +69,9 @@ class UPSDAPTermsOfServiceViewModel @Inject constructor(
         )
     }
 
-    val viewState = conditionsState.map { conditionsState ->
+    val viewState = combine(isLoading, conditionsState) { isLoading, conditionsState ->
         ViewState(
+            isLoading = isLoading,
             originShippingAddress = args.originAddress,
             conditionsState = conditionsState,
             onUrlClicked = ::onUrlClicked,
@@ -84,8 +90,18 @@ class UPSDAPTermsOfServiceViewModel @Inject constructor(
     }
 
     private fun onContinueClicked() {
-        // TODO handle accepting the terms and conditions
-        triggerEvent(MultiLiveEvent.Event.ExitWithResult(Unit))
+        launch {
+            isLoading.value = true
+            acceptUPSDAPTerms(args.originAddress).fold(
+                onSuccess = {
+                    triggerEvent(MultiLiveEvent.Event.ExitWithResult(Unit))
+                },
+                onFailure = {
+                    triggerEvent(MultiLiveEvent.Event.ShowSnackbar(R.string.error_generic))
+                }
+            )
+            isLoading.value = false
+        }
     }
 
     data class ConditionsState(
@@ -98,6 +114,7 @@ class UPSDAPTermsOfServiceViewModel @Inject constructor(
     )
 
     data class ViewState(
+        val isLoading: Boolean,
         val originShippingAddress: OriginShippingAddress,
         val conditionsState: ConditionsState,
         val onUrlClicked: (String) -> Unit,
@@ -105,7 +122,7 @@ class UPSDAPTermsOfServiceViewModel @Inject constructor(
     ) {
         val areAllConditionsAccepted: Boolean
             get() = conditionsState.isTermsOfServiceChecked &&
-                conditionsState.isProhibitedItemsChecked &&
-                conditionsState.isTechnologyAgreementChecked
+                    conditionsState.isProhibitedItemsChecked &&
+                    conditionsState.isTechnologyAgreementChecked
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/upsdap/UPSDAPTermsOfServiceViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/upsdap/UPSDAPTermsOfServiceViewModel.kt
@@ -22,9 +22,9 @@ class UPSDAPTermsOfServiceViewModel @Inject constructor(
 ) : ScopedViewModel(savedState) {
     companion object {
         private const val TERMS_URL = "https://www.ups.com/assets/resources/webcontent/" +
-                "en_US/ups_dap_supplemental_tc.pdf"
+            "en_US/ups_dap_supplemental_tc.pdf"
         private const val PROHIBITED_ITEMS_URL = "https://www.ups.com/us/en/support/shipping-support/" +
-                "shipping-special-care-regulated-items/prohibited-items.page"
+            "shipping-special-care-regulated-items/prohibited-items.page"
         private const val TECHNOLOGY_AGREEMENT_URL = "https://www.ups.com/assets/resources/webcontent/en_US/UTA.pdf"
     }
 
@@ -122,7 +122,7 @@ class UPSDAPTermsOfServiceViewModel @Inject constructor(
     ) {
         val areAllConditionsAccepted: Boolean
             get() = conditionsState.isTermsOfServiceChecked &&
-                    conditionsState.isProhibitedItemsChecked &&
-                    conditionsState.isTechnologyAgreementChecked
+                conditionsState.isProhibitedItemsChecked &&
+                conditionsState.isTechnologyAgreementChecked
     }
 }

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/WooShippingLabelCreationViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/WooShippingLabelCreationViewModelTest.kt
@@ -380,15 +380,7 @@ class WooShippingLabelCreationViewModelTest : BaseUnitTest() {
 
     @Test
     fun `when shipping rates succeed then display the shipping rates`() = testBlocking {
-        val order = OrderTestUtils.generateTestOrder(orderId = orderId).copy(
-            shippingLines = defaultShippingLines,
-            customer = Order.Customer(
-                billingAddress = defaultShipToAddress,
-                shippingAddress = defaultShipToAddress
-            )
-        )
         whenever(shouldRequireCustomsForm.invoke(any())) doReturn false
-        whenever(orderDetailRepository.getOrderById(any())) doReturn order
         whenever(
             getShippingRates(any(), any(), any(), any(), any(), any(), isNull(), isNull())
         ) doReturn Result.success(defaultShippingRates)
@@ -449,15 +441,7 @@ class WooShippingLabelCreationViewModelTest : BaseUnitTest() {
 
     @Test
     fun `when shipping rates fail then display an error`() = testBlocking {
-        val order = OrderTestUtils.generateTestOrder(orderId = orderId).copy(
-            shippingLines = defaultShippingLines,
-            customer = Order.Customer(
-                billingAddress = defaultShipToAddress,
-                shippingAddress = defaultShipToAddress
-            )
-        )
         whenever(shouldRequireCustomsForm.invoke(any())) doReturn false
-        whenever(orderDetailRepository.getOrderById(any())) doReturn order
         whenever(
             getShippingRates(any(), any(), any(), any(), any(), any(), isNull(), isNull())
         ) doReturn Result.failure(Exception("Random error"))
@@ -477,15 +461,7 @@ class WooShippingLabelCreationViewModelTest : BaseUnitTest() {
 
     @Test
     fun `when refresh rates is triggered then refresh shipping rates`() = testBlocking {
-        val order = OrderTestUtils.generateTestOrder(orderId = orderId).copy(
-            shippingLines = defaultShippingLines,
-            customer = Order.Customer(
-                billingAddress = defaultShipToAddress,
-                shippingAddress = defaultShipToAddress
-            )
-        )
         whenever(shouldRequireCustomsForm.invoke(any())) doReturn false
-        whenever(orderDetailRepository.getOrderById(any())) doReturn order
         whenever(
             getShippingRates(any(), any(), any(), any(), any(), any(), isNull(), isNull())
         ) doReturn Result.success(defaultShippingRates)
@@ -505,15 +481,7 @@ class WooShippingLabelCreationViewModelTest : BaseUnitTest() {
 
     @Test
     fun `when rates sort order is changed then DON'T refresh shipping rates`() = testBlocking {
-        val order = OrderTestUtils.generateTestOrder(orderId = orderId).copy(
-            shippingLines = defaultShippingLines,
-            customer = Order.Customer(
-                billingAddress = defaultShipToAddress,
-                shippingAddress = defaultShipToAddress
-            )
-        )
         whenever(shouldRequireCustomsForm.invoke(any())) doReturn false
-        whenever(orderDetailRepository.getOrderById(any())) doReturn order
         whenever(
             getShippingRates(any(), any(), any(), any(), any(), any(), isNull(), isNull())
         ) doReturn Result.success(defaultShippingRates)
@@ -534,15 +502,7 @@ class WooShippingLabelCreationViewModelTest : BaseUnitTest() {
 
     @Test
     fun `when rates sort order is NOT changed then DON'T refresh shipping rates`() = testBlocking {
-        val order = OrderTestUtils.generateTestOrder(orderId = orderId).copy(
-            shippingLines = defaultShippingLines,
-            customer = Order.Customer(
-                billingAddress = defaultShipToAddress,
-                shippingAddress = defaultShipToAddress
-            )
-        )
         whenever(shouldRequireCustomsForm.invoke(any())) doReturn false
-        whenever(orderDetailRepository.getOrderById(any())) doReturn order
         whenever(
             getShippingRates(any(), any(), any(), any(), any(), any(), isNull(), isNull())
         ) doReturn Result.success(defaultShippingRates)
@@ -686,10 +646,6 @@ class WooShippingLabelCreationViewModelTest : BaseUnitTest() {
     fun `CustomState is ItnMissing when shouldRequireCustomsForm returns true and ShippingLines exceeds the 2500 limit`() =
         testBlocking {
             var currentViewState: WooShippingViewState? = null
-            val order = OrderTestUtils.generateTestOrder(orderId = orderId).copy(
-                shippingLines = defaultShippingLines
-            )
-            whenever(orderDetailRepository.getOrderById(any())) doReturn order
 
             whenever(shouldRequireCustomsForm.invoke(any())) doReturn true
             whenever(shouldRequireITN.invoke(any(), any())) doReturn true
@@ -713,10 +669,6 @@ class WooShippingLabelCreationViewModelTest : BaseUnitTest() {
 
     @Test
     fun `when onPurchaseShippingLabel fails then show a snackbar`() = testBlocking {
-        val order = OrderTestUtils.generateTestOrder(orderId = orderId)
-
-        whenever(orderDetailRepository.getOrderById(any())) doReturn order
-
         whenever(
             purchaseShippingLabel(any(), any(), any(), any(), any(), any(), any(), any(), any(), isNull(), isNull())
         ) doReturn Result.failure(Exception("Random error"))
@@ -738,9 +690,6 @@ class WooShippingLabelCreationViewModelTest : BaseUnitTest() {
     @Test
     fun `when the view model is created, then get store options from the local preferences and update settings on background`() =
         testBlocking {
-            val order = OrderTestUtils.generateTestOrder(orderId = orderId)
-
-            whenever(orderDetailRepository.getOrderById(any())) doReturn order
             whenever(observeAccountSettings()) doReturn flowOf(null, defaultAccountSettings)
 
             createViewModel()
@@ -752,9 +701,6 @@ class WooShippingLabelCreationViewModelTest : BaseUnitTest() {
 
     @Test
     fun `when there is no cached store options and API request fails then display error`() = testBlocking {
-        val order = OrderTestUtils.generateTestOrder(orderId = orderId)
-
-        whenever(orderDetailRepository.getOrderById(any())) doReturn order
         whenever(observeAccountSettings()) doReturn flowOf(null)
 
         createViewModel()
@@ -767,9 +713,6 @@ class WooShippingLabelCreationViewModelTest : BaseUnitTest() {
 
     @Test
     fun `when shipment details is expanded then the back gesture closes the sheet`() = testBlocking {
-        val order = OrderTestUtils.generateTestOrder(orderId = orderId)
-
-        whenever(orderDetailRepository.getOrderById(any())) doReturn order
         whenever(observeAccountSettings()) doReturn flowOf(null)
 
         createViewModel()
@@ -788,9 +731,6 @@ class WooShippingLabelCreationViewModelTest : BaseUnitTest() {
 
     @Test
     fun `when there is no bottom sheet expanded, then on back navigates to the previous screen`() = testBlocking {
-        val order = OrderTestUtils.generateTestOrder(orderId = orderId)
-
-        whenever(orderDetailRepository.getOrderById(any())) doReturn order
         whenever(observeAccountSettings()) doReturn flowOf(null)
 
         createViewModel()
@@ -804,14 +744,11 @@ class WooShippingLabelCreationViewModelTest : BaseUnitTest() {
 
     @Test
     fun `when there are notices then display the notices`() = testBlocking {
-        val order = OrderTestUtils.generateTestOrder(orderId = orderId)
         val notice = NoticeBannerUiState(
             message = R.string.woo_shipping_address_notification_destination_missing,
             type = NoticeType.MISSING_DESTINATION_ADDRESS,
             error = true,
         )
-
-        whenever(orderDetailRepository.getOrderById(any())) doReturn order
 
         whenever(observeShippingLabelNotice(any(), any(), any(), any())) doReturn flowOf(notice)
 
@@ -825,11 +762,7 @@ class WooShippingLabelCreationViewModelTest : BaseUnitTest() {
 
     @Test
     fun `when there are no notices then do not display the notices`() = testBlocking {
-        val order = OrderTestUtils.generateTestOrder(orderId = orderId)
         val notice = null
-
-        whenever(orderDetailRepository.getOrderById(any())) doReturn order
-
         whenever(observeShippingLabelNotice(any(), any(), any(), any())) doReturn flowOf(notice)
 
         createViewModel()
@@ -842,13 +775,6 @@ class WooShippingLabelCreationViewModelTest : BaseUnitTest() {
 
     @Test
     fun `when current label is purchased, then do not display notices`() = testBlocking {
-        val order = OrderTestUtils.generateTestOrder(orderId = orderId)
-        val notice = NoticeBannerUiState(
-            message = R.string.woo_shipping_address_notification_destination_missing,
-            type = NoticeType.MISSING_DESTINATION_ADDRESS,
-            error = true,
-        )
-        whenever(orderDetailRepository.getOrderById(any())) doReturn order
         whenever(getShipments(any())) doReturn listOf(
             ShipmentUIModel(
                 localId = "0",
@@ -867,10 +793,6 @@ class WooShippingLabelCreationViewModelTest : BaseUnitTest() {
 
     @Test
     fun `when the destination address is missing then verify endpoint should not be called`() = testBlocking {
-        val order = OrderTestUtils.generateTestOrder(orderId = orderId)
-
-        whenever(orderDetailRepository.getOrderById(any())) doReturn order
-
         whenever(addressValidationHelper.isMissingDestinationAddress(any())) doReturn true
 
         createViewModel()
@@ -882,10 +804,6 @@ class WooShippingLabelCreationViewModelTest : BaseUnitTest() {
 
     @Test
     fun `when the destination address exists then verify endpoint should be called`() = testBlocking {
-        val order = OrderTestUtils.generateTestOrder(orderId = orderId)
-
-        whenever(orderDetailRepository.getOrderById(any())) doReturn order
-
         whenever(addressValidationHelper.isMissingDestinationAddress(any())) doReturn false
 
         createViewModel()
@@ -939,8 +857,6 @@ class WooShippingLabelCreationViewModelTest : BaseUnitTest() {
     fun `when NavigateToHazmatFormEdit is triggered with a selected category, the event contains the expected category value`() =
         testBlocking {
             var event: MultiLiveEvent.Event? = null
-            val order = OrderTestUtils.generateTestOrder(orderId = orderId)
-            whenever(orderDetailRepository.getOrderById(any())) doReturn order
 
             createViewModel()
 
@@ -954,9 +870,6 @@ class WooShippingLabelCreationViewModelTest : BaseUnitTest() {
 
     @Test
     fun `when initialized, show expected item quantity`() = testBlocking {
-        val order = OrderTestUtils.generateTestOrder(orderId = orderId)
-        whenever(orderDetailRepository.getOrderById(any())) doReturn order
-
         whenever(shouldRequireCustomsForm.invoke(any())) doReturn false
 
         val expectedItemQuantity = defaultShippableItems.size
@@ -995,9 +908,6 @@ class WooShippingLabelCreationViewModelTest : BaseUnitTest() {
 
     @Test
     fun `ViewState starts with LABEL paper size as default`() = testBlocking {
-        val order = OrderTestUtils.generateTestOrder(orderId = orderId)
-        whenever(orderDetailRepository.getOrderById(any())) doReturn order
-
         createViewModel()
 
         val currentViewState = sut.viewState.value
@@ -1008,9 +918,6 @@ class WooShippingLabelCreationViewModelTest : BaseUnitTest() {
 
     @Test
     fun `onLabelPaperSizeOptionSelected updates the ViewState as expected`() = testBlocking {
-        val order = OrderTestUtils.generateTestOrder(orderId = orderId)
-        whenever(orderDetailRepository.getOrderById(any())) doReturn order
-
         createViewModel()
 
         sut.onLabelPaperSizeOptionSelected(WooShippingLabelPaperSize.LETTER)
@@ -1178,7 +1085,6 @@ class WooShippingLabelCreationViewModelTest : BaseUnitTest() {
 
     @Test
     fun `when purchase shipping label fails with UPSDAP_MISSING_TOS_ERROR_CODE, then navigate to UPS DAP terms of service`() = testBlocking {
-        val order = OrderTestUtils.generateTestOrder(orderId = orderId)
         val wooError = WooError(
             type = WooErrorType.API_ERROR,
             original = GenericErrorType.UNKNOWN,
@@ -1186,8 +1092,6 @@ class WooShippingLabelCreationViewModelTest : BaseUnitTest() {
             message = "Missing UPS DAP terms of service acceptance"
         )
         val wooException = WooException(wooError)
-
-        whenever(orderDetailRepository.getOrderById(any())) doReturn order
         whenever(
             purchaseShippingLabel(any(), any(), any(), any(), any(), any(), any(), any(), any(), isNull(), isNull())
         ) doReturn Result.failure(wooException)

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/WooShippingLabelCreationViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/WooShippingLabelCreationViewModelTest.kt
@@ -32,12 +32,15 @@ import com.woocommerce.android.ui.orders.wooshippinglabels.components.WooShippin
 import com.woocommerce.android.ui.orders.wooshippinglabels.customs.domain.ShouldRequireCustomsForm
 import com.woocommerce.android.ui.orders.wooshippinglabels.customs.domain.ShouldRequireITN
 import com.woocommerce.android.ui.orders.wooshippinglabels.models.AccountSettingsModel
+import com.woocommerce.android.ui.orders.wooshippinglabels.models.DestinationShippingAddress
 import com.woocommerce.android.ui.orders.wooshippinglabels.models.OriginShippingAddress
 import com.woocommerce.android.ui.orders.wooshippinglabels.models.PaymentMethodModel
 import com.woocommerce.android.ui.orders.wooshippinglabels.models.PaymentMethodOptions
+import com.woocommerce.android.ui.orders.wooshippinglabels.models.PurchasedLabelData
 import com.woocommerce.android.ui.orders.wooshippinglabels.models.ShipmentUIModel
 import com.woocommerce.android.ui.orders.wooshippinglabels.models.ShippableItemModel
 import com.woocommerce.android.ui.orders.wooshippinglabels.models.ShippingLabelModel
+import com.woocommerce.android.ui.orders.wooshippinglabels.models.ShippingLabelStatus.PURCHASED
 import com.woocommerce.android.ui.orders.wooshippinglabels.models.ShippingLabelStatus.UNKNOWN
 import com.woocommerce.android.ui.orders.wooshippinglabels.models.StoreOptionsModel
 import com.woocommerce.android.ui.orders.wooshippinglabels.models.WooShippingCarrier
@@ -51,6 +54,7 @@ import com.woocommerce.android.ui.orders.wooshippinglabels.rates.ui.ShippingRate
 import com.woocommerce.android.ui.orders.wooshippinglabels.rates.ui.ShippingRateUI
 import com.woocommerce.android.ui.orders.wooshippinglabels.rates.ui.ShippingSortOption
 import com.woocommerce.android.util.CurrencyFormatter
+import com.woocommerce.android.util.runAndCaptureValues
 import com.woocommerce.android.viewmodel.BaseUnitTest
 import com.woocommerce.android.viewmodel.MultiLiveEvent
 import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.Exit
@@ -60,6 +64,7 @@ import kotlinx.coroutines.test.advanceUntilIdle
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.Test
 import org.mockito.kotlin.any
+import org.mockito.kotlin.anyOrNull
 import org.mockito.kotlin.doAnswer
 import org.mockito.kotlin.doReturn
 import org.mockito.kotlin.eq
@@ -174,7 +179,7 @@ class WooShippingLabelCreationViewModelTest : BaseUnitTest() {
         shipmentId = "1",
         rateId = "1",
         serviceId = "1",
-        carrierId = "1",
+        carrierId = WooShippingCarrier.UPS.carrierIds.first(),
         serviceName = "Default",
         deliveryDays = 1,
         price = BigDecimal(12),
@@ -258,7 +263,7 @@ class WooShippingLabelCreationViewModelTest : BaseUnitTest() {
         WooShippingLabelCreationFragmentArgs(orderId = orderId).toSavedStateHandle()
 
     private val shouldRequireCustomsForm: ShouldRequireCustomsForm = mock {
-        on { invoke(any()) } doReturn true
+        on { invoke(any()) } doReturn false
     }
 
     private val addressValidationHelper: AddressValidationHelper = mock {
@@ -273,8 +278,12 @@ class WooShippingLabelCreationViewModelTest : BaseUnitTest() {
     private val observeAccountSettings: ObserveAccountSettings = mock {
         on { invoke() } doReturn flowOf(defaultAccountSettings)
     }
-    private val verifyDestinationAddress: VerifyDestinationAddress = mock()
-    private val observeShippingLabelNotice: ObserveShippingLabelNotice = mock()
+    private val verifyDestinationAddress: VerifyDestinationAddress = mock {
+        onBlocking { invoke(orderId) } doReturn Result.success(DestinationShippingAddress(defaultShipToAddress, true))
+    }
+    private val observeShippingLabelNotice: ObserveShippingLabelNotice = mock {
+        on { invoke(any(), any(), any(), any()) } doReturn flowOf(null)
+    }
     private val shouldRequireITN: ShouldRequireITN = mock {
         on { invoke(any(), any()) } doReturn false
     }
@@ -1084,32 +1093,113 @@ class WooShippingLabelCreationViewModelTest : BaseUnitTest() {
     }
 
     @Test
-    fun `when purchase shipping label fails with UPSDAP_MISSING_TOS_ERROR_CODE, then navigate to UPS DAP terms of service`() = testBlocking {
-        val wooError = WooError(
-            type = WooErrorType.API_ERROR,
-            original = GenericErrorType.UNKNOWN,
-            apiErrorCode = WooShippingLabelCreationViewModel.UPSDAP_MISSING_TOS_ERROR_CODE,
-            message = "Missing UPS DAP terms of service acceptance"
+    fun `when purchase shipping label fails with UPSDAP_MISSING_TOS_ERROR_CODE, then navigate to UPS DAP terms of service`() =
+        testBlocking {
+            val wooError = WooError(
+                type = WooErrorType.API_ERROR,
+                original = GenericErrorType.UNKNOWN,
+                apiErrorCode = WooShippingLabelCreationViewModel.UPSDAP_MISSING_TOS_ERROR_CODE,
+                message = "Missing UPS DAP terms of service acceptance"
+            )
+            val wooException = WooException(wooError)
+            whenever(
+                purchaseShippingLabel(any(), any(), any(), any(), any(), any(), any(), any(), any(), isNull(), isNull())
+            ) doReturn Result.failure(wooException)
+
+            createViewModel()
+
+            val selectedRate = defaultShippingRates.values.first().first()
+            sut.onPackageSelected(defaultPackageData)
+            sut.onSelectedSippingRateChanged(selectedRate)
+
+            advanceUntilIdle()
+
+            var event: NavigateToUPSDAPTermsOfService? = null
+            sut.event.observeForever { if (it is NavigateToUPSDAPTermsOfService) event = it }
+
+            sut.onPurchaseShippingLabel()
+
+            assertThat(event).isNotNull
+            assertThat(event?.originAddress).isEqualTo(defaultOriginAddresses.first())
+        }
+
+    @Test
+    fun `when UPS terms accepted, then fetch new rates and reselect same rate as before`() = testBlocking {
+        val rateToBeSelected = defaultShippableItemUI.copy(
+            rate = defaultShippingRate.copy(rateId = "2")
         )
-        val wooException = WooException(wooError)
-        whenever(
-            purchaseShippingLabel(any(), any(), any(), any(), any(), any(), any(), any(), any(), isNull(), isNull())
-        ) doReturn Result.failure(wooException)
+        val secondRatesFetchResult = mapOf(
+            defaultCarrier to defaultShippableItems.map {
+                ShippingRateUI(
+                    options = mapOf(Option.DEFAULT to rateToBeSelected),
+                    selectedOption = rateToBeSelected
+                )
+            }
+        )
+        whenever(getShippingRates(any(), any(), any(), any(), any(), any(), anyOrNull(), anyOrNull()))
+            .thenReturn(Result.success(defaultShippingRates))
+            .thenReturn(Result.success(secondRatesFetchResult))
 
         createViewModel()
-
-        val selectedRate = defaultShippingRates.values.first().first()
-        sut.onPackageSelected(defaultPackageData)
-        sut.onSelectedSippingRateChanged(selectedRate)
-
         advanceUntilIdle()
 
-        var event: NavigateToUPSDAPTermsOfService? = null
-        sut.event.observeForever { if (it is NavigateToUPSDAPTermsOfService) event = it }
+        val viewState = sut.viewState.runAndCaptureValues {
+            // Select a package
+            sut.onPackageSelected(defaultPackageData)
+            advanceUntilIdle()
 
-        sut.onPurchaseShippingLabel()
+            // Select a shipping rate
+            val selectedRate = defaultShippingRates.values.first().first()
+            sut.onSelectedSippingRateChanged(selectedRate)
+            advanceUntilIdle()
 
-        assertThat(event).isNotNull
-        assertThat(event?.originAddress).isEqualTo(defaultOriginAddresses.first())
+            // Simulate UPS terms acceptance
+            sut.onUPSTermsAccepted()
+            advanceUntilIdle()
+        }.last() as DataState
+
+        // The rates should be fetched again and the same rate should be selected
+        verify(getShippingRates, times(2)).invoke(any(), any(), any(), any(), any(), any(), anyOrNull(), anyOrNull())
+        val shipment = viewState.shipmentUIList[0]
+        assertThat(shipment.shippingRatesState)
+            .isInstanceOf(WooShippingLabelCreationViewModel.ShippingRatesState.DataState::class.java)
+        val ratesState = shipment.shippingRatesState as WooShippingLabelCreationViewModel.ShippingRatesState.DataState
+        assertThat(ratesState.selectedRate!!.selectedOption).isEqualTo(rateToBeSelected)
+    }
+
+    @Test
+    fun `when UPS terms are accepted, then continue purchase`() = testBlocking {
+        whenever(getShippingRates(any(), any(), any(), any(), any(), any(), anyOrNull(), anyOrNull()))
+            .thenReturn(Result.success(defaultShippingRates))
+        val purchasedLabel = shippingLabelModel.copy(status = PURCHASED)
+        whenever(
+            purchaseShippingLabel(any(), any(), any(), any(), any(), any(), any(), any(), any(), isNull(), isNull())
+        ) doReturn Result.success(
+            PurchasedLabelData(
+                labels = listOf(purchasedLabel),
+                origin = emptyMap(),
+                destination = emptyMap(),
+                rates = emptyMap()
+            )
+        )
+
+        createViewModel()
+        advanceUntilIdle()
+
+        val viewState = sut.viewState.runAndCaptureValues {
+            sut.onPackageSelected(defaultPackageData)
+            advanceUntilIdle()
+
+            val selectedRate = defaultShippingRates.values.first().first()
+            sut.onSelectedSippingRateChanged(selectedRate)
+            advanceUntilIdle()
+
+            sut.onUPSTermsAccepted()
+            advanceUntilIdle()
+        }.last() as DataState
+
+        viewState.shipmentUIList.first().let {
+            assertThat(it.purchased).isTrue()
+        }
     }
 }


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

<!-- Id number of the Linear issue this PR addresses, e.g., WOOMOB-373. -->
Closes WOOMOB-679
Closes WOOMOB-678

### Description
This PR adds handling of the remaining parts of the UPSDAP tos flow:
- It adds networking for accepting the terms.
- It handles continuing the purchase flow after accepting the terms: fetching new rates, and then selecting a rate that matches the previously selected value, then restarting the purchase.

**Important:**
While working on this, I found multiple issues with our API usage that didn't surface with the other carriers. I attempted to fix them, and you can find below a description of the different changes:
- d4448e9 updates the logic of parsing the rates to avoid parsing rates that are not supported by the app. Before this change, we were assigning the rates with unknown option to the `Default` option, which overrides the real `Default` one, and results in showing wrong rates (more expensive ones).
- 1c9c412 updates the serialization of the origin address we use when fetching, we were using `address_1`, while the plugin expects `address`, this didn't cause issues before, but with UPS, it resulted in an error during the purchase as the rate didn't match the provided address.
- f1223eb we were accidentally passing the locally calculated `discount` instead of the `retailRate`, I'm not sure if this has any effect, but I fixed it anyway, I found out about it while investigating the purchase failure mentioned above.

### Steps to reproduce
1. Open the shipping label creation form.
2. Use an origin address that wasn't used with UPS rates before (you can also edit your address)
3. Select a UPS rate.
4. Start the purchase.
5. Accept the UPS terms.

### Testing information
- Confirm that after accepting the UPS terms, rates are refetched.
- Confirm that the previously selected rate is kept (including any additional options)
- Confirm that the purchase is continued afterwards.

### The tests that have been performed
The above.

### Images/gif
https://github.com/user-attachments/assets/47f626dc-5f1a-4f12-98f0-a25d26c01765



- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->