### PR TITLE
[Shipping Labels] Update tracking and handle in-progress purchase of existing shipments 

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -5,6 +5,7 @@
 -----
 - [*] Shipping Labels: Add error message for invalid dimensions errors to custom package creation screen [https://github.com/woocommerce/woocommerce-android/pull/14499]
 - [*] Shipping Labels: Update the UI of shipping label purchase in-progress and failure states [https://github.com/woocommerce/woocommerce-android/pull/14498]
+- [*] Shipping Labels: Fix handling of existing shipping labels with in-progress purchase status [https://github.com/woocommerce/woocommerce-android/pull/14501]
 
 23.1
 -----

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/WooShippingLabelCreationViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/WooShippingLabelCreationViewModel.kt
@@ -955,7 +955,7 @@ class WooShippingLabelCreationViewModel @Inject constructor(
         launch { refreshShippingRates.emit(Unit) }
     }
 
-    @Suppress("ComplexCondition", "LongMethod")
+    @Suppress("ComplexCondition")
     fun onPurchaseShippingLabel() {
         val selectedShipmentIndex = selectedShipmentIndex
         val selectedPackage = selectedPackagesFlow.value[selectedShipmentIndex]
@@ -994,13 +994,11 @@ class WooShippingLabelCreationViewModel @Inject constructor(
                 hazmatSelection
             ).fold(
                 onSuccess = {
-                    updateShipment(
-                        selectedShipmentIndex,
-                        shipments.value[selectedShipmentIndex].copy(
-                            isPurchaseAPILoading = false,
-                            label = it.labels.firstOrNull()
-                        )
+                    val updatedShipment = shipments.value[selectedShipmentIndex].copy(
+                        isPurchaseAPILoading = false,
+                        label = it.labels.firstOrNull()
                     )
+                    updateShipment(selectedShipmentIndex, updatedShipment)
                 },
                 onFailure = { exception ->
                     updateShipment(

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/WooShippingLabelCreationViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/WooShippingLabelCreationViewModel.kt
@@ -283,6 +283,11 @@ class WooShippingLabelCreationViewModel @Inject constructor(
 
                 if (result.status == ShippingLabelStatus.PURCHASED) {
                     analyticsTracker.track(AnalyticsEvent.WCS_PURCHASE_STEP, mapOf(KEY_STATE to "purchase_success"))
+                } else if (result.status == ShippingLabelStatus.PURCHASE_ERROR) {
+                    analyticsTracker.track(
+                        AnalyticsEvent.WCS_PURCHASE_STEP,
+                        mapOf(KEY_STATE to "purchase_failed", KEY_ERROR to result.shippingLabelModel?.error)
+                    )
                 }
 
                 if (result.status == ShippingLabelStatus.PURCHASED && uiState.value.markOrderComplete) {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/WooShippingLabelCreationViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/WooShippingLabelCreationViewModel.kt
@@ -89,9 +89,7 @@ import kotlinx.coroutines.flow.filterNotNull
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.flatMapLatest
 import kotlinx.coroutines.flow.flowOf
-import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.map
-import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.flow.onStart
 import kotlinx.coroutines.flow.shareIn
 import kotlinx.coroutines.flow.update
@@ -200,6 +198,7 @@ class WooShippingLabelCreationViewModel @Inject constructor(
         launch { observeShippingAddresses() }
         launch { observeCustomsDataChanges() }
         launch { observeNotices() }
+        launch { observeShippingLabelAsyncPurchaseStatus() }
     }
 
     private suspend fun trackScreenShownEvent() {
@@ -270,16 +269,29 @@ class WooShippingLabelCreationViewModel @Inject constructor(
                 }
             }
 
-    private fun observeShippingLabelPurchaseStatus(shipmentId: Int) {
-        launch {
-            val shipment = shipments.value[shipmentId]
-            val labelId = shipment.label?.labelId ?: return@launch
-            observeShippingLabelStatus(orderId = navArgs.orderId, labelId = labelId).onEach { result ->
-                val originAddress = shippingAddresses.value.getOrNull(shipmentId)?.shipFrom?.toAddress()
+    private suspend fun observeShippingLabelAsyncPurchaseStatus() {
+        val shipmentWithIndex = uiState.map { it.selectedIndex }.distinctUntilChanged()
+            .flatMapLatest { index ->
+                shipments.map { it.getOrNull(index) }
+                    .filterNotNull()
+                    .map { Pair(it, index) }
+            }
+
+        shipmentWithIndex
+            .filter { (shipment, _) -> shipment.label?.status == ShippingLabelStatus.PURCHASE_IN_PROGRESS }
+            .flatMapLatest { (shipment, index) ->
+                observeShippingLabelStatus(
+                    orderId = navArgs.orderId,
+                    labelId = shipment.label!!.labelId
+                ).map {
+                    Triple(shipment, index, it)
+                }
+            }.collect { (shipment, index, result) ->
+                val originAddress = shippingAddresses.value.getOrNull(index)?.shipFrom?.toAddress()
 
                 // If result has a label model update the label with it. Otherwise, just update the status.
-                val newLabel = result.shippingLabelModel ?: shipment.label.copy(status = result.status)
-                updateShipment(shipmentId, shipment.copy(label = newLabel.copy(originAddress = originAddress)))
+                val newLabel = result.shippingLabelModel ?: shipment.label?.copy(status = result.status)
+                updateShipment(index, shipment.copy(label = newLabel?.copy(originAddress = originAddress)))
 
                 if (result.status == ShippingLabelStatus.PURCHASED) {
                     analyticsTracker.track(AnalyticsEvent.WCS_PURCHASE_STEP, mapOf(KEY_STATE to "purchase_success"))
@@ -310,8 +322,7 @@ class WooShippingLabelCreationViewModel @Inject constructor(
                         }
                     )
                 }
-            }.launchIn(this)
-        }
+            }
     }
 
     private suspend fun getDestinationAddress() {
@@ -990,7 +1001,6 @@ class WooShippingLabelCreationViewModel @Inject constructor(
                             label = it.labels.firstOrNull()
                         )
                     )
-                    observeShippingLabelPurchaseStatus(selectedShipmentIndex)
                 },
                 onFailure = { exception ->
                     updateShipment(

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/WooShippingLabelCreationViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/WooShippingLabelCreationViewModel.kt
@@ -281,6 +281,10 @@ class WooShippingLabelCreationViewModel @Inject constructor(
                 val newLabel = result.shippingLabelModel ?: shipment.label.copy(status = result.status)
                 updateShipment(shipmentId, shipment.copy(label = newLabel.copy(originAddress = originAddress)))
 
+                if (result.status == ShippingLabelStatus.PURCHASED) {
+                    analyticsTracker.track(AnalyticsEvent.WCS_PURCHASE_STEP, mapOf(KEY_STATE to "purchase_success"))
+                }
+
                 if (result.status == ShippingLabelStatus.PURCHASED && uiState.value.markOrderComplete) {
                     markOrderAsComplete(navArgs.orderId).fold(
                         onSuccess = {
@@ -982,8 +986,6 @@ class WooShippingLabelCreationViewModel @Inject constructor(
                         )
                     )
                     observeShippingLabelPurchaseStatus(selectedShipmentIndex)
-                    // TODO check if we need to track this here or in the observeShippingLabelPurchaseStatus method
-                    analyticsTracker.track(AnalyticsEvent.WCS_PURCHASE_STEP, mapOf(KEY_STATE to "purchase_success"))
                 },
                 onFailure = { exception ->
                     updateShipment(

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/WooShippingLabelCreationViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/WooShippingLabelCreationViewModelTest.kt
@@ -307,7 +307,7 @@ class WooShippingLabelCreationViewModelTest : BaseUnitTest() {
             invoke(any(), any(), any(), any(), any(), any(), any(), any(), any(), isNull(), isNull())
         } doReturn Result.success(
             PurchasedLabelData(
-                labels = listOf(shippingLabelModel.copy(status = ShippingLabelStatus.PURCHASED)),
+                labels = listOf(shippingLabelModel.copy(status = ShippingLabelStatus.PURCHASE_IN_PROGRESS)),
                 origin = emptyMap(),
                 destination = emptyMap(),
                 rates = emptyMap()
@@ -793,7 +793,14 @@ class WooShippingLabelCreationViewModelTest : BaseUnitTest() {
     }
 
     @Test
-    fun `when onPurchaseShippingLabel succeed then track purchase_success`() = testBlocking {
+    fun `when label is purchased, then track purchase_success`() = testBlocking {
+        whenever(observeShippingLabelStatus(eq(orderId), any())) doReturn flowOf(
+            ObserveShippingLabelStatus.ObserveShippingLabelStatusResult(
+                status = ShippingLabelStatus.PURCHASED,
+                shippingLabelModel = shippingLabelModel.copy(status = ShippingLabelStatus.PURCHASED)
+            )
+        )
+
         createViewModel()
 
         val selectedRate = defaultShippingRates.values.first().first()
@@ -1543,5 +1550,32 @@ class WooShippingLabelCreationViewModelTest : BaseUnitTest() {
         assert(currentViewState is DataState)
         val dataState = currentViewState as DataState
         assertThat(dataState.purchaseSectionUI.isOrderAlreadyCompleted).isFalse()
+    }
+
+    @Test
+    fun `when opening a shipment with in-progress label, then fetch the label status`() = testBlocking {
+        val inProgressLabel = shippingLabelModel.copy(status = ShippingLabelStatus.PURCHASE_IN_PROGRESS)
+        whenever(getShipments(any())) doReturn listOf(
+            ShipmentUIModel(
+                localId = "0",
+                items = defaultShippableItems,
+                label = inProgressLabel
+            )
+        )
+        whenever(observeShippingLabelStatus(eq(orderId), any())) doReturn flowOf(
+            ObserveShippingLabelStatus.ObserveShippingLabelStatusResult(
+                status = ShippingLabelStatus.PURCHASED,
+                shippingLabelModel = inProgressLabel.copy(status = ShippingLabelStatus.PURCHASED)
+            )
+        )
+
+        createViewModel()
+        advanceUntilIdle()
+
+        val currentViewState = sut.viewState.value as DataState
+        assertThat(currentViewState.shipmentUIList).hasSize(1)
+        assertThat(currentViewState.shipmentUIList[0].isPurchased).isTrue
+        @Suppress("UnusedFlow")
+        verify(observeShippingLabelStatus).invoke(orderId, inProgressLabel.labelId)
     }
 }


### PR DESCRIPTION
### Description
This PR fixes two issues:
1. It updates the shipping label purchase tracking to be consistent with iOS:
    - Track success only when the async purchase finishes successfully.
    - Track a failure when the async purchase fails.
2. Handle the case of existing shipments with in-progress purchase: The async purchase means that the user can leave the app or wp-admin while a purchase is still ongoing, if they do this, the label will keep the `PURCHASE_IN_PROGRESS` status. We weren't handling this case; we had two different issues:
    - Before this [PR](https://github.com/woocommerce/woocommerce-android/pull/14493), the in-progress label was dismissed, and this was a major issue I think, as they user could be charged multiple times.
    - After the above PR, the app now shows correctly the in-progress label, but it will stay like this indefinitely, unless the user opens wp-admin, which will update the status correctly.

### Steps to reproduce
#### Tracking success
1. Purchase a label from the app.
2. Check logcat and confirm the following line `Tracked: woocommerceandroid_wcs_purchase_step, Properties: {"state":"purchase_success"...}` is tracked only after the label is completely purchased.

#### Optional: tracking failure
1. Check the testing steps to trigger a failure in this [PR](https://github.com/woocommerce/woocommerce-android/pull/14498) description, or use ApiFaker.
2. Check logcat and confirm the following line `Tracked: woocommerceandroid_wcs_purchase_step, Properties: {"state":"purchase_failed","error":..."...}` is tracked.

#### In-progress purchase from mobile
1. Start purchase of a shipping label in the app.
2. Leave the screen while the purchase is in progress.
3. Re-open the shipping labels form.
4. Confirm the purchase continues.

#### In-progress purchase from web
1. Start purchase of a shipping label in wp-admin.
2. Close the browser tab while the purchase is in progress.
3. Open the shipping labels form in the mobile app.
4. Confirm the purchase continues.

### Testing information
- Confirm the tracking works as expected.
- Confirm the in-progress labels are handled correctly.

### The tests that have been performed
The above.

### Images/gif
| Before #14493 | After #14493 | After this PR |
| --- | --- | --- |
| <video src=https://github.com/user-attachments/assets/b063a49d-f20f-454c-a98d-5e6d64bad067 /> | <video src=https://github.com/user-attachments/assets/cec05470-5085-4fb6-86ca-ba23daa5a4c6 /> | <video src=https://github.com/user-attachments/assets/b030750a-3b08-43b3-9687-bb2ddf29ae5a /> |


- [ ] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->