### PR TITLE
[POS as a Tab i2] Eligibility Screen Design

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/eligibility/WooPosEligibilityScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/eligibility/WooPosEligibilityScreen.kt
@@ -29,6 +29,7 @@ import com.woocommerce.android.ui.woopos.root.navigation.WooPosNavigationEvent
 import com.woocommerce.android.ui.woopos.tab.WooPosLaunchability
 
 @Composable
+@Suppress("UnusedParameter")
 fun WooPosEligibilityScreen(
     reason: WooPosLaunchability.NonLaunchabilityReason,
     onNavigationEvent: (WooPosNavigationEvent) -> Unit

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/eligibility/WooPosEligibilityScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/eligibility/WooPosEligibilityScreen.kt
@@ -1,17 +1,26 @@
 package com.woocommerce.android.ui.woopos.eligibility
 
 import androidx.activity.compose.BackHandler
+import androidx.compose.foundation.Image
 import androidx.compose.foundation.layout.Arrangement
-import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
+import com.woocommerce.android.R
 import com.woocommerce.android.ui.woopos.common.composeui.component.WooPosButton
+import com.woocommerce.android.ui.woopos.common.composeui.component.WooPosOutlinedButton
 import com.woocommerce.android.ui.woopos.common.composeui.component.WooPosText
 import com.woocommerce.android.ui.woopos.common.composeui.designsystem.WooPosSpacing
 import com.woocommerce.android.ui.woopos.common.composeui.designsystem.WooPosTypography
@@ -28,31 +37,60 @@ fun WooPosEligibilityScreen(
         onNavigationEvent(WooPosNavigationEvent.ExitPosClicked)
     }
 
-    Box(
+    Column(
         modifier = Modifier
             .fillMaxSize()
             .padding(WooPosSpacing.Large.value.toAdaptivePadding()),
-        contentAlignment = Alignment.Center
+        horizontalAlignment = Alignment.CenterHorizontally,
+        verticalArrangement = Arrangement.Center
     ) {
-        Column(
-            horizontalAlignment = Alignment.CenterHorizontally,
-            verticalArrangement = Arrangement.spacedBy(16.dp)
+        Image(
+            painter = painterResource(id = R.drawable.ic_woo_pos_error_x),
+            contentDescription = null
+        )
+
+        Spacer(modifier = Modifier.height(WooPosSpacing.Large.value.toAdaptivePadding()))
+
+        WooPosText(
+            text = "Unable to load",
+            style = WooPosTypography.Heading,
+            textAlign = TextAlign.Center
+        )
+
+        Spacer(modifier = Modifier.height(WooPosSpacing.Large.value.toAdaptivePadding()))
+
+        WooPosText(
+            text = "The POS system is not available for your store's currency. " +
+                "It currently supports only US dollars and British pounds. " +
+                "Please check your store currency settings or contact support for assistance.",
+            style = WooPosTypography.BodyLarge,
+            textAlign = TextAlign.Center,
+            modifier = Modifier.width(547.dp)
+        )
+
+        Spacer(modifier = Modifier.height(WooPosSpacing.XLarge.value.toAdaptivePadding()))
+
+        WooPosButton(
+            text = stringResource(id = R.string.woopos_eligibility_retry_check_label),
+            modifier = Modifier.size(width = 366.dp, height = 80.dp)
+        ) {}
+
+        Spacer(modifier = Modifier.height(WooPosSpacing.Medium.value.toAdaptivePadding()))
+
+        WooPosOutlinedButton(
+            text = stringResource(id = R.string.woopos_eligibility_exit_pos_label),
+            modifier = Modifier.size(width = 366.dp, height = 80.dp)
         ) {
-            WooPosText(
-                text = "This store is not eligible for POS.",
-                style = WooPosTypography.BodyLarge,
-                textAlign = TextAlign.Center,
-                modifier = Modifier.padding(bottom = WooPosSpacing.Medium.value.toAdaptivePadding())
-            )
-
-            WooPosText(
-                text = "Reason: ${reason.name}",
-                style = WooPosTypography.BodyLarge,
-                textAlign = TextAlign.Center,
-                modifier = Modifier.padding(bottom = WooPosSpacing.Medium.value.toAdaptivePadding())
-            )
-
-            WooPosButton(text = "Exit POS") { onNavigationEvent(WooPosNavigationEvent.ExitPosClicked) }
+            onNavigationEvent(WooPosNavigationEvent.ExitPosClicked)
         }
     }
+}
+
+@Preview(showBackground = true)
+@Composable
+private fun WooPosEligibilityScreenPreview() {
+    WooPosEligibilityScreen(
+        reason = WooPosLaunchability.NonLaunchabilityReason.UnsupportedCurrency,
+        onNavigationEvent = {}
+    )
 }

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -4466,6 +4466,9 @@
     <string name="woopos_search_coupons_error_title">Unable to load coupons</string>
     <string name="woopos_search_items_error_description">Please try again.</string>
 
+    <string name="woopos_eligibility_exit_pos_label">Exit POS</string>
+    <string name="woopos_eligibility_retry_check_label">Retry</string>
+
     <string name="customers_details_customer_section">Customer</string>
     <string name="customers_details_orders_section">Orders</string>
     <string name="customers_details_registration_section">Registration</string>


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->
⚠️ This PR builds on https://github.com/woocommerce/woocommerce-android/pull/14292 Wait for that to be merged before merging

<!-- Id number of the Linear issue this PR addresses, e.g., WOOMOB-373. -->
Part of WOOMOB-718

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
With this PR we update `WooPosEligibilityScreen` to match the design linked in the above issue. Please note that there will be two following PRs with these tasks:
- Display the copy with the reason for ineligibility
- React to Retry button action so the we can perform the checks again

### Steps to reproduce
<!-- Step-by-step testing instructions. For new user flows, consider instead stating the goal of the workflow and see if your PR reviewer can accomplish the workflow without specific steps! -->

WIth an ineligible store, e.g. US store with EUR currency

1. Open the app
2. Go to the POS tab
3. Check behavior with:
5  It shows the eligibility screen so you can check the design.



### Testing information
<!-- This is your opportunity to break out individual scenarios that need testing (when necessary) and/or include a checklist for the reviewer to go through. Consider documenting the following from your own completed testing: devices used, alternate workflows, edge cases, affected areas, critical flows, areas not tested, and any remaining unknowns. Provide feedback on this new section of the PR template through Sept 30, 2024 to Apps Quality; additional context here: https://woomobilep2.wordpress.com/2024/05/06/woocommerce-mobile-quality-report-march-april/#comment-12036 -->

### The tests that have been performed
<!-- To give the reviewer an idea of what could be missed in terms of testing -->

✅ Verified on:
- Small and large devices.
- Light and dark themes.

✅ Confirmed:
- Buttons align and respond correctly.
- Text wraps with proper margins and remains readable.
- Navigation event for Exit POS triggers correctly. The retry action will come in a future PR.

### Images/gif
<!-- Include before and after images or gifs when appropriate. -->
![Screenshot_20250709_130941_Woo (Dev)](https://github.com/user-attachments/assets/9129523d-04bc-4fab-a8ed-ab91813ae547)



- [X] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
