### PR TITLE
[Shipping Labels] Show refund notice about refunded labels in Order Details screen

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/views/OrderDetailWooShippingShipmentListView.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/views/OrderDetailWooShippingShipmentListView.kt
@@ -1,6 +1,7 @@
 package com.woocommerce.android.ui.orders.details.views
 
 import androidx.annotation.StringRes
+import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
@@ -12,6 +13,7 @@ import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.LocationOn
@@ -115,36 +117,58 @@ private fun ShipmentItem(
     modifier: Modifier = Modifier
 ) {
     Column(modifier = modifier) {
-        Row(
-            verticalAlignment = Alignment.CenterVertically,
-            horizontalArrangement = Arrangement.spacedBy(4.dp),
+        Column(
+            verticalArrangement = Arrangement.Center,
             modifier = Modifier
-                .padding(start = 16.dp)
-                .defaultMinSize(minHeight = 64.dp)
+                .fillMaxWidth()
         ) {
-            Text(
-                text = stringResource(
-                    id = R.string.orderdetail_shipping_label_shipment_header,
-                    "${index + 1}/$shipmentsSize"
-                ),
-                style = MaterialTheme.typography.titleMedium,
-                fontWeight = FontWeight.SemiBold
-            )
-
-            if (shipment.purchased && shipment.label != null) {
-                Icon(
-                    modifier = Modifier.size(16.dp),
-                    painter = painterResource(R.drawable.ic_progress_circle_complete),
-                    contentDescription = stringResource(R.string.purchased_shipment_content_description),
-                    tint = colorResource(id = R.color.woo_green_70)
+            Row(
+                verticalAlignment = Alignment.CenterVertically,
+                horizontalArrangement = Arrangement.spacedBy(4.dp),
+                modifier = Modifier
+                    .defaultMinSize(minHeight = 64.dp)
+                    .padding(start = 16.dp)
+            ) {
+                Text(
+                    text = stringResource(
+                        id = R.string.orderdetail_shipping_label_shipment_header,
+                        "${index + 1}/$shipmentsSize"
+                    ),
+                    style = MaterialTheme.typography.titleMedium,
+                    fontWeight = FontWeight.SemiBold
                 )
 
-                Spacer(Modifier.weight(1f))
+                if (shipment.label?.isPurchased == true) {
+                    Icon(
+                        modifier = Modifier.size(16.dp),
+                        painter = painterResource(R.drawable.ic_progress_circle_complete),
+                        contentDescription = stringResource(R.string.purchased_shipment_content_description),
+                        tint = colorResource(id = R.color.woo_green_70)
+                    )
 
-                WCOverflowMenu(
-                    items = listOf(stringResource(R.string.orderdetail_shipping_label_request_refund)),
-                    onSelected = { onRequestRefundClicked(shipment.label.labelId) },
+                    Spacer(Modifier.weight(1f))
+
+                    WCOverflowMenu(
+                        items = listOf(stringResource(R.string.orderdetail_shipping_label_request_refund)),
+                        onSelected = { onRequestRefundClicked(shipment.label.labelId) },
+                    )
+                }
+            }
+
+            if (shipment.label?.refund != null) {
+                Spacer(Modifier.height(8.dp))
+                Text(
+                    text = stringResource(R.string.orderdetail_shipping_label_refunded),
+                    modifier = Modifier
+                        .align(Alignment.CenterHorizontally)
+                        .padding(horizontal = 16.dp)
+                        .background(
+                            color = colorResource(R.color.woo_blue_5).copy(alpha = 0.2f),
+                            shape = RoundedCornerShape(4.dp)
+                        )
+                        .padding(16.dp)
                 )
+                Spacer(Modifier.height(16.dp))
             }
         }
         HorizontalDivider(Modifier.padding(start = 16.dp))
@@ -157,7 +181,7 @@ private fun ShipmentItem(
             HorizontalDivider(Modifier.padding(start = 16.dp))
         }
 
-        if (shipment.purchased && shipment.label != null) {
+        if (shipment.label?.isPurchased == true) {
             LabelTrackingRow(shipment.label)
 
             HorizontalDivider(Modifier.padding(start = 16.dp))
@@ -330,7 +354,10 @@ private fun OrderDetailWooShippingShipmentListViewPreview() {
     val shipments = remember {
         listOf(
             ShippingLabelSampleData.getShippingLabelUIModel(purchased = true),
-            ShippingLabelSampleData.getShippingLabelUIModel(purchased = false)
+            ShippingLabelSampleData.getShippingLabelUIModel(purchased = false),
+            ShippingLabelSampleData.getShippingLabelUIModel(purchased = true).let {
+                it.copy(label = it.label!!.copy(refund = ShippingLabelModel.Refund(null, null)))
+            }
         )
     }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/GetShipments.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/GetShipments.kt
@@ -68,13 +68,14 @@ class GetShipments @Inject constructor(
         shipmentUIModelList: List<ShipmentUIModel>,
         currentOrderLabels: List<ShippingLabelModel>
     ) = shipmentUIModelList.map { shipmentUIModel ->
-        val purchasedNonRefundedLabel = currentOrderLabels.find {
-            it.shipmentId == shipmentUIModel.remoteId && it.status == ShippingLabelStatus.PURCHASED && it.refund == null
+        val shipmentLabels = currentOrderLabels.filter {
+            it.shipmentId == shipmentUIModel.remoteId
+        }.sortedByDescending { it.createdDate?.time }
+
+        val purchasedLabel = shipmentLabels.find {
+            it.status == ShippingLabelStatus.PURCHASED && it.refund == null
         }
-        if (purchasedNonRefundedLabel == null) {
-            shipmentUIModel
-        } else {
-            shipmentUIModel.copy(purchased = true, label = purchasedNonRefundedLabel)
-        }
+
+        shipmentUIModel.copy(label = purchasedLabel ?: shipmentLabels.firstOrNull())
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/ShippingLabelSampleData.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/ShippingLabelSampleData.kt
@@ -239,7 +239,6 @@ object ShippingLabelSampleData {
                 currency = "USD"
             )
         ),
-        purchased = purchased,
         purchaseState = PurchaseState.NoStarted,
         label = if (purchased) {
             ShippingLabelModel(

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/WooShippingLabelCreationViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/WooShippingLabelCreationViewModel.kt
@@ -821,7 +821,7 @@ class WooShippingLabelCreationViewModel @Inject constructor(
 
         // If the shipment is found, reset its state
         if (shipmentIndex != -1) {
-            updateShipment(shipmentIndex, shipments.value[shipmentIndex].copy(purchased = false, label = null))
+            updateShipment(shipmentIndex, shipments.value[shipmentIndex].copy(label = null))
             selectedRatesFlow.value = selectedRatesFlow.value.toMutableList().apply { set(shipmentIndex, null) }
             selectedPackagesFlow.value = selectedPackagesFlow.value.toMutableList().apply { set(shipmentIndex, null) }
         }
@@ -998,7 +998,7 @@ class WooShippingLabelCreationViewModel @Inject constructor(
         result.labels
             .firstOrNull()
             ?.let { purchasedLabel ->
-                updateShipment(shipmentId, shipments.value[shipmentId].copy(purchased = true, label = purchasedLabel))
+                updateShipment(shipmentId, shipments.value[shipmentId].copy(label = purchasedLabel))
                 observeShippingLabelPurchaseStatus(shipmentId)
             }
         analyticsTracker.track(AnalyticsEvent.WCS_PURCHASE_STEP, mapOf(KEY_STATE to "purchase_success"))

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/models/ShipmentUIModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/models/ShipmentUIModel.kt
@@ -8,10 +8,17 @@ data class ShipmentUIModel(
     val localId: String,
     val remoteId: String? = null,
     val items: List<ShippableItemModel>,
-    val purchased: Boolean = false,
     val purchaseState: PurchaseState = PurchaseState.NoStarted,
     val label: ShippingLabelModel? = null,
-) : Parcelable
+) : Parcelable {
+    /**
+     * Whether the shipment has been purchased or not.
+     * A shipment is considered purchased if the label was already purchased or is in the process of being purchased.
+     */
+    val purchased: Boolean
+        get() = label?.status == ShippingLabelStatus.PURCHASE_IN_PROGRESS ||
+            (label?.status == ShippingLabelStatus.PURCHASED && label.refund == null)
+}
 
 @Parcelize
 sealed class PurchaseState : Parcelable {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/models/ShippingLabelModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/models/ShippingLabelModel.kt
@@ -66,6 +66,10 @@ data class ShippingLabelModel(
         }
 
     @IgnoredOnParcel
+    val isPurchased: Boolean
+        get() = status == ShippingLabelStatus.PURCHASED && refund == null
+
+    @IgnoredOnParcel
     private val hasLabelExpired: Boolean
         get() = status == ShippingLabelStatus.ANONYMIZED || usedDate != null || expiryDate < System.currentTimeMillis()
 

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -1024,6 +1024,7 @@
     <string name="orderdetail_shipping_label_shipment_header">Shipment %1$s</string>
     <string name="orderdetail_shipping_label_shipment_items">%1$d items</string>
     <string name="orderdetail_shipping_label_shipment_tracking_number">Tracking number</string>
+    <string name="orderdetail_shipping_label_refunded">You have successfully submitted a request for refund. You can purchase a new label.</string>
     <string name="orderdetail_custom_fields">Custom fields</string>
     <string name="orderdetail_ai_create_thank_you_note_button">✨Create thank-you note</string>
     <string name="receipt_preview_toolbar_title">Receipt Preview</string>

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/WooShippingLabelCreationViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/WooShippingLabelCreationViewModelTest.kt
@@ -46,8 +46,7 @@ import com.woocommerce.android.ui.orders.wooshippinglabels.models.PurchasedLabel
 import com.woocommerce.android.ui.orders.wooshippinglabels.models.ShipmentUIModel
 import com.woocommerce.android.ui.orders.wooshippinglabels.models.ShippableItemModel
 import com.woocommerce.android.ui.orders.wooshippinglabels.models.ShippingLabelModel
-import com.woocommerce.android.ui.orders.wooshippinglabels.models.ShippingLabelStatus.PURCHASED
-import com.woocommerce.android.ui.orders.wooshippinglabels.models.ShippingLabelStatus.UNKNOWN
+import com.woocommerce.android.ui.orders.wooshippinglabels.models.ShippingLabelStatus
 import com.woocommerce.android.ui.orders.wooshippinglabels.models.StoreOptionsModel
 import com.woocommerce.android.ui.orders.wooshippinglabels.models.WooShippingCarrier
 import com.woocommerce.android.ui.orders.wooshippinglabels.models.WooShippingLabelPaperSize
@@ -222,7 +221,7 @@ class WooShippingLabelCreationViewModelTest : BaseUnitTest() {
         labelId = 1,
         tracking = "",
         refundableAmount = BigDecimal.ZERO,
-        status = UNKNOWN,
+        status = ShippingLabelStatus.UNKNOWN,
         created = null,
         carrierId = "",
         serviceName = "",
@@ -308,7 +307,7 @@ class WooShippingLabelCreationViewModelTest : BaseUnitTest() {
             invoke(any(), any(), any(), any(), any(), any(), any(), any(), any(), isNull(), isNull())
         } doReturn Result.success(
             PurchasedLabelData(
-                labels = listOf(shippingLabelModel.copy(status = PURCHASED)),
+                labels = listOf(shippingLabelModel.copy(status = ShippingLabelStatus.PURCHASED)),
                 origin = emptyMap(),
                 destination = emptyMap(),
                 rates = emptyMap()
@@ -851,8 +850,8 @@ class WooShippingLabelCreationViewModelTest : BaseUnitTest() {
             whenever(markOrderAsComplete(orderId)) doReturn Result.success(Unit)
             whenever(observeShippingLabelStatus(eq(orderId), any())) doReturn flowOf(
                 ObserveShippingLabelStatus.ObserveShippingLabelStatusResult(
-                    status = PURCHASED,
-                    shippingLabelModel = shippingLabelModel.copy(status = PURCHASED)
+                    status = ShippingLabelStatus.PURCHASED,
+                    shippingLabelModel = shippingLabelModel.copy(status = ShippingLabelStatus.PURCHASED)
                 )
             )
 
@@ -884,8 +883,8 @@ class WooShippingLabelCreationViewModelTest : BaseUnitTest() {
         whenever(markOrderAsComplete(orderId)) doReturn Result.failure(Exception("Error marking order as complete"))
         whenever(observeShippingLabelStatus(eq(orderId), any())) doReturn flowOf(
             ObserveShippingLabelStatus.ObserveShippingLabelStatusResult(
-                status = PURCHASED,
-                shippingLabelModel = shippingLabelModel.copy(status = PURCHASED)
+                status = ShippingLabelStatus.PURCHASED,
+                shippingLabelModel = shippingLabelModel.copy(status = ShippingLabelStatus.PURCHASED)
             )
         )
 
@@ -981,8 +980,9 @@ class WooShippingLabelCreationViewModelTest : BaseUnitTest() {
             ShipmentUIModel(
                 localId = "0",
                 items = defaultShippableItems,
-                purchased = true,
-                label = shippingLabelModel
+                label = shippingLabelModel.copy(
+                    status = ShippingLabelStatus.PURCHASED
+                )
             )
         )
 
@@ -999,12 +999,12 @@ class WooShippingLabelCreationViewModelTest : BaseUnitTest() {
         val label = shippingLabelModel.copy(
             serviceName = "Test Service",
             rate = BigDecimal.TEN,
+            status = ShippingLabelStatus.PURCHASED
         )
         whenever(getShipments(any())) doReturn listOf(
             ShipmentUIModel(
                 localId = "0",
                 items = defaultShippableItems,
-                purchased = true,
                 label = label
             )
         )

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/split/GetSplitMovementsTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/split/GetSplitMovementsTest.kt
@@ -1,5 +1,6 @@
 package com.woocommerce.android.ui.orders.wooshippinglabels.split
 
+import com.woocommerce.android.ui.orders.wooshippinglabels.ShippingLabelSampleData
 import com.woocommerce.android.ui.orders.wooshippinglabels.models.ShipmentUIModel
 import com.woocommerce.android.ui.orders.wooshippinglabels.models.ShippableItemModel
 import com.woocommerce.android.ui.orders.wooshippinglabels.toSelectableUIModel
@@ -222,6 +223,8 @@ class GetSplitMovementsTest : BaseUnitTest() {
     }
 
     private val purchasedShipment = mapOf(
-        10 to ShipmentUIModel(localId = "0", remoteId = null, items = defaultShippableItems, purchased = true)
+        10 to ShippingLabelSampleData.getShippingLabelUIModel(purchased = true).copy(
+            items = defaultShippableItems
+        )
     )
 }

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/split/WooShippingSplitShipmentViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/split/WooShippingSplitShipmentViewModelTest.kt
@@ -1,6 +1,7 @@
 package com.woocommerce.android.ui.orders.wooshippinglabels.split
 
 import com.woocommerce.android.R
+import com.woocommerce.android.ui.orders.wooshippinglabels.ShippingLabelSampleData
 import com.woocommerce.android.ui.orders.wooshippinglabels.SplitShipment
 import com.woocommerce.android.ui.orders.wooshippinglabels.WooShippingLabelCreationViewModel.SplitShipmentArgs
 import com.woocommerce.android.ui.orders.wooshippinglabels.models.ShipmentUIModel
@@ -636,23 +637,5 @@ class WooShippingSplitShipmentViewModelTest : BaseUnitTest() {
         )
     )
 
-    val purchasedShipmentUIModel = ShipmentUIModel(
-        localId = "10",
-        items = listOf(
-            ShippableItemModel(
-                itemId = 1L,
-                productId = 1L,
-                title = "A product with quantity 1",
-                price = BigDecimal(30),
-                quantity = 1f,
-                imageUrl = null,
-                currency = "USD",
-                length = 3f,
-                width = 3f,
-                height = 3f,
-                weight = 8f
-            )
-        ),
-        purchased = true
-    )
+    val purchasedShipmentUIModel = ShippingLabelSampleData.getShippingLabelUIModel(purchased = true)
 }


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

<!-- Id number of the Linear issue this PR addresses, e.g., WOOMOB-373. -->
Closes WOOMOB-972

### Description
This PR adds a refund notice to the shipment details section in order details screen.

This PR required changing the logic of `GetShipments` to make sure we map the labels even when they are refunded.

### Steps to reproduce
##### Refund notice
Open an order that has a refunded label, or create a new one and refund it.

##### No regression
Test buying a new label from the app.

### Testing information
- Confirm the shipment details in the order details screen shows the refund notice.
- Confirm the `GetShipments` changes don't cause any regression.

### The tests that have been performed
The above.

### Images/gif
| Light | Dark |
| --- | --- |
| <img width="1080" height="2400" alt="Screenshot_20250820_133544" src="https://github.com/user-attachments/assets/64e2f9c2-1299-4aa4-b9f9-37cff0efab24" /> | <img width="1080" height="2400" alt="Screenshot_20250820_133555" src="https://github.com/user-attachments/assets/19301314-0c89-41e8-8326-4424142754c7" /> |


- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->