### PR TITLE
WOOMOB-1057 - Introduce basic implementation of background worker for POS local catalog

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/localcatalog/PosLocalCatalogSyncRepository.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/localcatalog/PosLocalCatalogSyncRepository.kt
@@ -1,9 +1,8 @@
 package com.woocommerce.android.ui.woopos.localcatalog
 
+import com.woocommerce.android.ui.woopos.common.util.WooPosLogWrapper
 import com.woocommerce.android.ui.woopos.util.datastore.WooPosSyncTimestampManager
 import com.woocommerce.android.util.CoroutineDispatchers
-import com.woocommerce.android.util.WooLog
-import com.woocommerce.android.util.WooLog.T
 import kotlinx.coroutines.withContext
 import org.wordpress.android.fluxc.model.SiteModel
 import javax.inject.Inject
@@ -27,6 +26,7 @@ class PosLocalCatalogSyncRepository @Inject constructor(
     private val posSyncProductsAction: PosSyncProductsAction,
     private val syncTimestampManager: WooPosSyncTimestampManager,
     private val dispatchers: CoroutineDispatchers,
+    private val logger: WooPosLogWrapper,
 ) {
     companion object {
         const val PAGE_SIZE = 100
@@ -58,7 +58,7 @@ class PosLocalCatalogSyncRepository @Inject constructor(
     ): PosLocalCatalogSyncResult {
         val startTime = System.currentTimeMillis()
 
-        WooLog.d(T.POS, "Starting sync for items modified after $modifiedAfterGmt, max pages: $maxPages")
+        logger.d("Starting sync for items modified after $modifiedAfterGmt, max pages: $maxPages")
 
         val productSyncResult = posSyncProductsAction.execute(site, modifiedAfterGmt, pageSize, maxPages)
         // TBD Local Catalog We'll want to trigger variations action here too

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/localcatalog/PosLocalCatalogSyncScheduler.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/localcatalog/PosLocalCatalogSyncScheduler.kt
@@ -1,0 +1,102 @@
+package com.woocommerce.android.ui.woopos.localcatalog
+
+import android.content.Context
+import androidx.work.BackoffPolicy
+import androidx.work.Constraints
+import androidx.work.ExistingPeriodicWorkPolicy
+import androidx.work.ExistingWorkPolicy
+import androidx.work.NetworkType
+import androidx.work.OneTimeWorkRequestBuilder
+import androidx.work.PeriodicWorkRequestBuilder
+import androidx.work.WorkInfo
+import androidx.work.WorkManager
+import com.woocommerce.android.util.WooLog
+import com.woocommerce.android.util.WooLog.T
+import dagger.hilt.android.qualifiers.ApplicationContext
+import java.util.Calendar
+import java.util.concurrent.TimeUnit
+import javax.inject.Inject
+import javax.inject.Singleton
+
+@Singleton
+class PosLocalCatalogSyncScheduler @Inject constructor(
+    @ApplicationContext private val context: Context
+) {
+
+    private companion object {
+        private const val ONE_TIME_WORK_NAME = "PosLocalCatalogSyncOneTime"
+
+        const val REFRESH_INTERVAL_HOURS = 24L
+        const val TIME_OF_DAY_FOR_PERIODIC_SYNC = 23 // 11 PM
+    }
+
+    private val workManager = WorkManager.getInstance(context)
+
+    fun schedulePeriodicFullCatalogSync() {
+        val syncWorkRequest = PeriodicWorkRequestBuilder<PosLocalCatalogSyncWorker>(
+            REFRESH_INTERVAL_HOURS,
+            TimeUnit.HOURS
+        )
+            .setInitialDelay(calculateDelayToNight(), TimeUnit.MILLISECONDS)
+            .setConstraints(getConstraints())
+            .setBackoffCriteria(
+                BackoffPolicy.EXPONENTIAL,
+                1,
+                TimeUnit.MINUTES
+            )
+            .build()
+
+        workManager.enqueueUniquePeriodicWork(
+            PosLocalCatalogSyncWorker.WORK_NAME,
+            ExistingPeriodicWorkPolicy.KEEP,
+            syncWorkRequest
+        )
+
+        WooLog.d(T.POS, "POS local catalog full sync scheduled.")
+    }
+
+    fun triggerManualFullCatalogSync() {
+        val oneTimeWorkRequest = OneTimeWorkRequestBuilder<PosLocalCatalogSyncWorker>()
+            .setConstraints(getConstraints())
+            .build()
+
+        workManager.enqueueUniqueWork(
+            ONE_TIME_WORK_NAME,
+            ExistingWorkPolicy.REPLACE,
+            oneTimeWorkRequest
+        )
+
+        WooLog.d(T.POS, "Manual POS local catalog sync triggered")
+    }
+
+    fun isPeriodicWorkRunning(): Boolean {
+        val periodicWork = workManager.getWorkInfosForUniqueWork(PosLocalCatalogSyncWorker.WORK_NAME).get()
+
+        return periodicWork.any { it.state == WorkInfo.State.RUNNING }
+    }
+
+    fun isOneTimeWorkRunning(): Boolean {
+        val oneTimeWork = workManager.getWorkInfosForUniqueWork(ONE_TIME_WORK_NAME).get()
+
+        return oneTimeWork.any { it.state == WorkInfo.State.RUNNING }
+    }
+
+    private fun getConstraints(): Constraints {
+        return Constraints.Builder()
+            .setRequiredNetworkType(NetworkType.CONNECTED)
+            .setRequiresBatteryNotLow(true)
+            .build()
+    }
+
+    private fun calculateDelayToNight(): Long {
+        val now = Calendar.getInstance()
+        val night = Calendar.getInstance().apply {
+            set(Calendar.HOUR_OF_DAY, TIME_OF_DAY_FOR_PERIODIC_SYNC)
+            set(Calendar.MINUTE, 0)
+            set(Calendar.SECOND, 0)
+
+            if (before(now)) add(Calendar.DAY_OF_YEAR, 1)
+        }
+        return night.timeInMillis - now.timeInMillis
+    }
+}

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/localcatalog/PosLocalCatalogSyncScheduler.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/localcatalog/PosLocalCatalogSyncScheduler.kt
@@ -10,8 +10,7 @@ import androidx.work.OneTimeWorkRequestBuilder
 import androidx.work.PeriodicWorkRequestBuilder
 import androidx.work.WorkInfo
 import androidx.work.WorkManager
-import com.woocommerce.android.util.WooLog
-import com.woocommerce.android.util.WooLog.T
+import com.woocommerce.android.ui.woopos.common.util.WooPosLogWrapper
 import dagger.hilt.android.qualifiers.ApplicationContext
 import java.util.Calendar
 import java.util.concurrent.TimeUnit
@@ -20,7 +19,8 @@ import javax.inject.Singleton
 
 @Singleton
 class PosLocalCatalogSyncScheduler @Inject constructor(
-    @ApplicationContext private val context: Context
+    @ApplicationContext private val context: Context,
+    private val logger: WooPosLogWrapper,
 ) {
 
     private companion object {
@@ -52,7 +52,7 @@ class PosLocalCatalogSyncScheduler @Inject constructor(
             syncWorkRequest
         )
 
-        WooLog.d(T.POS, "POS local catalog full sync scheduled.")
+        logger.d("POS local catalog full sync scheduled.")
     }
 
     fun triggerManualFullCatalogSync() {
@@ -66,7 +66,7 @@ class PosLocalCatalogSyncScheduler @Inject constructor(
             oneTimeWorkRequest
         )
 
-        WooLog.d(T.POS, "Manual POS local catalog sync triggered")
+        logger.d("Manual POS local catalog sync triggered")
     }
 
     fun isPeriodicWorkRunning(): Boolean {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/localcatalog/PosLocalCatalogSyncScheduler.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/localcatalog/PosLocalCatalogSyncScheduler.kt
@@ -58,6 +58,11 @@ class PosLocalCatalogSyncScheduler @Inject constructor(
     fun triggerManualFullCatalogSync() {
         val oneTimeWorkRequest = OneTimeWorkRequestBuilder<PosLocalCatalogSyncWorker>()
             .setConstraints(getConstraints())
+            .setBackoffCriteria(
+                BackoffPolicy.EXPONENTIAL,
+                1,
+                TimeUnit.MINUTES
+            )
             .build()
 
         workManager.enqueueUniqueWork(

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/localcatalog/PosLocalCatalogSyncWorker.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/localcatalog/PosLocalCatalogSyncWorker.kt
@@ -6,8 +6,7 @@ import androidx.work.CoroutineWorker
 import androidx.work.WorkerParameters
 import com.woocommerce.android.tools.SelectedSite
 import com.woocommerce.android.ui.login.AccountRepository
-import com.woocommerce.android.util.WooLog
-import com.woocommerce.android.util.WooLog.T
+import com.woocommerce.android.ui.woopos.common.util.WooPosLogWrapper
 import dagger.assisted.Assisted
 import dagger.assisted.AssistedInject
 
@@ -18,6 +17,7 @@ class PosLocalCatalogSyncWorker @AssistedInject constructor(
     private val accountRepository: AccountRepository,
     private val selectedSite: SelectedSite,
     private val syncRepository: PosLocalCatalogSyncRepository,
+    private val logger: WooPosLogWrapper,
 ) : CoroutineWorker(appContext, workerParams) {
 
     companion object {
@@ -27,24 +27,23 @@ class PosLocalCatalogSyncWorker @AssistedInject constructor(
     @Suppress("ReturnCount")
     override suspend fun doWork(): Result {
         if (!accountRepository.isUserLoggedIn()) {
-            WooLog.d(T.POS, "User not logged in, skipping local catalog sync")
+            logger.d("User not logged in, skipping local catalog sync")
             return Result.failure()
         }
 
         val site = selectedSite.getOrNull()
         if (site == null) {
-            WooLog.e(T.POS, "No selected WooCommerce site found, skipping local catalog sync")
+            logger.e("No selected WooCommerce site found, skipping local catalog sync")
             return Result.failure()
         }
 
-        WooLog.d(T.POS, "Starting full local catalog sync")
+        logger.d("Starting full local catalog sync")
 
         val syncResult = syncRepository.syncLocalCatalogFull(site)
 
         return when (syncResult) {
             is PosLocalCatalogSyncResult.Success -> {
-                WooLog.d(
-                    T.POS,
+                logger.d(
                     "Local catalog sync completed successfully. Products: ${syncResult.productsSynced}, " +
                         "Variations: ${syncResult.variationsSynced}, Duration: ${syncResult.syncDurationMs}ms"
                 )
@@ -52,12 +51,12 @@ class PosLocalCatalogSyncWorker @AssistedInject constructor(
             }
 
             is PosLocalCatalogSyncResult.Failure.UnexpectedError -> {
-                WooLog.e(T.POS, "Local catalog sync failed: ${syncResult.error}. Retrying ...")
+                logger.e("Local catalog sync failed: ${syncResult.error}. Retrying ...")
                 Result.retry()
             }
             is PosLocalCatalogSyncResult.Failure.CatalogTooLarge -> {
                 // TBD Local Catalog - stop future syncs for this site if catalog too large
-                WooLog.e(T.POS, "Local catalog sync failed: ${syncResult.error}.")
+                logger.e("Local catalog sync failed: ${syncResult.error}.")
                 Result.failure()
             }
         }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/localcatalog/PosLocalCatalogSyncWorker.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/localcatalog/PosLocalCatalogSyncWorker.kt
@@ -24,6 +24,7 @@ class PosLocalCatalogSyncWorker @AssistedInject constructor(
         const val WORK_NAME = "PosLocalCatalogSyncWork"
     }
 
+    @Suppress("ReturnCount")
     override suspend fun doWork(): Result {
         if (!accountRepository.isUserLoggedIn()) {
             WooLog.d(T.POS, "User not logged in, skipping local catalog sync")

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/localcatalog/PosLocalCatalogSyncWorker.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/localcatalog/PosLocalCatalogSyncWorker.kt
@@ -1,0 +1,64 @@
+package com.woocommerce.android.ui.woopos.localcatalog
+
+import android.content.Context
+import androidx.hilt.work.HiltWorker
+import androidx.work.CoroutineWorker
+import androidx.work.WorkerParameters
+import com.woocommerce.android.tools.SelectedSite
+import com.woocommerce.android.ui.login.AccountRepository
+import com.woocommerce.android.util.WooLog
+import com.woocommerce.android.util.WooLog.T
+import dagger.assisted.Assisted
+import dagger.assisted.AssistedInject
+
+@HiltWorker
+class PosLocalCatalogSyncWorker @AssistedInject constructor(
+    @Assisted appContext: Context,
+    @Assisted workerParams: WorkerParameters,
+    private val accountRepository: AccountRepository,
+    private val selectedSite: SelectedSite,
+    private val syncRepository: PosLocalCatalogSyncRepository,
+) : CoroutineWorker(appContext, workerParams) {
+
+    companion object {
+        const val WORK_NAME = "PosLocalCatalogSyncWork"
+    }
+
+    override suspend fun doWork(): Result {
+        if (!accountRepository.isUserLoggedIn()) {
+            WooLog.d(T.POS, "User not logged in, skipping local catalog sync")
+            return Result.failure()
+        }
+
+        val site = selectedSite.getOrNull()
+        if (site == null) {
+            WooLog.e(T.POS, "No selected WooCommerce site found, skipping local catalog sync")
+            return Result.failure()
+        }
+
+        WooLog.d(T.POS, "Starting full local catalog sync")
+
+        val syncResult = syncRepository.syncLocalCatalogFull(site)
+
+        return when (syncResult) {
+            is PosLocalCatalogSyncResult.Success -> {
+                WooLog.d(
+                    T.POS,
+                    "Local catalog sync completed successfully. Products: ${syncResult.productsSynced}, " +
+                        "Variations: ${syncResult.variationsSynced}, Duration: ${syncResult.syncDurationMs}ms"
+                )
+                Result.success()
+            }
+
+            is PosLocalCatalogSyncResult.Failure.UnexpectedError -> {
+                WooLog.e(T.POS, "Local catalog sync failed: ${syncResult.error}. Retrying ...")
+                Result.retry()
+            }
+            is PosLocalCatalogSyncResult.Failure.CatalogTooLarge -> {
+                // TBD Local Catalog - stop future syncs for this site if catalog too large
+                WooLog.e(T.POS, "Local catalog sync failed: ${syncResult.error}.")
+                Result.failure()
+            }
+        }
+    }
+}

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/localcatalog/PosSyncProductsAction.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/localcatalog/PosSyncProductsAction.kt
@@ -3,7 +3,7 @@ package com.woocommerce.android.ui.woopos.localcatalog
 import com.woocommerce.android.util.WooLog
 import com.woocommerce.android.util.WooLog.T
 import org.wordpress.android.fluxc.model.SiteModel
-import org.wordpress.android.fluxc.store.pos.PosLocalCatalogStore
+import org.wordpress.android.fluxc.store.pos.localcatalog.PosLocalCatalogStore
 import javax.inject.Inject
 
 class PosSyncProductsAction @Inject constructor(

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/localcatalog/PosSyncProductsAction.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/localcatalog/PosSyncProductsAction.kt
@@ -1,13 +1,13 @@
 package com.woocommerce.android.ui.woopos.localcatalog
 
-import com.woocommerce.android.util.WooLog
-import com.woocommerce.android.util.WooLog.T
+import com.woocommerce.android.ui.woopos.common.util.WooPosLogWrapper
 import org.wordpress.android.fluxc.model.SiteModel
 import org.wordpress.android.fluxc.store.pos.localcatalog.PosLocalCatalogStore
 import javax.inject.Inject
 
 class PosSyncProductsAction @Inject constructor(
-    private val posLocalCatalogStore: PosLocalCatalogStore
+    private val posLocalCatalogStore: PosLocalCatalogStore,
+    private val logger: WooPosLogWrapper,
 ) {
     sealed class Result {
         data class Success(val productsSynced: Int) : Result()
@@ -48,20 +48,19 @@ class PosSyncProductsAction @Inject constructor(
                     // TBD Local Catalog We should first fetch the headers to decide if the catalog size is acceptable
                     if (pagesSynced == 0) {
                         if (syncResult.totalPages > maxPages) {
-                            WooLog.e(
-                                T.POS,
+                            logger.e(
                                 "Catalog too large: $syncResult.totalPages pages exceed maximum of $maxPages pages"
                             )
                             return Result.Failed.CatalogTooLarge(syncResult.totalPages, maxPages)
                         }
                     }
 
-                    WooLog.d(T.POS, "Page ${pagesSynced + 1} synced, ${syncResult.syncedCount} products")
+                    logger.d("Page ${pagesSynced + 1} synced, ${syncResult.syncedCount} products")
                     totalSyncedProducts += syncResult.syncedCount
                     pagesSynced++
 
                     if (!syncResult.hasMore || syncResult.syncedCount == 0) {
-                        WooLog.d(T.POS, "No more products to sync")
+                        logger.d("No more products to sync")
                         shouldContinue = false
                     } else {
                         currentOffset = syncResult.nextOffset
@@ -69,13 +68,13 @@ class PosSyncProductsAction @Inject constructor(
                 },
                 onFailure = { error ->
                     // TBD Local Catalog Add retry logic. We shouldn't fail when one page fails.
-                    WooLog.e(T.POS, "Sync failed on page ${pagesSynced + 1}: ${error.message}")
+                    logger.e("Sync failed on page ${pagesSynced + 1}: ${error.message}")
                     return Result.Failed.UnexpectedError(error.message ?: "Unknown error")
                 }
             )
         }
 
-        WooLog.d(T.POS, "Products sync completed, $totalSyncedProducts products synced across $pagesSynced pages")
+        logger.d("Products sync completed, $totalSyncedProducts products synced across $pagesSynced pages")
         return Result.Success(totalSyncedProducts)
     }
 }

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/localcatalog/PosLocalCatalogSyncRepositoryTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/localcatalog/PosLocalCatalogSyncRepositoryTest.kt
@@ -23,7 +23,7 @@ class PosLocalCatalogSyncRepositoryTest : BaseUnitTest() {
     private var syncTimestampManager: WooPosSyncTimestampManager = mock()
     private lateinit var dispatchers: CoroutineDispatchers
     private lateinit var site: SiteModel
-    private lateinit var logger: WooPosLogWrapper
+    private var logger: WooPosLogWrapper = mock()
 
     @Before
     fun setup() {

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/localcatalog/PosLocalCatalogSyncRepositoryTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/localcatalog/PosLocalCatalogSyncRepositoryTest.kt
@@ -1,5 +1,6 @@
 package com.woocommerce.android.ui.woopos.localcatalog
 
+import com.woocommerce.android.ui.woopos.common.util.WooPosLogWrapper
 import com.woocommerce.android.ui.woopos.util.datastore.WooPosSyncTimestampManager
 import com.woocommerce.android.util.CoroutineDispatchers
 import com.woocommerce.android.viewmodel.BaseUnitTest
@@ -18,15 +19,14 @@ import org.wordpress.android.fluxc.model.SiteModel
 @ExperimentalCoroutinesApi
 class PosLocalCatalogSyncRepositoryTest : BaseUnitTest() {
     private lateinit var sut: PosLocalCatalogSyncRepository
-    private lateinit var posSyncProductsAction: PosSyncProductsAction
-    private lateinit var syncTimestampManager: WooPosSyncTimestampManager
+    private var posSyncProductsAction: PosSyncProductsAction = mock()
+    private var syncTimestampManager: WooPosSyncTimestampManager = mock()
     private lateinit var dispatchers: CoroutineDispatchers
     private lateinit var site: SiteModel
+    private lateinit var logger: WooPosLogWrapper
 
     @Before
     fun setup() {
-        posSyncProductsAction = mock()
-        syncTimestampManager = mock()
         dispatchers = CoroutineDispatchers(
             main = UnconfinedTestDispatcher(),
             io = UnconfinedTestDispatcher(),
@@ -36,7 +36,8 @@ class PosLocalCatalogSyncRepositoryTest : BaseUnitTest() {
         sut = PosLocalCatalogSyncRepository(
             posSyncProductsAction = posSyncProductsAction,
             syncTimestampManager = syncTimestampManager,
-            dispatchers = dispatchers
+            dispatchers = dispatchers,
+            logger = logger,
         )
 
         site = SiteModel().apply {

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/localcatalog/PosLocalCatalogSyncWorkerTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/localcatalog/PosLocalCatalogSyncWorkerTest.kt
@@ -175,8 +175,16 @@ class PosLocalCatalogSyncWorkerTest : BaseUnitTest() {
     @Test
     fun `when site changes between calls, then worker uses current site`() = testBlocking {
         // GIVEN
-        val site1 = SiteModel().apply { id = 1; siteId = 123L; name = "Site 1" }
-        val site2 = SiteModel().apply { id = 2; siteId = 456L; name = "Site 2" }
+        val site1 = SiteModel().apply {
+            id = 1
+            siteId = 123L
+            name = "Site 1"
+        }
+        val site2 = SiteModel().apply {
+            id = 2
+            siteId = 456L
+            name = "Site 2"
+        }
 
         whenever(accountRepository.isUserLoggedIn()).thenReturn(true)
         whenever(syncRepository.syncLocalCatalogFull(any()))

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/localcatalog/PosLocalCatalogSyncWorkerTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/localcatalog/PosLocalCatalogSyncWorkerTest.kt
@@ -5,6 +5,7 @@ import androidx.work.ListenableWorker
 import androidx.work.WorkerParameters
 import com.woocommerce.android.tools.SelectedSite
 import com.woocommerce.android.ui.login.AccountRepository
+import com.woocommerce.android.ui.woopos.common.util.WooPosLogWrapper
 import com.woocommerce.android.viewmodel.BaseUnitTest
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import org.assertj.core.api.Assertions.assertThat
@@ -20,12 +21,13 @@ import org.wordpress.android.fluxc.model.SiteModel
 @ExperimentalCoroutinesApi
 class PosLocalCatalogSyncWorkerTest : BaseUnitTest() {
 
-    private lateinit var context: Context
-    private lateinit var workerParams: WorkerParameters
-    private lateinit var accountRepository: AccountRepository
-    private lateinit var selectedSite: SelectedSite
-    private lateinit var syncRepository: PosLocalCatalogSyncRepository
+    private var context: Context = mock()
+    private var workerParams: WorkerParameters = mock()
+    private var accountRepository: AccountRepository = mock()
+    private var selectedSite: SelectedSite = mock()
+    private var syncRepository: PosLocalCatalogSyncRepository = mock()
     private lateinit var site: SiteModel
+    private var logger: WooPosLogWrapper = mock()
 
     private val successResponse = PosLocalCatalogSyncResult.Success(
         productsSynced = 10,
@@ -40,12 +42,6 @@ class PosLocalCatalogSyncWorkerTest : BaseUnitTest() {
 
     @Before
     fun setup() {
-        context = mock()
-        workerParams = mock()
-        accountRepository = mock()
-        selectedSite = mock()
-        syncRepository = mock()
-
         site = SiteModel().apply {
             id = 1
             siteId = 123L
@@ -62,7 +58,8 @@ class PosLocalCatalogSyncWorkerTest : BaseUnitTest() {
             workerParams = workerParams,
             accountRepository = accountRepository,
             selectedSite = selectedSite,
-            syncRepository = syncRepository
+            syncRepository = syncRepository,
+            logger = logger,
         )
     }
 
@@ -115,8 +112,6 @@ class PosLocalCatalogSyncWorkerTest : BaseUnitTest() {
     @Test
     fun `when sync fails with catalog too large, then returns failure without retry`() = testBlocking {
         // GIVEN
-        val totalPages = 15
-        val maxPages = 10
         whenever(syncRepository.syncLocalCatalogFull(site))
             .thenReturn(catalogTooLargeResponse)
 

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/localcatalog/PosLocalCatalogSyncWorkerTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/localcatalog/PosLocalCatalogSyncWorkerTest.kt
@@ -1,0 +1,205 @@
+package com.woocommerce.android.ui.woopos.localcatalog
+
+import android.content.Context
+import androidx.work.ListenableWorker
+import androidx.work.WorkerParameters
+import com.woocommerce.android.tools.SelectedSite
+import com.woocommerce.android.ui.login.AccountRepository
+import com.woocommerce.android.viewmodel.BaseUnitTest
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.Before
+import org.junit.Test
+import org.mockito.kotlin.any
+import org.mockito.kotlin.eq
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
+import org.wordpress.android.fluxc.model.SiteModel
+
+@ExperimentalCoroutinesApi
+class PosLocalCatalogSyncWorkerTest : BaseUnitTest() {
+
+    private lateinit var context: Context
+    private lateinit var workerParams: WorkerParameters
+    private lateinit var accountRepository: AccountRepository
+    private lateinit var selectedSite: SelectedSite
+    private lateinit var syncRepository: PosLocalCatalogSyncRepository
+    private lateinit var site: SiteModel
+
+    private val successResponse = PosLocalCatalogSyncResult.Success(
+        productsSynced = 10,
+        variationsSynced = 0,
+        syncDurationMs = 1000
+    )
+    private val catalogTooLargeResponse = PosLocalCatalogSyncResult.Failure.CatalogTooLarge(
+        error = "Catalog too large: 29 pages exceed maximum of 10 pages",
+        totalPages = 29,
+        maxPages = 10
+    )
+
+    @Before
+    fun setup() {
+        context = mock()
+        workerParams = mock()
+        accountRepository = mock()
+        selectedSite = mock()
+        syncRepository = mock()
+
+        site = SiteModel().apply {
+            id = 1
+            siteId = 123L
+            name = "Test Site"
+        }
+
+        whenever(accountRepository.isUserLoggedIn()).thenReturn(true)
+        whenever(selectedSite.getOrNull()).thenReturn(site)
+    }
+
+    private fun createWorker(): PosLocalCatalogSyncWorker {
+        return PosLocalCatalogSyncWorker(
+            appContext = context,
+            workerParams = workerParams,
+            accountRepository = accountRepository,
+            selectedSite = selectedSite,
+            syncRepository = syncRepository
+        )
+    }
+
+    @Test
+    fun `given user logged in and site available, when sync succeeds, then returns success`() = testBlocking {
+        // GIVEN
+        whenever(accountRepository.isUserLoggedIn()).thenReturn(true)
+        whenever(selectedSite.getOrNull()).thenReturn(site)
+        whenever(syncRepository.syncLocalCatalogFull(site))
+            .thenReturn(successResponse)
+
+        val worker = createWorker()
+
+        // WHEN
+        val result = worker.doWork()
+
+        // THEN
+        assertThat(result).isEqualTo(ListenableWorker.Result.success())
+    }
+
+    @Test
+    fun `when user is not logged in, then returns failure`() = testBlocking {
+        // GIVEN
+        whenever(accountRepository.isUserLoggedIn()).thenReturn(false)
+
+        val worker = createWorker()
+
+        // WHEN
+        val result = worker.doWork()
+
+        // THEN
+        assertThat(result).isEqualTo(ListenableWorker.Result.failure())
+    }
+
+    @Test
+    fun `given user logged in, when no site is selected, then returns failure`() = testBlocking {
+        // GIVEN
+        whenever(accountRepository.isUserLoggedIn()).thenReturn(true)
+        whenever(selectedSite.getOrNull()).thenReturn(null)
+
+        val worker = createWorker()
+
+        // WHEN
+        val result = worker.doWork()
+
+        // THEN
+        assertThat(result).isEqualTo(ListenableWorker.Result.failure())
+    }
+
+    @Test
+    fun `when sync fails with catalog too large, then returns failure without retry`() = testBlocking {
+        // GIVEN
+        val totalPages = 15
+        val maxPages = 10
+        whenever(syncRepository.syncLocalCatalogFull(site))
+            .thenReturn(catalogTooLargeResponse)
+
+        val worker = createWorker()
+
+        // WHEN
+        val result = worker.doWork()
+
+        // THEN
+        assertThat(result).isEqualTo(ListenableWorker.Result.failure())
+    }
+
+    @Test
+    fun `when sync fails with unexpected error, then returns failure with retry`() = testBlocking {
+        // GIVEN
+        whenever(syncRepository.syncLocalCatalogFull(site))
+            .thenReturn(PosLocalCatalogSyncResult.Failure.UnexpectedError(""))
+        val worker = createWorker()
+
+        // WHEN
+        val result = worker.doWork()
+
+        // THEN
+        assertThat(result).isEqualTo(ListenableWorker.Result.retry())
+    }
+
+    @Test
+    fun `when login state changes between calls, then behavior changes accordingly`() = testBlocking {
+        // GIVEN
+        val worker = createWorker()
+
+        whenever(accountRepository.isUserLoggedIn()).thenReturn(false)
+        val result1 = worker.doWork()
+
+        whenever(accountRepository.isUserLoggedIn()).thenReturn(true)
+        whenever(selectedSite.getOrNull()).thenReturn(null)
+        val result2 = worker.doWork()
+
+        whenever(selectedSite.getOrNull()).thenReturn(site)
+        whenever(syncRepository.syncLocalCatalogFull(site))
+            .thenReturn(
+                PosLocalCatalogSyncResult.Success(
+                    productsSynced = 100,
+                    variationsSynced = 0,
+                    syncDurationMs = 1000L
+                )
+            )
+        val result3 = worker.doWork()
+
+        // THEN
+        assertThat(result1).isEqualTo(ListenableWorker.Result.failure()) // Not logged in
+        assertThat(result2).isEqualTo(ListenableWorker.Result.failure()) // No site
+        assertThat(result3).isEqualTo(ListenableWorker.Result.success()) // Successful sync
+    }
+
+    @Test
+    fun `when site changes between calls, then worker uses current site`() = testBlocking {
+        // GIVEN
+        val site1 = SiteModel().apply { id = 1; siteId = 123L; name = "Site 1" }
+        val site2 = SiteModel().apply { id = 2; siteId = 456L; name = "Site 2" }
+
+        whenever(accountRepository.isUserLoggedIn()).thenReturn(true)
+        whenever(syncRepository.syncLocalCatalogFull(any()))
+            .thenReturn(
+                PosLocalCatalogSyncResult.Success(
+                    productsSynced = 50,
+                    variationsSynced = 5,
+                    syncDurationMs = 800L
+                )
+            )
+
+        val worker = createWorker()
+
+        whenever(selectedSite.getOrNull()).thenReturn(site1)
+        val result1 = worker.doWork()
+
+        whenever(selectedSite.getOrNull()).thenReturn(site2)
+        val result2 = worker.doWork()
+
+        // THEN
+        assertThat(result1).isEqualTo(ListenableWorker.Result.success())
+        assertThat(result2).isEqualTo(ListenableWorker.Result.success())
+        verify(syncRepository).syncLocalCatalogFull(eq(site1))
+        verify(syncRepository).syncLocalCatalogFull(eq(site2))
+    }
+}

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/localcatalog/PosSyncProductsActionTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/localcatalog/PosSyncProductsActionTest.kt
@@ -13,7 +13,8 @@ import org.mockito.kotlin.times
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
 import org.wordpress.android.fluxc.model.SiteModel
-import org.wordpress.android.fluxc.store.pos.PosLocalCatalogStore
+import org.wordpress.android.fluxc.store.pos.localcatalog.PosLocalCatalogStore
+import org.wordpress.android.fluxc.store.pos.localcatalog.PosLocalCatalogSyncResult
 import kotlin.Result as KotlinResult
 
 class PosSyncProductsActionTest {
@@ -209,7 +210,7 @@ class PosSyncProductsActionTest {
         whenever(posLocalCatalogStore.syncRecentlyModifiedProducts(any(), anyOrNull(), eq(0), any()))
             .thenReturn(
                 KotlinResult.success(
-                    org.wordpress.android.fluxc.store.pos.PosLocalCatalogSyncResult(
+                    PosLocalCatalogSyncResult(
                         syncedCount = productsCount,
                         hasMore = false,
                         nextOffset = 0,
@@ -223,7 +224,7 @@ class PosSyncProductsActionTest {
         whenever(posLocalCatalogStore.syncRecentlyModifiedProducts(any(), anyOrNull(), eq(0), any()))
             .thenReturn(
                 KotlinResult.success(
-                    org.wordpress.android.fluxc.store.pos.PosLocalCatalogSyncResult(
+                    PosLocalCatalogSyncResult(
                         syncedCount = page1Count,
                         hasMore = true,
                         nextOffset = page1Count,
@@ -235,7 +236,7 @@ class PosSyncProductsActionTest {
         whenever(posLocalCatalogStore.syncRecentlyModifiedProducts(any(), anyOrNull(), eq(page1Count), any()))
             .thenReturn(
                 KotlinResult.success(
-                    org.wordpress.android.fluxc.store.pos.PosLocalCatalogSyncResult(
+                    PosLocalCatalogSyncResult(
                         syncedCount = page2Count,
                         hasMore = true,
                         nextOffset = page1Count + page2Count,
@@ -254,7 +255,7 @@ class PosSyncProductsActionTest {
         )
             .thenReturn(
                 KotlinResult.success(
-                    org.wordpress.android.fluxc.store.pos.PosLocalCatalogSyncResult(
+                    PosLocalCatalogSyncResult(
                         syncedCount = page3Count,
                         hasMore = false,
                         nextOffset = 0,
@@ -268,7 +269,7 @@ class PosSyncProductsActionTest {
         whenever(posLocalCatalogStore.syncRecentlyModifiedProducts(any(), anyOrNull(), any(), any()))
             .thenReturn(
                 KotlinResult.success(
-                    org.wordpress.android.fluxc.store.pos.PosLocalCatalogSyncResult(
+                    PosLocalCatalogSyncResult(
                         syncedCount = 0,
                         hasMore = false,
                         nextOffset = 0,
@@ -292,7 +293,7 @@ class PosSyncProductsActionTest {
         whenever(posLocalCatalogStore.syncRecentlyModifiedProducts(any(), anyOrNull(), eq(0), any()))
             .thenReturn(
                 KotlinResult.success(
-                    org.wordpress.android.fluxc.store.pos.PosLocalCatalogSyncResult(
+                    PosLocalCatalogSyncResult(
                         syncedCount = 100,
                         hasMore = true,
                         nextOffset = 100,
@@ -311,7 +312,7 @@ class PosSyncProductsActionTest {
         whenever(posLocalCatalogStore.syncRecentlyModifiedProducts(any(), anyOrNull(), eq(0), any()))
             .thenReturn(
                 KotlinResult.success(
-                    org.wordpress.android.fluxc.store.pos.PosLocalCatalogSyncResult(
+                    PosLocalCatalogSyncResult(
                         syncedCount = 0,
                         hasMore = true,
                         nextOffset = 100,
@@ -323,7 +324,7 @@ class PosSyncProductsActionTest {
         whenever(posLocalCatalogStore.syncRecentlyModifiedProducts(any(), anyOrNull(), eq(100), any()))
             .thenReturn(
                 KotlinResult.success(
-                    org.wordpress.android.fluxc.store.pos.PosLocalCatalogSyncResult(
+                    PosLocalCatalogSyncResult(
                         syncedCount = 50,
                         hasMore = false,
                         nextOffset = 0,

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/localcatalog/PosSyncProductsActionTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/localcatalog/PosSyncProductsActionTest.kt
@@ -1,5 +1,6 @@
 package com.woocommerce.android.ui.woopos.localcatalog
 
+import com.woocommerce.android.ui.woopos.common.util.WooPosLogWrapper
 import com.woocommerce.android.ui.woopos.localcatalog.PosLocalCatalogSyncRepository.Companion.PAGE_SIZE
 import com.woocommerce.android.ui.woopos.localcatalog.PosSyncProductsAction.Result
 import kotlinx.coroutines.test.runTest
@@ -21,13 +22,13 @@ import kotlin.Result as KotlinResult
 class PosSyncProductsActionTest {
 
     private lateinit var sut: PosSyncProductsAction
-    private lateinit var posLocalCatalogStore: PosLocalCatalogStore
+    private var posLocalCatalogStore: PosLocalCatalogStore = mock()
     private lateinit var site: SiteModel
+    private var logger: WooPosLogWrapper = mock()
 
     @Before
     fun setup() {
-        posLocalCatalogStore = mock()
-        sut = PosSyncProductsAction(posLocalCatalogStore)
+        sut = PosSyncProductsAction(posLocalCatalogStore, logger)
         site = SiteModel().apply {
             id = 1
             siteId = 123L

--- a/libs/fluxc-plugin/src/main/kotlin/org/wordpress/android/fluxc/store/pos/localcatalog/PosLocalCatalogSyncResult.kt
+++ b/libs/fluxc-plugin/src/main/kotlin/org/wordpress/android/fluxc/store/pos/localcatalog/PosLocalCatalogSyncResult.kt
@@ -3,5 +3,6 @@ package org.wordpress.android.fluxc.store.pos.localcatalog
 data class PosLocalCatalogSyncResult(
     val syncedCount: Int,
     val hasMore: Boolean,
-    val nextOffset: Int
+    val nextOffset: Int,
+    val totalPages: Int,
 )


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

<!-- Id number of the Linear issue this PR addresses, e.g., WOOMOB-373. -->

#WOOMOB-1057

[Do not merge label - the parent PR needs to be merged first.](https://github.com/woocommerce/woocommerce-android/pull/14534)

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

This PR introduces a basic implementation of background worker for POS Local Catalog. It has several TBD comments, however, I decided to split the work to ensure the PRs remain reasonably long.

The scheduler uses static methods from the Android SDK, so I decided not to introduce any tests for it.


### Steps to reproduce
<!-- Step-by-step testing instructions. For new user flows, consider instead stating the goal of the workflow and see if your PR reviewer can accomplish the workflow without specific steps! -->

N/A The code isn't used yet, green CI is enough.

### Testing information
<!-- This is your opportunity to break out individual scenarios that need testing (when necessary) and/or include a checklist for the reviewer to go through. Consider documenting the following from your own completed testing: devices used, alternate workflows, edge cases, affected areas, critical flows, areas not tested, and any remaining unknowns. Provide feedback on this new section of the PR template through Sept 30, 2024 to Apps Quality; additional context here: p91TBi-b8z-p2#comment-12036 -->

N/A

### The tests that have been performed
<!-- To give the reviewer an idea of what could be missed in terms of testing -->

### Images/gif
<!-- Include before and after images or gifs when appropriate. -->
N/A

- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->