### PR TITLE
[POS as a Tab i2] Check eligibility on load and navigate to eligibility screen if ineligible

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/eligibility/WooPosEligibilityScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/eligibility/WooPosEligibilityScreen.kt
@@ -1,0 +1,58 @@
+package com.woocommerce.android.ui.woopos.eligibility
+
+import androidx.activity.compose.BackHandler
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.padding
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.dp
+import com.woocommerce.android.ui.woopos.common.composeui.component.WooPosButton
+import com.woocommerce.android.ui.woopos.common.composeui.component.WooPosText
+import com.woocommerce.android.ui.woopos.common.composeui.designsystem.WooPosSpacing
+import com.woocommerce.android.ui.woopos.common.composeui.designsystem.WooPosTypography
+import com.woocommerce.android.ui.woopos.common.composeui.designsystem.toAdaptivePadding
+import com.woocommerce.android.ui.woopos.root.navigation.WooPosNavigationEvent
+import com.woocommerce.android.ui.woopos.tab.WooPosLaunchability
+
+@Composable
+fun WooPosEligibilityScreen(
+    reason: WooPosLaunchability.NonLaunchabilityReason,
+    onNavigationEvent: (WooPosNavigationEvent) -> Unit
+) {
+    BackHandler {
+        onNavigationEvent(WooPosNavigationEvent.ExitPosClicked)
+    }
+
+    Box(
+        modifier = Modifier
+            .fillMaxSize()
+            .padding(WooPosSpacing.Large.value.toAdaptivePadding()),
+        contentAlignment = Alignment.Center
+    ) {
+        Column(
+            horizontalAlignment = Alignment.CenterHorizontally,
+            verticalArrangement = Arrangement.spacedBy(16.dp)
+        ) {
+            WooPosText(
+                text = "This store is not eligible for POS.",
+                style = WooPosTypography.BodyLarge,
+                textAlign = TextAlign.Center,
+                modifier = Modifier.padding(bottom = WooPosSpacing.Medium.value.toAdaptivePadding())
+            )
+
+            WooPosText(
+                text = "Reason: ${reason.name}",
+                style = WooPosTypography.BodyLarge,
+                textAlign = TextAlign.Center,
+                modifier = Modifier.padding(bottom = WooPosSpacing.Medium.value.toAdaptivePadding())
+            )
+
+            WooPosButton(text = "Exit POS") { onNavigationEvent(WooPosNavigationEvent.ExitPosClicked) }
+        }
+    }
+}

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/WooPosHomeNavigation.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/WooPosHomeNavigation.kt
@@ -105,7 +105,7 @@ fun NavGraphBuilder.eligibilityScreen(
     ) { entry ->
         val reasonName = entry.arguments?.getString(ELIGIBILITY_REASON_KEY)
         val reason = reasonName?.let { WooPosLaunchability.NonLaunchabilityReason.valueOf(it) }
-            ?: WooPosLaunchability.NonLaunchabilityReason.SiteSettingsUnavailable // Fallback if missing
+            ?: WooPosLaunchability.NonLaunchabilityReason.SiteSettingsUnavailable
 
         WooPosEligibilityScreen(
             reason = reason,

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/WooPosHomeNavigation.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/WooPosHomeNavigation.kt
@@ -8,11 +8,18 @@ import androidx.compose.animation.slideOutHorizontally
 import androidx.navigation.NavBackStackEntry
 import androidx.navigation.NavController
 import androidx.navigation.NavGraphBuilder
+import androidx.navigation.NavType
 import androidx.navigation.compose.composable
+import androidx.navigation.navArgument
+import com.woocommerce.android.ui.woopos.eligibility.WooPosEligibilityScreen
+import com.woocommerce.android.ui.woopos.root.navigation.WooPosNavigationEvent
 import com.woocommerce.android.ui.woopos.root.navigation.navigateOnce
+import com.woocommerce.android.ui.woopos.tab.WooPosLaunchability
 
 const val HOME_ROUTE = "home"
 const val HOME_PAYMENT_COMPLETED_VIA_CASH_KEY = "home_payment_completed_via_cash_key"
+const val ELIGIBILITY_ROUTE = "eligibility"
+const val ELIGIBILITY_REASON_KEY = "eligibility_reason"
 
 fun NavController.navigateToHomeScreen() {
     navigateOnce(HOME_ROUTE)
@@ -79,6 +86,30 @@ fun NavGraphBuilder.homeScreen(
         WooPosHomeScreen(
             isPaymentCompletedViaCash = isPaymentCompletedViaCash,
             viewModel = homeViewModel,
+        )
+    }
+}
+
+fun NavController.navigateToEligibilityScreen(reason: WooPosLaunchability.NonLaunchabilityReason) {
+    navigate("$ELIGIBILITY_ROUTE/${reason.name}")
+}
+
+fun NavGraphBuilder.eligibilityScreen(
+    onNavigationEvent: (WooPosNavigationEvent) -> Unit,
+) {
+    composable(
+        route = "$ELIGIBILITY_ROUTE/{$ELIGIBILITY_REASON_KEY}",
+        arguments = listOf(
+            navArgument(ELIGIBILITY_REASON_KEY) { type = NavType.StringType }
+        )
+    ) { entry ->
+        val reasonName = entry.arguments?.getString(ELIGIBILITY_REASON_KEY)
+        val reason = reasonName?.let { WooPosLaunchability.NonLaunchabilityReason.valueOf(it) }
+            ?: WooPosLaunchability.NonLaunchabilityReason.SiteSettingsUnavailable // Fallback if missing
+
+        WooPosEligibilityScreen(
+            reason = reason,
+            onNavigationEvent = onNavigationEvent
         )
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/root/navigation/WooPosMainFlowGraph.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/root/navigation/WooPosMainFlowGraph.kt
@@ -5,6 +5,7 @@ import androidx.navigation.compose.navigation
 import com.woocommerce.android.ui.woopos.cashpayment.cashPaymentScreen
 import com.woocommerce.android.ui.woopos.emailreceipt.emailReceiptScreen
 import com.woocommerce.android.ui.woopos.home.WooPosHomeViewModel
+import com.woocommerce.android.ui.woopos.home.eligibilityScreen
 import com.woocommerce.android.ui.woopos.home.homeScreen
 import com.woocommerce.android.ui.woopos.splash.SPLASH_ROUTE
 import com.woocommerce.android.ui.woopos.splash.splashScreen
@@ -23,5 +24,6 @@ fun NavGraphBuilder.mainGraph(
         homeScreen(homeViewModel = homeViewModel)
         cashPaymentScreen(onNavigationEvent = onNavigationEvent)
         emailReceiptScreen(onNavigationEvent = onNavigationEvent)
+        eligibilityScreen(onNavigationEvent = onNavigationEvent)
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/root/navigation/WooPosNavigationEvent.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/root/navigation/WooPosNavigationEvent.kt
@@ -1,5 +1,7 @@
 package com.woocommerce.android.ui.woopos.root.navigation
 
+import com.woocommerce.android.ui.woopos.tab.WooPosLaunchability
+
 sealed class WooPosNavigationEvent {
     data object ExitPosClicked : WooPosNavigationEvent()
     data object BackFromSplashClicked : WooPosNavigationEvent()
@@ -9,4 +11,7 @@ sealed class WooPosNavigationEvent {
     data object GoBack : WooPosNavigationEvent()
     data object OpenHomeFromCashPaymentAfterSuccessfulPayment : WooPosNavigationEvent()
     data object ReturnHomeFromCashPayment : WooPosNavigationEvent()
+    data class OpenEligibilityScreenFromSplash(
+        val reason: WooPosLaunchability.NonLaunchabilityReason
+    ) : WooPosNavigationEvent()
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/root/navigation/WooPosNavigationEventHandler.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/root/navigation/WooPosNavigationEventHandler.kt
@@ -5,6 +5,7 @@ import androidx.navigation.NavHostController
 import com.woocommerce.android.ui.woopos.cashpayment.CASH_ROUTE
 import com.woocommerce.android.ui.woopos.cashpayment.navigateToCashPaymentScreen
 import com.woocommerce.android.ui.woopos.emailreceipt.navigateToEmailReceipt
+import com.woocommerce.android.ui.woopos.home.navigateToEligibilityScreen
 import com.woocommerce.android.ui.woopos.home.navigateToHomeScreen
 import com.woocommerce.android.ui.woopos.home.navigateToHomeScreenAfterSuccessfulCashPayment
 import com.woocommerce.android.ui.woopos.home.navigateToHomeScreenIfHomeScreenNotOpen
@@ -38,5 +39,8 @@ fun NavHostController.handleNavigationEvent(
 
         is WooPosNavigationEvent.OpenEmailReceipt -> navigateToEmailReceipt(event.orderId)
         WooPosNavigationEvent.ReturnHomeFromCashPayment -> navigateToHomeScreenIfHomeScreenNotOpen()
+
+        is WooPosNavigationEvent.OpenEligibilityScreenFromSplash ->
+            navigateToEligibilityScreen(event.reason)
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/splash/WooPosSplashScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/splash/WooPosSplashScreen.kt
@@ -32,7 +32,8 @@ fun WooPosSplashScreen(onNavigationEvent: (WooPosNavigationEvent) -> Unit) {
             onNavigationEvent(WooPosNavigationEvent.OpenHomeFromSplash)
         }
         is WooPosSplashState.NotEligible -> {
-            // TODO: Show not eligible screen
+            val reason = (state.value as WooPosSplashState.NotEligible).reason
+            onNavigationEvent(WooPosNavigationEvent.OpenEligibilityScreenFromSplash(reason))
         }
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/splash/WooPosSplashScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/splash/WooPosSplashScreen.kt
@@ -31,6 +31,9 @@ fun WooPosSplashScreen(onNavigationEvent: (WooPosNavigationEvent) -> Unit) {
         is WooPosSplashState.Loaded -> {
             onNavigationEvent(WooPosNavigationEvent.OpenHomeFromSplash)
         }
+        is WooPosSplashState.NotEligible -> {
+            // TODO: Show not eligible screen
+        }
     }
 }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/splash/WooPosSplashState.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/splash/WooPosSplashState.kt
@@ -1,7 +1,9 @@
 package com.woocommerce.android.ui.woopos.splash
 
+import com.woocommerce.android.ui.woopos.tab.WooPosLaunchability
+
 sealed class WooPosSplashState {
     data object Loading : WooPosSplashState()
     data object Loaded : WooPosSplashState()
-    data object NotEligible: WooPosSplashState()
+    data class NotEligible(val reason: WooPosLaunchability.NonLaunchabilityReason) : WooPosSplashState()
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/splash/WooPosSplashState.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/splash/WooPosSplashState.kt
@@ -3,4 +3,5 @@ package com.woocommerce.android.ui.woopos.splash
 sealed class WooPosSplashState {
     data object Loading : WooPosSplashState()
     data object Loaded : WooPosSplashState()
+    data object NotEligible: WooPosSplashState()
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/splash/WooPosSplashViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/splash/WooPosSplashViewModel.kt
@@ -4,6 +4,9 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.woocommerce.android.ui.woopos.common.data.WooPosPopularProductsProvider
 import com.woocommerce.android.ui.woopos.home.items.products.WooPosProductsDataSource
+import com.woocommerce.android.ui.woopos.tab.WooPosCanBeLaunchedInTab
+import com.woocommerce.android.ui.woopos.tab.WooPosIsPosAsTabM2Enabled
+import com.woocommerce.android.ui.woopos.tab.WooPosLaunchability
 import com.woocommerce.android.ui.woopos.util.analytics.WooPosAnalyticsEvent.Event.Loaded
 import com.woocommerce.android.ui.woopos.util.analytics.WooPosAnalyticsTracker
 import dagger.hilt.android.lifecycle.HiltViewModel
@@ -19,6 +22,8 @@ class WooPosSplashViewModel @Inject constructor(
     private val productsDataSource: WooPosProductsDataSource,
     private val popularProductsProvider: WooPosPopularProductsProvider,
     private val analyticsTracker: WooPosAnalyticsTracker,
+    private val posAsTabM2Enabled: WooPosIsPosAsTabM2Enabled,
+    private val posCanBeLaunchedInTab: WooPosCanBeLaunchedInTab,
 ) : ViewModel() {
     private val _state = MutableStateFlow<WooPosSplashState>(WooPosSplashState.Loading)
     val state: StateFlow<WooPosSplashState> = _state
@@ -26,6 +31,13 @@ class WooPosSplashViewModel @Inject constructor(
     init {
         val splashScreenStartTime = System.currentTimeMillis()
         viewModelScope.launch {
+            val launchability = posCanBeLaunchedInTab()
+
+            if (launchability is WooPosLaunchability.NotLaunchable) {
+                _state.value = WooPosSplashState.NotEligible
+                return@launch
+            }
+
             joinAll(
                 launch { productsDataSource.prepopulateProductsCache() },
                 launch { popularProductsProvider.fetchAndCachePopularProducts() }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/splash/WooPosSplashViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/splash/WooPosSplashViewModel.kt
@@ -31,11 +31,13 @@ class WooPosSplashViewModel @Inject constructor(
     init {
         val splashScreenStartTime = System.currentTimeMillis()
         viewModelScope.launch {
-            val launchability = posCanBeLaunchedInTab()
+            if (posAsTabM2Enabled()) {
+                val launchability = posCanBeLaunchedInTab()
 
-            if (launchability is WooPosLaunchability.NotLaunchable) {
-                _state.value = WooPosSplashState.NotEligible(launchability.reason)
-                return@launch
+                if (launchability is WooPosLaunchability.NotLaunchable) {
+                    _state.value = WooPosSplashState.NotEligible(launchability.reason)
+                    return@launch
+                }
             }
 
             joinAll(

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/splash/WooPosSplashViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/splash/WooPosSplashViewModel.kt
@@ -34,7 +34,7 @@ class WooPosSplashViewModel @Inject constructor(
             val launchability = posCanBeLaunchedInTab()
 
             if (launchability is WooPosLaunchability.NotLaunchable) {
-                _state.value = WooPosSplashState.NotEligible
+                _state.value = WooPosSplashState.NotEligible(launchability.reason)
                 return@launch
             }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/tab/WooPosCanBeLaunchedInTab.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/tab/WooPosCanBeLaunchedInTab.kt
@@ -26,18 +26,18 @@ class WooPosCanBeLaunchedInTab @Inject constructor(
     suspend operator fun invoke(): WooPosLaunchability = withContext(Dispatchers.IO) {
         val selectedSite = selectedSite.getOrNull()
             ?: return@withContext WooPosLaunchability.NotLaunchable(
-                WooPosLaunchability.Reason.NoSiteSelected
+                WooPosLaunchability.NonLaunchabilityReason.NoSiteSelected
             )
 
         if (!isWooCoreSupportsOrderAutoDraftsAndExtraPaymentsProps()) {
             return@withContext WooPosLaunchability.NotLaunchable(
-                WooPosLaunchability.Reason.UnsupportedWooCommerceVersion
+                WooPosLaunchability.NonLaunchabilityReason.UnsupportedWooCommerceVersion
             )
         }
 
         if (isFeatureSwitchSupported() && isRemotelyEnabled() != true) {
             return@withContext WooPosLaunchability.NotLaunchable(
-                WooPosLaunchability.Reason.FeatureSwitchDisabled
+                WooPosLaunchability.NonLaunchabilityReason.FeatureSwitchDisabled
             )
         }
 
@@ -46,7 +46,7 @@ class WooPosCanBeLaunchedInTab @Inject constructor(
 
         if (siteSettings == null) {
             return@withContext WooPosLaunchability.NotLaunchable(
-                WooPosLaunchability.Reason.SiteSettingsUnavailable
+                WooPosLaunchability.NonLaunchabilityReason.SiteSettingsUnavailable
             )
         }
 
@@ -54,7 +54,7 @@ class WooPosCanBeLaunchedInTab @Inject constructor(
             WooPosLaunchability.Launchable
         } else {
             WooPosLaunchability.NotLaunchable(
-                WooPosLaunchability.Reason.UnsupportedCurrency
+                WooPosLaunchability.NonLaunchabilityReason.UnsupportedCurrency
             )
         }
     }
@@ -81,9 +81,9 @@ class WooPosCanBeLaunchedInTab @Inject constructor(
 
 sealed class WooPosLaunchability {
     object Launchable : WooPosLaunchability()
-    data class NotLaunchable(val reason: Reason) : WooPosLaunchability()
+    data class NotLaunchable(val reason: NonLaunchabilityReason) : WooPosLaunchability()
 
-    enum class Reason {
+    enum class NonLaunchabilityReason {
         UnsupportedWooCommerceVersion,
         SiteSettingsUnavailable,
         FeatureSwitchDisabled,

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/splash/WooPosSplashViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/splash/WooPosSplashViewModelTest.kt
@@ -2,6 +2,9 @@ package com.woocommerce.android.ui.woopos.splash
 
 import com.woocommerce.android.ui.woopos.common.data.WooPosPopularProductsProvider
 import com.woocommerce.android.ui.woopos.home.items.products.WooPosProductsDataSource
+import com.woocommerce.android.ui.woopos.tab.WooPosCanBeLaunchedInTab
+import com.woocommerce.android.ui.woopos.tab.WooPosIsPosAsTabM2Enabled
+import com.woocommerce.android.ui.woopos.tab.WooPosLaunchability
 import com.woocommerce.android.ui.woopos.util.WooPosCoroutineTestRule
 import com.woocommerce.android.ui.woopos.util.analytics.WooPosAnalyticsTracker
 import kotlinx.coroutines.Dispatchers
@@ -23,6 +26,8 @@ class WooPosSplashViewModelTest {
     private val productsDataSource: WooPosProductsDataSource = mock()
     private val analyticsTracker: WooPosAnalyticsTracker = mock()
     private val popularProductsProvider: WooPosPopularProductsProvider = mock()
+    private val posAsTabM2Enabled: WooPosIsPosAsTabM2Enabled = mock()
+    private val posCanBeLaunchedInTab: WooPosCanBeLaunchedInTab = mock()
 
     @Rule
     @JvmField
@@ -39,6 +44,36 @@ class WooPosSplashViewModelTest {
         assertThat(sut.state.value).isEqualTo(WooPosSplashState.Loading)
 
         Dispatchers.resetMain()
+    }
+
+    @Test
+    fun `given posAsTabM2Enabled true and site not eligible, should update state to NotEligible`() = runTest {
+        // GIVEN
+        whenever(posAsTabM2Enabled()).thenReturn(true)
+        whenever(posCanBeLaunchedInTab()).thenReturn(
+            WooPosLaunchability.NotLaunchable(WooPosLaunchability.NonLaunchabilityReason.UnsupportedCurrency)
+        )
+
+        // WHEN
+        val sut = createSut()
+
+        // THEN
+        assertThat(sut.state.value).isEqualTo(
+            WooPosSplashState.NotEligible(WooPosLaunchability.NonLaunchabilityReason.UnsupportedCurrency)
+        )
+    }
+
+    @Test
+    fun `given posAsTabM2Enabled true and site eligible, should update state to Loaded`() = runTest {
+        // GIVEN
+        whenever(posAsTabM2Enabled()).thenReturn(true)
+        whenever(posCanBeLaunchedInTab()).thenReturn(WooPosLaunchability.Launchable)
+
+        // WHEN
+        val sut = createSut()
+
+        // THEN
+        assertThat(sut.state.value).isEqualTo(WooPosSplashState.Loaded)
     }
 
     @Test
@@ -110,5 +145,11 @@ class WooPosSplashViewModelTest {
         assertThat(sut.state.value).isEqualTo(WooPosSplashState.Loaded)
     }
 
-    private fun createSut() = WooPosSplashViewModel(productsDataSource, popularProductsProvider, analyticsTracker)
+    private fun createSut() = WooPosSplashViewModel(
+        productsDataSource,
+        popularProductsProvider,
+        analyticsTracker,
+        posAsTabM2Enabled,
+        posCanBeLaunchedInTab
+    )
 }

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/tab/WooPosCanBeLaunchedInTabTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/tab/WooPosCanBeLaunchedInTabTest.kt
@@ -4,7 +4,7 @@ import com.woocommerce.android.tools.SelectedSite
 import com.woocommerce.android.ui.woopos.WooPOSIsRemotelyEnabled
 import com.woocommerce.android.ui.woopos.tab.WooPosLaunchability.Launchable
 import com.woocommerce.android.ui.woopos.tab.WooPosLaunchability.NotLaunchable
-import com.woocommerce.android.ui.woopos.tab.WooPosLaunchability.Reason
+import com.woocommerce.android.ui.woopos.tab.WooPosLaunchability.NonLaunchabilityReason
 import com.woocommerce.android.util.GetWooCorePluginCachedVersion
 import com.woocommerce.android.viewmodel.BaseUnitTest
 import kotlinx.coroutines.ExperimentalCoroutinesApi
@@ -59,14 +59,14 @@ class WooPosCanBeLaunchedInTabTest : BaseUnitTest() {
     fun `given no site selected, when invoked, then return NotLaunchable with NoSiteSelected`() = testBlocking {
         whenever(selectedSite.getOrNull()).thenReturn(null)
         val result = sut()
-        assertEquals(NotLaunchable(Reason.NoSiteSelected), result)
+        assertEquals(NotLaunchable(NonLaunchabilityReason.NoSiteSelected), result)
     }
 
     @Test
     fun `given unsupported WooCommerce version, when invoked, then return NotLaunchable with UnsupportedWooCommerceVersion`() = testBlocking {
         whenever(getWooCoreVersion()).thenReturn("9.5.0") // lower than 9.6.0
         val result = sut()
-        assertEquals(NotLaunchable(Reason.UnsupportedWooCommerceVersion), result)
+        assertEquals(NotLaunchable(NonLaunchabilityReason.UnsupportedWooCommerceVersion), result)
     }
 
     @Test
@@ -84,7 +84,7 @@ class WooPosCanBeLaunchedInTabTest : BaseUnitTest() {
         )
 
         val result = sut()
-        assertEquals(NotLaunchable(Reason.FeatureSwitchDisabled), result)
+        assertEquals(NotLaunchable(NonLaunchabilityReason.FeatureSwitchDisabled), result)
     }
 
     @Test
@@ -92,7 +92,7 @@ class WooPosCanBeLaunchedInTabTest : BaseUnitTest() {
         whenever(wooCommerceStore.getSiteSettings(any())).thenReturn(null)
         whenever(wooCommerceStore.fetchSiteGeneralSettings(any())).thenReturn(WooResult(null))
         val result = sut()
-        assertEquals(NotLaunchable(Reason.SiteSettingsUnavailable), result)
+        assertEquals(NotLaunchable(NonLaunchabilityReason.SiteSettingsUnavailable), result)
     }
 
     @Test
@@ -100,7 +100,7 @@ class WooPosCanBeLaunchedInTabTest : BaseUnitTest() {
         val siteSettings = buildSiteSettings(currencyCode = "eur")
         whenever(wooCommerceStore.getSiteSettings(any())).thenReturn(siteSettings)
         val result = sut()
-        assertEquals(NotLaunchable(Reason.UnsupportedCurrency), result)
+        assertEquals(NotLaunchable(NonLaunchabilityReason.UnsupportedCurrency), result)
     }
 
     @Test
@@ -120,7 +120,7 @@ class WooPosCanBeLaunchedInTabTest : BaseUnitTest() {
         whenever(wooCommerceStore.fetchSiteGeneralSettings(any())).thenReturn(WooResult(fetchedSettings))
 
         val result = sut()
-        assertEquals(NotLaunchable(Reason.UnsupportedCurrency), result)
+        assertEquals(NotLaunchable(NonLaunchabilityReason.UnsupportedCurrency), result)
     }
 
     private fun buildSiteSettings(currencyCode: String = "usd") =

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/tab/WooPosCanBeLaunchedInTabTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/tab/WooPosCanBeLaunchedInTabTest.kt
@@ -3,8 +3,8 @@ package com.woocommerce.android.ui.woopos.tab
 import com.woocommerce.android.tools.SelectedSite
 import com.woocommerce.android.ui.woopos.WooPOSIsRemotelyEnabled
 import com.woocommerce.android.ui.woopos.tab.WooPosLaunchability.Launchable
-import com.woocommerce.android.ui.woopos.tab.WooPosLaunchability.NotLaunchable
 import com.woocommerce.android.ui.woopos.tab.WooPosLaunchability.NonLaunchabilityReason
+import com.woocommerce.android.ui.woopos.tab.WooPosLaunchability.NotLaunchable
 import com.woocommerce.android.util.GetWooCorePluginCachedVersion
 import com.woocommerce.android.viewmodel.BaseUnitTest
 import kotlinx.coroutines.ExperimentalCoroutinesApi

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/tab/WooPosCanBeLaunchedInTabTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/tab/WooPosCanBeLaunchedInTabTest.kt
@@ -124,7 +124,7 @@ class WooPosCanBeLaunchedInTabTest : BaseUnitTest() {
         val siteSettings = buildSiteSettings(countryCode = "GB", currencyCode = "USD")
         whenever(wooCommerceStore.getSiteSettings(any())).thenReturn(siteSettings)
         val result = sut()
-        assertEquals(NotLaunchable(Reason.UnsupportedCurrency), result)
+        assertEquals(NotLaunchable(NonLaunchabilityReason.UnsupportedCurrency), result)
     }
 
     @Test
@@ -132,7 +132,7 @@ class WooPosCanBeLaunchedInTabTest : BaseUnitTest() {
         val siteSettings = buildSiteSettings(countryCode = "US", currencyCode = "GBP")
         whenever(wooCommerceStore.getSiteSettings(any())).thenReturn(siteSettings)
         val result = sut()
-        assertEquals(NotLaunchable(Reason.UnsupportedCurrency), result)
+        assertEquals(NotLaunchable(NonLaunchabilityReason.UnsupportedCurrency), result)
     }
 
     @Test


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

<!-- Id number of the Linear issue this PR addresses, e.g., WOOMOB-373. -->

Part of #WOOMOB-718

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

Adds eligibility check on POS load and navigates to the eligibility screen if the store is ineligible, skipping further loading. Note: The eligibility screen’s design and detailed logic are not part of this PR and will be handled separately.

#### 📌 What this PR does

- **Checks POS eligibility on app load** when **POS as a Tab i2** is enabled.
- Navigates to the **eligibility screen with reason** if the store is ineligible.
- Skips product prepopulation and proceeds to Home only if the store is eligible.

---

#### 🛠️ Implementation details

- Updated `WooPosSplashViewModel`:
  - Checks `posCanBeLaunchedInTab()` on init if `posAsTabM2Enabled()` is true.
  - Emits `WooPosSplashState.NotEligible(reason)` and halts further actions if ineligible.
- Added `OpenEligibilityScreenFromSplash` navigation event with the reason.
- Integrated eligibility navigation into `WooPosSplashScreen` and the navigation graph.
- Created `WooPosEligibilityScreen` to display the reason and allow exiting POS. Please note that this screen is not done yet, in further PRs we will adjust design and logic.
- Renames `Reason` to `NonLaunchabilityReason` for clarity and consistency.

---

### ✅ Why

- Ensure merchants see clear **eligibility feedback** before POS loads.
- Prevent **ineligible stores from partially loading POS** and failing later.
- Align with the **POS as a Tab i2 flow** for a smoother experience.

### Steps to reproduce
<!-- Step-by-step testing instructions. For new user flows, consider instead stating the goal of the workflow and see if your PR reviewer can accomplish the workflow without specific steps! -->

1. Open the app
2. Go to the POS tab
3. Check behavior with:
4. Eligible Store: It opens POS as usual
5. Ineligible store: It shows the eligibility screen with reason.

### The tests that have been performed
<!-- To give the reviewer an idea of what could be missed in terms of testing -->

- ✅ Eligible stores proceed to Home as usual.
- ✅ Ineligible stores show the eligibility screen with the correct reason.
- ✅ Navigation and back handling work as expected.

### Images/gif
<!-- Include before and after images or gifs when appropriate. -->

https://github.com/user-attachments/assets/1633471b-9298-4a89-9dd2-57d58c2715fb




- [X] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
