### PR TITLE
[Shipping labels] Update split message logic

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -5,7 +5,7 @@
 23.1
 -----
 - [*] Fixed bug when an order was not selected when navigating from my store screen [https://github.com/woocommerce/woocommerce-android/pull/14436]
-
+- [*] [Shipping labels] Display split shipment instructions only when necessary [https://github.com/woocommerce/woocommerce-android/pull/14450]
 
 23.0
 -----

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/split/WooShippingSplitShipmentViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/split/WooShippingSplitShipmentViewModel.kt
@@ -46,8 +46,10 @@ class WooShippingSplitShipmentViewModel @Inject constructor(
 
     init {
         launch {
-            delay(TOOLTIP_DELAY)
-            splitMessage.value = SplitShipmentMessage.Instructions
+            if (currentShipments.value.size == 1) {
+                delay(TOOLTIP_DELAY)
+                splitMessage.value = SplitShipmentMessage.Instructions
+            }
         }
         launch {
             currentShipments.collectLatest { shipments ->

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/split/WooShippingSplitShipmentViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/split/WooShippingSplitShipmentViewModelTest.kt
@@ -10,12 +10,14 @@ import com.woocommerce.android.util.CurrencyFormatter
 import com.woocommerce.android.util.observeForTesting
 import com.woocommerce.android.viewmodel.BaseUnitTest
 import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.advanceUntilIdle
 import org.assertj.core.api.Assertions.assertThat
 import org.mockito.kotlin.any
 import org.mockito.kotlin.doAnswer
 import org.mockito.kotlin.mock
 import java.math.BigDecimal
 import kotlin.test.Test
+import kotlin.test.assertNull
 
 @OptIn(ExperimentalCoroutinesApi::class)
 class WooShippingSplitShipmentViewModelTest : BaseUnitTest() {
@@ -448,6 +450,22 @@ class WooShippingSplitShipmentViewModelTest : BaseUnitTest() {
 
             assertThat(currentShipments.values.toList()[1].totalItemQuantity).isEqualTo(expectedItemQuantity)
         }
+
+    @Test
+    fun `when there are more than 1 shipment, then do not display the instructions message`() = testBlocking {
+        val shipmentArgs = SplitShipmentArgs(
+            orderId = 1L,
+            storeOptions = StoreOptionsModel.EMPTY,
+            shipments = twoShipments
+        )
+        createViewModel(shipmentArgs)
+
+        sut.viewState.observeForTesting { }
+        advanceUntilIdle()
+
+        val state = sut.viewState.value as WooShippingSplitShipmentViewModel.SplitShipmentViewState.DataState
+        assertNull(state.splitMessage)
+    }
 
     private val defaultShipments = listOf(
         ShipmentUIModel(


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

<!-- Id number of the Linear issue this PR addresses, e.g., WOOMOB-373. -->
Part of WOOMOB-580

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
This PR updates the logic for displaying the split shipments message. The message will no longer be shown if there are multiple shipments.

### Steps to reproduce
<!-- Step-by-step testing instructions. For new user flows, consider instead stating the goal of the workflow and see if your PR reviewer can accomplish the workflow without specific steps! -->
1. Open the Orders tab.
2. Tap an order that has multiple shipments.
3. Tap Create shipping label button.
4. Tap the split shipment button.
5. Verify that the instructions are not displayed.

### The tests that have been performed
<!-- To give the reviewer an idea of what could be missed in terms of testing -->
- Order with a single shipment
- Order with multiple shipments

### Images/gif
<!-- Include before and after images or gifs when appropriate. -->
[Screen_recording_20250811_112848.webm](https://github.com/user-attachments/assets/9f229c2d-9036-473b-8910-6112ac623344)

- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->