### PR TITLE
[Shipping Labels] Show cost of purchased labels

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/ShippableItemsMapper.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/ShippableItemsMapper.kt
@@ -50,7 +50,9 @@ fun List<ShippableItemModel>.toUIModel(
     val shippableItemsUI = map { item -> item.toUIModel(currencyFormatter, dimensionUnit, weightUnit) }
     val formattedTotalPrice = getFormattedTotalPrice(currencyFormatter)
     val formattedTotalWeight = getFormattedTotalWeight(weightUnit)
-    val shipmentCostUI = shippingRates.toShipmentCostUI(
+    val shipmentCostUI = getShipmentCostUI(
+        shipmentUIModel = shipmentUIModel,
+        ratesState = shippingRates,
         currencyFormatter = { currencyFormatter.formatCurrency(it, firstOrNull()?.currency.orEmpty()) }
     )
 
@@ -146,12 +148,24 @@ fun Order.getShippingLinesSummary(
     }
 }
 
-private fun ShippingRatesState.toShipmentCostUI(
+private fun getShipmentCostUI(
+    shipmentUIModel: ShipmentUIModel,
+    ratesState: ShippingRatesState,
     currencyFormatter: (BigDecimal) -> String
 ): ShipmentCostUI? {
-    return when (this) {
-        is ShippingRatesState.DataState -> {
-            val selectedRate = selectedRate ?: return null
+    return when {
+        shipmentUIModel.purchased -> {
+            requireNotNull(shipmentUIModel.label)
+            ShipmentCostUI(
+                serviceName = shipmentUIModel.label.serviceName,
+                formattedBasePrice = currencyFormatter(shipmentUIModel.label.rate),
+                formattedTotalPrice = currencyFormatter(shipmentUIModel.label.rate),
+                optionsWithFees = emptyMap()
+            )
+        }
+
+        ratesState is ShippingRatesState.DataState -> {
+            val selectedRate = ratesState.selectedRate ?: return null
             val totalPrice = selectedRate.selectedRateOption.rate.price +
                 selectedRate.additionalSelectedOptions.sumOf { selectedRate.options.getValue(it).fee }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/rates/domain/WooShippingRatesDomainMapper.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/rates/domain/WooShippingRatesDomainMapper.kt
@@ -174,7 +174,13 @@ class WooShippingRatesDomainMapper @Inject constructor(
         return when {
             price == null -> "N/A"
             price.isEqualTo(BigDecimal.ZERO) -> resourceProvider.getString(R.string.free)
-            else -> formatCurrency(price, currencyCode)
+            else -> formatCurrency(price, currencyCode).let {
+                if (price > BigDecimal.ZERO) {
+                    "+$it"
+                } else {
+                    it
+                }
+            }
         }
     }
 

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/WooShippingLabelCreationViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/WooShippingLabelCreationViewModelTest.kt
@@ -812,7 +812,8 @@ class WooShippingLabelCreationViewModelTest : BaseUnitTest() {
             ShipmentUIModel(
                 localId = "0",
                 items = defaultShippableItems,
-                purchased = true
+                purchased = true,
+                label = shippingLabelModel
             )
         )
 
@@ -822,6 +823,35 @@ class WooShippingLabelCreationViewModelTest : BaseUnitTest() {
 
         val dataState = sut.viewState.value as DataState
         assertThat(dataState.uiState.noticeBannerUiState).isNull()
+    }
+
+    @Test
+    fun `when current label is purchased, then show its price`() = testBlocking {
+        val label = shippingLabelModel.copy(
+            serviceName = "Test Service",
+            rate = BigDecimal.TEN,
+        )
+        whenever(getShipments(any())) doReturn listOf(
+            ShipmentUIModel(
+                localId = "0",
+                items = defaultShippableItems,
+                purchased = true,
+                label = label
+            )
+        )
+
+        createViewModel()
+
+        advanceUntilIdle()
+
+        val currentViewState = sut.viewState.value
+        assert(currentViewState is DataState)
+        val dataState = currentViewState as DataState
+        assertThat(dataState.shipmentUIList[0].shipmentCostUI?.formattedBasePrice)
+            .isEqualTo(currencyFormatter.formatCurrency(label.rate, label.currency))
+        assertThat(dataState.shipmentUIList[0].shipmentCostUI?.formattedTotalPrice)
+            .isEqualTo(currencyFormatter.formatCurrency(label.rate, label.currency))
+        assertThat(dataState.shipmentUIList[0].shipmentCostUI?.serviceName).isEqualTo(label.serviceName)
     }
 
     @Test


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

<!-- Id number of the Linear issue this PR addresses, e.g., WOOMOB-373. -->
Closes WOOMOB-668

### Description
This PR adds logic to construct `ShipmentCostUI` from the purchased label data.

**Note:** This change just aligns us with iOS by displaying the total cost, to display the cost split between the base fee and the options, we need to parse the `selected_rates` in the `/config` response data as discussed here p1751303271937159-slack-C05VBLKHHV1, I think this find to postpone until M5.

### Steps to reproduce
1. Open an order with a purchased label.
2. Tap on "view purchased label information"
3. Expand the shipment details

### Testing information
Confirm the price of the label is shown correctly.

### The tests that have been performed
The above.

### Images/gif
<img src=https://github.com/user-attachments/assets/64763e42-a565-40c2-bae3-3e699ee57b6f width=360 />

- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->