### PR TITLE
[WOOPRD-642][Woo POS][Barcodes] Add device selection screen for scanner setup

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/scanningsetup/WooPosScanningSetupDialog.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/scanningsetup/WooPosScanningSetupDialog.kt
@@ -6,6 +6,8 @@ import androidx.compose.animation.fadeOut
 import androidx.compose.animation.togetherWith
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
+import androidx.compose.foundation.border
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -47,6 +49,7 @@ import com.woocommerce.android.R
 import com.woocommerce.android.ui.compose.preview.FontScalePreviews
 import com.woocommerce.android.ui.woopos.common.composeui.WooPosPreview
 import com.woocommerce.android.ui.woopos.common.composeui.component.WooPosButton
+import com.woocommerce.android.ui.woopos.common.composeui.component.WooPosButtonState
 import com.woocommerce.android.ui.woopos.common.composeui.component.WooPosDialogWrapper
 import com.woocommerce.android.ui.woopos.common.composeui.component.WooPosOutlinedButton
 import com.woocommerce.android.ui.woopos.common.composeui.component.WooPosText
@@ -56,6 +59,7 @@ import com.woocommerce.android.ui.woopos.common.composeui.designsystem.WooPosSpa
 import com.woocommerce.android.ui.woopos.common.composeui.designsystem.WooPosTheme
 import com.woocommerce.android.ui.woopos.common.composeui.designsystem.WooPosTypography
 import com.woocommerce.android.ui.woopos.common.composeui.designsystem.toAdaptivePadding
+import com.woocommerce.android.ui.woopos.home.scanningsetup.WooPosScanningSetupState.BarcodeReaderDevice
 import com.woocommerce.android.ui.woopos.home.scanningsetup.WooPosScanningSetupState.ScanningSetupStep
 import com.woocommerce.android.util.ChromeCustomTabUtils
 
