### PR TITLE
[POS as a tab i2] [Bug] Not possible to refresh visibility of POS tab item 

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/tab/WooPosCanBeLaunchedInTab.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/tab/WooPosCanBeLaunchedInTab.kt
@@ -19,7 +19,7 @@ import javax.inject.Singleton
 @Singleton
 class WooPosCanBeLaunchedInTab @Inject constructor(
     private val selectedSite: SelectedSite,
-    private val getWooCoreVersion: GetWooCorePluginCachedVersion,
+    private val getWooCoreCachedVersion: GetWooCorePluginCachedVersion,
     private val fetchWooCoreVersion: FetchActiveWCPluginVersion,
     private val wooCommerceStore: WooCommerceStore,
     private val isRemotelyEnabled: WooPOSIsRemotelyEnabled
@@ -34,7 +34,7 @@ class WooPosCanBeLaunchedInTab @Inject constructor(
         val wooCoreVersion = if (forceRefresh) {
             fetchWooCoreVersion()
         } else {
-            getWooCoreVersion()
+            getWooCoreCachedVersion()
         } ?: return@withContext WooPosLaunchability.NotLaunchable(
             WooPosLaunchability.NonLaunchabilityReason.WooCommercePluginNotFound
         )

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/tab/WooPosTabController.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/tab/WooPosTabController.kt
@@ -41,21 +41,16 @@ class WooPosTabController @Inject constructor(
     }
 
     override fun onResume(owner: LifecycleOwner) {
-        super.onResume(owner)
         refreshPOSTabVisibility()
     }
 
     override fun onDestroy(owner: LifecycleOwner) {
-        super.onDestroy(owner)
         owner.lifecycle.removeObserver(this)
     }
 
     fun refreshPOSTabVisibility() {
         setPOSTabVisibility(false)
-        // Load visibility from prefs for fast UI feedback
         updatePOSTabVisibilityFromPrefs()
-
-        // Then update with the remote value
         updateTabVisibilityFromRemoteAndPersist()
     }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/tab/WooPosTabShouldBeVisible.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/tab/WooPosTabShouldBeVisible.kt
@@ -22,8 +22,7 @@ class WooPosTabShouldBeVisible @Inject constructor(
 
         if (!isScreenSizeAllowed()) return@withContext false
 
-        val siteSettings = wooCommerceStore.getSiteSettings(selectedSite)
-            ?: wooCommerceStore.fetchSiteGeneralSettings(selectedSite).model
+        val siteSettings = wooCommerceStore.fetchSiteGeneralSettings(selectedSite).model
 
         if (siteSettings == null) return@withContext false
 

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/tab/WooPosCanBeLaunchedInTabTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/tab/WooPosCanBeLaunchedInTabTest.kt
@@ -45,7 +45,7 @@ class WooPosCanBeLaunchedInTabTest : BaseUnitTest() {
 
         sut = WooPosCanBeLaunchedInTab(
             selectedSite = selectedSite,
-            getWooCoreVersion = getWooCoreVersion,
+            getWooCoreCachedVersion = getWooCoreVersion,
             fetchWooCoreVersion = fetchWooCoreVersion,
             wooCommerceStore = wooCommerceStore,
             isRemotelyEnabled = isRemotelyEnabled

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/tab/WooPosTabShouldBeVisibleTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/tab/WooPosTabShouldBeVisibleTest.kt
@@ -37,7 +37,7 @@ class WooPosTabShouldBeVisibleTest : BaseUnitTest() {
         whenever(isScreenSizeAllowed()).thenReturn(true)
         whenever(isRemoteFeatureFlagEnabled(WOO_POS)).thenReturn(true)
         val siteSettings = buildSiteSettings()
-        whenever(wooCommerceStore.getSiteSettings(siteModel)).thenReturn(siteSettings)
+        whenever(wooCommerceStore.fetchSiteGeneralSettings(siteModel)).thenReturn(WooResult(siteSettings))
 
         sut = WooPosTabShouldBeVisible(
             selectedSite = selectedSite,
@@ -73,13 +73,12 @@ class WooPosTabShouldBeVisibleTest : BaseUnitTest() {
     @Test
     fun `given unsupported country, when invoked, then return false`() = testBlocking {
         val siteSettings = buildSiteSettings(countryCode = "ca")
-        whenever(wooCommerceStore.getSiteSettings(any())).thenReturn(siteSettings)
+        whenever(wooCommerceStore.fetchSiteGeneralSettings(any())).thenReturn(WooResult(siteSettings))
         assertFalse(sut())
     }
 
     @Test
-    fun `given null local site settings, when invoked, then fetch remote settings`() = testBlocking {
-        whenever(wooCommerceStore.getSiteSettings(any())).thenReturn(null)
+    fun `when invoked, then always fetch remote settings`() = testBlocking {
         val fetchedSettings = buildSiteSettings(countryCode = "us")
         whenever(wooCommerceStore.fetchSiteGeneralSettings(any())).thenReturn(WooResult(fetchedSettings))
 
@@ -89,8 +88,7 @@ class WooPosTabShouldBeVisibleTest : BaseUnitTest() {
     }
 
     @Test
-    fun `given remote settings with supported country, when invoked, then return true`() = testBlocking {
-        whenever(wooCommerceStore.getSiteSettings(any())).thenReturn(null)
+    fun `given fetched settings with supported country, when invoked, then return true`() = testBlocking {
         val fetchedSettings = buildSiteSettings(countryCode = "gb")
         whenever(wooCommerceStore.fetchSiteGeneralSettings(any())).thenReturn(WooResult(fetchedSettings))
 
@@ -98,10 +96,16 @@ class WooPosTabShouldBeVisibleTest : BaseUnitTest() {
     }
 
     @Test
-    fun `given remote settings with unsupported country, when invoked, then return false`() = testBlocking {
-        whenever(wooCommerceStore.getSiteSettings(any())).thenReturn(null)
+    fun `given fetched settings with unsupported country, when invoked, then return false`() = testBlocking {
         val fetchedSettings = buildSiteSettings(countryCode = "ca")
         whenever(wooCommerceStore.fetchSiteGeneralSettings(any())).thenReturn(WooResult(fetchedSettings))
+
+        assertFalse(sut())
+    }
+
+    @Test
+    fun `given null fetched settings, when invoked, then return false`() = testBlocking {
+        whenever(wooCommerceStore.fetchSiteGeneralSettings(any())).thenReturn(WooResult(null))
 
         assertFalse(sut())
     }

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/tab/WooPosTabShouldBeVisibleTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/tab/WooPosTabShouldBeVisibleTest.kt
@@ -103,13 +103,6 @@ class WooPosTabShouldBeVisibleTest : BaseUnitTest() {
         assertFalse(sut())
     }
 
-    @Test
-    fun `given null fetched settings, when invoked, then return false`() = testBlocking {
-        whenever(wooCommerceStore.fetchSiteGeneralSettings(any())).thenReturn(WooResult(null))
-
-        assertFalse(sut())
-    }
-
     private fun buildSiteSettings(countryCode: String = "us") =
         WCSettingsTestUtils.generateSettings(
             siteId = LocalOrRemoteId.LocalId(1)


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->
This PR fixes problem with visibility of POS tab menu item in the bottom navigation menu.

<!-- Id number of the Linear issue this PR addresses, e.g., WOOMOB-373. -->
WOOPRD-694

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
The WooPosTabController is relying on WooPosTabShouldBeVisible to decide in POS tab should be visible. However, WooPosTabShouldBeVisible was never refreshing that data from the backend. As a result, the POS tab was not visible after user fixed store country setting in WP-admin.

### Steps to reproduce
<!-- Step-by-step testing instructions. For new user flows, consider instead stating the goal of the workflow and see if your PR reviewer can accomplish the workflow without specific steps! -->
1. Kill the app
2. Set store country in WP-admin to Malta
3. Open the app and verify the POS tab is hidden
4. Set store country to eligible country (e.g. UK)
5. Notice the POS tab is not showing even when you reopen the app

### Testing information
<!-- This is your opportunity to break out individual scenarios that need testing (when necessary) and/or include a checklist for the reviewer to go through. Consider documenting the following from your own completed testing: devices used, alternate workflows, edge cases, affected areas, critical flows, areas not tested, and any remaining unknowns. Provide feedback on this new section of the PR template through Sept 30, 2024 to Apps Quality; additional context here: p91TBi-b8z-p2#comment-12036 -->
1. Kill the app
2. Set store country in WP-admin to Malta
3. Open the app and verify the POS tab is hidden
4. Set store country to eligible country (e.g. UK)
5. Verify it's possible to get POS tab showing up after reopening the app

### The tests that have been performed
<!-- To give the reviewer an idea of what could be missed in terms of testing -->
Above

### Images/gif
<!-- Include before and after images or gifs when appropriate. -->
N/A

- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->