### PR TITLE
[Shipping labels] Remove extra divider from shipment details bottom sheet

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/ShipmentDetails.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/ShipmentDetails.kt
@@ -281,8 +281,8 @@ private fun ShipmentDetailsPortrait(
         Divider()
         if (!shipmentPurchased) {
             PaymentSection(paymentsSectionUI = paymentsSectionUI)
+            Divider()
         }
-        Divider()
         ShipmentCostSection(shipmentCostUI = shipmentCostUI)
     }
 }


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

<!-- Id number of the Linear issue this PR addresses, e.g., WOOMOB-373. -->
Part of WOOMOB-580

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
This removes an unnecessary extra divider from the shipment details bottom sheet.

### Steps to reproduce
<!-- Step-by-step testing instructions. For new user flows, consider instead stating the goal of the workflow and see if your PR reviewer can accomplish the workflow without specific steps! -->
1. Go to orders. 
2. Select an order that has a purchased shipment.
3. Tap Create shipping label button.
4. Tap Shipment Details bottom to open the bottom sheet.

### The tests that have been performed
Steps above

### Images/gif
<!-- Include before and after images or gifs when appropriate. -->
|Before|After|
|-|-|
|<img width="1344" height="2992" alt="before-extra-line" src="https://github.com/user-attachments/assets/29ab33d0-5176-46ad-b3cd-3d791004f600" />|<img width="1344" height="2992" alt="Screenshot_20250812_003438" src="https://github.com/user-attachments/assets/fcb029f9-49f4-4c03-bf8b-f51a322e746c" />|

- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->