### PR TITLE
[Shipping labels] Error handling for saving and removing packages

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/packages/UpdateSavedCarrierPackages.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/packages/UpdateSavedCarrierPackages.kt
@@ -1,11 +1,11 @@
 package com.woocommerce.android.ui.orders.wooshippinglabels.packages
 
+import com.woocommerce.android.WooException
 import com.woocommerce.android.tools.SelectedSite
 import com.woocommerce.android.ui.orders.wooshippinglabels.packages.datasource.WooShippingLabelPackageRepository
 import com.woocommerce.android.ui.orders.wooshippinglabels.packages.ui.Carrier
 import com.woocommerce.android.ui.orders.wooshippinglabels.packages.ui.CarrierPackageGroup
-import com.woocommerce.android.util.WooLog
-import com.woocommerce.android.util.WooLog.T
+import org.wordpress.android.fluxc.network.rest.wpcom.wc.WooResult
 import javax.inject.Inject
 
 class UpdateSavedCarrierPackages @Inject constructor(
@@ -17,27 +17,25 @@ class UpdateSavedCarrierPackages @Inject constructor(
         packageId: String,
         isUserDefined: Boolean,
         carrierPackages: Map<Carrier, List<CarrierPackageGroup>>? = null
-    ) {
-        if (savePackage) {
-            carrierPackages?.let {
-                repository.saveCarrierPackage(
-                    packageId,
-                    findCarrierIdForPackageId(packageId, carrierPackages),
-                    selectedSite.get()
-                )
-            } ?: WooLog.w(T.SHIPPING_LABELS, "Carrier packages should not be null when saving a package")
-        } else {
-            repository.deleteSavedCarrierPackage(packageId, isUserDefined, selectedSite.get())
-        }
+    ): Result<Unit> = if (savePackage) {
+        val carrierId = carrierPackages?.let { findCarrierIdForPackageId(packageId, it) }
+            ?: return Result.failure(IllegalArgumentException("Carrier ID not found for package $packageId"))
+
+        repository.saveCarrierPackage(packageId, carrierId, selectedSite.get()).toResultUnit()
+    } else {
+        repository.deleteSavedCarrierPackage(packageId, isUserDefined, selectedSite.get()).toResultUnit()
     }
+
+    private fun <T> WooResult<T>.toResultUnit(): Result<Unit> =
+        if (isError) Result.failure(WooException(error)) else Result.success(Unit)
 
     private fun findCarrierIdForPackageId(
         packageId: String,
         carrierPackages: Map<Carrier, List<CarrierPackageGroup>>
-    ): String = carrierPackages.entries.firstNotNullOfOrNull { (carrier, packageGroupList) ->
+    ): String? = carrierPackages.entries.firstNotNullOfOrNull { (carrier, packageGroupList) ->
         packageGroupList
             .flatMap { it.packages }
             .find { it.id == packageId }
             ?.let { carrier.id }
-    } ?: ""
+    }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/packages/WooShippingLabelPackageCreationFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/packages/WooShippingLabelPackageCreationFragment.kt
@@ -13,6 +13,7 @@ import com.woocommerce.android.extensions.handleDialogResult
 import com.woocommerce.android.extensions.navigateBackWithResult
 import com.woocommerce.android.extensions.navigateSafely
 import com.woocommerce.android.ui.base.BaseFragment
+import com.woocommerce.android.ui.base.UIMessageResolver
 import com.woocommerce.android.ui.compose.theme.WooThemeWithBackground
 import com.woocommerce.android.ui.dialog.WooDialog
 import com.woocommerce.android.ui.orders.wooshippinglabels.packages.WooShippingLabelPackageCreationViewModel.PackageSelected
@@ -20,11 +21,16 @@ import com.woocommerce.android.ui.orders.wooshippinglabels.packages.WooShippingL
 import com.woocommerce.android.ui.orders.wooshippinglabels.packages.WooShippingLabelPackageCreationViewModel.ShowLoadingDialog
 import com.woocommerce.android.ui.orders.wooshippinglabels.packages.WooShippingLabelPackageCreationViewModel.ShowPackageTypeDialog
 import com.woocommerce.android.ui.orders.wooshippinglabels.packages.WooShippingLabelPackageCreationViewModel.ShowTemplateCreationErrorDialog
