### PR TITLE
Fix/woomob 1190 transparent backgrounds in dark mode on android

### DIFF
--- a/WooCommerce/build.gradle
+++ b/WooCommerce/build.gradle
@@ -19,7 +19,9 @@ fladle {
     variant = "vanillaDebug"
     serviceAccountCredentials = rootProject.file(".configure-files/firebase.secrets.json")
     testTargets = [
-            "notPackage com.woocommerce.android.e2e.tests.screenshot"
+            "notPackage com.woocommerce.android.e2e.tests.screenshot",
+            "notClass com.woocommerce.android.e2e.tests.ui.OrdersRealAPI",
+            "notClass com.woocommerce.android.e2e.tests.ui.ProductsRealAPI"
     ]
     devices = [
             ["model": "MediumPhone.arm", "version": "35"]

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/compose/theme/WooColors.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/compose/theme/WooColors.kt
@@ -111,9 +111,9 @@ val Material3DarkColorScheme
         inverseSurface = colorResource(R.color.color_on_surface),
         inversePrimary = colorResource(R.color.color_on_primary),
         surfaceBright = colorResource(R.color.color_surface),
-        surfaceContainer = colorResource(R.color.color_surface_elevated_04),
+        surfaceContainer = colorResource(R.color.color_surface_elevated),
         surfaceContainerHigh = colorResource(R.color.color_surface_elevated),
         surfaceContainerHighest = colorResource(R.color.color_surface_elevated),
-        surfaceContainerLow = colorResource(R.color.color_elevation_overlay_01),
-        surfaceContainerLowest = colorResource(R.color.color_elevation_overlay_01),
+        surfaceContainerLow = colorResource(R.color.color_surface_elevated),
+        surfaceContainerLowest = colorResource(R.color.color_surface_elevated),
     )

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/address/WooShippingEditAddressScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/address/WooShippingEditAddressScreen.kt
@@ -308,7 +308,6 @@ fun WooShippingEditAddressScreen(
                         error = editableAddress.postalCode.error,
                         isRequired = editableAddress.postalCode.isRequired,
                         keyboardOptions = KeyboardOptions(
-                            keyboardType = KeyboardType.Number,
                             imeAction = ImeAction.Next
                         ),
                         keyboardActions = KeyboardActions(


### PR DESCRIPTION
⚠️ Do not merge until we discuss the best approach around background color issues.

Fixes WOOMOB-1190
Fixes WOOMOB-1191

### Description
This PR fixes 2 UI issues: 
- Bottom sheets and dropdown menus were shown transparent in dark mode after some recent color updates to Material3 theme: 

https://github.com/user-attachments/assets/70137fe4-49d6-48d0-b1b8-c3bf11b36767

https://github.com/user-attachments/assets/f579ca45-1325-4f72-bff8-1aea9b5835e7


- We were showing a numeric keyboard for zip code input text in shipping labels. However, there are zip codes that include letters in them. So, I've set the default text keyboard for this input text. 


### Testing information

**Zip code with text keyboard**
1. Open create shipping label flow
2. Tap on edit destination address
3. Check the keyboard shown when focusing the zip code text input is the text keyboard

**Bottom sheets and dropdown menus**

Set the app to dark mode. 

1. Open any drop-down menu, like tapping in the "3 dots" from any of the dashboard cards, and ensure the background of it is not transparent. 
2. Open any bottom sheet from the app. Like Blaze > Create Campaign > Select product > Budget > Tap Edit cta from Schedule section. Verify the bottom sheet background is opaque. 

### The tests that have been performed
<!-- To give the reviewer an idea of what could be missed in terms of testing -->
The above ☝🏼 
