### PR TITLE
[Shipping labels]Fix view purchased shipping label button opening the wrong shipment

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/adapter/OrderDetailShippingLabelsAdapter.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/adapter/OrderDetailShippingLabelsAdapter.kt
@@ -109,9 +109,14 @@ class OrderDetailShippingLabelsAdapter(
 
             // Shipping label header
             with(viewBinding.shippingLabelListLblPackage) {
+                val packageNumber = if (isRevampWooShippingEnabled) {
+                    (shippingLabel.shipmentId?.toIntOrNull() ?: -1) + 1
+                } else {
+                    bindingAdapterPosition + 1
+                }
                 text = context.getString(
                     R.string.orderdetail_shipping_label_item_header,
-                    bindingAdapterPosition + 1
+                    packageNumber
                 )
             }
 


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

<!-- Id number of the Linear issue this PR addresses, e.g., WOOMOB-373. -->
Closes WOOMOB-886

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
This fixes the incorrect package numbers on the order detail screen. Now, the package numbers will reflect their shipment number, such as “Package 1”.

Packages will be listed by the most recent purchase date, matching the behavior on the web.

### Steps to reproduce
<!-- Step-by-step testing instructions. For new user flows, consider instead stating the goal of the workflow and see if your PR reviewer can accomplish the workflow without specific steps! -->
1. Open Orders.
2. Select an order that has multiple purchased shipments.
3. On the order detail screen, tap "View purchased shipping label" buttons

### The tests that have been performed
<!-- To give the reviewer an idea of what could be missed in terms of testing -->
Tested steps above and disabled feature flag state.

### Images/gif
<!-- Include before and after images or gifs when appropriate. -->
|Before|After|
|-|-|
|<img width="1344" height="2992" alt="before" src="https://github.com/user-attachments/assets/0f336a11-beca-49e7-8255-4cf73f2eacc6" />|<img width="1344" height="2992" alt="after" src="https://github.com/user-attachments/assets/e9c6ee2c-29cb-41f2-accc-a678ba4bf015" />|

- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->