### PR TITLE
[WOOMOV-745][Woo POS] Navigation from the cash payment back to the checkout causes products list to be open

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/items/WooPosItemsSearchHelper.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/items/WooPosItemsSearchHelper.kt
@@ -67,7 +67,7 @@ class WooPosItemsSearchHelper @Inject constructor(
                     is ParentToChildrenEvent.CouponsRemoved -> Unit
                     is ParentToChildrenEvent.RemoveCouponsClicked -> Unit
                     is ParentToChildrenEvent.CouponsValidationFailed -> Unit
-                    is ParentToChildrenEvent.OrderSuccessfullyPaid  -> Unit
+                    is ParentToChildrenEvent.OrderSuccessfullyPaid -> Unit
                 }
             }
         }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/items/WooPosItemsSearchHelper.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/items/WooPosItemsSearchHelper.kt
@@ -56,7 +56,7 @@ class WooPosItemsSearchHelper @Inject constructor(
                         }
                     }
                     is ParentToChildrenEvent.CheckoutClicked -> {
-                        onCloseSearchClicked()
+                        closeSearchToPreventFocusAcquiringAfterNavigation()
                     }
 
                     is ParentToChildrenEvent.BackFromCheckoutToCartClicked -> Unit
@@ -87,7 +87,9 @@ class WooPosItemsSearchHelper @Inject constructor(
         }
     }
 
-    fun onCloseSearchClicked() {
+    fun onCloseSearchClicked() = closeSearch()
+
+    fun closeSearch() {
         wasLastStateClosed = true
         viewStateFlow.value = viewStateFlow.value.copy(
             search = SearchState.Visible(
@@ -95,6 +97,8 @@ class WooPosItemsSearchHelper @Inject constructor(
             )
         )
     }
+
+    private fun closeSearchToPreventFocusAcquiringAfterNavigation() = closeSearch()
 
     fun onClearSearchClicked() {
         coroutineScope.launch {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/items/WooPosItemsSearchHelper.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/items/WooPosItemsSearchHelper.kt
@@ -47,10 +47,6 @@ class WooPosItemsSearchHelper @Inject constructor(
                         updateLoadingState(isLoading = false)
                     }
 
-                    is ParentToChildrenEvent.OrderSuccessfullyPaid -> {
-                        onCloseSearchClicked()
-                    }
-
                     is ParentToChildrenEvent.SearchEvent.RecentSearchSelected -> {
                         onSearchChanged(event.query, event.query.length)
                     }
@@ -59,16 +55,19 @@ class WooPosItemsSearchHelper @Inject constructor(
                             onSearchChanged("", 0)
                         }
                     }
+                    is ParentToChildrenEvent.CheckoutClicked -> {
+                        onCloseSearchClicked()
+                    }
 
                     is ParentToChildrenEvent.BackFromCheckoutToCartClicked -> Unit
                     is ParentToChildrenEvent.BarcodeEvent -> Unit
                     is ParentToChildrenEvent.ItemClickedInItemsList -> Unit
-                    is ParentToChildrenEvent.CheckoutClicked -> Unit
                     is ParentToChildrenEvent.SearchEvent.ChangedQuery -> Unit
                     is ParentToChildrenEvent.OrderCreated -> Unit
                     is ParentToChildrenEvent.CouponsRemoved -> Unit
                     is ParentToChildrenEvent.RemoveCouponsClicked -> Unit
                     is ParentToChildrenEvent.CouponsValidationFailed -> Unit
+                    is ParentToChildrenEvent.OrderSuccessfullyPaid  -> Unit
                 }
             }
         }

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/home/items/WooPosItemsSearchHelperTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/home/items/WooPosItemsSearchHelperTest.kt
@@ -217,6 +217,29 @@ class WooPosItemsSearchHelperTest {
     }
 
     @Test
+    fun `given checkout clicked event, when received, then closes search`() = runTest {
+        // GIVEN
+        searchHelper.initialize(CoroutineScope(coroutinesTestRule.testDispatcher), viewStateFlow)
+        searchHelper.onSearchChanged("test query", "test query".length)
+
+        val initialState = viewStateFlow.value as WooPosItemsToolbarViewState.ProductList
+        val initialSearchState = initialState.search as WooPosItemsToolbarViewState.SearchState.Visible
+        assertThat(initialSearchState.state).isInstanceOf(WooPosSearchInputState.Open::class.java)
+
+        // WHEN
+        whenever(mockParentToChildrenEventReceiver.events).thenReturn(
+            flowOf(ParentToChildrenEvent.CheckoutClicked(emptyList()))
+        )
+        searchHelper.initialize(CoroutineScope(coroutinesTestRule.testDispatcher), viewStateFlow)
+        advanceUntilIdle()
+
+        // THEN
+        val currentState = viewStateFlow.value as WooPosItemsToolbarViewState.ProductList
+        val searchState = currentState.search as WooPosItemsToolbarViewState.SearchState.Visible
+        assertThat(searchState.state).isInstanceOf(WooPosSearchInputState.Closed::class.java)
+    }
+
+    @Test
     fun `given coupons screen, when search event started received, then loading state remains false`() = runTest {
         // GIVEN
         viewStateFlow.value = WooPosItemsToolbarViewState.CouponList(


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

<!-- Id number of the Linear issue this PR addresses, e.g., WOOMOB-373. -->


WOOMOV-745
### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
Currently, the search state is only reset when the order was successfully paid. But navigation back from the cash screen is not handled, and the focus is taken by the search input field which causes items screen to be shown

We have 3 options to fix that:
* On navigation back from the cash, reset the search state
* On click on the cash button reset the search state
* On click on the check-out reset the search state

The last one is chosen here:
* It covers all the potential navigation issues similar to this one
* It easiest to implement
* **BUT** the UX maybe is not great as in some cases a merchant wants to go back and continue the search
Wdyt? Which option would you go with here?


### Steps to reproduce
<!-- Step-by-step testing instructions. For new user flows, consider instead stating the goal of the workflow and see if your PR reviewer can accomplish the workflow without specific steps! -->
* Open POS
* Open search
* Add any amount of products
* Select cash payment
* Navigate back
* Notice that the search is in focus and that caused the products screen to be partially shown

### Testing information
<!-- This is your opportunity to break out individual scenarios that need testing (when necessary) and/or include a checklist for the reviewer to go through. Consider documenting the following from your own completed testing: devices used, alternate workflows, edge cases, affected areas, critical flows, areas not tested, and any remaining unknowns. Provide feedback on this new section of the PR template through Sept 30, 2024 to Apps Quality; additional context here: p91TBi-b8z-p2#comment-12036 -->
* Try different cases of the navigation from check out screen and back to the items
* Notice that nothing is weird is going on except that the search is closed after check out is clicked

### The tests that have been performed
<!-- To give the reviewer an idea of what could be missed in terms of testing -->
Above

### Images/gif
<!-- Include before and after images or gifs when appropriate. -->
#### before

https://github.com/user-attachments/assets/40d7ff5c-f7ed-4c64-b15b-d2e656f3c817

#### after


https://github.com/user-attachments/assets/241590b5-6782-45db-83d9-a716ac9ba39e



- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->