### PR TITLE
Fix crash when tax classes are duplicated

### DIFF
--- a/libs/fluxc-plugin/src/main/kotlin/org/wordpress/android/fluxc/persistence/dao/TaxClassDao.kt
+++ b/libs/fluxc-plugin/src/main/kotlin/org/wordpress/android/fluxc/persistence/dao/TaxClassDao.kt
@@ -2,6 +2,7 @@ package org.wordpress.android.fluxc.persistence.dao
 
 import androidx.room.Dao
 import androidx.room.Insert
+import androidx.room.OnConflictStrategy
 import androidx.room.Query
 import androidx.room.Transaction
 import org.wordpress.android.fluxc.model.LocalOrRemoteId.LocalId
@@ -31,6 +32,6 @@ internal abstract class TaxClassDao {
     )
     protected abstract suspend fun deleteAll(siteId: LocalId): Int
 
-    @Insert
+    @Insert(onConflict = OnConflictStrategy.REPLACE)
     protected abstract suspend fun insertAll(classes: List<WCTaxClassModel>)
 }

--- a/libs/fluxc-plugin/src/test/java/org/wordpress/android/fluxc/persistence/dao/TaxClassDaoTest.kt
+++ b/libs/fluxc-plugin/src/test/java/org/wordpress/android/fluxc/persistence/dao/TaxClassDaoTest.kt
@@ -121,4 +121,17 @@ class TaxClassDaoTest {
         val otherSiteResult = sut.getTaxClasses(LocalId(999))
         assertThat(otherSiteResult).containsExactly(differentSiteTaxClass)
     }
+
+    @Test
+    fun `when there are duplicate tax classes, replaceAll keeps the last one`() = runTest {
+        // given
+        val taxClasses = listOf(sampleTaxClass1, sampleTaxClass2, sampleTaxClass1)
+        sut.replaceAll(site.localId(), taxClasses)
+
+        // when
+        val result = sut.getTaxClasses(site.localId())
+
+        // then
+        assertThat(result).containsExactlyInAnyOrderElementsOf(listOf(sampleTaxClass1, sampleTaxClass2))
+    }
 }


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

<!-- Id number of the Linear issue this PR addresses, e.g., WOOMOB-373. -->
Closes WOOMOB-871

### Description
This PR fixes a crash on product details, the crash happens when the store includes duplicate tax classes, and is caused by the recent migration to Room in the PR https://github.com/woocommerce/woocommerce-android/pull/14237

### Steps to reproduce
`wp-admin` doesn't allow adding duplicate taxes, so the duplication is most probably caused by a plugin or manual handling of the site DB, so we'll use Api Faker to simulate this.
1. Open the Api Faker tool from the developer options menu.

<details>
<summary>2. Import the following configuration using the "import from clipboard" feature</summary>

```json
[
  {
    "request": {
      "httpMethod": "GET",
      "id": 0,
      "path": "/wc/v3/taxes/classes",
      "queryParameters": [],
      "type": {
        "type": "wp-api"
      }
    },
    "response": {
      "body": "[\n  {\n      \"slug\": \"standard\",\n      \"name\": \"Standard rate\",\n      \"_links\": {\n        \"collection\": [\n          {\n            \"href\": \"https://hichamwootest.blog/wp-json/wc/v3/taxes/classes\"\n          }\n        ]\n      }\n    },\n  {\n      \"slug\": \"standard\",\n      \"name\": \"Standard rate\",\n      \"_links\": {\n        \"collection\": [\n          {\n            \"href\": \"https://hichamwootest.blog/wp-json/wc/v3/taxes/classes\"\n          }\n        ]\n      }\n    }\n]",
      "endpointId": 0,
      "statusCode": 200
    }
  }
]
```
</details>

3. Open details screen of any product.

### Testing information
- Confirm the app doesn't crash on this branch.

### The tests that have been performed
The above.

- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->