### PR TITLE
[Shipping labels] Reset UI state after refunding

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/WooShippingLabelCreationViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/WooShippingLabelCreationViewModel.kt
@@ -762,9 +762,11 @@ class WooShippingLabelCreationViewModel @Inject constructor(
         // Find the shipment with the given labelId
         val shipmentIndex = shipments.value.indexOfFirst { it.label?.labelId == labelId }
 
-        // If the shipment is found, reset its purchased state
+        // If the shipment is found, reset its state
         if (shipmentIndex != -1) {
             updateShipment(shipmentIndex, shipments.value[shipmentIndex].copy(purchased = false, label = null))
+            selectedRatesFlow.value = selectedRatesFlow.value.toMutableList().apply { set(shipmentIndex, null) }
+            selectedPackagesFlow.value = selectedPackagesFlow.value.toMutableList().apply { set(shipmentIndex, null) }
         }
     }
 

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/WooShippingLabelCreationViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/WooShippingLabelCreationViewModelTest.kt
@@ -1232,6 +1232,41 @@ class WooShippingLabelCreationViewModelTest : BaseUnitTest() {
     }
 
     @Test
+    fun `when refunded, resets UI state`() = testBlocking {
+        val labelId = 123L
+        whenever(getShipments(any())) doReturn defaultShipments.toMutableList().apply {
+            set(0, defaultShipments.first().copy(label = shippingLabelModel.copy(labelId = labelId)))
+        }
+
+        createViewModel()
+
+        // Set up initial state with selected package and rates
+        sut.onPackageSelected(defaultPackageData)
+        advanceUntilIdle()
+
+        val initialViewState = sut.viewState.value as DataState
+        val initialShipment = initialViewState.shipmentUIList[0]
+
+        // Select shipping rate to have something to reset
+        val ratesState = initialShipment.shippingRatesState as ShippingRatesState.DataState
+        val selectedRate = defaultShippingRates.values.first().first()
+        ratesState.onSelectedShippingRateChanged(selectedRate)
+
+        sut.onShippingLabelRefunded(labelId)
+        advanceUntilIdle()
+
+        // Verify UI state is reset
+        val finalViewState = sut.viewState.value as DataState
+        val finalShipment = finalViewState.shipmentUIList[0]
+
+        // Verify package selection is reset
+        assertThat(finalShipment.packageSelectionState).isEqualTo(PackageSelectionState.NotSelected)
+
+        // Verify shipping rates are reset
+        assertThat(finalShipment.shippingRatesState).isEqualTo(ShippingRatesState.NoAvailable)
+    }
+
+    @Test
     fun `onLearnMoreClicked triggers OpenLearnMoreScreen event`() = testBlocking {
         createViewModel()
 


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

<!-- Id number of the Linear issue this PR addresses, e.g., WOOMOB-373. -->
Closes WOOMOB-900

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
We were not resetting the UI state after a refund. After refunding, the UI still displayed the previously selected shipping rate. However, each call to get shipping rates generates unique IDs. If the user attempted to repurchase the shipment using the old ID, it caused a backend error with the message:`Client attempted to re-purchase with shipping id: shp_abc123..."`

I'm targeting the beta. Although the purchase may succeed, I believe this could lead to unexpected issues in the shipping process.

### Steps to reproduce
<!-- Step-by-step testing instructions. For new user flows, consider instead stating the goal of the workflow and see if your PR reviewer can accomplish the workflow without specific steps! -->
1. Open an order that is eligible for shipping labels.
2. Tap Create shipping label button.
3. Fill package and shipping rates fields.
4. Purchase.
5. Refund.
6. Verify that there is no selected packages or rates.

### The tests that have been performed
<!-- To give the reviewer an idea of what could be missed in terms of testing -->
Steps above

### Images/gif
<!-- Include before and after images or gifs when appropriate. -->
https://github.com/user-attachments/assets/c011d815-f13e-4fe6-b99a-e4b945f9f8ad

- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->