### PR TITLE
Update `WooPosPreview` to render Phone layout in POS in previews

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/common/composeui/WooPosComposePreviewAnnotation.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/common/composeui/WooPosComposePreviewAnnotation.kt
@@ -3,7 +3,6 @@
 package com.woocommerce.android.ui.woopos.common.composeui
 
 import android.content.res.Configuration
-import androidx.compose.ui.tooling.preview.Devices.PHONE
 import androidx.compose.ui.tooling.preview.Preview
 
 @Retention(AnnotationRetention.BINARY)
@@ -23,7 +22,6 @@ import androidx.compose.ui.tooling.preview.Preview
     device = "spec:width=674dp,height=800dp,dpi=420,isRound=false,chinSize=0dp,orientation=landscape",
     uiMode = Configuration.UI_MODE_TYPE_NORMAL
 )
-
 @Preview(
     name = "Phone",
     showSystemUi = true,

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/common/composeui/WooPosComposePreviewAnnotation.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/common/composeui/WooPosComposePreviewAnnotation.kt
@@ -23,10 +23,11 @@ import androidx.compose.ui.tooling.preview.Preview
     device = "spec:width=674dp,height=800dp,dpi=420,isRound=false,chinSize=0dp,orientation=landscape",
     uiMode = Configuration.UI_MODE_TYPE_NORMAL
 )
+
 @Preview(
     name = "Phone",
     showSystemUi = true,
-    device = PHONE,
-    uiMode = Configuration.UI_MODE_TYPE_NORMAL or Configuration.UI_MODE_TYPE_NORMAL
+    device = "spec:width=400dp,height=800dp,dpi=420,orientation=landscape",
+    uiMode = Configuration.UI_MODE_TYPE_NORMAL or Configuration.UI_MODE_NIGHT_YES
 )
 annotation class WooPosPreview

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/common/composeui/WooPosComposePreviewAnnotation.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/common/composeui/WooPosComposePreviewAnnotation.kt
@@ -27,7 +27,7 @@ import androidx.compose.ui.tooling.preview.Preview
 @Preview(
     name = "Phone",
     showSystemUi = true,
-    device = "spec:width=400dp,height=800dp,dpi=420,orientation=landscape",
+    device = "spec:width=411dp,height=891dp,dpi=420,orientation=landscape",
     uiMode = Configuration.UI_MODE_TYPE_NORMAL or Configuration.UI_MODE_NIGHT_YES
 )
 annotation class WooPosPreview

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/common/composeui/WooPosComposePreviewAnnotation.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/common/composeui/WooPosComposePreviewAnnotation.kt
@@ -3,6 +3,7 @@
 package com.woocommerce.android.ui.woopos.common.composeui
 
 import android.content.res.Configuration
+import androidx.compose.ui.tooling.preview.Devices.PHONE
 import androidx.compose.ui.tooling.preview.Preview
 
 @Retention(AnnotationRetention.BINARY)
@@ -21,5 +22,11 @@ import androidx.compose.ui.tooling.preview.Preview
     showSystemUi = true,
     device = "spec:width=674dp,height=800dp,dpi=420,isRound=false,chinSize=0dp,orientation=landscape",
     uiMode = Configuration.UI_MODE_TYPE_NORMAL
+)
+@Preview(
+    name = "Phone",
+    showSystemUi = true,
+    device = PHONE,
+    uiMode = Configuration.UI_MODE_TYPE_NORMAL or Configuration.UI_MODE_TYPE_NORMAL
 )
 annotation class WooPosPreview


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

<!-- Id number of the Linear issue this PR addresses, e.g., WOOMOB-373. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
This PR updates `WooPosPreview` to render Compose layouts on phone window size class in addition to tablet. Reason: to start becoming aware of the gap, challenges, and effort required to potentially support phones in the future.

### Steps to reproduce
<!-- Step-by-step testing instructions. For new user flows, consider instead stating the goal of the workflow and see if your PR reviewer can accomplish the workflow without specific steps! -->
N/A

### Testing information
<!-- This is your opportunity to break out individual scenarios that need testing (when necessary) and/or include a checklist for the reviewer to go through. Consider documenting the following from your own completed testing: devices used, alternate workflows, edge cases, affected areas, critical flows, areas not tested, and any remaining unknowns. Provide feedback on this new section of the PR template through Sept 30, 2024 to Apps Quality; additional context here: p91TBi-b8z-p2#comment-12036 -->
Check that POS screens' previews are also rendered in small (phone) windows.

### The tests that have been performed
<!-- To give the reviewer an idea of what could be missed in terms of testing -->
Above.

### Images/gif
<!-- Include before and after images or gifs when appropriate. -->
—

- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->