### PR TITLE
Issue/woomob 1013 we mention manual refund on woopayments ipp payments

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/refunds/RefundSummaryFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/refunds/RefundSummaryFragment.kt
@@ -91,6 +91,7 @@ class RefundSummaryFragment : BaseFragment(R.layout.fragment_refund_summary), Ba
                         )
                     findNavController().navigateSafely(action)
                 }
+
                 is NavigateToCardReaderScreen -> {
                     val action = RefundSummaryFragmentDirections.actionRefundSummaryFragmentToCardReaderFlow(
                         cardReaderFlowParam = CardReaderFlowParam.PaymentOrRefund.Refund(
@@ -100,6 +101,7 @@ class RefundSummaryFragment : BaseFragment(R.layout.fragment_refund_summary), Ba
                     )
                     findNavController().navigateSafely(action)
                 }
+
                 else -> event.isHandled = false
             }
         }
@@ -129,6 +131,15 @@ class RefundSummaryFragment : BaseFragment(R.layout.fragment_refund_summary), Ba
                     binding.refundSummaryMethodDescription.show()
                 } else {
                     binding.refundSummaryMethodDescription.hide()
+                }
+            }
+            new.isFetchingCardData.takeIfNotEqualTo(old?.isFetchingCardData) { loading ->
+                if (loading) {
+                    binding.refundMethodLayout.hide()
+                    binding.loadingPaymentMethodSkeletons.show()
+                } else {
+                    binding.refundMethodLayout.show()
+                    binding.loadingPaymentMethodSkeletons.hide()
                 }
             }
         }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/refunds/RefundSummaryFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/refunds/RefundSummaryFragment.kt
@@ -56,7 +56,8 @@ class RefundSummaryFragment : BaseFragment(R.layout.fragment_refund_summary), Ba
         _binding = FragmentRefundSummaryBinding.bind(view)
         setupToolbar()
         initializeViews()
-        setupObservers()
+        setupUiStateObservers()
+        handleEvents()
         handleResults()
     }
 
@@ -75,37 +76,7 @@ class RefundSummaryFragment : BaseFragment(R.layout.fragment_refund_summary), Ba
         _binding = null
     }
 
-    private fun setupObservers() {
-        viewModel.event.observe(
-            viewLifecycleOwner
-        ) { event ->
-            when (event) {
-                is ShowSnackbar -> uiMessageResolver.getSnack(event.message, *event.args).show()
-                is Exit -> navigateBackWithNotice(REFUND_ORDER_NOTICE_KEY, R.id.orderDetailFragment)
-                is ShowRefundConfirmation -> {
-                    val action =
-                        RefundSummaryFragmentDirections.actionRefundSummaryFragmentToRefundConfirmationDialog(
-                            title = event.title,
-                            message = event.message,
-                            positiveButtonTitle = event.confirmButtonTitle
-                        )
-                    findNavController().navigateSafely(action)
-                }
-
-                is NavigateToCardReaderScreen -> {
-                    val action = RefundSummaryFragmentDirections.actionRefundSummaryFragmentToCardReaderFlow(
-                        cardReaderFlowParam = CardReaderFlowParam.PaymentOrRefund.Refund(
-                            event.orderId,
-                            event.refundAmount
-                        )
-                    )
-                    findNavController().navigateSafely(action)
-                }
-
-                else -> event.isHandled = false
-            }
-        }
-
+    private fun setupUiStateObservers() {
         viewModel.refundSummaryStateLiveData.observe(viewLifecycleOwner) { old, new ->
             new.isFormEnabled?.takeIfNotEqualTo(old?.isFormEnabled) {
                 binding.refundSummaryBtnRefund.isEnabled = new.isFormEnabled
@@ -141,6 +112,38 @@ class RefundSummaryFragment : BaseFragment(R.layout.fragment_refund_summary), Ba
                     binding.refundMethodLayout.show()
                     binding.loadingPaymentMethodSkeletons.hide()
                 }
+            }
+        }
+    }
+
+    private fun handleEvents() {
+        viewModel.event.observe(
+            viewLifecycleOwner
+        ) { event ->
+            when (event) {
+                is ShowSnackbar -> uiMessageResolver.getSnack(event.message, *event.args).show()
+                is Exit -> navigateBackWithNotice(REFUND_ORDER_NOTICE_KEY, R.id.orderDetailFragment)
+                is ShowRefundConfirmation -> {
+                    val action =
+                        RefundSummaryFragmentDirections.actionRefundSummaryFragmentToRefundConfirmationDialog(
+                            title = event.title,
+                            message = event.message,
+                            positiveButtonTitle = event.confirmButtonTitle
+                        )
+                    findNavController().navigateSafely(action)
+                }
+
+                is NavigateToCardReaderScreen -> {
+                    val action = RefundSummaryFragmentDirections.actionRefundSummaryFragmentToCardReaderFlow(
+                        cardReaderFlowParam = CardReaderFlowParam.PaymentOrRefund.Refund(
+                            event.orderId,
+                            event.refundAmount
+                        )
+                    )
+                    findNavController().navigateSafely(action)
+                }
+
+                else -> event.isHandled = false
             }
         }
     }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/refunds/RefundSummaryViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/refunds/RefundSummaryViewModel.kt
