### PR TITLE
[Shipping Labels] Improvements to the Customs Form screen

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/AppUrls.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/AppUrls.kt
@@ -60,7 +60,7 @@ object AppUrls {
         "https://woocommerce.com/posts/a-guide-to-woocommerce-user-roles-permissions-and-security/"
     const val SHIPPING_LABEL_CUSTOMS_ITN = "https://pe.usps.com/text/imm/immc5_010.htm"
     const val SHIPPING_LABEL_CUSTOMS_HS_TARIFF_NUMBER =
-        "https://woocommerce.com/document/woocommerce-shipping-and-tax/woocommerce-shipping/#section-29"
+        "https://woocommerce.com/document/woocommerce-shipping-and-tax/woocommerce-shipping/#section-35"
 
     const val WPCOM_ADD_PAYMENT_METHOD = "https://wordpress.com/me/purchases/add-payment-method"
     const val FETCH_PAYMENT_METHOD_URL_PATH = "me/payment-methods"

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/compose/component/WCOutlinedSpinner.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/compose/component/WCOutlinedSpinner.kt
@@ -6,8 +6,10 @@ import androidx.compose.foundation.focusable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.IntrinsicSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
 import androidx.compose.material.Icon
 import androidx.compose.material.MaterialTheme
 import androidx.compose.material.OutlinedTextField
@@ -37,7 +39,7 @@ fun WCOutlinedSpinner(
     helperText: String? = null,
     enabled: Boolean = true
 ) {
-    Column(modifier = modifier) {
+    Column(modifier = modifier.width(IntrinsicSize.Max)) {
         Box {
             OutlinedTextField(
                 value = value,
@@ -50,7 +52,8 @@ fun WCOutlinedSpinner(
                     Icon(painter = painterResource(id = R.drawable.ic_arrow_drop_down), contentDescription = null)
                 },
                 enabled = enabled,
-                modifier = modifier
+                modifier = Modifier
+                    .fillMaxWidth()
                     .focusable(false)
             )
             // Capture and consume click events, this makes the text field non-focusable too.

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/components/RoundedBorderDropdownWithLabel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/components/RoundedBorderDropdownWithLabel.kt
@@ -2,10 +2,14 @@ package com.woocommerce.android.ui.orders.wooshippinglabels.components
 
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.IntrinsicSize
 import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.RowScope
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.ArrowDropDown
 import androidx.compose.material3.Icon
@@ -26,14 +30,23 @@ fun RoundedBorderDropDownWithLabel(
     text: String,
     onClick: () -> Unit,
     modifier: Modifier = Modifier,
+    icon: @Composable (RowScope.() -> Unit)? = null
 ) {
-    Column(modifier = modifier) {
-        Text(
-            text = label,
-            style = MaterialTheme.typography.bodyMedium,
-            color = colorResource(id = R.color.color_on_surface),
-            modifier = Modifier.padding(vertical = 8.dp)
-        )
+    Column(modifier = modifier.width(IntrinsicSize.Max)) {
+        Row(
+            verticalAlignment = Alignment.CenterVertically,
+            horizontalArrangement = Arrangement.SpaceBetween,
+            modifier = Modifier.fillMaxWidth()
+        ) {
+            Text(
+                text = label,
+                style = MaterialTheme.typography.bodyMedium,
+                color = colorResource(id = R.color.color_on_surface),
+                modifier = Modifier.padding(vertical = 8.dp)
+            )
+
+            icon?.invoke(this)
+        }
         RoundedCornerBoxWithBorder(innerModifier = Modifier.clickable { onClick() }) {
             Row(
                 modifier = Modifier
@@ -68,7 +81,8 @@ private fun RoundedBorderDropDownWithLabelPreview() {
         RoundedBorderDropDownWithLabel(
             label = "Label",
             text = "Text",
-            onClick = {}
+            onClick = {},
+            modifier = Modifier.fillMaxWidth()
         )
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/customs/WooShippingCustomsFormFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/customs/WooShippingCustomsFormFragment.kt
@@ -5,7 +5,9 @@ import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import androidx.compose.material.Surface
+import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.ui.platform.ComposeView
+import androidx.compose.ui.platform.LocalUriHandler
 import androidx.compose.ui.platform.ViewCompositionStrategy.DisposeOnViewTreeLifecycleDestroyed
 import androidx.fragment.app.viewModels
 import androidx.navigation.fragment.findNavController
@@ -22,11 +24,19 @@ import com.woocommerce.android.ui.orders.wooshippinglabels.customs.WooShippingCu
 import com.woocommerce.android.ui.orders.wooshippinglabels.customs.WooShippingCustomsFormViewModel.ShowCountrySelector
 import com.woocommerce.android.ui.orders.wooshippinglabels.customs.WooShippingCustomsFormViewModel.ShowRestrictionTypeDialog
 import com.woocommerce.android.ui.searchfilter.SearchFilterItem
+import com.woocommerce.android.util.ChromeCustomTabUtils
 import dagger.hilt.android.AndroidEntryPoint
 
 @AndroidEntryPoint
 class WooShippingCustomsFormFragment : BaseFragment() {
     private val viewModel: WooShippingCustomsFormViewModel by viewModels()
+    private val chromeTabUriHandler by lazy {
+        object : androidx.compose.ui.platform.UriHandler {
+            override fun openUri(uri: String) {
+                ChromeCustomTabUtils.launchUrl(requireContext(), uri)
+            }
+        }
+    }
 
     override fun getFragmentTitle() = getString(R.string.shipping_label_create_customs)
 
@@ -34,9 +44,11 @@ class WooShippingCustomsFormFragment : BaseFragment() {
         return ComposeView(requireContext()).apply {
             setViewCompositionStrategy(DisposeOnViewTreeLifecycleDestroyed)
             setContent {
-                WooThemeWithBackground {
-                    Surface {
-                        WooShippingCustomsFormScreen(viewModel = viewModel)
+                CompositionLocalProvider(LocalUriHandler provides chromeTabUriHandler) {
+                    WooThemeWithBackground {
+                        Surface {
+                            WooShippingCustomsFormScreen(viewModel = viewModel)
+                        }
                     }
                 }
             }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/customs/WooShippingCustomsFormScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/customs/WooShippingCustomsFormScreen.kt
@@ -104,7 +104,7 @@ fun WooShippingCustomsFormScreen(
             .padding(16.dp)
     ) {
         Column(
-            modifier = modifier
+            modifier = Modifier
                 .weight(1f)
                 .verticalScroll(rememberScrollState()),
             verticalArrangement = Arrangement.spacedBy(16.dp)
@@ -113,7 +113,8 @@ fun WooShippingCustomsFormScreen(
                 onClick = onContentTypeClick,
                 value = stringResource(id = contentType.resourceId),
                 label = stringResource(id = R.string.woo_shipping_labels_customs_content_type_label),
-                modifier = modifier.fillMaxWidth()
+                modifier = Modifier
+                    .fillMaxWidth()
             )
 
             AnimatedVisibility(shouldDisplayContentTypeInput) {
@@ -124,7 +125,7 @@ fun WooShippingCustomsFormScreen(
                     singleLine = true,
                     isError = otherContentDetailsInput is InputValue.Error,
                     keyboardOptions = KeyboardOptions(imeAction = ImeAction.Next),
-                    modifier = modifier.fillMaxWidth(),
+                    modifier = Modifier.fillMaxWidth(),
                     helperText = otherContentDetailsInput.errorMessageOrNull?.getText()
                         ?: stringResource(R.string.woo_shipping_labels_customs_content_details_description)
                 )
@@ -134,7 +135,8 @@ fun WooShippingCustomsFormScreen(
                 onClick = onRestrictionTypeClick,
                 value = stringResource(id = restrictionType.resourceId),
                 label = stringResource(id = R.string.woo_shipping_labels_customs_restriction_type_label),
-                modifier = modifier.fillMaxWidth()
+                modifier = Modifier
+                    .fillMaxWidth()
             )
 
             AnimatedVisibility(shouldDisplayRestrictionTypeInput) {
@@ -145,7 +147,7 @@ fun WooShippingCustomsFormScreen(
                     singleLine = true,
                     isError = otherRestrictionDetailsInput is InputValue.Error,
                     keyboardOptions = KeyboardOptions(imeAction = ImeAction.Next),
-                    modifier = modifier.fillMaxWidth(),
+                    modifier = Modifier.fillMaxWidth(),
                     helperText = otherRestrictionDetailsInput.errorMessageOrNull?.getText()
                         ?: stringResource(R.string.woo_shipping_labels_customs_restriction_details_description)
                 )
@@ -158,18 +160,19 @@ fun WooShippingCustomsFormScreen(
                 singleLine = true,
                 isError = itnValue is InputValue.Error,
                 keyboardOptions = KeyboardOptions(imeAction = ImeAction.Next),
-                modifier = modifier.fillMaxWidth(),
+                modifier = Modifier
+                    .fillMaxWidth(),
                 helperText = itnValue.errorMessageOrNull?.getText()
             )
 
             Row(
                 horizontalArrangement = Arrangement.Absolute.SpaceBetween,
-                modifier = modifier.fillMaxWidth()
+                modifier = Modifier.fillMaxWidth()
             ) {
                 Text(
                     text = stringResource(id = R.string.woo_shipping_labels_customs_return_to_sender_label),
                     color = colorResource(id = R.color.color_on_surface),
-                    modifier = modifier
+                    modifier = Modifier
                         .align(Alignment.CenterVertically)
                         .weight(1f)
                 )
@@ -191,7 +194,7 @@ fun WooShippingCustomsFormScreen(
 
             shippingProducts.forEachIndexed { index, product ->
                 WooShippingCustomsProductListItem(
-                    modifier = modifier.fillMaxWidth(),
+                    modifier = Modifier.fillMaxWidth(),
                     itemData = product,
                     currencySymbol = currencySymbol,
                     weightUnit = weightUnit,
@@ -205,7 +208,7 @@ fun WooShippingCustomsFormScreen(
             }
         }
         WCColoredButton(
-            modifier = modifier.fillMaxWidth(),
+            modifier = Modifier.fillMaxWidth(),
             enabled = isAddCustomsButtonEnabled,
             onClick = onAddCustomsDataClick,
             text = stringResource(id = R.string.woo_shipping_labels_customs_add_missing_information)

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/customs/WooShippingCustomsFormScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/customs/WooShippingCustomsFormScreen.kt
@@ -4,14 +4,20 @@ import android.content.res.Configuration.UI_MODE_NIGHT_YES
 import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.Surface
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.outlined.Info
+import androidx.compose.material3.ButtonDefaults
 import androidx.compose.material3.Checkbox
 import androidx.compose.material3.CheckboxDefaults
 import androidx.compose.material3.MaterialTheme
@@ -21,15 +27,18 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.livedata.observeAsState
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalUriHandler
 import androidx.compose.ui.res.colorResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.input.ImeAction
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
+import com.woocommerce.android.AppUrls
 import com.woocommerce.android.R
 import com.woocommerce.android.ui.compose.component.WCColoredButton
 import com.woocommerce.android.ui.compose.component.WCOutlinedSpinner
 import com.woocommerce.android.ui.compose.component.WCOutlinedTextField
+import com.woocommerce.android.ui.compose.component.WCTextButton
 import com.woocommerce.android.ui.compose.component.getText
 import com.woocommerce.android.ui.compose.theme.WooThemeWithBackground
 import com.woocommerce.android.ui.orders.wooshippinglabels.customs.WooShippingCustomsFormViewModel.InputValue
@@ -106,8 +115,7 @@ fun WooShippingCustomsFormScreen(
         Column(
             modifier = Modifier
                 .weight(1f)
-                .verticalScroll(rememberScrollState()),
-            verticalArrangement = Arrangement.spacedBy(16.dp)
+                .verticalScroll(rememberScrollState())
         ) {
             WCOutlinedSpinner(
                 onClick = onContentTypeClick,
@@ -117,18 +125,24 @@ fun WooShippingCustomsFormScreen(
                     .fillMaxWidth()
             )
 
+            Spacer(Modifier.height(16.dp))
+
             AnimatedVisibility(shouldDisplayContentTypeInput) {
-                WCOutlinedTextField(
-                    value = otherContentDetailsInput.currentInput,
-                    onValueChange = onOtherContentDetailsInputChanged,
-                    label = stringResource(id = R.string.woo_shipping_labels_customs_content_details_label),
-                    singleLine = true,
-                    isError = otherContentDetailsInput is InputValue.Error,
-                    keyboardOptions = KeyboardOptions(imeAction = ImeAction.Next),
-                    modifier = Modifier.fillMaxWidth(),
-                    helperText = otherContentDetailsInput.errorMessageOrNull?.getText()
-                        ?: stringResource(R.string.woo_shipping_labels_customs_content_details_description)
-                )
+                Column {
+                    WCOutlinedTextField(
+                        value = otherContentDetailsInput.currentInput,
+                        onValueChange = onOtherContentDetailsInputChanged,
+                        label = stringResource(id = R.string.woo_shipping_labels_customs_content_details_label),
+                        singleLine = true,
+                        isError = otherContentDetailsInput is InputValue.Error,
+                        keyboardOptions = KeyboardOptions(imeAction = ImeAction.Next),
+                        modifier = Modifier
+                            .fillMaxWidth(),
+                        helperText = otherContentDetailsInput.errorMessageOrNull?.getText()
+                            ?: stringResource(R.string.woo_shipping_labels_customs_content_details_description)
+                    )
+                    Spacer(Modifier.height(16.dp))
+                }
             }
 
             WCOutlinedSpinner(
@@ -139,18 +153,25 @@ fun WooShippingCustomsFormScreen(
                     .fillMaxWidth()
             )
 
+            Spacer(Modifier.height(16.dp))
+
             AnimatedVisibility(shouldDisplayRestrictionTypeInput) {
-                WCOutlinedTextField(
-                    value = otherRestrictionDetailsInput.currentInput,
-                    onValueChange = onOtherRestrictionDetailsInputChanged,
-                    label = stringResource(id = R.string.woo_shipping_labels_customs_restriction_details_label),
-                    singleLine = true,
-                    isError = otherRestrictionDetailsInput is InputValue.Error,
-                    keyboardOptions = KeyboardOptions(imeAction = ImeAction.Next),
-                    modifier = Modifier.fillMaxWidth(),
-                    helperText = otherRestrictionDetailsInput.errorMessageOrNull?.getText()
-                        ?: stringResource(R.string.woo_shipping_labels_customs_restriction_details_description)
-                )
+                Column {
+                    WCOutlinedTextField(
+                        value = otherRestrictionDetailsInput.currentInput,
+                        onValueChange = onOtherRestrictionDetailsInputChanged,
+                        label = stringResource(id = R.string.woo_shipping_labels_customs_restriction_details_label),
+                        singleLine = true,
+                        isError = otherRestrictionDetailsInput is InputValue.Error,
+                        keyboardOptions = KeyboardOptions(imeAction = ImeAction.Next),
+                        modifier = Modifier
+                            .fillMaxWidth(),
+                        helperText = otherRestrictionDetailsInput.errorMessageOrNull?.getText()
+                            ?: stringResource(R.string.woo_shipping_labels_customs_restriction_details_description)
+                    )
+
+                    Spacer(Modifier.height(16.dp))
+                }
             }
 
             WCOutlinedTextField(
@@ -165,14 +186,28 @@ fun WooShippingCustomsFormScreen(
                 helperText = itnValue.errorMessageOrNull?.getText()
             )
 
+            val uriHandler = LocalUriHandler.current
+            WCTextButton(
+                text = stringResource(id = R.string.woo_shipping_labels_customs_itn_info_button),
+                onClick = { uriHandler.openUri(AppUrls.SHIPPING_LABEL_CUSTOMS_ITN) },
+                icon = Icons.Outlined.Info,
+                allCaps = false,
+                contentPadding = PaddingValues(
+                    horizontal = 4.dp,
+                    vertical = ButtonDefaults.TextButtonContentPadding.calculateTopPadding()
+                )
+            )
+
+            Spacer(Modifier.height(16.dp))
+
             Row(
                 horizontalArrangement = Arrangement.Absolute.SpaceBetween,
-                modifier = Modifier.fillMaxWidth()
+                modifier = modifier.fillMaxWidth()
             ) {
                 Text(
                     text = stringResource(id = R.string.woo_shipping_labels_customs_return_to_sender_label),
                     color = colorResource(id = R.color.color_on_surface),
-                    modifier = Modifier
+                    modifier = modifier
                         .align(Alignment.CenterVertically)
                         .weight(1f)
                 )
@@ -186,15 +221,19 @@ fun WooShippingCustomsFormScreen(
                 )
             }
 
+            Spacer(Modifier.height(16.dp))
+
             Text(
                 text = stringResource(R.string.woo_shipping_labels_customs_product_details_title),
                 color = colorResource(id = R.color.color_on_surface),
                 style = MaterialTheme.typography.titleMedium
             )
 
+            Spacer(Modifier.height(16.dp))
+
             shippingProducts.forEachIndexed { index, product ->
                 WooShippingCustomsProductListItem(
-                    modifier = Modifier.fillMaxWidth(),
+                    modifier = modifier.fillMaxWidth(),
                     itemData = product,
                     currencySymbol = currencySymbol,
                     weightUnit = weightUnit,
@@ -205,10 +244,12 @@ fun WooShippingCustomsFormScreen(
                     onWeightPerUnitChanged = { onWeightPerUnitChanged(index, it) },
                     onCountrySelectorClick = { onCountrySelectorClick(index) }
                 )
+                Spacer(Modifier.height(16.dp))
             }
         }
+
         WCColoredButton(
-            modifier = Modifier.fillMaxWidth(),
+            modifier = modifier.fillMaxWidth(),
             enabled = isAddCustomsButtonEnabled,
             onClick = onAddCustomsDataClick,
             text = stringResource(id = R.string.woo_shipping_labels_customs_add_missing_information)

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/customs/products/WooShippingCustomsProductListItem.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/customs/products/WooShippingCustomsProductListItem.kt
@@ -288,13 +288,10 @@ fun WooShippingCustomsProductExpandedListItem(
 
             Spacer(Modifier.height(16.dp))
 
-            RoundedBorderDropDownWithLabel(
-                label = stringResource(id = R.string.woo_shipping_labels_customs_product_details_origin_country),
+            OriginCountrySelector(
+                value = itemData.originCountry,
                 onClick = onCountrySelectorClick,
-                modifier = Modifier.fillMaxWidth(),
-                text = itemData.originCountry
-                    .takeIf { it.isNotBlank() }
-                    ?: stringResource(R.string.woo_shipping_labels_customs_product_details_origin_country_selection)
+                modifier = Modifier.fillMaxWidth()
             )
         }
     }
@@ -349,6 +346,55 @@ private fun DescriptionField(
                 )
             },
             dismissButton = {
+                WCTextButton(
+                    text = stringResource(id = android.R.string.ok),
+                    onClick = { isDialogOpen = false }
+                )
+            },
+            onDismissRequest = { isDialogOpen = false }
+        )
+    }
+}
+
+@Composable
+private fun OriginCountrySelector(
+    value: String,
+    onClick: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    var isDialogOpen by rememberSaveable { mutableStateOf(false) }
+
+    RoundedBorderDropDownWithLabel(
+        label = stringResource(id = R.string.woo_shipping_labels_customs_product_details_origin_country),
+        onClick = onClick,
+        text = value
+            .takeIf { it.isNotBlank() }
+            ?: stringResource(R.string.woo_shipping_labels_customs_product_details_origin_country_selection),
+        icon = {
+            IconButton(
+                onClick = { isDialogOpen = true }
+            ) {
+                Icon(
+                    imageVector = Icons.Outlined.Info,
+                    tint = MaterialTheme.colors.primary,
+                    contentDescription = stringResource(R.string.woo_shipping_labels_customs_origin_country_info_button)
+                )
+            }
+        },
+        modifier = modifier
+    )
+
+    if (isDialogOpen) {
+        AlertDialog(
+            title = {
+                Text(text = stringResource(id = R.string.woo_shipping_labels_customs_product_details_origin_country))
+            },
+            text = {
+                Text(
+                    text = stringResource(id = R.string.woo_shipping_labels_customs_origin_country_info)
+                )
+            },
+            confirmButton = {
                 WCTextButton(
                     text = stringResource(id = android.R.string.ok),
                     onClick = { isDialogOpen = false }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/customs/products/WooShippingCustomsProductListItem.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/customs/products/WooShippingCustomsProductListItem.kt
@@ -9,9 +9,11 @@ import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.shape.RoundedCornerShape
@@ -19,6 +21,8 @@ import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.material.MaterialTheme
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.outlined.Error
+import androidx.compose.material.icons.outlined.Info
+import androidx.compose.material3.ButtonDefaults
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
 import androidx.compose.material3.Text
@@ -26,6 +30,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.rotate
+import androidx.compose.ui.platform.LocalUriHandler
 import androidx.compose.ui.res.colorResource
 import androidx.compose.ui.res.dimensionResource
 import androidx.compose.ui.res.painterResource
@@ -35,8 +40,10 @@ import androidx.compose.ui.text.input.ImeAction
 import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
+import com.woocommerce.android.AppUrls
 import com.woocommerce.android.R
 import com.woocommerce.android.ui.compose.component.WCOutlinedTextField
+import com.woocommerce.android.ui.compose.component.WCTextButton
 import com.woocommerce.android.ui.compose.component.getText
 import com.woocommerce.android.ui.compose.theme.WooThemeWithBackground
 import com.woocommerce.android.ui.orders.wooshippinglabels.components.RoundedBorderDropDownWithLabel
@@ -194,7 +201,7 @@ fun WooShippingCustomsProductExpandedListItem(
     Column(modifier = modifier.fillMaxWidth()) {
         HorizontalDivider(Modifier.padding(vertical = 8.dp))
 
-        Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
+        Column {
             WCOutlinedTextField(
                 value = itemData.description.currentInput,
                 onValueChange = onDescriptionChanged,
@@ -205,6 +212,8 @@ fun WooShippingCustomsProductExpandedListItem(
                 modifier = Modifier.fillMaxWidth(),
                 helperText = itemData.description.errorMessageOrNull?.getText()
             )
+
+            Spacer(Modifier.height(16.dp))
 
             WCOutlinedTextField(
                 value = itemData.tariffNumber.currentInput,
@@ -219,6 +228,20 @@ fun WooShippingCustomsProductExpandedListItem(
                 modifier = Modifier.fillMaxWidth(),
                 helperText = itemData.tariffNumber.errorMessageOrNull?.getText()
             )
+
+            val uriHandler = LocalUriHandler.current
+            WCTextButton(
+                text = stringResource(id = R.string.woo_shipping_labels_customs_hs_tariff_info_button),
+                onClick = { uriHandler.openUri(AppUrls.SHIPPING_LABEL_CUSTOMS_HS_TARIFF_NUMBER) },
+                icon = Icons.Outlined.Info,
+                allCaps = false,
+                contentPadding = PaddingValues(
+                    horizontal = 4.dp,
+                    vertical = ButtonDefaults.TextButtonContentPadding.calculateTopPadding()
+                )
+            )
+
+            Spacer(Modifier.height(16.dp))
 
             Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
                 WCOutlinedTextField(
@@ -260,6 +283,8 @@ fun WooShippingCustomsProductExpandedListItem(
                     helperText = itemData.weightPerUnit.errorMessageOrNull?.getText()
                 )
             }
+
+            Spacer(Modifier.height(16.dp))
 
             RoundedBorderDropDownWithLabel(
                 label = stringResource(id = R.string.woo_shipping_labels_customs_product_details_origin_country),

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/customs/products/WooShippingCustomsProductListItem.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/customs/products/WooShippingCustomsProductListItem.kt
@@ -192,7 +192,7 @@ fun WooShippingCustomsProductExpandedListItem(
     onCountrySelectorClick: () -> Unit
 ) {
     Column(modifier = modifier.fillMaxWidth()) {
-        HorizontalDivider(modifier.padding(vertical = 8.dp))
+        HorizontalDivider(Modifier.padding(vertical = 8.dp))
 
         Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
             WCOutlinedTextField(
@@ -202,7 +202,7 @@ fun WooShippingCustomsProductExpandedListItem(
                 singleLine = true,
                 isError = itemData.description is InputValue.Error,
                 keyboardOptions = KeyboardOptions(imeAction = ImeAction.Next),
-                modifier = modifier.fillMaxWidth(),
+                modifier = Modifier.fillMaxWidth(),
                 helperText = itemData.description.errorMessageOrNull?.getText()
             )
 
@@ -216,7 +216,7 @@ fun WooShippingCustomsProductExpandedListItem(
                     imeAction = ImeAction.Next,
                     keyboardType = KeyboardType.Number
                 ),
-                modifier = modifier.fillMaxWidth(),
+                modifier = Modifier.fillMaxWidth(),
                 helperText = itemData.tariffNumber.errorMessageOrNull?.getText()
             )
 
@@ -238,7 +238,7 @@ fun WooShippingCustomsProductExpandedListItem(
                         imeAction = ImeAction.Next,
                         keyboardType = KeyboardType.Number
                     ),
-                    modifier = modifier.weight(1f),
+                    modifier = Modifier.weight(1f),
                     helperText = itemData.valuePerUnit.errorMessageOrNull?.getText()
                 )
 
@@ -256,7 +256,7 @@ fun WooShippingCustomsProductExpandedListItem(
                     singleLine = true,
                     isError = itemData.weightPerUnit is InputValue.Error,
                     keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Number, imeAction = ImeAction.Next),
-                    modifier = modifier.weight(1f),
+                    modifier = Modifier.weight(1f),
                     helperText = itemData.weightPerUnit.errorMessageOrNull?.getText()
                 )
             }
@@ -264,7 +264,7 @@ fun WooShippingCustomsProductExpandedListItem(
             RoundedBorderDropDownWithLabel(
                 label = stringResource(id = R.string.woo_shipping_labels_customs_product_details_origin_country),
                 onClick = onCountrySelectorClick,
-                modifier = modifier.fillMaxWidth(),
+                modifier = Modifier.fillMaxWidth(),
                 text = itemData.originCountry
                     .takeIf { it.isNotBlank() }
                     ?: stringResource(R.string.woo_shipping_labels_customs_product_details_origin_country_selection)

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/customs/products/WooShippingCustomsProductListItem.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/customs/products/WooShippingCustomsProductListItem.kt
@@ -22,11 +22,17 @@ import androidx.compose.material.MaterialTheme
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.outlined.Error
 import androidx.compose.material.icons.outlined.Info
+import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.ButtonDefaults
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.saveable.rememberSaveable
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.rotate
@@ -42,6 +48,7 @@ import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import com.woocommerce.android.AppUrls
 import com.woocommerce.android.R
+import com.woocommerce.android.model.UiString
 import com.woocommerce.android.ui.compose.component.WCOutlinedTextField
 import com.woocommerce.android.ui.compose.component.WCTextButton
 import com.woocommerce.android.ui.compose.component.getText
@@ -202,15 +209,10 @@ fun WooShippingCustomsProductExpandedListItem(
         HorizontalDivider(Modifier.padding(vertical = 8.dp))
 
         Column {
-            WCOutlinedTextField(
-                value = itemData.description.currentInput,
+            DescriptionField(
+                value = itemData.description,
                 onValueChange = onDescriptionChanged,
-                label = stringResource(id = R.string.woo_shipping_labels_customs_product_details_description),
-                singleLine = true,
-                isError = itemData.description is InputValue.Error,
-                keyboardOptions = KeyboardOptions(imeAction = ImeAction.Next),
-                modifier = Modifier.fillMaxWidth(),
-                helperText = itemData.description.errorMessageOrNull?.getText()
+                modifier = Modifier.fillMaxWidth()
             )
 
             Spacer(Modifier.height(16.dp))
@@ -295,6 +297,65 @@ fun WooShippingCustomsProductExpandedListItem(
                     ?: stringResource(R.string.woo_shipping_labels_customs_product_details_origin_country_selection)
             )
         }
+    }
+}
+
+@Composable
+private fun DescriptionField(
+    value: InputValue,
+    onValueChange: (String) -> Unit,
+    modifier: Modifier = Modifier
+) {
+    var isDialogOpen by rememberSaveable { mutableStateOf(false) }
+    val localUriHandler = LocalUriHandler.current
+
+    WCOutlinedTextField(
+        value = value.currentInput,
+        onValueChange = onValueChange,
+        label = stringResource(id = R.string.woo_shipping_labels_customs_product_details_description),
+        singleLine = true,
+        isError = value is InputValue.Error,
+        keyboardOptions = KeyboardOptions(imeAction = ImeAction.Next),
+        helperText = value.errorMessageOrNull?.getText(),
+        trailingIcon = {
+            IconButton(onClick = { isDialogOpen = true }) {
+                Icon(
+                    imageVector = Icons.Outlined.Info,
+                    tint = MaterialTheme.colors.primary,
+                    contentDescription = stringResource(R.string.woo_shipping_labels_customs_description_info_button)
+                )
+            }
+        },
+        modifier = modifier
+    )
+
+    if (isDialogOpen) {
+        AlertDialog(
+            title = {
+                Text(text = stringResource(id = R.string.woo_shipping_labels_customs_product_details_description))
+            },
+            text = {
+                Text(
+                    text = stringResource(id = R.string.woo_shipping_labels_customs_description_info)
+                )
+            },
+            confirmButton = {
+                WCTextButton(
+                    text = stringResource(id = R.string.learn_more),
+                    onClick = {
+                        isDialogOpen = false
+                        localUriHandler.openUri(AppUrls.EU_SHIPPING_CUSTOMS_REQUIREMENTS)
+                    }
+                )
+            },
+            dismissButton = {
+                WCTextButton(
+                    text = stringResource(id = android.R.string.ok),
+                    onClick = { isDialogOpen = false }
+                )
+            },
+            onDismissRequest = { isDialogOpen = false }
+        )
     }
 }
 
@@ -407,8 +468,8 @@ fun WooShippingCustomsProductListExpandedItemErrorPreview() {
                 itemData = WooShippingCustomsProductUIModel(
                     productId = 0,
                     name = "Little Nap Brazil 250g",
-                    description = InputValue.Error("Coffee Beans", 0),
-                    tariffNumber = InputValue.Error("HS 14-1", 0),
+                    description = InputValue.Error("Coffee Beans", UiString.UiStringText("Error")),
+                    tariffNumber = InputValue.Error("HS 14-1", UiString.UiStringText("Error")),
                     valuePerUnit = InputValue.Data("20.00"),
                     weightPerUnit = InputValue.Data("0.3"),
                     originCountry = "Japan",

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -4676,6 +4676,7 @@
     <string name="woo_shipping_labels_customs_product_details_origin_country_missing">Missing country</string>
     <string name="woo_shipping_labels_customs_product_details_origin_country_selection">Select a country</string>
     <string name="woo_shipping_labels_customs_itn_info_button">More info about ITN</string>
+    <string name="woo_shipping_labels_customs_hs_tariff_info_button">More info about HS tariff</string>
     <string name="woo_shipping_labels_hazmat_info_title">Are you shipping dangerous goods or hazardous materials?</string>
     <string name="woo_shipping_labels_hazmat_info_contains_hazmat">Contains hazardous materials</string>
     <string name="woo_shipping_labels_hazmat_info_full_description">Potentially hazardous material includes items such as batteries, dry ice, flammable liquids, aerosols, ammunition, fireworks, nail polish, perfume, paint, solvents, and more. Hazardous items must ship in separate packages.</string>

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -4677,6 +4677,8 @@
     <string name="woo_shipping_labels_customs_product_details_origin_country_selection">Select a country</string>
     <string name="woo_shipping_labels_customs_itn_info_button">More info about ITN</string>
     <string name="woo_shipping_labels_customs_hs_tariff_info_button">More info about HS tariff</string>
+    <string name="woo_shipping_labels_customs_description_info_button">More info about product description</string>
+    <string name="woo_shipping_labels_customs_description_info">When shipping to countries that follow European Union (EU) customs rules, you must provide a clear, specific description of every item. Otherwise, shipments may be delayed or interrupted at customs.</string>
     <string name="woo_shipping_labels_hazmat_info_title">Are you shipping dangerous goods or hazardous materials?</string>
     <string name="woo_shipping_labels_hazmat_info_contains_hazmat">Contains hazardous materials</string>
     <string name="woo_shipping_labels_hazmat_info_full_description">Potentially hazardous material includes items such as batteries, dry ice, flammable liquids, aerosols, ammunition, fireworks, nail polish, perfume, paint, solvents, and more. Hazardous items must ship in separate packages.</string>

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -4678,7 +4678,7 @@
     <string name="woo_shipping_labels_customs_itn_info_button">More info about ITN</string>
     <string name="woo_shipping_labels_customs_hs_tariff_info_button">More info about HS tariff</string>
     <string name="woo_shipping_labels_customs_description_info_button">More info about product description</string>
-    <string name="woo_shipping_labels_customs_description_info">When shipping to countries that follow European Union (EU) customs rules, you must provide a clear, specific description of every item. Otherwise, shipments may be delayed or interrupted at customs.</string>
+    <string name="woo_shipping_labels_customs_description_info">When shipping to countries that follow European Union (EU) customs rules, you must provide a clear, specific description on every item. For example, if you are sending clothing, you must indicate what type of clothing (e.g. men\'s shirts, girl\'s vest, boy\'s jacket) for the description to be acceptable. Otherwise, shipments may be delayed or interrupted at customs.</string>
     <string name="woo_shipping_labels_customs_origin_country_info_button">More info about product origin country</string>
     <string name="woo_shipping_labels_customs_origin_country_info">Country where the product was manufactured or assembled.</string>
     <string name="woo_shipping_labels_hazmat_info_title">Are you shipping dangerous goods or hazardous materials?</string>

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -4675,6 +4675,7 @@
     <string name="woo_shipping_labels_customs_product_details_origin_country">Origin country</string>
     <string name="woo_shipping_labels_customs_product_details_origin_country_missing">Missing country</string>
     <string name="woo_shipping_labels_customs_product_details_origin_country_selection">Select a country</string>
+    <string name="woo_shipping_labels_customs_itn_info_button">More info about ITN</string>
     <string name="woo_shipping_labels_hazmat_info_title">Are you shipping dangerous goods or hazardous materials?</string>
     <string name="woo_shipping_labels_hazmat_info_contains_hazmat">Contains hazardous materials</string>
     <string name="woo_shipping_labels_hazmat_info_full_description">Potentially hazardous material includes items such as batteries, dry ice, flammable liquids, aerosols, ammunition, fireworks, nail polish, perfume, paint, solvents, and more. Hazardous items must ship in separate packages.</string>

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -4679,6 +4679,8 @@
     <string name="woo_shipping_labels_customs_hs_tariff_info_button">More info about HS tariff</string>
     <string name="woo_shipping_labels_customs_description_info_button">More info about product description</string>
     <string name="woo_shipping_labels_customs_description_info">When shipping to countries that follow European Union (EU) customs rules, you must provide a clear, specific description of every item. Otherwise, shipments may be delayed or interrupted at customs.</string>
+    <string name="woo_shipping_labels_customs_origin_country_info_button">More info about product origin country</string>
+    <string name="woo_shipping_labels_customs_origin_country_info">Country where the product was manufactured or assembled.</string>
     <string name="woo_shipping_labels_hazmat_info_title">Are you shipping dangerous goods or hazardous materials?</string>
     <string name="woo_shipping_labels_hazmat_info_contains_hazmat">Contains hazardous materials</string>
     <string name="woo_shipping_labels_hazmat_info_full_description">Potentially hazardous material includes items such as batteries, dry ice, flammable liquids, aerosols, ammunition, fireworks, nail polish, perfume, paint, solvents, and more. Hazardous items must ship in separate packages.</string>


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

<!-- Id number of the Linear issue this PR addresses, e.g., WOOMOB-373. -->
Closes WOOMOB-878

### Description
This PR adds the following improvements to the Customs Form screen:
1. Add an info button to the ITN field that opens the official guidelines.
2. Add an info button the HS tariff field that opens the official guidelines.
3. Add an info button to the description field that shows a dialog with more information.
4. Add an info button to the origin country field that shows a dialog with more information.

> [!NOTE]
> For the description field, as we are using the material outlined text field, showing the info button next to the label like what we have in Figma and what iOS does is not possible, I instead opted to have it inlined in the end, let me know what you think. 

### Steps to reproduce
1. Open an international order.
2. Open shipping labels creation form.
3. Open the customs form.

### Testing information
- Confirm all the info buttons work as expected.

### The tests that have been performed
The above.

### Images/gif
| Before | After |
| --- | --- |
| <img width="1080" height="2400" alt="Screenshot_20250815_183954" src="https://github.com/user-attachments/assets/10b40549-6f30-4f90-89ce-eed86bab773d" /> | <img width="1080" height="2400" alt="Screenshot_20250815_183413" src="https://github.com/user-attachments/assets/45c0483c-cd5e-4cb8-9c97-46bd548b3460" /> |
| <img width="1080" height="2400" alt="Screenshot_20250815_184000" src="https://github.com/user-attachments/assets/48747364-9d14-4dd8-aa1f-02680e0a6a9d" /> | <img width="1080" height="2400" alt="Screenshot_20250815_183423" src="https://github.com/user-attachments/assets/a9dbdfc9-1f19-4555-ad98-16ac3c2e6858" /> |


- [ ] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->