### PR TITLE
[WOOMOB-775][Woo POS][Scanning] Implement barcode scanner setup flow with mocked UI

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/common/data/WooPosAppUrls.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/common/data/WooPosAppUrls.kt
@@ -1,0 +1,3 @@
+package com.woocommerce.android.ui.woopos.common.data
+
+const val WOO_POS_BARCODE_DOC_URL = "https://woocommerce.com/document/barcode-and-qr-code-scanner/"

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/WooPosBarcodeInfoDialog.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/WooPosBarcodeInfoDialog.kt
@@ -40,9 +40,8 @@ import com.woocommerce.android.ui.woopos.common.composeui.designsystem.WooPosSpa
 import com.woocommerce.android.ui.woopos.common.composeui.designsystem.WooPosTheme
 import com.woocommerce.android.ui.woopos.common.composeui.designsystem.WooPosTypography
 import com.woocommerce.android.ui.woopos.common.composeui.designsystem.toAdaptivePadding
+import com.woocommerce.android.ui.woopos.common.data.WOO_POS_BARCODE_DOC_URL
 import com.woocommerce.android.util.ChromeCustomTabUtils
-
-private const val WOO_POS_BARCODE_DOC_URL = "https://woocommerce.com/document/barcode-and-qr-code-scanner/"
 
 @Composable
 fun WooPosBarcodeInfoDialog(

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/WooPosHomeScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/WooPosHomeScreen.kt
@@ -215,13 +215,12 @@ private fun HandleScanningSetupDialog(
     state: ScanningSetupDialog,
     onHomeUIEvent: (WooPosHomeUIEvent) -> Unit
 ) {
-    if (state.isVisible) {
-        WooPosScanningSetupDialog(
-            onDismissRequest = {
-                onHomeUIEvent(WooPosHomeUIEvent.DismissScanningSetupDialog)
-            }
-        )
-    }
+    WooPosScanningSetupDialog(
+        outerState = state,
+        onDismissRequest = {
+            onHomeUIEvent(WooPosHomeUIEvent.DismissScanningSetupDialog)
+        }
+    )
 }
 
 @Composable

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/WooPosHomeScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/WooPosHomeScreen.kt
@@ -36,10 +36,12 @@ import com.woocommerce.android.ui.woopos.common.composeui.modifier.listenForBarc
 import com.woocommerce.android.ui.woopos.home.WooPosHomeState.BarcodeInfoDialog
 import com.woocommerce.android.ui.woopos.home.WooPosHomeState.ExitConfirmationDialog
 import com.woocommerce.android.ui.woopos.home.WooPosHomeState.ProductsInfoDialog
+import com.woocommerce.android.ui.woopos.home.WooPosHomeState.ScanningSetupDialog
 import com.woocommerce.android.ui.woopos.home.cart.WooPosCartScreen
 import com.woocommerce.android.ui.woopos.home.cart.WooPosCartScreenProductsPreview
 import com.woocommerce.android.ui.woopos.home.items.WooPosItemsScreen
 import com.woocommerce.android.ui.woopos.home.items.products.WooPosItemsScreenPreview
+import com.woocommerce.android.ui.woopos.home.scanningsetup.WooPosScanningSetupDialog
 import com.woocommerce.android.ui.woopos.home.toolbar.PreviewWooPosFloatingToolbarStatusConnectedWithMenu
 import com.woocommerce.android.ui.woopos.home.toolbar.WooPosFloatingToolbar
 import com.woocommerce.android.ui.woopos.home.totals.WooPosTotalsScreen
@@ -178,6 +180,7 @@ private fun WooPosHomeScreen(
 
         HandleProductsInfoDialog(state.productsInfoDialog, onHomeUIEvent)
         HandleBarcodeInfoDialog(state.barcodeInfoDialog, onHomeUIEvent)
+        HandleScanningSetupDialog(state.scanningSetupDialog, onHomeUIEvent)
     }
 }
 
@@ -205,6 +208,20 @@ private fun HandleBarcodeInfoDialog(
             onHomeUIEvent(WooPosHomeUIEvent.DismissBarcodeInfoDialog)
         }
     )
+}
+
+@Composable
+private fun HandleScanningSetupDialog(
+    state: ScanningSetupDialog,
+    onHomeUIEvent: (WooPosHomeUIEvent) -> Unit
+) {
+    if (state.isVisible) {
+        WooPosScanningSetupDialog(
+            onDismissRequest = {
+                onHomeUIEvent(WooPosHomeUIEvent.DismissScanningSetupDialog)
+            }
+        )
+    }
 }
 
 @Composable

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/WooPosHomeState.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/WooPosHomeState.kt
@@ -11,6 +11,7 @@ data class WooPosHomeState(
     val screenPositionState: ScreenPositionState,
     val productsInfoDialog: ProductsInfoDialog,
     val barcodeInfoDialog: BarcodeInfoDialog,
+    val scanningSetupDialog: ScanningSetupDialog = ScanningSetupDialog(isVisible = false),
     val exitConfirmationDialog: ExitConfirmationDialog,
 ) : Parcelable {
     @Parcelize
@@ -84,6 +85,9 @@ data class WooPosHomeState(
             @StringRes val label: Int,
         )
     }
