### PR TITLE
[AINFRA-435] Test Setup to Validate Android AMI (`android`)

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -9,7 +9,7 @@ common_params:
       format: "junit"
 
 agents:
-  queue: "android"
+  queue: "android-staging"
 
 steps:
   - label: Gradle Wrapper Validation

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -27,7 +27,6 @@ steps:
       - label: "☢️ Danger - PR Check"
         command: danger
         key: danger
-        if: "build.pull_request.id != null"
         retry:
           manual:
             permit_on_passed: true
@@ -52,14 +51,12 @@ steps:
 
       - label: "Dependency Tree Diff"
         command: comment_with_dependency_diff 'woocommerce' 'vanillaReleaseRuntimeClasspath'
-        if: build.pull_request.id != null
         plugins: [$CI_TOOLKIT]
         artifact_paths:
           - "**/build/reports/diff/*"
 
       - label: "Merged Manifest Diff"
         command: ".buildkite/commands/diff-merged-manifest.sh vanillaRelease"
-        if: build.pull_request.id != null
         plugins: [$CI_TOOLKIT]
         artifact_paths:
           - "**/build/reports/diff_manifest/**/**/*"
@@ -70,12 +67,10 @@ steps:
 
       - label: "🛠 Prototype Build: Mobile App"
         command: ".buildkite/commands/prototype-build.sh WooCommerce"
-        if: build.pull_request.id != null
         plugins: [$CI_TOOLKIT]
 
       - label: "🛠 Prototype Build: Wear App"
         command: ".buildkite/commands/prototype-build.sh WooCommerce-Wear"
-        if: build.pull_request.id != null
         plugins: [$CI_TOOLKIT]
 
   ########################################

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -20,6 +20,28 @@ steps:
   # Wait for Gradle Wrapper to be validated before running any other jobs
   - wait
 
+  - label: Print some debug values (staging AMI)
+    command: &debug_cmds |
+      echo "--- jenv info"
+      jenv versions
+      jenv version
+      echo "--- java version"
+      java -version
+      echo "--- env"
+      env
+      echo "--- SDK dir listing"
+      echo "~~~ ANDROID_SDK_ROOT: $${ANDROID_SDK_ROOT}"
+      ls -laF $${ANDROID_SDK_ROOT}
+      echo "~~~ cmdline-tools"
+      ls -laF $${ANDROID_SDK_ROOT}/cmdline-tools
+      echo "--- sdkmanager installed packages"
+      sdkmanager --list_installed
+
+  - label: Print some debug values (official AMI)
+    agents:
+      queue: "android"
+    command: *debug_cmds
+
   ########################################
   - group: "🕵️ Linters"
     steps:


### PR DESCRIPTION
Related: #14241

> [!IMPORTANT]
> DO NOT MERGE — This PR is used to test CI scenarios only

This is a draft PR that I will use to (primary) run the new Android AMI on the `android-staging` (based on `android`), which is part of [this](https://linear.app/a8c/project/provision-new-bare-metal-ci-agents-981ef3d39744) project.

FYI: Currently this will be used to test [AINFRA-435](https://linear.app/a8c/issue/AINFRA-435) but as the project progress I'm expecting I'll continue to use this dummy PR and branch to test more parts/steps/issues of the project (in the context of Android, mostly making sure that the Android AMI still works as expected).