### PR TITLE
[WOOMOB-1012] POS: Replace clear cart button with delete icon and add confirmation dropdown menu

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -12,6 +12,7 @@
 - [Internal] Added logging to POS tab visibility and eligibility checks [https://github.com/woocommerce/woocommerce-android/pull/14426]
 - [*] Bottom navigation menu has now labels shown under icons on tablet devices [https://github.com/woocommerce/woocommerce-android/pull/14429]
 - [Internal] Suppress edge to edge for Google PlayCoreDialogWrapperActivity [https://github.com/woocommerce/woocommerce-android/pull/14435]
+- [*] POS: Replace clear cart button with delete icon and add confirmation dropdown menu [https://github.com/woocommerce/woocommerce-android/pull/14441]
 
 22.9.1
 -----

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/common/composeui/component/WooPosButtons.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/common/composeui/component/WooPosButtons.kt
@@ -20,6 +20,7 @@ import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.DeleteOutline
 import androidx.compose.material.icons.filled.Search
 import androidx.compose.material3.Button
 import androidx.compose.material3.ButtonColors
@@ -176,6 +177,27 @@ fun WooPosCircularIconButton(
                 tint = MaterialTheme.colorScheme.onSurface,
             )
         }
+    }
+}
+
+@Composable
+fun WooPosIconButton(
+    modifier: Modifier = Modifier,
+    icon: ImageVector,
+    contentDescription: String? = null,
+    onClick: () -> Unit
+) {
+    IconButton(
+        onClick = onClick,
+        modifier = modifier,
+    ) {
+        Icon(
+            modifier = Modifier
+                .size(32.dp),
+            imageVector = icon,
+            contentDescription = contentDescription,
+            tint = MaterialTheme.colorScheme.onSurface,
+        )
     }
 }
 
@@ -338,6 +360,10 @@ fun WooPosSmallButtonsPreview() {
                 icon = Icons.Default.Search,
                 onClick = {}
             )
+
+            Spacer(modifier = Modifier.height(WooPosSpacing.Medium.value))
+
+            WooPosIconButton(icon = Icons.Default.DeleteOutline) {}
 
             Spacer(modifier = Modifier.height(WooPosSpacing.Medium.value))
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/common/composeui/component/WooPosButtons.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/common/composeui/component/WooPosButtons.kt
@@ -185,10 +185,12 @@ fun WooPosIconButton(
     modifier: Modifier = Modifier,
     icon: ImageVector,
     contentDescription: String? = null,
+    enabled: Boolean = true,
     onClick: () -> Unit
 ) {
     IconButton(
         onClick = onClick,
+        enabled = enabled,
         modifier = modifier,
     ) {
         Icon(
@@ -196,7 +198,11 @@ fun WooPosIconButton(
                 .size(32.dp),
             imageVector = icon,
             contentDescription = contentDescription,
-            tint = MaterialTheme.colorScheme.onSurface,
+            tint = if (enabled) {
+                MaterialTheme.colorScheme.onSurface
+            } else {
+                MaterialTheme.colorScheme.onSurface.copy(alpha = 0.38f)
+            },
         )
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/cart/WooPosCartScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/cart/WooPosCartScreen.kt
@@ -492,7 +492,7 @@ private fun ClearCartButton(
                         WooPosText(
                             text = clearCartButtonText,
                             style = WooPosTypography.BodyMedium,
-                            color = MaterialTheme.colorScheme.onSurface
+                            color = MaterialTheme.colorScheme.error
                         )
                     },
                     onClick = {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/cart/WooPosCartScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/cart/WooPosCartScreen.kt
@@ -475,29 +475,34 @@ private fun ClearCartButton(
             ),
         )
 
-        DropdownMenu(
-            expanded = dropdownExpanded,
-            onDismissRequest = { dropdownExpanded = false },
-            modifier = Modifier
-                .defaultMinSize(minWidth = 200.dp)
-                .background(color = MaterialTheme.colorScheme.surfaceContainerLowest),
-        ) {
-            DropdownMenuItem(
-                text = {
-                    WooPosText(
-                        text = clearCartButtonText,
-                        style = WooPosTypography.BodyMedium,
-                        color = MaterialTheme.colorScheme.onSurface
-                    )
-                },
-                onClick = {
-                    dropdownExpanded = false
-                    onClearCartClicked()
-                },
-                modifier = Modifier.semantics {
-                    contentDescription = clearCartButtonText
-                }
+        MaterialTheme(
+            shapes = MaterialTheme.shapes.copy(
+                extraSmall = RoundedCornerShape(WooPosCornerRadius.Medium.value)
             )
+        ) {
+            DropdownMenu(
+                expanded = dropdownExpanded,
+                onDismissRequest = { dropdownExpanded = false },
+                modifier = Modifier.defaultMinSize(minWidth = 200.dp)
+                    .background(color = MaterialTheme.colorScheme.surfaceContainerLowest),
+            ) {
+                DropdownMenuItem(
+                    text = {
+                        WooPosText(
+                            text = clearCartButtonText,
+                            style = WooPosTypography.BodyMedium,
+                            color = MaterialTheme.colorScheme.onSurface
+                        )
+                    },
+                    onClick = {
+                        dropdownExpanded = false
+                        onClearCartClicked()
+                    },
+                    modifier = Modifier.semantics {
+                        contentDescription = clearCartButtonText
+                    }
+                )
+            }
         }
     }
 }
@@ -580,7 +585,7 @@ private fun ProductItem(
             Column(
                 modifier = Modifier
                     .weight(1f)
-                    .padding(end = WooPosSpacing.Medium.value.toAdaptivePadding())
+                    .padding(end = WooPosSpacing.Medium.value.toAdaptivePadding(),)
                     .padding(vertical = WooPosSpacing.Medium.value.toAdaptivePadding())
             ) {
                 WooPosText(

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/cart/WooPosCartScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/cart/WooPosCartScreen.kt
@@ -33,6 +33,7 @@ import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material.icons.filled.DeleteOutline
 import androidx.compose.material.icons.outlined.Delete
 import androidx.compose.material.icons.outlined.Inventory2
 import androidx.compose.material.icons.outlined.LocalOffer
@@ -79,8 +80,8 @@ import com.woocommerce.android.ui.woopos.common.composeui.component.ShadowType
 import com.woocommerce.android.ui.woopos.common.composeui.component.WooPosButton
 import com.woocommerce.android.ui.woopos.common.composeui.component.WooPosButtonState
 import com.woocommerce.android.ui.woopos.common.composeui.component.WooPosCard
+import com.woocommerce.android.ui.woopos.common.composeui.component.WooPosIconButton
 import com.woocommerce.android.ui.woopos.common.composeui.component.WooPosLazyColumn
-import com.woocommerce.android.ui.woopos.common.composeui.component.WooPosOutlinedButtonSmall
 import com.woocommerce.android.ui.woopos.common.composeui.component.WooPosShimmerBox
 import com.woocommerce.android.ui.woopos.common.composeui.component.WooPosText
 import com.woocommerce.android.ui.woopos.common.composeui.designsystem.WooPosCornerRadius
@@ -440,15 +441,18 @@ private fun CartToolbar(
         }
 
         if (toolbar.isClearAllButtonVisible) {
-            WooPosOutlinedButtonSmall(
-                onClick = { onClearAllClicked() },
+            WooPosIconButton(
+                icon = Icons.Default.DeleteOutline,
                 modifier = Modifier
                     .constrainAs(clearAllButton) {
                         end.linkTo(parent.end)
                         centerVerticallyTo(parent)
                     }
                     .padding(end = WooPosSpacing.Medium.value.toAdaptivePadding()),
-                text = stringResource(R.string.woopos_clear_cart_button)
+                onClick = { onClearAllClicked() },
+                contentDescription = stringResource(
+                    id = R.string.woopos_cart_clear_all_button_content_description
+                ),
             )
         }
     }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/cart/WooPosCartScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/cart/WooPosCartScreen.kt
@@ -16,6 +16,7 @@ import androidx.compose.foundation.layout.IntrinsicSize
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.defaultMinSize
 import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
@@ -37,6 +38,8 @@ import androidx.compose.material.icons.filled.DeleteOutline
 import androidx.compose.material.icons.outlined.Delete
 import androidx.compose.material.icons.outlined.Inventory2
 import androidx.compose.material.icons.outlined.LocalOffer
+import androidx.compose.material3.DropdownMenu
+import androidx.compose.material3.DropdownMenuItem
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
@@ -47,6 +50,7 @@ import androidx.compose.runtime.livedata.observeAsState
 import androidx.compose.runtime.mutableIntStateOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.alpha
@@ -441,18 +445,58 @@ private fun CartToolbar(
         }
 
         if (toolbar.isClearAllButtonVisible) {
-            WooPosIconButton(
-                icon = Icons.Default.DeleteOutline,
+            ClearCartButton(
                 modifier = Modifier
                     .constrainAs(clearAllButton) {
                         end.linkTo(parent.end)
                         centerVerticallyTo(parent)
                     }
                     .padding(end = WooPosSpacing.Medium.value.toAdaptivePadding()),
-                onClick = { onClearAllClicked() },
-                contentDescription = stringResource(
-                    id = R.string.woopos_cart_clear_all_button_content_description
-                ),
+                onClearCartClicked = onClearAllClicked
+            )
+        }
+    }
+}
+
+@Composable
+private fun ClearCartButton(
+    modifier: Modifier = Modifier,
+    onClearCartClicked: () -> Unit
+) {
+    var dropdownExpanded by remember { mutableStateOf(false) }
+    val clearCartButtonText = stringResource(R.string.woopos_clear_cart_button)
+
+    Box(modifier = modifier) {
+        WooPosIconButton(
+            icon = Icons.Default.DeleteOutline,
+            onClick = { dropdownExpanded = true },
+            contentDescription = stringResource(
+                id = R.string.woopos_cart_clear_all_button_content_description
+            ),
+        )
+
+        DropdownMenu(
+            expanded = dropdownExpanded,
+            onDismissRequest = { dropdownExpanded = false },
+            modifier = Modifier
+                .defaultMinSize(minWidth = 200.dp)
+                .background(color = MaterialTheme.colorScheme.surfaceContainerLowest),
+        ) {
+            DropdownMenuItem(
+                text = {
+                    WooPosText(
+                        text = clearCartButtonText,
+                        style = WooPosTypography.BodyMedium,
+                        color = MaterialTheme.colorScheme.onSurface
+                    )
+                },
+                onClick = {
+                    dropdownExpanded = false
+                    onClearCartClicked()
+                },
+                modifier = Modifier.semantics {
+                    contentDescription = clearCartButtonText
+                }
             )
         }
     }
@@ -536,7 +580,7 @@ private fun ProductItem(
             Column(
                 modifier = Modifier
                     .weight(1f)
-                    .padding(end = WooPosSpacing.Medium.value.toAdaptivePadding(),)
+                    .padding(end = WooPosSpacing.Medium.value.toAdaptivePadding())
                     .padding(vertical = WooPosSpacing.Medium.value.toAdaptivePadding())
             ) {
                 WooPosText(

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/cart/WooPosCartScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/cart/WooPosCartScreen.kt
@@ -469,6 +469,7 @@ private fun ClearCartButton(
     Box(modifier = modifier) {
         WooPosIconButton(
             icon = Icons.Default.DeleteOutline,
+            enabled = !dropdownExpanded,
             onClick = { dropdownExpanded = true },
             contentDescription = stringResource(
                 id = R.string.woopos_cart_clear_all_button_content_description

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -4299,6 +4299,7 @@
     <string name="woopos_variable_product_item_content_description_v2">Variable Product %s</string>
     <string name="woopos_variation_item_content_description">Variation %s, Price %s</string>
     <string name="woopos_cart_item_product_content_description">Product in cart %s, Price %s</string>
+    <string name="woopos_cart_clear_all_button_content_description">Clear items in cart icon</string>
     <string name="woopos_cart_item_loading_content_description">Loading item %s</string>
     <string name="woopos_cart_item_error_content_description">Error loading item %s</string>
     <string name="woopos_coupon_item_content_description_v2">Coupon %s, %s</string>
@@ -4315,7 +4316,7 @@
     <string name="woopos_cart_barcode_scan_result_network_error">No internet connection</string>
     <string name="woopos_cart_barcode_scan_result_too_short">Scanned barcode is too short</string>
     <string name="woopos_cart_barcode_scan_result_no_terminator">Scanner did not send end-of-line character</string>
-    <string name="woopos_clear_cart_button">Clear</string>
+    <string name="woopos_clear_cart_button">Clear cart</string>
 
     <string name="woopos_banner_simple_products_dialog_content_description">Simple, variable and virtual products only dialog</string>
     <string name="woopos_banner_simple_products_dialog_primary_button_content_description">Double tap to dismiss the dialog</string>


### PR DESCRIPTION
Fixes WOOMOB-1012

### Description
Replaced the clear outline button with a delete icon in the WooPOS cart screen and added a contextual popup with a "Clear cart" menu item. When the user taps on the delete icon, a dropdown menu appears with a confirmation option that invokes the existing clear cart functionality.

### Testing information
1. Navigate to the POS
2. Add items to the cart
3. Verify the clear button has been replaced with a delete outline icon
4. Tap on the delete icon
5. Verify a dropdown menu appears with "Clear cart" option and the delete icon has reduced opacity
6. Tap on "Clear cart" to confirm the action
7. Verify the cart is cleared and the dropdown disappears
8. Test that tapping outside the dropdown dismisses it without clearing the cart

### The tests that have been performed
- Manual testing on the cart screen with various cart states
- Confirmed accessibility support with proper content descriptions
- Tested dropdown dismissal behavior
- Tested both dark and light mode


### Images/gif
<!-- Include before and after images or gifs when appropriate. -->

https://github.com/user-attachments/assets/62fe6273-61ee-4915-b5c9-88ac13dca26d


- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.
