### PR TITLE
[Shipping Labels] Fix validation of ITN

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/customs/WooShippingCustomsForm.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/customs/WooShippingCustomsForm.kt
@@ -26,7 +26,10 @@ data class CustomsItem(
     val hsTariffNumber: String,
     val originCountry: String,
     val originCountryCode: String
-) : Parcelable
+) : Parcelable {
+    val totalValue: BigDecimal
+        get() = value * quantity.toBigDecimal()
+}
 
 enum class ContentType(val resourceId: Int) {
     MERCHANDISE(R.string.woo_shipping_labels_customs_content_merchandise),

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/customs/WooShippingCustomsFormScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/customs/WooShippingCustomsFormScreen.kt
@@ -30,6 +30,7 @@ import com.woocommerce.android.R
 import com.woocommerce.android.ui.compose.component.WCColoredButton
 import com.woocommerce.android.ui.compose.component.WCOutlinedSpinner
 import com.woocommerce.android.ui.compose.component.WCOutlinedTextField
+import com.woocommerce.android.ui.compose.component.getText
 import com.woocommerce.android.ui.compose.theme.WooThemeWithBackground
 import com.woocommerce.android.ui.orders.wooshippinglabels.customs.WooShippingCustomsFormViewModel.InputValue
 import com.woocommerce.android.ui.orders.wooshippinglabels.customs.products.WooShippingCustomsProductListItem
@@ -120,8 +121,7 @@ fun WooShippingCustomsFormScreen(
                     isError = otherContentDetailsInput is InputValue.Error,
                     keyboardOptions = KeyboardOptions(imeAction = ImeAction.Next),
                     modifier = modifier.fillMaxWidth(),
-                    helperText = otherContentDetailsInput.errorMessageOrNull
-                        ?.let { stringResource(it) }
+                    helperText = otherContentDetailsInput.errorMessageOrNull?.getText()
                         ?: stringResource(R.string.woo_shipping_labels_customs_content_details_description)
                 )
             }
@@ -142,8 +142,7 @@ fun WooShippingCustomsFormScreen(
                     isError = otherRestrictionDetailsInput is InputValue.Error,
                     keyboardOptions = KeyboardOptions(imeAction = ImeAction.Next),
                     modifier = modifier.fillMaxWidth(),
-                    helperText = otherRestrictionDetailsInput.errorMessageOrNull
-                        ?.let { stringResource(it) }
+                    helperText = otherRestrictionDetailsInput.errorMessageOrNull?.getText()
                         ?: stringResource(R.string.woo_shipping_labels_customs_restriction_details_description)
                 )
             }
