### PR TITLE
[WOOMOB-934] Fix unintentional horizontal scroll on Payment Success screen when going through Barcode Setup flow

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -8,7 +8,7 @@
 22.9.1
 -----
 - [*] POS: Barcode scanning on the order success screen now opens the cart and adds an item to the cart [https://github.com/woocommerce/woocommerce-android/pull/14382]
-
+- [*] POS: Fixes an issue with the Barcode Scanner Setup flow that could result in an inconsistent UI state on the Checkout and Payment Success Screens [https://github.com/woocommerce/woocommerce-android/pull/14396]
 22.9
 -----
 - [*] Fixed infinite loading animation in Order details pane when order list is empty [https://github.com/woocommerce/woocommerce-android/pull/14316]

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/scanningsetup/WooPosScanningSetupDialog.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/scanningsetup/WooPosScanningSetupDialog.kt
@@ -150,11 +150,7 @@ fun WooPosScanningSetupDialog(
                 .padding(WooPosSpacing.XLarge.value.toAdaptivePadding())
                 .listenForBarcodes(
                     { barcodeResult ->
-                        if (state.currentStep is ScanningSetupStep.TestYourScanner
-                            || state.currentStep is ScanningSetupStep.TestYourScannerTimeout
-                        ) {
-                            viewModel.onUiEvent(WooPosScanningSetupUiEvent.OnBarcodeScanned(barcodeResult))
-                        }
+                        viewModel.onUiEvent(WooPosScanningSetupUiEvent.OnBarcodeScanned(barcodeResult))
                     }
                 )
         ) {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/scanningsetup/WooPosScanningSetupDialog.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/scanningsetup/WooPosScanningSetupDialog.kt
@@ -77,7 +77,6 @@ import com.woocommerce.android.ui.woopos.common.composeui.designsystem.WooPosSpa
 import com.woocommerce.android.ui.woopos.common.composeui.designsystem.WooPosTheme
 import com.woocommerce.android.ui.woopos.common.composeui.designsystem.WooPosTypography
 import com.woocommerce.android.ui.woopos.common.composeui.designsystem.toAdaptivePadding
-import com.woocommerce.android.ui.woopos.common.composeui.modifier.BarcodeInputDetector
 import com.woocommerce.android.ui.woopos.common.composeui.modifier.listenForBarcodes
 import com.woocommerce.android.ui.woopos.common.data.WOO_POS_BARCODE_DOC_URL
 import com.woocommerce.android.ui.woopos.home.scanningsetup.WooPosScanningSetupState.BarcodeReaderDevice
@@ -149,6 +148,15 @@ fun WooPosScanningSetupDialog(
             modifier = Modifier
                 .background(color = MaterialTheme.colorScheme.surfaceBright)
                 .padding(WooPosSpacing.XLarge.value.toAdaptivePadding())
+                .listenForBarcodes(
+                    { barcodeResult ->
+                        if (state.currentStep is ScanningSetupStep.TestYourScanner
+                            || state.currentStep is ScanningSetupStep.TestYourScannerTimeout
+                        ) {
+                            viewModel.onUiEvent(WooPosScanningSetupUiEvent.OnBarcodeScanned(barcodeResult))
+                        }
+                    }
+                )
         ) {
             Row {
                 Spacer(modifier = Modifier.weight(1f))
@@ -232,9 +240,6 @@ fun WooPosScanningSetupDialog(
                         barcodeValue = step.barcodeValue,
                         secondaryButtonText = stringResource(step.secondaryButtonTextRes),
                         onSecondaryClick = { viewModel.onUiEvent(WooPosScanningSetupUiEvent.OnSecondaryButtonClicked) },
-                        onBarcodeScanned = { barcodeResult ->
-                            viewModel.onUiEvent(WooPosScanningSetupUiEvent.OnBarcodeScanned(barcodeResult))
-                        }
                     )
 
                     is ScanningSetupStep.TestYourScannerTimeout -> TestScannerContent(
@@ -243,9 +248,6 @@ fun WooPosScanningSetupDialog(
                         barcodeValue = step.barcodeValue,
                         secondaryButtonText = stringResource(step.secondaryButtonTextRes),
                         onSecondaryClick = { viewModel.onUiEvent(WooPosScanningSetupUiEvent.OnSecondaryButtonClicked) },
-                        onBarcodeScanned = { barcodeResult ->
-                            viewModel.onUiEvent(WooPosScanningSetupUiEvent.OnBarcodeScanned(barcodeResult))
-                        }
                     )
 
                     is ScanningSetupStep.ScannerSetupSuccess -> ScannerSetupSuccessContent(
@@ -342,14 +344,12 @@ private fun TestScannerContent(
     message: String,
     barcodeValue: String,
     secondaryButtonText: String,
-    onSecondaryClick: () -> Unit,
-    onBarcodeScanned: (BarcodeInputDetector.BarcodeResult) -> Unit
+    onSecondaryClick: () -> Unit
 ) {
     Column(
         modifier = Modifier
             .fillMaxWidth()
-            .verticalScroll(rememberScrollState())
-            .listenForBarcodes(onBarcodeScanned),
+            .verticalScroll(rememberScrollState()),
         horizontalAlignment = Alignment.CenterHorizontally
     ) {
         WooPosText(
@@ -848,7 +848,6 @@ fun WooPosScanningSetupTestScannerStep() {
                 barcodeValue = "123456789012",
                 secondaryButtonText = "Skip",
                 onSecondaryClick = {},
-                onBarcodeScanned = {}
             )
         }
     }
@@ -906,7 +905,6 @@ fun WooPosScanningSetupTestBarcodeContent() {
                 title = "Scanner Mode Setup",
                 message = "Follow the instructions to set up your scanner in HID mode.",
                 barcodeValue = "123456789012",
-                onBarcodeScanned = {},
             )
         }
     }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/scanningsetup/WooPosScanningSetupViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/scanningsetup/WooPosScanningSetupViewModel.kt
@@ -176,6 +176,12 @@ class WooPosScanningSetupViewModel @Inject constructor(
     }
 
     private fun handleBarcodeScanned(barcodeResult: BarcodeInputDetector.BarcodeResult) {
+        val currentStep = _state.value.currentStep
+        if (currentStep !is ScanningSetupStep.TestYourScanner &&
+            currentStep !is ScanningSetupStep.TestYourScannerTimeout
+        ) {
+            return
+        }
         val selectedDevice = requireNotNull(_state.value.selectedDevice) { "Selected device cannot be null" }
         val nextStep = if (barcodeResult.barcode == TEST_BARCODE_EAN13) {
             viewModelScope.launch { analyticsTracker.trackTestScanSuccess(selectedDevice) }

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/home/scanningsetup/WooPosScanningSetupViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/home/scanningsetup/WooPosScanningSetupViewModelTest.kt
@@ -126,6 +126,164 @@ class WooPosScanningSetupViewModelTest {
     }
 
     @Test
+    fun `given DeviceSelection step, when barcode scanned, then scan ignored`() = runTest {
+        // GIVEN
+        val mockNextStep = ScanningSetupStep.ScannerHIDModeSetup(qrCodeImageRes = R.drawable.ic_barcode)
+        whenever(navigator.getNextStep(BarcodeReaderDevice.TERA_1200, ScanningSetupStep.DeviceSelection))
+            .thenReturn(mockNextStep)
+        val viewModel = createViewModel()
+
+        // WHEN
+        viewModel.onUiEvent(
+            WooPosScanningSetupUiEvent.OnBarcodeScanned(
+                BarcodeInputDetector.BarcodeResult.Success(barcode = TEST_BARCODE_EAN13, scanDurationMs = 1000L)
+            )
+        )
+
+        // THEN
+        assertThat(viewModel.state.value.selectedDevice).isNull()
+        assertThat(viewModel.state.value.currentStep).isEqualTo(ScanningSetupStep.DeviceSelection)
+    }
+
+    @Test
+    fun `given ScannerSetupInfo step, when barcode scanned, then scan ignored`() = runTest {
+        // GIVEN
+        whenever(navigator.getNextStep(BarcodeReaderDevice.OTHER, ScanningSetupStep.DeviceSelection))
+            .thenReturn(ScanningSetupStep.ScannerSetupInfo)
+        whenever(navigator.getNextStep(BarcodeReaderDevice.OTHER, ScanningSetupStep.ScannerSetupInfo))
+            .thenReturn(ScanningSetupStep.TestYourScanner)
+        val viewModel = createViewModel()
+        viewModel.onUiEvent(WooPosScanningSetupUiEvent.OnDeviceSelected(BarcodeReaderDevice.OTHER))
+
+        // WHEN
+        viewModel.onUiEvent(
+            WooPosScanningSetupUiEvent.OnBarcodeScanned(
+                BarcodeInputDetector.BarcodeResult.Success(barcode = TEST_BARCODE_EAN13, scanDurationMs = 1000L)
+            )
+        )
+
+        // THEN
+        assertThat(viewModel.state.value.currentStep).isEqualTo(ScanningSetupStep.ScannerSetupInfo)
+    }
+
+    @Test
+    fun `given ScannerHIDModeSetup step, when barcode scanned, then scan ignored`() = runTest {
+        // GIVEN
+        val hidModeStep = ScanningSetupStep.ScannerHIDModeSetup(qrCodeImageRes = R.drawable.ic_barcode)
+        val viewModel = createViewModel(
+            initialStep = hidModeStep,
+            selectedDevice = BarcodeReaderDevice.TERA_1200
+        )
+
+        // WHEN
+        viewModel.onUiEvent(
+            WooPosScanningSetupUiEvent.OnBarcodeScanned(
+                BarcodeInputDetector.BarcodeResult.Success(barcode = TEST_BARCODE_EAN13, scanDurationMs = 1000L)
+            )
+        )
+
+        // THEN
+        assertThat(viewModel.state.value.currentStep).isEqualTo(hidModeStep)
+    }
+
+    @Test
+    fun `given ScannerPairModeSetup step, when barcode scanned, then scan ignored`() = runTest {
+        // GIVEN
+        val pairModeStep = ScanningSetupStep.ScannerPairModeSetup(qrCodeImageRes = R.drawable.ic_barcode)
+        val viewModel = createViewModel(
+            initialStep = pairModeStep,
+            selectedDevice = BarcodeReaderDevice.TERA_1200
+        )
+
+        // WHEN
+        viewModel.onUiEvent(
+            WooPosScanningSetupUiEvent.OnBarcodeScanned(
+                BarcodeInputDetector.BarcodeResult.Success(barcode = TEST_BARCODE_EAN13, scanDurationMs = 1000L)
+            )
+        )
+
+        // THEN
+        assertThat(viewModel.state.value.currentStep).isEqualTo(pairModeStep)
+    }
+
+    @Test
+    fun `given PairYourScanner step, when barcode scanned, then scan ignored`() = runTest {
+        // GIVEN
+        val pairYourScannerStep = ScanningSetupStep.PairYourScanner(R.string.woopos_scanning_setup_device_tera_1200)
+        val viewModel = createViewModel(
+            initialStep = pairYourScannerStep,
+            selectedDevice = BarcodeReaderDevice.TERA_1200
+        )
+
+        // WHEN
+        viewModel.onUiEvent(
+            WooPosScanningSetupUiEvent.OnBarcodeScanned(
+                BarcodeInputDetector.BarcodeResult.Success(barcode = TEST_BARCODE_EAN13, scanDurationMs = 1000L)
+            )
+        )
+
+        // THEN
+        assertThat(viewModel.state.value.currentStep).isEqualTo(pairYourScannerStep)
+    }
+
+    @Test
+    fun `given ScannerSetupSuccess step, when barcode scanned, then scan ignored`() = runTest {
+        // GIVEN
+        val viewModel = createViewModel(
+            initialStep = ScanningSetupStep.ScannerSetupSuccess,
+            selectedDevice = BarcodeReaderDevice.TERA_1200
+        )
+
+        // WHEN
+        viewModel.onUiEvent(
+            WooPosScanningSetupUiEvent.OnBarcodeScanned(
+                BarcodeInputDetector.BarcodeResult.Success(barcode = TEST_BARCODE_EAN13, scanDurationMs = 1000L)
+            )
+        )
+
+        // THEN
+        assertThat(viewModel.state.value.currentStep).isEqualTo(ScanningSetupStep.ScannerSetupSuccess)
+    }
+
+    @Test
+    fun `given TestYourScannerScanFailed step, when barcode scanned, then scan ignored`() = runTest {
+        // GIVEN
+        val viewModel = createViewModel(
+            initialStep = ScanningSetupStep.TestYourScannerScanFailed,
+            selectedDevice = BarcodeReaderDevice.TERA_1200
+        )
+
+        // WHEN
+        viewModel.onUiEvent(
+            WooPosScanningSetupUiEvent.OnBarcodeScanned(
+                BarcodeInputDetector.BarcodeResult.Success(barcode = TEST_BARCODE_EAN13, scanDurationMs = 1000L)
+            )
+        )
+
+        // THEN
+        assertThat(viewModel.state.value.currentStep).isEqualTo(ScanningSetupStep.TestYourScannerScanFailed)
+    }
+
+    @Test
+    fun `given ScannerSetupBarcodesOnProducts step, when barcode scanned, then scan ignored`() = runTest {
+        // GIVEN
+        val viewModel = createViewModel(
+            initialStep = ScanningSetupStep.ScannerSetupBarcodesOnProducts,
+            selectedDevice = BarcodeReaderDevice.TERA_1200
+        )
+
+        // WHEN
+        viewModel.onUiEvent(
+            WooPosScanningSetupUiEvent.OnBarcodeScanned(
+                BarcodeInputDetector.BarcodeResult.Success(barcode = TEST_BARCODE_EAN13, scanDurationMs = 1000L)
+            )
+        )
+
+        // THEN
+        assertThat(viewModel.state.value.currentStep).isEqualTo(ScanningSetupStep.ScannerSetupBarcodesOnProducts)
+    }
+
+    @Test
     fun `given TestYourScanner step, when correct barcode scanned, then should navigate to next step`() = runTest {
         // GIVEN
         val mockNextStep = ScanningSetupStep.ScannerSetupSuccess
@@ -518,34 +676,36 @@ class WooPosScanningSetupViewModelTest {
     }
 
     @Test
-    fun `when TERA_1200 device is selected, then should track scanner selected event with tera_1200 scanner`() = runTest {
-        // GIVEN
-        val mockNextStep = ScanningSetupStep.ScannerHIDModeSetup(qrCodeImageRes = R.drawable.ic_barcode)
-        whenever(navigator.getNextStep(BarcodeReaderDevice.TERA_1200, ScanningSetupStep.DeviceSelection))
-            .thenReturn(mockNextStep)
-        val viewModel = createViewModel()
+    fun `when TERA_1200 device is selected, then should track scanner selected event with tera_1200 scanner`() =
+        runTest {
+            // GIVEN
+            val mockNextStep = ScanningSetupStep.ScannerHIDModeSetup(qrCodeImageRes = R.drawable.ic_barcode)
+            whenever(navigator.getNextStep(BarcodeReaderDevice.TERA_1200, ScanningSetupStep.DeviceSelection))
+                .thenReturn(mockNextStep)
+            val viewModel = createViewModel()
 
-        // WHEN
-        viewModel.onUiEvent(WooPosScanningSetupUiEvent.OnDeviceSelected(BarcodeReaderDevice.TERA_1200))
+            // WHEN
+            viewModel.onUiEvent(WooPosScanningSetupUiEvent.OnDeviceSelected(BarcodeReaderDevice.TERA_1200))
 
-        // THEN
-        verify(analyticsTracker).trackScannerSelected(BarcodeReaderDevice.TERA_1200)
-    }
+            // THEN
+            verify(analyticsTracker).trackScannerSelected(BarcodeReaderDevice.TERA_1200)
+        }
 
     @Test
-    fun `when STAR_BSH_20B device is selected, then should track scanner selected event with star_bsh_20b scanner`() = runTest {
-        // GIVEN
-        val mockNextStep = ScanningSetupStep.ScannerHIDModeSetup(qrCodeImageRes = R.drawable.ic_barcode)
-        whenever(navigator.getNextStep(BarcodeReaderDevice.STAR_BSH_20B, ScanningSetupStep.DeviceSelection))
-            .thenReturn(mockNextStep)
-        val viewModel = createViewModel()
+    fun `when STAR_BSH_20B device is selected, then should track scanner selected event with star_bsh_20b scanner`() =
+        runTest {
+            // GIVEN
+            val mockNextStep = ScanningSetupStep.ScannerHIDModeSetup(qrCodeImageRes = R.drawable.ic_barcode)
+            whenever(navigator.getNextStep(BarcodeReaderDevice.STAR_BSH_20B, ScanningSetupStep.DeviceSelection))
+                .thenReturn(mockNextStep)
+            val viewModel = createViewModel()
 
-        // WHEN
-        viewModel.onUiEvent(WooPosScanningSetupUiEvent.OnDeviceSelected(BarcodeReaderDevice.STAR_BSH_20B))
+            // WHEN
+            viewModel.onUiEvent(WooPosScanningSetupUiEvent.OnDeviceSelected(BarcodeReaderDevice.STAR_BSH_20B))
 
-        // THEN
-        verify(analyticsTracker).trackScannerSelected(BarcodeReaderDevice.STAR_BSH_20B)
-    }
+            // THEN
+            verify(analyticsTracker).trackScannerSelected(BarcodeReaderDevice.STAR_BSH_20B)
+        }
 
     @Test
     fun `when OTHER device is selected, then should track scanner selected event with other scanner`() = runTest {


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

<!-- Id number of the Linear issue this PR addresses, e.g., WOOMOB-373. -->

#WOOMOB-934

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

This issue turned out to be more tricky than I anticipated. The problem is that when we display the Barcode Scanner Setup flow on the Payment Success screen, for some reason when you scan a barcode the search icon gets focus -> the `/n/r` at the end of the scan triggers submit action => the app automatically scrolls horizontally a bit (not fully) to make the button/search-input visible.

I wanted to fix the root cause and prevent the app from focusing the search field/search icon, however, compose works in mysterious ways to me so I wasn't able to implement such fix. Instead, I opted for handling the scanning logic for the scanner setup flow a bit differently -> the flow now consumes all scanning events and ignores them unless the app is on the Test Scan or Test Scan Timeout steps.


**Note: Considering this flow doesn't block the user and is quite improbable to happen - initial scanner setup on payment success screen, I'm thinking about merging this into trunk. Mostly because, the change has a risk of breaking something else. The current branch was created on top of the release branch so it contains your other fix, but I can update that after we make a final call. Wdyt?**

### Steps to reproduce
<!-- Step-by-step testing instructions. For new user flows, consider instead stating the goal of the workflow and see if your PR reviewer can accomplish the workflow without specific steps! -->

1. Open POS
2. Add an item to the order
3. Go to checkout
4. Tap on Cash payment
5. Enter amount and confirm
6. Tap on more menu
7. Tap on `Setup barcode scanner`
8. Scan something with your scanner and notice the view in the background scroll roughly 500px.

The same happens if you scan a barcode on steps that do not have the scanning modifier applied.

### Testing information
<!-- This is your opportunity to break out individual scenarios that need testing (when necessary) and/or include a checklist for the reviewer to go through. Consider documenting the following from your own completed testing: devices used, alternate workflows, edge cases, affected areas, critical flows, areas not tested, and any remaining unknowns. Provide feedback on this new section of the PR template through Sept 30, 2024 to Apps Quality; additional context here: p91TBi-b8z-p2#comment-12036 -->

1. Repeat the above steps and double check the app works as expected.

### The tests that have been performed
<!-- To give the reviewer an idea of what could be missed in terms of testing -->

A bunch of tests but it's very weird - sometimes I get a scanner into a state in which even when I repeat the above steps before the fix, the issue isn't reproducible. I haven't figured out how that happens - the only clue I have is that it's way more probable to happen when the scanner doesn't send the `end of line` character after scan.

### Images/gif
<!-- Include before and after images or gifs when appropriate. -->

No user facing changes.

- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->