### PR TITLE
Update surface container colors of Material 3 theme

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/compose/theme/WooColors.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/compose/theme/WooColors.kt
@@ -111,9 +111,9 @@ val Material3DarkColorScheme
         inverseSurface = colorResource(R.color.color_on_surface),
         inversePrimary = colorResource(R.color.color_on_primary),
         surfaceBright = colorResource(R.color.color_surface),
-        surfaceContainer = colorResource(R.color.color_surface_elevated),
+        surfaceContainer = colorResource(R.color.color_surface_elevated_04),
         surfaceContainerHigh = colorResource(R.color.color_surface_elevated),
         surfaceContainerHighest = colorResource(R.color.color_surface_elevated),
-        surfaceContainerLow = colorResource(R.color.color_surface_elevated),
-        surfaceContainerLowest = colorResource(R.color.color_surface_elevated),
+        surfaceContainerLow = colorResource(R.color.color_elevation_overlay_01),
+        surfaceContainerLowest = colorResource(R.color.color_elevation_overlay_01),
     )

--- a/WooCommerce/src/main/res/values-night/colors_base.xml
+++ b/WooCommerce/src/main/res/values-night/colors_base.xml
@@ -13,7 +13,7 @@
     <color name="color_error">@color/woo_red_30</color>
     <color name="color_alert">@color/woo_yellow_30</color>
 
-    <color name="color_surface_elevated_04">@color/woo_white_alpha_009</color>
+    <color name="color_surface_elevated_04">#262626</color>
 
     <color name="color_on_surface">@color/woo_white</color>
     <color name="color_on_surface_high">@color/woo_white_alpha_087</color>
@@ -57,7 +57,7 @@
     <!--
         Elevation colors
     -->
-    <color name="color_elevation_overlay_01">@color/woo_white_alpha_005</color>
+    <color name="color_elevation_overlay_01">#1d1d1d</color>
 
     <!--
         Default graph colors


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

<!-- Id number of the Linear issue this PR addresses, e.g., WOOMOB-373. -->

### Description
In https://github.com/woocommerce/woocommerce-android/pull/14530, we reverted a change to Material theme 3 dark colors as it caused a transparent background in some components, but the revert also brought back some issues, as the colors are brighter than what they should as shown in this [comment](https://github.com/woocommerce/woocommerce-android/pull/14530#pullrequestreview-3165761007).

For some context, the original change was needed because Material 3 differs from Material 2 in how it handles elevation, in Material 2, an overlay was automatically applied for elevated components in dark theme, but in Material 3 we use different levels of colors, and using `color_surface_elevated` for all the levels didn't work well.

This PR brings back the change, but it removes the transparency from the overlay colors that were used, the new colors were calculated by compositing the previous colors over `color_surface`, as this is how they are also applied in the app, so the change shouldn't bring any UI changes for previous places where the colors were used.

### Steps to reproduce
#### Usage in cards
1. Make sure Woo Shipping is installed and configured.
2. Open order details.
3. Check the Shipping Labels section.

#### Usage in bottom sheets
1. Open Blaze campaign creation.
2. Open budget screen.
3. Tap on Edit.

### Testing information
- Confirm the colors are correct.
- Confirm the shade is darker than before, which also matches closely the Material 2 theme.

### The tests that have been performed
The above.

### Images/gif
| Before | After |
| --- | --- |
| <img width="1080" height="2400" alt="Screenshot_20250828_182731" src="https://github.com/user-attachments/assets/fb0d481b-9aaf-4019-924c-7b2ddcb1b23c" /> | <img width="1080" height="2400" alt="Screenshot_20250828_182742" src="https://github.com/user-attachments/assets/f1dcafb4-96d0-4882-a6e5-afbce140c7c3" /> |
| <img width="1080" height="2400" alt="Screenshot_20250828_182647" src="https://github.com/user-attachments/assets/5a04d8bd-430f-4de8-b7a8-5d5625b1bcb3" /> | <img width="1080" height="2400" alt="Screenshot_20250828_182706" src="https://github.com/user-attachments/assets/acb96654-b1ab-4e85-ab9f-4a7a4ee8234a" /> |


- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->