### PR TITLE
[Hack Week] App logs improvements: display all stored log files

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -6,6 +6,7 @@
 - [*] You can now remove background from product images in the app. Just open the product image and click "Remove background" button. [https://github.com/woocommerce/woocommerce-android/pull/14445]
 - [*] Fixed bug when an order was not selected when navigating from my store screen [https://github.com/woocommerce/woocommerce-android/pull/14436]
 - [*] Updated behavior on the POS cash payment screen [https://github.com/woocommerce/woocommerce-android/pull/14449]
+- [Internal] Added support for persisting log files in the app's internal storage [https://github.com/woocommerce/woocommerce-android/pull/14425]
 
 23.0
 -----

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/support/WooLogViewerActivity.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/support/WooLogViewerActivity.kt
@@ -4,37 +4,25 @@ import android.content.Intent
 import android.os.Bundle
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
-import androidx.compose.runtime.LaunchedEffect
-import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.remember
-import androidx.compose.runtime.setValue
+import androidx.activity.viewModels
 import com.woocommerce.android.R
 import com.woocommerce.android.extensions.copyToClipboard
 import com.woocommerce.android.ui.compose.theme.WooTheme
 import com.woocommerce.android.util.WooLog
 import com.woocommerce.android.util.WooLog.T
-import com.woocommerce.android.util.logs.LogEntry
+import dagger.hilt.android.AndroidEntryPoint
 import org.wordpress.android.util.ToastUtils
 
+@AndroidEntryPoint
 class WooLogViewerActivity : ComponentActivity() {
+    private val viewModel: WooLogViewerViewModel by viewModels()
+
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
 
         setContent {
             WooTheme {
-                var logEntries by remember { mutableStateOf<List<LogEntry>>(emptyList()) }
-
-                LaunchedEffect(Unit) {
-                    logEntries = WooLog.getCurrentLogEntries()
-                }
-
-                WooLogViewerScreen(
-                    logEntries,
-                    onBackPress = onBackPressedDispatcher::onBackPressed,
-                    onCopyButtonClick = ::copyAppLogToClipboard,
-                    onShareButtonClick = ::shareAppLog
-                )
+                WooLogViewerScreen(viewModel)
             }
         }
     }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/support/WooLogViewerActivity.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/support/WooLogViewerActivity.kt
@@ -25,13 +25,19 @@ class WooLogViewerActivity : ComponentActivity() {
                 WooLogViewerScreen(viewModel)
             }
         }
+
+        viewModel.event.observe(this) { event ->
+            when (event) {
+                is WooLogViewerViewModel.ShareLogs -> shareAppLog(event.logs)
+                is WooLogViewerViewModel.CopyLogs -> copyAppLogToClipboard(event.logs)
+            }
+        }
     }
 
-    private fun shareAppLog() {
-        WooLog.addDeviceInfoEntry(T.DEVICE, WooLog.LogLevel.w)
+    private fun shareAppLog(logs: String) {
         val intent = Intent(Intent.ACTION_SEND)
         intent.type = "text/plain"
-        intent.putExtra(Intent.EXTRA_TEXT, WooLog.toString())
+        intent.putExtra(Intent.EXTRA_TEXT, logs)
         intent.putExtra(Intent.EXTRA_SUBJECT, getString(R.string.app_name) + " " + title)
         try {
             startActivity(Intent.createChooser(intent, getString(R.string.share)))
@@ -40,10 +46,9 @@ class WooLogViewerActivity : ComponentActivity() {
         }
     }
 
-    private fun copyAppLogToClipboard() {
+    private fun copyAppLogToClipboard(logs: String) {
         try {
-            WooLog.addDeviceInfoEntry(T.DEVICE, WooLog.LogLevel.w)
-            copyToClipboard("AppLog", WooLog.toString())
+            copyToClipboard("AppLog", logs)
             ToastUtils.showToast(this, R.string.logviewer_copied_to_clipboard)
         } catch (e: Exception) {
             WooLog.e(T.UTILS, e)

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/support/WooLogViewerScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/support/WooLogViewerScreen.kt
@@ -1,6 +1,10 @@
 package com.woocommerce.android.support
 
 import androidx.activity.compose.LocalOnBackPressedDispatcherOwner
+import androidx.compose.animation.AnimatedContent
+import androidx.compose.animation.slideInHorizontally
+import androidx.compose.animation.slideOutHorizontally
+import androidx.compose.animation.togetherWith
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
@@ -66,13 +70,36 @@ fun WooLogViewerScreen(
     viewerViewModel: WooLogViewerViewModel
 ) {
     viewerViewModel.uiState.observeAsState().value?.let {
-        when (it) {
-            is WooLogViewerViewModel.UiState.LogFilesList -> {
-                LogFilesListScreen(it)
+        AnimatedContent(
+            targetState = it,
+            transitionSpec = {
+                slideInHorizontally { width ->
+                    if (targetState is WooLogViewerViewModel.UiState.LogFileContent) {
+                        width
+                    } else {
+                        -width
+                    }
+                } togetherWith slideOutHorizontally { width ->
+                    if (targetState is WooLogViewerViewModel.UiState.LogFileContent) {
+                        -width
+                    } else {
+                        width
+                    }
+                }
             }
+        ) { targetState ->
+            when (targetState) {
+                is WooLogViewerViewModel.UiState.LogFilesList -> {
+                    LogFilesListScreen(targetState)
+                }
 
-            is WooLogViewerViewModel.UiState.LogFileContent -> {
-                LogFileContent(state = it)
+                is WooLogViewerViewModel.UiState.LogFileContent -> {
+                    LogFileContent(
+                        state = targetState.copy(
+                            logContent = targetState.logContent
+                        )
+                    )
+                }
             }
         }
     }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/support/WooLogViewerScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/support/WooLogViewerScreen.kt
@@ -60,8 +60,8 @@ import com.woocommerce.android.model.UiString
 import com.woocommerce.android.ui.compose.component.SearchLayoutWithParams
 import com.woocommerce.android.ui.compose.component.SearchLayoutWithParamsState
 import com.woocommerce.android.ui.compose.component.Toolbar
-import com.woocommerce.android.ui.compose.theme.WooTheme
 import com.woocommerce.android.ui.compose.component.getText
+import com.woocommerce.android.ui.compose.theme.WooTheme
 import com.woocommerce.android.util.WooLog
 import com.woocommerce.android.util.logs.LogEntry
 import kotlinx.coroutines.launch
@@ -97,11 +97,7 @@ fun WooLogViewerScreen(
                 }
 
                 is WooLogViewerViewModel.UiState.LogFileContent -> {
-                    LogFileContent(
-                        state = targetState.copy(
-                            logContent = targetState.logContent
-                        )
-                    )
+                    LogFileContent(targetState)
                 }
             }
         }
@@ -179,11 +175,11 @@ private fun LogFileContent(
     val lazyListState = rememberLazyListState()
     val coroutineScope = rememberCoroutineScope()
 
-    val searchMatches = remember(state.logContent, searchQuery) {
+    val searchMatches = remember(state.logEntries, searchQuery) {
         if (searchQuery.isBlank()) {
             emptyList()
         } else {
-            state.logContent.mapIndexedNotNull { index, entry ->
+            state.logEntries.mapIndexedNotNull { index, entry ->
                 if (entry.toString().contains(searchQuery, ignoreCase = true)) {
                     index
                 } else {
@@ -281,7 +277,7 @@ private fun LogFileContent(
                 onSearchTypeSelected = { }
             )
             LogViewerEntries(
-                entries = state.logContent,
+                entries = state.logEntries,
                 lazyListState = lazyListState,
                 currentMatchIndex = if (hasMatches) searchMatches[currentMatchIndex] else -1,
                 modifier = Modifier.weight(1f)
@@ -449,7 +445,7 @@ private fun LogFileContentPreview() {
                     "log_example.txt",
                     UiString.UiStringText("Example Log File")
                 ),
-                logContent = entries,
+                logEntries = entries,
                 onBackPressed = {},
                 onShareClicked = {},
                 onCopyClicked = {}

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/support/WooLogViewerScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/support/WooLogViewerScreen.kt
@@ -1,5 +1,6 @@
 package com.woocommerce.android.support
 
+import androidx.activity.compose.BackHandler
 import androidx.activity.compose.LocalOnBackPressedDispatcherOwner
 import androidx.compose.animation.AnimatedContent
 import androidx.compose.animation.slideInHorizontally
@@ -222,6 +223,9 @@ private fun LogFileContent(
             currentMatchIndex--
         }
     }
+
+    BackHandler(onBack = state.onBackPressed)
+
     Scaffold(
         topBar = {
             Toolbar(

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/support/WooLogViewerScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/support/WooLogViewerScreen.kt
@@ -56,10 +56,12 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import com.woocommerce.android.R
+import com.woocommerce.android.model.UiString
 import com.woocommerce.android.ui.compose.component.SearchLayoutWithParams
 import com.woocommerce.android.ui.compose.component.SearchLayoutWithParamsState
 import com.woocommerce.android.ui.compose.component.Toolbar
 import com.woocommerce.android.ui.compose.theme.WooTheme
+import com.woocommerce.android.ui.compose.component.getText
 import com.woocommerce.android.util.WooLog
 import com.woocommerce.android.util.logs.LogEntry
 import kotlinx.coroutines.launch
@@ -131,7 +133,7 @@ private fun LogFilesListScreen(state: WooLogViewerViewModel.UiState.LogFilesList
         ) {
             item {
                 Text(
-                    "Log files by created date",
+                    text = stringResource(R.string.logviewer_log_files_list_header),
                     style = MaterialTheme.typography.titleLarge,
                     modifier = Modifier.padding(16.dp)
                 )
@@ -142,7 +144,7 @@ private fun LogFilesListScreen(state: WooLogViewerViewModel.UiState.LogFilesList
                     HorizontalDivider()
                 }
                 Text(
-                    text = logFile.displayName,
+                    text = logFile.displayName.getText(),
                     style = MaterialTheme.typography.titleMedium,
                     modifier = Modifier
                         .clickable(onClick = { state.onLogFileSelected(logFile) })
@@ -157,7 +159,7 @@ private fun LogFilesListScreen(state: WooLogViewerViewModel.UiState.LogFilesList
 
             item {
                 Text(
-                    "Up to seven day's worth of logs are stored.",
+                    text = stringResource(R.string.logviewer_log_files_list_footer),
                     style = MaterialTheme.typography.bodySmall,
                     modifier = Modifier.padding(16.dp)
                 )
@@ -229,7 +231,7 @@ private fun LogFileContent(
     Scaffold(
         topBar = {
             Toolbar(
-                title = state.logFile.displayName,
+                title = state.logFile.displayName.getText(),
                 onNavigationButtonClick = state.onBackPressed,
                 windowInsets = TopAppBarDefaults.windowInsets,
                 actions = {
@@ -417,9 +419,9 @@ private fun logLevelColorM3(level: WooLog.LogLevel): Color {
 @Composable
 private fun LogFilesListPreview() {
     val logFiles = listOf(
-        WooLogViewerViewModel.LogFile("log1.txt", "Log File 1"),
-        WooLogViewerViewModel.LogFile("log2.txt", "Log File 2"),
-        WooLogViewerViewModel.LogFile("log3.txt", "Log File 3")
+        WooLogViewerViewModel.LogFile("log1.txt", UiString.UiStringText("Log File 1")),
+        WooLogViewerViewModel.LogFile("log2.txt", UiString.UiStringText("Log File 2")),
+        WooLogViewerViewModel.LogFile("log3.txt", UiString.UiStringText("Log File 3"))
     )
     val state = WooLogViewerViewModel.UiState.LogFilesList(
         logFiles = logFiles,
@@ -445,7 +447,7 @@ private fun LogFileContentPreview() {
             state = WooLogViewerViewModel.UiState.LogFileContent(
                 logFile = WooLogViewerViewModel.LogFile(
                     "log_example.txt",
-                    "Example Log File"
+                    UiString.UiStringText("Example Log File")
                 ),
                 logContent = entries,
                 onBackPressed = {}

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/support/WooLogViewerScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/support/WooLogViewerScreen.kt
@@ -1,11 +1,14 @@
 package com.woocommerce.android.support
 
+import androidx.activity.compose.LocalOnBackPressedDispatcherOwner
 import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.WindowInsetsSides
+import androidx.compose.foundation.layout.asPaddingValues
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.only
@@ -33,6 +36,7 @@ import androidx.compose.material3.TopAppBarDefaults
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.livedata.observeAsState
 import androidx.compose.runtime.mutableIntStateOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
@@ -56,6 +60,83 @@ import com.woocommerce.android.util.logs.LogEntry
 import kotlinx.coroutines.launch
 import java.lang.String.format
 import java.util.Locale
+
+@Composable
+fun WooLogViewerScreen(
+    viewerViewModel: WooLogViewerViewModel
+) {
+    viewerViewModel.uiState.observeAsState().value?.let {
+        when (it) {
+            is WooLogViewerViewModel.UiState.LogFilesList -> {
+                LogFilesListScreen(it)
+            }
+
+            is WooLogViewerViewModel.UiState.LogFileContent -> {
+                TODO()
+            }
+        }
+    }
+}
+
+@Composable
+private fun LogFilesListScreen(state: WooLogViewerViewModel.UiState.LogFilesList) {
+    val backDispatcher = LocalOnBackPressedDispatcherOwner.current
+
+    Scaffold(
+        topBar = {
+            Toolbar(
+                title = stringResource(id = R.string.logviewer_activity_title),
+                onNavigationButtonClick = { backDispatcher?.onBackPressedDispatcher?.onBackPressed() }
+            )
+        },
+        modifier = Modifier
+            .fillMaxSize()
+            .background(color = colorResource(id = R.color.color_toolbar))
+            .windowInsetsPadding(WindowInsets.safeDrawing.only(WindowInsetsSides.Horizontal + WindowInsetsSides.Top)),
+    ) { padding ->
+        LazyColumn(
+            modifier = Modifier
+                .padding(padding)
+                .fillMaxSize()
+                .background(MaterialTheme.colorScheme.surface),
+            contentPadding = WindowInsets.safeDrawing.only(WindowInsetsSides.Bottom).asPaddingValues(),
+        ) {
+            item {
+                Text(
+                    "Log files by created date",
+                    style = MaterialTheme.typography.titleLarge,
+                    modifier = Modifier.padding(16.dp)
+                )
+            }
+
+            itemsIndexed(state.logFiles) { index, logFile ->
+                if (index == 0) {
+                    HorizontalDivider()
+                }
+                Text(
+                    text = logFile.displayName,
+                    style = MaterialTheme.typography.titleMedium,
+                    modifier = Modifier
+                        .clickable(onClick = { state.onLogFileSelected(logFile) })
+                        .fillMaxWidth()
+                        .padding(
+                            horizontal = 16.dp,
+                            vertical = 16.dp
+                        ),
+                )
+                HorizontalDivider()
+            }
+
+            item {
+                Text(
+                    "Up to seven day's worth of logs are stored.",
+                    style = MaterialTheme.typography.bodySmall,
+                    modifier = Modifier.padding(16.dp)
+                )
+            }
+        }
+    }
+}
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/support/WooLogViewerScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/support/WooLogViewerScreen.kt
@@ -243,14 +243,14 @@ private fun LogFileContent(
                         onNextClick = goToNextMatch
                     )
                     if (searchQuery.isBlank()) {
-                        IconButton(onClick = { TODO("onCopyButtonClick()") }) {
+                        IconButton(onClick = state.onCopyClicked) {
                             Icon(
                                 painter = painterResource(R.drawable.ic_copy_white_24dp),
                                 contentDescription = stringResource(id = R.string.copy),
                                 tint = colorResource(id = R.color.color_icon_menu)
                             )
                         }
-                        IconButton(onClick = { TODO("onShareButtonClick()") }) {
+                        IconButton(onClick = state.onShareClicked) {
                             Icon(
                                 Icons.Filled.Share,
                                 contentDescription = stringResource(id = R.string.share),
@@ -450,7 +450,9 @@ private fun LogFileContentPreview() {
                     UiString.UiStringText("Example Log File")
                 ),
                 logContent = entries,
-                onBackPressed = {}
+                onBackPressed = {},
+                onShareClicked = {},
+                onCopyClicked = {}
             )
         )
     }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/support/WooLogViewerScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/support/WooLogViewerScreen.kt
@@ -21,7 +21,6 @@ import androidx.compose.foundation.lazy.itemsIndexed
 import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.foundation.text.selection.SelectionContainer
 import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.filled.ContentCopy
 import androidx.compose.material.icons.filled.KeyboardArrowDown
 import androidx.compose.material.icons.filled.KeyboardArrowUp
 import androidx.compose.material.icons.filled.Share
@@ -47,6 +46,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.res.colorResource
 import androidx.compose.ui.res.dimensionResource
+import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
@@ -72,7 +72,7 @@ fun WooLogViewerScreen(
             }
 
             is WooLogViewerViewModel.UiState.LogFileContent -> {
-                TODO()
+                LogFileContent(state = it)
             }
         }
     }
@@ -140,11 +140,8 @@ private fun LogFilesListScreen(state: WooLogViewerViewModel.UiState.LogFilesList
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
-fun WooLogViewerScreen(
-    entries: List<LogEntry>,
-    onBackPress: () -> Unit,
-    onCopyButtonClick: () -> Unit,
-    onShareButtonClick: () -> Unit
+private fun LogFileContent(
+    state: WooLogViewerViewModel.UiState.LogFileContent
 ) {
     var searchQuery by rememberSaveable { mutableStateOf("") }
     var currentMatchIndex by rememberSaveable { mutableIntStateOf(0) }
@@ -152,13 +149,11 @@ fun WooLogViewerScreen(
     val lazyListState = rememberLazyListState()
     val coroutineScope = rememberCoroutineScope()
 
-    val allEntries = remember(entries) { entries.toList() }
-
-    val searchMatches = remember(allEntries, searchQuery) {
+    val searchMatches = remember(state.logContent, searchQuery) {
         if (searchQuery.isBlank()) {
             emptyList()
         } else {
-            allEntries.mapIndexedNotNull { index, entry ->
+            state.logContent.mapIndexedNotNull { index, entry ->
                 if (entry.toString().contains(searchQuery, ignoreCase = true)) {
                     index
                 } else {
@@ -203,8 +198,8 @@ fun WooLogViewerScreen(
     Scaffold(
         topBar = {
             Toolbar(
-                title = stringResource(id = R.string.logviewer_activity_title),
-                onNavigationButtonClick = onBackPress,
+                title = state.logFile.displayName,
+                onNavigationButtonClick = state.onBackPressed,
                 windowInsets = TopAppBarDefaults.windowInsets,
                 actions = {
                     SearchNavigationActions(
@@ -215,16 +210,18 @@ fun WooLogViewerScreen(
                         onNextClick = goToNextMatch
                     )
                     if (searchQuery.isBlank()) {
-                        IconButton(onClick = { onCopyButtonClick() }) {
+                        IconButton(onClick = { TODO("onCopyButtonClick()") }) {
                             Icon(
-                                imageVector = Icons.Filled.ContentCopy,
+                                painter = painterResource(R.drawable.ic_copy_white_24dp),
                                 contentDescription = stringResource(id = R.string.copy),
+                                tint = colorResource(id = R.color.color_icon_menu)
                             )
                         }
-                        IconButton(onClick = { onShareButtonClick() }) {
+                        IconButton(onClick = { TODO("onShareButtonClick()") }) {
                             Icon(
-                                imageVector = Icons.Filled.Share,
+                                Icons.Filled.Share,
                                 contentDescription = stringResource(id = R.string.share),
+                                tint = colorResource(id = R.color.color_icon_menu)
                             )
                         }
                     }
@@ -251,7 +248,7 @@ fun WooLogViewerScreen(
                 onSearchTypeSelected = { }
             )
             LogViewerEntries(
-                entries = allEntries,
+                entries = state.logContent,
                 lazyListState = lazyListState,
                 currentMatchIndex = if (hasMatches) searchMatches[currentMatchIndex] else -1,
                 modifier = Modifier.weight(1f)
@@ -387,7 +384,24 @@ private fun logLevelColorM3(level: WooLog.LogLevel): Color {
 
 @Preview
 @Composable
-private fun WooLogViewerScreenPreview() {
+private fun LogFilesListPreview() {
+    val logFiles = listOf(
+        WooLogViewerViewModel.LogFile("log1.txt", "Log File 1"),
+        WooLogViewerViewModel.LogFile("log2.txt", "Log File 2"),
+        WooLogViewerViewModel.LogFile("log3.txt", "Log File 3")
+    )
+    val state = WooLogViewerViewModel.UiState.LogFilesList(
+        logFiles = logFiles,
+        onLogFileSelected = {}
+    )
+    WooTheme {
+        LogFilesListScreen(state)
+    }
+}
+
+@Preview
+@Composable
+private fun LogFileContentPreview() {
     val entries = buildList {
         add(LogEntry(WooLog.T.ORDERS, WooLog.LogLevel.v, "Verbose"))
         add(LogEntry(WooLog.T.PRODUCTS, WooLog.LogLevel.d, "Debug"))
@@ -396,11 +410,15 @@ private fun WooLogViewerScreenPreview() {
         add(LogEntry(WooLog.T.DASHBOARD, WooLog.LogLevel.e, "Error"))
     }
     WooTheme {
-        WooLogViewerScreen(
-            entries,
-            onBackPress = {},
-            onShareButtonClick = {},
-            onCopyButtonClick = {}
+        LogFileContent(
+            state = WooLogViewerViewModel.UiState.LogFileContent(
+                logFile = WooLogViewerViewModel.LogFile(
+                    "log_example.txt",
+                    "Example Log File"
+                ),
+                logContent = entries,
+                onBackPressed = {}
+            )
         )
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/support/WooLogViewerScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/support/WooLogViewerScreen.kt
@@ -2,10 +2,6 @@ package com.woocommerce.android.support
 
 import androidx.activity.compose.BackHandler
 import androidx.activity.compose.LocalOnBackPressedDispatcherOwner
-import androidx.compose.animation.AnimatedContent
-import androidx.compose.animation.slideInHorizontally
-import androidx.compose.animation.slideOutHorizontally
-import androidx.compose.animation.togetherWith
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
@@ -72,33 +68,17 @@ import java.util.Locale
 fun WooLogViewerScreen(
     viewerViewModel: WooLogViewerViewModel
 ) {
-    viewerViewModel.uiState.observeAsState().value?.let {
-        AnimatedContent(
-            targetState = it,
-            transitionSpec = {
-                slideInHorizontally { width ->
-                    if (targetState is WooLogViewerViewModel.UiState.LogFileContent) {
-                        width
-                    } else {
-                        -width
-                    }
-                } togetherWith slideOutHorizontally { width ->
-                    if (targetState is WooLogViewerViewModel.UiState.LogFileContent) {
-                        -width
-                    } else {
-                        width
-                    }
-                }
+    viewerViewModel.uiState.observeAsState().value?.let { state ->
+        // TODO animate transitions between states
+        //  For now, I had to remove the AnimatedContent as it caused a very noticeable delay
+        //  when navigating to the LogFileContent state when the log file is large (> 1000 entries).
+        when (state) {
+            is WooLogViewerViewModel.UiState.LogFilesList -> {
+                LogFilesListScreen(state)
             }
-        ) { targetState ->
-            when (targetState) {
-                is WooLogViewerViewModel.UiState.LogFilesList -> {
-                    LogFilesListScreen(targetState)
-                }
 
-                is WooLogViewerViewModel.UiState.LogFileContent -> {
-                    LogFileContent(targetState)
-                }
+            is WooLogViewerViewModel.UiState.LogFileContent -> {
+                LogFileContent(state)
             }
         }
     }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/support/WooLogViewerViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/support/WooLogViewerViewModel.kt
@@ -75,27 +75,18 @@ class WooLogViewerViewModel @Inject constructor(
     }
 
     private suspend fun prepareLogFileContentState(logFile: LogFile): UiState.LogFileContent {
-        val logContent = wooFileLogger.getLogFileContent(logFile.name).orEmpty()
+        fun getShareLogs(entries: List<LogEntry>): String {
+            return (entries.takeLast(MAX_LOG_ENTRIES_TO_SHARE) + getDeviceInfo())
+                .joinToString("\n")
+        }
+
+        val logEntries = wooFileLogger.getLogFileContent(logFile.name).orEmpty()
         return UiState.LogFileContent(
             logFile = logFile,
-            logContent = logContent,
-            onBackPressed = {
-                selectedLogFile.value = null
-            },
-            onShareClicked = {
-                triggerEvent(
-                    ShareLogs(
-                        logs = (logContent + getDeviceInfo()).joinToString("\n")
-                    )
-                )
-            },
-            onCopyClicked = {
-                triggerEvent(
-                    CopyLogs(
-                        logs = (logContent + getDeviceInfo()).joinToString("\n")
-                    )
-                )
-            }
+            logEntries = logEntries,
+            onBackPressed = { selectedLogFile.value = null },
+            onShareClicked = { triggerEvent(ShareLogs(logs = getShareLogs(logEntries))) },
+            onCopyClicked = { triggerEvent(CopyLogs(logs = getShareLogs(logEntries))) }
         )
     }
 
@@ -113,7 +104,7 @@ class WooLogViewerViewModel @Inject constructor(
 
         data class LogFileContent(
             val logFile: LogFile,
-            val logContent: List<LogEntry>,
+            val logEntries: List<LogEntry>,
             val onBackPressed: () -> Unit,
             val onShareClicked: () -> Unit,
             val onCopyClicked: () -> Unit
@@ -128,4 +119,10 @@ class WooLogViewerViewModel @Inject constructor(
 
     data class ShareLogs(val logs: String) : MultiLiveEvent.Event()
     data class CopyLogs(val logs: String) : MultiLiveEvent.Event()
+
+    companion object {
+        // If we try to share very large number of entries, Android might throw TransactionTooLargeException
+        // when trying to send the intent.
+        private const val MAX_LOG_ENTRIES_TO_SHARE = 1000
+    }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/support/WooLogViewerViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/support/WooLogViewerViewModel.kt
@@ -50,7 +50,7 @@ class WooLogViewerViewModel @Inject constructor(
 
     private suspend fun prepareLogFileContentState(logFile: LogFile) =
         UiState.LogFileContent(
-            logFileName = logFile,
+            logFile = logFile,
             logContent = wooFileLogger.getLogFileContent(logFile.name).orEmpty(),
             onBackPressed = {
                 selectedLogFile.value = null
@@ -64,7 +64,7 @@ class WooLogViewerViewModel @Inject constructor(
         ) : UiState
 
         data class LogFileContent(
-            val logFileName: LogFile,
+            val logFile: LogFile,
             val logContent: List<LogEntry>,
             val onBackPressed: () -> Unit
         ) : UiState

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/support/WooLogViewerViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/support/WooLogViewerViewModel.kt
@@ -6,8 +6,11 @@ import androidx.lifecycle.asLiveData
 import androidx.lifecycle.viewModelScope
 import com.woocommerce.android.R
 import com.woocommerce.android.model.UiString
+import com.woocommerce.android.util.DeviceInfo
+import com.woocommerce.android.util.WooLog
 import com.woocommerce.android.util.logs.LogEntry
 import com.woocommerce.android.util.logs.WooFileLogger
+import com.woocommerce.android.viewmodel.MultiLiveEvent
 import com.woocommerce.android.viewmodel.ScopedViewModel
 import com.woocommerce.android.viewmodel.getNullableStateFlow
 import dagger.hilt.android.lifecycle.HiltViewModel
@@ -54,14 +57,36 @@ class WooLogViewerViewModel @Inject constructor(
         )
     }
 
-    private suspend fun prepareLogFileContentState(logFile: LogFile) =
-        UiState.LogFileContent(
+    private suspend fun prepareLogFileContentState(logFile: LogFile): UiState.LogFileContent {
+        val logContent = wooFileLogger.getLogFileContent(logFile.name).orEmpty()
+        return UiState.LogFileContent(
             logFile = logFile,
-            logContent = wooFileLogger.getLogFileContent(logFile.name).orEmpty(),
+            logContent = logContent,
             onBackPressed = {
                 selectedLogFile.value = null
+            },
+            onShareClicked = {
+                triggerEvent(
+                    ShareLogs(
+                        logs = (logContent + getDeviceInfo()).joinToString("\n")
+                    )
+                )
+            },
+            onCopyClicked = {
+                triggerEvent(
+                    CopyLogs(
+                        logs = (logContent + getDeviceInfo()).joinToString("\n")
+                    )
+                )
             }
         )
+    }
+
+    private fun getDeviceInfo(): LogEntry {
+        return with(DeviceInfo) {
+            LogEntry(WooLog.T.DEVICE, WooLog.LogLevel.w, "OS: ${OS}\nDeviceName: ${name}\nLanguage: $locale")
+        }
+    }
 
     sealed interface UiState {
         data class LogFilesList(
@@ -72,7 +97,9 @@ class WooLogViewerViewModel @Inject constructor(
         data class LogFileContent(
             val logFile: LogFile,
             val logContent: List<LogEntry>,
-            val onBackPressed: () -> Unit
+            val onBackPressed: () -> Unit,
+            val onShareClicked: () -> Unit,
+            val onCopyClicked: () -> Unit
         ) : UiState
     }
 
@@ -81,4 +108,7 @@ class WooLogViewerViewModel @Inject constructor(
         val name: String,
         val displayName: UiString
     ) : Parcelable
+
+    data class ShareLogs(val logs: String) : MultiLiveEvent.Event()
+    data class CopyLogs(val logs: String) : MultiLiveEvent.Event()
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/support/WooLogViewerViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/support/WooLogViewerViewModel.kt
@@ -1,0 +1,78 @@
+package com.woocommerce.android.support
+
+import android.os.Parcelable
+import androidx.lifecycle.SavedStateHandle
+import androidx.lifecycle.asLiveData
+import androidx.lifecycle.viewModelScope
+import com.woocommerce.android.util.logs.LogEntry
+import com.woocommerce.android.util.logs.WooFileLogger
+import com.woocommerce.android.viewmodel.ScopedViewModel
+import com.woocommerce.android.viewmodel.getNullableStateFlow
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.flow.map
+import kotlinx.parcelize.Parcelize
+import javax.inject.Inject
+
+@HiltViewModel
+class WooLogViewerViewModel @Inject constructor(
+    savedState: SavedStateHandle,
+    private val wooFileLogger: WooFileLogger
+) : ScopedViewModel(savedState) {
+
+    private val selectedLogFile = savedState.getNullableStateFlow<LogFile?>(
+        viewModelScope,
+        null,
+        LogFile::class.java,
+        "selected_log_file"
+    )
+
+    val uiState = selectedLogFile.map { logFile ->
+        if (logFile == null) {
+            prepareFilesListState()
+        } else {
+            prepareLogFileContentState(logFile)
+        }
+    }.asLiveData()
+
+    private suspend fun prepareFilesListState(): UiState.LogFilesList {
+        return UiState.LogFilesList(
+            logFiles = wooFileLogger.getLogFiles().mapIndexed { index, file ->
+                LogFile(
+                    name = file.name,
+                    displayName = if (index == 0) "Current" else file.name
+                )
+            },
+            onLogFileSelected = { selectedFile ->
+                selectedLogFile.value = selectedFile
+            }
+        )
+    }
+
+    private suspend fun prepareLogFileContentState(logFile: LogFile) =
+        UiState.LogFileContent(
+            logFileName = logFile,
+            logContent = wooFileLogger.getLogFileContent(logFile.name).orEmpty(),
+            onBackPressed = {
+                selectedLogFile.value = null
+            }
+        )
+
+    sealed interface UiState {
+        data class LogFilesList(
+            val logFiles: List<LogFile>,
+            val onLogFileSelected: (LogFile) -> Unit
+        ) : UiState
+
+        data class LogFileContent(
+            val logFileName: LogFile,
+            val logContent: List<LogEntry>,
+            val onBackPressed: () -> Unit
+        ) : UiState
+    }
+
+    @Parcelize
+    data class LogFile(
+        val name: String,
+        val displayName: String
+    ) : Parcelable
+}

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/support/WooLogViewerViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/support/WooLogViewerViewModel.kt
@@ -49,10 +49,12 @@ class WooLogViewerViewModel @Inject constructor(
                 .removePrefix(LogFileWriter.LOG_FILE_NAME_PREFIX)
                 .substringBeforeLast(".")
 
-            val date = SimpleDateFormat(LogFileWriter.DATE_FORMAT_PATTERN, Locale.ROOT).parse(dateString)
-            val dateDisplayFormatter = SimpleDateFormat.getDateInstance()
+            val date = runCatching {
+                SimpleDateFormat(LogFileWriter.DATE_FORMAT_PATTERN, Locale.ROOT).parse(dateString)
+            }.getOrNull()
 
             return date?.let {
+                val dateDisplayFormatter = SimpleDateFormat.getDateInstance()
                 dateDisplayFormatter.format(date)
             } ?: dateString
         }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/support/WooLogViewerViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/support/WooLogViewerViewModel.kt
@@ -65,7 +65,8 @@ class WooLogViewerViewModel @Inject constructor(
                         UiString.UiStringRes(R.string.logviewer_current_log_file)
                     } else {
                         UiString.UiStringText(prepareFileDisplayName(file))
-                    }
+                    },
+                    isCurrent = index == 0
                 )
             },
             onLogFileSelected = { selectedFile ->
@@ -80,6 +81,10 @@ class WooLogViewerViewModel @Inject constructor(
                 .joinToString("\n")
         }
 
+        if (logFile.isCurrent) {
+            // When the current log file is selected, ensure the buffer is flushed to disk
+            wooFileLogger.forceFlush()
+        }
         val logEntries = wooFileLogger.getLogFileContent(logFile.name).orEmpty()
         return UiState.LogFileContent(
             logFile = logFile,
@@ -114,7 +119,8 @@ class WooLogViewerViewModel @Inject constructor(
     @Parcelize
     data class LogFile(
         val name: String,
-        val displayName: UiString
+        val displayName: UiString,
+        val isCurrent: Boolean = false
     ) : Parcelable
 
     data class ShareLogs(val logs: String) : MultiLiveEvent.Event()

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/support/WooLogViewerViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/support/WooLogViewerViewModel.kt
@@ -9,6 +9,7 @@ import com.woocommerce.android.model.UiString
 import com.woocommerce.android.util.DeviceInfo
 import com.woocommerce.android.util.WooLog
 import com.woocommerce.android.util.logs.LogEntry
+import com.woocommerce.android.util.logs.LogFileWriter
 import com.woocommerce.android.util.logs.WooFileLogger
 import com.woocommerce.android.viewmodel.MultiLiveEvent
 import com.woocommerce.android.viewmodel.ScopedViewModel
@@ -16,6 +17,9 @@ import com.woocommerce.android.viewmodel.getNullableStateFlow
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.map
 import kotlinx.parcelize.Parcelize
+import java.io.File
+import java.text.SimpleDateFormat
+import java.util.Locale
 import javax.inject.Inject
 
 @HiltViewModel
@@ -24,7 +28,7 @@ class WooLogViewerViewModel @Inject constructor(
     private val wooFileLogger: WooFileLogger
 ) : ScopedViewModel(savedState) {
 
-    private val selectedLogFile = savedState.getNullableStateFlow<LogFile?>(
+    private val selectedLogFile = savedState.getNullableStateFlow(
         viewModelScope,
         null,
         LogFile::class.java,
@@ -40,6 +44,19 @@ class WooLogViewerViewModel @Inject constructor(
     }.asLiveData()
 
     private suspend fun prepareFilesListState(): UiState.LogFilesList {
+        fun prepareFileDisplayName(file: File): String {
+            val dateString = file.name
+                .removePrefix(LogFileWriter.LOG_FILE_NAME_PREFIX)
+                .substringBeforeLast(".")
+
+            val date = SimpleDateFormat(LogFileWriter.DATE_FORMAT_PATTERN, Locale.ROOT).parse(dateString)
+            val dateDisplayFormatter = SimpleDateFormat.getDateInstance()
+
+            return date?.let {
+                dateDisplayFormatter.format(date)
+            } ?: dateString
+        }
+
         return UiState.LogFilesList(
             logFiles = wooFileLogger.getLogFiles().mapIndexed { index, file ->
                 LogFile(
@@ -47,7 +64,7 @@ class WooLogViewerViewModel @Inject constructor(
                     displayName = if (index == 0) {
                         UiString.UiStringRes(R.string.logviewer_current_log_file)
                     } else {
-                        UiString.UiStringText(file.name)
+                        UiString.UiStringText(prepareFileDisplayName(file))
                     }
                 )
             },

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/support/WooLogViewerViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/support/WooLogViewerViewModel.kt
@@ -4,6 +4,8 @@ import android.os.Parcelable
 import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.asLiveData
 import androidx.lifecycle.viewModelScope
+import com.woocommerce.android.R
+import com.woocommerce.android.model.UiString
 import com.woocommerce.android.util.logs.LogEntry
 import com.woocommerce.android.util.logs.WooFileLogger
 import com.woocommerce.android.viewmodel.ScopedViewModel
@@ -39,7 +41,11 @@ class WooLogViewerViewModel @Inject constructor(
             logFiles = wooFileLogger.getLogFiles().mapIndexed { index, file ->
                 LogFile(
                     name = file.name,
-                    displayName = if (index == 0) "Current" else file.name
+                    displayName = if (index == 0) {
+                        UiString.UiStringRes(R.string.logviewer_current_log_file)
+                    } else {
+                        UiString.UiStringText(file.name)
+                    }
                 )
             },
             onLogFileSelected = { selectedFile ->
@@ -73,6 +79,6 @@ class WooLogViewerViewModel @Inject constructor(
     @Parcelize
     data class LogFile(
         val name: String,
-        val displayName: String
+        val displayName: UiString
     ) : Parcelable
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/util/WooLog.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/util/WooLog.kt
@@ -205,12 +205,6 @@ object WooLog {
         }
     }
 
-    fun addDeviceInfoEntry(tag: T, level: LogLevel = LogLevel.i) {
-        with(DeviceInfo) {
-            addEntry(tag, level, "OS: ${OS}\nDeviceName: ${name}\nLanguage: $locale")
-        }
-    }
-
     private fun getStringStackTrace(throwable: Throwable): String {
         val errors = StringWriter()
         throwable.printStackTrace(PrintWriter(errors))

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/util/logs/LogFileWriter.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/util/logs/LogFileWriter.kt
@@ -22,7 +22,7 @@ class LogFileWriter(
 ) {
     private var lastUsedFile: File? = null
     private val dateFormatter
-        get() = SimpleDateFormat("yyyy-MM-dd", Locale.US)
+        get() = SimpleDateFormat(DATE_FORMAT_PATTERN, Locale.ROOT)
     private val mutex = Mutex()
 
     suspend fun writeLogs(logs: String) {
@@ -42,7 +42,7 @@ class LogFileWriter(
     suspend fun getLogFiles(): List<File> {
         ensureDirectoryExists()
         return withContext(dispatchers.io) {
-            logsDirectory.listFiles { file -> file.isFile && file.name.startsWith("log_") }
+            logsDirectory.listFiles { file -> file.isFile && file.name.startsWith(LOG_FILE_NAME_PREFIX) }
                 ?.sortedByDescending { it.lastModified() }
                 ?: emptyList()
         }
@@ -70,7 +70,7 @@ class LogFileWriter(
         }
 
         val today = dateFormatter.format(java.util.Date())
-        val logFileName = "log_$today.txt"
+        val logFileName = "$LOG_FILE_NAME_PREFIX$today.txt"
 
         lastUsedFile?.let {
             if (it.name == logFileName) {
@@ -90,7 +90,7 @@ class LogFileWriter(
 
     private suspend fun rotateLogFilesIfNeeded() {
         withContext(dispatchers.io) {
-            val logFiles = logsDirectory.listFiles { file -> file.isFile && file.name.startsWith("log_") }
+            val logFiles = logsDirectory.listFiles { file -> file.isFile && file.name.startsWith(LOG_FILE_NAME_PREFIX) }
                 ?.sortedByDescending { it.lastModified() } ?: return@withContext
 
             mutex.withLock {
@@ -101,5 +101,10 @@ class LogFileWriter(
                 }
             }
         }
+    }
+
+    companion object {
+        const val LOG_FILE_NAME_PREFIX = "log_"
+        const val DATE_FORMAT_PATTERN = "yyyy-MM-dd"
     }
 }

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -2654,14 +2654,22 @@
     <string name="support_contact_email_not_set">Not set</string>
     <string name="support_push_notification_title">WooCommerce</string>
     <string name="support_push_notification_message">New message from \'Help &amp; Support\'</string>
-    <string name="logviewer_activity_title">Application log</string>
-    <string name="logviewer_copied_to_clipboard">Log copied to clipboard</string>
-    <string name="logviewer_error_copy_to_clipboard">Error copying to clipboard</string>
-    <string name="logviewer_share_error">Unable to share log</string>
     <string name="about_appname">WooCommerce for Android</string>
     <string name="about_tos">Terms of Service</string>
     <string name="about_version">Version %s</string>
     <string name="about_copyright" translatable="false">© %1$d WooCommerce, Inc and WooCommerce Ireland Ltd</string>
+
+    <!--
+        Log Viewer
+    -->
+    <string name="logviewer_activity_title">Application log</string>
+    <string name="logviewer_copied_to_clipboard">Log copied to clipboard</string>
+    <string name="logviewer_error_copy_to_clipboard">Error copying to clipboard</string>
+    <string name="logviewer_share_error">Unable to share log</string>
+    <string name="logviewer_log_files_list_header">Log files by created date</string>
+    <string name="logviewer_log_files_list_footer">Up to seven day\'s worth of logs are stored.</string>
+    <string name="logviewer_current_log_file">Current</string>
+
     <!--
         Login Library Imported Strings
     -->


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

<!-- Id number of the Linear issue this PR addresses, e.g., WOOMOB-373. -->
Closes WOOMOB-948

> [!IMPORTANT]
> Please don't merge, we have a PR that migrates the `WooLogViewerScreen` to Material 3 #14406, and merging this will cause conflicts, so let's wait until it's merged, and I'll rebase my branch. 

### Description
This PR updates the `WooLogViewerActivity` to display a list of the available log files, and tapping on each log file will open its content, this is similar to what the iOS app does.

> [!NOTE]
> For time constraints, I took some shortcuts in the implementation, we have a single ViewModel with both the list and detail states, this was simpler to implement, and I think it does the job well. 

### Steps to reproduce
1. To simulate having multiple log files, change the device date, then open the app, this will create a log file for each date.
2. Open the application log viewer from the support screen.

### Testing information
- Confirm that the list of last seven log files is shown.
- Tap on the log files, and confirm the correct contents are shown.
- Test tapping on Copy and Share.

### The tests that have been performed
The above.

### Images/gif

https://github.com/user-attachments/assets/464ade8a-4b48-4858-8af7-5e305c447c4f


- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->