### PR TITLE
[Shipping labels] update paper sizes to match the behavior of web

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/ShippableItemsMapper.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/ShippableItemsMapper.kt
@@ -9,11 +9,11 @@ import com.woocommerce.android.ui.orders.shippinglabels.creation.ShippingLabelHa
 import com.woocommerce.android.ui.orders.wooshippinglabels.WooShippingLabelCreationViewModel.CustomsState
 import com.woocommerce.android.ui.orders.wooshippinglabels.WooShippingLabelCreationViewModel.PackageSelectionState
 import com.woocommerce.android.ui.orders.wooshippinglabels.WooShippingLabelCreationViewModel.ShippingRatesState
-import com.woocommerce.android.ui.orders.wooshippinglabels.components.WooShippingLabelPaperSize
 import com.woocommerce.android.ui.orders.wooshippinglabels.models.ShipmentUIModel
 import com.woocommerce.android.ui.orders.wooshippinglabels.models.ShippableItemModel
 import com.woocommerce.android.ui.orders.wooshippinglabels.models.ShippableItemModel.Companion.SINGLE_QUANTITY
 import com.woocommerce.android.ui.orders.wooshippinglabels.models.ShippingLabelStatus
+import com.woocommerce.android.ui.orders.wooshippinglabels.models.WooShippingLabelPaperSize
 import com.woocommerce.android.ui.orders.wooshippinglabels.rates.ui.ShippingRateOption
 import com.woocommerce.android.ui.orders.wooshippinglabels.split.SelectableShippableItemUI
 import com.woocommerce.android.ui.orders.wooshippinglabels.split.SelectableShippableItemsUI

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/ShippableItemsMapper.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/ShippableItemsMapper.kt
@@ -9,6 +9,7 @@ import com.woocommerce.android.ui.orders.shippinglabels.creation.ShippingLabelHa
 import com.woocommerce.android.ui.orders.wooshippinglabels.WooShippingLabelCreationViewModel.CustomsState
 import com.woocommerce.android.ui.orders.wooshippinglabels.WooShippingLabelCreationViewModel.PackageSelectionState
 import com.woocommerce.android.ui.orders.wooshippinglabels.WooShippingLabelCreationViewModel.ShippingRatesState
+import com.woocommerce.android.ui.orders.wooshippinglabels.components.WooShippingLabelPaperSize
 import com.woocommerce.android.ui.orders.wooshippinglabels.models.ShipmentUIModel
 import com.woocommerce.android.ui.orders.wooshippinglabels.models.ShippableItemModel
 import com.woocommerce.android.ui.orders.wooshippinglabels.models.ShippableItemModel.Companion.SINGLE_QUANTITY
@@ -69,8 +70,11 @@ fun List<ShippableItemModel>.toUIModel(
         shipmentCostUI = shipmentCostUI,
         purchaseState = shipmentUIModel.purchaseState,
         status = shipmentUIModel.label?.status ?: ShippingLabelStatus.UNKNOWN,
-        isRefundAvailable = shipmentUIModel.label?.isRefundAvailable == true,
-        isCustomsFormAvailable = shipmentUIModel.label?.commercialInvoiceUrl.isNotNullOrEmpty()
+        shipmentPrintLabelUI = ShipmentPrintLabelUI(
+            availablePrintSizes = getPaperSizes(shipmentUIModel.label?.originAddress?.country?.code),
+            isRefundAvailable = shipmentUIModel.label?.isRefundAvailable == true,
+            isCustomsFormAvailable = shipmentUIModel.label?.commercialInvoiceUrl.isNotNullOrEmpty()
+        ),
     )
 }
 
@@ -191,3 +195,10 @@ private fun getShipmentCostUI(
         else -> null
     }
 }
+
+private fun getPaperSizes(countryCode: String?): List<WooShippingLabelPaperSize> =
+    if (countryCode.isNullOrEmpty() || countryCode.uppercase() in listOf("US", "CA", "MX", "DO")) {
+        WooShippingLabelPaperSize.entries.minus(WooShippingLabelPaperSize.A4)
+    } else {
+        WooShippingLabelPaperSize.entries
+    }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/ShippingLabelSampleData.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/ShippingLabelSampleData.kt
@@ -5,12 +5,12 @@ import com.woocommerce.android.model.Address
 import com.woocommerce.android.model.AmbiguousLocation
 import com.woocommerce.android.model.Location
 import com.woocommerce.android.ui.orders.wooshippinglabels.WooShippingLabelCreationViewModel.ShippingRatesState
