### PR TITLE
[POS as a Tab i2] Add logic to determine if POS can be launched in the tab

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/tab/WooPosCanBeLaunched.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/tab/WooPosCanBeLaunched.kt
@@ -1,0 +1,95 @@
+package com.woocommerce.android.ui.woopos
+
+import com.woocommerce.android.extensions.semverCompareTo
+import com.woocommerce.android.tools.SelectedSite
+import com.woocommerce.android.util.GetWooCorePluginCachedVersion
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+import org.wordpress.android.fluxc.store.WooCommerceStore
+import javax.inject.Inject
+import javax.inject.Singleton
+
+@Singleton
+class WooPosCanBeLaunched @Inject constructor(
+    private val selectedSite: SelectedSite,
+    private val isScreenSizeAllowed: WooPosIsScreenSizeAllowed,
+    private val getWooCoreVersion: GetWooCorePluginCachedVersion,
+    private val wooCommerceStore: WooCommerceStore,
+    private val isRemotelyEnabled: WooPOSIsRemotelyEnabled
+) {
+    @Suppress("ReturnCount")
+    suspend operator fun invoke(): WooPosLaunchability = withContext(Dispatchers.IO) {
+        val selectedSite = selectedSite.getOrNull()
+            ?: return@withContext WooPosLaunchability.NotLaunchable(
+                WooPosLaunchability.Reason.NoSiteSelected
+            )
+
+        if (!isScreenSizeAllowed()) {
+            return@withContext WooPosLaunchability.NotLaunchable(
+                WooPosLaunchability.Reason.NotTablet
+            )
+        }
+
+        if (!isWooCoreSupportsOrderAutoDraftsAndExtraPaymentsProps()) {
+            return@withContext WooPosLaunchability.NotLaunchable(
+                WooPosLaunchability.Reason.UnsupportedWooCommerceVersion
+            )
+        }
+
+        if (isFeatureSwitchSupported() && isRemotelyEnabled() != true) {
+            return@withContext WooPosLaunchability.NotLaunchable(
+                WooPosLaunchability.Reason.FeatureSwitchDisabled
+            )
+        }
+
+        val siteSettings = wooCommerceStore.getSiteSettings(selectedSite)
+            ?: wooCommerceStore.fetchSiteGeneralSettings(selectedSite).model
+
+        if (siteSettings == null) {
+            return@withContext WooPosLaunchability.NotLaunchable(
+                WooPosLaunchability.Reason.SiteSettingsUnavailable
+            )
+        }
+
+        return@withContext if (isCurrencySupported(siteSettings.currencyCode)) {
+            WooPosLaunchability.Launchable
+        } else {
+            WooPosLaunchability.NotLaunchable(
+                WooPosLaunchability.Reason.UnsupportedCurrency
+            )
+        }
+    }
+
+    private fun isCurrencySupported(currency: String) = SUPPORTED_CURRENCIES.contains(currency)
+
+    private fun isWooCoreSupportsOrderAutoDraftsAndExtraPaymentsProps(): Boolean {
+        val wooCoreVersion = getWooCoreVersion() ?: return false
+        return wooCoreVersion.semverCompareTo(WC_VERSION_SUPPORTS_POS_PRODUCT_FILTERING) >= 0
+    }
+
+    private fun isFeatureSwitchSupported(): Boolean {
+        val wooCoreVersion = getWooCoreVersion() ?: return false
+        return wooCoreVersion.semverCompareTo(WC_VERSION_SUPPORTS_POS_FEATURE_SWITCH) >= 0
+    }
+
+    private companion object {
+        const val WC_VERSION_SUPPORTS_POS_PRODUCT_FILTERING = "9.6.0"
+        const val WC_VERSION_SUPPORTS_POS_FEATURE_SWITCH = "10.0.0"
+
+        val SUPPORTED_CURRENCIES = listOf("usd", "gbp")
+    }
+}
+
+sealed class WooPosLaunchability {
+    object Launchable : WooPosLaunchability()
+    data class NotLaunchable(val reason: Reason) : WooPosLaunchability()
+
+    enum class Reason {
+        NotTablet,
+        UnsupportedWooCommerceVersion,
+        SiteSettingsUnavailable,
+        FeatureSwitchDisabled,
+        UnsupportedCurrency,
+        NoSiteSelected,
+    }
+}

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/tab/WooPosCanBeLaunchedInTab.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/tab/WooPosCanBeLaunchedInTab.kt
@@ -9,8 +9,13 @@ import org.wordpress.android.fluxc.store.WooCommerceStore
 import javax.inject.Inject
 import javax.inject.Singleton
 
