### PR TITLE
[Jetpack Performance] Fetch app passwords support on app launch

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/jetpack/JetpackActivationRepository.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/jetpack/JetpackActivationRepository.kt
@@ -165,12 +165,9 @@ class JetpackActivationRepository @Inject constructor(
                 WooLog.d(WooLog.T.LOGIN, "Jetpack Activation: Site $siteUrl is missing from account sites")
                 Result.failure(IllegalStateException("Site missing"))
             } else {
-                if (!site.hasWooCommerce) {
-                    // If the site doesn't have WooCommerce, let's do one additional fetch using `fetchSite`,
-                    // this function will make sure to fetch data from the remote site, which might result in more
-                    // accurate result
-                    siteStore.fetchSite(site)
-                }
+                // Fetch full site details from the remote site, this will also allow us to fetch the
+                // Applications Passwords support on the site
+                siteStore.fetchSite(site)
                 Result.success(site)
             }
         }

--- a/libs/fluxc-plugin/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/system/WooSystemRestClient.kt
+++ b/libs/fluxc-plugin/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/system/WooSystemRestClient.kt
@@ -5,10 +5,8 @@ import com.google.gson.annotations.SerializedName
 import org.wordpress.android.fluxc.generated.endpoint.WOOCOMMERCE
 import org.wordpress.android.fluxc.generated.endpoint.WPAPI
 import org.wordpress.android.fluxc.model.SiteModel
-import org.wordpress.android.fluxc.network.rest.wpapi.WPAPIResponse
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.WooNetwork
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.WooPayload
-import org.wordpress.android.fluxc.network.rest.wpcom.wc.toWooError
 import org.wordpress.android.fluxc.utils.toWooPayload
 import javax.inject.Inject
 
@@ -41,51 +39,6 @@ class WooSystemRestClient @Inject constructor(private val wooNetwork: WooNetwork
             params = mapOf("_fields" to "environment,database,active_plugins,theme,settings,security,pages"),
             clazz = SSRResponse::class.java
         )
-        return response.toWooPayload()
-    }
-
-    /**
-     * Test the settings endpoint of WooCommerce to confirm if the plugin is available or not.
-     * We pass an empty _fields just to reduce the response payload size, as we don't care about the contents
-     *
-     * @return JetpackSuccess(true) if WooCommerce is installed, JetpackSuccess(false) is we get a 404,
-     *         and JetpackError otherwise
-     */
-    suspend fun checkIfWooCommerceIsAvailable(site: SiteModel): WooPayload<Boolean> {
-        val url = WOOCOMMERCE.settings.pathV3
-
-        val response = wooNetwork.executeGetGsonRequest(
-            site = site,
-            path = url,
-            params = mapOf("_fields" to ""),
-            clazz = Any::class.java
-        )
-
-        return when (response) {
-            is WPAPIResponse.Success -> WooPayload(true)
-            is WPAPIResponse.Error -> {
-                when (response.error.volleyError?.networkResponse?.statusCode) {
-                    NOT_FOUND -> WooPayload(false)
-                    FORBIDDEN -> {
-                        // If we get a 403 status code, we can infer that Woo is installed,
-                        // the user just doesn't have permission to access the Woo API
-                        WooPayload(true)
-                    }
-                    else -> WooPayload(response.error.toWooError())
-                }
-            }
-        }
-    }
-
-    suspend fun fetchSiteSettings(site: SiteModel): WooPayload<WPSiteSettingsResponse> {
-        val url = WPAPI.settings.urlV2
-
-        val response = wooNetwork.executeGetGsonRequest(
-            site = site,
-            path = url,
-            clazz = WPSiteSettingsResponse::class.java
-        )
-
         return response.toWooPayload()
     }
 
@@ -138,13 +91,5 @@ class WooSystemRestClient @Inject constructor(private val wooNetwork: WooNetwork
         val settings: JsonElement? = null,
         val security: JsonElement? = null,
         val pages: JsonElement? = null
-    )
-
-    data class WPSiteSettingsResponse(
-        @SerializedName("title") val title: String? = null,
-        @SerializedName("description") val description: String? = null,
-        @SerializedName("url") val url: String? = null,
-        @SerializedName("show_on_front") val showOnFront: String? = null,
-        @SerializedName("page_on_front") val pageOnFront: Long? = null
     )
 }

--- a/libs/fluxc-plugin/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/system/WooSystemRestClient.kt
+++ b/libs/fluxc-plugin/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/system/WooSystemRestClient.kt
@@ -12,8 +12,6 @@ import javax.inject.Inject
 
 class WooSystemRestClient @Inject constructor(private val wooNetwork: WooNetwork) {
     companion object {
-        private const val NOT_FOUND = 404
-        private const val FORBIDDEN = 403
         private const val SAVE_SITE_TITLE_RESPONSE_FIELD = "title"
     }
 

--- a/libs/fluxc-plugin/src/main/kotlin/org/wordpress/android/fluxc/store/WooCommerceStore.kt
+++ b/libs/fluxc-plugin/src/main/kotlin/org/wordpress/android/fluxc/store/WooCommerceStore.kt
@@ -3,9 +3,6 @@ package org.wordpress.android.fluxc.store
 import android.content.Context
 import com.wellsql.generated.SiteModelTable
 import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.async
-import kotlinx.coroutines.awaitAll
-import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.runBlocking
@@ -524,9 +521,5 @@ open class WooCommerceStore @Inject internal constructor(
         applyDecimalFormatting: Boolean
     ): String {
         return formatCurrencyForDisplay(amount.toString(), site, currencyCode, applyDecimalFormatting)
-    }
-
-    private suspend fun <A, B> Iterable<A>.pmap(f: suspend (A) -> B): List<B> = coroutineScope {
-        map { async { f(it) } }.awaitAll()
     }
 }

--- a/libs/fluxc-plugin/src/main/kotlin/org/wordpress/android/fluxc/store/WooCommerceStore.kt
+++ b/libs/fluxc-plugin/src/main/kotlin/org/wordpress/android/fluxc/store/WooCommerceStore.kt
@@ -92,9 +92,6 @@ open class WooCommerceStore @Inject internal constructor(
         const val WOO_API_NAMESPACE_V3 = "wc/v3"
     }
 
-    private val SiteModel.needsAdditionalCheckForWooInstallation
-        get() = origin == SiteModel.ORIGIN_XMLRPC || (origin == SiteModel.ORIGIN_WPCOM_REST && isJetpackCPConnected)
-
     override fun onRegister() = AppLog.d(T.API, "WooCommerceStore onRegister")
 
     @Subscribe(threadMode = ThreadMode.ASYNC)
