### PR TITLE
Fix crash when navigating after double click

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -3,7 +3,7 @@
 *** For entries which are touching the Android Wear app's, start entry with `[WEAR]` too.
 22.9
 -----
-
+- [*] Fixed rare crash on the Payment Selection screen. [https://github.com/woocommerce/woocommerce-android/pull/14318]
 
 22.8
 -----

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/methodselection/SelectPaymentMethodFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/methodselection/SelectPaymentMethodFragment.kt
@@ -194,7 +194,7 @@ class SelectPaymentMethodFragment : BaseFragment(R.layout.fragment_select_paymen
                             .actionSelectPaymentMethodFragmentToScanToPayDialogFragment(
                                 event.paymentUrl
                             )
-                    findNavController().navigate(action)
+                    findNavController().navigateSafely(action)
                 }
 
                 is NavigateToCardReaderPaymentFlow -> {
@@ -203,7 +203,7 @@ class SelectPaymentMethodFragment : BaseFragment(R.layout.fragment_select_paymen
                             event.cardReaderFlowParam,
                             event.cardReaderType
                         )
-                    findNavController().navigate(action)
+                    findNavController().navigateSafely(action)
                 }
 
                 is NavigateToCardReaderHubFlow -> {
@@ -211,7 +211,7 @@ class SelectPaymentMethodFragment : BaseFragment(R.layout.fragment_select_paymen
                         SelectPaymentMethodFragmentDirections.actionSelectPaymentMethodFragmentToCardReaderHubFlow(
                             event.cardReaderFlowParam
                         )
-                    findNavController().navigate(action)
+                    findNavController().navigateSafely(action)
                 }
 
                 is NavigateToCardReaderRefundFlow -> {
@@ -220,7 +220,7 @@ class SelectPaymentMethodFragment : BaseFragment(R.layout.fragment_select_paymen
                             event.cardReaderFlowParam,
                             event.cardReaderType
                         )
-                    findNavController().navigate(action)
+                    findNavController().navigateSafely(action)
                 }
 
                 is NavigateBackToOrderList -> {
@@ -261,7 +261,7 @@ class SelectPaymentMethodFragment : BaseFragment(R.layout.fragment_select_paymen
                             .actionSelectPaymentMethodFragmentToChangeDueCalculatorFragment(
                                 orderId = event.order.id
                             )
-                    findNavController().navigate(action)
+                    findNavController().navigateSafely(action)
                 }
 
                 is NavigateToTapToPaySummary -> {


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

<!-- Id number of the Linear issue this PR addresses, e.g., WOOMOB-373. -->

Fixes #WOOMOB-790

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

This PR replaces `navigate` with `navigateSafely` to avoid crashes after double-clicking on one of the items in the PaymentSelection screen.

### Steps to reproduce
<!-- Step-by-step testing instructions. For new user flows, consider instead stating the goal of the workflow and see if your PR reviewer can accomplish the workflow without specific steps! -->

1. Open detail of an unpaid order
2. Tap on Collect Payment
3. Tap on `Card Reader` twice very fast - I kind of tapped with two fingers, but one finger was few milliseconds late. 
4. Notice the crash

### Testing information
<!-- This is your opportunity to break out individual scenarios that need testing (when necessary) and/or include a checklist for the reviewer to go through. Consider documenting the following from your own completed testing: devices used, alternate workflows, edge cases, affected areas, critical flows, areas not tested, and any remaining unknowns. Provide feedback on this new section of the PR template through Sept 30, 2024 to Apps Quality; additional context here: p91TBi-b8z-p2#comment-12036 -->

Repeat the above steps and verify the navigation works but the app doesn't crash after double click

### The tests that have been performed
<!-- To give the reviewer an idea of what could be missed in terms of testing -->

The above

### Images/gif
<!-- Include before and after images or gifs when appropriate. -->
N/A

- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->