### PR TITLE
[WOOMOB-842][Woo POS][Barcodes] Other device opens Scanning info state instead of the dialog

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/WooPosHomeScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/WooPosHomeScreen.kt
@@ -194,9 +194,6 @@ private fun Dialogs(
         isVisible = dialogState is WooPosHomeState.DialogState.ScanningSetupDialog,
         onDismissRequest = {
             onHomeUIEvent(WooPosHomeUIEvent.DismissScanningSetupDialog)
-        },
-        onShowBarcodeInfoDialog = {
-            onHomeUIEvent(WooPosHomeUIEvent.ShowBarcodeInfoDialog)
         }
     )
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/WooPosHomeUIEvent.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/WooPosHomeUIEvent.kt
@@ -8,7 +8,6 @@ sealed class WooPosHomeUIEvent {
     data object DismissProductsInfoDialog : WooPosHomeUIEvent()
     data object DismissBarcodeInfoDialog : WooPosHomeUIEvent()
     data object DismissScanningSetupDialog : WooPosHomeUIEvent()
-    data object ShowBarcodeInfoDialog : WooPosHomeUIEvent()
     data object OnPaymentCompletedViaCash : WooPosHomeUIEvent()
     data object ExitPosClicked : WooPosHomeUIEvent()
     data class OnBarcodeEvent(

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/WooPosHomeViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/WooPosHomeViewModel.kt
@@ -90,12 +90,6 @@ class WooPosHomeViewModel @Inject constructor(
                 )
             }
 
-            WooPosHomeUIEvent.ShowBarcodeInfoDialog -> {
-                _state.value = _state.value.copy(
-                    dialogState = DialogState.BarcodeInfoDialog
-                )
-            }
-
             WooPosHomeUIEvent.OnPaymentCompletedViaCash -> onOrderSuccessfullyPaid(
                 PaymentMethod.CASH
             )

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/scanningsetup/WooPosScanningSetupDialog.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/scanningsetup/WooPosScanningSetupDialog.kt
@@ -197,7 +197,7 @@ fun WooPosScanningSetupDialog(
 
                     is ScanningSetupStep.ScannerSetupSuccess -> ScannerSetupSuccessContent(
                         step = step,
-                        onSecondaryClick = { viewModel.onUiEvent(WooPosScanningSetupUiEvent.OnSecondaryButtonClicked) }
+                        onPrimaryClick = { viewModel.onUiEvent(WooPosScanningSetupUiEvent.OnPrimaryButtonClicked) }
                     )
 
                     is ScanningSetupStep.ScannerSetupInfo -> ScannerSetupInfoContent(
@@ -490,7 +490,7 @@ private fun SetupButtonsRow(
 @Composable
 private fun ScannerSetupSuccessContent(
     step: ScanningSetupStep.ScannerSetupSuccess,
-    onSecondaryClick: () -> Unit,
+    onPrimaryClick: () -> Unit,
 ) {
     Column(
         modifier = Modifier
@@ -521,7 +521,7 @@ private fun ScannerSetupSuccessContent(
         Spacer(modifier = Modifier.height(WooPosSpacing.XLarge.value.toAdaptivePadding()))
 
         WooPosOutlinedButton(
-            onClick = onSecondaryClick,
+            onClick = onPrimaryClick,
             text = step.moreInfoButtonText,
             modifier = Modifier.fillMaxWidth()
         )
@@ -631,7 +631,8 @@ fun WooPosScanningSetupDialogPreview() {
                         BarcodeReaderDevice.STAR_BSH_20B,
                         BarcodeReaderDevice.INATECK_BLUETOOTH,
                         BarcodeReaderDevice.OTHER
-                    )
+                    ),
+                    previousStep = null
                 ),
                 onDeviceSelected = {}
             )

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/scanningsetup/WooPosScanningSetupDialog.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/scanningsetup/WooPosScanningSetupDialog.kt
@@ -76,7 +76,6 @@ import com.woocommerce.android.util.WooLog
 fun WooPosScanningSetupDialog(
     isVisible: Boolean,
     onDismissRequest: () -> Unit,
-    onShowBarcodeInfoDialog: () -> Unit = {},
 ) {
     val viewModel = hiltViewModel<WooPosScanningSetupViewModel>()
     val context = LocalContext.current
@@ -85,11 +84,6 @@ fun WooPosScanningSetupDialog(
         viewModel.resetToInitialState()
     }
 
-    LaunchedEffect(Unit) {
-        viewModel.showBarcodeInfoDialogEvent.collect {
-            onShowBarcodeInfoDialog()
-        }
-    }
     LaunchedEffect(Unit) {
         viewModel.openBluetoothSettingsEvent.collect {
             try {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/scanningsetup/WooPosScanningSetupState.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/scanningsetup/WooPosScanningSetupState.kt
@@ -19,11 +19,13 @@ data class WooPosScanningSetupState(
         OTHER(R.string.woopos_scanning_setup_device_other)
     }
     sealed class ScanningSetupStep : Parcelable {
+        abstract val previousStep: ScanningSetupStep?
 
         @Parcelize
         data class DeviceSelection(
             val title: String,
             val devices: List<BarcodeReaderDevice>,
+            override val previousStep: ScanningSetupStep?
         ) : ScanningSetupStep()
 
         @Parcelize
@@ -33,6 +35,7 @@ data class WooPosScanningSetupState(
             @DrawableRes val qrCodeImageRes: Int,
             val primaryButtonText: String,
             val secondaryButtonText: String,
+            override val previousStep: ScanningSetupStep
         ) : ScanningSetupStep()
 
         @Parcelize
@@ -42,6 +45,7 @@ data class WooPosScanningSetupState(
             @DrawableRes val qrCodeImageRes: Int,
             val primaryButtonText: String,
             val secondaryButtonText: String,
+            override val previousStep: ScanningSetupStep
         ) : ScanningSetupStep()
 
         @Parcelize
@@ -52,6 +56,7 @@ data class WooPosScanningSetupState(
             val primaryButtonText: String,
             val secondaryButtonText: String,
             val bluetoothSettingsButtonText: String,
+            override val previousStep: ScanningSetupStep
         ) : ScanningSetupStep()
 
         @Parcelize
@@ -60,6 +65,7 @@ data class WooPosScanningSetupState(
             val message: String,
             @DrawableRes val barcodeImageRes: Int,
             val secondaryButtonText: String,
+            override val previousStep: ScanningSetupStep
         ) : ScanningSetupStep()
 
         @Parcelize
@@ -67,6 +73,7 @@ data class WooPosScanningSetupState(
             val title: String,
             val message: String,
             val moreInfoButtonText: String,
+            override val previousStep: ScanningSetupStep?
         ) : ScanningSetupStep()
 
         @Parcelize
@@ -77,6 +84,7 @@ data class WooPosScanningSetupState(
             val infoText: String,
             val backButtonText: String,
             val doneButtonText: String,
+            override val previousStep: ScanningSetupStep?
         ) : ScanningSetupStep()
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/scanningsetup/WooPosScanningSetupUiEvent.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/scanningsetup/WooPosScanningSetupUiEvent.kt
@@ -1,0 +1,10 @@
+package com.woocommerce.android.ui.woopos.home.scanningsetup
+
+import com.woocommerce.android.ui.woopos.home.scanningsetup.WooPosScanningSetupState.BarcodeReaderDevice
+
+sealed class WooPosScanningSetupUiEvent {
+    data object OnPrimaryButtonClicked : WooPosScanningSetupUiEvent()
+    data object OnSecondaryButtonClicked : WooPosScanningSetupUiEvent()
+    data object OnOpenBluetoothSettings : WooPosScanningSetupUiEvent()
+    data class OnDeviceSelected(val device: BarcodeReaderDevice) : WooPosScanningSetupUiEvent()
+}

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/scanningsetup/WooPosScanningSetupViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/scanningsetup/WooPosScanningSetupViewModel.kt
@@ -217,10 +217,3 @@ class WooPosScanningSetupViewModel @Inject constructor(
         private const val AUTO_NAVIGATION_DELAY_MS = 3000L
     }
 }
-
-sealed class WooPosScanningSetupUiEvent {
-    data object OnPrimaryButtonClicked : WooPosScanningSetupUiEvent()
-    data object OnSecondaryButtonClicked : WooPosScanningSetupUiEvent()
-    data object OnOpenBluetoothSettings : WooPosScanningSetupUiEvent()
-    data class OnDeviceSelected(val device: BarcodeReaderDevice) : WooPosScanningSetupUiEvent()
-}

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/scanningsetup/WooPosScanningSetupViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/scanningsetup/WooPosScanningSetupViewModel.kt
@@ -31,9 +31,6 @@ class WooPosScanningSetupViewModel @Inject constructor(
     )
     val state: StateFlow<WooPosScanningSetupState> = _state.asStateFlow()
 
-    private val _showBarcodeInfoDialogEvent = MutableSharedFlow<Unit>()
-    val showBarcodeInfoDialogEvent: SharedFlow<Unit> = _showBarcodeInfoDialogEvent.asSharedFlow()
-
     private val _openBluetoothSettingsEvent = MutableSharedFlow<Unit>()
     val openBluetoothSettingsEvent: SharedFlow<Unit> = _openBluetoothSettingsEvent.asSharedFlow()
 
@@ -48,9 +45,9 @@ class WooPosScanningSetupViewModel @Inject constructor(
                 )
 
                 when (event.device) {
-                    BarcodeReaderDevice.OTHER -> viewModelScope.launch {
-                        _showBarcodeInfoDialogEvent.emit(Unit)
-                    }
+                    BarcodeReaderDevice.OTHER -> _state.value = _state.value.copy(
+                        currentStep = createScannerSetupInfoStep()
+                    )
 
                     else -> _state.value = _state.value.copy(
                         currentStep = createScannerHIDModeSetupStep()

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/scanningsetup/WooPosScanningSetupViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/scanningsetup/WooPosScanningSetupViewModel.kt
@@ -46,11 +46,11 @@ class WooPosScanningSetupViewModel @Inject constructor(
 
                 when (event.device) {
                     BarcodeReaderDevice.OTHER -> _state.value = _state.value.copy(
-                        currentStep = createScannerSetupInfoStep()
+                        currentStep = createScannerSetupInfoStep(_state.value.currentStep)
                     )
 
                     else -> _state.value = _state.value.copy(
-                        currentStep = createScannerHIDModeSetupStep()
+                        currentStep = createScannerHIDModeSetupStep(_state.value.currentStep)
                     )
                 }
             }
@@ -86,18 +86,19 @@ class WooPosScanningSetupViewModel @Inject constructor(
 
             is ScanningSetupStep.ScannerHIDModeSetup -> {
                 _state.value = _state.value.copy(
-                    currentStep = createScannerPairModeSetupStep()
+                    currentStep = createScannerPairModeSetupStep(_state.value.currentStep)
                 )
             }
 
             is ScanningSetupStep.ScannerPairModeSetup -> {
                 _state.value = _state.value.copy(
-                    currentStep = createPairYourScannerStep()
+                    currentStep = createPairYourScannerStep(_state.value.currentStep)
                 )
             }
+
             is ScanningSetupStep.PairYourScanner -> {
                 _state.value = _state.value.copy(
-                    currentStep = createTestYourScannerStep()
+                    currentStep = createTestYourScannerStep(_state.value.currentStep)
                 )
                 startAutoNavigationToSuccess()
             }
@@ -107,7 +108,7 @@ class WooPosScanningSetupViewModel @Inject constructor(
             }
 
             is ScanningSetupStep.ScannerSetupSuccess -> {
-                error("Primary button should not be available on ScannerSetupSuccess step")
+                error("Not implemented yet")
             }
 
             is ScanningSetupStep.ScannerSetupInfo -> {
@@ -119,46 +120,10 @@ class WooPosScanningSetupViewModel @Inject constructor(
     }
 
     private fun handleSecondaryButtonClick() {
-        when (_state.value.currentStep) {
-            is ScanningSetupStep.DeviceSelection -> error(
-                "Secondary button should not be available on DeviceSelection step"
-            )
-
-            is ScanningSetupStep.ScannerHIDModeSetup -> {
-                _state.value = _state.value.copy(
-                    currentStep = createDeviceSelectionStep()
-                )
-            }
-
-            is ScanningSetupStep.ScannerPairModeSetup -> {
-                _state.value = _state.value.copy(
-                    currentStep = createScannerHIDModeSetupStep()
-                )
-            }
-            is ScanningSetupStep.PairYourScanner -> {
-                _state.value = _state.value.copy(
-                    currentStep = createScannerPairModeSetupStep()
-                )
-            }
-
-            is ScanningSetupStep.TestYourScanner -> {
-                _state.value = _state.value.copy(
-                    currentStep = createPairYourScannerStep()
-                )
-            }
-
-            is ScanningSetupStep.ScannerSetupSuccess -> {
-                _state.value = _state.value.copy(
-                    currentStep = createScannerSetupInfoStep()
-                )
-            }
-
-            is ScanningSetupStep.ScannerSetupInfo -> {
-                _state.value = _state.value.copy(
-                    currentStep = createScannerSetupSuccessStep()
-                )
-            }
-        }
+        val previousStep = requireNotNull(
+            _state.value.currentStep.previousStep
+        ) { "Previous step cannot be null if secondary button present" }
+        _state.value = _state.value.copy(currentStep = previousStep)
     }
 
     private fun createDeviceSelectionStep() = ScanningSetupStep.DeviceSelection(
@@ -168,25 +133,32 @@ class WooPosScanningSetupViewModel @Inject constructor(
             BarcodeReaderDevice.STAR_BSH_20B,
             BarcodeReaderDevice.INATECK_BLUETOOTH,
             BarcodeReaderDevice.OTHER
-        )
+        ),
+        previousStep = null
     )
 
-    private fun createScannerHIDModeSetupStep() = ScanningSetupStep.ScannerHIDModeSetup(
+    private fun createScannerHIDModeSetupStep(previousStep: ScanningSetupStep) = ScanningSetupStep.ScannerHIDModeSetup(
         title = resourceProvider.getString(R.string.woopos_scanning_setup_introduction_title),
         message = resourceProvider.getString(R.string.woopos_scanning_setup_introduction_message),
         qrCodeImageRes = R.drawable.ic_barcode,
         primaryButtonText = resourceProvider.getString(R.string.woopos_scanning_setup_button_next),
-        secondaryButtonText = resourceProvider.getString(R.string.woopos_scanning_setup_button_back)
+        secondaryButtonText = resourceProvider.getString(R.string.woopos_scanning_setup_button_back),
+        previousStep = previousStep
     )
 
-    private fun createScannerPairModeSetupStep() = ScanningSetupStep.ScannerPairModeSetup(
-        title = resourceProvider.getString(R.string.woopos_scanning_setup_scanner_pair_mode_title),
-        message = resourceProvider.getString(R.string.woopos_scanning_setup_scanner_pair_mode_message),
-        qrCodeImageRes = R.drawable.ic_barcode,
-        primaryButtonText = resourceProvider.getString(R.string.woopos_scanning_setup_button_next),
-        secondaryButtonText = resourceProvider.getString(R.string.woopos_scanning_setup_button_back)
-    )
-    private fun createPairYourScannerStep() = ScanningSetupStep.PairYourScanner(
+    private fun createScannerPairModeSetupStep(previousStep: ScanningSetupStep) =
+        ScanningSetupStep.ScannerPairModeSetup(
+            title = resourceProvider.getString(R.string.woopos_scanning_setup_scanner_pair_mode_title),
+            message = resourceProvider.getString(R.string.woopos_scanning_setup_scanner_pair_mode_message),
+            qrCodeImageRes = R.drawable.ic_barcode,
+            primaryButtonText = resourceProvider.getString(R.string.woopos_scanning_setup_button_next),
+            secondaryButtonText = resourceProvider.getString(R.string.woopos_scanning_setup_button_back),
+            previousStep = previousStep
+        )
+
+    private fun createPairYourScannerStep(
+        previousStep: ScanningSetupStep
+    ) = ScanningSetupStep.PairYourScanner(
         title = resourceProvider.getString(R.string.woopos_scanning_setup_pair_your_scanner_title),
         message = resourceProvider.getString(
             R.string.woopos_scanning_setup_pair_your_scanner_message,
@@ -195,23 +167,28 @@ class WooPosScanningSetupViewModel @Inject constructor(
         iconRes = R.drawable.ic_woopos_bluetooth_settings,
         primaryButtonText = resourceProvider.getString(R.string.woopos_scanning_setup_button_next),
         secondaryButtonText = resourceProvider.getString(R.string.woopos_scanning_setup_button_back),
-        bluetoothSettingsButtonText = resourceProvider.getString(R.string.woopos_scanning_setup_go_to_settings)
+        bluetoothSettingsButtonText = resourceProvider.getString(R.string.woopos_scanning_setup_go_to_settings),
+        previousStep = previousStep
     )
 
-    private fun createTestYourScannerStep() = ScanningSetupStep.TestYourScanner(
+    private fun createTestYourScannerStep(
+        previousStep: ScanningSetupStep
+    ) = ScanningSetupStep.TestYourScanner(
         title = resourceProvider.getString(R.string.woopos_scanning_setup_test_scanner_title),
         message = resourceProvider.getString(R.string.woopos_scanning_setup_test_scanner_message),
         barcodeImageRes = R.drawable.ic_barcode,
-        secondaryButtonText = resourceProvider.getString(R.string.woopos_scanning_setup_button_back)
+        secondaryButtonText = resourceProvider.getString(R.string.woopos_scanning_setup_button_back),
+        previousStep = previousStep
     )
 
     private fun createScannerSetupSuccessStep() = ScanningSetupStep.ScannerSetupSuccess(
         title = resourceProvider.getString(R.string.woopos_scanning_setup_success_title),
         message = resourceProvider.getString(R.string.woopos_scanning_setup_success_message),
-        moreInfoButtonText = resourceProvider.getString(R.string.woopos_scanning_setup_more_information)
+        moreInfoButtonText = resourceProvider.getString(R.string.woopos_scanning_setup_more_information),
+        previousStep = null
     )
 
-    private fun createScannerSetupInfoStep() = ScanningSetupStep.ScannerSetupInfo(
+    private fun createScannerSetupInfoStep(previousStep: ScanningSetupStep) = ScanningSetupStep.ScannerSetupInfo(
         title = resourceProvider.getString(R.string.woopos_scanning_setup_info_title),
         message = resourceProvider.getString(R.string.woopos_scanning_setup_info_message),
         bulletPoints = listOf(
@@ -221,7 +198,8 @@ class WooPosScanningSetupViewModel @Inject constructor(
         ),
         infoText = resourceProvider.getString(R.string.woopos_scanning_setup_info_text),
         backButtonText = resourceProvider.getString(R.string.woopos_scanning_setup_button_back),
-        doneButtonText = resourceProvider.getString(R.string.woopos_scanning_setup_button_done)
+        doneButtonText = resourceProvider.getString(R.string.woopos_scanning_setup_button_done),
+        previousStep = previousStep
     )
 
     private fun startAutoNavigationToSuccess() {

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/home/scanningsetup/WooPosScanningSetupViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/home/scanningsetup/WooPosScanningSetupViewModelTest.kt
@@ -1,0 +1,332 @@
+package com.woocommerce.android.ui.woopos.home.scanningsetup
+
+import app.cash.turbine.test
+import com.woocommerce.android.R
+import com.woocommerce.android.ui.woopos.home.scanningsetup.WooPosScanningSetupState.BarcodeReaderDevice
+import com.woocommerce.android.ui.woopos.home.scanningsetup.WooPosScanningSetupState.ScanningSetupStep
+import com.woocommerce.android.ui.woopos.util.WooPosCoroutineTestRule
+import com.woocommerce.android.viewmodel.ResourceProvider
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.runTest
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.Rule
+import org.junit.Test
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.whenever
+
+@ExperimentalCoroutinesApi
+class WooPosScanningSetupViewModelTest {
+    @Rule
+    @JvmField
+    val coroutinesTestRule = WooPosCoroutineTestRule()
+
+    private val resourceProvider: ResourceProvider = mock()
+
+    @Test
+    fun `given initialized, when no action taken, then should start with DeviceSelection step`() = runTest {
+        // GIVEN
+        val viewModel = createViewModel()
+
+        // THEN
+        assertThat(viewModel.state.value.currentStep)
+            .isInstanceOf(ScanningSetupStep.DeviceSelection::class.java)
+        assertThat(viewModel.state.value.selectedDevice).isNull()
+    }
+
+    @Test
+    fun `given DeviceSelection step, when OTHER device selected, then should navigate to ScannerSetupInfo`() = runTest {
+        // GIVEN
+        val viewModel = createViewModel()
+
+        // WHEN
+        viewModel.onUiEvent(WooPosScanningSetupUiEvent.OnDeviceSelected(BarcodeReaderDevice.OTHER))
+
+        // THEN
+        assertThat(viewModel.state.value.currentStep)
+            .isInstanceOf(ScanningSetupStep.ScannerSetupInfo::class.java)
+        assertThat(viewModel.state.value.selectedDevice).isEqualTo(BarcodeReaderDevice.OTHER)
+    }
+
+    @Test
+    fun `given DeviceSelection step, when non-OTHER device selected, then should navigate to ScannerHIDModeSetup`() =
+        runTest {
+            // GIVEN
+            val viewModel = createViewModel()
+
+            // WHEN
+            viewModel.onUiEvent(WooPosScanningSetupUiEvent.OnDeviceSelected(BarcodeReaderDevice.TERA_1200))
+
+            // THEN
+            assertThat(viewModel.state.value.currentStep)
+                .isInstanceOf(ScanningSetupStep.ScannerHIDModeSetup::class.java)
+            assertThat(viewModel.state.value.selectedDevice).isEqualTo(BarcodeReaderDevice.TERA_1200)
+        }
+
+    @Test
+    fun `given ScannerHIDModeSetup step, when primary button clicked, then should navigate to ScannerPairModeSetup`() =
+        runTest {
+            // GIVEN
+            val viewModel = createViewModel()
+            viewModel.onUiEvent(WooPosScanningSetupUiEvent.OnDeviceSelected(BarcodeReaderDevice.TERA_1200))
+
+            // WHEN
+            viewModel.onUiEvent(WooPosScanningSetupUiEvent.OnPrimaryButtonClicked)
+
+            // THEN
+            assertThat(viewModel.state.value.currentStep)
+                .isInstanceOf(ScanningSetupStep.ScannerPairModeSetup::class.java)
+        }
+
+    @Test
+    fun `given ScannerPairModeSetup step, when primary button clicked, then should navigate to PairYourScanner`() =
+        runTest {
+            // GIVEN
+            val viewModel = createViewModel()
+            viewModel.onUiEvent(WooPosScanningSetupUiEvent.OnDeviceSelected(BarcodeReaderDevice.TERA_1200))
+            viewModel.onUiEvent(WooPosScanningSetupUiEvent.OnPrimaryButtonClicked)
+
+            // WHEN
+            viewModel.onUiEvent(WooPosScanningSetupUiEvent.OnPrimaryButtonClicked)
+
+            // THEN
+            assertThat(viewModel.state.value.currentStep)
+                .isInstanceOf(ScanningSetupStep.PairYourScanner::class.java)
+        }
+
+    @Test
+    fun `given PairYourScanner step, when primary button clicked, then should navigate to TestYourScanner`() = runTest {
+        // GIVEN
+        val viewModel = createViewModel()
+        viewModel.onUiEvent(WooPosScanningSetupUiEvent.OnDeviceSelected(BarcodeReaderDevice.TERA_1200))
+        viewModel.onUiEvent(WooPosScanningSetupUiEvent.OnPrimaryButtonClicked)
+        viewModel.onUiEvent(WooPosScanningSetupUiEvent.OnPrimaryButtonClicked)
+
+        // WHEN
+        viewModel.onUiEvent(WooPosScanningSetupUiEvent.OnPrimaryButtonClicked)
+
+        // THEN
+        assertThat(viewModel.state.value.currentStep)
+            .isInstanceOf(ScanningSetupStep.TestYourScanner::class.java)
+    }
+
+    @Test
+    fun `given ScannerSetupInfo step from DeviceSelection, when secondary button clicked, then should navigate back to DeviceSelection`() =
+        runTest {
+            // GIVEN
+            val viewModel = createViewModel()
+            viewModel.onUiEvent(WooPosScanningSetupUiEvent.OnDeviceSelected(BarcodeReaderDevice.OTHER))
+
+            // WHEN
+            viewModel.onUiEvent(WooPosScanningSetupUiEvent.OnSecondaryButtonClicked)
+
+            // THEN
+            assertThat(viewModel.state.value.currentStep)
+                .isInstanceOf(ScanningSetupStep.DeviceSelection::class.java)
+        }
+
+    @Test
+    fun `given ScannerHIDModeSetup step, when secondary button clicked, then should navigate back to DeviceSelection`() =
+        runTest {
+            // GIVEN
+            val viewModel = createViewModel()
+            viewModel.onUiEvent(WooPosScanningSetupUiEvent.OnDeviceSelected(BarcodeReaderDevice.TERA_1200))
+
+            // WHEN
+            viewModel.onUiEvent(WooPosScanningSetupUiEvent.OnSecondaryButtonClicked)
+
+            // THEN
+            assertThat(viewModel.state.value.currentStep)
+                .isInstanceOf(ScanningSetupStep.DeviceSelection::class.java)
+        }
+
+    @Test
+    fun `given ScannerPairModeSetup step, when secondary button clicked, then should navigate back to ScannerHIDModeSetup`() =
+        runTest {
+            // GIVEN
+            val viewModel = createViewModel()
+            viewModel.onUiEvent(WooPosScanningSetupUiEvent.OnDeviceSelected(BarcodeReaderDevice.TERA_1200))
+            viewModel.onUiEvent(WooPosScanningSetupUiEvent.OnPrimaryButtonClicked)
+
+            // WHEN
+            viewModel.onUiEvent(WooPosScanningSetupUiEvent.OnSecondaryButtonClicked)
+
+            // THEN
+            assertThat(viewModel.state.value.currentStep)
+                .isInstanceOf(ScanningSetupStep.ScannerHIDModeSetup::class.java)
+        }
+
+    @Test
+    fun `given PairYourScanner step, when secondary button clicked, then should navigate back to ScannerPairModeSetup`() =
+        runTest {
+            // GIVEN
+            val viewModel = createViewModel()
+            viewModel.onUiEvent(WooPosScanningSetupUiEvent.OnDeviceSelected(BarcodeReaderDevice.TERA_1200))
+            viewModel.onUiEvent(WooPosScanningSetupUiEvent.OnPrimaryButtonClicked)
+            viewModel.onUiEvent(WooPosScanningSetupUiEvent.OnPrimaryButtonClicked)
+
+            // WHEN
+            viewModel.onUiEvent(WooPosScanningSetupUiEvent.OnSecondaryButtonClicked)
+
+            // THEN
+            assertThat(viewModel.state.value.currentStep)
+                .isInstanceOf(ScanningSetupStep.ScannerPairModeSetup::class.java)
+        }
+
+    @Test
+    fun `given TestYourScanner step, when secondary button clicked, then should navigate back to PairYourScanner`() =
+        runTest {
+            // GIVEN
+            val viewModel = createViewModel()
+            viewModel.onUiEvent(WooPosScanningSetupUiEvent.OnDeviceSelected(BarcodeReaderDevice.TERA_1200))
+            viewModel.onUiEvent(WooPosScanningSetupUiEvent.OnPrimaryButtonClicked)
+            viewModel.onUiEvent(WooPosScanningSetupUiEvent.OnPrimaryButtonClicked)
+            viewModel.onUiEvent(WooPosScanningSetupUiEvent.OnPrimaryButtonClicked)
+
+            // WHEN
+            viewModel.onUiEvent(WooPosScanningSetupUiEvent.OnSecondaryButtonClicked)
+
+            // THEN
+            assertThat(viewModel.state.value.currentStep)
+                .isInstanceOf(ScanningSetupStep.PairYourScanner::class.java)
+        }
+
+    @Test
+    fun `given ScannerSetupInfo step, when primary button clicked, then should emit dismiss dialog event`() = runTest {
+        // GIVEN
+        val viewModel = createViewModel()
+        viewModel.onUiEvent(WooPosScanningSetupUiEvent.OnDeviceSelected(BarcodeReaderDevice.OTHER))
+
+        viewModel.dismissDialogEvent.test {
+            // WHEN
+            viewModel.onUiEvent(WooPosScanningSetupUiEvent.OnPrimaryButtonClicked)
+
+            // THEN
+            awaitItem()
+        }
+    }
+
+    @Test
+    fun `given OnOpenBluetoothSettings event, when triggered, then should emit openBluetoothSettingsEvent`() = runTest {
+        // GIVEN
+        val viewModel = createViewModel()
+
+        viewModel.openBluetoothSettingsEvent.test {
+            // WHEN
+            viewModel.onUiEvent(WooPosScanningSetupUiEvent.OnOpenBluetoothSettings)
+
+            // THEN
+            awaitItem()
+        }
+    }
+
+    @Test
+    fun `given resetToInitialState called, when invoked, then should reset to DeviceSelection step`() = runTest {
+        // GIVEN
+        val viewModel = createViewModel()
+        viewModel.onUiEvent(WooPosScanningSetupUiEvent.OnDeviceSelected(BarcodeReaderDevice.TERA_1200))
+        viewModel.onUiEvent(WooPosScanningSetupUiEvent.OnPrimaryButtonClicked)
+
+        // WHEN
+        viewModel.resetToInitialState()
+
+        // THEN
+        assertThat(viewModel.state.value.currentStep)
+            .isInstanceOf(ScanningSetupStep.DeviceSelection::class.java)
+        assertThat(viewModel.state.value.selectedDevice).isNull()
+    }
+
+    @Test
+    fun `given ScannerSetupInfo step, when verifying previousStep is tracked, then should maintain proper navigation history`() =
+        runTest {
+            // GIVEN
+            val viewModel = createViewModel()
+
+            // WHEN
+            viewModel.onUiEvent(WooPosScanningSetupUiEvent.OnDeviceSelected(BarcodeReaderDevice.OTHER))
+
+            // THEN
+            val currentStep = viewModel.state.value.currentStep as ScanningSetupStep.ScannerSetupInfo
+            assertThat(currentStep.previousStep)
+                .isInstanceOf(ScanningSetupStep.DeviceSelection::class.java)
+        }
+
+    @Test
+    fun `given multi-step navigation, when checking previousStep chain, then should maintain proper navigation stack`() =
+        runTest {
+            // GIVEN
+            val viewModel = createViewModel()
+
+            // WHEN
+            viewModel.onUiEvent(WooPosScanningSetupUiEvent.OnDeviceSelected(BarcodeReaderDevice.TERA_1200))
+            viewModel.onUiEvent(WooPosScanningSetupUiEvent.OnPrimaryButtonClicked)
+
+            // THEN
+            val currentStep = viewModel.state.value.currentStep as ScanningSetupStep.ScannerPairModeSetup
+            assertThat(currentStep.previousStep)
+                .isInstanceOf(ScanningSetupStep.ScannerHIDModeSetup::class.java)
+
+            val previousStep = currentStep.previousStep as ScanningSetupStep.ScannerHIDModeSetup
+            assertThat(previousStep.previousStep)
+                .isInstanceOf(ScanningSetupStep.DeviceSelection::class.java)
+        }
+
+    private fun createViewModel(): WooPosScanningSetupViewModel {
+        setupMockResourceProvider()
+        return WooPosScanningSetupViewModel(resourceProvider)
+    }
+
+    private fun setupMockResourceProvider() {
+        whenever(resourceProvider.getString(R.string.woopos_scanning_setup_device_selection_title))
+            .thenReturn("Set up a barcode scanner")
+        whenever(resourceProvider.getString(R.string.woopos_scanning_setup_introduction_title))
+            .thenReturn("Introduction")
+        whenever(resourceProvider.getString(R.string.woopos_scanning_setup_introduction_message))
+            .thenReturn("Introduction message")
+        whenever(resourceProvider.getString(R.string.woopos_scanning_setup_scanner_pair_mode_title))
+            .thenReturn("Pair mode")
+        whenever(resourceProvider.getString(R.string.woopos_scanning_setup_scanner_pair_mode_message))
+            .thenReturn("Pair mode message")
+        whenever(resourceProvider.getString(R.string.woopos_scanning_setup_pair_your_scanner_title))
+            .thenReturn("Pair your scanner")
+        whenever(resourceProvider.getString(R.string.woopos_scanning_setup_pair_your_scanner_message, "TERA 1200"))
+            .thenReturn("Pair your scanner message TERA 1200")
+        whenever(resourceProvider.getString(R.string.woopos_scanning_setup_test_scanner_title))
+            .thenReturn("Test scanner")
+        whenever(resourceProvider.getString(R.string.woopos_scanning_setup_test_scanner_message))
+            .thenReturn("Test scanner message")
+        whenever(resourceProvider.getString(R.string.woopos_scanning_setup_success_title))
+            .thenReturn("Success")
+        whenever(resourceProvider.getString(R.string.woopos_scanning_setup_success_message))
+            .thenReturn("Success message")
+        whenever(resourceProvider.getString(R.string.woopos_scanning_setup_info_title))
+            .thenReturn("Info")
+        whenever(resourceProvider.getString(R.string.woopos_scanning_setup_info_message))
+            .thenReturn("Info message")
+        whenever(resourceProvider.getString(R.string.woopos_scanning_setup_info_bullet_1))
+            .thenReturn("Bullet 1")
+        whenever(resourceProvider.getString(R.string.woopos_scanning_setup_info_bullet_2))
+            .thenReturn("Bullet 2")
+        whenever(resourceProvider.getString(R.string.woopos_scanning_setup_info_bullet_3))
+            .thenReturn("Bullet 3")
+        whenever(resourceProvider.getString(R.string.woopos_scanning_setup_info_text))
+            .thenReturn("Info text")
+        whenever(resourceProvider.getString(R.string.woopos_scanning_setup_button_next))
+            .thenReturn("Next")
+        whenever(resourceProvider.getString(R.string.woopos_scanning_setup_button_back))
+            .thenReturn("Back")
+        whenever(resourceProvider.getString(R.string.woopos_scanning_setup_button_done))
+            .thenReturn("Done")
+        whenever(resourceProvider.getString(R.string.woopos_scanning_setup_go_to_settings))
+            .thenReturn("Go to settings")
+        whenever(resourceProvider.getString(R.string.woopos_scanning_setup_more_information))
+            .thenReturn("More information")
+        whenever(resourceProvider.getString(R.string.woopos_scanning_setup_device_tera_1200))
+            .thenReturn("TERA 1200")
+        whenever(resourceProvider.getString(R.string.woopos_scanning_setup_device_star_bsh_20b))
+            .thenReturn("STAR BSH 20B")
+        whenever(resourceProvider.getString(R.string.woopos_scanning_setup_device_inateck_bluetooth))
+            .thenReturn("INATECK Bluetooth")
+        whenever(resourceProvider.getString(R.string.woopos_scanning_setup_device_other))
+            .thenReturn("Other")
+    }
+}


### PR DESCRIPTION
WOOMOB-842

### Description

This PR adds navigation to the Scanning info state instead of scanning info dialog when "other" device is selected

The main changes include:

- Removed barcode info dialog handling from the setup flow and instead navigate directly to the Scanner setup info step when "Other" device is selected
- Refactored navigation to use a state-based approach with previousStep tracking for proper back navigation
- Updated the success step to use primary button instead of secondary button for "More Information" action
- Moved the sealed class for scanning setup UI events to a separate file for better organization
- Added some unit tests of the VM

### Testing information
1. Open POS
2. Select "Other" device - verify it goes directly to Scanner setup info step instead of showing barcode dialog
3. Test back navigation throughout the flow - verify each step goes back to the correct previous step
4. Test the complete flow with different device selections to ensure proper navigation

### The tests that have been performed
Above


https://github.com/user-attachments/assets/7fa551f6-4c5b-4964-9097-1e8d099c43d1

