### PR TITLE
[Shipping labels] Use stored destination address for purchased labels

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/GetShipments.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/GetShipments.kt
@@ -8,6 +8,7 @@ import com.woocommerce.android.ui.orders.wooshippinglabels.models.ShipmentUIMode
 import com.woocommerce.android.ui.orders.wooshippinglabels.models.ShippableItemModel
 import com.woocommerce.android.ui.orders.wooshippinglabels.networking.ShippingLabelDTO
 import com.woocommerce.android.ui.orders.wooshippinglabels.networking.WooShippingNetworkingMapper
+import com.woocommerce.android.ui.orders.wooshippinglabels.rates.networking.DestinationAddressDTO
 import com.woocommerce.android.ui.products.details.ProductDetailRepository
 import kotlinx.coroutines.flow.first
 import javax.inject.Inject
@@ -47,7 +48,7 @@ class GetShipments @Inject constructor(
 
         val shipments = config?.shipments
 
-        val shipmentUIModelList = if (shipments.isNullOrEmpty()) {
+        var shipmentUIModelList = if (shipments.isNullOrEmpty()) {
             listOf(ShipmentUIModel(localId = "0", items = orderItems))
         } else {
             shipments.map { (shipmentId, shipmentItems) ->
@@ -61,10 +62,19 @@ class GetShipments @Inject constructor(
             }
         }.sortedBy { it.localId.toLong() }
 
-        // If there are purchased labels, merge their data into the result list
-        return config?.shippingLabelData?.currentOrderLabels?.let { data ->
-            mergePurchaseData(shipmentUIModelList, data)
-        } ?: shipmentUIModelList
+        config?.shippingLabelData?.let { data ->
+            // If there are purchased labels, merge their data into the result list
+            data.currentOrderLabels?.let { labels ->
+                shipmentUIModelList = mergePurchaseData(shipmentUIModelList, labels)
+            }
+
+            // If there are stored destination address, merge it into the result list
+            data.storedData?.selectedDestination?.let { selectedDestination ->
+                shipmentUIModelList = mergeDestinationAddresses(shipmentUIModelList, selectedDestination)
+            }
+        }
+
+        return shipmentUIModelList
     }
 
     private fun mergePurchaseData(
@@ -80,4 +90,20 @@ class GetShipments @Inject constructor(
             shipmentUIModel.copy(purchased = true, label = mapper.invoke(noRefundedLabelForShipment))
         }
     }
+
+    private fun mergeDestinationAddresses(
+        shipmentUIModelList: List<ShipmentUIModel>,
+        destinationAddresses: Map<String, DestinationAddressDTO>
+    ) = shipmentUIModelList.map { shipmentUIModel ->
+        val id = shipmentUIModel.remoteId
+        if (id != null && destinationAddresses.contains(getStoredDataKey(id))) {
+            destinationAddresses[getStoredDataKey(id)]?.let {
+                shipmentUIModel.copy(label = shipmentUIModel.label?.copy(destinationAddress = mapper.invoke(it)))
+            } ?: shipmentUIModel
+        } else {
+            shipmentUIModel
+        }
+    }
+
+    private fun getStoredDataKey(shipmentId: String) = "shipment_$shipmentId"
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/GetShipments.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/GetShipments.kt
@@ -96,7 +96,7 @@ class GetShipments @Inject constructor(
         destinationAddresses: Map<String, DestinationAddressDTO>
     ) = shipmentUIModelList.map { shipmentUIModel ->
         val id = shipmentUIModel.remoteId
-        if (id != null && destinationAddresses.contains(getStoredDataKey(id))) {
+        if (id != null) {
             destinationAddresses[getStoredDataKey(id)]?.let {
                 shipmentUIModel.copy(label = shipmentUIModel.label?.copy(destinationAddress = mapper.invoke(it)))
             } ?: shipmentUIModel

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/WooShippingLabelCreationViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/WooShippingLabelCreationViewModel.kt
@@ -264,19 +264,30 @@ class WooShippingLabelCreationViewModel @Inject constructor(
     }
 
     private suspend fun getDestinationAddress() {
-        order.drop(1).collectLatest { order ->
-            val defaultDestination = DestinationShippingAddress(
-                address = order.shippingAddress.copy(email = order.billingAddress.email),
-                isVerified = false
-            )
-
-            destinationAddress.value = defaultDestination
-
-            if (addressValidationHelper.isMissingDestinationAddress(order.shippingAddress).not()) {
-                verifyDestinationAddress(order.id).fold(
-                    onSuccess = { destinationAddress.value = it },
-                    onFailure = { }
+        combine(
+            order.drop(1),
+            shipments.drop(1),
+            uiState.map { it.selectedIndex }.distinctUntilChanged()
+        ) { order, shipments, selectedIndex ->
+            Pair(order, shipments[selectedIndex].label?.destinationAddress)
+        }.collectLatest { (order, labelDestination) ->
+            if (labelDestination == null) {
+                val defaultDestination = DestinationShippingAddress(
+                    address = order.shippingAddress.copy(email = order.billingAddress.email),
+                    isVerified = false
                 )
+
+                destinationAddress.value = defaultDestination
+
+                if (addressValidationHelper.isMissingDestinationAddress(order.shippingAddress).not()) {
+                    verifyDestinationAddress(order.id).fold(
+                        onSuccess = { destinationAddress.value = it },
+                        onFailure = { }
+                    )
+                }
+            } else {
+                // Using stored destination address for purchased labels
+                destinationAddress.value = DestinationShippingAddress(address = labelDestination, isVerified = true)
             }
         }
     }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/networking/DTOs.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/networking/DTOs.kt
@@ -82,7 +82,12 @@ data class ConfigDTO(
 )
 
 data class ShippingLabelDataDTO(
-    @SerializedName("currentOrderLabels") val currentOrderLabels: List<ShippingLabelDTO>
+    @SerializedName("currentOrderLabels") val currentOrderLabels: List<ShippingLabelDTO>?,
+    @SerializedName("storedData") val storedData: StoredDataDTO?
+)
+
+data class StoredDataDTO(
+    @SerializedName("selected_destination") val selectedDestination: Map<String, DestinationAddressDTO>,
 )
 
 data class Item(@SerializedName("id") val id: Long?, @SerializedName("subItems") val subItems: List<String>?)

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/purchased/ObserveShippingLabelStatus.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/purchased/ObserveShippingLabelStatus.kt
@@ -84,7 +84,7 @@ class ObserveShippingLabelStatus @Inject constructor(
         val updatedConfig = currentConfig.copy(
             shippingLabelData = currentConfig.shippingLabelData.copy(
                 currentOrderLabels = addPurchasedLabelToConfigDTO(
-                    currentConfig.shippingLabelData.currentOrderLabels,
+                    currentConfig.shippingLabelData.currentOrderLabels ?: emptyList(),
                     response
                 )
             )

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/GetShipmentsTests.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/GetShipmentsTests.kt
@@ -1,14 +1,20 @@
 package com.woocommerce.android.ui.orders.wooshippinglabels
 
+import com.woocommerce.android.model.Address
 import com.woocommerce.android.model.Refund
 import com.woocommerce.android.ui.orders.OrderTestUtils
 import com.woocommerce.android.ui.orders.details.OrderDetailRepository
 import com.woocommerce.android.ui.orders.wooshippinglabels.datasource.WooShippingConfigDataStore
+import com.woocommerce.android.ui.orders.wooshippinglabels.models.ShippingLabelModel
+import com.woocommerce.android.ui.orders.wooshippinglabels.models.ShippingLabelStatus
 import com.woocommerce.android.ui.orders.wooshippinglabels.networking.ConfigDTO
 import com.woocommerce.android.ui.orders.wooshippinglabels.networking.Item
 import com.woocommerce.android.ui.orders.wooshippinglabels.networking.LabelRefund
 import com.woocommerce.android.ui.orders.wooshippinglabels.networking.ShippingLabelDTO
 import com.woocommerce.android.ui.orders.wooshippinglabels.networking.ShippingLabelDataDTO
+import com.woocommerce.android.ui.orders.wooshippinglabels.networking.StoredDataDTO
+import com.woocommerce.android.ui.orders.wooshippinglabels.networking.WooShippingNetworkingMapper
+import com.woocommerce.android.ui.orders.wooshippinglabels.rates.networking.DestinationAddressDTO
 import com.woocommerce.android.ui.products.ProductTestUtils
 import com.woocommerce.android.ui.products.details.ProductDetailRepository
 import com.woocommerce.android.viewmodel.BaseUnitTest
@@ -24,8 +30,10 @@ import org.mockito.kotlin.mock
 import org.mockito.kotlin.never
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
+import java.math.BigDecimal
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
+import kotlin.test.assertNotNull
 
 @OptIn(ExperimentalCoroutinesApi::class)
 class GetShipmentsTests : BaseUnitTest() {
@@ -34,8 +42,9 @@ class GetShipmentsTests : BaseUnitTest() {
     private val configDataStore: WooShippingConfigDataStore = mock {
         doReturn(flowOf(null)).whenever(it).observeConfig(any())
     }
+    private val mapper: WooShippingNetworkingMapper = mock()
 
-    private val sut = GetShipments(orderDetailRepository, productDetailRepository, configDataStore, mock())
+    private val sut = GetShipments(orderDetailRepository, productDetailRepository, configDataStore, mapper)
 
     @Test
     fun `when order only contains refunded products then should return empty list`() = testBlocking {
@@ -174,7 +183,7 @@ class GetShipmentsTests : BaseUnitTest() {
             )
         )
         whenever(configDataStore.observeConfig(eq(order.id))) doReturn flowOf(
-            ConfigDTO(shipments = shipments, shippingLabelData = ShippingLabelDataDTO(emptyList()))
+            ConfigDTO(shipments = shipments, shippingLabelData = ShippingLabelDataDTO(null, null))
         )
 
         val result = sut.invoke(order)
@@ -206,7 +215,7 @@ class GetShipmentsTests : BaseUnitTest() {
         )
         val configDTO = ConfigDTO(
             shipments = shipments,
-            shippingLabelData = ShippingLabelDataDTO(currentOrderLabels = listOf(shippingLabel))
+            shippingLabelData = ShippingLabelDataDTO(currentOrderLabels = listOf(shippingLabel), null)
         )
         whenever(configDataStore.observeConfig(eq(order.id))) doReturn flowOf(configDTO)
 
@@ -214,5 +223,65 @@ class GetShipmentsTests : BaseUnitTest() {
         val shipmentUIModel = result.first()
 
         assertFalse(shipmentUIModel.purchased)
+    }
+
+    @Suppress("LongMethod")
+    @Test
+    fun `when there are stored address in config, result should contain label with address`() = testBlocking {
+        val orderItem = OrderTestUtils.generateTestOrderItems(count = 1).first()
+        val order = OrderTestUtils.generateTestOrder().copy(items = listOf(orderItem))
+        val shipmentId = "0"
+        val labelId = 12L
+
+        val shippingLabel = ShippingLabelDTO(labelId = labelId, shipmentId = shipmentId)
+        val destinationAddressDTO = DestinationAddressDTO()
+        val configDTO = ConfigDTO(
+            shipments = mapOf(shipmentId to listOf(Item(id = orderItem.itemId, subItems = emptyList()))),
+            shippingLabelData = ShippingLabelDataDTO(
+                currentOrderLabels = listOf(shippingLabel),
+                storedData = StoredDataDTO(selectedDestination = mapOf("shipment_$shipmentId" to destinationAddressDTO))
+            )
+        )
+
+        whenever(orderDetailRepository.getOrderRefunds(eq(order.id))) doReturn emptyList()
+        whenever(productDetailRepository.getProductAsync(any())).thenAnswer { invocation ->
+            val productId = invocation.arguments[0] as Long
+            ProductTestUtils.generateProduct(productId = productId, productName = "Product $productId")
+        }
+        whenever(configDataStore.observeConfig(eq(order.id))) doReturn flowOf(configDTO)
+        whenever(mapper.invoke(shippingLabel)) doReturn ShippingLabelModel(
+            labelId = labelId,
+            tracking = "",
+            refundableAmount = BigDecimal.ZERO,
+            status = ShippingLabelStatus.UNKNOWN,
+            created = null,
+            carrierId = "",
+            serviceName = "",
+            commercialInvoiceUrl = "",
+            isCommercialInvoiceSubmittedElectronically = false,
+            packageName = "",
+            isLetter = false,
+            productNames = emptyList(),
+            productIds = emptyList(),
+            shipmentId = shipmentId,
+            receiptItemId = 0L,
+            createdDate = null,
+            mainReceiptId = 0L,
+            rate = BigDecimal.ZERO,
+            currency = "",
+            expiryDate = 0L,
+            usedDate = 0L,
+            refund = null,
+        )
+        whenever(mapper.invoke(destinationAddressDTO)) doReturn Address.EMPTY.copy(
+            firstName = "Test",
+            lastName = "Shipping"
+        )
+
+        val result = sut.invoke(order)
+        val shipmentUIModel = result.first()
+
+        assertNotNull(shipmentUIModel.label)
+        assertNotNull(shipmentUIModel.label.destinationAddress)
     }
 }


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

<!-- Id number of the Linear issue this PR addresses, e.g., WOOMOB-373. -->
Closes WOOMOB-748

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
This adds functionality to use the destination address stored on the backend for purchased labels.

### Steps to reproduce
<!-- Step-by-step testing instructions. For new user flows, consider instead stating the goal of the workflow and see if your PR reviewer can accomplish the workflow without specific steps! -->
1. Create a test order on the web.
2. Create multiple shipments for the order.
3. Purchase a label for one shipment.
4. Purchase another label for a different shipment, using a different destination address.
5. Open the order in the app.
6. Start the "Create shipping label" flow.
7. Change the selected shipment.
8. Tap on Shipment details.
9. Verify that the "Ship to" address matches the one shown on the web.

### The tests that have been performed
<!-- To give the reviewer an idea of what could be missed in terms of testing -->
Steps above

### Images/gif
<!-- Include before and after images or gifs when appropriate. -->

- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->