### PR TITLE
[Shipping Label] Fix getting stuck in loading state when an invalid weight is entered

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/WooShippingLabelCreationViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/WooShippingLabelCreationViewModel.kt
@@ -533,42 +533,35 @@ class WooShippingLabelCreationViewModel @Inject constructor(
      */
     @Suppress("CyclomaticComplexMethod")
     private suspend fun updateShippingRates(index: Int, shippingRatesInfo: ShippingRatesInfo?) {
-        val currentMutableShippingRatesList = shippingRatesStatesFlow.value.toMutableList()
-        when {
-            shippingRatesInfo == null -> {
-                shippingRatesStatesFlow.value = currentMutableShippingRatesList.apply {
-                    set(index, ShippingRatesState.NoAvailable)
-                }
+        fun updateState(newState: ShippingRatesState) {
+            shippingRatesStatesFlow.update {
+                it.toMutableList().apply { set(index, newState) }
             }
+        }
+
+        when {
+            shippingRatesInfo == null -> updateState(ShippingRatesState.NoAvailable)
 
             shippingRatesInfo.shipTo == null ||
                 !addressValidationHelper.canFetchShippingRates(shippingRatesInfo.shipTo) ->
-                shippingRatesStatesFlow.value = currentMutableShippingRatesList.apply {
-                    set(
-                        index,
-                        ShippingRatesState.MissingInfo(
-                            missingTitle = R.string.woo_shipping_labels_shipping_rates_missing_destination,
-                            missingDescription = R.string.woo_shipping_labels_shipping_rates_missing_destination_desc
-                        )
+                updateState(
+                    ShippingRatesState.MissingInfo(
+                        missingTitle = R.string.woo_shipping_labels_shipping_rates_missing_destination,
+                        missingDescription = R.string.woo_shipping_labels_shipping_rates_missing_destination_desc
                     )
-                }
+                )
 
             shippingRatesInfo.weight == null || shippingRatesInfo.weight == 0f ->
-                shippingRatesStatesFlow.value = currentMutableShippingRatesList.apply {
-                    set(
-                        index,
-                        ShippingRatesState.MissingInfo(
-                            missingTitle = R.string.woo_shipping_labels_shipping_rates_missing_weight,
-                            missingDescription = R.string.woo_shipping_labels_shipping_rates_missing_weight_desc
-                        )
+                updateState(
+                    ShippingRatesState.MissingInfo(
+                        missingTitle = R.string.woo_shipping_labels_shipping_rates_missing_weight,
+                        missingDescription = R.string.woo_shipping_labels_shipping_rates_missing_weight_desc
                     )
-                }
+                )
 
             else -> {
                 val sortOrder = selectedRatesSortOrdersFlow.value[index]
-                shippingRatesStatesFlow.value = currentMutableShippingRatesList.apply {
-                    set(index, ShippingRatesState.Loading(sortOrder))
-                }
+                updateState(ShippingRatesState.Loading(sortOrder))
 
                 val shippingRatesResult = getShippingRates(
                     shippingRatesInfo.orderId,
@@ -586,9 +579,7 @@ class WooShippingLabelCreationViewModel @Inject constructor(
                         set(index, shippingRatesResult.getOrThrow())
                     }
                 } else {
-                    shippingRatesStatesFlow.value = currentMutableShippingRatesList.apply {
-                        set(index, ShippingRatesState.Error)
-                    }
+                    updateState(ShippingRatesState.Error)
                 }
                 selectedRatesFlow.value = selectedRatesFlow.value.toMutableList().apply { set(index, null) }
             }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/rates/ui/ShippingRatesCard.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/rates/ui/ShippingRatesCard.kt
@@ -96,8 +96,6 @@ internal fun ShippingRatesCard(
 @Preview(name = "light", uiMode = Configuration.UI_MODE_NIGHT_NO, device = Devices.PIXEL)
 @Composable
 private fun ShippingRatesCardPreview() {
-    val rates = ShippingLabelSampleData.generateShippingRates()
-    val selected = rates.values.first().first()
     WooThemeWithBackground {
         ShippingRatesCard(
             state = ShippingLabelSampleData.getShippingRatesSection(),


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

<!-- Id number of the Linear issue this PR addresses, e.g., WOOMOB-373. -->
Closes WOOMOB-801

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
This fixes an issue where entering invalid weight values caused the UI to get stuck on a loading screen. Now, it displays an error view instead.

### Steps to reproduce
<!-- Step-by-step testing instructions. For new user flows, consider instead stating the goal of the workflow and see if your PR reviewer can accomplish the workflow without specific steps! -->
1. Go to create shipping label screen.
2. Select a package.
3. Enter 999999 to weight.

### The tests that have been performed
<!-- To give the reviewer an idea of what could be missed in terms of testing -->
Steps above

### Images/gif
<!-- Include before and after images or gifs when appropriate. -->
|Before|After|
|-|-|
|<img width="350" src="https://github.com/user-attachments/assets/c118c17f-b59f-4fb1-8cd7-869711fd1436" />|<img width="350" src="https://github.com/user-attachments/assets/b0eed4b1-4044-48db-82b1-ea13caaeefb4" />|

- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->