### PR TITLE
Fix leaking view in ProductDetailsToolbarHelper

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -6,6 +6,7 @@
 - [*] Fixed a rare crash in the POS when adding a variation product to the cart by scanning a barcode. [https://github.com/woocommerce/woocommerce-android/pull/14259]
 - [*] POS: Show error messages when scanned barcodes are too short or improperly formatted [https://github.com/woocommerce/woocommerce-android/pull/14255]
 - [*] Use new Woo brand colors on the card reader update indicator in the in-person payments flow [https://github.com/woocommerce/woocommerce-android/pull/14249]
+- [internal] Fixed a memory leak on the ProductDetailScreen [https://github.com/woocommerce/woocommerce-android/pull/14264]
 
 22.7
 -----

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/details/ProductDetailsToolbarHelper.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/details/ProductDetailsToolbarHelper.kt
@@ -18,8 +18,11 @@ import com.woocommerce.android.databinding.FragmentProductDetailBinding
 import com.woocommerce.android.ui.products.list.ProductListFragment
 import com.woocommerce.android.util.IsWindowClassLargeThanCompact
 import org.wordpress.android.util.ActivityUtils
+import javax.inject.Inject
 
-class ProductDetailsToolbarHelper : FragmentManager.FragmentLifecycleCallbacks(), Toolbar.OnMenuItemClickListener {
+class ProductDetailsToolbarHelper @Inject constructor() :
+    FragmentManager.FragmentLifecycleCallbacks(),
+    Toolbar.OnMenuItemClickListener {
     private var fragment: ProductDetailFragment? = null
     private var binding: FragmentProductDetailBinding? = null
     private var viewModel: ProductDetailViewModel? = null
@@ -85,6 +88,7 @@ class ProductDetailsToolbarHelper : FragmentManager.FragmentLifecycleCallbacks()
                         null
                     }
                 }
+
                 isPartOfProductListFlow() -> {
                     AppCompatResources.getDrawable(activity!!, R.drawable.ic_back_24dp)
                 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/details/ProductDetailsToolbarHelper.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/details/ProductDetailsToolbarHelper.kt
@@ -18,15 +18,13 @@ import com.woocommerce.android.databinding.FragmentProductDetailBinding
 import com.woocommerce.android.ui.products.list.ProductListFragment
 import com.woocommerce.android.util.IsWindowClassLargeThanCompact
 import org.wordpress.android.util.ActivityUtils
-import javax.inject.Inject
 
-class ProductDetailsToolbarHelper @Inject constructor(
-    private val activity: Activity,
-    private val isWindowClassLargeThanCompact: IsWindowClassLargeThanCompact,
-) : FragmentManager.FragmentLifecycleCallbacks(), Toolbar.OnMenuItemClickListener {
+class ProductDetailsToolbarHelper : FragmentManager.FragmentLifecycleCallbacks(), Toolbar.OnMenuItemClickListener {
     private var fragment: ProductDetailFragment? = null
     private var binding: FragmentProductDetailBinding? = null
     private var viewModel: ProductDetailViewModel? = null
+    private var activity: Activity? = null
+    private var isWindowClassLargeThanCompact: IsWindowClassLargeThanCompact? = null
 
     private var menu: Menu? = null
 
@@ -38,6 +36,8 @@ class ProductDetailsToolbarHelper @Inject constructor(
         this.fragment = fragment
         this.binding = binding
         this.viewModel = viewModel
+        this.activity = fragment.activity
+        this.isWindowClassLargeThanCompact = IsWindowClassLargeThanCompact(activity!!)
 
         fragment.parentFragmentManager.registerFragmentLifecycleCallbacks(this, false)
 
@@ -54,6 +54,8 @@ class ProductDetailsToolbarHelper @Inject constructor(
             menu = null
             fragment = null
             viewModel = null
+            activity = null
+            isWindowClassLargeThanCompact = null
             fm.unregisterFragmentLifecycleCallbacks(this)
         }
     }
@@ -72,23 +74,23 @@ class ProductDetailsToolbarHelper @Inject constructor(
 
         toolbar.navigationIcon =
             when {
-                isWindowClassLargeThanCompact() -> {
+                isWindowClassLargeThanCompact!!.invoke() -> {
                     val startMode = viewModel?.startMode
                     val isAddNewModeCreationFlow = startMode == ProductDetailFragment.Mode.AddNewProduct
                     val isProductShownAfterGenerationWithAi = startMode is ProductDetailFragment.Mode.ShowProduct &&
                         startMode.afterGeneratedWithAi
                     if (isAddNewModeCreationFlow || isProductShownAfterGenerationWithAi) {
-                        AppCompatResources.getDrawable(activity, R.drawable.ic_back_24dp)
+                        AppCompatResources.getDrawable(activity!!, R.drawable.ic_back_24dp)
                     } else {
                         null
                     }
                 }
                 isPartOfProductListFlow() -> {
-                    AppCompatResources.getDrawable(activity, R.drawable.ic_back_24dp)
+                    AppCompatResources.getDrawable(activity!!, R.drawable.ic_back_24dp)
                 }
 
                 else -> {
-                    AppCompatResources.getDrawable(activity, R.drawable.ic_gridicons_cross_24dp)
+                    AppCompatResources.getDrawable(activity!!, R.drawable.ic_gridicons_cross_24dp)
                 }
             }
 
@@ -109,7 +111,7 @@ class ProductDetailsToolbarHelper @Inject constructor(
             title.setSpan(
                 ForegroundColorSpan(
                     ContextCompat.getColor(
-                        activity,
+                        activity!!,
                         R.color.woo_red_30
                     )
                 ),
@@ -131,7 +133,7 @@ class ProductDetailsToolbarHelper @Inject constructor(
     override fun onMenuItemClick(item: MenuItem): Boolean {
         return when (item.itemId) {
             R.id.menu_publish -> {
-                ActivityUtils.hideKeyboard(activity)
+                ActivityUtils.hideKeyboard(activity!!)
                 viewModel?.onPublishButtonClicked()
                 true
             }
@@ -147,7 +149,7 @@ class ProductDetailsToolbarHelper @Inject constructor(
             }
 
             R.id.menu_save -> {
-                ActivityUtils.hideKeyboard(activity)
+                ActivityUtils.hideKeyboard(activity!!)
                 viewModel?.onSaveButtonClicked()
                 true
             }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/details/ProductDetailsToolbarHelper.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/details/ProductDetailsToolbarHelper.kt
@@ -9,8 +9,8 @@ import androidx.annotation.IdRes
 import androidx.appcompat.content.res.AppCompatResources
 import androidx.appcompat.widget.Toolbar
 import androidx.core.content.ContextCompat
-import androidx.lifecycle.DefaultLifecycleObserver
-import androidx.lifecycle.LifecycleOwner
+import androidx.fragment.app.Fragment
+import androidx.fragment.app.FragmentManager
 import androidx.navigation.NavController
 import androidx.navigation.fragment.findNavController
 import com.woocommerce.android.R
@@ -23,8 +23,7 @@ import javax.inject.Inject
 class ProductDetailsToolbarHelper @Inject constructor(
     private val activity: Activity,
     private val isWindowClassLargeThanCompact: IsWindowClassLargeThanCompact,
-) : DefaultLifecycleObserver,
-    Toolbar.OnMenuItemClickListener {
+) : FragmentManager.FragmentLifecycleCallbacks(), Toolbar.OnMenuItemClickListener {
     private var fragment: ProductDetailFragment? = null
     private var binding: FragmentProductDetailBinding? = null
     private var viewModel: ProductDetailViewModel? = null
@@ -40,7 +39,7 @@ class ProductDetailsToolbarHelper @Inject constructor(
         this.binding = binding
         this.viewModel = viewModel
 
-        fragment.lifecycle.addObserver(this)
+        fragment.parentFragmentManager.registerFragmentLifecycleCallbacks(this, false)
 
         setupToolbar()
 
@@ -49,15 +48,18 @@ class ProductDetailsToolbarHelper @Inject constructor(
         }
     }
 
-    fun updateTitle(title: String) {
-        binding?.productDetailToolbar?.title = title
+    override fun onFragmentViewDestroyed(fm: FragmentManager, f: Fragment) {
+        if (f == fragment) {
+            binding = null
+            menu = null
+            fragment = null
+            viewModel = null
+            fm.unregisterFragmentLifecycleCallbacks(this)
+        }
     }
 
-    override fun onDestroy(owner: LifecycleOwner) {
-        fragment = null
-        binding = null
-        viewModel = null
-        menu = null
+    fun updateTitle(title: String) {
+        binding?.productDetailToolbar?.title = title
     }
 
     fun setupToolbar() {


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

<!-- Id number of the Linear issue this PR addresses, e.g., WOOMOB-373. -->
Fixes WOOMOB-739

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

Fixes memory leak on the ProductDetail screen. The issue is that we store references to view in onViewCreated but we relieve them in onDestroy instead of onDestroyView. Fragment might be alive even after its view is destroyed, so holding reference to a view leads to a memory leak.

### Steps to reproduce
<!-- Step-by-step testing instructions. For new user flows, consider instead stating the goal of the workflow and see if your PR reviewer can accomplish the workflow without specific steps! -->

1. Open Product Detail
2. Go to the Order List
3. Notice the leak

### Testing information
<!-- This is your opportunity to break out individual scenarios that need testing (when necessary) and/or include a checklist for the reviewer to go through. Consider documenting the following from your own completed testing: devices used, alternate workflows, edge cases, affected areas, critical flows, areas not tested, and any remaining unknowns. Provide feedback on this new section of the PR template through Sept 30, 2024 to Apps Quality; additional context here: p91TBi-b8z-p2#comment-12036 -->

Smoke test product detail and product list.

### The tests that have been performed
<!-- To give the reviewer an idea of what could be missed in terms of testing -->

I've smoke tested opening the product detail, navigation product list and configuration changes.

### Images/gif
<!-- Include before and after images or gifs when appropriate. -->
No user facing changes

- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->