### PR TITLE
Fix `No enum constant` on `CurrencyPosition`

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -9,6 +9,8 @@
 -----
 - [*] POS: Barcode scanning on the order success screen now opens the cart and adds an item to the cart [https://github.com/woocommerce/woocommerce-android/pull/14382]
 - [*] POS: Fixes an issue with the Barcode Scanner Setup flow that could result in an inconsistent UI state on the Checkout and Payment Success Screens [https://github.com/woocommerce/woocommerce-android/pull/14396]
+- [*] Fix `No enum constant` on `CurrencyPosition` [https://github.com/woocommerce/woocommerce-android/pull/14423]
+
 22.9
 -----
 - [*] Fixed infinite loading animation in Order details pane when order list is empty [https://github.com/woocommerce/woocommerce-android/pull/14316]

--- a/libs/fluxc-plugin/src/main/kotlin/org/wordpress/android/fluxc/model/settings/WCSettingsMapper.kt
+++ b/libs/fluxc-plugin/src/main/kotlin/org/wordpress/android/fluxc/model/settings/WCSettingsMapper.kt
@@ -47,7 +47,7 @@ class WCSettingsMapper
     }
 
     private fun String?.toCurrencyPositionOrDefault(): CurrencyPosition = this?.let {
-        CurrencyPosition.valueOf(it.uppercase())
+        CurrencyPosition.entries.find { entry -> entry.name.equals(it, ignoreCase = true) }
     } ?: CurrencyPosition.LEFT
 
     fun mapProductSettings(response: List<SiteSettingsResponse>, site: SiteModel): WCProductSettingsModel {

--- a/libs/fluxc-plugin/src/test/java/org/wordpress/android/fluxc/wc/settings/WCSettingsMapperTest.kt
+++ b/libs/fluxc-plugin/src/test/java/org/wordpress/android/fluxc/wc/settings/WCSettingsMapperTest.kt
@@ -76,4 +76,16 @@ internal class WCSettingsMapperTest {
             assertEquals(expectedModel.weightUnit, weightUnit)
         }
     }
+
+    @Test
+    fun `incorrect currency position maps to default`() {
+        // given
+        val siteProductResponse = WCSettingsTestUtils.getMalformedCurrencyPosSiteSettingsResponse()
+
+        // when
+        val result = mapper.mapSiteSettings(siteProductResponse!!, site)
+
+        // then
+        assertEquals(CurrencyPosition.LEFT, result.currencyPosition)
+    }
 }

--- a/libs/fluxc-plugin/src/testFixtures/kotlin/org/wordpress/android/fluxc/wc/settings/WCSettingsTestUtils.kt
+++ b/libs/fluxc-plugin/src/testFixtures/kotlin/org/wordpress/android/fluxc/wc/settings/WCSettingsTestUtils.kt
@@ -38,6 +38,11 @@ object WCSettingsTestUtils {
             .jsonFileAs(Array<SiteSettingsResponse>::class.java)
             ?.toList()
 
+    fun getMalformedCurrencyPosSiteSettingsResponse() =
+        "wc/site-settings-malformed-currency-pos.json"
+            .jsonFileAs(Array<SiteSettingsResponse>::class.java)
+            ?.toList()
+
     fun getSiteProductSettingsResponse() =
         "wc/product-settings-response.json"
             .jsonFileAs(Array<SiteSettingsResponse>::class.java)

--- a/libs/fluxc-tests/src/test/resources/wc/site-settings-malformed-currency-pos.json
+++ b/libs/fluxc-tests/src/test/resources/wc/site-settings-malformed-currency-pos.json
@@ -1,0 +1,6 @@
+[
+  {
+    "id": "woocommerce_currency_pos",
+    "value": -42
+  }
+]


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

<!-- Id number of the Linear issue this PR addresses, e.g., WOOMOB-373. -->

Closes: WOOMOB-954

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

This PR fixes a crash that can happen _if_ the API will return an unexpected value of `woocommerce_currency_pos` site settings. It can happen for various reasons, including a plugin that modifies the contract.

### Steps to reproduce
<!-- Step-by-step testing instructions. For new user flows, consider instead stating the goal of the workflow and see if your PR reviewer can accomplish the workflow without specific steps! -->
Checkout 38b9d3f commit that introduces a reproduction test-case and run `incorrect currency position maps to default` - see it fails with a similar message and stacktrace to the one attached in Sentry issue.

### Testing information
<!-- This is your opportunity to break out individual scenarios that need testing (when necessary) and/or include a checklist for the reviewer to go through. Consider documenting the following from your own completed testing: devices used, alternate workflows, edge cases, affected areas, critical flows, areas not tested, and any remaining unknowns. Provide feedback on this new section of the PR template through Sept 30, 2024 to Apps Quality; additional context here: p91TBi-b8z-p2#comment-12036 -->

This test passing on CI after 7367e08 proves that fix works

### The tests that have been performed
<!-- To give the reviewer an idea of what could be missed in terms of testing -->

### Images/gif
<!-- Include before and after images or gifs when appropriate. -->

- [ ] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->