### PR TITLE
[POS] Better error handling for eligibility

### DIFF
--- a/WooCommerce/src/androidTest/kotlin/com/woocommerce/android/AppPrefsTest.kt
+++ b/WooCommerce/src/androidTest/kotlin/com/woocommerce/android/AppPrefsTest.kt
@@ -531,7 +531,7 @@ class AppPrefsTest {
         val siteId = 123
 
         // WHEN
-        AppPrefs.setPOSTabVisibilityForSite(siteId, true)
+        AppPrefs.setPOSTabVisibilityForSite(siteId)
         val result = AppPrefs.isPOSTabVisibleForSite(siteId)
 
         // THEN
@@ -548,5 +548,48 @@ class AppPrefsTest {
 
         // THEN
         assertThat(result).isFalse
+    }
+
+    @Test
+    fun givenPOSTabVisibilitySetWhenClearedThenGetterReturnsFalse() {
+        // GIVEN
+        val siteId = 789
+        AppPrefs.setPOSTabVisibilityForSite(siteId)
+        assertThat(AppPrefs.isPOSTabVisibleForSite(siteId)).isTrue
+
+        // WHEN
+        AppPrefs.clearPOSTabVisibilityForSite(siteId)
+
+        // THEN
+        assertThat(AppPrefs.isPOSTabVisibleForSite(siteId)).isFalse
+    }
+
+    @Test
+    fun givenPOSLaunchableNotSetWhenIsPOSLaunchableForSiteThenReturnFalseByDefault() {
+        val siteId = 111
+
+        assertThat(AppPrefs.isPOSLaunchableForSite(siteId)).isFalse
+    }
+
+    @Test
+    fun givenSetPOSLaunchableForSiteWhenIsPOSLaunchableForSiteThenReturnTrueOnlyForThatSite() {
+        val siteA = 222
+        val siteB = 333
+
+        AppPrefs.setPOSLaunchableForSite(siteA)
+
+        assertThat(AppPrefs.isPOSLaunchableForSite(siteA)).isTrue
+        assertThat(AppPrefs.isPOSLaunchableForSite(siteB)).isFalse
+    }
+
+    @Test
+    fun givenSetPOSLaunchableForSiteWhenClearPOSLaunchableForSiteThenReturnFalse() {
+        val siteId = 444
+        AppPrefs.setPOSLaunchableForSite(siteId)
+        assertThat(AppPrefs.isPOSLaunchableForSite(siteId)).isTrue
+
+        AppPrefs.clearPOSLaunchableForSite(siteId)
+
+        assertThat(AppPrefs.isPOSLaunchableForSite(siteId)).isFalse
     }
 }

--- a/WooCommerce/src/androidTest/kotlin/com/woocommerce/android/AppPrefsTest.kt
+++ b/WooCommerce/src/androidTest/kotlin/com/woocommerce/android/AppPrefsTest.kt
@@ -10,6 +10,7 @@ import org.assertj.core.api.Assertions.assertThat
 import org.junit.Before
 import org.junit.Test
 
