### PR TITLE
Re-enable RealApi UI tests

### DIFF
--- a/WooCommerce/build.gradle
+++ b/WooCommerce/build.gradle
@@ -19,9 +19,7 @@ fladle {
     variant = "vanillaDebug"
     serviceAccountCredentials = rootProject.file(".configure-files/firebase.secrets.json")
     testTargets = [
-            "notPackage com.woocommerce.android.e2e.tests.screenshot",
-            "notClass com.woocommerce.android.e2e.tests.ui.OrdersRealAPI",
-            "notClass com.woocommerce.android.e2e.tests.ui.ProductsRealAPI"
+            "notPackage com.woocommerce.android.e2e.tests.screenshot"
     ]
     devices = [
             ["model": "MediumPhone.arm", "version": "35"]


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

<!-- Id number of the Linear issue this PR addresses, e.g., WOOMOB-373. -->

### Description
This reverts commit caca74e5ef52720c95f8ac55bca519b52c5a0048, as now the login issue for RealApi UI tests is fixed.

### Testing information
Just green CI.

- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->