### PR TITLE
[WOOMOB-961] Remove unused libsapachehttpclientandroid dependency

### DIFF
--- a/WooCommerce/build.gradle
+++ b/WooCommerce/build.gradle
@@ -369,6 +369,7 @@ dependencies {
             because("version shipped with WireMock 2.26.3 contains security vulnerabilities")
         }
     }
+    androidTestImplementation(libs.apache.http.client.android)
 
     implementation(libs.zendesk.support) {
         exclude group: 'com.android.support', module: 'support-annotations'

--- a/WooCommerce/build.gradle
+++ b/WooCommerce/build.gradle
@@ -369,7 +369,6 @@ dependencies {
             because("version shipped with WireMock 2.26.3 contains security vulnerabilities")
         }
     }
-    androidTestImplementation(libs.apache.http.client.android)
 
     implementation(libs.zendesk.support) {
         exclude group: 'com.android.support', module: 'support-annotations'

--- a/libs/fluxc/build.gradle
+++ b/libs/fluxc/build.gradle
@@ -125,6 +125,8 @@ dependencyAnalysis {
         onUnusedDependencies {
             // This dependency is actually needed otherwise the app will crash with a runtime exception.
             exclude(libs.eventbus.android.get().module.toString())
+            // This dependency is actually needed otherwise UI tests will crash with a runtime exception.
+            exclude(libs.apache.http.client.android.get().module.toString())
         }
     }
 }


### PR DESCRIPTION
Fixes WOOMOB-961

### Description
This PR removes the unused libs.apache.http.client.android dependency from the project. The dependency was identified as no longer needed and removing it helps reduce the app size and potential security surface area.

### Testing information

Green CI should be enough.

### The tests that have been performed
I ran `./gradlew :WooCommerce:assembleWasabiDebugAndroidTest` to verify the dependency truly wasn't used.

### Images/gif 
Not applicable for dependency removal.

- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.