### PR TITLE
Fix local execution of e2e tests

### DIFF
--- a/WooCommerce/build.gradle
+++ b/WooCommerce/build.gradle
@@ -433,6 +433,7 @@ dependencies {
 
     testImplementation(testFixtures(project(":libs:fluxc-plugin")))
 
+    androidTestImplementation libs.androidx.test.main.runner
     androidTestUtil libs.androidx.test.orchestrator
 }
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -25,10 +25,13 @@ androidx-recyclerview-main = '1.3.2'
 androidx-recyclerview-selection = '1.1.0'
 androidx-room = "2.6.1"
 androidx-security-crypto = "1.0.0"
-androidx-test-espresso = '3.4.0'
-androidx-test-ext = '1.1.5'
-androidx-test-main = '1.4.0'
-androidx-test-uiautomator = '2.2.0'
+androidx-test-core = '1.6.1'
+androidx-test-espresso = '3.6.1'
+androidx-test-ext = '1.2.1'
+androidx-test-rules = '1.6.1'
+androidx-test-runner = '1.6.2'
+androidx-test-orchestrator = '1.5.1'
+androidx-test-uiautomator = '2.3.0'
 androidx-transition = '1.5.1'
 androidx-wear-compose = '1.4.0'
 androidx-wear-tiles = '1.3.0'
@@ -165,10 +168,10 @@ androidx-security-crypto = { module = "androidx.security:security-crypto", versi
 androidx-test-espresso-contrib = { group = "androidx.test.espresso", name = "espresso-contrib", version.ref = "androidx-test-espresso" }
 androidx-test-espresso-core = { group = "androidx.test.espresso", name = "espresso-core", version.ref = "androidx-test-espresso" }
 androidx-test-ext-junit = { group = "androidx.test.ext", name = "junit", version.ref = "androidx-test-ext" }
-androidx-test-main-core = { group = "androidx.test", name = "core", version.ref = "androidx-test-main" }
-androidx-test-main-rules = { group = "androidx.test", name = "rules", version.ref = "androidx-test-main" }
-androidx-test-main-runner = { group = "androidx.test", name = "runner", version.ref = "androidx-test-main" }
-androidx-test-orchestrator = { group = "androidx.test", name = "orchestrator", version.ref = "androidx-test-main" }
+androidx-test-main-core = { group = "androidx.test", name = "core", version.ref = "androidx-test-core" }
+androidx-test-main-rules = { group = "androidx.test", name = "rules", version.ref = "androidx-test-rules" }
+androidx-test-main-runner = { group = "androidx.test", name = "runner", version.ref = "androidx-test-runner" }
+androidx-test-orchestrator = { group = "androidx.test", name = "orchestrator", version.ref = "androidx-test-orchestrator" }
 androidx-test-uiautomator = { group = "androidx.test.uiautomator", name = "uiautomator", version.ref = "androidx-test-uiautomator" }
 androidx-transition = { group = "androidx.transition", name = "transition", version.ref = "androidx-transition" }
 androidx-wear-compose-material = { group = "androidx.wear.compose", name = "compose-material", version.ref = "androidx-wear-compose" }


### PR DESCRIPTION
- add `runner` in `androidTestImplementation` configuration.
- update test dependencies

<!-- Remember about a good descriptive title. -->

<!-- Id number of the Linear issue this PR addresses, e.g., WOOMOB-373. -->

Internal: p1753274981503279-slack-CGPNUU63E

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing 
“See original issue” – clarify what the problem was and how you’ve fixed it. -->

This PR fixes local test execution by updating test dependencies and adding test runner dependency via `androidTestImplementation` configuration.

### Testing information
<!-- This is your opportunity to break out individual scenarios that need testing (when necessary) and/or include a checklist for the reviewer to go through. Consider documenting the following from your own completed testing: devices used, alternate workflows, edge cases, affected areas, critical flows, areas not tested, and any remaining unknowns. Provide feedback on this new section of the PR template through Sept 30, 2024 to Apps Quality; additional context here: p91TBi-b8z-p2#comment-12036 -->

Run `./gradlew :WooCommerce:connectedVanillaDebugAndroidTest` and see that tests are executed (except of screenshots tests - they'll fail but it's expected).

- [ ] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->