### PR TITLE
Add GitHub warning to constraint layout dependency updates

### DIFF
--- a/.github/workflows/dependabot-constraintlayout-check.yml
+++ b/.github/workflows/dependabot-constraintlayout-check.yml
@@ -1,0 +1,67 @@
+name: Dependabot POS Reminder
+
+on:
+  pull_request:
+    types: [opened, reopened]
+
+jobs:
+  add-pos-reminder:
+    runs-on: ubuntu-latest
+    if: github.actor == 'dependabot[bot]'
+
+    steps:
+      # Check if PR contains the constraintlayout dependency
+      - name: Check for ConstraintLayout Compose dependency
+        id: check-dependency
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const title = context.payload.pull_request.title;
+            const body = context.payload.pull_request.body;
+            const searchTerm = 'androidx.constraintlayout:constraintlayout-compose';
+
+            const containsDependency =
+              title.includes(searchTerm) ||
+              body.includes(searchTerm);
+
+            console.log(`PR contains ${searchTerm}: ${containsDependency}`);
+            return containsDependency;
+          result-encoding: string
+
+      # Add comment if dependency is found
+      - name: Comment on PR
+        if: steps.check-dependency.outputs.result == 'true'
+        uses: actions/github-script@v7
+        with:
+          script: |
+            // Check if comment already exists to avoid duplicates
+            const comments = await github.rest.issues.listComments({
+              issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo
+            });
+
+            const botComment = comments.data.find(comment =>
+              comment.user.type === 'Bot' &&
+              comment.body.includes('POS testing')
+            );
+
+            if (!botComment) {
+              const commentBody = `## ⚠️ POS Testing Required
+
+              This PR updates \`androidx.constraintlayout:constraintlayout-compose\`, which affects the Point of Sale system.
+
+              **Required Testing:**
+              - [ ] Cart items remain visible during checkout
+              - [ ] Layout constraints work correctly on all screen sizes
+              - [ ] No UI elements disappear unexpectedly
+
+              Please complete POS testing before merging this PR.`;
+
+              await github.rest.issues.createComment({
+                issue_number: context.issue.number,
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                body: commentBody
+              });
+            }


### PR DESCRIPTION
This PR adds a github action that should drop a comment/warning on PRs created by dependabot that update the constraintlayout-compose dependency. We found out that the new version breaks the POS, specifically the items in the cart start disappearing during screen transitions. 

The code was vibe coded and hasn't been tested. I've checked it and it looks fine.

I noticed it uses github-script@v7 while we use v4 in the other scripts - not sure if that's fine or not, but according to Claude v7 should be more secure.

Let me know what you think, thanks!