### PR TITLE
[Dependabot] Add `automattic-encryptedlogging` to Ignore Configuration

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -23,6 +23,7 @@ updates:
       - dependency-name: "org.wordpress:utils"
       - dependency-name: "com.automattic:Automattic-Tracks-Android"
       - dependency-name: "com.automattic.tracks:experimentation"
+      - dependency-name: "com.automattic:encryptedlogging"
       # Assertj is a java first library only used for testing. It has caused troubles several times due to library
       # updates with Kotlin breaking changes. For that it has been decided to update this library on a manual basis
       - dependency-name: "org.assertj:assertj-core"


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

<!-- Id number of the Linear issue this PR addresses, e.g., WOOMOB-373. -->

Similar: [JP/WPAndroid#22082](https://github.com/wordpress-mobile/WordPress-Android/pull/22082)

---

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

Having #14354 merged, we now have one more of our libraries that are stored in S3 and have a custom versioning scheme which doesn't work with :dependabot:. Thus this library should be ignored as well, just like the rest.

FYI: At least for now and until we make this whole :dependabot: process work for such S3 libraries of ours as well.

---

### Testing information
<!-- This is your opportunity to break out individual scenarios that need testing (when necessary) and/or include a checklist for the reviewer to go through. Consider documenting the following from your own completed testing: devices used, alternate workflows, edge cases, affected areas, critical flows, areas not tested, and any remaining unknowns. Provide feedback on this new section of the PR template through Sept 30, 2024 to Apps Quality; additional context here: https://woomobilep2.wordpress.com/2024/05/06/woocommerce-mobile-quality-report-march-april/#comment-12036 -->

Not needed, we just make sure that no :dependabot: PRs (like [this](https://github.com/wordpress-mobile/WordPress-Android/pull/22063)) gets opened from here onwards and for this repo. 

---

- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
