### PR TITLE
Mention the new POS tab in 23.0 RELEASE-NOTES

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -4,7 +4,7 @@
 
 23.0
 -----
-- [**] We added Point of Sale (POS) tab to the app's bottom navigation bar, allowing easy access to the POS mode. [https://github.com/woocommerce/woocommerce-android/pull/14337]
+- [**] You can now access POS mode faster than ever with the new POS tab in the app’s bottom navigation bar—just one tap and you’re in! If you spotted this feature mentioned a couple releases ago… well, let’s just say we got a little too excited. 😅 It’s finally here for real, and fully available in the UK and US! [https://github.com/woocommerce/woocommerce-android/pull/14337]
 
 22.9
 -----

--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -4,7 +4,7 @@
 
 23.0
 -----
-
+- [**] We added Point of Sale (POS) tab to the app's bottom navigation bar, allowing easy access to the POS mode. [https://github.com/woocommerce/woocommerce-android/pull/14337]
 
 22.9
 -----


### PR DESCRIPTION
This PR adds info about POS tab to the release-notes, so that we mention POS tab in next release.