### PR TITLE
Fix rare crash during login with site credentials.

### DIFF
--- a/libs/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpapi/applicationpasswords/ApplicationPasswordsManager.kt
+++ b/libs/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpapi/applicationpasswords/ApplicationPasswordsManager.kt
@@ -80,7 +80,13 @@ internal class ApplicationPasswordsManager @Inject constructor(
         return if (site.origin == SiteModel.ORIGIN_WPCOM_REST) {
             jetpackApplicationPasswordsRestClient.fetchWPAdminUsername(site)
         } else {
-            UsernameFetchPayload(site.username)
+            site.username?.let { UsernameFetchPayload(it) }
+                ?: UsernameFetchPayload(
+                    BaseNetworkError(
+                        GenericErrorType.UNKNOWN,
+                        "Username is missing for the site"
+                    )
+                )
         }
     }
 


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

<!-- Id number of the Linear issue this PR addresses, e.g., WOOMOB-373. -->
Closes WOOMOB-381

### Description
This PR fixes a crash that seems happens during site credentials, we had a previous attempt in https://github.com/woocommerce/woocommerce-android/pull/14103 that reduced the number of occurrences quite a lot, now, the crash is rarely happening, but as it's still happening, this PR updates the logic to show an error instead of crashing.

### Steps to reproduce
I couldn't reproduce the crash, so just code review should be enough.

- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->