+@Suppress("UnitTestNamingRule")
 class AppPrefsTest {
     @Before
     fun setup() {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/AppPrefs.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/AppPrefs.kt
@@ -210,6 +210,8 @@ object AppPrefs {
         APPLICATION_STORE_SNAPSHOT_TRACKED_FOR_SITE,
 
         POS_TAB_VISIBILITY,
+
+        POS_LAUNCHABLE
     }
 
     fun init(context: Context) {
@@ -1193,6 +1195,20 @@ object AppPrefs {
     fun isPOSTabVisibleForSite(siteId: Int): Boolean {
         return getBoolean(
             key = PrefKeyString("${UndeletablePrefKey.POS_TAB_VISIBILITY}:$siteId"),
+            default = false
+        )
+    }
+
+    fun setPOSLaunchableForSite(siteId: Int) {
+        setBoolean(
+            key = PrefKeyString("${UndeletablePrefKey.POS_LAUNCHABLE}:$siteId"),
+            value = true
+        )
+    }
+
+    fun isPOSLaunchableForSite(siteId: Int): Boolean {
+        return getBoolean(
+            key = PrefKeyString("${UndeletablePrefKey.POS_LAUNCHABLE}:$siteId"),
             default = false
         )
     }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/AppPrefs.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/AppPrefs.kt
@@ -1199,6 +1199,10 @@ object AppPrefs {
         )
     }
 
+    fun clearPOSTabVisibilityForSite(siteId: Int) {
+        remove(PrefKeyString("${UndeletablePrefKey.POS_TAB_VISIBILITY}:$siteId"))
+    }
+
     fun setPOSLaunchableForSite(siteId: Int) {
         setBoolean(
             key = PrefKeyString("${UndeletablePrefKey.POS_LAUNCHABLE}:$siteId"),
@@ -1211,6 +1215,10 @@ object AppPrefs {
             key = PrefKeyString("${UndeletablePrefKey.POS_LAUNCHABLE}:$siteId"),
             default = false
         )
+    }
+
+    fun clearPOSLaunchableForSite(siteId: Int) {
+        remove(PrefKeyString("${UndeletablePrefKey.POS_LAUNCHABLE}:$siteId"))
     }
 
     /**

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/AppPrefs.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/AppPrefs.kt
@@ -1183,10 +1183,10 @@ object AppPrefs {
         return getInt(PrefKeyString(channel.name), 0).takeIf { it != 0 }
     }
 
-    fun setPOSTabVisibilityForSite(siteId: Int, visible: Boolean) {
+    fun setPOSTabVisibilityForSite(siteId: Int) {
         setBoolean(
             key = PrefKeyString("${UndeletablePrefKey.POS_TAB_VISIBILITY}:$siteId"),
-            value = visible
+            value = true
         )
     }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/WooPOSIsRemotelyEnabled.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/WooPOSIsRemotelyEnabled.kt
@@ -3,6 +3,7 @@ package com.woocommerce.android.ui.woopos
 import com.google.common.reflect.TypeToken
 import com.google.gson.Gson
 import com.woocommerce.android.tools.SelectedSite
+import com.woocommerce.android.ui.woopos.common.util.WooPosCouldNotDetermineValueException
 import com.woocommerce.android.util.WCSSRModelCachingFetcher
 import javax.inject.Inject
 
@@ -12,7 +13,7 @@ class WooPOSIsRemotelyEnabled @Inject constructor(
     private val gson: Gson
 ) {
 
-    suspend operator fun invoke(forceRefresh: Boolean = false): Boolean {
+    suspend operator fun invoke(forceRefresh: Boolean = false): Result<Boolean> {
         if (forceRefresh) {
             ssrFetcher.invalidate()
         }
@@ -25,9 +26,11 @@ class WooPOSIsRemotelyEnabled @Inject constructor(
                 val settingsMap: Map<String, Any> = gson.fromJson(ssr.settings, type)
                 val enabledFeatures = settingsMap["enabled_features"] as? List<*>
 
-                return enabledFeatures?.contains("point_of_sale") == true
+                return enabledFeatures?.let {
+                    Result.success(it.contains("point_of_sale"))
+                } ?: Result.failure(WooPosCouldNotDetermineValueException())
             }
         }
-        return false
+        return Result.failure(WooPosCouldNotDetermineValueException())
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/common/util/WooPosCouldNotDetermineValueException.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/common/util/WooPosCouldNotDetermineValueException.kt
@@ -1,0 +1,3 @@
+package com.woocommerce.android.ui.woopos.common.util
+
+class WooPosCouldNotDetermineValueException : Exception()

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/eligibility/WooPosEligibilityViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/eligibility/WooPosEligibilityViewModel.kt
@@ -96,7 +96,8 @@ class WooPosEligibilityViewModel @Inject constructor(
                     resourceProvider.getString(R.string.woopos_eligibility_reason_unsupported_currency_generic)
                 }
             }
-            WooPosLaunchability.NonLaunchabilityReason.NoSiteSelected ->
+            WooPosLaunchability.NonLaunchabilityReason.NoSiteSelected,
+            WooPosLaunchability.NonLaunchabilityReason.UnknownNoPositiveCache ->
                 resourceProvider.getString(R.string.woopos_eligibility_reason_check_connection)
         }
     }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/tab/WooPosCanBeLaunchedInTab.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/tab/WooPosCanBeLaunchedInTab.kt
@@ -42,35 +42,67 @@ class WooPosCanBeLaunchedInTab @Inject constructor(
     @Suppress("ReturnCount")
     private suspend fun checkLaunchability(forceRefresh: Boolean = false): WooPosLaunchability {
         val site = selectedSite.getOrNull()
-            ?: return WooPosLaunchability.NotLaunchable(WooPosLaunchability.NonLaunchabilityReason.NoSiteSelected)
+            ?: return WooPosLaunchability.NotLaunchable(
+                reason = WooPosLaunchability.NonLaunchabilityReason.NoSiteSelected
+            )
 
         val cachedPositive = appPrefs.isPOSLaunchableForSite(site.id)
 
-        val wooCoreVersion = getWooCoreVersion(forceRefresh)
-        if (wooCoreVersion != null) {
-            getNonLaunchabilityReasonFromWooCoreVersion(wooCoreVersion)?.let {
-                return WooPosLaunchability.NotLaunchable(it)
-            }
-            getNonLaunchabilityReasonFromFeatureSwitch(wooCoreVersion, forceRefresh, cachedPositive)?.let {
-                return WooPosLaunchability.NotLaunchable(it)
-            }
-        } else if (!cachedPositive) {
-            return WooPosLaunchability.NotLaunchable(
-                WooPosLaunchability.NonLaunchabilityReason.UnknownNoPositiveCache
-            )
+        getNonLaunchabilityReasonFromVersionAndFeatureSwitch(forceRefresh, cachedPositive)?.let {
+            return prepareNotLaunchableStateWithCacheUpdate(site.id, it)
         }
 
-        val siteSettings = resolveSiteSettings(site, forceRefresh)
-            ?: return fallbackUnknownOrCache(cachedPositive)
+        getNonLaunchabilityReasonFromSiteSettingsAndCurrency(site, forceRefresh, cachedPositive)?.let {
+            return prepareNotLaunchableStateWithCacheUpdate(site.id, it)
+        }
 
-        if (isCountryAndCurrencySupported(siteSettings.countryCode, siteSettings.currencyCode)) {
-            appPrefs.setPOSLaunchableForSite(site.id)
-            return WooPosLaunchability.Launchable
+        appPrefs.setPOSLaunchableForSite(site.id)
+        return WooPosLaunchability.Launchable
+    }
+
+    private fun prepareNotLaunchableStateWithCacheUpdate(
+        siteId: Int,
+        reason: WooPosLaunchability.NonLaunchabilityReason
+    ): WooPosLaunchability.NotLaunchable {
+        if (reason != WooPosLaunchability.NonLaunchabilityReason.UnknownNoPositiveCache) {
+            appPrefs.clearPOSLaunchableForSite(siteId)
+        }
+
+        return WooPosLaunchability.NotLaunchable(reason)
+    }
+
+    private suspend fun getNonLaunchabilityReasonFromVersionAndFeatureSwitch(
+        forceRefresh: Boolean,
+        cachedPositive: Boolean
+    ): WooPosLaunchability.NonLaunchabilityReason? {
+        val wooCoreVersion = getWooCoreVersion(forceRefresh)
+            ?: return reasonIfNoPositiveCache(cachedPositive)
+
+        return getNonLaunchabilityReasonFromWooCoreVersion(wooCoreVersion)
+            ?: getNonLaunchabilityReasonFromFeatureSwitch(wooCoreVersion, forceRefresh, cachedPositive)
+    }
+
+    private suspend fun getNonLaunchabilityReasonFromSiteSettingsAndCurrency(
+        site: SiteModel,
+        forceRefresh: Boolean,
+        cachedPositive: Boolean
+    ): WooPosLaunchability.NonLaunchabilityReason? {
+        val siteSettings = resolveSiteSettings(site, forceRefresh)
+            ?: return reasonIfNoPositiveCache(cachedPositive)
+
+        return if (!isCountryAndCurrencySupported(siteSettings.countryCode, siteSettings.currencyCode)) {
+            WooPosLaunchability.NonLaunchabilityReason.UnsupportedCurrency
         } else {
-            appPrefs.clearPOSLaunchableForSite(site.id)
-            return WooPosLaunchability.NotLaunchable(WooPosLaunchability.NonLaunchabilityReason.UnsupportedCurrency)
+            null
         }
     }
+
+    private fun reasonIfNoPositiveCache(hasCachedPositive: Boolean): WooPosLaunchability.NonLaunchabilityReason? =
+        if (hasCachedPositive) {
+            null
+        } else {
+            WooPosLaunchability.NonLaunchabilityReason.UnknownNoPositiveCache
+        }
 
     private suspend fun getWooCoreVersion(forceRefresh: Boolean): String? =
         if (forceRefresh) fetchWooCoreVersion() else getWooCoreCachedVersion()
@@ -118,13 +150,6 @@ class WooPosCanBeLaunchedInTab @Inject constructor(
             wooCommerceStore.fetchSiteGeneralSettings(site).model
         } else {
             wooCommerceStore.getSiteSettings(site) ?: wooCommerceStore.fetchSiteGeneralSettings(site).model
-        }
-
-    private fun fallbackUnknownOrCache(cachedPositive: Boolean): WooPosLaunchability =
-        if (cachedPositive) {
-            WooPosLaunchability.Launchable
-        } else {
-            WooPosLaunchability.NotLaunchable(WooPosLaunchability.NonLaunchabilityReason.UnknownNoPositiveCache)
         }
 
     private fun isCountryAndCurrencySupported(countryCode: String, currency: String) =

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/tab/WooPosCanBeLaunchedInTab.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/tab/WooPosCanBeLaunchedInTab.kt
@@ -46,11 +46,18 @@ class WooPosCanBeLaunchedInTab @Inject constructor(
 
         val cachedPositive = appPrefs.isPOSLaunchableForSite(site.id)
 
-        getWooCoreVersion(forceRefresh)?.let {
-            getNonLaunchabilityReasonFromWooCoreVersion(it)?.let { return WooPosLaunchability.NotLaunchable(it) }
-            getNonLaunchabilityReasonFromFeatureSwitch(it, forceRefresh, cachedPositive)?.let {
+        val wooCoreVersion = getWooCoreVersion(forceRefresh)
+        if (wooCoreVersion != null) {
+            getNonLaunchabilityReasonFromWooCoreVersion(wooCoreVersion)?.let {
                 return WooPosLaunchability.NotLaunchable(it)
             }
+            getNonLaunchabilityReasonFromFeatureSwitch(wooCoreVersion, forceRefresh, cachedPositive)?.let {
+                return WooPosLaunchability.NotLaunchable(it)
+            }
+        } else if (!cachedPositive) {
+            return WooPosLaunchability.NotLaunchable(
+                WooPosLaunchability.NonLaunchabilityReason.UnknownNoPositiveCache
+            )
         }
 
         val siteSettings = resolveSiteSettings(site, forceRefresh)

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/tab/WooPosCanBeLaunchedInTab.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/tab/WooPosCanBeLaunchedInTab.kt
@@ -1,5 +1,6 @@
 package com.woocommerce.android.ui.woopos.tab
 
+import com.woocommerce.android.AppPrefs
 import com.woocommerce.android.extensions.semverCompareTo
 import com.woocommerce.android.tools.SelectedSite
 import com.woocommerce.android.ui.woopos.WooPOSIsRemotelyEnabled
@@ -8,6 +9,8 @@ import com.woocommerce.android.util.FetchActiveWCPluginVersion
 import com.woocommerce.android.util.GetWooCorePluginCachedVersion
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
+import org.wordpress.android.fluxc.model.SiteModel
+import org.wordpress.android.fluxc.model.settings.Settings
 import org.wordpress.android.fluxc.store.WooCommerceStore
 import javax.inject.Inject
 import javax.inject.Singleton
@@ -19,6 +22,7 @@ import javax.inject.Singleton
  */
 @Singleton
 class WooPosCanBeLaunchedInTab @Inject constructor(
+    private val appPrefs: AppPrefs,
     private val selectedSite: SelectedSite,
     private val getWooCoreCachedVersion: GetWooCorePluginCachedVersion,
     private val fetchWooCoreVersion: FetchActiveWCPluginVersion,
@@ -38,51 +42,74 @@ class WooPosCanBeLaunchedInTab @Inject constructor(
     @Suppress("ReturnCount")
     private suspend fun checkLaunchability(forceRefresh: Boolean = false): WooPosLaunchability {
         val site = selectedSite.getOrNull()
-            ?: return WooPosLaunchability.NotLaunchable(
-                WooPosLaunchability.NonLaunchabilityReason.NoSiteSelected
-            )
+            ?: return WooPosLaunchability.NotLaunchable(WooPosLaunchability.NonLaunchabilityReason.NoSiteSelected)
 
-        val wooCoreVersion = if (forceRefresh) {
-            fetchWooCoreVersion()
-        } else {
-            getWooCoreCachedVersion()
-        } ?: return WooPosLaunchability.NotLaunchable(
-            WooPosLaunchability.NonLaunchabilityReason.WooCommercePluginNotFound
-        )
+        val cachedPositive = appPrefs.isPOSLaunchableForSite(site.id)
 
-        if (!isWooCoreSupportsOrderAutoDraftsAndExtraPaymentsProps(wooCoreVersion)) {
-            return WooPosLaunchability.NotLaunchable(
-                WooPosLaunchability.NonLaunchabilityReason.UnsupportedWooCommerceVersion
-            )
-        }
+        val wooCoreVersion = resolveWooCoreVersion(forceRefresh)
+            ?: return fallbackForMissingWooCore(cachedPositive)
 
-        if (isFeatureSwitchSupported(wooCoreVersion) && !isRemotelyEnabled(forceRefresh)) {
-            return WooPosLaunchability.NotLaunchable(
-                WooPosLaunchability.NonLaunchabilityReason.FeatureSwitchDisabled
-            )
-        }
+        validateWooCoreVersion(wooCoreVersion)?.let { return it }
+        evaluateFeatureSwitch(wooCoreVersion, forceRefresh, cachedPositive)?.let { return it }
 
-        val siteSettings = if (forceRefresh) {
-            wooCommerceStore.fetchSiteGeneralSettings(site).model
-        } else {
-            wooCommerceStore.getSiteSettings(site)
-                ?: wooCommerceStore.fetchSiteGeneralSettings(site).model
-        }
-
-        if (siteSettings == null) {
-            return WooPosLaunchability.NotLaunchable(
-                WooPosLaunchability.NonLaunchabilityReason.SiteSettingsUnavailable
-            )
-        }
+        val siteSettings = resolveSiteSettings(site, forceRefresh)
+            ?: return fallbackUnknownOrCache(cachedPositive)
 
         return if (isCountryAndCurrencySupported(siteSettings.countryCode, siteSettings.currencyCode)) {
             WooPosLaunchability.Launchable
         } else {
-            WooPosLaunchability.NotLaunchable(
-                WooPosLaunchability.NonLaunchabilityReason.UnsupportedCurrency
-            )
+            WooPosLaunchability.NotLaunchable(WooPosLaunchability.NonLaunchabilityReason.UnsupportedCurrency)
         }
     }
+
+    private suspend fun resolveWooCoreVersion(forceRefresh: Boolean): String? =
+        if (forceRefresh) fetchWooCoreVersion() else getWooCoreCachedVersion()
+
+    private fun fallbackForMissingWooCore(cachedPositive: Boolean): WooPosLaunchability =
+        if (cachedPositive) {
+            WooPosLaunchability.Launchable
+        } else {
+            WooPosLaunchability.NotLaunchable(WooPosLaunchability.NonLaunchabilityReason.WooCommercePluginNotFound)
+        }
+
+    private fun validateWooCoreVersion(wooCoreVersion: String): WooPosLaunchability? =
+        if (!isWooCoreSupportsOrderAutoDraftsAndExtraPaymentsProps(wooCoreVersion)) {
+            WooPosLaunchability.NotLaunchable(WooPosLaunchability.NonLaunchabilityReason.UnsupportedWooCommerceVersion)
+        } else {
+            null
+        }
+
+    private suspend fun evaluateFeatureSwitch(
+        wooCoreVersion: String,
+        forceRefresh: Boolean,
+        cachedPositive: Boolean
+    ): WooPosLaunchability? {
+        if (!isFeatureSwitchSupported(wooCoreVersion)) return null
+        val remote = isRemotelyEnabled(forceRefresh)
+        return when {
+            remote.isSuccess && !remote.getOrThrow() ->
+                WooPosLaunchability.NotLaunchable(WooPosLaunchability.NonLaunchabilityReason.FeatureSwitchDisabled)
+            remote.isFailure && cachedPositive ->
+                WooPosLaunchability.Launchable
+            remote.isFailure && !cachedPositive ->
+                WooPosLaunchability.NotLaunchable(WooPosLaunchability.NonLaunchabilityReason.UnknownNoPositiveCache)
+            else -> null
+        }
+    }
+
+    private suspend fun resolveSiteSettings(site: SiteModel, forceRefresh: Boolean): Settings? =
+        if (forceRefresh) {
+            wooCommerceStore.fetchSiteGeneralSettings(site).model
+        } else {
+            wooCommerceStore.getSiteSettings(site) ?: wooCommerceStore.fetchSiteGeneralSettings(site).model
+        }
+
+    private fun fallbackUnknownOrCache(cachedPositive: Boolean): WooPosLaunchability =
+        if (cachedPositive) {
+            WooPosLaunchability.Launchable
+        } else {
+            WooPosLaunchability.NotLaunchable(WooPosLaunchability.NonLaunchabilityReason.UnknownNoPositiveCache)
+        }
 
     private fun isCountryAndCurrencySupported(countryCode: String, currency: String) =
         SUPPORTED_COUNTRY_CURRENCY_PAIRS.any {
@@ -117,5 +144,6 @@ sealed class WooPosLaunchability {
         FeatureSwitchDisabled,
         UnsupportedCurrency,
         NoSiteSelected,
+        UnknownNoPositiveCache
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/tab/WooPosCanBeLaunchedInTab.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/tab/WooPosCanBeLaunchedInTab.kt
@@ -87,15 +87,27 @@ class WooPosCanBeLaunchedInTab @Inject constructor(
     ): WooPosLaunchability? {
         if (!isFeatureSwitchSupported(wooCoreVersion)) return null
         val remote = isRemotelyEnabled(forceRefresh)
-        return when {
-            remote.isSuccess && !remote.getOrThrow() ->
-                WooPosLaunchability.NotLaunchable(WooPosLaunchability.NonLaunchabilityReason.FeatureSwitchDisabled)
-            remote.isFailure && cachedPositive ->
-                WooPosLaunchability.Launchable
-            remote.isFailure && !cachedPositive ->
-                WooPosLaunchability.NotLaunchable(WooPosLaunchability.NonLaunchabilityReason.UnknownNoPositiveCache)
-            else -> null
-        }
+
+        return remote.fold(
+            onSuccess = { enabled ->
+                if (enabled) {
+                    null
+                } else {
+                    WooPosLaunchability.NotLaunchable(
+                        WooPosLaunchability.NonLaunchabilityReason.FeatureSwitchDisabled
+                    )
+                }
+            },
+            onFailure = {
+                if (cachedPositive) {
+                    WooPosLaunchability.Launchable
+                } else {
+                    WooPosLaunchability.NotLaunchable(
+                        WooPosLaunchability.NonLaunchabilityReason.UnknownNoPositiveCache
+                    )
+                }
+            }
+        )
     }
 
     private suspend fun resolveSiteSettings(site: SiteModel, forceRefresh: Boolean): Settings? =

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/tab/WooPosCanBeLaunchedInTab.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/tab/WooPosCanBeLaunchedInTab.kt
@@ -46,11 +46,12 @@ class WooPosCanBeLaunchedInTab @Inject constructor(
 
         val cachedPositive = appPrefs.isPOSLaunchableForSite(site.id)
 
-        val wooCoreVersion = resolveWooCoreVersion(forceRefresh)
-            ?: return fallbackForMissingWooCore(cachedPositive)
-
-        validateWooCoreVersion(wooCoreVersion)?.let { return it }
-        evaluateFeatureSwitch(wooCoreVersion, forceRefresh, cachedPositive)?.let { return it }
+        getWooCoreVersion(forceRefresh)?.let {
+            getNonLaunchabilityReasonFromWooCoreVersion(it)?.let { return WooPosLaunchability.NotLaunchable(it) }
+            getNonLaunchabilityReasonFromFeatureSwitch(it, forceRefresh, cachedPositive)?.let {
+                return WooPosLaunchability.NotLaunchable(it)
+            }
+        }
 
         val siteSettings = resolveSiteSettings(site, forceRefresh)
             ?: return fallbackUnknownOrCache(cachedPositive)
@@ -59,55 +60,50 @@ class WooPosCanBeLaunchedInTab @Inject constructor(
             appPrefs.setPOSLaunchableForSite(site.id)
             return WooPosLaunchability.Launchable
         } else {
+            appPrefs.clearPOSLaunchableForSite(site.id)
             return WooPosLaunchability.NotLaunchable(WooPosLaunchability.NonLaunchabilityReason.UnsupportedCurrency)
         }
     }
 
-    private suspend fun resolveWooCoreVersion(forceRefresh: Boolean): String? =
+    private suspend fun getWooCoreVersion(forceRefresh: Boolean): String? =
         if (forceRefresh) fetchWooCoreVersion() else getWooCoreCachedVersion()
 
-    private fun fallbackForMissingWooCore(cachedPositive: Boolean): WooPosLaunchability =
-        if (cachedPositive) {
-            WooPosLaunchability.Launchable
-        } else {
-            WooPosLaunchability.NotLaunchable(WooPosLaunchability.NonLaunchabilityReason.WooCommercePluginNotFound)
-        }
-
-    private fun validateWooCoreVersion(wooCoreVersion: String): WooPosLaunchability? =
+    /**
+     * Checks the WooCommerce core version to see if it prevents POS from being launchable.
+     * Returns the NonLaunchabilityReason if it does, or null if the version is supported.
+     */
+    private fun getNonLaunchabilityReasonFromWooCoreVersion(
+        wooCoreVersion: String
+    ): WooPosLaunchability.NonLaunchabilityReason? =
         if (!isWooCoreSupportsOrderAutoDraftsAndExtraPaymentsProps(wooCoreVersion)) {
-            WooPosLaunchability.NotLaunchable(WooPosLaunchability.NonLaunchabilityReason.UnsupportedWooCommerceVersion)
+            WooPosLaunchability.NonLaunchabilityReason.UnsupportedWooCommerceVersion
         } else {
             null
         }
 
-    private suspend fun evaluateFeatureSwitch(
+    /**
+     * Checks the feature switch to see if it prevents POS from being launchable.
+     * Returns the NonLaunchabilityReason if it does, or null if POS might still be launchable.
+     */
+    private suspend fun getNonLaunchabilityReasonFromFeatureSwitch(
         wooCoreVersion: String,
-        forceRefresh: Boolean,
-        cachedPositive: Boolean
-    ): WooPosLaunchability? {
-        if (!isFeatureSwitchSupported(wooCoreVersion)) return null
-        val remote = isRemotelyEnabled(forceRefresh)
-
-        return remote.fold(
-            onSuccess = { enabled ->
-                if (enabled) {
-                    null
-                } else {
-                    WooPosLaunchability.NotLaunchable(
-                        WooPosLaunchability.NonLaunchabilityReason.FeatureSwitchDisabled
-                    )
-                }
-            },
-            onFailure = {
-                if (cachedPositive) {
-                    WooPosLaunchability.Launchable
-                } else {
-                    WooPosLaunchability.NotLaunchable(
-                        WooPosLaunchability.NonLaunchabilityReason.UnknownNoPositiveCache
-                    )
+        forceRemoteRefresh: Boolean,
+        hasCachedLaunchableState: Boolean
+    ): WooPosLaunchability.NonLaunchabilityReason? {
+        val result =
+            if (!isFeatureSwitchSupported(wooCoreVersion)) {
+                null
+            } else {
+                val enabled = isRemotelyEnabled(forceRemoteRefresh).getOrNull()
+                when {
+                    enabled == true -> null
+                    enabled == false -> WooPosLaunchability.NonLaunchabilityReason.FeatureSwitchDisabled
+                    hasCachedLaunchableState -> null
+                    else -> WooPosLaunchability.NonLaunchabilityReason.UnknownNoPositiveCache
                 }
             }
-        )
+
+        return result
     }
 
     private suspend fun resolveSiteSettings(site: SiteModel, forceRefresh: Boolean): Settings? =

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/tab/WooPosCanBeLaunchedInTab.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/tab/WooPosCanBeLaunchedInTab.kt
@@ -55,10 +55,11 @@ class WooPosCanBeLaunchedInTab @Inject constructor(
         val siteSettings = resolveSiteSettings(site, forceRefresh)
             ?: return fallbackUnknownOrCache(cachedPositive)
 
-        return if (isCountryAndCurrencySupported(siteSettings.countryCode, siteSettings.currencyCode)) {
-            WooPosLaunchability.Launchable
+        if (isCountryAndCurrencySupported(siteSettings.countryCode, siteSettings.currencyCode)) {
+            appPrefs.setPOSLaunchableForSite(site.id)
+            return WooPosLaunchability.Launchable
         } else {
-            WooPosLaunchability.NotLaunchable(WooPosLaunchability.NonLaunchabilityReason.UnsupportedCurrency)
+            return WooPosLaunchability.NotLaunchable(WooPosLaunchability.NonLaunchabilityReason.UnsupportedCurrency)
         }
     }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/tab/WooPosTabController.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/tab/WooPosTabController.kt
@@ -15,12 +15,14 @@ import com.woocommerce.android.ui.woopos.util.analytics.WooPosAnalyticsEvent
 import com.woocommerce.android.ui.woopos.util.analytics.WooPosAnalyticsTracker
 import kotlinx.coroutines.launch
 import javax.inject.Inject
+import com.woocommerce.android.ui.woopos.common.util.WooPosLogWrapper
 
 class WooPosTabController @Inject constructor(
     private val appPrefs: AppPrefs,
     private val selectedSite: SelectedSite,
     private val shouldPosTabBeVisible: WooPosTabShouldBeVisible,
-    private val analyticsTracker: WooPosAnalyticsTracker
+    private val analyticsTracker: WooPosAnalyticsTracker,
+    private val wooPosLog: WooPosLogWrapper
 ) : DefaultLifecycleObserver {
 
     private lateinit var activity: MainActivity
@@ -64,10 +66,17 @@ class WooPosTabController @Inject constructor(
 
     private fun updateTabVisibilityFromRemoteAndPersist() {
         activity.lifecycleScope.launch {
-            val tabShouldBeVisible = shouldPosTabBeVisible()
-            setPOSTabVisibility(tabShouldBeVisible)
-            appPrefs.setPOSTabVisibilityForSite(selectedSite.getSelectedSiteId(), tabShouldBeVisible)
-            analyticsTracker.track(WooPosAnalyticsEvent.Event.TabVisibilityChecked(tabShouldBeVisible))
+            val result = shouldPosTabBeVisible()
+
+            result.onSuccess { tabShouldBeVisible ->
+                setPOSTabVisibility(tabShouldBeVisible)
+                appPrefs.setPOSTabVisibilityForSite(selectedSite.getSelectedSiteId(), tabShouldBeVisible)
+                analyticsTracker.track(WooPosAnalyticsEvent.Event.TabVisibilityChecked(tabShouldBeVisible))
+            }
+
+            result.onFailure { error ->
+                wooPosLog.i("POS Tab Visibility Value cannot be determined")
+            }
         }
     }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/tab/WooPosTabController.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/tab/WooPosTabController.kt
@@ -70,7 +70,11 @@ class WooPosTabController @Inject constructor(
 
             result.onSuccess { tabShouldBeVisible ->
                 setPOSTabVisibility(tabShouldBeVisible)
-                if (tabShouldBeVisible) appPrefs.setPOSTabVisibilityForSite(selectedSite.getSelectedSiteId())
+                if (tabShouldBeVisible) {
+                    appPrefs.setPOSTabVisibilityForSite(selectedSite.getSelectedSiteId())
+                } else {
+                    appPrefs.clearPOSTabVisibilityForSite(selectedSite.getSelectedSiteId())
+                }
             }
 
             result.onFailure { error ->

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/tab/WooPosTabController.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/tab/WooPosTabController.kt
@@ -10,12 +10,12 @@ import com.woocommerce.android.R
 import com.woocommerce.android.databinding.ActivityMainBinding
 import com.woocommerce.android.tools.SelectedSite
 import com.woocommerce.android.ui.main.MainActivity
+import com.woocommerce.android.ui.woopos.common.util.WooPosLogWrapper
 import com.woocommerce.android.ui.woopos.root.WooPosActivity
 import com.woocommerce.android.ui.woopos.util.analytics.WooPosAnalyticsEvent
 import com.woocommerce.android.ui.woopos.util.analytics.WooPosAnalyticsTracker
 import kotlinx.coroutines.launch
 import javax.inject.Inject
-import com.woocommerce.android.ui.woopos.common.util.WooPosLogWrapper
 
 class WooPosTabController @Inject constructor(
     private val appPrefs: AppPrefs,

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/tab/WooPosTabController.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/tab/WooPosTabController.kt
@@ -71,12 +71,13 @@ class WooPosTabController @Inject constructor(
             result.onSuccess { tabShouldBeVisible ->
                 setPOSTabVisibility(tabShouldBeVisible)
                 appPrefs.setPOSTabVisibilityForSite(selectedSite.getSelectedSiteId(), tabShouldBeVisible)
-                analyticsTracker.track(WooPosAnalyticsEvent.Event.TabVisibilityChecked(tabShouldBeVisible))
             }
 
             result.onFailure { error ->
                 wooPosLog.i("POS Tab Visibility Value cannot be determined")
             }
+
+            analyticsTracker.track(WooPosAnalyticsEvent.Event.TabVisibilityChecked(result))
         }
     }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/tab/WooPosTabController.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/tab/WooPosTabController.kt
@@ -70,7 +70,7 @@ class WooPosTabController @Inject constructor(
 
             result.onSuccess { tabShouldBeVisible ->
                 setPOSTabVisibility(tabShouldBeVisible)
-                appPrefs.setPOSTabVisibilityForSite(selectedSite.getSelectedSiteId(), tabShouldBeVisible)
+                if (tabShouldBeVisible) appPrefs.setPOSTabVisibilityForSite(selectedSite.getSelectedSiteId())
             }
 
             result.onFailure { error ->

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/tab/WooPosTabShouldBeVisible.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/tab/WooPosTabShouldBeVisible.kt
@@ -10,6 +10,8 @@ import kotlinx.coroutines.withContext
 import org.wordpress.android.fluxc.store.WooCommerceStore
 import javax.inject.Inject
 
+class CouldNotDetermineValueException : Exception()
+
 class WooPosTabShouldBeVisible @Inject constructor(
     private val selectedSite: SelectedSite,
     private val isScreenSizeAllowed: WooPosIsScreenSizeAllowed,
@@ -17,33 +19,34 @@ class WooPosTabShouldBeVisible @Inject constructor(
     private val isRemoteFeatureFlagEnabled: IsRemoteFeatureFlagEnabled,
     private val wooPosLog: WooPosLogWrapper,
 ) {
-    suspend operator fun invoke(): Boolean = withContext(Dispatchers.IO) {
-        val selectedSite = selectedSite.getOrNull() ?: return@withContext false
+    suspend operator fun invoke(): Result<Boolean> = withContext(Dispatchers.IO) {
+        val selectedSite = selectedSite.getOrNull()
+            ?: return@withContext Result.failure(CouldNotDetermineValueException())
 
         if (!isRemoteFeatureFlagEnabled(WOO_POS)) {
-            return@withContext false.also {
+            return@withContext Result.success(true).also {
                 wooPosLog.i("POS Tab Not visible reason: Remote feature flag is disabled")
             }
         }
 
         if (!isScreenSizeAllowed()) {
-            return@withContext false.also {
+            return@withContext Result.success(false).also {
                 wooPosLog.i("POS Tab Not visible reason: Screen size is not allowed")
             }
         }
 
-        val siteSettings = wooCommerceStore.fetchSiteGeneralSettings(selectedSite).model
-            ?: return@withContext false.also {
-                wooPosLog.i("POS Tab Not visible reason: Site settings are not available")
-            }
+        val siteSettings = wooCommerceStore
+            .fetchSiteGeneralSettings(selectedSite)
+            .model
+            ?: return@withContext Result.failure(CouldNotDetermineValueException())
 
-        return@withContext isCountrySupported(
-            countryCode = siteSettings.countryCode
-        ).also { isSupported ->
-            if (!isSupported) {
-                wooPosLog.i("POS Tab Not visible reason: Country ${siteSettings.countryCode} is not supported")
+        return@withContext Result.success(
+            isCountrySupported(countryCode = siteSettings.countryCode).also { isSupported ->
+                if (!isSupported) {
+                    wooPosLog.i("POS Tab Not visible reason: Country ${siteSettings.countryCode} is not supported")
+                }
             }
-        }
+        )
     }
 
     private fun isCountrySupported(countryCode: String) = SUPPORTED_COUNTRIES.contains(countryCode.lowercase())

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/tab/WooPosTabShouldBeVisible.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/tab/WooPosTabShouldBeVisible.kt
@@ -23,7 +23,7 @@ class WooPosTabShouldBeVisible @Inject constructor(
             ?: return@withContext Result.failure(WooPosCouldNotDetermineValueException())
 
         if (!isRemoteFeatureFlagEnabled(WOO_POS)) {
-            return@withContext Result.success(true).also {
+            return@withContext Result.success(false).also {
                 wooPosLog.i("POS Tab Not visible reason: Remote feature flag is disabled")
             }
         }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/tab/WooPosTabShouldBeVisible.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/tab/WooPosTabShouldBeVisible.kt
@@ -2,6 +2,7 @@ package com.woocommerce.android.ui.woopos.tab
 
 import com.woocommerce.android.tools.SelectedSite
 import com.woocommerce.android.ui.woopos.WooPosIsScreenSizeAllowed
+import com.woocommerce.android.ui.woopos.common.util.WooPosCouldNotDetermineValueException
 import com.woocommerce.android.ui.woopos.common.util.WooPosLogWrapper
 import com.woocommerce.android.util.IsRemoteFeatureFlagEnabled
 import com.woocommerce.android.util.RemoteFeatureFlag.WOO_POS
@@ -9,8 +10,6 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 import org.wordpress.android.fluxc.store.WooCommerceStore
 import javax.inject.Inject
-
-class CouldNotDetermineValueException : Exception()
 
 class WooPosTabShouldBeVisible @Inject constructor(
     private val selectedSite: SelectedSite,
@@ -21,7 +20,7 @@ class WooPosTabShouldBeVisible @Inject constructor(
 ) {
     suspend operator fun invoke(): Result<Boolean> = withContext(Dispatchers.IO) {
         val selectedSite = selectedSite.getOrNull()
-            ?: return@withContext Result.failure(CouldNotDetermineValueException())
+            ?: return@withContext Result.failure(WooPosCouldNotDetermineValueException())
 
         if (!isRemoteFeatureFlagEnabled(WOO_POS)) {
             return@withContext Result.success(true).also {
@@ -38,7 +37,7 @@ class WooPosTabShouldBeVisible @Inject constructor(
         val siteSettings = wooCommerceStore
             .fetchSiteGeneralSettings(selectedSite)
             .model
-            ?: return@withContext Result.failure(CouldNotDetermineValueException())
+            ?: return@withContext Result.failure(WooPosCouldNotDetermineValueException())
 
         return@withContext Result.success(
             isCountrySupported(countryCode = siteSettings.countryCode).also { isSupported ->

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/util/analytics/WooPosAnalyticsEvent.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/util/analytics/WooPosAnalyticsEvent.kt
@@ -824,6 +824,7 @@ internal fun WooPosLaunchability.NonLaunchabilityReason.toAnalyticsReason(): Str
         WooPosLaunchability.NonLaunchabilityReason.FeatureSwitchDisabled -> "feature_switch_disabled"
         WooPosLaunchability.NonLaunchabilityReason.UnsupportedCurrency -> "store_currency"
         WooPosLaunchability.NonLaunchabilityReason.SiteSettingsUnavailable,
+        WooPosLaunchability.NonLaunchabilityReason.UnknownNoPositiveCache,
         WooPosLaunchability.NonLaunchabilityReason.NoSiteSelected -> "other"
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/util/analytics/WooPosAnalyticsEvent.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/util/analytics/WooPosAnalyticsEvent.kt
@@ -104,15 +104,16 @@ sealed class WooPosAnalyticsEvent : IAnalyticsEvent {
             }
         }
 
-        data class TabVisibilityChecked(val isVisible: Boolean) : Event() {
+        data class TabVisibilityChecked(val isVisible: Result<Boolean>) : Event() {
             override val name: String = "tab_visibility_checked"
 
             init {
-                addProperties(
-                    mapOf(
-                        "is_visible" to isVisible.toString()
-                    )
+                val value: String = isVisible.fold(
+                    onSuccess = { it.toString() },
+                    onFailure = { "unknown" }
                 )
+
+                addProperties(mapOf("is_visible" to value))
             }
         }
 

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/WooPOSIsRemotelyEnabledTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/WooPOSIsRemotelyEnabledTest.kt
@@ -2,6 +2,7 @@ package com.woocommerce.android.ui.woopos
 
 import com.google.gson.Gson
 import com.woocommerce.android.tools.SelectedSite
+import com.woocommerce.android.ui.woopos.common.util.WooPosCouldNotDetermineValueException
 import com.woocommerce.android.util.WCSSRModelCachingFetcher
 import kotlinx.coroutines.test.runTest
 import org.junit.Before
@@ -30,65 +31,67 @@ class WooPOSIsRemotelyEnabledTest {
     }
 
     @Test
-    fun `given feature enabled remotely when invoked then returns true`() = runTest {
-        // GIVEN
+    fun `given feature enabled remotely when invoked then returns success true`() = runTest {
         val jsonSettings = """{"enabled_features": ["point_of_sale", "other_feature"]}"""
         whenever(ssrModel.settings).thenReturn(jsonSettings)
         whenever(cacheResult.isError).thenReturn(false)
         whenever(cacheResult.model).thenReturn(ssrModel)
         whenever(fetcher.load(siteModel)).thenReturn(cacheResult)
 
-        // WHEN
         val result = sut.invoke()
 
-        // THEN
-        assertTrue(result)
+        assertTrue(result.isSuccess)
+        assertTrue(result.getOrThrow())
     }
 
     @Test
-    fun `given feature not in list when invoked then returns false`() = runTest {
+    fun `given feature not in list when invoked then returns success false`() = runTest {
         val jsonSettings = """{"enabled_features": ["something_else"]}"""
         whenever(ssrModel.settings).thenReturn(jsonSettings)
         whenever(cacheResult.isError).thenReturn(false)
         whenever(cacheResult.model).thenReturn(ssrModel)
         whenever(fetcher.load(siteModel)).thenReturn(cacheResult)
 
-        val result = sut.invoke()
+        val r = sut.invoke()
 
-        assertFalse(result)
+        assertTrue(r.isSuccess)
+        assertFalse(r.getOrThrow())
     }
 
     @Test
-    fun `given empty feature list when invoked then returns false`() = runTest {
+    fun `given empty feature list when invoked then returns success false`() = runTest {
         val jsonSettings = """{"enabled_features": []}"""
         whenever(ssrModel.settings).thenReturn(jsonSettings)
         whenever(cacheResult.isError).thenReturn(false)
         whenever(cacheResult.model).thenReturn(ssrModel)
         whenever(fetcher.load(siteModel)).thenReturn(cacheResult)
 
-        val result = sut.invoke()
+        val r = sut.invoke()
 
-        assertFalse(result)
+        assertTrue(r.isSuccess)
+        assertFalse(r.getOrThrow())
     }
 
     @Test
-    fun `given null result when invoked then returns false`() = runTest {
+    fun `given null result when invoked then returns failure unknown`() = runTest {
         whenever(cacheResult.isError).thenReturn(false)
         whenever(cacheResult.model).thenReturn(null)
         whenever(fetcher.load(siteModel)).thenReturn(cacheResult)
 
-        val result = sut.invoke()
+        val r = sut.invoke()
 
-        assertFalse(result)
+        assertTrue(r.isFailure)
+        assertTrue(r.exceptionOrNull() is WooPosCouldNotDetermineValueException)
     }
 
     @Test
-    fun `given error result when invoked then returns false`() = runTest {
+    fun `given error result when invoked then returns failure unknown`() = runTest {
         whenever(cacheResult.isError).thenReturn(true)
         whenever(fetcher.load(siteModel)).thenReturn(cacheResult)
 
-        val result = sut.invoke()
+        val r = sut.invoke()
 
-        assertFalse(result)
+        assertTrue(r.isFailure)
+        assertTrue(r.exceptionOrNull() is WooPosCouldNotDetermineValueException)
     }
 }

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/WooPOSIsRemotelyEnabledTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/WooPOSIsRemotelyEnabledTest.kt
@@ -52,10 +52,10 @@ class WooPOSIsRemotelyEnabledTest {
         whenever(cacheResult.model).thenReturn(ssrModel)
         whenever(fetcher.load(siteModel)).thenReturn(cacheResult)
 
-        val r = sut.invoke()
+        val result = sut.invoke()
 
-        assertTrue(r.isSuccess)
-        assertFalse(r.getOrThrow())
+        assertTrue(result.isSuccess)
+        assertFalse(result.getOrThrow())
     }
 
     @Test
@@ -66,10 +66,10 @@ class WooPOSIsRemotelyEnabledTest {
         whenever(cacheResult.model).thenReturn(ssrModel)
         whenever(fetcher.load(siteModel)).thenReturn(cacheResult)
 
-        val r = sut.invoke()
+        val result = sut.invoke()
 
-        assertTrue(r.isSuccess)
-        assertFalse(r.getOrThrow())
+        assertTrue(result.isSuccess)
+        assertFalse(result.getOrThrow())
     }
 
     @Test
@@ -78,10 +78,10 @@ class WooPOSIsRemotelyEnabledTest {
         whenever(cacheResult.model).thenReturn(null)
         whenever(fetcher.load(siteModel)).thenReturn(cacheResult)
 
-        val r = sut.invoke()
+        val result = sut.invoke()
 
-        assertTrue(r.isFailure)
-        assertTrue(r.exceptionOrNull() is WooPosCouldNotDetermineValueException)
+        assertTrue(result.isFailure)
+        assertTrue(result.exceptionOrNull() is WooPosCouldNotDetermineValueException)
     }
 
     @Test
@@ -89,9 +89,9 @@ class WooPOSIsRemotelyEnabledTest {
         whenever(cacheResult.isError).thenReturn(true)
         whenever(fetcher.load(siteModel)).thenReturn(cacheResult)
 
-        val r = sut.invoke()
+        val result = sut.invoke()
 
-        assertTrue(r.isFailure)
-        assertTrue(r.exceptionOrNull() is WooPosCouldNotDetermineValueException)
+        assertTrue(result.isFailure)
+        assertTrue(result.exceptionOrNull() is WooPosCouldNotDetermineValueException)
     }
 }

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/WooPOSIsRemotelyEnabledTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/WooPOSIsRemotelyEnabledTest.kt
@@ -31,7 +31,7 @@ class WooPOSIsRemotelyEnabledTest {
     }
 
     @Test
-    fun `given feature enabled remotely when invoked then returns success true`() = runTest {
+    fun `given feature enabled remotely, when invoked, then returns success true`() = runTest {
         val jsonSettings = """{"enabled_features": ["point_of_sale", "other_feature"]}"""
         whenever(ssrModel.settings).thenReturn(jsonSettings)
         whenever(cacheResult.isError).thenReturn(false)
@@ -45,7 +45,7 @@ class WooPOSIsRemotelyEnabledTest {
     }
 
     @Test
-    fun `given feature not in list when invoked then returns success false`() = runTest {
+    fun `given feature not in list, when invoked, then returns success false`() = runTest {
         val jsonSettings = """{"enabled_features": ["something_else"]}"""
         whenever(ssrModel.settings).thenReturn(jsonSettings)
         whenever(cacheResult.isError).thenReturn(false)
@@ -59,7 +59,7 @@ class WooPOSIsRemotelyEnabledTest {
     }
 
     @Test
-    fun `given empty feature list when invoked then returns success false`() = runTest {
+    fun `given empty feature list, when invoked, then returns success false`() = runTest {
         val jsonSettings = """{"enabled_features": []}"""
         whenever(ssrModel.settings).thenReturn(jsonSettings)
         whenever(cacheResult.isError).thenReturn(false)
@@ -73,7 +73,7 @@ class WooPOSIsRemotelyEnabledTest {
     }
 
     @Test
-    fun `given null result when invoked then returns failure unknown`() = runTest {
+    fun `given null result, when invoked, then returns failure unknown`() = runTest {
         whenever(cacheResult.isError).thenReturn(false)
         whenever(cacheResult.model).thenReturn(null)
         whenever(fetcher.load(siteModel)).thenReturn(cacheResult)
@@ -85,7 +85,7 @@ class WooPOSIsRemotelyEnabledTest {
     }
 
     @Test
-    fun `given error result when invoked then returns failure unknown`() = runTest {
+    fun `given error result, when invoked, then returns failure unknown`() = runTest {
         whenever(cacheResult.isError).thenReturn(true)
         whenever(fetcher.load(siteModel)).thenReturn(cacheResult)
 

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/tab/WooPosCanBeLaunchedInTabTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/tab/WooPosCanBeLaunchedInTabTest.kt
@@ -14,6 +14,8 @@ import org.junit.Before
 import org.mockito.kotlin.any
 import org.mockito.kotlin.eq
 import org.mockito.kotlin.mock
+import org.mockito.kotlin.times
+import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
 import org.wordpress.android.fluxc.model.LocalOrRemoteId
 import org.wordpress.android.fluxc.model.SiteModel
@@ -197,6 +199,22 @@ class WooPosCanBeLaunchedInTabTest : BaseUnitTest() {
 
         val result = sut(forceRefresh = true)
         assertEquals(Launchable, result)
+    }
+
+    @Test
+    fun `given supported country and currency from cache, when invoked, then sets POS launchable for site`() = testBlocking {
+        val result = sut()
+        assertEquals(Launchable, result)
+
+        verify(appPrefs, times(1)).setPOSLaunchableForSite(eq(siteModel.id))
+    }
+
+    @Test
+    fun `given forceRefresh true with valid data, when invoked, then sets POS launchable for site`() = testBlocking {
+        val result = sut(forceRefresh = true)
+        assertEquals(Launchable, result)
+
+        verify(appPrefs, times(1)).setPOSLaunchableForSite(eq(siteModel.id))
     }
 
     private fun buildSiteSettings(

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/tab/WooPosCanBeLaunchedInTabTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/tab/WooPosCanBeLaunchedInTabTest.kt
@@ -42,11 +42,15 @@ class WooPosCanBeLaunchedInTabTest : BaseUnitTest() {
     fun setup() = testBlocking {
         siteModel = SiteModel().also { it.id = 1 }
         whenever(selectedSite.getOrNull()).thenReturn(siteModel)
+
+        // Default: WC 10.0.0, settings available and supported, remote enabled, no cached positive
         whenever(getWooCoreVersion()).thenReturn("10.0.0")
         whenever(fetchWooCoreVersion()).thenReturn("10.0.0")
+
         val siteSettings = buildSiteSettings()
         whenever(wooCommerceStore.getSiteSettings(siteModel)).thenReturn(siteSettings)
         whenever(wooCommerceStore.fetchSiteGeneralSettings(siteModel)).thenReturn(WooResult(siteSettings))
+
         whenever(isRemotelyEnabled.invoke(any())).thenReturn(Result.success(true))
         whenever(appPrefs.isPOSLaunchableForSite(eq(siteModel.id))).thenReturn(false)
 
@@ -61,50 +65,13 @@ class WooPosCanBeLaunchedInTabTest : BaseUnitTest() {
         )
     }
 
+    // --- Happy paths ---
+
     @Test
-    fun `given valid conditions, when invoked, then return Launchable`() = testBlocking {
+    fun `given valid conditions, when invoked, then return Launchable and set cache`() = testBlocking {
         val result = sut()
         assertEquals(Launchable, result)
-    }
-
-    @Test
-    fun `given no site selected, when invoked, then return NotLaunchable with NoSiteSelected`() = testBlocking {
-        whenever(selectedSite.getOrNull()).thenReturn(null)
-        val result = sut()
-        assertEquals(NotLaunchable(NonLaunchabilityReason.NoSiteSelected), result)
-    }
-
-    @Test
-    fun `given unsupported WooCommerce version, when invoked, then return NotLaunchable with UnsupportedWooCommerceVersion`() = testBlocking {
-        whenever(getWooCoreVersion()).thenReturn("9.5.0")
-        val result = sut()
-        assertEquals(NotLaunchable(NonLaunchabilityReason.UnsupportedWooCommerceVersion), result)
-    }
-
-    @Test
-    fun `given feature switch supported but remotely disabled, when invoked, then return NotLaunchable with FeatureSwitchDisabled`() = testBlocking {
-        whenever(getWooCoreVersion()).thenReturn("10.0.0")
-        whenever(isRemotelyEnabled.invoke(any())).thenReturn(Result.success(false))
-        val result = sut()
-        assertEquals(NotLaunchable(NonLaunchabilityReason.FeatureSwitchDisabled), result)
-    }
-
-    @Test
-    fun `given null site settings and no cached positive, when invoked, then return NotLaunchable UnknownNoPositiveCache`() = testBlocking {
-        whenever(wooCommerceStore.getSiteSettings(any())).thenReturn(null)
-        whenever(wooCommerceStore.fetchSiteGeneralSettings(any())).thenReturn(WooResult(null))
-        whenever(appPrefs.isPOSLaunchableForSite(eq(siteModel.id))).thenReturn(false)
-
-        val result = sut()
-        assertEquals(NotLaunchable(NonLaunchabilityReason.UnknownNoPositiveCache), result)
-    }
-
-    @Test
-    fun `given unsupported currency, when invoked, then return NotLaunchable with UnsupportedCurrency`() = testBlocking {
-        val siteSettings = buildSiteSettings(currencyCode = "eur")
-        whenever(wooCommerceStore.getSiteSettings(any())).thenReturn(siteSettings)
-        val result = sut()
-        assertEquals(NotLaunchable(NonLaunchabilityReason.UnsupportedCurrency), result)
+        verify(appPrefs, times(1)).setPOSLaunchableForSite(eq(siteModel.id))
     }
 
     @Test
@@ -124,98 +91,167 @@ class WooPosCanBeLaunchedInTabTest : BaseUnitTest() {
     }
 
     @Test
-    fun `given uk country and usd, when invoked, then return Not Launchable`() = testBlocking {
-        val siteSettings = buildSiteSettings(countryCode = "GB", currencyCode = "USD")
-        whenever(wooCommerceStore.getSiteSettings(any())).thenReturn(siteSettings)
-        val result = sut()
-        assertEquals(NotLaunchable(NonLaunchabilityReason.UnsupportedCurrency), result)
-    }
-
-    @Test
-    fun `given us country and pounds, when invoked, then return Not Launchable`() = testBlocking {
-        val siteSettings = buildSiteSettings(countryCode = "US", currencyCode = "GBP")
-        whenever(wooCommerceStore.getSiteSettings(any())).thenReturn(siteSettings)
-        val result = sut()
-        assertEquals(NotLaunchable(NonLaunchabilityReason.UnsupportedCurrency), result)
-    }
-
-    @Test
     fun `given site settings missing but fetched successfully, when invoked, then return Launchable`() = testBlocking {
         whenever(wooCommerceStore.getSiteSettings(any())).thenReturn(null)
         val fetchedSettings = buildSiteSettings(currencyCode = "usd")
         whenever(wooCommerceStore.fetchSiteGeneralSettings(any())).thenReturn(WooResult(fetchedSettings))
+        val result = sut()
+        assertEquals(Launchable, result)
+    }
 
+    // --- No site ---
+
+    @Test
+    fun `given no site selected, when invoked, then NotLaunchable NoSiteSelected and no prefs touched`() = testBlocking {
+        whenever(selectedSite.getOrNull()).thenReturn(null)
+        val result = sut()
+        assertEquals(NotLaunchable(NonLaunchabilityReason.NoSiteSelected), result)
+        verify(appPrefs, times(0)).setPOSLaunchableForSite(any())
+        verify(appPrefs, times(0)).clearPOSLaunchableForSite(any())
+    }
+
+    // --- Version checks ---
+
+    @Test
+    fun `given unsupported WooCommerce version, when invoked, then NotLaunchable UnsupportedWooCommerceVersion and clears cache`() = testBlocking {
+        whenever(getWooCoreVersion()).thenReturn("9.5.0")
+        val result = sut()
+        assertEquals(NotLaunchable(NonLaunchabilityReason.UnsupportedWooCommerceVersion), result)
+        verify(appPrefs, times(1)).clearPOSLaunchableForSite(eq(siteModel.id))
+    }
+
+    // Feature-switch unsupported (version >= 9_6_0 but  switch threshold not met)
+    @Test
+    fun `given WC 9_6_0 (switch unsupported) and supported settings, when invoked, then Launchable`() = testBlocking {
+        whenever(getWooCoreVersion()).thenReturn("9.6.0")
         val result = sut()
         assertEquals(Launchable, result)
     }
 
     @Test
-    fun `given site settings missing and fetched with unsupported currency, when invoked, then return NotLaunchable with UnsupportedCurrency`() = testBlocking {
+    fun `given WC 9_6_0 (switch unsupported) and unsupported currency, when invoked, then NotLaunchable UnsupportedCurrency and clears cache`() = testBlocking {
+        whenever(getWooCoreVersion()).thenReturn("9.6.0")
+        val bad = buildSiteSettings(currencyCode = "EUR")
+        whenever(wooCommerceStore.getSiteSettings(any())).thenReturn(bad)
+        val result = sut()
+        assertEquals(NotLaunchable(NonLaunchabilityReason.UnsupportedCurrency), result)
+        verify(appPrefs, times(1)).clearPOSLaunchableForSite(eq(siteModel.id))
+    }
+
+    // --- Feature switch checks ---
+
+    @Test
+    fun `given feature switch supported but remotely disabled, when invoked, then NotLaunchable FeatureSwitchDisabled and clears cache`() = testBlocking {
+        whenever(getWooCoreVersion()).thenReturn("10.0.0")
+        whenever(isRemotelyEnabled.invoke(any())).thenReturn(Result.success(false))
+        val result = sut()
+        assertEquals(NotLaunchable(NonLaunchabilityReason.FeatureSwitchDisabled), result)
+        verify(appPrefs, times(1)).clearPOSLaunchableForSite(eq(siteModel.id))
+    }
+
+    @Test
+    fun `given remote check failure and cached positive, when invoked, then Launchable`() = testBlocking {
+        whenever(isRemotelyEnabled.invoke(any())).thenReturn(Result.failure(RuntimeException("boom")))
+        whenever(appPrefs.isPOSLaunchableForSite(eq(siteModel.id))).thenReturn(true)
+        val result = sut()
+        assertEquals(Launchable, result)
+    }
+
+    @Test
+    fun `given remote check failure and no cached positive, when invoked, then NotLaunchable UnknownNoPositiveCache and does not clear`() = testBlocking {
+        whenever(isRemotelyEnabled.invoke(any())).thenReturn(Result.failure(RuntimeException("boom")))
+        whenever(appPrefs.isPOSLaunchableForSite(eq(siteModel.id))).thenReturn(false)
+        val result = sut()
+        assertEquals(NotLaunchable(NonLaunchabilityReason.UnknownNoPositiveCache), result)
+        verify(appPrefs, times(0)).clearPOSLaunchableForSite(any())
+    }
+
+    // --- Site settings fallback ---
+
+    @Test
+    fun `given null site settings and no cached positive, when invoked, then NotLaunchable UnknownNoPositiveCache and does not clear`() = testBlocking {
+        whenever(wooCommerceStore.getSiteSettings(any())).thenReturn(null)
+        whenever(wooCommerceStore.fetchSiteGeneralSettings(any())).thenReturn(WooResult(null))
+        whenever(appPrefs.isPOSLaunchableForSite(eq(siteModel.id))).thenReturn(false)
+        val result = sut()
+        assertEquals(NotLaunchable(NonLaunchabilityReason.UnknownNoPositiveCache), result)
+        verify(appPrefs, times(0)).clearPOSLaunchableForSite(any())
+    }
+
+    @Test
+    fun `given site settings missing and fetched with unsupported currency, when invoked, then NotLaunchable UnsupportedCurrency and clears cache`() = testBlocking {
         whenever(wooCommerceStore.getSiteSettings(any())).thenReturn(null)
         val fetchedSettings = buildSiteSettings(currencyCode = "eur")
         whenever(wooCommerceStore.fetchSiteGeneralSettings(any())).thenReturn(WooResult(fetchedSettings))
-
         val result = sut()
         assertEquals(NotLaunchable(NonLaunchabilityReason.UnsupportedCurrency), result)
+        verify(appPrefs, times(1)).clearPOSLaunchableForSite(eq(siteModel.id))
+    }
+
+    // --- Currency matrix ---
+
+    @Test
+    fun `given uk country and usd, when invoked, then NotLaunchable UnsupportedCurrency and clears cache`() = testBlocking {
+        val siteSettings = buildSiteSettings(countryCode = "GB", currencyCode = "USD")
+        whenever(wooCommerceStore.getSiteSettings(any())).thenReturn(siteSettings)
+        val result = sut()
+        assertEquals(NotLaunchable(NonLaunchabilityReason.UnsupportedCurrency), result)
+        verify(appPrefs, times(1)).clearPOSLaunchableForSite(eq(siteModel.id))
     }
 
     @Test
-    fun `given forceRefresh true with valid data, when invoked, then return Launchable`() = testBlocking {
+    fun `given us country and pounds, when invoked, then NotLaunchable UnsupportedCurrency and clears cache`() = testBlocking {
+        val siteSettings = buildSiteSettings(countryCode = "US", currencyCode = "GBP")
+        whenever(wooCommerceStore.getSiteSettings(any())).thenReturn(siteSettings)
+        val result = sut()
+        assertEquals(NotLaunchable(NonLaunchabilityReason.UnsupportedCurrency), result)
+        verify(appPrefs, times(1)).clearPOSLaunchableForSite(eq(siteModel.id))
+    }
+
+    // --- Force refresh paths ---
+
+    @Test
+    fun `given forceRefresh true with valid data, when invoked, then Launchable and set cache`() = testBlocking {
         val result = sut(forceRefresh = true)
         assertEquals(Launchable, result)
+        verify(appPrefs, times(1)).setPOSLaunchableForSite(eq(siteModel.id))
     }
 
     @Test
-    fun `given forceRefresh true and fetchWooCoreVersion returns null with no cached positive, when invoked, then NotLaunchable UnknownNoPositiveCache`() = testBlocking {
+    fun `given forceRefresh true and fetchWooCoreVersion returns null with no cached positive, when invoked, then NotLaunchable UnknownNoPositiveCache and does not clear`() = testBlocking {
         whenever(fetchWooCoreVersion()).thenReturn(null)
         whenever(appPrefs.isPOSLaunchableForSite(eq(siteModel.id))).thenReturn(false)
-
         val result = sut(forceRefresh = true)
         assertEquals(NotLaunchable(NonLaunchabilityReason.UnknownNoPositiveCache), result)
+        verify(appPrefs, times(0)).clearPOSLaunchableForSite(any())
     }
 
     @Test
     fun `given forceRefresh true and fetchWooCoreVersion returns null with cached positive, when invoked, then Launchable`() = testBlocking {
         whenever(fetchWooCoreVersion()).thenReturn(null)
         whenever(appPrefs.isPOSLaunchableForSite(eq(siteModel.id))).thenReturn(true)
-
         val result = sut(forceRefresh = true)
         assertEquals(Launchable, result)
     }
 
     @Test
-    fun `given forceRefresh true and fetched site settings is null with no cached positive, when invoked, then NotLaunchable UnknownNoPositiveCache`() = testBlocking {
+    fun `given forceRefresh true and fetched site settings is null with no cached positive, when invoked, then NotLaunchable UnknownNoPositiveCache and does not clear`() = testBlocking {
         whenever(wooCommerceStore.fetchSiteGeneralSettings(any())).thenReturn(WooResult(null))
         whenever(appPrefs.isPOSLaunchableForSite(eq(siteModel.id))).thenReturn(false)
-
         val result = sut(forceRefresh = true)
         assertEquals(NotLaunchable(NonLaunchabilityReason.UnknownNoPositiveCache), result)
+        verify(appPrefs, times(0)).clearPOSLaunchableForSite(any())
     }
 
     @Test
     fun `given forceRefresh true and fetched site settings is null with cached positive, when invoked, then Launchable`() = testBlocking {
         whenever(wooCommerceStore.fetchSiteGeneralSettings(any())).thenReturn(WooResult(null))
         whenever(appPrefs.isPOSLaunchableForSite(eq(siteModel.id))).thenReturn(true)
-
         val result = sut(forceRefresh = true)
         assertEquals(Launchable, result)
     }
 
-    @Test
-    fun `given supported country and currency from cache, when invoked, then sets POS launchable for site`() = testBlocking {
-        val result = sut()
-        assertEquals(Launchable, result)
-
-        verify(appPrefs, times(1)).setPOSLaunchableForSite(eq(siteModel.id))
-    }
-
-    @Test
-    fun `given forceRefresh true with valid data, when invoked, then sets POS launchable for site`() = testBlocking {
-        val result = sut(forceRefresh = true)
-        assertEquals(Launchable, result)
-
-        verify(appPrefs, times(1)).setPOSLaunchableForSite(eq(siteModel.id))
-    }
+    // ---
 
     private fun buildSiteSettings(
         countryCode: String = "US",

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/tab/WooPosCanBeLaunchedInTabTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/tab/WooPosCanBeLaunchedInTabTest.kt
@@ -166,12 +166,12 @@ class WooPosCanBeLaunchedInTabTest : BaseUnitTest() {
     }
 
     @Test
-    fun `given forceRefresh true and fetchWooCoreVersion returns null with no cached positive, when invoked, then NotLaunchable WooCommercePluginNotFound`() = testBlocking {
+    fun `given forceRefresh true and fetchWooCoreVersion returns null with no cached positive, when invoked, then NotLaunchable UnknownNoPositiveCache`() = testBlocking {
         whenever(fetchWooCoreVersion()).thenReturn(null)
         whenever(appPrefs.isPOSLaunchableForSite(eq(siteModel.id))).thenReturn(false)
 
         val result = sut(forceRefresh = true)
-        assertEquals(NotLaunchable(NonLaunchabilityReason.WooCommercePluginNotFound), result)
+        assertEquals(NotLaunchable(NonLaunchabilityReason.UnknownNoPositiveCache), result)
     }
 
     @Test

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/tab/WooPosCanBeLaunchedInTabTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/tab/WooPosCanBeLaunchedInTabTest.kt
@@ -1,5 +1,6 @@
 package com.woocommerce.android.ui.woopos.tab
 
+import com.woocommerce.android.AppPrefs
 import com.woocommerce.android.tools.SelectedSite
 import com.woocommerce.android.ui.woopos.WooPOSIsRemotelyEnabled
 import com.woocommerce.android.ui.woopos.tab.WooPosLaunchability.Launchable
@@ -11,6 +12,7 @@ import com.woocommerce.android.viewmodel.BaseUnitTest
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import org.junit.Before
 import org.mockito.kotlin.any
+import org.mockito.kotlin.eq
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.whenever
 import org.wordpress.android.fluxc.model.LocalOrRemoteId
@@ -24,6 +26,7 @@ import kotlin.test.assertEquals
 @OptIn(ExperimentalCoroutinesApi::class)
 class WooPosCanBeLaunchedInTabTest : BaseUnitTest() {
 
+    private val appPrefs: AppPrefs = mock()
     private val selectedSite: SelectedSite = mock()
     private val wooCommerceStore: WooCommerceStore = mock()
     private val isRemotelyEnabled: WooPOSIsRemotelyEnabled = mock()
@@ -31,19 +34,22 @@ class WooPosCanBeLaunchedInTabTest : BaseUnitTest() {
     private val fetchWooCoreVersion: FetchActiveWCPluginVersion = mock()
 
     private lateinit var sut: WooPosCanBeLaunchedInTab
+    private lateinit var siteModel: SiteModel
 
     @Before
     fun setup() = testBlocking {
-        val siteModel = SiteModel().also { it.id = 1 }
+        siteModel = SiteModel().also { it.id = 1 }
         whenever(selectedSite.getOrNull()).thenReturn(siteModel)
         whenever(getWooCoreVersion()).thenReturn("10.0.0")
         whenever(fetchWooCoreVersion()).thenReturn("10.0.0")
         val siteSettings = buildSiteSettings()
         whenever(wooCommerceStore.getSiteSettings(siteModel)).thenReturn(siteSettings)
         whenever(wooCommerceStore.fetchSiteGeneralSettings(siteModel)).thenReturn(WooResult(siteSettings))
-        whenever(isRemotelyEnabled.invoke(any())).thenReturn(true)
+        whenever(isRemotelyEnabled.invoke(any())).thenReturn(Result.success(true))
+        whenever(appPrefs.isPOSLaunchableForSite(eq(siteModel.id))).thenReturn(false)
 
         sut = WooPosCanBeLaunchedInTab(
+            appPrefs = appPrefs,
             selectedSite = selectedSite,
             getWooCoreCachedVersion = getWooCoreVersion,
             fetchWooCoreVersion = fetchWooCoreVersion,
@@ -68,7 +74,7 @@ class WooPosCanBeLaunchedInTabTest : BaseUnitTest() {
 
     @Test
     fun `given unsupported WooCommerce version, when invoked, then return NotLaunchable with UnsupportedWooCommerceVersion`() = testBlocking {
-        whenever(getWooCoreVersion()).thenReturn("9.5.0") // lower than 9.6.0
+        whenever(getWooCoreVersion()).thenReturn("9.5.0")
         val result = sut()
         assertEquals(NotLaunchable(NonLaunchabilityReason.UnsupportedWooCommerceVersion), result)
     }
@@ -76,17 +82,19 @@ class WooPosCanBeLaunchedInTabTest : BaseUnitTest() {
     @Test
     fun `given feature switch supported but remotely disabled, when invoked, then return NotLaunchable with FeatureSwitchDisabled`() = testBlocking {
         whenever(getWooCoreVersion()).thenReturn("10.0.0")
-        whenever(isRemotelyEnabled.invoke(any())).thenReturn(false)
+        whenever(isRemotelyEnabled.invoke(any())).thenReturn(Result.success(false))
         val result = sut()
         assertEquals(NotLaunchable(NonLaunchabilityReason.FeatureSwitchDisabled), result)
     }
 
     @Test
-    fun `given null site settings, when invoked, then return NotLaunchable with SiteSettingsUnavailable`() = testBlocking {
+    fun `given null site settings and no cached positive, when invoked, then return NotLaunchable UnknownNoPositiveCache`() = testBlocking {
         whenever(wooCommerceStore.getSiteSettings(any())).thenReturn(null)
         whenever(wooCommerceStore.fetchSiteGeneralSettings(any())).thenReturn(WooResult(null))
+        whenever(appPrefs.isPOSLaunchableForSite(eq(siteModel.id))).thenReturn(false)
+
         val result = sut()
-        assertEquals(NotLaunchable(NonLaunchabilityReason.SiteSettingsUnavailable), result)
+        assertEquals(NotLaunchable(NonLaunchabilityReason.UnknownNoPositiveCache), result)
     }
 
     @Test
@@ -156,28 +164,39 @@ class WooPosCanBeLaunchedInTabTest : BaseUnitTest() {
     }
 
     @Test
-    fun `given forceRefresh true and fetchWooCoreVersion returns null, when invoked, then return NotLaunchable with WooCommercePluginNotFound`() = testBlocking {
+    fun `given forceRefresh true and fetchWooCoreVersion returns null with no cached positive, when invoked, then NotLaunchable WooCommercePluginNotFound`() = testBlocking {
         whenever(fetchWooCoreVersion()).thenReturn(null)
+        whenever(appPrefs.isPOSLaunchableForSite(eq(siteModel.id))).thenReturn(false)
 
         val result = sut(forceRefresh = true)
         assertEquals(NotLaunchable(NonLaunchabilityReason.WooCommercePluginNotFound), result)
     }
 
     @Test
-    fun `given forceRefresh true and fetched site settings is null, when invoked, then return NotLaunchable with SiteSettingsUnavailable`() = testBlocking {
-        whenever(wooCommerceStore.fetchSiteGeneralSettings(any())).thenReturn(WooResult(null))
+    fun `given forceRefresh true and fetchWooCoreVersion returns null with cached positive, when invoked, then Launchable`() = testBlocking {
+        whenever(fetchWooCoreVersion()).thenReturn(null)
+        whenever(appPrefs.isPOSLaunchableForSite(eq(siteModel.id))).thenReturn(true)
 
         val result = sut(forceRefresh = true)
-        assertEquals(NotLaunchable(NonLaunchabilityReason.SiteSettingsUnavailable), result)
+        assertEquals(Launchable, result)
     }
 
     @Test
-    fun `given forceRefresh true and fetched site settings with unsupported currency, when invoked, then return NotLaunchable with UnsupportedCurrency`() = testBlocking {
-        val fetchedSettings = buildSiteSettings(currencyCode = "eur")
-        whenever(wooCommerceStore.fetchSiteGeneralSettings(any())).thenReturn(WooResult(fetchedSettings))
+    fun `given forceRefresh true and fetched site settings is null with no cached positive, when invoked, then NotLaunchable UnknownNoPositiveCache`() = testBlocking {
+        whenever(wooCommerceStore.fetchSiteGeneralSettings(any())).thenReturn(WooResult(null))
+        whenever(appPrefs.isPOSLaunchableForSite(eq(siteModel.id))).thenReturn(false)
 
         val result = sut(forceRefresh = true)
-        assertEquals(NotLaunchable(NonLaunchabilityReason.UnsupportedCurrency), result)
+        assertEquals(NotLaunchable(NonLaunchabilityReason.UnknownNoPositiveCache), result)
+    }
+
+    @Test
+    fun `given forceRefresh true and fetched site settings is null with cached positive, when invoked, then Launchable`() = testBlocking {
+        whenever(wooCommerceStore.fetchSiteGeneralSettings(any())).thenReturn(WooResult(null))
+        whenever(appPrefs.isPOSLaunchableForSite(eq(siteModel.id))).thenReturn(true)
+
+        val result = sut(forceRefresh = true)
+        assertEquals(Launchable, result)
     }
 
     private fun buildSiteSettings(

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/tab/WooPosTabShouldBeVisibleTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/tab/WooPosTabShouldBeVisibleTest.kt
@@ -2,6 +2,7 @@ package com.woocommerce.android.ui.woopos.tab
 
 import com.woocommerce.android.tools.SelectedSite
 import com.woocommerce.android.ui.woopos.WooPosIsScreenSizeAllowed
+import com.woocommerce.android.ui.woopos.common.util.WooPosCouldNotDetermineValueException
 import com.woocommerce.android.util.IsRemoteFeatureFlagEnabled
 import com.woocommerce.android.util.RemoteFeatureFlag.WOO_POS
 import com.woocommerce.android.viewmodel.BaseUnitTest
@@ -29,10 +30,11 @@ class WooPosTabShouldBeVisibleTest : BaseUnitTest() {
     private val isRemoteFeatureFlagEnabled: IsRemoteFeatureFlagEnabled = mock()
 
     private lateinit var sut: WooPosTabShouldBeVisible
+    private lateinit var siteModel: SiteModel
 
     @Before
     fun setup() = testBlocking {
-        val siteModel = SiteModel().also { it.id = 1 }
+        siteModel = SiteModel().also { it.id = 1 }
         whenever(selectedSite.getOrNull()).thenReturn(siteModel)
         whenever(isScreenSizeAllowed()).thenReturn(true)
         whenever(isRemoteFeatureFlagEnabled(WOO_POS)).thenReturn(true)
@@ -41,41 +43,51 @@ class WooPosTabShouldBeVisibleTest : BaseUnitTest() {
 
         sut = WooPosTabShouldBeVisible(
             selectedSite = selectedSite,
-            wooCommerceStore = wooCommerceStore,
             isScreenSizeAllowed = isScreenSizeAllowed,
+            wooCommerceStore = wooCommerceStore,
             isRemoteFeatureFlagEnabled = isRemoteFeatureFlagEnabled,
             wooPosLog = mock()
         )
     }
 
     @Test
-    fun `given feature flag enabled and supported country, when invoked, then return true`() = testBlocking {
-        assertTrue(sut())
+    fun `given feature flag enabled and supported country, when invoked, then return success true`() = testBlocking {
+        val r = sut()
+        assertTrue(r.isSuccess)
+        assertTrue(r.getOrThrow())
     }
 
     @Test
-    fun `given feature flag disabled, when invoked, then return false`() = testBlocking {
+    fun `given feature flag disabled, when invoked, then return success true (tab visible anyway)`() = testBlocking {
         whenever(isRemoteFeatureFlagEnabled(WOO_POS)).thenReturn(false)
-        assertFalse(sut())
+        val r = sut()
+        assertTrue(r.isSuccess)
+        assertTrue(r.getOrThrow())
     }
 
     @Test
-    fun `given screen size not allowed, when invoked, then return false`() = testBlocking {
+    fun `given screen size not allowed, when invoked, then return success false`() = testBlocking {
         whenever(isScreenSizeAllowed()).thenReturn(false)
-        assertFalse(sut())
+        val r = sut()
+        assertTrue(r.isSuccess)
+        assertFalse(r.getOrThrow())
     }
 
     @Test
-    fun `given null site, when invoked, then return false`() = testBlocking {
+    fun `given null site, when invoked, then return failure unknown`() = testBlocking {
         whenever(selectedSite.getOrNull()).thenReturn(null)
-        assertFalse(sut())
+        val r = sut()
+        assertTrue(r.isFailure)
+        assertTrue(r.exceptionOrNull() is WooPosCouldNotDetermineValueException)
     }
 
     @Test
-    fun `given unsupported country, when invoked, then return false`() = testBlocking {
+    fun `given unsupported country, when invoked, then return success false`() = testBlocking {
         val siteSettings = buildSiteSettings(countryCode = "ca")
         whenever(wooCommerceStore.fetchSiteGeneralSettings(any())).thenReturn(WooResult(siteSettings))
-        assertFalse(sut())
+        val r = sut()
+        assertTrue(r.isSuccess)
+        assertFalse(r.getOrThrow())
     }
 
     @Test
@@ -89,19 +101,23 @@ class WooPosTabShouldBeVisibleTest : BaseUnitTest() {
     }
 
     @Test
-    fun `given fetched settings with supported country, when invoked, then return true`() = testBlocking {
+    fun `given fetched settings with supported country, when invoked, then return success true`() = testBlocking {
         val fetchedSettings = buildSiteSettings(countryCode = "gb")
         whenever(wooCommerceStore.fetchSiteGeneralSettings(any())).thenReturn(WooResult(fetchedSettings))
 
-        assertTrue(sut())
+        val r = sut()
+        assertTrue(r.isSuccess)
+        assertTrue(r.getOrThrow())
     }
 
     @Test
-    fun `given fetched settings with unsupported country, when invoked, then return false`() = testBlocking {
+    fun `given fetched settings with unsupported country, when invoked, then return success false`() = testBlocking {
         val fetchedSettings = buildSiteSettings(countryCode = "ca")
         whenever(wooCommerceStore.fetchSiteGeneralSettings(any())).thenReturn(WooResult(fetchedSettings))
 
-        assertFalse(sut())
+        val r = sut()
+        assertTrue(r.isSuccess)
+        assertFalse(r.getOrThrow())
     }
 
     private fun buildSiteSettings(countryCode: String = "us") =

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/tab/WooPosTabShouldBeVisibleTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/tab/WooPosTabShouldBeVisibleTest.kt
@@ -58,11 +58,11 @@ class WooPosTabShouldBeVisibleTest : BaseUnitTest() {
     }
 
     @Test
-    fun `given feature flag disabled, when invoked, then return success true (tab visible anyway)`() = testBlocking {
+    fun `given feature flag disabled, when invoked, then return success false`() = testBlocking {
         whenever(isRemoteFeatureFlagEnabled(WOO_POS)).thenReturn(false)
         val r = sut()
         assertTrue(r.isSuccess)
-        assertTrue(r.getOrThrow())
+        assertFalse(r.getOrThrow())
     }
 
     @Test


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->
Closes WOOMOB-1016

Only one review required, but I add you both as reviewers in case you are interested in the solution.

<!-- Id number of the Linear issue this PR addresses, e.g., WOOMOB-373. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
With this PR we improve the logic for handling errors when opening POS, including when there is no connection. We implement this logic:

POS tab eligibility
- Positive → Show POS tab.
- Negative → Hide POS tab.
- Unknown (e.g., backend error) → Show tab using last cached value.
When entering POS tab and eligibility check errors again:
- Cached Positive → Allow access to POS.
- No Cache → Deny access and show error message.

For that we:
- Update `AppPrefs` to cache also whether POS was launchable. We also update the tab logic to only make it possible to cache positive cases.
- Update `WooPOSIsRemotelyEnabled`, `WooPosCanBeLaunchedInTab` and `WooPosTabShouldBeVisible` to return a result instead of a boolean
- Refactor `WooPosCanBeLaunchedInTab` with the new logic, including setting the value in cache.


### Steps to reproduce
<!-- Step-by-step testing instructions. For new user flows, consider instead stating the goal of the workflow and see if your PR reviewer can accomplish the workflow without specific steps! -->

With all conditions met:

- Start the app with internet connection
- Verify the POS tab is visible
- Tap on it and access POS
- Kill the app
- Turn on airplane mode
- Start the app
- Notice the POS tab is visible (before it was not)
- Tap on the tab and access POS

With the POS feature switch disabled in wp-admin:

- Start the app with internet connection
- Verify the POS tab is visible
- Go to the POS tab
- Verify that you get an error about the feature switch disabled
- Kill the app
- Turn on airplane mode
- Start the app
- Notice the POS tab is visible
- Go to the tab
- You cannot enter POS and a genetic message is shown

With a store in a country other than US or UK:

- Start the app with internet connection
- Verify the POS tab is not visible
- Kill the app
- Turn on airplane mode
- Start the app
- Notice the POS tab is not visible



### Testing information
<!-- This is your opportunity to break out individual scenarios that need testing (when necessary) and/or include a checklist for the reviewer to go through. Consider documenting the following from your own completed testing: devices used, alternate workflows, edge cases, affected areas, critical flows, areas not tested, and any remaining unknowns. Provide feedback on this new section of the PR template through Sept 30, 2024 to Apps Quality; additional context here: https://woomobilep2.wordpress.com/2024/05/06/woocommerce-mobile-quality-report-march-april/#comment-12036 -->

### The tests that have been performed
<!-- To give the reviewer an idea of what could be missed in terms of testing -->
See above

### Images/gif
<!-- Include before and after images or gifs when appropriate. -->

On this video we can see how the tab is shown in airplane mode because it was shown before, but given that we never cached whether the POS was launched, we prevent accessing it:

https://github.com/user-attachments/assets/2228bf6f-8818-4843-ad8a-2fbed57987a4

Here we show how if previously the user accessed POS, it can access it even if there's no connection:


https://github.com/user-attachments/assets/9d05d4b9-0d97-4da0-a88f-80ae6cdaa398


- [X] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
