### PR TITLE
[WOOMOB-877][Woo POS][Barcodes] Update scanner setup copy for better clarity

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/scanningsetup/WooPosScanningSetupState.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/scanningsetup/WooPosScanningSetupState.kt
@@ -79,11 +79,11 @@ data class WooPosScanningSetupState(
         ) : ScanningSetupStep() {
             @get:StringRes
             @IgnoredOnParcel
-            val titleRes = R.string.woopos_scanning_setup_introduction_title
+            val titleRes = R.string.woopos_scanning_setup_hid_title
 
             @get:StringRes
             @IgnoredOnParcel
-            val messageRes = R.string.woopos_scanning_setup_introduction_message
+            val messageRes = R.string.woopos_scanning_setup_hid_message
 
             @get:StringRes
             @IgnoredOnParcel

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -4484,10 +4484,10 @@
     <string name="woopos_scanning_setup_barcode_content_description">Barcode</string>
     <string name="woopos_scanning_setup_device_selection_title">Set up a barcode scanner</string>
     <string name="woopos_scanning_setup_device_selection_message">Select a model from the list:</string>
-    <string name="woopos_scanning_setup_introduction_title">Scanner set up</string>
-    <string name="woopos_scanning_setup_introduction_message">Scan the Bluetooth HID symbol.</string>
+    <string name="woopos_scanning_setup_hid_title">Scanner set up</string>
+    <string name="woopos_scanning_setup_hid_message">Use your barcode scanner to scan the QR code below to enable Bluetooth HID mode.</string>
     <string name="woopos_scanning_setup_scanner_pair_mode_title">Scanner set up</string>
-    <string name="woopos_scanning_setup_scanner_pair_mode_message">Scan the Pair symbol to get the scanner ready for pairing.</string>
+    <string name="woopos_scanning_setup_scanner_pair_mode_message">Use your barcode scanner to scan the QR code below to enter pairing mode.</string>
     <string name="woopos_scanning_setup_pair_your_scanner_title">Pair your scanner</string>
     <string name="woopos_scanning_setup_pair_your_scanner_message">Enable Bluetooth and select your %s scanner in the OS settings.\nThe scanner will beep and show a solid LED when paired.</string>
     <string name="woopos_scanning_setup_go_to_settings">Go to your device settings</string>

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/home/scanningsetup/WooPosScanningSetupViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/home/scanningsetup/WooPosScanningSetupViewModelTest.kt
@@ -298,8 +298,8 @@ class WooPosScanningSetupViewModelTest {
         val step = viewModel.state.value.currentStep as ScanningSetupStep.ScannerHIDModeSetup
 
         // THEN
-        assertThat(step.titleRes).isEqualTo(R.string.woopos_scanning_setup_introduction_title)
-        assertThat(step.messageRes).isEqualTo(R.string.woopos_scanning_setup_introduction_message)
+        assertThat(step.titleRes).isEqualTo(R.string.woopos_scanning_setup_hid_title)
+        assertThat(step.messageRes).isEqualTo(R.string.woopos_scanning_setup_hid_message)
         assertThat(step.primaryButtonTextRes).isEqualTo(R.string.woopos_scanning_setup_button_next)
         assertThat(step.secondaryButtonTextRes).isEqualTo(R.string.woopos_scanning_setup_button_back)
     }


### PR DESCRIPTION
WOOMOB-877

### Description
Updated the copy text in the scanner setup flow to provide clearer instructions. The previous text was too generic and didn't clearly explain what users needed to do with their barcode scanner.

### Changes made:
- Renamed string resources from "introduction" to "hid" for better semantic meaning
- Updated HID mode setup message to explicitly mention scanning QR codes
- Updated pair mode setup message to be more descriptive

### Steps to reproduce
1. Navigate to WooCommerce POS
2. Go to scanner setup flow
3. Observe the updated copy text in the HID mode setup and pair mode setup screens

### Testing information
- Verify the new copy text displays correctly in the scanner setup flow
- Ensure the flow still works as expected with the updated strings
- Check that the text is clear and provides better guidance to users

<img width="690" height="437" alt="image" src="https://github.com/user-attachments/assets/caac095d-a2c2-462d-8ac0-652807224b55" />
<img width="692" height="438" alt="image" src="https://github.com/user-attachments/assets/0d5f45d5-4bf6-45bb-90c2-c998a5c69f6f" />


- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.