### PR TITLE
[WOOMOB-1214] Add WooPos prefix to all local catalog classes

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/localcatalog/WooPosLocalCatalogSyncRepository.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/localcatalog/WooPosLocalCatalogSyncRepository.kt
@@ -1,6 +1,7 @@
 package com.woocommerce.android.ui.woopos.localcatalog
 
 import com.woocommerce.android.ui.woopos.common.util.WooPosLogWrapper
+import com.woocommerce.android.ui.woopos.localcatalog.WooPosSyncProductsAction.WooPosSyncProductsResult
 import com.woocommerce.android.ui.woopos.util.datastore.WooPosSyncTimestampManager
 import com.woocommerce.android.util.CoroutineDispatchers
 import kotlinx.coroutines.withContext
@@ -23,7 +24,7 @@ sealed class PosLocalCatalogSyncResult {
 
 @Singleton
 class PosLocalCatalogSyncRepository @Inject constructor(
-    private val posSyncProductsAction: PosSyncProductsAction,
+    private val posSyncProductsAction: WooPosSyncProductsAction,
     private val syncTimestampManager: WooPosSyncTimestampManager,
     private val dispatchers: CoroutineDispatchers,
     private val logger: WooPosLogWrapper,
@@ -66,7 +67,7 @@ class PosLocalCatalogSyncRepository @Inject constructor(
         val syncDuration = System.currentTimeMillis() - startTime
 
         return when (productSyncResult) {
-            is PosSyncProductsAction.Result.Success -> {
+            is WooPosSyncProductsResult.Success -> {
                 // TBD Local Catalog we need to use store server timestamp
                 val currentTime = System.currentTimeMillis()
                 // TBD Local Catalog We need to store incremental and full sync timestamps separately
@@ -79,7 +80,7 @@ class PosLocalCatalogSyncRepository @Inject constructor(
                 )
             }
 
-            is PosSyncProductsAction.Result.Failed.CatalogTooLarge -> {
+            is WooPosSyncProductsResult.Failed.CatalogTooLarge -> {
                 PosLocalCatalogSyncResult.Failure.CatalogTooLarge(
                     error = "Catalog too large: ${productSyncResult.totalPages} pages exceed maximum " +
                         "of ${productSyncResult.maxPages} pages",
@@ -88,7 +89,7 @@ class PosLocalCatalogSyncRepository @Inject constructor(
                 )
             }
 
-            is PosSyncProductsAction.Result.Failed -> {
+            is WooPosSyncProductsResult.Failed -> {
                 PosLocalCatalogSyncResult.Failure.UnexpectedError(productSyncResult.error)
             }
         }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/localcatalog/WooPosLocalCatalogSyncScheduler.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/localcatalog/WooPosLocalCatalogSyncScheduler.kt
@@ -23,7 +23,7 @@ class WooPosLocalCatalogSyncScheduler @Inject constructor(
     private val logger: WooPosLogWrapper,
 ) {
 
-    private companion object Companion {
+    private companion object {
         private const val ONE_TIME_WORK_NAME = "PosLocalCatalogSyncOneTime"
 
         const val REFRESH_INTERVAL_HOURS = 24L

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/localcatalog/WooPosLocalCatalogSyncScheduler.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/localcatalog/WooPosLocalCatalogSyncScheduler.kt
@@ -18,12 +18,12 @@ import javax.inject.Inject
 import javax.inject.Singleton
 
 @Singleton
-class PosLocalCatalogSyncScheduler @Inject constructor(
+class WooPosLocalCatalogSyncScheduler @Inject constructor(
     @ApplicationContext private val context: Context,
     private val logger: WooPosLogWrapper,
 ) {
 
-    private companion object {
+    private companion object Companion {
         private const val ONE_TIME_WORK_NAME = "PosLocalCatalogSyncOneTime"
 
         const val REFRESH_INTERVAL_HOURS = 24L
@@ -33,7 +33,7 @@ class PosLocalCatalogSyncScheduler @Inject constructor(
     private val workManager = WorkManager.getInstance(context)
 
     fun schedulePeriodicFullCatalogSync() {
-        val syncWorkRequest = PeriodicWorkRequestBuilder<PosLocalCatalogSyncWorker>(
+        val syncWorkRequest = PeriodicWorkRequestBuilder<WooPosLocalCatalogSyncWorker>(
             REFRESH_INTERVAL_HOURS,
             TimeUnit.HOURS
         )
@@ -47,7 +47,7 @@ class PosLocalCatalogSyncScheduler @Inject constructor(
             .build()
 
         workManager.enqueueUniquePeriodicWork(
-            PosLocalCatalogSyncWorker.WORK_NAME,
+            WooPosLocalCatalogSyncWorker.WORK_NAME,
             ExistingPeriodicWorkPolicy.KEEP,
             syncWorkRequest
         )
@@ -56,7 +56,7 @@ class PosLocalCatalogSyncScheduler @Inject constructor(
     }
 
     fun triggerManualFullCatalogSync() {
-        val oneTimeWorkRequest = OneTimeWorkRequestBuilder<PosLocalCatalogSyncWorker>()
+        val oneTimeWorkRequest = OneTimeWorkRequestBuilder<WooPosLocalCatalogSyncWorker>()
             .setConstraints(getConstraints())
             .setBackoffCriteria(
                 BackoffPolicy.EXPONENTIAL,
@@ -75,7 +75,7 @@ class PosLocalCatalogSyncScheduler @Inject constructor(
     }
 
     fun isPeriodicWorkRunning(): Boolean {
-        val periodicWork = workManager.getWorkInfosForUniqueWork(PosLocalCatalogSyncWorker.WORK_NAME).get()
+        val periodicWork = workManager.getWorkInfosForUniqueWork(WooPosLocalCatalogSyncWorker.WORK_NAME).get()
 
         return periodicWork.any { it.state == WorkInfo.State.RUNNING }
     }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/localcatalog/WooPosLocalCatalogSyncWorker.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/localcatalog/WooPosLocalCatalogSyncWorker.kt
@@ -11,7 +11,7 @@ import dagger.assisted.Assisted
 import dagger.assisted.AssistedInject
 
 @HiltWorker
-class PosLocalCatalogSyncWorker @AssistedInject constructor(
+class WooPosLocalCatalogSyncWorker @AssistedInject constructor(
     @Assisted appContext: Context,
     @Assisted workerParams: WorkerParameters,
     private val accountRepository: AccountRepository,
@@ -20,7 +20,7 @@ class PosLocalCatalogSyncWorker @AssistedInject constructor(
     private val logger: WooPosLogWrapper,
 ) : CoroutineWorker(appContext, workerParams) {
 
-    companion object {
+    companion object Companion {
         const val WORK_NAME = "PosLocalCatalogSyncWork"
     }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/localcatalog/WooPosLocalCatalogSyncWorker.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/localcatalog/WooPosLocalCatalogSyncWorker.kt
@@ -20,7 +20,7 @@ class WooPosLocalCatalogSyncWorker @AssistedInject constructor(
     private val logger: WooPosLogWrapper,
 ) : CoroutineWorker(appContext, workerParams) {
 
-    companion object Companion {
+    companion object {
         const val WORK_NAME = "PosLocalCatalogSyncWork"
     }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/localcatalog/WooPosSyncProductsAction.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/localcatalog/WooPosSyncProductsAction.kt
@@ -2,19 +2,20 @@ package com.woocommerce.android.ui.woopos.localcatalog
 
 import com.woocommerce.android.ui.woopos.common.util.WooPosLogWrapper
 import org.wordpress.android.fluxc.model.SiteModel
-import org.wordpress.android.fluxc.store.pos.localcatalog.PosLocalCatalogStore
+import org.wordpress.android.fluxc.store.pos.localcatalog.WooPosLocalCatalogStore
 import javax.inject.Inject
 
-class PosSyncProductsAction @Inject constructor(
-    private val posLocalCatalogStore: PosLocalCatalogStore,
+class WooPosSyncProductsAction @Inject constructor(
+    private val posLocalCatalogStore: WooPosLocalCatalogStore,
     private val logger: WooPosLogWrapper,
 ) {
-    sealed class Result {
-        data class Success(val productsSynced: Int) : Result()
+    sealed class WooPosSyncProductsResult {
+        data class Success(val productsSynced: Int) : WooPosSyncProductsResult()
 
-        sealed class Failed(val error: String) : Result() {
+        sealed class Failed(val error: String) : WooPosSyncProductsResult() {
             class CatalogTooLarge(val totalPages: Int, val maxPages: Int) :
                 Failed("Catalog too large: $totalPages pages exceed maximum of $maxPages pages")
+
             class UnexpectedError(error: String) : Failed(error)
         }
     }
@@ -25,7 +26,7 @@ class PosSyncProductsAction @Inject constructor(
         modifiedAfterGmt: String? = null,
         pageSize: Int,
         maxPages: Int
-    ): Result {
+    ): WooPosSyncProductsResult {
         var currentOffset = 0
         var pagesSynced = 0
         var totalSyncedProducts = 0
@@ -51,7 +52,7 @@ class PosSyncProductsAction @Inject constructor(
                             logger.e(
                                 "Catalog too large: $syncResult.totalPages pages exceed maximum of $maxPages pages"
                             )
-                            return Result.Failed.CatalogTooLarge(syncResult.totalPages, maxPages)
+                            return WooPosSyncProductsResult.Failed.CatalogTooLarge(syncResult.totalPages, maxPages)
                         }
                     }
 
@@ -69,12 +70,12 @@ class PosSyncProductsAction @Inject constructor(
                 onFailure = { error ->
                     // TBD Local Catalog Add retry logic. We shouldn't fail when one page fails.
                     logger.e("Sync failed on page ${pagesSynced + 1}: ${error.message}")
-                    return Result.Failed.UnexpectedError(error.message ?: "Unknown error")
+                    return WooPosSyncProductsResult.Failed.UnexpectedError(error.message ?: "Unknown error")
                 }
             )
         }
 
         logger.d("Products sync completed, $totalSyncedProducts products synced across $pagesSynced pages")
-        return Result.Success(totalSyncedProducts)
+        return WooPosSyncProductsResult.Success(totalSyncedProducts)
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/util/crashlogging/EncryptedLogsFileProvider.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/util/crashlogging/EncryptedLogsFileProvider.kt
@@ -20,7 +20,7 @@ class EncryptedLogsFileProvider @Inject constructor(
         }
     }
 
-    companion object Companion {
+    companion object {
         private const val LOG_ENTRIES_LIMIT = 1000
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/util/logs/WooFileLogger.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/util/logs/WooFileLogger.kt
@@ -132,7 +132,7 @@ class WooFileLogger(
         }
     }
 
-    companion object Companion {
+    companion object {
         // Flush logs every 5 seconds when the app is in the foreground
         @VisibleForTesting
         const val FOREGROUND_FLUSH_PERIOD_MS = 5000L

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/tracking/OrderShipmentProvidersRepositoryTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/tracking/OrderShipmentProvidersRepositoryTest.kt
@@ -23,7 +23,7 @@ import org.wordpress.android.fluxc.store.WCOrderStore.OrderError
 
 @ExperimentalCoroutinesApi
 class OrderShipmentProvidersRepositoryTest : BaseUnitTest() {
-    private companion object Companion {
+    private companion object {
         const val ORDER_ID = 1L
 
         val testSite = SiteModel()

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/localcatalog/WooPosLocalCatalogSyncRepositoryTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/localcatalog/WooPosLocalCatalogSyncRepositoryTest.kt
@@ -17,9 +17,9 @@ import org.mockito.kotlin.whenever
 import org.wordpress.android.fluxc.model.SiteModel
 
 @ExperimentalCoroutinesApi
-class PosLocalCatalogSyncRepositoryTest : BaseUnitTest() {
+class WooPosLocalCatalogSyncRepositoryTest : BaseUnitTest() {
     private lateinit var sut: PosLocalCatalogSyncRepository
-    private var posSyncProductsAction: PosSyncProductsAction = mock()
+    private var posSyncProductsAction: WooPosSyncProductsAction = mock()
     private var syncTimestampManager: WooPosSyncTimestampManager = mock()
     private lateinit var dispatchers: CoroutineDispatchers
     private lateinit var site: SiteModel
@@ -51,7 +51,7 @@ class PosLocalCatalogSyncRepositoryTest : BaseUnitTest() {
         // GIVEN
         val productsSynced = 150
         whenever(posSyncProductsAction.execute(any(), anyOrNull(), any(), any()))
-            .thenReturn(PosSyncProductsAction.Result.Success(productsSynced))
+            .thenReturn(WooPosSyncProductsAction.WooPosSyncProductsResult.Success(productsSynced))
 
         // WHEN
         val result = sut.syncLocalCatalogFull(site)
@@ -65,7 +65,7 @@ class PosLocalCatalogSyncRepositoryTest : BaseUnitTest() {
         // GIVEN
         val productsSynced = 150
         whenever(posSyncProductsAction.execute(any(), anyOrNull(), any(), any()))
-            .thenReturn(PosSyncProductsAction.Result.Success(productsSynced))
+            .thenReturn(WooPosSyncProductsAction.WooPosSyncProductsResult.Success(productsSynced))
 
         // WHEN
         sut.syncLocalCatalogFull(site)
@@ -80,7 +80,7 @@ class PosLocalCatalogSyncRepositoryTest : BaseUnitTest() {
         val totalPages = 15
         val maxPages = PosLocalCatalogSyncRepository.MAX_PAGES_PER_FULL_SYNC
         whenever(posSyncProductsAction.execute(any(), anyOrNull(), any(), any()))
-            .thenReturn(PosSyncProductsAction.Result.Failed.CatalogTooLarge(totalPages, maxPages))
+            .thenReturn(WooPosSyncProductsAction.WooPosSyncProductsResult.Failed.CatalogTooLarge(totalPages, maxPages))
 
         // WHEN
         val result = sut.syncLocalCatalogFull(site)
@@ -94,7 +94,7 @@ class PosLocalCatalogSyncRepositoryTest : BaseUnitTest() {
         // GIVEN
         val errorMessage = "Network timeout"
         whenever(posSyncProductsAction.execute(any(), anyOrNull(), any(), any()))
-            .thenReturn(PosSyncProductsAction.Result.Failed.UnexpectedError(errorMessage))
+            .thenReturn(WooPosSyncProductsAction.WooPosSyncProductsResult.Failed.UnexpectedError(errorMessage))
 
         // WHEN
         val result = sut.syncLocalCatalogFull(site)
@@ -108,7 +108,7 @@ class PosLocalCatalogSyncRepositoryTest : BaseUnitTest() {
         // GIVEN
         val productsSynced = 150
         whenever(posSyncProductsAction.execute(any(), anyOrNull(), any(), any()))
-            .thenReturn(PosSyncProductsAction.Result.Success(productsSynced))
+            .thenReturn(WooPosSyncProductsAction.WooPosSyncProductsResult.Success(productsSynced))
 
         // WHEN
         val result = sut.syncLocalCatalogIncremental(site)
@@ -122,7 +122,7 @@ class PosLocalCatalogSyncRepositoryTest : BaseUnitTest() {
         // GIVEN
         val productsSynced = 150
         whenever(posSyncProductsAction.execute(any(), anyOrNull(), any(), any()))
-            .thenReturn(PosSyncProductsAction.Result.Success(productsSynced))
+            .thenReturn(WooPosSyncProductsAction.WooPosSyncProductsResult.Success(productsSynced))
 
         // WHEN
         sut.syncLocalCatalogIncremental(site)
@@ -137,7 +137,7 @@ class PosLocalCatalogSyncRepositoryTest : BaseUnitTest() {
         val totalPages = 15
         val maxPages = PosLocalCatalogSyncRepository.MAX_PAGES_PER_FULL_SYNC
         whenever(posSyncProductsAction.execute(any(), anyOrNull(), any(), any()))
-            .thenReturn(PosSyncProductsAction.Result.Failed.CatalogTooLarge(totalPages, maxPages))
+            .thenReturn(WooPosSyncProductsAction.WooPosSyncProductsResult.Failed.CatalogTooLarge(totalPages, maxPages))
 
         // WHEN
         val result = sut.syncLocalCatalogIncremental(site)
@@ -151,7 +151,7 @@ class PosLocalCatalogSyncRepositoryTest : BaseUnitTest() {
         // GIVEN
         val errorMessage = "Network timeout"
         whenever(posSyncProductsAction.execute(any(), anyOrNull(), any(), any()))
-            .thenReturn(PosSyncProductsAction.Result.Failed.UnexpectedError(errorMessage))
+            .thenReturn(WooPosSyncProductsAction.WooPosSyncProductsResult.Failed.UnexpectedError(errorMessage))
 
         // WHEN
         val result = sut.syncLocalCatalogIncremental(site)

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/localcatalog/WooPosLocalCatalogSyncWorkerTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/localcatalog/WooPosLocalCatalogSyncWorkerTest.kt
@@ -19,7 +19,7 @@ import org.mockito.kotlin.whenever
 import org.wordpress.android.fluxc.model.SiteModel
 
 @ExperimentalCoroutinesApi
-class PosLocalCatalogSyncWorkerTest : BaseUnitTest() {
+class WooPosLocalCatalogSyncWorkerTest : BaseUnitTest() {
 
     private var context: Context = mock()
     private var workerParams: WorkerParameters = mock()
@@ -52,8 +52,8 @@ class PosLocalCatalogSyncWorkerTest : BaseUnitTest() {
         whenever(selectedSite.getOrNull()).thenReturn(site)
     }
 
-    private fun createWorker(): PosLocalCatalogSyncWorker {
-        return PosLocalCatalogSyncWorker(
+    private fun createWorker(): WooPosLocalCatalogSyncWorker {
+        return WooPosLocalCatalogSyncWorker(
             appContext = context,
             workerParams = workerParams,
             accountRepository = accountRepository,

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/localcatalog/WooPosSyncProductsActionTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/localcatalog/WooPosSyncProductsActionTest.kt
@@ -2,7 +2,7 @@ package com.woocommerce.android.ui.woopos.localcatalog
 
 import com.woocommerce.android.ui.woopos.common.util.WooPosLogWrapper
 import com.woocommerce.android.ui.woopos.localcatalog.PosLocalCatalogSyncRepository.Companion.PAGE_SIZE
-import com.woocommerce.android.ui.woopos.localcatalog.PosSyncProductsAction.Result
+import com.woocommerce.android.ui.woopos.localcatalog.WooPosSyncProductsAction.WooPosSyncProductsResult
 import kotlinx.coroutines.test.runTest
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.Before
@@ -15,20 +15,20 @@ import org.mockito.kotlin.times
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
 import org.wordpress.android.fluxc.model.SiteModel
-import org.wordpress.android.fluxc.store.pos.localcatalog.PosLocalCatalogStore
-import org.wordpress.android.fluxc.store.pos.localcatalog.PosLocalCatalogSyncResult
+import org.wordpress.android.fluxc.store.pos.localcatalog.WooPosLocalCatalogStore
+import org.wordpress.android.fluxc.store.pos.localcatalog.WooPosLocalCatalogSyncResult
 import kotlin.Result as KotlinResult
 
-class PosSyncProductsActionTest {
+class WooPosSyncProductsActionTest {
 
-    private lateinit var sut: PosSyncProductsAction
-    private var posLocalCatalogStore: PosLocalCatalogStore = mock()
+    private lateinit var sut: WooPosSyncProductsAction
+    private var posLocalCatalogStore: WooPosLocalCatalogStore = mock()
     private lateinit var site: SiteModel
     private var logger: WooPosLogWrapper = mock()
 
     @Before
     fun setup() {
-        sut = PosSyncProductsAction(posLocalCatalogStore, logger)
+        sut = WooPosSyncProductsAction(posLocalCatalogStore, logger)
         site = SiteModel().apply {
             id = 1
             siteId = 123L
@@ -44,8 +44,8 @@ class PosSyncProductsActionTest {
         val result = sut.execute(site, pageSize = 100, maxPages = 2)
 
         // THEN
-        assertThat(result).isInstanceOf(Result.Success::class.java)
-        assertThat((result as Result.Success).productsSynced).isEqualTo(50)
+        assertThat(result).isInstanceOf(WooPosSyncProductsResult.Success::class.java)
+        assertThat((result as WooPosSyncProductsResult.Success).productsSynced).isEqualTo(50)
     }
 
     @Test
@@ -62,8 +62,8 @@ class PosSyncProductsActionTest {
         val result = sut.execute(site, modifiedAfterGmt = null, pageSize = 100, maxPages = maxPages)
 
         // THEN
-        assertThat(result).isInstanceOf(Result.Success::class.java)
-        assertThat((result as Result.Success).productsSynced).isEqualTo(250)
+        assertThat(result).isInstanceOf(WooPosSyncProductsResult.Success::class.java)
+        assertThat((result as WooPosSyncProductsResult.Success).productsSynced).isEqualTo(250)
     }
 
     @Test
@@ -76,8 +76,8 @@ class PosSyncProductsActionTest {
         val result = sut.execute(site, modifiedAfterGmt = null, pageSize = 100, maxPages = maxPages)
 
         // THEN
-        assertThat(result).isInstanceOf(Result.Success::class.java)
-        assertThat((result as Result.Success).productsSynced).isEqualTo(0)
+        assertThat(result).isInstanceOf(WooPosSyncProductsResult.Success::class.java)
+        assertThat((result as WooPosSyncProductsResult.Success).productsSynced).isEqualTo(0)
     }
 
     @Test
@@ -97,7 +97,7 @@ class PosSyncProductsActionTest {
             offset = eq(0),
             pageSize = eq(100)
         )
-        assertThat(result).isInstanceOf(Result.Success::class.java)
+        assertThat(result).isInstanceOf(WooPosSyncProductsResult.Success::class.java)
     }
 
     @Test
@@ -114,8 +114,8 @@ class PosSyncProductsActionTest {
         val result = sut.execute(site, modifiedAfterGmt = null, pageSize = 100, maxPages = maxPages)
 
         // THEN
-        assertThat(result).isInstanceOf(Result.Success::class.java)
-        assertThat((result as Result.Success).productsSynced).isEqualTo(300)
+        assertThat(result).isInstanceOf(WooPosSyncProductsResult.Success::class.java)
+        assertThat((result as WooPosSyncProductsResult.Success).productsSynced).isEqualTo(300)
     }
 
     @Test
@@ -132,7 +132,7 @@ class PosSyncProductsActionTest {
         val result = sut.execute(site, modifiedAfterGmt = null, pageSize = 100, maxPages = maxPages)
 
         // THEN
-        assertThat(result).isInstanceOf(Result.Failed.CatalogTooLarge::class.java)
+        assertThat(result).isInstanceOf(WooPosSyncProductsResult.Failed.CatalogTooLarge::class.java)
     }
 
     @Test
@@ -145,8 +145,8 @@ class PosSyncProductsActionTest {
         val result = sut.execute(site, modifiedAfterGmt = null, pageSize = 100, maxPages = 10)
 
         // THEN
-        assertThat(result).isInstanceOf(Result.Failed.UnexpectedError::class.java)
-        assertThat((result as Result.Failed).error).isEqualTo(errorMessage)
+        assertThat(result).isInstanceOf(WooPosSyncProductsResult.Failed.UnexpectedError::class.java)
+        assertThat((result as WooPosSyncProductsResult.Failed).error).isEqualTo(errorMessage)
     }
 
     @Test
@@ -160,8 +160,8 @@ class PosSyncProductsActionTest {
         val result = sut.execute(site, modifiedAfterGmt = null, pageSize = 100, maxPages = maxPages)
 
         // THEN
-        assertThat(result).isInstanceOf(Result.Failed.UnexpectedError::class.java)
-        assertThat((result as Result.Failed).error).isEqualTo(errorMessage)
+        assertThat(result).isInstanceOf(WooPosSyncProductsResult.Failed.UnexpectedError::class.java)
+        assertThat((result as WooPosSyncProductsResult.Failed).error).isEqualTo(errorMessage)
     }
 
     @Test
@@ -174,8 +174,8 @@ class PosSyncProductsActionTest {
         val result = sut.execute(site, modifiedAfterGmt = null, pageSize = 100, maxPages = maxPages)
 
         // THEN
-        assertThat(result).isInstanceOf(Result.Failed.UnexpectedError::class.java)
-        assertThat((result as Result.Failed).error).isEqualTo("Unknown error")
+        assertThat(result).isInstanceOf(WooPosSyncProductsResult.Failed.UnexpectedError::class.java)
+        assertThat((result as WooPosSyncProductsResult.Failed).error).isEqualTo("Unknown error")
     }
 
     @Test
@@ -188,7 +188,7 @@ class PosSyncProductsActionTest {
         val result = sut.execute(site, modifiedAfterGmt = null, pageSize = 100, maxPages = maxPages)
 
         // THEN
-        assertThat(result).isInstanceOf(Result.Success::class.java)
+        assertThat(result).isInstanceOf(WooPosSyncProductsResult.Success::class.java)
         verify(posLocalCatalogStore, times(1))
             .syncRecentlyModifiedProducts(any(), anyOrNull(), any(), any())
     }
@@ -203,7 +203,7 @@ class PosSyncProductsActionTest {
         val result = sut.execute(site, modifiedAfterGmt = null, pageSize = 100, maxPages = maxPages)
 
         // THEN
-        assertThat(result).isInstanceOf(Result.Success::class.java)
+        assertThat(result).isInstanceOf(WooPosSyncProductsResult.Success::class.java)
         verify(posLocalCatalogStore, times(1))
             .syncRecentlyModifiedProducts(any(), anyOrNull(), any(), any())
     }
@@ -212,7 +212,7 @@ class PosSyncProductsActionTest {
         whenever(posLocalCatalogStore.syncRecentlyModifiedProducts(any(), anyOrNull(), eq(0), any()))
             .thenReturn(
                 KotlinResult.success(
-                    PosLocalCatalogSyncResult(
+                    WooPosLocalCatalogSyncResult(
                         syncedCount = productsCount,
                         hasMore = false,
                         nextOffset = 0,
@@ -226,7 +226,7 @@ class PosSyncProductsActionTest {
         whenever(posLocalCatalogStore.syncRecentlyModifiedProducts(any(), anyOrNull(), eq(0), any()))
             .thenReturn(
                 KotlinResult.success(
-                    PosLocalCatalogSyncResult(
+                    WooPosLocalCatalogSyncResult(
                         syncedCount = page1Count,
                         hasMore = true,
                         nextOffset = page1Count,
@@ -238,7 +238,7 @@ class PosSyncProductsActionTest {
         whenever(posLocalCatalogStore.syncRecentlyModifiedProducts(any(), anyOrNull(), eq(page1Count), any()))
             .thenReturn(
                 KotlinResult.success(
-                    PosLocalCatalogSyncResult(
+                    WooPosLocalCatalogSyncResult(
                         syncedCount = page2Count,
                         hasMore = true,
                         nextOffset = page1Count + page2Count,
@@ -257,7 +257,7 @@ class PosSyncProductsActionTest {
         )
             .thenReturn(
                 KotlinResult.success(
-                    PosLocalCatalogSyncResult(
+                    WooPosLocalCatalogSyncResult(
                         syncedCount = page3Count,
                         hasMore = false,
                         nextOffset = 0,
@@ -271,7 +271,7 @@ class PosSyncProductsActionTest {
         whenever(posLocalCatalogStore.syncRecentlyModifiedProducts(any(), anyOrNull(), any(), any()))
             .thenReturn(
                 KotlinResult.success(
-                    PosLocalCatalogSyncResult(
+                    WooPosLocalCatalogSyncResult(
                         syncedCount = 0,
                         hasMore = false,
                         nextOffset = 0,
@@ -295,7 +295,7 @@ class PosSyncProductsActionTest {
         whenever(posLocalCatalogStore.syncRecentlyModifiedProducts(any(), anyOrNull(), eq(0), any()))
             .thenReturn(
                 KotlinResult.success(
-                    PosLocalCatalogSyncResult(
+                    WooPosLocalCatalogSyncResult(
                         syncedCount = 100,
                         hasMore = true,
                         nextOffset = 100,
@@ -314,7 +314,7 @@ class PosSyncProductsActionTest {
         whenever(posLocalCatalogStore.syncRecentlyModifiedProducts(any(), anyOrNull(), eq(0), any()))
             .thenReturn(
                 KotlinResult.success(
-                    PosLocalCatalogSyncResult(
+                    WooPosLocalCatalogSyncResult(
                         syncedCount = 0,
                         hasMore = true,
                         nextOffset = 100,
@@ -326,7 +326,7 @@ class PosSyncProductsActionTest {
         whenever(posLocalCatalogStore.syncRecentlyModifiedProducts(any(), anyOrNull(), eq(100), any()))
             .thenReturn(
                 KotlinResult.success(
-                    PosLocalCatalogSyncResult(
+                    WooPosLocalCatalogSyncResult(
                         syncedCount = 50,
                         hasMore = false,
                         nextOffset = 0,

--- a/libs/fluxc-plugin/src/main/kotlin/org/wordpress/android/fluxc/model/pos/WooPosCatalogStatusResponse.kt
+++ b/libs/fluxc-plugin/src/main/kotlin/org/wordpress/android/fluxc/model/pos/WooPosCatalogStatusResponse.kt
@@ -2,7 +2,7 @@ package org.wordpress.android.fluxc.model.pos
 
 import com.google.gson.annotations.SerializedName
 
-data class PosCatalogStatusResponse(
+data class WooPosCatalogStatusResponse(
     @SerializedName("status")
     val status: String? = null,
     @SerializedName("download_url")

--- a/libs/fluxc-plugin/src/main/kotlin/org/wordpress/android/fluxc/model/pos/WooPosGenerateCatalogResponse.kt
+++ b/libs/fluxc-plugin/src/main/kotlin/org/wordpress/android/fluxc/model/pos/WooPosGenerateCatalogResponse.kt
@@ -2,7 +2,7 @@ package org.wordpress.android.fluxc.model.pos
 
 import com.google.gson.annotations.SerializedName
 
-data class PosGenerateCatalogResponse(
+data class WooPosGenerateCatalogResponse(
     @SerializedName("job_id")
     val jobId: Long? = null,
 )

--- a/libs/fluxc-plugin/src/main/kotlin/org/wordpress/android/fluxc/model/pos/WooPosVariationApiResponse.kt
+++ b/libs/fluxc-plugin/src/main/kotlin/org/wordpress/android/fluxc/model/pos/WooPosVariationApiResponse.kt
@@ -5,7 +5,7 @@ import com.google.gson.annotations.SerializedName
 /**
  * Response model for WooCommerce Analytics variations endpoint (/wc-analytics/variations).
  */
-data class PosVariationApiResponse(
+data class WooPosVariationApiResponse(
     @SerializedName("id")
     val id: Long = 0L,
 

--- a/libs/fluxc-plugin/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/product/pos/WooPosProductResponseToEntityMapper.kt
+++ b/libs/fluxc-plugin/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/product/pos/WooPosProductResponseToEntityMapper.kt
@@ -1,7 +1,7 @@
 package org.wordpress.android.fluxc.network.rest.wpcom.wc.product.pos
 
 import org.wordpress.android.fluxc.model.LocalOrRemoteId
-import org.wordpress.android.fluxc.model.pos.PosVariationApiResponse
+import org.wordpress.android.fluxc.model.pos.WooPosVariationApiResponse
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.product.ProductApiResponse
 import org.wordpress.android.fluxc.persistence.entity.pos.WCPosProductModel
 import org.wordpress.android.fluxc.persistence.entity.pos.WCPosVariationModel
@@ -38,7 +38,7 @@ fun ProductApiResponse.mapToPOSModel(): WCPosProductModel =
         attributes = this.attributes?.toString() ?: "",
     )
 
-fun PosVariationApiResponse.mapToPosVariationModel(
+fun WooPosVariationApiResponse.mapToPosVariationModel(
     localSiteId: LocalOrRemoteId.LocalId
 ): WCPosVariationModel {
     return WCPosVariationModel(

--- a/libs/fluxc-plugin/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/product/pos/WooPosProductRestClient.kt
+++ b/libs/fluxc-plugin/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/product/pos/WooPosProductRestClient.kt
@@ -2,9 +2,9 @@ package org.wordpress.android.fluxc.network.rest.wpcom.wc.product.pos
 
 import org.wordpress.android.fluxc.generated.endpoint.WOOCOMMERCE
 import org.wordpress.android.fluxc.model.SiteModel
-import org.wordpress.android.fluxc.model.pos.PosCatalogStatusResponse
-import org.wordpress.android.fluxc.model.pos.PosGenerateCatalogResponse
-import org.wordpress.android.fluxc.model.pos.PosVariationApiResponse
+import org.wordpress.android.fluxc.model.pos.WooPosCatalogStatusResponse
+import org.wordpress.android.fluxc.model.pos.WooPosGenerateCatalogResponse
+import org.wordpress.android.fluxc.model.pos.WooPosVariationApiResponse
 import org.wordpress.android.fluxc.network.rest.wpapi.WPAPIResponse
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.WooNetwork
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.WooResult
@@ -12,10 +12,10 @@ import org.wordpress.android.fluxc.network.rest.wpcom.wc.product.ProductApiRespo
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.toWooError
 import javax.inject.Inject
 
-class PosProductRestClient @Inject constructor(
+class WooPosProductRestClient @Inject constructor(
     private val wooNetwork: WooNetwork,
 ) {
-    companion object {
+    companion object Companion {
         private const val PRODUCT_FIELDS = "localSiteId,id,name,sku,global_unique_id,type,price,downloadable," +
             "images,attributes,parent_id,status,regular_price,sale_price,on_sale,description," +
             "short_description,manage_stock,stock_quantity,stock_status,backorders_allowed," +
@@ -63,7 +63,7 @@ class PosProductRestClient @Inject constructor(
         modifiedAfter: String? = null,
         page: Int,
         pageSize: Int,
-    ): WooResult<Array<PosVariationApiResponse>> {
+    ): WooResult<Array<WooPosVariationApiResponse>> {
         val url = "/wc-analytics/variations"
         val params = mutableMapOf(
             "per_page" to pageSize.toString(),
@@ -79,7 +79,7 @@ class PosProductRestClient @Inject constructor(
             site = site,
             path = url,
             params = params,
-            clazz = Array<PosVariationApiResponse>::class.java
+            clazz = Array<WooPosVariationApiResponse>::class.java
         )
 
         return when (response) {
@@ -95,7 +95,7 @@ class PosProductRestClient @Inject constructor(
 
     suspend fun postGenerateCatalog(
         site: SiteModel,
-    ): WooResult<PosGenerateCatalogResponse> {
+    ): WooResult<WooPosGenerateCatalogResponse> {
         val url = WOOCOMMERCE.catalog.pathV3
         val params = mutableMapOf(
             "_fields" to PRODUCT_FIELDS
@@ -105,7 +105,7 @@ class PosProductRestClient @Inject constructor(
             site = site,
             path = url,
             body = params,
-            clazz = PosGenerateCatalogResponse::class.java
+            clazz = WooPosGenerateCatalogResponse::class.java
         )
 
         return when (response) {
@@ -122,7 +122,7 @@ class PosProductRestClient @Inject constructor(
     suspend fun getCatalogStatus(
         site: SiteModel,
         jobId: String,
-    ): WooResult<PosCatalogStatusResponse> {
+    ): WooResult<WooPosCatalogStatusResponse> {
         val url = WOOCOMMERCE.catalog.status.id(jobId).pathV3
         val params = mutableMapOf(
             "_fields" to PRODUCT_FIELDS
@@ -132,7 +132,7 @@ class PosProductRestClient @Inject constructor(
             site = site,
             path = url,
             params = params,
-            clazz = PosCatalogStatusResponse::class.java
+            clazz = WooPosCatalogStatusResponse::class.java
         )
 
         return when (response) {

--- a/libs/fluxc-plugin/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/product/pos/WooPosProductRestClient.kt
+++ b/libs/fluxc-plugin/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/product/pos/WooPosProductRestClient.kt
@@ -15,7 +15,7 @@ import javax.inject.Inject
 class WooPosProductRestClient @Inject constructor(
     private val wooNetwork: WooNetwork,
 ) {
-    companion object Companion {
+    companion object {
         private const val PRODUCT_FIELDS = "localSiteId,id,name,sku,global_unique_id,type,price,downloadable," +
             "images,attributes,parent_id,status,regular_price,sale_price,on_sale,description," +
             "short_description,manage_stock,stock_quantity,stock_status,backorders_allowed," +

--- a/libs/fluxc-plugin/src/main/kotlin/org/wordpress/android/fluxc/persistence/WCAndroidDatabase.kt
+++ b/libs/fluxc-plugin/src/main/kotlin/org/wordpress/android/fluxc/persistence/WCAndroidDatabase.kt
@@ -61,8 +61,8 @@ import org.wordpress.android.fluxc.persistence.dao.UserDao
 import org.wordpress.android.fluxc.persistence.dao.VisitorSummaryStatsDao
 import org.wordpress.android.fluxc.persistence.dao.WooPaymentsDepositsOverviewDao
 import org.wordpress.android.fluxc.persistence.dao.WooShippingDao
-import org.wordpress.android.fluxc.persistence.dao.pos.PosProductsDao
-import org.wordpress.android.fluxc.persistence.dao.pos.PosVariationsDao
+import org.wordpress.android.fluxc.persistence.dao.pos.WooPosProductsDao
+import org.wordpress.android.fluxc.persistence.dao.pos.WooPosVariationsDao
 import org.wordpress.android.fluxc.persistence.entity.AddonEntity
 import org.wordpress.android.fluxc.persistence.entity.AddonOptionEntity
 import org.wordpress.android.fluxc.persistence.entity.CouponEmailEntity
@@ -232,8 +232,8 @@ abstract class WCAndroidDatabase : RoomDatabase(), TransactionExecutor {
     internal abstract val orderShipmentProvidersDao: OrderShipmentProvidersDao
     internal abstract val customerDao: CustomerDao
     internal abstract val productsDao: ProductsDao
-    internal abstract val posProductsDao: PosProductsDao
-    internal abstract val posVariationsDao: PosVariationsDao
+    internal abstract val posProductsDao: WooPosProductsDao
+    internal abstract val posVariationsDao: WooPosVariationsDao
     internal abstract val productVariationsDao: ProductVariationsDao
     internal abstract val productCategoriesDao: ProductCategoriesDao
     internal abstract val productTagsDao: ProductTagsDao

--- a/libs/fluxc-plugin/src/main/kotlin/org/wordpress/android/fluxc/persistence/dao/pos/WooPosProductsDao.kt
+++ b/libs/fluxc-plugin/src/main/kotlin/org/wordpress/android/fluxc/persistence/dao/pos/WooPosProductsDao.kt
@@ -9,7 +9,7 @@ import org.wordpress.android.fluxc.model.LocalOrRemoteId.RemoteId
 import org.wordpress.android.fluxc.persistence.entity.pos.WCPosProductModel
 
 @Dao
-abstract class PosProductsDao {
+abstract class WooPosProductsDao {
     @Query("SELECT * FROM PosProductEntity WHERE localSiteId = :localSiteId")
     abstract fun observeAllProducts(localSiteId: LocalId): Flow<List<WCPosProductModel>>
 

--- a/libs/fluxc-plugin/src/main/kotlin/org/wordpress/android/fluxc/persistence/dao/pos/WooPosVariationsDao.kt
+++ b/libs/fluxc-plugin/src/main/kotlin/org/wordpress/android/fluxc/persistence/dao/pos/WooPosVariationsDao.kt
@@ -9,7 +9,7 @@ import org.wordpress.android.fluxc.model.LocalOrRemoteId.RemoteId
 import org.wordpress.android.fluxc.persistence.entity.pos.WCPosVariationModel
 
 @Dao
-abstract class PosVariationsDao {
+abstract class WooPosVariationsDao {
 
     @Query("SELECT * FROM PosVariationEntity WHERE localSiteId = :localSiteId AND remoteProductId = :productId ORDER BY variationName ASC")
     abstract fun observeVariationsForProduct(localSiteId: LocalId, productId: RemoteId): Flow<List<WCPosVariationModel>>

--- a/libs/fluxc-plugin/src/main/kotlin/org/wordpress/android/fluxc/store/pos/localcatalog/WooPosCatalogStatusResult.kt
+++ b/libs/fluxc-plugin/src/main/kotlin/org/wordpress/android/fluxc/store/pos/localcatalog/WooPosCatalogStatusResult.kt
@@ -1,6 +1,6 @@
 package org.wordpress.android.fluxc.store.pos.localcatalog
 
-data class PosCatalogStatusResult(
+data class WooPosCatalogStatusResult(
     val downloadUrl: String?,
     val status: String,
 )

--- a/libs/fluxc-plugin/src/main/kotlin/org/wordpress/android/fluxc/store/pos/localcatalog/WooPosGenerateCatalogResult.kt
+++ b/libs/fluxc-plugin/src/main/kotlin/org/wordpress/android/fluxc/store/pos/localcatalog/WooPosGenerateCatalogResult.kt
@@ -1,5 +1,5 @@
 package org.wordpress.android.fluxc.store.pos.localcatalog
 
-data class PosGenerateCatalogResult(
+data class WooPosGenerateCatalogResult(
     val jobId: String,
 )

--- a/libs/fluxc-plugin/src/main/kotlin/org/wordpress/android/fluxc/store/pos/localcatalog/WooPosLocalCatalogError.kt
+++ b/libs/fluxc-plugin/src/main/kotlin/org/wordpress/android/fluxc/store/pos/localcatalog/WooPosLocalCatalogError.kt
@@ -1,6 +1,6 @@
 package org.wordpress.android.fluxc.store.pos.localcatalog
 
-sealed class PosLocalCatalogError(
+sealed class WooPosLocalCatalogError(
     override val message: String,
     override val cause: Throwable? = null
 ) : Exception(message, cause) {
@@ -8,18 +8,18 @@ sealed class PosLocalCatalogError(
     data class NetworkError(
         val errorMessage: String,
         val code: String? = null
-    ) : PosLocalCatalogError(errorMessage)
+    ) : WooPosLocalCatalogError(errorMessage)
 
     data class DatabaseError(
         val errorMessage: String,
         val throwable: Throwable? = null
-    ) : PosLocalCatalogError(errorMessage, throwable)
+    ) : WooPosLocalCatalogError(errorMessage, throwable)
 
-    object EmptyResponse : PosLocalCatalogError("Empty response from server")
+    object EmptyResponse : WooPosLocalCatalogError("Empty response from server")
 
-    data class InvalidResponse(val errorMessage: String) : PosLocalCatalogError(errorMessage)
+    data class InvalidResponse(val errorMessage: String) : WooPosLocalCatalogError(errorMessage)
 
     data class UnknownError(
         val throwable: Throwable
-    ) : PosLocalCatalogError(throwable.message ?: "Unknown error", throwable)
+    ) : WooPosLocalCatalogError(throwable.message ?: "Unknown error", throwable)
 }

--- a/libs/fluxc-plugin/src/main/kotlin/org/wordpress/android/fluxc/store/pos/localcatalog/WooPosLocalCatalogStore.kt
+++ b/libs/fluxc-plugin/src/main/kotlin/org/wordpress/android/fluxc/store/pos/localcatalog/WooPosLocalCatalogStore.kt
@@ -6,11 +6,11 @@ import org.wordpress.android.fluxc.model.LocalOrRemoteId
 import org.wordpress.android.fluxc.model.SiteModel
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.WooError
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.WooErrorType
-import org.wordpress.android.fluxc.network.rest.wpcom.wc.product.pos.PosProductRestClient
+import org.wordpress.android.fluxc.network.rest.wpcom.wc.product.pos.WooPosProductRestClient
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.product.pos.mapToPOSModel
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.product.pos.mapToPosVariationModel
-import org.wordpress.android.fluxc.persistence.dao.pos.PosProductsDao
-import org.wordpress.android.fluxc.persistence.dao.pos.PosVariationsDao
+import org.wordpress.android.fluxc.persistence.dao.pos.WooPosProductsDao
+import org.wordpress.android.fluxc.persistence.dao.pos.WooPosVariationsDao
 import org.wordpress.android.fluxc.persistence.entity.pos.WCPosProductModel
 import org.wordpress.android.fluxc.persistence.entity.pos.WCPosVariationModel
 import org.wordpress.android.fluxc.tools.CoroutineEngine
@@ -20,10 +20,10 @@ import javax.inject.Singleton
 
 @Singleton
 class WooPosLocalCatalogStore @Inject constructor(
-    private val posProductRestClient: PosProductRestClient,
+    private val posProductRestClient: WooPosProductRestClient,
     private val coroutineEngine: CoroutineEngine,
-    private val posProductDao: PosProductsDao,
-    private val posVariationsDao: PosVariationsDao,
+    private val posProductDao: WooPosProductsDao,
+    private val posVariationsDao: WooPosVariationsDao,
 ) {
     companion object Companion {
         private const val DEFAULT_PAGE_SIZE = 100

--- a/libs/fluxc-plugin/src/main/kotlin/org/wordpress/android/fluxc/store/pos/localcatalog/WooPosLocalCatalogStore.kt
+++ b/libs/fluxc-plugin/src/main/kotlin/org/wordpress/android/fluxc/store/pos/localcatalog/WooPosLocalCatalogStore.kt
@@ -25,7 +25,7 @@ class WooPosLocalCatalogStore @Inject constructor(
     private val posProductDao: WooPosProductsDao,
     private val posVariationsDao: WooPosVariationsDao,
 ) {
-    companion object {
+    private companion object {
         private const val DEFAULT_PAGE_SIZE = 100
         private const val MAX_PAGE_SIZE = 100
     }

--- a/libs/fluxc-plugin/src/main/kotlin/org/wordpress/android/fluxc/store/pos/localcatalog/WooPosLocalCatalogStore.kt
+++ b/libs/fluxc-plugin/src/main/kotlin/org/wordpress/android/fluxc/store/pos/localcatalog/WooPosLocalCatalogStore.kt
@@ -25,7 +25,7 @@ class WooPosLocalCatalogStore @Inject constructor(
     private val posProductDao: WooPosProductsDao,
     private val posVariationsDao: WooPosVariationsDao,
 ) {
-    companion object Companion {
+    companion object {
         private const val DEFAULT_PAGE_SIZE = 100
         private const val MAX_PAGE_SIZE = 100
     }

--- a/libs/fluxc-plugin/src/main/kotlin/org/wordpress/android/fluxc/store/pos/localcatalog/WooPosLocalCatalogStore.kt
+++ b/libs/fluxc-plugin/src/main/kotlin/org/wordpress/android/fluxc/store/pos/localcatalog/WooPosLocalCatalogStore.kt
@@ -19,13 +19,13 @@ import javax.inject.Inject
 import javax.inject.Singleton
 
 @Singleton
-class PosLocalCatalogStore @Inject constructor(
+class WooPosLocalCatalogStore @Inject constructor(
     private val posProductRestClient: PosProductRestClient,
     private val coroutineEngine: CoroutineEngine,
     private val posProductDao: PosProductsDao,
     private val posVariationsDao: PosVariationsDao,
 ) {
-    companion object {
+    companion object Companion {
         private const val DEFAULT_PAGE_SIZE = 100
         private const val MAX_PAGE_SIZE = 100
     }
@@ -74,7 +74,7 @@ class PosLocalCatalogStore @Inject constructor(
         modifiedAfterGmt: String?,
         offset: Int = 0,
         pageSize: Int = DEFAULT_PAGE_SIZE,
-    ): Result<PosLocalCatalogSyncResult> =
+    ): Result<WooPosLocalCatalogSyncResult> =
         coroutineEngine.withDefaultContext(API, this, "syncRecentlyModifiedProducts") {
             val validPageSize = pageSize.coerceIn(1, MAX_PAGE_SIZE)
 
@@ -94,7 +94,7 @@ class PosLocalCatalogStore @Inject constructor(
 
                     response.model.isNullOrEmpty() -> {
                         Result.success(
-                            PosLocalCatalogSyncResult(
+                            WooPosLocalCatalogSyncResult(
                                 syncedCount = 0,
                                 hasMore = false,
                                 nextOffset = offset,
@@ -112,7 +112,7 @@ class PosLocalCatalogStore @Inject constructor(
 
                         if (upsertResult.isFailure) {
                             return@withDefaultContext Result.failure(
-                                PosLocalCatalogError.DatabaseError(
+                                WooPosLocalCatalogError.DatabaseError(
                                     errorMessage = "Failed to save products to database",
                                     throwable = upsertResult.exceptionOrNull()
                                 )
@@ -122,7 +122,7 @@ class PosLocalCatalogStore @Inject constructor(
                         val hasMore = products.size == validPageSize
 
                         Result.success(
-                            PosLocalCatalogSyncResult(
+                            WooPosLocalCatalogSyncResult(
                                 syncedCount = products.size,
                                 hasMore = hasMore,
                                 nextOffset = if (hasMore) offset + products.size else offset,
@@ -174,14 +174,14 @@ class PosLocalCatalogStore @Inject constructor(
      * @param modifiedAfterGmt ISO 8601 formatted date string (GMT)
      * @param page Starting page for pagination (1-based)
      * @param pageSize Number of variations to fetch per page (default: 100, max: 100)
-     * @return [Result] containing [PosVariationsSyncResult] with pagination info or error
+     * @return [Result] containing [WooPosVariationsSyncResult] with pagination info or error
      */
     suspend fun syncRecentlyModifiedVariations(
         site: SiteModel,
         modifiedAfterGmt: String,
         page: Int = 1,
         pageSize: Int = DEFAULT_PAGE_SIZE,
-    ): Result<PosVariationsSyncResult> =
+    ): Result<WooPosVariationsSyncResult> =
         coroutineEngine.withDefaultContext(API, this, "syncRecentlyModifiedVariations") {
             val validPageSize = pageSize.coerceIn(1, MAX_PAGE_SIZE)
 
@@ -201,7 +201,7 @@ class PosLocalCatalogStore @Inject constructor(
 
                 response.model.isNullOrEmpty() -> {
                     Result.success(
-                        PosVariationsSyncResult(
+                        WooPosVariationsSyncResult(
                             syncedCount = 0,
                             hasMore = false,
                             nextPage = page
@@ -222,7 +222,7 @@ class PosLocalCatalogStore @Inject constructor(
 
                     if (upsertResult.isFailure) {
                         return@withDefaultContext Result.failure(
-                            PosLocalCatalogError.DatabaseError(
+                            WooPosLocalCatalogError.DatabaseError(
                                 errorMessage = "Failed to save variations to database",
                                 throwable = upsertResult.exceptionOrNull()
                             )
@@ -232,7 +232,7 @@ class PosLocalCatalogStore @Inject constructor(
                     val hasMore = variations.size == validPageSize
 
                     Result.success(
-                        PosVariationsSyncResult(
+                        WooPosVariationsSyncResult(
                             syncedCount = variations.size,
                             hasMore = hasMore,
                             nextPage = if (hasMore) {
@@ -254,7 +254,7 @@ class PosLocalCatalogStore @Inject constructor(
      */
     suspend fun generateCatalog(
         site: SiteModel
-    ): Result<PosGenerateCatalogResult> =
+    ): Result<WooPosGenerateCatalogResult> =
         coroutineEngine.withDefaultContext(API, this, "generateCatalog") {
             val response = posProductRestClient.postGenerateCatalog(site)
 
@@ -266,17 +266,17 @@ class PosLocalCatalogStore @Inject constructor(
                 }
 
                 response.model == null -> {
-                    Result.failure(PosLocalCatalogError.EmptyResponse)
+                    Result.failure(WooPosLocalCatalogError.EmptyResponse)
                 }
 
                 response.model.jobId == null -> {
-                    Result.failure(PosLocalCatalogError.InvalidResponse("Missing job ID in response"))
+                    Result.failure(WooPosLocalCatalogError.InvalidResponse("Missing job ID in response"))
                 }
 
                 else -> {
                     val jobId = response.model.jobId.toString()
                     Result.success(
-                        PosGenerateCatalogResult(jobId = jobId)
+                        WooPosGenerateCatalogResult(jobId = jobId)
                     )
                 }
             }
@@ -292,7 +292,7 @@ class PosLocalCatalogStore @Inject constructor(
     suspend fun fetchCatalogStatus(
         site: SiteModel,
         jobId: String
-    ): Result<PosCatalogStatusResult> =
+    ): Result<WooPosCatalogStatusResult> =
         coroutineEngine.withDefaultContext(API, this, "fetchCatalogStatus") {
             val response = posProductRestClient.getCatalogStatus(site, jobId)
 
@@ -304,16 +304,16 @@ class PosLocalCatalogStore @Inject constructor(
                 }
 
                 response.model == null -> {
-                    Result.failure(PosLocalCatalogError.EmptyResponse)
+                    Result.failure(WooPosLocalCatalogError.EmptyResponse)
                 }
 
                 response.model.status.isNullOrEmpty() -> {
-                    Result.failure(PosLocalCatalogError.InvalidResponse("Missing job ID in response"))
+                    Result.failure(WooPosLocalCatalogError.InvalidResponse("Missing job ID in response"))
                 }
 
                 else -> {
                     Result.success(
-                        PosCatalogStatusResult(
+                        WooPosCatalogStatusResult(
                             status = response.model.status,
                             downloadUrl = response.model.downloadUrl
                         )
@@ -322,26 +322,26 @@ class PosLocalCatalogStore @Inject constructor(
             }
         }
 
-    private fun mapResponseError(error: WooError?): PosLocalCatalogError {
+    private fun mapResponseError(error: WooError?): WooPosLocalCatalogError {
         return when (error?.type) {
-            WooErrorType.TIMEOUT -> PosLocalCatalogError.NetworkError(
+            WooErrorType.TIMEOUT -> WooPosLocalCatalogError.NetworkError(
                 errorMessage = "Request timed out",
                 code = error.type.name
             )
-            WooErrorType.NO_CONNECTION -> PosLocalCatalogError.NetworkError(
+            WooErrorType.NO_CONNECTION -> WooPosLocalCatalogError.NetworkError(
                 errorMessage = error.message ?: "No network connection",
                 code = error.type.name
             )
-            WooErrorType.INVALID_RESPONSE -> PosLocalCatalogError.NetworkError(
+            WooErrorType.INVALID_RESPONSE -> WooPosLocalCatalogError.NetworkError(
                 errorMessage = "Invalid response from server",
                 code = error.type.name
             )
-            WooErrorType.API_ERROR -> PosLocalCatalogError.NetworkError(
+            WooErrorType.API_ERROR -> WooPosLocalCatalogError.NetworkError(
                 errorMessage = error.message ?: "API error occurred",
                 code = error.type.name
             )
-            WooErrorType.EMPTY_RESPONSE -> PosLocalCatalogError.EmptyResponse
-            else -> PosLocalCatalogError.NetworkError(
+            WooErrorType.EMPTY_RESPONSE -> WooPosLocalCatalogError.EmptyResponse
+            else -> WooPosLocalCatalogError.NetworkError(
                 errorMessage = error?.message ?: "Unknown error occurred",
                 code = error?.type?.name
             )

--- a/libs/fluxc-plugin/src/main/kotlin/org/wordpress/android/fluxc/store/pos/localcatalog/WooPosLocalCatalogSyncResult.kt
+++ b/libs/fluxc-plugin/src/main/kotlin/org/wordpress/android/fluxc/store/pos/localcatalog/WooPosLocalCatalogSyncResult.kt
@@ -1,6 +1,6 @@
 package org.wordpress.android.fluxc.store.pos.localcatalog
 
-data class PosLocalCatalogSyncResult(
+data class WooPosLocalCatalogSyncResult(
     val syncedCount: Int,
     val hasMore: Boolean,
     val nextOffset: Int,

--- a/libs/fluxc-plugin/src/main/kotlin/org/wordpress/android/fluxc/store/pos/localcatalog/WooPosVariationsSyncResult.kt
+++ b/libs/fluxc-plugin/src/main/kotlin/org/wordpress/android/fluxc/store/pos/localcatalog/WooPosVariationsSyncResult.kt
@@ -1,6 +1,6 @@
 package org.wordpress.android.fluxc.store.pos.localcatalog
 
-data class PosVariationsSyncResult(
+data class WooPosVariationsSyncResult(
     val syncedCount: Int,
     val hasMore: Boolean,
     val nextPage: Int

--- a/libs/fluxc-plugin/src/test/java/org/wordpress/android/fluxc/network/rest/wpcom/wc/product/pos/WooPosVariationMapperTest.kt
+++ b/libs/fluxc-plugin/src/test/java/org/wordpress/android/fluxc/network/rest/wpcom/wc/product/pos/WooPosVariationMapperTest.kt
@@ -3,14 +3,14 @@ package org.wordpress.android.fluxc.network.rest.wpcom.wc.product.pos
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.Test
 import org.wordpress.android.fluxc.model.LocalOrRemoteId
-import org.wordpress.android.fluxc.model.pos.PosVariationApiResponse
+import org.wordpress.android.fluxc.model.pos.WooPosVariationApiResponse
 
-class PosVariationMapperTest {
+class WooPosVariationMapperTest {
 
     @Test
     fun `given complete API response, when mapper called, then all fields mapped correctly`() {
         // Given
-        val response = PosVariationApiResponse(
+        val response = WooPosVariationApiResponse(
             id = 123L,
             productId = 456L,
             name = "Blue Large T-Shirt",
@@ -27,10 +27,10 @@ class PosVariationMapperTest {
             manageStock = true,
             backordered = false,
             attributes = listOf(
-                PosVariationApiResponse.VariationAttribute(1, "Color", "Blue"),
-                PosVariationApiResponse.VariationAttribute(2, "Size", "Large")
+                WooPosVariationApiResponse.VariationAttribute(1, "Color", "Blue"),
+                WooPosVariationApiResponse.VariationAttribute(2, "Size", "Large")
             ),
-            image = PosVariationApiResponse.VariationImage(
+            image = WooPosVariationApiResponse.VariationImage(
                 id = 789,
                 src = "https://example.com/image.jpg",
                 name = "product-image",
@@ -70,7 +70,7 @@ class PosVariationMapperTest {
     @Test
     fun `given null stock quantity, when mapper called, then defaults to zero`() {
         // Given
-        val response = PosVariationApiResponse(
+        val response = WooPosVariationApiResponse(
             id = 123L,
             productId = 456L,
             stockQuantity = null
@@ -86,7 +86,7 @@ class PosVariationMapperTest {
     @Test
     fun `given null image, when mapper called, then image URL is empty`() {
         // Given
-        val response = PosVariationApiResponse(
+        val response = WooPosVariationApiResponse(
             id = 123L,
             productId = 456L,
             image = null
@@ -102,7 +102,7 @@ class PosVariationMapperTest {
     @Test
     fun `given empty attributes, when mapper called, then JSON is empty array`() {
         // Given
-        val response = PosVariationApiResponse(
+        val response = WooPosVariationApiResponse(
             id = 123L,
             productId = 456L,
             attributes = emptyList()
@@ -118,13 +118,13 @@ class PosVariationMapperTest {
     @Test
     fun `given multiple attributes, when mapper called, then JSON contains all attributes`() {
         // Given
-        val response = PosVariationApiResponse(
+        val response = WooPosVariationApiResponse(
             id = 123L,
             productId = 456L,
             attributes = listOf(
-                PosVariationApiResponse.VariationAttribute(1, "Color", "Red"),
-                PosVariationApiResponse.VariationAttribute(2, "Size", "Medium"),
-                PosVariationApiResponse.VariationAttribute(3, "Material", "Cotton")
+                WooPosVariationApiResponse.VariationAttribute(1, "Color", "Red"),
+                WooPosVariationApiResponse.VariationAttribute(2, "Size", "Medium"),
+                WooPosVariationApiResponse.VariationAttribute(3, "Material", "Cotton")
             )
         )
 
@@ -143,7 +143,7 @@ class PosVariationMapperTest {
     @Test
     fun `given special characters in fields, when mapper called, then characters preserved`() {
         // Given
-        val response = PosVariationApiResponse(
+        val response = WooPosVariationApiResponse(
             id = 123L,
             productId = 456L,
             name = "Product with \"quotes\" & special <chars>",
@@ -163,7 +163,7 @@ class PosVariationMapperTest {
     @Test
     fun `given edge case numeric values, when mapper called, then values handled correctly`() {
         // Given
-        val response = PosVariationApiResponse(
+        val response = WooPosVariationApiResponse(
             id = Long.MAX_VALUE,
             productId = 0L,
             price = "0.01",
@@ -187,7 +187,7 @@ class PosVariationMapperTest {
     @Test
     fun `given minimal API response, when mapper called, then defaults applied correctly`() {
         // Given - only required fields
-        val response = PosVariationApiResponse(
+        val response = WooPosVariationApiResponse(
             id = 1L,
             productId = 2L
         )

--- a/libs/fluxc-plugin/src/test/java/org/wordpress/android/fluxc/persistence/dao/pos/WooPosProductsDaoTest.kt
+++ b/libs/fluxc-plugin/src/test/java/org/wordpress/android/fluxc/persistence/dao/pos/WooPosProductsDaoTest.kt
@@ -19,13 +19,13 @@ import kotlin.test.assertNull
 import kotlin.test.assertTrue
 
 @RunWith(RobolectricTestRunner::class)
-class PosProductsDaoTest {
+class WooPosProductsDaoTest {
 
     @Rule
     @JvmField
     val databaseRule = DatabaseTestRule(ApplicationProvider.getApplicationContext<Application>())
 
-    private lateinit var sut: PosProductsDao
+    private lateinit var sut: WooPosProductsDao
 
     @Before
     fun setUp() {

--- a/libs/fluxc-plugin/src/test/java/org/wordpress/android/fluxc/persistence/dao/pos/WooPosVariationsDaoTest.kt
+++ b/libs/fluxc-plugin/src/test/java/org/wordpress/android/fluxc/persistence/dao/pos/WooPosVariationsDaoTest.kt
@@ -19,13 +19,13 @@ import kotlin.test.assertNull
 import kotlin.test.assertTrue
 
 @RunWith(RobolectricTestRunner::class)
-class PosVariationsDaoTest {
+class WooPosVariationsDaoTest {
 
     @Rule
     @JvmField
     val databaseRule = DatabaseTestRule(ApplicationProvider.getApplicationContext<Application>())
 
-    private lateinit var sut: PosVariationsDao
+    private lateinit var sut: WooPosVariationsDao
 
     @Before
     fun setUp() {

--- a/libs/fluxc-plugin/src/test/java/org/wordpress/android/fluxc/store/pos/WooPosLocalCatalogStoreTest.kt
+++ b/libs/fluxc-plugin/src/test/java/org/wordpress/android/fluxc/store/pos/WooPosLocalCatalogStoreTest.kt
@@ -45,7 +45,7 @@ class WooPosLocalCatalogStoreTest {
 
     private lateinit var store: WooPosLocalCatalogStore
 
-    companion object Companion {
+    companion object {
         private val SITE_ID = LocalId(123)
         private val PRODUCT_ID = RemoteId(456)
         private val SITE = SiteModel().apply { id = 123 }

--- a/libs/fluxc-plugin/src/test/java/org/wordpress/android/fluxc/store/pos/WooPosLocalCatalogStoreTest.kt
+++ b/libs/fluxc-plugin/src/test/java/org/wordpress/android/fluxc/store/pos/WooPosLocalCatalogStoreTest.kt
@@ -16,15 +16,15 @@ import org.mockito.kotlin.whenever
 import org.wordpress.android.fluxc.model.LocalOrRemoteId.LocalId
 import org.wordpress.android.fluxc.model.LocalOrRemoteId.RemoteId
 import org.wordpress.android.fluxc.model.SiteModel
-import org.wordpress.android.fluxc.model.pos.PosCatalogStatusResponse
-import org.wordpress.android.fluxc.model.pos.PosGenerateCatalogResponse
+import org.wordpress.android.fluxc.model.pos.WooPosCatalogStatusResponse
+import org.wordpress.android.fluxc.model.pos.WooPosGenerateCatalogResponse
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.WooError
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.WooErrorType
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.WooResult
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.product.ProductApiResponse
-import org.wordpress.android.fluxc.network.rest.wpcom.wc.product.pos.PosProductRestClient
-import org.wordpress.android.fluxc.persistence.dao.pos.PosProductsDao
-import org.wordpress.android.fluxc.persistence.dao.pos.PosVariationsDao
+import org.wordpress.android.fluxc.network.rest.wpcom.wc.product.pos.WooPosProductRestClient
+import org.wordpress.android.fluxc.persistence.dao.pos.WooPosProductsDao
+import org.wordpress.android.fluxc.persistence.dao.pos.WooPosVariationsDao
 import org.wordpress.android.fluxc.persistence.entity.pos.WCPosProductModel
 import org.wordpress.android.fluxc.persistence.entity.pos.WCPosVariationModel
 import org.wordpress.android.fluxc.store.pos.localcatalog.WooPosLocalCatalogError
@@ -35,13 +35,13 @@ import org.wordpress.android.fluxc.utils.initCoroutineEngine
 class WooPosLocalCatalogStoreTest {
 
     @Mock
-    private lateinit var posProductRestClient: PosProductRestClient
+    private lateinit var posProductRestClient: WooPosProductRestClient
 
     @Mock
-    private lateinit var posProductsDao: PosProductsDao
+    private lateinit var posProductsDao: WooPosProductsDao
 
     @Mock
-    private lateinit var posVariationsDao: PosVariationsDao
+    private lateinit var posVariationsDao: WooPosVariationsDao
 
     private lateinit var store: WooPosLocalCatalogStore
 
@@ -475,7 +475,7 @@ class WooPosLocalCatalogStoreTest {
     fun `when generating catalog successfully, then returns job ID`() = runTest {
         // GIVEN
         val expectedJobId = 12345L
-        val response = PosGenerateCatalogResponse(jobId = expectedJobId)
+        val response = WooPosGenerateCatalogResponse(jobId = expectedJobId)
         whenever(posProductRestClient.postGenerateCatalog(testSite))
             .thenReturn(WooResult(response))
 
@@ -528,7 +528,7 @@ class WooPosLocalCatalogStoreTest {
         val jobId = "12345"
         val expectedStatus = "completed"
         val expectedDownloadUrl = "https://example.com/catalog.zip"
-        val response = PosCatalogStatusResponse(
+        val response = WooPosCatalogStatusResponse(
             status = expectedStatus,
             downloadUrl = expectedDownloadUrl
         )
@@ -585,7 +585,7 @@ class WooPosLocalCatalogStoreTest {
     fun `when fetching catalog status for in-progress job, then returns processing status`() = runTest {
         // GIVEN
         val jobId = "12345"
-        val response = PosCatalogStatusResponse(
+        val response = WooPosCatalogStatusResponse(
             status = "processing",
             downloadUrl = null
         )
@@ -603,7 +603,7 @@ class WooPosLocalCatalogStoreTest {
     @Test
     fun `when generating catalog returns null job ID, then returns invalid response error`() = runTest {
         // GIVEN
-        val response = PosGenerateCatalogResponse(jobId = null)
+        val response = WooPosGenerateCatalogResponse(jobId = null)
         whenever(posProductRestClient.postGenerateCatalog(testSite))
             .thenReturn(WooResult(response))
 
@@ -620,7 +620,7 @@ class WooPosLocalCatalogStoreTest {
     fun `when fetching catalog status with null status field, then returns invalid response error`() = runTest {
         // GIVEN
         val jobId = "12345"
-        val response = PosCatalogStatusResponse(
+        val response = WooPosCatalogStatusResponse(
             status = null,
             downloadUrl = "https://example.com/catalog.zip"
         )
@@ -640,7 +640,7 @@ class WooPosLocalCatalogStoreTest {
     fun `when fetching catalog status with empty status field, then returns invalid response error`() = runTest {
         // GIVEN
         val jobId = "12345"
-        val response = PosCatalogStatusResponse(
+        val response = WooPosCatalogStatusResponse(
             status = "",
             downloadUrl = "https://example.com/catalog.zip"
         )
@@ -659,7 +659,7 @@ class WooPosLocalCatalogStoreTest {
     private fun createTestVariationApiResponse(
         id: Long = 200L,
         productId: Long = 100L
-    ) = org.wordpress.android.fluxc.model.pos.PosVariationApiResponse(
+    ) = org.wordpress.android.fluxc.model.pos.WooPosVariationApiResponse(
         id = id,
         productId = productId,
         sku = "VAR-SKU-$id",

--- a/libs/fluxc-plugin/src/test/java/org/wordpress/android/fluxc/store/pos/WooPosLocalCatalogStoreTest.kt
+++ b/libs/fluxc-plugin/src/test/java/org/wordpress/android/fluxc/store/pos/WooPosLocalCatalogStoreTest.kt
@@ -27,12 +27,12 @@ import org.wordpress.android.fluxc.persistence.dao.pos.PosProductsDao
 import org.wordpress.android.fluxc.persistence.dao.pos.PosVariationsDao
 import org.wordpress.android.fluxc.persistence.entity.pos.WCPosProductModel
 import org.wordpress.android.fluxc.persistence.entity.pos.WCPosVariationModel
-import org.wordpress.android.fluxc.store.pos.localcatalog.PosLocalCatalogError
-import org.wordpress.android.fluxc.store.pos.localcatalog.PosLocalCatalogStore
+import org.wordpress.android.fluxc.store.pos.localcatalog.WooPosLocalCatalogError
+import org.wordpress.android.fluxc.store.pos.localcatalog.WooPosLocalCatalogStore
 import org.wordpress.android.fluxc.utils.initCoroutineEngine
 
 @RunWith(MockitoJUnitRunner::class)
-class PosLocalCatalogStoreTest {
+class WooPosLocalCatalogStoreTest {
 
     @Mock
     private lateinit var posProductRestClient: PosProductRestClient
@@ -43,9 +43,9 @@ class PosLocalCatalogStoreTest {
     @Mock
     private lateinit var posVariationsDao: PosVariationsDao
 
-    private lateinit var store: PosLocalCatalogStore
+    private lateinit var store: WooPosLocalCatalogStore
 
-    companion object {
+    companion object Companion {
         private val SITE_ID = LocalId(123)
         private val PRODUCT_ID = RemoteId(456)
         private val SITE = SiteModel().apply { id = 123 }
@@ -63,7 +63,7 @@ class PosLocalCatalogStoreTest {
 
     @Before
     fun setUp() {
-        store = PosLocalCatalogStore(
+        store = WooPosLocalCatalogStore(
             posProductRestClient = posProductRestClient,
             coroutineEngine = initCoroutineEngine(),
             posProductDao = posProductsDao,
@@ -198,7 +198,7 @@ class PosLocalCatalogStoreTest {
 
         // THEN
         assertThat(result.isFailure).isTrue()
-        val error = result.exceptionOrNull() as PosLocalCatalogError.NetworkError
+        val error = result.exceptionOrNull() as WooPosLocalCatalogError.NetworkError
         assertThat(error.errorMessage).contains("Connection failed")
         verifyNoInteractions(posProductsDao)
     }
@@ -218,7 +218,7 @@ class PosLocalCatalogStoreTest {
 
         // THEN
         assertThat(result.isFailure).isTrue()
-        val error = result.exceptionOrNull() as PosLocalCatalogError.DatabaseError
+        val error = result.exceptionOrNull() as WooPosLocalCatalogError.DatabaseError
         assertThat(error.errorMessage).contains("Failed to save products to database")
         assertThat(error.throwable).isEqualTo(storageException)
     }
@@ -287,7 +287,7 @@ class PosLocalCatalogStoreTest {
 
         // THEN
         assertThat(result.isFailure).isTrue()
-        val error = result.exceptionOrNull() as PosLocalCatalogError.NetworkError
+        val error = result.exceptionOrNull() as WooPosLocalCatalogError.NetworkError
         assertThat(error.errorMessage).contains("Request timed out")
         assertThat(error.code).isEqualTo("TIMEOUT")
     }
@@ -382,7 +382,7 @@ class PosLocalCatalogStoreTest {
 
         // THEN
         assertThat(result.isFailure).isTrue()
-        val error = result.exceptionOrNull() as PosLocalCatalogError.NetworkError
+        val error = result.exceptionOrNull() as WooPosLocalCatalogError.NetworkError
         assertThat(error.errorMessage).contains("Network error")
         verifyNoInteractions(posVariationsDao)
     }
@@ -421,7 +421,7 @@ class PosLocalCatalogStoreTest {
 
         // THEN
         assertThat(result.isFailure).isTrue()
-        assertThat(result.exceptionOrNull()).isInstanceOf(PosLocalCatalogError.DatabaseError::class.java)
+        assertThat(result.exceptionOrNull()).isInstanceOf(WooPosLocalCatalogError.DatabaseError::class.java)
     }
 
     @Test
@@ -498,7 +498,7 @@ class PosLocalCatalogStoreTest {
 
         // THEN
         assertThat(result.isFailure).isTrue()
-        assertThat(result.exceptionOrNull()).isInstanceOf(PosLocalCatalogError.EmptyResponse::class.java)
+        assertThat(result.exceptionOrNull()).isInstanceOf(WooPosLocalCatalogError.EmptyResponse::class.java)
     }
 
     @Test
@@ -517,7 +517,7 @@ class PosLocalCatalogStoreTest {
 
         // THEN
         assertThat(result.isFailure).isTrue()
-        val error = result.exceptionOrNull() as PosLocalCatalogError.NetworkError
+        val error = result.exceptionOrNull() as WooPosLocalCatalogError.NetworkError
         assertThat(error.errorMessage).contains("Network request failed")
         assertThat(error.code).isEqualTo("API_ERROR")
     }
@@ -556,7 +556,7 @@ class PosLocalCatalogStoreTest {
 
         // THEN
         assertThat(result.isFailure).isTrue()
-        assertThat(result.exceptionOrNull()).isInstanceOf(PosLocalCatalogError.EmptyResponse::class.java)
+        assertThat(result.exceptionOrNull()).isInstanceOf(WooPosLocalCatalogError.EmptyResponse::class.java)
     }
 
     @Test
@@ -576,7 +576,7 @@ class PosLocalCatalogStoreTest {
 
         // THEN
         assertThat(result.isFailure).isTrue()
-        val error = result.exceptionOrNull() as PosLocalCatalogError.NetworkError
+        val error = result.exceptionOrNull() as WooPosLocalCatalogError.NetworkError
         assertThat(error.errorMessage).contains("Request timed out")
         assertThat(error.code).isEqualTo("TIMEOUT")
     }
@@ -612,7 +612,7 @@ class PosLocalCatalogStoreTest {
 
         // THEN
         assertThat(result.isFailure).isTrue()
-        val error = result.exceptionOrNull() as PosLocalCatalogError.InvalidResponse
+        val error = result.exceptionOrNull() as WooPosLocalCatalogError.InvalidResponse
         assertThat(error.message).isEqualTo("Missing job ID in response")
     }
 
@@ -632,7 +632,7 @@ class PosLocalCatalogStoreTest {
 
         // THEN
         assertThat(result.isFailure).isTrue()
-        val error = result.exceptionOrNull() as PosLocalCatalogError.InvalidResponse
+        val error = result.exceptionOrNull() as WooPosLocalCatalogError.InvalidResponse
         assertThat(error.message).isEqualTo("Missing job ID in response")
     }
 
@@ -652,7 +652,7 @@ class PosLocalCatalogStoreTest {
 
         // THEN
         assertThat(result.isFailure).isTrue()
-        val error = result.exceptionOrNull() as PosLocalCatalogError.InvalidResponse
+        val error = result.exceptionOrNull() as WooPosLocalCatalogError.InvalidResponse
         assertThat(error.message).isEqualTo("Missing job ID in response")
     }
 


### PR DESCRIPTION
Fixes WOOMOB-1214

### Description
This PR adds the WooPos prefix to all classes related to the Local Catalog project to maintain consistent naming conventions and clearly identify POS-specific components.

### Testing information
The changes in this PR are primarily renaming/refactoring changes. All existing unit tests have been updated to use the new class names and continue to pass. No functional changes were made, only class naming updates.

### The tests that have been performed
- Verified all unit tests pass with the renamed classes

### Images/gif
N/A - This is a refactoring change with no UI impact.

- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.