### PR TITLE
[POS as tab] Update release notes

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -9,7 +9,7 @@
 -----
 - [*] POS: Barcode scanning on the order success screen now opens the cart and adds an item to the cart [https://github.com/woocommerce/woocommerce-android/pull/14382]
 - [*] POS: Fixes an issue with the Barcode Scanner Setup flow that could result in an inconsistent UI state on the Checkout and Payment Success Screens [https://github.com/woocommerce/woocommerce-android/pull/14396]
-- [**] You can now access POS mode faster than ever with the new POS tab in the app’s bottom navigation bar—just one tap and you’re in! If you spotted this feature mentioned a couple releases ago… well, let’s just say we got a little too excited. 😅 It’s finally here for real, and fully available in the UK and US! [https://github.com/woocommerce/woocommerce-android/pull/14337]
+- [**] You can now access POS mode faster than ever with the new POS tab in the app’s bottom navigation bar—just one tap and you’re in. It’s fully available in the UK and US! [https://github.com/woocommerce/woocommerce-android/pull/14337]
 - [*] Add search functionality to application log viewer [https://github.com/woocommerce/woocommerce-android/pull/14386]
 
 


### PR DESCRIPTION
Following up on: discussion here: https://github.com/woocommerce/woocommerce-android/pull/14383#discussion_r2241435718, This PR updates `release-notes.txt` again, to mention POS tab in 23.0 release notes correctly.