### PR TITLE
[Shipping Labels] Fix shipment weight issues

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/WooShippingLabelCreationScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/WooShippingLabelCreationScreen.kt
@@ -330,7 +330,6 @@ private fun LabelCreationScreenWithBottomSheet(
         ) {
             Column(
                 modifier
-                    .verticalScroll(rememberScrollState())
                     .padding(bottom = 8.dp),
             ) {
                 val scope = rememberCoroutineScope()
@@ -394,7 +393,9 @@ private fun LabelCreationScreenWithBottomSheet(
 
                 HorizontalPager(
                     state = pagerState,
-                    modifier = Modifier.fillMaxSize(),
+                    modifier = Modifier
+                        .fillMaxSize()
+                        .verticalScroll(rememberScrollState()),
                     verticalAlignment = Alignment.Top,
                 ) { page ->
                     CreateShippingCards(

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/WooShippingLabelCreationViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/WooShippingLabelCreationViewModel.kt
@@ -515,7 +515,7 @@ class WooShippingLabelCreationViewModel @Inject constructor(
         ) { shipmentItems, selectedPackage, customWeightString ->
             if (selectedPackage.size == shipments.value.size && customWeightString.size == shipments.value.size) {
                 shipmentItems.mapIndexed { index, shipmentItemModelList ->
-                    val itemsWeight = shipmentItemModelList.sumByFloat { it.weight }
+                    val itemsWeight = shipmentItemModelList.sumByFloat { it.weight * it.quantity }
                     val packageWeight = selectedPackage[index]?.weight?.toFloatOrNull()
                     PackageWeight(
                         itemsWeight = itemsWeight,

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/WooShippingLabelCreationViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/WooShippingLabelCreationViewModel.kt
@@ -790,7 +790,7 @@ class WooShippingLabelCreationViewModel @Inject constructor(
 
     private suspend fun adjustFlowSizesToShipmentCount(shipments: List<ShipmentUIModel>) {
         suspend fun <T> MutableStateFlow<List<T>>.updateSize(defaultValue: suspend (Int) -> T) =
-            this.update { currentList ->
+            update { currentList ->
                 if (currentList.size <= shipments.size) {
                     currentList + List(shipments.size - currentList.size) { index ->
                         defaultValue(currentList.size + index)

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/WooShippingLabelCreationViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/WooShippingLabelCreationViewModel.kt
@@ -144,7 +144,7 @@ class WooShippingLabelCreationViewModel @Inject constructor(
 
     private val selectedPackagesFlow = MutableStateFlow<List<PackageData?>>(emptyList())
     private val customsFormDataFlow = MutableStateFlow<List<CustomsData?>>(emptyList())
-    private val packageWeightsFlow = MutableStateFlow<List<PackageWeight?>>(emptyList())
+    private val shipmentWeightsFlow = MutableStateFlow<List<ShipmentWeight?>>(emptyList())
     private val packageSelectionsFlow = MutableStateFlow<List<PackageSelectionState>>(emptyList())
     private val customsStatesFlow = MutableStateFlow<List<CustomsState>>(emptyList())
     private val hazmatStatesFlow = MutableStateFlow<List<HazmatState>>(emptyList())
@@ -191,7 +191,7 @@ class WooShippingLabelCreationViewModel @Inject constructor(
         launch { setAccountDefaults() }
         launch { getShippingAddresses() }
         launch { getOrderInformation() }
-        launch { observePackageWeight() }
+        launch { observeShipmentWeight() }
         launch { observePackageChanges() }
         launch { observeShippingRates() }
         launch { observeShippingRatesState() }
@@ -395,11 +395,11 @@ class WooShippingLabelCreationViewModel @Inject constructor(
             accountSettings,
             selectedPackagesFlow.filter { it.isNotEmpty() },
             shippingAddresses.filter { it.isNotEmpty() },
-            packageWeightsFlow.filter { it.isNotEmpty() },
+            shipmentWeightsFlow.filter { it.isNotEmpty() },
             customsStatesFlow.filter { it.isNotEmpty() },
             hazmatStatesFlow.filter { it.isNotEmpty() },
             refreshShippingRates.onStart { emit(Unit) },
-        ) { accountSettings, selectedPackages, addresses, packageWeight, customState, hazmatStates, _ ->
+        ) { accountSettings, selectedPackages, addresses, shipmentWeights, customState, hazmatStates, _ ->
             val customsFulfilled = customState[selectedShipmentIndex] is CustomsState.DataAvailable ||
                 customState[selectedShipmentIndex] is CustomsState.NotRequired
             val selectedPackage = selectedPackages[selectedShipmentIndex]
@@ -410,7 +410,7 @@ class WooShippingLabelCreationViewModel @Inject constructor(
                     packageSelected = selectedPackage,
                     shipFrom = selectedAddress.shipFrom,
                     shipTo = selectedAddress.shipTo.address,
-                    weight = packageWeight[selectedShipmentIndex]?.totalWeight,
+                    weight = shipmentWeights[selectedShipmentIndex]?.totalWeight,
                     currencyCode = accountSettings?.storeOptions?.currencySymbol,
                     customsData = customsFormDataFlow.value[selectedShipmentIndex],
                     hazmatSelection = hazmatStates[selectedShipmentIndex].hazmatSelection
@@ -505,7 +505,7 @@ class WooShippingLabelCreationViewModel @Inject constructor(
     }
 
     @OptIn(FlowPreview::class)
-    private suspend fun observePackageWeight() {
+    private suspend fun observeShipmentWeight() {
         combine(
             shipmentItems.filter { it.isNotEmpty() && it.size > selectedShipmentIndex },
             selectedPackagesFlow.filter { it.isNotEmpty() && it.size == shipments.value.size },
@@ -517,7 +517,7 @@ class WooShippingLabelCreationViewModel @Inject constructor(
                 shipmentItems.mapIndexed { index, shipmentItemModelList ->
                     val itemsWeight = shipmentItemModelList.sumByFloat { it.weight * it.quantity }
                     val packageWeight = selectedPackage[index]?.weight?.toFloatOrNull()
-                    PackageWeight(
+                    ShipmentWeight(
                         itemsWeight = itemsWeight,
                         packageWeight = packageWeight,
                         customWeight = customWeightString[index].toFloatOrNull()
@@ -527,13 +527,13 @@ class WooShippingLabelCreationViewModel @Inject constructor(
                 null
             }
         }.filterNotNull()
-            .collectLatest { packageWeightsFlow.value = it }
+            .collectLatest { shipmentWeightsFlow.value = it }
     }
 
     private suspend fun observePackageChanges() {
         combine(
             selectedPackagesFlow.filter { it.isNotEmpty() },
-            packageWeightsFlow.filter { it.isNotEmpty() },
+            shipmentWeightsFlow.filter { it.isNotEmpty() },
             accountSettings.map { it?.storeOptions },
             packageSelectionsFlow.filter { it.isNotEmpty() }
         ) { packagesSelected, packageWeight, storeOptions, _ ->
@@ -811,7 +811,7 @@ class WooShippingLabelCreationViewModel @Inject constructor(
         customsFormDataFlow.updateSize { index ->
             createDefaultCustomsData(shipments[index], shippingAddresses.value[index])
         }
-        packageWeightsFlow.updateSize { null }
+        shipmentWeightsFlow.updateSize { null }
         packageSelectionsFlow.updateSize { NotSelected }
         customsStatesFlow.updateSize { CustomsState.NotRequired }
         hazmatStatesFlow.updateSize { NoSelection }
@@ -961,7 +961,7 @@ class WooShippingLabelCreationViewModel @Inject constructor(
         val selectedPackage = selectedPackagesFlow.value[selectedShipmentIndex]
         val selectedAddress = shippingAddresses.value.getOrNull(selectedShipmentIndex)
         val shippingRate = selectedRatesFlow.value[selectedShipmentIndex]
-        val weight = packageWeightsFlow.value[selectedShipmentIndex]?.totalWeight
+        val weight = shipmentWeightsFlow.value[selectedShipmentIndex]?.totalWeight
 
         if (selectedPackage == null || selectedAddress == null || shippingRate == null || weight == null) return
 
@@ -1315,7 +1315,7 @@ class WooShippingLabelCreationViewModel @Inject constructor(
         ) : PackageSelectionState()
     }
 
-    data class PackageWeight(
+    data class ShipmentWeight(
         val itemsWeight: Float,
         val packageWeight: Float? = null,
         val customWeight: Float? = null

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/address/WooShippingEditAddressScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/address/WooShippingEditAddressScreen.kt
@@ -240,6 +240,7 @@ fun WooShippingEditAddressScreen(
                 RoundedBorderDropDownWithLabel(
                     label = "${stringResource(id = R.string.woo_shipping_label_country)} *",
                     text = editableAddress.country.name,
+                    modifier = Modifier.fillMaxWidth(),
                     onClick = onCountryChange
                 )
                 RoundedBorderTextFieldWithLabel(

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/WooShippingLabelCreationViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/WooShippingLabelCreationViewModelTest.kt
@@ -645,6 +645,47 @@ class WooShippingLabelCreationViewModelTest : BaseUnitTest() {
     }
 
     @Test
+    fun `when multiple-quantity items, then shows correct default weight`() = testBlocking {
+        val items = listOf(
+            ShippableItemModel(
+                itemId = 1,
+                productId = 1,
+                title = "title",
+                price = BigDecimal.ONE,
+                quantity = 2f,
+                weight = 1.5f,
+                currency = "USD",
+                width = 1f,
+                height = 1f,
+                length = 1f
+            )
+        )
+        whenever(getShipments(any())) doReturn listOf(ShipmentUIModel(localId = "0", items = items))
+
+        createViewModel()
+        advanceUntilIdle()
+
+        // Select a package with weight 0.5
+        val pkg = PackageData(
+            id = "1",
+            name = "name",
+            dimensions = "1 x 1 x 1",
+            weight = "0.5",
+            isSelected = true,
+            isLetter = true
+        )
+        sut.onPackageSelected(pkg)
+
+        advanceUntilIdle()
+
+        val currentViewState = sut.viewState.value
+        val dataState = currentViewState as DataState
+        val selection = dataState.shipmentUIList[0].packageSelectionState
+        val data = selection as PackageSelectionState.DataAvailable
+        assertThat(data.defaultWeight).isEqualTo("3.5")
+    }
+
+    @Test
     fun `CustomState is NotRequired when shouldRequireCustomsForm returns false`() = testBlocking {
         var currentViewState: WooShippingViewState? = null
 


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

<!-- Id number of the Linear issue this PR addresses, e.g., WOOMOB-373. -->
Closes WOOMOB-581

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
The issue itself actually describes a different change. Currently, the app uses a hint as the default weight (items weight + package weight). But the issue asks for removing the default weight feature and instead using the total weight as a normal entered text. I initially implemented this after some refactoring, but then I realized the current behavior has some advantages.
With the current approach, the manually entered value and the default value can differ. For example, if no manual weight is entered and a shipment item is moved to another shipment, the default value is updated (as the total items weight is changed). However, if the user entered a custom weight (even if it equals the total weight), that value won’t be updated after moving an item. I believe this is a preferable behavior, so I’d prefer not to change it. Please comment if you think otherwise.

That said, I noticed an issue with the default weight: it was not considering item quantity. I fixed that.

I also fixed a couple of unrelated issues I noticed:
- The country dropdown on the edit address screen is now full-width.
- Shipment tabs now stick to the top.

### Steps to reproduce
<!-- Step-by-step testing instructions. For new user flows, consider instead stating the goal of the workflow and see if your PR reviewer can accomplish the workflow without specific steps! -->
#### Multiple quantity issue
1. Go to Orders.
2. Select an order that is eligible to create shipping labels and has multiple items.
3. Tap Create shipping label button.
4. Select a package.
5. Verify that the default weight value is correct.

#### The country dropdown
1. Go to Orders.
2. Select an order that is eligible to create shipping labels .
3. Tap Shipment Details at bottom.
4. Tap the edit button near destination address.

#### Sticky shipment tabs
1. Go to Orders.
2. Select an order that is eligible to create shipping labels .
3. Select a package to make the page scrollable.
4. Scroll.

### The tests that have been performed
<!-- To give the reviewer an idea of what could be missed in terms of testing -->
Steps above.

### Images/gif
<!-- Include before and after images or gifs when appropriate. -->
|Before|After|
|-|-|
|<img width="1344" height="2992" alt="before" src="https://github.com/user-attachments/assets/aea57240-e565-4913-9635-16dd8db28347" />|<img width="1344" height="2992" alt="after" src="https://github.com/user-attachments/assets/7ac10a1a-1e54-4009-bda2-3f0d204cab78" />|
|<img width="1344" height="2992" alt="before-country" src="https://github.com/user-attachments/assets/6268156f-308d-4653-8341-845c5a31cb33" />|<img width="1344" height="2992" alt="after-country" src="https://github.com/user-attachments/assets/fcaad2cc-89f3-4faf-a440-7070076b7ae6" />|
|<img width="1344" height="2992" alt="before-tab" src="https://github.com/user-attachments/assets/b1f53f77-62ff-47c6-a339-97934bf43d32" />|<img width="1344" height="2992" alt="after-tab" src="https://github.com/user-attachments/assets/4ba790eb-a64c-4f37-991c-a045f8f0a84c" />|

- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->