### PR TITLE
Fix crash when navigating back from Media Upload Errors screen

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/media/ProductImagesNotificationHandler.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/media/ProductImagesNotificationHandler.kt
@@ -150,15 +150,19 @@ class ProductImagesNotificationHandler @Inject constructor(
     fun postUploadFailureNotification(product: Product?, errors: List<ProductImageUploadData>) {
         val productId = product?.remoteId ?: errors.first().remoteProductId
 
+        val productDetailFragmentArgs = ProductDetailFragmentArgs(
+            mode = ProductDetailFragment.Mode.ShowProduct(productId)
+        ).toBundle()
+
+        val mediaUploadErrorsFragmentArgs = MediaUploadErrorListFragmentArgs(
+            remoteProductId = productId,
+            errorList = errors.toTypedArray()
+        ).toBundle()
+
         val pendingIntent = NavDeepLinkBuilder(context)
             .setGraph(R.navigation.nav_graph_main)
-            .setDestination(R.id.mediaUploadErrorsFragment)
-            .setArguments(
-                MediaUploadErrorListFragmentArgs(
-                    remoteProductId = productId,
-                    errorList = errors.toTypedArray()
-                ).toBundle()
-            )
+            .addDestination(R.id.productDetailFragment, productDetailFragmentArgs)
+            .addDestination(R.id.mediaUploadErrorsFragment, mediaUploadErrorsFragmentArgs)
             .createPendingIntent()
 
         val message = StringUtils.getQuantityString(


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

<!-- Id number of the Linear issue this PR addresses, e.g., WOOMOB-373. -->
Closes WOOMOB-763

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
This PR fixes a crash reported via Sentry that occurred after tapping the media upload failure notification.

I’m adding this fix to the release branch, but I won’t publish a new beta just for this. It will be included in the next 22.7 beta or production release.

When tapping the failure notification, the app navigates to the media upload errors screen. This screen’s parent fragment is `productDetailFragment`, but we weren’t setting the necessary navigation arguments for it. As a result, the app would crash when navigating back from `mediaUploadErrorsFragment`. This PR adds the missing orderId navigation argument to `productDetailFragment` to prevent the crash.

https://github.com/user-attachments/assets/cf886b3e-b73e-4a03-9349-326c5074efa6

### Steps to reproduce
<!-- Step-by-step testing instructions. For new user flows, consider instead stating the goal of the workflow and see if your PR reviewer can accomplish the workflow without specific steps! -->
I was able to reproduce this crash once, but couldn’t consistently replicate it. The steps below use a debug patch that forces the media upload failure notification:

1. Apply this patch:
[Force_upload_failure_notification_for_debugging_purposes.patch](https://github.com/user-attachments/files/21111325/Force_upload_failure_notification_for_debugging_purposes.patch)
This will force failure notification even though upload is successful.
2. Launch the app.
2. Go to Products.
3. Select a product.
4. Tap Add image.
5. Tap Choose from device.
6. Select a few photos.
7. An error notification will appear:
<img width="350" alt="image" src="https://github.com/user-attachments/assets/7a864e87-e19c-473e-aabb-9218bfd3df08" />

8. Tap the notification.
9. Tap the back button.

### The tests that have been performed
<!-- To give the reviewer an idea of what could be missed in terms of testing -->
Steps above

### Images/gif
<!-- Include before and after images or gifs when appropriate. -->

- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->