@@ -108,33 +105,7 @@ open class WooCommerceStore @Inject internal constructor(
             OnSiteChanged()
         }
 
-        if (fetchResult.isError) {
-            emitChange(fetchResult)
-
-            return WooResult(
-                WooError(
-                    type = GENERIC_ERROR,
-                    message = fetchResult.error.message,
-                    original = UNKNOWN
-                )
-            )
-        }
-
-        // Fetch WooCommerce availability for non-Jetpack sites
-        val updatedSites = siteStore.sites
-            .filter { it.needsAdditionalCheckForWooInstallation }
-            .pmap { site ->
-                val isResultUpdated = fetchAndUpdateNonJetpackSite(site)
-                if (isResultUpdated.model == true && !fetchResult.updatedSites.contains(site)) {
-                    1
-                } else {
-                    0
-                }
-            }.sum()
-
-        val rowsAffected = fetchResult.rowsAffected + updatedSites
-
-        emitChange(OnSiteChanged(rowsAffected, fetchResult.updatedSites))
+        emitChange(fetchResult)
 
         return withContext(Dispatchers.IO) { WooResult(getWooCommerceSites()) }
     }
@@ -158,28 +129,7 @@ open class WooCommerceStore @Inject internal constructor(
             }
         }
 
-        if (!site.isJetpackCPConnected) {
-            // The endpoint used by siteStore to fetch a single site is broken for Jetpack CP sites, so skip it for them
-            siteStore.fetchSite(site).let {
-                if (it.isError) {
-                    return WooResult(
-                        WooError(
-                            type = GENERIC_ERROR,
-                            message = it.error.message,
-                            original = UNKNOWN
-                        )
-                    )
-                }
-            }
-        }
-
-        val isSiteUpdated = if (site.needsAdditionalCheckForWooInstallation) {
-            fetchAndUpdateNonJetpackSite(site).let {
-                if (it.isError) return WooResult(it.error)
-
-                it.model!!
-            }
-        } else false
+        val fetchResult = siteStore.fetchSite(site)
 
         val updatedSite = withContext(Dispatchers.IO) {
             siteStore.getSiteByLocalId(site.id)
@@ -191,7 +141,7 @@ open class WooCommerceStore @Inject internal constructor(
             )
         )
 
-        if (isSiteUpdated) {
+        if (fetchResult.rowsAffected > 0) {
             emitChange(OnSiteChanged(1, listOf(updatedSite)))
         }
 
@@ -330,83 +280,6 @@ open class WooCommerceStore @Inject internal constructor(
         }
     }
 
-    /**
-     * Fetch additional data about non-Jetpack connected sites, and here we mean two types:
-     * 1. Jetpack CP connected sites.
-     * 2. Self-hosted sites accessed using site credentials.
-     *
-     * @return [WooResult] representing whether the result succeeded and whether the site was updated
-     */
-    @Suppress("ReturnCount")
-    private suspend fun fetchAndUpdateNonJetpackSite(site: SiteModel): WooResult<Boolean> {
-        // Fetch site metadata for Jetpack CP sites
-        val isMetadataUpdated = if (site.isJetpackCPConnected) {
-            fetchAndUpdateMetaDataFromSiteSettings(site).let {
-                if (it.isError) {
-                    return it
-                }
-                it.model!!
-            }
-        } else false
-
-        // Check Woo installation status for Jetpack CP sites and non-Jetpack sites
-        val isWooStatusUpdated = fetchAndUpdateWooCommerceAvailability(site).let {
-            if (it.isError) {
-                return it
-            }
-            it.model!!
-        }
-
-        return WooResult(isMetadataUpdated || isWooStatusUpdated)
-    }
-
-    private suspend fun fetchAndUpdateMetaDataFromSiteSettings(site: SiteModel): WooResult<Boolean> {
-        fun SiteModel.updateFromSiteSettings(response: WooSystemRestClient.WPSiteSettingsResponse) = apply {
-            name = response.title ?: name
-            description = response.description ?: description
-            url = response.url ?: url
-            showOnFront = response.showOnFront ?: showOnFront
-            pageOnFront = response.pageOnFront ?: pageOnFront
-        }
-
-        return coroutineEngine.withDefaultContext(T.API, this, "fetchAndUpdateMetaDataFromSiteSettings") {
-            val response = systemRestClient.fetchSiteSettings(site)
-            return@withDefaultContext when {
-                response.isError -> {
-                    AppLog.w(T.API, "fetching site settings  site ${site.siteId}")
-                    WooResult(response.error)
-                }
-
-                else -> {
-                    WooResult(response.result?.let {
-                        siteSqlUtils.insertOrUpdateSite(site.updateFromSiteSettings(it)) == 1
-                    } ?: false)
-                }
-            }
-        }
-    }
-
-    private suspend fun fetchAndUpdateWooCommerceAvailability(site: SiteModel): WooResult<Boolean> {
-        return coroutineEngine.withDefaultContext(T.API, this, "fetchAndUpdateWooCommerceAvailability") {
-            val response = systemRestClient.checkIfWooCommerceIsAvailable(site)
-            return@withDefaultContext when {
-                response.isError -> {
-                    AppLog.w(T.API, "Checking WooCommerce availability failed for site ${site.siteId}")
-                    WooResult(response.error)
-                }
-
-                else -> {
-                    val updated = response.result?.takeIf { it != site.hasWooCommerce }?.let {
-                        site.hasWooCommerce = it
-                        siteSqlUtils.insertOrUpdateSite(site)
-                        true
-                    } ?: false
-                    WooResult(updated)
-                }
-            }
-        }
-    }
-
     suspend fun fetchSupportedApiVersion(
         site: SiteModel,
         overrideRetryPolicy: Boolean = false
@@ -531,11 +404,13 @@ open class WooCommerceStore @Inject internal constructor(
                     )
                     WooResult(response.error)
                 }
+
                 response.result != null -> {
                     val settings = settingsMapper.mapTaxBasedOnSettings(response.result, site.localId())
                     taxBasedOnDao.insertOrUpdate(settings)
                     WooResult(settings)
                 }
+
                 else -> {
                     WooResult(WooError(GENERIC_ERROR, UNKNOWN))
                 }
@@ -554,12 +429,14 @@ open class WooCommerceStore @Inject internal constructor(
                     )
                     WooResult(response.error)
                 }
+
                 response.result != null -> {
                     val settingsMap = response.result.associate { setting ->
                         setting.id to (setting.value ?: setting.default ?: "")
                     }
                     WooResult(settingsMap)
                 }
+
                 else -> {
                     WooResult(WooError(GENERIC_ERROR, UNKNOWN))
                 }

