### PR TITLE
[Shipping Labels] Handle marking orders as complete

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/MarkOrderAsComplete.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/MarkOrderAsComplete.kt
@@ -16,8 +16,7 @@ class MarkOrderAsComplete @Inject constructor(
             orderId = orderId,
             newStatus = CoreOrderStatus.COMPLETED.value
         )
-            .filter { it is UpdateOrderResult.RemoteUpdateResult }
-            .first()
+            .first { it is UpdateOrderResult.RemoteUpdateResult }
 
         return when {
             result.event.isError -> Result.failure(OnChangedException(result.event.error))

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/MarkOrderAsComplete.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/MarkOrderAsComplete.kt
@@ -2,7 +2,6 @@ package com.woocommerce.android.ui.orders.wooshippinglabels
 
 import com.woocommerce.android.OnChangedException
 import com.woocommerce.android.ui.orders.details.OrderDetailRepository
-import kotlinx.coroutines.flow.filter
 import kotlinx.coroutines.flow.first
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.order.CoreOrderStatus
 import org.wordpress.android.fluxc.store.WCOrderStore.UpdateOrderResult
@@ -18,9 +17,10 @@ class MarkOrderAsComplete @Inject constructor(
         )
             .first { it is UpdateOrderResult.RemoteUpdateResult }
 
-        return when {
-            result.event.isError -> Result.failure(OnChangedException(result.event.error))
-            else -> Result.success(Unit)
+        return if (result.event.isError) {
+            Result.failure(OnChangedException(result.event.error))
+        } else {
+            Result.success(Unit)
         }
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/MarkOrderAsComplete.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/MarkOrderAsComplete.kt
@@ -1,0 +1,27 @@
+package com.woocommerce.android.ui.orders.wooshippinglabels
+
+import com.woocommerce.android.OnChangedException
+import com.woocommerce.android.ui.orders.details.OrderDetailRepository
+import kotlinx.coroutines.flow.filter
+import kotlinx.coroutines.flow.first
+import org.wordpress.android.fluxc.network.rest.wpcom.wc.order.CoreOrderStatus
+import org.wordpress.android.fluxc.store.WCOrderStore.UpdateOrderResult
+import javax.inject.Inject
+
+class MarkOrderAsComplete @Inject constructor(
+    private val orderDetailRepository: OrderDetailRepository
+) {
+    suspend operator fun invoke(orderId: Long): Result<Unit> {
+        val result = orderDetailRepository.updateOrderStatus(
+            orderId = orderId,
+            newStatus = CoreOrderStatus.COMPLETED.value
+        )
+            .filter { it is UpdateOrderResult.RemoteUpdateResult }
+            .first()
+
+        return when {
+            result.event.isError -> Result.failure(OnChangedException(result.event.error))
+            else -> Result.success(Unit)
+        }
+    }
+}

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/PurchaseShippingLabel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/PurchaseShippingLabel.kt
@@ -28,7 +28,7 @@ class PurchaseShippingLabel @Inject constructor(
         shipFrom: OriginShippingAddress,
         shippingRate: ShippingRateUI,
         weight: Float,
-        lastOrderComplete: Boolean,
+        lastOrderCompleted: Boolean,
         customsData: CustomsData? = null,
         hazmatSelection: ShippingLabelHazmatCategory? = null
     ): Result<PurchasedLabelData> {
@@ -41,7 +41,7 @@ class PurchaseShippingLabel @Inject constructor(
             shipFrom = shipFrom,
             selectedRate = ratesMapper(shippingRate),
             weight = weight,
-            lastOrderComplete = lastOrderComplete,
+            lastOrderCompleted = lastOrderCompleted,
             customsData = customsData,
             hazmatSelection = hazmatSelection,
             site = selectedSite.get()

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/WooShippingLabelCreationViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/WooShippingLabelCreationViewModel.kt
@@ -12,6 +12,7 @@ import androidx.lifecycle.viewModelScope
 import com.woocommerce.android.R
 import com.woocommerce.android.WooException
 import com.woocommerce.android.analytics.AnalyticsEvent
+import com.woocommerce.android.analytics.AnalyticsTracker
 import com.woocommerce.android.analytics.AnalyticsTracker.Companion.KEY_ERROR
 import com.woocommerce.android.analytics.AnalyticsTracker.Companion.KEY_STATE
 import com.woocommerce.android.analytics.AnalyticsTracker.Companion.VALUE_STARTED
@@ -283,9 +284,24 @@ class WooShippingLabelCreationViewModel @Inject constructor(
                 updateShipment(shipmentId, shipment.copy(label = newLabel.copy(originAddress = originAddress)))
 
                 if (result.status == ShippingLabelStatus.PURCHASED && uiState.value.markOrderComplete) {
-                    markOrderAsComplete(navArgs.orderId).onFailure {
-                        triggerEvent(Event.ShowSnackbar(R.string.woo_shipping_labels_order_completion_error))
-                    }
+                    markOrderAsComplete(navArgs.orderId).fold(
+                        onSuccess = {
+                            analyticsTracker.track(
+                                stat = AnalyticsEvent.SHIPPING_LABEL_ORDER_FULFILL_SUCCEEDED,
+                                properties = mapOf(AnalyticsTracker.KEY_IS_REVAMPED_FLOW to true)
+                            )
+                        },
+                        onFailure = {
+                            triggerEvent(Event.ShowSnackbar(R.string.woo_shipping_labels_order_completion_error))
+                            analyticsTracker.track(
+                                stat = AnalyticsEvent.SHIPPING_LABEL_ORDER_FULFILL_FAILED,
+                                properties = mapOf(AnalyticsTracker.KEY_IS_REVAMPED_FLOW to true),
+                                errorType = (it as? WooException)?.error?.type?.name,
+                                errorContext = this@WooShippingLabelCreationViewModel::javaClass.name,
+                                errorDescription = (it as? WooException)?.error?.message
+                            )
+                        }
+                    )
                 }
             }.launchIn(this)
         }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/WooShippingLabelCreationViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/WooShippingLabelCreationViewModel.kt
@@ -192,7 +192,7 @@ class WooShippingLabelCreationViewModel @Inject constructor(
         launch { getDestinationAddress() }
         launch { trackScreenShownEvent() }
         launch { getSavedShipments() }
-        launch { setDefaultPaperSize() }
+        launch { setAccountDefaults() }
         launch { getShippingAddresses() }
         launch { getOrderInformation() }
         launch { observePackageWeight() }
@@ -336,9 +336,15 @@ class WooShippingLabelCreationViewModel @Inject constructor(
         order.drop(1).collectLatest { order -> shipments.value = getShipments(order) }
     }
 
-    private suspend fun setDefaultPaperSize() {
-        val paperSize = accountSettings.first()?.paperSize ?: WooShippingLabelPaperSize.LABEL
-        uiState.update { it.copy(paperSizeOption = paperSize) }
+    private suspend fun setAccountDefaults() {
+        accountSettings.first()?.let { accountSettings ->
+            uiState.update {
+                it.copy(
+                    paperSizeOption = accountSettings.paperSize,
+                    markOrderComplete = accountSettings.lastOrderCompleted
+                )
+            }
+        }
     }
 
     @Suppress("ComplexCondition")

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/WooShippingLabelCreationViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/WooShippingLabelCreationViewModel.kt
@@ -297,7 +297,7 @@ class WooShippingLabelCreationViewModel @Inject constructor(
                                 stat = AnalyticsEvent.SHIPPING_LABEL_ORDER_FULFILL_FAILED,
                                 properties = mapOf(AnalyticsTracker.KEY_IS_REVAMPED_FLOW to true),
                                 errorType = (it as? WooException)?.error?.type?.name,
-                                errorContext = this@WooShippingLabelCreationViewModel::javaClass.name,
+                                errorContext = this@WooShippingLabelCreationViewModel.javaClass.simpleName,
                                 errorDescription = (it as? WooException)?.error?.message
                             )
                         }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/WooShippingLabelCreationViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/WooShippingLabelCreationViewModel.kt
@@ -318,7 +318,7 @@ class WooShippingLabelCreationViewModel @Inject constructor(
             val orderShippingEmail = order.shippingAddress.email.ifBlank { order.billingAddress.email }
 
             if (labelDestination == null) {
-                if (destinationAddress.value == WooShippingAddresses.EMPTY) {
+                if (destinationAddress.value == DestinationShippingAddress.EMPTY) {
                     val defaultDestination = DestinationShippingAddress(
                         address = order.shippingAddress.copy(email = orderShippingEmail),
                         isVerified = false

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/WooShippingLabelCreationViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/WooShippingLabelCreationViewModel.kt
@@ -118,6 +118,7 @@ class WooShippingLabelCreationViewModel @Inject constructor(
     private val fetchOriginAddresses: FetchOriginAddresses,
     private val getShippingRates: GetShippingRates,
     private val purchaseShippingLabel: PurchaseShippingLabel,
+    private val markOrderAsComplete: MarkOrderAsComplete,
     observeAccountSettings: ObserveAccountSettings,
     private val fetchAccountSettings: FetchAccountSettings,
     private val addressValidationHelper: AddressValidationHelper,
@@ -280,6 +281,12 @@ class WooShippingLabelCreationViewModel @Inject constructor(
                 // If result has a label model update the label with it. Otherwise, just update the status.
                 val newLabel = result.shippingLabelModel ?: shipment.label.copy(status = result.status)
                 updateShipment(shipmentId, shipment.copy(label = newLabel.copy(originAddress = originAddress)))
+
+                if (result.status == ShippingLabelStatus.PURCHASED && uiState.value.markOrderComplete) {
+                    markOrderAsComplete(navArgs.orderId).onFailure {
+                        triggerEvent(Event.ShowSnackbar(R.string.woo_shipping_labels_order_completion_error))
+                    }
+                }
             }.launchIn(this)
         }
     }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/models/AccountSettingsModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/models/AccountSettingsModel.kt
@@ -11,7 +11,8 @@ data class AccountSettingsModel(
     val canEditSettings: Boolean,
     val storeOwnerName: String,
     val storeOwnerUsername: String,
-    val paperSize: WooShippingLabelPaperSize
+    val paperSize: WooShippingLabelPaperSize,
+    val lastOrderCompleted: Boolean
 )
 
 @Parcelize

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/networking/DTOs.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/networking/DTOs.kt
@@ -22,7 +22,8 @@ data class EligibilityResponse(
 data class AccountSettingsDTO(
     val storeOptions: StoreOptionsDTO,
     val formData: FormDataDTO,
-    val formMeta: FormMetaDTO
+    val formMeta: FormMetaDTO,
+    val userMeta: UserMetaDTO,
 )
 
 data class StoreOptionsDTO(
@@ -45,6 +46,10 @@ data class FormMetaDTO(
     @SerializedName("can_edit_settings") val canEditSettings: Boolean = true,
     @SerializedName("master_user_name") val masterUserName: String = "",
     @SerializedName("master_user_wpcom_login") val masterUserWpcomLogin: String = ""
+)
+
+data class UserMetaDTO(
+    @SerializedName("last_order_completed") val lastOrderCompleted: Boolean,
 )
 
 data class PaymentMethodDTO(

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/networking/WooShippingLabelRepository.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/networking/WooShippingLabelRepository.kt
@@ -118,7 +118,7 @@ class WooShippingLabelRepository @Inject constructor(
         shipFrom: OriginShippingAddress,
         selectedRate: WooShippingSelectedRateModel,
         weight: Float,
-        lastOrderComplete: Boolean,
+        lastOrderCompleted: Boolean,
         customsData: CustomsData?,
         hazmatSelection: ShippingLabelHazmatCategory? = null
     ): WooResult<PurchasedLabelData> {
@@ -139,7 +139,7 @@ class WooShippingLabelRepository @Inject constructor(
             selectedRateOptions = mapper.toSelectedRateOptions(selectedRate),
             customs = customsData?.let { mapper.toCustomsDTO(it) },
             hazmat = mapper.toHazmatDTO(hazmatSelection),
-            markOrderComplete = lastOrderComplete
+            lastOrderCompleted = lastOrderCompleted
         ).asWooResult { mapper(it) }
     }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/networking/WooShippingLabelRestClient.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/networking/WooShippingLabelRestClient.kt
@@ -154,7 +154,7 @@ class WooShippingLabelRestClient @Inject constructor(
         selectedRate: RateDTO,
         parentRate: RateDTO?,
         selectedRateOptions: Map<WooShippingRateModel.Option, ShippingRateSurchargeDTO>,
-        markOrderComplete: Boolean,
+        lastOrderCompleted: Boolean,
         hazmat: HazmatDTO,
         customs: CustomsDTO?,
     ): WooPayload<PurchasedShippingLabelResponseDTO> {
@@ -176,7 +176,7 @@ class WooShippingLabelRestClient @Inject constructor(
                 "selected_rate_options" to selectedRateOptions.mapKeys { it.key.typeId },
                 "hazmat" to mapOf(shipmentKey to hazmat),
                 "customs" to customs?.let { mapOf(shipmentKey to it) }.orEmpty(),
-                "user_meta" to mapOf("last_order_completed" to markOrderComplete),
+                "user_meta" to mapOf("last_order_completed" to lastOrderCompleted),
                 "features_supported_by_client" to listOf("upsdap"),
             ),
             clazz = PurchasedShippingLabelResponseDTO::class.java,

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/networking/WooShippingNetworkingMapper.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/networking/WooShippingNetworkingMapper.kt
@@ -58,7 +58,8 @@ class WooShippingNetworkingMapper @Inject constructor(
                 canEditSettings = formMeta.canEditSettings,
                 storeOwnerName = formMeta.masterUserName,
                 storeOwnerUsername = formMeta.masterUserWpcomLogin,
-                paperSize = formData.paperSize
+                paperSize = formData.paperSize,
+                lastOrderCompleted = userMeta.lastOrderCompleted
             )
         }
     }

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -4637,6 +4637,7 @@
     <string name="woo_shipping_labels_package_removing_error">Unable to remove the package</string>
     <string name="woo_shipping_labels_package_saving_error">Unable to save the package</string>
     <string name="woo_shipping_labels_purchase_error">We are unable to purchase the shipping label. Please try again.</string>
+    <string name="woo_shipping_labels_order_completion_error">Couldn\'t mark the order as complete</string>
     <string name="woo_shipping_split_shipment_error">We were unable to split the shipments. Please try again.</string>
     <string name="woo_shipping_labels_loading_error">Unable to load data</string>
     <string name="woo_shipping_address_save_changes">Save changes</string>

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/FetchAccountSettingsTests.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/FetchAccountSettingsTests.kt
@@ -45,7 +45,8 @@ class FetchAccountSettingsTests : BaseUnitTest() {
         canEditSettings = true,
         storeOwnerName = "",
         storeOwnerUsername = "",
-        paperSize = WooShippingLabelPaperSize.LABEL
+        paperSize = WooShippingLabelPaperSize.LABEL,
+        lastOrderCompleted = false
     )
 
     val sut = FetchAccountSettings(

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/MarkOrderAsCompleteTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/MarkOrderAsCompleteTest.kt
@@ -5,7 +5,6 @@ import com.woocommerce.android.ui.orders.details.OrderDetailRepository
 import com.woocommerce.android.viewmodel.BaseUnitTest
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.flowOf
-import kotlinx.coroutines.test.advanceUntilIdle
 import org.junit.Before
 import org.junit.Test
 import org.mockito.kotlin.mock
@@ -42,7 +41,6 @@ class MarkOrderAsCompleteTest : BaseUnitTest() {
         val result = markOrderAsComplete(orderId)
 
         // Then
-        advanceUntilIdle()
         verify(orderDetailRepository).updateOrderStatus(orderId, CoreOrderStatus.COMPLETED.value)
         assertTrue(result.isSuccess)
     }
@@ -60,11 +58,10 @@ class MarkOrderAsCompleteTest : BaseUnitTest() {
         val result = markOrderAsComplete(orderId)
 
         // Then
-        advanceUntilIdle()
         verify(orderDetailRepository).updateOrderStatus(orderId, CoreOrderStatus.COMPLETED.value)
         assertTrue(result.isFailure)
         val exception = result.exceptionOrNull()
         assertTrue(exception is OnChangedException)
-        assertEquals(error, (exception as OnChangedException).error)
+        assertEquals(error, exception.error)
     }
 }

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/MarkOrderAsCompleteTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/MarkOrderAsCompleteTest.kt
@@ -1,0 +1,70 @@
+package com.woocommerce.android.ui.orders.wooshippinglabels
+
+import com.woocommerce.android.OnChangedException
+import com.woocommerce.android.ui.orders.details.OrderDetailRepository
+import com.woocommerce.android.viewmodel.BaseUnitTest
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.test.advanceUntilIdle
+import org.junit.Before
+import org.junit.Test
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
+import org.wordpress.android.fluxc.network.rest.wpcom.wc.order.CoreOrderStatus
+import org.wordpress.android.fluxc.store.WCOrderStore.OnOrderChanged
+import org.wordpress.android.fluxc.store.WCOrderStore.OrderError
+import org.wordpress.android.fluxc.store.WCOrderStore.UpdateOrderResult
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+@ExperimentalCoroutinesApi
+class MarkOrderAsCompleteTest : BaseUnitTest() {
+    private lateinit var markOrderAsComplete: MarkOrderAsComplete
+    private val orderDetailRepository: OrderDetailRepository = mock()
+
+    private val orderId = 123L
+
+    @Before
+    fun setup() {
+        markOrderAsComplete = MarkOrderAsComplete(orderDetailRepository)
+    }
+
+    @Test
+    fun `When update order status succeeds, then return success result`() = testBlocking {
+        // Given
+        val successEvent = OnOrderChanged()
+        val updateResult = UpdateOrderResult.RemoteUpdateResult(successEvent)
+        whenever(orderDetailRepository.updateOrderStatus(orderId, CoreOrderStatus.COMPLETED.value))
+            .thenReturn(flowOf(updateResult))
+
+        // When
+        val result = markOrderAsComplete(orderId)
+
+        // Then
+        advanceUntilIdle()
+        verify(orderDetailRepository).updateOrderStatus(orderId, CoreOrderStatus.COMPLETED.value)
+        assertTrue(result.isSuccess)
+    }
+
+    @Test
+    fun `When update order status fails, then return failure result with error`() = testBlocking {
+        // Given
+        val error = OrderError(message = "Error updating order status")
+        val failureEvent = OnOrderChanged(orderError = error)
+        val updateResult = UpdateOrderResult.RemoteUpdateResult(failureEvent)
+        whenever(orderDetailRepository.updateOrderStatus(orderId, CoreOrderStatus.COMPLETED.value))
+            .thenReturn(flowOf(updateResult))
+
+        // When
+        val result = markOrderAsComplete(orderId)
+
+        // Then
+        advanceUntilIdle()
+        verify(orderDetailRepository).updateOrderStatus(orderId, CoreOrderStatus.COMPLETED.value)
+        assertTrue(result.isFailure)
+        val exception = result.exceptionOrNull()
+        assertTrue(exception is OnChangedException)
+        assertEquals(error, (exception as OnChangedException).error)
+    }
+}

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/ObserveAccountSettingsTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/ObserveAccountSettingsTest.kt
@@ -37,7 +37,8 @@ class ObserveAccountSettingsTest : BaseUnitTest() {
         canEditSettings = true,
         storeOwnerName = "",
         storeOwnerUsername = "",
-        paperSize = WooShippingLabelPaperSize.LABEL
+        paperSize = WooShippingLabelPaperSize.LABEL,
+        lastOrderCompleted = false
     )
 
     val sut = ObserveAccountSettings(

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/WooShippingLabelCreationViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/WooShippingLabelCreationViewModelTest.kt
@@ -50,6 +50,7 @@ import com.woocommerce.android.ui.orders.wooshippinglabels.models.StoreOptionsMo
 import com.woocommerce.android.ui.orders.wooshippinglabels.models.WooShippingCarrier
 import com.woocommerce.android.ui.orders.wooshippinglabels.models.WooShippingLabelPaperSize
 import com.woocommerce.android.ui.orders.wooshippinglabels.packages.ui.PackageData
+import com.woocommerce.android.ui.orders.wooshippinglabels.purchased.ObserveShippingLabelStatus
 import com.woocommerce.android.ui.orders.wooshippinglabels.purchased.printing.FetchShippingLabelFile
 import com.woocommerce.android.ui.orders.wooshippinglabels.rates.datasource.WooShippingRateModel
 import com.woocommerce.android.ui.orders.wooshippinglabels.rates.datasource.WooShippingRateModel.Option
@@ -63,6 +64,7 @@ import com.woocommerce.android.util.CurrencyFormatter
 import com.woocommerce.android.util.runAndCaptureValues
 import com.woocommerce.android.viewmodel.BaseUnitTest
 import com.woocommerce.android.viewmodel.MultiLiveEvent
+import com.woocommerce.android.viewmodel.MultiLiveEvent.Event
 import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.Exit
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.flowOf
@@ -297,7 +299,19 @@ class WooShippingLabelCreationViewModelTest : BaseUnitTest() {
             )
         } doReturn Result.success(defaultShippingRates)
     }
-    private val purchaseShippingLabel: PurchaseShippingLabel = mock()
+    private val purchaseShippingLabel: PurchaseShippingLabel = mock {
+        onBlocking {
+            invoke(any(), any(), any(), any(), any(), any(), any(), any(), any(), isNull(), isNull())
+        } doReturn Result.success(
+            PurchasedLabelData(
+                labels = listOf(shippingLabelModel.copy(status = PURCHASED)),
+                origin = emptyMap(),
+                destination = emptyMap(),
+                rates = emptyMap()
+            )
+        )
+    }
+    private val markOrderAsComplete: MarkOrderAsComplete = mock()
     private val observeAccountSettings: ObserveAccountSettings = mock {
         on { invoke() } doReturn flowOf(defaultAccountSettings)
     }
@@ -311,6 +325,7 @@ class WooShippingLabelCreationViewModelTest : BaseUnitTest() {
         on { invoke(any(), any()) } doReturn false
     }
     private val fetchShippingLabelFile: FetchShippingLabelFile = mock()
+    private val observeShippingLabelStatus: ObserveShippingLabelStatus = mock()
     private val file: File = mock()
     private val analyticsTracker: AnalyticsTrackerWrapper = mock()
 
@@ -325,6 +340,7 @@ class WooShippingLabelCreationViewModelTest : BaseUnitTest() {
             fetchOriginAddresses = mock(),
             getShippingRates = getShippingRates,
             purchaseShippingLabel = purchaseShippingLabel,
+            markOrderAsComplete = markOrderAsComplete,
             observeAccountSettings = observeAccountSettings,
             fetchAccountSettings = mock(),
             addressValidationHelper = addressValidationHelper,
@@ -333,7 +349,7 @@ class WooShippingLabelCreationViewModelTest : BaseUnitTest() {
             shouldRequireCustoms = shouldRequireCustomsForm,
             shouldRequireITN = shouldRequireITN,
             fetchShippingLabelFile = fetchShippingLabelFile,
-            observeShippingLabelStatus = mock(),
+            observeShippingLabelStatus = observeShippingLabelStatus,
             downloadAndPrintInvoiceUseCase = mock(),
             analyticsTracker = analyticsTracker,
             savedState = savedState
@@ -732,12 +748,12 @@ class WooShippingLabelCreationViewModelTest : BaseUnitTest() {
 
         val selectedRate = defaultShippingRates.values.first().first()
 
-        val ratesState = (
-            sut.viewState.runAndCaptureValues {
-                sut.onPackageSelected(defaultPackageData)
-                advanceUntilIdle()
-            }.last() as DataState
-            ).shipmentUIList.first().shippingRatesState as ShippingRatesState.DataState
+        val ratesState = sut.viewState.runAndCaptureValues {
+            sut.onPackageSelected(defaultPackageData)
+            advanceUntilIdle()
+        }.last().let { viewState ->
+            (viewState as DataState).shipmentUIList.first().shippingRatesState as ShippingRatesState.DataState
+        }
 
         ratesState.onSelectedShippingRateChanged(selectedRate)
 
@@ -756,12 +772,12 @@ class WooShippingLabelCreationViewModelTest : BaseUnitTest() {
 
         val selectedRate = defaultShippingRates.values.first().first()
 
-        val ratesState = (
-            sut.viewState.runAndCaptureValues {
-                sut.onPackageSelected(defaultPackageData)
-                advanceUntilIdle()
-            }.last() as DataState
-            ).shipmentUIList.first().shippingRatesState as ShippingRatesState.DataState
+        val ratesState = sut.viewState.runAndCaptureValues {
+            sut.onPackageSelected(defaultPackageData)
+            advanceUntilIdle()
+        }.last().let { viewState ->
+            (viewState as DataState).shipmentUIList.first().shippingRatesState as ShippingRatesState.DataState
+        }
 
         ratesState.onSelectedShippingRateChanged(selectedRate)
 
@@ -774,28 +790,16 @@ class WooShippingLabelCreationViewModelTest : BaseUnitTest() {
 
     @Test
     fun `when onPurchaseShippingLabel succeed then track purchase_success`() = testBlocking {
-        val purchasedLabel = shippingLabelModel.copy(status = PURCHASED)
-        whenever(
-            purchaseShippingLabel(any(), any(), any(), any(), any(), any(), any(), any(), any(), isNull(), isNull())
-        ) doReturn Result.success(
-            PurchasedLabelData(
-                labels = listOf(purchasedLabel),
-                origin = emptyMap(),
-                destination = emptyMap(),
-                rates = emptyMap()
-            )
-        )
-
         createViewModel()
 
         val selectedRate = defaultShippingRates.values.first().first()
 
-        val ratesState = (
-            sut.viewState.runAndCaptureValues {
-                sut.onPackageSelected(defaultPackageData)
-                advanceUntilIdle()
-            }.last() as DataState
-            ).shipmentUIList.first().shippingRatesState as ShippingRatesState.DataState
+        val ratesState = sut.viewState.runAndCaptureValues {
+            sut.onPackageSelected(defaultPackageData)
+            advanceUntilIdle()
+        }.last().let { viewState ->
+            (viewState as DataState).shipmentUIList.first().shippingRatesState as ShippingRatesState.DataState
+        }
 
         ratesState.onSelectedShippingRateChanged(selectedRate)
 
@@ -817,12 +821,12 @@ class WooShippingLabelCreationViewModelTest : BaseUnitTest() {
 
         val selectedRate = defaultShippingRates.values.first().first()
 
-        val ratesState = (
-            sut.viewState.runAndCaptureValues {
-                sut.onPackageSelected(defaultPackageData)
-                advanceUntilIdle()
-            }.last() as DataState
-            ).shipmentUIList.first().shippingRatesState as ShippingRatesState.DataState
+        val ratesState = sut.viewState.runAndCaptureValues {
+            sut.onPackageSelected(defaultPackageData)
+            advanceUntilIdle()
+        }.last().let { viewState ->
+            (viewState as DataState).shipmentUIList.first().shippingRatesState as ShippingRatesState.DataState
+        }
 
         ratesState.onSelectedShippingRateChanged(selectedRate)
 
@@ -834,6 +838,91 @@ class WooShippingLabelCreationViewModelTest : BaseUnitTest() {
             AnalyticsEvent.WCS_PURCHASE_STEP,
             mapOf(KEY_STATE to "purchase_failed", KEY_ERROR to error)
         )
+    }
+
+    @Test
+    fun `when shipping label is purchased and markOrderComplete is true, then markOrderAsComplete is called`() =
+        testBlocking {
+            // Given
+            whenever(markOrderAsComplete(orderId)) doReturn Result.success(Unit)
+
+            // Mock observeShippingLabelStatus to emit a status update with the purchased label
+            whenever(observeShippingLabelStatus(eq(orderId), any())) doReturn flowOf(
+                ObserveShippingLabelStatus.ObserveShippingLabelStatusResult(
+                    status = PURCHASED,
+                    shippingLabelModel = shippingLabelModel.copy(status = PURCHASED)
+                )
+            )
+
+            createViewModel()
+
+            // Set markOrderComplete to true
+            sut.onMarkOrderCompleteChange(true)
+
+            val selectedRate = defaultShippingRates.values.first().first()
+
+            val ratesState = sut.viewState.runAndCaptureValues {
+                sut.onPackageSelected(defaultPackageData)
+                advanceUntilIdle()
+            }.last().let { viewState ->
+                (viewState as DataState).shipmentUIList.first().shippingRatesState as ShippingRatesState.DataState
+            }
+
+            ratesState.onSelectedShippingRateChanged(selectedRate)
+
+            advanceUntilIdle()
+
+            // When
+            sut.onPurchaseShippingLabel()
+            advanceUntilIdle()
+
+            // Then
+            verify(markOrderAsComplete).invoke(orderId)
+        }
+
+    @Test
+    fun `when markOrderAsComplete fails, then show a snackbar with error message`() = testBlocking {
+        // Given
+        whenever(markOrderAsComplete(orderId)) doReturn Result.failure(Exception("Error marking order as complete"))
+
+        // Mock observeShippingLabelStatus to emit a status update with the purchased label
+        whenever(observeShippingLabelStatus(eq(orderId), any())) doReturn flowOf(
+            ObserveShippingLabelStatus.ObserveShippingLabelStatusResult(
+                status = PURCHASED,
+                shippingLabelModel = shippingLabelModel.copy(status = PURCHASED)
+            )
+        )
+
+        createViewModel()
+
+        // Set markOrderComplete to true
+        sut.onMarkOrderCompleteChange(true)
+
+        val selectedRate = defaultShippingRates.values.first().first()
+
+        val ratesState = sut.viewState.runAndCaptureValues {
+            sut.onPackageSelected(defaultPackageData)
+            advanceUntilIdle()
+        }.last().let { viewState ->
+            (viewState as DataState).shipmentUIList.first().shippingRatesState as ShippingRatesState.DataState
+        }
+
+        ratesState.onSelectedShippingRateChanged(selectedRate)
+
+        advanceUntilIdle()
+
+        // When
+        sut.onPurchaseShippingLabel()
+        advanceUntilIdle()
+
+        // Then
+        verify(markOrderAsComplete).invoke(orderId)
+
+        // Verify that the ShowSnackbar event is triggered with the correct message
+        var showSnackbarEvent: Event.ShowSnackbar? = null
+        sut.event.observeForever { if (it is Event.ShowSnackbar) showSnackbarEvent = it }
+
+        assertThat(showSnackbarEvent?.message).isEqualTo(R.string.woo_shipping_labels_order_completion_error)
     }
 
     @Test
@@ -1358,17 +1447,6 @@ class WooShippingLabelCreationViewModelTest : BaseUnitTest() {
     fun `when UPS terms are accepted, then continue purchase`() = testBlocking {
         whenever(getShippingRates(any(), any(), any(), any(), any(), any(), anyOrNull(), anyOrNull()))
             .thenReturn(Result.success(defaultShippingRates))
-        val purchasedLabel = shippingLabelModel.copy(status = PURCHASED)
-        whenever(
-            purchaseShippingLabel(any(), any(), any(), any(), any(), any(), any(), any(), any(), isNull(), isNull())
-        ) doReturn Result.success(
-            PurchasedLabelData(
-                labels = listOf(purchasedLabel),
-                origin = emptyMap(),
-                destination = emptyMap(),
-                rates = emptyMap()
-            )
-        )
 
         createViewModel()
         advanceUntilIdle()

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/WooShippingLabelCreationViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/WooShippingLabelCreationViewModelTest.kt
@@ -5,6 +5,7 @@ import androidx.lifecycle.asLiveData
 import com.woocommerce.android.R
 import com.woocommerce.android.WooException
 import com.woocommerce.android.analytics.AnalyticsEvent
+import com.woocommerce.android.analytics.AnalyticsTracker
 import com.woocommerce.android.analytics.AnalyticsTracker.Companion.KEY_ERROR
 import com.woocommerce.android.analytics.AnalyticsTracker.Companion.KEY_STATE
 import com.woocommerce.android.analytics.AnalyticsTrackerWrapper
@@ -61,6 +62,7 @@ import com.woocommerce.android.ui.orders.wooshippinglabels.rates.ui.ShippingRate
 import com.woocommerce.android.ui.orders.wooshippinglabels.rates.ui.ShippingRateUI
 import com.woocommerce.android.ui.orders.wooshippinglabels.rates.ui.ShippingSortOption
 import com.woocommerce.android.util.CurrencyFormatter
+import com.woocommerce.android.util.captureValues
 import com.woocommerce.android.util.runAndCaptureValues
 import com.woocommerce.android.viewmodel.BaseUnitTest
 import com.woocommerce.android.viewmodel.MultiLiveEvent
@@ -166,7 +168,8 @@ class WooShippingLabelCreationViewModelTest : BaseUnitTest() {
         canEditSettings = true,
         storeOwnerName = "",
         storeOwnerUsername = "",
-        paperSize = WooShippingLabelPaperSize.LABEL
+        paperSize = WooShippingLabelPaperSize.LABEL,
+        lastOrderCompleted = false
     )
 
     private val defaultPackageData = PackageData(
@@ -843,10 +846,7 @@ class WooShippingLabelCreationViewModelTest : BaseUnitTest() {
     @Test
     fun `when shipping label is purchased and markOrderComplete is true, then markOrderAsComplete is called`() =
         testBlocking {
-            // Given
             whenever(markOrderAsComplete(orderId)) doReturn Result.success(Unit)
-
-            // Mock observeShippingLabelStatus to emit a status update with the purchased label
             whenever(observeShippingLabelStatus(eq(orderId), any())) doReturn flowOf(
                 ObserveShippingLabelStatus.ObserveShippingLabelStatusResult(
                     status = PURCHASED,
@@ -856,36 +856,30 @@ class WooShippingLabelCreationViewModelTest : BaseUnitTest() {
 
             createViewModel()
 
-            // Set markOrderComplete to true
             sut.onMarkOrderCompleteChange(true)
-
             val selectedRate = defaultShippingRates.values.first().first()
-
             val ratesState = sut.viewState.runAndCaptureValues {
                 sut.onPackageSelected(defaultPackageData)
                 advanceUntilIdle()
             }.last().let { viewState ->
                 (viewState as DataState).shipmentUIList.first().shippingRatesState as ShippingRatesState.DataState
             }
-
             ratesState.onSelectedShippingRateChanged(selectedRate)
-
             advanceUntilIdle()
 
-            // When
             sut.onPurchaseShippingLabel()
             advanceUntilIdle()
 
-            // Then
             verify(markOrderAsComplete).invoke(orderId)
+            verify(analyticsTracker).track(
+                stat = AnalyticsEvent.SHIPPING_LABEL_ORDER_FULFILL_SUCCEEDED,
+                properties = mapOf(AnalyticsTracker.KEY_IS_REVAMPED_FLOW to true)
+            )
         }
 
     @Test
     fun `when markOrderAsComplete fails, then show a snackbar with error message`() = testBlocking {
-        // Given
         whenever(markOrderAsComplete(orderId)) doReturn Result.failure(Exception("Error marking order as complete"))
-
-        // Mock observeShippingLabelStatus to emit a status update with the purchased label
         whenever(observeShippingLabelStatus(eq(orderId), any())) doReturn flowOf(
             ObserveShippingLabelStatus.ObserveShippingLabelStatusResult(
                 status = PURCHASED,
@@ -895,34 +889,33 @@ class WooShippingLabelCreationViewModelTest : BaseUnitTest() {
 
         createViewModel()
 
-        // Set markOrderComplete to true
         sut.onMarkOrderCompleteChange(true)
 
         val selectedRate = defaultShippingRates.values.first().first()
-
         val ratesState = sut.viewState.runAndCaptureValues {
             sut.onPackageSelected(defaultPackageData)
             advanceUntilIdle()
         }.last().let { viewState ->
             (viewState as DataState).shipmentUIList.first().shippingRatesState as ShippingRatesState.DataState
         }
-
         ratesState.onSelectedShippingRateChanged(selectedRate)
-
         advanceUntilIdle()
 
-        // When
         sut.onPurchaseShippingLabel()
         advanceUntilIdle()
 
-        // Then
         verify(markOrderAsComplete).invoke(orderId)
 
-        // Verify that the ShowSnackbar event is triggered with the correct message
-        var showSnackbarEvent: Event.ShowSnackbar? = null
-        sut.event.observeForever { if (it is Event.ShowSnackbar) showSnackbarEvent = it }
+        val showSnackbarEvent = sut.event.captureValues().filterIsInstance<Event.ShowSnackbar>().last()
+        assertThat(showSnackbarEvent.message).isEqualTo(R.string.woo_shipping_labels_order_completion_error)
 
-        assertThat(showSnackbarEvent?.message).isEqualTo(R.string.woo_shipping_labels_order_completion_error)
+        verify(analyticsTracker).track(
+            stat = eq(AnalyticsEvent.SHIPPING_LABEL_ORDER_FULFILL_FAILED),
+            properties = eq(mapOf(AnalyticsTracker.KEY_IS_REVAMPED_FLOW to true)),
+            errorType = anyOrNull(),
+            errorContext = anyOrNull(),
+            errorDescription = anyOrNull()
+        )
     }
 
     @Test

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/payment/WooShippingEditPaymentViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/payment/WooShippingEditPaymentViewModelTest.kt
@@ -67,7 +67,8 @@ class WooShippingEditPaymentViewModelTest : BaseUnitTest() {
         canEditSettings = true,
         storeOwnerName = "John Doe",
         storeOwnerUsername = "johndoe",
-        paperSize = WooShippingLabelPaperSize.LABEL
+        paperSize = WooShippingLabelPaperSize.LABEL,
+        lastOrderCompleted = false
     )
 
     private val observeAccountSettings: ObserveAccountSettings = mock {


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

<!-- Id number of the Linear issue this PR addresses, e.g., WOOMOB-373. -->
Closes WOOMOB-797

### Description
This PR implements the logic of marking orders as complete when purchasing a shipping label, it also adds logic to set the default value of the toggle using the account settings, to match the web behavior.

### Steps to reproduce
##### Happy path
1. Open shipping label creation form.
2. Enable the option "Mark order as complete" from the shipment details bottom sheet.
3. Purchase the label.
4. Wait for the label to be purchased.
5. Confirm the order was marked as complete.

##### Unhappy path
<details>
<summary>1. Import the following config to the Api Faker</summary>

```json
[
  {
    "request": {
      "httpMethod": "PUT",
      "id": 0,
      "path": "/wc/v3/orders/%",
      "queryParameters": [],
      "type": {
        "type": "wp-api"
      }
    },
    "response": {
      "body": "",
      "endpointId": 0,
      "statusCode": 403
    }
  }
]
```
</details>

2. Follow steps 1 to 4 from the happy path case.
3. Confirm that a Snack Bar is shown to indicate the failure to mark the order as complete.

##### Default value of the toggle
Confirm that the toggle uses the value that was used in last purchase.

### Testing information
The above TCs have all the details

### The tests that have been performed
The above.

- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->