@@ -104,6 +108,16 @@ fun WooPosScanningSetupDialog(
                         onViewDocumentation = {
                             viewModel.onUiEvent(WooPosScanningSetupUiEvent.OnViewDocumentation)
                         }
+                    )
+
+                    is ScanningSetupStep.DeviceSelection -> DeviceSelectionContent(
+                        step = step,
+                        selectedDevice = state.selectedDevice,
+                        onDeviceSelected = { device ->
+                            viewModel.onUiEvent(WooPosScanningSetupUiEvent.OnDeviceSelected(device))
+                        },
+                        onPrimaryClick = { viewModel.onUiEvent(WooPosScanningSetupUiEvent.OnPrimaryButtonClicked) },
+                        onSecondaryClick = { viewModel.onUiEvent(WooPosScanningSetupUiEvent.OnSecondaryButtonClicked) }
                     )
 
                     is ScanningSetupStep.Introduction -> IntroductionContent(
@@ -441,6 +455,107 @@ private fun SetupCompleteContent(
             onClick = onDone,
             text = step.primaryButtonText,
             modifier = Modifier.fillMaxWidth()
+        )
+    }
+}
+
+@Composable
+private fun DeviceSelectionContent(
+    step: ScanningSetupStep.DeviceSelection,
+    selectedDevice: BarcodeReaderDevice?,
+    onDeviceSelected: (BarcodeReaderDevice) -> Unit,
+    onPrimaryClick: () -> Unit,
+    onSecondaryClick: () -> Unit,
+) {
+    Column(
+        modifier = Modifier
+            .fillMaxWidth()
+            .verticalScroll(rememberScrollState()),
+        horizontalAlignment = Alignment.CenterHorizontally
+    ) {
+        WooPosText(
+            text = step.title,
+            style = WooPosTypography.Heading,
+            fontWeight = FontWeight.Bold,
+            textAlign = TextAlign.Center,
+            modifier = Modifier.padding(bottom = WooPosSpacing.Medium.value.toAdaptivePadding())
+        )
+
+        WooPosText(
+            text = "Select a model from the list:",
+            style = WooPosTypography.BodyLarge,
+            textAlign = TextAlign.Center,
+            modifier = Modifier.padding(bottom = WooPosSpacing.XLarge.value.toAdaptivePadding())
+        )
+
+        Column(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(bottom = WooPosSpacing.XLarge.value.toAdaptivePadding()),
+            verticalArrangement = Arrangement.spacedBy(WooPosSpacing.Medium.value.toAdaptivePadding())
+        ) {
+            step.devices.forEach { device ->
+                DeviceSelectionItem(
+                    device = device,
+                    isSelected = selectedDevice == device,
+                    onClick = { onDeviceSelected(device) }
+                )
+            }
+        }
+
+        Row(
+            modifier = Modifier.fillMaxWidth(),
+            horizontalArrangement = Arrangement.spacedBy(WooPosSpacing.Medium.value.toAdaptivePadding())
+        ) {
+            WooPosOutlinedButton(
+                onClick = onSecondaryClick,
+                text = step.secondaryButtonText,
+                modifier = Modifier.weight(1f)
+            )
+
+            WooPosButton(
+                onClick = onPrimaryClick,
+                text = step.primaryButtonText,
+                modifier = Modifier.weight(1f),
+                state = if (selectedDevice != null) WooPosButtonState.ENABLED else WooPosButtonState.DISABLED
+            )
+        }
+    }
+}
+
+@Composable
+private fun DeviceSelectionItem(
+    device: BarcodeReaderDevice,
+    isSelected: Boolean,
+    onClick: () -> Unit,
+) {
+    val deviceName = when (device) {
+        BarcodeReaderDevice.TERA_1200 -> "Tera 1200"
+        BarcodeReaderDevice.STAR_BSH_20B -> "Star BSH-20B"
+        BarcodeReaderDevice.INATECK_BLUETOOTH -> "Inateck Bluetooth"
+    }
+
+    Box(
+        modifier = Modifier
+            .fillMaxWidth()
+            .clip(RoundedCornerShape(WooPosCornerRadius.Medium.value))
+            .border(
+                width = if (isSelected) 2.dp else 1.dp,
+                color = if (isSelected) MaterialTheme.colorScheme.primary else MaterialTheme.colorScheme.outlineVariant,
+                shape = RoundedCornerShape(WooPosCornerRadius.Medium.value)
+            )
+            .background(
+                color = if (isSelected) MaterialTheme.colorScheme.primary.copy(alpha = 0.08f) else Color.Transparent
+            )
+            .clickable { onClick() }
+            .padding(WooPosSpacing.Large.value.toAdaptivePadding()),
+        contentAlignment = Alignment.Center
+    ) {
+        WooPosText(
+            text = deviceName,
+            style = WooPosTypography.BodyLarge,
+            fontWeight = if (isSelected) FontWeight.Bold else FontWeight.Normal,
+            color = if (isSelected) MaterialTheme.colorScheme.primary else MaterialTheme.colorScheme.onSurface
         )
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/scanningsetup/WooPosScanningSetupDialog.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/scanningsetup/WooPosScanningSetupDialog.kt
@@ -246,22 +246,12 @@ private fun IntroductionContent(
             modifier = Modifier.padding(bottom = WooPosSpacing.XLarge.value.toAdaptivePadding())
         )
 
-        Row(
-            modifier = Modifier.fillMaxWidth(),
-            horizontalArrangement = Arrangement.spacedBy(WooPosSpacing.Medium.value.toAdaptivePadding())
-        ) {
-            WooPosOutlinedButton(
-                onClick = onSecondaryClick,
-                text = step.secondaryButtonText,
-                modifier = Modifier.weight(1f)
-            )
-
-            WooPosButton(
-                onClick = onPrimaryClick,
-                text = step.primaryButtonText,
-                modifier = Modifier.weight(1f)
-            )
-        }
+        SetupButtonsRow(
+            primaryButtonText = step.primaryButtonText,
+            secondaryButtonText = step.secondaryButtonText,
+            onPrimaryClick = onPrimaryClick,
+            onSecondaryClick = onSecondaryClick
+        )
     }
 }
 
@@ -292,22 +282,12 @@ private fun BluetoothWarningContent(
             modifier = Modifier.padding(bottom = WooPosSpacing.XLarge.value.toAdaptivePadding())
         )
 