@@ -180,7 +180,7 @@ class RefundSummaryViewModel @Inject constructor(
                 }
                 updateRefundSummaryState(paymentTitle, isMethodDescriptionVisible = true)
             } else {
-                enrichRefundMethodWithCardDetails(gateway.title.ifBlank { manualRefundMethod })
+                enrichRefundMethodWithCardDetails(gateway.title)
             }
         }
     }
@@ -205,7 +205,9 @@ class RefundSummaryViewModel @Inject constructor(
                     val refundMethodWithCard = result.run {
                         val brand = result.cardBrand.orEmpty().replaceFirstChar { it.uppercase() }
                         val last4 = result.cardLast4.orEmpty()
-                        "$refundMethod ($brand **** $last4)"
+                        val creditCardRefundDefaultText =
+                            resourceProvider.getString(R.string.order_refunds_credit_card_refund)
+                        "${refundMethod.ifBlank { creditCardRefundDefaultText }} ($brand **** $last4)"
                     }
                     updateRefundSummaryState(refundMethodWithCard, isMethodDescriptionVisible = false)
                 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/refunds/RefundSummaryViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/refunds/RefundSummaryViewModel.kt
@@ -180,7 +180,7 @@ class RefundSummaryViewModel @Inject constructor(
                 }
                 updateRefundSummaryState(paymentTitle, isMethodDescriptionVisible = true)
             } else {
-                enrichRefundMethodWithCardDetails(gateway.title)
+                enrichRefundMethodWithCardDetails(gateway.title.ifBlank { gateway.methodTitle })
             }
         }
     }

--- a/WooCommerce/src/main/res/layout/fragment_refund_summary.xml
+++ b/WooCommerce/src/main/res/layout/fragment_refund_summary.xml
@@ -1,11 +1,10 @@
-<androidx.core.widget.NestedScrollView
-    xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:tools="http://schemas.android.com/tools"
+<androidx.core.widget.NestedScrollView xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
     android:id="@+id/scrollView"
-    android:fillViewport="true"
     android:layout_width="match_parent"
-    android:layout_height="match_parent">
+    android:layout_height="match_parent"
+    android:fillViewport="true">
 
     <LinearLayout
         android:layout_width="match_parent"
@@ -51,9 +50,9 @@
                         style="@style/Woo.Card.Body.High"
                         android:layout_width="0dp"
                         android:layout_height="wrap_content"
-                        android:layout_weight="1"
                         android:layout_marginTop="@dimen/major_75"
-                        android:text="@string/order_refunds_previously_refunded"/>
+                        android:layout_weight="1"
+                        android:text="@string/order_refunds_previously_refunded" />
 
                     <com.google.android.material.textview.MaterialTextView
                         android:id="@+id/refundSummary_previouslyRefunded"
@@ -61,7 +60,7 @@
                         android:layout_width="wrap_content"
                         android:layout_height="wrap_content"
                         android:layout_marginTop="@dimen/major_75"
-                        tools:text="$45.00"/>
+                        tools:text="$45.00" />
 
                 </LinearLayout>
 
@@ -69,9 +68,9 @@
                 <View
                     style="@style/Woo.Divider"
                     android:layout_marginStart="@dimen/major_100"
-                    android:layout_marginEnd="@dimen/minor_00"
                     android:layout_marginTop="@dimen/major_75"
-                    android:layout_marginBottom="@dimen/major_75"/>
+                    android:layout_marginEnd="@dimen/minor_00"
+                    android:layout_marginBottom="@dimen/major_75" />
 
                 <!-- Refund amount -->
                 <LinearLayout
@@ -92,7 +91,7 @@
                         style="@style/Woo.Card.Body.Bold"
                         android:layout_width="wrap_content"
                         android:layout_height="wrap_content"
-                        tools:text="$45.00"/>
+                        tools:text="$45.00" />
 
                 </LinearLayout>
 
