### PR TITLE
[POS as a Tab i2] Add retry mechanism for WooPOS eligibility check from the eligibility screen

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/WooPOSIsRemotelyEnabled.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/WooPOSIsRemotelyEnabled.kt
@@ -12,7 +12,11 @@ class WooPOSIsRemotelyEnabled @Inject constructor(
     private val gson: Gson
 ) {
 
-    suspend operator fun invoke(): Boolean {
+    suspend operator fun invoke(forceRefresh: Boolean = false): Boolean {
+        if (forceRefresh) {
+            ssrFetcher.invalidate()
+        }
+
         val result = ssrFetcher.load(selectedSite.get())
 
         if (!result.isError) {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/eligibility/WooPosEligibilityScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/eligibility/WooPosEligibilityScreen.kt
@@ -11,6 +11,7 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.painterResource
@@ -18,8 +19,10 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
+import androidx.hilt.navigation.compose.hiltViewModel
 import com.woocommerce.android.R
 import com.woocommerce.android.ui.woopos.common.composeui.component.WooPosButton
+import com.woocommerce.android.ui.woopos.common.composeui.component.WooPosButtonState
 import com.woocommerce.android.ui.woopos.common.composeui.component.WooPosOutlinedButton
 import com.woocommerce.android.ui.woopos.common.composeui.component.WooPosText
 import com.woocommerce.android.ui.woopos.common.composeui.designsystem.WooPosSpacing
@@ -32,7 +35,8 @@ import com.woocommerce.android.ui.woopos.tab.WooPosLaunchability
 @Suppress("UnusedParameter")
 fun WooPosEligibilityScreen(
     reason: WooPosLaunchability.NonLaunchabilityReason,
-    onNavigationEvent: (WooPosNavigationEvent) -> Unit
+    onNavigationEvent: (WooPosNavigationEvent) -> Unit,
+    viewModel: WooPosEligibilityViewModel = hiltViewModel()
 ) {
     BackHandler {
         onNavigationEvent(WooPosNavigationEvent.ExitPosClicked)
@@ -71,10 +75,14 @@ fun WooPosEligibilityScreen(
 
         Spacer(modifier = Modifier.height(WooPosSpacing.XLarge.value.toAdaptivePadding()))
 
+        val isRetryLoading = viewModel.isRetryLoading.collectAsState().value
+
         WooPosButton(
             text = stringResource(id = R.string.woopos_eligibility_retry_check_label),
+            onClick = { viewModel.retryEligibilityCheck() },
+            state = if (isRetryLoading) WooPosButtonState.LOADING else WooPosButtonState.ENABLED,
             modifier = Modifier.size(width = 366.dp, height = 80.dp)
-        ) {}
+        )
 
         Spacer(modifier = Modifier.height(WooPosSpacing.Medium.value.toAdaptivePadding()))
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/eligibility/WooPosEligibilityScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/eligibility/WooPosEligibilityScreen.kt
@@ -11,6 +11,7 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -38,6 +39,14 @@ fun WooPosEligibilityScreen(
     onNavigationEvent: (WooPosNavigationEvent) -> Unit,
     viewModel: WooPosEligibilityViewModel = hiltViewModel()
 ) {
+    val retryState = viewModel.retryState.collectAsState().value
+
+    LaunchedEffect(retryState) {
+        if (retryState == WooPosEligibilityRetryState.Eligible) {
+            onNavigationEvent(WooPosNavigationEvent.OpenHomeFromSplash)
+        }
+    }
+
     BackHandler {
         onNavigationEvent(WooPosNavigationEvent.ExitPosClicked)
     }
@@ -75,12 +84,14 @@ fun WooPosEligibilityScreen(
 
         Spacer(modifier = Modifier.height(WooPosSpacing.XLarge.value.toAdaptivePadding()))
 
-        val isRetryLoading = viewModel.isRetryLoading.collectAsState().value
-
         WooPosButton(
             text = stringResource(id = R.string.woopos_eligibility_retry_check_label),
             onClick = { viewModel.retryEligibilityCheck() },
-            state = if (isRetryLoading) WooPosButtonState.LOADING else WooPosButtonState.ENABLED,
+            state = if (retryState == WooPosEligibilityRetryState.Loading) {
+                WooPosButtonState.LOADING
+            } else {
+                WooPosButtonState.ENABLED
+            },
             modifier = Modifier.size(width = 366.dp, height = 80.dp)
         )
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/eligibility/WooPosEligibilityViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/eligibility/WooPosEligibilityViewModel.kt
@@ -2,26 +2,39 @@ package com.woocommerce.android.ui.woopos.eligibility
 
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import com.woocommerce.android.ui.woopos.tab.WooPosCanBeLaunchedInTab
+import com.woocommerce.android.ui.woopos.tab.WooPosLaunchability
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.launch
 import javax.inject.Inject
 
-@HiltViewModel
-class WooPosEligibilityViewModel @Inject constructor() : ViewModel() {
+sealed interface WooPosEligibilityRetryState {
+    object Loading : WooPosEligibilityRetryState
+    object Eligible : WooPosEligibilityRetryState
+    object Ineligible : WooPosEligibilityRetryState
+}
 
-    private val _isRetryLoading = MutableStateFlow(false)
-    val isRetryLoading: StateFlow<Boolean> = _isRetryLoading
+@HiltViewModel
+class WooPosEligibilityViewModel @Inject constructor(
+    private val canBeLaunchedInTab: WooPosCanBeLaunchedInTab
+) : ViewModel() {
+
+    private val _retryState = MutableStateFlow<WooPosEligibilityRetryState?>(null)
+    val retryState: StateFlow<WooPosEligibilityRetryState?> = _retryState
 
     fun retryEligibilityCheck() {
         viewModelScope.launch {
-            _isRetryLoading.value = true
+            _retryState.value = WooPosEligibilityRetryState.Loading
 
-            val dummyDelay = 2000
-            kotlinx.coroutines.delay(dummyDelay) // simulate retry work
+            val result = canBeLaunchedInTab(forceRefresh = true)
 
-            _isRetryLoading.value = false
+            _retryState.value = if (result is WooPosLaunchability.Launchable) {
+                WooPosEligibilityRetryState.Eligible
+            } else {
+                WooPosEligibilityRetryState.Ineligible
+            }
         }
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/eligibility/WooPosEligibilityViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/eligibility/WooPosEligibilityViewModel.kt
@@ -1,0 +1,27 @@
+package com.woocommerce.android.ui.woopos.eligibility
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.launch
+import javax.inject.Inject
+
+@HiltViewModel
+class WooPosEligibilityViewModel @Inject constructor() : ViewModel() {
+
+    private val _isRetryLoading = MutableStateFlow(false)
+    val isRetryLoading: StateFlow<Boolean> = _isRetryLoading
+
+    fun retryEligibilityCheck() {
+        viewModelScope.launch {
+            _isRetryLoading.value = true
+
+            val dummyDelay = 2000
+            kotlinx.coroutines.delay(dummyDelay) // simulate retry work
+
+            _isRetryLoading.value = false
+        }
+    }
+}

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/tab/WooPosCanBeLaunchedInTab.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/tab/WooPosCanBeLaunchedInTab.kt
@@ -3,6 +3,7 @@ package com.woocommerce.android.ui.woopos.tab
 import com.woocommerce.android.extensions.semverCompareTo
 import com.woocommerce.android.tools.SelectedSite
 import com.woocommerce.android.ui.woopos.WooPOSIsRemotelyEnabled
+import com.woocommerce.android.util.FetchWooCorePluginVersion
 import com.woocommerce.android.util.GetWooCorePluginCachedVersion
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
@@ -19,30 +20,43 @@ import javax.inject.Singleton
 class WooPosCanBeLaunchedInTab @Inject constructor(
     private val selectedSite: SelectedSite,
     private val getWooCoreVersion: GetWooCorePluginCachedVersion,
+    private val fetchWooCoreVersion: FetchWooCorePluginVersion,
     private val wooCommerceStore: WooCommerceStore,
     private val isRemotelyEnabled: WooPOSIsRemotelyEnabled
 ) {
     @Suppress("ReturnCount")
-    suspend operator fun invoke(): WooPosLaunchability = withContext(Dispatchers.IO) {
-        val selectedSite = selectedSite.getOrNull()
+    suspend operator fun invoke(forceRefresh: Boolean = false): WooPosLaunchability = withContext(Dispatchers.IO) {
+        val site = selectedSite.getOrNull()
             ?: return@withContext WooPosLaunchability.NotLaunchable(
                 WooPosLaunchability.NonLaunchabilityReason.NoSiteSelected
             )
 
-        if (!isWooCoreSupportsOrderAutoDraftsAndExtraPaymentsProps()) {
+        val wooCoreVersion = if (forceRefresh) {
+            fetchWooCoreVersion()
+        } else {
+            getWooCoreVersion()
+        } ?: return@withContext WooPosLaunchability.NotLaunchable(
+            WooPosLaunchability.NonLaunchabilityReason.UnsupportedWooCommerceVersion
+        )
+
+        if (!isWooCoreSupportsOrderAutoDraftsAndExtraPaymentsProps(wooCoreVersion)) {
             return@withContext WooPosLaunchability.NotLaunchable(
                 WooPosLaunchability.NonLaunchabilityReason.UnsupportedWooCommerceVersion
             )
         }
 
-        if (isFeatureSwitchSupported() && isRemotelyEnabled() != true) {
+        if (isFeatureSwitchSupported(wooCoreVersion) && !isRemotelyEnabled(forceRefresh)) {
             return@withContext WooPosLaunchability.NotLaunchable(
                 WooPosLaunchability.NonLaunchabilityReason.FeatureSwitchDisabled
             )
         }
 
-        val siteSettings = wooCommerceStore.getSiteSettings(selectedSite)
-            ?: wooCommerceStore.fetchSiteGeneralSettings(selectedSite).model
+        val siteSettings = if (forceRefresh) {
+            wooCommerceStore.fetchSiteGeneralSettings(site).model
+        } else {
+            wooCommerceStore.getSiteSettings(site)
+                ?: wooCommerceStore.fetchSiteGeneralSettings(site).model
+        }
 
         if (siteSettings == null) {
             return@withContext WooPosLaunchability.NotLaunchable(
@@ -59,15 +73,14 @@ class WooPosCanBeLaunchedInTab @Inject constructor(
         }
     }
 
-    private fun isCurrencySupported(currency: String) = SUPPORTED_CURRENCIES.contains(currency.lowercase())
+    private fun isCurrencySupported(currency: String) =
+        SUPPORTED_CURRENCIES.contains(currency.lowercase())
 
-    private fun isWooCoreSupportsOrderAutoDraftsAndExtraPaymentsProps(): Boolean {
-        val wooCoreVersion = getWooCoreVersion() ?: return false
+    private fun isWooCoreSupportsOrderAutoDraftsAndExtraPaymentsProps(wooCoreVersion: String): Boolean {
         return wooCoreVersion.semverCompareTo(WC_VERSION_SUPPORTS_POS_PRODUCT_FILTERING) >= 0
     }
 
-    private fun isFeatureSwitchSupported(): Boolean {
-        val wooCoreVersion = getWooCoreVersion() ?: return false
+    private fun isFeatureSwitchSupported(wooCoreVersion: String): Boolean {
         return wooCoreVersion.semverCompareTo(WC_VERSION_SUPPORTS_POS_FEATURE_SWITCH) >= 0
     }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/util/FetchWooCorePluginVersion.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/util/FetchWooCorePluginVersion.kt
@@ -1,0 +1,30 @@
+package com.woocommerce.android.util
+
+import com.woocommerce.android.tools.SelectedSite
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+import org.wordpress.android.fluxc.model.plugin.SitePluginModel
+import org.wordpress.android.fluxc.store.WooCommerceStore
+import javax.inject.Inject
+
+class FetchWooCorePluginVersion @Inject constructor(
+    private val wooCommerceStore: WooCommerceStore,
+    private val selectedSite: SelectedSite,
+) {
+    suspend operator fun invoke(): String? = withContext(Dispatchers.IO) {
+        selectedSite.getOrNull()?.let { selectedSite ->
+            val fetchSitePluginsResult = wooCommerceStore.fetchSitePlugins(selectedSite)
+
+            if (fetchSitePluginsResult.isError) {
+                return@withContext null
+            }
+            val wooPluginInfo = fetchSitePluginsResult.model.getWooPlugin()
+
+            return@withContext wooPluginInfo?.version
+        }
+    }
+
+    private fun List<SitePluginModel>?.getWooPlugin() = this?.firstOrNull {
+        it.name.endsWith(WooCommerceStore.WooPlugin.WOO_CORE.pluginName)
+    }
+}

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/util/WCSSRModelCachingFetcher.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/util/WCSSRModelCachingFetcher.kt
@@ -43,4 +43,8 @@ class WCSSRModelCachingFetcher @Inject constructor(
         cache[siteModel.siteId] = CachedSSR(fetched)
         return WooResult(fetched)
     }
+
+    suspend fun invalidate() = mutex.withLock {
+        cache.clear()
+    }
 }

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/eligibility/WooPosEligibilityViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/eligibility/WooPosEligibilityViewModelTest.kt
@@ -1,0 +1,54 @@
+package com.woocommerce.android.ui.woopos.eligibility
+
+import com.woocommerce.android.ui.woopos.tab.WooPosCanBeLaunchedInTab
+import com.woocommerce.android.ui.woopos.tab.WooPosLaunchability
+import com.woocommerce.android.ui.woopos.util.WooPosCoroutineTestRule
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.runTest
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.Rule
+import org.junit.Test
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.whenever
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class WooPosEligibilityViewModelTest {
+
+    private val canBeLaunchedInTab: WooPosCanBeLaunchedInTab = mock()
+
+    @Rule
+    @JvmField
+    val coroutinesTestRule = WooPosCoroutineTestRule()
+
+    @Test
+    fun `given POS is eligible on retry, should update state to Eligible`() = runTest {
+        // GIVEN
+        whenever(canBeLaunchedInTab(forceRefresh = true)).thenReturn(WooPosLaunchability.Launchable)
+        val sut = createSut()
+
+        // WHEN
+        sut.retryEligibilityCheck()
+
+        // THEN
+        coroutinesTestRule.testDispatcher.scheduler.advanceUntilIdle()
+        assertThat(sut.retryState.value).isEqualTo(WooPosEligibilityRetryState.Eligible)
+    }
+
+    @Test
+    fun `given POS is ineligible on retry, should update state to Ineligible`() = runTest {
+        // GIVEN
+        whenever(canBeLaunchedInTab(forceRefresh = true)).thenReturn(
+            WooPosLaunchability.NotLaunchable(WooPosLaunchability.NonLaunchabilityReason.UnsupportedCurrency)
+        )
+        val sut = createSut()
+
+        // WHEN
+        sut.retryEligibilityCheck()
+
+        // THEN
+        coroutinesTestRule.testDispatcher.scheduler.advanceUntilIdle()
+        assertThat(sut.retryState.value).isEqualTo(WooPosEligibilityRetryState.Ineligible)
+    }
+
+    private fun createSut() = WooPosEligibilityViewModel(canBeLaunchedInTab)
+}

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/tab/WooPosCanBeLaunchedInTabTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/tab/WooPosCanBeLaunchedInTabTest.kt
@@ -5,6 +5,7 @@ import com.woocommerce.android.ui.woopos.WooPOSIsRemotelyEnabled
 import com.woocommerce.android.ui.woopos.tab.WooPosLaunchability.Launchable
 import com.woocommerce.android.ui.woopos.tab.WooPosLaunchability.NonLaunchabilityReason
 import com.woocommerce.android.ui.woopos.tab.WooPosLaunchability.NotLaunchable
+import com.woocommerce.android.util.FetchWooCorePluginVersion
 import com.woocommerce.android.util.GetWooCorePluginCachedVersion
 import com.woocommerce.android.viewmodel.BaseUnitTest
 import kotlinx.coroutines.ExperimentalCoroutinesApi
@@ -25,11 +26,10 @@ class WooPosCanBeLaunchedInTabTest : BaseUnitTest() {
 
     private val selectedSite: SelectedSite = mock()
     private val wooCommerceStore: WooCommerceStore = mock()
-
     private val isRemotelyEnabled: WooPOSIsRemotelyEnabled = mock()
-    private val getWooCoreVersion: GetWooCorePluginCachedVersion = mock {
-        on { invoke() }.thenReturn("9.6.0")
-    }
+    private val getWooCoreVersion: GetWooCorePluginCachedVersion = mock()
+    private val fetchWooCoreVersion: FetchWooCorePluginVersion = mock()
+
     private lateinit var sut: WooPosCanBeLaunchedInTab
 
     @Before
@@ -37,13 +37,16 @@ class WooPosCanBeLaunchedInTabTest : BaseUnitTest() {
         val siteModel = SiteModel().also { it.id = 1 }
         whenever(selectedSite.getOrNull()).thenReturn(siteModel)
         whenever(getWooCoreVersion()).thenReturn("10.0.0")
+        whenever(fetchWooCoreVersion()).thenReturn("10.0.0")
         val siteSettings = buildSiteSettings()
         whenever(wooCommerceStore.getSiteSettings(siteModel)).thenReturn(siteSettings)
-        whenever(isRemotelyEnabled.invoke()).thenReturn(true)
+        whenever(wooCommerceStore.fetchSiteGeneralSettings(siteModel)).thenReturn(WooResult(siteSettings))
+        whenever(isRemotelyEnabled.invoke(any())).thenReturn(true)
 
         sut = WooPosCanBeLaunchedInTab(
             selectedSite = selectedSite,
             getWooCoreVersion = getWooCoreVersion,
+            fetchWooCoreVersion = fetchWooCoreVersion,
             wooCommerceStore = wooCommerceStore,
             isRemotelyEnabled = isRemotelyEnabled
         )
@@ -72,17 +75,7 @@ class WooPosCanBeLaunchedInTabTest : BaseUnitTest() {
     @Test
     fun `given feature switch supported but remotely disabled, when invoked, then return NotLaunchable with FeatureSwitchDisabled`() = testBlocking {
         whenever(getWooCoreVersion()).thenReturn("10.0.0")
-        whenever(
-            isRemotelyEnabled.invoke()
-        ).thenReturn(false)
-
-        sut = WooPosCanBeLaunchedInTab(
-            selectedSite = selectedSite,
-            getWooCoreVersion = getWooCoreVersion,
-            wooCommerceStore = wooCommerceStore,
-            isRemotelyEnabled = isRemotelyEnabled
-        )
-
+        whenever(isRemotelyEnabled.invoke(any())).thenReturn(false)
         val result = sut()
         assertEquals(NotLaunchable(NonLaunchabilityReason.FeatureSwitchDisabled), result)
     }
@@ -120,6 +113,37 @@ class WooPosCanBeLaunchedInTabTest : BaseUnitTest() {
         whenever(wooCommerceStore.fetchSiteGeneralSettings(any())).thenReturn(WooResult(fetchedSettings))
 
         val result = sut()
+        assertEquals(NotLaunchable(NonLaunchabilityReason.UnsupportedCurrency), result)
+    }
+
+    @Test
+    fun `given forceRefresh true with valid data, when invoked, then return Launchable`() = testBlocking {
+        val result = sut(forceRefresh = true)
+        assertEquals(Launchable, result)
+    }
+
+    @Test
+    fun `given forceRefresh true and fetchWooCoreVersion returns null, when invoked, then return NotLaunchable with UnsupportedWooCommerceVersion`() = testBlocking {
+        whenever(fetchWooCoreVersion()).thenReturn(null)
+
+        val result = sut(forceRefresh = true)
+        assertEquals(NotLaunchable(NonLaunchabilityReason.UnsupportedWooCommerceVersion), result)
+    }
+
+    @Test
+    fun `given forceRefresh true and fetched site settings is null, when invoked, then return NotLaunchable with SiteSettingsUnavailable`() = testBlocking {
+        whenever(wooCommerceStore.fetchSiteGeneralSettings(any())).thenReturn(WooResult(null))
+
+        val result = sut(forceRefresh = true)
+        assertEquals(NotLaunchable(NonLaunchabilityReason.SiteSettingsUnavailable), result)
+    }
+
+    @Test
+    fun `given forceRefresh true and fetched site settings with unsupported currency, when invoked, then return NotLaunchable with UnsupportedCurrency`() = testBlocking {
+        val fetchedSettings = buildSiteSettings(currencyCode = "eur")
+        whenever(wooCommerceStore.fetchSiteGeneralSettings(any())).thenReturn(WooResult(fetchedSettings))
+
+        val result = sut(forceRefresh = true)
         assertEquals(NotLaunchable(NonLaunchabilityReason.UnsupportedCurrency), result)
     }
 

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/util/FetchWooCorePluginVersionTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/util/FetchWooCorePluginVersionTest.kt
@@ -1,0 +1,107 @@
+package com.woocommerce.android.util
+
+import com.woocommerce.android.tools.SelectedSite
+import com.woocommerce.android.viewmodel.BaseUnitTest
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.runTest
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.Before
+import org.junit.Test
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.whenever
+import org.wordpress.android.fluxc.model.SiteModel
+import org.wordpress.android.fluxc.model.plugin.SitePluginModel
+import org.wordpress.android.fluxc.network.rest.wpcom.wc.WooResult
+import org.wordpress.android.fluxc.store.WooCommerceStore
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class FetchWooCorePluginVersionTest : BaseUnitTest() {
+
+    private val wooCommerceStore: WooCommerceStore = mock()
+    private val selectedSite: SelectedSite = mock()
+    private lateinit var sut: FetchWooCorePluginVersion
+
+    @Before
+    fun setup() {
+        sut = FetchWooCorePluginVersion(
+            wooCommerceStore = wooCommerceStore,
+            selectedSite = selectedSite
+        )
+    }
+
+    @Test
+    fun `given selected site is null, when invoke is called, then return null`() = runTest {
+        // GIVEN
+        whenever(selectedSite.getOrNull()).thenReturn(null)
+
+        // WHEN
+        val result = sut()
+
+        // THEN
+        assertThat(result).isNull()
+    }
+
+    @Test
+    fun `given fetch result has error, when invoke is called, then return null`() = runTest {
+        // GIVEN
+        val siteModel = mock<SiteModel>()
+        whenever(selectedSite.getOrNull()).thenReturn(siteModel)
+
+        val fetchResult = mock<WooResult<List<SitePluginModel>>> {
+            on { isError }.thenReturn(true)
+        }
+        whenever(wooCommerceStore.fetchSitePlugins(siteModel)).thenReturn(fetchResult)
+
+        // WHEN
+        val result = sut()
+
+        // THEN
+        assertThat(result).isNull()
+    }
+
+    @Test
+    fun `given fetch result has no error and plugin not found, when invoke is called, then return null`() = runTest {
+        // GIVEN
+        val siteModel = mock<SiteModel>()
+        whenever(selectedSite.getOrNull()).thenReturn(siteModel)
+
+        val plugins: List<SitePluginModel> = emptyList()
+        val fetchResult = mock<WooResult<List<SitePluginModel>>> {
+            on { isError }.thenReturn(false)
+            on { model }.thenReturn(plugins)
+        }
+        whenever(wooCommerceStore.fetchSitePlugins(siteModel)).thenReturn(fetchResult)
+
+        // WHEN
+        val result = sut()
+
+        // THEN
+        assertThat(result).isNull()
+    }
+
+    @Test
+    fun `given fetch result has no error and WooCore plugin found, when invoke is called, then return plugin version`() = runTest {
+        // GIVEN
+        val siteModel = mock<SiteModel>()
+        whenever(selectedSite.getOrNull()).thenReturn(siteModel)
+
+        val version = "1.2.3"
+        val wooCorePlugin = mock<SitePluginModel>()
+        whenever(wooCorePlugin.name).thenReturn("woocommerce/woocommerce") // CORRECT VALUE
+        whenever(wooCorePlugin.version).thenReturn(version)
+
+        val plugins: List<SitePluginModel> = listOf(wooCorePlugin)
+
+        val fetchResult = mock<WooResult<List<SitePluginModel>>> {
+            on { isError }.thenReturn(false)
+            on { model }.thenReturn(plugins)
+        }
+        whenever(wooCommerceStore.fetchSitePlugins(siteModel)).thenReturn(fetchResult)
+
+        // WHEN
+        val result = sut()
+
+        // THEN
+        assertThat(result).isEqualTo(version)
+    }
+}


### PR DESCRIPTION
Part of WOOMOB-718

⚠️ This PR depends on https://github.com/woocommerce/woocommerce-android/pull/14298 Merge that first

---

## Description

This PR enables users to **retry the WooPOS eligibility check directly from the eligibility screen in the POS tab**.

Previously, if eligibility failed (e.g., due to unsupported currency or remote feature checks), users landing on the eligibility screen **had no way to retry eligibility without leaving and re-entering the POS tab**.

With this change:

- Adds logic to the **retry button** to the WooPOS eligibility screen to trigger a fresh eligibility check.
- Uses `forceRefresh = true` to **bypass cached values and fetch fresh plugin versions and site settings remotely**.
- Navigates users into POS automatically if eligibility passes upon retry.
- Displays a loading state on the retry button during the retry process.

In the next PR we will add the right copy for each ineligible state reason.

---

## Steps to reproduce

1. Open the WooPOS tab when eligibility fails (e.g., unsupported currency).
2. You are taken to the eligibility screen.
3. Tap **Retry**.
4. If eligibility conditions are now satisfied, you are taken into POS automatically.
5. If eligibility still fails, you remain on the eligibility screen without errors.

---

## Testing information

- Verified eligibility retry on the WooPOS eligibility screen:
  - ✅ Successful retry navigates into POS.
  - ✅ Failed retry keeps the user on the eligibility screen.
  - ✅ Loading state displays correctly during retry.
- Tested conditions:
  - Unsupported WooCommerce version.
  - Unsupported currency.
  - Feature switch disabled remotely.
  - Recovery when eligibility conditions are fixed.
- Verified:
  - `WooPosCanBeLaunchedInTab` correctly handles `forceRefresh = true`.
  - `FetchWooCorePluginVersion` and supporting fetchers work under retry.
  - `WooPosEligibilityViewModel` transitions states correctly.
- All related unit tests are passing.

---

## The tests that have been performed

- ✅ Manual testing of retry under various eligibility success and failure scenarios.
- ✅ Unit tests for `forceRefresh` paths in eligibility logic.
- ✅ Regression testing for POS eligibility and launch flows.

---

## Images/gif


https://github.com/user-attachments/assets/246ef8cc-840d-4a79-b874-62c3f635c8b9



---

- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary.

---