+import com.woocommerce.android.viewmodel.MultiLiveEvent
 import com.woocommerce.android.widgets.CustomProgressDialog
 import dagger.hilt.android.AndroidEntryPoint
+import javax.inject.Inject
 
 @AndroidEntryPoint
 class WooShippingLabelPackageCreationFragment : BaseFragment() {
+    @Inject
+    lateinit var uiMessageResolver: UIMessageResolver
+
     val viewModel: WooShippingLabelPackageCreationViewModel by viewModels()
 
     private var progressDialog: CustomProgressDialog? = null
@@ -55,6 +61,7 @@ class WooShippingLabelPackageCreationFragment : BaseFragment() {
                 is ShowLoadingDialog -> showLoadingDialog(event.show)
                 is ShowTemplateCreationErrorDialog -> handleTemplateCreationError()
                 is PackageSelected -> navigateBackWithResult(PACKAGE_SELECTION_RESULT, event.packageData)
+                is MultiLiveEvent.Event.ShowSnackbar -> uiMessageResolver.showSnack(event.message)
             }
         }
     }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/packages/WooShippingLabelPackageCreationViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/packages/WooShippingLabelPackageCreationViewModel.kt
@@ -15,6 +15,7 @@ import com.woocommerce.android.ui.orders.wooshippinglabels.packages.ui.CustomPac
 import com.woocommerce.android.ui.orders.wooshippinglabels.packages.ui.PackageData
 import com.woocommerce.android.ui.orders.wooshippinglabels.packages.ui.StoreOptionsForPackages
 import com.woocommerce.android.viewmodel.MultiLiveEvent
+import com.woocommerce.android.viewmodel.MultiLiveEvent.Event
 import com.woocommerce.android.viewmodel.ResourceProvider
 import com.woocommerce.android.viewmodel.ScopedViewModel
 import com.woocommerce.android.viewmodel.getStateFlow
@@ -97,25 +98,23 @@ class WooShippingLabelPackageCreationViewModel @Inject constructor(
     }
 
     fun onSavedPackageRemoved(removedPackage: PackageData) {
-        _viewState.update { viewState ->
-            val packagesState = viewState.packagesData ?: return@update viewState
-            viewState.copy(
-                packagesState = packagesState.copy(
-                    savedPackages = packagesState.savedPackages.filterNot { it.id == removedPackage.id },
-                    carrierPackages = starCarrierPackage(
-                        carrierPackages = packagesState.carrierPackages,
-                        star = false,
-                        packageId = removedPackage.id
-                    )
-                )
-            )
-        }
+        // Update UI
+        updateSavedPackageUI(packageData = removedPackage, saved = false)
+
+        // Send to backend
         launch {
             updateSavedCarrierPackages(
                 savePackage = false,
                 packageId = removedPackage.id,
                 isUserDefined = removedPackage.isUserDefined,
-            )
+            ).let {
+                if (it.isFailure) {
+                    triggerEvent(Event.ShowSnackbar(R.string.woo_shipping_labels_package_removing_error))
+
+                    // If the removal fails, revert the UI change
+                    updateSavedPackageUI(packageData = removedPackage, saved = true)
+                }
+            }
         }
     }
 
