### PR TITLE
[WOOMOB-1083][Woo POS][Settings] Implement card reader update flow from settings

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/cardreader/update/CardReaderUpdateDialogFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/cardreader/update/CardReaderUpdateDialogFragment.kt
@@ -16,6 +16,7 @@ import com.woocommerce.android.model.UiString
 import com.woocommerce.android.ui.payments.PaymentsBaseDialogFragment
 import com.woocommerce.android.ui.payments.cardreader.update.CardReaderUpdateViewModel.CardReaderUpdateEvent.SoftwareUpdateProgress
 import com.woocommerce.android.ui.payments.cardreader.update.CardReaderUpdateViewModel.UpdateResult
+import com.woocommerce.android.ui.woopos.cardreader.WooPosCardReaderActivity
 import com.woocommerce.android.util.UiHelpers
 import com.woocommerce.android.util.announceAccessibilityChange
 import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.ExitWithResult
@@ -49,10 +50,25 @@ class CardReaderUpdateDialogFragment : PaymentsBaseDialogFragment(R.layout.card_
             viewLifecycleOwner
         ) { event ->
             when (event) {
-                is ExitWithResult<*> -> navigateBackWithResult(
-                    KEY_READER_UPDATE_RESULT,
-                    event.data as UpdateResult
-                )
+                is ExitWithResult<*> -> {
+                    val args = arguments
+                    val isWooPosFlow = args?.getBoolean(
+                        KEY_READER_UPDATE_WOO_POS_FLOW,
+                        false
+                    ) ?: false
+
+                    if (isWooPosFlow) {
+                        parentFragmentManager.setFragmentResult(
+                            WooPosCardReaderActivity.WOO_POS_CARD_UPDATE_REQUEST_KEY,
+                            Bundle()
+                        )
+                    } else {
+                        navigateBackWithResult(
+                            KEY_READER_UPDATE_RESULT,
+                            event.data as UpdateResult
+                        )
+                    }
+                }
 
                 is SoftwareUpdateProgress ->
                     announceSoftwareUpdateProgress(event.progress, binding)
@@ -94,5 +110,6 @@ class CardReaderUpdateDialogFragment : PaymentsBaseDialogFragment(R.layout.card_
 
     companion object {
         const val KEY_READER_UPDATE_RESULT = "key_reader_update_result"
+        const val KEY_READER_UPDATE_WOO_POS_FLOW = "key_reader_update_woo_pos_flow"
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/developer/DeveloperOptionsViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/developer/DeveloperOptionsViewModel.kt
@@ -174,6 +174,7 @@ class DeveloperOptionsViewModel @Inject constructor(
             NEVER(R.string.never_update_reader),
             LOW_BATTERY_ERROR(R.string.low_battery_error_update_reader),
             LOW_BATTERY_SUCCEED_CONNECT(R.string.low_battery_succeed_connect_update_reader),
+            OPTIONAL_UPDATE_AVAILABLE(R.string.optional_update_available_reader),
             RANDOM(R.string.randomly_update_reader);
 
             fun toDomainModel() = CardReaderManager.SimulatorUpdateFrequency.valueOf(name)

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/cardreader/WooPosCardReaderActivity.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/cardreader/WooPosCardReaderActivity.kt
@@ -103,7 +103,6 @@ class WooPosCardReaderActivity : AppCompatActivity(R.layout.activity_woo_pos_car
 
     private fun observeUpdateResult(navHostFragment: NavHostFragment) {
         val navController = navHostFragment.navController
-        
         // Observe the result from CardReaderUpdateDialogFragment
         // The dialog will set the result on its previous back stack entry
         navController.currentBackStackEntry?.savedStateHandle?.getLiveData<Any>(
@@ -134,7 +133,6 @@ class WooPosCardReaderActivity : AppCompatActivity(R.layout.activity_woo_pos_car
                 // has something to return result to
                 graph.setStartDestination(R.id.cardReaderStatusCheckerDialogFragment)
                 navController.setGraph(graph, null)
-                
                 // Then immediately navigate to the update dialog
                 navController.navigate(R.id.cardReaderUpdateDialogFragment)
             }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/cardreader/WooPosCardReaderActivity.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/cardreader/WooPosCardReaderActivity.kt
@@ -103,19 +103,18 @@ class WooPosCardReaderActivity : AppCompatActivity(R.layout.activity_woo_pos_car
     }
 
     private fun observeUpdateResult(navHostFragment: NavHostFragment) {
-        // Since CardReaderUpdateDialogFragment is the start destination and uses navigateBackWithResult,
-        // which won't work without a previous destination, we monitor the fragment lifecycle.
-        // When the dialog fragment is removed, we close the activity.
-        navHostFragment.childFragmentManager.registerFragmentLifecycleCallbacks(
-            object : androidx.fragment.app.FragmentManager.FragmentLifecycleCallbacks() {
-                override fun onFragmentDetached(fm: androidx.fragment.app.FragmentManager, f: androidx.fragment.app.Fragment) {
-                    if (f is CardReaderUpdateDialogFragment) {
-                        finish()
-                    }
+        navHostFragment.childFragmentManager.setFragmentResultListener(
+            WOO_POS_CARD_UPDATE_REQUEST_KEY,
+            this
+        ) { requestKey, bundle ->
+            when (requestKey) {
+                WOO_POS_CARD_UPDATE_REQUEST_KEY -> {
+                    finish()
                 }
-            },
-            false
-        )
+
+                else -> logResultListenerError(requestKey)
+            }
+        }
     }
 
     private fun setupNavGraph(navHostFragment: NavHostFragment, flowType: FlowType) {
@@ -135,9 +134,16 @@ class WooPosCardReaderActivity : AppCompatActivity(R.layout.activity_woo_pos_car
             }
 
             FlowType.UPDATE -> {
-                // Set the update dialog as the start destination
                 graph.setStartDestination(R.id.cardReaderUpdateDialogFragment)
-                navController.setGraph(graph, null)
+                navController.setGraph(
+                    graph,
+                    Bundle().apply {
+                        putBoolean(
+                            CardReaderUpdateDialogFragment.KEY_READER_UPDATE_WOO_POS_FLOW,
+                            true
+                        )
+                    }
+                )
             }
         }
     }
@@ -150,6 +156,7 @@ class WooPosCardReaderActivity : AppCompatActivity(R.layout.activity_woo_pos_car
 
     companion object {
         const val WOO_POS_CARD_PAYMENT_REQUEST_KEY = "woo_pos_card_payment_request"
+        const val WOO_POS_CARD_UPDATE_REQUEST_KEY = "woo_pos_card_update_request"
         const val FLOW_TYPE_KEY = "flow_type"
 
         fun buildIntentForCardReaderConnection(context: Context) =

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/cardreader/WooPosCardReaderActivity.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/cardreader/WooPosCardReaderActivity.kt
@@ -17,6 +17,7 @@ import com.woocommerce.android.extensions.adjustActivityTransition
 import com.woocommerce.android.ui.payments.cardreader.onboarding.CardReaderFlowParam
 import com.woocommerce.android.ui.payments.cardreader.onboarding.CardReaderType
 import com.woocommerce.android.ui.payments.cardreader.statuschecker.CardReaderStatusCheckerDialogFragmentArgs
+import com.woocommerce.android.ui.payments.cardreader.update.CardReaderUpdateDialogFragment
 import com.woocommerce.android.ui.woopos.util.ext.isGestureNavigation
 import com.woocommerce.android.util.WooLog
 import com.woocommerce.android.util.parcelable
@@ -102,14 +103,19 @@ class WooPosCardReaderActivity : AppCompatActivity(R.layout.activity_woo_pos_car
     }
 
     private fun observeUpdateResult(navHostFragment: NavHostFragment) {
-        val navController = navHostFragment.navController
-        // Observe the result from CardReaderUpdateDialogFragment
-        // The dialog will set the result on its previous back stack entry
-        navController.currentBackStackEntry?.savedStateHandle?.getLiveData<Any>(
-            "key_reader_update_result"
-        )?.observe(this) { _ ->
-            finish()
-        }
+        // Since CardReaderUpdateDialogFragment is the start destination and uses navigateBackWithResult,
+        // which won't work without a previous destination, we monitor the fragment lifecycle.
+        // When the dialog fragment is removed, we close the activity.
+        navHostFragment.childFragmentManager.registerFragmentLifecycleCallbacks(
+            object : androidx.fragment.app.FragmentManager.FragmentLifecycleCallbacks() {
+                override fun onFragmentDetached(fm: androidx.fragment.app.FragmentManager, f: androidx.fragment.app.Fragment) {
+                    if (f is CardReaderUpdateDialogFragment) {
+                        finish()
+                    }
+                }
+            },
+            false
+        )
     }
 
     private fun setupNavGraph(navHostFragment: NavHostFragment, flowType: FlowType) {
@@ -129,12 +135,9 @@ class WooPosCardReaderActivity : AppCompatActivity(R.layout.activity_woo_pos_car
             }
 
             FlowType.UPDATE -> {
-                // Set a dummy start destination first so that CardReaderUpdateDialogFragment
-                // has something to return result to
-                graph.setStartDestination(R.id.cardReaderStatusCheckerDialogFragment)
+                // Set the update dialog as the start destination
+                graph.setStartDestination(R.id.cardReaderUpdateDialogFragment)
                 navController.setGraph(graph, null)
-                // Then immediately navigate to the update dialog
-                navController.navigate(R.id.cardReaderUpdateDialogFragment)
             }
         }
     }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/cardreader/WooPosCardReaderActivity.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/cardreader/WooPosCardReaderActivity.kt
@@ -4,6 +4,7 @@ import android.content.Context
 import android.content.Intent
 import android.content.pm.ActivityInfo
 import android.os.Bundle
+import android.os.Parcelable
 import android.view.View
 import androidx.appcompat.app.AppCompatActivity
 import androidx.core.view.ViewCompat
@@ -18,10 +19,18 @@ import com.woocommerce.android.ui.payments.cardreader.onboarding.CardReaderType
 import com.woocommerce.android.ui.payments.cardreader.statuschecker.CardReaderStatusCheckerDialogFragmentArgs
 import com.woocommerce.android.ui.woopos.util.ext.isGestureNavigation
 import com.woocommerce.android.util.WooLog
+import com.woocommerce.android.util.parcelable
 import dagger.hilt.android.AndroidEntryPoint
+import kotlinx.parcelize.Parcelize
 
 @AndroidEntryPoint
 class WooPosCardReaderActivity : AppCompatActivity(R.layout.activity_woo_pos_card_reader) {
+
+    @Parcelize
+    enum class FlowType : Parcelable {
+        CONNECTION,
+        UPDATE
+    }
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
@@ -32,7 +41,8 @@ class WooPosCardReaderActivity : AppCompatActivity(R.layout.activity_woo_pos_car
             R.id.woopos_card_reader_nav_host_fragment
         ) as NavHostFragment
 
-        setupNavGraph(navHostFragment)
+        val flowType = intent.parcelable<FlowType>(FLOW_TYPE_KEY)!!
+        setupNavGraph(navHostFragment, flowType)
         observeResult(navHostFragment)
     }
 
@@ -84,18 +94,26 @@ class WooPosCardReaderActivity : AppCompatActivity(R.layout.activity_woo_pos_car
         }
     }
 
-    private fun setupNavGraph(navHostFragment: NavHostFragment) {
+    private fun setupNavGraph(navHostFragment: NavHostFragment, flowType: FlowType) {
         val navController = navHostFragment.navController
-        val graph = navController.navInflater.inflate(R.navigation.nav_graph_payment_flow).apply {
-            setStartDestination(R.id.cardReaderStatusCheckerDialogFragment)
+        val graph = navController.navInflater.inflate(R.navigation.nav_graph_payment_flow)
+
+        when (flowType) {
+            FlowType.CONNECTION -> {
+                graph.setStartDestination(R.id.cardReaderStatusCheckerDialogFragment)
+                navController.setGraph(
+                    graph,
+                    CardReaderStatusCheckerDialogFragmentArgs(
+                        cardReaderFlowParam = CardReaderFlowParam.WooPosConnection,
+                        cardReaderType = CardReaderType.EXTERNAL,
+                    ).toBundle()
+                )
+            }
+            FlowType.UPDATE -> {
+                graph.setStartDestination(R.id.cardReaderUpdateDialogFragment)
+                navController.setGraph(graph, null)
+            }
         }
-        navController.setGraph(
-            graph,
-            CardReaderStatusCheckerDialogFragmentArgs(
-                cardReaderFlowParam = CardReaderFlowParam.WooPosConnection,
-                cardReaderType = CardReaderType.EXTERNAL,
-            ).toBundle()
-        )
     }
 
     private fun logResultListenerError(requestKey: String) {
@@ -106,8 +124,16 @@ class WooPosCardReaderActivity : AppCompatActivity(R.layout.activity_woo_pos_car
 
     companion object {
         const val WOO_POS_CARD_PAYMENT_REQUEST_KEY = "woo_pos_card_payment_request"
+        const val FLOW_TYPE_KEY = "flow_type"
 
         fun buildIntentForCardReaderConnection(context: Context) =
-            Intent(context, WooPosCardReaderActivity::class.java)
+            Intent(context, WooPosCardReaderActivity::class.java).apply {
+                putExtra(FLOW_TYPE_KEY, FlowType.CONNECTION as Parcelable)
+            }
+
+        fun buildIntentForCardReaderUpdate(context: Context) =
+            Intent(context, WooPosCardReaderActivity::class.java).apply {
+                putExtra(FLOW_TYPE_KEY, FlowType.UPDATE as Parcelable)
+            }
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/cardreader/WooPosCardReaderActivity.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/cardreader/WooPosCardReaderActivity.kt
@@ -17,6 +17,7 @@ import com.woocommerce.android.extensions.adjustActivityTransition
 import com.woocommerce.android.ui.payments.cardreader.onboarding.CardReaderFlowParam
 import com.woocommerce.android.ui.payments.cardreader.onboarding.CardReaderType
 import com.woocommerce.android.ui.payments.cardreader.statuschecker.CardReaderStatusCheckerDialogFragmentArgs
+import com.woocommerce.android.ui.payments.cardreader.update.CardReaderUpdateDialogFragment
 import com.woocommerce.android.ui.woopos.util.ext.isGestureNavigation
 import com.woocommerce.android.util.WooLog
 import com.woocommerce.android.util.parcelable
@@ -43,7 +44,8 @@ class WooPosCardReaderActivity : AppCompatActivity(R.layout.activity_woo_pos_car
 
         val flowType = intent.parcelable<FlowType>(FLOW_TYPE_KEY)!!
         setupNavGraph(navHostFragment, flowType)
-        observeResult(navHostFragment)
+        observeConnectionResult(navHostFragment)
+        observeUpdateResult(navHostFragment)
     }
 
     private fun setupTopAndBottomInsets() {
@@ -79,7 +81,7 @@ class WooPosCardReaderActivity : AppCompatActivity(R.layout.activity_woo_pos_car
         )
     }
 
-    private fun observeResult(navHostFragment: NavHostFragment) {
+    private fun observeConnectionResult(navHostFragment: NavHostFragment) {
         navHostFragment.childFragmentManager.setFragmentResultListener(
             WOO_POS_CARD_PAYMENT_REQUEST_KEY,
             this
@@ -91,6 +93,15 @@ class WooPosCardReaderActivity : AppCompatActivity(R.layout.activity_woo_pos_car
 
                 else -> logResultListenerError(requestKey)
             }
+        }
+    }
+
+    private fun observeUpdateResult(navHostFragment: NavHostFragment) {
+        val navController = navHostFragment.navController
+        navController.currentBackStackEntry?.savedStateHandle?.getLiveData<Any>(
+            CardReaderUpdateDialogFragment.KEY_READER_UPDATE_RESULT
+        )?.observe(this) { _ ->
+            finish()
         }
     }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/cardreader/WooPosCardReaderActivity.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/cardreader/WooPosCardReaderActivity.kt
@@ -17,7 +17,6 @@ import com.woocommerce.android.extensions.adjustActivityTransition
 import com.woocommerce.android.ui.payments.cardreader.onboarding.CardReaderFlowParam
 import com.woocommerce.android.ui.payments.cardreader.onboarding.CardReaderType
 import com.woocommerce.android.ui.payments.cardreader.statuschecker.CardReaderStatusCheckerDialogFragmentArgs
-import com.woocommerce.android.ui.payments.cardreader.update.CardReaderUpdateDialogFragment
 import com.woocommerce.android.ui.woopos.util.ext.isGestureNavigation
 import com.woocommerce.android.util.WooLog
 import com.woocommerce.android.util.parcelable
@@ -44,8 +43,7 @@ class WooPosCardReaderActivity : AppCompatActivity(R.layout.activity_woo_pos_car
 
         val flowType = intent.parcelable<FlowType>(FLOW_TYPE_KEY)!!
         setupNavGraph(navHostFragment, flowType)
-        observeConnectionResult(navHostFragment)
-        observeUpdateResult(navHostFragment)
+        observeResult(navHostFragment, flowType)
     }
 
     private fun setupTopAndBottomInsets() {
@@ -81,6 +79,13 @@ class WooPosCardReaderActivity : AppCompatActivity(R.layout.activity_woo_pos_car
         )
     }
 
+    private fun observeResult(navHostFragment: NavHostFragment, flowType: FlowType) {
+        when (flowType) {
+            FlowType.CONNECTION -> observeConnectionResult(navHostFragment)
+            FlowType.UPDATE -> observeUpdateResult(navHostFragment)
+        }
+    }
+
     private fun observeConnectionResult(navHostFragment: NavHostFragment) {
         navHostFragment.childFragmentManager.setFragmentResultListener(
             WOO_POS_CARD_PAYMENT_REQUEST_KEY,
@@ -98,8 +103,11 @@ class WooPosCardReaderActivity : AppCompatActivity(R.layout.activity_woo_pos_car
 
     private fun observeUpdateResult(navHostFragment: NavHostFragment) {
         val navController = navHostFragment.navController
+        
+        // Observe the result from CardReaderUpdateDialogFragment
+        // The dialog will set the result on its previous back stack entry
         navController.currentBackStackEntry?.savedStateHandle?.getLiveData<Any>(
-            CardReaderUpdateDialogFragment.KEY_READER_UPDATE_RESULT
+            "key_reader_update_result"
         )?.observe(this) { _ ->
             finish()
         }
@@ -120,9 +128,15 @@ class WooPosCardReaderActivity : AppCompatActivity(R.layout.activity_woo_pos_car
                     ).toBundle()
                 )
             }
+
             FlowType.UPDATE -> {
-                graph.setStartDestination(R.id.cardReaderUpdateDialogFragment)
+                // Set a dummy start destination first so that CardReaderUpdateDialogFragment
+                // has something to return result to
+                graph.setStartDestination(R.id.cardReaderStatusCheckerDialogFragment)
                 navController.setGraph(graph, null)
+                
+                // Then immediately navigate to the update dialog
+                navController.navigate(R.id.cardReaderUpdateDialogFragment)
             }
         }
     }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/cardreader/WooPosCardReaderFacade.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/cardreader/WooPosCardReaderFacade.kt
@@ -38,6 +38,13 @@ class WooPosCardReaderFacade @Inject constructor(
         startActivity(intent)
     }
 
+    fun updateReader() {
+        val intent = WooPosCardReaderActivity.buildIntentForCardReaderUpdate(activity!!).apply {
+            addFlags(Intent.FLAG_ACTIVITY_CLEAR_TOP or Intent.FLAG_ACTIVITY_SINGLE_TOP)
+        }
+        startActivity(intent)
+    }
+
     suspend fun disconnectFromReader() {
         cardReaderManager.disconnectReader()
     }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/settings/details/hardware/cardreader/WooPosSettingsHardwareCardReaderScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/settings/details/hardware/cardreader/WooPosSettingsHardwareCardReaderScreen.kt
@@ -72,7 +72,8 @@ fun WooPosSettingsHardwareCardReaderScreen(
         uiState = uiState,
         onConnectClicked = viewModel::onConnectClicked,
         onDisconnectClicked = viewModel::onDisconnectClicked,
-        onDocumentationClicked = viewModel::onDocumentationClicked
+        onDocumentationClicked = viewModel::onDocumentationClicked,
+        onUpdateClick = viewModel::onUpdateClick
     )
 }
 
@@ -81,7 +82,8 @@ private fun WooPosSettingsHardwareCardReaderContent(
     uiState: WooPosSettingsHardwareCardReaderUiState,
     onConnectClicked: () -> Unit,
     onDisconnectClicked: () -> Unit,
-    onDocumentationClicked: () -> Unit
+    onDocumentationClicked: () -> Unit,
+    onUpdateClick: () -> Unit,
 ) {
     AnimatedContent(
         targetState = uiState,
@@ -104,7 +106,8 @@ private fun WooPosSettingsHardwareCardReaderContent(
                             R.string.woopos_settings_card_reader_unknown_firmware
                         ),
                         isSoftwareUpdateAvailable = state.isSoftwareUpdateAvailable,
-                        onDisconnectClicked = onDisconnectClicked
+                        onDisconnectClicked = onDisconnectClicked,
+                        onUpdateClick = onUpdateClick
                     )
                 }
 
@@ -125,7 +128,8 @@ private fun ConnectedContent(
     batteryLevel: Float?,
     firmwareVersion: String,
     isSoftwareUpdateAvailable: Boolean,
-    onDisconnectClicked: () -> Unit
+    onDisconnectClicked: () -> Unit,
+    onUpdateClick: () -> Unit
 ) {
     Card(
         modifier = Modifier
@@ -171,7 +175,7 @@ private fun ConnectedContent(
     FirmwareMenuItem(
         firmwareVersion = firmwareVersion,
         isSoftwareUpdateAvailable = isSoftwareUpdateAvailable,
-        onUpdateClick = { }
+        onUpdateClick = onUpdateClick
     )
 
     Spacer(modifier = Modifier.height(WooPosSpacing.Small.value))
@@ -342,7 +346,8 @@ fun WooPosSettingsHardwareCardReaderScreenNotConnectedPreview() {
             uiState = WooPosSettingsHardwareCardReaderUiState.Disconnected,
             onConnectClicked = { },
             onDisconnectClicked = { },
-            onDocumentationClicked = { }
+            onDocumentationClicked = { },
+            onUpdateClick = { }
         )
     }
 }
@@ -360,7 +365,8 @@ fun WooPosSettingsHardwareCardReaderScreenConnectedPreview() {
             ),
             onConnectClicked = { },
             onDisconnectClicked = { },
-            onDocumentationClicked = { }
+            onDocumentationClicked = { },
+            onUpdateClick = { }
         )
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/settings/details/hardware/cardreader/WooPosSettingsHardwareCardReaderViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/settings/details/hardware/cardreader/WooPosSettingsHardwareCardReaderViewModel.kt
@@ -73,7 +73,7 @@ class WooPosSettingsHardwareCardReaderViewModel @Inject constructor(
     }
 
     fun onUpdateClick() {
-
+        cardReaderFacade.updateReader()
     }
 
     private fun listenForSoftwareUpdateAvailability() {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/settings/details/hardware/cardreader/WooPosSettingsHardwareCardReaderViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/settings/details/hardware/cardreader/WooPosSettingsHardwareCardReaderViewModel.kt
@@ -72,6 +72,10 @@ class WooPosSettingsHardwareCardReaderViewModel @Inject constructor(
         }
     }
 
+    fun onUpdateClick() {
+
+    }
+
     private fun listenForSoftwareUpdateAvailability() {
         softwareUpdateAvailabilityJob = viewModelScope.launch {
             cardReaderFacade.softwareUpdateAvailability.collect { updateAvailability ->

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/settings/details/hardware/cardreader/WooPosSettingsHardwareCardReaderViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/settings/details/hardware/cardreader/WooPosSettingsHardwareCardReaderViewModel.kt
@@ -106,6 +106,7 @@ class WooPosSettingsHardwareCardReaderViewModel @Inject constructor(
                             ),
                             batteryLevel = status.cardReader.currentBatteryLevel,
                             firmwareVersion = status.cardReader.firmwareVersion,
+                            isSoftwareUpdateAvailable = currentSoftwareUpdateAvailable
                         )
                     }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/settings/details/hardware/cardreader/WooPosSettingsHardwareCardReaderViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/settings/details/hardware/cardreader/WooPosSettingsHardwareCardReaderViewModel.kt
@@ -106,7 +106,6 @@ class WooPosSettingsHardwareCardReaderViewModel @Inject constructor(
                             ),
                             batteryLevel = status.cardReader.currentBatteryLevel,
                             firmwareVersion = status.cardReader.firmwareVersion,
-                            isSoftwareUpdateAvailable = true
                         )
                     }
 

--- a/WooCommerce/src/main/res/navigation/nav_graph_payment_flow.xml
+++ b/WooCommerce/src/main/res/navigation/nav_graph_payment_flow.xml
@@ -274,6 +274,10 @@
             android:name="requiredUpdate"
             android:defaultValue="false"
             app:argType="boolean" />
+        <argument
+            android:name="isWooPosFlow"
+            android:defaultValue="false"
+            app:argType="boolean" />
     </dialog>
     <dialog
         android:id="@+id/cardReaderTutorialDialogFragment"

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -2614,6 +2614,7 @@
     <string name="never_update_reader">Never</string>
     <string name="low_battery_error_update_reader" translatable="false">Low Battery Error</string>
     <string name="low_battery_succeed_connect_update_reader" translatable="false">Low Battery Succeed Connect</string>
+    <string name="optional_update_available_reader" translatable="false">Optional Update Available</string>
     <string name="randomly_update_reader">Randomly</string>
     <string name="enable_interac_payment" translatable="false">Enable Interac Payment</string>
 

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/settings/details/hardware/cardreader/WooPosSettingsHardwareCardReaderViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/settings/details/hardware/cardreader/WooPosSettingsHardwareCardReaderViewModelTest.kt
@@ -117,7 +117,7 @@ class WooPosSettingsHardwareCardReaderViewModelTest {
         }
         whenever(cardReaderFacade.readerStatus).thenReturn(readerStatusFlow)
         whenever(cardReaderFacade.softwareUpdateAvailability).thenReturn(softwareUpdateFlow)
-        
+
         // WHEN
         val viewModel = createViewModel()
         readerStatusFlow.value = CardReaderStatus.Connected(mockReader)
@@ -141,7 +141,7 @@ class WooPosSettingsHardwareCardReaderViewModelTest {
         }
         whenever(cardReaderFacade.readerStatus).thenReturn(readerStatusFlow)
         whenever(cardReaderFacade.softwareUpdateAvailability).thenReturn(softwareUpdateFlow)
-        
+
         // WHEN
         val viewModel = createViewModel()
         readerStatusFlow.value = CardReaderStatus.Connected(mockReader)

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/settings/details/hardware/cardreader/WooPosSettingsHardwareCardReaderViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/settings/details/hardware/cardreader/WooPosSettingsHardwareCardReaderViewModelTest.kt
@@ -93,6 +93,68 @@ class WooPosSettingsHardwareCardReaderViewModelTest {
         verify(cardReaderFacade).connectToReader()
     }
 
+    @Test
+    fun `when update clicked, then calls facade update reader`() = runTest {
+        // GIVEN
+        whenever(cardReaderFacade.readerStatus).thenReturn(readerStatusFlow)
+        whenever(cardReaderFacade.softwareUpdateAvailability).thenReturn(softwareUpdateFlow)
+        val viewModel = createViewModel()
+
+        // WHEN
+        viewModel.onUpdateClick()
+
+        // THEN
+        verify(cardReaderFacade).updateReader()
+    }
+
+    @Test
+    fun `given connected reader, when software update available, then shows update available`() = runTest {
+        // GIVEN
+        val mockReader = mock<CardReader> {
+            whenever(it.id).thenReturn("Test Reader")
+            whenever(it.currentBatteryLevel).thenReturn(0.75f)
+            whenever(it.firmwareVersion).thenReturn("1.2.3")
+        }
+        whenever(cardReaderFacade.readerStatus).thenReturn(readerStatusFlow)
+        whenever(cardReaderFacade.softwareUpdateAvailability).thenReturn(softwareUpdateFlow)
+        
+        // WHEN
+        val viewModel = createViewModel()
+        readerStatusFlow.value = CardReaderStatus.Connected(mockReader)
+        softwareUpdateFlow.value = SoftwareUpdateAvailability.Available
+        advanceUntilIdle()
+
+        // THEN
+        val uiState = viewModel.uiState.value
+        assertThat(uiState).isInstanceOf(WooPosSettingsHardwareCardReaderUiState.Connected::class.java)
+        val connectedState = uiState as WooPosSettingsHardwareCardReaderUiState.Connected
+        assertThat(connectedState.isSoftwareUpdateAvailable).isTrue()
+    }
+
+    @Test
+    fun `given connected reader, when software update not available, then shows update not available`() = runTest {
+        // GIVEN
+        val mockReader = mock<CardReader> {
+            whenever(it.id).thenReturn("Test Reader")
+            whenever(it.currentBatteryLevel).thenReturn(0.75f)
+            whenever(it.firmwareVersion).thenReturn("1.2.3")
+        }
+        whenever(cardReaderFacade.readerStatus).thenReturn(readerStatusFlow)
+        whenever(cardReaderFacade.softwareUpdateAvailability).thenReturn(softwareUpdateFlow)
+        
+        // WHEN
+        val viewModel = createViewModel()
+        readerStatusFlow.value = CardReaderStatus.Connected(mockReader)
+        softwareUpdateFlow.value = SoftwareUpdateAvailability.NotAvailable
+        advanceUntilIdle()
+
+        // THEN
+        val uiState = viewModel.uiState.value
+        assertThat(uiState).isInstanceOf(WooPosSettingsHardwareCardReaderUiState.Connected::class.java)
+        val connectedState = uiState as WooPosSettingsHardwareCardReaderUiState.Connected
+        assertThat(connectedState.isSoftwareUpdateAvailable).isFalse()
+    }
+
     private fun createViewModel() = WooPosSettingsHardwareCardReaderViewModel(
         cardReaderFacade = cardReaderFacade,
         resourceProvider = resourceProvider,

--- a/libs/cardreader/src/main/java/com/woocommerce/android/cardreader/CardReaderManager.kt
+++ b/libs/cardreader/src/main/java/com/woocommerce/android/cardreader/CardReaderManager.kt
@@ -66,7 +66,8 @@ interface CardReaderManager {
         ALWAYS,
         LOW_BATTERY_ERROR,
         LOW_BATTERY_SUCCEED_CONNECT,
-        RANDOM
+        RANDOM,
+        OPTIONAL_UPDATE_AVAILABLE,
     }
 
     data class TapToPayUxConfig(

--- a/libs/cardreader/src/main/java/com/woocommerce/android/cardreader/internal/wrappers/TerminalWrapper.kt
+++ b/libs/cardreader/src/main/java/com/woocommerce/android/cardreader/internal/wrappers/TerminalWrapper.kt
@@ -114,6 +114,8 @@ internal class TerminalWrapper {
                 SimulateReaderUpdate.LOW_BATTERY_SUCCEED_CONNECT
             }
             CardReaderManager.SimulatorUpdateFrequency.RANDOM -> SimulateReaderUpdate.RANDOM
+            CardReaderManager.SimulatorUpdateFrequency.OPTIONAL_UPDATE_AVAILABLE ->
+                SimulateReaderUpdate.UPDATE_AVAILABLE
         }
     }
 


### PR DESCRIPTION
WOOMOB-1083

### Description
Added card reader update flow from Woo POS settings. Users can tap "Update" button when reader is connected to start firmware update.

Added "Optional update available" to the developer options of the app

### Steps to reproduce
Enable "Optional update available" in the developer options first

1. Open Woo POS → Settings → Hardware → Card Reader
2. Connect a reader with available update
3. Tap "Update" button
4. Verify update dialog appears and closes properly

### Testing information
- Added tests for onUpdateClick and software update availability
- Verified update flow navigation and activity cleanup
- Tested parameter passing to handle WooPos flow specifically

### The tests that have been performed
- Update button triggers correct facade method
- Activity closes after update completion/cancellation
- Software update availability properly reflected in UI


https://github.com/user-attachments/assets/63eae164-690d-4cfd-be43-7dc1b17bab43



- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.