+
+    @Parcelize
+    data class ScanningSetupDialog(val isVisible: Boolean) : Parcelable
 
     @Parcelize
     data class ExitConfirmationDialog(val isVisible: Boolean) : Parcelable {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/WooPosHomeUIEvent.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/WooPosHomeUIEvent.kt
@@ -7,6 +7,7 @@ sealed class WooPosHomeUIEvent {
     data object ExitConfirmationDialogDismissed : WooPosHomeUIEvent()
     data object DismissProductsInfoDialog : WooPosHomeUIEvent()
     data object DismissBarcodeInfoDialog : WooPosHomeUIEvent()
+    data object DismissScanningSetupDialog : WooPosHomeUIEvent()
     data object OnPaymentCompletedViaCash : WooPosHomeUIEvent()
     data object ExitPosClicked : WooPosHomeUIEvent()
     data class OnBarcodeEvent(

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/WooPosHomeViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/WooPosHomeViewModel.kt
@@ -15,10 +15,12 @@ import com.woocommerce.android.ui.woopos.home.ParentToChildrenEvent.SearchEvent.
 import com.woocommerce.android.ui.woopos.home.WooPosHomeState.BarcodeInfoDialog
 import com.woocommerce.android.ui.woopos.home.WooPosHomeState.ExitConfirmationDialog
 import com.woocommerce.android.ui.woopos.home.WooPosHomeState.ProductsInfoDialog
+import com.woocommerce.android.ui.woopos.home.WooPosHomeState.ScanningSetupDialog
 import com.woocommerce.android.ui.woopos.home.WooPosHomeState.ScreenPositionState
 import com.woocommerce.android.ui.woopos.util.analytics.WooPosAnalyticsEvent
 import com.woocommerce.android.ui.woopos.util.analytics.WooPosAnalyticsEvent.Event.BackToCartTapped
 import com.woocommerce.android.ui.woopos.util.analytics.WooPosAnalyticsTracker
+import com.woocommerce.android.util.FeatureFlag
 import com.woocommerce.android.viewmodel.getStateFlow
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.MutableSharedFlow
@@ -42,6 +44,7 @@ class WooPosHomeViewModel @Inject constructor(
             screenPositionState = ScreenPositionState.Cart,
             productsInfoDialog = ProductsInfoDialog(isVisible = false),
             barcodeInfoDialog = BarcodeInfoDialog(isVisible = false),
+            scanningSetupDialog = ScanningSetupDialog(isVisible = false),
             exitConfirmationDialog = ExitConfirmationDialog(isVisible = false),
         )
     )
@@ -108,6 +111,12 @@ class WooPosHomeViewModel @Inject constructor(
             WooPosHomeUIEvent.DismissBarcodeInfoDialog -> {
                 _state.value = _state.value.copy(
                     barcodeInfoDialog = BarcodeInfoDialog(isVisible = false)
+                )
+            }
+
+            WooPosHomeUIEvent.DismissScanningSetupDialog -> {
+                _state.value = _state.value.copy(
+                    scanningSetupDialog = ScanningSetupDialog(isVisible = false)
                 )
             }
 
@@ -201,9 +210,15 @@ class WooPosHomeViewModel @Inject constructor(
                     }
 
                     ChildToParentEvent.BarcodeInfoMenuItemClicked -> {
-                        _state.value = _state.value.copy(
-                            barcodeInfoDialog = BarcodeInfoDialog(isVisible = true)
-                        )
+                        if (FeatureFlag.WOO_POS_SCANNER_SETUP.isEnabled()) {
+                            _state.value = _state.value.copy(
+                                scanningSetupDialog = ScanningSetupDialog(isVisible = true)
+                            )
+                        } else {
+                            _state.value = _state.value.copy(
+                                barcodeInfoDialog = BarcodeInfoDialog(isVisible = true)
+                            )
+                        }
                     }
 
                     is ChildToParentEvent.ToastMessageDisplayed -> {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/scanningsetup/WooPosScanningSetupDialog.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/scanningsetup/WooPosScanningSetupDialog.kt
@@ -81,27 +81,13 @@ fun WooPosScanningSetupDialog(
                 .background(color = MaterialTheme.colorScheme.surfaceBright)
                 .padding(WooPosSpacing.XLarge.value.toAdaptivePadding())
         ) {
-            IconButton(
-                onClick = onDismissRequest,
-                modifier = Modifier
-                    .align(Alignment.TopEnd)
-            ) {
-                Icon(
-                    Icons.Default.Close,
-                    contentDescription = stringResource(
-                        id = R.string.woopos_exit_dialog_confirmation_close_content_description
-                    ),
-                    modifier = Modifier
-                        .size(40.dp),
-                    tint = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.6f)
-                )
-            }
             AnimatedContent(
                 targetState = state.currentStep,
                 transitionSpec = {
                     fadeIn() togetherWith fadeOut()
                 },
-                label = "step_transition"
+                label = "step_transition",
+                modifier = Modifier.padding(top = WooPosSpacing.XLarge.value.toAdaptivePadding()),
             ) { step ->
                 when (step) {
                     is ScanningSetupStep.Welcome -> WelcomeContent(
@@ -143,6 +129,22 @@ fun WooPosScanningSetupDialog(
                         onDone = onDismissRequest
                     )
                 }
+            }
+
+            IconButton(
+                onClick = onDismissRequest,
+                modifier = Modifier
+                    .align(Alignment.TopEnd)
+            ) {
+                Icon(
+                    Icons.Default.Close,
+                    contentDescription = stringResource(
+                        id = R.string.woopos_exit_dialog_confirmation_close_content_description
+                    ),
+                    modifier = Modifier
+                        .size(40.dp),
+                    tint = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.6f)
+                )
             }
         }
     }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/scanningsetup/WooPosScanningSetupDialog.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/scanningsetup/WooPosScanningSetupDialog.kt
@@ -340,6 +340,8 @@ private fun BarcodeStepContent(
             primaryText = step.primaryButtonText
             secondaryText = step.secondaryButtonText
         }
+
+        else -> error("Invalid step type for BarcodeStepContent: $step")
     }
 
     Column(

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/scanningsetup/WooPosScanningSetupDialog.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/scanningsetup/WooPosScanningSetupDialog.kt
@@ -17,10 +17,10 @@ import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.filled.CheckCircle
 import androidx.compose.material.icons.filled.Close
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
@@ -32,10 +32,13 @@ import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
+import androidx.compose.ui.draw.shadow
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.res.vectorResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
@@ -48,6 +51,7 @@ import com.woocommerce.android.ui.woopos.common.composeui.component.WooPosDialog
 import com.woocommerce.android.ui.woopos.common.composeui.component.WooPosOutlinedButton
 import com.woocommerce.android.ui.woopos.common.composeui.component.WooPosText
 import com.woocommerce.android.ui.woopos.common.composeui.designsystem.WooPosCornerRadius
+import com.woocommerce.android.ui.woopos.common.composeui.designsystem.WooPosElevation
 import com.woocommerce.android.ui.woopos.common.composeui.designsystem.WooPosSpacing
 import com.woocommerce.android.ui.woopos.common.composeui.designsystem.WooPosTheme
 import com.woocommerce.android.ui.woopos.common.composeui.designsystem.WooPosTypography
@@ -65,6 +69,7 @@ fun WooPosScanningSetupDialog(
     val context = LocalContext.current
 
     LaunchedEffect(Unit) {
+        viewModel.resetToWelcomeState()
         viewModel.openUrlEvent.collect { url ->
             ChromeCustomTabUtils.launchUrl(context, url, enableSlideAnimation = true)
         }
@@ -403,13 +408,8 @@ private fun SetupCompleteContent(
             .verticalScroll(rememberScrollState()),
         horizontalAlignment = Alignment.CenterHorizontally
     ) {
-        Icon(
-            imageVector = Icons.Default.CheckCircle,
-            contentDescription = null,
-            modifier = Modifier
-                .size(64.dp)
-                .padding(bottom = WooPosSpacing.Large.value.toAdaptivePadding()),
-            tint = MaterialTheme.colorScheme.primary
+        SetupCompleteCheckIcon(
+            modifier = Modifier.padding(bottom = WooPosSpacing.Large.value.toAdaptivePadding())
         )
 
         WooPosText(
@@ -431,6 +431,30 @@ private fun SetupCompleteContent(
             onClick = onDone,
             text = step.primaryButtonText,
             modifier = Modifier.fillMaxWidth()
+        )
+    }
+}
+
+@Composable
+private fun SetupCompleteCheckIcon(
+    modifier: Modifier = Modifier,
+) {
+    Box(
+        contentAlignment = Alignment.Center,
+        modifier = modifier
+            .size(166.dp)
+            .shadow(
+                elevation = WooPosElevation.Medium.value,
+                shape = CircleShape,
+                clip = false
+            )
+            .background(WooPosTheme.colors.success, CircleShape)
+    ) {
+        Icon(
+            imageVector = ImageVector.vectorResource(id = R.drawable.ic_woo_pos_check),
+            tint = WooPosTheme.colors.onSuccess,
+            contentDescription = stringResource(id = R.string.woopos_payment_successful_label),
+            modifier = Modifier.size(72.dp)
         )
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/scanningsetup/WooPosScanningSetupDialog.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/scanningsetup/WooPosScanningSetupDialog.kt
@@ -78,14 +78,11 @@ fun WooPosScanningSetupDialog(
         val state by viewModel.state.collectAsState()
         Box(
             modifier = Modifier
-                .background(
-                    color = MaterialTheme.colorScheme.surfaceBright,
-                    shape = RoundedCornerShape(WooPosCornerRadius.Large.value)
-                )
+                .background(color = MaterialTheme.colorScheme.surfaceBright)
                 .padding(WooPosSpacing.XLarge.value.toAdaptivePadding())
         ) {
             IconButton(
-                onClick = { onDismissRequest() },
+                onClick = onDismissRequest,
                 modifier = Modifier
                     .align(Alignment.TopEnd)
             ) {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/scanningsetup/WooPosScanningSetupDialog.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/scanningsetup/WooPosScanningSetupDialog.kt
@@ -1,9 +1,11 @@
 package com.woocommerce.android.ui.woopos.home.scanningsetup
 
+import androidx.compose.animation.AnimatedContent
+import androidx.compose.animation.fadeIn
+import androidx.compose.animation.fadeOut
+import androidx.compose.animation.togetherWith
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
-import androidx.compose.foundation.border
-import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -14,14 +16,14 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
-import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.filled.Bluetooth
 import androidx.compose.material.icons.filled.CheckCircle
+import androidx.compose.material.icons.filled.Close
 import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
@@ -31,13 +33,14 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
+import com.woocommerce.android.R
 import com.woocommerce.android.ui.compose.preview.FontScalePreviews
 import com.woocommerce.android.ui.woopos.common.composeui.WooPosPreview
 import com.woocommerce.android.ui.woopos.common.composeui.component.WooPosButton
@@ -57,8 +60,8 @@ import com.woocommerce.android.util.ChromeCustomTabUtils
 fun WooPosScanningSetupDialog(
     outerState: WooPosHomeState.ScanningSetupDialog,
     onDismissRequest: () -> Unit,
-    viewModel: WooPosScanningSetupViewModel = hiltViewModel(),
 ) {
+    val viewModel = hiltViewModel<WooPosScanningSetupViewModel>()
     val context = LocalContext.current
 
     LaunchedEffect(Unit) {
@@ -81,46 +84,68 @@ fun WooPosScanningSetupDialog(
                 )
                 .padding(WooPosSpacing.XLarge.value.toAdaptivePadding())
         ) {
-            when (val step = state.currentStep) {
-                is ScanningSetupStep.Welcome -> WelcomeContent(
-                    step = step,
-                    onBluetoothSelected = {
-                        viewModel.onUiEvent(WooPosScanningSetupUiEvent.OnBluetoothScannerSelected)
-                    },
-                    onSkip = onDismissRequest,
-                    onViewDocumentation = {
-                        viewModel.onUiEvent(WooPosScanningSetupUiEvent.OnViewDocumentation)
-                    }
+            IconButton(
+                onClick = { onDismissRequest() },
+                modifier = Modifier
+                    .align(Alignment.TopEnd)
+            ) {
+                Icon(
+                    Icons.Default.Close,
+                    contentDescription = stringResource(
+                        id = R.string.woopos_exit_dialog_confirmation_close_content_description
+                    ),
+                    modifier = Modifier
+                        .size(40.dp),
+                    tint = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.6f)
                 )
-                is ScanningSetupStep.Introduction -> IntroductionContent(
-                    step = step,
-                    onPrimaryClick = { viewModel.onUiEvent(WooPosScanningSetupUiEvent.OnPrimaryButtonClicked) },
-                    onSecondaryClick = { viewModel.onUiEvent(WooPosScanningSetupUiEvent.OnSecondaryButtonClicked) }
-                )
-                is ScanningSetupStep.BluetoothWarning -> BluetoothWarningContent(
-                    step = step,
-                    onPrimaryClick = { viewModel.onUiEvent(WooPosScanningSetupUiEvent.OnPrimaryButtonClicked) },
-                    onSecondaryClick = { viewModel.onUiEvent(WooPosScanningSetupUiEvent.OnSecondaryButtonClicked) }
-                )
-                is ScanningSetupStep.BluetoothPairing -> BarcodeStepContent(
-                    step = step,
-                    onPrimaryClick = { viewModel.onUiEvent(WooPosScanningSetupUiEvent.OnPrimaryButtonClicked) },
-                    onSecondaryClick = { viewModel.onUiEvent(WooPosScanningSetupUiEvent.OnSecondaryButtonClicked) }
-                )
-                is ScanningSetupStep.PairOnYourDevice -> BarcodeStepContent(
-                    step = step,
-                    onPrimaryClick = { viewModel.onUiEvent(WooPosScanningSetupUiEvent.OnPrimaryButtonClicked) },
-                    onSecondaryClick = { viewModel.onUiEvent(WooPosScanningSetupUiEvent.OnSecondaryButtonClicked) }
-                )
-                is ScanningSetupStep.TestYourScanner -> BarcodeStepContent(
-                    step = step,
-                    onPrimaryClick = { viewModel.onUiEvent(WooPosScanningSetupUiEvent.OnPrimaryButtonClicked) },
-                    onSecondaryClick = { viewModel.onUiEvent(WooPosScanningSetupUiEvent.OnSecondaryButtonClicked) }
-                )
-                is ScanningSetupStep.ScannerSetupComplete -> SetupCompleteContent(
-                    step = step,
-                    onDone = onDismissRequest
-                )
+            }
+            AnimatedContent(
+                targetState = state.currentStep,
+                transitionSpec = {
+                    fadeIn() togetherWith fadeOut()
+                },
+                label = "step_transition"
+            ) { step ->
+                when (step) {
+                    is ScanningSetupStep.Welcome -> WelcomeContent(
+                        step = step,
+                        onBluetoothSelected = {
+                            viewModel.onUiEvent(WooPosScanningSetupUiEvent.OnBluetoothScannerSelected)
+                        },
+                        onViewDocumentation = {
+                            viewModel.onUiEvent(WooPosScanningSetupUiEvent.OnViewDocumentation)
+                        }
+                    )
+                    is ScanningSetupStep.Introduction -> IntroductionContent(
+                        step = step,
+                        onPrimaryClick = { viewModel.onUiEvent(WooPosScanningSetupUiEvent.OnPrimaryButtonClicked) },
+                        onSecondaryClick = { viewModel.onUiEvent(WooPosScanningSetupUiEvent.OnSecondaryButtonClicked) }
+                    )
+                    is ScanningSetupStep.BluetoothWarning -> BluetoothWarningContent(
+                        step = step,
+                        onPrimaryClick = { viewModel.onUiEvent(WooPosScanningSetupUiEvent.OnPrimaryButtonClicked) },
+                        onSecondaryClick = { viewModel.onUiEvent(WooPosScanningSetupUiEvent.OnSecondaryButtonClicked) }
+                    )
+                    is ScanningSetupStep.BluetoothPairing -> BarcodeStepContent(
+                        step = step,
+                        onPrimaryClick = { viewModel.onUiEvent(WooPosScanningSetupUiEvent.OnPrimaryButtonClicked) },
+                        onSecondaryClick = { viewModel.onUiEvent(WooPosScanningSetupUiEvent.OnSecondaryButtonClicked) }
+                    )
+                    is ScanningSetupStep.PairOnYourDevice -> BarcodeStepContent(
+                        step = step,
+                        onPrimaryClick = { viewModel.onUiEvent(WooPosScanningSetupUiEvent.OnPrimaryButtonClicked) },
+                        onSecondaryClick = { viewModel.onUiEvent(WooPosScanningSetupUiEvent.OnSecondaryButtonClicked) }
+                    )
+                    is ScanningSetupStep.TestYourScanner -> BarcodeStepContent(
+                        step = step,
+                        onPrimaryClick = { viewModel.onUiEvent(WooPosScanningSetupUiEvent.OnPrimaryButtonClicked) },
+                        onSecondaryClick = { viewModel.onUiEvent(WooPosScanningSetupUiEvent.OnSecondaryButtonClicked) }
+                    )
+                    is ScanningSetupStep.ScannerSetupComplete -> SetupCompleteContent(
+                        step = step,
+                        onDone = onDismissRequest
+                    )
+                }
             }
         }
     }
@@ -130,7 +155,6 @@ fun WooPosScanningSetupDialog(
 private fun WelcomeContent(
     step: ScanningSetupStep.Welcome,
     onBluetoothSelected: () -> Unit,
-    onSkip: () -> Unit,
     onViewDocumentation: () -> Unit,
 ) {
     Column(
@@ -154,76 +178,19 @@ private fun WelcomeContent(
             modifier = Modifier.padding(bottom = WooPosSpacing.XLarge.value.toAdaptivePadding())
         )
 
-        ScannerOptionCard(
-            title = step.bluetoothOptionTitle,
-            description = step.bluetoothOptionDescription,
-            icon = Icons.Default.Bluetooth,
-            onClick = onBluetoothSelected
+        WooPosOutlinedButton(
+            onClick = onBluetoothSelected,
+            text = step.setupButtonText,
+            modifier = Modifier.fillMaxWidth()
         )
 
-        Spacer(modifier = Modifier.height(WooPosSpacing.XLarge.value.toAdaptivePadding()))
+        Spacer(modifier = Modifier.height(WooPosSpacing.Medium.value.toAdaptivePadding()))
 
         WooPosOutlinedButton(
             onClick = onViewDocumentation,
-            text = "View barcode scanner documentation",
+            text = step.documentationButtonText,
             modifier = Modifier.fillMaxWidth()
         )
-
-        WooPosOutlinedButton(
-            onClick = onSkip,
-            text = step.skipButtonText,
-            modifier = Modifier.fillMaxWidth()
-        )
-    }
-}
-
-@Composable
-private fun ScannerOptionCard(
-    title: String,
-    description: String,
-    icon: ImageVector,
-    onClick: () -> Unit,
-) {
-    Box(
-        modifier = Modifier
-            .fillMaxWidth()
-            .clip(RoundedCornerShape(WooPosCornerRadius.Medium.value))
-            .border(
-                width = 1.dp,
-                color = MaterialTheme.colorScheme.outline,
-                shape = RoundedCornerShape(WooPosCornerRadius.Medium.value)
-            )
-            .clickable { onClick() }
-            .padding(WooPosSpacing.Large.value.toAdaptivePadding())
-    ) {
-        Row(
-            modifier = Modifier.fillMaxWidth(),
-            verticalAlignment = Alignment.CenterVertically
-        ) {
-            Icon(
-                imageVector = icon,
-                contentDescription = null,
-                modifier = Modifier.size(48.dp),
-                tint = MaterialTheme.colorScheme.primary
-            )
-
-            Spacer(modifier = Modifier.width(WooPosSpacing.Medium.value.toAdaptivePadding()))
-
-            Column(
-                modifier = Modifier.weight(1f)
-            ) {
-                WooPosText(
-                    text = title,
-                    style = WooPosTypography.BodyLarge,
-                    fontWeight = FontWeight.SemiBold
-                )
-                WooPosText(
-                    text = description,
-                    style = WooPosTypography.BodyMedium,
-                    color = MaterialTheme.colorScheme.onSurfaceVariant
-                )
-            }
-        }
     }
 }
 
@@ -480,14 +447,12 @@ fun WooPosScanningSetupDialogPreview() {
         ) {
             WelcomeContent(
                 step = ScanningSetupStep.Welcome(
-                    title = "Set up a barcode scanner",
+                    title = "Start using a barcode scanner",
                     message = "Choose the type of scanner you'd like to connect",
-                    bluetoothOptionTitle = "Bluetooth scanner",
-                    bluetoothOptionDescription = "Connect wirelessly via Bluetooth",
-                    skipButtonText = "Skip"
+                    setupButtonText = "Set up a barcode scanner",
+                    documentationButtonText = "View barcode scanner documentation"
                 ),
                 onBluetoothSelected = {},
-                onSkip = {},
                 onViewDocumentation = {}
             )
         }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/scanningsetup/WooPosScanningSetupDialog.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/scanningsetup/WooPosScanningSetupDialog.kt
@@ -68,13 +68,17 @@ fun WooPosScanningSetupDialog(
     val viewModel = hiltViewModel<WooPosScanningSetupViewModel>()
     val context = LocalContext.current
 
+    LaunchedEffect(outerState.isVisible) {
+        if (outerState.isVisible) {
+            viewModel.resetToWelcomeState()
+        }
+    }
+
     LaunchedEffect(Unit) {
-        viewModel.resetToWelcomeState()
         viewModel.openUrlEvent.collect { url ->
             ChromeCustomTabUtils.launchUrl(context, url, enableSlideAnimation = true)
         }
     }
-
     WooPosDialogWrapper(
         isVisible = outerState.isVisible,
         onDismissRequest = onDismissRequest,
@@ -104,31 +108,37 @@ fun WooPosScanningSetupDialog(
                             viewModel.onUiEvent(WooPosScanningSetupUiEvent.OnViewDocumentation)
                         }
                     )
+
                     is ScanningSetupStep.Introduction -> IntroductionContent(
                         step = step,
                         onPrimaryClick = { viewModel.onUiEvent(WooPosScanningSetupUiEvent.OnPrimaryButtonClicked) },
                         onSecondaryClick = { viewModel.onUiEvent(WooPosScanningSetupUiEvent.OnSecondaryButtonClicked) }
                     )
+
                     is ScanningSetupStep.BluetoothWarning -> BluetoothWarningContent(
                         step = step,
                         onPrimaryClick = { viewModel.onUiEvent(WooPosScanningSetupUiEvent.OnPrimaryButtonClicked) },
                         onSecondaryClick = { viewModel.onUiEvent(WooPosScanningSetupUiEvent.OnSecondaryButtonClicked) }
                     )
+
                     is ScanningSetupStep.BluetoothPairing -> BarcodeStepContent(
                         step = step,
                         onPrimaryClick = { viewModel.onUiEvent(WooPosScanningSetupUiEvent.OnPrimaryButtonClicked) },
                         onSecondaryClick = { viewModel.onUiEvent(WooPosScanningSetupUiEvent.OnSecondaryButtonClicked) }
                     )
+
                     is ScanningSetupStep.PairOnYourDevice -> BarcodeStepContent(
                         step = step,
                         onPrimaryClick = { viewModel.onUiEvent(WooPosScanningSetupUiEvent.OnPrimaryButtonClicked) },
                         onSecondaryClick = { viewModel.onUiEvent(WooPosScanningSetupUiEvent.OnSecondaryButtonClicked) }
                     )
+
                     is ScanningSetupStep.TestYourScanner -> BarcodeStepContent(
                         step = step,
                         onPrimaryClick = { viewModel.onUiEvent(WooPosScanningSetupUiEvent.OnPrimaryButtonClicked) },
                         onSecondaryClick = { viewModel.onUiEvent(WooPosScanningSetupUiEvent.OnSecondaryButtonClicked) }
                     )
+
                     is ScanningSetupStep.ScannerSetupComplete -> SetupCompleteContent(
                         step = step,
                         onDone = onDismissRequest
@@ -312,6 +322,7 @@ private fun BarcodeStepContent(
             primaryText = step.primaryButtonText
             secondaryText = step.secondaryButtonText
         }
+
         is ScanningSetupStep.PairOnYourDevice -> {
             title = step.title
             message = step.message
@@ -320,6 +331,7 @@ private fun BarcodeStepContent(
             primaryText = step.primaryButtonText
             secondaryText = step.secondaryButtonText
         }
+
         is ScanningSetupStep.TestYourScanner -> {
             title = step.title
             message = step.message
@@ -328,7 +340,6 @@ private fun BarcodeStepContent(
             primaryText = step.primaryButtonText
             secondaryText = step.secondaryButtonText
         }
-        else -> return
     }
 
     Column(

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/scanningsetup/WooPosScanningSetupDialog.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/scanningsetup/WooPosScanningSetupDialog.kt
@@ -1,0 +1,500 @@
+package com.woocommerce.android.ui.woopos.home.scanningsetup
+
+import androidx.compose.foundation.Image
+import androidx.compose.foundation.background
+import androidx.compose.foundation.border
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Bluetooth
+import androidx.compose.material.icons.filled.CheckCircle
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.dp
+import androidx.hilt.navigation.compose.hiltViewModel
+import com.woocommerce.android.ui.compose.preview.FontScalePreviews
+import com.woocommerce.android.ui.woopos.common.composeui.WooPosPreview
+import com.woocommerce.android.ui.woopos.common.composeui.component.WooPosButton
+import com.woocommerce.android.ui.woopos.common.composeui.component.WooPosDialogWrapper
+import com.woocommerce.android.ui.woopos.common.composeui.component.WooPosOutlinedButton
+import com.woocommerce.android.ui.woopos.common.composeui.component.WooPosText
+import com.woocommerce.android.ui.woopos.common.composeui.designsystem.WooPosCornerRadius
+import com.woocommerce.android.ui.woopos.common.composeui.designsystem.WooPosSpacing
+import com.woocommerce.android.ui.woopos.common.composeui.designsystem.WooPosTheme
+import com.woocommerce.android.ui.woopos.common.composeui.designsystem.WooPosTypography
+import com.woocommerce.android.ui.woopos.common.composeui.designsystem.toAdaptivePadding
+import com.woocommerce.android.ui.woopos.home.scanningsetup.WooPosScanningSetupState.ScanningSetupStep
+import com.woocommerce.android.util.ChromeCustomTabUtils
+
+@Composable
+fun WooPosScanningSetupDialog(
+    onDismissRequest: () -> Unit,
+    viewModel: WooPosScanningSetupViewModel = hiltViewModel(),
+) {
+    val state by viewModel.state.collectAsState()
+    val context = LocalContext.current
+
+    LaunchedEffect(Unit) {
+        viewModel.openUrlEvent.collect { url ->
+            ChromeCustomTabUtils.launchUrl(context, url, enableSlideAnimation = true)
+        }
+    }
+
+    WooPosDialogWrapper(
+        isVisible = state.isVisible,
+        onDismissRequest = onDismissRequest,
+        dialogBackgroundContentDescription = "Scanner setup dialog"
+    ) {
+        Box(
+            modifier = Modifier
+                .background(
+                    color = MaterialTheme.colorScheme.surfaceBright,
+                    shape = RoundedCornerShape(WooPosCornerRadius.Large.value)
+                )
+                .padding(WooPosSpacing.XLarge.value.toAdaptivePadding())
+        ) {
+            when (val step = state.currentStep) {
+                null -> {
+                    LaunchedEffect(state.isVisible) {
+                        if (state.isVisible) {
+                            viewModel.show()
+                        }
+                    }
+                }
+                is ScanningSetupStep.Welcome -> WelcomeContent(
+                    step = step,
+                    onBluetoothSelected = {
+                        viewModel.onUiEvent(WooPosScanningSetupUiEvent.OnBluetoothScannerSelected)
+                    },
+                    onSkip = onDismissRequest,
+                    onViewDocumentation = {
+                        viewModel.onUiEvent(WooPosScanningSetupUiEvent.OnViewDocumentation)
+                    }
+                )
+                is ScanningSetupStep.Introduction -> IntroductionContent(
+                    step = step,
+                    onPrimaryClick = { viewModel.onUiEvent(WooPosScanningSetupUiEvent.OnPrimaryButtonClicked) },
+                    onSecondaryClick = { viewModel.onUiEvent(WooPosScanningSetupUiEvent.OnSecondaryButtonClicked) }
+                )
+                is ScanningSetupStep.BluetoothWarning -> BluetoothWarningContent(
+                    step = step,
+                    onPrimaryClick = { viewModel.onUiEvent(WooPosScanningSetupUiEvent.OnPrimaryButtonClicked) },
+                    onSecondaryClick = { viewModel.onUiEvent(WooPosScanningSetupUiEvent.OnSecondaryButtonClicked) }
+                )
+                is ScanningSetupStep.BluetoothPairing -> BarcodeStepContent(
+                    step = step,
+                    onPrimaryClick = { viewModel.onUiEvent(WooPosScanningSetupUiEvent.OnPrimaryButtonClicked) },
+                    onSecondaryClick = { viewModel.onUiEvent(WooPosScanningSetupUiEvent.OnSecondaryButtonClicked) }
+                )
+                is ScanningSetupStep.PairOnYourDevice -> BarcodeStepContent(
+                    step = step,
+                    onPrimaryClick = { viewModel.onUiEvent(WooPosScanningSetupUiEvent.OnPrimaryButtonClicked) },
+                    onSecondaryClick = { viewModel.onUiEvent(WooPosScanningSetupUiEvent.OnSecondaryButtonClicked) }
+                )
+                is ScanningSetupStep.TestYourScanner -> BarcodeStepContent(
+                    step = step,
+                    onPrimaryClick = { viewModel.onUiEvent(WooPosScanningSetupUiEvent.OnPrimaryButtonClicked) },
+                    onSecondaryClick = { viewModel.onUiEvent(WooPosScanningSetupUiEvent.OnSecondaryButtonClicked) }
+                )
+                is ScanningSetupStep.ScannerSetupComplete -> SetupCompleteContent(
+                    step = step,
+                    onDone = onDismissRequest
+                )
+            }
+        }
+    }
+}
+
+@Composable
+private fun WelcomeContent(
+    step: ScanningSetupStep.Welcome,
+    onBluetoothSelected: () -> Unit,
+    onSkip: () -> Unit,
+    onViewDocumentation: () -> Unit,
+) {
+    Column(
+        modifier = Modifier
+            .fillMaxWidth()
+            .verticalScroll(rememberScrollState()),
+        horizontalAlignment = Alignment.CenterHorizontally
+    ) {
+        WooPosText(
+            text = step.title,
+            style = WooPosTypography.Heading,
+            fontWeight = FontWeight.Bold,
+            textAlign = TextAlign.Center,
+            modifier = Modifier.padding(bottom = WooPosSpacing.Medium.value.toAdaptivePadding())
+        )
+
+        WooPosText(
+            text = step.message,
+            style = WooPosTypography.BodyLarge,
+            textAlign = TextAlign.Center,
+            modifier = Modifier.padding(bottom = WooPosSpacing.XLarge.value.toAdaptivePadding())
+        )
+
+        ScannerOptionCard(
+            title = step.bluetoothOptionTitle,
+            description = step.bluetoothOptionDescription,
+            icon = Icons.Default.Bluetooth,
+            onClick = onBluetoothSelected
+        )
+
+        Spacer(modifier = Modifier.height(WooPosSpacing.XLarge.value.toAdaptivePadding()))
+
+        WooPosOutlinedButton(
+            onClick = onViewDocumentation,
+            text = "View barcode scanner documentation",
+            modifier = Modifier.fillMaxWidth()
+        )
+
+        WooPosOutlinedButton(
+            onClick = onSkip,
+            text = step.skipButtonText,
+            modifier = Modifier.fillMaxWidth()
+        )
+    }
+}
+
+@Composable
+private fun ScannerOptionCard(
+    title: String,
+    description: String,
+    icon: ImageVector,
+    onClick: () -> Unit,
+) {
+    Box(
+        modifier = Modifier
+            .fillMaxWidth()
+            .clip(RoundedCornerShape(WooPosCornerRadius.Medium.value))
+            .border(
+                width = 1.dp,
+                color = MaterialTheme.colorScheme.outline,
+                shape = RoundedCornerShape(WooPosCornerRadius.Medium.value)
+            )
+            .clickable { onClick() }
+            .padding(WooPosSpacing.Large.value.toAdaptivePadding())
+    ) {
+        Row(
+            modifier = Modifier.fillMaxWidth(),
+            verticalAlignment = Alignment.CenterVertically
+        ) {
+            Icon(
+                imageVector = icon,
+                contentDescription = null,
+                modifier = Modifier.size(48.dp),
+                tint = MaterialTheme.colorScheme.primary
+            )
+
+            Spacer(modifier = Modifier.width(WooPosSpacing.Medium.value.toAdaptivePadding()))
+
+            Column(
+                modifier = Modifier.weight(1f)
+            ) {
+                WooPosText(
+                    text = title,
+                    style = WooPosTypography.BodyLarge,
+                    fontWeight = FontWeight.SemiBold
+                )
+                WooPosText(
+                    text = description,
+                    style = WooPosTypography.BodyMedium,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant
+                )
+            }
+        }
+    }
+}
+
+@Composable
+private fun IntroductionContent(
+    step: ScanningSetupStep.Introduction,
+    onPrimaryClick: () -> Unit,
+    onSecondaryClick: () -> Unit,
+) {
+    Column(
+        modifier = Modifier
+            .fillMaxWidth()
+            .verticalScroll(rememberScrollState()),
+        horizontalAlignment = Alignment.CenterHorizontally
+    ) {
+        WooPosText(
+            text = step.title,
+            style = WooPosTypography.Heading,
+            fontWeight = FontWeight.Bold,
+            textAlign = TextAlign.Center,
+            modifier = Modifier.padding(bottom = WooPosSpacing.Medium.value.toAdaptivePadding())
+        )
+
+        WooPosText(
+            text = step.message,
+            style = WooPosTypography.BodyLarge,
+            textAlign = TextAlign.Center,
+            modifier = Modifier.padding(bottom = WooPosSpacing.XLarge.value.toAdaptivePadding())
+        )
+
+        Row(
+            modifier = Modifier.fillMaxWidth(),
+            horizontalArrangement = Arrangement.spacedBy(WooPosSpacing.Medium.value.toAdaptivePadding())
+        ) {
+            WooPosOutlinedButton(
+                onClick = onSecondaryClick,
+                text = step.secondaryButtonText,
+                modifier = Modifier.weight(1f)
+            )
+
+            WooPosButton(
+                onClick = onPrimaryClick,
+                text = step.primaryButtonText,
+                modifier = Modifier.weight(1f)
+            )
+        }
+    }
+}
+
+@Composable
+private fun BluetoothWarningContent(
+    step: ScanningSetupStep.BluetoothWarning,
+    onPrimaryClick: () -> Unit,
+    onSecondaryClick: () -> Unit,
+) {
+    Column(
+        modifier = Modifier
+            .fillMaxWidth()
+            .verticalScroll(rememberScrollState()),
+        horizontalAlignment = Alignment.CenterHorizontally
+    ) {
+        WooPosText(
+            text = step.title,
+            style = WooPosTypography.Heading,
+            fontWeight = FontWeight.Bold,
+            textAlign = TextAlign.Center,
+            modifier = Modifier.padding(bottom = WooPosSpacing.Medium.value.toAdaptivePadding())
+        )
+
+        WooPosText(
+            text = step.message,
+            style = WooPosTypography.BodyLarge,
+            textAlign = TextAlign.Center,
+            modifier = Modifier.padding(bottom = WooPosSpacing.XLarge.value.toAdaptivePadding())
+        )
+
+        Row(
+            modifier = Modifier.fillMaxWidth(),
+            horizontalArrangement = Arrangement.spacedBy(WooPosSpacing.Medium.value.toAdaptivePadding())
+        ) {
+            WooPosOutlinedButton(
+                onClick = onSecondaryClick,
+                text = step.secondaryButtonText,
+                modifier = Modifier.weight(1f)
+            )
+
+            WooPosButton(
+                onClick = onPrimaryClick,
+                text = step.primaryButtonText,
+                modifier = Modifier.weight(1f)
+            )
+        }
+    }
+}
+
+@Composable
+private fun BarcodeStepContent(
+    step: ScanningSetupStep,
+    onPrimaryClick: () -> Unit,
+    onSecondaryClick: () -> Unit,
+) {
+    val title: String
+    val message: String
+    val barcodeRes: Int
+    val instruction: String
+    val primaryText: String
+    val secondaryText: String
+
+    when (step) {
+        is ScanningSetupStep.BluetoothPairing -> {
+            title = step.title
+            message = step.message
+            barcodeRes = step.barcodeImageRes
+            instruction = step.instructionText
+            primaryText = step.primaryButtonText
+            secondaryText = step.secondaryButtonText
+        }
+        is ScanningSetupStep.PairOnYourDevice -> {
+            title = step.title
+            message = step.message
+            barcodeRes = step.barcodeImageRes
+            instruction = step.instructionText
+            primaryText = step.primaryButtonText
+            secondaryText = step.secondaryButtonText
+        }
+        is ScanningSetupStep.TestYourScanner -> {
+            title = step.title
+            message = step.message
+            barcodeRes = step.barcodeImageRes
+            instruction = step.instructionText
+            primaryText = step.primaryButtonText
+            secondaryText = step.secondaryButtonText
+        }
+        else -> return
+    }
+
+    Column(
+        modifier = Modifier
+            .fillMaxWidth()
+            .verticalScroll(rememberScrollState()),
+        horizontalAlignment = Alignment.CenterHorizontally
+    ) {
+        WooPosText(
+            text = title,
+            style = WooPosTypography.Heading,
+            fontWeight = FontWeight.Bold,
+            textAlign = TextAlign.Center,
+            modifier = Modifier.padding(bottom = WooPosSpacing.Medium.value.toAdaptivePadding())
+        )
+
+        WooPosText(
+            text = message,
+            style = WooPosTypography.BodyLarge,
+            textAlign = TextAlign.Center,
+            modifier = Modifier.padding(bottom = WooPosSpacing.Large.value.toAdaptivePadding())
+        )
+
+        Box(
+            modifier = Modifier
+                .size(200.dp)
+                .clip(RoundedCornerShape(WooPosCornerRadius.Medium.value))
+                .background(Color.White)
+                .padding(WooPosSpacing.Medium.value.toAdaptivePadding()),
+            contentAlignment = Alignment.Center
+        ) {
+            Image(
+                painter = painterResource(id = barcodeRes),
+                contentDescription = "Barcode",
+                modifier = Modifier.fillMaxSize()
+            )
+        }
+
+        WooPosText(
+            text = instruction,
+            style = WooPosTypography.BodyMedium,
+            textAlign = TextAlign.Center,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+            modifier = Modifier.padding(
+                top = WooPosSpacing.Large.value.toAdaptivePadding(),
+                bottom = WooPosSpacing.XLarge.value.toAdaptivePadding()
+            )
+        )
+
+        Row(
+            modifier = Modifier.fillMaxWidth(),
+            horizontalArrangement = Arrangement.spacedBy(WooPosSpacing.Medium.value.toAdaptivePadding())
+        ) {
+            WooPosOutlinedButton(
+                onClick = onSecondaryClick,
+                text = secondaryText,
+                modifier = Modifier.weight(1f)
+            )
+
+            WooPosButton(
+                onClick = onPrimaryClick,
+                text = primaryText,
+                modifier = Modifier.weight(1f)
+            )
+        }
+    }
+}
+
+@Composable
+private fun SetupCompleteContent(
+    step: ScanningSetupStep.ScannerSetupComplete,
+    onDone: () -> Unit,
+) {
+    Column(
+        modifier = Modifier
+            .fillMaxWidth()
+            .verticalScroll(rememberScrollState()),
+        horizontalAlignment = Alignment.CenterHorizontally
+    ) {
+        Icon(
+            imageVector = Icons.Default.CheckCircle,
+            contentDescription = null,
+            modifier = Modifier
+                .size(64.dp)
+                .padding(bottom = WooPosSpacing.Large.value.toAdaptivePadding()),
+            tint = MaterialTheme.colorScheme.primary
+        )
+
+        WooPosText(
+            text = step.title,
+            style = WooPosTypography.Heading,
+            fontWeight = FontWeight.Bold,
+            textAlign = TextAlign.Center,
+            modifier = Modifier.padding(bottom = WooPosSpacing.Medium.value.toAdaptivePadding())
+        )
+
+        WooPosText(
+            text = step.message,
+            style = WooPosTypography.BodyLarge,
+            textAlign = TextAlign.Center,
+            modifier = Modifier.padding(bottom = WooPosSpacing.XLarge.value.toAdaptivePadding())
+        )
+
+        WooPosButton(
+            onClick = onDone,
+            text = step.primaryButtonText,
+            modifier = Modifier.fillMaxWidth()
+        )
+    }
+}
+
+@FontScalePreviews
+@WooPosPreview
+@Composable
+fun WooPosScanningSetupDialogPreview() {
+    WooPosTheme {
+        Box(
+            modifier = Modifier.fillMaxSize(),
+            contentAlignment = Alignment.Center
+        ) {
+            WelcomeContent(
+                step = ScanningSetupStep.Welcome(
+                    title = "Set up a barcode scanner",
+                    message = "Choose the type of scanner you'd like to connect",
+                    bluetoothOptionTitle = "Bluetooth scanner",
+                    bluetoothOptionDescription = "Connect wirelessly via Bluetooth",
+                    skipButtonText = "Skip"
+                ),
+                onBluetoothSelected = {},
+                onSkip = {},
+                onViewDocumentation = {}
+            )
+        }
+    }
+}

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/scanningsetup/WooPosScanningSetupDialog.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/scanningsetup/WooPosScanningSetupDialog.kt
@@ -80,13 +80,6 @@ fun WooPosScanningSetupDialog(
                 .padding(WooPosSpacing.XLarge.value.toAdaptivePadding())
         ) {
             when (val step = state.currentStep) {
-                null -> {
-                    LaunchedEffect(state.isVisible) {
-                        if (state.isVisible) {
-                            viewModel.show()
-                        }
-                    }
-                }
                 is ScanningSetupStep.Welcome -> WelcomeContent(
                     step = step,
                     onBluetoothSelected = {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/scanningsetup/WooPosScanningSetupDialog.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/scanningsetup/WooPosScanningSetupDialog.kt
@@ -49,15 +49,16 @@ import com.woocommerce.android.ui.woopos.common.composeui.designsystem.WooPosSpa
 import com.woocommerce.android.ui.woopos.common.composeui.designsystem.WooPosTheme
 import com.woocommerce.android.ui.woopos.common.composeui.designsystem.WooPosTypography
 import com.woocommerce.android.ui.woopos.common.composeui.designsystem.toAdaptivePadding
+import com.woocommerce.android.ui.woopos.home.WooPosHomeState
 import com.woocommerce.android.ui.woopos.home.scanningsetup.WooPosScanningSetupState.ScanningSetupStep
 import com.woocommerce.android.util.ChromeCustomTabUtils
 
 @Composable
 fun WooPosScanningSetupDialog(
+    outerState: WooPosHomeState.ScanningSetupDialog,
     onDismissRequest: () -> Unit,
     viewModel: WooPosScanningSetupViewModel = hiltViewModel(),
 ) {
-    val state by viewModel.state.collectAsState()
     val context = LocalContext.current
 
     LaunchedEffect(Unit) {
@@ -67,10 +68,11 @@ fun WooPosScanningSetupDialog(
     }
 
     WooPosDialogWrapper(
-        isVisible = state.isVisible,
+        isVisible = outerState.isVisible,
         onDismissRequest = onDismissRequest,
         dialogBackgroundContentDescription = "Scanner setup dialog"
     ) {
+        val state by viewModel.state.collectAsState()
         Box(
             modifier = Modifier
                 .background(

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/scanningsetup/WooPosScanningSetupState.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/scanningsetup/WooPosScanningSetupState.kt
@@ -14,9 +14,8 @@ data class WooPosScanningSetupState(
         data class Welcome(
             val title: String,
             val message: String,
-            val bluetoothOptionTitle: String,
-            val bluetoothOptionDescription: String,
-            val skipButtonText: String,
+            val setupButtonText: String,
+            val documentationButtonText: String,
         ) : ScanningSetupStep()
 
         @Parcelize

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/scanningsetup/WooPosScanningSetupState.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/scanningsetup/WooPosScanningSetupState.kt
@@ -1,0 +1,75 @@
+package com.woocommerce.android.ui.woopos.home.scanningsetup
+
+import android.os.Parcelable
+import androidx.annotation.DrawableRes
+import kotlinx.parcelize.Parcelize
+
+@Parcelize
+data class WooPosScanningSetupState(
+    val isVisible: Boolean = false,
+    val currentStep: ScanningSetupStep? = null,
+) : Parcelable {
+    sealed class ScanningSetupStep : Parcelable {
+        @Parcelize
+        data class Welcome(
+            val title: String,
+            val message: String,
+            val bluetoothOptionTitle: String,
+            val bluetoothOptionDescription: String,
+            val skipButtonText: String,
+        ) : ScanningSetupStep()
+
+        @Parcelize
+        data class Introduction(
+            val title: String,
+            val message: String,
+            val primaryButtonText: String,
+            val secondaryButtonText: String,
+        ) : ScanningSetupStep()
+
+        @Parcelize
+        data class BluetoothWarning(
+            val title: String,
+            val message: String,
+            val primaryButtonText: String,
+            val secondaryButtonText: String,
+        ) : ScanningSetupStep()
+
+        @Parcelize
+        data class BluetoothPairing(
+            val title: String,
+            val message: String,
+            @DrawableRes val barcodeImageRes: Int,
+            val instructionText: String,
+            val primaryButtonText: String,
+            val secondaryButtonText: String,
+        ) : ScanningSetupStep()
+
+        @Parcelize
+        data class PairOnYourDevice(
+            val title: String,
+            val message: String,
+            @DrawableRes val barcodeImageRes: Int,
+            val instructionText: String,
+            val primaryButtonText: String,
+            val secondaryButtonText: String,
+        ) : ScanningSetupStep()
+
+        @Parcelize
+        data class TestYourScanner(
+            val title: String,
+            val message: String,
+            @DrawableRes val barcodeImageRes: Int,
+            val instructionText: String,
+            val primaryButtonText: String,
+            val secondaryButtonText: String,
+        ) : ScanningSetupStep()
+
+        @Parcelize
+        data class ScannerSetupComplete(
+            val title: String,
+            val message: String,
+            val primaryButtonText: String,
+        ) : ScanningSetupStep()
+    }
+}

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/scanningsetup/WooPosScanningSetupState.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/scanningsetup/WooPosScanningSetupState.kt
@@ -7,7 +7,7 @@ import kotlinx.parcelize.Parcelize
 @Parcelize
 data class WooPosScanningSetupState(
     val isVisible: Boolean = false,
-    val currentStep: ScanningSetupStep? = null,
+    val currentStep: ScanningSetupStep
 ) : Parcelable {
     sealed class ScanningSetupStep : Parcelable {
         @Parcelize

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/scanningsetup/WooPosScanningSetupViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/scanningsetup/WooPosScanningSetupViewModel.kt
@@ -3,6 +3,7 @@ package com.woocommerce.android.ui.woopos.home.scanningsetup
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.woocommerce.android.R
+import com.woocommerce.android.ui.woopos.common.data.WOO_POS_BARCODE_DOC_URL
 import com.woocommerce.android.ui.woopos.home.scanningsetup.WooPosScanningSetupState.ScanningSetupStep
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.MutableSharedFlow
@@ -27,10 +28,6 @@ class WooPosScanningSetupViewModel @Inject constructor() : ViewModel() {
 
     private val _openUrlEvent = MutableSharedFlow<String>()
     val openUrlEvent: SharedFlow<String> = _openUrlEvent.asSharedFlow()
-
-    companion object {
-        private const val WOO_POS_BARCODE_DOC_URL = "https://woocommerce.com/document/barcode-and-qr-code-scanner/"
-    }
 
     fun onUiEvent(event: WooPosScanningSetupUiEvent) {
         when (event) {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/scanningsetup/WooPosScanningSetupViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/scanningsetup/WooPosScanningSetupViewModel.kt
@@ -56,6 +56,12 @@ class WooPosScanningSetupViewModel @Inject constructor() : ViewModel() {
         }
     }
 
+    fun resetToWelcomeState() {
+        _state.value = _state.value.copy(
+            currentStep = createWelcomeStep()
+        )
+    }
+
     private fun handlePrimaryButtonClick() {
         when (_state.value.currentStep) {
             is ScanningSetupStep.Welcome -> {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/scanningsetup/WooPosScanningSetupViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/scanningsetup/WooPosScanningSetupViewModel.kt
@@ -1,0 +1,183 @@
+package com.woocommerce.android.ui.woopos.home.scanningsetup
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.woocommerce.android.R
+import com.woocommerce.android.ui.woopos.home.scanningsetup.WooPosScanningSetupState.ScanningSetupStep
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.SharedFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asSharedFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.launch
+import javax.inject.Inject
+
+@HiltViewModel
+class WooPosScanningSetupViewModel @Inject constructor() : ViewModel() {
+
+    private val _state = MutableStateFlow(
+        WooPosScanningSetupState(
+            isVisible = false,
+            currentStep = null
+        )
+    )
+    val state: StateFlow<WooPosScanningSetupState> = _state.asStateFlow()
+
+    private val _openUrlEvent = MutableSharedFlow<String>()
+    val openUrlEvent: SharedFlow<String> = _openUrlEvent.asSharedFlow()
+
+    companion object {
+        private const val WOO_POS_BARCODE_DOC_URL = "https://woocommerce.com/document/barcode-and-qr-code-scanner/"
+    }
+
+    fun onUiEvent(event: WooPosScanningSetupUiEvent) {
+        when (event) {
+            WooPosScanningSetupUiEvent.OnBluetoothScannerSelected -> {
+                _state.value = _state.value.copy(
+                    currentStep = createBluetoothIntroductionStep()
+                )
+            }
+
+            WooPosScanningSetupUiEvent.OnPrimaryButtonClicked -> {
+                handlePrimaryButtonClick()
+            }
+
+            WooPosScanningSetupUiEvent.OnSecondaryButtonClicked -> {
+                handleSecondaryButtonClick()
+            }
+
+            WooPosScanningSetupUiEvent.OnViewDocumentation -> {
+                viewModelScope.launch {
+                    _openUrlEvent.emit(WOO_POS_BARCODE_DOC_URL)
+                }
+            }
+        }
+    }
+
+    fun show() {
+        _state.value = WooPosScanningSetupState(
+            isVisible = true,
+            currentStep = createWelcomeStep()
+        )
+    }
+
+    private fun handlePrimaryButtonClick() {
+        when (_state.value.currentStep) {
+            null -> error("Primary button clicked but dialog not initialized yet")
+            is ScanningSetupStep.Welcome -> {
+                error("Primary button should not be available on Welcome step")
+            }
+            is ScanningSetupStep.Introduction -> {
+                _state.value = _state.value.copy(
+                    currentStep = createBluetoothWarningStep()
+                )
+            }
+            is ScanningSetupStep.BluetoothWarning -> {
+                _state.value = _state.value.copy(
+                    currentStep = createBluetoothPairingStep()
+                )
+            }
+            is ScanningSetupStep.BluetoothPairing -> {
+                _state.value = _state.value.copy(
+                    currentStep = createPairOnYourDeviceStep()
+                )
+            }
+            is ScanningSetupStep.PairOnYourDevice -> {
+                _state.value = _state.value.copy(
+                    currentStep = createTestYourScannerStep()
+                )
+            }
+            is ScanningSetupStep.TestYourScanner -> {
+                _state.value = _state.value.copy(
+                    currentStep = createScannerSetupCompleteStep()
+                )
+            }
+            is ScanningSetupStep.ScannerSetupComplete -> {
+                // Handled by parent through onDismissRequest
+            }
+        }
+    }
+
+    private fun handleSecondaryButtonClick() {
+        when (_state.value.currentStep) {
+            null -> error("Secondary button clicked but dialog not initialized yet")
+            is ScanningSetupStep.Welcome -> error("Secondary button should not be available on Welcome step")
+            is ScanningSetupStep.Introduction,
+            is ScanningSetupStep.BluetoothWarning,
+            is ScanningSetupStep.BluetoothPairing,
+            is ScanningSetupStep.PairOnYourDevice,
+            is ScanningSetupStep.TestYourScanner -> {
+                _state.value = _state.value.copy(
+                    currentStep = createWelcomeStep()
+                )
+            }
+            is ScanningSetupStep.ScannerSetupComplete -> {
+                // No secondary button on complete screen
+            }
+        }
+    }
+
+    private fun createWelcomeStep() = ScanningSetupStep.Welcome(
+        title = "Set up a barcode scanner",
+        message = "Connect a Bluetooth barcode scanner to quickly add products to orders.",
+        bluetoothOptionTitle = "Bluetooth scanner",
+        bluetoothOptionDescription = "Connect wirelessly via Bluetooth",
+        skipButtonText = "Skip"
+    )
+
+    private fun createBluetoothIntroductionStep() = ScanningSetupStep.Introduction(
+        title = "Set up a Bluetooth scanner",
+        message = "Follow these steps to connect your Bluetooth barcode scanner.",
+        primaryButtonText = "Next",
+        secondaryButtonText = "Back"
+    )
+
+    private fun createBluetoothWarningStep() = ScanningSetupStep.BluetoothWarning(
+        title = "Bluetooth pairing",
+        message = "Make sure your scanner is in pairing mode before proceeding.",
+        primaryButtonText = "Next",
+        secondaryButtonText = "Back"
+    )
+
+    private fun createBluetoothPairingStep() = ScanningSetupStep.BluetoothPairing(
+        title = "Scan this barcode",
+        message = "Use your scanner to scan this barcode to configure it for pairing.",
+        barcodeImageRes = R.drawable.ic_barcode,
+        instructionText = "Scan the barcode above with your scanner",
+        primaryButtonText = "Next",
+        secondaryButtonText = "Back"
+    )
+
+    private fun createPairOnYourDeviceStep() = ScanningSetupStep.PairOnYourDevice(
+        title = "Pair on your device",
+        message = "Now scan this barcode to complete the pairing process.",
+        barcodeImageRes = R.drawable.ic_barcode,
+        instructionText = "Scan the barcode above to complete pairing",
+        primaryButtonText = "Next",
+        secondaryButtonText = "Back"
+    )
+
+    private fun createTestYourScannerStep() = ScanningSetupStep.TestYourScanner(
+        title = "Test your scanner",
+        message = "Scan this test barcode to verify your scanner is working correctly.",
+        barcodeImageRes = R.drawable.ic_barcode,
+        instructionText = "Scan the barcode above to test your scanner",
+        primaryButtonText = "Done",
+        secondaryButtonText = "Back"
+    )
+
+    private fun createScannerSetupCompleteStep() = ScanningSetupStep.ScannerSetupComplete(
+        title = "Scanner setup complete!",
+        message = "Your barcode scanner is now ready to use. You can start scanning products to add them to orders.",
+        primaryButtonText = "Done"
+    )
+}
+
+sealed class WooPosScanningSetupUiEvent {
+    data object OnBluetoothScannerSelected : WooPosScanningSetupUiEvent()
+    data object OnPrimaryButtonClicked : WooPosScanningSetupUiEvent()
+    data object OnSecondaryButtonClicked : WooPosScanningSetupUiEvent()
+    data object OnViewDocumentation : WooPosScanningSetupUiEvent()
+}

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/scanningsetup/WooPosScanningSetupViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/scanningsetup/WooPosScanningSetupViewModel.kt
@@ -20,7 +20,7 @@ class WooPosScanningSetupViewModel @Inject constructor() : ViewModel() {
     private val _state = MutableStateFlow(
         WooPosScanningSetupState(
             isVisible = false,
-            currentStep = null
+            currentStep = createWelcomeStep()
         )
     )
     val state: StateFlow<WooPosScanningSetupState> = _state.asStateFlow()
@@ -56,16 +56,8 @@ class WooPosScanningSetupViewModel @Inject constructor() : ViewModel() {
         }
     }
 
-    fun show() {
-        _state.value = WooPosScanningSetupState(
-            isVisible = true,
-            currentStep = createWelcomeStep()
-        )
-    }
-
     private fun handlePrimaryButtonClick() {
         when (_state.value.currentStep) {
-            null -> error("Primary button clicked but dialog not initialized yet")
             is ScanningSetupStep.Welcome -> {
                 error("Primary button should not be available on Welcome step")
             }
@@ -102,7 +94,6 @@ class WooPosScanningSetupViewModel @Inject constructor() : ViewModel() {
 
     private fun handleSecondaryButtonClick() {
         when (_state.value.currentStep) {
-            null -> error("Secondary button clicked but dialog not initialized yet")
             is ScanningSetupStep.Welcome -> error("Secondary button should not be available on Welcome step")
             is ScanningSetupStep.Introduction,
             is ScanningSetupStep.BluetoothWarning,
@@ -114,7 +105,7 @@ class WooPosScanningSetupViewModel @Inject constructor() : ViewModel() {
                 )
             }
             is ScanningSetupStep.ScannerSetupComplete -> {
-                // No secondary button on complete screen
+                error("Secondary button should not be available on ScannerSetupComplete step")
             }
         }
     }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/scanningsetup/WooPosScanningSetupViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/scanningsetup/WooPosScanningSetupViewModel.kt
@@ -95,13 +95,29 @@ class WooPosScanningSetupViewModel @Inject constructor() : ViewModel() {
     private fun handleSecondaryButtonClick() {
         when (_state.value.currentStep) {
             is ScanningSetupStep.Welcome -> error("Secondary button should not be available on Welcome step")
-            is ScanningSetupStep.Introduction,
-            is ScanningSetupStep.BluetoothWarning,
-            is ScanningSetupStep.BluetoothPairing,
-            is ScanningSetupStep.PairOnYourDevice,
-            is ScanningSetupStep.TestYourScanner -> {
+            is ScanningSetupStep.Introduction -> {
                 _state.value = _state.value.copy(
                     currentStep = createWelcomeStep()
+                )
+            }
+            is ScanningSetupStep.BluetoothWarning -> {
+                _state.value = _state.value.copy(
+                    currentStep = createBluetoothIntroductionStep()
+                )
+            }
+            is ScanningSetupStep.BluetoothPairing -> {
+                _state.value = _state.value.copy(
+                    currentStep = createBluetoothWarningStep()
+                )
+            }
+            is ScanningSetupStep.PairOnYourDevice -> {
+                _state.value = _state.value.copy(
+                    currentStep = createBluetoothPairingStep()
+                )
+            }
+            is ScanningSetupStep.TestYourScanner -> {
+                _state.value = _state.value.copy(
+                    currentStep = createPairOnYourDeviceStep()
                 )
             }
             is ScanningSetupStep.ScannerSetupComplete -> {
@@ -111,11 +127,10 @@ class WooPosScanningSetupViewModel @Inject constructor() : ViewModel() {
     }
 
     private fun createWelcomeStep() = ScanningSetupStep.Welcome(
-        title = "Set up a barcode scanner",
+        title = "Start using a barcode scanner",
         message = "Connect a Bluetooth barcode scanner to quickly add products to orders.",
-        bluetoothOptionTitle = "Bluetooth scanner",
-        bluetoothOptionDescription = "Connect wirelessly via Bluetooth",
-        skipButtonText = "Skip"
+        setupButtonText = "Set up a barcode scanner",
+        documentationButtonText = "View barcode scanner documentation"
     )
 
     private fun createBluetoothIntroductionStep() = ScanningSetupStep.Introduction(

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/scanningsetup/WooPosScanningSetupViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/scanningsetup/WooPosScanningSetupViewModel.kt
@@ -67,31 +67,37 @@ class WooPosScanningSetupViewModel @Inject constructor() : ViewModel() {
             is ScanningSetupStep.Welcome -> {
                 error("Primary button should not be available on Welcome step")
             }
+
             is ScanningSetupStep.Introduction -> {
                 _state.value = _state.value.copy(
                     currentStep = createBluetoothWarningStep()
                 )
             }
+
             is ScanningSetupStep.BluetoothWarning -> {
                 _state.value = _state.value.copy(
                     currentStep = createBluetoothPairingStep()
                 )
             }
+
             is ScanningSetupStep.BluetoothPairing -> {
                 _state.value = _state.value.copy(
                     currentStep = createPairOnYourDeviceStep()
                 )
             }
+
             is ScanningSetupStep.PairOnYourDevice -> {
                 _state.value = _state.value.copy(
                     currentStep = createTestYourScannerStep()
                 )
             }
+
             is ScanningSetupStep.TestYourScanner -> {
                 _state.value = _state.value.copy(
                     currentStep = createScannerSetupCompleteStep()
                 )
             }
+
             is ScanningSetupStep.ScannerSetupComplete -> {
                 // Handled by parent through onDismissRequest
             }
@@ -106,26 +112,31 @@ class WooPosScanningSetupViewModel @Inject constructor() : ViewModel() {
                     currentStep = createWelcomeStep()
                 )
             }
+
             is ScanningSetupStep.BluetoothWarning -> {
                 _state.value = _state.value.copy(
                     currentStep = createBluetoothIntroductionStep()
                 )
             }
+
             is ScanningSetupStep.BluetoothPairing -> {
                 _state.value = _state.value.copy(
                     currentStep = createBluetoothWarningStep()
                 )
             }
+
             is ScanningSetupStep.PairOnYourDevice -> {
                 _state.value = _state.value.copy(
                     currentStep = createBluetoothPairingStep()
                 )
             }
+
             is ScanningSetupStep.TestYourScanner -> {
                 _state.value = _state.value.copy(
                     currentStep = createPairOnYourDeviceStep()
                 )
             }
+
             is ScanningSetupStep.ScannerSetupComplete -> {
                 error("Secondary button should not be available on ScannerSetupComplete step")
             }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/scanningsetup/WooPosScanningSetupViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/scanningsetup/WooPosScanningSetupViewModel.kt
@@ -128,7 +128,7 @@ class WooPosScanningSetupViewModel @Inject constructor() : ViewModel() {
 
     private fun createWelcomeStep() = ScanningSetupStep.Welcome(
         title = "Start using a barcode scanner",
-        message = "Connect a Bluetooth barcode scanner to quickly add products to orders.",
+        message = "Choose an option:",
         setupButtonText = "Set up a barcode scanner",
         documentationButtonText = "View barcode scanner documentation"
     )

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/util/FeatureFlag.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/util/FeatureFlag.kt
@@ -10,6 +10,7 @@ enum class FeatureFlag {
     WC_SHIPPING_BANNER,
     BETTER_CUSTOMER_SEARCH_M2,
     ORDER_CREATION_AUTO_TAX_RATE,
+    WOO_POS_SCANNER_SETUP,
     NEW_SHIPPING_SUPPORT,
     REVAMP_WOO_SHIPPING,
     BULK_UPDATE_ORDERS_STATUS,
@@ -24,6 +25,7 @@ enum class FeatureFlag {
             WC_SHIPPING_BANNER,
             BETTER_CUSTOMER_SEARCH_M2,
             ORDER_CREATION_AUTO_TAX_RATE,
+            WOO_POS_SCANNER_SETUP,
             REVAMP_WOO_SHIPPING -> PackageUtils.isDebugBuild()
 
             NEW_SHIPPING_SUPPORT,


### PR DESCRIPTION
<\!-- Remember about a good descriptive title. -->

WOOMOB-775

### Description
<\!-- Take the time to write a good summary. Why is needed? What does it do? When fixing bugs try to avoid just writing "See original issue" – clarify what the problem was and how you've fixed it. -->
This PR implements a comprehensive barcode scanner setup flow for WooCommerce POS with improved user experience and proper state management.

The UI is based on the prototype so largely can be ignored. Every subscreen's UI should be properly reimplemented when the final UI is reader

**Key Features:**
- **Multi-step guided setup flow** for Bluetooth barcode scanners with fade-in/out animations
- **State-driven architecture** with proper ViewModel integration and reactive UI updates  

**Technical Implementation:**
- Created dedicated `scanningsetup` package under `com.woocommerce.android.ui.woopos.home`
- Implemented `WooPosScanningSetupState` with sealed class hierarchy for type-safe step management

**Flow Steps:**
1. **Welcome** - "Start using a barcode scanner" with setup button and documentation link
2. **Introduction** - Overview of Bluetooth scanner setup process
3. **Bluetooth Warning** - Pairing mode preparation instructions  
4. **Bluetooth Pairing** - Scan configuration barcode step
5. **Pair on Device** - Complete pairing process step
6. **Test Scanner** - Verify scanner functionality step
7. **Setup Complete** - Success confirmation with done action

### Steps to reproduce
<\!-- Step-by-step testing instructions. For new user flows, consider instead stating the goal of the workflow and see if your PR reviewer can accomplish the workflow without specific steps\! -->
1. Enable the `WOO_POS_SCANNER_SETUP` feature flag (enabled in debug)
2. Navigate to WooCommerce POS home screen
3. Tap the menu button and select "Barcode scanner info"
4. Verify the new setup flow opens instead of the old info dialog
5. Test navigation through all steps using Next/Back buttons
6. Test close button (X) in top-right corner
7. Test "View barcode scanner documentation" link opens correctly
8. Verify fade transitions between steps
9. Test back navigation goes to previous step
10. Complete full setup flow to success screen

### The tests that have been performed
<\!-- To give the reviewer an idea of what could be missed in terms of testing -->
Above

### Images/gif
<\!-- Include before and after images or gifs when appropriate. -->

https://github.com/user-attachments/assets/1cc7be4a-b455-47a0-bf34-5e37b78172ca


- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.

<\!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->