### PR TITLE
[Shipping labels] Use stored origin address for purchased labels

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/GetShipments.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/GetShipments.kt
@@ -9,6 +9,7 @@ import com.woocommerce.android.ui.orders.wooshippinglabels.models.ShippableItemM
 import com.woocommerce.android.ui.orders.wooshippinglabels.networking.ShippingLabelDTO
 import com.woocommerce.android.ui.orders.wooshippinglabels.networking.WooShippingNetworkingMapper
 import com.woocommerce.android.ui.orders.wooshippinglabels.rates.networking.DestinationAddressDTO
+import com.woocommerce.android.ui.orders.wooshippinglabels.rates.networking.OriginAddressDTO
 import com.woocommerce.android.ui.products.details.ProductDetailRepository
 import kotlinx.coroutines.flow.first
 import javax.inject.Inject
@@ -68,9 +69,13 @@ class GetShipments @Inject constructor(
                 shipmentUIModelList = mergePurchaseData(shipmentUIModelList, labels)
             }
 
-            // If there are stored destination address, merge it into the result list
-            data.storedData?.selectedDestination?.let { selectedDestination ->
-                shipmentUIModelList = mergeDestinationAddresses(shipmentUIModelList, selectedDestination)
+            // If there are stored addresses, merge them into the result list
+            data.storedData?.let { storedData ->
+                shipmentUIModelList = mergeAddresses(
+                    shipmentUIModelList,
+                    storedData.selectedOrigin,
+                    storedData.selectedDestination
+                )
             }
         }
 
@@ -91,17 +96,26 @@ class GetShipments @Inject constructor(
         }
     }
 