@@ -156,8 +155,7 @@ fun WooShippingCustomsFormScreen(
                 isError = itnValue is InputValue.Error,
                 keyboardOptions = KeyboardOptions(imeAction = ImeAction.Next),
                 modifier = modifier.fillMaxWidth(),
-                helperText = itnValue.errorMessageOrNull
-                    ?.let { stringResource(it) }
+                helperText = itnValue.errorMessageOrNull?.getText()
             )
 
             Row(

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/customs/WooShippingCustomsFormViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/customs/WooShippingCustomsFormViewModel.kt
@@ -7,6 +7,7 @@ import androidx.lifecycle.viewModelScope
 import com.woocommerce.android.R
 import com.woocommerce.android.model.AmbiguousLocation
 import com.woocommerce.android.model.Location
+import com.woocommerce.android.model.UiString
 import com.woocommerce.android.ui.orders.wooshippinglabels.address.GetAllCountries
 import com.woocommerce.android.ui.orders.wooshippinglabels.customs.domain.ValidateHSTariffNumber
 import com.woocommerce.android.ui.orders.wooshippinglabels.customs.domain.ValidateITN
@@ -65,13 +66,16 @@ class WooShippingCustomsFormViewModel @Inject constructor(
     private fun monitorITNValidationStatus() {
         fun ValidateITN.ITNMissingCause.errorMessage() = when (this) {
             ValidateITN.ITNMissingCause.TotalValue ->
-                R.string.woo_shipping_labels_customs_itn_required_total_value
+                UiString.UiStringRes(R.string.woo_shipping_labels_customs_itn_required_total_value)
 
             is ValidateITN.ITNMissingCause.HSTariffValue ->
-                R.string.woo_shipping_labels_customs_itn_required_hs_tariff_value
+                UiString.UiStringRes(
+                    stringRes = R.string.woo_shipping_labels_customs_itn_required_hs_tariff_value,
+                    params = listOf(UiString.UiStringText(this.hsTariffNumber))
+                )
 
             ValidateITN.ITNMissingCause.DestinationCountry ->
-                R.string.woo_shipping_labels_customs_itn_required_destination_country
+                UiString.UiStringRes(R.string.woo_shipping_labels_customs_itn_required_destination_country)
         }
 
         _viewState.map { it.asCustomData }
@@ -359,8 +363,13 @@ class WooShippingCustomsFormViewModel @Inject constructor(
         data class Data(val input: String) : InputValue()
         data class Error(
             val input: String,
-            val errorMessageId: Int
-        ) : InputValue()
+            val errorMessageId: UiString
+        ) : InputValue() {
+            constructor(input: String, errorMessageId: Int) : this(
+                input = input,
+                errorMessageId = UiString.UiStringRes(errorMessageId)
+            )
+        }
 
         data object Empty : InputValue()
 
@@ -374,7 +383,7 @@ class WooShippingCustomsFormViewModel @Inject constructor(
                 is Empty -> ""
             }
 
-        val errorMessageOrNull: Int?
+        val errorMessageOrNull: UiString?
             get() = run { this as? Error }?.errorMessageId
     }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/customs/WooShippingCustomsFormViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/customs/WooShippingCustomsFormViewModel.kt
@@ -8,16 +8,17 @@ import com.woocommerce.android.R
 import com.woocommerce.android.model.AmbiguousLocation
 import com.woocommerce.android.model.Location
 import com.woocommerce.android.ui.orders.wooshippinglabels.address.GetAllCountries
-import com.woocommerce.android.ui.orders.wooshippinglabels.customs.domain.ShouldRequireITN
 import com.woocommerce.android.ui.orders.wooshippinglabels.customs.domain.ValidateHSTariffNumber
+import com.woocommerce.android.ui.orders.wooshippinglabels.customs.domain.ValidateITN
 import com.woocommerce.android.ui.orders.wooshippinglabels.customs.products.WooShippingCustomsProductUIModel
 import com.woocommerce.android.ui.orders.wooshippinglabels.models.ShippableItemModel
+import com.woocommerce.android.util.CoroutineDispatchers
 import com.woocommerce.android.viewmodel.MultiLiveEvent
 import com.woocommerce.android.viewmodel.ScopedViewModel
 import com.woocommerce.android.viewmodel.getStateFlow
 import com.woocommerce.android.viewmodel.navArgs
 import dagger.hilt.android.lifecycle.HiltViewModel
-import kotlinx.coroutines.flow.distinctUntilChanged
+import kotlinx.coroutines.flow.flowOn
 import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.onEach
@@ -30,12 +31,11 @@ import javax.inject.Inject
 @HiltViewModel
 class WooShippingCustomsFormViewModel @Inject constructor(
     private val getAllCountries: GetAllCountries,
-    private val shouldRequireITN: ShouldRequireITN,
+    private val validateITN: ValidateITN,
     private val validateHSTariffNumber: ValidateHSTariffNumber,
+    private val dispatchers: CoroutineDispatchers,
     savedState: SavedStateHandle
 ) : ScopedViewModel(savedState) {
-    private val itnRegex by lazy { ITN_REGEX_STRING.toRegex() }
-
     private val navArgs: WooShippingCustomsFormFragmentArgs by savedState.navArgs()
     private val destinationCountryCode = navArgs.destinationCountryCode
 
@@ -48,19 +48,9 @@ class WooShippingCustomsFormViewModel @Inject constructor(
     private var possibleLocations: List<Location>? = null
     private var itemIndexUnderCountrySelection: Int? = null
 
-    private val List<WooShippingCustomsProductUIModel>.isITNRequired: Boolean
-        get() {
-            val totalShippingValue = mapNotNull { it.shippingTotalValue }
-                .takeIf { it.isNotEmpty() }
-                ?.reduce { acc, current -> acc + current }
-                ?: BigDecimal.ZERO
-
-            return shouldRequireITN(destinationCountryCode, totalShippingValue)
-        }
-
     init {
         launch { loadCountries() }
-        observeShippableItemsChanges()
+        monitorITNValidationStatus()
     }
 
     private fun initViewState(): ViewState {
@@ -72,13 +62,43 @@ class WooShippingCustomsFormViewModel @Inject constructor(
         }
     }
 
-    private fun observeShippableItemsChanges() {
-        _viewState
-            .map { Pair(it.shippingProducts, it.itnValue) }
-            .distinctUntilChanged()
-            .onEach { (products, itnValue) ->
-                onITNChanged(itnValue.currentInput, products.isITNRequired)
-            }.launchIn(viewModelScope)
+    private fun monitorITNValidationStatus() {
+        fun ValidateITN.ITNMissingCause.errorMessage() = when (this) {
+            ValidateITN.ITNMissingCause.TotalValue ->
+                R.string.woo_shipping_labels_customs_itn_required_total_value
+
+            is ValidateITN.ITNMissingCause.HSTariffValue ->
+                R.string.woo_shipping_labels_customs_itn_required_hs_tariff_value
+
+            ValidateITN.ITNMissingCause.DestinationCountry ->
+                R.string.woo_shipping_labels_customs_itn_required_destination_country
+        }
+
+        _viewState.map { it.asCustomData }
+            .map { customsData ->
+                validateITN(customsData, destinationCountryCode)
+            }
+            .flowOn(dispatchers.computation)
+            .onEach { validationResult ->
+                _viewState.update {
+                    val itnValue = it.itnValue.currentInput
+                    it.copy(
+                        itnValue = when (validationResult) {
+                            ValidateITN.ITNValidationResult.Valid -> InputValue.Data(itnValue)
+                            is ValidateITN.ITNValidationResult.Missing -> InputValue.Error(
+                                input = itnValue,
+                                errorMessageId = validationResult.cause.errorMessage()
+                            )
+
+                            ValidateITN.ITNValidationResult.InvalidFormat -> InputValue.Error(
+                                input = itnValue,
+                                errorMessageId = R.string.woo_shipping_labels_customs_itn_error_message
+                            )
+                        }
+                    )
+                }
+            }
+            .launchIn(viewModelScope)
     }
 
     private fun loadViewStateFromExistentCustomData(customData: CustomsData): ViewState {
@@ -160,26 +180,8 @@ class WooShippingCustomsFormViewModel @Inject constructor(
         }
     }
 
-    fun onITNChanged(
-        newItnValue: String,
-        shouldRequireITN: Boolean = false
-    ) {
-        val input = when {
-            newItnValue.isBlank() && shouldRequireITN ->
-                InputValue.Error(
-                    input = newItnValue,
-                    errorMessageId = R.string.woo_shipping_labels_customs_itn_required_message
-                )
-
-            newItnValue.isNotBlank() && itnRegex.matches(newItnValue).not() ->
-                InputValue.Error(
-                    input = newItnValue,
-                    errorMessageId = R.string.woo_shipping_labels_customs_itn_error_message
-                )
-
-            else -> InputValue.Data(newItnValue)
-        }
-        _viewState.update { it.copy(itnValue = input) }
+    fun onITNChanged(newItnValue: String) {
+        _viewState.update { it.copy(itnValue = InputValue.Data(newItnValue)) }
     }
 
     fun onShippableProductExpanded(itemIndex: Int, isExpanded: Boolean) {
@@ -380,13 +382,4 @@ class WooShippingCustomsFormViewModel @Inject constructor(
     data class ShowRestrictionTypeDialog(val currentSelection: RestrictionType) : MultiLiveEvent.Event()
     data class ShowCountrySelector(val countries: List<Location>) : MultiLiveEvent.Event()
     data class FinishCustomsForm(val customData: CustomsData) : MultiLiveEvent.Event()
-
-    companion object {
-        /**
-         * For information regarding the format of the ITN, check the Appendix A of
-         * [Export Compliance Customs Data Requirements](https://postalpro.usps.com/node/3973)
-         */
-        private const val ITN_REGEX_STRING =
-            """^(?:(?:AES X\d{14})|(?:NOEEI 30\.\d{1,2}(?:\([a-z]\)(?:\(\d\))?)?))${'$'}"""
-    }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/customs/WooShippingCustomsFormViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/customs/WooShippingCustomsFormViewModel.kt
@@ -306,7 +306,7 @@ class WooShippingCustomsFormViewModel @Inject constructor(
                 errorMessageId = R.string.woo_shipping_labels_customs_product_details_value_required
             )
 
-            else -> InputValue.Data(shippingTotalValue.toString())
+            else -> InputValue.Data(price.toString())
         },
         weightPerUnit = when {
             weight == 0f -> InputValue.Error(

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/customs/domain/ValidateHSTariffNumber.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/customs/domain/ValidateHSTariffNumber.kt
@@ -10,10 +10,10 @@ class ValidateHSTariffNumber @Inject constructor() {
     @Suppress("MagicNumber")
     operator fun invoke(
         tariffNumber: String,
-        destinationCountryCode: String
+        destinationCountryCode: String? = null
     ): WooShippingCustomsFormViewModel.InputValue {
-        val shouldValidateHSTariffNumber =
-            shouldRequireHSTariffNumber(destinationCountryCode) || tariffNumber.isNotEmpty()
+        val shouldValidateHSTariffNumber = shouldRequireHSTariffNumber(destinationCountryCode) ||
+                tariffNumber.isNotEmpty()
         if (!shouldValidateHSTariffNumber) return WooShippingCustomsFormViewModel.InputValue.Data(tariffNumber)
 
         val digits = tariffNumber.replace(Regex("""\D"""), "")
@@ -32,7 +32,7 @@ class ValidateHSTariffNumber @Inject constructor() {
         } ?: WooShippingCustomsFormViewModel.InputValue.Data(tariffNumber)
     }
 
-    private fun shouldRequireHSTariffNumber(destinationCountryCode: String) =
+    private fun shouldRequireHSTariffNumber(destinationCountryCode: String?) =
         destinationCountryCode in EU_UNION_COUNTRIES
 
     companion object {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/customs/domain/ValidateHSTariffNumber.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/customs/domain/ValidateHSTariffNumber.kt
@@ -13,7 +13,7 @@ class ValidateHSTariffNumber @Inject constructor() {
         destinationCountryCode: String? = null
     ): WooShippingCustomsFormViewModel.InputValue {
         val shouldValidateHSTariffNumber = shouldRequireHSTariffNumber(destinationCountryCode) ||
-                tariffNumber.isNotEmpty()
+            tariffNumber.isNotEmpty()
         if (!shouldValidateHSTariffNumber) return WooShippingCustomsFormViewModel.InputValue.Data(tariffNumber)
 
         val digits = tariffNumber.replace(Regex("""\D"""), "")

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/customs/domain/ValidateITN.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/customs/domain/ValidateITN.kt
@@ -23,7 +23,7 @@ class ValidateITN @Inject constructor(
     }
 
     private val List<CustomsItem>.totalValue: BigDecimal
-        get() = this.sumOf { it.value }
+        get() = this.sumOf { it.value * it.quantity.toBigDecimal() }
 
     private val CustomsData.classesAbove2500: Map<String, List<CustomsItem>>
         get() = this.items.filter {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/customs/domain/ValidateITN.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/customs/domain/ValidateITN.kt
@@ -5,7 +5,9 @@ import com.woocommerce.android.ui.orders.wooshippinglabels.customs.CustomsItem
 import java.math.BigDecimal
 import javax.inject.Inject
 
-class ValidateITN @Inject constructor() {
+class ValidateITN @Inject constructor(
+    private val validateHSTariffNumber: ValidateHSTariffNumber
+) {
     companion object {
         private val itnExemptCountries = listOf("CA")
         private val itnRequiredCountries = listOf("IR", "KP", "SY", "CU", "SD")
@@ -24,7 +26,9 @@ class ValidateITN @Inject constructor() {
         get() = this.sumOf { it.totalValue }
 
     private val CustomsData.classesAbove2500: Map<String, List<CustomsItem>>
-        get() = this.items.filter { it.hsTariffNumber.isNotEmpty() }
+        get() = this.items.filter {
+            it.hsTariffNumber.isNotEmpty() && validateHSTariffNumber(it.hsTariffNumber).isValid
+        }
             .groupBy { it.hsTariffNumber }
             .filter { it.value.totalValue > MAX_SHIPPING_ITEM_VALUE_FOR_CUSTOMS.toBigDecimal() }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/customs/domain/ValidateITN.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/customs/domain/ValidateITN.kt
@@ -1,0 +1,70 @@
+package com.woocommerce.android.ui.orders.wooshippinglabels.customs.domain
+
+import com.woocommerce.android.ui.orders.wooshippinglabels.customs.CustomsData
+import com.woocommerce.android.ui.orders.wooshippinglabels.customs.CustomsItem
+import java.math.BigDecimal
+import javax.inject.Inject
+
+class ValidateITN @Inject constructor() {
+    companion object {
+        private val itnExemptCountries = listOf("CA")
+        private val itnRequiredCountries = listOf("IR", "KP", "SY", "CU", "SD")
+
+        private const val MAX_SHIPPING_ITEM_VALUE_FOR_CUSTOMS = 2500
+
+        /**
+         * For information regarding the format of the ITN, check the Appendix A of
+         * [Export Compliance Customs Data Requirements](https://postalpro.usps.com/node/3973)
+         */
+        private const val ITN_REGEX_STRING =
+            """^(?:(?:AES X\d{14})|(?:NOEEI 30\.\d{1,2}(?:\([a-z]\)(?:\(\d\))?)?))${'$'}"""
+    }
+
+    private val List<CustomsItem>.totalValue: BigDecimal
+        get() = this.sumOf { it.totalValue }
+
+    private val CustomsData.classesAbove2500: Map<String, List<CustomsItem>>
+        get() = this.items.groupBy { it.hsTariffNumber }
+            .filter { it.value.totalValue > MAX_SHIPPING_ITEM_VALUE_FOR_CUSTOMS.toBigDecimal() }
+
+    operator fun invoke(
+        customsData: CustomsData,
+        destinationCountry: String
+    ): ITNValidationResult {
+        val itn = customsData.itn.trim()
+
+        return when {
+            itn.isNotEmpty() -> {
+                if (itn.matches(ITN_REGEX_STRING.toRegex())) {
+                    ITNValidationResult.Valid
+                } else {
+                    ITNValidationResult.InvalidFormat
+                }
+            }
+
+            customsData.items.totalValue > MAX_SHIPPING_ITEM_VALUE_FOR_CUSTOMS.toBigDecimal() ->
+                ITNValidationResult.Missing(ITNMissingCause.TOTAL_VALUE)
+
+            itnExemptCountries.contains(destinationCountry) -> ITNValidationResult.Valid
+
+            customsData.classesAbove2500.isNotEmpty() -> ITNValidationResult.Missing(ITNMissingCause.HS_TARIFF_VALUE)
+
+            itnRequiredCountries.contains(destinationCountry) ->
+                ITNValidationResult.Missing(ITNMissingCause.DESTINATION_COUNTRY)
+
+            else -> ITNValidationResult.Valid
+        }
+    }
+
+    sealed interface ITNValidationResult {
+        data object Valid : ITNValidationResult
+        data class Missing(val cause: ITNMissingCause) : ITNValidationResult
+        data object InvalidFormat : ITNValidationResult
+    }
+
+    enum class ITNMissingCause {
+        TOTAL_VALUE,
+        HS_TARIFF_VALUE,
+        DESTINATION_COUNTRY,
+    }
+}

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/customs/domain/ValidateITN.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/customs/domain/ValidateITN.kt
@@ -51,7 +51,7 @@ class ValidateITN @Inject constructor(
 
             customsData.items.totalValue > MAX_SHIPPING_ITEM_VALUE_FOR_CUSTOMS.toBigDecimal() &&
                 customsData.items.none { it.hsTariffNumber.isNotEmpty() } ->
-                    ITNValidationResult.Missing(ITNMissingCause.TotalValue)
+                ITNValidationResult.Missing(ITNMissingCause.TotalValue)
 
             customsData.classesAbove2500.isNotEmpty() ->
                 ITNValidationResult.Missing(ITNMissingCause.HSTariffValue(customsData.classesAbove2500.keys.first()))

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/customs/domain/ValidateITN.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/customs/domain/ValidateITN.kt
@@ -23,7 +23,7 @@ class ValidateITN @Inject constructor(
     }
 
     private val List<CustomsItem>.totalValue: BigDecimal
-        get() = this.sumOf { it.totalValue }
+        get() = this.sumOf { it.value }
 
     private val CustomsData.classesAbove2500: Map<String, List<CustomsItem>>
         get() = this.items.filter {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/customs/domain/ValidateITN.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/customs/domain/ValidateITN.kt
@@ -19,7 +19,7 @@ class ValidateITN @Inject constructor(
          * [Export Compliance Customs Data Requirements](https://postalpro.usps.com/node/3973)
          */
         private const val ITN_REGEX_STRING =
-            """^(?:(?:AES X\d{14})|(?:NOEEI 30\.\d{1,2}(?:\([a-z]\)(?:\(\d\))?)?))${'$'}"""
+            """^(?:AES X\d{14}|NOEEI 30\.\d{1,2}(?:\([a-z]\)(?:\(\d\))?)?)${'$'}"""
     }
 
     private val List<CustomsItem>.totalValue: BigDecimal

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/customs/domain/ValidateITN.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/customs/domain/ValidateITN.kt
@@ -24,7 +24,8 @@ class ValidateITN @Inject constructor() {
         get() = this.sumOf { it.totalValue }
 
     private val CustomsData.classesAbove2500: Map<String, List<CustomsItem>>
-        get() = this.items.groupBy { it.hsTariffNumber }
+        get() = this.items.filter { it.hsTariffNumber.isNotEmpty() }
+            .groupBy { it.hsTariffNumber }
             .filter { it.value.totalValue > MAX_SHIPPING_ITEM_VALUE_FOR_CUSTOMS.toBigDecimal() }
 
     operator fun invoke(
@@ -42,15 +43,17 @@ class ValidateITN @Inject constructor() {
                 }
             }
 
-            customsData.items.totalValue > MAX_SHIPPING_ITEM_VALUE_FOR_CUSTOMS.toBigDecimal() ->
-                ITNValidationResult.Missing(ITNMissingCause.TOTAL_VALUE)
-
             itnExemptCountries.contains(destinationCountry) -> ITNValidationResult.Valid
 
-            customsData.classesAbove2500.isNotEmpty() -> ITNValidationResult.Missing(ITNMissingCause.HS_TARIFF_VALUE)
+            customsData.items.totalValue > MAX_SHIPPING_ITEM_VALUE_FOR_CUSTOMS.toBigDecimal() &&
+                customsData.items.none { it.hsTariffNumber.isNotEmpty() } ->
+                    ITNValidationResult.Missing(ITNMissingCause.TotalValue)
+
+            customsData.classesAbove2500.isNotEmpty() ->
+                ITNValidationResult.Missing(ITNMissingCause.HSTariffValue(customsData.classesAbove2500.keys.first()))
 
             itnRequiredCountries.contains(destinationCountry) ->
-                ITNValidationResult.Missing(ITNMissingCause.DESTINATION_COUNTRY)
+                ITNValidationResult.Missing(ITNMissingCause.DestinationCountry)
 
             else -> ITNValidationResult.Valid
         }
@@ -62,9 +65,9 @@ class ValidateITN @Inject constructor() {
         data object InvalidFormat : ITNValidationResult
     }
 
-    enum class ITNMissingCause {
-        TOTAL_VALUE,
-        HS_TARIFF_VALUE,
-        DESTINATION_COUNTRY,
+    sealed interface ITNMissingCause {
+        data object TotalValue : ITNMissingCause
+        data class HSTariffValue(val hsTariffNumber: String) : ITNMissingCause
+        data object DestinationCountry : ITNMissingCause
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/customs/products/WooShippingCustomsProductListItem.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/customs/products/WooShippingCustomsProductListItem.kt
@@ -37,6 +37,7 @@ import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import com.woocommerce.android.R
 import com.woocommerce.android.ui.compose.component.WCOutlinedTextField
+import com.woocommerce.android.ui.compose.component.getText
 import com.woocommerce.android.ui.compose.theme.WooThemeWithBackground
 import com.woocommerce.android.ui.orders.wooshippinglabels.components.RoundedBorderDropDownWithLabel
 import com.woocommerce.android.ui.orders.wooshippinglabels.customs.WooShippingCustomsFormViewModel.InputValue
@@ -196,8 +197,7 @@ fun WooShippingCustomsProductExpandedListItem(
                 isError = itemData.description is InputValue.Error,
                 keyboardOptions = KeyboardOptions(imeAction = ImeAction.Next),
                 modifier = modifier.fillMaxWidth(),
-                helperText = itemData.description.errorMessageOrNull
-                    ?.let { stringResource(it) }
+                helperText = itemData.description.errorMessageOrNull?.getText()
             )
 
             WCOutlinedTextField(
@@ -211,8 +211,7 @@ fun WooShippingCustomsProductExpandedListItem(
                     keyboardType = KeyboardType.Number
                 ),
                 modifier = modifier.fillMaxWidth(),
-                helperText = itemData.tariffNumber.errorMessageOrNull
-                    ?.let { stringResource(it) }
+                helperText = itemData.tariffNumber.errorMessageOrNull?.getText()
             )
 
             Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
@@ -227,8 +226,7 @@ fun WooShippingCustomsProductExpandedListItem(
                         keyboardType = KeyboardType.Number
                     ),
                     modifier = modifier.weight(1f),
-                    helperText = itemData.valuePerUnit.errorMessageOrNull
-                        ?.let { stringResource(it) }
+                    helperText = itemData.valuePerUnit.errorMessageOrNull?.getText()
                 )
 
                 WCOutlinedTextField(
@@ -239,8 +237,7 @@ fun WooShippingCustomsProductExpandedListItem(
                     isError = itemData.weightPerUnit is InputValue.Error,
                     keyboardOptions = KeyboardOptions(imeAction = ImeAction.Next),
                     modifier = modifier.weight(1f),
-                    helperText = itemData.weightPerUnit.errorMessageOrNull
-                        ?.let { stringResource(it) }
+                    helperText = itemData.weightPerUnit.errorMessageOrNull?.getText()
                 )
             }
 

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -4578,7 +4578,9 @@
     <string name="woo_shipping_labels_customs_other_error_message">Type must not be empty</string>
     <string name="woo_shipping_labels_customs_itn_error_message">Invalid ITN format</string>
     <string name="woo_shipping_labels_customs_itn_required_error">ITN is required</string>
-    <string name="woo_shipping_labels_customs_itn_required_message">For shipments over $2,500, you need to obtain a 14-digit AES ITN for U.S. export reporting verification.</string>
+    <string name="woo_shipping_labels_customs_itn_required_total_value">For shipments over $2,500, you need to obtain a 14-digit AES ITN for U.S. export reporting verification.</string>
+    <string name="woo_shipping_labels_customs_itn_required_hs_tariff_value">International Transaction Number is required for shipping items valued over $2,500 per tariff number.</string>
+    <string name="woo_shipping_labels_customs_itn_required_destination_country">International Transaction Number is required for shipments to the destination country.</string>
     <string name="woo_shipping_labels_customs_product_details_title">Product Details</string>
     <string name="woo_shipping_labels_customs_product_details_description">Description</string>
     <string name="woo_shipping_labels_customs_product_details_description_missing">Missing Description</string>

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -4579,7 +4579,7 @@
     <string name="woo_shipping_labels_customs_itn_error_message">Invalid ITN format</string>
     <string name="woo_shipping_labels_customs_itn_required_error">ITN is required</string>
     <string name="woo_shipping_labels_customs_itn_required_total_value">For shipments over $2,500, you need to obtain a 14-digit AES ITN for U.S. export reporting verification.</string>
-    <string name="woo_shipping_labels_customs_itn_required_hs_tariff_value">International Transaction Number is required for shipping items valued over $2,500 per tariff number.</string>
+    <string name="woo_shipping_labels_customs_itn_required_hs_tariff_value">International Transaction Number is required for shipping items valued over $2,500 per tariff number.\nProducts with tariff number %1$s add up to more than $2,500.</string>
     <string name="woo_shipping_labels_customs_itn_required_destination_country">International Transaction Number is required for shipments to the destination country.</string>
     <string name="woo_shipping_labels_customs_product_details_title">Product Details</string>
     <string name="woo_shipping_labels_customs_product_details_description">Description</string>

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/customs/WooShippingCustomsFormViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/customs/WooShippingCustomsFormViewModelTest.kt
@@ -7,6 +7,7 @@ import com.woocommerce.android.ui.orders.wooshippinglabels.customs.WooShippingCu
 import com.woocommerce.android.ui.orders.wooshippinglabels.customs.WooShippingCustomsFormViewModel.ShowCountrySelector
 import com.woocommerce.android.ui.orders.wooshippinglabels.customs.WooShippingCustomsFormViewModel.ShowRestrictionTypeDialog
 import com.woocommerce.android.ui.orders.wooshippinglabels.customs.WooShippingCustomsFormViewModel.ViewState
+import com.woocommerce.android.ui.orders.wooshippinglabels.customs.domain.ValidateHSTariffNumber
 import com.woocommerce.android.ui.orders.wooshippinglabels.customs.domain.ValidateITN
 import com.woocommerce.android.ui.orders.wooshippinglabels.models.ShippableItemModel
 import com.woocommerce.android.util.runAndCaptureValues
@@ -18,6 +19,7 @@ import org.assertj.core.api.Assertions.assertThat
 import org.junit.Before
 import org.junit.Test
 import org.mockito.kotlin.any
+import org.mockito.kotlin.anyOrNull
 import org.mockito.kotlin.doAnswer
 import org.mockito.kotlin.doReturn
 import org.mockito.kotlin.mock
@@ -26,13 +28,7 @@ import java.math.BigDecimal
 
 @ExperimentalCoroutinesApi
 class WooShippingCustomsFormViewModelTest : BaseUnitTest() {
-    private lateinit var viewModel: WooShippingCustomsFormViewModel
-    private lateinit var getAllCountries: GetAllCountries
-    private lateinit var shouldRequireITN: ShouldRequireITN
-
-    @Before
-    fun setup() {
-        // Create mock locations for the tests
+    private val getAllCountries: GetAllCountries = mock {
         val mockLocations = listOf(
             mock<Location> {
                 on { code } doReturn "US"
@@ -43,22 +39,22 @@ class WooShippingCustomsFormViewModelTest : BaseUnitTest() {
                 on { name } doReturn "Canada"
             }
         )
-
-        // Configure the mock to return our test locations
-        getAllCountries = mock {
-            onBlocking { invoke() } doReturn Result.success(mockLocations)
+        onBlocking { invoke() } doReturn Result.success(mockLocations)
+    }
+    private val validateHSTariffNumber: ValidateHSTariffNumber = mock {
+        on { invoke(any(), anyOrNull()) } doAnswer {
+            InputValue.Data(it.arguments[0] as String)
         }
+    }
 
-        validateITN = mock {
-            on { invoke(any(), any()) } doReturn ValidateITN.ITNValidationResult.Valid
-        }
+    private val validateITN: ValidateITN = mock {
+        on { invoke(any(), any()) } doReturn ValidateITN.ITNValidationResult.Valid
+    }
 
-        validateHSTariffNumber = mock {
-            on { invoke(any(), any()) } doAnswer {
-                InputValue.Data(it.arguments[0] as String)
-            }
-        }
+    private lateinit var viewModel: WooShippingCustomsFormViewModel
 
+    @Before
+    fun setup() {
         createSut()
     }
 
@@ -91,17 +87,6 @@ class WooShippingCustomsFormViewModelTest : BaseUnitTest() {
         }
         viewModel.onITNChanged(newItnValue)
         assertThat(capturedViewState?.itnValue).isEqualTo(InputValue.Data(newItnValue))
-    }
-
-    @Test
-    fun `onITNChanged should update itnValue with invalid input`() = testBlocking {
-        val newItnValue = "INVALID_ITN"
-        var capturedViewState: ViewState? = null
-        viewModel.viewState.observeForever {
-            capturedViewState = it
-        }
-        viewModel.onITNChanged(newItnValue)
-        assertThat(capturedViewState?.itnValue).isInstanceOf(InputValue.Error::class.java)
     }
 
     @Test
@@ -395,7 +380,7 @@ class WooShippingCustomsFormViewModelTest : BaseUnitTest() {
         }.last()
 
         // Then
-        assertThat(capturedViewState?.itnValue).isInstanceOf(InputValue.Error::class.java)
+        assertThat(capturedViewState.itnValue).isInstanceOf(InputValue.Error::class.java)
     }
 
     private fun createSut() {
@@ -430,8 +415,8 @@ class WooShippingCustomsFormViewModelTest : BaseUnitTest() {
         viewModel = WooShippingCustomsFormViewModel(
             getAllCountries = getAllCountries,
             validateITN = validateITN,
-            dispatchers = coroutinesTestRule.testDispatchers,
             validateHSTariffNumber = validateHSTariffNumber,
+            dispatchers = coroutinesTestRule.testDispatchers,
             savedState = WooShippingCustomsFormFragmentArgs(
                 shippableItems = arrayOf(testProduct, expensiveProduct),
                 destinationCountryCode = "CA",

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/customs/WooShippingCustomsFormViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/customs/WooShippingCustomsFormViewModelTest.kt
@@ -7,9 +7,9 @@ import com.woocommerce.android.ui.orders.wooshippinglabels.customs.WooShippingCu
 import com.woocommerce.android.ui.orders.wooshippinglabels.customs.WooShippingCustomsFormViewModel.ShowCountrySelector
 import com.woocommerce.android.ui.orders.wooshippinglabels.customs.WooShippingCustomsFormViewModel.ShowRestrictionTypeDialog
 import com.woocommerce.android.ui.orders.wooshippinglabels.customs.WooShippingCustomsFormViewModel.ViewState
-import com.woocommerce.android.ui.orders.wooshippinglabels.customs.domain.ShouldRequireITN
-import com.woocommerce.android.ui.orders.wooshippinglabels.customs.domain.ValidateHSTariffNumber
+import com.woocommerce.android.ui.orders.wooshippinglabels.customs.domain.ValidateITN
 import com.woocommerce.android.ui.orders.wooshippinglabels.models.ShippableItemModel
+import com.woocommerce.android.util.runAndCaptureValues
 import com.woocommerce.android.viewmodel.BaseUnitTest
 import com.woocommerce.android.viewmodel.MultiLiveEvent
 import kotlinx.coroutines.ExperimentalCoroutinesApi
@@ -21,6 +21,7 @@ import org.mockito.kotlin.any
 import org.mockito.kotlin.doAnswer
 import org.mockito.kotlin.doReturn
 import org.mockito.kotlin.mock
+import org.mockito.kotlin.whenever
 import java.math.BigDecimal
 
 @ExperimentalCoroutinesApi
@@ -28,7 +29,6 @@ class WooShippingCustomsFormViewModelTest : BaseUnitTest() {
     private lateinit var viewModel: WooShippingCustomsFormViewModel
     private lateinit var getAllCountries: GetAllCountries
     private lateinit var shouldRequireITN: ShouldRequireITN
-    private lateinit var validateHSTariffNumber: ValidateHSTariffNumber
 
     @Before
     fun setup() {
@@ -49,8 +49,8 @@ class WooShippingCustomsFormViewModelTest : BaseUnitTest() {
             onBlocking { invoke() } doReturn Result.success(mockLocations)
         }
 
-        shouldRequireITN = mock {
-            on { invoke(any(), any()) } doReturn false
+        validateITN = mock {
+            on { invoke(any(), any()) } doReturn ValidateITN.ITNValidationResult.Valid
         }
 
         validateHSTariffNumber = mock {
@@ -382,24 +382,17 @@ class WooShippingCustomsFormViewModelTest : BaseUnitTest() {
     }
 
     @Test
-    fun `onITNChanged with blank value should set error when ITN is required`() = testBlocking {
+    fun `when ITN is required, then setting an empty should trigger an error`() = testBlocking {
         // Given
-        val blankItn = ""
-        shouldRequireITN = mock {
-            on { invoke(any(), any()) } doReturn true
-        }
+        whenever(validateITN(any(), any())).thenReturn(
+            ValidateITN.ITNValidationResult.Missing(ValidateITN.ITNMissingCause.DestinationCountry)
+        )
         createSut()
 
-        // The second product in our setup is the expensive one,
-        // so expanding the second product will make the ITN required
-        var capturedViewState: ViewState? = null
-        viewModel.viewState.observeForever {
-            capturedViewState = it
-        }
-
         // When
-        viewModel.onShippableProductValuePerUnitChanged(1, "2600")
-        viewModel.onITNChanged(blankItn)
+        val capturedViewState = viewModel.viewState.runAndCaptureValues {
+            viewModel.onITNChanged("")
+        }.last()
 
         // Then
         assertThat(capturedViewState?.itnValue).isInstanceOf(InputValue.Error::class.java)
@@ -435,14 +428,15 @@ class WooShippingCustomsFormViewModelTest : BaseUnitTest() {
         )
 
         viewModel = WooShippingCustomsFormViewModel(
+            getAllCountries = getAllCountries,
+            validateITN = validateITN,
+            dispatchers = coroutinesTestRule.testDispatchers,
+            validateHSTariffNumber = validateHSTariffNumber,
             savedState = WooShippingCustomsFormFragmentArgs(
                 shippableItems = arrayOf(testProduct, expensiveProduct),
                 destinationCountryCode = "CA",
                 customsData = null
-            ).toSavedStateHandle(),
-            getAllCountries = getAllCountries,
-            shouldRequireITN = shouldRequireITN,
-            validateHSTariffNumber = validateHSTariffNumber
+            ).toSavedStateHandle()
         )
     }
 }

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/customs/domain/ValidateITNTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/customs/domain/ValidateITNTest.kt
@@ -87,12 +87,12 @@ class ValidateITNTest : BaseUnitTest() {
     }
 
     @Test
-    fun `when ITN is empty and total value exceeds limit, then validation result is Missing with TOTAL_VALUE cause`() {
+    fun `when ITN is empty and total value exceeds limit with no HS tariff numbers, then validation result is Missing with TotalValue cause`() {
         // Arrange
         val customsData = createCustomsData(
             itn = "",
             items = listOf(
-                createCustomsItem(value = BigDecimal("1000"), quantity = 3f) // Total value: 3000
+                createCustomsItem(value = BigDecimal("1000"), quantity = 3f, hsTariffNumber = "") // Total value: 3000
             )
         )
 
@@ -101,10 +101,7 @@ class ValidateITNTest : BaseUnitTest() {
 
         // Assert
         assertTrue(result is ValidateITN.ITNValidationResult.Missing)
-        assertEquals(
-            ValidateITN.ITNMissingCause.TOTAL_VALUE,
-            (result as ValidateITN.ITNValidationResult.Missing).cause
-        )
+        assertEquals(ValidateITN.ITNMissingCause.TotalValue, result.cause)
     }
 
     @Test
@@ -120,7 +117,7 @@ class ValidateITNTest : BaseUnitTest() {
     }
 
     @Test
-    fun `when ITN is empty and total value exceeds limit for single item, then validation result is Missing with TOTAL_VALUE cause`() {
+    fun `when ITN is empty and total value exceeds limit for single item with HS tariff number, then validation result is Missing with HSTariffValue cause`() {
         // Arrange
         val customsData = createCustomsData(
             itn = "",
@@ -138,20 +135,23 @@ class ValidateITNTest : BaseUnitTest() {
 
         // Assert
         assertTrue(result is ValidateITN.ITNValidationResult.Missing)
-        assertEquals(ValidateITN.ITNMissingCause.TOTAL_VALUE, result.cause)
+        assertEquals(ValidateITN.ITNMissingCause.HSTariffValue("1234.56"), result.cause)
     }
 
     @Test
-    fun `when ITN is empty and destination country requires ITN, then validation result is Missing with DESTINATION_COUNTRY cause`() {
+    fun `when ITN is empty and destination country requires ITN, then validation result is Missing with DestinationCountry cause`() {
         // Arrange
-        val customsData = createCustomsData(itn = "")
+        val customsData = createCustomsData(
+            itn = "",
+            items = listOf(createCustomsItem(hsTariffNumber = "")) // Ensure no HS tariff numbers
+        )
 
         // Act
         val result = validateITN(customsData, "IR") // Iran requires ITN
 
         // Assert
         assertTrue(result is ValidateITN.ITNValidationResult.Missing)
-        assertEquals(ValidateITN.ITNMissingCause.DESTINATION_COUNTRY, result.cause)
+        assertEquals(ValidateITN.ITNMissingCause.DestinationCountry, result.cause)
     }
 
     @Test
@@ -160,7 +160,7 @@ class ValidateITNTest : BaseUnitTest() {
         val customsData = createCustomsData(
             itn = "",
             items = listOf(
-                createCustomsItem(value = BigDecimal("100"), quantity = 1f) // Total value: 100
+                createCustomsItem(value = BigDecimal("100"), quantity = 1f, hsTariffNumber = "") // Total value: 100
             )
         )
 
@@ -184,12 +184,12 @@ class ValidateITNTest : BaseUnitTest() {
     }
 
     @Test
-    fun `when ITN is empty and total value is exactly at limit, then validation result is Valid`() {
+    fun `when ITN is empty and total value is exactly at limit with no HS tariff number, then validation result is Valid`() {
         // Arrange
         val customsData = createCustomsData(
             itn = "",
             items = listOf(
-                createCustomsItem(value = BigDecimal("2500"), quantity = 1f) // Total value: 2500
+                createCustomsItem(value = BigDecimal("2500"), quantity = 1f, hsTariffNumber = "") // Total value: 2500
             )
         )
 
@@ -201,12 +201,12 @@ class ValidateITNTest : BaseUnitTest() {
     }
 
     @Test
-    fun `when ITN is empty and total value is slightly below limit, then validation result is Valid`() {
+    fun `when ITN is empty and total value is slightly below limit with no HS tariff number, then validation result is Valid`() {
         // Arrange
         val customsData = createCustomsData(
             itn = "",
             items = listOf(
-                createCustomsItem(value = BigDecimal("2499.99"), quantity = 1f) // Total value: 2499.99
+                createCustomsItem(value = BigDecimal("2499.99"), quantity = 1f, hsTariffNumber = "") // Total value: 2499.99
             )
         )
 
@@ -218,12 +218,12 @@ class ValidateITNTest : BaseUnitTest() {
     }
 
     @Test
-    fun `when ITN is empty and total value is slightly above limit, then validation result is Missing with TOTAL_VALUE cause`() {
+    fun `when ITN is empty and total value is slightly above limit with no HS tariff number, then validation result is Missing with TotalValue cause`() {
         // Arrange
         val customsData = createCustomsData(
             itn = "",
             items = listOf(
-                createCustomsItem(value = BigDecimal("2500.01"), quantity = 1f) // Total value: 2500.01
+                createCustomsItem(value = BigDecimal("2500.01"), quantity = 1f, hsTariffNumber = "") // Total value: 2500.01
             )
         )
 
@@ -232,11 +232,11 @@ class ValidateITNTest : BaseUnitTest() {
 
         // Assert
         assertTrue(result is ValidateITN.ITNValidationResult.Missing)
-        assertEquals(ValidateITN.ITNMissingCause.TOTAL_VALUE, result.cause)
+        assertEquals(ValidateITN.ITNMissingCause.TotalValue, result.cause)
     }
 
     @Test
-    fun `when ITN is empty and multiple items with different HS tariff numbers exceed total limit, then validation result is Missing with TOTAL_VALUE cause`() {
+    fun `when ITN is empty and multiple items with different HS tariff numbers but none exceeds limit, then validation result is Valid`() {
         // Arrange
         val customsData = createCustomsData(
             itn = "",
@@ -251,7 +251,28 @@ class ValidateITNTest : BaseUnitTest() {
                     quantity = 1f,
                     hsTariffNumber = "7890.12"
                 ) // Total value: 1300
-                // Combined total: 2600, exceeds limit
+                // Each HS tariff number group is below the $2500 limit
+            )
+        )
+
+        // Act
+        val result = validateITN(customsData, "US")
+
+        // Assert
+        assertTrue(result is ValidateITN.ITNValidationResult.Valid)
+    }
+
+    @Test
+    fun `when ITN is empty and a single HS tariff number exceeds limit, then validation result is Missing with HSTariffValue cause`() {
+        // Arrange
+        val customsData = createCustomsData(
+            itn = "",
+            items = listOf(
+                createCustomsItem(
+                    value = BigDecimal("2600"),
+                    quantity = 1f,
+                    hsTariffNumber = "1234.56"
+                ) // Total value: 2600, exceeds the $2500 limit
             )
         )
 
@@ -260,11 +281,11 @@ class ValidateITNTest : BaseUnitTest() {
 
         // Assert
         assertTrue(result is ValidateITN.ITNValidationResult.Missing)
-        assertEquals(ValidateITN.ITNMissingCause.TOTAL_VALUE, result.cause)
+        assertEquals(ValidateITN.ITNMissingCause.HSTariffValue("1234.56"), result.cause)
     }
 
     @Test
-    fun `when ITN is empty and multiple items with same HS tariff number exceed total limit, then validation result is Missing with TOTAL_VALUE cause`() {
+    fun `when ITN is empty and multiple items with same HS tariff number exceed total limit, then validation result is Missing with HSTariffValue cause`() {
         // Arrange
         val customsData = createCustomsData(
             itn = "",
@@ -289,10 +310,7 @@ class ValidateITNTest : BaseUnitTest() {
 
         // Assert
         assertTrue(result is ValidateITN.ITNValidationResult.Missing)
-        assertEquals(
-            ValidateITN.ITNMissingCause.TOTAL_VALUE,
-            (result as ValidateITN.ITNValidationResult.Missing).cause
-        )
+        assertEquals(ValidateITN.ITNMissingCause.HSTariffValue("1234.56"), result.cause)
     }
 
     private fun createCustomsData(
@@ -316,7 +334,7 @@ class ValidateITNTest : BaseUnitTest() {
         quantity: Float = 1f,
         value: BigDecimal = BigDecimal("100"),
         weight: Float = 1f,
-        hsTariffNumber: String = "1234.56",
+        hsTariffNumber: String = "",
         originCountry: String = "United States",
         originCountryCode: String = "US"
     ): CustomsItem {

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/customs/domain/ValidateITNTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/customs/domain/ValidateITNTest.kt
@@ -4,17 +4,24 @@ import com.woocommerce.android.ui.orders.wooshippinglabels.customs.ContentType
 import com.woocommerce.android.ui.orders.wooshippinglabels.customs.CustomsData
 import com.woocommerce.android.ui.orders.wooshippinglabels.customs.CustomsItem
 import com.woocommerce.android.ui.orders.wooshippinglabels.customs.RestrictionType
+import com.woocommerce.android.ui.orders.wooshippinglabels.customs.WooShippingCustomsFormViewModel
 import com.woocommerce.android.viewmodel.BaseUnitTest
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import org.junit.Test
+import org.mockito.kotlin.any
+import org.mockito.kotlin.anyOrNull
+import org.mockito.kotlin.doReturn
+import org.mockito.kotlin.mock
 import java.math.BigDecimal
 import kotlin.test.assertEquals
 import kotlin.test.assertTrue
 
 @ExperimentalCoroutinesApi
 class ValidateITNTest : BaseUnitTest() {
-
-    private val validateITN = ValidateITN()
+    private val validateHSTariffNumber: ValidateHSTariffNumber = mock {
+        on { invoke(any(), anyOrNull()) } doReturn WooShippingCustomsFormViewModel.InputValue.Data("123456")
+    }
+    private val validateITN = ValidateITN(validateHSTariffNumber)
 
     // Valid ITN examples
     private val validAesItn = "AES X12345678901234"
@@ -206,7 +213,11 @@ class ValidateITNTest : BaseUnitTest() {
         val customsData = createCustomsData(
             itn = "",
             items = listOf(
-                createCustomsItem(value = BigDecimal("2499.99"), quantity = 1f, hsTariffNumber = "") // Total value: 2499.99
+                createCustomsItem(
+                    value = BigDecimal("2499.99"),
+                    quantity = 1f,
+                    hsTariffNumber = ""
+                ) // Total value: 2499.99
             )
         )
 
@@ -223,7 +234,11 @@ class ValidateITNTest : BaseUnitTest() {
         val customsData = createCustomsData(
             itn = "",
             items = listOf(
-                createCustomsItem(value = BigDecimal("2500.01"), quantity = 1f, hsTariffNumber = "") // Total value: 2500.01
+                createCustomsItem(
+                    value = BigDecimal("2500.01"),
+                    quantity = 1f,
+                    hsTariffNumber = ""
+                ) // Total value: 2500.01
             )
         )
 

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/customs/domain/ValidateITNTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/customs/domain/ValidateITNTest.kt
@@ -1,0 +1,334 @@
+package com.woocommerce.android.ui.orders.wooshippinglabels.customs.domain
+
+import com.woocommerce.android.ui.orders.wooshippinglabels.customs.ContentType
+import com.woocommerce.android.ui.orders.wooshippinglabels.customs.CustomsData
+import com.woocommerce.android.ui.orders.wooshippinglabels.customs.CustomsItem
+import com.woocommerce.android.ui.orders.wooshippinglabels.customs.RestrictionType
+import com.woocommerce.android.viewmodel.BaseUnitTest
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import org.junit.Test
+import java.math.BigDecimal
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+@ExperimentalCoroutinesApi
+class ValidateITNTest : BaseUnitTest() {
+
+    private val validateITN = ValidateITN()
+
+    // Valid ITN examples
+    private val validAesItn = "AES X12345678901234"
+    private val validNoEeiItn = "NOEEI 30.36"
+    private val validNoEeiWithParenthesesItn = "NOEEI 30.36(a)"
+    private val validNoEeiWithNestedParenthesesItn = "NOEEI 30.36(a)(2)"
+    private val validItnWithWhitespace = "  AES X12345678901234  "
+
+    // Invalid ITN examples
+    private val invalidItn = "INVALID ITN"
+
+    @Test
+    fun `when ITN is valid AES format, then validation result is Valid`() {
+        // Arrange
+        val customsData = createCustomsData(itn = validAesItn)
+
+        // Act
+        val result = validateITN(customsData, "US")
+
+        // Assert
+        assertTrue(result is ValidateITN.ITNValidationResult.Valid)
+    }
+
+    @Test
+    fun `when ITN is valid NOEEI format, then validation result is Valid`() {
+        // Arrange
+        val customsData = createCustomsData(itn = validNoEeiItn)
+
+        // Act
+        val result = validateITN(customsData, "US")
+
+        // Assert
+        assertTrue(result is ValidateITN.ITNValidationResult.Valid)
+    }
+
+    @Test
+    fun `when ITN is valid NOEEI format with parentheses, then validation result is Valid`() {
+        // Arrange
+        val customsData = createCustomsData(itn = validNoEeiWithParenthesesItn)
+
+        // Act
+        val result = validateITN(customsData, "US")
+
+        // Assert
+        assertTrue(result is ValidateITN.ITNValidationResult.Valid)
+    }
+
+    @Test
+    fun `when ITN is valid NOEEI format with nested parentheses, then validation result is Valid`() {
+        // Arrange
+        val customsData = createCustomsData(itn = validNoEeiWithNestedParenthesesItn)
+
+        // Act
+        val result = validateITN(customsData, "US")
+
+        // Assert
+        assertTrue(result is ValidateITN.ITNValidationResult.Valid)
+    }
+
+    @Test
+    fun `when ITN is invalid format, then validation result is InvalidFormat`() {
+        // Arrange
+        val customsData = createCustomsData(itn = invalidItn)
+
+        // Act
+        val result = validateITN(customsData, "US")
+
+        // Assert
+        assertTrue(result is ValidateITN.ITNValidationResult.InvalidFormat)
+    }
+
+    @Test
+    fun `when ITN is empty and total value exceeds limit, then validation result is Missing with TOTAL_VALUE cause`() {
+        // Arrange
+        val customsData = createCustomsData(
+            itn = "",
+            items = listOf(
+                createCustomsItem(value = BigDecimal("1000"), quantity = 3f) // Total value: 3000
+            )
+        )
+
+        // Act
+        val result = validateITN(customsData, "US")
+
+        // Assert
+        assertTrue(result is ValidateITN.ITNValidationResult.Missing)
+        assertEquals(
+            ValidateITN.ITNMissingCause.TOTAL_VALUE,
+            (result as ValidateITN.ITNValidationResult.Missing).cause
+        )
+    }
+
+    @Test
+    fun `when ITN is empty and destination country is exempt, then validation result is Valid`() {
+        // Arrange
+        val customsData = createCustomsData(itn = "")
+
+        // Act
+        val result = validateITN(customsData, "CA") // Canada is exempt
+
+        // Assert
+        assertTrue(result is ValidateITN.ITNValidationResult.Valid)
+    }
+
+    @Test
+    fun `when ITN is empty and total value exceeds limit for single item, then validation result is Missing with TOTAL_VALUE cause`() {
+        // Arrange
+        val customsData = createCustomsData(
+            itn = "",
+            items = listOf(
+                createCustomsItem(
+                    value = BigDecimal("800"),
+                    quantity = 3.2f, // Total value: 2560, above the $2500 limit
+                    hsTariffNumber = "1234.56"
+                )
+            )
+        )
+
+        // Act
+        val result = validateITN(customsData, "US")
+
+        // Assert
+        assertTrue(result is ValidateITN.ITNValidationResult.Missing)
+        assertEquals(ValidateITN.ITNMissingCause.TOTAL_VALUE, result.cause)
+    }
+
+    @Test
+    fun `when ITN is empty and destination country requires ITN, then validation result is Missing with DESTINATION_COUNTRY cause`() {
+        // Arrange
+        val customsData = createCustomsData(itn = "")
+
+        // Act
+        val result = validateITN(customsData, "IR") // Iran requires ITN
+
+        // Assert
+        assertTrue(result is ValidateITN.ITNValidationResult.Missing)
+        assertEquals(ValidateITN.ITNMissingCause.DESTINATION_COUNTRY, result.cause)
+    }
+
+    @Test
+    fun `when ITN is empty and no conditions require ITN, then validation result is Valid`() {
+        // Arrange
+        val customsData = createCustomsData(
+            itn = "",
+            items = listOf(
+                createCustomsItem(value = BigDecimal("100"), quantity = 1f) // Total value: 100
+            )
+        )
+
+        // Act
+        val result = validateITN(customsData, "US") // Not in required or exempt list
+
+        // Assert
+        assertTrue(result is ValidateITN.ITNValidationResult.Valid)
+    }
+
+    @Test
+    fun `when ITN has whitespace, then validation result is Valid`() {
+        // Arrange
+        val customsData = createCustomsData(itn = validItnWithWhitespace)
+
+        // Act
+        val result = validateITN(customsData, "US")
+
+        // Assert
+        assertTrue(result is ValidateITN.ITNValidationResult.Valid)
+    }
+
+    @Test
+    fun `when ITN is empty and total value is exactly at limit, then validation result is Valid`() {
+        // Arrange
+        val customsData = createCustomsData(
+            itn = "",
+            items = listOf(
+                createCustomsItem(value = BigDecimal("2500"), quantity = 1f) // Total value: 2500
+            )
+        )
+
+        // Act
+        val result = validateITN(customsData, "US")
+
+        // Assert
+        assertTrue(result is ValidateITN.ITNValidationResult.Valid)
+    }
+
+    @Test
+    fun `when ITN is empty and total value is slightly below limit, then validation result is Valid`() {
+        // Arrange
+        val customsData = createCustomsData(
+            itn = "",
+            items = listOf(
+                createCustomsItem(value = BigDecimal("2499.99"), quantity = 1f) // Total value: 2499.99
+            )
+        )
+
+        // Act
+        val result = validateITN(customsData, "US")
+
+        // Assert
+        assertTrue(result is ValidateITN.ITNValidationResult.Valid)
+    }
+
+    @Test
+    fun `when ITN is empty and total value is slightly above limit, then validation result is Missing with TOTAL_VALUE cause`() {
+        // Arrange
+        val customsData = createCustomsData(
+            itn = "",
+            items = listOf(
+                createCustomsItem(value = BigDecimal("2500.01"), quantity = 1f) // Total value: 2500.01
+            )
+        )
+
+        // Act
+        val result = validateITN(customsData, "US")
+
+        // Assert
+        assertTrue(result is ValidateITN.ITNValidationResult.Missing)
+        assertEquals(ValidateITN.ITNMissingCause.TOTAL_VALUE, result.cause)
+    }
+
+    @Test
+    fun `when ITN is empty and multiple items with different HS tariff numbers exceed total limit, then validation result is Missing with TOTAL_VALUE cause`() {
+        // Arrange
+        val customsData = createCustomsData(
+            itn = "",
+            items = listOf(
+                createCustomsItem(
+                    value = BigDecimal("1300"),
+                    quantity = 1f,
+                    hsTariffNumber = "1234.56"
+                ), // Total value: 1300
+                createCustomsItem(
+                    value = BigDecimal("1300"),
+                    quantity = 1f,
+                    hsTariffNumber = "7890.12"
+                ) // Total value: 1300
+                // Combined total: 2600, exceeds limit
+            )
+        )
+
+        // Act
+        val result = validateITN(customsData, "US")
+
+        // Assert
+        assertTrue(result is ValidateITN.ITNValidationResult.Missing)
+        assertEquals(ValidateITN.ITNMissingCause.TOTAL_VALUE, result.cause)
+    }
+
+    @Test
+    fun `when ITN is empty and multiple items with same HS tariff number exceed total limit, then validation result is Missing with TOTAL_VALUE cause`() {
+        // Arrange
+        val customsData = createCustomsData(
+            itn = "",
+            items = listOf(
+                // First HS tariff number (1234.56) with total value of 2600
+                createCustomsItem(
+                    value = BigDecimal("1300"),
+                    quantity = 1f,
+                    hsTariffNumber = "1234.56"
+                ), // Value: 1300
+                createCustomsItem(
+                    value = BigDecimal("1300"),
+                    quantity = 1f,
+                    hsTariffNumber = "1234.56"
+                ) // Value: 1300
+                // Combined total: 2600, exceeds the $2500 limit
+            )
+        )
+
+        // Act
+        val result = validateITN(customsData, "US")
+
+        // Assert
+        assertTrue(result is ValidateITN.ITNValidationResult.Missing)
+        assertEquals(
+            ValidateITN.ITNMissingCause.TOTAL_VALUE,
+            (result as ValidateITN.ITNValidationResult.Missing).cause
+        )
+    }
+
+    private fun createCustomsData(
+        itn: String = "",
+        items: List<CustomsItem> = listOf(createCustomsItem())
+    ): CustomsData {
+        return CustomsData(
+            contentType = ContentType.MERCHANDISE,
+            contentDescription = "Test merchandise",
+            restrictionType = RestrictionType.NONE,
+            restrictionDescription = "",
+            isReturnToSender = false,
+            itn = itn,
+            items = items
+        )
+    }
+
+    private fun createCustomsItem(
+        productID: Long = 1L,
+        description: String = "Test product",
+        quantity: Float = 1f,
+        value: BigDecimal = BigDecimal("100"),
+        weight: Float = 1f,
+        hsTariffNumber: String = "1234.56",
+        originCountry: String = "United States",
+        originCountryCode: String = "US"
+    ): CustomsItem {
+        return CustomsItem(
+            productID = productID,
+            description = description,
+            quantity = quantity,
+            value = value,
+            weight = weight,
+            hsTariffNumber = hsTariffNumber,
+            originCountry = originCountry,
+            originCountryCode = originCountryCode
+        )
+    }
+}


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

<!-- Id number of the Linear issue this PR addresses, e.g., WOOMOB-373. -->
Part of WOOMOB-630

> [!WARNING]
> Please don't merge this until the PR #14351 is merged to the `release/22.8` branch and the backmerge PR from the release branch is merged to `trunk`. When this is done, update the base branch of this PR to `trunk`. 

### Description
This PR updates the ITN validation logic, we were missing quite a few cases.

The ITN validation rules are as follows:
- When the destination country is Canada, the ITN is not required.
- When the total value is more than 2500USD (and HS Tariffs not used) then ITN is required.
- When the value of items belonging to the same HS Tariff is more than 2500USD then ITN is required.
- When the destination country is one of `"IR", "KP", "SY", "CU", "SD"` then ITN is required.
- When an ITN is entered, we validate its format.

> [!NOTE]
> The `WooShippingLabelCreationViewModel` still uses the old `ShouldRequireITN` use case, given the size of this PR, I handled this change in a separate PR #14353  

> [!IMPORTANT]
> The rules match what iOS does, the plugin has some differences for now, and we are still waiting for the team confirmation about them p1752754617716169-slack-C05VBLKHHV1 

### Steps to reproduce
Test the steps in this PR https://github.com/woocommerce/woocommerce-ios/pull/15319, just ignore the last two steps, as they are part of the next PR.

### Testing information
Check the above steps.

### The tests that have been performed
The above.

- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->