### PR TITLE
Remove duplicate entry in RELEASE-NOTES.txt

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -12,7 +12,6 @@
 -----
 - [*] POS: Barcode scanning on the order success screen now opens the cart and adds an item to the cart [https://github.com/woocommerce/woocommerce-android/pull/14382]
 - [*] POS: Fixes an issue with the Barcode Scanner Setup flow that could result in an inconsistent UI state on the Checkout and Payment Success Screens [https://github.com/woocommerce/woocommerce-android/pull/14396]
-- [**] You can now access POS mode faster than ever with the new POS tab in the app’s bottom navigation bar—just one tap and you’re in. It’s fully available in the UK and US! [https://github.com/woocommerce/woocommerce-android/pull/14337]
 - [*] Add search functionality to application log viewer [https://github.com/woocommerce/woocommerce-android/pull/14386]
 
 22.9

--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -12,7 +12,6 @@
 -----
 - [*] POS: Barcode scanning on the order success screen now opens the cart and adds an item to the cart [https://github.com/woocommerce/woocommerce-android/pull/14382]
 - [*] POS: Fixes an issue with the Barcode Scanner Setup flow that could result in an inconsistent UI state on the Checkout and Payment Success Screens [https://github.com/woocommerce/woocommerce-android/pull/14396]
-- [*] Add search functionality to application log viewer [https://github.com/woocommerce/woocommerce-android/pull/14386]
 
 22.9
 -----


### PR DESCRIPTION
## Release notes clean up

This PR removes duplicate entry in 23.0 and 22.9.1 sections. The entry is expected to be only in 22.3 version.