### PR TITLE
Handle null values when API returns null user roles

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/common/UserEligibilityErrorFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/common/UserEligibilityErrorFragment.kt
@@ -19,6 +19,7 @@ import com.woocommerce.android.analytics.AnalyticsTracker
 import com.woocommerce.android.databinding.FragmentUserEligibilityErrorBinding
 import com.woocommerce.android.extensions.takeIfNotEqualTo
 import com.woocommerce.android.model.User
+import com.woocommerce.android.model.UserRole
 import com.woocommerce.android.support.help.HelpActivity
 import com.woocommerce.android.support.help.HelpOrigin.USER_ELIGIBILITY_ERROR
 import com.woocommerce.android.ui.base.BaseFragment
@@ -119,9 +120,11 @@ class UserEligibilityErrorFragment : BaseFragment(layout.fragment_user_eligibili
                 is ShowSnackbar -> {
                     uiMessageResolver.showSnack(event.message)
                 }
+
                 is Exit -> {
                     findNavController().navigateUp()
                 }
+
                 is Logout -> {
                     requireActivity().apply {
                         setResult(Activity.RESULT_CANCELED)
@@ -132,6 +135,7 @@ class UserEligibilityErrorFragment : BaseFragment(layout.fragment_user_eligibili
                         finish()
                     }
                 }
+
                 else -> event.isHandled = false
             }
         }
@@ -139,6 +143,14 @@ class UserEligibilityErrorFragment : BaseFragment(layout.fragment_user_eligibili
 
     private fun showView(user: User) {
         binding.textDisplayname.text = user.getUserNameForDisplay()
+        if (user.roles.any { it == UserRole.Other("null") }) {
+            binding.textErrorMessage.text = getString(
+                R.string.user_role_access_error_user_roles_null,
+                user.getUserNameForDisplay()
+            )
+        } else {
+            binding.textErrorMessage.text = getString(R.string.user_role_access_error_msg)
+        }
         binding.textUserRoles.text = user.roles.joinToString(", ") { it.value }
     }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/common/UserEligibilityErrorFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/common/UserEligibilityErrorFragment.kt
@@ -144,14 +144,12 @@ class UserEligibilityErrorFragment : BaseFragment(layout.fragment_user_eligibili
     private fun showView(user: User) {
         binding.textDisplayname.text = user.getUserNameForDisplay()
         if (user.roles.any { it == UserRole.Other("null") }) {
-            binding.textErrorMessage.text = getString(
-                R.string.user_role_access_error_user_roles_null,
-                user.getUserNameForDisplay()
-            )
+            binding.textErrorMessage.text = getString(R.string.user_role_access_error_user_roles_null)
+            binding.textUserRoles.text = user.username
         } else {
+            binding.textUserRoles.text = user.roles.joinToString(", ") { it.value }
             binding.textErrorMessage.text = getString(R.string.user_role_access_error_msg)
         }
-        binding.textUserRoles.text = user.roles.joinToString(", ") { it.value }
     }
 
     private fun showProgressDialog(show: Boolean) {

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -290,7 +290,7 @@
     <string name="login_troubleshooting_tips">Read our troubleshooting tips</string>
     <string name="login_discovery_error_option_select">Select an option</string>
     <string name="login_no_wpcom_account_found">Your email isn\'t used with a WordPress.com account.</string>
-    <string name="user_role_access_error_user_roles_null">This app supports only Administrator and Shop Manager user roles. We were unable to fetch user roles for your account: %1$s. Please contact support.</string>
+    <string name="user_role_access_error_user_roles_null">This app supports only Administrator and Shop Manager user roles. We were unable to fetch user roles for your account. Please contact support.</string>
     <string name="user_role_access_error_msg">This app supports only Administrator and Shop Manager user roles. Please contact your store owner to upgrade your role.</string>
     <string name="user_role_access_error_link">Learn more about roles and permissions</string>
     <string name="user_role_access_error_retry">You don\'t have the correct user role</string>

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -290,6 +290,7 @@
     <string name="login_troubleshooting_tips">Read our troubleshooting tips</string>
     <string name="login_discovery_error_option_select">Select an option</string>
     <string name="login_no_wpcom_account_found">Your email isn\'t used with a WordPress.com account.</string>
+    <string name="user_role_access_error_user_roles_null">This app supports only Administrator and Shop Manager user roles. We were unable to fetch user roles for your account: %1$s. Please contact support.</string>
     <string name="user_role_access_error_msg">This app supports only Administrator and Shop Manager user roles. Please contact your store owner to upgrade your role.</string>
     <string name="user_role_access_error_link">Learn more about roles and permissions</string>
     <string name="user_role_access_error_retry">You don\'t have the correct user role</string>

--- a/libs/fluxc-plugin/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/user/WCUserRestClient.kt
+++ b/libs/fluxc-plugin/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/user/WCUserRestClient.kt
@@ -33,6 +33,6 @@ class WCUserRestClient @Inject constructor(private val wooNetwork: WooNetwork) {
         @SerializedName("first_name") val firstName: String?,
         @SerializedName("last_name") val lastName: String?,
         val email: String?,
-        val roles: JsonElement
+        val roles: JsonElement?
     )
 }


### PR DESCRIPTION
Closes: WOOMOB-471

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
Fixes NullPointerException crash https://a8c.sentry.io/issues/4727853296/?project=1459556
Makes user roles a nullable field and ensures we handle the case where the API returns a null value for the roles by providing a new error message. 

### Steps to reproduce
<!-- Step-by-step testing instructions. For new user flows, consider instead stating the goal of the workflow and see if your PR reviewer can accomplish the workflow without specific steps! -->
I don't know in which rare cases the API may end up returning a null value for roles. I suspect a custom roles plugin like https://easydigitaldownloads.com/ my be messing up with this. 
Apply the following patch to simulate the API returning null.
[Simulate_API_returning_null_value.patch](https://github.com/user-attachments/files/21735374/Simulate_API_returning_null_value.patch)

### Testing information
1. Apply the above patch
2. Log into the app using WP.com credentials
3. Check the below error message is displayed

<img width="300"  src="https://github.com/user-attachments/assets/a7ed9b15-6b48-473e-a356-e512988a3480"> 

Repeat the same steps but log in with site credentials. 

### The tests that have been performed
<!-- To give the reviewer an idea of what could be missed in terms of testing -->
The above. 

- [X] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->