-    private fun mergeDestinationAddresses(
+    private fun mergeAddresses(
         shipmentUIModelList: List<ShipmentUIModel>,
-        destinationAddresses: Map<String, DestinationAddressDTO>
+        originAddresses: Map<String, OriginAddressDTO>?,
+        destinationAddresses: Map<String, DestinationAddressDTO>?
     ) = shipmentUIModelList.map { shipmentUIModel ->
         val id = shipmentUIModel.remoteId
-        if (id != null) {
-            destinationAddresses[getStoredDataKey(id)]?.let {
-                shipmentUIModel.copy(label = shipmentUIModel.label?.copy(destinationAddress = mapper.invoke(it)))
-            } ?: shipmentUIModel
-        } else {
+        if (id == null) {
             shipmentUIModel
+        } else {
+            var updatedShipment = shipmentUIModel
+            originAddresses?.get(getStoredDataKey(id))?.let {
+                updatedShipment = updatedShipment.copy(
+                    label = updatedShipment.label?.copy(originAddress = mapper.invoke(it))
+                )
+            }
+            destinationAddresses?.get(getStoredDataKey(id))?.let {
+                updatedShipment =
+                    updatedShipment.copy(label = updatedShipment.label?.copy(destinationAddress = mapper.invoke(it)))
+            }
+            updatedShipment
         }
     }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/GetShipments.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/GetShipments.kt
@@ -100,23 +100,17 @@ class GetShipments @Inject constructor(
         shipmentUIModelList: List<ShipmentUIModel>,
         originAddresses: Map<String, OriginAddressDTO>?,
         destinationAddresses: Map<String, DestinationAddressDTO>?
-    ) = shipmentUIModelList.map { shipmentUIModel ->
-        val id = shipmentUIModel.remoteId
-        if (id == null) {
-            shipmentUIModel
-        } else {
-            var updatedShipment = shipmentUIModel
-            originAddresses?.get(getStoredDataKey(id))?.let {
-                updatedShipment = updatedShipment.copy(
-                    label = updatedShipment.label?.copy(originAddress = mapper.invoke(it))
-                )
-            }
-            destinationAddresses?.get(getStoredDataKey(id))?.let {
-                updatedShipment =
-                    updatedShipment.copy(label = updatedShipment.label?.copy(destinationAddress = mapper.invoke(it)))
-            }
-            updatedShipment
-        }
+    ): List<ShipmentUIModel> = shipmentUIModelList.map { shipmentUIModel ->
+        val remoteId = shipmentUIModel.remoteId ?: return@map shipmentUIModel
+        val key = getStoredDataKey(remoteId)
+
+        val updatedLabel = shipmentUIModel.label?.copy(
+            originAddress = originAddresses?.get(key)?.let { mapper(it) }
+                ?: shipmentUIModel.label.originAddress,
+            destinationAddress = destinationAddresses?.get(key)?.let { mapper(it) }
+                ?: shipmentUIModel.label.destinationAddress
+        )
+        shipmentUIModel.copy(label = updatedLabel)
     }
 
     private fun getStoredDataKey(shipmentId: String) = "shipment_$shipmentId"

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/WooShippingLabelCreationScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/WooShippingLabelCreationScreen.kt
@@ -151,8 +151,8 @@ fun WooShippingLabelCreationScreen(
     shippingLines: List<ShippingLineSummaryUI>,
     paymentsSectionUI: PaymentsSectionUI,
     purchaseSectionUI: PurchaseSectionUI,
-    shippingAddresses: WooShippingAddresses,
-    onSelectedShipmentChanged: (index: Int) -> Unit,
+    shippingAddresses: List<WooShippingAddresses>,
+    onSelectedShipmentChanged: (Int) -> Unit,
     onOriginAddressSelected: (OriginShippingAddress) -> Unit,
     onEditOriginAddress: (OriginShippingAddress) -> Unit,
     onSelectPackageClick: () -> Unit,
@@ -253,8 +253,8 @@ private fun LabelCreationScreenWithBottomSheet(
     paymentsSectionUI: PaymentsSectionUI,
     purchaseSectionUI: PurchaseSectionUI,
     onSelectPackageClick: () -> Unit,
-    shippingAddresses: WooShippingAddresses,
-    onSelectedShipmentChanged: (index: Int) -> Unit,
+    shippingAddresses: List<WooShippingAddresses>,
+    onSelectedShipmentChanged: (Int) -> Unit,
     onEditOriginAddress: (OriginShippingAddress) -> Unit,
     onOriginAddressSelected: (OriginShippingAddress) -> Unit,
     onSelectedRateSortOrderChanged: (ShippingSortOption) -> Unit,
@@ -282,6 +282,7 @@ private fun LabelCreationScreenWithBottomSheet(
     val snackbarHostState = remember { SnackbarHostState() }
 
     val selectedShipment = shipmentUIList[uiState.selectedIndex]
+    val selectedAddress = shippingAddresses[uiState.selectedIndex]
 
     var bottomSheetPeekHeight by remember { mutableStateOf(0.dp) }
 
@@ -304,7 +305,7 @@ private fun LabelCreationScreenWithBottomSheet(
                 totalItems = totalItems,
                 totalItemsCost = totalItemsCost,
                 shippingLines = shippingLines,
-                shippingAddresses = shippingAddresses,
+                shippingAddresses = selectedAddress,
                 shipmentCostUI = selectedShipment.shipmentCostUI,
                 paymentsSectionUI = paymentsSectionUI,
                 purchaseSectionUI = purchaseSectionUI,
@@ -851,10 +852,12 @@ private fun WooShippingLabelCreationScreenPreview() {
             purchaseSectionUI = ShippingLabelSampleData.getPurchaseSection(),
             modifier = Modifier.fillMaxSize(),
             onSelectPackageClick = {},
-            shippingAddresses = WooShippingAddresses(
-                shipFrom = ShippingLabelSampleData.getShipFrom(),
-                shipTo = ShippingLabelSampleData.getShipTo(),
-                originAddresses = listOf(ShippingLabelSampleData.getShipFrom())
+            shippingAddresses = listOf(
+                WooShippingAddresses(
+                    shipFrom = ShippingLabelSampleData.getShipFrom(),
+                    shipTo = ShippingLabelSampleData.getShipTo(),
+                    originAddresses = listOf(ShippingLabelSampleData.getShipFrom())
+                )
             ),
             onSelectedShipmentChanged = {},
             onOriginAddressSelected = {},

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/WooShippingLabelCreationViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/WooShippingLabelCreationViewModel.kt
@@ -127,7 +127,6 @@ class WooShippingLabelCreationViewModel @Inject constructor(
 
     private val emptyOrder = Order.getEmptyOrder(Date(), Date())
     private val order = MutableStateFlow(emptyOrder)
-    private val destinationAddress = MutableStateFlow(DestinationShippingAddress.EMPTY)
     private val shippingAddresses = MutableStateFlow<List<WooShippingAddresses>>(emptyList())
     private val loadTrigger = MutableSharedFlow<Unit>()
 
@@ -177,7 +176,6 @@ class WooShippingLabelCreationViewModel @Inject constructor(
 
     init {
         launch { observeShippingLabelInformation() }
-        launch { getDestinationAddress() }
         launch { getSavedShipments() }
         launch { getShippingAddresses() }
         launch { getOrderInformation() }
@@ -255,43 +253,17 @@ class WooShippingLabelCreationViewModel @Inject constructor(
             val labelId = shipment.label?.labelId ?: return@launch
             observeShippingLabelStatus(orderId = navArgs.orderId, labelId = labelId).onEach { result ->
                 val originAddress = shippingAddresses.value.getOrNull(shipmentId)?.shipFrom?.toAddress()
+                val destinationAddress = shippingAddresses.value.getOrNull(shipmentId)?.shipTo?.address
 
                 // If result has a label model update the label with it. Otherwise, just update the status.
                 val newLabel = result.shippingLabelModel ?: shipment.label.copy(status = result.status)
-                updateShipment(shipmentId, shipment.copy(label = newLabel.copy(originAddress = originAddress)))
+                updateShipment(
+                    shipmentId,
+                    shipment.copy(
+                        label = newLabel.copy(originAddress = originAddress, destinationAddress = destinationAddress)
+                    )
+                )
             }.launchIn(this)
-        }
-    }
-
-    private suspend fun getDestinationAddress() {
-        combine(
-            order.drop(1),
-            shipments.drop(1),
-            uiState.map { it.selectedIndex }.distinctUntilChanged()
-        ) { order, shipments, selectedIndex ->
-            Pair(order, shipments[selectedIndex].label?.destinationAddress)
-        }.collectLatest { (order, labelDestination) ->
-            if (labelDestination == null) {
-                if (destinationAddress.value == WooShippingAddresses.EMPTY) {
-                    val defaultDestination = DestinationShippingAddress(
-                        address = order.shippingAddress.copy(email = order.billingAddress.email),
-                        isVerified = false
-                    )
-                    destinationAddress.value = defaultDestination
-                }
-
-                if (addressValidationHelper.isMissingDestinationAddress(order.shippingAddress).not() &&
-                    !destinationAddress.value.isVerified
-                ) {
-                    verifyDestinationAddress(order.id).fold(
-                        onSuccess = { destinationAddress.value = it },
-                        onFailure = { }
-                    )
-                }
-            } else {
-                // Using stored destination address for purchased labels
-                destinationAddress.value = DestinationShippingAddress(address = labelDestination, isVerified = true)
-            }
         }
     }
 
@@ -467,11 +439,10 @@ class WooShippingLabelCreationViewModel @Inject constructor(
     private suspend fun getShippingAddresses() {
         combine(
             order.drop(1),
-            destinationAddress,
             observeOriginAddresses(),
             shipments.drop(1),
             uiState.map { it.selectedIndex }.distinctUntilChanged(),
-        ) { order, destination, originAddresses, shipments, selectedIndex ->
+        ) { order, originAddresses, shipments, selectedIndex ->
             val currentShipment = shipments[selectedIndex]
             val updatedAddress = if (currentShipment.purchased) {
                 val selectedAddress = shippingAddresses.value.getOrNull(selectedShipmentIndex)
@@ -479,23 +450,25 @@ class WooShippingLabelCreationViewModel @Inject constructor(
                     ?: currentShipment.label?.originAddress?.let { originAddress ->
                         OriginShippingAddress.fromAddress(originAddress).copy(isVerified = true)
                     }
+                val shipTo = selectedAddress?.shipTo?.takeIf { it != DestinationShippingAddress.EMPTY }
+                    ?: currentShipment.label?.destinationAddress?.let { destinationAddress ->
+                        DestinationShippingAddress(address = destinationAddress, isVerified = true)
+                    }
 
                 WooShippingAddresses(
                     shipFrom = shipFrom ?: OriginShippingAddress.EMPTY,
                     originAddresses = originAddresses.orEmpty(),
-                    shipTo = DestinationShippingAddress(
-                        address = currentShipment.label?.destinationAddress ?: destination.address,
-                        isVerified = true
-                    )
+                    shipTo = shipTo ?: getDefaultDestinationAddress()
                 )
             } else if (originAddresses.isNullOrEmpty()) {
                 WooShippingAddresses.EMPTY
             } else {
                 val selectedOriginAddress = getSelectedOriginAddress(originAddresses, selectedIndex)
+                val selectedDestinationAddress = getSelectedDestinationAddress(order, selectedIndex)
                 WooShippingAddresses(
                     shipFrom = selectedOriginAddress,
                     originAddresses = originAddresses,
-                    shipTo = destination
+                    shipTo = selectedDestinationAddress
                 )
             }
 
@@ -705,6 +678,29 @@ class WooShippingLabelCreationViewModel @Inject constructor(
         it != OriginShippingAddress.EMPTY
     } ?: originAddresses.first()
 
+    private fun getSelectedDestinationAddress(
+        order: Order,
+        selectedIndex: Int
+    ): DestinationShippingAddress = shippingAddresses.value.getOrNull(selectedIndex)?.shipTo?.takeIf {
+        it != DestinationShippingAddress.EMPTY
+    } ?: run {
+        getDefaultDestinationAddress().also {
+            launch {
+                if (addressValidationHelper.isMissingDestinationAddress(order.shippingAddress).not()) {
+                    verifyDestinationAddress(order.id).fold(
+                        onSuccess = { onUpdateDestinationAddress(it) },
+                        onFailure = { }
+                    )
+                }
+            }
+        }
+    }
+
+    private fun getDefaultDestinationAddress() = DestinationShippingAddress(
+        address = order.value.shippingAddress.copy(email = order.value.billingAddress.email),
+        isVerified = false
+    )
+
     fun onSelectedShipmentChanged(index: Int) {
         if (index >= shipments.value.size) return // This can happen after shipment split when the UI is not updated yet
 
@@ -733,7 +729,13 @@ class WooShippingLabelCreationViewModel @Inject constructor(
     }
 
     fun onUpdateDestinationAddress(updatedDestinationAddress: DestinationShippingAddress) {
-        destinationAddress.value = updatedDestinationAddress
+        shippingAddresses.value = shippingAddresses.value.toMutableList().apply {
+            set(
+                selectedShipmentIndex,
+                shippingAddresses.value.getOrNull(selectedShipmentIndex)?.copy(shipTo = updatedDestinationAddress)
+                    ?: WooShippingAddresses.EMPTY
+            )
+        }
     }
 
     fun onRefreshShippingRates() {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/WooShippingLabelCreationViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/WooShippingLabelCreationViewModel.kt
@@ -272,14 +272,17 @@ class WooShippingLabelCreationViewModel @Inject constructor(
             Pair(order, shipments[selectedIndex].label?.destinationAddress)
         }.collectLatest { (order, labelDestination) ->
             if (labelDestination == null) {
-                val defaultDestination = DestinationShippingAddress(
-                    address = order.shippingAddress.copy(email = order.billingAddress.email),
-                    isVerified = false
-                )
+                if (destinationAddress.value == WooShippingAddresses.EMPTY) {
+                    val defaultDestination = DestinationShippingAddress(
+                        address = order.shippingAddress.copy(email = order.billingAddress.email),
+                        isVerified = false
+                    )
+                    destinationAddress.value = defaultDestination
+                }
 
-                destinationAddress.value = defaultDestination
-
-                if (addressValidationHelper.isMissingDestinationAddress(order.shippingAddress).not()) {
+                if (addressValidationHelper.isMissingDestinationAddress(order.shippingAddress).not() &&
+                    !destinationAddress.value.isVerified
+                ) {
                     verifyDestinationAddress(order.id).fold(
                         onSuccess = { destinationAddress.value = it },
                         onFailure = { }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/WooShippingLabelCreationViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/WooShippingLabelCreationViewModel.kt
@@ -440,8 +440,10 @@ class WooShippingLabelCreationViewModel @Inject constructor(
             shippingAddresses,
             customsFormDataFlow.filter { it.isNotEmpty() },
             shipmentItems.filter { it.isNotEmpty() },
-        ) { addresses, customsData, shipmentItems ->
-            val customsRequired = addresses != null && shouldRequireCustoms(addresses)
+            uiState.map { it.selectedIndex }.distinctUntilChanged()
+        ) { addresses, customsData, shipmentItems, selectedIndex ->
+            val selectedAddress = addresses.getOrNull(selectedIndex)
+            val customsRequired = selectedAddress != null && shouldRequireCustoms(selectedAddress)
 
             shipmentItems.mapIndexed { index, shippableItemModelList ->
                 val currentItemCustomsData = customsData[index]

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/WooShippingLabelCreationViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/WooShippingLabelCreationViewModel.kt
@@ -254,9 +254,11 @@ class WooShippingLabelCreationViewModel @Inject constructor(
             val shipment = shipments.value[shipmentId]
             val labelId = shipment.label?.labelId ?: return@launch
             observeShippingLabelStatus(orderId = navArgs.orderId, labelId = labelId).onEach { result ->
+                val originAddress = shippingAddresses.value.getOrNull(shipmentId)?.shipFrom?.toAddress()
+
                 // If result has a label model update the label with it. Otherwise, just update the status.
                 val newLabel = result.shippingLabelModel ?: shipment.label.copy(status = result.status)
-                updateShipment(shipmentId, shipment.copy(label = newLabel))
+                updateShipment(shipmentId, shipment.copy(label = newLabel.copy(originAddress = originAddress)))
             }.launchIn(this)
         }
     }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/WooShippingLabelCreationViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/WooShippingLabelCreationViewModel.kt
@@ -127,6 +127,7 @@ class WooShippingLabelCreationViewModel @Inject constructor(
 
     private val emptyOrder = Order.getEmptyOrder(Date(), Date())
     private val order = MutableStateFlow(emptyOrder)
+    private val destinationAddress = MutableStateFlow(DestinationShippingAddress.EMPTY)
     private val shippingAddresses = MutableStateFlow<List<WooShippingAddresses>>(emptyList())
     private val loadTrigger = MutableSharedFlow<Unit>()
 
@@ -176,6 +177,7 @@ class WooShippingLabelCreationViewModel @Inject constructor(
 
     init {
         launch { observeShippingLabelInformation() }
+        launch { getDestinationAddress() }
         launch { getSavedShipments() }
         launch { getShippingAddresses() }
         launch { getOrderInformation() }
@@ -253,17 +255,43 @@ class WooShippingLabelCreationViewModel @Inject constructor(
             val labelId = shipment.label?.labelId ?: return@launch
             observeShippingLabelStatus(orderId = navArgs.orderId, labelId = labelId).onEach { result ->
                 val originAddress = shippingAddresses.value.getOrNull(shipmentId)?.shipFrom?.toAddress()
-                val destinationAddress = shippingAddresses.value.getOrNull(shipmentId)?.shipTo?.address
 
                 // If result has a label model update the label with it. Otherwise, just update the status.
                 val newLabel = result.shippingLabelModel ?: shipment.label.copy(status = result.status)
-                updateShipment(
-                    shipmentId,
-                    shipment.copy(
-                        label = newLabel.copy(originAddress = originAddress, destinationAddress = destinationAddress)
-                    )
-                )
+                updateShipment(shipmentId, shipment.copy(label = newLabel.copy(originAddress = originAddress)))
             }.launchIn(this)
+        }
+    }
+
+    private suspend fun getDestinationAddress() {
+        combine(
+            order.drop(1),
+            shipments.drop(1),
+            uiState.map { it.selectedIndex }.distinctUntilChanged()
+        ) { order, shipments, selectedIndex ->
+            Pair(order, shipments[selectedIndex].label?.destinationAddress)
+        }.collectLatest { (order, labelDestination) ->
+            if (labelDestination == null) {
+                if (destinationAddress.value == WooShippingAddresses.EMPTY) {
+                    val defaultDestination = DestinationShippingAddress(
+                        address = order.shippingAddress.copy(email = order.billingAddress.email),
+                        isVerified = false
+                    )
+                    destinationAddress.value = defaultDestination
+                }
+
+                if (addressValidationHelper.isMissingDestinationAddress(order.shippingAddress).not() &&
+                    !destinationAddress.value.isVerified
+                ) {
+                    verifyDestinationAddress(order.id).fold(
+                        onSuccess = { destinationAddress.value = it },
+                        onFailure = { }
+                    )
+                }
+            } else {
+                // Using stored destination address for purchased labels
+                destinationAddress.value = DestinationShippingAddress(address = labelDestination, isVerified = true)
+            }
         }
     }
 
@@ -439,10 +467,11 @@ class WooShippingLabelCreationViewModel @Inject constructor(
     private suspend fun getShippingAddresses() {
         combine(
             order.drop(1),
+            destinationAddress,
             observeOriginAddresses(),
             shipments.drop(1),
             uiState.map { it.selectedIndex }.distinctUntilChanged(),
-        ) { order, originAddresses, shipments, selectedIndex ->
+        ) { order, destination, originAddresses, shipments, selectedIndex ->
             val currentShipment = shipments[selectedIndex]
             val updatedAddress = if (currentShipment.purchased) {
                 val selectedAddress = shippingAddresses.value.getOrNull(selectedShipmentIndex)
@@ -450,25 +479,23 @@ class WooShippingLabelCreationViewModel @Inject constructor(
                     ?: currentShipment.label?.originAddress?.let { originAddress ->
                         OriginShippingAddress.fromAddress(originAddress).copy(isVerified = true)
                     }
-                val shipTo = selectedAddress?.shipTo?.takeIf { it != DestinationShippingAddress.EMPTY }
-                    ?: currentShipment.label?.destinationAddress?.let { destinationAddress ->
-                        DestinationShippingAddress(address = destinationAddress, isVerified = true)
-                    }
 
                 WooShippingAddresses(
                     shipFrom = shipFrom ?: OriginShippingAddress.EMPTY,
                     originAddresses = originAddresses.orEmpty(),
-                    shipTo = shipTo ?: getDefaultDestinationAddress()
+                    shipTo = DestinationShippingAddress(
+                        address = currentShipment.label?.destinationAddress ?: destination.address,
+                        isVerified = true
+                    )
                 )
             } else if (originAddresses.isNullOrEmpty()) {
                 WooShippingAddresses.EMPTY
             } else {
                 val selectedOriginAddress = getSelectedOriginAddress(originAddresses, selectedIndex)
-                val selectedDestinationAddress = getSelectedDestinationAddress(order, selectedIndex)
                 WooShippingAddresses(
                     shipFrom = selectedOriginAddress,
                     originAddresses = originAddresses,
-                    shipTo = selectedDestinationAddress
+                    shipTo = destination
                 )
             }
 
@@ -678,29 +705,6 @@ class WooShippingLabelCreationViewModel @Inject constructor(
         it != OriginShippingAddress.EMPTY
     } ?: originAddresses.first()
 
-    private fun getSelectedDestinationAddress(
-        order: Order,
-        selectedIndex: Int
-    ): DestinationShippingAddress = shippingAddresses.value.getOrNull(selectedIndex)?.shipTo?.takeIf {
-        it != DestinationShippingAddress.EMPTY
-    } ?: run {
-        getDefaultDestinationAddress().also {
-            launch {
-                if (addressValidationHelper.isMissingDestinationAddress(order.shippingAddress).not()) {
-                    verifyDestinationAddress(order.id).fold(
-                        onSuccess = { onUpdateDestinationAddress(it) },
-                        onFailure = { }
-                    )
-                }
-            }
-        }
-    }
-
-    private fun getDefaultDestinationAddress() = DestinationShippingAddress(
-        address = order.value.shippingAddress.copy(email = order.value.billingAddress.email),
-        isVerified = false
-    )
-
     fun onSelectedShipmentChanged(index: Int) {
         if (index >= shipments.value.size) return // This can happen after shipment split when the UI is not updated yet
 
@@ -729,13 +733,7 @@ class WooShippingLabelCreationViewModel @Inject constructor(
     }
 
     fun onUpdateDestinationAddress(updatedDestinationAddress: DestinationShippingAddress) {
-        shippingAddresses.value = shippingAddresses.value.toMutableList().apply {
-            set(
-                selectedShipmentIndex,
-                shippingAddresses.value.getOrNull(selectedShipmentIndex)?.copy(shipTo = updatedDestinationAddress)
-                    ?: WooShippingAddresses.EMPTY
-            )
-        }
+        destinationAddress.value = updatedDestinationAddress
     }
 
     fun onRefreshShippingRates() {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/WooShippingLabelCreationViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/WooShippingLabelCreationViewModel.kt
@@ -279,7 +279,7 @@ class WooShippingLabelCreationViewModel @Inject constructor(
             val orderShippingEmail = order.shippingAddress.email.ifBlank { order.billingAddress.email }
 
             if (labelDestination == null) {
-                if (destinationAddress.value == com.woocommerce.android.ui.orders.wooshippinglabels.WooShippingAddresses.EMPTY) {
+                if (destinationAddress.value == WooShippingAddresses.EMPTY) {
                     val defaultDestination = DestinationShippingAddress(
                         address = order.shippingAddress.copy(email = orderShippingEmail),
                         isVerified = false
@@ -288,7 +288,8 @@ class WooShippingLabelCreationViewModel @Inject constructor(
                 }
 
                 if (addressValidationHelper.isMissingDestinationAddress(order.shippingAddress).not() &&
-                    !destinationAddress.value.isVerified) {
+                    !destinationAddress.value.isVerified
+                ) {
                     verifyDestinationAddress(order.id).fold(
                         onSuccess = {
                             destinationAddress.value = it.copy(

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/WooShippingLabelCreationViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/WooShippingLabelCreationViewModel.kt
@@ -35,6 +35,7 @@ import com.woocommerce.android.ui.orders.wooshippinglabels.address.ObserveShippi
 import com.woocommerce.android.ui.orders.wooshippinglabels.address.destination.VerifyDestinationAddress
 import com.woocommerce.android.ui.orders.wooshippinglabels.address.origin.FetchOriginAddresses
 import com.woocommerce.android.ui.orders.wooshippinglabels.address.origin.ObserveOriginAddresses
+import com.woocommerce.android.ui.orders.wooshippinglabels.address.toAddress
 import com.woocommerce.android.ui.orders.wooshippinglabels.components.NoticeBannerUiState
 import com.woocommerce.android.ui.orders.wooshippinglabels.components.NoticeType
 import com.woocommerce.android.ui.orders.wooshippinglabels.components.ShippingLabelsSnackbarData
@@ -127,7 +128,7 @@ class WooShippingLabelCreationViewModel @Inject constructor(
     private val emptyOrder = Order.getEmptyOrder(Date(), Date())
     private val order = MutableStateFlow(emptyOrder)
     private val destinationAddress = MutableStateFlow(DestinationShippingAddress.EMPTY)
-    private val shippingAddresses = MutableStateFlow<WooShippingAddresses?>(WooShippingAddresses.EMPTY)
+    private val shippingAddresses = MutableStateFlow<List<WooShippingAddresses>>(emptyList())
     private val loadTrigger = MutableSharedFlow<Unit>()
 
     private val shipments = MutableStateFlow<List<ShipmentUIModel>>(emptyList())
@@ -222,20 +223,18 @@ class WooShippingLabelCreationViewModel @Inject constructor(
                             onTapped = {
                                 when (noticeBanner.type) {
                                     NoticeType.UNVERIFIED_ORIGIN_ADDRESS -> {
-                                        shippingAddresses.value?.shipFrom?.let { shipFrom ->
-                                            onEditOriginAddress(
-                                                shipFrom
-                                            )
-                                        }
+                                        shippingAddresses.value.getOrNull(selectedShipmentIndex)
+                                            ?.shipFrom?.let { shipFrom ->
+                                                onEditOriginAddress(shipFrom)
+                                            }
                                     }
 
                                     NoticeType.MISSING_DESTINATION_ADDRESS,
                                     NoticeType.UNVERIFIED_DESTINATION_ADDRESS -> {
-                                        shippingAddresses.value?.shipTo?.let { shipTo ->
-                                            onEditDestinationAddress(
-                                                shipTo
-                                            )
-                                        }
+                                        shippingAddresses.value.getOrNull(selectedShipmentIndex)
+                                            ?.shipTo?.let { shipTo ->
+                                                onEditDestinationAddress(shipTo)
+                                            }
                                     }
 
                                     NoticeType.MISSING_ITN -> {
@@ -301,7 +300,7 @@ class WooShippingLabelCreationViewModel @Inject constructor(
         combine(
             accountSettings,
             selectedPackagesFlow.filter { it.isNotEmpty() },
-            shippingAddresses,
+            shippingAddresses.filter { it.isNotEmpty() },
             packageWeightsFlow.filter { it.isNotEmpty() },
             customsStatesFlow.filter { it.isNotEmpty() },
             hazmatStatesFlow.filter { it.isNotEmpty() },
@@ -310,12 +309,13 @@ class WooShippingLabelCreationViewModel @Inject constructor(
             val customsFulfilled = customState[selectedShipmentIndex] is CustomsState.DataAvailable ||
                 customState[selectedShipmentIndex] is NotRequired
             val selectedPackage = selectedPackages[selectedShipmentIndex]
-            if (selectedPackage != null && addresses != null && customsFulfilled) {
+            val selectedAddress = addresses[selectedShipmentIndex]
+            if (selectedPackage != null && customsFulfilled) {
                 ShippingRatesInfo(
                     orderId = navArgs.orderId,
                     packageSelected = selectedPackage,
-                    shipFrom = addresses.shipFrom,
-                    shipTo = addresses.shipTo.address,
+                    shipFrom = selectedAddress.shipFrom,
+                    shipTo = selectedAddress.shipTo.address,
                     weight = packageWeight[selectedShipmentIndex]?.totalWeight,
                     currencyCode = accountSettings?.storeOptions?.currencySymbol,
                     customsData = customsFormDataFlow.value[selectedShipmentIndex],
@@ -458,17 +458,46 @@ class WooShippingLabelCreationViewModel @Inject constructor(
     }
 
     private suspend fun getShippingAddresses() {
-        combine(destinationAddress, observeOriginAddresses()) { destination, originAddresses ->
-            if (!originAddresses.isNullOrEmpty()) {
-                val selectedOriginAddress = getSelectedOriginAddress(originAddresses)
+        combine(
+            order.drop(1),
+            destinationAddress,
+            observeOriginAddresses(),
+            shipments.drop(1),
+            uiState.map { it.selectedIndex }.distinctUntilChanged(),
+        ) { order, destination, originAddresses, shipments, selectedIndex ->
+            val currentShipment = shipments[selectedIndex]
+            val updatedAddress = if (currentShipment.purchased) {
+                val selectedAddress = shippingAddresses.value.getOrNull(selectedShipmentIndex)
+                val shipFrom = selectedAddress?.shipFrom?.takeIf { it != OriginShippingAddress.EMPTY }
+                    ?: currentShipment.label?.originAddress?.let { originAddress ->
+                        OriginShippingAddress.fromAddress(originAddress).copy(isVerified = true)
+                    }
+
+                WooShippingAddresses(
+                    shipFrom = shipFrom ?: OriginShippingAddress.EMPTY,
+                    originAddresses = originAddresses.orEmpty(),
+                    shipTo = DestinationShippingAddress(
+                        address = currentShipment.label?.destinationAddress ?: destination.address,
+                        isVerified = true
+                    )
+                )
+            } else if (originAddresses.isNullOrEmpty()) {
+                WooShippingAddresses.EMPTY
+            } else {
+                val selectedOriginAddress = getSelectedOriginAddress(originAddresses, selectedIndex)
                 WooShippingAddresses(
                     shipFrom = selectedOriginAddress,
                     originAddresses = originAddresses,
                     shipTo = destination
                 )
-            } else {
-                null
             }
+
+            if (shippingAddresses.value.isEmpty()) {
+                // Initialize the list during the initial load
+                shippingAddresses.value = List(shipments.size) { WooShippingAddresses.EMPTY }
+            }
+
+            shippingAddresses.value.toMutableList().apply { set(selectedIndex, updatedAddress) }
         }.collect { shippingAddresses.value = it }
     }
 
@@ -553,23 +582,21 @@ class WooShippingLabelCreationViewModel @Inject constructor(
             hazmatStatesFlow
         ) { accountSettings, order, shipments, addresses, shippingRatesList,
             packageSelections, uiState, customsState, hazmatStates ->
-            if (accountSettings == null || addresses == null ||
-                shipments.any { it.purchaseState is PurchaseState.Error }
-            ) {
+            if (accountSettings == null || shipments.any { it.purchaseState is PurchaseState.Error }) {
                 return@combine WooShippingViewState.Error
-            }
-
-            val destinationStatus = when {
-                addressValidationHelper.isMissingDestinationAddress(addresses.shipTo.address) -> {
-                    AddressStatus.MISSING_ADDRESS
-                }
-
-                addresses.shipTo.isVerified -> AddressStatus.VERIFIED
-                else -> AddressStatus.UNVERIFIED
             }
 
             shipmentItems.value = shipments.map { it.items }
             adjustFlowSizesToShipmentCount(shipments.size)
+
+            val destinationStatus = when {
+                addressValidationHelper.isMissingDestinationAddress(
+                    addresses[uiState.selectedIndex].shipTo.address
+                ) -> AddressStatus.MISSING_ADDRESS
+
+                addresses[uiState.selectedIndex].shipTo.isVerified -> AddressStatus.VERIFIED
+                else -> AddressStatus.UNVERIFIED
+            }
 
             val shippingLineSummary = order.getShippingLinesSummary(currencyFormatter)
             val shipmentUIList = shipmentItems.value.mapIndexed { index, shippableItemModels ->
@@ -622,6 +649,7 @@ class WooShippingLabelCreationViewModel @Inject constructor(
             }
         }
 
+        shippingAddresses.updateSize(WooShippingAddresses.EMPTY)
         selectedPackagesFlow.updateSize(null)
         customsFormDataFlow.updateSize(null)
         packageWeightsFlow.updateSize(null)
@@ -663,11 +691,12 @@ class WooShippingLabelCreationViewModel @Inject constructor(
         }
     }
 
-    private fun getSelectedOriginAddress(originAddresses: List<OriginShippingAddress>): OriginShippingAddress {
-        return shippingAddresses.value?.shipFrom?.takeIf {
-            it != OriginShippingAddress.EMPTY
-        } ?: originAddresses.first()
-    }
+    private fun getSelectedOriginAddress(
+        originAddresses: List<OriginShippingAddress>,
+        selectedIndex: Int
+    ): OriginShippingAddress = shippingAddresses.value.getOrNull(selectedIndex)?.shipFrom?.takeIf {
+        it != OriginShippingAddress.EMPTY
+    } ?: originAddresses.first()
 
     fun onSelectedShipmentChanged(index: Int) {
         if (index >= shipments.value.size) return // This can happen after shipment split when the UI is not updated yet
@@ -676,8 +705,10 @@ class WooShippingLabelCreationViewModel @Inject constructor(
     }
 
     fun onOriginAddressSelected(address: OriginShippingAddress) {
-        shippingAddresses.value?.let {
-            shippingAddresses.value = it.copy(shipFrom = address)
+        shippingAddresses.value.getOrNull(selectedShipmentIndex)?.let {
+            shippingAddresses.value = shippingAddresses.value.toMutableList().apply {
+                set(selectedShipmentIndex, it.copy(shipFrom = address))
+            }
         }
     }
 
@@ -760,11 +791,11 @@ class WooShippingLabelCreationViewModel @Inject constructor(
     @Suppress("ComplexCondition")
     fun onPurchaseShippingLabel() {
         val selectedPackage = selectedPackagesFlow.value[selectedShipmentIndex]
-        val addresses = shippingAddresses.value
+        val selectedAddress = shippingAddresses.value.getOrNull(selectedShipmentIndex)
         val shippingRate = selectedRatesFlow.value[selectedShipmentIndex]
         val weight = packageWeightsFlow.value[selectedShipmentIndex]?.totalWeight
 
-        if (selectedPackage == null || addresses == null || shippingRate == null || weight == null) return
+        if (selectedPackage == null || selectedAddress == null || shippingRate == null || weight == null) return
 
         val orderId = navArgs.orderId
         val lastOrderComplete = uiState.value.markOrderComplete
@@ -785,8 +816,8 @@ class WooShippingLabelCreationViewModel @Inject constructor(
                 shippableItemsIdList,
                 selectedPackage,
                 selectedShipmentIndex,
-                addresses.shipTo.address,
-                addresses.shipFrom,
+                selectedAddress.shipTo.address,
+                selectedAddress.shipFrom,
                 shippingRate,
                 weight,
                 lastOrderComplete,
@@ -802,9 +833,7 @@ class WooShippingLabelCreationViewModel @Inject constructor(
                         shipments.value[selectedShipmentIndex].copy(purchaseState = fallbackPurchaseState)
                     )
                     if (exception is WooException && exception.error.apiErrorCode == UPSDAP_MISSING_TOS_ERROR_CODE) {
-                        shippingAddresses.value?.shipFrom?.let { shipFrom ->
-                            triggerEvent(NavigateToUPSDAPTermsOfService(shipFrom))
-                        }
+                        triggerEvent(NavigateToUPSDAPTermsOfService(selectedAddress.shipFrom))
                     } else {
                         snackbarData = ShippingLabelsSnackbarData(
                             message = R.string.woo_shipping_labels_purchase_error,
@@ -883,7 +912,7 @@ class WooShippingLabelCreationViewModel @Inject constructor(
     }
 
     fun onEditCustomsClick() {
-        val destinationCountryCode = shippingAddresses.value
+        val destinationCountryCode = shippingAddresses.value.getOrNull(selectedShipmentIndex)
             ?.shipTo?.address?.country?.code.orEmpty()
 
         val event = NavigateToCustomsFormEdit(
@@ -1019,7 +1048,7 @@ class WooShippingLabelCreationViewModel @Inject constructor(
             ?.reduce { acc, current -> acc + current }
             ?: BigDecimal.ZERO
 
-        val destinationCountryCode = shippingAddresses.value
+        val destinationCountryCode = shippingAddresses.value.getOrNull(selectedShipmentIndex)
             ?.shipTo?.address?.country?.code.orEmpty()
 
         return shouldRequireITN(destinationCountryCode, totalShippingValue)
@@ -1058,7 +1087,7 @@ class WooShippingLabelCreationViewModel @Inject constructor(
             val totalItems: Int,
             val totalItemsCost: String,
             val shippingLines: List<ShippingLineSummaryUI>,
-            val shippingAddresses: WooShippingAddresses,
+            val shippingAddresses: List<WooShippingAddresses>,
             val uiState: UIControlsState,
             val destinationStatus: AddressStatus,
             val paymentsSectionUI: PaymentsSectionUI,

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/address/ObserveShippingLabelNotice.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/address/ObserveShippingLabelNotice.kt
@@ -17,7 +17,7 @@ import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.combine
-import kotlinx.coroutines.flow.filterNotNull
+import kotlinx.coroutines.flow.filter
 import kotlinx.coroutines.launch
 import javax.inject.Inject
 
@@ -26,17 +26,18 @@ class ObserveShippingLabelNotice @Inject constructor(private val addressValidati
     private var previousNotice: NoticeType? = null
 
     operator fun invoke(
-        shippingAddresses: Flow<WooShippingAddresses?>,
+        shippingAddresses: Flow<List<WooShippingAddresses>>,
         customsState: Flow<List<CustomsState>>,
         selectedIndexFlow: Flow<Int>,
         coroutineScope: CoroutineScope,
     ) = combine(
-        shippingAddresses.filterNotNull(),
+        shippingAddresses.filter { it.isNotEmpty() },
         customsState,
         selectedIndexFlow,
         isDismissedFlow
     ) { addresses, customs, selectedIndex, isDismissed ->
-        val noticeType = getNoticeType(addresses, customs[selectedIndex], isDismissed) ?: return@combine null
+        val noticeType =
+            getNoticeType(addresses[selectedIndex], customs[selectedIndex], isDismissed) ?: return@combine null
         getNoticeBannerUiState(noticeType).also { state ->
             previousNotice = state.type
             if (state.autoDismiss) {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/models/OriginShippingAddress.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/models/OriginShippingAddress.kt
@@ -2,6 +2,7 @@ package com.woocommerce.android.ui.orders.wooshippinglabels.models
 
 import android.os.Parcelable
 import com.woocommerce.android.extensions.appendWithIfNotEmpty
+import com.woocommerce.android.model.Address
 import kotlinx.parcelize.Parcelize
 
 @Parcelize
@@ -37,6 +38,20 @@ data class OriginShippingAddress(
             phone = null,
             isDefault = false,
             isVerified = false
+        )
+
+        fun fromAddress(address: Address) = EMPTY.copy(
+            company = address.company,
+            firstName = address.firstName,
+            lastName = address.lastName,
+            email = address.email,
+            address1 = address.address1,
+            address2 = address.address2,
+            city = address.city,
+            state = address.state.codeOrRaw,
+            postcode = address.postcode,
+            country = address.country.code,
+            phone = address.phone
         )
     }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/networking/DTOs.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/networking/DTOs.kt
@@ -10,6 +10,7 @@ import com.google.gson.annotations.SerializedName
 import com.google.gson.reflect.TypeToken
 import com.woocommerce.android.ui.orders.wooshippinglabels.models.ShippingLabelStatus
 import com.woocommerce.android.ui.orders.wooshippinglabels.rates.networking.DestinationAddressDTO
+import com.woocommerce.android.ui.orders.wooshippinglabels.rates.networking.OriginAddressDTO
 import java.lang.reflect.Type
 import java.math.BigDecimal
 
@@ -87,6 +88,7 @@ data class ShippingLabelDataDTO(
 )
 
 data class StoredDataDTO(
+    @SerializedName("selected_origin") val selectedOrigin: Map<String, OriginAddressDTO>,
     @SerializedName("selected_destination") val selectedDestination: Map<String, DestinationAddressDTO>,
 )
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/networking/DTOs.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/networking/DTOs.kt
@@ -88,8 +88,12 @@ data class ShippingLabelDataDTO(
 )
 
 data class StoredDataDTO(
-    @SerializedName("selected_origin") val selectedOrigin: Map<String, OriginAddressDTO>,
-    @SerializedName("selected_destination") val selectedDestination: Map<String, DestinationAddressDTO>,
+    @SerializedName("selected_origin")
+    @JsonAdapter(MapOrEmptyMapDeserializer::class)
+    val selectedOrigin: Map<String, OriginAddressDTO>,
+    @SerializedName("selected_destination")
+    @JsonAdapter(MapOrEmptyMapDeserializer::class)
+    val selectedDestination: Map<String, DestinationAddressDTO>,
 )
 
 data class Item(@SerializedName("id") val id: Long?, @SerializedName("subItems") val subItems: List<String>?)
@@ -222,6 +226,22 @@ data class CustomsItemDTO(
 )
 
 data class RefundLabelResponseDTO(val success: Boolean)
+
+private class MapOrEmptyMapDeserializer : JsonDeserializer<Map<*, *>?> {
+    override fun deserialize(
+        json: JsonElement,
+        typeOfT: Type,
+        context: JsonDeserializationContext
+    ): Map<*, *> = try {
+        if (json.isJsonObject) {
+            context.deserialize(json, typeOfT)
+        } else {
+            emptyMap<Any, Any>()
+        }
+    } catch (_: Exception) {
+        emptyMap<Any, Any>()
+    }
+}
 
 private class ShipmentMapDeserializer : JsonDeserializer<ShipmentMap> {
     override fun deserialize(json: JsonElement, typeOfT: Type, context: JsonDeserializationContext): ShipmentMap {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/networking/DTOs.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/networking/DTOs.kt
@@ -247,10 +247,10 @@ private class ShipmentMapDeserializer : JsonDeserializer<ShipmentMap> {
     override fun deserialize(json: JsonElement, typeOfT: Type, context: JsonDeserializationContext): ShipmentMap {
         // Handle string-encoded JSON or direct JSON object
         val jsonObject = if (json.isJsonPrimitive && json.asJsonPrimitive.isString) {
-            JsonParser.parseString(json.asString).asJsonObject
+            JsonParser.parseString(json.asString)
         } else {
-            json.asJsonObject
-        }
+            json
+        }.asJsonObject
 
         val mapType = object : TypeToken<ShipmentMap>() {}.type
         return Gson().fromJson(jsonObject, mapType)

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/networking/WooShippingNetworkingMapper.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/networking/WooShippingNetworkingMapper.kt
@@ -93,11 +93,11 @@ class WooShippingNetworkingMapper @Inject constructor(
     }
 
     operator fun invoke(originAddressDTO: OriginAddressDTO): Address {
-        val name = originAddressDTO.name?.split(" ") ?: listOf("", "")
+        val (firstName, lastName) = parseFullName(originAddressDTO.name)
         return Address(
             company = originAddressDTO.company.orEmpty(),
-            firstName = name.getOrElse(0) { "" },
-            lastName = name.getOrElse(1) { "" },
+            firstName = firstName,
+            lastName = lastName,
             phone = originAddressDTO.phone.orEmpty(),
             country = Location(
                 name = originAddressDTO.country.orEmpty(),
@@ -113,7 +113,7 @@ class WooShippingNetworkingMapper @Inject constructor(
     }
 
     operator fun invoke(destinationAddressDTO: DestinationAddressDTO): Address {
-        val name = destinationAddressDTO.name?.split(" ") ?: listOf("", "")
+        val (firstName, lastName) = parseFullName(destinationAddressDTO.name)
         return Address(
             company = destinationAddressDTO.company.orEmpty(),
             address1 = destinationAddressDTO.address.orEmpty(),
@@ -124,16 +124,16 @@ class WooShippingNetworkingMapper @Inject constructor(
                 name = destinationAddressDTO.country.orEmpty(),
                 code = destinationAddressDTO.country.orEmpty()
             ),
-            firstName = name.getOrElse(0) { "" },
+            firstName = firstName,
             phone = destinationAddressDTO.phone.orEmpty(),
             address2 = destinationAddressDTO.address2.orEmpty(),
             email = destinationAddressDTO.email.orEmpty(),
-            lastName = name.getOrElse(1) { "" }
+            lastName = lastName
         )
     }
 
     operator fun invoke(originAddressPurchaseDTO: OriginAddressPurchaseDTO): OriginShippingAddress {
-        val name = originAddressPurchaseDTO.name?.split(" ") ?: listOf("", "")
+        val (firstName, lastName) = parseFullName(originAddressPurchaseDTO.name)
         return OriginShippingAddress(
             id = originAddressPurchaseDTO.id.orEmpty(),
             address1 = originAddressPurchaseDTO.address,
@@ -142,13 +142,13 @@ class WooShippingNetworkingMapper @Inject constructor(
             state = originAddressPurchaseDTO.state,
             postcode = originAddressPurchaseDTO.postcode.orEmpty(),
             country = originAddressPurchaseDTO.country.orEmpty(),
-            firstName = name.getOrElse(0) { "" },
+            firstName = firstName,
             company = originAddressPurchaseDTO.company,
             phone = originAddressPurchaseDTO.phone.orEmpty(),
             email = originAddressPurchaseDTO.email.orEmpty(),
             isDefault = false,
             isVerified = originAddressPurchaseDTO.isVerified,
-            lastName = name.getOrElse(1) { "" }
+            lastName = lastName
         )
     }
 
@@ -389,4 +389,14 @@ class WooShippingNetworkingMapper @Inject constructor(
                 category = hazmatSelection.requestFieldValue
             )
         } ?: HazmatDTO()
+
+    private fun parseFullName(name: String?): Pair<String, String> {
+        val safeName = name.orEmpty()
+        val lastSpaceIndex = safeName.indexOfLast { it == ' ' }
+        return if (lastSpaceIndex == -1) {
+            "" to ""
+        } else {
+            safeName.substring(0, lastSpaceIndex) to safeName.substring(lastSpaceIndex + 1)
+        }
+    }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/networking/WooShippingNetworkingMapper.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/networking/WooShippingNetworkingMapper.kt
@@ -21,6 +21,7 @@ import com.woocommerce.android.ui.orders.wooshippinglabels.rates.datasource.WooS
 import com.woocommerce.android.ui.orders.wooshippinglabels.rates.datasource.WooShippingRatesDatasourceMapper
 import com.woocommerce.android.ui.orders.wooshippinglabels.rates.datasource.WooShippingSelectedRateModel
 import com.woocommerce.android.ui.orders.wooshippinglabels.rates.networking.DestinationAddressDTO
+import com.woocommerce.android.ui.orders.wooshippinglabels.rates.networking.OriginAddressDTO
 import com.woocommerce.android.ui.orders.wooshippinglabels.rates.networking.ShippingRateSurchargeDTO
 import com.woocommerce.android.util.StringUtils.combineStrings
 import java.math.BigDecimal
@@ -88,6 +89,26 @@ class WooShippingNetworkingMapper @Inject constructor(
             refund = shippingLabelDTO.refund?.let { refund ->
                 ShippingLabelModel.Refund(status = refund.status, requestDate = refund.requestDate?.let { Date(it) })
             }
+        )
+    }
+
+    operator fun invoke(originAddressDTO: OriginAddressDTO): Address {
+        val name = originAddressDTO.name?.split(" ") ?: listOf("", "")
+        return Address(
+            company = originAddressDTO.company.orEmpty(),
+            firstName = name.getOrElse(0) { "" },
+            lastName = name.getOrElse(1) { "" },
+            phone = originAddressDTO.phone.orEmpty(),
+            country = Location(
+                name = originAddressDTO.country.orEmpty(),
+                code = originAddressDTO.country.orEmpty()
+            ),
+            state = AmbiguousLocation.Raw(originAddressDTO.state.orEmpty()),
+            address1 = originAddressDTO.address.orEmpty(),
+            address2 = originAddressDTO.address2.orEmpty(),
+            city = originAddressDTO.city.orEmpty(),
+            postcode = originAddressDTO.postcode.orEmpty(),
+            email = ""
         )
     }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/networking/WooShippingNetworkingMapper.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/networking/WooShippingNetworkingMapper.kt
@@ -128,7 +128,7 @@ class WooShippingNetworkingMapper @Inject constructor(
             phone = destinationAddressDTO.phone.orEmpty(),
             address2 = destinationAddressDTO.address2.orEmpty(),
             email = "", // We set the email later from the order details
-            lastName =lastName
+            lastName = lastName
         )
     }
 

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/GetShipmentsTests.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/GetShipmentsTests.kt
@@ -15,6 +15,7 @@ import com.woocommerce.android.ui.orders.wooshippinglabels.networking.ShippingLa
 import com.woocommerce.android.ui.orders.wooshippinglabels.networking.StoredDataDTO
 import com.woocommerce.android.ui.orders.wooshippinglabels.networking.WooShippingNetworkingMapper
 import com.woocommerce.android.ui.orders.wooshippinglabels.rates.networking.DestinationAddressDTO
+import com.woocommerce.android.ui.orders.wooshippinglabels.rates.networking.OriginAddressDTO
 import com.woocommerce.android.ui.products.ProductTestUtils
 import com.woocommerce.android.ui.products.details.ProductDetailRepository
 import com.woocommerce.android.viewmodel.BaseUnitTest
@@ -235,11 +236,15 @@ class GetShipmentsTests : BaseUnitTest() {
 
         val shippingLabel = ShippingLabelDTO(labelId = labelId, shipmentId = shipmentId)
         val destinationAddressDTO = DestinationAddressDTO()
+        val originAddressDTO = OriginAddressDTO()
         val configDTO = ConfigDTO(
             shipments = mapOf(shipmentId to listOf(Item(id = orderItem.itemId, subItems = emptyList()))),
             shippingLabelData = ShippingLabelDataDTO(
                 currentOrderLabels = listOf(shippingLabel),
-                storedData = StoredDataDTO(selectedDestination = mapOf("shipment_$shipmentId" to destinationAddressDTO))
+                storedData = StoredDataDTO(
+                    selectedOrigin = mapOf("shipment_$shipmentId" to originAddressDTO),
+                    selectedDestination = mapOf("shipment_$shipmentId" to destinationAddressDTO)
+                )
             )
         )
 

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/WooShippingLabelCreationViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/WooShippingLabelCreationViewModelTest.kt
@@ -380,18 +380,6 @@ class WooShippingLabelCreationViewModelTest : BaseUnitTest() {
     }
 
     @Test
-    fun `when there are no origin addresses, then show an error`() = testBlocking {
-        whenever(observeOriginAddresses()) doReturn flowOf(emptyList())
-
-        createViewModel()
-
-        advanceUntilIdle()
-
-        val currentViewState = sut.viewState.value
-        assert(currentViewState is WooShippingViewState.Error)
-    }
-
-    @Test
     fun `when there are origin addresses, then display the origin addresses`() = testBlocking {
         createViewModel()
 
@@ -400,8 +388,8 @@ class WooShippingLabelCreationViewModelTest : BaseUnitTest() {
         val currentViewState = sut.viewState.value
         assert(currentViewState is DataState)
         val dataState = currentViewState as DataState
-        assertEquals(dataState.shippingAddresses.originAddresses.size, defaultOriginAddresses.size)
-        val ids = dataState.shippingAddresses.originAddresses.map { it.id }
+        assertEquals(dataState.shippingAddresses.first().originAddresses.size, defaultOriginAddresses.size)
+        val ids = dataState.shippingAddresses.first().originAddresses.map { it.id }
         assert(ids.containsAll(defaultOriginAddresses.map { it.id }))
     }
 

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/address/ObserveShippingLabelNoticeTests.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/address/ObserveShippingLabelNoticeTests.kt
@@ -48,7 +48,7 @@ class ObserveShippingLabelNoticeTests : BaseUnitTest() {
         ),
         originAddresses = emptyList()
     )
-    private val defaultAddressesFlow = flowOf(defaultAddresses)
+    private val defaultAddressesFlow = flowOf(listOf(defaultAddresses))
     private val customsFlow = flowOf(listOf(CustomsState.NotRequired))
     private val selectedIndexFlow = flowOf(0)
 
@@ -62,7 +62,7 @@ class ObserveShippingLabelNoticeTests : BaseUnitTest() {
     fun `when missing origin address was displayed but it is now verified, then display verified notice`() = runTest {
         val missingOriginAddress = defaultAddresses.copy(shipFrom = OriginShippingAddress.EMPTY)
         val result = sut.invoke(
-            flowOf(missingOriginAddress, defaultAddresses),
+            flowOf(listOf(missingOriginAddress), listOf(defaultAddresses)),
             customsFlow,
             selectedIndexFlow,
             coroutineScope
@@ -77,7 +77,7 @@ class ObserveShippingLabelNoticeTests : BaseUnitTest() {
         runTest {
             val missingDestinationAddress = defaultAddresses.copy(shipTo = DestinationShippingAddress.EMPTY)
             val result = sut.invoke(
-                flowOf(missingDestinationAddress, defaultAddresses),
+                flowOf(listOf(missingDestinationAddress), listOf(defaultAddresses)),
                 customsFlow,
                 selectedIndexFlow,
                 coroutineScope
@@ -91,7 +91,7 @@ class ObserveShippingLabelNoticeTests : BaseUnitTest() {
     fun `when shipFrom is not verified, then display origin not verified`() = runTest {
         val addresses = defaultAddresses.copy(shipFrom = defaultAddresses.shipFrom.copy(isVerified = false))
 
-        val result = sut.invoke(flowOf(addresses), customsFlow, selectedIndexFlow, coroutineScope).first()
+        val result = sut.invoke(flowOf(listOf(addresses)), customsFlow, selectedIndexFlow, coroutineScope).first()
 
         assertThat(result?.type).isEqualTo(NoticeType.UNVERIFIED_ORIGIN_ADDRESS)
     }
@@ -100,7 +100,7 @@ class ObserveShippingLabelNoticeTests : BaseUnitTest() {
     fun `when shipTo is not verified, then display destination not verified`() = runTest {
         val addresses = defaultAddresses.copy(shipTo = defaultAddresses.shipTo.copy(isVerified = false))
 
-        val result = sut.invoke(flowOf(addresses), customsFlow, selectedIndexFlow, coroutineScope).first()
+        val result = sut.invoke(flowOf(listOf(addresses)), customsFlow, selectedIndexFlow, coroutineScope).first()
 
         assertThat(result?.type).isEqualTo(NoticeType.UNVERIFIED_DESTINATION_ADDRESS)
     }
@@ -114,16 +114,19 @@ class ObserveShippingLabelNoticeTests : BaseUnitTest() {
         ) doReturn true
 
         val result =
-            sut.invoke(flowOf(missingDestinationAddress), customsFlow, selectedIndexFlow, coroutineScope).first()
+            sut.invoke(flowOf(listOf(missingDestinationAddress)), customsFlow, selectedIndexFlow, coroutineScope)
+                .first()
 
         assertThat(result?.type).isEqualTo(NoticeType.MISSING_DESTINATION_ADDRESS)
     }
 
     @Test
     fun `testing both addresses and customs with issues flow`() = runTest {
-        var addresses = defaultAddresses.copy(
-            shipTo = defaultAddresses.shipTo.copy(isVerified = false),
-            shipFrom = defaultAddresses.shipFrom.copy(isVerified = false)
+        var addresses = mutableListOf(
+            defaultAddresses.copy(
+                shipTo = defaultAddresses.shipTo.copy(isVerified = false),
+                shipFrom = defaultAddresses.shipFrom.copy(isVerified = false)
+            )
         )
         val addressesFlow = MutableStateFlow(addresses)
         val missingCustoms = MutableStateFlow<List<CustomsState>>(listOf(CustomsState.ItnMissing))
@@ -134,13 +137,13 @@ class ObserveShippingLabelNoticeTests : BaseUnitTest() {
         assertThat(result.first()?.type).isEqualTo(NoticeType.UNVERIFIED_ORIGIN_ADDRESS)
 
         // Fix origin issue
-        addresses = addresses.copy(shipFrom = defaultAddresses.shipFrom.copy(isVerified = true))
+        addresses = mutableListOf(addresses.first().copy(shipFrom = defaultAddresses.shipFrom.copy(isVerified = true)))
         addressesFlow.value = addresses
 
         assertThat(result.first()?.type).isEqualTo(NoticeType.UNVERIFIED_DESTINATION_ADDRESS)
 
         // Fix destination issue
-        addresses = defaultAddresses
+        addresses = mutableListOf(defaultAddresses)
         addressesFlow.value = addresses
 
         assertThat(result.first()?.type).isEqualTo(NoticeType.VERIFIED_DESTINATION_ADDRESS)


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

<!-- Id number of the Linear issue this PR addresses, e.g., WOOMOB-373. -->
Closes WOOMOB-786

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
This adds functionality to use the origin address stored on the backend for purchased labels.
I also added support for using different origin and destination addresses for each shipment.

Please test this PR on an order with multiple shipments and use different addresses.

### Steps to reproduce
<!-- Step-by-step testing instructions. For new user flows, consider instead stating the goal of the workflow and see if your PR reviewer can accomplish the workflow without specific steps! -->
1. Create a test order on the web.
2. Create multiple shipments for the order.
3. Purchase a label for one shipment.
4. Purchase another label for a different shipment, using a different store address.
5. Open the order in the app.
6. Start the "Create shipping label" flow.
7. Change the selected shipment.
8. Tap on Shipment details.
9. Verify that the "Ship from" address matches the one shown on the web.

### The tests that have been performed
<!-- To give the reviewer an idea of what could be missed in terms of testing -->
Steps above

### Images/gif
<!-- Include before and after images or gifs when appropriate. -->

- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->