### PR TITLE
Temporarily disable end-to-end tests in build configuration

### DIFF
--- a/WooCommerce/build.gradle
+++ b/WooCommerce/build.gradle
@@ -19,7 +19,7 @@ fladle {
     variant = "vanillaDebug"
     serviceAccountCredentials = rootProject.file(".configure-files/firebase.secrets.json")
     testTargets = [
-            "notPackage com.woocommerce.android.e2e.tests.screenshot"
+            "notPackage com.woocommerce.android.e2e"
     ]
     devices = [
             ["model": "Pixel2.arm", "version": "30"]


### PR DESCRIPTION
Related to WOOMOB-789

Check the CI to ensure that the end-to-end tests were not run in instrumented-tests