-import com.woocommerce.android.ui.orders.wooshippinglabels.components.WooShippingLabelPaperSize
 import com.woocommerce.android.ui.orders.wooshippinglabels.models.DestinationShippingAddress
 import com.woocommerce.android.ui.orders.wooshippinglabels.models.OriginShippingAddress
 import com.woocommerce.android.ui.orders.wooshippinglabels.models.PaymentMethodModel
 import com.woocommerce.android.ui.orders.wooshippinglabels.models.PaymentMethodOptions
 import com.woocommerce.android.ui.orders.wooshippinglabels.models.WooShippingCarrier
+import com.woocommerce.android.ui.orders.wooshippinglabels.models.WooShippingLabelPaperSize
 import com.woocommerce.android.ui.orders.wooshippinglabels.rates.datasource.WooShippingRateModel
 import com.woocommerce.android.ui.orders.wooshippinglabels.rates.ui.CarrierUI
 import com.woocommerce.android.ui.orders.wooshippinglabels.rates.ui.ShippingRateOptionUI

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/ShippingLabelSampleData.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/ShippingLabelSampleData.kt
@@ -5,6 +5,7 @@ import com.woocommerce.android.model.Address
 import com.woocommerce.android.model.AmbiguousLocation
 import com.woocommerce.android.model.Location
 import com.woocommerce.android.ui.orders.wooshippinglabels.WooShippingLabelCreationViewModel.ShippingRatesState
+import com.woocommerce.android.ui.orders.wooshippinglabels.components.WooShippingLabelPaperSize
 import com.woocommerce.android.ui.orders.wooshippinglabels.models.DestinationShippingAddress
 import com.woocommerce.android.ui.orders.wooshippinglabels.models.OriginShippingAddress
 import com.woocommerce.android.ui.orders.wooshippinglabels.models.PaymentMethodModel
@@ -193,4 +194,10 @@ object ShippingLabelSampleData {
             )
         )
     }
