### PR TITLE
[WOOMOB-777][Woo POS] Remodel state of the home screen so only one dialog can be visible at a time

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/WooPosBarcodeInfoDialog.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/WooPosBarcodeInfoDialog.kt
@@ -46,7 +46,8 @@ private const val WOO_POS_BARCODE_DOC_URL = "https://woocommerce.com/document/ba
 
 @Composable
 fun WooPosBarcodeInfoDialog(
-    state: WooPosHomeState.BarcodeInfoDialog,
+    state: WooPosHomeState.DialogState.BarcodeInfoDialog,
+    isVisible: Boolean,
     onDismissRequest: () -> Unit,
 ) {
     val context = LocalContext.current
@@ -62,7 +63,7 @@ fun WooPosBarcodeInfoDialog(
         modifier = Modifier.semantics {
             disabled() // enforce talkback to read dialog content first while allowing to dismiss the dialog
         },
-        isVisible = state.isVisible,
+        isVisible = isVisible,
         dialogBackgroundContentDescription = dialogBackgroundContentDescription,
         onDismissRequest = onDismissRequest,
     ) {
@@ -264,7 +265,7 @@ fun WooPosBarcodeInfoDialog(
 }
 
 @Composable
-private fun getCombinedContentDescription(state: WooPosHomeState.BarcodeInfoDialog): String {
+private fun getCombinedContentDescription(state: WooPosHomeState.DialogState.BarcodeInfoDialog): String {
     val dialogContentDescription = stringResource(
         id = R.string.woopos_dialog_barcode_info_content_description
     )
@@ -284,7 +285,8 @@ fun BarcodeInfoDialogPreview() {
             contentAlignment = Alignment.Center
         ) {
             WooPosBarcodeInfoDialog(
-                state = WooPosHomeState.BarcodeInfoDialog(isVisible = true),
+                state = WooPosHomeState.DialogState.BarcodeInfoDialog,
+                isVisible = true,
                 onDismissRequest = {},
             )
         }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/WooPosHomeProductInfoDialog.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/WooPosHomeProductInfoDialog.kt
@@ -35,7 +35,8 @@ import com.woocommerce.android.ui.woopos.common.composeui.designsystem.toAdaptiv
 
 @Composable
 fun WooPosProductInfoDialog(
-    state: WooPosHomeState.ProductsInfoDialog,
+    state: WooPosHomeState.DialogState.ProductsInfoDialog,
+    isVisible: Boolean,
     onDismissRequest: () -> Unit,
 ) {
     val dialogContentDescription = getCombinedContentDescription(state = state)
@@ -47,7 +48,7 @@ fun WooPosProductInfoDialog(
     )
     WooPosDialogWrapper(
         modifier = Modifier,
-        isVisible = state.isVisible,
+        isVisible = isVisible,
         dialogBackgroundContentDescription = dialogBackgroundContentDescription,
         onDismissRequest = onDismissRequest
     ) {
@@ -145,7 +146,7 @@ fun WooPosProductInfoDialog(
 }
 
 @Composable
-private fun getCombinedContentDescription(state: WooPosHomeState.ProductsInfoDialog): String {
+private fun getCombinedContentDescription(state: WooPosHomeState.DialogState.ProductsInfoDialog): String {
     val dialogContentDescription = stringResource(
         id = R.string.woopos_banner_simple_products_dialog_content_description
     )
@@ -162,7 +163,8 @@ fun ProductInfoDialogPreview() {
             contentAlignment = Alignment.Center
         ) {
             WooPosProductInfoDialog(
-                state = WooPosHomeState.ProductsInfoDialog(isVisible = true),
+                state = WooPosHomeState.DialogState.ProductsInfoDialog,
+                isVisible = true,
                 onDismissRequest = {},
             )
         }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/WooPosHomeScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/WooPosHomeScreen.kt
@@ -117,15 +117,6 @@ private fun WooPosHomeScreen(
         totalsWidthDp = totalsWidthAnimatedDp,
         onHomeUIEvent = onHomeUIEvent,
     )
-
-    WooPosExitConfirmationDialog(
-        isVisible = state.dialogState == WooPosHomeState.DialogState.ExitConfirmationDialog,
-        title = stringResource(id = WooPosHomeState.DialogState.ExitConfirmationDialog.title),
-        message = stringResource(id = WooPosHomeState.DialogState.ExitConfirmationDialog.message),
-        dismissButtonText = stringResource(id = WooPosHomeState.DialogState.ExitConfirmationDialog.confirmButton),
-        onDismissRequest = { onHomeUIEvent(WooPosHomeUIEvent.ExitConfirmationDialogDismissed) },
-        onExit = { onHomeUIEvent(WooPosHomeUIEvent.ExitPosClicked) }
-    )
 }
 
 @Composable
@@ -174,50 +165,46 @@ private fun WooPosHomeScreen(
                 .align(Alignment.BottomStart),
         )
 
-        HandleProductsInfoDialog(state.dialogState, onHomeUIEvent)
-        HandleBarcodeInfoDialog(state.dialogState, onHomeUIEvent)
-        HandleScanningSetupDialog(state.dialogState, onHomeUIEvent)
+        Dialogs(state.dialogState, onHomeUIEvent)
     }
 }
 
 @Composable
-private fun HandleProductsInfoDialog(
+private fun Dialogs(
     dialogState: WooPosHomeState.DialogState,
     onHomeUIEvent: (WooPosHomeUIEvent) -> Unit
 ) {
+    // Always render all dialogs but control visibility for animations
     WooPosProductInfoDialog(
         state = WooPosHomeState.DialogState.ProductsInfoDialog,
-        isVisible = dialogState == WooPosHomeState.DialogState.ProductsInfoDialog,
+        isVisible = dialogState is WooPosHomeState.DialogState.ProductsInfoDialog,
         onDismissRequest = {
             onHomeUIEvent(WooPosHomeUIEvent.DismissProductsInfoDialog)
         }
     )
-}
 
-@Composable
-private fun HandleBarcodeInfoDialog(
-    dialogState: WooPosHomeState.DialogState,
-    onHomeUIEvent: (WooPosHomeUIEvent) -> Unit
-) {
     WooPosBarcodeInfoDialog(
         state = WooPosHomeState.DialogState.BarcodeInfoDialog,
-        isVisible = dialogState == WooPosHomeState.DialogState.BarcodeInfoDialog,
+        isVisible = dialogState is WooPosHomeState.DialogState.BarcodeInfoDialog,
         onDismissRequest = {
             onHomeUIEvent(WooPosHomeUIEvent.DismissBarcodeInfoDialog)
         }
     )
-}
 
-@Composable
-private fun HandleScanningSetupDialog(
-    dialogState: WooPosHomeState.DialogState,
-    onHomeUIEvent: (WooPosHomeUIEvent) -> Unit
-) {
     WooPosScanningSetupDialog(
-        isVisible = dialogState == WooPosHomeState.DialogState.ScanningSetupDialog,
+        isVisible = dialogState is WooPosHomeState.DialogState.ScanningSetupDialog,
         onDismissRequest = {
             onHomeUIEvent(WooPosHomeUIEvent.DismissScanningSetupDialog)
         }
+    )
+
+    WooPosExitConfirmationDialog(
+        isVisible = dialogState is WooPosHomeState.DialogState.ExitConfirmationDialog,
+        title = stringResource(id = WooPosHomeState.DialogState.ExitConfirmationDialog.title),
+        message = stringResource(id = WooPosHomeState.DialogState.ExitConfirmationDialog.message),
+        dismissButtonText = stringResource(id = WooPosHomeState.DialogState.ExitConfirmationDialog.confirmButton),
+        onDismissRequest = { onHomeUIEvent(WooPosHomeUIEvent.ExitConfirmationDialogDismissed) },
+        onExit = { onHomeUIEvent(WooPosHomeUIEvent.ExitPosClicked) }
     )
 }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/WooPosHomeScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/WooPosHomeScreen.kt
@@ -33,10 +33,6 @@ import com.woocommerce.android.ui.woopos.common.composeui.designsystem.WooPosThe
 import com.woocommerce.android.ui.woopos.common.composeui.designsystem.toAdaptivePadding
 import com.woocommerce.android.ui.woopos.common.composeui.isPreviewMode
 import com.woocommerce.android.ui.woopos.common.composeui.modifier.listenForBarcodes
-import com.woocommerce.android.ui.woopos.home.WooPosHomeState.BarcodeInfoDialog
-import com.woocommerce.android.ui.woopos.home.WooPosHomeState.ExitConfirmationDialog
-import com.woocommerce.android.ui.woopos.home.WooPosHomeState.ProductsInfoDialog
-import com.woocommerce.android.ui.woopos.home.WooPosHomeState.ScanningSetupDialog
 import com.woocommerce.android.ui.woopos.home.cart.WooPosCartScreen
 import com.woocommerce.android.ui.woopos.home.cart.WooPosCartScreenProductsPreview
 import com.woocommerce.android.ui.woopos.home.items.WooPosItemsScreen
@@ -123,10 +119,10 @@ private fun WooPosHomeScreen(
     )
 
     WooPosExitConfirmationDialog(
-        isVisible = state.exitConfirmationDialog.isVisible,
-        title = stringResource(id = state.exitConfirmationDialog.title),
-        message = stringResource(id = state.exitConfirmationDialog.message),
-        dismissButtonText = stringResource(id = state.exitConfirmationDialog.confirmButton),
+        isVisible = state.dialogState == WooPosHomeState.DialogState.ExitConfirmationDialog,
+        title = stringResource(id = WooPosHomeState.DialogState.ExitConfirmationDialog.title),
+        message = stringResource(id = WooPosHomeState.DialogState.ExitConfirmationDialog.message),
+        dismissButtonText = stringResource(id = WooPosHomeState.DialogState.ExitConfirmationDialog.confirmButton),
         onDismissRequest = { onHomeUIEvent(WooPosHomeUIEvent.ExitConfirmationDialogDismissed) },
         onExit = { onHomeUIEvent(WooPosHomeUIEvent.ExitPosClicked) }
     )
@@ -178,19 +174,20 @@ private fun WooPosHomeScreen(
                 .align(Alignment.BottomStart),
         )
 
-        HandleProductsInfoDialog(state.productsInfoDialog, onHomeUIEvent)
-        HandleBarcodeInfoDialog(state.barcodeInfoDialog, onHomeUIEvent)
-        HandleScanningSetupDialog(state.scanningSetupDialog, onHomeUIEvent)
+        HandleProductsInfoDialog(state.dialogState, onHomeUIEvent)
+        HandleBarcodeInfoDialog(state.dialogState, onHomeUIEvent)
+        HandleScanningSetupDialog(state.dialogState, onHomeUIEvent)
     }
 }
 
 @Composable
 private fun HandleProductsInfoDialog(
-    state: ProductsInfoDialog,
+    dialogState: WooPosHomeState.DialogState,
     onHomeUIEvent: (WooPosHomeUIEvent) -> Unit
 ) {
     WooPosProductInfoDialog(
-        state = state,
+        state = WooPosHomeState.DialogState.ProductsInfoDialog,
+        isVisible = dialogState == WooPosHomeState.DialogState.ProductsInfoDialog,
         onDismissRequest = {
             onHomeUIEvent(WooPosHomeUIEvent.DismissProductsInfoDialog)
         }
@@ -199,11 +196,12 @@ private fun HandleProductsInfoDialog(
 
 @Composable
 private fun HandleBarcodeInfoDialog(
-    state: BarcodeInfoDialog,
+    dialogState: WooPosHomeState.DialogState,
     onHomeUIEvent: (WooPosHomeUIEvent) -> Unit
 ) {
     WooPosBarcodeInfoDialog(
-        state = state,
+        state = WooPosHomeState.DialogState.BarcodeInfoDialog,
+        isVisible = dialogState == WooPosHomeState.DialogState.BarcodeInfoDialog,
         onDismissRequest = {
             onHomeUIEvent(WooPosHomeUIEvent.DismissBarcodeInfoDialog)
         }
@@ -212,11 +210,11 @@ private fun HandleBarcodeInfoDialog(
 
 @Composable
 private fun HandleScanningSetupDialog(
-    state: ScanningSetupDialog,
+    dialogState: WooPosHomeState.DialogState,
     onHomeUIEvent: (WooPosHomeUIEvent) -> Unit
 ) {
     WooPosScanningSetupDialog(
-        outerState = state,
+        isVisible = dialogState == WooPosHomeState.DialogState.ScanningSetupDialog,
         onDismissRequest = {
             onHomeUIEvent(WooPosHomeUIEvent.DismissScanningSetupDialog)
         }
@@ -287,9 +285,7 @@ fun WooPosHomeCartScreenPreview() {
         WooPosHomeScreen(
             state = WooPosHomeState(
                 screenPositionState = WooPosHomeState.ScreenPositionState.Cart,
-                productsInfoDialog = ProductsInfoDialog(isVisible = false),
-                barcodeInfoDialog = BarcodeInfoDialog(isVisible = false),
-                exitConfirmationDialog = ExitConfirmationDialog(isVisible = false),
+                dialogState = WooPosHomeState.DialogState.Hidden,
             ),
             onHomeUIEvent = { },
         )
@@ -303,9 +299,7 @@ fun WooPosHomeCheckoutScreenPreview() {
         WooPosHomeScreen(
             state = WooPosHomeState(
                 screenPositionState = WooPosHomeState.ScreenPositionState.Checkout.CartWithTotals,
-                productsInfoDialog = ProductsInfoDialog(isVisible = false),
-                barcodeInfoDialog = BarcodeInfoDialog(isVisible = false),
-                exitConfirmationDialog = ExitConfirmationDialog(isVisible = false),
+                dialogState = WooPosHomeState.DialogState.Hidden,
             ),
             onHomeUIEvent = { },
         )
@@ -319,9 +313,7 @@ fun WooPosHomeCheckoutPaidScreenPreview() {
         WooPosHomeScreen(
             state = WooPosHomeState(
                 screenPositionState = WooPosHomeState.ScreenPositionState.Checkout.FullScreenTotals,
-                productsInfoDialog = ProductsInfoDialog(isVisible = false),
-                barcodeInfoDialog = BarcodeInfoDialog(isVisible = false),
-                exitConfirmationDialog = ExitConfirmationDialog(isVisible = false),
+                dialogState = WooPosHomeState.DialogState.Hidden,
             ),
             onHomeUIEvent = { },
         )

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/WooPosHomeScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/WooPosHomeScreen.kt
@@ -174,7 +174,6 @@ private fun Dialogs(
     dialogState: WooPosHomeState.DialogState,
     onHomeUIEvent: (WooPosHomeUIEvent) -> Unit
 ) {
-    // Always render all dialogs but control visibility for animations
     WooPosProductInfoDialog(
         state = WooPosHomeState.DialogState.ProductsInfoDialog,
         isVisible = dialogState is WooPosHomeState.DialogState.ProductsInfoDialog,

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/WooPosHomeState.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/WooPosHomeState.kt
@@ -9,10 +9,7 @@ import kotlinx.parcelize.Parcelize
 @Parcelize
 data class WooPosHomeState(
     val screenPositionState: ScreenPositionState,
-    val productsInfoDialog: ProductsInfoDialog,
-    val barcodeInfoDialog: BarcodeInfoDialog,
-    val scanningSetupDialog: ScanningSetupDialog = ScanningSetupDialog(isVisible = false),
-    val exitConfirmationDialog: ExitConfirmationDialog,
+    val dialogState: DialogState = DialogState.Hidden,
 ) : Parcelable {
     @Parcelize
     sealed class ScreenPositionState : Parcelable {
@@ -30,74 +27,80 @@ data class WooPosHomeState(
     }
 
     @Parcelize
-    data class ProductsInfoDialog(val isVisible: Boolean) : Parcelable {
-        @IgnoredOnParcel
-        val header: Int = R.string.woopos_dialog_products_info_heading
+    sealed class DialogState : Parcelable {
+        @Parcelize
+        data object Hidden : DialogState()
 
-        @IgnoredOnParcel
-        val primaryMessage: Int = R.string.woopos_dialog_products_info_primary_message
+        @Parcelize
+        data object ProductsInfoDialog : DialogState() {
+            @IgnoredOnParcel
+            val header: Int = R.string.woopos_dialog_products_info_heading
 
-        @IgnoredOnParcel
-        val secondaryMessage: Int = R.string.woopos_dialog_products_info_secondary_message
+            @IgnoredOnParcel
+            val primaryMessage: Int = R.string.woopos_dialog_products_info_primary_message
 
-        @IgnoredOnParcel
-        val tertiaryMessage: Int = R.string.woopos_dialog_products_info_tertiary_message
+            @IgnoredOnParcel
+            val secondaryMessage: Int = R.string.woopos_dialog_products_info_secondary_message
 
-        @IgnoredOnParcel
-        val primaryButton: PrimaryButton = PrimaryButton(
-            label = R.string.woopos_dialog_products_info_button_label,
-        )
+            @IgnoredOnParcel
+            val tertiaryMessage: Int = R.string.woopos_dialog_products_info_tertiary_message
 
-        data class PrimaryButton(
-            @StringRes val label: Int,
-        )
-    }
+            @IgnoredOnParcel
+            val primaryButton: PrimaryButton = PrimaryButton(
+                label = R.string.woopos_dialog_products_info_button_label,
+            )
 
-    @Parcelize
-    data class BarcodeInfoDialog(val isVisible: Boolean) : Parcelable {
-        @IgnoredOnParcel
-        val header: Int = R.string.woopos_dialog_barcode_info_heading
+            data class PrimaryButton(
+                @StringRes val label: Int,
+            )
+        }
 
-        @IgnoredOnParcel
-        val introMessage: Int = R.string.woopos_dialog_barcode_info_intro_message
+        @Parcelize
+        data object BarcodeInfoDialog : DialogState() {
+            @IgnoredOnParcel
+            val header: Int = R.string.woopos_dialog_barcode_info_heading
 
-        @IgnoredOnParcel
-        val primaryMessage: Int = R.string.woopos_dialog_barcode_info_primary_message
+            @IgnoredOnParcel
+            val introMessage: Int = R.string.woopos_dialog_barcode_info_intro_message
 
-        @IgnoredOnParcel
-        val secondaryMessage: Int = R.string.woopos_dialog_barcode_info_secondary_message
+            @IgnoredOnParcel
+            val primaryMessage: Int = R.string.woopos_dialog_barcode_info_primary_message
 
-        @IgnoredOnParcel
-        val tertiaryMessage: Int = R.string.woopos_dialog_barcode_info_tertiary_message
+            @IgnoredOnParcel
+            val secondaryMessage: Int = R.string.woopos_dialog_barcode_info_secondary_message
 
-        @IgnoredOnParcel
-        val quaternaryMessage: Int = R.string.woopos_dialog_barcode_info_quaternary_message
+            @IgnoredOnParcel
+            val tertiaryMessage: Int = R.string.woopos_dialog_barcode_info_tertiary_message
 
-        @IgnoredOnParcel
-        val quinaryMessage: Int = R.string.woopos_dialog_barcode_info_quinary_message
+            @IgnoredOnParcel
+            val quaternaryMessage: Int = R.string.woopos_dialog_barcode_info_quaternary_message
 
-        @IgnoredOnParcel
-        val primaryButton: PrimaryButton = PrimaryButton(
-            label = R.string.woopos_dialog_barcode_info_button_label,
-        )
+            @IgnoredOnParcel
+            val quinaryMessage: Int = R.string.woopos_dialog_barcode_info_quinary_message
 
-        data class PrimaryButton(
-            @StringRes val label: Int,
-        )
-    }
+            @IgnoredOnParcel
+            val primaryButton: PrimaryButton = PrimaryButton(
+                label = R.string.woopos_dialog_barcode_info_button_label,
+            )
 
-    @Parcelize
-    data class ScanningSetupDialog(val isVisible: Boolean) : Parcelable
+            data class PrimaryButton(
+                @StringRes val label: Int,
+            )
+        }
 
-    @Parcelize
-    data class ExitConfirmationDialog(val isVisible: Boolean) : Parcelable {
-        @IgnoredOnParcel
-        val title: Int = R.string.woopos_exit_dialog_confirmation_title
+        @Parcelize
+        data object ScanningSetupDialog : DialogState()
 
-        @IgnoredOnParcel
-        val message: Int = R.string.woopos_exit_dialog_confirmation_message
+        @Parcelize
+        data object ExitConfirmationDialog : DialogState() {
+            @IgnoredOnParcel
+            val title: Int = R.string.woopos_exit_dialog_confirmation_title
 
-        @IgnoredOnParcel
-        val confirmButton: Int = R.string.woopos_exit_dialog_confirmation_confirm_button
+            @IgnoredOnParcel
+            val message: Int = R.string.woopos_exit_dialog_confirmation_message
+
+            @IgnoredOnParcel
+            val confirmButton: Int = R.string.woopos_exit_dialog_confirmation_confirm_button
+        }
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/WooPosHomeViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/WooPosHomeViewModel.kt
@@ -64,31 +64,7 @@ class WooPosHomeViewModel @Inject constructor(
 
     fun onUIEvent(event: WooPosHomeUIEvent) {
         when (event) {
-            WooPosHomeUIEvent.SystemBackClicked -> {
-                when (_state.value.screenPositionState) {
-                    ScreenPositionState.Checkout.CartWithTotals -> {
-                        _state.value = _state.value.copy(
-                            screenPositionState = ScreenPositionState.Cart
-                        )
-                        sendEventToChildren(ParentToChildrenEvent.BackFromCheckoutToCartClicked)
-                        viewModelScope.launch {
-                            analyticsTracker.track(BackToCartTapped)
-                        }
-                    }
-
-                    ScreenPositionState.Checkout.FullScreenTotals -> {
-                        _state.value = _state.value.copy(
-                            screenPositionState = ScreenPositionState.Cart
-                        )
-                    }
-
-                    is ScreenPositionState.Cart -> {
-                        _state.value = _state.value.copy(
-                            dialogState = DialogState.ExitConfirmationDialog
-                        )
-                    }
-                }
-            }
+            WooPosHomeUIEvent.SystemBackClicked -> handleSystemBackClicked()
 
             WooPosHomeUIEvent.ExitConfirmationDialogDismissed -> {
                 _state.value = _state.value.copy(
@@ -127,6 +103,41 @@ class WooPosHomeViewModel @Inject constructor(
 
             is WooPosHomeUIEvent.OnBarcodeEvent -> {
                 sendEventToChildren(ParentToChildrenEvent.BarcodeEvent(event.result))
+            }
+        }
+    }
+
+    private fun handleSystemBackClicked() {
+        when (_state.value.screenPositionState) {
+            ScreenPositionState.Checkout.CartWithTotals -> {
+                _state.value = _state.value.copy(
+                    screenPositionState = ScreenPositionState.Cart
+                )
+                sendEventToChildren(ParentToChildrenEvent.BackFromCheckoutToCartClicked)
+                viewModelScope.launch {
+                    analyticsTracker.track(BackToCartTapped)
+                }
+            }
+
+            ScreenPositionState.Checkout.FullScreenTotals -> {
+                _state.value = _state.value.copy(
+                    screenPositionState = ScreenPositionState.Cart
+                )
+            }
+
+            is ScreenPositionState.Cart -> {
+                when (_state.value.dialogState) {
+                    DialogState.Hidden -> {
+                        _state.value = _state.value.copy(
+                            dialogState = DialogState.ExitConfirmationDialog
+                        )
+                    }
+                    else -> {
+                        _state.value = _state.value.copy(
+                            dialogState = DialogState.Hidden
+                        )
+                    }
+                }
             }
         }
     }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/WooPosHomeViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/WooPosHomeViewModel.kt
@@ -12,10 +12,7 @@ import com.woocommerce.android.ui.woopos.home.ParentToChildrenEvent.OrderCreated
 import com.woocommerce.android.ui.woopos.home.ParentToChildrenEvent.OrderSuccessfullyPaid.PaymentMethod
 import com.woocommerce.android.ui.woopos.home.ParentToChildrenEvent.SearchEvent.ChangedQuery
 import com.woocommerce.android.ui.woopos.home.ParentToChildrenEvent.SearchEvent.RecentSearchSelected
-import com.woocommerce.android.ui.woopos.home.WooPosHomeState.BarcodeInfoDialog
-import com.woocommerce.android.ui.woopos.home.WooPosHomeState.ExitConfirmationDialog
-import com.woocommerce.android.ui.woopos.home.WooPosHomeState.ProductsInfoDialog
-import com.woocommerce.android.ui.woopos.home.WooPosHomeState.ScanningSetupDialog
+import com.woocommerce.android.ui.woopos.home.WooPosHomeState.DialogState
 import com.woocommerce.android.ui.woopos.home.WooPosHomeState.ScreenPositionState
 import com.woocommerce.android.ui.woopos.util.analytics.WooPosAnalyticsEvent
 import com.woocommerce.android.ui.woopos.util.analytics.WooPosAnalyticsEvent.Event.BackToCartTapped
@@ -42,10 +39,7 @@ class WooPosHomeViewModel @Inject constructor(
         key = "home_state",
         initialValue = WooPosHomeState(
             screenPositionState = ScreenPositionState.Cart,
-            productsInfoDialog = ProductsInfoDialog(isVisible = false),
-            barcodeInfoDialog = BarcodeInfoDialog(isVisible = false),
-            scanningSetupDialog = ScanningSetupDialog(isVisible = false),
-            exitConfirmationDialog = ExitConfirmationDialog(isVisible = false),
+            dialogState = DialogState.Hidden,
         )
     )
     val state: StateFlow<WooPosHomeState> = _state
@@ -90,7 +84,7 @@ class WooPosHomeViewModel @Inject constructor(
 
                     is ScreenPositionState.Cart -> {
                         _state.value = _state.value.copy(
-                            exitConfirmationDialog = ExitConfirmationDialog(isVisible = true)
+                            dialogState = DialogState.ExitConfirmationDialog
                         )
                     }
                 }
@@ -98,25 +92,25 @@ class WooPosHomeViewModel @Inject constructor(
 
             WooPosHomeUIEvent.ExitConfirmationDialogDismissed -> {
                 _state.value = _state.value.copy(
-                    exitConfirmationDialog = ExitConfirmationDialog(isVisible = false)
+                    dialogState = DialogState.Hidden
                 )
             }
 
             WooPosHomeUIEvent.DismissProductsInfoDialog -> {
                 _state.value = _state.value.copy(
-                    productsInfoDialog = ProductsInfoDialog(isVisible = false)
+                    dialogState = DialogState.Hidden
                 )
             }
 
             WooPosHomeUIEvent.DismissBarcodeInfoDialog -> {
                 _state.value = _state.value.copy(
-                    barcodeInfoDialog = BarcodeInfoDialog(isVisible = false)
+                    dialogState = DialogState.Hidden
                 )
             }
 
             WooPosHomeUIEvent.DismissScanningSetupDialog -> {
                 _state.value = _state.value.copy(
-                    scanningSetupDialog = ScanningSetupDialog(isVisible = false)
+                    dialogState = DialogState.Hidden
                 )
             }
 
@@ -199,24 +193,24 @@ class WooPosHomeViewModel @Inject constructor(
 
                     ChildToParentEvent.ExitPosClicked -> {
                         _state.value = _state.value.copy(
-                            exitConfirmationDialog = ExitConfirmationDialog(isVisible = true)
+                            dialogState = DialogState.ExitConfirmationDialog
                         )
                     }
 
                     ChildToParentEvent.SimpleProductExplanationMenuItemClicked -> {
                         _state.value = _state.value.copy(
-                            productsInfoDialog = ProductsInfoDialog(isVisible = true)
+                            dialogState = DialogState.ProductsInfoDialog
                         )
                     }
 
                     ChildToParentEvent.BarcodeInfoMenuItemClicked -> {
                         if (FeatureFlag.WOO_POS_SCANNER_SETUP.isEnabled()) {
                             _state.value = _state.value.copy(
-                                scanningSetupDialog = ScanningSetupDialog(isVisible = true)
+                                dialogState = DialogState.ScanningSetupDialog
                             )
                         } else {
                             _state.value = _state.value.copy(
-                                barcodeInfoDialog = BarcodeInfoDialog(isVisible = true)
+                                dialogState = DialogState.BarcodeInfoDialog
                             )
                         }
                     }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/scanningsetup/WooPosScanningSetupDialog.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/scanningsetup/WooPosScanningSetupDialog.kt
@@ -56,22 +56,19 @@ import com.woocommerce.android.ui.woopos.common.composeui.designsystem.WooPosSpa
 import com.woocommerce.android.ui.woopos.common.composeui.designsystem.WooPosTheme
 import com.woocommerce.android.ui.woopos.common.composeui.designsystem.WooPosTypography
 import com.woocommerce.android.ui.woopos.common.composeui.designsystem.toAdaptivePadding
-import com.woocommerce.android.ui.woopos.home.WooPosHomeState
 import com.woocommerce.android.ui.woopos.home.scanningsetup.WooPosScanningSetupState.ScanningSetupStep
 import com.woocommerce.android.util.ChromeCustomTabUtils
 
 @Composable
 fun WooPosScanningSetupDialog(
-    outerState: WooPosHomeState.ScanningSetupDialog,
+    isVisible: Boolean,
     onDismissRequest: () -> Unit,
 ) {
     val viewModel = hiltViewModel<WooPosScanningSetupViewModel>()
     val context = LocalContext.current
 
-    LaunchedEffect(outerState.isVisible) {
-        if (outerState.isVisible) {
-            viewModel.resetToWelcomeState()
-        }
+    LaunchedEffect(isVisible) {
+        viewModel.resetToWelcomeState()
     }
 
     LaunchedEffect(Unit) {
@@ -80,7 +77,7 @@ fun WooPosScanningSetupDialog(
         }
     }
     WooPosDialogWrapper(
-        isVisible = outerState.isVisible,
+        isVisible = isVisible,
         onDismissRequest = onDismissRequest,
         dialogBackgroundContentDescription = "Scanner setup dialog"
     ) {

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/home/WooPosHomeViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/home/WooPosHomeViewModelTest.kt
@@ -2,7 +2,6 @@ package com.woocommerce.android.ui.woopos.home
 
 import androidx.arch.core.executor.testing.InstantTaskExecutorRule
 import androidx.lifecycle.SavedStateHandle
-import com.woocommerce.android.R
 import com.woocommerce.android.ui.woopos.common.util.WooPosSoundHelper
 import com.woocommerce.android.ui.woopos.home.ParentToChildrenEvent.OrderSuccessfullyPaid.PaymentMethod
 import com.woocommerce.android.ui.woopos.home.WooPosHomeUIEvent.ExitPosClicked
@@ -87,10 +86,8 @@ class WooPosHomeViewModelTest {
         viewModel.onUIEvent(SystemBackClicked)
 
         // THEN
-        assertThat(viewModel.state.value.exitConfirmationDialog).isEqualTo(
-            WooPosHomeState.ExitConfirmationDialog(
-                isVisible = true
-            )
+        assertThat(viewModel.state.value.dialogState).isEqualTo(
+            WooPosHomeState.DialogState.ExitConfirmationDialog
         )
     }
 
@@ -129,7 +126,7 @@ class WooPosHomeViewModelTest {
             viewModel.onUIEvent(WooPosHomeUIEvent.ExitConfirmationDialogDismissed)
 
             // THEN
-            assertThat(viewModel.state.value.exitConfirmationDialog.isVisible).isFalse()
+            assertThat(viewModel.state.value.dialogState).isEqualTo(WooPosHomeState.DialogState.Hidden)
         }
 
     @Test
@@ -159,12 +156,9 @@ class WooPosHomeViewModelTest {
             eventsFlow.emit(ChildToParentEvent.ExitPosClicked)
 
             // THEN
-            assertThat(viewModel.state.value.exitConfirmationDialog)
-                .isEqualTo(
-                    WooPosHomeState.ExitConfirmationDialog(
-                        isVisible = true
-                    )
-                )
+            assertThat(viewModel.state.value.dialogState).isEqualTo(
+                WooPosHomeState.DialogState.ExitConfirmationDialog
+            )
         }
 
     @Test
@@ -176,8 +170,8 @@ class WooPosHomeViewModelTest {
         val viewModel = createViewModel()
 
         // THEN
-        assertThat(viewModel.state.value.productsInfoDialog).isEqualTo(
-            WooPosHomeState.ProductsInfoDialog(isVisible = true)
+        assertThat(viewModel.state.value.dialogState).isEqualTo(
+            WooPosHomeState.DialogState.ProductsInfoDialog
         )
     }
 
@@ -190,10 +184,8 @@ class WooPosHomeViewModelTest {
         val viewModel = createViewModel()
 
         // THEN
-        assertThat(
-            (viewModel.state.value.productsInfoDialog).header
-        ).isEqualTo(
-            R.string.woopos_dialog_products_info_heading
+        assertThat(viewModel.state.value.dialogState).isEqualTo(
+            WooPosHomeState.DialogState.ProductsInfoDialog
         )
     }
 
@@ -206,10 +198,8 @@ class WooPosHomeViewModelTest {
         val viewModel = createViewModel()
 
         // THEN
-        assertThat(
-            (viewModel.state.value.productsInfoDialog).primaryMessage
-        ).isEqualTo(
-            R.string.woopos_dialog_products_info_primary_message
+        assertThat(viewModel.state.value.dialogState).isEqualTo(
+            WooPosHomeState.DialogState.ProductsInfoDialog
         )
     }
 
@@ -222,10 +212,8 @@ class WooPosHomeViewModelTest {
         val viewModel = createViewModel()
 
         // THEN
-        assertThat(
-            (viewModel.state.value.productsInfoDialog).secondaryMessage
-        ).isEqualTo(
-            R.string.woopos_dialog_products_info_secondary_message
+        assertThat(viewModel.state.value.dialogState).isEqualTo(
+            WooPosHomeState.DialogState.ProductsInfoDialog
         )
     }
 
@@ -238,10 +226,8 @@ class WooPosHomeViewModelTest {
         val viewModel = createViewModel()
 
         // THEN
-        assertThat(
-            (viewModel.state.value.productsInfoDialog).tertiaryMessage
-        ).isEqualTo(
-            R.string.woopos_dialog_products_info_tertiary_message
+        assertThat(viewModel.state.value.dialogState).isEqualTo(
+            WooPosHomeState.DialogState.ProductsInfoDialog
         )
     }
 
@@ -256,10 +242,8 @@ class WooPosHomeViewModelTest {
         val viewModel = createViewModel()
 
         // THEN
-        assertThat(
-            (viewModel.state.value.productsInfoDialog).primaryButton.label
-        ).isEqualTo(
-            R.string.woopos_dialog_products_info_button_label
+        assertThat(viewModel.state.value.dialogState).isEqualTo(
+            WooPosHomeState.DialogState.ProductsInfoDialog
         )
     }
 
@@ -275,7 +259,7 @@ class WooPosHomeViewModelTest {
         viewModel.onUIEvent(WooPosHomeUIEvent.DismissProductsInfoDialog)
 
         // THEN
-        assertThat(viewModel.state.value.productsInfoDialog.isVisible).isFalse()
+        assertThat(viewModel.state.value.dialogState).isEqualTo(WooPosHomeState.DialogState.Hidden)
     }
 
     @Test

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/home/WooPosHomeViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/home/WooPosHomeViewModelTest.kt
@@ -410,6 +410,54 @@ class WooPosHomeViewModelTest {
         analyticsTracker.track(BackToCartTapped)
     }
 
+    @Test
+    fun `given Cart state with ProductsInfoDialog visible, when SystemBackClicked, then dialog should be dismissed`() = runTest {
+        // GIVEN
+        val events = MutableSharedFlow<ChildToParentEvent>()
+        whenever(childrenToParentEventReceiver.events).thenReturn(events)
+        val viewModel = createViewModel()
+        events.emit(ChildToParentEvent.SimpleProductExplanationMenuItemClicked)
+        assertThat(viewModel.state.value.dialogState).isEqualTo(WooPosHomeState.DialogState.ProductsInfoDialog)
+
+        // WHEN
+        viewModel.onUIEvent(SystemBackClicked)
+
+        // THEN
+        assertThat(viewModel.state.value.dialogState).isEqualTo(WooPosHomeState.DialogState.Hidden)
+    }
+
+    @Test
+    fun `given Cart state with ScanningSetupDialog visible, when SystemBackClicked, then dialog should be dismissed`() = runTest {
+        // GIVEN
+        val events = MutableSharedFlow<ChildToParentEvent>()
+        whenever(childrenToParentEventReceiver.events).thenReturn(events)
+        val viewModel = createViewModel()
+        events.emit(ChildToParentEvent.BarcodeInfoMenuItemClicked)
+        assertThat(viewModel.state.value.dialogState).isEqualTo(WooPosHomeState.DialogState.ScanningSetupDialog)
+
+        // WHEN
+        viewModel.onUIEvent(SystemBackClicked)
+
+        // THEN
+        assertThat(viewModel.state.value.dialogState).isEqualTo(WooPosHomeState.DialogState.Hidden)
+    }
+
+    @Test
+    fun `given Cart state with ExitConfirmationDialog visible, when SystemBackClicked, then dialog should be dismissed`() = runTest {
+        // GIVEN
+        val events = MutableSharedFlow<ChildToParentEvent>()
+        whenever(childrenToParentEventReceiver.events).thenReturn(events)
+        val viewModel = createViewModel()
+        events.emit(ChildToParentEvent.ExitPosClicked)
+        assertThat(viewModel.state.value.dialogState).isEqualTo(WooPosHomeState.DialogState.ExitConfirmationDialog)
+
+        // WHEN
+        viewModel.onUIEvent(SystemBackClicked)
+
+        // THEN
+        assertThat(viewModel.state.value.dialogState).isEqualTo(WooPosHomeState.DialogState.Hidden)
+    }
+
     private fun createViewModel() = WooPosHomeViewModel(
         childrenToParentEventReceiver,
         parentToChildrenEventSender,


### PR DESCRIPTION
<\!-- Remember about a good descriptive title. -->

WOOMOB-777

### Description
This PR refactors the WooPosHomeState to ensure only one dialog can be visible at a time using a sealed class approach while maintaining proper animation support.

**Problem:**
Previously, WooPosHomeState contained multiple dialog properties (`productsInfoDialog`, `barcodeInfoDialog`, `scanningSetupDialog`, `exitConfirmationDialog`) each with individual `isVisible` boolean flags. This design allowed multiple dialogs to potentially be visible simultaneously and made state management complex.

**Solution:**
- **Single dialog state management** using a sealed class `DialogState` with variants: `Hidden`, `ProductsInfoDialog`, `BarcodeInfoDialog`, `ScanningSetupDialog`, `ExitConfirmationDialog`
- **Type-safe state transitions** ensuring only one dialog can be active at any time
- **Preserved animation support** by always rendering all dialogs but controlling visibility through `isVisible` parameter

### Steps to reproduce
1. Navigate to WooCommerce POS home screen
2. Trigger any dialog (menu -> barcode scanner info, products info, or back button for exit confirmation)
3. Verify only one dialog is visible at a time
4. Test dialog transitions maintain proper animations (both appearing and disappearing)
5. Verify all dialog functionality works as expected

### The tests that have been performed
above

### Images/gif
N/A - No UI changes, only state management refactoring

- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.

<\!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->