### PR TITLE
[Wear app] Add missing release notes

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -6,6 +6,8 @@
 - [*] Shipping Labels: Add error message for invalid dimensions errors to custom package creation screen [https://github.com/woocommerce/woocommerce-android/pull/14499]
 - [*] Shipping Labels: Update the UI of shipping label purchase in-progress and failure states [https://github.com/woocommerce/woocommerce-android/pull/14498]
 - [*] Shipping Labels: Fix handling of existing shipping labels with in-progress purchase status [https://github.com/woocommerce/woocommerce-android/pull/14501]
+- [Internal] [WEAR] Update horologist to 0.6.23 [https://github.com/woocommerce/woocommerce-android/pull/13395]
+- [WEAR] Updated UserAgent of API requests to use `http.agent` System Property to fix performance issues related to WebView usage on app launch [https://github.com/woocommerce/woocommerce-android/pull/14431]
 
 23.1
 -----


### PR DESCRIPTION
### Description
This PR adds missing Wear app release notes to ensure we update the Wear app in the next release, and we publish the correct release notes. Check this thread p1755852721568009/1755851062.496089-slack-C6H8C3G23

### Steps to reproduce
No changes.

### Testing information
No changes.

### The tests that have been performed
No changes.

- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->