+
+    fun getShipmentPrintLabelUI() = ShipmentPrintLabelUI(
+        availablePrintSizes = listOf(WooShippingLabelPaperSize.LABEL, WooShippingLabelPaperSize.LETTER),
+        isRefundAvailable = true,
+        isCustomsFormAvailable = true
+    )
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/WooShippingLabelCreationScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/WooShippingLabelCreationScreen.kt
@@ -460,11 +460,12 @@ private fun CreateShippingCards(
     Column {
         val isExpanded = remember { mutableStateOf(false) }
 
-        if (shipmentUI.purchased) {
+        if (shipmentUI.purchased && shipmentUI.shipmentPrintLabelUI != null) {
             PrintShippingLabelSection(
                 status = shipmentUI.status,
-                isCustomsFormAvailable = shipmentUI.isCustomsFormAvailable,
-                isRefundAvailable = shipmentUI.isRefundAvailable,
+                isCustomsFormAvailable = shipmentUI.shipmentPrintLabelUI.isCustomsFormAvailable,
+                isRefundAvailable = shipmentUI.shipmentPrintLabelUI.isRefundAvailable,
+                availablePaperSizes = shipmentUI.shipmentPrintLabelUI.availablePrintSizes,
                 selectedLabelPaperSizeOption = uiState.paperSizeOption,
                 onLabelPaperSizeOptionSelected = onLabelPaperSizeOptionSelected,
                 onPrintShippingLabelClicked = onPrintShippingLabelClicked,
@@ -842,6 +843,7 @@ private fun WooShippingLabelCreationScreenPreview() {
                     hazmatState = Declared(ShippingLabelHazmatCategory.CLASS_1),
                     shippingRatesState = ShippingLabelSampleData.getShippingRatesSection(),
                     shipmentCostUI = ShippingLabelSampleData.getShippingRateSummaryUI(),
+                    shipmentPrintLabelUI = ShippingLabelSampleData.getShipmentPrintLabelUI(),
                 )
             ),
             shouldShowSplitShipmentButton = true,

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/WooShippingLabelCreationScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/WooShippingLabelCreationScreen.kt
@@ -77,11 +77,11 @@ import com.woocommerce.android.ui.orders.wooshippinglabels.components.ShipmentsT
 import com.woocommerce.android.ui.orders.wooshippinglabels.components.ShippingLabelsSnackbar
 import com.woocommerce.android.ui.orders.wooshippinglabels.components.ShippingLabelsSnackbarData
 import com.woocommerce.android.ui.orders.wooshippinglabels.components.ShippingLabelsSnackbarVisuals
-import com.woocommerce.android.ui.orders.wooshippinglabels.components.WooShippingLabelPaperSize
 import com.woocommerce.android.ui.orders.wooshippinglabels.hazmat.HazmatCard
 import com.woocommerce.android.ui.orders.wooshippinglabels.models.DestinationShippingAddress
 import com.woocommerce.android.ui.orders.wooshippinglabels.models.OriginShippingAddress
 import com.woocommerce.android.ui.orders.wooshippinglabels.models.PurchaseState
+import com.woocommerce.android.ui.orders.wooshippinglabels.models.WooShippingLabelPaperSize
 import com.woocommerce.android.ui.orders.wooshippinglabels.packages.components.ErrorMessageWithButton
 import com.woocommerce.android.ui.orders.wooshippinglabels.packages.ui.PackageData
 import com.woocommerce.android.ui.orders.wooshippinglabels.rates.ui.ShippingRatesSection

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/WooShippingLabelCreationViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/WooShippingLabelCreationViewModel.kt
@@ -39,7 +39,6 @@ import com.woocommerce.android.ui.orders.wooshippinglabels.address.toAddress
 import com.woocommerce.android.ui.orders.wooshippinglabels.components.NoticeBannerUiState
 import com.woocommerce.android.ui.orders.wooshippinglabels.components.NoticeType
 import com.woocommerce.android.ui.orders.wooshippinglabels.components.ShippingLabelsSnackbarData
-import com.woocommerce.android.ui.orders.wooshippinglabels.components.WooShippingLabelPaperSize
 import com.woocommerce.android.ui.orders.wooshippinglabels.customs.CustomsData
 import com.woocommerce.android.ui.orders.wooshippinglabels.customs.domain.ShouldRequireCustomsForm
 import com.woocommerce.android.ui.orders.wooshippinglabels.customs.domain.ShouldRequireITN
@@ -52,6 +51,7 @@ import com.woocommerce.android.ui.orders.wooshippinglabels.models.ShipmentUIMode
 import com.woocommerce.android.ui.orders.wooshippinglabels.models.ShippableItemModel
 import com.woocommerce.android.ui.orders.wooshippinglabels.models.ShippingLabelStatus
 import com.woocommerce.android.ui.orders.wooshippinglabels.models.StoreOptionsModel
+import com.woocommerce.android.ui.orders.wooshippinglabels.models.WooShippingLabelPaperSize
 import com.woocommerce.android.ui.orders.wooshippinglabels.packages.ui.PackageData
 import com.woocommerce.android.ui.orders.wooshippinglabels.purchased.ObserveShippingLabelStatus
 import com.woocommerce.android.ui.orders.wooshippinglabels.purchased.printing.FetchShippingLabelFile

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/WooShippingLabelCreationViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/WooShippingLabelCreationViewModel.kt
@@ -1264,8 +1264,7 @@ data class ShipmentUI(
     val shipmentCostUI: ShipmentCostUI?,
     val purchaseState: PurchaseState = PurchaseState.NoStarted,
     val status: ShippingLabelStatus = ShippingLabelStatus.UNKNOWN,
-    val isRefundAvailable: Boolean = false,
-    val isCustomsFormAvailable: Boolean = false,
+    val shipmentPrintLabelUI: ShipmentPrintLabelUI?,
 ) : Parcelable {
     val totalItemQuantity
         get() = shippableItems.sumByFloat { it.quantity }.toInt()
@@ -1283,6 +1282,13 @@ data class ShipmentCostUI(
     val formattedBasePrice: String,
     val formattedTotalPrice: String,
     val optionsWithFees: Map<String, String>,
+) : Parcelable
+
+@Parcelize
+data class ShipmentPrintLabelUI(
+    val availablePrintSizes: List<WooShippingLabelPaperSize>,
+    val isRefundAvailable: Boolean = false,
+    val isCustomsFormAvailable: Boolean = false,
 ) : Parcelable
 
 data class PurchaseSectionUI(

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/WooShippingLabelCreationViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/WooShippingLabelCreationViewModel.kt
@@ -179,6 +179,7 @@ class WooShippingLabelCreationViewModel @Inject constructor(
         launch { observeShippingLabelInformation() }
         launch { getDestinationAddress() }
         launch { getSavedShipments() }
+        launch { setDefaultPaperSize() }
         launch { getShippingAddresses() }
         launch { getOrderInformation() }
         launch { observePackageWeight() }
@@ -297,6 +298,11 @@ class WooShippingLabelCreationViewModel @Inject constructor(
 
     private suspend fun getSavedShipments() {
         order.drop(1).collectLatest { order -> shipments.value = getShipments(order) }
+    }
+
+    private suspend fun setDefaultPaperSize() {
+        val paperSize = accountSettings.first()?.paperSize ?: WooShippingLabelPaperSize.LABEL
+        uiState.update { it.copy(paperSizeOption = paperSize) }
     }
 
     @Suppress("ComplexCondition")

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/WooShippingProductsCard.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/WooShippingProductsCard.kt
@@ -101,7 +101,8 @@ private fun ShippingProductsCardPreview(@PreviewParameter(IsExpandedProvider::cl
                     customsState = WooShippingLabelCreationViewModel.CustomsState.NotRequired,
                     hazmatState = WooShippingLabelCreationViewModel.HazmatState.NoSelection,
                     shippingRatesState = WooShippingLabelCreationViewModel.ShippingRatesState.NoAvailable,
-                    shipmentCostUI = ShippingLabelSampleData.getShippingRateSummaryUI()
+                    shipmentCostUI = ShippingLabelSampleData.getShippingRateSummaryUI(),
+                    shipmentPrintLabelUI = ShippingLabelSampleData.getShipmentPrintLabelUI()
                 ),
                 isExpanded = isExpanded
             )
@@ -177,7 +178,8 @@ private fun ShippingProductsCardHeaderPreview() {
         customsState = WooShippingLabelCreationViewModel.CustomsState.NotRequired,
         hazmatState = WooShippingLabelCreationViewModel.HazmatState.NoSelection,
         shippingRatesState = WooShippingLabelCreationViewModel.ShippingRatesState.NoAvailable,
-        shipmentCostUI = ShippingLabelSampleData.getShippingRateSummaryUI()
+        shipmentCostUI = ShippingLabelSampleData.getShippingRateSummaryUI(),
+        shipmentPrintLabelUI = ShippingLabelSampleData.getShipmentPrintLabelUI()
     )
     val isExpanded = remember { mutableStateOf(false) }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/components/PrintShippingLabelSection.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/components/PrintShippingLabelSection.kt
@@ -1,7 +1,6 @@
 package com.woocommerce.android.ui.orders.wooshippinglabels.components
 
 import android.content.res.Configuration
-import androidx.annotation.StringRes
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
@@ -46,6 +45,7 @@ import com.woocommerce.android.ui.orders.wooshippinglabels.RoundedCornerBoxWithB
 import com.woocommerce.android.ui.orders.wooshippinglabels.models.ShippingLabelStatus
 import com.woocommerce.android.ui.orders.wooshippinglabels.models.ShippingLabelStatus.PURCHASED
 import com.woocommerce.android.ui.orders.wooshippinglabels.models.ShippingLabelStatus.PURCHASE_IN_PROGRESS
+import com.woocommerce.android.ui.orders.wooshippinglabels.models.WooShippingLabelPaperSize
 
 @Composable
 fun PrintShippingLabelSection(
@@ -344,10 +344,4 @@ private fun ShippingLabelLinkPreview() {
             showIcon = true
         )
     }
-}
-
-enum class WooShippingLabelPaperSize(@StringRes val stringResource: Int) {
-    A4(R.string.shipping_label_paper_size_a4),
-    LABEL(R.string.shipping_label_paper_size_label),
-    LETTER(R.string.shipping_label_paper_size_letter)
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/components/PrintShippingLabelSection.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/components/PrintShippingLabelSection.kt
@@ -52,6 +52,7 @@ fun PrintShippingLabelSection(
     status: ShippingLabelStatus,
     isCustomsFormAvailable: Boolean,
     isRefundAvailable: Boolean,
+    availablePaperSizes: List<WooShippingLabelPaperSize>,
     selectedLabelPaperSizeOption: WooShippingLabelPaperSize,
     onLabelPaperSizeOptionSelected: (WooShippingLabelPaperSize) -> Unit,
     onPrintShippingLabelClicked: () -> Unit,
@@ -97,6 +98,7 @@ fun PrintShippingLabelSection(
             isPrintButtonEnabled = status == PURCHASED,
             isCustomsFormAvailable = isCustomsFormAvailable,
             isRefundAvailable = isRefundAvailable,
+            availablePaperSizes = availablePaperSizes,
             selectedLabelPaperSizeOption = selectedLabelPaperSizeOption,
             onLabelPaperSizeOptionSelected = onLabelPaperSizeOptionSelected,
             onPrintShippingLabelClicked = onPrintShippingLabelClicked,
@@ -121,6 +123,7 @@ private fun PrintShippingLabelCard(
     isPrintButtonEnabled: Boolean,
     isCustomsFormAvailable: Boolean,
     isRefundAvailable: Boolean,
+    availablePaperSizes: List<WooShippingLabelPaperSize>,
     selectedLabelPaperSizeOption: WooShippingLabelPaperSize,
     onLabelPaperSizeOptionSelected: (WooShippingLabelPaperSize) -> Unit,
     onPrintShippingLabelClicked: () -> Unit,
@@ -141,6 +144,7 @@ private fun PrintShippingLabelCard(
     ) {
         RoundedCornerBoxWithBorder(backgroundColor = colorResource(id = R.color.woo_shipping_label_success_surface)) {
             LabelPaperSizeDropdownMenu(
+                availablePaperSizes = availablePaperSizes,
                 selectedLabelPaperSizeOption = selectedLabelPaperSizeOption,
                 onLabelPaperSizeOptionSelected = onLabelPaperSizeOptionSelected,
                 modifier = Modifier
@@ -215,12 +219,12 @@ private fun PrintShippingLabelCard(
 
 @Composable
 private fun LabelPaperSizeDropdownMenu(
+    availablePaperSizes: List<WooShippingLabelPaperSize>,
     selectedLabelPaperSizeOption: WooShippingLabelPaperSize,
     onLabelPaperSizeOptionSelected: (WooShippingLabelPaperSize) -> Unit,
     modifier: Modifier = Modifier,
 ) {
     var expanded by remember { mutableStateOf(false) }
-    val options = WooShippingLabelPaperSize.entries
 
     Box {
         Row(
@@ -250,7 +254,7 @@ private fun LabelPaperSizeDropdownMenu(
             onDismissRequest = { expanded = false },
             modifier = Modifier.align(alignment = Alignment.CenterEnd)
         ) {
-            options.forEach { option ->
+            availablePaperSizes.forEach { option ->
                 DropdownMenuItem(onClick = {
                     onLabelPaperSizeOptionSelected(option)
                     expanded = false
@@ -311,12 +315,12 @@ private fun ShippingLabelLink(
 internal fun PrintShippingLabelSectionPreview() {
     WooThemeWithBackground {
         Surface {
-            val selectedLabelPaperSizeOption =
-                remember { mutableStateOf(WooShippingLabelPaperSize.LEGAL) }
+            val selectedLabelPaperSizeOption = remember { mutableStateOf(WooShippingLabelPaperSize.A4) }
             PrintShippingLabelSection(
                 status = PURCHASED,
                 isCustomsFormAvailable = true,
                 isRefundAvailable = true,
+                availablePaperSizes = emptyList(),
                 selectedLabelPaperSizeOption = selectedLabelPaperSizeOption.value,
                 onLabelPaperSizeOptionSelected = { selectedLabelPaperSizeOption.value = it },
                 onPrintShippingLabelClicked = {},

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/components/PrintShippingLabelSection.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/components/PrintShippingLabelSection.kt
@@ -343,7 +343,7 @@ private fun ShippingLabelLinkPreview() {
 }
 
 enum class WooShippingLabelPaperSize(@StringRes val stringResource: Int) {
-    LEGAL(R.string.shipping_label_paper_size_legal),
-    LETTER(R.string.shipping_label_paper_size_letter),
-    LABEL(R.string.shipping_label_paper_size_label)
+    A4(R.string.shipping_label_paper_size_a4),
+    LABEL(R.string.shipping_label_paper_size_label),
+    LETTER(R.string.shipping_label_paper_size_letter)
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/models/AccountSettingsModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/models/AccountSettingsModel.kt
@@ -10,7 +10,8 @@ data class AccountSettingsModel(
     val canManagePayments: Boolean,
     val canEditSettings: Boolean,
     val storeOwnerName: String,
-    val storeOwnerUsername: String
+    val storeOwnerUsername: String,
+    val paperSize: WooShippingLabelPaperSize
 )
 
 @Parcelize

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/models/WooShippingLabelPaperSize.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/models/WooShippingLabelPaperSize.kt
@@ -1,0 +1,16 @@
+package com.woocommerce.android.ui.orders.wooshippinglabels.models
+
+import androidx.annotation.StringRes
+import com.google.gson.annotations.SerializedName
+import com.woocommerce.android.R
+
+enum class WooShippingLabelPaperSize(@StringRes val stringResource: Int) {
+    @SerializedName("a4")
+    A4(R.string.shipping_label_paper_size_a4),
+
+    @SerializedName("label")
+    LABEL(R.string.shipping_label_paper_size_label),
+
+    @SerializedName("letter")
+    LETTER(R.string.shipping_label_paper_size_letter)
+}

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/networking/DTOs.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/networking/DTOs.kt
@@ -9,6 +9,7 @@ import com.google.gson.annotations.JsonAdapter
 import com.google.gson.annotations.SerializedName
 import com.google.gson.reflect.TypeToken
 import com.woocommerce.android.ui.orders.wooshippinglabels.models.ShippingLabelStatus
+import com.woocommerce.android.ui.orders.wooshippinglabels.models.WooShippingLabelPaperSize
 import com.woocommerce.android.ui.orders.wooshippinglabels.rates.networking.DestinationAddressDTO
 import com.woocommerce.android.ui.orders.wooshippinglabels.rates.networking.OriginAddressDTO
 import java.lang.reflect.Type
@@ -33,7 +34,8 @@ data class StoreOptionsDTO(
 
 data class FormDataDTO(
     @SerializedName("selected_payment_method_id") val selectedPaymentId: Long?,
-    @SerializedName("email_receipts") val emailReceipts: Boolean = false
+    @SerializedName("email_receipts") val emailReceipts: Boolean = false,
+    @SerializedName("paper_size") val paperSize: WooShippingLabelPaperSize
 )
 
 data class FormMetaDTO(

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/networking/WooShippingNetworkingMapper.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/networking/WooShippingNetworkingMapper.kt
@@ -57,7 +57,8 @@ class WooShippingNetworkingMapper @Inject constructor(
                 canManagePayments = formMeta.canManagePayments,
                 canEditSettings = formMeta.canEditSettings,
                 storeOwnerName = formMeta.masterUserName,
-                storeOwnerUsername = formMeta.masterUserWpcomLogin
+                storeOwnerUsername = formMeta.masterUserWpcomLogin,
+                paperSize = formData.paperSize
             )
         }
     }

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -1125,6 +1125,7 @@
     <string name="shipping_label_preview_error">Error previewing shipping label</string>
     <string name="shipping_label_preview_pdf_app_missing">Unable to preview shipping label. Please install a PDF viewer app and try again.</string>
     <string name="shipping_label_paper_size_legal">Legal (8.5 x 14 in)</string>
+    <string name="shipping_label_paper_size_a4">A4 (210 x 297mm)</string>
     <string name="shipping_label_paper_size_letter">Letter (8.5 x 11 in)</string>
     <string name="shipping_label_paper_size_label">Label (4 x 6 in)</string>
     <string name="print_receipt_label_info_step_count_1" translatable="false">1</string>

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/FetchAccountSettingsTests.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/FetchAccountSettingsTests.kt
@@ -4,6 +4,7 @@ import com.woocommerce.android.tools.SelectedSite
 import com.woocommerce.android.ui.orders.wooshippinglabels.models.AccountSettingsModel
 import com.woocommerce.android.ui.orders.wooshippinglabels.models.PaymentMethodOptions
 import com.woocommerce.android.ui.orders.wooshippinglabels.models.StoreOptionsModel
+import com.woocommerce.android.ui.orders.wooshippinglabels.models.WooShippingLabelPaperSize
 import com.woocommerce.android.ui.orders.wooshippinglabels.networking.WooShippingLabelRepository
 import com.woocommerce.android.viewmodel.BaseUnitTest
 import kotlinx.coroutines.ExperimentalCoroutinesApi
@@ -43,7 +44,8 @@ class FetchAccountSettingsTests : BaseUnitTest() {
         canManagePayments = false,
         canEditSettings = true,
         storeOwnerName = "",
-        storeOwnerUsername = ""
+        storeOwnerUsername = "",
+        paperSize = WooShippingLabelPaperSize.LABEL
     )
 
     val sut = FetchAccountSettings(

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/ObserveAccountSettingsTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/ObserveAccountSettingsTest.kt
@@ -4,6 +4,7 @@ import com.woocommerce.android.ui.orders.wooshippinglabels.datasource.WooShippin
 import com.woocommerce.android.ui.orders.wooshippinglabels.models.AccountSettingsModel
 import com.woocommerce.android.ui.orders.wooshippinglabels.models.PaymentMethodOptions
 import com.woocommerce.android.ui.orders.wooshippinglabels.models.StoreOptionsModel
+import com.woocommerce.android.ui.orders.wooshippinglabels.models.WooShippingLabelPaperSize
 import com.woocommerce.android.viewmodel.BaseUnitTest
 import junit.framework.TestCase.assertTrue
 import kotlinx.coroutines.ExperimentalCoroutinesApi
@@ -35,7 +36,8 @@ class ObserveAccountSettingsTest : BaseUnitTest() {
         canManagePayments = false,
         canEditSettings = true,
         storeOwnerName = "",
-        storeOwnerUsername = ""
+        storeOwnerUsername = "",
+        paperSize = WooShippingLabelPaperSize.LABEL
     )
 
     val sut = ObserveAccountSettings(

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/WooShippingLabelCreationViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/WooShippingLabelCreationViewModelTest.kt
@@ -990,6 +990,22 @@ class WooShippingLabelCreationViewModelTest : BaseUnitTest() {
     }
 
     @Test
+    fun `when viewmodel initializes, then default paper size is set`() = testBlocking {
+        val expectedPaperSize = WooShippingLabelPaperSize.A4
+        given(observeAccountSettings()).willReturn(
+            flowOf(
+                defaultAccountSettings.copy(paperSize = expectedPaperSize)
+            )
+        )
+
+        createViewModel()
+        advanceUntilIdle()
+
+        val dataState = sut.viewState.value as DataState
+        assertThat(dataState.uiState.paperSizeOption).isEqualTo(expectedPaperSize)
+    }
+
+    @Test
     fun `onRefundClicked triggers NavigateToRefundRequest event`() = testBlocking {
         val labelId = 123L
         whenever(getShipments(any())) doReturn defaultShipments.toMutableList().apply {

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/WooShippingLabelCreationViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/WooShippingLabelCreationViewModelTest.kt
@@ -29,7 +29,6 @@ import com.woocommerce.android.ui.orders.wooshippinglabels.address.destination.V
 import com.woocommerce.android.ui.orders.wooshippinglabels.address.origin.ObserveOriginAddresses
 import com.woocommerce.android.ui.orders.wooshippinglabels.components.NoticeBannerUiState
 import com.woocommerce.android.ui.orders.wooshippinglabels.components.NoticeType
-import com.woocommerce.android.ui.orders.wooshippinglabels.components.WooShippingLabelPaperSize
 import com.woocommerce.android.ui.orders.wooshippinglabels.customs.domain.ShouldRequireCustomsForm
 import com.woocommerce.android.ui.orders.wooshippinglabels.customs.domain.ShouldRequireITN
 import com.woocommerce.android.ui.orders.wooshippinglabels.models.AccountSettingsModel
@@ -45,6 +44,7 @@ import com.woocommerce.android.ui.orders.wooshippinglabels.models.ShippingLabelS
 import com.woocommerce.android.ui.orders.wooshippinglabels.models.ShippingLabelStatus.UNKNOWN
 import com.woocommerce.android.ui.orders.wooshippinglabels.models.StoreOptionsModel
 import com.woocommerce.android.ui.orders.wooshippinglabels.models.WooShippingCarrier
+import com.woocommerce.android.ui.orders.wooshippinglabels.models.WooShippingLabelPaperSize
 import com.woocommerce.android.ui.orders.wooshippinglabels.packages.ui.PackageData
 import com.woocommerce.android.ui.orders.wooshippinglabels.purchased.printing.FetchShippingLabelFile
 import com.woocommerce.android.ui.orders.wooshippinglabels.rates.datasource.WooShippingRateModel
@@ -159,7 +159,8 @@ class WooShippingLabelCreationViewModelTest : BaseUnitTest() {
         canManagePayments = false,
         canEditSettings = true,
         storeOwnerName = "",
-        storeOwnerUsername = ""
+        storeOwnerUsername = "",
+        paperSize = WooShippingLabelPaperSize.LABEL
     )
 
     private val defaultPackageData = PackageData(

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/payment/WooShippingEditPaymentViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/payment/WooShippingEditPaymentViewModelTest.kt
@@ -9,6 +9,7 @@ import com.woocommerce.android.ui.orders.wooshippinglabels.models.AccountSetting
 import com.woocommerce.android.ui.orders.wooshippinglabels.models.PaymentMethodModel
 import com.woocommerce.android.ui.orders.wooshippinglabels.models.PaymentMethodOptions
 import com.woocommerce.android.ui.orders.wooshippinglabels.models.StoreOptionsModel
+import com.woocommerce.android.ui.orders.wooshippinglabels.models.WooShippingLabelPaperSize
 import com.woocommerce.android.util.captureValues
 import com.woocommerce.android.util.getOrAwaitValue
 import com.woocommerce.android.util.runAndCaptureValues
@@ -61,7 +62,8 @@ class WooShippingEditPaymentViewModelTest : BaseUnitTest() {
         canManagePayments = true,
         canEditSettings = true,
         storeOwnerName = "John Doe",
-        storeOwnerUsername = "johndoe"
+        storeOwnerUsername = "johndoe",
+        paperSize = WooShippingLabelPaperSize.LABEL
     )
 
     private val observeAccountSettings: ObserveAccountSettings = mock {

--- a/libs/fluxc-plugin/src/main/kotlin/org/wordpress/android/fluxc/model/shippinglabels/WCShippingLabelPaperSize.kt
+++ b/libs/fluxc-plugin/src/main/kotlin/org/wordpress/android/fluxc/model/shippinglabels/WCShippingLabelPaperSize.kt
@@ -3,13 +3,12 @@ package org.wordpress.android.fluxc.model.shippinglabels
 enum class WCShippingLabelPaperSize(val stringValue: String) {
     A4("a4"),
     LABEL("label"),
-    LEGAL("legal"),
     LETTER("letter");
 
     companion object {
         fun fromString(value: String): WCShippingLabelPaperSize {
             // When the value is unknown, WCS in wp-admin uses Label by default
-            return WCShippingLabelPaperSize.values().find { it.stringValue == value } ?: LABEL
+            return entries.find { it.stringValue == value } ?: LABEL
         }
     }
 }


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

<!-- Id number of the Linear issue this PR addresses, e.g., WOOMOB-373. -->
Closes WOOMOB-641

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
This PR makes two changes:
	•	Updates the logic for displaying paper size options. The available options are A4, Letter, and Label. The A4 option is not shown for US, MX, DO, and CA.
	•	Uses the saved paper size preference as the default option in the UI.

### Steps to reproduce
<!-- Step-by-step testing instructions. For new user flows, consider instead stating the goal of the workflow and see if your PR reviewer can accomplish the workflow without specific steps! -->
1. Open an order that has a shipping label.
2. Select a shipment that has been purchased.
3. Tap the **Paper Size** dropdown.

### Testing information
<!-- This is your opportunity to break out individual scenarios that need testing (when necessary) and/or include a checklist for the reviewer to go through. Consider documenting the following from your own completed testing: devices used, alternate workflows, edge cases, affected areas, critical flows, areas not tested, and any remaining unknowns. Provide feedback on this new section of the PR template through Sept 30, 2024 to Apps Quality; additional context here: p91TBi-b8z-p2#comment-12036 -->

### The tests that have been performed
<!-- To give the reviewer an idea of what could be missed in terms of testing -->

### Images/gif
<!-- Include before and after images or gifs when appropriate. -->
|Before|After|
|-|-|
|<img src="https://github.com/user-attachments/assets/4a832340-adce-4692-9cfd-8f60c12563d9" width=350>|<img src="https://github.com/user-attachments/assets/c550c5ac-df9c-41eb-a423-0c14605537b1" width=350>|

- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->