--- a/libs/fluxc-plugin/src/test/java/org/wordpress/android/fluxc/wc/WooCommerceStoreTest.kt
+++ b/libs/fluxc-plugin/src/test/java/org/wordpress/android/fluxc/wc/WooCommerceStoreTest.kt
@@ -10,7 +10,6 @@ import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.mockito.kotlin.any
-import org.mockito.kotlin.argumentCaptor
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.never
 import org.mockito.kotlin.verify
@@ -39,13 +38,11 @@ import org.wordpress.android.fluxc.network.rest.wpcom.wc.system.WCApiVersionResp
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.system.WCSystemPluginResponse
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.system.WCSystemPluginResponse.SystemPluginModel
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.system.WooSystemRestClient
-import org.wordpress.android.fluxc.network.rest.wpcom.wc.system.WooSystemRestClient.WPSiteSettingsResponse
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.system.toDomainModel
 import org.wordpress.android.fluxc.persistence.DatabaseTestRule
 import org.wordpress.android.fluxc.persistence.PluginSqlUtilsWrapper
 import org.wordpress.android.fluxc.persistence.WellSqlConfig
 import org.wordpress.android.fluxc.persistence.dao.TaxBasedOnDao
-import org.wordpress.android.fluxc.site.SiteUtils
 import org.wordpress.android.fluxc.store.AccountStore
 import org.wordpress.android.fluxc.store.SiteStore
 import org.wordpress.android.fluxc.store.SiteStore.OnSiteChanged
@@ -374,99 +371,6 @@ class WooCommerceStoreTest {
             wooCommerceStore.fetchWooCommerceSites()
 
             verify(siteStore, never()).fetchSites(any())
-        }
-    }
-
-    @Test
-    fun `when fetching a jetpack cp site, then fetch metadata from the remote site manually`() {
-        runBlocking {
-            val site = SiteUtils.generateJetpackCPSite()
-            whenever(accountStore.hasAccessToken()).thenReturn(true)
-            whenever(siteStore.fetchSites(any())).thenReturn(OnSiteChanged(1, updatedSites = listOf(site)))
-            whenever(siteStore.sites).thenReturn(listOf(site))
-            whenever(restClient.fetchSiteSettings(site)).thenReturn(
-                WooPayload(
-                    WPSiteSettingsResponse(title = "new title")
-                )
-            )
-            whenever(restClient.checkIfWooCommerceIsAvailable(site)).thenReturn(WooPayload(true))
-
-            val sites = wooCommerceStore.fetchWooCommerceSites().model!!
-
-            verify(restClient).fetchSiteSettings(site)
-            verify(restClient).checkIfWooCommerceIsAvailable(site)
-            assertThat(sites.first().hasWooCommerce).isTrue
-            assertThat(sites.first().name).isEqualTo("new title")
-        }
-    }
-
-    @Test
-    fun `given 3 woo and 3 updated sites, when fetching a jetpack cp site, emit event with 6 rows affected`() {
-        runBlocking {
-            val sites = (0..4).map {
-                SiteUtils.generateSelfHostedNonJPSite().apply { siteId = it.toLong() }
-            }
-            whenever(siteStore.sites).thenReturn(sites)
-
-            whenever(accountStore.hasAccessToken()).thenReturn(true)
-            val updatedSites = (0..4).map {
-                SiteUtils.generateJetpackCPSite().apply { siteId = it.toLong() }
-            }
-            whenever(siteStore.fetchSites(any())).thenReturn(
-                OnSiteChanged(3, updatedSites = updatedSites)
-            )
-            sites.forEach {
-                whenever(restClient.fetchSiteSettings(it)).thenReturn(
-                    WooPayload(WPSiteSettingsResponse(title = "new title"))
-                )
-            }
-            whenever(restClient.checkIfWooCommerceIsAvailable(sites[0])).thenReturn(WooPayload(true))
-            whenever(restClient.checkIfWooCommerceIsAvailable(sites[1])).thenReturn(WooPayload(true))
-            whenever(restClient.checkIfWooCommerceIsAvailable(sites[2])).thenReturn(WooPayload(true))
-            whenever(restClient.checkIfWooCommerceIsAvailable(sites[3])).thenReturn(WooPayload(null))
-            whenever(restClient.checkIfWooCommerceIsAvailable(sites[4])).thenReturn(WooPayload(null))
-
-            wooCommerceStore.fetchWooCommerceSites()
-
-            val eventCaptor = argumentCaptor<OnSiteChanged>()
-            verify(dispatcher).emitChange(eventCaptor.capture())
-            assertThat(eventCaptor.firstValue.rowsAffected).isEqualTo(6)
-        }
-    }
-
-    @Test
-    fun `when fetching a non-Jetpack self-hosted site, then detect WooCommerce installation manually`() {
-        runBlocking {
-            val site = SiteUtils.generateSelfHostedNonJPSite()
-            whenever(accountStore.hasAccessToken()).thenReturn(false)
-            whenever(siteStore.fetchSite(any())).thenReturn(OnSiteChanged(1, updatedSites = listOf(site)))
-            whenever(siteStore.sites).thenReturn(listOf(site))
-            whenever(siteStore.getSiteByLocalId(any())).thenReturn(site)
-            whenever(restClient.checkIfWooCommerceIsAvailable(site)).thenReturn(WooPayload(true))
-            fetchSupportedWooApiVersion(response = RootWPAPIRestResponse())
-
-            wooCommerceStore.fetchWooCommerceSite(site)
-
-            verify(siteStore).fetchSite(site)
-            verify(restClient).checkIfWooCommerceIsAvailable(site)
-        }
-    }
-
-    @Test
-    fun `when fetching a Jetpack site using site credentials, then detect WooCommerce installation manually`() {
-        runBlocking {
-            val site = SiteUtils.generateJetpackSiteOverXMLRPC()
-            whenever(accountStore.hasAccessToken()).thenReturn(false)
-            whenever(siteStore.fetchSite(any())).thenReturn(OnSiteChanged(1, updatedSites = listOf(site)))
-            whenever(siteStore.sites).thenReturn(listOf(site))
-            whenever(siteStore.getSiteByLocalId(any())).thenReturn(site)
-            whenever(restClient.checkIfWooCommerceIsAvailable(site)).thenReturn(WooPayload(true))
-            fetchSupportedWooApiVersion(response = RootWPAPIRestResponse())
-
-            wooCommerceStore.fetchWooCommerceSite(site)
-
-            verify(siteStore).fetchSite(site)
-            verify(restClient).checkIfWooCommerceIsAvailable(site)
         }
     }
 

