### PR TITLE
[Shipping labels] Add missing tracks

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/WooShippingLabelCreationViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/WooShippingLabelCreationViewModel.kt
@@ -596,7 +596,9 @@ class WooShippingLabelCreationViewModel @Inject constructor(
                     trackShippingRatesLoading(isSuccess = true)
                 } else {
                     updateState(ShippingRatesState.Error)
-                    trackShippingRatesLoading(isSuccess = false, error = shippingRatesResult.exceptionOrNull()?.message)
+                    val error = shippingRatesResult.exceptionOrNull()?.message
+                        ?: if (shippingRatesResult.getOrNull()?.isEmpty() == true) "no_rates_available" else null
+                    trackShippingRatesLoading(isSuccess = false, error = error)
                 }
                 selectedRatesFlow.value = selectedRatesFlow.value.toMutableList().apply { set(index, null) }
             }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/WooShippingLabelCreationViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/WooShippingLabelCreationViewModel.kt
@@ -579,7 +579,7 @@ class WooShippingLabelCreationViewModel @Inject constructor(
             else -> {
                 val sortOrder = selectedRatesSortOrdersFlow.value[index]
                 updateState(ShippingRatesState.Loading(sortOrder))
-                val shippingRatesResult = getShippingRates(
+                getShippingRates(
                     shippingRatesInfo.orderId,
                     shippingRatesInfo.packageSelected,
                     shippingRatesInfo.shipTo,
@@ -588,18 +588,18 @@ class WooShippingLabelCreationViewModel @Inject constructor(
                     shippingRatesInfo.currencyCode,
                     shippingRatesInfo.customsData,
                     shippingRatesInfo.hazmatSelection
-                )
-                if (shippingRatesResult.isSuccess && shippingRatesResult.getOrThrow().isNotEmpty()) {
-                    shippingRatesListFlow.value = shippingRatesListFlow.value.toMutableList().apply {
-                        set(index, shippingRatesResult.getOrThrow())
+                ).fold(
+                    onSuccess = { result ->
+                        shippingRatesListFlow.value = shippingRatesListFlow.value.toMutableList().apply {
+                            set(index, result)
+                        }
+                        trackShippingRatesLoading(isSuccess = true)
+                    },
+                    onFailure = { exception ->
+                        updateState(ShippingRatesState.Error)
+                        trackShippingRatesLoading(isSuccess = false, error = exception.message)
                     }
-                    trackShippingRatesLoading(isSuccess = true)
-                } else {
-                    updateState(ShippingRatesState.Error)
-                    val error = shippingRatesResult.exceptionOrNull()?.message
-                        ?: if (shippingRatesResult.getOrNull()?.isEmpty() == true) "no_rates_available" else null
-                    trackShippingRatesLoading(isSuccess = false, error = error)
-                }
+                )
                 selectedRatesFlow.value = selectedRatesFlow.value.toMutableList().apply { set(index, null) }
             }
         }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/packages/WooShippingLabelPackageCreationViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/packages/WooShippingLabelPackageCreationViewModel.kt
@@ -264,10 +264,15 @@ class WooShippingLabelPackageCreationViewModel @Inject constructor(
                         triggerEvent(
                             PackageSelected(customPackage.toPackageData(dimensionUnit = storeOptions.dimensionUnit))
                         )
+                        tracker.track(AnalyticsEvent.WCS_PACKAGE_SELECTION_STEP, mapOf(KEY_STATE to "saving_success"))
                     },
                     onFailure = {
                         triggerEvent(ShowLoadingDialog(false))
                         triggerEvent(ShowTemplateCreationErrorDialog)
+                        tracker.track(
+                            AnalyticsEvent.WCS_PACKAGE_SELECTION_STEP,
+                            mapOf(KEY_STATE to "saving_failed", KEY_ERROR to it.message.orEmpty())
+                        )
                     }
                 ) ?: triggerEvent(
                 PackageSelected(
@@ -297,7 +302,7 @@ class WooShippingLabelPackageCreationViewModel @Inject constructor(
             ?.model?.firstOrNull()
             ?.let { PackageData.fromPackageDAO(it) }
             ?.let { Result.success(it) }
-            ?: Result.failure(Throwable("Failed to save package"))
+            ?: Result.failure(Throwable(response.error.type.toString()))
     }
 
     fun onCarrierPackageStarred(packageData: PackageData, isStarred: Boolean) {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/packages/WooShippingLabelPackageCreationViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/packages/WooShippingLabelPackageCreationViewModel.kt
@@ -329,7 +329,10 @@ class WooShippingLabelPackageCreationViewModel @Inject constructor(
                     updateSavedPackageUI(packageData = packageData, saved = !isStarred)
                     tracker.track(
                         AnalyticsEvent.WCS_PACKAGE_SELECTION_STEP,
-                        mapOf(KEY_STATE to "saving_failed", KEY_ERROR to it.exceptionOrNull()?.message.orEmpty())
+                        mapOf(
+                            KEY_STATE to if (isStarred) "saving_failed" else "removing_failed",
+                            KEY_ERROR to it.exceptionOrNull()?.message.orEmpty()
+                        )
                     )
                 }
             }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/packages/WooShippingLabelPackageCreationViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/packages/WooShippingLabelPackageCreationViewModel.kt
@@ -5,6 +5,7 @@ import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.asLiveData
 import androidx.lifecycle.viewModelScope
 import com.woocommerce.android.R
+import com.woocommerce.android.WooException
 import com.woocommerce.android.analytics.AnalyticsEvent
 import com.woocommerce.android.analytics.AnalyticsTracker.Companion.KEY_ERROR
 import com.woocommerce.android.analytics.AnalyticsTracker.Companion.KEY_STATE
@@ -131,7 +132,10 @@ class WooShippingLabelPackageCreationViewModel @Inject constructor(
                     updateSavedPackageUI(packageData = removedPackage, saved = true)
                     tracker.track(
                         AnalyticsEvent.WCS_PACKAGE_SELECTION_STEP,
-                        mapOf(KEY_STATE to "removing_failed", KEY_ERROR to it.exceptionOrNull()?.message.orEmpty())
+                        mapOf(
+                            KEY_STATE to "removing_failed",
+                            KEY_ERROR to (it.exceptionOrNull() as? WooException)?.error?.type?.name.orEmpty()
+                        )
                     )
                 }
             }
@@ -336,7 +340,7 @@ class WooShippingLabelPackageCreationViewModel @Inject constructor(
                         AnalyticsEvent.WCS_PACKAGE_SELECTION_STEP,
                         mapOf(
                             KEY_STATE to if (isStarred) "saving_failed" else "removing_failed",
-                            KEY_ERROR to it.exceptionOrNull()?.message.orEmpty()
+                            KEY_ERROR to (it.exceptionOrNull() as? WooException)?.error?.type?.name.orEmpty()
                         )
                     )
                 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/rates/domain/GetShippingRates.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/rates/domain/GetShippingRates.kt
@@ -15,7 +15,7 @@ class GetShippingRates @Inject constructor(
     private val shippingMapper: WooShippingRatesDomainMapper
 ) {
 
-    @Suppress("LongParameterList")
+    @Suppress("LongParameterList", "TooGenericExceptionCaught")
     suspend operator fun invoke(
         orderId: Long,
         selectedPackage: PackageData,
@@ -25,21 +25,29 @@ class GetShippingRates @Inject constructor(
         currencyCode: String?,
         customsData: CustomsData?,
         hazmatSelection: ShippingLabelHazmatCategory? = null
-    ): Result<Map<CarrierUI, List<ShippingRateUI>>> {
-        val result = repository.getShippingRates(
-            orderId = orderId,
-            selectedPackage = selectedPackage,
-            shipTo = shipTo,
-            shipFrom = shipFrom,
-            weight = weight,
-            customsData = customsData,
-            hazmatSelection = hazmatSelection
-        )
-        return if (result.isSuccess) {
-            val rates = shippingMapper(result.getOrThrow(), currencyCode)
-            Result.success(rates)
-        } else {
-            Result.failure(result.exceptionOrNull() ?: Exception("Failed to get shipping rates"))
+    ): Result<Map<CarrierUI, List<ShippingRateUI>>> = repository.getShippingRates(
+        orderId = orderId,
+        selectedPackage = selectedPackage,
+        shipTo = shipTo,
+        shipFrom = shipFrom,
+        weight = weight,
+        customsData = customsData,
+        hazmatSelection = hazmatSelection
+    ).fold(
+        onSuccess = { ratesResponse ->
+            if (ratesResponse.isEmpty()) {
+                Result.failure(Exception("no_rates_available"))
+            } else {
+                try {
+                    val mappedRates = shippingMapper(ratesResponse, currencyCode)
+                    Result.success(mappedRates)
+                } catch (e: Exception) {
+                    Result.failure(Exception("Failed to map shipping rates", e))
+                }
+            }
+        },
+        onFailure = { exception ->
+            Result.failure(exception)
         }
-    }
+    )
 }

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/packages/WooShippingLabelPackageCreationViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/packages/WooShippingLabelPackageCreationViewModelTest.kt
@@ -14,6 +14,7 @@ import com.woocommerce.android.ui.orders.wooshippinglabels.packages.WooShippingL
 import com.woocommerce.android.ui.orders.wooshippinglabels.packages.WooShippingLabelPackageCreationViewModel.ShowPackageTypeDialog
 import com.woocommerce.android.ui.orders.wooshippinglabels.packages.WooShippingLabelPackageCreationViewModel.ViewState
 import com.woocommerce.android.ui.orders.wooshippinglabels.packages.datasource.FetchPackagesFromStore
+import com.woocommerce.android.ui.orders.wooshippinglabels.packages.datasource.PackageDAO
 import com.woocommerce.android.ui.orders.wooshippinglabels.packages.datasource.WooShippingLabelPackageRepository
 import com.woocommerce.android.ui.orders.wooshippinglabels.packages.ui.Carrier
 import com.woocommerce.android.ui.orders.wooshippinglabels.packages.ui.Carrier.DHL
@@ -37,6 +38,10 @@ import org.mockito.kotlin.times
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
 import org.wordpress.android.fluxc.model.SiteModel
+import org.wordpress.android.fluxc.network.BaseRequest
+import org.wordpress.android.fluxc.network.rest.wpcom.wc.WooError
+import org.wordpress.android.fluxc.network.rest.wpcom.wc.WooErrorType
+import org.wordpress.android.fluxc.network.rest.wpcom.wc.WooResult
 
 @OptIn(ExperimentalCoroutinesApi::class)
 class WooShippingLabelPackageCreationViewModelTest : BaseUnitTest() {
@@ -152,6 +157,45 @@ class WooShippingLabelPackageCreationViewModelTest : BaseUnitTest() {
 
         verify(packageRepository, times(1)).createCustomPackage(any(), any())
     }
+
+    @Test
+    fun `when saveAsTemplate is true and saving succeed, track WCS_PACKAGE_SELECTION_STEP event with saving_success`() =
+        testBlocking {
+            whenever(packageRepository.createCustomPackage(any(), any())).thenReturn(
+                WooResult(
+                    listOf(
+                        PackageDAO(
+                            id = "1",
+                            name = "Saved Package 1",
+                            dimensions = "dimensions",
+                            weight = "weight",
+                            isLetter = false,
+                            dimensionUnit = "cm",
+                            weightUnit = "kg",
+                            saved = true
+                        )
+                    )
+                )
+            )
+
+            sut.onAddCustomPackageClick(savePackageAsTemplate = true)
+
+            verify(tracker).track(AnalyticsEvent.WCS_PACKAGE_SELECTION_STEP, mapOf(KEY_STATE to "saving_success"))
+        }
+
+    @Test
+    fun `when saveAsTemplate is true and saving fails, track WCS_PACKAGE_SELECTION_STEP event with saving_failed`() =
+        testBlocking {
+            val error = WooError(WooErrorType.API_ERROR, BaseRequest.GenericErrorType.NETWORK_ERROR)
+            whenever(packageRepository.createCustomPackage(any(), any())).thenReturn(WooResult(error))
+
+            sut.onAddCustomPackageClick(savePackageAsTemplate = true)
+
+            verify(tracker).track(
+                AnalyticsEvent.WCS_PACKAGE_SELECTION_STEP,
+                mapOf(KEY_STATE to "saving_failed", KEY_ERROR to error.type.toString())
+            )
+        }
 
     @Test
     fun `onAddPackageClick skips createCustomPackage when saveAsTemplate is false`() = testBlocking {

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/packages/WooShippingLabelPackageCreationViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/packages/WooShippingLabelPackageCreationViewModelTest.kt
@@ -2,6 +2,7 @@ package com.woocommerce.android.ui.orders.wooshippinglabels.packages
 
 import androidx.lifecycle.SavedStateHandle
 import com.woocommerce.android.R
+import com.woocommerce.android.WooException
 import com.woocommerce.android.analytics.AnalyticsEvent
 import com.woocommerce.android.analytics.AnalyticsTracker.Companion.KEY_ERROR
 import com.woocommerce.android.analytics.AnalyticsTracker.Companion.KEY_STATE
@@ -39,6 +40,7 @@ import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
 import org.wordpress.android.fluxc.model.SiteModel
 import org.wordpress.android.fluxc.network.BaseRequest
+import org.wordpress.android.fluxc.network.BaseRequest.GenericErrorType
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.WooError
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.WooErrorType
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.WooResult
@@ -648,8 +650,9 @@ class WooShippingLabelPackageCreationViewModelTest : BaseUnitTest() {
                 savedPackages = initialSavedPackages
             )
         )
-        val error = "test_error"
-        whenever(updateSavedCarrierPackages(any(), any(), any(), any())).thenReturn(Result.failure(Exception(error)))
+        val wooError = WooError(type = WooErrorType.API_ERROR, original = GenericErrorType.UNKNOWN)
+        val wooException = WooException(wooError)
+        whenever(updateSavedCarrierPackages(any(), any(), any(), any())).thenReturn(Result.failure(wooException))
 
         sut = WooShippingLabelPackageCreationViewModel(
             SavedStateHandle(),
@@ -667,7 +670,7 @@ class WooShippingLabelPackageCreationViewModelTest : BaseUnitTest() {
         advanceUntilIdle()
 
         // Verify WCS_PACKAGE_SELECTION_STEP event is tracked with "removing_failed" property
-        val expectedProperty = mapOf(KEY_STATE to "removing_failed", KEY_ERROR to error)
+        val expectedProperty = mapOf(KEY_STATE to "removing_failed", KEY_ERROR to WooErrorType.API_ERROR.name)
         verify(tracker).track(AnalyticsEvent.WCS_PACKAGE_SELECTION_STEP, expectedProperty)
     }
 

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/packages/WooShippingLabelPackageCreationViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/packages/WooShippingLabelPackageCreationViewModelTest.kt
@@ -3,6 +3,7 @@ package com.woocommerce.android.ui.orders.wooshippinglabels.packages
 import androidx.lifecycle.SavedStateHandle
 import com.woocommerce.android.R
 import com.woocommerce.android.analytics.AnalyticsEvent
+import com.woocommerce.android.analytics.AnalyticsTracker.Companion.KEY_ERROR
 import com.woocommerce.android.analytics.AnalyticsTracker.Companion.KEY_STATE
 import com.woocommerce.android.analytics.AnalyticsTracker.Companion.VALUE_STARTED
 import com.woocommerce.android.analytics.AnalyticsTrackerWrapper
@@ -577,6 +578,53 @@ class WooShippingLabelPackageCreationViewModelTest : BaseUnitTest() {
         // Verify it's removed from saved packages
         val savedPackages = lastViewState?.packagesData?.savedPackages
         assertThat(savedPackages).isEmpty()
+    }
+
+    @Test
+    fun `when unstarring a package fails, then track event with removing_failed property`() = testBlocking {
+        val carrier: Carrier = USPS
+        val packageToUnstar = PackageData(
+            id = "1",
+            name = "Package 1 - Carrier 1",
+            dimensions = "10 x 10 x 10",
+            weight = "10",
+            isSelected = false,
+            isLetter = false,
+            isStarred = true // Initially starred
+        )
+        val initialCarrierPackages = mapOf(
+            carrier to listOf(CarrierPackageGroup(groupName = "Group A", packages = listOf(packageToUnstar)))
+        )
+        val initialSavedPackages = listOf(packageToUnstar)
+
+        whenever(fetchPackages()).thenReturn(
+            Data(
+                storeOptions = StoreOptionsForPackages.DEFAULT,
+                carrierPackages = initialCarrierPackages,
+                savedPackages = initialSavedPackages
+            )
+        )
+        val error = "test_error"
+        whenever(updateSavedCarrierPackages(any(), any(), any(), any())).thenReturn(Result.failure(Exception(error)))
+
+        sut = WooShippingLabelPackageCreationViewModel(
+            SavedStateHandle(),
+            selectedSite,
+            resourceProvider,
+            fetchPackages,
+            updateSavedCarrierPackages,
+            packageRepository,
+            tracker
+        )
+        advanceUntilIdle()
+
+        // Unstar a package
+        sut.onCarrierPackageStarred(packageToUnstar, false)
+        advanceUntilIdle()
+
+        // Verify WCS_PACKAGE_SELECTION_STEP event is tracked with "removing_failed" property
+        val expectedProperty = mapOf(KEY_STATE to "removing_failed", KEY_ERROR to error)
+        verify(tracker).track(AnalyticsEvent.WCS_PACKAGE_SELECTION_STEP, expectedProperty)
     }
 
     @Test

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/packages/WooShippingLabelPackageCreationViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/packages/WooShippingLabelPackageCreationViewModelTest.kt
@@ -256,7 +256,7 @@ class WooShippingLabelPackageCreationViewModelTest : BaseUnitTest() {
             fetchPackages,
             updateSavedCarrierPackages,
             packageRepository,
-            mock()
+            tracker
         )
         sut.viewState.observeForever { lastViewState = it }
         sut.onSavedPackageSelected(package1, true)
@@ -310,7 +310,7 @@ class WooShippingLabelPackageCreationViewModelTest : BaseUnitTest() {
             fetchPackages,
             updateSavedCarrierPackages,
             packageRepository,
-            mock()
+            tracker
         )
         sut.viewState.observeForever { lastViewState = it }
         sut.onCarrierPackageSelected(package1, true)
@@ -395,7 +395,7 @@ class WooShippingLabelPackageCreationViewModelTest : BaseUnitTest() {
             fetchPackages,
             updateSavedCarrierPackages,
             packageRepository,
-            mock()
+            tracker
         )
 
         sut.viewState.observeForever { lastViewState = it }
@@ -452,7 +452,7 @@ class WooShippingLabelPackageCreationViewModelTest : BaseUnitTest() {
                 fetchPackages,
                 updateSavedCarrierPackages,
                 packageRepository,
-                mock()
+                tracker
             )
             advanceUntilIdle()
 
@@ -514,7 +514,7 @@ class WooShippingLabelPackageCreationViewModelTest : BaseUnitTest() {
             fetchPackages,
             updateSavedCarrierPackages,
             packageRepository,
-            mock()
+            tracker
         )
         advanceUntilIdle()
 
@@ -563,7 +563,7 @@ class WooShippingLabelPackageCreationViewModelTest : BaseUnitTest() {
             fetchPackages,
             updateSavedCarrierPackages,
             packageRepository,
-            mock()
+            tracker
         )
         advanceUntilIdle()
 
@@ -611,7 +611,7 @@ class WooShippingLabelPackageCreationViewModelTest : BaseUnitTest() {
             fetchPackages,
             updateSavedCarrierPackages,
             packageRepository,
-            mock()
+            tracker
         )
         advanceUntilIdle()
 

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/rates/domain/GetShippingRatesTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/rates/domain/GetShippingRatesTest.kt
@@ -113,4 +113,22 @@ class GetShippingRatesTest : BaseUnitTest() {
         assertTrue(result.isFailure)
         verify(mapper, never()).invoke(any(), any())
     }
+
+    @Test
+    fun `when shipping rates request returns empty list, then result is a failure`() = testBlocking {
+        whenever(repository.getShippingRates(any(), any(), any(), any(), any(), any(), isNull()))
+            .doReturn(Result.success(emptyList()))
+
+        val result = sut.invoke(
+            orderId = 3L,
+            selectedPackage = defaultSelectedPackage,
+            shipTo = Address.EMPTY,
+            shipFrom = OriginShippingAddress.EMPTY,
+            weight = 15f,
+            currencyCode = "USD",
+            customsData = defaultCustomData
+        )
+
+        assertTrue(result.isFailure)
+    }
 }


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

<!-- Id number of the Linear issue this PR addresses, e.g., WOOMOB-373. -->
Closes WOOMOB-684

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
This PR adds missing events for shipping labels and improves error tracking. The changes in this PR are based on feedback from #14306.

### Steps to reproduce
<!-- Step-by-step testing instructions. For new user flows, consider instead stating the goal of the workflow and see if your PR reviewer can accomplish the workflow without specific steps! -->
#### wcs_package_selection_step
1. Open create shipping label screen.
2. Tap "Select a package"
3. Fill "Length", "Width" and "Height" fields.
4. Check "Save this as a new package template".
5. Fill "Weight", and "Package Name" fields.
6. Tap Add Package button.
7. `🔵 Tracked: woocommerceandroid_wcs_package_selection_step, Properties {"state":"saving_success"`
8. For error, follow steps in https://github.com/woocommerce/woocommerce-android/pull/14295.
9. Repeat steps 1-7.
10. `🔵 Tracked: woocommerceandroid_wcs_package_selection_step, Properties: {"state":"saving_failed","error":"API_ERROR"`
11. Go to Carrier tab.
12. Unstar a package.
13. `🔵 Tracked: woocommerceandroid_wcs_package_selection_step, Properties: {"state":"removing_failed"`
14. Go to Saved tab.
15. Remove a package.
16. `🔵 Tracked: woocommerceandroid_wcs_package_selection_step, Properties: {"state":"removing_failed"`

#### wcs_rate_selection_step
1. Open create shipping label screen.
2. Select a package.
3. Type 9999999999 weight.
4. `🔵 Tracked: woocommerceandroid_wcs_rate_selection_step, Properties: {"state":"loading_failed","error":"no_rates_available"`

### The tests that have been performed
<!-- To give the reviewer an idea of what could be missed in terms of testing -->
Steps above

### Images/gif
<!-- Include before and after images or gifs when appropriate. -->

- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->