-        Row(
-            modifier = Modifier.fillMaxWidth(),
-            horizontalArrangement = Arrangement.spacedBy(WooPosSpacing.Medium.value.toAdaptivePadding())
-        ) {
-            WooPosOutlinedButton(
-                onClick = onSecondaryClick,
-                text = step.secondaryButtonText,
-                modifier = Modifier.weight(1f)
-            )
-
-            WooPosButton(
-                onClick = onPrimaryClick,
-                text = step.primaryButtonText,
-                modifier = Modifier.weight(1f)
-            )
-        }
+        SetupButtonsRow(
+            primaryButtonText = step.primaryButtonText,
+            secondaryButtonText = step.secondaryButtonText,
+            onPrimaryClick = onPrimaryClick,
+            onSecondaryClick = onSecondaryClick
+        )
     }
 }
 
@@ -402,22 +382,12 @@ private fun BarcodeStepContent(
             )
         )
 
-        Row(
-            modifier = Modifier.fillMaxWidth(),
-            horizontalArrangement = Arrangement.spacedBy(WooPosSpacing.Medium.value.toAdaptivePadding())
-        ) {
-            WooPosOutlinedButton(
-                onClick = onSecondaryClick,
-                text = secondaryText,
-                modifier = Modifier.weight(1f)
-            )
-
-            WooPosButton(
-                onClick = onPrimaryClick,
-                text = primaryText,
-                modifier = Modifier.weight(1f)
-            )
-        }
+        SetupButtonsRow(
+            primaryButtonText = primaryText,
+            secondaryButtonText = secondaryText,
+            onPrimaryClick = onPrimaryClick,
+            onSecondaryClick = onSecondaryClick
+        )
     }
 }
 
@@ -503,23 +473,13 @@ private fun DeviceSelectionContent(
             }
         }
 
-        Row(
-            modifier = Modifier.fillMaxWidth(),
-            horizontalArrangement = Arrangement.spacedBy(WooPosSpacing.Medium.value.toAdaptivePadding())
-        ) {
-            WooPosOutlinedButton(
-                onClick = onSecondaryClick,
-                text = step.secondaryButtonText,
-                modifier = Modifier.weight(1f)
-            )
-
-            WooPosButton(
-                onClick = onPrimaryClick,
-                text = step.primaryButtonText,
-                modifier = Modifier.weight(1f),
-                state = if (selectedDevice != null) WooPosButtonState.ENABLED else WooPosButtonState.DISABLED
-            )
-        }
+        SetupButtonsRow(
+            primaryButtonText = step.primaryButtonText,
+            secondaryButtonText = step.secondaryButtonText,
+            onPrimaryClick = onPrimaryClick,
+            onSecondaryClick = onSecondaryClick,
+            primaryButtonState = if (selectedDevice != null) WooPosButtonState.ENABLED else WooPosButtonState.DISABLED
+        )
     }
 }
 
