### PR TITLE
Make phone number required for non-US addresses

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/address/WooShippingEditAddressViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/address/WooShippingEditAddressViewModel.kt
@@ -255,9 +255,9 @@ class WooShippingEditAddressViewModel @Inject constructor(
     @OptIn(ExperimentalCoroutinesApi::class)
     private suspend fun loadStates() {
         country.mapLatest { country ->
-            phone = phone.copy(isRequired = shouldRequirePhone())
             getStatesByCountryCode(country.code)
         }.collectLatest { states ->
+            phone = phone.copy(isRequired = shouldRequirePhone())
             statesState.value = LocationState.Loaded(states)
             val stateCode = if (country.value.code == currentAddress.value.country.code) {
                 currentAddress.value.state.codeOrRaw

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/address/WooShippingEditAddressViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/address/WooShippingEditAddressViewModel.kt
@@ -65,14 +65,8 @@ class WooShippingEditAddressViewModel @Inject constructor(
     private var city by mutableStateOf(InputValue(value = "", isRequired = true))
     private var postalCode by mutableStateOf(InputValue(value = "", isRequired = true))
     private var email by mutableStateOf(InputValue(value = "", isRequired = true))
-    private var phone by mutableStateOf(
-        InputValue(
-            value = "",
-            isRequired = navArgs.flow is EditAddressFlow.EditOriginAddress
-        )
-    )
-
     private var country = MutableStateFlow(Location.EMPTY)
+    private var phone by mutableStateOf(InputValue(value = "", isRequired = shouldRequirePhone()))
 
     private var rawState by mutableStateOf("")
     private val selectedState = MutableStateFlow(Location.EMPTY)
@@ -260,32 +254,36 @@ class WooShippingEditAddressViewModel @Inject constructor(
 
     @OptIn(ExperimentalCoroutinesApi::class)
     private suspend fun loadStates() {
-        country.mapLatest { country -> getStatesByCountryCode(country.code) }
-            .collectLatest { states ->
-                statesState.value = LocationState.Loaded(states)
-                val stateCode = if (country.value.code == currentAddress.value.country.code) {
-                    currentAddress.value.state.codeOrRaw
-                } else {
-                    ""
+        country.mapLatest { country ->
+            phone = phone.copy(isRequired = shouldRequirePhone())
+            getStatesByCountryCode(country.code)
+        }.collectLatest { states ->
+            statesState.value = LocationState.Loaded(states)
+            val stateCode = if (country.value.code == currentAddress.value.country.code) {
+                currentAddress.value.state.codeOrRaw
+            } else {
+                ""
+            }
+            when {
+                states.isNotEmpty() && stateCode.isNotEmpty() -> {
+                    selectedState.value = findLocationByCode(stateCode, statesState.value)
+                        .takeIf { it != Location.EMPTY } ?: states.first()
+                    rawState = ""
                 }
-                when {
-                    states.isNotEmpty() && stateCode.isNotEmpty() -> {
-                        selectedState.value = findLocationByCode(stateCode, statesState.value)
-                            .takeIf { it != Location.EMPTY } ?: states.first()
-                        rawState = ""
-                    }
 
-                    states.isNotEmpty() -> {
-                        selectedState.value = states.first()
-                    }
+                states.isNotEmpty() -> {
+                    selectedState.value = states.first()
+                }
 
-                    else -> {
-                        rawState = stateCode
-                        selectedState.value = Location.EMPTY
-                    }
+                else -> {
+                    rawState = stateCode
+                    selectedState.value = Location.EMPTY
                 }
             }
+        }
     }
+
+    private fun shouldRequirePhone() = navArgs.flow is EditAddressFlow.EditOriginAddress || country.value.code != "US"
 
     fun handleBackPress(): Boolean {
         if (allowBackNavigation()) {

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/address/destination/WooShippingEditDestinationViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/address/destination/WooShippingEditDestinationViewModelTest.kt
@@ -218,8 +218,9 @@ class WooShippingEditDestinationViewModelTest : WooShippingEditAddressViewModelT
     }
 
     @Test
-    fun `when phone is empty phone then error is null`() = testBlocking {
-        val address = Address.EMPTY.copy(phone = "")
+    fun `when phone is empty phone then error is null for US`() = testBlocking {
+        val address = Address.EMPTY.copy(phone = "", country = AmbiguousLocation.Raw("US").asLocation())
+        whenever(getAllCountries.invoke()).doReturn(Result.success(countries))
         whenever(addressValidator.validateAtLeastOneOf(eq(""), eq(""))).doReturn("error")
         whenever(addressValidator.validateFieldRequired("")).doReturn("error")
         Snapshot.withMutableSnapshot {
@@ -234,6 +235,26 @@ class WooShippingEditDestinationViewModelTest : WooShippingEditAddressViewModelT
         assertThat(result).isInstanceOf(WooShippingEditAddressViewModel.ViewState::class.java)
 
         assertThat(result.editableAddress.phone.error).isNull()
+    }
+
+    @Test
+    fun `when phone is empty phone then error is not null`() = testBlocking {
+        val address = Address.EMPTY.copy(phone = "", country = AmbiguousLocation.Raw("CA").asLocation())
+        whenever(getAllCountries.invoke()).doReturn(Result.success(countries))
+        whenever(addressValidator.validateAtLeastOneOf(eq(""), eq(""))).doReturn("error")
+        whenever(addressValidator.validateFieldRequired("")).doReturn("error")
+        Snapshot.withMutableSnapshot {
+            val savedState = createSavedStateHandle(address)
+            createViewModel(savedState)
+        }
+
+        advanceUntilIdle()
+
+        val result = sut.viewState.value
+
+        assertThat(result).isInstanceOf(WooShippingEditAddressViewModel.ViewState::class.java)
+
+        assertThat(result.editableAddress.phone.error).isNotNull()
     }
 
     @Test


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

<!-- Id number of the Linear issue this PR addresses, e.g., WOOMOB-373. -->
Closes WOOMOB-885

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
This PR makes Phone field required for all countries except US.

### Steps to reproduce
<!-- Step-by-step testing instructions. For new user flows, consider instead stating the goal of the workflow and see if your PR reviewer can accomplish the workflow without specific steps! -->
1. Go to Orders.
2. Select an order that is eligible for creating shipping labels.
3. Tap Shipment "Details"
4. Tap edit button on "Ship to" section.
5. Change country and verify the Phone field is not required for US, but required for others.

### The tests that have been performed
<!-- To give the reviewer an idea of what could be missed in terms of testing -->
Steps above

### Images/gif
<!-- Include before and after images or gifs when appropriate. -->
|Before|After|
|-|-|
|<img width="600" src="https://github.com/user-attachments/assets/ffe93ef4-545b-40bd-94dc-4dc81b4e9fd6" />|<img width="600" src="https://github.com/user-attachments/assets/38186b59-2539-4145-9977-f8a985760b4b" />|

- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->