### PR TITLE
[Login] Improve root endpoint response deserialization to fix login issues

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -9,6 +9,7 @@
 - [*] Shipping Labels: Fix handling of existing shipping labels with in-progress purchase status [https://github.com/woocommerce/woocommerce-android/pull/14501]
 - [Internal] [WEAR] Update horologist to 0.6.23 [https://github.com/woocommerce/woocommerce-android/pull/13395]
 - [WEAR] Updated UserAgent of API requests to use `http.agent` System Property to fix performance issues related to WebView usage on app launch [https://github.com/woocommerce/woocommerce-android/pull/14431]
+- [*] [Login] Improved the detection of WooCommerce API version during login flow [https://github.com/woocommerce/woocommerce-android/pull/14524]
 
 23.1
 -----

--- a/libs/fluxc/src/main/java/org/wordpress/android/fluxc/network/discovery/NamespacesDeserializer.kt
+++ b/libs/fluxc/src/main/java/org/wordpress/android/fluxc/network/discovery/NamespacesDeserializer.kt
@@ -1,0 +1,45 @@
+package org.wordpress.android.fluxc.network.discovery
+
+import com.google.gson.JsonDeserializationContext
+import com.google.gson.JsonDeserializer
+import com.google.gson.JsonElement
+import com.google.gson.JsonParseException
+import java.lang.reflect.Type
+
+/**
+ * Deserializes the namespaces field that can be either an array of strings or an object with numeric keys.
+ * By default WordPress sites return namespaces as an array: ["namespace1", "namespace2"]
+ * While others return it as an object: {"0": "namespace1", "1": "namespace2"} when some plugins are installed.
+ * This deserializer handles both cases and converts them to a List<String>.
+ */
+class NamespacesDeserializer : JsonDeserializer<List<String>?> {
+    @Throws(JsonParseException::class)
+    override fun deserialize(
+        json: JsonElement,
+        typeOfT: Type?,
+        context: JsonDeserializationContext?
+    ): List<String> {
+        return if (json.isJsonArray) {
+            json.getAsJsonArray().mapNotNull {
+                if (it.isJsonPrimitive && it.getAsJsonPrimitive().isString) {
+                    it.asString
+                } else {
+                    null
+                }
+            }
+        } else if (json.isJsonObject) {
+            buildList {
+                val jsonObject = json.getAsJsonObject()
+
+                for (key in jsonObject.keySet()) {
+                    val element = jsonObject.get(key)
+                    if (element.isJsonPrimitive && element.getAsJsonPrimitive().isString) {
+                        add(element.asString)
+                    }
+                }
+            }
+        } else {
+            throw JsonParseException("Unexpected JSON type for namespaces")
+        }
+    }
+}

--- a/libs/fluxc/src/main/java/org/wordpress/android/fluxc/network/discovery/RootWPAPIRestResponse.kt
+++ b/libs/fluxc/src/main/java/org/wordpress/android/fluxc/network/discovery/RootWPAPIRestResponse.kt
@@ -1,5 +1,6 @@
 package org.wordpress.android.fluxc.network.discovery
 
+import com.google.gson.annotations.JsonAdapter
 import com.google.gson.annotations.SerializedName
 import org.wordpress.android.fluxc.network.Response
 import org.wordpress.android.fluxc.network.rest.JsonObjectOrEmptyArray
@@ -9,7 +10,7 @@ class RootWPAPIRestResponse(
     val description: String? = null,
     val url: String? = null,
     @SerializedName("gmt_offset") val gmtOffset: String? = null,
-    val namespaces: List<String>? = null,
+    @JsonAdapter(NamespacesDeserializer::class) val namespaces: List<String>? = null,
     val authentication: Authentication? = null
 ) : Response {
     class Authentication(

--- a/libs/fluxc/src/test/java/org/wordpress/android/fluxc/network/discovery/RootWPAPIRestResponseTest.kt
+++ b/libs/fluxc/src/test/java/org/wordpress/android/fluxc/network/discovery/RootWPAPIRestResponseTest.kt
@@ -1,0 +1,112 @@
+package org.wordpress.android.fluxc.network.discovery
+
+import com.google.gson.Gson
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.Test
+
+class RootWPAPIRestResponseTest {
+    @Test
+    fun `given namespaces as array, when deserializing, then should parse correctly`() {
+        val json = """
+            {
+              "name": "Test Site",
+              "description": "Test Description",
+              "url": "https://example.com",
+              "gmt_offset": "0",
+              "namespaces": ["oembed/1.0", "wc/v3", "wp/v2"]
+            }
+        """.trimIndent()
+
+        val gson = Gson()
+        val response = gson.fromJson(json, RootWPAPIRestResponse::class.java)
+
+        assertThat(response.namespaces).hasSize(3)
+        val expectedNamespaces = listOf("oembed/1.0", "wc/v3", "wp/v2")
+        assertThat(response.namespaces).isEqualTo(expectedNamespaces)
+    }
+
+    @Test
+    fun `given namespaces as object, when deserializing, then should parse correctly`() {
+        val json = """
+            {
+              "name": "Test Site",
+              "description": "Test Description",
+              "url": "https://example.com",
+              "gmt_offset": "0",
+              "namespaces": {
+                "0": "oembed/1.0",
+                "1": "akismet/v1",
+                "4": "jetpack/v4",
+                "8": "wc/v3",
+                "29": "wp/v2"
+              }
+            }
+        """.trimIndent()
+
+        val gson = Gson()
+        val response = gson.fromJson(json, RootWPAPIRestResponse::class.java)
+
+        assertThat(response.namespaces).hasSize(5)
+        val expectedNamespaces = listOf("oembed/1.0", "akismet/v1", "jetpack/v4", "wc/v3", "wp/v2")
+        assertThat(response.namespaces).hasSize(expectedNamespaces.size)
+        expectedNamespaces.forEach { namespace ->
+            assertThat(response.namespaces).contains(namespace)
+        }
+    }
+
+    @Test
+    fun `given namespaces missing, when deserializing, then should be null`() {
+        val json = """
+            {
+              "name": "Test Site",
+              "description": "Test Description",
+              "url": "https://example.com",
+              "gmt_offset": "0"
+            }
+        """.trimIndent()
+
+        val gson = Gson()
+        val response = gson.fromJson(json, RootWPAPIRestResponse::class.java)
+
+        assertThat(response).isNotNull
+        assertThat(response.namespaces).isNull()
+    }
+
+    @Test
+    fun `given namespaces as empty array, when deserializing, then should return empty list`() {
+        val json = """
+            {
+              "name": "Test Site",
+              "description": "Test Description",
+              "url": "https://example.com",
+              "gmt_offset": "0",
+              "namespaces": []
+            }
+        """.trimIndent()
+
+        val gson = Gson()
+        val response = gson.fromJson(json, RootWPAPIRestResponse::class.java)
+
+        assertThat(response.namespaces).isNotNull
+        assertThat(response.namespaces).isEmpty()
+    }
+
+    @Test
+    fun `given namespaces as empty object, when deserializing, then should return empty list`() {
+        val json = """
+            {
+              "name": "Test Site",
+              "description": "Test Description",
+              "url": "https://example.com",
+              "gmt_offset": "0",
+              "namespaces": {}
+            }
+        """.trimIndent()
+
+        val gson = Gson()
+        val response = gson.fromJson(json, RootWPAPIRestResponse::class.java)
+
+        assertThat(response.namespaces).isNotNull
+        assertThat(response.namespaces).isEmpty()
+    }
+}


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

<!-- Id number of the Linear issue this PR addresses, e.g., WOOMOB-373. -->
Closes WOOMOB-1179

> [!NOTE]
> Given we are going to depend more on the root API response for the Jetpack Performance project, I prioritized working on this task.

### Description 
When we released the Jetpack Performance experiment, we got a spike in the reported ParseErrors, and after investigation we found out this was related to the `namespaces` field in the root endpoint response, some sites return an object instead of the expected array. An example can be found here https://a8c.sentry.io/issues/6775905263/events/9b0ff9afc5804035ac31d0e5cfa2fed1.

After checking the API response, I found out that the response is a dictionary with numeric keys instead of array, like this:
```json
"namespaces": {
    "0": "akismet/v1",
    "1": "jetpack/v4",
    "2": "jetpack-boost/v1",
    "3": "my-jetpack/v1",
    "4": "jetpack/v4/explat",
    "5": "wc/v3",
    "6": "wc/v1",
    "7":  "wp/v2",
  },
```

So I updated our deserialization logic to handle this case too.

I was also able to identify a plugin that causes this behavior, so we now have exact steps to reproduce it. 

### Steps to reproduce
1. Install the [CoCart API plugin](https://wordpress.org/plugins/cart-rest-api-for-woocommerce/)
2. Open the app and sign in to the site, or switch to it (after switching to a different site)

### Testing information
- In `trunk` the above steps will lead to an error, but should succeed in this branch.

### The tests that have been performed
The above.

- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->