@@ -546,6 +506,33 @@ private fun DeviceSelectionItem(
             text = device.displayName,
             style = WooPosTypography.BodyLarge,
             fontWeight = FontWeight.Bold,
+        )
+    }
+}
+
+@Composable
+private fun SetupButtonsRow(
+    primaryButtonText: String,
+    secondaryButtonText: String,
+    onPrimaryClick: () -> Unit,
+    onSecondaryClick: () -> Unit,
+    primaryButtonState: WooPosButtonState = WooPosButtonState.ENABLED,
+) {
+    Row(
+        modifier = Modifier.fillMaxWidth(),
+        horizontalArrangement = Arrangement.spacedBy(WooPosSpacing.Medium.value.toAdaptivePadding())
+    ) {
+        WooPosOutlinedButton(
+            onClick = onSecondaryClick,
+            text = secondaryButtonText,
+            modifier = Modifier.weight(1f)
+        )
+
+        WooPosButton(
+            onClick = onPrimaryClick,
+            text = primaryButtonText,
+            modifier = Modifier.weight(1f),
+            state = primaryButtonState
         )
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/scanningsetup/WooPosScanningSetupDialog.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/scanningsetup/WooPosScanningSetupDialog.kt
@@ -469,8 +469,7 @@ private fun DeviceSelectionContent(
 ) {
     Column(
         modifier = Modifier
-            .fillMaxWidth()
-            .verticalScroll(rememberScrollState()),
+            .fillMaxWidth(),
         horizontalAlignment = Alignment.CenterHorizontally
     ) {
         WooPosText(
@@ -491,6 +490,7 @@ private fun DeviceSelectionContent(
         Column(
             modifier = Modifier
                 .fillMaxWidth()
+                .verticalScroll(rememberScrollState())
                 .padding(bottom = WooPosSpacing.XLarge.value.toAdaptivePadding()),
             verticalArrangement = Arrangement.spacedBy(WooPosSpacing.Medium.value.toAdaptivePadding())
         ) {
@@ -534,12 +534,9 @@ private fun DeviceSelectionItem(
             .fillMaxWidth()
             .clip(RoundedCornerShape(WooPosCornerRadius.Medium.value))
             .border(
-                width = if (isSelected) 2.dp else 1.dp,
+                width = if (isSelected) 4.dp else 2.dp,
                 color = if (isSelected) MaterialTheme.colorScheme.primary else MaterialTheme.colorScheme.outlineVariant,
                 shape = RoundedCornerShape(WooPosCornerRadius.Medium.value)
-            )
-            .background(
-                color = if (isSelected) MaterialTheme.colorScheme.primary.copy(alpha = 0.08f) else Color.Transparent
             )
             .clickable { onClick() }
             .padding(WooPosSpacing.Large.value.toAdaptivePadding()),
@@ -548,8 +545,7 @@ private fun DeviceSelectionItem(
         WooPosText(
             text = device.displayName,
             style = WooPosTypography.BodyLarge,
-            fontWeight = if (isSelected) FontWeight.Bold else FontWeight.Normal,
-            color = if (isSelected) MaterialTheme.colorScheme.primary else MaterialTheme.colorScheme.onSurface
+            fontWeight = FontWeight.Bold,
         )
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/scanningsetup/WooPosScanningSetupDialog.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/scanningsetup/WooPosScanningSetupDialog.kt
@@ -529,12 +529,6 @@ private fun DeviceSelectionItem(
     isSelected: Boolean,
     onClick: () -> Unit,
 ) {
-    val deviceName = when (device) {
-        BarcodeReaderDevice.TERA_1200 -> "Tera 1200"
-        BarcodeReaderDevice.STAR_BSH_20B -> "Star BSH-20B"
-        BarcodeReaderDevice.INATECK_BLUETOOTH -> "Inateck Bluetooth"
-    }
-
     Box(
         modifier = Modifier
             .fillMaxWidth()
@@ -552,7 +546,7 @@ private fun DeviceSelectionItem(
         contentAlignment = Alignment.Center
     ) {
         WooPosText(
-            text = deviceName,
+            text = device.displayName,
             style = WooPosTypography.BodyLarge,
             fontWeight = if (isSelected) FontWeight.Bold else FontWeight.Normal,
             color = if (isSelected) MaterialTheme.colorScheme.primary else MaterialTheme.colorScheme.onSurface

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/scanningsetup/WooPosScanningSetupState.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/scanningsetup/WooPosScanningSetupState.kt
@@ -10,10 +10,10 @@ data class WooPosScanningSetupState(
     val currentStep: ScanningSetupStep,
     val selectedDevice: BarcodeReaderDevice? = null
 ) : Parcelable {
-    enum class BarcodeReaderDevice {
-        TERA_1200,
-        STAR_BSH_20B,
-        INATECK_BLUETOOTH
+    enum class BarcodeReaderDevice(val displayName: String) {
+        TERA_1200("Tera 1200"),
+        STAR_BSH_20B("Star BSH-20B"),
+        INATECK_BLUETOOTH("Inateck Bluetooth")
     }
     sealed class ScanningSetupStep : Parcelable {
         @Parcelize

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/scanningsetup/WooPosScanningSetupState.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/scanningsetup/WooPosScanningSetupState.kt
@@ -7,8 +7,14 @@ import kotlinx.parcelize.Parcelize
 @Parcelize
 data class WooPosScanningSetupState(
     val isVisible: Boolean = false,
-    val currentStep: ScanningSetupStep
+    val currentStep: ScanningSetupStep,
+    val selectedDevice: BarcodeReaderDevice? = null
 ) : Parcelable {
+    enum class BarcodeReaderDevice {
+        TERA_1200,
+        STAR_BSH_20B,
+        INATECK_BLUETOOTH
+    }
     sealed class ScanningSetupStep : Parcelable {
         @Parcelize
         data class Welcome(
@@ -16,6 +22,14 @@ data class WooPosScanningSetupState(
             val message: String,
             val setupButtonText: String,
             val documentationButtonText: String,
+        ) : ScanningSetupStep()
+
+        @Parcelize
+        data class DeviceSelection(
+            val title: String,
+            val devices: List<BarcodeReaderDevice>,
+            val primaryButtonText: String,
+            val secondaryButtonText: String,
         ) : ScanningSetupStep()
 
         @Parcelize

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/scanningsetup/WooPosScanningSetupViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/scanningsetup/WooPosScanningSetupViewModel.kt
@@ -3,8 +3,8 @@ package com.woocommerce.android.ui.woopos.home.scanningsetup
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.woocommerce.android.R
-import com.woocommerce.android.ui.woopos.home.scanningsetup.WooPosScanningSetupState.BarcodeReaderDevice
 import com.woocommerce.android.ui.woopos.common.data.WOO_POS_BARCODE_DOC_URL
+import com.woocommerce.android.ui.woopos.home.scanningsetup.WooPosScanningSetupState.BarcodeReaderDevice
 import com.woocommerce.android.ui.woopos.home.scanningsetup.WooPosScanningSetupState.ScanningSetupStep
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.MutableSharedFlow

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/scanningsetup/WooPosScanningSetupViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/scanningsetup/WooPosScanningSetupViewModel.kt
@@ -3,6 +3,7 @@ package com.woocommerce.android.ui.woopos.home.scanningsetup
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.woocommerce.android.R
+import com.woocommerce.android.ui.woopos.home.scanningsetup.WooPosScanningSetupState.BarcodeReaderDevice
 import com.woocommerce.android.ui.woopos.home.scanningsetup.WooPosScanningSetupState.ScanningSetupStep
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.MutableSharedFlow
@@ -20,7 +21,8 @@ class WooPosScanningSetupViewModel @Inject constructor() : ViewModel() {
     private val _state = MutableStateFlow(
         WooPosScanningSetupState(
             isVisible = false,
-            currentStep = createWelcomeStep()
+            currentStep = createWelcomeStep(),
+            selectedDevice = null
         )
     )
     val state: StateFlow<WooPosScanningSetupState> = _state.asStateFlow()
@@ -36,7 +38,13 @@ class WooPosScanningSetupViewModel @Inject constructor() : ViewModel() {
         when (event) {
             WooPosScanningSetupUiEvent.OnBluetoothScannerSelected -> {
                 _state.value = _state.value.copy(
-                    currentStep = createBluetoothIntroductionStep()
+                    currentStep = createDeviceSelectionStep()
+                )
+            }
+
+            is WooPosScanningSetupUiEvent.OnDeviceSelected -> {
+                _state.value = _state.value.copy(
+                    selectedDevice = event.device
                 )
             }
 
@@ -58,7 +66,8 @@ class WooPosScanningSetupViewModel @Inject constructor() : ViewModel() {
 
     fun resetToWelcomeState() {
         _state.value = _state.value.copy(
-            currentStep = createWelcomeStep()
+            currentStep = createWelcomeStep(),
+            selectedDevice = null
         )
     }
 
@@ -66,6 +75,14 @@ class WooPosScanningSetupViewModel @Inject constructor() : ViewModel() {
         when (_state.value.currentStep) {
             is ScanningSetupStep.Welcome -> {
                 error("Primary button should not be available on Welcome step")
+            }
+
+            is ScanningSetupStep.DeviceSelection -> {
+                if (_state.value.selectedDevice != null) {
+                    _state.value = _state.value.copy(
+                        currentStep = createBluetoothIntroductionStep()
+                    )
+                }
             }
 
             is ScanningSetupStep.Introduction -> {
@@ -107,9 +124,16 @@ class WooPosScanningSetupViewModel @Inject constructor() : ViewModel() {
     private fun handleSecondaryButtonClick() {
         when (_state.value.currentStep) {
             is ScanningSetupStep.Welcome -> error("Secondary button should not be available on Welcome step")
+            is ScanningSetupStep.DeviceSelection -> {
+                _state.value = _state.value.copy(
+                    currentStep = createWelcomeStep(),
+                    selectedDevice = null
+                )
+            }
+
             is ScanningSetupStep.Introduction -> {
                 _state.value = _state.value.copy(
-                    currentStep = createWelcomeStep()
+                    currentStep = createDeviceSelectionStep()
                 )
             }
 
@@ -148,6 +172,17 @@ class WooPosScanningSetupViewModel @Inject constructor() : ViewModel() {
         message = "Choose an option:",
         setupButtonText = "Set up a barcode scanner",
         documentationButtonText = "View barcode scanner documentation"
+    )
+
+    private fun createDeviceSelectionStep() = ScanningSetupStep.DeviceSelection(
+        title = "Set up a barcode scanner",
+        devices = listOf(
+            BarcodeReaderDevice.TERA_1200,
+            BarcodeReaderDevice.STAR_BSH_20B,
+            BarcodeReaderDevice.INATECK_BLUETOOTH
+        ),
+        primaryButtonText = "Next",
+        secondaryButtonText = "Back"
     )
 
     private fun createBluetoothIntroductionStep() = ScanningSetupStep.Introduction(
@@ -203,4 +238,5 @@ sealed class WooPosScanningSetupUiEvent {
     data object OnPrimaryButtonClicked : WooPosScanningSetupUiEvent()
     data object OnSecondaryButtonClicked : WooPosScanningSetupUiEvent()
     data object OnViewDocumentation : WooPosScanningSetupUiEvent()
+    data class OnDeviceSelected(val device: BarcodeReaderDevice) : WooPosScanningSetupUiEvent()
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/scanningsetup/WooPosScanningSetupViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/scanningsetup/WooPosScanningSetupViewModel.kt
@@ -186,8 +186,8 @@ class WooPosScanningSetupViewModel @Inject constructor() : ViewModel() {
     )
 
     private fun createBluetoothIntroductionStep() = ScanningSetupStep.Introduction(
-        title = "Set up a Bluetooth scanner",
-        message = "Follow these steps to connect your Bluetooth barcode scanner.",
+        title = "Set up your ${_state.value.selectedDevice!!.displayName}",
+        message = "Follow these steps to connect your ${_state.value.selectedDevice!!.displayName} barcode scanner.",
         primaryButtonText = "Next",
         secondaryButtonText = "Back"
     )


### PR DESCRIPTION
WOOPRD-642

### Description
This PR adds a device selection screen to the barcode scanner setup flow, allowing users to choose from available scanner models before proceeding with the setup process. Based not on the final design

**Problem:**
The current barcode scanner setup flow lacks device-specific guidance, making it unclear which scanner model the user is configuring.

**Solution:**
- **Add device selection step** after the welcome screen with three predefined options: Tera 1200, Star BSH-20B, and Inateck Bluetooth
- **Implement device enum** with display names for consistent device representation
- **Update introduction step** to show selected device name for confirmation
- **Extract common button pattern** into reusable SetupButtonsRow component for better maintainability
- **Enforce device selection** by disabling Next button until a device is chosen

### Steps to reproduce
1. Navigate to WooCommerce POS home screen
2. Open menu and select "Barcode scanning"
3. Click "Set up a barcode scanner" 
4. Verify device selection screen appears with three options
5. Select a device and confirm Next button becomes enabled
6. Proceed to next step and verify selected device name is displayed

### The tests that have been performed
above

### Images/gif

https://github.com/user-attachments/assets/d86422fa-811c-4998-a210-4e0fd2b8f4ed



- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.