+/**
+ * Determines if POS can be launched *from within the POS tab* based on launch conditions,
+ * e.g., currency support, WooCommerce version, feature flags, etc.
+ * This is only checked once the POS tab is already visible.
+ */
 @Singleton
-class WooPosCanBeLaunched @Inject constructor(
+class WooPosCanBeLaunchedInTab @Inject constructor(
     private val selectedSite: SelectedSite,
     private val isScreenSizeAllowed: WooPosIsScreenSizeAllowed,
     private val getWooCoreVersion: GetWooCorePluginCachedVersion,
@@ -23,12 +28,6 @@ class WooPosCanBeLaunched @Inject constructor(
             ?: return@withContext WooPosLaunchability.NotLaunchable(
                 WooPosLaunchability.Reason.NoSiteSelected
             )
-
-        if (!isScreenSizeAllowed()) {
-            return@withContext WooPosLaunchability.NotLaunchable(
-                WooPosLaunchability.Reason.NotTablet
-            )
-        }
 
         if (!isWooCoreSupportsOrderAutoDraftsAndExtraPaymentsProps()) {
             return@withContext WooPosLaunchability.NotLaunchable(
@@ -85,7 +84,6 @@ sealed class WooPosLaunchability {
     data class NotLaunchable(val reason: Reason) : WooPosLaunchability()
 
     enum class Reason {
-        NotTablet,
         UnsupportedWooCommerceVersion,
         SiteSettingsUnavailable,
         FeatureSwitchDisabled,

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/tab/WooPosCanBeLaunchedInTab.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/tab/WooPosCanBeLaunchedInTab.kt
@@ -17,7 +17,6 @@ import javax.inject.Singleton
 @Singleton
 class WooPosCanBeLaunchedInTab @Inject constructor(
     private val selectedSite: SelectedSite,
-    private val isScreenSizeAllowed: WooPosIsScreenSizeAllowed,
     private val getWooCoreVersion: GetWooCorePluginCachedVersion,
     private val wooCommerceStore: WooCommerceStore,
     private val isRemotelyEnabled: WooPOSIsRemotelyEnabled

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/tab/WooPosCanBeLaunchedInTab.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/tab/WooPosCanBeLaunchedInTab.kt
@@ -1,7 +1,8 @@
-package com.woocommerce.android.ui.woopos
+package com.woocommerce.android.ui.woopos.tab
 
 import com.woocommerce.android.extensions.semverCompareTo
 import com.woocommerce.android.tools.SelectedSite
+import com.woocommerce.android.ui.woopos.WooPOSIsRemotelyEnabled
 import com.woocommerce.android.util.GetWooCorePluginCachedVersion
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/tab/WooPosCanBeLaunchedInTab.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/tab/WooPosCanBeLaunchedInTab.kt
@@ -59,7 +59,7 @@ class WooPosCanBeLaunchedInTab @Inject constructor(
         }
     }
 
-    private fun isCurrencySupported(currency: String) = SUPPORTED_CURRENCIES.contains(currency)
+    private fun isCurrencySupported(currency: String) = SUPPORTED_CURRENCIES.contains(currency.lowercase())
 
     private fun isWooCoreSupportsOrderAutoDraftsAndExtraPaymentsProps(): Boolean {
         val wooCoreVersion = getWooCoreVersion() ?: return false

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/tab/WooPosCanBeLaunchedInTabTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/tab/WooPosCanBeLaunchedInTabTest.kt
@@ -1,0 +1,131 @@
+package com.woocommerce.android.ui.woopos
+
+import com.woocommerce.android.tools.SelectedSite
+import com.woocommerce.android.ui.woopos.WooPosLaunchability.*
+import com.woocommerce.android.ui.woopos.WooPosLaunchability.Reason
+import com.woocommerce.android.ui.woopos.WooPosIsScreenSizeAllowed
+import com.woocommerce.android.util.GetWooCorePluginCachedVersion
+import com.woocommerce.android.viewmodel.BaseUnitTest
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import org.junit.Before
+import org.mockito.kotlin.any
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.whenever
+import org.wordpress.android.fluxc.model.LocalOrRemoteId
+import org.wordpress.android.fluxc.model.SiteModel
+import org.wordpress.android.fluxc.network.rest.wpcom.wc.WooResult
+import org.wordpress.android.fluxc.store.WooCommerceStore
+import org.wordpress.android.fluxc.wc.settings.WCSettingsTestUtils
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class WooPosCanBeLaunchedInTabTest : BaseUnitTest() {
+
+    private val selectedSite: SelectedSite = mock()
+    private val wooCommerceStore: WooCommerceStore = mock()
+
+    private val isRemotelyEnabled: WooPOSIsRemotelyEnabled = mock()
+    private val getWooCoreVersion: GetWooCorePluginCachedVersion = mock {
+        on { invoke() }.thenReturn("9.6.0")
+    }
+    private lateinit var sut: WooPosCanBeLaunchedInTab
+
+    @Before
+    fun setup() = testBlocking {
+        val siteModel = SiteModel().also { it.id = 1 }
+        whenever(selectedSite.getOrNull()).thenReturn(siteModel)
+        whenever(getWooCoreVersion()).thenReturn("10.0.0")
+        val siteSettings = buildSiteSettings()
+        whenever(wooCommerceStore.getSiteSettings(siteModel)).thenReturn(siteSettings)
+        whenever(isRemotelyEnabled.invoke()).thenReturn(true)
+
+        sut = WooPosCanBeLaunchedInTab(
+            selectedSite = selectedSite,
+            getWooCoreVersion = getWooCoreVersion,
+            wooCommerceStore = wooCommerceStore,
+            isRemotelyEnabled = isRemotelyEnabled
+        )
+    }
+
+    @Test
+    fun `given valid conditions, when invoked, then return Launchable`() = testBlocking {
+        val result = sut()
+        assertEquals(Launchable, result)
+    }
+
+    @Test
+    fun `given no site selected, when invoked, then return NotLaunchable with NoSiteSelected`() = testBlocking {
+        whenever(selectedSite.getOrNull()).thenReturn(null)
+        val result = sut()
+        assertEquals(NotLaunchable(Reason.NoSiteSelected), result)
+    }
+
+    @Test
+    fun `given unsupported WooCommerce version, when invoked, then return NotLaunchable with UnsupportedWooCommerceVersion`() = testBlocking {
+        whenever(getWooCoreVersion()).thenReturn("9.5.0") // lower than 9.6.0
+        val result = sut()
+        assertEquals(NotLaunchable(Reason.UnsupportedWooCommerceVersion), result)
+    }
+
+    @Test
+    fun `given feature switch supported but remotely disabled, when invoked, then return NotLaunchable with FeatureSwitchDisabled`() = testBlocking {
+        whenever(getWooCoreVersion()).thenReturn("10.0.0")
+        whenever(
+            isRemotelyEnabled.invoke()
+        ).thenReturn(false)
+
+        sut = WooPosCanBeLaunchedInTab(
+            selectedSite = selectedSite,
+            getWooCoreVersion = getWooCoreVersion,
+            wooCommerceStore = wooCommerceStore,
+            isRemotelyEnabled = isRemotelyEnabled
+        )
+
+        val result = sut()
+        assertEquals(NotLaunchable(Reason.FeatureSwitchDisabled), result)
+    }
+
+    @Test
+    fun `given null site settings, when invoked, then return NotLaunchable with SiteSettingsUnavailable`() = testBlocking {
+        whenever(wooCommerceStore.getSiteSettings(any())).thenReturn(null)
+        whenever(wooCommerceStore.fetchSiteGeneralSettings(any())).thenReturn(WooResult(null))
+        val result = sut()
+        assertEquals(NotLaunchable(Reason.SiteSettingsUnavailable), result)
+    }
+
+    @Test
+    fun `given unsupported currency, when invoked, then return NotLaunchable with UnsupportedCurrency`() = testBlocking {
+        val siteSettings = buildSiteSettings(currencyCode = "eur")
+        whenever(wooCommerceStore.getSiteSettings(any())).thenReturn(siteSettings)
+        val result = sut()
+        assertEquals(NotLaunchable(Reason.UnsupportedCurrency), result)
+    }
+
+    @Test
+    fun `given site settings missing but fetched successfully, when invoked, then return Launchable`() = testBlocking {
+        whenever(wooCommerceStore.getSiteSettings(any())).thenReturn(null)
+        val fetchedSettings = buildSiteSettings(currencyCode = "usd")
+        whenever(wooCommerceStore.fetchSiteGeneralSettings(any())).thenReturn(WooResult(fetchedSettings))
+
+        val result = sut()
+        assertEquals(Launchable, result)
+    }
+
+    @Test
+    fun `given site settings missing and fetched with unsupported currency, when invoked, then return NotLaunchable with UnsupportedCurrency`() = testBlocking {
+        whenever(wooCommerceStore.getSiteSettings(any())).thenReturn(null)
+        val fetchedSettings = buildSiteSettings(currencyCode = "eur")
+        whenever(wooCommerceStore.fetchSiteGeneralSettings(any())).thenReturn(WooResult(fetchedSettings))
+
+        val result = sut()
+        assertEquals(NotLaunchable(Reason.UnsupportedCurrency), result)
+    }
+
+    private fun buildSiteSettings(currencyCode: String = "usd") =
+        WCSettingsTestUtils.generateSettings(
+            siteId = LocalOrRemoteId.LocalId(1)
+        ).copy(
+            currencyCode = currencyCode
+        )
+}

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/tab/WooPosCanBeLaunchedInTabTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/tab/WooPosCanBeLaunchedInTabTest.kt
@@ -1,9 +1,10 @@
-package com.woocommerce.android.ui.woopos
+package com.woocommerce.android.ui.woopos.tab
 
 import com.woocommerce.android.tools.SelectedSite
-import com.woocommerce.android.ui.woopos.WooPosLaunchability.*
-import com.woocommerce.android.ui.woopos.WooPosLaunchability.Reason
-import com.woocommerce.android.ui.woopos.WooPosIsScreenSizeAllowed
+import com.woocommerce.android.ui.woopos.WooPOSIsRemotelyEnabled
+import com.woocommerce.android.ui.woopos.tab.WooPosLaunchability.Launchable
+import com.woocommerce.android.ui.woopos.tab.WooPosLaunchability.NotLaunchable
+import com.woocommerce.android.ui.woopos.tab.WooPosLaunchability.Reason
 import com.woocommerce.android.util.GetWooCorePluginCachedVersion
 import com.woocommerce.android.viewmodel.BaseUnitTest
 import kotlinx.coroutines.ExperimentalCoroutinesApi


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->
⚠️ This PR depends builds on top of https://github.com/woocommerce/woocommerce-android/pull/14271 Please do not merge until that one is merged too
<!-- Id number of the Linear issue this PR addresses, e.g., WOOMOB-373. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
This PR adds the logic to determine whether POS mode can be launched once the user visits the tab. It introduces a new class, WooPosCanBeLaunchedInTab, which checks the launch conditions and returns either that POS can be launched or, if not, the specific reason why it cannot.

This class is not yet used in the app; a future PR will integrate it to either launch POS or display an error explaining why it cannot be launched.

### Steps to reproduce
<!-- Step-by-step testing instructions. For new user flows, consider instead stating the goal of the workflow and see if your PR reviewer can accomplish the workflow without specific steps! -->
As it's not used yet, we just have to review the code and verify that tests pass.

- [X] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
