### PR TITLE
[WOOPRD-621] Remove isNumericOnly property from WooPOS barcode analytics events

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/util/analytics/WooPosAnalyticsEvent.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/util/analytics/WooPosAnalyticsEvent.kt
@@ -127,7 +127,6 @@ sealed class WooPosAnalyticsEvent : IAnalyticsEvent {
 
         data class BarcodeScanned(
             val scanDurationMs: Long,
-            val isNumericOnly: Boolean,
             val barcodeLength: Int,
             val scannerInfo: String?,
         ) : Event() {
@@ -138,7 +137,6 @@ sealed class WooPosAnalyticsEvent : IAnalyticsEvent {
                     mapOf(
                         "barcode_length" to barcodeLength.toString(),
                         "scan_duration_ms" to scanDurationMs.toString(),
-                        "is_numeric_only" to isNumericOnly.toString(),
                         "scanner_info" to (scannerInfo ?: "unknown")
                     )
                 )
@@ -147,7 +145,6 @@ sealed class WooPosAnalyticsEvent : IAnalyticsEvent {
 
         data class BarcodeScanningFailed(
             val scanDurationMs: Long,
-            val isNumericOnly: Boolean,
             val barcodeLength: Int,
             val scannerInfo: String?,
             val failReason: String,
@@ -159,7 +156,6 @@ sealed class WooPosAnalyticsEvent : IAnalyticsEvent {
                     mapOf(
                         "barcode_length" to barcodeLength.toString(),
                         "scan_duration_ms" to scanDurationMs.toString(),
-                        "is_numeric_only" to isNumericOnly.toString(),
                         "scanner_info" to (scannerInfo ?: "unknown"),
                         "fail_reason" to failReason
                     )

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/util/analytics/WooPosBarcodeEventTracker.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/util/analytics/WooPosBarcodeEventTracker.kt
@@ -20,7 +20,6 @@ class WooPosBarcodeEventTracker @Inject constructor(
                 analyticsTracker.track(
                     WooPosAnalyticsEvent.Event.BarcodeScanned(
                         scanDurationMs = result.scanDurationMs,
-                        isNumericOnly = result.barcode.all { it.isDigit() },
                         barcodeLength = result.barcode.length,
                         scannerInfo = scannerInfo,
                     )
@@ -31,7 +30,6 @@ class WooPosBarcodeEventTracker @Inject constructor(
                 analyticsTracker.track(
                     WooPosAnalyticsEvent.Event.BarcodeScanningFailed(
                         scanDurationMs = result.scanDurationMs,
-                        isNumericOnly = result.barcode.all { it.isDigit() },
                         barcodeLength = result.barcode.length,
                         scannerInfo = scannerInfo,
                         failReason = result.failureReason.value,


### PR DESCRIPTION
### Description

WOOPRD-621

This PR removes the `isNumericOnly` property from the WooPOS barcode analytics events (`BarcodeScanned` and `BarcodeScanningFailed`). This property is no longer needed for analytics tracking.

### Changes Made

- Removed `isNumericOnly` parameter from `BarcodeScanned` event in `WooPosAnalyticsEvent.kt`
- Removed `isNumericOnly` parameter from `BarcodeScanningFailed` event in `WooPosAnalyticsEvent.kt`
- Removed `is_numeric_only` property from analytics tracking in both events
- Updated `WooPosBarcodeEventTracker.kt` to not calculate or pass the `isNumericOnly` parameter

### Steps to reproduce

1. Open WooPOS mode
2. Scan a barcode (numeric or alphanumeric)
3. Verify that barcode scanning works correctly
4. Check that analytics events are still tracked properly (without the `is_numeric_only` property)

### The tests that have been performed
above

### Images/gif

N/A - This is an analytics-only change with no UI impact

- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.