### PR TITLE
[WOOMOB-852][Woo POS][Barcodes] Disable barcode listener on cart when set up flow is visible

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/WooPosHomeScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/WooPosHomeScreen.kt
@@ -136,7 +136,8 @@ private fun WooPosHomeScreen(
                 onBarcodeEvent = { result ->
                     onHomeUIEvent(WooPosHomeUIEvent.OnBarcodeEvent(result))
                 },
-                enabled = state.screenPositionState is WooPosHomeState.ScreenPositionState.Cart
+                enabled = state.screenPositionState is WooPosHomeState.ScreenPositionState.Cart &&
+                    state.dialogState !is WooPosHomeState.DialogState.ScanningSetupDialog
             )
     ) {
         Row(

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/scanningsetup/WooPosScanningSetupDialog.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/scanningsetup/WooPosScanningSetupDialog.kt
@@ -39,6 +39,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -71,6 +72,7 @@ import com.woocommerce.android.ui.woopos.common.composeui.designsystem.toAdaptiv
 import com.woocommerce.android.ui.woopos.home.scanningsetup.WooPosScanningSetupState.BarcodeReaderDevice
 import com.woocommerce.android.ui.woopos.home.scanningsetup.WooPosScanningSetupState.ScanningSetupStep
 import com.woocommerce.android.util.WooLog
+import kotlinx.coroutines.delay
 
 @Composable
 fun WooPosScanningSetupDialog(
@@ -80,8 +82,20 @@ fun WooPosScanningSetupDialog(
     val viewModel = hiltViewModel<WooPosScanningSetupViewModel>()
     val context = LocalContext.current
 
-    LaunchedEffect(isVisible) {
-        viewModel.resetToInitialState()
+    val isClosing = remember { mutableStateOf(false) }
+
+    LaunchedEffect(isClosing.value) {
+        if (isClosing.value) {
+            // Delay to allow the dialog to close before resetting state
+            delay(300)
+            viewModel.resetToInitialState()
+            isClosing.value = false
+        }
+    }
+
+    val onDismissRequestWrapper: () -> Unit = {
+        onDismissRequest()
+        isClosing.value = true
     }
 
     LaunchedEffect(Unit) {
@@ -97,13 +111,13 @@ fun WooPosScanningSetupDialog(
     }
     LaunchedEffect(Unit) {
         viewModel.dismissDialogEvent.collect {
-            onDismissRequest()
+            onDismissRequestWrapper()
         }
     }
 
     WooPosDialogWrapper(
         isVisible = isVisible,
-        onDismissRequest = onDismissRequest,
+        onDismissRequest = onDismissRequestWrapper,
         dialogBackgroundContentDescription = stringResource(
             id = R.string.woopos_scanning_setup_dialog_content_description
         )
@@ -117,7 +131,7 @@ fun WooPosScanningSetupDialog(
             Row {
                 Spacer(modifier = Modifier.weight(1f))
                 IconButton(
-                    onClick = onDismissRequest,
+                    onClick = onDismissRequestWrapper,
                     modifier = Modifier
                 ) {
                     Icon(

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/scanningsetup/WooPosScanningSetupState.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/scanningsetup/WooPosScanningSetupState.kt
@@ -8,7 +8,6 @@ import kotlinx.parcelize.Parcelize
 
 @Parcelize
 data class WooPosScanningSetupState(
-    val isVisible: Boolean = false,
     val currentStep: ScanningSetupStep,
     val selectedDevice: BarcodeReaderDevice? = null
 ) : Parcelable {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/scanningsetup/WooPosScanningSetupViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/scanningsetup/WooPosScanningSetupViewModel.kt
@@ -24,7 +24,6 @@ class WooPosScanningSetupViewModel @Inject constructor(
 
     private val _state = MutableStateFlow(
         WooPosScanningSetupState(
-            isVisible = false,
             currentStep = createDeviceSelectionStep(),
             selectedDevice = null
         )


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

<!-- Id number of the Linear issue this PR addresses, e.g., WOOMOB-373. -->

WOOMOB-852

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
* Disables barcode listener in the cart when set up flow is visible
* Fixes the issue when on configuration change the flow was reseted to the beginning

### Steps to reproduce
<!-- Step-by-step testing instructions. For new user flows, consider instead stating the goal of the workflow and see if your PR reviewer can accomplish the workflow without specific steps! -->
* Scan a barcode when scanning set up flow is visible
* Change dark/light mode when scanning set up flow is visible

### Testing information
<!-- This is your opportunity to break out individual scenarios that need testing (when necessary) and/or include a checklist for the reviewer to go through. Consider documenting the following from your own completed testing: devices used, alternate workflows, edge cases, affected areas, critical flows, areas not tested, and any remaining unknowns. Provide feedback on this new section of the PR template through Sept 30, 2024 to Apps Quality; additional context here: p91TBi-b8z-p2#comment-12036 -->
Check both cases from the steps to reproduce

### Images/gif
<!-- Include before and after images or gifs when appropriate. -->

https://github.com/user-attachments/assets/68821522-b09a-487f-a8b5-2d166683a0e0


- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->