### PR TITLE
Show disabled button state when missing required fields

### DIFF
--- a/WooCommerce/src/main/res/layout/activity_support_request_form.xml
+++ b/WooCommerce/src/main/res/layout/activity_support_request_form.xml
@@ -213,6 +213,7 @@
             android:layout_marginHorizontal="@dimen/major_100"
             android:layout_marginTop="@dimen/minor_100"
             android:layout_marginBottom="@dimen/major_200"
+            android:backgroundTint="@color/color_primary_selector"
             android:text="@string/support_request_submit" />
 
     </androidx.appcompat.widget.LinearLayoutCompat>


### PR DESCRIPTION
Closes: WOOMOB-940

### Description

The current support form is a bit confusing because the "Submit Support Request" is shown as enabled even when it is disabled behind scenes because there's missing required info in the form. 
This PR simply adds a disabled state to the button so that it reflects it's current enabled/disabled status clearly

### Steps to reproduce
<!-- Step-by-step testing instructions. For new user flows, consider instead stating the goal of the workflow and see if your PR reviewer can accomplish the workflow without specific steps! -->

### Testing information
1. Navigate to Settings > Help & Support > Contact Support
2. Verify the button is shown as disabled in both light and dark mode
3. Enter all the required field
4. Check how the button is shown as enabled
5. Erase any of the required fields and confirm the button is shown as disabled again. 

### The tests that have been performed
<!-- To give the reviewer an idea of what could be missed in terms of testing -->
The above

https://github.com/user-attachments/assets/42e2cc53-95ff-4935-8dd1-3248bca63d5d


