### PR TITLE
[Shipping Labels] Fix HS tariff number validation

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/customs/WooShippingCustomsFormViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/customs/WooShippingCustomsFormViewModel.kt
@@ -9,6 +9,7 @@ import com.woocommerce.android.model.AmbiguousLocation
 import com.woocommerce.android.model.Location
 import com.woocommerce.android.ui.orders.wooshippinglabels.address.GetAllCountries
 import com.woocommerce.android.ui.orders.wooshippinglabels.customs.domain.ShouldRequireITN
+import com.woocommerce.android.ui.orders.wooshippinglabels.customs.domain.ValidateHSTariffNumber
 import com.woocommerce.android.ui.orders.wooshippinglabels.customs.products.WooShippingCustomsProductUIModel
 import com.woocommerce.android.ui.orders.wooshippinglabels.models.ShippableItemModel
 import com.woocommerce.android.viewmodel.MultiLiveEvent
@@ -30,6 +31,7 @@ import javax.inject.Inject
 class WooShippingCustomsFormViewModel @Inject constructor(
     private val getAllCountries: GetAllCountries,
     private val shouldRequireITN: ShouldRequireITN,
+    private val validateHSTariffNumber: ValidateHSTariffNumber,
     savedState: SavedStateHandle
 ) : ScopedViewModel(savedState) {
     private val itnRegex by lazy { ITN_REGEX_STRING.toRegex() }
@@ -204,22 +206,13 @@ class WooShippingCustomsFormViewModel @Inject constructor(
     }
 
     fun onShippableProductTariffNumberChanged(itemIndex: Int, newValue: String) {
-        fun String.isValidHSTariffNumber(): Boolean {
-            val regex = Regex("""^(\d{1,2}\.?){3,6}$""")
-            if (!regex.matches(this)) return false
-
-            val digits = replace(Regex("""\D"""), "")
-            return digits.length in 6..12
-        }
-
         updateShippingProductsAt(itemIndex) { item ->
-            when (newValue.isBlank() || newValue.isValidHSTariffNumber()) {
-                true -> InputValue.Data(newValue)
-                else -> InputValue.Error(
-                    input = newValue,
-                    errorMessageId = R.string.woo_shipping_labels_customs_product_details_tariff_invalid
+            item.copy(
+                tariffNumber = validateHSTariffNumber(
+                    tariffNumber = newValue,
+                    destinationCountryCode = destinationCountryCode
                 )
-            }.let { item.copy(tariffNumber = it) }
+            )
         }
     }
 
@@ -296,7 +289,7 @@ class WooShippingCustomsFormViewModel @Inject constructor(
         productId = productId,
         name = title,
         description = "".asInputValueError,
-        tariffNumber = InputValue.Data(""),
+        tariffNumber = validateHSTariffNumber("", destinationCountryCode),
         quantity = quantity,
         originCountry = "",
         originCountryCode = "",
@@ -368,6 +361,9 @@ class WooShippingCustomsFormViewModel @Inject constructor(
         ) : InputValue()
 
         data object Empty : InputValue()
+
+        val isValid: Boolean
+            get() = this is Data
 
         val currentInput
             get() = when (this) {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/customs/WooShippingCustomsFormViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/customs/WooShippingCustomsFormViewModel.kt
@@ -39,7 +39,7 @@ class WooShippingCustomsFormViewModel @Inject constructor(
 
     private val _viewState = savedState.getStateFlow(
         scope = viewModelScope,
-        initialValue = ViewState()
+        initialValue = initViewState()
     )
     val viewState = _viewState.asLiveData()
 
@@ -58,13 +58,16 @@ class WooShippingCustomsFormViewModel @Inject constructor(
 
     init {
         launch { loadCountries() }
-        navArgs.customsData?.let { customData ->
+        observeShippableItemsChanges()
+    }
+
+    private fun initViewState(): ViewState {
+        return navArgs.customsData?.let { customData ->
             loadViewStateFromExistentCustomData(customData)
         } ?: run {
             val shippableProducts = navArgs.shippableItems.map { item -> item.toProductUIModel() }
-            _viewState.update { it.copy(shippingProducts = shippableProducts) }
+            ViewState().copy(shippingProducts = shippableProducts)
         }
-        observeShippableItemsChanges()
     }
 
     private fun observeShippableItemsChanges() {
@@ -76,31 +79,29 @@ class WooShippingCustomsFormViewModel @Inject constructor(
             }.launchIn(viewModelScope)
     }
 
-    private fun loadViewStateFromExistentCustomData(customData: CustomsData) {
-        _viewState.update {
-            it.copy(
-                contentType = customData.contentType,
-                otherContentInput = InputValue.Data(customData.contentDescription),
-                restrictionType = customData.restrictionType,
-                otherRestrictionInput = InputValue.Data(customData.restrictionDescription),
-                itnValue = InputValue.Data(customData.itn),
-                returnToSenderChecked = customData.isReturnToSender,
-                shippingProducts = customData.items.map { item ->
-                    WooShippingCustomsProductUIModel(
-                        productId = item.productID,
-                        name = item.description,
-                        description = InputValue.Data(item.description),
-                        tariffNumber = InputValue.Data(item.hsTariffNumber),
-                        valuePerUnit = InputValue.Data(item.value.toString()),
-                        weightPerUnit = InputValue.Data(item.weight.toString()),
-                        originCountry = item.originCountry,
-                        originCountryCode = item.originCountryCode,
-                        quantity = item.quantity,
-                        isExpanded = false
-                    )
-                }
-            )
-        }
+    private fun loadViewStateFromExistentCustomData(customData: CustomsData): ViewState {
+        return ViewState(
+            contentType = customData.contentType,
+            otherContentInput = InputValue.Data(customData.contentDescription),
+            restrictionType = customData.restrictionType,
+            otherRestrictionInput = InputValue.Data(customData.restrictionDescription),
+            itnValue = InputValue.Data(customData.itn),
+            returnToSenderChecked = customData.isReturnToSender,
+            shippingProducts = customData.items.map { item ->
+                WooShippingCustomsProductUIModel(
+                    productId = item.productID,
+                    name = item.description,
+                    description = InputValue.Data(item.description),
+                    tariffNumber = InputValue.Data(item.hsTariffNumber),
+                    valuePerUnit = InputValue.Data(item.value.toString()),
+                    weightPerUnit = InputValue.Data(item.weight.toString()),
+                    originCountry = item.originCountry,
+                    originCountryCode = item.originCountryCode,
+                    quantity = item.quantity,
+                    isExpanded = false
+                )
+            }
+        )
     }
 
     fun onContentTypeClick() {
@@ -305,6 +306,7 @@ class WooShippingCustomsFormViewModel @Inject constructor(
                 input = "",
                 errorMessageId = R.string.woo_shipping_labels_customs_product_details_value_required
             )
+
             else -> InputValue.Data(shippingTotalValue.toString())
         },
         weightPerUnit = when {
@@ -312,6 +314,7 @@ class WooShippingCustomsFormViewModel @Inject constructor(
                 input = "",
                 errorMessageId = R.string.woo_shipping_labels_customs_product_details_value_required
             )
+
             else -> InputValue.Data(weight.toString())
         }
     )

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/customs/WooShippingCustomsFormViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/customs/WooShippingCustomsFormViewModel.kt
@@ -203,10 +203,18 @@ class WooShippingCustomsFormViewModel @Inject constructor(
     }
 
     fun onShippableProductTariffNumberChanged(itemIndex: Int, newValue: String) {
+        fun String.isValidHSTariffNumber(): Boolean {
+            val regex = Regex("""^(\d{1,2}\.?){3,6}$""")
+            if (!regex.matches(this)) return false
+
+            val digits = replace(Regex("""\D"""), "")
+            return digits.length in 6..12
+        }
+
         updateShippingProductsAt(itemIndex) { item ->
-            when (newValue.isBlank()) {
-                false -> InputValue.Data(newValue)
-                true -> InputValue.Error(
+            when (newValue.isBlank() || newValue.isValidHSTariffNumber()) {
+                true -> InputValue.Data(newValue)
+                else -> InputValue.Error(
                     input = newValue,
                     errorMessageId = R.string.woo_shipping_labels_customs_product_details_tariff_missing
                 )
@@ -287,7 +295,7 @@ class WooShippingCustomsFormViewModel @Inject constructor(
         productId = productId,
         name = title,
         description = "".asInputValueError,
-        tariffNumber = "".asInputValueError,
+        tariffNumber = InputValue.Data(""),
         quantity = quantity,
         originCountry = "",
         originCountryCode = "",

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/customs/WooShippingCustomsFormViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/customs/WooShippingCustomsFormViewModel.kt
@@ -216,7 +216,7 @@ class WooShippingCustomsFormViewModel @Inject constructor(
                 true -> InputValue.Data(newValue)
                 else -> InputValue.Error(
                     input = newValue,
-                    errorMessageId = R.string.woo_shipping_labels_customs_product_details_tariff_missing
+                    errorMessageId = R.string.woo_shipping_labels_customs_product_details_tariff_invalid
                 )
             }.let { item.copy(tariffNumber = it) }
         }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/customs/domain/ValidateHSTariffNumber.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/customs/domain/ValidateHSTariffNumber.kt
@@ -32,7 +32,8 @@ class ValidateHSTariffNumber @Inject constructor() {
         } ?: WooShippingCustomsFormViewModel.InputValue.Data(tariffNumber)
     }
 
-    private fun shouldRequireHSTariffNumber(destinationCountryCode: String) = destinationCountryCode in EU_UNION_COUNTRIES
+    private fun shouldRequireHSTariffNumber(destinationCountryCode: String) =
+        destinationCountryCode in EU_UNION_COUNTRIES
 
     companion object {
         private val EU_UNION_COUNTRIES = listOf(

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/customs/domain/ValidateHSTariffNumber.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/customs/domain/ValidateHSTariffNumber.kt
@@ -32,10 +32,10 @@ class ValidateHSTariffNumber @Inject constructor() {
         } ?: WooShippingCustomsFormViewModel.InputValue.Data(tariffNumber)
     }
 
-    private fun shouldRequireHSTariffNumber(destinationCountryCode: String) = destinationCountryCode in euUnionCountries
+    private fun shouldRequireHSTariffNumber(destinationCountryCode: String) = destinationCountryCode in EU_UNION_COUNTRIES
 
     companion object {
-        private val euUnionCountries = listOf(
+        private val EU_UNION_COUNTRIES = listOf(
             "AT", "BE", "BG", "CY", "CZ", "DE", "DK", "EE", "ES", "FI", "FR", "GR", "HR", "HU", "IE", "IT", "LT", "LU",
             "LV", "MT", "NL", "PL", "PT", "RO", "SE", "SI", "SK"
         )

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/customs/domain/ValidateHSTariffNumber.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/customs/domain/ValidateHSTariffNumber.kt
@@ -7,6 +7,7 @@ import javax.inject.Inject
 class ValidateHSTariffNumber @Inject constructor() {
     private val regex by lazy { Regex("""^(\d{1,2}\.?){3,6}$""") }
 
+    @Suppress("MagicNumber")
     operator fun invoke(
         tariffNumber: String,
         destinationCountryCode: String

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/customs/domain/ValidateHSTariffNumber.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/customs/domain/ValidateHSTariffNumber.kt
@@ -1,0 +1,42 @@
+package com.woocommerce.android.ui.orders.wooshippinglabels.customs.domain
+
+import com.woocommerce.android.R
+import com.woocommerce.android.ui.orders.wooshippinglabels.customs.WooShippingCustomsFormViewModel
+import javax.inject.Inject
+
+class ValidateHSTariffNumber @Inject constructor() {
+    private val regex by lazy { Regex("""^(\d{1,2}\.?){3,6}$""") }
+
+    operator fun invoke(
+        tariffNumber: String,
+        destinationCountryCode: String
+    ): WooShippingCustomsFormViewModel.InputValue {
+        val shouldValidateHSTariffNumber =
+            shouldRequireHSTariffNumber(destinationCountryCode) || tariffNumber.isNotEmpty()
+        if (!shouldValidateHSTariffNumber) return WooShippingCustomsFormViewModel.InputValue.Data(tariffNumber)
+
+        val digits = tariffNumber.replace(Regex("""\D"""), "")
+
+        val errorCode = when {
+            tariffNumber.isEmpty() -> R.string.woo_shipping_labels_customs_product_details_value_required
+
+            !regex.matches(tariffNumber) || digits.length !in 6..12 ->
+                R.string.woo_shipping_labels_customs_product_details_tariff_invalid
+
+            else -> null
+        }
+
+        return errorCode?.let {
+            WooShippingCustomsFormViewModel.InputValue.Error(tariffNumber, it)
+        } ?: WooShippingCustomsFormViewModel.InputValue.Data(tariffNumber)
+    }
+
+    private fun shouldRequireHSTariffNumber(destinationCountryCode: String) = destinationCountryCode in euUnionCountries
+
+    companion object {
+        private val euUnionCountries = listOf(
+            "AT", "BE", "BG", "CY", "CZ", "DE", "DK", "EE", "ES", "FI", "FR", "GR", "HR", "HU", "IE", "IT", "LT", "LU",
+            "LV", "MT", "NL", "PL", "PT", "RO", "SE", "SI", "SK"
+        )
+    }
+}

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/customs/products/WooShippingCustomsProductListItem.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/customs/products/WooShippingCustomsProductListItem.kt
@@ -147,13 +147,14 @@ fun WooShippingCustomsProductCollapsedListItem(
                     .takeIf { it.isNotBlank() }
                     ?: stringResource(id = R.string.woo_shipping_labels_customs_product_details_description_missing)
             )
-            Text(
-                style = MaterialTheme.typography.bodySmall,
-                color = colorResource(id = R.color.color_on_surface),
-                text = itemData.tariffNumber.currentInput
-                    .takeIf { it.isNotBlank() }
-                    ?: stringResource(id = R.string.woo_shipping_labels_customs_product_details_tariff_missing)
-            )
+            itemData.tariffNumber.currentInput
+                .takeIf { it.isNotBlank() }?.let {
+                    Text(
+                        style = MaterialTheme.typography.bodySmall,
+                        color = colorResource(id = R.color.color_on_surface),
+                        text = it,
+                    )
+                }
         }
         Row {
             Text(

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/networking/WooShippingNetworkingMapper.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/networking/WooShippingNetworkingMapper.kt
@@ -379,7 +379,7 @@ class WooShippingNetworkingMapper @Inject constructor(
                     quantity = it.quantity,
                     value = it.value.toDouble(),
                     weight = it.weight.toDouble(),
-                    hsTariffNumber = it.hsTariffNumber,
+                    hsTariffNumber = it.hsTariffNumber.replace(Regex("""\D"""), ""),
                     originCountry = it.originCountryCode
                 )
             }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/rates/datasource/WooShippingRatesRepository.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/rates/datasource/WooShippingRatesRepository.kt
@@ -97,7 +97,7 @@ class WooShippingRatesRepository @Inject constructor(
                         quantity = it.quantity,
                         value = it.value.toDouble(),
                         weight = it.weight.toDouble(),
-                        hsTariffNumber = it.hsTariffNumber,
+                        hsTariffNumber = it.hsTariffNumber.replace(Regex("""\D"""), ""),
                         originCountry = it.originCountryCode
                     )
                 }

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -4583,7 +4583,7 @@
     <string name="woo_shipping_labels_customs_product_details_description">Description</string>
     <string name="woo_shipping_labels_customs_product_details_description_missing">Missing Description</string>
     <string name="woo_shipping_labels_customs_product_details_tariff">HS tariff number</string>
-    <string name="woo_shipping_labels_customs_product_details_tariff_missing">Missing tariff number</string>
+    <string name="woo_shipping_labels_customs_product_details_tariff_invalid">The tariff number must be between 6 and 12 digits long</string>
     <string name="woo_shipping_labels_customs_product_details_value_per_unit">Value per unit</string>
     <string name="woo_shipping_labels_customs_product_details_weight_per_unit">Weight per unit</string>
     <string name="woo_shipping_labels_customs_product_details_value_required">Value required</string>

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/customs/WooShippingCustomsFormViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/customs/WooShippingCustomsFormViewModelTest.kt
@@ -8,6 +8,7 @@ import com.woocommerce.android.ui.orders.wooshippinglabels.customs.WooShippingCu
 import com.woocommerce.android.ui.orders.wooshippinglabels.customs.WooShippingCustomsFormViewModel.ShowRestrictionTypeDialog
 import com.woocommerce.android.ui.orders.wooshippinglabels.customs.WooShippingCustomsFormViewModel.ViewState
 import com.woocommerce.android.ui.orders.wooshippinglabels.customs.domain.ShouldRequireITN
+import com.woocommerce.android.ui.orders.wooshippinglabels.customs.domain.ValidateHSTariffNumber
 import com.woocommerce.android.ui.orders.wooshippinglabels.models.ShippableItemModel
 import com.woocommerce.android.viewmodel.BaseUnitTest
 import com.woocommerce.android.viewmodel.MultiLiveEvent
@@ -17,6 +18,7 @@ import org.assertj.core.api.Assertions.assertThat
 import org.junit.Before
 import org.junit.Test
 import org.mockito.kotlin.any
+import org.mockito.kotlin.doAnswer
 import org.mockito.kotlin.doReturn
 import org.mockito.kotlin.mock
 import java.math.BigDecimal
@@ -26,6 +28,7 @@ class WooShippingCustomsFormViewModelTest : BaseUnitTest() {
     private lateinit var viewModel: WooShippingCustomsFormViewModel
     private lateinit var getAllCountries: GetAllCountries
     private lateinit var shouldRequireITN: ShouldRequireITN
+    private lateinit var validateHSTariffNumber: ValidateHSTariffNumber
 
     @Before
     fun setup() {
@@ -48,6 +51,12 @@ class WooShippingCustomsFormViewModelTest : BaseUnitTest() {
 
         shouldRequireITN = mock {
             on { invoke(any(), any()) } doReturn false
+        }
+
+        validateHSTariffNumber = mock {
+            on { invoke(any(), any()) } doAnswer {
+                InputValue.Data(it.arguments[0] as String)
+            }
         }
 
         createSut()
@@ -432,7 +441,8 @@ class WooShippingCustomsFormViewModelTest : BaseUnitTest() {
                 customsData = null
             ).toSavedStateHandle(),
             getAllCountries = getAllCountries,
-            shouldRequireITN = shouldRequireITN
+            shouldRequireITN = shouldRequireITN,
+            validateHSTariffNumber = validateHSTariffNumber
         )
     }
 }

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/customs/WooShippingCustomsFormViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/customs/WooShippingCustomsFormViewModelTest.kt
@@ -234,7 +234,7 @@ class WooShippingCustomsFormViewModelTest : BaseUnitTest() {
     fun `onShippableProductTariffNumberChanged should update tariffNumber with valid input`() = testBlocking {
         // Given
         val itemIndex = 0
-        val newTariff = "HS 12345"
+        val newTariff = "123456"
         var capturedViewState: ViewState? = null
         viewModel.viewState.observeForever {
             capturedViewState = it
@@ -247,25 +247,6 @@ class WooShippingCustomsFormViewModelTest : BaseUnitTest() {
         assertThat(capturedViewState?.shippingProducts?.get(itemIndex)?.tariffNumber)
             .isEqualTo(InputValue.Data(newTariff))
     }
-
-    @Test
-    fun `onShippableProductTariffNumberChanged should update tariffNumber with error for blank input`() =
-        testBlocking {
-            // Given
-            val itemIndex = 0
-            val blankTariff = ""
-            var capturedViewState: ViewState? = null
-            viewModel.viewState.observeForever {
-                capturedViewState = it
-            }
-
-            // When
-            viewModel.onShippableProductTariffNumberChanged(itemIndex, blankTariff)
-
-            // Then
-            assertThat(capturedViewState?.shippingProducts?.get(itemIndex)?.tariffNumber)
-                .isInstanceOf(InputValue.Error::class.java)
-        }
 
     @Test
     fun `onShippableProductValuePerUnitChanged should update valuePerUnit with valid input`() = testBlocking {

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/customs/domain/ValidateHSTariffNumberTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/customs/domain/ValidateHSTariffNumberTest.kt
@@ -1,0 +1,56 @@
+package com.woocommerce.android.ui.orders.wooshippinglabels.customs.domain
+
+import com.woocommerce.android.viewmodel.BaseUnitTest
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class ValidateHSTariffNumberTest : BaseUnitTest() {
+    private val sut = ValidateHSTariffNumber()
+
+    @Test
+    fun `when tariff number is valid, then return Data`() {
+        val validHSTariffNumber = "1234567890"
+
+        val result = sut(validHSTariffNumber, "US")
+
+        assertEquals(true, result.isValid)
+    }
+
+    @Test
+    fun `when tariff number includes dots and has 6 digits, then return Data`() {
+        val validHSTariffNumber = "12.34.56"
+
+        val result = sut(validHSTariffNumber, "US")
+
+        assertEquals(true, result.isValid)
+    }
+
+    @Test
+    fun `when tariff number is invalid, then return Data`() {
+        val invalidHSTariffNumber = "12345"
+
+        val result = sut(invalidHSTariffNumber, "US")
+
+        assertEquals(false, result.isValid)
+    }
+
+    @Test
+    fun `given a non-EU country, when tariff number is empty, then return Data`() {
+        val emptyHSTariffNumber = ""
+
+        val result = sut(emptyHSTariffNumber, "US")
+
+        assertEquals(true, result.isValid)
+    }
+
+    @Test
+    fun `given an EU country, when tariff number is empty, then return Error`() {
+        val emptyHSTariffNumber = ""
+
+        val result = sut(emptyHSTariffNumber, "FR")
+
+        assertEquals(false, result.isValid)
+    }
+}


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

<!-- Id number of the Linear issue this PR addresses, e.g., WOOMOB-373. -->
Part of WOOMOB-630

### Description
This PR implements the first part of the customs form validation fixes, I'm targeting the beta with this part because as discussed internally it could be a blocker for customs who don't own an HS tariff number.

The PR adds the following changes:
- It makes the HS tariff number optional for all countries except the EU union countries.
- It adds validation to the format of the HS tariff number following what the web does.
- It adds logic to sanitize the HS tariff number by removing the non-digits characters (only dots are accepted) before sending it to the API.

> [!NOTE]
> The customs form has other validation issues (check the ticket for details), and they are critical, but given they don't block the users, as we don't validate some fields as we should, I'm going to fix them on trunk and not on the release branch. Please let me know what you think about this. 

### Steps to reproduce
1. Create an order with shipping address to a country that's not part of EU union.
2. Open shipping labels creation form.
3. Open the customs form.
4. Confirm the HS tariff number is optional.
5. Enter some input in the HS tariff number and confirm the format is validated (a valid HS tariff number has between 6 and 12 digits, and can contain dots)
6. Change the shipping country to a EU union country (for example FR)
7. Open the customs form
8. Confirm the HS tariff number is required.

### Testing information
The above scenarios

### The tests that have been performed
The above

- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->