### PR TITLE
[POS Orders] Add POS badge to `Most recent orders` section in My store

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -6,6 +6,7 @@
 - [*] Fixed infinite loading animation in Order details pane when order list is empty [https://github.com/woocommerce/woocommerce-android/pull/14316]
 - [*] Fixed rare crash on the Payment Selection screen. [https://github.com/woocommerce/woocommerce-android/pull/14318]
 - [**] Added option to filter orders by Point of Sale sales channel in Orders screen [https://github.com/woocommerce/woocommerce-android/pull/14286]
+- [*] Added POS badge to Most recent orders section in the My store dashboard [https://github.com/woocommerce/woocommerce-android/pull/14328]
 
 22.8
 -----

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/orders/DashboardOrdersCard.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/orders/DashboardOrdersCard.kt
@@ -5,6 +5,7 @@ import androidx.compose.foundation.clickable
 import androidx.compose.foundation.focusable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
@@ -270,7 +271,7 @@ private fun OrderListItem(order: OrderItem, onOrderClicked: (OrderItem) -> Unit)
             .clickable(onClick = { onOrderClicked(order) })
             .padding(16.dp)
     ) {
-        val (number, date, name, status, total) = createRefs()
+        val (number, date, name, statusRow, total) = createRefs()
 
         Text(
             text = order.number,
@@ -305,17 +306,30 @@ private fun OrderListItem(order: OrderItem, onOrderClicked: (OrderItem) -> Unit)
                 }
         )
 
-        WCTag(
+        Row(
             modifier = Modifier
-                .constrainAs(status) {
+                .constrainAs(statusRow) {
                     top.linkTo(parent.top)
                     end.linkTo(parent.end)
                 },
-            text = order.status,
-            textColor = colorResource(id = R.color.color_on_secondary),
-            backgroundColor = colorResource(id = order.statusColor),
-            fontWeight = FontWeight.Normal
-        )
+            horizontalArrangement = Arrangement.spacedBy(8.dp)
+        ) {
+            WCTag(
+                text = order.status,
+                textColor = colorResource(id = R.color.color_on_secondary),
+                backgroundColor = colorResource(id = order.statusColor),
+                fontWeight = FontWeight.Normal
+            )
+
+            if (order.isPosOrder) {
+                WCTag(
+                    text = stringResource(id = R.string.pos_badge),
+                    textColor = colorResource(id = R.color.tag_text_pos),
+                    backgroundColor = colorResource(id = R.color.tag_bg_pos),
+                    fontWeight = FontWeight.Normal
+                )
+            }
+        }
 
         Text(
             text = order.totalPrice,
@@ -323,7 +337,7 @@ private fun OrderListItem(order: OrderItem, onOrderClicked: (OrderItem) -> Unit)
             modifier = Modifier
                 .padding(top = 8.dp)
                 .constrainAs(total) {
-                    top.linkTo(status.bottom)
+                    top.linkTo(statusRow.bottom)
                     end.linkTo(parent.end)
                 }
         )
@@ -375,7 +389,8 @@ fun PreviewTopOrders() {
                 customerName = "John Doe",
                 status = "Processing",
                 statusColor = R.color.tag_bg_processing,
-                totalPrice = "$100.00"
+                totalPrice = "$100.00",
+                isPosOrder = true
             ),
             OrderItem(
                 id = 0L,
@@ -384,7 +399,8 @@ fun PreviewTopOrders() {
                 customerName = "Jane Doe",
                 status = "Completed",
                 statusColor = R.color.tag_bg_completed,
-                totalPrice = "$200.00"
+                totalPrice = "$200.00",
+                isPosOrder = false
             )
         ),
         selectedFilter = OrderStatusOption(

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/orders/DashboardOrdersViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/orders/DashboardOrdersViewModel.kt
@@ -128,7 +128,8 @@ class DashboardOrdersViewModel @AssistedInject constructor(
                                     },
                                     status = status,
                                     statusColor = order.status.color,
-                                    totalPrice = currencyFormatter.formatCurrency(order.total, order.currency)
+                                    totalPrice = currencyFormatter.formatCurrency(order.total, order.currency),
+                                    isPosOrder = order.salesChannel == Order.SalesChannel.POS
                                 )
                             },
                             filterOptions = statusOptions,
@@ -214,7 +215,8 @@ class DashboardOrdersViewModel @AssistedInject constructor(
             val customerName: String,
             val status: String,
             @ColorRes val statusColor: Int,
-            val totalPrice: String
+            val totalPrice: String,
+            val isPosOrder: Boolean = false
         )
     }
 


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->
## Add POS badge to `Most recent orders` section in My store

WOOMOB-866 
<!-- Id number of the Linear issue this PR addresses, e.g., WOOMOB-373. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
This PR adds POS badge to `Most recent orders` section in My store. This change is supposed to match the POS badge being displayed in Orders and Order details for orders made in POS.

### Steps to reproduce
<!-- Step-by-step testing instructions. For new user flows, consider instead stating the goal of the workflow and see if your PR reviewer can accomplish the workflow without specific steps! -->
N/A

### Testing information
<!-- This is your opportunity to break out individual scenarios that need testing (when necessary) and/or include a checklist for the reviewer to go through. Consider documenting the following from your own completed testing: devices used, alternate workflows, edge cases, affected areas, critical flows, areas not tested, and any remaining unknowns. Provide feedback on this new section of the PR template through Sept 30, 2024 to Apps Quality; additional context here: https://woomobilep2.wordpress.com/2024/05/06/woocommerce-mobile-quality-report-march-april/#comment-12036 -->
1. Go to My store and display "Most recent orders" section (you may need to add it to the dashboard)
2. Verify that orders created in POS have the POS badge visible next to the orders status

### The tests that have been performed
<!-- To give the reviewer an idea of what could be missed in terms of testing -->

### Images/gif
<!-- Include before and after images or gifs when appropriate. -->
<img width="2304" height="1440" alt="image" src="https://github.com/user-attachments/assets/4a2ad3bc-42df-426f-bd73-33885dbce52d" />

- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