@@ -276,14 +275,41 @@ class WooShippingLabelPackageCreationViewModel @Inject constructor(
     }
 
     fun onCarrierPackageStarred(packageData: PackageData, isStarred: Boolean) {
+        // Update UI
+        updateSavedPackageUI(packageData = packageData, saved = isStarred)
+
+        // Send to backend
+        launch {
+            updateSavedCarrierPackages(
+                savePackage = isStarred,
+                packageId = packageData.id,
+                isUserDefined = packageData.isUserDefined,
+                carrierPackages = _viewState.value.packagesData?.carrierPackages ?: emptyMap()
+            ).let {
+                if (it.isFailure) {
+                    val errorMessage = if (isStarred) {
+                        R.string.woo_shipping_labels_package_saving_error
+                    } else {
+                        R.string.woo_shipping_labels_package_removing_error
+                    }
+                    triggerEvent(Event.ShowSnackbar(errorMessage))
+
+                    // If failed, revert the UI change
+                    updateSavedPackageUI(packageData = packageData, saved = !isStarred)
+                }
+            }
+        }
+    }
+
+    private fun updateSavedPackageUI(packageData: PackageData, saved: Boolean) {
         _viewState.update { viewState ->
-            val packages = viewState.packagesData ?: return@update viewState
+            val packages = viewState.packagesData ?: return
             val updatedCarrierPackages = starCarrierPackage(
                 carrierPackages = packages.carrierPackages,
-                star = isStarred,
+                star = saved,
                 packageId = packageData.id
             )
-            val updatedSavedPackages = if (isStarred) {
+            val updatedSavedPackages = if (saved) {
                 packages.savedPackages + packageData
             } else {
                 packages.savedPackages.filterNot { it.id == packageData.id }
@@ -293,14 +319,6 @@ class WooShippingLabelPackageCreationViewModel @Inject constructor(
                     carrierPackages = updatedCarrierPackages,
                     savedPackages = updatedSavedPackages
                 )
-            )
-        }
-        launch {
-            updateSavedCarrierPackages(
-                savePackage = isStarred,
-                packageId = packageData.id,
-                isUserDefined = packageData.isUserDefined,
-                carrierPackages = _viewState.value.packagesData?.carrierPackages ?: emptyMap()
             )
         }
     }

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -4630,6 +4630,8 @@
     <string name="woo_shipping_address_validate_and_save">Validate &amp; Save</string>
     <string name="woo_shipping_address_missing_info_hint">Add missing information</string>
     <string name="woo_shipping_labels_loading_order_error">Unable to load the order</string>
+    <string name="woo_shipping_labels_package_removing_error">Unable to remove the package</string>
+    <string name="woo_shipping_labels_package_saving_error">Unable to save the package</string>
     <string name="woo_shipping_labels_purchase_error">We are unable to purchase the shipping label. Please try again.</string>
     <string name="woo_shipping_split_shipment_error">We were unable to split the shipments. Please try again.</string>
     <string name="woo_shipping_labels_loading_error">Unable to load data</string>

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/packages/UpdateSavedCarrierPackagesTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/packages/UpdateSavedCarrierPackagesTest.kt
@@ -16,7 +16,12 @@ import org.mockito.Mockito.times
 import org.mockito.kotlin.any
 import org.mockito.kotlin.doReturn
 import org.mockito.kotlin.verifyBlocking
+import org.mockito.kotlin.whenever
 import org.wordpress.android.fluxc.model.SiteModel
+import org.wordpress.android.fluxc.network.BaseRequest.GenericErrorType
+import org.wordpress.android.fluxc.network.rest.wpcom.wc.WooError
+import org.wordpress.android.fluxc.network.rest.wpcom.wc.WooErrorType
+import org.wordpress.android.fluxc.network.rest.wpcom.wc.WooResult
 
 @OptIn(ExperimentalCoroutinesApi::class)
 class UpdateSavedCarrierPackagesTest : BaseUnitTest() {
@@ -34,6 +39,13 @@ class UpdateSavedCarrierPackagesTest : BaseUnitTest() {
         val packageIdToSave = "usps_package_123"
         val expectedCarrier = Carrier.USPS
         val carrierPackages = createDummyCarrierPackages(packageIdToSave, expectedCarrier)
+        whenever(
+            repository.saveCarrierPackage(
+                savedPackageId = packageIdToSave,
+                parentCarrierId = expectedCarrier.id,
+                site = selectedSite.get()
+            )
+        ).thenReturn(WooResult(emptyList()))
 
         // When
         useCase(
@@ -59,6 +71,13 @@ class UpdateSavedCarrierPackagesTest : BaseUnitTest() {
         val expectedCarrier = Carrier.USPS
         val carrierPackages = createDummyCarrierPackages(packageIdToDelete, expectedCarrier)
         val isUserDefined = false
+        whenever(
+            repository.deleteSavedCarrierPackage(
+                packageId = packageIdToDelete,
+                isUserDefined = isUserDefined,
+                site = selectedSite.get()
+            )
+        ).thenReturn(WooResult(emptyList()))
 
         // When
         useCase(
@@ -75,6 +94,46 @@ class UpdateSavedCarrierPackagesTest : BaseUnitTest() {
         verifyBlocking(repository, never()) {
             saveCarrierPackage(any(), any(), any())
         }
+    }
+
+    @Test
+    fun `given save fails, when starring a package, then return failure`() = runTest {
+        // Given
+        val packageIdToSave = "usps_package_123"
+        val expectedCarrier = Carrier.USPS
+        val carrierPackages = createDummyCarrierPackages(packageIdToSave, expectedCarrier)
+        val error = WooError(type = WooErrorType.GENERIC_ERROR, original = GenericErrorType.SERVER_ERROR)
+        whenever(repository.saveCarrierPackage(any(), any(), any())).thenReturn(WooResult(error = error))
+
+        // When
+        val result = useCase(
+            savePackage = true,
+            packageId = packageIdToSave,
+            isUserDefined = false,
+            carrierPackages = carrierPackages,
+        )
+
+        // Then
+        assert(result.isFailure)
+    }
+
+    @Test
+    fun `given delete fails, when un-starring a package, then return failure`() = runTest {
+        // Given
+        val packageIdToDelete = "usps_package_123"
+        val isUserDefined = false
+        val error = WooError(type = WooErrorType.GENERIC_ERROR, original = GenericErrorType.SERVER_ERROR)
+        whenever(repository.deleteSavedCarrierPackage(any(), any(), any())).thenReturn(WooResult(error = error))
+
+        // When
+        val result = useCase(
+            savePackage = false,
+            packageId = packageIdToDelete,
+            isUserDefined = isUserDefined,
+        )
+
+        // Then
+        assert(result.isFailure)
     }
 
     private fun createDummyCarrierPackages(


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

<!-- Id number of the Linear issue this PR addresses, e.g., WOOMOB-373. -->
Closes WOOMOB-13
Closes WOOMOB-300

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
This PR adds error handling for saving and removing saved packages.

### Steps to reproduce
<!-- Step-by-step testing instructions. For new user flows, consider instead stating the goal of the workflow and see if your PR reviewer can accomplish the workflow without specific steps! -->
1. Go to Menu → Settings → Developer Options → API Faker and import the conditions below:
```
[
  {
    "request": {
      "httpMethod": "POST",
      "id": 0,
      "path": "/wcshipping/v1/packages",
      "queryParameters": [],
      "type": {
        "type": "wp-api"
      }
    },
    "response": {
      "body": "",
      "endpointId": 0,
      "statusCode": 404
    }
  },
  {
    "request": {
      "httpMethod": "DELETE",
      "id": 0,
      "path": "/wcshipping/v1/packages/%",
      "queryParameters": [],
      "type": {
        "type": "wp-api"
      }
    },
    "response": {
      "body": "",
      "endpointId": 0,
      "statusCode": 404
    }
  }
]
```
2. Go to Orders.
3. Select an order.
4. Tap Create shipping label button.
5. Tap Select a Package button.
6. Go to Carrier Package.
7. Star and unstar some packages.
8. Go to Saved tab.
9. Remove some packages

### The tests that have been performed
<!-- To give the reviewer an idea of what could be missed in terms of testing -->
The video below

### Images/gif
<!-- Include before and after images or gifs when appropriate. -->
[after.webm](https://github.com/user-attachments/assets/3231afae-8997-411e-b20b-b3dc6c46a99b)

- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->