### PR TITLE
Fix input background color on the shipping selection screen

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/shipping/OrderShippingScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/shipping/OrderShippingScreen.kt
@@ -30,6 +30,7 @@ import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.alpha
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.SolidColor
 import androidx.compose.ui.res.dimensionResource
 import androidx.compose.ui.res.painterResource
@@ -223,7 +224,11 @@ fun FieldEditValue(
     text: String,
     onValueChange: (String) -> Unit,
     modifier: Modifier = Modifier,
-    colors: TextFieldColors = TextFieldDefaults.textFieldColors(),
+    colors: TextFieldColors = TextFieldDefaults.textFieldColors(
+        backgroundColor = Color.Transparent,
+        focusedIndicatorColor = Color.Transparent,
+        unfocusedIndicatorColor = Color.Transparent
+    ),
     interactionSource: MutableInteractionSource = remember { MutableInteractionSource() },
 ) {
     BasicTextField(
@@ -252,7 +257,12 @@ fun FieldEditValue(
                 },
                 enabled = true,
                 singleLine = true,
-                visualTransformation = VisualTransformation.None
+                visualTransformation = VisualTransformation.None,
+                colors = TextFieldDefaults.textFieldColors(
+                    backgroundColor = Color.Transparent,
+                    focusedIndicatorColor = Color.Transparent,
+                    unfocusedIndicatorColor = Color.Transparent
+                )
             )
         }
     )


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

<!-- Id number of the Linear issue this PR addresses, e.g., WOOMOB-373. -->
Fixes WooMob-952

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

This PR updates background color for the `Name` input field on the Add Shipping screen. 

### Testing information
<!-- This is your opportunity to break out individual scenarios that need testing (when necessary) and/or include a checklist for the reviewer to go through. Consider documenting the following from your own completed testing: devices used, alternate workflows, edge cases, affected areas, critical flows, areas not tested, and any remaining unknowns. Provide feedback on this new section of the PR template through Sept 30, 2024 to Apps Quality; additional context here: https://woomobilep2.wordpress.com/2024/05/06/woocommerce-mobile-quality-report-march-april/#comment-12036 -->

1. Start order creation
2. Add a product to the cart
3. Tap on Add shipping
4. Notice the background for `Name` input looks fine in both light and dark mode

### The tests that have been performed
<!-- To give the reviewer an idea of what could be missed in terms of testing -->

The above

### Images/gif
<!-- Include before and after images or gifs when appropriate. -->

###Before

https://github.com/user-attachments/assets/470519b2-9140-403d-89f4-3c1efe4b05ce

### After

https://github.com/user-attachments/assets/dc146e9a-90b0-423d-9c83-e2335abef533




- [ ] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
