### PR TITLE
[WOOMOB-967] Fix edge-to-edge rendering issue with Google Play review dialog

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -10,6 +10,7 @@
 - [Internal] Introduced Material 3 based theme and migrated some components to Material 3 [https://github.com/woocommerce/woocommerce-android/pull/14401]
 - [Internal] Added logging to POS tab visibility and eligibility checks [https://github.com/woocommerce/woocommerce-android/pull/14426]
 - [*] Bottom navigation menu has now labels shown under icons on tablet devices [https://github.com/woocommerce/woocommerce-android/pull/14429]
+- [Internal] Suppress edge to edge for Google PlayCoreDialogWrapperActivity [https://github.com/woocommerce/woocommerce-android/pull/14435]
 
 22.9.1
 -----

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/util/ApplicationEdgeToEdgeEnabler.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/util/ApplicationEdgeToEdgeEnabler.kt
@@ -53,7 +53,11 @@ class ApplicationEdgeToEdgeEnabler @Inject constructor(
         }
     }
 
-    private fun isEdgeToEdgeSupported(activity: Activity) = !activity::class.java.name.startsWith("leakcanary")
+    private fun isEdgeToEdgeSupported(activity: Activity) =
+        activity::class.java.name.let { className ->
+            !className.startsWith("leakcanary") &&
+                !className.startsWith("com.google.android.play.core.common.PlayCoreDialogWrapperActivity")
+        }
 
     override fun onActivityStarted(activity: Activity) {
         // no-op

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/util/ApplicationEdgeToEdgeEnabler.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/util/ApplicationEdgeToEdgeEnabler.kt
@@ -56,7 +56,7 @@ class ApplicationEdgeToEdgeEnabler @Inject constructor(
     private fun isEdgeToEdgeSupported(activity: Activity) =
         activity::class.java.name.let { className ->
             !className.startsWith("leakcanary") &&
-                !className.startsWith("com.google.android.play.core.common.PlayCoreDialogWrapperActivity")
+                !className.startsWith("com.google.android.play.core")
         }
 
     override fun onActivityStarted(activity: Activity) {


### PR DESCRIPTION
Fixes WOOMOB-967

### Description
This PR fixes a non-fatal exception Sentry is reporting - `Activity com.google.android.play.core.common.PlayCoreDialogWrapperActivity@9f880c7 is not a ComponentActivity`. The `PlayCoreDialogWrapperActivity` (used by Google Play's in-app review feature) has been added to the list of activities that should not have edge-to-edge rendering enabled.

<img width="1519" height="379" alt="Screenshot 2025-08-06 at 8 57 30" src="https://github.com/user-attachments/assets/e10b0269-e359-4ff8-85b7-2296aef1fb6f" />


While I haven't been able to reproduce the issue directly, this change feels safe to make.

### Testing information
I tried enforcing the display of the dialog, but even when it displays, I don't see the error logs - I'm not sure why. So I guess there isn't much to test here.

### The tests that have been performed
- Verified the Google review flow works as expected when I enforce the app to show it on each restart.


- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.