### PR TITLE
[POS][Local Catalog] Repo for incremental sync timestamps

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/util/datastore/WooPosSyncTimestampManager.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/util/datastore/WooPosSyncTimestampManager.kt
@@ -14,6 +14,7 @@ class WooPosSyncTimestampManager @Inject constructor(
 ) {
     private val gmtDateFormat = SimpleDateFormat(GMT_DATE_FORMAT, Locale.US).apply {
         timeZone = TimeZone.getTimeZone("GMT")
+        isLenient = false
     }
 
     suspend fun storeProductsLastSyncTimestamp(timestamp: Date) {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/util/datastore/WooPosSyncTimestampManager.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/util/datastore/WooPosSyncTimestampManager.kt
@@ -1,0 +1,69 @@
+package com.woocommerce.android.ui.woopos.util.datastore
+
+import java.text.SimpleDateFormat
+import java.util.Date
+import java.util.Locale
+import java.util.TimeZone
+import javax.inject.Inject
+import javax.inject.Singleton
+
+@Singleton
+class WooPosSyncTimestampManager @Inject constructor(
+    private val timestampRepository: WooPosSyncTimestampRepository
+) {
+    private val gmtDateFormat = SimpleDateFormat(GMT_DATE_FORMAT, Locale.US).apply {
+        timeZone = TimeZone.getTimeZone("GMT")
+    }
+
+    suspend fun storeProductsLastSyncTimestamp(timestamp: Date) {
+        val timestampGmt: String = gmtDateFormat.format(timestamp)
+        timestampRepository.storeProductsLastSyncTimestamp(timestampGmt)
+    }
+
+    suspend fun getProductsLastSyncTimestamp(): Date? {
+        val timestampString = timestampRepository.getProductsLastSyncTimestamp()
+        return timestampString?.let { parseGmtTimestamp(it) }
+    }
+
+    suspend fun clearProductsLastSyncTimestamp() {
+        timestampRepository.clearProductsLastSyncTimestamp()
+    }
+
+    suspend fun storeVariationsLastSyncTimestamp(timestamp: Date) {
+        val timestampGmt: String = gmtDateFormat.format(timestamp)
+        timestampRepository.storeVariationsLastSyncTimestamp(timestampGmt)
+    }
+
+    suspend fun getVariationsLastSyncTimestamp(): Date? {
+        val timestampString = timestampRepository.getVariationsLastSyncTimestamp()
+        return timestampString?.let { parseGmtTimestamp(it) }
+    }
+
+    suspend fun clearVariationsLastSyncTimestamp() {
+        timestampRepository.clearVariationsLastSyncTimestamp()
+    }
+
+    suspend fun clearAllSyncTimestamps() {
+        timestampRepository.clearAllSyncTimestamps()
+    }
+
+    fun formatTimestampForApi(timestamp: Date): String {
+        return gmtDateFormat.format(timestamp)
+    }
+
+    fun parseTimestampFromApi(timestampString: String): Date? {
+        return parseGmtTimestamp(timestampString)
+    }
+
+    private fun parseGmtTimestamp(timestampString: String): Date? {
+        return try {
+            gmtDateFormat.parse(timestampString)
+        } catch (e: Exception) {
+            null
+        }
+    }
+
+    private companion object {
+        const val GMT_DATE_FORMAT = "yyyy-MM-dd'T'HH:mm:ss"
+    }
+}

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/util/datastore/WooPosSyncTimestampManager.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/util/datastore/WooPosSyncTimestampManager.kt
@@ -1,5 +1,7 @@
 package com.woocommerce.android.ui.woopos.util.datastore
 
+import com.woocommerce.android.ui.woopos.common.util.WooPosLogWrapper
+import java.text.ParseException
 import java.text.SimpleDateFormat
 import java.util.Date
 import java.util.Locale
@@ -9,7 +11,8 @@ import javax.inject.Singleton
 
 @Singleton
 class WooPosSyncTimestampManager @Inject constructor(
-    private val timestampRepository: WooPosSyncTimestampRepository
+    private val timestampRepository: WooPosSyncTimestampRepository,
+    private val logger: WooPosLogWrapper
 ) {
     private val gmtDateFormat = SimpleDateFormat(GMT_DATE_FORMAT, Locale.US).apply {
         timeZone = TimeZone.getTimeZone("GMT")
@@ -58,7 +61,8 @@ class WooPosSyncTimestampManager @Inject constructor(
     private fun parseGmtTimestamp(timestampString: String): Date? {
         return try {
             gmtDateFormat.parse(timestampString)
-        } catch (e: Exception) {
+        } catch (e: ParseException) {
+            logger.e("Failed to parse GMT timestamp: '$timestampString'", e)
             null
         }
     }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/util/datastore/WooPosSyncTimestampManager.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/util/datastore/WooPosSyncTimestampManager.kt
@@ -7,9 +7,7 @@ import java.util.Date
 import java.util.Locale
 import java.util.TimeZone
 import javax.inject.Inject
-import javax.inject.Singleton
 
-@Singleton
 class WooPosSyncTimestampManager @Inject constructor(
     private val timestampRepository: WooPosSyncTimestampRepository,
     private val logger: WooPosLogWrapper

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/util/datastore/WooPosSyncTimestampManager.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/util/datastore/WooPosSyncTimestampManager.kt
@@ -1,45 +1,32 @@
 package com.woocommerce.android.ui.woopos.util.datastore
 
 import com.woocommerce.android.ui.woopos.common.util.WooPosLogWrapper
-import java.text.ParseException
-import java.text.SimpleDateFormat
-import java.util.Date
+import java.time.Instant
+import java.time.LocalDateTime
+import java.time.ZoneOffset
+import java.time.format.DateTimeFormatter
+import java.time.format.DateTimeParseException
 import java.util.Locale
-import java.util.TimeZone
 import javax.inject.Inject
 
 class WooPosSyncTimestampManager @Inject constructor(
     private val timestampRepository: WooPosSyncTimestampRepository,
     private val logger: WooPosLogWrapper
 ) {
-    private val gmtDateFormat = SimpleDateFormat(GMT_DATE_FORMAT, Locale.US).apply {
-        timeZone = TimeZone.getTimeZone("GMT")
-        isLenient = false
+    private val gmtFormatter = DateTimeFormatter.ofPattern(GMT_DATE_FORMAT, Locale.US).withZone(ZoneOffset.UTC)
+
+    suspend fun storeProductsLastSyncTimestamp(timestamp: Long) {
+        timestampRepository.storeProductsLastSyncTimestamp(timestamp)
     }
 
-    suspend fun storeProductsLastSyncTimestamp(timestamp: Date) {
-        val timestampGmt: String = gmtDateFormat.format(timestamp)
-        timestampRepository.storeProductsLastSyncTimestamp(timestampGmt)
-    }
+    suspend fun getProductsLastSyncTimestamp(): Long? = timestampRepository.getProductsLastSyncTimestamp()
 
-    suspend fun getProductsLastSyncTimestamp(): Date? {
-        val timestampString = timestampRepository.getProductsLastSyncTimestamp()
-        return timestampString?.let { parseGmtTimestamp(it) }
-    }
+    suspend fun clearProductsLastSyncTimestamp() = timestampRepository.clearProductsLastSyncTimestamp()
 
-    suspend fun clearProductsLastSyncTimestamp() {
-        timestampRepository.clearProductsLastSyncTimestamp()
-    }
+    suspend fun storeVariationsLastSyncTimestamp(timestamp: Long) =
+        timestampRepository.storeVariationsLastSyncTimestamp(timestamp)
 
-    suspend fun storeVariationsLastSyncTimestamp(timestamp: Date) {
-        val timestampGmt: String = gmtDateFormat.format(timestamp)
-        timestampRepository.storeVariationsLastSyncTimestamp(timestampGmt)
-    }
-
-    suspend fun getVariationsLastSyncTimestamp(): Date? {
-        val timestampString = timestampRepository.getVariationsLastSyncTimestamp()
-        return timestampString?.let { parseGmtTimestamp(it) }
-    }
+    suspend fun getVariationsLastSyncTimestamp(): Long? = timestampRepository.getVariationsLastSyncTimestamp()
 
     suspend fun clearVariationsLastSyncTimestamp() {
         timestampRepository.clearVariationsLastSyncTimestamp()
@@ -49,19 +36,20 @@ class WooPosSyncTimestampManager @Inject constructor(
         timestampRepository.clearAllSyncTimestamps()
     }
 
-    fun formatTimestampForApi(timestamp: Date): String {
-        return gmtDateFormat.format(timestamp)
+    fun formatTimestampForApi(timestamp: Long): String {
+        return gmtFormatter.format(Instant.ofEpochMilli(timestamp))
     }
 
-    fun parseTimestampFromApi(timestampString: String): Date? {
-        return parseGmtTimestamp(timestampString)
+    fun parseTimestampFromApi(dateFromApi: String): Long? {
+        return parseGmtTimestamp(dateFromApi)
     }
 
-    private fun parseGmtTimestamp(timestampString: String): Date? {
+    private fun parseGmtTimestamp(dateFromApi: String): Long? {
         return try {
-            gmtDateFormat.parse(timestampString)
-        } catch (e: ParseException) {
-            logger.e("Failed to parse GMT timestamp: '$timestampString'", e)
+            val localDateTime = LocalDateTime.parse(dateFromApi, gmtFormatter)
+            return localDateTime.toInstant(ZoneOffset.UTC).toEpochMilli()
+        } catch (e: DateTimeParseException) {
+            logger.e("Failed to parse GMT timestamp: '$dateFromApi'", e)
             null
         }
     }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/util/datastore/WooPosSyncTimestampRepository.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/util/datastore/WooPosSyncTimestampRepository.kt
@@ -5,63 +5,93 @@ import androidx.datastore.preferences.core.Preferences
 import androidx.datastore.preferences.core.edit
 import androidx.datastore.preferences.core.stringPreferencesKey
 import com.woocommerce.android.tools.SelectedSite
+import com.woocommerce.android.ui.woopos.common.util.WooPosLogWrapper
 import kotlinx.coroutines.flow.first
 import javax.inject.Inject
 import javax.inject.Singleton
 
-/**
- * Repository for managing POS incremental sync timestamps using DataStore.
- * Stores and retrieves timestamps specific to the current site for products and variations sync.
- */
 @Singleton
 class WooPosSyncTimestampRepository @Inject constructor(
     private val selectedSite: SelectedSite,
-    private val dataStore: DataStore<Preferences>
+    private val dataStore: DataStore<Preferences>,
+    private val logger: WooPosLogWrapper
 ) {
-    private val productsTimestampKey = buildSiteSpecificKey(PRODUCTS_TIMESTAMP_KEY)
-    private val variationsTimestampKey = buildSiteSpecificKey(VARIATIONS_TIMESTAMP_KEY)
 
     suspend fun storeProductsLastSyncTimestamp(timestampGmt: String) {
-        dataStore.edit { preferences ->
-            preferences[productsTimestampKey] = timestampGmt
+        val key = buildSiteSpecificKey(PRODUCTS_TIMESTAMP_KEY)
+        if (key != null) {
+            dataStore.edit { preferences ->
+                preferences[key] = timestampGmt
+            }
         }
     }
 
     suspend fun getProductsLastSyncTimestamp(): String? {
-        return dataStore.data.first()[productsTimestampKey]
+        val key = buildSiteSpecificKey(PRODUCTS_TIMESTAMP_KEY)
+        return if (key != null) {
+            dataStore.data.first()[key]
+        } else {
+            null
+        }
     }
 
     suspend fun clearProductsLastSyncTimestamp() {
-        dataStore.edit { preferences ->
-            preferences.remove(productsTimestampKey)
+        val key = buildSiteSpecificKey(PRODUCTS_TIMESTAMP_KEY)
+        if (key != null) {
+            dataStore.edit { preferences ->
+                preferences.remove(key)
+            }
         }
     }
 
     suspend fun storeVariationsLastSyncTimestamp(timestampGmt: String) {
-        dataStore.edit { preferences ->
-            preferences[variationsTimestampKey] = timestampGmt
+        val key = buildSiteSpecificKey(VARIATIONS_TIMESTAMP_KEY)
+        if (key != null) {
+            dataStore.edit { preferences ->
+                preferences[key] = timestampGmt
+            }
         }
     }
 
     suspend fun getVariationsLastSyncTimestamp(): String? {
-        return dataStore.data.first()[variationsTimestampKey]
+        val key = buildSiteSpecificKey(VARIATIONS_TIMESTAMP_KEY)
+        return if (key != null) {
+            dataStore.data.first()[key]
+        } else {
+            null
+        }
     }
 
     suspend fun clearVariationsLastSyncTimestamp() {
-        dataStore.edit { preferences ->
-            preferences.remove(variationsTimestampKey)
+        val key = buildSiteSpecificKey(VARIATIONS_TIMESTAMP_KEY)
+        if (key != null) {
+            dataStore.edit { preferences ->
+                preferences.remove(key)
+            }
         }
     }
 
     suspend fun clearAllSyncTimestamps() {
-        dataStore.edit { preferences ->
-            preferences.remove(productsTimestampKey)
-            preferences.remove(variationsTimestampKey)
+        val productsKey = buildSiteSpecificKey(PRODUCTS_TIMESTAMP_KEY)
+        val variationsKey = buildSiteSpecificKey(VARIATIONS_TIMESTAMP_KEY)
+
+        if (productsKey != null && variationsKey != null) {
+            dataStore.edit { preferences ->
+                preferences.remove(productsKey)
+                preferences.remove(variationsKey)
+            }
         }
     }
 
-    private fun buildSiteSpecificKey(key: String): Preferences.Key<String> =
-        stringPreferencesKey("${selectedSite.getOrNull()?.siteId}-$key")
+    private fun buildSiteSpecificKey(key: String): Preferences.Key<String>? {
+        val site = selectedSite.getOrNull()
+        return if (site != null) {
+            stringPreferencesKey("${site.siteId}-$key")
+        } else {
+            logger.e("Cannot build site-specific key '$key': no site selected")
+            null
+        }
+    }
 
     private companion object {
         const val PRODUCTS_TIMESTAMP_KEY = "pos_products_sync_timestamp"

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/util/datastore/WooPosSyncTimestampRepository.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/util/datastore/WooPosSyncTimestampRepository.kt
@@ -8,9 +8,7 @@ import com.woocommerce.android.tools.SelectedSite
 import com.woocommerce.android.ui.woopos.common.util.WooPosLogWrapper
 import kotlinx.coroutines.flow.first
 import javax.inject.Inject
-import javax.inject.Singleton
 
-@Singleton
 class WooPosSyncTimestampRepository @Inject constructor(
     private val selectedSite: SelectedSite,
     private val dataStore: DataStore<Preferences>,

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/util/datastore/WooPosSyncTimestampRepository.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/util/datastore/WooPosSyncTimestampRepository.kt
@@ -1,0 +1,70 @@
+package com.woocommerce.android.ui.woopos.util.datastore
+
+import androidx.datastore.core.DataStore
+import androidx.datastore.preferences.core.Preferences
+import androidx.datastore.preferences.core.edit
+import androidx.datastore.preferences.core.stringPreferencesKey
+import com.woocommerce.android.tools.SelectedSite
+import kotlinx.coroutines.flow.first
+import javax.inject.Inject
+import javax.inject.Singleton
+
+/**
+ * Repository for managing POS incremental sync timestamps using DataStore.
+ * Stores and retrieves timestamps specific to the current site for products and variations sync.
+ */
+@Singleton
+class WooPosSyncTimestampRepository @Inject constructor(
+    private val selectedSite: SelectedSite,
+    private val dataStore: DataStore<Preferences>
+) {
+    private val productsTimestampKey = buildSiteSpecificKey(PRODUCTS_TIMESTAMP_KEY)
+    private val variationsTimestampKey = buildSiteSpecificKey(VARIATIONS_TIMESTAMP_KEY)
+
+    suspend fun storeProductsLastSyncTimestamp(timestampGmt: String) {
+        dataStore.edit { preferences ->
+            preferences[productsTimestampKey] = timestampGmt
+        }
+    }
+
+    suspend fun getProductsLastSyncTimestamp(): String? {
+        return dataStore.data.first()[productsTimestampKey]
+    }
+
+    suspend fun clearProductsLastSyncTimestamp() {
+        dataStore.edit { preferences ->
+            preferences.remove(productsTimestampKey)
+        }
+    }
+
+    suspend fun storeVariationsLastSyncTimestamp(timestampGmt: String) {
+        dataStore.edit { preferences ->
+            preferences[variationsTimestampKey] = timestampGmt
+        }
+    }
+
+    suspend fun getVariationsLastSyncTimestamp(): String? {
+        return dataStore.data.first()[variationsTimestampKey]
+    }
+
+    suspend fun clearVariationsLastSyncTimestamp() {
+        dataStore.edit { preferences ->
+            preferences.remove(variationsTimestampKey)
+        }
+    }
+
+    suspend fun clearAllSyncTimestamps() {
+        dataStore.edit { preferences ->
+            preferences.remove(productsTimestampKey)
+            preferences.remove(variationsTimestampKey)
+        }
+    }
+
+    private fun buildSiteSpecificKey(key: String): Preferences.Key<String> =
+        stringPreferencesKey("${selectedSite.getOrNull()?.siteId}-$key")
+
+    private companion object {
+        const val PRODUCTS_TIMESTAMP_KEY = "pos_products_sync_timestamp"
+        const val VARIATIONS_TIMESTAMP_KEY = "pos_variations_sync_timestamp"
+    }
+}

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/util/datastore/WooPosSyncTimestampRepository.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/util/datastore/WooPosSyncTimestampRepository.kt
@@ -15,19 +15,19 @@ class WooPosSyncTimestampRepository @Inject constructor(
     private val logger: WooPosLogWrapper
 ) {
 
-    suspend fun storeProductsLastSyncTimestamp(timestampGmt: String) {
+    suspend fun storeProductsLastSyncTimestamp(timestamp: Long) {
         val key = buildSiteSpecificKey(PRODUCTS_TIMESTAMP_KEY)
         if (key != null) {
             dataStore.edit { preferences ->
-                preferences[key] = timestampGmt
+                preferences[key] = timestamp.toString()
             }
         }
     }
 
-    suspend fun getProductsLastSyncTimestamp(): String? {
+    suspend fun getProductsLastSyncTimestamp(): Long? {
         val key = buildSiteSpecificKey(PRODUCTS_TIMESTAMP_KEY)
         return if (key != null) {
-            dataStore.data.first()[key]
+            dataStore.data.first()[key]?.toLong()
         } else {
             null
         }
@@ -42,19 +42,19 @@ class WooPosSyncTimestampRepository @Inject constructor(
         }
     }
 
-    suspend fun storeVariationsLastSyncTimestamp(timestampGmt: String) {
+    suspend fun storeVariationsLastSyncTimestamp(timestamp: Long) {
         val key = buildSiteSpecificKey(VARIATIONS_TIMESTAMP_KEY)
         if (key != null) {
             dataStore.edit { preferences ->
-                preferences[key] = timestampGmt
+                preferences[key] = timestamp.toString()
             }
         }
     }
 
-    suspend fun getVariationsLastSyncTimestamp(): String? {
+    suspend fun getVariationsLastSyncTimestamp(): Long? {
         val key = buildSiteSpecificKey(VARIATIONS_TIMESTAMP_KEY)
         return if (key != null) {
-            dataStore.data.first()[key]
+            dataStore.data.first()[key]?.toLong()
         } else {
             null
         }

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/util/datastore/WooPosSyncTimestampManagerTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/util/datastore/WooPosSyncTimestampManagerTest.kt
@@ -10,164 +10,131 @@ import org.mockito.kotlin.eq
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
-import java.text.SimpleDateFormat
-import java.util.Date
+import java.time.LocalDateTime
+import java.time.ZoneOffset
+import java.time.format.DateTimeFormatter
 import java.util.Locale
-import java.util.TimeZone
 
 class WooPosSyncTimestampManagerTest {
     private val repository: WooPosSyncTimestampRepository = mock()
     private val logger: WooPosLogWrapper = mock()
 
     private lateinit var manager: WooPosSyncTimestampManager
-    private lateinit var gmtDateFormat: SimpleDateFormat
+    private val gmtFormatter = DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss", Locale.US).withZone(ZoneOffset.UTC)
 
     @Before
     fun setup() {
         manager = WooPosSyncTimestampManager(repository, logger)
-        gmtDateFormat = SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss", Locale.US).apply {
-            timeZone = TimeZone.getTimeZone("GMT")
+    }
+
+    @Test
+    fun `given timestamp in millis, when storing products timestamp, then timestamp is stored`() {
+        runTest {
+            // GIVEN
+            val timestamp = LocalDateTime.parse("2024-01-15T10:30:00", gmtFormatter)
+                .toInstant(ZoneOffset.UTC).toEpochMilli()
+
+            // WHEN
+            manager.storeProductsLastSyncTimestamp(timestamp)
+
+            // THEN
+            verify(repository).storeProductsLastSyncTimestamp(timestamp)
         }
     }
 
     @Test
-    fun `given date object, when storing products timestamp, then formatted GMT string is stored`() {
+    fun `given valid timestamp in repository, when getting products timestamp, then timestamp is returned`() {
         runTest {
-            // Given
-            val date: Date = gmtDateFormat.parse("2024-01-15T10:30:00")!!
+            // GIVEN
+            val expectedTimestamp = LocalDateTime.parse("2024-01-15T10:30:00", gmtFormatter)
+                .toInstant(ZoneOffset.UTC).toEpochMilli()
+            whenever(repository.getProductsLastSyncTimestamp()).thenReturn(expectedTimestamp)
 
-            // When
-            manager.storeProductsLastSyncTimestamp(date)
-
-            // Then
-            verify(repository).storeProductsLastSyncTimestamp("2024-01-15T10:30:00")
-        }
-    }
-
-    @Test
-    fun `given valid timestamp string in repository, when getting products timestamp, then date object is returned`() {
-        runTest {
-            // Given
-            val timestampString = "2024-01-15T10:30:00"
-            val expectedDate = gmtDateFormat.parse(timestampString)
-            whenever(repository.getProductsLastSyncTimestamp()).thenReturn(timestampString)
-
-            // When
+            // WHEN
             val result = manager.getProductsLastSyncTimestamp()
 
-            // Then
-            assertThat(result).isEqualTo(expectedDate)
+            // THEN
+            assertThat(result).isEqualTo(expectedTimestamp)
         }
     }
 
     @Test
     fun `given no timestamp in repository, when getting products timestamp, then null is returned`() {
         runTest {
-            // Given
+            // GIVEN
             whenever(repository.getProductsLastSyncTimestamp()).thenReturn(null)
 
-            // When
+            // WHEN
             val result = manager.getProductsLastSyncTimestamp()
 
-            // Then
+            // THEN
             assertThat(result).isNull()
-        }
-    }
-
-    @Test
-    fun `given invalid timestamp string in repository, when getting products timestamp, then null is returned and error logged`() {
-        runTest {
-            // Given
-            val invalidTimestamp = "not-a-valid-timestamp"
-            whenever(repository.getProductsLastSyncTimestamp()).thenReturn(invalidTimestamp)
-
-            // When
-            val result = manager.getProductsLastSyncTimestamp()
-
-            // Then
-            assertThat(result).isNull()
-            verify(logger).e(eq("Failed to parse GMT timestamp: 'not-a-valid-timestamp'"), any())
         }
     }
 
     @Test
     fun `when clearing products timestamp, then repository clear method is called`() {
         runTest {
-            // When
+            // WHEN
             manager.clearProductsLastSyncTimestamp()
 
-            // Then
+            // THEN
             verify(repository).clearProductsLastSyncTimestamp()
         }
     }
 
     @Test
-    fun `given date object, when storing variations timestamp, then formatted GMT string is stored`() {
+    fun `given timestamp in millis, when storing variations timestamp, then timestamp is stored`() {
         runTest {
-            // Given
-            val date = gmtDateFormat.parse("2024-01-15T11:45:00")!!
+            // GIVEN
+            val timestamp = LocalDateTime.parse("2024-01-15T11:45:00", gmtFormatter)
+                .toInstant(ZoneOffset.UTC).toEpochMilli()
 
-            // When
-            manager.storeVariationsLastSyncTimestamp(date)
+            // WHEN
+            manager.storeVariationsLastSyncTimestamp(timestamp)
 
-            // Then
-            verify(repository).storeVariationsLastSyncTimestamp("2024-01-15T11:45:00")
+            // THEN
+            verify(repository).storeVariationsLastSyncTimestamp(timestamp)
         }
     }
 
     @Test
-    fun `given valid timestamp string in repository, when getting variations timestamp, then date object is returned`() {
+    fun `given valid timestamp in repository, when getting variations timestamp, then timestamp is returned`() {
         runTest {
-            // Given
-            val timestampString = "2024-01-15T11:45:00"
-            val expectedDate = gmtDateFormat.parse(timestampString)
-            whenever(repository.getVariationsLastSyncTimestamp()).thenReturn(timestampString)
+            // GIVEN
+            val expectedTimestamp = LocalDateTime.parse("2024-01-15T11:45:00", gmtFormatter)
+                .toInstant(ZoneOffset.UTC).toEpochMilli()
+            whenever(repository.getVariationsLastSyncTimestamp()).thenReturn(expectedTimestamp)
 
-            // When
+            // WHEN
             val result = manager.getVariationsLastSyncTimestamp()
 
-            // Then
-            assertThat(result).isEqualTo(expectedDate)
+            // THEN
+            assertThat(result).isEqualTo(expectedTimestamp)
         }
     }
 
     @Test
     fun `given no timestamp in repository, when getting variations timestamp, then null is returned`() {
         runTest {
-            // Given
+            // GIVEN
             whenever(repository.getVariationsLastSyncTimestamp()).thenReturn(null)
 
-            // When
+            // WHEN
             val result = manager.getVariationsLastSyncTimestamp()
 
-            // Then
+            // THEN
             assertThat(result).isNull()
-        }
-    }
-
-    @Test
-    fun `given invalid timestamp string in repository, when getting variations timestamp, then null is returned and error logged`() {
-        runTest {
-            // Given
-            val invalidTimestamp = "invalid-date-format"
-            whenever(repository.getVariationsLastSyncTimestamp()).thenReturn(invalidTimestamp)
-
-            // When
-            val result = manager.getVariationsLastSyncTimestamp()
-
-            // Then
-            assertThat(result).isNull()
-            verify(logger).e(eq("Failed to parse GMT timestamp: 'invalid-date-format'"), any())
         }
     }
 
     @Test
     fun `when clearing variations timestamp, then repository clear method is called`() {
         runTest {
-            // When
+            // WHEN
             manager.clearVariationsLastSyncTimestamp()
 
-            // Then
+            // THEN
             verify(repository).clearVariationsLastSyncTimestamp()
         }
     }
@@ -175,88 +142,104 @@ class WooPosSyncTimestampManagerTest {
     @Test
     fun `when clearing all timestamps, then repository clear all method is called`() {
         runTest {
-            // When
+            // WHEN
             manager.clearAllSyncTimestamps()
 
-            // Then
+            // THEN
             verify(repository).clearAllSyncTimestamps()
         }
     }
 
     @Test
-    fun `given date object, when formatting for API, then correct GMT string is returned`() {
-        // Given
-        val date = gmtDateFormat.parse("2024-01-15T14:30:00")!!
+    fun `given timestamp in millis, when formatting for API, then correct GMT string is returned`() {
+        // GIVEN
+        val timestamp = LocalDateTime.parse("2024-01-15T14:30:00", gmtFormatter)
+            .toInstant(ZoneOffset.UTC).toEpochMilli()
 
-        // When
-        val result = manager.formatTimestampForApi(date)
+        // WHEN
+        val result = manager.formatTimestampForApi(timestamp)
 
-        // Then
+        // THEN
         assertThat(result).isEqualTo("2024-01-15T14:30:00")
     }
 
     @Test
-    fun `given valid timestamp string, when parsing from API, then correct date object is returned`() {
-        // Given
+    fun `given valid timestamp string, when parsing from API, then correct timestamp in millis is returned`() {
+        // GIVEN
         val timestampString = "2024-01-15T14:30:00"
-        val expectedDate = gmtDateFormat.parse(timestampString)
+        val expectedTimestamp = LocalDateTime.parse(timestampString, gmtFormatter)
+            .toInstant(ZoneOffset.UTC).toEpochMilli()
 
-        // When
+        // WHEN
         val result = manager.parseTimestampFromApi(timestampString)
 
-        // Then
-        assertThat(result).isEqualTo(expectedDate)
+        // THEN
+        assertThat(result).isEqualTo(expectedTimestamp)
     }
 
     @Test
     fun `given invalid timestamp string, when parsing from API, then null is returned and error logged`() {
-        // Given
+        // GIVEN
         val invalidTimestamp = "2024-15-45T25:70:90"
 
-        // When
+        // WHEN
         val result = manager.parseTimestampFromApi(invalidTimestamp)
 
-        // Then
+        // THEN
         assertThat(result).isNull()
         verify(logger).e(eq("Failed to parse GMT timestamp: '2024-15-45T25:70:90'"), any())
     }
 
     @Test
-    fun `given timestamp with milliseconds, when parsing, then parsing handles format correctly`() {
-        // Given
+    fun `given timestamp without milliseconds, when parsing, then parsing handles format correctly`() {
+        // GIVEN
         val timestampWithoutMillis = "2024-01-15T10:30:00"
-        val expectedDate = gmtDateFormat.parse(timestampWithoutMillis)
+        val expectedTimestamp = LocalDateTime.parse(timestampWithoutMillis, gmtFormatter)
+            .toInstant(ZoneOffset.UTC).toEpochMilli()
 
-        // When
+        // WHEN
         val result = manager.parseTimestampFromApi(timestampWithoutMillis)
 
-        // Then
-        assertThat(result).isEqualTo(expectedDate)
+        // THEN
+        assertThat(result).isEqualTo(expectedTimestamp)
     }
 
     @Test
     fun `given empty string timestamp, when parsing from API, then null is returned and error logged`() {
-        // Given
+        // GIVEN
         val emptyTimestamp = ""
 
-        // When
+        // WHEN
         val result = manager.parseTimestampFromApi(emptyTimestamp)
 
-        // Then
+        // THEN
         assertThat(result).isNull()
         verify(logger).e(eq("Failed to parse GMT timestamp: ''"), any())
     }
 
     @Test
     fun `given whitespace timestamp, when parsing from API, then null is returned and error logged`() {
-        // Given
+        // GIVEN
         val whitespaceTimestamp = "   "
 
-        // When
+        // WHEN
         val result = manager.parseTimestampFromApi(whitespaceTimestamp)
 
-        // Then
+        // THEN
         assertThat(result).isNull()
         verify(logger).e(eq("Failed to parse GMT timestamp: '   '"), any())
+    }
+
+    @Test
+    fun `given timestamp with timezone suffix, when parsing from API, then null is returned`() {
+        // GIVEN
+        val timestampWithTZ = "2024-01-15T10:30:00Z"
+
+        // WHEN
+        val result = manager.parseTimestampFromApi(timestampWithTZ)
+
+        // THEN
+        assertThat(result).isNull()
+        verify(logger).e(eq("Failed to parse GMT timestamp: '2024-01-15T10:30:00Z'"), any())
     }
 }

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/util/datastore/WooPosSyncTimestampManagerTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/util/datastore/WooPosSyncTimestampManagerTest.kt
@@ -1,0 +1,262 @@
+package com.woocommerce.android.ui.woopos.util.datastore
+
+import com.woocommerce.android.ui.woopos.common.util.WooPosLogWrapper
+import kotlinx.coroutines.test.runTest
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.Before
+import org.junit.Test
+import org.mockito.kotlin.any
+import org.mockito.kotlin.eq
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
+import java.text.SimpleDateFormat
+import java.util.Date
+import java.util.Locale
+import java.util.TimeZone
+
+class WooPosSyncTimestampManagerTest {
+    private val repository: WooPosSyncTimestampRepository = mock()
+    private val logger: WooPosLogWrapper = mock()
+
+    private lateinit var manager: WooPosSyncTimestampManager
+    private lateinit var gmtDateFormat: SimpleDateFormat
+
+    @Before
+    fun setup() {
+        manager = WooPosSyncTimestampManager(repository, logger)
+        gmtDateFormat = SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss", Locale.US).apply {
+            timeZone = TimeZone.getTimeZone("GMT")
+        }
+    }
+
+    @Test
+    fun `given date object, when storing products timestamp, then formatted GMT string is stored`() {
+        runTest {
+            // Given
+            val date: Date = gmtDateFormat.parse("2024-01-15T10:30:00")!!
+
+            // When
+            manager.storeProductsLastSyncTimestamp(date)
+
+            // Then
+            verify(repository).storeProductsLastSyncTimestamp("2024-01-15T10:30:00")
+        }
+    }
+
+    @Test
+    fun `given valid timestamp string in repository, when getting products timestamp, then date object is returned`() {
+        runTest {
+            // Given
+            val timestampString = "2024-01-15T10:30:00"
+            val expectedDate = gmtDateFormat.parse(timestampString)
+            whenever(repository.getProductsLastSyncTimestamp()).thenReturn(timestampString)
+
+            // When
+            val result = manager.getProductsLastSyncTimestamp()
+
+            // Then
+            assertThat(result).isEqualTo(expectedDate)
+        }
+    }
+
+    @Test
+    fun `given no timestamp in repository, when getting products timestamp, then null is returned`() {
+        runTest {
+            // Given
+            whenever(repository.getProductsLastSyncTimestamp()).thenReturn(null)
+
+            // When
+            val result = manager.getProductsLastSyncTimestamp()
+
+            // Then
+            assertThat(result).isNull()
+        }
+    }
+
+    @Test
+    fun `given invalid timestamp string in repository, when getting products timestamp, then null is returned and error logged`() {
+        runTest {
+            // Given
+            val invalidTimestamp = "not-a-valid-timestamp"
+            whenever(repository.getProductsLastSyncTimestamp()).thenReturn(invalidTimestamp)
+
+            // When
+            val result = manager.getProductsLastSyncTimestamp()
+
+            // Then
+            assertThat(result).isNull()
+            verify(logger).e(eq("Failed to parse GMT timestamp: 'not-a-valid-timestamp'"), any())
+        }
+    }
+
+    @Test
+    fun `when clearing products timestamp, then repository clear method is called`() {
+        runTest {
+            // When
+            manager.clearProductsLastSyncTimestamp()
+
+            // Then
+            verify(repository).clearProductsLastSyncTimestamp()
+        }
+    }
+
+    @Test
+    fun `given date object, when storing variations timestamp, then formatted GMT string is stored`() {
+        runTest {
+            // Given
+            val date = gmtDateFormat.parse("2024-01-15T11:45:00")!!
+
+            // When
+            manager.storeVariationsLastSyncTimestamp(date)
+
+            // Then
+            verify(repository).storeVariationsLastSyncTimestamp("2024-01-15T11:45:00")
+        }
+    }
+
+    @Test
+    fun `given valid timestamp string in repository, when getting variations timestamp, then date object is returned`() {
+        runTest {
+            // Given
+            val timestampString = "2024-01-15T11:45:00"
+            val expectedDate = gmtDateFormat.parse(timestampString)
+            whenever(repository.getVariationsLastSyncTimestamp()).thenReturn(timestampString)
+
+            // When
+            val result = manager.getVariationsLastSyncTimestamp()
+
+            // Then
+            assertThat(result).isEqualTo(expectedDate)
+        }
+    }
+
+    @Test
+    fun `given no timestamp in repository, when getting variations timestamp, then null is returned`() {
+        runTest {
+            // Given
+            whenever(repository.getVariationsLastSyncTimestamp()).thenReturn(null)
+
+            // When
+            val result = manager.getVariationsLastSyncTimestamp()
+
+            // Then
+            assertThat(result).isNull()
+        }
+    }
+
+    @Test
+    fun `given invalid timestamp string in repository, when getting variations timestamp, then null is returned and error logged`() {
+        runTest {
+            // Given
+            val invalidTimestamp = "invalid-date-format"
+            whenever(repository.getVariationsLastSyncTimestamp()).thenReturn(invalidTimestamp)
+
+            // When
+            val result = manager.getVariationsLastSyncTimestamp()
+
+            // Then
+            assertThat(result).isNull()
+            verify(logger).e(eq("Failed to parse GMT timestamp: 'invalid-date-format'"), any())
+        }
+    }
+
+    @Test
+    fun `when clearing variations timestamp, then repository clear method is called`() {
+        runTest {
+            // When
+            manager.clearVariationsLastSyncTimestamp()
+
+            // Then
+            verify(repository).clearVariationsLastSyncTimestamp()
+        }
+    }
+
+    @Test
+    fun `when clearing all timestamps, then repository clear all method is called`() {
+        runTest {
+            // When
+            manager.clearAllSyncTimestamps()
+
+            // Then
+            verify(repository).clearAllSyncTimestamps()
+        }
+    }
+
+    @Test
+    fun `given date object, when formatting for API, then correct GMT string is returned`() {
+        // Given
+        val date = gmtDateFormat.parse("2024-01-15T14:30:00")!!
+
+        // When
+        val result = manager.formatTimestampForApi(date)
+
+        // Then
+        assertThat(result).isEqualTo("2024-01-15T14:30:00")
+    }
+
+    @Test
+    fun `given valid timestamp string, when parsing from API, then correct date object is returned`() {
+        // Given
+        val timestampString = "2024-01-15T14:30:00"
+        val expectedDate = gmtDateFormat.parse(timestampString)
+
+        // When
+        val result = manager.parseTimestampFromApi(timestampString)
+
+        // Then
+        assertThat(result).isEqualTo(expectedDate)
+    }
+
+    @Test
+    fun `given invalid timestamp string, when parsing from API, then null is returned and error logged`() {
+        // Given
+        val invalidTimestamp = "2024-15-45T25:70:90"
+
+        // When
+        val result = manager.parseTimestampFromApi(invalidTimestamp)
+
+        // Then
+        assertThat(result).isNull()
+        verify(logger).e(eq("Failed to parse GMT timestamp: '2024-15-45T25:70:90'"), any())
+    }
+
+    @Test
+    fun `given timestamp with milliseconds, when parsing, then parsing handles format correctly`() {
+        // Given
+        val timestampWithoutMillis = "2024-01-15T10:30:00"
+        val expectedDate = gmtDateFormat.parse(timestampWithoutMillis)
+
+        // When
+        val result = manager.parseTimestampFromApi(timestampWithoutMillis)
+
+        // Then
+        assertThat(result).isEqualTo(expectedDate)
+    }
+
+    @Test
+    fun `given empty string timestamp, when parsing from API, then null is returned and error logged`() {
+        // Given
+        val emptyTimestamp = ""
+
+        // When
+        val result = manager.parseTimestampFromApi(emptyTimestamp)
+
+        // Then
+        assertThat(result).isNull()
+        verify(logger).e(eq("Failed to parse GMT timestamp: ''"), any())
+    }
+
+    @Test
+    fun `given whitespace timestamp, when parsing from API, then null is returned and error logged`() {
+        // Given
+        val whitespaceTimestamp = "   "
+
+        // When
+        val result = manager.parseTimestampFromApi(whitespaceTimestamp)
+
+        // Then
+        assertThat(result).isNull()
+        verify(logger).e(eq("Failed to parse GMT timestamp: '   '"), any())
+    }
+}


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->
# POS Incremental Sync Timestamp Storage


<!-- Id number of the Linear issue this PR addresses, e.g., WOOMOB-373. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

#####  Summary

Implemented a repository system for storing and retrieving site-specific incremental sync timestamps for POS products and variations using DataStore preferences.

#####   Changes

  - `WooPosSyncTimestampRepository`: Low-level repository for string timestamp storage with site-specific keys
  - `WooPosSyncTimestampManager`: High-level manager providing Date object API with GMT timezone handling

#####   Key Features
  - Site-specific storage: Timestamps are isolated per site using dynamic key generation
  - Type-safe API: Date objects for convenience, strings for raw access
  - Error handling: Graceful null site handling with logging

### Steps to reproduce
<!-- Step-by-step testing instructions. For new user flows, consider instead stating the goal of the workflow and see if your PR reviewer can accomplish the workflow without specific steps! -->

### Testing information
<!-- This is your opportunity to break out individual scenarios that need testing (when necessary) and/or include a checklist for the reviewer to go through. Consider documenting the following from your own completed testing: devices used, alternate workflows, edge cases, affected areas, critical flows, areas not tested, and any remaining unknowns. Provide feedback on this new section of the PR template through Sept 30, 2024 to Apps Quality; additional context here: p91TBi-b8z-p2#comment-12036 -->
This code is not used at the moment. Check if CI is green and if the code looks good.

### The tests that have been performed
<!-- To give the reviewer an idea of what could be missed in terms of testing -->
Above 

### Images/gif
<!-- Include before and after images or gifs when appropriate. -->
N/A

- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->