### PR TITLE
Update jetty version and add constraints for jetty server

### DIFF
--- a/WooCommerce/build.gradle
+++ b/WooCommerce/build.gradle
@@ -356,6 +356,9 @@ dependencies {
         androidTestImplementation(libs.jetty.webapp) {
             because("version shipped with WireMock 2.26.3 contains security vulnerabilities")
         }
+        androidTestImplementation(libs.jetty.server) {
+            because("version shipped with WireMock 2.26.3 contains security vulnerabilities")
+        }
         androidTestImplementation(libs.jackson.databind) {
             because("version shipped with WireMock 2.26.3 contains security vulnerabilities")
         }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -80,7 +80,6 @@ google-zxing = '3.5.3'
 gravatar = '0.2.0'
 jackson-databind = '2.12.7.1'
 java = '11'
-jetty-webapp = '9.4.51.v20230217'
 jetty = '9.4.57.v20241219'
 json-path = '2.9.0'
 junit = '4.13.2'
@@ -242,7 +241,7 @@ google-protobuf-protoc = { group = "com.google.protobuf", name = "protoc", versi
 google-zxing-core = { group = "com.google.zxing", name = "core", version.ref = "google-zxing" }
 gravatar = { group = "com.gravatar", name = "gravatar", version.ref = "gravatar" }
 jackson-databind = { group = "com.fasterxml.jackson.core", name = "jackson-databind", version.ref = "jackson-databind" }
-jetty-webapp = { group = "org.eclipse.jetty", name = "jetty-webapp", version.ref = "jetty-webapp" }
+jetty-webapp = { group = "org.eclipse.jetty", name = "jetty-webapp", version.ref = "jetty" }
 jetty-server = { group = "org.eclipse.jetty", name = "jetty-server", version.ref = "jetty" }
 json-path = { group = "com.jayway.jsonpath", name = "json-path", version.ref = "json-path" }
 junit = { group = "junit", name = "junit", version.ref = "junit" }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -81,6 +81,7 @@ gravatar = '0.2.0'
 jackson-databind = '2.12.7.1'
 java = '11'
 jetty-webapp = '9.4.51.v20230217'
+jetty = '9.4.57.v20241219'
 json-path = '2.9.0'
 junit = '4.13.2'
 lottie = '5.2.0'
@@ -242,6 +243,7 @@ google-zxing-core = { group = "com.google.zxing", name = "core", version.ref = "
 gravatar = { group = "com.gravatar", name = "gravatar", version.ref = "gravatar" }
 jackson-databind = { group = "com.fasterxml.jackson.core", name = "jackson-databind", version.ref = "jackson-databind" }
 jetty-webapp = { group = "org.eclipse.jetty", name = "jetty-webapp", version.ref = "jetty-webapp" }
+jetty-server = { group = "org.eclipse.jetty", name = "jetty-server", version.ref = "jetty" }
 json-path = { group = "com.jayway.jsonpath", name = "json-path", version.ref = "json-path" }
 junit = { group = "junit", name = "junit", version.ref = "junit" }
 lottie-compose = { group = "com.airbnb.android", name = "lottie-compose", version.ref = "lottie" }


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

<!-- Id number of the Linear issue this PR addresses, e.g., WOOMOB-373. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
This resolves depandabot security issue: https://github.com/woocommerce/woocommerce-android/security/dependabot/150

The warning suggests that we update `org.eclipse.jetty:jetty-server` to version 9.4.57.v20241219.

The Jetty library is used by the WireMock library. Since we can’t update WireMock, we set constraints for the libraries WireMock uses. I’ve added an additional constraint for the Jetty server. I also updated the version of the jetty-webapp library, this update wasn’t required for the warning itself, but it’s better to keep all Jetty libraries on the same version.

### Steps to reproduce
<!-- Step-by-step testing instructions. For new user flows, consider instead stating the goal of the workflow and see if your PR reviewer can accomplish the workflow without specific steps! -->
- Green check for UI tests.

### The tests that have been performed
<!-- To give the reviewer an idea of what could be missed in terms of testing -->

### Images/gif
<!-- Include before and after images or gifs when appropriate. -->

- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->