### PR TITLE
[WOOMOB-1161][Woo POS][Settings]Remove email field from the store settings

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/settings/details/store/WooPosSettingsReceiptRepository.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/settings/details/store/WooPosSettingsReceiptRepository.kt
@@ -32,7 +32,6 @@ class WooPosSettingsReceiptRepository @Inject constructor(
                     storeName = settings["woocommerce_pos_store_name"] ?: "",
                     address = settings["woocommerce_pos_store_address"] ?: "",
                     phone = settings["woocommerce_pos_store_phone"] ?: "",
-                    email = settings["woocommerce_pos_store_email"] ?: "",
                     refundPolicy = settings["woocommerce_pos_refund_returns_policy"] ?: ""
                 )
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/settings/details/store/WooPosSettingsStoreRepository.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/settings/details/store/WooPosSettingsStoreRepository.kt
@@ -19,8 +19,7 @@ class WooPosSettingsStoreRepository @Inject constructor(
 
             WooPosSettingsStoreState.StoreInfo(
                 storeName = site.name ?: "",
-                address = storeAddress,
-                email = site.email ?: ""
+                address = storeAddress
             )
         }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/settings/details/store/WooPosSettingsStoreScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/settings/details/store/WooPosSettingsStoreScreen.kt
@@ -11,7 +11,6 @@ import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.filled.Email
 import androidx.compose.material.icons.filled.Home
 import androidx.compose.material.icons.filled.Phone
 import androidx.compose.material.icons.filled.Receipt
@@ -117,12 +116,6 @@ private fun StoreInformationSection(storeInfo: WooPosSettingsStoreState.StoreInf
         title = stringResource(R.string.woopos_settings_store_address_label),
         subtitle = storeInfo.address.ifBlank { stringResource(R.string.woopos_settings_store_not_set) }
     )
-
-    WooPosSettingsDetailsMenuItem(
-        icon = Icons.Default.Email,
-        title = stringResource(R.string.woopos_settings_store_email_label),
-        subtitle = storeInfo.email.ifBlank { stringResource(R.string.woopos_settings_store_not_set) }
-    )
 }
 
 @Composable
