### PR TITLE
[Woo POS] Update copy on the configuration of a keyboard screen

### DIFF
--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -4511,7 +4511,7 @@
     <string name="woopos_scanning_setup_software_keyboard_hint">Tap here to test keyboard visibility</string>
     <string name="woopos_scanning_setup_software_keyboard_bullet_one">Look for a keyboard icon or toolbar on the screen.</string>
     <string name="woopos_scanning_setup_software_keyboard_bullet_two">Go to device settings, search \"keyboard\", then enable \"Show on-screen keyboard when physical keyboard connected\". This setting may be in your keyboard app settings.</string>
-    <string name="woopos_scanning_setup_software_keyboard_bullet_three">Still not working? Check your mobile device\'s support.</string>
+    <string name="woopos_scanning_setup_software_keyboard_bullet_three">Still not working? Contact your device manufacturer\'s customer support.</string>
     <string name="woopos_scanning_setup_device_tera_1200">Tera 1200</string>
     <string name="woopos_scanning_setup_device_star_bsh_20b">Star BSH-20B</string>
     <string name="woopos_scanning_setup_device_netum_1228bc">Netum 1228BC</string>


### PR DESCRIPTION
### Description

This PR updates the support contact information in the keyboard setup instructions to be more specific and actionable. Instead of vaguely referencing "your mobile device's support", the text now clearly directs users to "Contact your device manufacturer's customer support" for better clarity and user experience.

### Testing information

1. Navigate to WooPos barcode scanning setup
2. Go through the keyboard setup flow
3. Verify the updated text appears correctly in the third bullet point
4. Confirm the instruction is clear and actionable for users

### The tests that have been performed

Manual testing of the keyboard setup flow to verify text appears correctly.

- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.