### PR TITLE
[POS as Tab i2] Show labels in navigation menu on tablets

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -9,6 +9,7 @@
 - [*] POS: Extra step into the barcode scanner setup flow to explain how to setup software keyboard [https://github.com/woocommerce/woocommerce-android/pull/14395]
 - [Internal] Introduced Material 3 based theme and migrated some components to Material 3 [https://github.com/woocommerce/woocommerce-android/pull/14401]
 - [Internal] Added logging to POS tab visibility and eligibility checks [https://github.com/woocommerce/woocommerce-android/pull/14426]
+- [*] Bottom navigation menu has now labels shown under icons on tablet devices [https://github.com/woocommerce/woocommerce-android/pull/14429]
 
 22.9.1
 -----

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/main/MainBottomNavigationView.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/main/MainBottomNavigationView.kt
@@ -14,7 +14,6 @@ import androidx.navigation.NavDestination.Companion.hierarchy
 import androidx.navigation.ui.NavigationUI
 import com.google.android.material.badge.BadgeDrawable
 import com.google.android.material.bottomnavigation.BottomNavigationView
-import com.google.android.material.navigation.NavigationBarView
 import com.google.android.material.navigation.NavigationBarView.OnItemReselectedListener
 import com.google.android.material.navigation.NavigationBarView.OnItemSelectedListener
 import com.woocommerce.android.R

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/main/MainBottomNavigationView.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/main/MainBottomNavigationView.kt
@@ -14,9 +14,12 @@ import androidx.navigation.NavDestination.Companion.hierarchy
 import androidx.navigation.ui.NavigationUI
 import com.google.android.material.badge.BadgeDrawable
 import com.google.android.material.bottomnavigation.BottomNavigationView
+import com.google.android.material.navigation.NavigationBarView
 import com.google.android.material.navigation.NavigationBarView.OnItemReselectedListener
 import com.google.android.material.navigation.NavigationBarView.OnItemSelectedListener
 import com.woocommerce.android.R
+import com.woocommerce.android.extensions.WindowSizeClass
+import com.woocommerce.android.extensions.windowWidthSizeClass
 import java.lang.ref.WeakReference
 
 class MainBottomNavigationView @JvmOverloads constructor(
@@ -45,6 +48,7 @@ class MainBottomNavigationView @JvmOverloads constructor(
         this.navController = navController
         this.listener = listener
 
+        setupLabelVisibilityMode()
         addTopDivider()
         createBadges()
 
@@ -70,6 +74,14 @@ class MainBottomNavigationView @JvmOverloads constructor(
                 }
             }
         )
+    }
+
+    private fun setupLabelVisibilityMode() {
+        labelVisibilityMode = when (context.windowWidthSizeClass) {
+            WindowSizeClass.Compact -> LABEL_VISIBILITY_AUTO
+            WindowSizeClass.Medium,
+            WindowSizeClass.ExpandedAndBigger -> LABEL_VISIBILITY_LABELED
+        }
     }
 
     private fun createBadges() {


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

<!-- Id number of the Linear issue this PR addresses, e.g., WOOMOB-373. -->
WOOPRD-695

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
This PR addresses UI feedback from POS as tab i2 Call for testing: pdfdoF-7FH-p2#comment-8892

App's bottom navigation menu has labels shown under menu items on tablets. On phones UI remains unchanged.

### Steps to reproduce
<!-- Step-by-step testing instructions. For new user flows, consider instead stating the goal of the workflow and see if your PR reviewer can accomplish the workflow without specific steps! -->
N/A

### Testing information
<!-- This is your opportunity to break out individual scenarios that need testing (when necessary) and/or include a checklist for the reviewer to go through. Consider documenting the following from your own completed testing: devices used, alternate workflows, edge cases, affected areas, critical flows, areas not tested, and any remaining unknowns. Provide feedback on this new section of the PR template through Sept 30, 2024 to Apps Quality; additional context here: p91TBi-b8z-p2#comment-12036 -->
Verify app's bottom menu with Compact/Medium/Large window size classes.

### The tests that have been performed
<!-- To give the reviewer an idea of what could be missed in terms of testing -->
Tested Compact/Medium/Large window size classes. See the results below.

### Images/gif
<!-- Include before and after images or gifs when appropriate. -->
#### Compact 
<img width="400" height="2400" alt="Screenshot_20250804_184724" src="https://github.com/user-attachments/assets/2018acc8-6814-49cc-a4f7-5dffa0224cf2" />

#### Medium
<img width="600" height="2152" alt="Screenshot_20250805_103247" src="https://github.com/user-attachments/assets/4aab5157-aa19-40ad-a467-7d3fcb9e3cf2" />

#### Large
<img width="2000" height="1440" alt="Screenshot_20250805_103339" src="https://github.com/user-attachments/assets/0634c99a-31f2-465c-9153-970a6225a6d8" />

- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->