--- a/libs/fluxc-tests/src/test/java/org/wordpress/android/fluxc/network/rest/wpcom/site/SiteRestClientTest.kt
+++ b/libs/fluxc-tests/src/test/java/org/wordpress/android/fluxc/network/rest/wpcom/site/SiteRestClientTest.kt
@@ -24,12 +24,15 @@ import org.wordpress.android.fluxc.model.SiteModel
 import org.wordpress.android.fluxc.network.BaseRequest.BaseNetworkError
 import org.wordpress.android.fluxc.network.BaseRequest.GenericErrorType
 import org.wordpress.android.fluxc.network.UserAgent
+import org.wordpress.android.fluxc.network.discovery.RootWPAPIRestResponse
 import org.wordpress.android.fluxc.network.rest.wpcom.WPComGsonRequest.WPComGsonNetworkError
 import org.wordpress.android.fluxc.network.rest.wpcom.WPComGsonRequestBuilder
 import org.wordpress.android.fluxc.network.rest.wpcom.WPComGsonRequestBuilder.Response
 import org.wordpress.android.fluxc.network.rest.wpcom.WPComGsonRequestBuilder.Response.Success
 import org.wordpress.android.fluxc.network.rest.wpcom.auth.AccessToken
 import org.wordpress.android.fluxc.network.rest.wpcom.auth.AppSecrets
+import org.wordpress.android.fluxc.network.rest.wpcom.jetpacktunnel.JetpackTunnelGsonRequestBuilder
+import org.wordpress.android.fluxc.network.rest.wpcom.jetpacktunnel.JetpackTunnelGsonRequestBuilder.JetpackResponse
 import org.wordpress.android.fluxc.network.rest.wpcom.site.NewSiteResponse.BlogDetails
 import org.wordpress.android.fluxc.network.rest.wpcom.site.SiteWPComRestResponse.SitesResponse
 import org.wordpress.android.fluxc.network.rest.wpcom.site.StatusType.ERROR
