### PR TITLE
[Shipping Labels] Rework the shipment details layout to improve UI and fix scroll issues

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/PurchaseSection.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/PurchaseSection.kt
@@ -1,6 +1,9 @@
 package com.woocommerce.android.ui.orders.wooshippinglabels
 
+import android.content.res.Configuration
+import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
@@ -9,65 +12,84 @@ import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalConfiguration
 import androidx.compose.ui.res.dimensionResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
 import com.woocommerce.android.R
 import com.woocommerce.android.ui.compose.component.WCColoredButton
 import com.woocommerce.android.ui.compose.component.WCSwitch
 import com.woocommerce.android.ui.compose.theme.WooThemeWithBackground
 
 @Composable
-internal fun PurchasesSection(
-    total: String?,
-    markOrderComplete: Boolean,
-    onMarkOrderCompleteChange: (Boolean) -> Unit,
-    onPurchaseShippingLabel: () -> Unit,
+fun PurchaseSection(
+    state: PurchaseSectionUI,
+    orderCompleteToggleVisible: Boolean,
     modifier: Modifier = Modifier
 ) {
-    Column(modifier) {
-        MarkComplete(
-            markOrderComplete = markOrderComplete,
-            onMarkOrderCompleteChange = onMarkOrderCompleteChange
+    if (!state.isVisible) return
+    if (LocalConfiguration.current.orientation == Configuration.ORIENTATION_LANDSCAPE) {
+        PurchasesSectionLandscape(
+            state = state,
+            orderCompleteToggleVisible = orderCompleteToggleVisible,
+            modifier = modifier
         )
-        PurchaseButton(total, onPurchaseShippingLabel)
+    } else {
+        PurchasesSectionPortrait(
+            state = state,
+            orderCompleteToggleVisible = orderCompleteToggleVisible,
+            modifier = modifier
+        )
     }
 }
 
 @Composable
-internal fun PurchasesSectionLandscape(
-    total: String?,
-    markOrderComplete: Boolean,
-    onMarkOrderCompleteChange: (Boolean) -> Unit,
-    onPurchaseShippingLabel: () -> Unit,
+private fun PurchasesSectionPortrait(
+    state: PurchaseSectionUI,
+    orderCompleteToggleVisible: Boolean,
     modifier: Modifier = Modifier
 ) {
-    Column(modifier.fillMaxWidth()) {
-        Row(verticalAlignment = Alignment.CenterVertically) {
+    Column(
+        verticalArrangement = Arrangement.spacedBy(8.dp),
+        modifier = modifier
+    ) {
+        AnimatedVisibility(orderCompleteToggleVisible) {
             MarkComplete(
-                markOrderComplete = markOrderComplete,
-                onMarkOrderCompleteChange = onMarkOrderCompleteChange,
-                modifier = Modifier.weight(1f)
+                markOrderComplete = state.markOrderComplete,
+                onMarkOrderCompleteChange = state.onMarkOrderCompleteChange
             )
-            PurchaseButton(
-                total = total,
-                onPurchaseShippingLabel = onPurchaseShippingLabel,
+        }
+
+        PurchaseButton(
+            total = state.formattedPrice,
+            onPurchaseShippingLabel = state.onPurchaseShippingLabel
+        )
+    }
+}
+
+@Composable
+private fun PurchasesSectionLandscape(
+    state: PurchaseSectionUI,
+    orderCompleteToggleVisible: Boolean,
+    modifier: Modifier = Modifier
+) {
+    Row(
+        verticalAlignment = Alignment.CenterVertically,
+        horizontalArrangement = Arrangement.spacedBy(16.dp),
+        modifier = modifier
+    ) {
+        AnimatedVisibility(orderCompleteToggleVisible) {
+            MarkComplete(
+                markOrderComplete = state.markOrderComplete,
+                onMarkOrderCompleteChange = state.onMarkOrderCompleteChange,
                 modifier = Modifier.weight(1f)
             )
         }
-    }
-}
-
-@Preview(widthDp = 750, heightDp = 200)
-@Composable
-fun PurchasesSectionLandscapePreview() {
-    WooThemeWithBackground {
-        PurchasesSectionLandscape(
-            total = "$12.00",
-            markOrderComplete = true,
-            onMarkOrderCompleteChange = {},
-            onPurchaseShippingLabel = {},
-            modifier = Modifier.padding(dimensionResource(R.dimen.major_100))
+        PurchaseButton(
+            total = state.formattedPrice,
+            onPurchaseShippingLabel = state.onPurchaseShippingLabel,
+            modifier = Modifier.weight(1f)
         )
     }
 }
@@ -79,11 +101,11 @@ internal fun MarkComplete(
     modifier: Modifier = Modifier
 ) {
     Row(
+        horizontalArrangement = Arrangement.spacedBy(16.dp),
+        verticalAlignment = Alignment.CenterVertically,
         modifier = modifier
             .clickable { onMarkOrderCompleteChange(!markOrderComplete) }
-            .fillMaxWidth()
-            .padding(dimensionResource(R.dimen.major_100)),
-        verticalAlignment = Alignment.CenterVertically
+            .fillMaxWidth(),
     ) {
         Text(
             text = stringResource(id = R.string.shipping_label_shipment_details_mark_order_complete),
@@ -91,9 +113,7 @@ internal fun MarkComplete(
         )
         WCSwitch(
             checked = markOrderComplete,
-            onCheckedChange = onMarkOrderCompleteChange,
-            modifier = Modifier
-                .padding(end = dimensionResource(R.dimen.minor_100))
+            onCheckedChange = onMarkOrderCompleteChange
         )
     }
 }
@@ -113,24 +133,28 @@ internal fun PurchaseButton(
         text = buttonText,
         modifier = modifier
             .fillMaxWidth()
-            .padding(
-                top = dimensionResource(R.dimen.minor_100),
-                bottom = dimensionResource(R.dimen.major_100),
-                start = dimensionResource(R.dimen.major_100),
-                end = dimensionResource(R.dimen.major_100)
-            )
     )
 }
 
 @Preview
 @Composable
-internal fun PurchasesSectionPreview() {
+internal fun PurchasesSectionPortraitPreview() {
     WooThemeWithBackground {
-        PurchasesSection(
-            total = null,
-            markOrderComplete = true,
-            onMarkOrderCompleteChange = {},
-            onPurchaseShippingLabel = {},
+        PurchasesSectionPortrait(
+            state = ShippingLabelSampleData.getPurchaseSection(),
+            orderCompleteToggleVisible = true,
+            modifier = Modifier.padding(dimensionResource(R.dimen.major_100))
+        )
+    }
+}
+
+@Preview(widthDp = 750, heightDp = 120)
+@Composable
+fun PurchasesSectionLandscapePreview() {
+    WooThemeWithBackground {
+        PurchasesSectionLandscape(
+            state = ShippingLabelSampleData.getPurchaseSection(),
+            orderCompleteToggleVisible = true,
             modifier = Modifier.padding(dimensionResource(R.dimen.major_100))
         )
     }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/PurchaseSection.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/PurchaseSection.kt
@@ -79,11 +79,10 @@ private fun PurchasesSectionLandscape(
         horizontalArrangement = Arrangement.spacedBy(16.dp),
         modifier = modifier
     ) {
-        AnimatedVisibility(orderCompleteToggleVisible) {
+        AnimatedVisibility(visible = orderCompleteToggleVisible, modifier = Modifier.weight(1f)) {
             MarkComplete(
                 markOrderComplete = state.markOrderComplete,
                 onMarkOrderCompleteChange = state.onMarkOrderCompleteChange,
-                modifier = Modifier.weight(1f)
             )
         }
         PurchaseButton(

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/ShipmentDetails.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/ShipmentDetails.kt
@@ -77,7 +77,6 @@ fun ShipmentDetails(
     destinationStatus: AddressStatus,
     markOrderComplete: Boolean = false,
     onMarkOrderCompleteChange: (Boolean) -> Unit,
-    onEditPaymentMethodClicked: () -> Unit,
     handlerModifier: Modifier = Modifier,
     shipmentPurchased: Boolean
 ) {
@@ -138,7 +137,6 @@ fun ShipmentDetails(
                 onEditDestinationAddress = onEditDestinationAddress,
                 onEditOriginAddress = onEditOriginAddress,
                 onOriginAddressSelected = onOriginAddressSelected,
-                onEditPaymentMethodClicked = onEditPaymentMethodClicked,
                 destinationStatus = destinationStatus
             )
         } else {
@@ -156,7 +154,6 @@ fun ShipmentDetails(
                 onEditDestinationAddress = onEditDestinationAddress,
                 onEditOriginAddress = onEditOriginAddress,
                 onOriginAddressSelected = onOriginAddressSelected,
-                onEditPaymentMethodClicked = onEditPaymentMethodClicked,
                 destinationStatus = destinationStatus
             )
         }
@@ -176,7 +173,6 @@ private fun ShipmentDetailsPortrait(
     onEditDestinationAddress: (DestinationShippingAddress) -> Unit,
     onEditOriginAddress: (OriginShippingAddress) -> Unit,
     onOriginAddressSelected: (OriginShippingAddress) -> Unit,
-    onEditPaymentMethodClicked: () -> Unit,
     destinationStatus: AddressStatus,
     modifier: Modifier = Modifier,
     shipmentPurchased: Boolean
@@ -203,7 +199,6 @@ private fun ShipmentDetailsPortrait(
             if (!shipmentPurchased) {
                 PaymentSection(
                     paymentsSectionUI = paymentsSectionUI,
-                    onEditPaymentMethodClicked = onEditPaymentMethodClicked,
                     modifier = Modifier.padding(16.dp)
                 )
             }
@@ -234,7 +229,6 @@ private fun ShipmentDetailsLandscape(
     onEditDestinationAddress: (DestinationShippingAddress) -> Unit,
     onEditOriginAddress: (OriginShippingAddress) -> Unit,
     onOriginAddressSelected: (OriginShippingAddress) -> Unit,
-    onEditPaymentMethodClicked: () -> Unit,
     destinationStatus: AddressStatus,
     modifier: Modifier = Modifier,
     shipmentPurchased: Boolean = false
@@ -271,7 +265,6 @@ private fun ShipmentDetailsLandscape(
                     if (!shipmentPurchased) {
                         PaymentSection(
                             paymentsSectionUI = paymentsSectionUI,
-                            onEditPaymentMethodClicked = onEditPaymentMethodClicked,
                             modifier = Modifier.padding(16.dp)
                         )
                     }
@@ -465,7 +458,6 @@ private fun TotalItem(
 @Composable
 private fun PaymentSection(
     paymentsSectionUI: PaymentsSectionUI,
-    onEditPaymentMethodClicked: () -> Unit,
     modifier: Modifier = Modifier
 ) {
     Column(
@@ -479,7 +471,7 @@ private fun PaymentSection(
         Row(
             verticalAlignment = Alignment.CenterVertically,
             modifier = Modifier
-                .clickable(onClick = onEditPaymentMethodClicked)
+                .clickable(onClick = paymentsSectionUI.onEditPaymentMethodClicked)
                 .padding(vertical = 4.dp)
         ) {
             if (paymentsSectionUI.selectedPaymentMethod != null) {
@@ -615,7 +607,6 @@ fun ShipmentDetailsLandscapePreview() {
                 destinationStatus = AddressStatus.VERIFIED,
                 markOrderComplete = false,
                 onMarkOrderCompleteChange = {},
-                onEditPaymentMethodClicked = {},
                 handlerModifier = Modifier,
                 shipmentPurchased = false
             )

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/ShipmentDetails.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/ShipmentDetails.kt
@@ -1,6 +1,7 @@
 package com.woocommerce.android.ui.orders.wooshippinglabels
 
 import android.content.res.Configuration
+import androidx.activity.compose.BackHandler
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.interaction.MutableInteractionSource
@@ -37,6 +38,7 @@ import androidx.compose.runtime.derivedStateOf
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableIntStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -67,6 +69,7 @@ import com.woocommerce.android.ui.orders.wooshippinglabels.components.NoticeBann
 import com.woocommerce.android.ui.orders.wooshippinglabels.models.DestinationShippingAddress
 import com.woocommerce.android.ui.orders.wooshippinglabels.models.OriginShippingAddress
 import com.woocommerce.android.util.StringUtils
+import kotlinx.coroutines.launch
 
 @Composable
 fun ShipmentDetails(
@@ -80,7 +83,6 @@ fun ShipmentDetails(
     purchaseSectionUI: PurchaseSectionUI,
     modifier: Modifier = Modifier,
     noticeBannerUiState: NoticeBannerUiState? = null,
-    onShipmentDetailsExpandedChange: (Boolean) -> Unit,
     onEditDestinationAddress: (DestinationShippingAddress) -> Unit,
     onEditOriginAddress: (OriginShippingAddress) -> Unit,
     onOriginAddressSelected: (OriginShippingAddress) -> Unit,
@@ -100,6 +102,11 @@ fun ShipmentDetails(
         } else {
             it
         }
+    }
+    val coroutineScope = rememberCoroutineScope()
+
+    BackHandler(enabled = bottomSheetState.isExpanded) {
+        coroutineScope.launch { bottomSheetState.collapse() }
     }
 
     val isLandscape = LocalConfiguration.current.orientation == Configuration.ORIENTATION_LANDSCAPE
@@ -138,7 +145,15 @@ fun ShipmentDetails(
                 .padding(top = 16.dp)
                 .align(Alignment.CenterHorizontally)
                 .clickable(
-                    onClick = { onShipmentDetailsExpandedChange(bottomSheetState.isCollapsed) },
+                    onClick = {
+                        coroutineScope.launch {
+                            if (bottomSheetState.isCollapsed) {
+                                bottomSheetState.expand()
+                            } else {
+                                bottomSheetState.collapse()
+                            }
+                        }
+                    },
                     interactionSource = remember { MutableInteractionSource() },
                     indication = null
                 )
@@ -661,7 +676,6 @@ fun ShipmentDetailsExpandedPreview() {
                 purchaseSectionUI = ShippingLabelSampleData.getPurchaseSection(),
                 modifier = Modifier.fillMaxSize(),
                 noticeBannerUiState = null,
-                onShipmentDetailsExpandedChange = {},
                 onEditDestinationAddress = {},
                 onEditOriginAddress = {},
                 onOriginAddressSelected = {},
@@ -696,7 +710,6 @@ private fun ShipmentDetailsCollapsedPreview() {
                 purchaseSectionUI = ShippingLabelSampleData.getPurchaseSection(),
                 modifier = Modifier.heightIn(max = 180.dp),
                 noticeBannerUiState = null,
-                onShipmentDetailsExpandedChange = {},
                 onEditDestinationAddress = {},
                 onEditOriginAddress = {},
                 onOriginAddressSelected = {},

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/ShipmentDetails.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/ShipmentDetails.kt
@@ -104,10 +104,7 @@ fun ShipmentDetails(
         }
     }
     val coroutineScope = rememberCoroutineScope()
-
-    BackHandler(enabled = bottomSheetState.isExpanded) {
-        coroutineScope.launch { bottomSheetState.collapse() }
-    }
+    val density = LocalDensity.current
 
     val isLandscape = LocalConfiguration.current.orientation == Configuration.ORIENTATION_LANDSCAPE
 
@@ -122,7 +119,9 @@ fun ShipmentDetails(
         }
     }
 
-    val density = LocalDensity.current
+    BackHandler(enabled = bottomSheetState.isExpanded) {
+        coroutineScope.launch { bottomSheetState.collapse() }
+    }
 
     LaunchedEffect(collapsedContentHeight) {
         val peekHeight = with(density) {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/ShipmentDetails.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/ShipmentDetails.kt
@@ -133,7 +133,7 @@ fun ShipmentDetails(
 
     Column(modifier.fillMaxHeight()) {
         Icon(
-            painter = if (bottomSheetState.isExpanded) {
+            painter = if (expandProgress > 0.5f) {
                 painterResource(R.drawable.ic_arrow_down_26)
             } else {
                 painterResource(R.drawable.ic_arrow_up_26)

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/ShipmentDetails.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/ShipmentDetails.kt
@@ -1,7 +1,6 @@
 package com.woocommerce.android.ui.orders.wooshippinglabels
 
 import android.content.res.Configuration
-import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.interaction.MutableInteractionSource
@@ -12,15 +11,17 @@ import androidx.compose.foundation.layout.IntrinsicSize
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxHeight
+import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.heightIn
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.sizeIn
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
-import androidx.compose.material.BottomSheetScaffoldState
+import androidx.compose.material.BottomSheetState
+import androidx.compose.material.BottomSheetValue
 import androidx.compose.material.Divider
 import androidx.compose.material.Icon
 import androidx.compose.material.MaterialTheme
@@ -29,13 +30,22 @@ import androidx.compose.material.Text
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Add
 import androidx.compose.material.icons.filled.Edit
-import androidx.compose.material.rememberBottomSheetScaffoldState
+import androidx.compose.material.rememberBottomSheetState
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.derivedStateOf
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableIntStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.alpha
+import androidx.compose.ui.graphics.graphicsLayer
+import androidx.compose.ui.layout.onSizeChanged
 import androidx.compose.ui.platform.LocalConfiguration
 import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.res.colorResource
 import androidx.compose.ui.res.dimensionResource
 import androidx.compose.ui.res.painterResource
@@ -60,103 +70,165 @@ import com.woocommerce.android.util.StringUtils
 
 @Composable
 fun ShipmentDetails(
-    scaffoldState: BottomSheetScaffoldState,
+    bottomSheetState: BottomSheetState,
     totalItems: Int,
     totalItemsCost: String,
     shippingLines: List<ShippingLineSummaryUI>,
     shippingAddresses: WooShippingAddresses,
     shipmentCostUI: ShipmentCostUI?,
     paymentsSectionUI: PaymentsSectionUI,
+    purchaseSectionUI: PurchaseSectionUI,
     modifier: Modifier = Modifier,
     noticeBannerUiState: NoticeBannerUiState? = null,
-    isShipmentDetailsExpanded: Boolean = false,
     onShipmentDetailsExpandedChange: (Boolean) -> Unit,
     onEditDestinationAddress: (DestinationShippingAddress) -> Unit,
     onEditOriginAddress: (OriginShippingAddress) -> Unit,
     onOriginAddressSelected: (OriginShippingAddress) -> Unit,
     destinationStatus: AddressStatus,
-    markOrderComplete: Boolean = false,
-    onMarkOrderCompleteChange: (Boolean) -> Unit,
-    handlerModifier: Modifier = Modifier,
-    shipmentPurchased: Boolean
+    shipmentPurchased: Boolean,
+    onPeekHeightChanged: (Dp) -> Unit
 ) {
-    Column {
-        Column(
-            handlerModifier
+    val expandProgress = bottomSheetState.progress(
+        from = BottomSheetValue.Collapsed,
+        to = BottomSheetValue.Expanded
+    ).let {
+        if (it == 1f && bottomSheetState.isCollapsed &&
+            bottomSheetState.targetValue == BottomSheetValue.Collapsed
+        ) {
+            // Sometimes the progress is 1f at the end of the collapse drag, we want to reset it to 0f
+            0f
+        } else {
+            it
+        }
+    }
+
+    val isLandscape = LocalConfiguration.current.orientation == Configuration.ORIENTATION_LANDSCAPE
+
+    var expandableContentHeight by remember { mutableIntStateOf(0) }
+    var sheetHandleHeight by remember { mutableIntStateOf(0) }
+    var topSectionHeight by remember { mutableIntStateOf(0) }
+    var purchaseSectionHeight by remember { mutableIntStateOf(0) }
+
+    val collapsedContentHeight by remember(purchaseSectionUI.isVisible) {
+        derivedStateOf {
+            sheetHandleHeight + topSectionHeight + if (purchaseSectionUI.isVisible) purchaseSectionHeight else 0
+        }
+    }
+
+    val density = LocalDensity.current
+
+    LaunchedEffect(collapsedContentHeight) {
+        val peekHeight = with(density) {
+            collapsedContentHeight.toDp()
+        }
+        onPeekHeightChanged(peekHeight)
+    }
+
+    Column(modifier.fillMaxHeight()) {
+        Icon(
+            painter = if (bottomSheetState.isExpanded) {
+                painterResource(R.drawable.ic_arrow_down_26)
+            } else {
+                painterResource(R.drawable.ic_arrow_up_26)
+            },
+            contentDescription = stringResource(R.string.order_creation_expand_collapse_order_totals),
+            tint = colorResource(id = R.color.color_primary),
+            modifier = Modifier
+                .onSizeChanged { sheetHandleHeight = it.height }
+                .padding(top = 16.dp)
+                .align(Alignment.CenterHorizontally)
                 .clickable(
-                    onClick = { onShipmentDetailsExpandedChange(isShipmentDetailsExpanded.not()) },
+                    onClick = { onShipmentDetailsExpandedChange(bottomSheetState.isCollapsed) },
                     interactionSource = remember { MutableInteractionSource() },
                     indication = null
                 )
-                .fillMaxWidth()
-                .padding(dimensionResource(R.dimen.minor_100)),
-            verticalArrangement = Arrangement.Center,
-            horizontalAlignment = Alignment.CenterHorizontally
+        )
+
+        Box(
+            Modifier
+                .onSizeChanged { expandableContentHeight = it.height }
+                .weight(1f)
         ) {
-            Icon(
-                modifier = Modifier.padding(top = dimensionResource(R.dimen.minor_100)),
-                painter = if (scaffoldState.bottomSheetState.isExpanded) {
-                    painterResource(R.drawable.ic_arrow_down_26)
-                } else {
-                    painterResource(R.drawable.ic_arrow_up_26)
-                },
-                contentDescription = stringResource(R.string.order_creation_expand_collapse_order_totals),
-                tint = colorResource(id = R.color.color_primary),
-            )
-            AnimatedVisibility(isShipmentDetailsExpanded.not()) {
+            if (expandProgress < 1f) {
                 Column(
                     horizontalAlignment = Alignment.CenterHorizontally,
+                    verticalArrangement = Arrangement.spacedBy(8.dp),
+                    modifier = Modifier
+                        .onSizeChanged { topSectionHeight = it.height }
+                        .padding(horizontal = 16.dp)
+                        .padding(top = 8.dp, bottom = 16.dp)
+                        .fillMaxWidth()
+                        .alpha(1 - expandProgress)
                 ) {
                     Text(
                         text = stringResource(R.string.shipping_label_shipment_details_title),
                         color = MaterialTheme.colors.primary,
                         modifier = Modifier
-                            .padding(top = dimensionResource(R.dimen.minor_100) * LocalConfiguration.current.fontScale)
                     )
-
                     NoticeBanner(noticeBannerUiState)
+                }
+            }
 
-                    Spacer(
-                        modifier = Modifier.size(
-                            dimensionResource(R.dimen.major_200) * LocalConfiguration.current.fontScale
+            if (expandProgress > 0f) {
+                Column(
+                    modifier = Modifier
+                        .padding(vertical = 16.dp)
+                        .alpha(expandProgress)
+                ) {
+                    if (isLandscape) {
+                        ShipmentDetailsLandscape(
+                            totalItems = totalItems,
+                            totalItemsCost = totalItemsCost,
+                            shippingLines = shippingLines,
+                            shippingAddresses = shippingAddresses,
+                            shipmentCostUI = shipmentCostUI,
+                            paymentsSectionUI = paymentsSectionUI,
+                            modifier = Modifier
+                                .weight(1f)
+                                .padding(horizontal = 16.dp),
+                            shipmentPurchased = shipmentPurchased,
+                            onEditDestinationAddress = onEditDestinationAddress,
+                            onEditOriginAddress = onEditOriginAddress,
+                            onOriginAddressSelected = onOriginAddressSelected,
+                            destinationStatus = destinationStatus
                         )
-                    )
+                    } else {
+                        ShipmentDetailsPortrait(
+                            totalItems = totalItems,
+                            totalItemsCost = totalItemsCost,
+                            shippingLines = shippingLines,
+                            shippingAddresses = shippingAddresses,
+                            shipmentCostUI = shipmentCostUI,
+                            paymentsSectionUI = paymentsSectionUI,
+                            modifier = Modifier
+                                .weight(1f)
+                                .padding(horizontal = 16.dp),
+                            shipmentPurchased = shipmentPurchased,
+                            onEditDestinationAddress = onEditDestinationAddress,
+                            onEditOriginAddress = onEditOriginAddress,
+                            onOriginAddressSelected = onOriginAddressSelected,
+                            destinationStatus = destinationStatus
+                        )
+                    }
+
+                    Divider()
                 }
             }
         }
-        if (LocalConfiguration.current.orientation == Configuration.ORIENTATION_LANDSCAPE) {
-            ShipmentDetailsLandscape(
-                totalItems = totalItems,
-                totalItemsCost = totalItemsCost,
-                shippingLines = shippingLines,
-                shippingAddresses = shippingAddresses,
-                shipmentCostUI = shipmentCostUI,
-                paymentsSectionUI = paymentsSectionUI,
-                modifier = modifier.padding(top = dimensionResource(R.dimen.major_100)),
-                shipmentPurchased = shipmentPurchased,
-                onEditDestinationAddress = onEditDestinationAddress,
-                onEditOriginAddress = onEditOriginAddress,
-                onOriginAddressSelected = onOriginAddressSelected,
-                destinationStatus = destinationStatus
-            )
-        } else {
-            ShipmentDetailsPortrait(
-                totalItems = totalItems,
-                totalItemsCost = totalItemsCost,
-                shippingLines = shippingLines,
-                markOrderComplete = markOrderComplete,
-                shippingAddresses = shippingAddresses,
-                shipmentCostUI = shipmentCostUI,
-                paymentsSectionUI = paymentsSectionUI,
-                modifier = modifier.padding(top = dimensionResource(R.dimen.minor_100)),
-                shipmentPurchased = shipmentPurchased,
-                onMarkOrderCompleteChange = onMarkOrderCompleteChange,
-                onEditDestinationAddress = onEditDestinationAddress,
-                onEditOriginAddress = onEditOriginAddress,
-                onOriginAddressSelected = onOriginAddressSelected,
-                destinationStatus = destinationStatus
-            )
-        }
+
+        PurchaseSection(
+            state = purchaseSectionUI,
+            orderCompleteToggleVisible = isLandscape || bottomSheetState.isExpanded,
+            modifier = Modifier
+                .onSizeChanged { purchaseSectionHeight = it.height }
+                .graphicsLayer(
+                    translationY = (expandProgress - 1) * (expandableContentHeight - topSectionHeight)
+                )
+                .fillMaxWidth()
+                .background(MaterialTheme.colors.surface)
+                .padding(horizontal = 16.dp)
+                .padding(bottom = 16.dp)
+        )
     }
 }
 
@@ -166,10 +238,8 @@ private fun ShipmentDetailsPortrait(
     totalItemsCost: String,
     shippingLines: List<ShippingLineSummaryUI>,
     shippingAddresses: WooShippingAddresses,
-    markOrderComplete: Boolean,
     shipmentCostUI: ShipmentCostUI?,
     paymentsSectionUI: PaymentsSectionUI,
-    onMarkOrderCompleteChange: (Boolean) -> Unit,
     onEditDestinationAddress: (DestinationShippingAddress) -> Unit,
     onEditOriginAddress: (OriginShippingAddress) -> Unit,
     onOriginAddressSelected: (OriginShippingAddress) -> Unit,
@@ -177,44 +247,29 @@ private fun ShipmentDetailsPortrait(
     modifier: Modifier = Modifier,
     shipmentPurchased: Boolean
 ) {
-    Column(modifier) {
-        Column(
-            Modifier
-                .fillMaxWidth()
-                .weight(1f)
-                .verticalScroll(rememberScrollState())
-        ) {
-            OrderDetailsSection(
-                shippingAddresses = shippingAddresses,
-                totalItems = totalItems,
-                totalItemsCost = totalItemsCost,
-                shippingLines = shippingLines,
-                isReadOnly = shipmentPurchased,
-                onEditDestinationAddress = onEditDestinationAddress,
-                onEditOriginAddress = onEditOriginAddress,
-                onOriginAddressSelected = onOriginAddressSelected,
-                destinationStatus = destinationStatus
-            )
-            Divider(modifier = Modifier.padding(horizontal = 16.dp))
-            if (!shipmentPurchased) {
-                PaymentSection(
-                    paymentsSectionUI = paymentsSectionUI,
-                    modifier = Modifier.padding(16.dp)
-                )
-            }
-            Divider(modifier = Modifier.padding(horizontal = 16.dp))
-            ShipmentCostSection(
-                shipmentCostUI = shipmentCostUI,
-                modifier = Modifier.padding(16.dp)
-            )
+    Column(
+        verticalArrangement = Arrangement.spacedBy(16.dp),
+        modifier = modifier
+            .fillMaxWidth()
+            .verticalScroll(rememberScrollState())
+    ) {
+        OrderDetailsSection(
+            shippingAddresses = shippingAddresses,
+            totalItems = totalItems,
+            totalItemsCost = totalItemsCost,
+            shippingLines = shippingLines,
+            isReadOnly = shipmentPurchased,
+            onEditDestinationAddress = onEditDestinationAddress,
+            onEditOriginAddress = onEditOriginAddress,
+            onOriginAddressSelected = onOriginAddressSelected,
+            destinationStatus = destinationStatus
+        )
+        Divider()
+        if (!shipmentPurchased) {
+            PaymentSection(paymentsSectionUI = paymentsSectionUI)
         }
-        if (shipmentPurchased.not()) {
-            Divider()
-            MarkComplete(
-                markOrderComplete = markOrderComplete,
-                onMarkOrderCompleteChange = onMarkOrderCompleteChange
-            )
-        }
+        Divider()
+        ShipmentCostSection(shipmentCostUI = shipmentCostUI)
     }
 }
 
@@ -233,48 +288,49 @@ private fun ShipmentDetailsLandscape(
     modifier: Modifier = Modifier,
     shipmentPurchased: Boolean = false
 ) {
-    Column(modifier) {
-        Column(
-            Modifier
+    Column(
+        modifier
+            .fillMaxWidth()
+            .verticalScroll(rememberScrollState())
+    ) {
+        AddressSectionLandscape(
+            shippingAddresses = shippingAddresses,
+            isReadOnly = shipmentPurchased,
+            onEditDestinationAddress = onEditDestinationAddress,
+            onEditOriginAddress = onEditOriginAddress,
+            onOriginAddressSelected = onOriginAddressSelected,
+            destinationStatus = destinationStatus
+        )
+        Row(
+            modifier = Modifier
+                .height(IntrinsicSize.Min)
                 .fillMaxWidth()
-                .weight(1f)
-                .verticalScroll(rememberScrollState())
         ) {
-            AddressSectionLandscape(
-                shippingAddresses = shippingAddresses,
-                modifier = Modifier.padding(horizontal = 16.dp),
-                isReadOnly = shipmentPurchased,
-                onEditDestinationAddress = onEditDestinationAddress,
-                onEditOriginAddress = onEditOriginAddress,
-                onOriginAddressSelected = onOriginAddressSelected,
-                destinationStatus = destinationStatus
-            )
-            Row(
+            OrderDetailsSectionLandscape(
+                totalItems = totalItems,
+                totalItemsCost = totalItemsCost,
+                shippingLines = shippingLines,
                 modifier = Modifier
-                    .height(IntrinsicSize.Min)
-                    .fillMaxWidth()
-            ) {
-                OrderDetailsSectionLandscape(
-                    totalItems = totalItems,
-                    totalItemsCost = totalItemsCost,
-                    shippingLines = shippingLines,
-                    modifier = Modifier.weight(1f)
-                )
-                VerticalDivider(modifier = Modifier.padding(top = 16.dp))
-                Column(modifier = Modifier.weight(1f)) {
-                    if (!shipmentPurchased) {
-                        PaymentSection(
-                            paymentsSectionUI = paymentsSectionUI,
-                            modifier = Modifier.padding(16.dp)
-                        )
-                    }
-                    Divider()
-                    ShipmentCostSection(
-                        shipmentCostUI = shipmentCostUI,
+                    .weight(1f)
+                    .padding(end = 16.dp)
+            )
+            VerticalDivider(Modifier.padding(top = 16.dp))
+            Column(modifier = Modifier.weight(1f)) {
+                if (!shipmentPurchased) {
+                    PaymentSection(
+                        paymentsSectionUI = paymentsSectionUI,
                         modifier = Modifier
-                            .padding(16.dp)
+                            .padding(vertical = 16.dp)
+                            .padding(start = 16.dp)
                     )
                 }
+                Divider()
+                ShipmentCostSection(
+                    shipmentCostUI = shipmentCostUI,
+                    modifier = Modifier
+                        .padding(vertical = 16.dp)
+                        .padding(start = 16.dp)
+                )
             }
         }
     }
@@ -314,15 +370,15 @@ private fun OrderDetailsSection(
     modifier: Modifier = Modifier,
     isReadOnly: Boolean = false
 ) {
-    Column(modifier.fillMaxWidth()) {
+    Column(
+        verticalArrangement = Arrangement.spacedBy(16.dp),
+        modifier = modifier.fillMaxWidth()
+    ) {
         ShipmentDetailsSectionTitle(
-            title = stringResource(R.string.shipping_label_shipment_details_order_details),
-            modifier = Modifier.padding(start = dimensionResource(R.dimen.major_100))
+            title = stringResource(R.string.shipping_label_shipment_details_order_details)
         )
-        Spacer(modifier = Modifier.height(dimensionResource(R.dimen.major_100)))
         AddressSectionPortrait(
             shippingAddresses = shippingAddresses,
-            modifier = Modifier.padding(horizontal = dimensionResource(R.dimen.major_100)),
             isReadOnly = isReadOnly,
             onEditDestinationAddress = onEditDestinationAddress,
             onEditOriginAddress = onEditOriginAddress,
@@ -333,7 +389,6 @@ private fun OrderDetailsSection(
             totalItems = totalItems,
             totalItemsCost = totalItemsCost,
             shippingLines = shippingLines,
-            modifier = Modifier.padding(dimensionResource(R.dimen.major_100))
         )
     }
 }
@@ -345,19 +400,20 @@ private fun OrderDetailsSectionLandscape(
     shippingLines: List<ShippingLineSummaryUI>,
     modifier: Modifier = Modifier,
 ) {
-    Column(modifier.fillMaxWidth()) {
+    Column(
+        verticalArrangement = Arrangement.spacedBy(16.dp),
+        modifier = modifier.fillMaxWidth()
+    ) {
         ShipmentDetailsSectionTitle(
             title = stringResource(R.string.shipping_label_shipment_details_order_details),
             modifier = Modifier.padding(
-                top = dimensionResource(R.dimen.major_100),
-                start = dimensionResource(R.dimen.major_100)
+                top = dimensionResource(R.dimen.major_100)
             )
         )
         TotalCard(
             totalItems = totalItems,
             totalItemsCost = totalItemsCost,
             shippingLines = shippingLines,
-            modifier = Modifier.padding(dimensionResource(R.dimen.major_100))
         )
     }
 }
@@ -421,7 +477,7 @@ private fun TotalItem(
     Row(
         modifier = modifier
             .fillMaxWidth()
-            .padding(dimensionResource(R.dimen.minor_50)),
+            .padding(vertical = dimensionResource(R.dimen.minor_50)),
         verticalAlignment = Alignment.CenterVertically
     ) {
         Box(
@@ -514,7 +570,10 @@ private fun ShipmentCostSection(
         )
 
         val serviceName = if (shipmentCostUI?.optionsWithFees?.isNotEmpty() == true) {
-            stringResource(R.string.shipping_label_shipment_details_shipment_cost_base_fee, shipmentCostUI.serviceName)
+            stringResource(
+                R.string.shipping_label_shipment_details_shipment_cost_base_fee,
+                shipmentCostUI.serviceName
+            )
         } else {
             shipmentCostUI?.serviceName
         }
@@ -582,11 +641,13 @@ fun VerticalDivider(
 @LightDarkThemePreviews
 @OrientationPreviews
 @Composable
-fun ShipmentDetailsLandscapePreview() {
+fun ShipmentDetailsExpandedPreview() {
     WooThemeWithBackground {
         Surface {
             ShipmentDetails(
-                scaffoldState = rememberBottomSheetScaffoldState(),
+                bottomSheetState = rememberBottomSheetState(
+                    initialValue = BottomSheetValue.Expanded
+                ),
                 totalItems = 6,
                 totalItemsCost = "$92.78",
                 shippingLines = ShippingLabelSampleData.getShippingLines(),
@@ -597,18 +658,51 @@ fun ShipmentDetailsLandscapePreview() {
                 ),
                 shipmentCostUI = null,
                 paymentsSectionUI = ShippingLabelSampleData.getPaymentsSection(),
-                modifier = Modifier,
+                purchaseSectionUI = ShippingLabelSampleData.getPurchaseSection(),
+                modifier = Modifier.fillMaxSize(),
                 noticeBannerUiState = null,
-                isShipmentDetailsExpanded = false,
                 onShipmentDetailsExpandedChange = {},
                 onEditDestinationAddress = {},
                 onEditOriginAddress = {},
                 onOriginAddressSelected = {},
                 destinationStatus = AddressStatus.VERIFIED,
-                markOrderComplete = false,
-                onMarkOrderCompleteChange = {},
-                handlerModifier = Modifier,
-                shipmentPurchased = false
+                shipmentPurchased = false,
+                onPeekHeightChanged = {}
+            )
+        }
+    }
+}
+
+@LightDarkThemePreviews
+@OrientationPreviews
+@Composable
+private fun ShipmentDetailsCollapsedPreview() {
+    WooThemeWithBackground {
+        Surface {
+            ShipmentDetails(
+                bottomSheetState = rememberBottomSheetState(
+                    initialValue = BottomSheetValue.Collapsed
+                ),
+                totalItems = 6,
+                totalItemsCost = "$92.78",
+                shippingLines = ShippingLabelSampleData.getShippingLines(),
+                shippingAddresses = WooShippingAddresses(
+                    shipFrom = ShippingLabelSampleData.getShipFrom(),
+                    shipTo = ShippingLabelSampleData.getShipTo(),
+                    originAddresses = listOf(ShippingLabelSampleData.getShipFrom())
+                ),
+                shipmentCostUI = null,
+                paymentsSectionUI = ShippingLabelSampleData.getPaymentsSection(),
+                purchaseSectionUI = ShippingLabelSampleData.getPurchaseSection(),
+                modifier = Modifier.heightIn(max = 180.dp),
+                noticeBannerUiState = null,
+                onShipmentDetailsExpandedChange = {},
+                onEditDestinationAddress = {},
+                onEditOriginAddress = {},
+                onOriginAddressSelected = {},
+                destinationStatus = AddressStatus.VERIFIED,
+                shipmentPurchased = false,
+                onPeekHeightChanged = {},
             )
         }
     }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/ShippingLabelSampleData.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/ShippingLabelSampleData.kt
@@ -61,7 +61,8 @@ object ShippingLabelSampleData {
     }
 
     fun getPaymentsSection() = PaymentsSectionUI(
-        selectedPaymentMethod = getPaymentMethod()
+        selectedPaymentMethod = getPaymentMethod(),
+        onEditPaymentMethodClicked = {}
     )
 
     fun getPaymentOptions(countOfPaymentMethods: Int = 3) = PaymentMethodOptions(

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/ShippingLabelSampleData.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/ShippingLabelSampleData.kt
@@ -65,6 +65,14 @@ object ShippingLabelSampleData {
         onEditPaymentMethodClicked = {}
     )
 
+    fun getPurchaseSection() = PurchaseSectionUI(
+        markOrderComplete = true,
+        isVisible = true,
+        formattedPrice = "$10.00",
+        onPurchaseShippingLabel = {},
+        onMarkOrderCompleteChange = {},
+    )
+
     fun getPaymentOptions(countOfPaymentMethods: Int = 3) = PaymentMethodOptions(
         selectedPaymentId = if (countOfPaymentMethods > 0) 1 else null,
         paymentMethods = List(countOfPaymentMethods) { getPaymentMethod(it) },

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/WooShippingLabelCreationFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/WooShippingLabelCreationFragment.kt
@@ -18,7 +18,6 @@ import com.woocommerce.android.ui.base.UIMessageResolver
 import com.woocommerce.android.ui.compose.theme.WooThemeWithBackground
 import com.woocommerce.android.ui.dialog.WooDialog
 import com.woocommerce.android.ui.main.AppBarStatus
-import com.woocommerce.android.ui.main.MainActivity.Companion.BackPressListener
 import com.woocommerce.android.ui.orders.shippinglabels.creation.ShippingLabelHazmatCategory
 import com.woocommerce.android.ui.orders.wooshippinglabels.WooShippingLabelCreationViewModel.NavigatePackageSelection
 import com.woocommerce.android.ui.orders.wooshippinglabels.WooShippingLabelCreationViewModel.NavigateToCustomsFormEdit
@@ -44,7 +43,7 @@ import java.io.File
 import javax.inject.Inject
 
 @AndroidEntryPoint
-class WooShippingLabelCreationFragment : BaseFragment(), BackPressListener {
+class WooShippingLabelCreationFragment : BaseFragment() {
     @Inject
     lateinit var uiMessageResolver: UIMessageResolver
 
@@ -177,8 +176,6 @@ class WooShippingLabelCreationFragment : BaseFragment(), BackPressListener {
             viewModel.onUPSTermsAccepted()
         }
     }
-
-    override fun onRequestAllowBackPress(): Boolean = viewModel.allowBackNavigation()
 
     private fun openShippingLabelPreview(file: File) {
         ActivityUtils.previewPDFFile(requireActivity(), file)

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/WooShippingLabelCreationScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/WooShippingLabelCreationScreen.kt
@@ -1,11 +1,9 @@
 package com.woocommerce.android.ui.orders.wooshippinglabels
 
-import android.content.res.Configuration
 import androidx.compose.foundation.background
 import androidx.compose.foundation.border
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.interaction.MutableInteractionSource
-import androidx.compose.foundation.isSystemInDarkTheme
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -45,12 +43,13 @@ import androidx.compose.material3.SnackbarResult
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.platform.LocalConfiguration
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.res.colorResource
 import androidx.compose.ui.res.dimensionResource
@@ -74,7 +73,6 @@ import com.woocommerce.android.ui.orders.wooshippinglabels.WooShippingLabelCreat
 import com.woocommerce.android.ui.orders.wooshippinglabels.WooShippingLabelCreationViewModel.PackageSelectionState
 import com.woocommerce.android.ui.orders.wooshippinglabels.WooShippingLabelCreationViewModel.PackageSelectionState.DataAvailable
 import com.woocommerce.android.ui.orders.wooshippinglabels.WooShippingLabelCreationViewModel.PackageSelectionState.NotSelected
-import com.woocommerce.android.ui.orders.wooshippinglabels.WooShippingLabelCreationViewModel.ShippingRatesState
 import com.woocommerce.android.ui.orders.wooshippinglabels.address.AddressStatus
 import com.woocommerce.android.ui.orders.wooshippinglabels.components.PrintShippingLabelSection
 import com.woocommerce.android.ui.orders.wooshippinglabels.components.ShipmentTabData
@@ -103,13 +101,13 @@ fun WooShippingLabelCreationScreen(viewModel: WooShippingLabelCreationViewModel)
         is WooShippingLabelCreationViewModel.WooShippingViewState.DataState -> {
             WooShippingLabelCreationScreen(
                 onSelectPackageClick = viewModel::onSelectPackageClicked,
-                onPurchaseShippingLabel = viewModel::onPurchaseShippingLabel,
                 shipmentUIList = viewState.shipmentUIList,
                 shouldShowSplitShipmentButton = viewState.shouldShowSplitShipmentButton,
                 totalItems = viewState.totalItems,
                 totalItemsCost = viewState.totalItemsCost,
                 shippingLines = viewState.shippingLines,
                 paymentsSectionUI = viewState.paymentsSectionUI,
+                purchaseSectionUI = viewState.purchaseSectionUI,
                 shippingAddresses = viewState.shippingAddresses,
                 onSelectedShipmentChanged = viewModel::onSelectedShipmentChanged,
                 onOriginAddressSelected = viewModel::onOriginAddressSelected,
@@ -119,7 +117,6 @@ fun WooShippingLabelCreationScreen(viewModel: WooShippingLabelCreationViewModel)
                 customWeightList = viewModel.customWeight,
                 onCustomWeightChange = viewModel::onCustomWeightChange,
                 uiState = viewState.uiState,
-                onMarkOrderCompleteChange = viewModel::onMarkOrderCompleteChange,
                 onNavigateBack = viewModel::onNavigateBack,
                 onShipmentDetailsExpandedChange = viewModel::onShipmentDetailsExpandedChange,
                 onEditCustomsClick = viewModel::onEditCustomsClick,
@@ -157,18 +154,17 @@ fun WooShippingLabelCreationScreen(
     totalItemsCost: String,
     shippingLines: List<ShippingLineSummaryUI>,
     paymentsSectionUI: PaymentsSectionUI,
+    purchaseSectionUI: PurchaseSectionUI,
     shippingAddresses: WooShippingAddresses,
     onSelectedShipmentChanged: (index: Int) -> Unit,
     onOriginAddressSelected: (OriginShippingAddress) -> Unit,
     onEditOriginAddress: (OriginShippingAddress) -> Unit,
     onSelectPackageClick: () -> Unit,
-    onPurchaseShippingLabel: () -> Unit,
     onSelectedRateSortOrderChanged: (ShippingSortOption) -> Unit,
     onRefreshShippingRates: () -> Unit,
     onCustomWeightChange: (String) -> Unit,
     customWeightList: List<String>,
     uiState: WooShippingLabelCreationViewModel.UIControlsState,
-    onMarkOrderCompleteChange: (Boolean) -> Unit,
     onShipmentDetailsExpandedChange: (Boolean) -> Unit,
     onEditCustomsClick: () -> Unit,
     onNavigateBack: () -> Unit,
@@ -217,6 +213,7 @@ fun WooShippingLabelCreationScreen(
             scaffoldState = scaffoldState,
             shippingLines = shippingLines,
             paymentsSectionUI = paymentsSectionUI,
+            purchaseSectionUI = purchaseSectionUI,
             shippingAddresses = shippingAddresses,
             onSelectedShipmentChanged = onSelectedShipmentChanged,
             onOriginAddressSelected = onOriginAddressSelected,
@@ -227,7 +224,6 @@ fun WooShippingLabelCreationScreen(
             onCustomWeightChange = onCustomWeightChange,
             uiState = uiState,
             onNavigateBack = onNavigateBack,
-            onMarkOrderCompleteChange = onMarkOrderCompleteChange,
             onShipmentDetailsExpandedChange = onShipmentDetailsExpandedChange,
             onEditCustomsClick = onEditCustomsClick,
             onEditDestinationAddress = onEditDestinationAddress,
@@ -243,39 +239,8 @@ fun WooShippingLabelCreationScreen(
             onPrintCustomsClicked = onPrintCustomsClicked,
             onLearnMoreClicked = onLearnMoreClicked,
         )
-        val isDarkTheme = isSystemInDarkTheme()
-        val isCollapsed = scaffoldState.bottomSheetState.isCollapsed
-        val elevation = when {
-            isDarkTheme && isCollapsed -> 7.dp
-            !isDarkTheme && isCollapsed -> 0.dp
-            isDarkTheme && !isCollapsed -> 16.dp
-            else -> 8.dp
-        }
+
         val selectedShipment = shipmentUIList[uiState.selectedIndex]
-        val selectedShippingRatesState = selectedShipment.shippingRatesState
-        if (selectedShippingRatesState is ShippingRatesState.DataState && !selectedShipment.purchased) {
-            Box(
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .align(Alignment.BottomCenter)
-            ) {
-                Surface(elevation = elevation) {
-                    if (LocalConfiguration.current.orientation == Configuration.ORIENTATION_LANDSCAPE) {
-                        PurchasesSectionLandscape(
-                            total = selectedShipment.shipmentCostUI?.formattedTotalPrice,
-                            markOrderComplete = uiState.markOrderComplete,
-                            onMarkOrderCompleteChange = onMarkOrderCompleteChange,
-                            onPurchaseShippingLabel = onPurchaseShippingLabel
-                        )
-                    } else {
-                        PurchaseButton(
-                            total = selectedShipment.shipmentCostUI?.formattedTotalPrice,
-                            onPurchaseShippingLabel = onPurchaseShippingLabel
-                        )
-                    }
-                }
-            }
-        }
         val selectedPurchaseState = selectedShipment.purchaseState
         if (selectedPurchaseState is PurchaseState.InProgress) {
             Box(
@@ -304,6 +269,7 @@ private fun LabelCreationScreenWithBottomSheet(
     totalItemsCost: String,
     shippingLines: List<ShippingLineSummaryUI>,
     paymentsSectionUI: PaymentsSectionUI,
+    purchaseSectionUI: PurchaseSectionUI,
     onSelectPackageClick: () -> Unit,
     shippingAddresses: WooShippingAddresses,
     onSelectedShipmentChanged: (index: Int) -> Unit,
@@ -315,7 +281,6 @@ private fun LabelCreationScreenWithBottomSheet(
     onCustomWeightChange: (String) -> Unit,
     uiState: WooShippingLabelCreationViewModel.UIControlsState,
     scaffoldState: BottomSheetScaffoldState,
-    onMarkOrderCompleteChange: (Boolean) -> Unit,
     onNavigateBack: () -> Unit,
     onShipmentDetailsExpandedChange: (Boolean) -> Unit,
     onEditCustomsClick: () -> Unit,
@@ -336,24 +301,8 @@ private fun LabelCreationScreenWithBottomSheet(
     val snackbarHostState = remember { SnackbarHostState() }
 
     val selectedShipment = shipmentUIList[uiState.selectedIndex]
-    val shippingRatesState = selectedShipment.shippingRatesState
-    val isPurchaseButtonDisplayed = shippingRatesState is ShippingRatesState.DataState && !selectedShipment.purchased
-    val requiresLargePeekHeight = isPurchaseButtonDisplayed || uiState.noticeBannerUiState != null
 
-    val bottomSheetPeekHeight = when {
-        requiresLargePeekHeight -> 128.dp
-        else -> 72.dp
-    } * LocalConfiguration.current.fontScale
-
-    val paddingBottom = when {
-        isPurchaseButtonDisplayed -> 72.dp
-        else -> 0.dp
-    }
-    val snackbarPaddingBottom = if (isPurchaseButtonDisplayed && scaffoldState.bottomSheetState.isExpanded) {
-        paddingBottom
-    } else {
-        0.dp
-    }
+    var bottomSheetPeekHeight by remember { mutableStateOf(0.dp) }
 
     val screenTitle = if (shipmentUIList[uiState.selectedIndex].purchased) {
         R.string.shipping_label_print_screen_title
@@ -363,26 +312,21 @@ private fun LabelCreationScreenWithBottomSheet(
 
     BottomSheetScaffold(
         snackbarHost = {
-            SnackbarHost(
-                snackbarHostState,
-                modifier = Modifier.padding(bottom = snackbarPaddingBottom)
-            ) { data ->
+            SnackbarHost(snackbarHostState) { data ->
                 val visuals = data.visuals as ShippingLabelsSnackbarVisuals
                 ShippingLabelsSnackbar(visuals = visuals, action = { data.performAction() })
             }
         },
         sheetContent = {
             ShipmentDetails(
-                scaffoldState = scaffoldState,
+                bottomSheetState = scaffoldState.bottomSheetState,
                 totalItems = totalItems,
                 totalItemsCost = totalItemsCost,
                 shippingLines = shippingLines,
-                onMarkOrderCompleteChange = onMarkOrderCompleteChange,
                 shippingAddresses = shippingAddresses,
                 shipmentCostUI = selectedShipment.shipmentCostUI,
                 paymentsSectionUI = paymentsSectionUI,
-                isShipmentDetailsExpanded = uiState.isShipmentDetailsExpanded,
-                markOrderComplete = uiState.markOrderComplete,
+                purchaseSectionUI = purchaseSectionUI,
                 onShipmentDetailsExpandedChange = onShipmentDetailsExpandedChange,
                 onEditDestinationAddress = onEditDestinationAddress,
                 onEditOriginAddress = onEditOriginAddress,
@@ -390,6 +334,7 @@ private fun LabelCreationScreenWithBottomSheet(
                 destinationStatus = destinationStatus,
                 noticeBannerUiState = uiState.noticeBannerUiState,
                 shipmentPurchased = selectedShipment.purchased,
+                onPeekHeightChanged = { bottomSheetPeekHeight = it },
             )
         },
         sheetPeekHeight = bottomSheetPeekHeight,
@@ -929,9 +874,9 @@ private fun WooShippingLabelCreationScreenPreview() {
             totalItemsCost = "$92.78",
             shippingLines = ShippingLabelSampleData.getShippingLines(),
             paymentsSectionUI = ShippingLabelSampleData.getPaymentsSection(),
+            purchaseSectionUI = ShippingLabelSampleData.getPurchaseSection(),
             modifier = Modifier.fillMaxSize(),
             onSelectPackageClick = {},
-            onPurchaseShippingLabel = {},
             shippingAddresses = WooShippingAddresses(
                 shipFrom = ShippingLabelSampleData.getShipFrom(),
                 shipTo = ShippingLabelSampleData.getShipTo(),
@@ -943,7 +888,6 @@ private fun WooShippingLabelCreationScreenPreview() {
             onSelectedRateSortOrderChanged = {},
             customWeightList = listOf(""),
             onCustomWeightChange = {},
-            onMarkOrderCompleteChange = {},
             onNavigateBack = {},
             onEditOriginAddress = {},
             uiState = WooShippingLabelCreationViewModel.UIControlsState(

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/WooShippingLabelCreationScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/WooShippingLabelCreationScreen.kt
@@ -19,9 +19,7 @@ import androidx.compose.foundation.text.BasicTextField
 import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.BottomSheetScaffold
-import androidx.compose.material.BottomSheetScaffoldDefaults
 import androidx.compose.material.BottomSheetScaffoldState
-import androidx.compose.material.BottomSheetState
 import androidx.compose.material.BottomSheetValue
 import androidx.compose.material.CircularProgressIndicator
 import androidx.compose.material.Icon
@@ -37,6 +35,7 @@ import androidx.compose.material.icons.filled.Edit
 import androidx.compose.material.icons.filled.Star
 import androidx.compose.material.icons.outlined.Star
 import androidx.compose.material.rememberBottomSheetScaffoldState
+import androidx.compose.material.rememberBottomSheetState
 import androidx.compose.material3.SnackbarHost
 import androidx.compose.material3.SnackbarHostState
 import androidx.compose.material3.SnackbarResult
@@ -50,7 +49,6 @@ import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.res.colorResource
 import androidx.compose.ui.res.dimensionResource
 import androidx.compose.ui.res.stringResource
@@ -118,7 +116,6 @@ fun WooShippingLabelCreationScreen(viewModel: WooShippingLabelCreationViewModel)
                 onCustomWeightChange = viewModel::onCustomWeightChange,
                 uiState = viewState.uiState,
                 onNavigateBack = viewModel::onNavigateBack,
-                onShipmentDetailsExpandedChange = viewModel::onShipmentDetailsExpandedChange,
                 onEditCustomsClick = viewModel::onEditCustomsClick,
                 onEditDestinationAddress = viewModel::onEditDestinationAddress,
                 destinationStatus = viewState.destinationStatus,
@@ -165,7 +162,6 @@ fun WooShippingLabelCreationScreen(
     onCustomWeightChange: (String) -> Unit,
     customWeightList: List<String>,
     uiState: WooShippingLabelCreationViewModel.UIControlsState,
-    onShipmentDetailsExpandedChange: (Boolean) -> Unit,
     onEditCustomsClick: () -> Unit,
     onNavigateBack: () -> Unit,
     onEditDestinationAddress: (DestinationShippingAddress) -> Unit,
@@ -182,20 +178,8 @@ fun WooShippingLabelCreationScreen(
     onPrintCustomsClicked: () -> Unit,
     onLearnMoreClicked: () -> Unit,
 ) {
-    val shipmentDetailsValue = if (uiState.isShipmentDetailsExpanded) {
-        BottomSheetValue.Expanded
-    } else {
-        BottomSheetValue.Collapsed
-    }
-
-    val shipmentDetailsBottomSheetState = BottomSheetState(
-        initialValue = shipmentDetailsValue,
-        animationSpec = BottomSheetScaffoldDefaults.AnimationSpec,
-        density = LocalDensity.current,
-        confirmValueChange = {
-            onShipmentDetailsExpandedChange(it == BottomSheetValue.Expanded)
-            true
-        }
+    val shipmentDetailsBottomSheetState = rememberBottomSheetState(
+        initialValue = BottomSheetValue.Collapsed
     )
 
     val scaffoldState = rememberBottomSheetScaffoldState(
@@ -224,7 +208,6 @@ fun WooShippingLabelCreationScreen(
             onCustomWeightChange = onCustomWeightChange,
             uiState = uiState,
             onNavigateBack = onNavigateBack,
-            onShipmentDetailsExpandedChange = onShipmentDetailsExpandedChange,
             onEditCustomsClick = onEditCustomsClick,
             onEditDestinationAddress = onEditDestinationAddress,
             destinationStatus = destinationStatus,
@@ -282,7 +265,6 @@ private fun LabelCreationScreenWithBottomSheet(
     uiState: WooShippingLabelCreationViewModel.UIControlsState,
     scaffoldState: BottomSheetScaffoldState,
     onNavigateBack: () -> Unit,
-    onShipmentDetailsExpandedChange: (Boolean) -> Unit,
     onEditCustomsClick: () -> Unit,
     onEditDestinationAddress: (DestinationShippingAddress) -> Unit,
     destinationStatus: AddressStatus,
@@ -327,7 +309,6 @@ private fun LabelCreationScreenWithBottomSheet(
                 shipmentCostUI = selectedShipment.shipmentCostUI,
                 paymentsSectionUI = paymentsSectionUI,
                 purchaseSectionUI = purchaseSectionUI,
-                onShipmentDetailsExpandedChange = onShipmentDetailsExpandedChange,
                 onEditDestinationAddress = onEditDestinationAddress,
                 onEditOriginAddress = onEditOriginAddress,
                 onOriginAddressSelected = onOriginAddressSelected,
@@ -892,10 +873,8 @@ private fun WooShippingLabelCreationScreenPreview() {
             onEditOriginAddress = {},
             uiState = WooShippingLabelCreationViewModel.UIControlsState(
                 markOrderComplete = false,
-                isShipmentDetailsExpanded = false,
                 paperSizeOption = WooShippingLabelPaperSize.LABEL
             ),
-            onShipmentDetailsExpandedChange = {},
             onEditCustomsClick = {},
             onEditDestinationAddress = {},
             destinationStatus = AddressStatus.VERIFIED,

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/WooShippingLabelCreationScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/WooShippingLabelCreationScreen.kt
@@ -135,7 +135,6 @@ fun WooShippingLabelCreationScreen(viewModel: WooShippingLabelCreationViewModel)
                 onRefundClicked = viewModel::onRefundClicked,
                 onPrintCustomsClicked = viewModel::onPrintCustomsClicked,
                 onLearnMoreClicked = viewModel::onLearnMoreClicked,
-                onEditPaymentMethodClicked = viewModel::onEditPaymentMethodClicked,
             )
         }
 
@@ -186,7 +185,6 @@ fun WooShippingLabelCreationScreen(
     onRefundClicked: () -> Unit,
     onPrintCustomsClicked: () -> Unit,
     onLearnMoreClicked: () -> Unit,
-    onEditPaymentMethodClicked: () -> Unit,
 ) {
     val shipmentDetailsValue = if (uiState.isShipmentDetailsExpanded) {
         BottomSheetValue.Expanded
@@ -244,7 +242,6 @@ fun WooShippingLabelCreationScreen(
             onRefundClicked = onRefundClicked,
             onPrintCustomsClicked = onPrintCustomsClicked,
             onLearnMoreClicked = onLearnMoreClicked,
-            onEditPaymentMethodClicked = onEditPaymentMethodClicked,
         )
         val isDarkTheme = isSystemInDarkTheme()
         val isCollapsed = scaffoldState.bottomSheetState.isCollapsed
@@ -335,7 +332,6 @@ private fun LabelCreationScreenWithBottomSheet(
     onRefundClicked: () -> Unit,
     onPrintCustomsClicked: () -> Unit,
     onLearnMoreClicked: () -> Unit,
-    onEditPaymentMethodClicked: () -> Unit,
 ) {
     val snackbarHostState = remember { SnackbarHostState() }
 
@@ -394,7 +390,6 @@ private fun LabelCreationScreenWithBottomSheet(
                 destinationStatus = destinationStatus,
                 noticeBannerUiState = uiState.noticeBannerUiState,
                 shipmentPurchased = selectedShipment.purchased,
-                onEditPaymentMethodClicked = onEditPaymentMethodClicked,
             )
         },
         sheetPeekHeight = bottomSheetPeekHeight,
@@ -967,7 +962,6 @@ private fun WooShippingLabelCreationScreenPreview() {
             onRefundClicked = {},
             onPrintCustomsClicked = {},
             onLearnMoreClicked = {},
-            onEditPaymentMethodClicked = {},
         )
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/WooShippingLabelCreationScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/WooShippingLabelCreationScreen.kt
@@ -648,9 +648,9 @@ private fun SelectPackageCard(
             )
             .dashedBorder(
                 color = colorResource(R.color.divider_color),
-                strokeWidth = 2.dp,
-                dashLength = 8.dp,
-                gapLength = 8.dp,
+                strokeWidth = 1.dp,
+                dashLength = 4.dp,
+                gapLength = 6.dp,
                 shape = RoundedCornerShape(dimensionResource(R.dimen.corner_radius_large))
             )
             .padding(dimensionResource(id = R.dimen.major_200))

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/WooShippingLabelCreationViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/WooShippingLabelCreationViewModel.kt
@@ -528,7 +528,7 @@ class WooShippingLabelCreationViewModel @Inject constructor(
         }
     }
 
-    @Suppress("ComplexCondition")
+    @Suppress("ComplexCondition", "LongMethod")
     private suspend fun observeShippingLabelInformation() {
         combine(
             accountSettings,

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/WooShippingLabelCreationViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/WooShippingLabelCreationViewModel.kt
@@ -586,6 +586,14 @@ class WooShippingLabelCreationViewModel @Inject constructor(
                 paymentsSectionUI = PaymentsSectionUI(
                     selectedPaymentMethod = accountSettings.paymentMethodOptions.selectedPaymentMethod,
                     onEditPaymentMethodClicked = ::onEditPaymentMethodClicked
+                ),
+                purchaseSectionUI = PurchaseSectionUI(
+                    isVisible = !shipmentUIList[uiState.selectedIndex].purchased &&
+                        shippingRatesStatesFlow.value[uiState.selectedIndex] is ShippingRatesState.DataState,
+                    markOrderComplete = uiState.markOrderComplete,
+                    formattedPrice = shipmentUIList[uiState.selectedIndex].shipmentCostUI?.formattedTotalPrice,
+                    onMarkOrderCompleteChange = ::onMarkOrderCompleteChange,
+                    onPurchaseShippingLabel = ::onPurchaseShippingLabel
                 )
             )
         }.combine(loadTrigger.onStart { emit(Unit) }) { viewState, _ ->
@@ -1059,7 +1067,8 @@ class WooShippingLabelCreationViewModel @Inject constructor(
             val shippingAddresses: WooShippingAddresses,
             val uiState: UIControlsState,
             val destinationStatus: AddressStatus,
-            val paymentsSectionUI: PaymentsSectionUI
+            val paymentsSectionUI: PaymentsSectionUI,
+            val purchaseSectionUI: PurchaseSectionUI
         ) : WooShippingViewState() {
             val shouldShowSplitShipmentButton: Boolean
                 get() {
@@ -1246,6 +1255,14 @@ data class ShipmentCostUI(
     val formattedTotalPrice: String,
     val optionsWithFees: Map<String, String>,
 ) : Parcelable
+
+data class PurchaseSectionUI(
+    val isVisible: Boolean,
+    val markOrderComplete: Boolean,
+    val formattedPrice: String?,
+    val onMarkOrderCompleteChange: (Boolean) -> Unit,
+    val onPurchaseShippingLabel: () -> Unit,
+)
 
 data class PaymentsSectionUI(
     val selectedPaymentMethod: PaymentMethodModel?,

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/WooShippingLabelCreationViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/WooShippingLabelCreationViewModel.kt
@@ -583,7 +583,10 @@ class WooShippingLabelCreationViewModel @Inject constructor(
                 shippingAddresses = addresses,
                 uiState = uiState,
                 destinationStatus = destinationStatus,
-                paymentsSectionUI = PaymentsSectionUI(accountSettings.paymentMethodOptions.selectedPaymentMethod)
+                paymentsSectionUI = PaymentsSectionUI(
+                    selectedPaymentMethod = accountSettings.paymentMethodOptions.selectedPaymentMethod,
+                    onEditPaymentMethodClicked = ::onEditPaymentMethodClicked
+                )
             )
         }.combine(loadTrigger.onStart { emit(Unit) }) { viewState, _ ->
             viewState
@@ -969,10 +972,6 @@ class WooShippingLabelCreationViewModel @Inject constructor(
         triggerEvent(OpenLearnMoreScreen)
     }
 
-    fun onEditPaymentMethodClicked() {
-        triggerEvent(NavigateToPaymentMethodEdit)
-    }
-
     fun allowBackNavigation(): Boolean {
         val state = uiState.value
         return when {
@@ -1006,6 +1005,10 @@ class WooShippingLabelCreationViewModel @Inject constructor(
                 loadTrigger.emit(Unit)
             }
         }
+    }
+
+    private fun onEditPaymentMethodClicked() {
+        triggerEvent(NavigateToPaymentMethodEdit)
     }
 
     private fun List<ShippableItemModel>.isItnRequired(): Boolean {
@@ -1245,5 +1248,6 @@ data class ShipmentCostUI(
 ) : Parcelable
 
 data class PaymentsSectionUI(
-    val selectedPaymentMethod: PaymentMethodModel?
+    val selectedPaymentMethod: PaymentMethodModel?,
+    val onEditPaymentMethodClicked: () -> Unit
 )

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/WooShippingLabelCreationViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/WooShippingLabelCreationViewModel.kt
@@ -147,7 +147,6 @@ class WooShippingLabelCreationViewModel @Inject constructor(
         UIControlsState(
             markOrderComplete = false,
             selectedIndex = navArgs.shipmentId,
-            isShipmentDetailsExpanded = false,
             paperSizeOption = WooShippingLabelPaperSize.LABEL
         )
     )
@@ -696,10 +695,6 @@ class WooShippingLabelCreationViewModel @Inject constructor(
         uiState.update { it.copy(markOrderComplete = value) }
     }
 
-    fun onShipmentDetailsExpandedChange(value: Boolean) {
-        uiState.update { it.copy(isShipmentDetailsExpanded = value) }
-    }
-
     fun onSelectPackageClicked() {
         triggerEvent(NavigatePackageSelection)
     }
@@ -980,20 +975,8 @@ class WooShippingLabelCreationViewModel @Inject constructor(
         triggerEvent(OpenLearnMoreScreen)
     }
 
-    fun allowBackNavigation(): Boolean {
-        val state = uiState.value
-        return when {
-            state.isShipmentDetailsExpanded -> {
-                uiState.update { it.copy(isShipmentDetailsExpanded = false) }
-                false
-            }
-
-            else -> true
-        }
-    }
-
     fun onNavigateBack() {
-        if (allowBackNavigation()) triggerEvent(Event.Exit)
+        triggerEvent(Event.Exit)
     }
 
     fun onRetry() {
@@ -1126,7 +1109,6 @@ class WooShippingLabelCreationViewModel @Inject constructor(
     data class UIControlsState(
         val markOrderComplete: Boolean,
         val selectedIndex: Int = 0,
-        val isShipmentDetailsExpanded: Boolean,
         val noticeBannerUiState: NoticeBannerUiState? = null,
         val paperSizeOption: WooShippingLabelPaperSize,
     )

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/components/NoticeBanner.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/components/NoticeBanner.kt
@@ -73,7 +73,6 @@ fun NoticeBanner(noticeBannerUiState: NoticeBannerUiState?, modifier: Modifier =
         Row(
             verticalAlignment = Alignment.CenterVertically,
             modifier = rowModifier
-                .padding(dimensionResource(R.dimen.major_100))
                 .background(
                     color = colorResource(backgroundColor),
                     shape = RoundedCornerShape(dimensionResource(R.dimen.corner_radius_large))

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/payment/WooShippingEditPaymentScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/payment/WooShippingEditPaymentScreen.kt
@@ -41,10 +41,8 @@ import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.livedata.observeAsState
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.geometry.Size
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.input.nestedscroll.nestedScroll
-import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.platform.rememberNestedScrollInteropConnection
 import androidx.compose.ui.res.colorResource
 import androidx.compose.ui.res.dimensionResource
@@ -246,12 +244,6 @@ fun EmptyPaymentMethodsView(
     onAddNewPaymentMethod: () -> Unit,
     modifier: Modifier = Modifier
 ) {
-    val dividerColor = colorResource(R.color.divider_color)
-    val cornerRadius = MaterialTheme.shapes.medium.topStart.toPx(
-        shapeSize = Size.Unspecified,
-        density = LocalDensity.current
-    )
-
     Column(modifier) {
         Column(
             horizontalAlignment = Alignment.CenterHorizontally,

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/payment/WooShippingEditPaymentScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/payment/WooShippingEditPaymentScreen.kt
@@ -41,12 +41,8 @@ import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.livedata.observeAsState
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.draw.drawBehind
-import androidx.compose.ui.geometry.CornerRadius
 import androidx.compose.ui.geometry.Size
 import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.graphics.PathEffect
-import androidx.compose.ui.graphics.drawscope.Stroke
 import androidx.compose.ui.input.nestedscroll.nestedScroll
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.platform.rememberNestedScrollInteropConnection
@@ -63,6 +59,7 @@ import com.woocommerce.android.ui.compose.component.WCColoredButton
 import com.woocommerce.android.ui.compose.component.WCOutlinedButton
 import com.woocommerce.android.ui.compose.component.WCSwitch
 import com.woocommerce.android.ui.compose.component.web.WCWebView
+import com.woocommerce.android.ui.compose.modifiers.dashedBorder
 import com.woocommerce.android.ui.compose.preview.LightDarkThemePreviews
 import com.woocommerce.android.ui.compose.theme.WooThemeWithBackground
 import com.woocommerce.android.ui.orders.wooshippinglabels.ShippingLabelSampleData
@@ -254,7 +251,6 @@ fun EmptyPaymentMethodsView(
         shapeSize = Size.Unspecified,
         density = LocalDensity.current
     )
-    val borderWidth = with(LocalDensity.current) { 1.dp.toPx() }
 
     Column(modifier) {
         Column(
@@ -262,17 +258,13 @@ fun EmptyPaymentMethodsView(
             verticalArrangement = Arrangement.Center,
             modifier = Modifier
                 .fillMaxWidth()
-                .drawBehind {
-                    val stroke = Stroke(
-                        width = borderWidth,
-                        pathEffect = PathEffect.dashPathEffect(floatArrayOf(10f, 10f), 0f)
-                    )
-                    drawRoundRect(
-                        color = dividerColor,
-                        style = stroke,
-                        cornerRadius = CornerRadius(cornerRadius)
-                    )
-                }
+                .dashedBorder(
+                    color = colorResource(R.color.divider_color),
+                    shape = RoundedCornerShape(8.dp),
+                    strokeWidth = 1.dp,
+                    dashLength = 4.dp,
+                    gapLength = 6.dp,
+                )
         ) {
             Spacer(Modifier.height(48.dp))
             Image(

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/rates/ui/ShippingRatesCard.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/rates/ui/ShippingRatesCard.kt
@@ -115,9 +115,9 @@ internal fun ShippingRatesSectionMissingInfo(
         modifier = modifier
             .dashedBorder(
                 color = colorResource(R.color.divider_color),
-                strokeWidth = 2.dp,
-                dashLength = 8.dp,
-                gapLength = 8.dp,
+                strokeWidth = 1.dp,
+                dashLength = 4.dp,
+                gapLength = 6.dp,
                 shape = RoundedCornerShape(dimensionResource(R.dimen.corner_radius_large))
             )
             .padding(horizontal = 32.dp, vertical = 40.dp),
@@ -163,9 +163,9 @@ internal fun ShippingRatesLoading(
                 .fillMaxWidth()
                 .dashedBorder(
                     color = colorResource(R.color.divider_color),
-                    strokeWidth = 2.dp,
-                    dashLength = 8.dp,
-                    gapLength = 8.dp,
+                    strokeWidth = 1.dp,
+                    dashLength = 4.dp,
+                    gapLength = 6.dp,
                     shape = RoundedCornerShape(dimensionResource(R.dimen.corner_radius_large))
                 )
                 .padding(horizontal = 32.dp, vertical = 40.dp),

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/rates/ui/ShippingRatesSection.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/rates/ui/ShippingRatesSection.kt
@@ -27,7 +27,7 @@ internal fun ShippingRatesSection(
 
         is WooShippingLabelCreationViewModel.ShippingRatesState.MissingInfo -> {
             ShippingRatesSectionMissingInfo(
-                modifier = Modifier.padding(horizontal = 16.dp),
+                modifier = Modifier.fillMaxWidth().padding(horizontal = 16.dp),
                 missingInfo = shippingRatesState
             )
         }

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/WooShippingLabelCreationViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/WooShippingLabelCreationViewModelTest.kt
@@ -745,37 +745,6 @@ class WooShippingLabelCreationViewModelTest : BaseUnitTest() {
     }
 
     @Test
-    fun `when shipment details is expanded then the back gesture closes the sheet`() = testBlocking {
-        whenever(observeAccountSettings()) doReturn flowOf(null)
-
-        createViewModel()
-
-        advanceUntilIdle()
-        sut.onShipmentDetailsExpandedChange(true)
-
-        // Close shipment details
-        var shouldNavigateBack = sut.allowBackNavigation()
-        assertThat(shouldNavigateBack).isFalse()
-
-        // Navigate back
-        shouldNavigateBack = sut.allowBackNavigation()
-        assertThat(shouldNavigateBack).isTrue()
-    }
-
-    @Test
-    fun `when there is no bottom sheet expanded, then on back navigates to the previous screen`() = testBlocking {
-        whenever(observeAccountSettings()) doReturn flowOf(null)
-
-        createViewModel()
-
-        advanceUntilIdle()
-
-        // Navigate back
-        val shouldNavigateBack = sut.allowBackNavigation()
-        assertThat(shouldNavigateBack).isTrue()
-    }
-
-    @Test
     fun `when there are notices then display the notices`() = testBlocking {
         val notice = NoticeBannerUiState(
             message = R.string.woo_shipping_address_notification_destination_missing,


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

<!-- Id number of the Linear issue this PR addresses, e.g., WOOMOB-373. -->
Closes WOOMOB-753

### Description
My goal with this PR was to fix just the scrolling issues, but after looking at the layout, I found out that to properly fix them, we'll need to rework the layout, as before, we were showing the purchase button on top of the bottom sheet, which causes it to hide some of its content, making us think they are scrolling issues.

I know the PR is quite big, but hopefully the changes are easy to follow, and I think the most important part is the testing.

### Steps to reproduce
1. Open shipping labels creation form.
2. Test the shipment details bottom sheet.
3. Select a package and enter weight.
4. Test the shipment details bottom sheet again.

### Testing information
- Confirm the expand animation looks good.
- Confirm the peek height is calculated correctly.
- Confirm the purchase button doesn't hide any content.

### The tests that have been performed
The above.

### Images/gif
##### Portrait
https://github.com/user-attachments/assets/e0780f76-72b7-445d-ab31-3129c478f29a


##### Landscape
https://github.com/user-attachments/assets/cb63c17e-e81a-4973-bda2-e49d7b08e3cc

##### Before vs After
| Before | After |
| --- | --- |
| ![Screenshot_20250704_100511](https://github.com/user-attachments/assets/68578b78-ed4e-4be8-a752-d1912dc189fc) | ![Screenshot_20250704_100607](https://github.com/user-attachments/assets/02e7cedb-f8c5-448c-881e-745027d9cc1c) |
| ![Screenshot_20250704_100518](https://github.com/user-attachments/assets/3e2a8b7e-b0c7-41af-8357-a126d3733b16) | ![Screenshot_20250704_100614](https://github.com/user-attachments/assets/2fcd6c19-7637-4292-aa4a-8b783a2aa684) |
| ![Screenshot_20250704_100529](https://github.com/user-attachments/assets/a69ae9a2-74a2-4980-9184-289dde0b5f51) | ![Screenshot_20250704_100629](https://github.com/user-attachments/assets/6467b67d-0e91-4cd1-af45-0cd4166125c0) |
| ![Screenshot_20250704_100537](https://github.com/user-attachments/assets/42f206a5-aeea-4443-bcb2-f03658f44c44) | ![Screenshot_20250704_100639](https://github.com/user-attachments/assets/f9ca8398-42b8-48b0-80af-300cee94eb3f) |

- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->