### PR TITLE
[WOOPRD-644][Woo POS][Barcodes] Add Bluetooth settings button to barcode scanner pairing screen

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/scanningsetup/WooPosScanningSetupDialog.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/scanningsetup/WooPosScanningSetupDialog.kt
@@ -148,7 +148,7 @@ fun WooPosScanningSetupDialog(
                         onSecondaryClick = { viewModel.onUiEvent(WooPosScanningSetupUiEvent.OnSecondaryButtonClicked) }
                     )
 
-                    is ScanningSetupStep.PairOnYourDevice -> BarcodeStepContent(
+                    is ScanningSetupStep.PairOnYourDevice -> PairOnYourDeviceContent(
                         step = step,
                         onPrimaryClick = { viewModel.onUiEvent(WooPosScanningSetupUiEvent.OnPrimaryButtonClicked) },
                         onSecondaryClick = { viewModel.onUiEvent(WooPosScanningSetupUiEvent.OnSecondaryButtonClicked) },
@@ -309,7 +309,6 @@ private fun BarcodeStepContent(
     step: ScanningSetupStep,
     onPrimaryClick: () -> Unit,
     onSecondaryClick: () -> Unit,
-    onOpenBluetoothSettings: (() -> Unit)? = null,
 ) {
     val title: String
     val message: String
@@ -370,16 +369,6 @@ private fun BarcodeStepContent(
             modifier = Modifier.padding(bottom = WooPosSpacing.Large.value.toAdaptivePadding())
         )
 
-        if (step is ScanningSetupStep.PairOnYourDevice && onOpenBluetoothSettings != null) {
-            WooPosOutlinedButton(
-                text = step.bluetoothSettingsButtonText,
-                onClick = onOpenBluetoothSettings,
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .padding(bottom = WooPosSpacing.Large.value.toAdaptivePadding()),
-            )
-        }
-
         Box(
             modifier = Modifier
                 .size(200.dp)
@@ -409,6 +398,53 @@ private fun BarcodeStepContent(
         SetupButtonsRow(
             primaryButtonText = primaryText,
             secondaryButtonText = secondaryText,
+            onPrimaryClick = onPrimaryClick,
+            onSecondaryClick = onSecondaryClick
+        )
+    }
+}
+
+@Composable
+private fun PairOnYourDeviceContent(
+    step: ScanningSetupStep.PairOnYourDevice,
+    onPrimaryClick: () -> Unit,
+    onSecondaryClick: () -> Unit,
+    onOpenBluetoothSettings: () -> Unit,
+) {
+    Column(
+        modifier = Modifier
+            .fillMaxWidth()
+            .verticalScroll(rememberScrollState()),
+        horizontalAlignment = Alignment.CenterHorizontally
+    ) {
+        WooPosText(
+            text = step.title,
+            style = WooPosTypography.Heading,
+            fontWeight = FontWeight.Bold,
+            textAlign = TextAlign.Center,
+            modifier = Modifier.padding(bottom = WooPosSpacing.Medium.value.toAdaptivePadding())
+        )
+
+        WooPosText(
+            text = step.message,
+            style = WooPosTypography.BodyLarge,
+            textAlign = TextAlign.Center,
+            modifier = Modifier.padding(bottom = WooPosSpacing.Large.value.toAdaptivePadding())
+        )
+
+        WooPosOutlinedButton(
+            text = step.bluetoothSettingsButtonText,
+            onClick = onOpenBluetoothSettings,
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(bottom = WooPosSpacing.XLarge.value.toAdaptivePadding()),
+        )
+
+        Spacer(modifier = Modifier.weight(1f))
+
+        SetupButtonsRow(
+            primaryButtonText = step.primaryButtonText,
+            secondaryButtonText = step.secondaryButtonText,
             onPrimaryClick = onPrimaryClick,
             onSecondaryClick = onSecondaryClick
         )

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/scanningsetup/WooPosScanningSetupDialog.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/scanningsetup/WooPosScanningSetupDialog.kt
@@ -1,5 +1,6 @@
 package com.woocommerce.android.ui.woopos.home.scanningsetup
 
+import android.content.ActivityNotFoundException
 import android.content.Intent
 import android.provider.Settings
 import androidx.compose.animation.AnimatedContent
@@ -64,6 +65,7 @@ import com.woocommerce.android.ui.woopos.common.composeui.designsystem.toAdaptiv
 import com.woocommerce.android.ui.woopos.home.scanningsetup.WooPosScanningSetupState.BarcodeReaderDevice
 import com.woocommerce.android.ui.woopos.home.scanningsetup.WooPosScanningSetupState.ScanningSetupStep
 import com.woocommerce.android.util.ChromeCustomTabUtils
+import com.woocommerce.android.util.WooLog
 
 @Composable
 fun WooPosScanningSetupDialog(
@@ -85,8 +87,12 @@ fun WooPosScanningSetupDialog(
 
     LaunchedEffect(Unit) {
         viewModel.openBluetoothSettingsEvent.collect {
-            val intent = Intent(Settings.ACTION_BLUETOOTH_SETTINGS)
-            context.startActivity(intent)
+            try {
+                val intent = Intent(Settings.ACTION_BLUETOOTH_SETTINGS)
+                context.startActivity(intent)
+            } catch (e: ActivityNotFoundException) {
+                WooLog.e(WooLog.T.POS, "Bluetooth settings activity not found.", e)
+            }
         }
     }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/scanningsetup/WooPosScanningSetupDialog.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/scanningsetup/WooPosScanningSetupDialog.kt
@@ -1,5 +1,7 @@
 package com.woocommerce.android.ui.woopos.home.scanningsetup
 
+import android.content.Intent
+import android.provider.Settings
 import androidx.compose.animation.AnimatedContent
 import androidx.compose.animation.fadeIn
 import androidx.compose.animation.fadeOut
@@ -80,6 +82,14 @@ fun WooPosScanningSetupDialog(
             ChromeCustomTabUtils.launchUrl(context, url, enableSlideAnimation = true)
         }
     }
+
+    LaunchedEffect(Unit) {
+        viewModel.openBluetoothSettingsEvent.collect {
+            val intent = Intent(Settings.ACTION_BLUETOOTH_SETTINGS)
+            context.startActivity(intent)
+        }
+    }
+
     WooPosDialogWrapper(
         isVisible = isVisible,
         onDismissRequest = onDismissRequest,
@@ -141,7 +151,10 @@ fun WooPosScanningSetupDialog(
                     is ScanningSetupStep.PairOnYourDevice -> BarcodeStepContent(
                         step = step,
                         onPrimaryClick = { viewModel.onUiEvent(WooPosScanningSetupUiEvent.OnPrimaryButtonClicked) },
-                        onSecondaryClick = { viewModel.onUiEvent(WooPosScanningSetupUiEvent.OnSecondaryButtonClicked) }
+                        onSecondaryClick = { viewModel.onUiEvent(WooPosScanningSetupUiEvent.OnSecondaryButtonClicked) },
+                        onOpenBluetoothSettings = {
+                            viewModel.onUiEvent(WooPosScanningSetupUiEvent.OnOpenBluetoothSettings)
+                        }
                     )
 
                     is ScanningSetupStep.TestYourScanner -> BarcodeStepContent(
@@ -296,6 +309,7 @@ private fun BarcodeStepContent(
     step: ScanningSetupStep,
     onPrimaryClick: () -> Unit,
     onSecondaryClick: () -> Unit,
+    onOpenBluetoothSettings: (() -> Unit)? = null,
 ) {
     val title: String
     val message: String
@@ -355,6 +369,16 @@ private fun BarcodeStepContent(
             textAlign = TextAlign.Center,
             modifier = Modifier.padding(bottom = WooPosSpacing.Large.value.toAdaptivePadding())
         )
+
+        if (step is ScanningSetupStep.PairOnYourDevice && onOpenBluetoothSettings != null) {
+            WooPosOutlinedButton(
+                text = step.bluetoothSettingsButtonText,
+                onClick = onOpenBluetoothSettings,
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(bottom = WooPosSpacing.Large.value.toAdaptivePadding()),
+            )
+        }
 
         Box(
             modifier = Modifier

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/scanningsetup/WooPosScanningSetupState.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/scanningsetup/WooPosScanningSetupState.kt
@@ -66,6 +66,7 @@ data class WooPosScanningSetupState(
             val instructionText: String,
             val primaryButtonText: String,
             val secondaryButtonText: String,
+            val bluetoothSettingsButtonText: String,
         ) : ScanningSetupStep()
 
         @Parcelize

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/scanningsetup/WooPosScanningSetupViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/scanningsetup/WooPosScanningSetupViewModel.kt
@@ -30,6 +30,9 @@ class WooPosScanningSetupViewModel @Inject constructor() : ViewModel() {
     private val _openUrlEvent = MutableSharedFlow<String>()
     val openUrlEvent: SharedFlow<String> = _openUrlEvent.asSharedFlow()
 
+    private val _openBluetoothSettingsEvent = MutableSharedFlow<Unit>()
+    val openBluetoothSettingsEvent: SharedFlow<Unit> = _openBluetoothSettingsEvent.asSharedFlow()
+
     companion object {
         private const val WOO_POS_BARCODE_DOC_URL = "https://woocommerce.com/document/barcode-and-qr-code-scanner/"
     }
@@ -59,6 +62,12 @@ class WooPosScanningSetupViewModel @Inject constructor() : ViewModel() {
             WooPosScanningSetupUiEvent.OnViewDocumentation -> {
                 viewModelScope.launch {
                     _openUrlEvent.emit(WOO_POS_BARCODE_DOC_URL)
+                }
+            }
+
+            WooPosScanningSetupUiEvent.OnOpenBluetoothSettings -> {
+                viewModelScope.launch {
+                    _openBluetoothSettingsEvent.emit(Unit)
                 }
             }
         }
@@ -210,11 +219,12 @@ class WooPosScanningSetupViewModel @Inject constructor() : ViewModel() {
 
     private fun createPairOnYourDeviceStep() = ScanningSetupStep.PairOnYourDevice(
         title = "Pair on your device",
-        message = "Now scan this barcode to complete the pairing process.",
+        message = "Enable bluetooth on your device and locate your ${_state.value.selectedDevice!!.displayName}",
         barcodeImageRes = R.drawable.ic_barcode,
         instructionText = "Scan the barcode above to complete pairing",
         primaryButtonText = "Next",
-        secondaryButtonText = "Back"
+        secondaryButtonText = "Back",
+        bluetoothSettingsButtonText = "Open Bluetooth Settings"
     )
 
     private fun createTestYourScannerStep() = ScanningSetupStep.TestYourScanner(
@@ -238,5 +248,6 @@ sealed class WooPosScanningSetupUiEvent {
     data object OnPrimaryButtonClicked : WooPosScanningSetupUiEvent()
     data object OnSecondaryButtonClicked : WooPosScanningSetupUiEvent()
     data object OnViewDocumentation : WooPosScanningSetupUiEvent()
+    data object OnOpenBluetoothSettings : WooPosScanningSetupUiEvent()
     data class OnDeviceSelected(val device: BarcodeReaderDevice) : WooPosScanningSetupUiEvent()
 }


### PR DESCRIPTION
WOOPRD-644

### Description
This PR adds a dedicated Bluetooth settings button to the barcode scanner pairing screen, allowing users to easily access Android's Bluetooth settings during the setup process.

The design is not final and is based on prototype.

**Problem:**
Users need to manually navigate to Bluetooth settings to pair their barcode scanner, which interrupts the setup flow and creates a poor user experience.

**Solution:**
- **Add "Open Bluetooth Settings" button** to the PairOnYourDevice screen that launches Android's Bluetooth settings
- **Create dedicated `PairOnYourDeviceContent` composable** for better code organization and separation of concerns
- **Remove barcode image** from PairOnYourDevice step as it's not needed for this screen

### Steps to reproduce
1. Navigate to WooCommerce POS home screen
2. Open menu and select "Barcode scanning"
3. Click "Set up a barcode scanner"
4. Select a scanner device and proceed through the flow
5. Reach the "Pair on your device" screen
6. Verify the "Open Bluetooth Settings" button is displayed with a settings icon
7. Tap the button and verify it opens Android's Bluetooth settings
8. Verify the screen layout looks clean without the barcode image
9. Test that Next/Back navigation still works correctly

### The tests that have been performed
above

### Images/gif

https://github.com/user-attachments/assets/b710b129-f1bf-4875-859d-d8508b9f94ba



- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.