### PR TITLE
[Shipping labels] Fix displaying only custom packages in saved tab

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/packages/WooShippingLabelPackageCreationViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/packages/WooShippingLabelPackageCreationViewModel.kt
@@ -6,7 +6,7 @@ import androidx.lifecycle.asLiveData
 import androidx.lifecycle.viewModelScope
 import com.woocommerce.android.R
 import com.woocommerce.android.tools.SelectedSite
-import com.woocommerce.android.ui.orders.wooshippinglabels.packages.datasource.FetchPredefinedPackagesFromStore
+import com.woocommerce.android.ui.orders.wooshippinglabels.packages.datasource.FetchPackagesFromStore
 import com.woocommerce.android.ui.orders.wooshippinglabels.packages.datasource.WooShippingLabelPackageRepository
 import com.woocommerce.android.ui.orders.wooshippinglabels.packages.networking.CustomPackageCreationRequestData
 import com.woocommerce.android.ui.orders.wooshippinglabels.packages.ui.Carrier
@@ -31,7 +31,7 @@ class WooShippingLabelPackageCreationViewModel @Inject constructor(
     savedState: SavedStateHandle,
     private val selectedSite: SelectedSite,
     private val resourceProvider: ResourceProvider,
-    private val fetchPredefinedPackages: FetchPredefinedPackagesFromStore,
+    private val fetchPackages: FetchPackagesFromStore,
     private val updateSavedCarrierPackages: UpdateSavedCarrierPackages,
     private val packageRepository: WooShippingLabelPackageRepository
 ) : ScopedViewModel(savedState) {
@@ -43,9 +43,7 @@ class WooShippingLabelPackageCreationViewModel @Inject constructor(
     val viewState = _viewState.asLiveData()
 
     private val storeOptions: StoreOptionsForPackages
-        get() = _viewState.value.predefinedPackagesData
-            ?.storeOptions
-            ?: StoreOptionsForPackages.DEFAULT
+        get() = _viewState.value.packagesData?.storeOptions ?: StoreOptionsForPackages.DEFAULT
 
     private val pageTabs
         get() = listOf(
@@ -69,31 +67,31 @@ class WooShippingLabelPackageCreationViewModel @Inject constructor(
 
     private fun loadData(): Job {
         return launch {
-            fetchPredefinedPackages().let { response ->
-                _viewState.update { viewState -> viewState.copy(predefinedPackagesState = response) }
+            fetchPackages().let { response ->
+                _viewState.update { viewState -> viewState.copy(packagesState = response) }
             }
         }
     }
 
     fun onCarrierPackageSelected(selectedPackage: PackageData, isSelected: Boolean) {
         _viewState.update { viewState ->
-            val predefinedPackages = viewState.predefinedPackagesData
-            predefinedPackages?.carrierPackages
+            val packages = viewState.packagesData
+            packages?.carrierPackages
                 ?.map { updateCarrierPackagesSelection(it, selectedPackage, isSelected) }
                 ?.let {
-                    viewState.copy(predefinedPackagesState = predefinedPackages.copy(carrierPackages = it.toMap()))
+                    viewState.copy(packagesState = packages.copy(carrierPackages = it.toMap()))
                 } ?: _viewState.value
         }
     }
 
     fun onSavedPackageSelected(selectedPackage: PackageData, isSelected: Boolean) {
         _viewState.update { viewState ->
-            val predefinedPackages = viewState.predefinedPackagesData
-            predefinedPackages?.savedPackages
+            val packages = viewState.packagesData
+            packages?.savedPackages
                 ?.map { it.copy(isSelected = false) }
                 ?.toMutableList()
                 ?.safelyUpdate(selectedPackage, selectedPackage.copy(isSelected = isSelected))
-                ?.let { viewState.copy(predefinedPackagesState = predefinedPackages.copy(savedPackages = it)) }
+                ?.let { viewState.copy(packagesState = packages.copy(savedPackages = it)) }
                 ?: _viewState.value
         }
     }
@@ -107,7 +105,7 @@ class WooShippingLabelPackageCreationViewModel @Inject constructor(
     }
 
     fun onAddCarrierPackageClick() {
-        _viewState.value.predefinedPackagesData?.carrierPackages
+        _viewState.value.packagesData?.carrierPackages
             ?.asSequence()
             ?.flatMap { it.value }
             ?.flatMap { it.packages }
@@ -116,7 +114,7 @@ class WooShippingLabelPackageCreationViewModel @Inject constructor(
     }
 
     fun onAddSavedPackageClick() {
-        _viewState.value.predefinedPackagesData
+        _viewState.value.packagesData
             ?.savedPackages
             ?.find { it.isSelected }
             ?.let { triggerEvent(PackageSelected(it)) }
@@ -256,8 +254,8 @@ class WooShippingLabelPackageCreationViewModel @Inject constructor(
 
     fun onCarrierPackageStarred(packageData: PackageData, isStarred: Boolean) {
         _viewState.update { viewState ->
-            val predefinedPackages = viewState.predefinedPackagesData ?: return@update viewState
-            val updatedCarrierPackages = predefinedPackages.carrierPackages.mapValues { (_, packageGroupList) ->
+            val packages = viewState.packagesData ?: return@update viewState
+            val updatedCarrierPackages = packages.carrierPackages.mapValues { (_, packageGroupList) ->
                 packageGroupList.map { packageGroup ->
                     val updatedPackages = packageGroup.packages.map {
                         when {
@@ -269,14 +267,14 @@ class WooShippingLabelPackageCreationViewModel @Inject constructor(
                 }
             }
             viewState.copy(
-                predefinedPackagesState = predefinedPackages.copy(carrierPackages = updatedCarrierPackages)
+                packagesState = packages.copy(carrierPackages = updatedCarrierPackages)
             )
         }
         launch {
             updateSavedCarrierPackages(
                 savePackage = isStarred,
                 packageId = packageData.id,
-                carrierPackages = _viewState.value.predefinedPackagesData?.carrierPackages ?: emptyMap()
+                carrierPackages = _viewState.value.packagesData?.carrierPackages ?: emptyMap()
             )
         }
     }
@@ -285,21 +283,21 @@ class WooShippingLabelPackageCreationViewModel @Inject constructor(
     data class ViewState(
         val pageTabs: List<PageTab> = emptyList(),
         val customPackageCreationData: CustomPackageCreationData = CustomPackageCreationData.EMPTY,
-        val predefinedPackagesState: PredefinedPackagesState = PredefinedPackagesState.Waiting,
+        val packagesState: PackagesState = PackagesState.Waiting,
     ) : Parcelable {
-        val predefinedPackagesData
-            get() = (predefinedPackagesState as? PredefinedPackagesState.Data)
+        val packagesData
+            get() = (packagesState as? PackagesState.Data)
     }
 
     @Parcelize
-    sealed class PredefinedPackagesState : Parcelable {
-        data object Error : PredefinedPackagesState()
-        data object Waiting : PredefinedPackagesState()
+    sealed class PackagesState : Parcelable {
+        data object Error : PackagesState()
+        data object Waiting : PackagesState()
         data class Data(
             val storeOptions: StoreOptionsForPackages,
             val savedPackages: List<PackageData>,
             val carrierPackages: Map<Carrier, List<CarrierPackageGroup>>
-        ) : PredefinedPackagesState() {
+        ) : PackagesState() {
             val hasCarrierSelection: Boolean
                 get() = carrierPackages.values.flatten().find { group ->
                     group.packages.find { it.isSelected } != null

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/packages/datasource/FetchPackagesFromStore.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/packages/datasource/FetchPackagesFromStore.kt
@@ -1,25 +1,25 @@
 package com.woocommerce.android.ui.orders.wooshippinglabels.packages.datasource
 
 import com.woocommerce.android.tools.SelectedSite
-import com.woocommerce.android.ui.orders.wooshippinglabels.packages.WooShippingLabelPackageCreationViewModel.PredefinedPackagesState
+import com.woocommerce.android.ui.orders.wooshippinglabels.packages.WooShippingLabelPackageCreationViewModel.PackagesState
 import com.woocommerce.android.ui.orders.wooshippinglabels.packages.ui.Carrier
 import com.woocommerce.android.ui.orders.wooshippinglabels.packages.ui.CarrierPackageGroup
 import com.woocommerce.android.ui.orders.wooshippinglabels.packages.ui.PackageData
 import com.woocommerce.android.ui.orders.wooshippinglabels.packages.ui.StoreOptionsForPackages
 import javax.inject.Inject
 
-class FetchPredefinedPackagesFromStore @Inject constructor(
+class FetchPackagesFromStore @Inject constructor(
     private val selectedSite: SelectedSite,
     private val packageRepository: WooShippingLabelPackageRepository
 ) {
-    suspend operator fun invoke(): PredefinedPackagesState {
+    suspend operator fun invoke(): PackagesState {
         val storePackages = selectedSite.getOrNull()
             ?.let { packageRepository.fetchAllStorePackages(it) }
             ?.takeIf { it.isError.not() }
             ?.model
-            ?: return PredefinedPackagesState.Error
+            ?: return PackagesState.Error
 
-        return PredefinedPackagesState.Data(
+        return PackagesState.Data(
             storeOptions = storePackages.storeOptions.toStoreOptionsForPackages(),
             savedPackages = storePackages.savedPackages
                 .map { PackageData.fromPackageDAO(it) },

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/packages/datasource/PackageDAOs.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/packages/datasource/PackageDAOs.kt
@@ -37,5 +37,9 @@ data class StoreOptionsDAO(
 enum class CarrierType(val id: String) {
     USPS(id = "usps"),
     DHL(id = "dhlexpress"),
-    UPS(id = "upsdap")
+    UPS(id = "upsdap");
+
+    companion object {
+        fun fromId(id: String): CarrierType? = entries.firstOrNull { it.id == id }
+    }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/packages/datasource/WooShippingLabelPackageMapper.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/packages/datasource/WooShippingLabelPackageMapper.kt
@@ -2,25 +2,28 @@ package com.woocommerce.android.ui.orders.wooshippinglabels.packages.datasource
 
 import com.woocommerce.android.ui.orders.wooshippinglabels.packages.networking.CarrierPackageGroupDTO
 import com.woocommerce.android.ui.orders.wooshippinglabels.packages.networking.CarrierPredefinedPackagesDTO
-import com.woocommerce.android.ui.orders.wooshippinglabels.packages.networking.CustomPackageDTO
 import com.woocommerce.android.ui.orders.wooshippinglabels.packages.networking.PackageCreationResponse
 import com.woocommerce.android.ui.orders.wooshippinglabels.packages.networking.PackageResponse
 import com.woocommerce.android.ui.orders.wooshippinglabels.packages.networking.PackageStoreOptionsDTO
+import com.woocommerce.android.ui.orders.wooshippinglabels.packages.networking.SavedPackageInfoDTO
 import javax.inject.Inject
 
 class WooShippingLabelPackageMapper @Inject constructor() {
     operator fun invoke(response: PackageResponse): StorePackagesDAO {
-        val savedPackagesResponse = response.packages?.saved?.custom ?: emptyList()
+        val savedPackageInfoDTO = response.packages?.saved
         val storeOptionsResponse = response.storeOptions ?: PackageStoreOptionsDTO()
+        val carrierPackages = mapCarrierPackages(
+            response.storeOptions,
+            response.packages?.predefined,
+            response.packages?.saved?.predefined
+        )
 
         return StorePackagesDAO(
             storeOptions = mapStoreOptions(storeOptionsResponse),
-            savedPackages = mapSavedPackages(savedPackagesResponse, response.storeOptions),
-            carrierPackages = mapCarrierPackages(
-                response.storeOptions,
-                response.packages?.predefined,
-                response.packages?.saved?.predefined
-            )
+            savedPackages = savedPackageInfoDTO?.let {
+                mapSavedPackages(it, response.storeOptions, carrierPackages)
+            } ?: emptyList(),
+            carrierPackages = carrierPackages
         )
     }
 
@@ -42,10 +45,20 @@ class WooShippingLabelPackageMapper @Inject constructor() {
     }
 
     private fun mapSavedPackages(
-        savedResponse: List<CustomPackageDTO>,
-        storeOptions: PackageStoreOptionsDTO?
+        savedPackageInfoDTO: SavedPackageInfoDTO,
+        storeOptions: PackageStoreOptionsDTO?,
+        carrierPackages: Map<CarrierType, CarrierDAO>?
     ): List<PackageDAO> {
-        return savedResponse.map {
+        val savedCarrierPackages = savedPackageInfoDTO.predefined?.flatMap { (carrierId, packageIds) ->
+            val carrier = CarrierType.fromId(carrierId)
+            val allPackagesForCarrier = carrierPackages?.get(carrier)
+                ?.packageGroup
+                ?.flatMap { it.packages }
+
+            packageIds.mapNotNull { packageId -> allPackagesForCarrier?.find { it.id == packageId } }
+        } ?: emptyList()
+
+        val savedCustomPackages = savedPackageInfoDTO.custom?.map {
             PackageDAO(
                 id = it.id.orEmpty(),
                 name = it.name.orEmpty(),
@@ -56,7 +69,8 @@ class WooShippingLabelPackageMapper @Inject constructor() {
                 weightUnit = storeOptions?.weightUnit.orEmpty(),
                 saved = true
             )
-        }
+        }.orEmpty()
+        return savedCarrierPackages + savedCustomPackages
     }
 
     private fun mapCarrierPackages(

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/packages/ui/WooShippingCarrierPackageScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/packages/ui/WooShippingCarrierPackageScreen.kt
@@ -44,8 +44,8 @@ import androidx.compose.ui.unit.dp
 import com.woocommerce.android.R
 import com.woocommerce.android.ui.compose.theme.WooThemeWithBackground
 import com.woocommerce.android.ui.orders.wooshippinglabels.packages.WooShippingLabelPackageCreationViewModel
-import com.woocommerce.android.ui.orders.wooshippinglabels.packages.WooShippingLabelPackageCreationViewModel.PageType
 import com.woocommerce.android.ui.orders.wooshippinglabels.packages.WooShippingLabelPackageCreationViewModel.PackagesState
+import com.woocommerce.android.ui.orders.wooshippinglabels.packages.WooShippingLabelPackageCreationViewModel.PageType
 import com.woocommerce.android.ui.orders.wooshippinglabels.packages.components.ErrorMessageWithButton
 import com.woocommerce.android.ui.orders.wooshippinglabels.packages.components.WooShippingPackageListItem
 import com.woocommerce.android.ui.orders.wooshippinglabels.packages.components.WooShippingPackageListItemSkeleton

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/packages/ui/WooShippingCarrierPackageScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/packages/ui/WooShippingCarrierPackageScreen.kt
@@ -45,7 +45,7 @@ import com.woocommerce.android.R
 import com.woocommerce.android.ui.compose.theme.WooThemeWithBackground
 import com.woocommerce.android.ui.orders.wooshippinglabels.packages.WooShippingLabelPackageCreationViewModel
 import com.woocommerce.android.ui.orders.wooshippinglabels.packages.WooShippingLabelPackageCreationViewModel.PageType
-import com.woocommerce.android.ui.orders.wooshippinglabels.packages.WooShippingLabelPackageCreationViewModel.PredefinedPackagesState
+import com.woocommerce.android.ui.orders.wooshippinglabels.packages.WooShippingLabelPackageCreationViewModel.PackagesState
 import com.woocommerce.android.ui.orders.wooshippinglabels.packages.components.ErrorMessageWithButton
 import com.woocommerce.android.ui.orders.wooshippinglabels.packages.components.WooShippingPackageListItem
 import com.woocommerce.android.ui.orders.wooshippinglabels.packages.components.WooShippingPackageListItemSkeleton
@@ -58,8 +58,8 @@ fun WooShippingCarrierPackageScreen(
 ) {
     val viewState by viewModel.viewState.observeAsState()
     WooShippingCarrierPackageScreen(
-        packageState = viewState?.predefinedPackagesState ?: PredefinedPackagesState.Waiting,
-        isAddPackageEnabled = viewState?.predefinedPackagesData?.hasCarrierSelection == true,
+        packageState = viewState?.packagesState ?: PackagesState.Waiting,
+        isAddPackageEnabled = viewState?.packagesData?.hasCarrierSelection == true,
         onPackageSelected = viewModel::onCarrierPackageSelected,
         onAddPackageClick = viewModel::onAddCarrierPackageClick,
         onRetryClick = viewModel::onRetryClick,
@@ -71,7 +71,7 @@ fun WooShippingCarrierPackageScreen(
 @Composable
 fun WooShippingCarrierPackageScreen(
     modifier: Modifier = Modifier,
-    packageState: PredefinedPackagesState,
+    packageState: PackagesState,
     onPackageSelected: (PackageData, Boolean) -> Unit,
     isAddPackageEnabled: Boolean = false,
     onAddPackageClick: () -> Unit = {},
@@ -82,26 +82,26 @@ fun WooShippingCarrierPackageScreen(
     Column(modifier = modifier) {
         Box(modifier = modifier.weight(1f)) {
             when {
-                packageState is PredefinedPackagesState.Data && packageState.carrierPackages.isEmpty() -> EmptyPackages(
+                packageState is PackagesState.Data && packageState.carrierPackages.isEmpty() -> EmptyPackages(
                     modifier = modifier,
                     R.drawable.ic_delivery,
                     R.string.woo_shipping_labels_package_creation_empty_carrier_message
                 ) { onTabChange(PageType.CUSTOM) }
 
-                packageState is PredefinedPackagesState.Data -> WooShippingCarrierPackageContent(
+                packageState is PackagesState.Data -> WooShippingCarrierPackageContent(
                     modifier = modifier,
                     carrierPackages = packageState.carrierPackages,
                     onPackageSelected = onPackageSelected,
                     onPackageStarred = onPackageStarred
                 )
 
-                packageState is PredefinedPackagesState.Error -> ErrorMessageWithButton(
+                packageState is PackagesState.Error -> ErrorMessageWithButton(
                     modifier = modifier,
                     message = R.string.woo_shipping_labels_package_creation_carrier_loading_error,
                     onRetryClick = onRetryClick
                 )
 
-                packageState is PredefinedPackagesState.Waiting -> Column(
+                packageState is PackagesState.Waiting -> Column(
                     modifier = modifier
                         .fillMaxSize()
                         .padding(16.dp)
@@ -379,7 +379,7 @@ fun WooShippingCarrierPackageScreenPreview() {
 fun WooShippingCarrierPackageEmptyScreenPreview() {
     WooThemeWithBackground {
         WooShippingCarrierPackageScreen(
-            packageState = PredefinedPackagesState.Data(
+            packageState = PackagesState.Data(
                 storeOptions = StoreOptionsForPackages.DEFAULT,
                 savedPackages = emptyList(),
                 carrierPackages = emptyMap()

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/packages/ui/WooShippingSavedPackageScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/packages/ui/WooShippingSavedPackageScreen.kt
@@ -19,8 +19,8 @@ import androidx.compose.ui.unit.dp
 import com.woocommerce.android.R
 import com.woocommerce.android.ui.compose.theme.WooThemeWithBackground
 import com.woocommerce.android.ui.orders.wooshippinglabels.packages.WooShippingLabelPackageCreationViewModel
-import com.woocommerce.android.ui.orders.wooshippinglabels.packages.WooShippingLabelPackageCreationViewModel.PageType
 import com.woocommerce.android.ui.orders.wooshippinglabels.packages.WooShippingLabelPackageCreationViewModel.PackagesState
+import com.woocommerce.android.ui.orders.wooshippinglabels.packages.WooShippingLabelPackageCreationViewModel.PageType
 import com.woocommerce.android.ui.orders.wooshippinglabels.packages.components.ErrorMessageWithButton
 import com.woocommerce.android.ui.orders.wooshippinglabels.packages.components.WooShippingPackageListItem
 import com.woocommerce.android.ui.orders.wooshippinglabels.packages.components.WooShippingPackageListItemSkeleton

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/packages/ui/WooShippingSavedPackageScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/packages/ui/WooShippingSavedPackageScreen.kt
@@ -20,7 +20,7 @@ import com.woocommerce.android.R
 import com.woocommerce.android.ui.compose.theme.WooThemeWithBackground
 import com.woocommerce.android.ui.orders.wooshippinglabels.packages.WooShippingLabelPackageCreationViewModel
 import com.woocommerce.android.ui.orders.wooshippinglabels.packages.WooShippingLabelPackageCreationViewModel.PageType
-import com.woocommerce.android.ui.orders.wooshippinglabels.packages.WooShippingLabelPackageCreationViewModel.PredefinedPackagesState
+import com.woocommerce.android.ui.orders.wooshippinglabels.packages.WooShippingLabelPackageCreationViewModel.PackagesState
 import com.woocommerce.android.ui.orders.wooshippinglabels.packages.components.ErrorMessageWithButton
 import com.woocommerce.android.ui.orders.wooshippinglabels.packages.components.WooShippingPackageListItem
 import com.woocommerce.android.ui.orders.wooshippinglabels.packages.components.WooShippingPackageListItemSkeleton
@@ -32,8 +32,8 @@ fun WooShippingSavedPackageScreen(
 ) {
     val viewState = viewModel.viewState.observeAsState()
     WooShippingSavedPackageScreen(
-        packageState = viewState.value?.predefinedPackagesState ?: PredefinedPackagesState.Waiting,
-        isAddPackageEnabled = viewState.value?.predefinedPackagesData?.hasSavedSelection == true,
+        packageState = viewState.value?.packagesState ?: PackagesState.Waiting,
+        isAddPackageEnabled = viewState.value?.packagesData?.hasSavedSelection == true,
         onAddPackageClick = viewModel::onAddSavedPackageClick,
         onSavedPackageSelected = viewModel::onSavedPackageSelected,
         onRetryClick = viewModel::onRetryClick,
@@ -44,7 +44,7 @@ fun WooShippingSavedPackageScreen(
 @Composable
 fun WooShippingSavedPackageScreen(
     modifier: Modifier = Modifier,
-    packageState: PredefinedPackagesState,
+    packageState: PackagesState,
     isAddPackageEnabled: Boolean,
     onAddPackageClick: () -> Unit,
     onSavedPackageSelected: (PackageData, Boolean) -> Unit,
@@ -54,13 +54,13 @@ fun WooShippingSavedPackageScreen(
     Column(modifier = modifier) {
         Box(modifier = modifier.weight(1f)) {
             when {
-                packageState is PredefinedPackagesState.Data && packageState.savedPackages.isEmpty() -> EmptyPackages(
+                packageState is PackagesState.Data && packageState.savedPackages.isEmpty() -> EmptyPackages(
                     modifier = modifier,
                     R.drawable.ic_boxes,
                     R.string.woo_shipping_labels_package_creation_empty_saved_message
                 ) { onTabChange(PageType.CUSTOM) }
 
-                packageState is PredefinedPackagesState.Data -> {
+                packageState is PackagesState.Data -> {
                     WooShippingSavedPackageContent(
                         modifier = modifier,
                         savedPackages = packageState.savedPackages,
@@ -68,7 +68,7 @@ fun WooShippingSavedPackageScreen(
                     )
                 }
 
-                packageState is PredefinedPackagesState.Error -> {
+                packageState is PackagesState.Error -> {
                     ErrorMessageWithButton(
                         modifier = modifier,
                         message = R.string.woo_shipping_labels_package_creation_saved_loading_error,
@@ -76,7 +76,7 @@ fun WooShippingSavedPackageScreen(
                     )
                 }
 
-                packageState is PredefinedPackagesState.Waiting -> {
+                packageState is PackagesState.Waiting -> {
                     Column(
                         modifier = modifier
                             .fillMaxSize()
@@ -131,7 +131,7 @@ fun WooShippingSavedPackageContent(
 fun WooShippingSavedPackageScreenPreview() {
     WooThemeWithBackground {
         WooShippingSavedPackageScreen(
-            packageState = PredefinedPackagesState.Data(
+            packageState = PackagesState.Data(
                 storeOptions = StoreOptionsForPackages.DEFAULT,
                 savedPackages = listOf(
                     PackageData(
@@ -175,7 +175,7 @@ fun WooShippingSavedPackageScreenPreview() {
 fun WooShippingSavedPackageScreenLoadingPreview() {
     WooThemeWithBackground {
         WooShippingSavedPackageScreen(
-            packageState = PredefinedPackagesState.Waiting,
+            packageState = PackagesState.Waiting,
             isAddPackageEnabled = false,
             onAddPackageClick = {},
             onSavedPackageSelected = { _, _ -> },
@@ -190,7 +190,7 @@ fun WooShippingSavedPackageScreenLoadingPreview() {
 fun WooShippingSavedPackageScreenErrorPreview() {
     WooThemeWithBackground {
         WooShippingSavedPackageScreen(
-            packageState = PredefinedPackagesState.Error,
+            packageState = PackagesState.Error,
             isAddPackageEnabled = false,
             onAddPackageClick = {},
             onSavedPackageSelected = { _, _ -> },

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/packages/WooShippingLabelPackageCreationViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/packages/WooShippingLabelPackageCreationViewModelTest.kt
@@ -5,10 +5,10 @@ import com.woocommerce.android.R
 import com.woocommerce.android.tools.SelectedSite
 import com.woocommerce.android.ui.orders.wooshippinglabels.packages.WooShippingLabelPackageCreationViewModel.PackageSelected
 import com.woocommerce.android.ui.orders.wooshippinglabels.packages.WooShippingLabelPackageCreationViewModel.PackageType.ENVELOPE
-import com.woocommerce.android.ui.orders.wooshippinglabels.packages.WooShippingLabelPackageCreationViewModel.PredefinedPackagesState.Data
+import com.woocommerce.android.ui.orders.wooshippinglabels.packages.WooShippingLabelPackageCreationViewModel.PackagesState.Data
 import com.woocommerce.android.ui.orders.wooshippinglabels.packages.WooShippingLabelPackageCreationViewModel.ShowPackageTypeDialog
 import com.woocommerce.android.ui.orders.wooshippinglabels.packages.WooShippingLabelPackageCreationViewModel.ViewState
-import com.woocommerce.android.ui.orders.wooshippinglabels.packages.datasource.FetchPredefinedPackagesFromStore
+import com.woocommerce.android.ui.orders.wooshippinglabels.packages.datasource.FetchPackagesFromStore
 import com.woocommerce.android.ui.orders.wooshippinglabels.packages.datasource.WooShippingLabelPackageRepository
 import com.woocommerce.android.ui.orders.wooshippinglabels.packages.ui.Carrier
 import com.woocommerce.android.ui.orders.wooshippinglabels.packages.ui.Carrier.DHL
@@ -38,7 +38,7 @@ class WooShippingLabelPackageCreationViewModelTest : BaseUnitTest() {
 
     private lateinit var sut: WooShippingLabelPackageCreationViewModel
     private val resourceProvider: ResourceProvider = mock()
-    private val fetchPredefinedPackages: FetchPredefinedPackagesFromStore = mock()
+    private val fetchPackages: FetchPackagesFromStore = mock()
     private val packageRepository: WooShippingLabelPackageRepository = mock()
     private val selectedSite: SelectedSite = mock {
         on { getOrNull() } doReturn SiteModel().apply { siteId = 123 }
@@ -61,7 +61,7 @@ class WooShippingLabelPackageCreationViewModelTest : BaseUnitTest() {
             SavedStateHandle(),
             selectedSite,
             resourceProvider,
-            fetchPredefinedPackages,
+            fetchPackages,
             updateSavedCarrierPackages,
             packageRepository
         )
@@ -192,7 +192,7 @@ class WooShippingLabelPackageCreationViewModelTest : BaseUnitTest() {
             isSelected = false,
             isLetter = true,
         )
-        whenever(fetchPredefinedPackages()).thenReturn(
+        whenever(fetchPackages()).thenReturn(
             Data(
                 storeOptions = StoreOptionsForPackages.DEFAULT,
                 carrierPackages = emptyMap(),
@@ -204,14 +204,14 @@ class WooShippingLabelPackageCreationViewModelTest : BaseUnitTest() {
             SavedStateHandle(),
             selectedSite,
             resourceProvider,
-            fetchPredefinedPackages,
+            fetchPackages,
             updateSavedCarrierPackages,
             packageRepository
         )
         sut.viewState.observeForever { lastViewState = it }
         sut.onSavedPackageSelected(package1, true)
 
-        val selectedPackages = lastViewState?.predefinedPackagesData?.savedPackages?.filter { it.isSelected }
+        val selectedPackages = lastViewState?.packagesData?.savedPackages?.filter { it.isSelected }
         assertThat(selectedPackages).isNotNull
         assertThat(selectedPackages).size().isEqualTo(1)
         assertThat(selectedPackages?.first()).isEqualTo(package1.copy(isSelected = true))
@@ -245,7 +245,7 @@ class WooShippingLabelPackageCreationViewModelTest : BaseUnitTest() {
                 )
             )
         )
-        whenever(fetchPredefinedPackages()).thenReturn(
+        whenever(fetchPackages()).thenReturn(
             Data(
                 storeOptions = StoreOptionsForPackages.DEFAULT,
                 carrierPackages = carrierPackages,
@@ -257,7 +257,7 @@ class WooShippingLabelPackageCreationViewModelTest : BaseUnitTest() {
             SavedStateHandle(),
             selectedSite,
             resourceProvider,
-            fetchPredefinedPackages,
+            fetchPackages,
             updateSavedCarrierPackages,
             packageRepository
         )
@@ -265,7 +265,7 @@ class WooShippingLabelPackageCreationViewModelTest : BaseUnitTest() {
         sut.onCarrierPackageSelected(package1, true)
 
         val selectedPackages = lastViewState
-            ?.predefinedPackagesData
+            ?.packagesData
             ?.carrierPackages
             ?.values
             ?.flatten()
@@ -329,7 +329,7 @@ class WooShippingLabelPackageCreationViewModelTest : BaseUnitTest() {
                 )
             )
         )
-        whenever(fetchPredefinedPackages()).thenReturn(
+        whenever(fetchPackages()).thenReturn(
             Data(
                 storeOptions = StoreOptionsForPackages.DEFAULT,
                 carrierPackages = carrierPackages,
@@ -341,7 +341,7 @@ class WooShippingLabelPackageCreationViewModelTest : BaseUnitTest() {
             SavedStateHandle(),
             selectedSite,
             resourceProvider,
-            fetchPredefinedPackages,
+            fetchPackages,
             updateSavedCarrierPackages,
             packageRepository
         )
@@ -352,7 +352,7 @@ class WooShippingLabelPackageCreationViewModelTest : BaseUnitTest() {
         advanceUntilIdle()
 
         val selectedPackages = lastViewState
-            ?.predefinedPackagesData
+            ?.packagesData
             ?.carrierPackages
             ?.values
             ?.flatten()
@@ -385,7 +385,7 @@ class WooShippingLabelPackageCreationViewModelTest : BaseUnitTest() {
                     )
                 )
             )
-            whenever(fetchPredefinedPackages()).thenReturn(
+            whenever(fetchPackages()).thenReturn(
                 Data(
                     storeOptions = StoreOptionsForPackages.DEFAULT,
                     carrierPackages = initialCarrierPackages,
@@ -397,7 +397,7 @@ class WooShippingLabelPackageCreationViewModelTest : BaseUnitTest() {
                 SavedStateHandle(),
                 selectedSite,
                 resourceProvider,
-                fetchPredefinedPackages,
+                fetchPackages,
                 updateSavedCarrierPackages,
                 packageRepository
             )
@@ -413,12 +413,12 @@ class WooShippingLabelPackageCreationViewModelTest : BaseUnitTest() {
             verify(updateSavedCarrierPackages, times(1)).invoke(
                 true,
                 packageToStar.id,
-                lastViewState?.predefinedPackagesData?.carrierPackages!!
+                lastViewState?.packagesData?.carrierPackages!!
             )
 
             // Verify viewState is updated
             val updatedPackage = lastViewState
-                ?.predefinedPackagesData
+                ?.packagesData
                 ?.carrierPackages
                 ?.get(carrier)
                 ?.flatMap { it.packages }

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/packages/datasource/FetchPackagesFromStoreTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/packages/datasource/FetchPackagesFromStoreTest.kt
@@ -1,7 +1,7 @@
 package com.woocommerce.android.ui.orders.wooshippinglabels.packages.datasource
 
 import com.woocommerce.android.tools.SelectedSite
-import com.woocommerce.android.ui.orders.wooshippinglabels.packages.WooShippingLabelPackageCreationViewModel.PredefinedPackagesState
+import com.woocommerce.android.ui.orders.wooshippinglabels.packages.WooShippingLabelPackageCreationViewModel.PackagesState
 import com.woocommerce.android.ui.orders.wooshippinglabels.packages.ui.Carrier
 import com.woocommerce.android.ui.orders.wooshippinglabels.packages.ui.CarrierPackageGroup
 import com.woocommerce.android.ui.orders.wooshippinglabels.packages.ui.PackageData
@@ -18,23 +18,20 @@ import org.wordpress.android.fluxc.network.rest.wpcom.wc.WooErrorType
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.WooResult
 
 @OptIn(ExperimentalCoroutinesApi::class)
-class FetchPredefinedPackagesFromStoreTest : BaseUnitTest() {
+class FetchPackagesFromStoreTest : BaseUnitTest() {
 
     private val packageRepository: WooShippingLabelPackageRepository = mock()
     private val selectedSite: SelectedSite = mock()
-    private val fetchPredefinedPackagesFromStore = FetchPredefinedPackagesFromStore(
-        selectedSite,
-        packageRepository
-    )
+    private val fetchPackagesFromStore = FetchPackagesFromStore(selectedSite, packageRepository)
 
     @Test
-    fun `invoke should return StorePredefinedPackages with carrier and saved packages`() = testBlocking {
+    fun `invoke should return Data with carrier and saved packages`() = testBlocking {
         val storePackages = generatePackagesData()
         val site = SiteModel().apply { id = 1 }
         whenever(selectedSite.getOrNull()).thenReturn(site)
         whenever(packageRepository.fetchAllStorePackages(site)).thenReturn(WooResult(storePackages))
 
-        val result = fetchPredefinedPackagesFromStore() as PredefinedPackagesState.Data
+        val result = fetchPackagesFromStore() as PackagesState.Data
 
         assertThat(result.savedPackages).containsExactly(
             PackageData(
@@ -76,24 +73,24 @@ class FetchPredefinedPackagesFromStoreTest : BaseUnitTest() {
     }
 
     @Test
-    fun `invoke should return Error StorePredefinedPackages when fetchAllStorePackages returns error`() = testBlocking {
+    fun `invoke should return Error when fetchAllStorePackages returns error`() = testBlocking {
         val error = WooError(WooErrorType.GENERIC_ERROR, BaseRequest.GenericErrorType.UNKNOWN)
         val site = SiteModel().apply { id = 1 }
         whenever(selectedSite.getOrNull()).thenReturn(site)
         whenever(packageRepository.fetchAllStorePackages(site)).thenReturn(WooResult(error))
 
-        val result = fetchPredefinedPackagesFromStore()
+        val result = fetchPackagesFromStore()
 
-        assertThat(result).isEqualTo(PredefinedPackagesState.Error)
+        assertThat(result).isEqualTo(PackagesState.Error)
     }
 
     @Test
-    fun `invoke should return Error StorePredefinedPackages when site is not available`() = testBlocking {
+    fun `invoke should return Error when site is not available`() = testBlocking {
         whenever(selectedSite.getOrNull()).thenReturn(null)
 
-        val result = fetchPredefinedPackagesFromStore()
+        val result = fetchPackagesFromStore()
 
-        assertThat(result).isEqualTo(PredefinedPackagesState.Error)
+        assertThat(result).isEqualTo(PackagesState.Error)
     }
 
     private fun generatePackagesData() = StorePackagesDAO(


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

<!-- Id number of the Linear issue this PR addresses, e.g., WOOMOB-373. -->
Closes WOOMOB-766

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
Saved tab was displaying only saved Carrier packages because we were not parsing custom saved packages from the endpoint response. This PR fixes it.

I also renamed the `FetchPredefinedPackagesFromStore` class to `FetchPackagesFromStore` because it doesn’t fetch only predefined packages. It also fetches saved packages, which can be either predefined or custom.

These package tabs still have some issues, and I’ll address them in the following PRs.

### Steps to reproduce
<!-- Step-by-step testing instructions. For new user flows, consider instead stating the goal of the workflow and see if your PR reviewer can accomplish the workflow without specific steps! -->
1. Go to the Order.
2. Tap an order.
3. Tap the "Create shipping label" button.
4. Tap "Select a package".
5. Tap "Saved".
6. Compare the saved packages with those the web.

### The tests that have been performed
<!-- To give the reviewer an idea of what could be missed in terms of testing -->
Steps above

### Images/gif
<!-- Include before and after images or gifs when appropriate. -->
|Before|After|
|-|-|
|<img src="https://github.com/user-attachments/assets/9e1ffa8b-2602-41f7-b8a1-a0f30d54e9a1" width=350>|<img src="https://github.com/user-attachments/assets/b435fe42-1f2c-42c0-b449-a7a58682bc99" width=350>|

- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->