### PR TITLE
[POS] Remove deprecated accessibility function

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/common/composeui/component/WooPosAccessibilityAnnouncement.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/common/composeui/component/WooPosAccessibilityAnnouncement.kt
@@ -1,0 +1,31 @@
+package com.woocommerce.android.ui.woopos.common.composeui.component
+
+import androidx.compose.foundation.layout.Box
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.key
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.semantics.LiveRegionMode
+import androidx.compose.ui.semantics.liveRegion
+import androidx.compose.ui.semantics.semantics
+
+/**
+ * Announces the given text to accessibility services using a live region.
+ * Ensures screen readers pick up the message even on repeated values.
+ */
+@Composable
+fun AccessibilityAnnouncement(text: String) {
+    key(text + System.currentTimeMillis()) { // Forces recomposition
+        Box(
+            modifier = Modifier
+                .semantics {
+                    liveRegion = LiveRegionMode.Assertive
+                }
+        ) {
+            // Intentionally using Text instead of WooPosText to ensure accessibility announcements work reliably.
+            // WooPosText might change or wrap semantics in a way that breaks live region behavior.
+            @Suppress("WooPosDesignSystemTextUsageRule")
+            (Text(text = text))
+        }
+    }
+}

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/totals/WooPosTotalsScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/totals/WooPosTotalsScreen.kt
@@ -24,16 +24,20 @@ import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.key
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.semantics.LiveRegionMode
+import androidx.compose.ui.semantics.liveRegion
+import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.core.text.HtmlCompat
@@ -61,7 +65,6 @@ import com.woocommerce.android.ui.woopos.home.totals.WooPosTotalsViewState.Total
 import com.woocommerce.android.ui.woopos.home.totals.payment.failed.WooPosPaymentFailedScreen
 import com.woocommerce.android.ui.woopos.home.totals.payment.inprogress.WooPosPaymentInProgressScreen
 import com.woocommerce.android.ui.woopos.home.totals.payment.success.WooPosPaymentSuccessScreen
