### PR TITLE
[WOOMOB-1015] Fix WooPos cash payment screen behavior consistency

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -1,6 +1,9 @@
 *** PLEASE FOLLOW THIS FORMAT: [<priority indicator, more stars = higher priority>] <description> [<PR URL>]
 *** Use [*****] to indicate smoke tests of all critical flows should be run on the final APK before release (e.g. major library or targetSdk updates).
 *** For entries which are touching the Android Wear app's, start entry with `[WEAR]` too.
+23.1
+-----
+- [*] Updated behavior on the POS cash payment screen [https://github.com/woocommerce/woocommerce-android/pull/14449]
 
 23.0
 -----

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/cashpayment/WooPosCashPaymentScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/cashpayment/WooPosCashPaymentScreen.kt
@@ -149,6 +149,7 @@ private fun Collecting(
                 currencyPosition = state.currencyPosition,
                 decimalSeparator = state.decimalSeparator,
                 numberOfDecimals = state.numberOfDecimals,
+                preselectText = true,
             )
 
             Spacer(modifier = Modifier.height(WooPosSpacing.Small.value))

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/cashpayment/WooPosCashPaymentViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/cashpayment/WooPosCashPaymentViewModel.kt
@@ -44,7 +44,7 @@ class WooPosCashPaymentViewModel @Inject constructor(
 
             val order = repository.getOrderById(orderId)!!
             _state.value = WooPosCashPaymentState.Collecting(
-                enteredAmount = null,
+                enteredAmount = order.total,
                 changeDueText = "",
                 changeDue = null,
                 total = order.total,

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/cashpayment/WooPosCashPaymentViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/cashpayment/WooPosCashPaymentViewModel.kt
@@ -59,7 +59,7 @@ class WooPosCashPaymentViewModel @Inject constructor(
                 numberOfDecimals = repository.getNumberOfDecimals(),
                 button = WooPosCashPaymentState.Collecting.Button(
                     text = resourceProvider.getString(R.string.woopos_complete_cash_order_button),
-                    status = WooPosCashPaymentState.Collecting.Button.Status.DISABLED
+                    status = WooPosCashPaymentState.Collecting.Button.Status.ENABLED
                 )
             )
         }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/common/composeui/component/WooPosInputFields.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/common/composeui/component/WooPosInputFields.kt
@@ -84,7 +84,7 @@ fun WooPosMoneyInputField(
         stateSaver = TextFieldValue.Saver,
     ) {
         currentValue = value
-        mutableStateOf(TextFieldValue(valueMapper.printValue(value)))
+        mutableStateOf(TextFieldValue(valueMapper.printValue(value), TextRange(0, value.toString().length)))
     }
 
     var labelWidth by remember { mutableIntStateOf(0) }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/common/composeui/component/WooPosInputFields.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/common/composeui/component/WooPosInputFields.kt
@@ -56,6 +56,7 @@ fun WooPosMoneyInputField(
     keyboardOptions: KeyboardOptions = KeyboardOptions.Default,
     keyboardActions: KeyboardActions = KeyboardActions.Default,
     contentAlignment: Alignment = Alignment.CenterStart,
+    preselectText: Boolean = false,
 ) {
     val visualTransformation = remember {
         CurrencyVisualTransformation(
@@ -84,7 +85,12 @@ fun WooPosMoneyInputField(
         stateSaver = TextFieldValue.Saver,
     ) {
         currentValue = value
-        mutableStateOf(TextFieldValue(valueMapper.printValue(value), TextRange(0, value.toString().length)))
+        mutableStateOf(
+            TextFieldValue(
+                text = valueMapper.printValue(value),
+                selection = if (preselectText) TextRange(0, value.toString().length) else TextRange.Zero
+            )
+        )
     }
 
     var labelWidth by remember { mutableIntStateOf(0) }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/totals/WooPosTotalsAnalyticsTracker.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/totals/WooPosTotalsAnalyticsTracker.kt
@@ -95,4 +95,8 @@ class WooPosTotalsAnalyticsTracker @Inject constructor(
     suspend fun trackCreateNewOrderTapped() {
         analyticsTracker.track(CreateNewOrderTapped)
     }
+
+    suspend fun trackCashPaymentTapped() {
+        analyticsTracker.track(WooPosAnalyticsEvent.Event.CheckoutCashPaymentTapped)
+    }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/totals/WooPosTotalsViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/totals/WooPosTotalsViewModel.kt
@@ -158,7 +158,7 @@ class WooPosTotalsViewModel @Inject constructor(
 
             WooPosTotalsUIEvent.OnStartReceiptFlowClicked -> handleEmailReceiptClicked()
 
-            WooPosTotalsUIEvent.OnCashPaymentClicked -> informParentAboutNavigatingToCashPayment()
+            WooPosTotalsUIEvent.OnCashPaymentClicked -> handleCashPaymentClicked()
 
             WooPosTotalsUIEvent.GoBackToCheckoutAfterFailedPayment -> handleGoBackToCheckoutClickedWhenPaymentFailed()
 
@@ -183,7 +183,8 @@ class WooPosTotalsViewModel @Inject constructor(
         }
     }
 
-    private fun informParentAboutNavigatingToCashPayment() = viewModelScope.launch {
+    private fun handleCashPaymentClicked() = viewModelScope.launch {
+        totalsAnalyticsTracker.trackCashPaymentTapped()
         childrenToParentEventSender.sendToParent(
             ToCashPayment(dataState.value.orderId)
         )

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/util/analytics/WooPosAnalyticsEvent.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/util/analytics/WooPosAnalyticsEvent.kt
@@ -47,6 +47,9 @@ sealed class WooPosAnalyticsEvent : IAnalyticsEvent {
         data object CashCollectPaymentSuccess : Event() {
             override val name: String = "cash_collect_payment_success"
         }
+        data object CheckoutCashPaymentTapped : Event() {
+            override val name: String = "checkout_cash_payment_tapped"
+        }
         data object CashPaymentTapped : Event() {
             override val name: String = "cash_payment_tapped"
         }

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/cashpayment/WooPosCashPaymentViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/cashpayment/WooPosCashPaymentViewModelTest.kt
@@ -95,6 +95,17 @@ class WooPosCashPaymentViewModelTest {
     }
 
     @Test
+    fun `when ViewModel initializes, then entered amount prefilled with total value`() = runTest {
+        // WHEN
+        val state = viewModel.state.first()
+
+        // THEN
+        assertThat(state).isInstanceOf(WooPosCashPaymentState.Collecting::class.java)
+        val collectingState = state as WooPosCashPaymentState.Collecting
+        assertThat(collectingState.enteredAmount).isEqualTo(BigDecimal("100.00"))
+    }
+
+    @Test
     fun `given valid amount,when onUIEvent AmountChanged , then button is enabled and changeDue is updated`() = runTest {
         // GIVEN
         val enteredAmount = BigDecimal("120.00")

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/cashpayment/WooPosCashPaymentViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/cashpayment/WooPosCashPaymentViewModelTest.kt
@@ -95,7 +95,7 @@ class WooPosCashPaymentViewModelTest {
     }
 
     @Test
-    fun `when ViewModel initializes, then entered amount prefilled with total value`() = runTest {
+    fun `when ViewModel initializes, then entered amount prefilled with total value and button is enabled`() = runTest {
         // WHEN
         val state = viewModel.state.first()
 
@@ -103,6 +103,7 @@ class WooPosCashPaymentViewModelTest {
         assertThat(state).isInstanceOf(WooPosCashPaymentState.Collecting::class.java)
         val collectingState = state as WooPosCashPaymentState.Collecting
         assertThat(collectingState.enteredAmount).isEqualTo(BigDecimal("100.00"))
+        assertThat(collectingState.button.status).isEqualTo(WooPosCashPaymentState.Collecting.Button.Status.ENABLED)
     }
 
     @Test


### PR DESCRIPTION
Fixes WOOMOB-1015

### Description
This PR implements consistent behavior for the POS cash payment screen:

1. **Pre-filled total amount**: The total amount is now pre-entered and selected when the cash payment screen opens, allowing users to easily replace it by typing.
2. **Button state validation**: The "Mark as completed" button is disabled unless the entered amount is equal to or higher than the total amount.
3. **Analytics tracking**: Updated tracking

### Testing information

   - Open the POS and add items to the cart.
   - Navigate to checkout and select "Cash payment" button.
   - Verify "checkout_cash_payment_tapped" is tracked.
   - Verify the total amount is pre-filled and selected in the input field.
   - Verify the "Mark as complete" button is enabled.
   - Start typing and verify the pre-filled amount is replaced. Also verify the button is disabled unless the amount is equal or higher than total.
   - Turn on airplane mode and tap on "Mark as complete" - verify "cash_payment_tapped" and "cash_payment_failed" is tracked.
   - Turn off airplane mode and tap on "Mark as complete" - verify "cash_payment_tapped" and  "cash_collect_payment_success" is tracked.

### The tests that have been performed
- The above

### Images/gif



https://github.com/user-attachments/assets/33472a2c-9ddb-4626-b302-ae95038ad65c





- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.