@@ -47,18 +50,37 @@ import kotlin.test.assertNotNull
 
 @RunWith(MockitoJUnitRunner::class)
 class SiteRestClientTest {
-    @Mock private lateinit var dispatcher: Dispatcher
-    @Mock private lateinit var wpComGsonRequestBuilder: WPComGsonRequestBuilder
-    @Mock private lateinit var site: SiteModel
-    @Mock private lateinit var requestQueue: RequestQueue
-    @Mock private lateinit var accessToken: AccessToken
-    @Mock private lateinit var userAgent: UserAgent
-    @Mock private lateinit var appSecrets: AppSecrets
+    @Mock
+    private lateinit var dispatcher: Dispatcher
+
+    @Mock
+    private lateinit var wpComGsonRequestBuilder: WPComGsonRequestBuilder
+
+    @Mock
+    private lateinit var jetpackTunnelGsonRequestBuilder: JetpackTunnelGsonRequestBuilder
+
+    @Mock
+    private lateinit var requestQueue: RequestQueue
+
+    @Mock
+    private lateinit var accessToken: AccessToken
+
+    @Mock
+    private lateinit var userAgent: UserAgent
+
+    @Mock
+    private lateinit var appSecrets: AppSecrets
     private lateinit var urlCaptor: KArgumentCaptor<String>
     private lateinit var paramsCaptor: KArgumentCaptor<Map<String, String>>
     private lateinit var bodyCaptor: KArgumentCaptor<Map<String, Any>>
     private lateinit var restClient: SiteRestClient
+
     private val siteId: Long = 12
+    private val site = SiteModel().apply {
+        siteId = this@SiteRestClientTest.siteId
+        setIsJetpackConnected(true)
+    }
+
 
     @Before
     fun setUp() {
@@ -71,11 +93,11 @@ class SiteRestClientTest {
             requestQueue = requestQueue,
             appSecrets = appSecrets,
             wpComGsonRequestBuilder = wpComGsonRequestBuilder,
+            jetpackTunnelGsonRequestBuilder = jetpackTunnelGsonRequestBuilder,
             coroutineEngine = initCoroutineEngine(),
             accessToken = accessToken,
             userAgent = userAgent
         )
-        whenever(site.siteId).thenReturn(siteId)
     }
 
     @Test
@@ -92,7 +114,7 @@ class SiteRestClientTest {
         assertThat(responseModel.name).isEqualTo(name)
         assertThat(responseModel.siteId).isEqualTo(siteId)
         assertThat(urlCaptor.lastValue)
-                .isEqualTo("https://public-api.wordpress.com/rest/v1.1/sites/12")
+            .isEqualTo("https://public-api.wordpress.com/rest/v1.1/sites/12")
         assertThat(paramsCaptor.lastValue).isEqualTo(mapOf("fields" to SiteRestClient.SITE_FIELDS))
     }
 
@@ -100,13 +122,13 @@ class SiteRestClientTest {
     fun `fetchSite returns error when API call fails`() = test {
         val errorMessage = "message"
         initSiteResponse(
-                error = WPComGsonNetworkError(
-                        BaseNetworkError(
-                                GenericErrorType.NETWORK_ERROR,
-                                errorMessage,
-                                VolleyError(errorMessage)
-                        )
+            error = WPComGsonNetworkError(
+                BaseNetworkError(
+                    GenericErrorType.NETWORK_ERROR,
+                    errorMessage,
+                    VolleyError(errorMessage)
                 )
+            )
         )
         val errorResponse = restClient.fetchSite(site)
 
@@ -135,9 +157,9 @@ class SiteRestClientTest {
         assertThat(responseModel.sites[0].siteId).isEqualTo(siteId)
 
         assertThat(urlCaptor.firstValue)
-                .isEqualTo("https://public-api.wordpress.com/rest/v1.2/me/sites/")
+            .isEqualTo("https://public-api.wordpress.com/rest/v1.2/me/sites/")
         assertThat(urlCaptor.lastValue)
-                .isEqualTo("https://public-api.wordpress.com/rest/v1.1/me/sites/features/")
+            .isEqualTo("https://public-api.wordpress.com/rest/v1.1/me/sites/features/")
         assertThat(paramsCaptor.firstValue).isEqualTo(
             mapOf(
                 "filters" to "wpcom",
@@ -182,6 +204,7 @@ class SiteRestClientTest {
         val sitesResponse = SitesResponse()
         sitesResponse.sites = listOf(response)
 
+        initRootEndpointResponse()
         initSitesResponse(data = sitesResponse)
         initSitesFeaturesResponse(data = SitesFeaturesRestResponse(features = emptyMap()))
 
@@ -194,13 +217,13 @@ class SiteRestClientTest {
     fun `fetchSites returns error when API call fails`() = test {
         val errorMessage = "message"
         initSitesResponse(
-                error = WPComGsonNetworkError(
-                        BaseNetworkError(
-                                GenericErrorType.NETWORK_ERROR,
-                                errorMessage,
-                                VolleyError(errorMessage)
-                        )
+            error = WPComGsonNetworkError(
+                BaseNetworkError(
+                    GenericErrorType.NETWORK_ERROR,
+                    errorMessage,
+                    VolleyError(errorMessage)
                 )
+            )
         )
         val errorResponse = restClient.fetchSites(listOf(), false)
 
@@ -248,23 +271,23 @@ class SiteRestClientTest {
         assertThat(result.dryRun).isEqualTo(dryRun)
 
         assertThat(urlCaptor.lastValue)
-                .isEqualTo("https://public-api.wordpress.com/rest/v1.1/sites/new/")
+            .isEqualTo("https://public-api.wordpress.com/rest/v1.1/sites/new/")
         assertThat(bodyCaptor.lastValue).isEqualTo(
-                mapOf(
-                        "blog_name" to siteName,
-                        "blog_title" to siteTitle,
-                        "lang_id" to language,
-                        "public" to "1",
-                        "validate" to "0",
-                        "find_available_url" to findAvailableUrl.toString(),
-                        "client_id" to appId,
-                        "client_secret" to appSecret,
-                        "options" to mapOf<String, Any>(
-                                "site_segment" to segmentId,
-                                "template" to siteDesign,
-                                "timezone_string" to timeZoneId,
-                        )
+            mapOf(
+                "blog_name" to siteName,
+                "blog_title" to siteTitle,
+                "lang_id" to language,
+                "public" to "1",
+                "validate" to "0",
+                "find_available_url" to findAvailableUrl.toString(),
+                "client_id" to appId,
+                "client_secret" to appSecret,
+                "options" to mapOf<String, Any>(
+                    "site_segment" to segmentId,
+                    "template" to siteDesign,
+                    "timezone_string" to timeZoneId,
                 )
+            )
         )
     }
 
@@ -421,19 +444,19 @@ class SiteRestClientTest {
         assertThat(result.dryRun).isEqualTo(dryRun)
 
         assertThat(urlCaptor.lastValue)
-                .isEqualTo("https://public-api.wordpress.com/rest/v1.1/sites/new/")
+            .isEqualTo("https://public-api.wordpress.com/rest/v1.1/sites/new/")
         assertThat(bodyCaptor.lastValue).isEqualTo(
-                mapOf(
-                        "blog_name" to siteName,
-                        "lang_id" to language,
-                        "public" to "-1",
-                        "validate" to "1",
-                        "client_id" to appId,
-                        "client_secret" to appSecret,
-                        "options" to mapOf<String, Any>(
-                            "timezone_string" to timeZoneId,
-                        )
+            mapOf(
+                "blog_name" to siteName,
+                "lang_id" to language,
+                "public" to "-1",
+                "validate" to "1",
+                "client_id" to appId,
+                "client_secret" to appSecret,
+                "options" to mapOf<String, Any>(
+                    "timezone_string" to timeZoneId,
                 )
+            )
         )
     }
 
@@ -449,6 +472,7 @@ class SiteRestClientTest {
 
         // then
         val body = bodyCaptor.lastValue
+
         @Suppress("UNCHECKED_CAST")
         val options = body["options"] as Map<String, String>
 
@@ -481,6 +505,7 @@ class SiteRestClientTest {
 
         // then
         val body = bodyCaptor.lastValue
+
         @Suppress("UNCHECKED_CAST")
         val options = body["options"] as Map<String, String>
 
@@ -581,6 +606,102 @@ class SiteRestClientTest {
         urlUtilsMock.close()
     }
 
+    @Test
+    fun `given a Jetpack site, when fetching site info, then fetch app passwords url from root endpoint`() = test {
+        initSiteResponse(
+            SiteWPComRestResponse().apply {
+                ID = siteId
+                URL = "site.com"
+                jetpack = true
+                jetpack_connection = true
+            }
+        )
+        val response = RootWPAPIRestResponse(
+            authentication = RootWPAPIRestResponse.Authentication(
+                applicationPasswords = RootWPAPIRestResponse.Authentication.ApplicationPasswords(
+                    endpoints = RootWPAPIRestResponse.Authentication.ApplicationPasswords.Endpoints(
+                        authorization = "https://test.com/application-passwords"
+                    )
+                )
+            )
+        )
+
+        initRootEndpointResponse(response)
+
+        val result = restClient.fetchSite(site)
+
+        assertThat(result.applicationPasswordsAuthorizeUrl).isEqualTo(
+            response.authentication?.applicationPasswords?.endpoints?.authorization
+        )
+    }
+
+    @Test
+    fun `given a Jetpack CP site, when fetching site info, then use root endpoint`() = test {
+        val jetpackCPSite = SiteModel().apply {
+            setIsJetpackConnected(false)
+            setIsJetpackCPConnected(false)
+        }
+        val response = RootWPAPIRestResponse(
+            name = "Test site",
+            description = "Description",
+            authentication = RootWPAPIRestResponse.Authentication(
+                applicationPasswords = RootWPAPIRestResponse.Authentication.ApplicationPasswords(
+                    endpoints = RootWPAPIRestResponse.Authentication.ApplicationPasswords.Endpoints(
+                        authorization = "https://test.com/application-passwords"
+                    )
+                )
+            )
+        )
+
+        initRootEndpointResponse(response)
+
+        val result = restClient.fetchSite(jetpackCPSite)
+
+        assertThat(result.name).isEqualTo(response.name)
+        assertThat(result.description).isEqualTo(response.description)
+        assertThat(result.applicationPasswordsAuthorizeUrl).isEqualTo(
+            response.authentication?.applicationPasswords?.endpoints?.authorization
+        )
+    }
+
+    @Test
+    fun `given Jetpack CP sites, when fetching sites, then use root endpoint for additional data`() = test {
+        val wpComSiteResponse = SiteWPComRestResponse()
+        wpComSiteResponse.ID = siteId
+        val name = "Test site"
+        wpComSiteResponse.name = name
+        wpComSiteResponse.URL = "site.com"
+        wpComSiteResponse.jetpack = false
+        wpComSiteResponse.jetpack_connection = true
+
+        val sitesResponse = SitesResponse()
+        sitesResponse.sites = listOf(wpComSiteResponse)
+        initSitesResponse(sitesResponse)
+
+        val rootResponse = RootWPAPIRestResponse(
+            name = "Updated name",
+            description = "Description",
+            authentication = RootWPAPIRestResponse.Authentication(
+                applicationPasswords = RootWPAPIRestResponse.Authentication.ApplicationPasswords(
+                    endpoints = RootWPAPIRestResponse.Authentication.ApplicationPasswords.Endpoints(
+                        authorization = "https://test.com/application-passwords"
+                    )
+                )
+            )
+        )
+        initRootEndpointResponse(rootResponse)
+
+        val result = restClient.fetchSites(emptyList(), false)
+
+        assertThat(result.sites).hasSize(1)
+        val site = result.sites[0]
+        assertThat(site.name).isEqualTo(rootResponse.name)
+        assertThat(site.description).isEqualTo(rootResponse.description)
+        assertThat(site.applicationPasswordsAuthorizeUrl).isEqualTo(
+            rootResponse.authentication?.applicationPasswords?.endpoints?.authorization
+        )
+    }
+
     private suspend fun initSiteResponse(
         data: SiteWPComRestResponse? = null,
         error: WPComGsonNetworkError? = null
@@ -606,14 +727,45 @@ class SiteRestClientTest {
         data: SitesFeaturesRestResponse? = null,
         error: WPComGsonNetworkError? = null
     ): Response<SitesFeaturesRestResponse> {
-        return initGetResponse(SitesFeaturesRestResponse::class.java, data ?: mock(), error)
+        return initGetResponse(
+            clazz = SitesFeaturesRestResponse::class.java,
+            data = data ?: SitesFeaturesRestResponse(emptyMap()),
+            error = error
+        )
     }
 
     private suspend fun initAllDomainsResponse(
         data: AllDomainsResponse? = null,
         error: WPComGsonNetworkError? = null
     ): Response<AllDomainsResponse> {
-        return initGetResponse(AllDomainsResponse::class.java, data ?: mock(), error)
+        return initGetResponse(AllDomainsResponse::class.java, data ?: AllDomainsResponse(emptyList()), error)
+    }
+
+    private suspend fun initRootEndpointResponse(
+        data: RootWPAPIRestResponse = RootWPAPIRestResponse(),
+        error: WPComGsonNetworkError? = null
+    ): JetpackResponse<RootWPAPIRestResponse> {
+        val response = if (error != null) {
+            JetpackResponse.JetpackError(error)
+        } else {
+            JetpackResponse.JetpackSuccess(data, emptyList())
+        }
+
+        whenever(
+            jetpackTunnelGsonRequestBuilder.syncGetRequest(
+                restClient = eq(restClient),
+                site = any(),
+                url = eq("/"),
+                params = any(),
+                clazz = eq(RootWPAPIRestResponse::class.java),
+                enableCaching = any(),
+                cacheTimeToLive = any(),
+                forced = any(),
+                retryPolicy = anyOrNull()
+            )
+        ).thenReturn(response)
+
+        return response
     }
 
     private suspend fun <T> initGetResponse(
@@ -626,17 +778,17 @@ class SiteRestClientTest {
         }
         val response = if (error != null) Response.Error(error) else Success<T>(data!!, emptyList())
         whenever(
-                wpComGsonRequestBuilder.syncGetRequest(
-                        eq(restClient),
-                        urlCaptor.capture(),
-                        paramsCaptor.capture(),
-                        eq(clazz),
-                        any(),
-                        any(),
-                        any(),
-                        customGsonBuilder = anyOrNull(),
-                        authenticatedRequest = any()
-                )
+            wpComGsonRequestBuilder.syncGetRequest(
+                eq(restClient),
+                urlCaptor.capture(),
+                paramsCaptor.capture(),
+                eq(clazz),
+                any(),
+                any(),
+                any(),
+                customGsonBuilder = anyOrNull(),
+                authenticatedRequest = any()
+            )
         ).thenReturn(response)
         return response
     }
@@ -648,15 +800,15 @@ class SiteRestClientTest {
     ): Response<T> {
         val response = if (error != null) Response.Error(error) else Success(data, emptyList())
         whenever(
-                wpComGsonRequestBuilder.syncPostRequest(
-                        eq(restClient),
-                        urlCaptor.capture(),
-                        paramsCaptor.capture(),
-                        bodyCaptor.capture(),
-                        eq(clazz),
-                        anyOrNull(),
-                        anyOrNull(),
-                )
+            wpComGsonRequestBuilder.syncPostRequest(
+                eq(restClient),
+                urlCaptor.capture(),
+                paramsCaptor.capture(),
+                bodyCaptor.capture(),
+                eq(clazz),
+                anyOrNull(),
+                anyOrNull(),
+            )
         ).thenReturn(response)
         return response
     }

--- a/libs/fluxc-tests/src/test/java/org/wordpress/android/fluxc/network/rest/wpcom/site/SiteRestClientTest.kt
+++ b/libs/fluxc-tests/src/test/java/org/wordpress/android/fluxc/network/rest/wpcom/site/SiteRestClientTest.kt
@@ -81,7 +81,6 @@ class SiteRestClientTest {
         setIsJetpackConnected(true)
     }
 
-
     @Before
     fun setUp() {
         urlCaptor = argumentCaptor()

--- a/libs/fluxc-tests/src/test/java/org/wordpress/android/fluxc/store/SiteStoreTest.kt
+++ b/libs/fluxc-tests/src/test/java/org/wordpress/android/fluxc/store/SiteStoreTest.kt
@@ -8,8 +8,6 @@ import org.junit.Test
 import org.junit.runner.RunWith
 import org.mockito.Mock
 import org.mockito.junit.MockitoJUnitRunner
-import org.mockito.kotlin.any
-import org.mockito.kotlin.argWhere
 import org.mockito.kotlin.inOrder
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.verifyNoInteractions
@@ -360,26 +358,5 @@ class SiteStoreTest {
 
         val expectedErrorType = AllDomainsError(AllDomainsErrorType.GENERIC_ERROR, null).type
         assertThat(onAllDomainsFetched.error.type).isEqualTo(expectedErrorType)
-    }
-
-    @Test
-    fun `when updating site from WPCom REST API, then preserve existing app passwords authorize URL`() = test {
-        val siteId = 1234L
-        val authorizationUrl = "https://example.com/authorize"
-        whenever(siteSqlUtils.getSitesWithRemoteId(siteId)).thenReturn(listOf(SiteModel().apply {
-            this.siteId = siteId
-            applicationPasswordsAuthorizeUrl = authorizationUrl
-        }))
-        val fetchedSite = SiteModel().apply {
-            this.origin = SiteModel.ORIGIN_WPCOM_REST
-            this.siteId = siteId
-        }
-        whenever(siteRestClient.fetchSite(any())).thenReturn(fetchedSite)
-
-        siteStore.fetchSite(fetchedSite)
-
-        verify(siteSqlUtils).insertOrUpdateSite(argWhere { site ->
-            site.applicationPasswordsAuthorizeUrl == authorizationUrl
-        })
     }
 }

--- a/libs/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/site/SiteRestClient.kt
+++ b/libs/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/site/SiteRestClient.kt
@@ -7,6 +7,9 @@ import com.android.volley.DefaultRetryPolicy
 import com.android.volley.RequestQueue
 import com.android.volley.VolleyError
 import com.google.gson.reflect.TypeToken
+import kotlinx.coroutines.async
+import kotlinx.coroutines.awaitAll
+import kotlinx.coroutines.coroutineScope
 import org.apache.commons.text.StringEscapeUtils
 import org.json.JSONException
 import org.json.JSONObject
@@ -21,6 +24,7 @@ import org.wordpress.android.fluxc.model.SitesModel
 import org.wordpress.android.fluxc.network.BaseRequest.BaseNetworkError
 import org.wordpress.android.fluxc.network.BaseRequest.GenericErrorType
 import org.wordpress.android.fluxc.network.UserAgent
+import org.wordpress.android.fluxc.network.discovery.RootWPAPIRestResponse
 import org.wordpress.android.fluxc.network.rest.wpcom.BaseWPComRestClient
 import org.wordpress.android.fluxc.network.rest.wpcom.WPComGsonRequest
 import org.wordpress.android.fluxc.network.rest.wpcom.WPComGsonRequest.WPComGsonNetworkError
@@ -30,6 +34,8 @@ import org.wordpress.android.fluxc.network.rest.wpcom.WPComGsonRequestBuilder.Re
 import org.wordpress.android.fluxc.network.rest.wpcom.WPComGsonRequestBuilder.Response.Success
 import org.wordpress.android.fluxc.network.rest.wpcom.auth.AccessToken
 import org.wordpress.android.fluxc.network.rest.wpcom.auth.AppSecrets
+import org.wordpress.android.fluxc.network.rest.wpcom.jetpacktunnel.JetpackTunnelGsonRequestBuilder
+import org.wordpress.android.fluxc.network.rest.wpcom.jetpacktunnel.JetpackTunnelGsonRequestBuilder.JetpackResponse
 import org.wordpress.android.fluxc.network.rest.wpcom.site.SiteWPComRestResponse.SitesResponse
 import org.wordpress.android.fluxc.store.SiteStore.AccessCookieErrorType
 import org.wordpress.android.fluxc.store.SiteStore.AutomatedTransferEligibilityResponsePayload
@@ -101,6 +107,7 @@ class SiteRestClient @Inject constructor(
     @Named("regular") requestQueue: RequestQueue?,
     private val appSecrets: AppSecrets,
     private val wpComGsonRequestBuilder: WPComGsonRequestBuilder,
+    private val jetpackTunnelGsonRequestBuilder: JetpackTunnelGsonRequestBuilder,
     private val coroutineEngine: CoroutineEngine,
     accessToken: AccessToken?,
     userAgent: UserAgent?
@@ -166,7 +173,10 @@ class SiteRestClient @Inject constructor(
                     if (filterJetpackConnectedPackageSite && siteModel.isJetpackCPConnected) continue
                     siteArray.add(siteModel)
                 }
-                SitesModel(siteArray, jetpackCPSiteArray)
+
+                val updatedJetpackCPSites = fetchAdditionalDetailsForJetpackCPSites(jetpackCPSiteArray)
+
+                SitesModel(siteArray, updatedJetpackCPSites)
             }
 
             is Error -> {
@@ -174,6 +184,28 @@ class SiteRestClient @Inject constructor(
                 payload.error = response.error
                 payload
             }
+        }
+    }
+
+    private suspend fun fetchAdditionalDetailsForJetpackCPSites(sites: List<SiteModel>): List<SiteModel> {
+        return coroutineScope {
+            sites.map { site ->
+                async {
+                    // Fetching the root endpoint will update the hasWooCommerce field and other site metadata
+                    fetchSiteUsingRootEndpoint(site).let {
+                        if (it.isError) {
+                            // If there was an error just ignore it and return the original site
+                            AppLog.w(
+                                AppLog.T.API,
+                                "Error fetching root endpoint for Jetpack CP connected site: ${site.url}, error: ${it.error}"
+                            )
+                            site
+                        } else {
+                            it
+                        }
+                    }
+                }
+            }.awaitAll()
         }
     }
 
@@ -200,6 +232,18 @@ class SiteRestClient @Inject constructor(
     }
 
     suspend fun fetchSite(site: SiteModel): SiteModel {
+        return if (site.isJetpackConnected) {
+            fetchSiteUsingWPComEndpoint(site).apply {
+                fetchAppPasswordsAuthorizationUrl(site).onSuccess {
+                    applicationPasswordsAuthorizeUrl = it
+                }
+            }
+        } else {
+            fetchSiteUsingRootEndpoint(site)
+        }
+    }
+
+    private suspend fun fetchSiteUsingWPComEndpoint(site: SiteModel): SiteModel {
         val params = mutableMapOf<String, String>()
         params[FIELDS] = SITE_FIELDS
         val url = WPCOMREST.sites.urlV1_1 + site.siteId
@@ -214,12 +258,61 @@ class SiteRestClient @Inject constructor(
                 }
                 newSite
             }
+
             is Error -> {
                 val payload = SiteModel()
                 payload.error = response.error
                 payload
             }
         }
+    }
+
+    private suspend fun fetchSiteUsingRootEndpoint(site: SiteModel): SiteModel {
+        val result = jetpackTunnelGsonRequestBuilder.syncGetRequest(
+            restClient = this,
+            site = site,
+            url = "/",
+            params = mapOf("_fields" to ROOT_ENDPOINT_FIELDS),
+            clazz = RootWPAPIRestResponse::class.java
+        )
+
+        return when {
+            result is JetpackResponse.JetpackSuccess && result.data != null -> {
+                // Keep existing fields, and update only fields fetched from the root endpoint
+                site.apply {
+                    name = result.data.name
+                    description = result.data.description
+                    timezone = result.data.gmtOffset
+                    hasWooCommerce = result.data.namespaces?.any {
+                        it.startsWith(WOO_API_NAMESPACE_PREFIX)
+                    } ?: false
+
+                    applicationPasswordsAuthorizeUrl = result.data.authentication?.applicationPasswords
+                        ?.endpoints?.authorization
+                }
+            }
+
+            else -> {
+                val payload = SiteModel()
+                payload.error = (result as? JetpackResponse.JetpackError)?.error
+                    ?: BaseNetworkError(GenericErrorType.UNKNOWN)
+                payload
+            }
+        }
+    }
+
+    private suspend fun fetchAppPasswordsAuthorizationUrl(site: SiteModel): Result<String?> {
+        val result = jetpackTunnelGsonRequestBuilder.syncGetRequest(
+            restClient = this,
+            site = site,
+            url = "/",
+            params = mapOf("_fields" to "authentication"),
+            clazz = RootWPAPIRestResponse::class.java
+        )
+
+        return (result as? JetpackResponse.JetpackSuccess)?.let {
+            Result.success(it.data?.authentication?.applicationPasswords?.endpoints?.authorization)
+        } ?: Result.failure(Exception((result as? JetpackResponse.JetpackError)?.error?.message ?: "Unknown error"))
     }
 
     /**
@@ -1092,8 +1185,10 @@ class SiteRestClient @Inject constructor(
         private const val NEW_SITE_TIMEOUT_MS = 90000
         @VisibleForTesting
         const val SITE_FIELDS = "ID,URL,name,description,jetpack,jetpack_connection,visible,is_private," +
-                "options,plan,capabilities,quota,icon,meta,zendesk_site_meta,organization_id," +
-                "was_ecommerce_trial,single_user_site,jetpack_modules"
+            "options,plan,capabilities,quota,icon,meta,zendesk_site_meta,organization_id," +
+            "was_ecommerce_trial,single_user_site,jetpack_modules"
+        private const val ROOT_ENDPOINT_FIELDS = "name,description,gmt_offset,namespaces,authentication"
+        private const val WOO_API_NAMESPACE_PREFIX = "wc/"
         private const val FIELDS = "fields"
         private const val FILTERS = "filters"
     }

--- a/libs/fluxc/src/main/java/org/wordpress/android/fluxc/store/SiteStore.kt
+++ b/libs/fluxc/src/main/java/org/wordpress/android/fluxc/store/SiteStore.kt
@@ -1304,7 +1304,7 @@ open class SiteStore @Inject constructor(
             OnSiteChanged(SiteErrorUtils.genericToSiteError(siteModel.error))
         } else {
             try {
-                OnSiteChanged(createOrUpdateSite(siteModel))
+                OnSiteChanged(createOrUpdateSite(siteModel, includesAppPasswordsUrl = true))
             } catch (e: DuplicateSiteException) {
                 OnSiteChanged(SiteError(DUPLICATE_SITE))
             }
@@ -1352,7 +1352,7 @@ open class SiteStore @Inject constructor(
         val updatedSites = mutableListOf<SiteModel>()
         for (site in sites.sites) {
             try {
-                val isUpdated = (createOrUpdateSite(site) == 1)
+                val isUpdated = (createOrUpdateSite(site, includesAppPasswordsUrl = false) == 1)
                 if (isUpdated) {
                     rowsAffected++
                     updatedSites.add(site)
@@ -1364,7 +1364,7 @@ open class SiteStore @Inject constructor(
         return UpdateSitesResult(rowsAffected, updatedSites, duplicateSiteFound)
     }
 
-    private fun createOrUpdateSite(site: SiteModel): Int {
+    private fun createOrUpdateSite(site: SiteModel, includesAppPasswordsUrl: Boolean): Int {
         val freshSiteFromDB = getSiteBySiteId(site.siteId)
         // Update the site with existing values from the DB that are not returned by the REST API
         if (freshSiteFromDB != null) {
@@ -1373,7 +1373,7 @@ open class SiteStore @Inject constructor(
             site.webEditor = freshSiteFromDB.webEditor
 
             // The WPCom REST API doesn't return info about the application passwords authorize URL.
-            if (site.origin == SiteModel.ORIGIN_WPCOM_REST) {
+            if (site.origin == SiteModel.ORIGIN_WPCOM_REST && !includesAppPasswordsUrl) {
                 site.applicationPasswordsAuthorizeUrl = freshSiteFromDB.applicationPasswordsAuthorizeUrl
             }
         }


### PR DESCRIPTION
Closes WOOMOB-1181

> [!IMPORTANT]
> Please read the description thoroughly to gain a better understanding of the changes and their rationale.
> In the description, the root endpoint is the WordPress root endpoint which is generally at `/wp-json/`.
 
### Description
This PR's main task is to add the fetching of App Passwords support on app launch as discussed pe5sF9-4ye-p2#comment-4756, but while doing so, I added other improvements to optimize the number of requests that we make when fetching sites, and I'll explain below the changes.

#### Before this PR
Before this PR, the logic for fetching sites was as following:
- **For Jetpack Sites**: we were making a single API request to the WPCom endpoint `/sites/<site-id>`
- **For Jetpack CP sites**: since the endpoint `/sites/<site-id>` does not work, we made two separate requests — first, `/wc/v3/settings` to check if WooCommerce is installed, and then `/wp/v2/settings` to retrieve site metadata.

The above wasn't optimal, as we made two requests for Jetpack CP sites and self-hosted sites, where there is a better way that I'll explain below.

#### After this PR
With the changes of this PR, we'll make the following requests for each type of site:
- **For Jetpack Sites**: we'll continue to use `/sites/<site-id>`, and then we'll fetch whether the site supports App Passwords from the root endpoint.
- **For Jetpack CP sites**: we'll make a single request to the root endpoint, and this will allow us to get site metadata, whether WooCommerce is installed or not, and whether the site supports App Passwords or not.

With this change, we optimized the number of requests for all sites, and we added only a single request for Jetpack sites to detect whether App Passwords are supported or not.

**Requests when opening site picker**
With a single Jetpack CP site
| Before | After |
| --- | --- |
| <img width="1104" height="105" alt="Screenshot 2025-08-29 at 19 43 13" src="https://github.com/user-attachments/assets/47bd94ca-0ff0-4e28-b538-9854f6eea626" /> | <img width="1104" height="80" alt="Screenshot 2025-08-29 at 19 44 02" src="https://github.com/user-attachments/assets/19c2fa83-21ff-46a6-a554-7bca9061ccc7" /> |


Also, the logic now is in `SiteStore` completely, so we simplified `WooCommerceStore`, as this is generally outside of its scope. Before, when FluxC was reused between us and the WPAndroid app, we couldn't make big modifications to `SiteStore`, now we have more freedom.

### Steps to reproduce
Test login with the three types of sites and confirm there is no regression:
1. A Jetpack-connected site.
2. A Jetpack CP site (by using the WooCommerce Payments plugin, for example).
3. A self-hosted site and site credentials login.

### Testing information
- Confirm signing in works without issues.
- Confirm switching sites using site picker works without issues.
- Relaunch the app and confirm there are no issues logged in logcat.

### The tests that have been performed
- The above.

- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->