### PR TITLE
[Shipping labels] Migrate shipping labels eligibility endpoint

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/OrderDetailViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/OrderDetailViewModel.kt
@@ -951,9 +951,8 @@ class OrderDetailViewModel @Inject constructor(
     }
 
     private suspend fun isOrderEligibleForSLCreation(orderEligibleForInPersonPayments: Boolean) =
-        if (FeatureFlag.REVAMP_WOO_SHIPPING.isEnabled()) {
-            shippingLabelOnboardingRepository.shippingPluginSupport.isWooShippingSupported() &&
-                eligibilityDataStore.observeEligibility(awaitOrder().id).first() == true
+        if (isRevampWooShippingEnabled) {
+            eligibilityDataStore.observeEligibility(awaitOrder().id).first() == true
         } else {
             shippingLabelOnboardingRepository.shippingPluginSupport.isSupported() &&
                 orderDetailRepository.isOrderEligibleForSLCreation(awaitOrder().id)

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/OrderDetailViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/OrderDetailViewModel.kt
@@ -58,6 +58,7 @@ import com.woocommerce.android.ui.orders.creation.shipping.GetShippingMethodsWit
 import com.woocommerce.android.ui.orders.creation.shipping.RefreshShippingMethods
 import com.woocommerce.android.ui.orders.creation.shipping.ShippingLineDetails
 import com.woocommerce.android.ui.orders.creation.shipping.ShippingMethodsRepository
+import com.woocommerce.android.ui.orders.wooshippinglabels.datasource.WooShippingEligibilityDataStore
 import com.woocommerce.android.ui.orders.wooshippinglabels.networking.WooShippingLabelRepository
 import com.woocommerce.android.ui.payments.cardreader.onboarding.CardReaderFlowParam
 import com.woocommerce.android.ui.payments.cardreader.payment.CardReaderPaymentCollectibilityChecker
@@ -110,6 +111,7 @@ class OrderDetailViewModel @Inject constructor(
     private val tracker: OrderDetailTracker,
     private val shippingLabelOnboardingRepository: ShippingLabelOnboardingRepository,
     private val shippingLabelRepository: WooShippingLabelRepository,
+    private val eligibilityDataStore: WooShippingEligibilityDataStore,
     private val orderDetailsTransactionLauncher: OrderDetailsTransactionLauncher,
     private val getOrderSubscriptions: GetOrderSubscriptions,
     private val giftCardRepository: GiftCardRepository,
@@ -810,7 +812,9 @@ class OrderDetailViewModel @Inject constructor(
     }
 
     private fun fetchSLCreationEligibilityAsync() = async {
-        if (shippingLabelOnboardingRepository.shippingPluginSupport.isSupported()) {
+        if (isRevampWooShippingEnabled) {
+            shippingLabelRepository.fetchShippingEligibility(selectedSite.get(), navArgs.orderId)
+        } else if (shippingLabelOnboardingRepository.shippingPluginSupport.isSupported()) {
             orderDetailRepository.fetchSLCreationEligibility(navArgs.orderId)
         }
         orderDetailsTransactionLauncher.onPackageCreationEligibleFetched()
@@ -921,9 +925,7 @@ class OrderDetailViewModel @Inject constructor(
 
         val orderEligibleForInPersonPayments = viewState.orderInfo?.isPaymentCollectableWithCardReader == true
 
-        val isOrderEligibleForSLCreation = shippingLabelOnboardingRepository.shippingPluginSupport.isSupported() &&
-            orderDetailRepository.isOrderEligibleForSLCreation(awaitOrder().id) &&
-            !orderEligibleForInPersonPayments
+        val isOrderEligibleForSLCreation = isOrderEligibleForSLCreation(orderEligibleForInPersonPayments)
 
         if (isOrderEligibleForSLCreation &&
             viewState.isCreateShippingLabelButtonVisible != true &&
@@ -947,6 +949,15 @@ class OrderDetailViewModel @Inject constructor(
             isAIThankYouNoteButtonShown = shouldShowThankYouNoteButton()
         )
     }
+
+    private suspend fun isOrderEligibleForSLCreation(orderEligibleForInPersonPayments: Boolean) =
+        if (FeatureFlag.REVAMP_WOO_SHIPPING.isEnabled()) {
+            shippingLabelOnboardingRepository.shippingPluginSupport.isWooShippingSupported() &&
+                eligibilityDataStore.observeEligibility(awaitOrder().id).first() == true
+        } else {
+            shippingLabelOnboardingRepository.shippingPluginSupport.isSupported() &&
+                orderDetailRepository.isOrderEligibleForSLCreation(awaitOrder().id)
+        } && !orderEligibleForInPersonPayments
 
     private suspend fun shouldShowThankYouNoteButton() =
         selectedSite.getIfExists()?.isWPComAtomic == true &&

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/datasource/WooShippingEligibilityDataStore.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/datasource/WooShippingEligibilityDataStore.kt
@@ -1,0 +1,34 @@
+package com.woocommerce.android.ui.orders.wooshippinglabels.datasource
+
+import androidx.datastore.core.DataStore
+import androidx.datastore.preferences.core.Preferences
+import androidx.datastore.preferences.core.booleanPreferencesKey
+import androidx.datastore.preferences.core.edit
+import com.woocommerce.android.datastore.DataStoreQualifier
+import com.woocommerce.android.datastore.DataStoreType
+import com.woocommerce.android.tools.SelectedSite
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.distinctUntilChanged
+import kotlinx.coroutines.flow.map
+import javax.inject.Inject
+
+class WooShippingEligibilityDataStore @Inject constructor(
+    @DataStoreQualifier(DataStoreType.SHIPPING_LABELS_DATA) private val dataStore: DataStore<Preferences>,
+    private val selectedSite: SelectedSite,
+) {
+    private fun getEligibilityKey(orderId: Long) = "${selectedSite.get().id}:${orderId}Eligibility"
+
+    fun observeEligibility(orderId: Long): Flow<Boolean?> = dataStore.data.map { prefs ->
+        prefs[booleanPreferencesKey(getEligibilityKey(orderId))]
+    }.distinctUntilChanged()
+
+    suspend fun saveEligibility(orderId: Long, isEligible: Boolean?) {
+        dataStore.edit { preferences ->
+            if (isEligible == null) {
+                preferences.remove(booleanPreferencesKey(getEligibilityKey(orderId)))
+            } else {
+                preferences[booleanPreferencesKey(getEligibilityKey(orderId))] = isEligible
+            }
+        }
+    }
+}

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/networking/DTOs.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/networking/DTOs.kt
@@ -13,6 +13,10 @@ import com.woocommerce.android.ui.orders.wooshippinglabels.rates.networking.Dest
 import java.lang.reflect.Type
 import java.math.BigDecimal
 
+data class EligibilityResponse(
+    @SerializedName("is_eligible") val isEligible: Boolean? = null,
+)
+
 data class AccountSettingsDTO(
     val storeOptions: StoreOptionsDTO,
     val formData: FormDataDTO,

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/networking/WooShippingLabelRepository.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/networking/WooShippingLabelRepository.kt
@@ -6,6 +6,7 @@ import com.woocommerce.android.ui.orders.wooshippinglabels.customs.CustomsData
 import com.woocommerce.android.ui.orders.wooshippinglabels.datasource.WooShippingAccountSettingsDataStore
 import com.woocommerce.android.ui.orders.wooshippinglabels.datasource.WooShippingAddressDataStore
 import com.woocommerce.android.ui.orders.wooshippinglabels.datasource.WooShippingConfigDataStore
+import com.woocommerce.android.ui.orders.wooshippinglabels.datasource.WooShippingEligibilityDataStore
 import com.woocommerce.android.ui.orders.wooshippinglabels.models.AddressNormalizationModel
 import com.woocommerce.android.ui.orders.wooshippinglabels.models.DestinationShippingAddress
 import com.woocommerce.android.ui.orders.wooshippinglabels.models.OriginShippingAddress
@@ -22,10 +23,20 @@ import javax.inject.Inject
 class WooShippingLabelRepository @Inject constructor(
     private val restClient: WooShippingLabelRestClient,
     private val mapper: WooShippingNetworkingMapper,
+    private val eligibilityDataStore: WooShippingEligibilityDataStore,
     private val configDataStore: WooShippingConfigDataStore,
     private val accountSettingsDataStore: WooShippingAccountSettingsDataStore,
     private val addressDataStore: WooShippingAddressDataStore
 ) {
+    suspend fun fetchShippingEligibility(
+        site: SiteModel,
+        orderId: Long,
+    ) = restClient.fetchShippingEligibility(site = site, orderId = orderId).asWooResult().also { response ->
+        response.model
+            ?.takeIf { response.isError.not() }
+            ?.let { eligibilityDataStore.saveEligibility(orderId, it.isEligible) }
+    }
+
     suspend fun fetchShippingLabelPrinting(
         site: SiteModel,
         labelIds: List<Long>,

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/networking/WooShippingLabelRestClient.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/networking/WooShippingLabelRestClient.kt
@@ -18,6 +18,16 @@ import javax.inject.Inject
 class WooShippingLabelRestClient @Inject constructor(
     private val wooNetwork: WooNetwork
 ) {
+    suspend fun fetchShippingEligibility(site: SiteModel, orderId: Long): WooPayload<EligibilityResponse> {
+        val url = "/wcshipping/v1/eligibility/$orderId"
+
+        return wooNetwork.executeGetGsonRequest(
+            site = site,
+            path = url,
+            clazz = EligibilityResponse::class.java,
+        ).toWooPayload()
+    }
+
     suspend fun fetchShippingLabelPrinting(
         site: SiteModel,
         labelIds: List<Long>,

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/networking/WooShippingLabelRestClient.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/networking/WooShippingLabelRestClient.kt
@@ -24,6 +24,11 @@ class WooShippingLabelRestClient @Inject constructor(
         return wooNetwork.executeGetGsonRequest(
             site = site,
             path = url,
+            params = mapOf(
+                "can_create_customs_form" to true.toString(),
+                "can_create_package" to true.toString(),
+                "can_create_payment_method" to true.toString()
+            ),
             clazz = EligibilityResponse::class.java,
         ).toWooPayload()
     }
@@ -89,6 +94,7 @@ class WooShippingLabelRestClient @Inject constructor(
                     message = "Something went wrong"
                 )
             )
+
             else -> WooPayload(Unit)
         }
     }

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/OrderDetailViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/OrderDetailViewModelTest.kt
@@ -44,6 +44,7 @@ import com.woocommerce.android.ui.orders.details.OrderProduct
 import com.woocommerce.android.ui.orders.details.OrderProductMapper
 import com.woocommerce.android.ui.orders.details.ShippingLabelOnboardingRepository
 import com.woocommerce.android.ui.orders.details.ShippingLabelOnboardingRepository.ShippingLabelSupport
+import com.woocommerce.android.ui.orders.wooshippinglabels.datasource.WooShippingEligibilityDataStore
 import com.woocommerce.android.ui.orders.wooshippinglabels.networking.WooShippingLabelRepository
 import com.woocommerce.android.ui.payments.cardreader.payment.CardReaderPaymentCollectibilityChecker
 import com.woocommerce.android.ui.payments.receipt.PaymentReceiptHelper
@@ -127,6 +128,7 @@ class OrderDetailViewModelTest : BaseUnitTest() {
         doReturn(ShippingLabelSupport.WCS_SUPPORTED).whenever(it).shippingPluginSupport
     }
     private val shippingLabelRepository: WooShippingLabelRepository = mock()
+    private val shippingEligibilityDataStore: WooShippingEligibilityDataStore = mock()
 
     private val savedState = OrderDetailFragmentArgs(
         orderId = ORDER_ID,
@@ -208,6 +210,7 @@ class OrderDetailViewModelTest : BaseUnitTest() {
                 orderDetailTracker,
                 shippingLabelOnboardingRepository,
                 shippingLabelRepository,
+                shippingEligibilityDataStore,
                 orderDetailsTransactionLauncher,
                 getOrderSubscriptions,
                 giftCardRepository,
@@ -630,14 +633,16 @@ class OrderDetailViewModelTest : BaseUnitTest() {
     @Test
     fun `Show Products area menu when shipping labels are available`() =
         testBlocking {
+            doReturn(ShippingLabelSupport.WC_SHIPPING_SUPPORTED)
+                .whenever(shippingLabelOnboardingRepository).shippingPluginSupport
+            doReturn(flowOf(true))
+                .whenever(shippingEligibilityDataStore).observeEligibility(any())
             doReturn(order).whenever(orderDetailRepository).fetchOrderById(any())
 
             doReturn(true).whenever(orderDetailRepository).fetchOrderNotes(any())
 
             doReturn(orderShippingLabels).whenever(orderDetailRepository).getOrderShippingLabels(any())
             doReturn(false).whenever(addonsRepository).containsAddonsFrom(any())
-
-            doReturn(true).whenever(orderDetailRepository).isOrderEligibleForSLCreation(order.id)
 
             val shippingLabels = ArrayList<ShippingLabel>()
             viewModel.shippingLabels.observeForever { it?.let { shippingLabels.addAll(it) } }
@@ -928,11 +933,12 @@ class OrderDetailViewModelTest : BaseUnitTest() {
 
     @Test
     fun `show shipping label creation if the order is eligible`() = testBlocking {
+        doReturn(ShippingLabelSupport.WC_SHIPPING_SUPPORTED)
+            .whenever(shippingLabelOnboardingRepository).shippingPluginSupport
+        doReturn(flowOf(true))
+            .whenever(shippingEligibilityDataStore).observeEligibility(any())
         doReturn(order).whenever(orderDetailRepository).getOrderById(any())
         doReturn(order).whenever(orderDetailRepository).fetchOrderById(any())
-
-        doReturn(Unit).whenever(orderDetailRepository).fetchSLCreationEligibility(order.id)
-        doReturn(true).whenever(orderDetailRepository).isOrderEligibleForSLCreation(order.id)
 
         doReturn(true).whenever(orderDetailRepository).fetchOrderNotes(any())
         doReturn(RequestResult.SUCCESS).whenever(orderDetailRepository).fetchOrderShipmentTrackingList(any())
@@ -940,8 +946,6 @@ class OrderDetailViewModelTest : BaseUnitTest() {
         doReturn(emptyList<Refund>()).whenever(orderDetailRepository).fetchOrderRefunds(any())
         doReturn(emptyList<Product>()).whenever(orderDetailRepository).fetchProductsByRemoteIds(any())
         doReturn(false).whenever(addonsRepository).containsAddonsFrom(any())
-        doReturn(ShippingLabelSupport.WCS_SUPPORTED)
-            .whenever(shippingLabelOnboardingRepository).shippingPluginSupport
 
         var isCreateShippingLabelButtonVisible: Boolean? = null
         viewModel.viewStateData.observeForever { _, new ->
@@ -1738,7 +1742,8 @@ class OrderDetailViewModelTest : BaseUnitTest() {
 
     @Test
     fun `when there is no info about the plugins, then optimistically fetch plugin data`() = testBlocking {
-        doReturn(ShippingLabelSupport.WCS_SUPPORTED).whenever(shippingLabelOnboardingRepository).shippingPluginSupport
+        doReturn(ShippingLabelSupport.WCS_SUPPORTED)
+            .whenever(shippingLabelOnboardingRepository).shippingPluginSupport
         doReturn(order).whenever(orderDetailRepository).getOrderById(any())
         doReturn(true).whenever(orderDetailRepository).fetchOrderNotes(any())
         doReturn(true).whenever(addonsRepository).containsAddonsFrom(any())
@@ -2348,7 +2353,6 @@ class OrderDetailViewModelTest : BaseUnitTest() {
     fun `when woo shipping is installed, then navigate to the new shipping flow`() = testBlocking {
         doReturn(order).whenever(orderDetailRepository).getOrderById(any())
         doReturn(true).whenever(addonsRepository).containsAddonsFrom(any())
-        doReturn(true).whenever(orderDetailRepository).fetchOrderNotes(any())
         doReturn(ShippingLabelSupport.WC_SHIPPING_SUPPORTED)
             .whenever(shippingLabelOnboardingRepository).shippingPluginSupport
 


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

<!-- Id number of the Linear issue this PR addresses, e.g., WOOMOB-373. -->
Closes WOOMOB-655

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
This PR adds the eligibility endpoint for shipping labels and uses it on the order detail screen when the feature flag is enabled.

### Steps to reproduce
<!-- Step-by-step testing instructions. For new user flows, consider instead stating the goal of the workflow and see if your PR reviewer can accomplish the workflow without specific steps! -->
1. Go to the Orders screen.
2. Open an order that is eligible for shipping labels.
3. Repeat with an order that is not eligible for shipping labels. 

### The tests that have been performed
<!-- To give the reviewer an idea of what could be missed in terms of testing -->
I also tested this for disabled flag case.

### Images/gif
<!-- Include before and after images or gifs when appropriate. -->

- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->