@@ -102,16 +101,16 @@
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
                     android:layout_marginTop="@dimen/major_75"
+                    android:hint="@string/order_refunds_reason_hint"
                     app:counterEnabled="true"
-                    app:counterMaxLength="@integer/maxlength_order_refund_summary_reason"
-                    android:hint="@string/order_refunds_reason_hint" >
+                    app:counterMaxLength="@integer/maxlength_order_refund_summary_reason">
 
                     <com.google.android.material.textfield.TextInputEditText
                         android:id="@+id/refundSummary_reason"
                         style="@style/Woo.TextInputEditText"
                         android:layout_width="match_parent"
                         android:layout_height="wrap_content"
-                        android:inputType="textMultiLine"/>
+                        android:inputType="textMultiLine" />
 
                 </com.google.android.material.textfield.TextInputLayout>
 
@@ -125,10 +124,11 @@
             android:layout_height="wrap_content">
 
             <LinearLayout
+                android:id="@+id/refund_method_layout"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
-                android:paddingBottom="@dimen/major_75"
-                android:orientation="vertical">
+                android:orientation="vertical"
+                android:paddingBottom="@dimen/major_75">
 
                 <com.google.android.material.textview.MaterialTextView
                     style="@style/Woo.Card.Header"
@@ -149,11 +149,35 @@
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
                     android:layout_marginTop="@dimen/minor_50"
-                    android:text="@string/order_refunds_refund_manual_refund_note"
                     android:lineSpacingMultiplier="1.4"
+                    android:text="@string/order_refunds_refund_manual_refund_note"
                     android:textIsSelectable="true" />
 
             </LinearLayout>
+
+            <LinearLayout
+                android:id="@+id/loading_payment_method_skeletons"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:orientation="vertical"
+                android:padding="@dimen/major_75"
+                android:visibility="gone"
+                tools:visibility="visible">
+
+                <View
+                    android:layout_width="@dimen/skeleton_text_medium_width"
+                    android:layout_height="@dimen/skeleton_text_height_100"
+                    android:layout_marginTop="@dimen/minor_50"
+                    android:background="@color/skeleton_color" />
+
+                <View
+                    android:layout_width="@dimen/skeleton_text_large_width"
+                    android:layout_height="@dimen/skeleton_text_height_75"
+                    android:layout_marginTop="@dimen/major_75"
+                    android:background="@color/skeleton_color" />
+
+            </LinearLayout>
+
 
         </com.google.android.material.card.MaterialCardView>
 
@@ -162,10 +186,10 @@
             style="@style/Woo.Button.Colored"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:layout_marginTop="@dimen/minor_100"
-            android:layout_marginBottom="@dimen/minor_100"
             android:layout_marginStart="@dimen/major_100"
+            android:layout_marginTop="@dimen/minor_100"
             android:layout_marginEnd="@dimen/major_100"
+            android:layout_marginBottom="@dimen/minor_100"
             android:text="@string/order_refunds_refund" />
 
     </LinearLayout>

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -1467,6 +1467,7 @@
     <string name="order_refunds_method">%1$s via %2$s</string>
     <string name="order_refunds_refund_details">Refund details</string>
     <string name="order_refunds_manual_refund">Manual refund</string>
+    <string name="order_refunds_credit_card_refund">Credit card</string>
     <string name="order_refunds_quote_image_description">Quotation icon</string>
     <string name="order_refunds_amount_refund_progress_message">Your refund for %s is being processed. Please wait…</string>
     <string name="order_refunds_amount_refund_confirmation_message">Waiting for refund confirmation…</string>


### PR DESCRIPTION

Fixes WOOMOB-1013

### Description
Fixes 2 issues when handling order refunds: 
- Instead of showing "Manual Refund" texts while we load card details for refund we'll show skeletons. 
- Show new text "Credit card" when refund is automatically made to the credit card used when paying the order. This is consistent with iOS behaviour. 

I'll give some more context on why I opted for this 2 options

### Testing information
1. Open a full filled order paid with a credit card
2. Tap on issue refund
3. Select a product to refund and tap Next
4. Check skeletons are shown while card details are fetched. 
5. Check card details are shown and new text "Credit card" is prefixed. 


https://github.com/user-attachments/assets/c4192a19-c771-4425-8e1f-11da0e7e00f6


### The tests that have been performed
<!-- To give the reviewer an idea of what could be missed in terms of testing -->
The above

### Images/gif
<!-- Include before and after images or gifs when appropriate. -->

- [ ] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
