### PR TITLE
[Shipping labels] Fix `paperSize` parsing error

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/networking/DTOs.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/networking/DTOs.kt
@@ -36,7 +36,7 @@ data class StoreOptionsDTO(
 data class FormDataDTO(
     @SerializedName("selected_payment_method_id") val selectedPaymentId: Long?,
     @SerializedName("email_receipts") val emailReceipts: Boolean = false,
-    @SerializedName("paper_size") val paperSize: WooShippingLabelPaperSize
+    @SerializedName("paper_size") val paperSize: WooShippingLabelPaperSize?
 )
 
 data class FormMetaDTO(

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/networking/WooShippingNetworkingMapper.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/networking/WooShippingNetworkingMapper.kt
@@ -16,6 +16,7 @@ import com.woocommerce.android.ui.orders.wooshippinglabels.models.PaymentMethodO
 import com.woocommerce.android.ui.orders.wooshippinglabels.models.PurchasedLabelData
 import com.woocommerce.android.ui.orders.wooshippinglabels.models.ShippingLabelModel
 import com.woocommerce.android.ui.orders.wooshippinglabels.models.StoreOptionsModel
+import com.woocommerce.android.ui.orders.wooshippinglabels.models.WooShippingLabelPaperSize
 import com.woocommerce.android.ui.orders.wooshippinglabels.packages.ui.PackageData
 import com.woocommerce.android.ui.orders.wooshippinglabels.rates.datasource.WooShippingRateModel
 import com.woocommerce.android.ui.orders.wooshippinglabels.rates.datasource.WooShippingRatesDatasourceMapper
@@ -58,7 +59,7 @@ class WooShippingNetworkingMapper @Inject constructor(
                 canEditSettings = formMeta.canEditSettings,
                 storeOwnerName = formMeta.masterUserName,
                 storeOwnerUsername = formMeta.masterUserWpcomLogin,
-                paperSize = formData.paperSize,
+                paperSize = formData.paperSize ?: WooShippingLabelPaperSize.LABEL,
                 lastOrderCompleted = userMeta.lastOrderCompleted
             )
         }


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

<!-- Id number of the Linear issue this PR addresses, e.g., WOOMOB-373. -->
Closes WOOMOB-973

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
The backend sometimes send `paperSize` data that app doesn't know and this was causing crash. This PR defaults these unknown responses to "Label" type.

### Steps to reproduce
<!-- Step-by-step testing instructions. For new user flows, consider instead stating the goal of the workflow and see if your PR reviewer can accomplish the workflow without specific steps! -->
1. Launch app.
2. Go to Menu → Settings → Developer Options → API Faker
3. Tap the Import button and paste the following settings. (This simulates an error response. You can also use an actual response with `"paper_size": "legal"` to reproduce the same crash.)
```
[
  {
    "request": {
      "id": 0,
      "path": "/wcshipping/v1/account/settings/",
      "queryParameters": [],
      "type": {
        "type": "wp-api"
      }
    },
    "response": {
      "body": "",
      "endpointId": 0,
      "statusCode": 500
    }
  }
]
```
4. Go to Orders.
5. Open an order that is eligible for creating shipping labels.
6. Tap the "Create shipping labels" button.

### Testing information
<!-- This is your opportunity to break out individual scenarios that need testing (when necessary) and/or include a checklist for the reviewer to go through. Consider documenting the following from your own completed testing: devices used, alternate workflows, edge cases, affected areas, critical flows, areas not tested, and any remaining unknowns. Provide feedback on this new section of the PR template through Sept 30, 2024 to Apps Quality; additional context here: p91TBi-b8z-p2#comment-12036 -->
Ensure it doesn't crash.

### The tests that have been performed
<!-- To give the reviewer an idea of what could be missed in terms of testing -->
Steps above.

### Images/gif
<!-- Include before and after images or gifs when appropriate. -->
[Screen_recording_20250804_214031.webm](https://github.com/user-attachments/assets/95e70dfe-2581-48ba-a8bc-446e874dd8ed)

- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->