-import com.woocommerce.android.ui.woopos.util.ext.announceForAccessibility
 
 @Composable
 fun WooPosTotalsScreen(modifier: Modifier = Modifier) {
@@ -92,7 +95,7 @@ private fun WooPosTotalsScreen(
 
         StateChangeAnimated(visible = state is WooPosTotalsViewState.PaymentSuccess) {
             if (state is WooPosTotalsViewState.PaymentSuccess) {
-                LocalContext.current.announceForAccessibility(stringResource(R.string.woopos_payment_successful_label))
+                AccessibilityAnnouncement(text = stringResource(R.string.woopos_payment_successful_label))
                 WooPosPaymentSuccessScreen(
                     state,
                     onReceiptClicked = { onUIEvent(WooPosTotalsUIEvent.OnStartReceiptFlowClicked) },
@@ -109,7 +112,7 @@ private fun WooPosTotalsScreen(
 
         StateChangeAnimated(visible = state is WooPosTotalsViewState.Error) {
             if (state is WooPosTotalsViewState.Error) {
-                LocalContext.current.announceForAccessibility(state.message)
+                AccessibilityAnnouncement(text = state.message)
                 TotalsErrorScreen(
                     errorMessage = state.message,
                     onUIEvent = onUIEvent
@@ -119,7 +122,7 @@ private fun WooPosTotalsScreen(
 
         StateChangeAnimated(visible = state is WooPosTotalsViewState.InvalidCouponError) {
             if (state is WooPosTotalsViewState.InvalidCouponError) {
-                LocalContext.current.announceForAccessibility("${state.message}: ${state.reason}")
+                AccessibilityAnnouncement(text = "${state.message}: ${state.reason}")
                 TotalsInvalidCouponsErrorScreen(
                     errorMessage = state.message,
                     errorReason = state.reason,
@@ -130,14 +133,15 @@ private fun WooPosTotalsScreen(
 
         StateChangeAnimated(visible = state is WooPosTotalsViewState.PaymentInProgress) {
             if (state is WooPosTotalsViewState.PaymentInProgress) {
-                LocalContext.current.announceForAccessibility(state.title)
+                AccessibilityAnnouncement(state.title)
+
                 WooPosPaymentInProgressScreen(state, onUIEvent)
             }
         }
 
         StateChangeAnimated(visible = state is WooPosTotalsViewState.PaymentFailed) {
             if (state is WooPosTotalsViewState.PaymentFailed) {
-                LocalContext.current.announceForAccessibility(state.title)
+                AccessibilityAnnouncement(state.title)
                 WooPosPaymentFailedScreen(
                     state = state,
                     onUIEvent = onUIEvent,
@@ -187,25 +191,25 @@ private fun TotalsLoaded(
                 when (val readerStatus = state.readerStatus) {
                     is WooPosTotalsViewState.ReaderStatus.Disconnected -> {
                         ReaderDisconnected(status = readerStatus, onUIEvent = onUIEvent)
-                        LocalContext.current.announceForAccessibility(readerStatus.title)
+                        AccessibilityAnnouncement(text = readerStatus.title)
                     }
                     is WooPosTotalsViewState.ReaderStatus.Preparing -> {
                         PreparingReader(
                             title = readerStatus.title,
                             subtitle = readerStatus.subtitle
                         )
-                        LocalContext.current.announceForAccessibility(readerStatus.title)
+                        AccessibilityAnnouncement(text = readerStatus.title)
                     }
                     is WooPosTotalsViewState.ReaderStatus.CheckingOrder -> {
                         PreparingReader(
                             title = readerStatus.title,
                             subtitle = readerStatus.subtitle
                         )
-                        LocalContext.current.announceForAccessibility(readerStatus.title)
+                        AccessibilityAnnouncement(text = readerStatus.title)
                     }
                     is WooPosTotalsViewState.ReaderStatus.ReadyForPayment -> {
                         ReaderReadyForPayment(readerStatus)
-                        LocalContext.current.announceForAccessibility(readerStatus.title)
+                        AccessibilityAnnouncement(text = readerStatus.title)
                     }
                     WooPosTotalsViewState.ReaderStatus.Unavailable -> Unit
                 }
@@ -636,6 +640,27 @@ fun PreparingReaderPReview() {
                 title = "Getting ready",
                 subtitle = "Preparing reader for payment",
             )
+        }
+    }
+}
+
+/**
+ * Announces the given text to accessibility services using a live region.
+ * Ensures screen readers pick up the message even on repeated values.
+ */
+@Composable
+private fun AccessibilityAnnouncement(text: String) {
+    key(text + System.currentTimeMillis()) { // Forces recomposition
+        Box(
+            modifier = Modifier
+                .semantics {
+                    liveRegion = LiveRegionMode.Assertive
+                }
+        ) {
+            // Intentionally using Text instead of WooPosText to ensure accessibility announcements work reliably.
+            // WooPosText might change or wrap semantics in a way that breaks live region behavior.
+            @Suppress("WooPosDesignSystemTextUsageRule")
+            Text(text = text)
         }
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/totals/WooPosTotalsScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/totals/WooPosTotalsScreen.kt
@@ -24,20 +24,15 @@ import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
-import androidx.compose.runtime.key
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
-import androidx.compose.ui.semantics.LiveRegionMode
-import androidx.compose.ui.semantics.liveRegion
-import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.core.text.HtmlCompat
@@ -49,6 +44,7 @@ import com.airbnb.lottie.compose.LottieConstants
 import com.airbnb.lottie.compose.rememberLottieComposition
 import com.woocommerce.android.R
 import com.woocommerce.android.ui.woopos.common.composeui.WooPosPreview
+import com.woocommerce.android.ui.woopos.common.composeui.component.AccessibilityAnnouncement
 import com.woocommerce.android.ui.woopos.common.composeui.component.Button
 import com.woocommerce.android.ui.woopos.common.composeui.component.WooPosButton
 import com.woocommerce.android.ui.woopos.common.composeui.component.WooPosCircularLoadingIndicator
@@ -640,27 +636,6 @@ fun PreparingReaderPReview() {
                 title = "Getting ready",
                 subtitle = "Preparing reader for payment",
             )
-        }
-    }
-}
-
-/**
- * Announces the given text to accessibility services using a live region.
- * Ensures screen readers pick up the message even on repeated values.
- */
-@Composable
-private fun AccessibilityAnnouncement(text: String) {
-    key(text + System.currentTimeMillis()) { // Forces recomposition
-        Box(
-            modifier = Modifier
-                .semantics {
-                    liveRegion = LiveRegionMode.Assertive
-                }
-        ) {
-            // Intentionally using Text instead of WooPosText to ensure accessibility announcements work reliably.
-            // WooPosText might change or wrap semantics in a way that breaks live region behavior.
-            @Suppress("WooPosDesignSystemTextUsageRule")
-            Text(text = text)
         }
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/util/ext/WooPosContextExt.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/util/ext/WooPosContextExt.kt
@@ -1,9 +1,6 @@
 package com.woocommerce.android.ui.woopos.util.ext
 
 import android.content.Context
-import android.os.Build
-import android.view.accessibility.AccessibilityEvent
-import android.view.accessibility.AccessibilityManager
 import androidx.compose.ui.unit.dp
 import androidx.datastore.core.DataStore
 import androidx.datastore.preferences.core.Preferences
@@ -22,18 +19,3 @@ fun Context.getScreenHeightDp(): Int {
 }
 
 fun Context.getLongestScreenSideDp() = maxOf(getScreenWidthDp(), getScreenHeightDp()).dp
-
-fun Context.announceForAccessibility(text: String) {
-    val manager = getSystemService(Context.ACCESSIBILITY_SERVICE) as AccessibilityManager
-    if (manager.isEnabled) {
-        val event = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
-            AccessibilityEvent()
-        } else {
-            @Suppress("DEPRECATION")
-            AccessibilityEvent.obtain()
-        }
-        event.eventType = AccessibilityEvent.TYPE_ANNOUNCEMENT
-        event.text.add(text)
-        manager.sendAccessibilityEvent(event)
-    }
-}


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

<!-- Id number of the Linear issue this PR addresses, e.g., WOOMOB-373. -->

Linear ID: WOOMOB-892

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
This PR introduces a Compose-native solution to announce cart item changes for accessibility using liveRegion = LiveRegionMode.Assertive. It replaces deprecated announceForAccessibility() calls with a reusable composable that ensures screen readers properly announce updates like product additions, coupon applications, or error messages.

Using a Text composable directly (instead of our design system WooPosText) avoids unexpected side effects due to future styling or semantic overrides. The announcement is triggered from the composition using state and recomposition to ensure even repeated messages are read aloud.

### Steps to reproduce
<!-- Step-by-step testing instructions. For new user flows, consider instead stating the goal of the workflow and see if your PR reviewer can accomplish the workflow without specific steps! -->

- Enable TalkBack (Android) or VoiceOver (iOS).
- Launch WooPOS and add a product to the cart.
- Proceed to the totals screen
- The announcements should still be triggered clearly each time: Payment Sucess, Errors, Coupon Error, Card Reader states, etc

### Testing information
<!-- This is your opportunity to break out individual scenarios that need testing (when necessary) and/or include a checklist for the reviewer to go through. Consider documenting the following from your own completed testing: devices used, alternate workflows, edge cases, affected areas, critical flows, areas not tested, and any remaining unknowns. Provide feedback on this new section of the PR template through Sept 30, 2024 to Apps Quality; additional context here: https://woomobilep2.wordpress.com/2024/05/06/woocommerce-mobile-quality-report-march-april/#comment-12036 -->
✅ TalkBack tested on Samsung Tab A8

### Images/gif
<!-- Include before and after images or gifs when appropriate. -->
N/A

- [/] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
