### PR TITLE
[WOOMOB-908] Improve scanning performance in dark mode for Scanner setup flow

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/compose/component/BarcodeComponent.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/compose/component/BarcodeComponent.kt
@@ -80,8 +80,8 @@ fun BarcodeEAN13Code(
     content: String,
     widthDp: Dp,
     heightDp: Dp,
-    codeColor: Color,
-    backgroundColor: Color,
+    codeColor: Color = colorResource(id = R.color.woo_black_90),
+    backgroundColor: Color = colorResource(id = R.color.woo_white),
     @DrawableRes overlayId: Int? = null,
 ) {
     Image(

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/compose/component/BrightnessControl.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/compose/component/BrightnessControl.kt
@@ -16,14 +16,22 @@ fun BrightnessControl(temporarilyIncreaseToMax: Boolean = true) {
     var originalBrightness by remember { mutableStateOf<Float?>(null) }
 
     LaunchedEffect(temporarilyIncreaseToMax) {
+        val activity = context as? Activity ?: return@LaunchedEffect
+        val window = activity.window
+
         if (temporarilyIncreaseToMax) {
-            val activity = context as? Activity ?: return@LaunchedEffect
-            val window = activity.window
-
-            originalBrightness = window.attributes.screenBrightness
-
+            if (originalBrightness == null) {
+                originalBrightness = window.attributes.screenBrightness
+            }
             window.attributes = window.attributes.apply {
                 screenBrightness = 1.0f
+            }
+        } else {
+            originalBrightness?.let {
+                window.attributes = window.attributes.apply {
+                    screenBrightness = it
+                }
+                originalBrightness = null
             }
         }
     }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/compose/component/BrightnessControl.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/compose/component/BrightnessControl.kt
@@ -1,0 +1,41 @@
+package com.woocommerce.android.ui.compose.component
+
+import android.app.Activity
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.platform.LocalContext
+
+@Composable
+fun BrightnessControl(temporarilyIncreaseToMax: Boolean = true) {
+    val context = LocalContext.current
+    var originalBrightness by remember { mutableStateOf<Float?>(null) }
+
+    LaunchedEffect(temporarilyIncreaseToMax) {
+        if (temporarilyIncreaseToMax) {
+            val activity = context as? Activity ?: return@LaunchedEffect
+            val window = activity.window
+
+            originalBrightness = window.attributes.screenBrightness
+
+            window.attributes = window.attributes.apply {
+                screenBrightness = 1.0f
+            }
+        }
+    }
+
+    DisposableEffect(Unit) {
+        onDispose {
+            if (temporarilyIncreaseToMax && originalBrightness != null) {
+                val activity = context as? Activity ?: return@onDispose
+                activity.window.attributes = activity.window.attributes.apply {
+                    screenBrightness = originalBrightness ?: -1.0f
+                }
+            }
+        }
+    }
+}

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/common/composeui/component/WooPosBrightnessControl.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/common/composeui/component/WooPosBrightnessControl.kt
@@ -1,4 +1,4 @@
-package com.woocommerce.android.ui.compose.component
+package com.woocommerce.android.ui.woopos.common.composeui.component
 
 import android.app.Activity
 import androidx.compose.runtime.Composable
@@ -11,7 +11,7 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.platform.LocalContext
 
 @Composable
-fun BrightnessControl(temporarilyIncreaseToMax: Boolean = true) {
+fun WooPosBrightnessControl(temporarilyIncreaseToMax: Boolean = true) {
     val context = LocalContext.current
     var originalBrightness by remember { mutableStateOf<Float?>(null) }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/scanningsetup/WooPosScanningSetupDialog.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/scanningsetup/WooPosScanningSetupDialog.kt
@@ -63,10 +63,10 @@ import androidx.hilt.navigation.compose.hiltViewModel
 import com.woocommerce.android.R
 import com.woocommerce.android.WooCommerce
 import com.woocommerce.android.ui.compose.component.BarcodeEAN13Code
-import com.woocommerce.android.ui.compose.component.BrightnessControl
 import com.woocommerce.android.ui.compose.component.getText
 import com.woocommerce.android.ui.compose.preview.FontScalePreviews
 import com.woocommerce.android.ui.woopos.common.composeui.WooPosPreview
+import com.woocommerce.android.ui.woopos.common.composeui.component.WooPosBrightnessControl
 import com.woocommerce.android.ui.woopos.common.composeui.component.WooPosButton
 import com.woocommerce.android.ui.woopos.common.composeui.component.WooPosButtonState
 import com.woocommerce.android.ui.woopos.common.composeui.component.WooPosDialogWrapper
@@ -142,7 +142,7 @@ fun WooPosScanningSetupDialog(
             id = R.string.woopos_scanning_setup_dialog_content_description
         )
     ) {
-        BrightnessControl(temporarilyIncreaseToMax = true)
+        WooPosBrightnessControl(temporarilyIncreaseToMax = true)
 
         val state by viewModel.state.collectAsState()
         Column(

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/scanningsetup/WooPosScanningSetupDialog.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/scanningsetup/WooPosScanningSetupDialog.kt
@@ -308,10 +308,10 @@ private fun ScannerModeSetupContent(
 
         Box(
             modifier = Modifier
-                .size(172.dp)
+                .size(184.dp)
                 .clip(RoundedCornerShape(WooPosCornerRadius.Medium.value))
                 .background(Color.White)
-                .padding(WooPosSpacing.Small.value.toAdaptivePadding()),
+                .padding(WooPosSpacing.Medium.value.toAdaptivePadding()),
             contentAlignment = Alignment.Center
         ) {
             Image(
@@ -366,13 +366,20 @@ private fun TestScannerContent(
             modifier = Modifier.padding(bottom = WooPosSpacing.Large.value.toAdaptivePadding())
         )
 
-        BarcodeEAN13Code(
-            barcodeValue,
-            300.dp,
-            150.dp,
-            codeColor = MaterialTheme.colorScheme.onSurface,
-            backgroundColor = MaterialTheme.colorScheme.surfaceBright
-        )
+        Box(
+            modifier = Modifier
+                .size(300.dp, 150.dp)
+                .clip(RoundedCornerShape(WooPosCornerRadius.Medium.value))
+                .background(Color.White)
+                .padding(WooPosSpacing.Medium.value.toAdaptivePadding()),
+            contentAlignment = Alignment.Center
+        ) {
+            BarcodeEAN13Code(
+                barcodeValue,
+                300.dp,
+                150.dp
+            )
+        }
 
         Spacer(modifier = Modifier.height(WooPosSpacing.XLarge.value.toAdaptivePadding()))
 
@@ -858,6 +865,47 @@ fun WooPosScanningSetupTestScannerFailedStep() {
                 step = ScanningSetupStep.TestYourScannerScanFailed,
                 onPrimaryClick = {},
                 onSecondaryClick = {},
+            )
+        }
+    }
+}
+
+@WooPosPreview
+@Composable
+fun WooPosScanningSetupTestQRContent() {
+    WooPosTheme {
+        Box(
+            modifier = Modifier.fillMaxSize(),
+            contentAlignment = Alignment.Center
+        ) {
+            ScannerModeSetupContent(
+                onPrimaryClick = {},
+                onSecondaryClick = {},
+                primaryButtonText = "Next",
+                secondaryButtonText = "Back",
+                title = "Scanner Mode Setup",
+                message = "Follow the instructions to set up your scanner in HID mode.",
+                qrCodeImageRes = R.drawable.ic_woopos_reader_setup_code_star_bsh_20
+            )
+        }
+    }
+}
+
+@WooPosPreview
+@Composable
+fun WooPosScanningSetupTestBarcodeContent() {
+    WooPosTheme {
+        Box(
+            modifier = Modifier.fillMaxSize(),
+            contentAlignment = Alignment.Center
+        ) {
+            TestScannerContent(
+                onSecondaryClick = {},
+                secondaryButtonText = "Back",
+                title = "Scanner Mode Setup",
+                message = "Follow the instructions to set up your scanner in HID mode.",
+                barcodeValue = "123456789012",
+                onBarcodeScanned = {},
             )
         }
     }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/scanningsetup/WooPosScanningSetupDialog.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/scanningsetup/WooPosScanningSetupDialog.kt
@@ -63,6 +63,7 @@ import androidx.hilt.navigation.compose.hiltViewModel
 import com.woocommerce.android.R
 import com.woocommerce.android.WooCommerce
 import com.woocommerce.android.ui.compose.component.BarcodeEAN13Code
+import com.woocommerce.android.ui.compose.component.BrightnessControl
 import com.woocommerce.android.ui.compose.component.getText
 import com.woocommerce.android.ui.compose.preview.FontScalePreviews
 import com.woocommerce.android.ui.woopos.common.composeui.WooPosPreview
@@ -141,6 +142,8 @@ fun WooPosScanningSetupDialog(
             id = R.string.woopos_scanning_setup_dialog_content_description
         )
     ) {
+        BrightnessControl(temporarilyIncreaseToMax = true)
+
         val state by viewModel.state.collectAsState()
         Column(
             modifier = Modifier


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

<!-- Id number of the Linear issue this PR addresses, e.g., WOOMOB-373. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

This PR improves scanners ability to properly scan setup codes by:
- Increasing the empty area around the barcodes
- Automatically increasing brightness for the setup flow - it increases it to the maximum for the whole setup flow, let me know if you believe it'd be better to increase it just for the steps with a barcode. I tried that and it felt a bit off as the brightness was going up and down depending on the step.


### Testing information
<!-- This is your opportunity to break out individual scenarios that need testing (when necessary) and/or include a checklist for the reviewer to go through. Consider documenting the following from your own completed testing: devices used, alternate workflows, edge cases, affected areas, critical flows, areas not tested, and any remaining unknowns. Provide feedback on this new section of the PR template through Sept 30, 2024 to Apps Quality; additional context here: https://woomobilep2.wordpress.com/2024/05/06/woocommerce-mobile-quality-report-march-april/#comment-12036 -->

Verify the brightness increases when you start the flow and restores back to the original when you dismiss it or background the app.

### The tests that have been performed
<!-- To give the reviewer an idea of what could be missed in terms of testing -->

The above

### Images/gif
<!-- Include before and after images or gifs when appropriate. -->


https://github.com/user-attachments/assets/4128c701-989d-4c90-adf9-5b1ec0c098ea


- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
