### PR TITLE
[POS as a Tab i2] Fix currencies check

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/tab/WooPosCanBeLaunchedInTab.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/tab/WooPosCanBeLaunchedInTab.kt
@@ -50,7 +50,7 @@ class WooPosCanBeLaunchedInTab @Inject constructor(
             )
         }
 
-        return@withContext if (isCurrencySupported(siteSettings.currencyCode)) {
+        return@withContext if (isCountryAndCurrencySupported(siteSettings.countryCode, siteSettings.currencyCode)) {
             WooPosLaunchability.Launchable
         } else {
             WooPosLaunchability.NotLaunchable(
@@ -59,7 +59,10 @@ class WooPosCanBeLaunchedInTab @Inject constructor(
         }
     }
 
-    private fun isCurrencySupported(currency: String) = SUPPORTED_CURRENCIES.contains(currency.lowercase())
+    private fun isCountryAndCurrencySupported(countryCode: String, currency: String) =
+        SUPPORTED_COUNTRY_CURRENCY_PAIRS.any {
+            it.first.equals(countryCode, true) && it.second.equals(currency, true)
+        }
 
     private fun isWooCoreSupportsOrderAutoDraftsAndExtraPaymentsProps(): Boolean {
         val wooCoreVersion = getWooCoreVersion() ?: return false
@@ -75,7 +78,7 @@ class WooPosCanBeLaunchedInTab @Inject constructor(
         const val WC_VERSION_SUPPORTS_POS_PRODUCT_FILTERING = "9.6.0"
         const val WC_VERSION_SUPPORTS_POS_FEATURE_SWITCH = "10.0.0"
 
-        val SUPPORTED_CURRENCIES = listOf("usd", "gbp")
+        val SUPPORTED_COUNTRY_CURRENCY_PAIRS = listOf("us" to "usd", "gb" to "gbp")
     }
 }
 

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/tab/WooPosCanBeLaunchedInTabTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/tab/WooPosCanBeLaunchedInTabTest.kt
@@ -112,7 +112,15 @@ class WooPosCanBeLaunchedInTabTest : BaseUnitTest() {
     }
 
     @Test
-    fun `given uk country and usd, when invoked, then return Launchable`() = testBlocking {
+    fun `given us country and dollars, when invoked, then return Launchable`() = testBlocking {
+        val siteSettings = buildSiteSettings(countryCode = "US", currencyCode = "USD")
+        whenever(wooCommerceStore.getSiteSettings(any())).thenReturn(siteSettings)
+        val result = sut()
+        assertEquals(Launchable, result)
+    }
+
+    @Test
+    fun `given uk country and usd, when invoked, then return Not Launchable`() = testBlocking {
         val siteSettings = buildSiteSettings(countryCode = "GB", currencyCode = "USD")
         whenever(wooCommerceStore.getSiteSettings(any())).thenReturn(siteSettings)
         val result = sut()

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/tab/WooPosCanBeLaunchedInTabTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/tab/WooPosCanBeLaunchedInTabTest.kt
@@ -104,6 +104,30 @@ class WooPosCanBeLaunchedInTabTest : BaseUnitTest() {
     }
 
     @Test
+    fun `given uk country and pounds, when invoked, then return Launchable`() = testBlocking {
+        val siteSettings = buildSiteSettings(countryCode = "GB", currencyCode = "GBP")
+        whenever(wooCommerceStore.getSiteSettings(any())).thenReturn(siteSettings)
+        val result = sut()
+        assertEquals(Launchable, result)
+    }
+
+    @Test
+    fun `given uk country and usd, when invoked, then return Launchable`() = testBlocking {
+        val siteSettings = buildSiteSettings(countryCode = "GB", currencyCode = "USD")
+        whenever(wooCommerceStore.getSiteSettings(any())).thenReturn(siteSettings)
+        val result = sut()
+        assertEquals(NotLaunchable(Reason.UnsupportedCurrency), result)
+    }
+
+    @Test
+    fun `given us country and pounds, when invoked, then return Not Launchable`() = testBlocking {
+        val siteSettings = buildSiteSettings(countryCode = "US", currencyCode = "GBP")
+        whenever(wooCommerceStore.getSiteSettings(any())).thenReturn(siteSettings)
+        val result = sut()
+        assertEquals(NotLaunchable(Reason.UnsupportedCurrency), result)
+    }
+
+    @Test
     fun `given site settings missing but fetched successfully, when invoked, then return Launchable`() = testBlocking {
         whenever(wooCommerceStore.getSiteSettings(any())).thenReturn(null)
         val fetchedSettings = buildSiteSettings(currencyCode = "usd")
@@ -123,10 +147,13 @@ class WooPosCanBeLaunchedInTabTest : BaseUnitTest() {
         assertEquals(NotLaunchable(Reason.UnsupportedCurrency), result)
     }
 
-    private fun buildSiteSettings(currencyCode: String = "usd") =
-        WCSettingsTestUtils.generateSettings(
-            siteId = LocalOrRemoteId.LocalId(1)
-        ).copy(
-            currencyCode = currencyCode
-        )
+    private fun buildSiteSettings(
+        countryCode: String = "US",
+        currencyCode: String = "USD"
+    ) = WCSettingsTestUtils.generateSettings(
+        siteId = LocalOrRemoteId.LocalId(1)
+    ).copy(
+        countryCode = countryCode,
+        currencyCode = currencyCode
+    )
 }


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

<!-- Id number of the Linear issue this PR addresses, e.g., WOOMOB-373. -->
Part of WOOMOB-715

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

From this comment https://github.com/woocommerce/woocommerce-android/pull/14274#discussion_r2185169418

With this PR we fix the logic for checking the POS eligibility based on currency. Before we just checked the currencies, but we should actually verify that the pair store country and currency is the right one. It should be:

- UK Store, British Pound
- US Store, US Dollar

Any other combination won't be allowed

### Steps to reproduce
<!-- Step-by-step testing instructions. For new user flows, consider instead stating the goal of the workflow and see if your PR reviewer can accomplish the workflow without specific steps! -->
As this class is still not being used, we should verify that we cover the cases in the unit tests and that they pass succesfully.


- [X] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