@@ -196,12 +189,6 @@ private fun ReceiptInformationSection(receiptInfo: WooPosSettingsStoreState.Rece
     )
 
     WooPosSettingsDetailsMenuItem(
-        icon = Icons.Default.Email,
-        title = stringResource(R.string.woopos_settings_store_email_label),
-        subtitle = receiptInfo.email.ifBlank { stringResource(R.string.woopos_settings_store_not_set) }
-    )
-
-    WooPosSettingsDetailsMenuItem(
         icon = Icons.Default.Receipt,
         title = stringResource(R.string.woopos_settings_refund_policy_label),
         subtitle = receiptInfo.refundPolicy.ifBlank { stringResource(R.string.woopos_settings_store_not_set) }
@@ -216,8 +203,7 @@ fun WooPosSettingsStoreScreenPreview() {
             storeInfoState = WooPosSettingsStoreState.StoreState.Loaded(
                 WooPosSettingsStoreState.StoreInfo(
                     storeName = "My WooCommerce Store",
-                    address = "123 Main Street, City, State 12345, US",
-                    email = "myemail@something.com"
+                    address = "123 Main Street, City, State 12345, US"
                 )
             ),
             receiptState = WooPosSettingsStoreState.ReceiptState.Success(
@@ -225,7 +211,6 @@ fun WooPosSettingsStoreScreenPreview() {
                     storeName = "My WooCommerce Store",
                     address = "123 Main Street, City, State 12345, US",
                     phone = "+1 555 1234 1234",
-                    email = "myemail@something.com",
                     refundPolicy = "Returns accepted within 30 days"
                 )
             )
@@ -243,8 +228,7 @@ fun WooPosSettingsStoreScreenLoadingPreview() {
             storeInfoState = WooPosSettingsStoreState.StoreState.Loaded(
                 WooPosSettingsStoreState.StoreInfo(
                     storeName = "My WooCommerce Store",
-                    address = "123 Main Street, City, State 12345, US",
-                    email = "myemail@something.com"
+                    address = "123 Main Street, City, State 12345, US"
                 )
             ),
             receiptState = WooPosSettingsStoreState.ReceiptState.Loading

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/settings/details/store/WooPosSettingsStoreState.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/settings/details/store/WooPosSettingsStoreState.kt
@@ -6,15 +6,13 @@ data class WooPosSettingsStoreState(
 ) {
     data class StoreInfo(
         val storeName: String,
-        val address: String,
-        val email: String
+        val address: String
     )
 
     data class ReceiptInfo(
         val storeName: String,
         val address: String,
         val phone: String,
-        val email: String,
         val refundPolicy: String
     )
 

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -4578,7 +4578,6 @@
     <string name="woopos_settings_store_name_label">Store name</string>
     <string name="woopos_settings_store_address_label">Address</string>
     <string name="woopos_settings_store_phone_label">Phone</string>
-    <string name="woopos_settings_store_email_label">Email</string>
     <string name="woopos_settings_refund_policy_label">Refund &amp; Returns Policy</string>
     <string name="woopos_settings_store_not_set">Not set</string>
 

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/settings/details/store/WooPosSettingsReceiptRepositoryTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/settings/details/store/WooPosSettingsReceiptRepositoryTest.kt
@@ -60,7 +60,6 @@ class WooPosSettingsReceiptRepositoryTest {
             "woocommerce_pos_store_name" to "Test Store",
             "woocommerce_pos_store_address" to "123 Test Street",
             "woocommerce_pos_store_phone" to "+1234567890",
-            "woocommerce_pos_store_email" to "test@store.com",
             "woocommerce_pos_refund_returns_policy" to "30 day returns"
         )
         val apiResult = WooResult(settingsMap)
@@ -75,7 +74,6 @@ class WooPosSettingsReceiptRepositoryTest {
         assertThat(successData.receiptInfo.storeName).isEqualTo("Test Store")
         assertThat(successData.receiptInfo.address).isEqualTo("123 Test Street")
         assertThat(successData.receiptInfo.phone).isEqualTo("+1234567890")
-        assertThat(successData.receiptInfo.email).isEqualTo("test@store.com")
         assertThat(successData.receiptInfo.refundPolicy).isEqualTo("30 day returns")
     }
 
@@ -95,7 +93,6 @@ class WooPosSettingsReceiptRepositoryTest {
         assertThat(successData.receiptInfo.storeName).isEqualTo("")
         assertThat(successData.receiptInfo.address).isEqualTo("")
         assertThat(successData.receiptInfo.phone).isEqualTo("")
-        assertThat(successData.receiptInfo.email).isEqualTo("")
         assertThat(successData.receiptInfo.refundPolicy).isEqualTo("")
     }
 

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/settings/details/store/WooPosSettingsStoreRepositoryTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/settings/details/store/WooPosSettingsStoreRepositoryTest.kt
@@ -27,7 +27,6 @@ class WooPosSettingsStoreRepositoryTest {
     fun `given complete site and settings data, when getStoreInfo, then returns full store info`() = runTest {
         // GIVEN
         whenever(siteModel.name).thenReturn("My WooCommerce Store")
-        whenever(siteModel.email).thenReturn("store@example.com")
 
         val settings = Settings(
             currencyCode = "USD",
@@ -50,15 +49,13 @@ class WooPosSettingsStoreRepositoryTest {
 
         // THEN
         assertThat(result.storeName).isEqualTo("My WooCommerce Store")
-        assertThat(result.email).isEqualTo("store@example.com")
         assertThat(result.address).isEqualTo("123 Main Street, Suite 456, New York, NY 10001, US")
     }
 
     @Test
-    fun `given site with null name and email, when getStoreInfo, then returns empty strings`() = runTest {
+    fun `given site with null name, when getStoreInfo, then returns empty strings`() = runTest {
         // GIVEN
         whenever(siteModel.name).thenReturn(null)
-        whenever(siteModel.email).thenReturn(null)
         whenever(wooCommerceStore.getSiteSettings(siteModel)).thenReturn(null)
 
         // WHEN
@@ -66,7 +63,6 @@ class WooPosSettingsStoreRepositoryTest {
 
         // THEN
         assertThat(result.storeName).isEqualTo("")
-        assertThat(result.email).isEqualTo("")
         assertThat(result.address).isEqualTo("")
     }
 
@@ -74,7 +70,6 @@ class WooPosSettingsStoreRepositoryTest {
     fun `given partial address data, when getStoreInfo, then returns formatted address with available fields`() = runTest {
         // GIVEN
         whenever(siteModel.name).thenReturn("Test Store")
-        whenever(siteModel.email).thenReturn("test@store.com")
 
         val settings = Settings(
             currencyCode = "USD",
@@ -97,7 +92,6 @@ class WooPosSettingsStoreRepositoryTest {
 
         // THEN
         assertThat(result.storeName).isEqualTo("Test Store")
-        assertThat(result.email).isEqualTo("test@store.com")
         assertThat(result.address).isEqualTo("456 Oak Avenue, San Francisco, CA, US")
     }
 
@@ -105,7 +99,6 @@ class WooPosSettingsStoreRepositoryTest {
     fun `given address with only street address, when getStoreInfo, then returns just street address`() = runTest {
         // GIVEN
         whenever(siteModel.name).thenReturn("Minimal Store")
-        whenever(siteModel.email).thenReturn("minimal@store.com")
 
         val settings = Settings(
             currencyCode = "USD",
@@ -134,7 +127,6 @@ class WooPosSettingsStoreRepositoryTest {
     fun `given settings with all blank address fields, when getStoreInfo, then returns empty address`() = runTest {
         // GIVEN
         whenever(siteModel.name).thenReturn("Empty Address Store")
-        whenever(siteModel.email).thenReturn("empty@store.com")
 
         val settings = Settings(
             currencyCode = "USD",
@@ -163,7 +155,6 @@ class WooPosSettingsStoreRepositoryTest {
     fun `given null settings, when getStoreInfo, then returns empty address`() = runTest {
         // GIVEN
         whenever(siteModel.name).thenReturn("No Settings Store")
-        whenever(siteModel.email).thenReturn("nosettings@store.com")
         whenever(wooCommerceStore.getSiteSettings(siteModel)).thenReturn(null)
 
         // WHEN
@@ -171,7 +162,6 @@ class WooPosSettingsStoreRepositoryTest {
 
         // THEN
         assertThat(result.storeName).isEqualTo("No Settings Store")
-        assertThat(result.email).isEqualTo("nosettings@store.com")
         assertThat(result.address).isEqualTo("")
     }
 
@@ -179,7 +169,6 @@ class WooPosSettingsStoreRepositoryTest {
     fun `given address with city and country only, when getStoreInfo, then returns city and country`() = runTest {
         // GIVEN
         whenever(siteModel.name).thenReturn("International Store")
-        whenever(siteModel.email).thenReturn("international@store.com")
 
         val settings = Settings(
             currencyCode = "GBP",
@@ -208,7 +197,6 @@ class WooPosSettingsStoreRepositoryTest {
     fun `given address with postal code and space formatting, when getStoreInfo, then formats postal code correctly`() = runTest {
         // GIVEN
         whenever(siteModel.name).thenReturn("Postal Store")
-        whenever(siteModel.email).thenReturn("postal@store.com")
 
         val settings = Settings(
             currencyCode = "USD",

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/settings/details/store/WooPosSettingsStoreViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/settings/details/store/WooPosSettingsStoreViewModelTest.kt
@@ -25,14 +25,12 @@ class WooPosSettingsStoreViewModelTest {
         // GIVEN
         val storeInfo = WooPosSettingsStoreState.StoreInfo(
             storeName = "Test Store",
-            address = "123 Test St",
-            email = "test@store.com"
+            address = "123 Test St"
         )
         val receiptInfo = WooPosSettingsStoreState.ReceiptInfo(
             storeName = "Test Store",
             address = "123 Test St",
             phone = "+1234567890",
-            email = "test@store.com",
             refundPolicy = "30 day returns"
         )
         whenever(storeRepository.getStoreInfo()).thenReturn(storeInfo)
@@ -53,8 +51,7 @@ class WooPosSettingsStoreViewModelTest {
         // GIVEN
         val storeInfo = WooPosSettingsStoreState.StoreInfo(
             storeName = "Test Store",
-            address = "123 Test St",
-            email = "test@store.com"
+            address = "123 Test St"
         )
         whenever(storeRepository.getStoreInfo()).thenReturn(storeInfo)
         whenever(receiptRepository.getReceiptInfo()).thenReturn(WooPosReceiptDataResult.NotAvailable)
@@ -74,8 +71,7 @@ class WooPosSettingsStoreViewModelTest {
         // GIVEN
         val storeInfo = WooPosSettingsStoreState.StoreInfo(
             storeName = "Test Store",
-            address = "123 Test St",
-            email = "test@store.com"
+            address = "123 Test St"
         )
         whenever(storeRepository.getStoreInfo()).thenReturn(storeInfo)
         whenever(receiptRepository.getReceiptInfo()).thenReturn(WooPosReceiptDataResult.Error)
@@ -105,8 +101,7 @@ class WooPosSettingsStoreViewModelTest {
         // GIVEN
         val emptyStoreInfo = WooPosSettingsStoreState.StoreInfo(
             storeName = "",
-            address = "",
-            email = ""
+            address = ""
         )
         whenever(storeRepository.getStoreInfo()).thenReturn(emptyStoreInfo)
         whenever(receiptRepository.getReceiptInfo()).thenReturn(WooPosReceiptDataResult.NotAvailable)


### PR DESCRIPTION
WOOMOB-1161

### Description
Removed the email field from the store settings screen as it was not available via API

### Steps to reproduce
1. Open the app and navigate to POS mode
2. Go to Settings
3. Tap on Store
4. Verify that the Store information section shows only Store name and Address
5. Verify that the Receipt information section (if available) shows Store name, Address, Phone, and Refund & Returns Policy

### Images/gif

<img width="803" height="507" alt="image" src="https://github.com/user-attachments/assets/fef669b3-ba25-4fbb-9c1a-e57004f1ce33" />


- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.