### PR TITLE
Get rid of some DB blocking calls 

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/categories/AddProductCategoryFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/categories/AddProductCategoryFragment.kt
@@ -31,7 +31,6 @@ import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.ShowSnackbar
 import com.woocommerce.android.viewmodel.fixedHiltNavGraphViewModels
 import com.woocommerce.android.widgets.CustomProgressDialog
 import dagger.hilt.android.AndroidEntryPoint
-import kotlinx.coroutines.runBlocking
 import org.wordpress.android.util.ActivityUtils
 import javax.inject.Inject
 
@@ -48,7 +47,8 @@ class AddProductCategoryFragment :
 
     private var progressDialog: CustomProgressDialog? = null
 
-    @Inject lateinit var uiMessageResolver: UIMessageResolver
+    @Inject
+    lateinit var uiMessageResolver: UIMessageResolver
 
     private var _binding: FragmentAddProductCategoryBinding? = null
     private val binding get() = _binding!!
@@ -112,7 +112,6 @@ class AddProductCategoryFragment :
         }
 
         with(binding.productCategoryParent) {
-            runBlocking { viewModel.getSelectedParentCategoryName()?.let { setText(it) } }
             setClickListener {
                 val action = AddProductCategoryFragmentDirections
                     .actionAddProductCategoryFragmentToParentCategoryListFragment(
@@ -163,10 +162,9 @@ class AddProductCategoryFragment :
                     binding.productCategoryName.text = it.parseAsHtml().toString()
                 }
             }
-            new.selectedParentId.takeIfNotEqualTo(old?.selectedParentId) {
-                val parentCategoryName = runBlocking { viewModel.getSelectedParentCategoryName() }
-                if (parentCategoryName != null) {
-                    binding.productCategoryParent.setHtmlText(parentCategoryName)
+            new.selectedParentName.takeIfNotEqualTo(old?.selectedParentName) {
+                if (it != null) {
+                    binding.productCategoryParent.setHtmlText(it)
                 } else {
                     binding.productCategoryParent.setHtmlText("")
                 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/categories/AddProductCategoryViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/categories/AddProductCategoryViewModel.kt
@@ -51,8 +51,14 @@ class AddProductCategoryViewModel @Inject constructor(
             categoryName = navArgs.productCategory?.name ?: "",
             selectedParentId = navArgs.productCategory?.parentId,
             isEditingMode = navArgs.productCategory != null
-        )
+        ),
+        onChange = { old, new ->
+            if (old?.selectedParentId != new.selectedParentId) {
+                refreshParentCategoryName()
+            }
+        }
     )
+
     private var addProductCategoryViewState by addProductCategoryViewStateLiveData
 
     /**
@@ -209,6 +215,20 @@ class AddProductCategoryViewModel @Inject constructor(
         )
     }
 
+    private fun refreshParentCategoryName() {
+        launch {
+            val selectedParentId = addProductCategoryViewState.selectedParentId
+            val selectedParentName = if (selectedParentId != null && selectedParentId != 0L) {
+                productCategoriesRepository.getProductCategoryByRemoteId(selectedParentId)?.name
+            } else {
+                null
+            }
+            addProductCategoryViewState = addProductCategoryViewState.copy(
+                selectedParentName = selectedParentName
+            )
+        }
+    }
+
     fun fetchParentCategories() {
         loadParentCategories()
     }
@@ -219,9 +239,6 @@ class AddProductCategoryViewModel @Inject constructor(
     }
 
     fun getSelectedParentId() = addProductCategoryViewState.selectedParentId ?: 0L
-
-    suspend fun getSelectedParentCategoryName(): String? =
-        productCategoriesRepository.getProductCategoryByRemoteId(getSelectedParentId())?.name
 
     /**
      * Refreshes the list of categories by calling the [loadParentCategories] method
@@ -345,6 +362,7 @@ class AddProductCategoryViewModel @Inject constructor(
         val categoryNameErrorMessage: Int? = null,
         val categoryName: String = "",
         val selectedParentId: Long? = null,
+        val selectedParentName: String? = null,
         val shouldShowDiscardDialog: Boolean = true,
         val isEditingMode: Boolean = false
     ) : Parcelable

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/details/ProductDetailCardBuilder.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/details/ProductDetailCardBuilder.kt
@@ -85,7 +85,6 @@ import com.woocommerce.android.util.CurrencyFormatter
 import com.woocommerce.android.util.PriceUtils
 import com.woocommerce.android.util.StringUtils
 import com.woocommerce.android.viewmodel.ResourceProvider
-import kotlinx.coroutines.runBlocking
 import java.math.BigDecimal
 
 @Suppress("LargeClass", "LongParameterList")
@@ -474,7 +473,7 @@ class ProductDetailCardBuilder(
     }
 
     @Suppress("LongMethod")
-    private fun ProductAggregate.shipping(): ProductProperty? {
+    private suspend fun ProductAggregate.shipping(): ProductProperty? {
         val currentProduct = this.product
         return if (!currentProduct.isVirtual && hasShipping) {
             val weightWithUnits = product.getWeightWithUnits(parameters.weightUnit)
@@ -484,7 +483,7 @@ class ProductDetailCardBuilder(
                 put(resources.getString(string.product_dimensions), sizeWithUnits)
                 put(
                     resources.getString(string.product_shipping_class),
-                    runBlocking { viewModel.getShippingClassByRemoteShippingClassId(currentProduct.shippingClassId) }
+                    viewModel.getShippingClassByRemoteShippingClassId(currentProduct.shippingClassId)
                 )
 
                 // Only add "One time shipping" info if product is Subscription types
@@ -494,6 +493,25 @@ class ProductDetailCardBuilder(
                         buildOneTimeShippingDescription(subscription)
                     )
                 }
+            }
+
+            val subscriptionShippingData = if (product.productType == SUBSCRIPTION ||
+                product.productType == VARIABLE_SUBSCRIPTION
+            ) {
+                ShippingData.SubscriptionShippingData(
+                    oneTimeShipping = subscription?.oneTimeShipping ?: false,
+                    canEnableOneTimeShipping = if (product.productType == SUBSCRIPTION) {
+                        subscription?.supportsOneTimeShipping ?: false
+                    } else {
+                        // For variable subscription products, we need to check against the variations
+                        variationRepository.getProductVariationList(product.remoteId).all {
+                            (it as? SubscriptionProductVariation)?.subscriptionDetails
+                                ?.supportsOneTimeShipping ?: false
+                        }
+                    }
+                )
+            } else {
+                null
             }
 
             PropertyGroup(
@@ -510,26 +528,7 @@ class ProductDetailCardBuilder(
                             height = product.height,
                             shippingClassSlug = product.shippingClass,
                             shippingClassId = product.shippingClassId,
-                            subscriptionShippingData = if (product.productType == SUBSCRIPTION ||
-                                product.productType == VARIABLE_SUBSCRIPTION
-                            ) {
-                                ShippingData.SubscriptionShippingData(
-                                    oneTimeShipping = subscription?.oneTimeShipping ?: false,
-                                    canEnableOneTimeShipping = if (product.productType == SUBSCRIPTION) {
-                                        subscription?.supportsOneTimeShipping ?: false
-                                    } else {
-                                        // For variable subscription products, we need to check against the variations
-                                        runBlocking {
-                                            variationRepository.getProductVariationList(product.remoteId).all {
-                                                (it as? SubscriptionProductVariation)?.subscriptionDetails
-                                                    ?.supportsOneTimeShipping ?: false
-                                            }
-                                        }
-                                    }
-                                )
-                            } else {
-                                null
-                            }
+                            subscriptionShippingData = subscriptionShippingData
                         )
                     ),
                     AnalyticsEvent.PRODUCT_DETAIL_VIEW_SHIPPING_SETTINGS_TAPPED


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

<!-- Id number of the Linear issue this PR addresses, e.g., WOOMOB-373. -->
Closes WOOMOB-992
Closes WOOMOB-993

### Description
This PR addresses two locations where we are using `runBlocking` when accessing the DB: In `ProductDetailCardBuilder` and `AddProductCategoryFragment`.

### Steps to reproduce
##### `AddProductCategoryFragment`
1. Open a product.
2. Open the categories screen.
3. Tap on Add category.
4. Select a parent.
5. Clear the parent.

##### `ProductDetailCardBuilder`
**IMO this test is optional, as this is fairly small change, and the test requires installing a new plugin**
1. Install the Product subscriptions extension.
2. Add a subscription product.
3. Add shipping details.
4. Enable "One time shipping"

### Testing information
- For `AddProductCategoryFragment`, confirm that the parent category name is shown correctly, and cleared when needed.
- For `ProductDetailCardBuilder`, confirm that the shipping row shows `One time shipping: enabled`.

### The tests that have been performed
The above.

- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->