### PR TITLE
[Shipping labels] Fix issue with origin address after shipment removal

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/WooShippingLabelCreationViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/WooShippingLabelCreationViewModel.kt
@@ -726,7 +726,10 @@ class WooShippingLabelCreationViewModel @Inject constructor(
             }
         }
 
-        shippingAddresses.updateSize(WooShippingAddresses.EMPTY)
+        val originAddresses = shippingAddresses.value.first().originAddresses
+        shippingAddresses.updateSize(
+            WooShippingAddresses.EMPTY.copy(originAddresses = originAddresses, shipFrom = originAddresses.first())
+        )
         selectedPackagesFlow.updateSize(null)
         customsFormDataFlow.updateSize(null)
         packageWeightsFlow.updateSize(null)


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

<!-- Id number of the Linear issue this PR addresses, e.g., WOOMOB-373. -->
Closes WOOMOB-915

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
After removing a shipment, the origin address was becoming empty and couldn't be updated, which broke the flow. We were also losing the saved store addresses.
~~We could consider a hotfix, but since removing a shipment is not a critical flow, I think we should merge this into the release branch.~~

### Steps to reproduce
<!-- Step-by-step testing instructions. For new user flows, consider instead stating the goal of the workflow and see if your PR reviewer can accomplish the workflow without specific steps! -->
1. Open an order that is eligible to create shipping label and with multiple items.
2. Tap Create shipping label button.
3. Tap split shipment button. 
4. Tap split shipment button.
5. If you only have a single shipment, create some shipments, and tap Done button.
6. Remove a shipment.
7. Tap Done button.
8. Tap Shipment details.
9. Verify origin address is not empty.

### Images/gif
<!-- Include before and after images or gifs when appropriate. -->
|Before|After|
|-|-|
|<img width="1344" height="2992" alt="before" src="https://github.com/user-attachments/assets/bb9c9b37-bef2-4db0-a7e4-b9945bd33ccd" />|<img width="1344" height="2992" alt="Screenshot_20250721_214601" src="https://github.com/user-attachments/assets/079c7684-b2bd-41a3-910c-02997914e658" />|
|<img width="1344" height="2992" alt="before2" src="https://github.com/user-attachments/assets/91e1e0e9-76d2-4967-b399-f911aca39178" />|<img width="1344" height="2992" alt="Screenshot_20250721_214608" src="https://github.com/user-attachments/assets/cbc93769-b3a9-4b5b-9519-f938d853d069" />|

- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->