### PR TITLE
[POS as a Tab i2] Keep eligibility reason visible during loading state

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/eligibility/WooPosEligibilityScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/eligibility/WooPosEligibilityScreen.kt
@@ -13,6 +13,10 @@ import androidx.compose.foundation.layout.width
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.painterResource
@@ -69,6 +73,16 @@ fun WooPosEligibilityScreen(
         onNavigationEvent(WooPosNavigationEvent.ExitPosClicked)
     }
 
+    val lastIneligibleReason = remember {
+        mutableStateOf<WooPosLaunchability.NonLaunchabilityReason?>(null)
+    }
+
+    LaunchedEffect(retryState) {
+        if (retryState is WooPosEligibilityRetryState.Ineligible) {
+            lastIneligibleReason.value = retryState.reason
+        }
+    }
+
     Column(
         modifier = Modifier
             .fillMaxSize()
@@ -91,11 +105,9 @@ fun WooPosEligibilityScreen(
 
         Spacer(modifier = Modifier.height(WooPosSpacing.Large.value.toAdaptivePadding()))
 
-        val currentReason = (retryState as? WooPosEligibilityRetryState.Ineligible)?.reason
-
-        if (currentReason != null) {
+        lastIneligibleReason.value?.let { reason ->
             WooPosText(
-                text = getSuggestionText(currentReason),
+                text = getSuggestionText(reason),
                 style = WooPosTypography.BodyLarge,
                 textAlign = TextAlign.Center,
                 modifier = Modifier.width(547.dp)


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

<!-- Id number of the Linear issue this PR addresses, e.g., WOOMOB-373. -->
Closes WOOMOB-718

### Description
This PR improves the UX of the POS eligibility screen by preserving and displaying the last known ineligibility reason even when the state transitions to `Loading`. Previously, the error message would disappear during retry, resulting in a subpar user experience.

We now store the last `Ineligible` reason using a `remember + LaunchedEffect` pattern and continue to show the relevant suggestion text while the retry check is in progress.

This ensures a smoother and more informative experience for users attempting to access POS again after a failure.

### Steps to reproduce
1. Set up a site that will trigger an ineligible POS state (e.g. unsupported currency).
2. Open the POS app and reach the eligibility screen.
3. Tap the "Retry" button.
4. Observe that the message is preserved while the retry is loading.

### Testing information
- Alternate workflows: Verified behavior across different ineligibility reasons.
- Edge cases: Confirmed that the message remains visible in `Loading` and disappears only when navigation occurs.
- Affected areas: Eligibility screen for Woo POS.
- Critical flows: Retry flow on eligibility check.
- Not tested: Eligibility logic itself (out of scope).
- Remaining unknowns: None known.

### The tests that have been performed
- Manually triggered retry and verified text preservation.
- Confirmed that navigation triggers correctly when state becomes `Eligible`.
- Verified that "Exit POS" still works normally during loading.

### Images/gif

https://github.com/user-attachments/assets/0c9124ff-ed6f-4106-afd4-42624e62bd00



- [X] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
