### PR TITLE
[WOOMOB-1043] Extract scanning setup dialog from home to POS root

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/WooPosHomeScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/WooPosHomeScreen.kt
@@ -37,11 +37,11 @@ import com.woocommerce.android.ui.woopos.home.cart.WooPosCartScreen
 import com.woocommerce.android.ui.woopos.home.cart.WooPosCartScreenProductsPreview
 import com.woocommerce.android.ui.woopos.home.items.WooPosItemsScreen
 import com.woocommerce.android.ui.woopos.home.items.products.WooPosItemsScreenPreview
-import com.woocommerce.android.ui.woopos.scanningsetup.WooPosScanningSetupDialog
 import com.woocommerce.android.ui.woopos.home.toolbar.PreviewWooPosFloatingToolbarStatusConnectedWithMenu
 import com.woocommerce.android.ui.woopos.home.toolbar.WooPosFloatingToolbar
 import com.woocommerce.android.ui.woopos.home.totals.WooPosTotalsScreen
 import com.woocommerce.android.ui.woopos.home.totals.WooPosTotalsScreenPreview
+import com.woocommerce.android.ui.woopos.scanningsetup.WooPosScanningSetupDialog
 import org.wordpress.android.util.ToastUtils
 
 @Composable

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/WooPosHomeScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/WooPosHomeScreen.kt
@@ -37,7 +37,7 @@ import com.woocommerce.android.ui.woopos.home.cart.WooPosCartScreen
 import com.woocommerce.android.ui.woopos.home.cart.WooPosCartScreenProductsPreview
 import com.woocommerce.android.ui.woopos.home.items.WooPosItemsScreen
 import com.woocommerce.android.ui.woopos.home.items.products.WooPosItemsScreenPreview
-import com.woocommerce.android.ui.woopos.home.scanningsetup.WooPosScanningSetupDialog
+import com.woocommerce.android.ui.woopos.scanningsetup.WooPosScanningSetupDialog
 import com.woocommerce.android.ui.woopos.home.toolbar.PreviewWooPosFloatingToolbarStatusConnectedWithMenu
 import com.woocommerce.android.ui.woopos.home.toolbar.WooPosFloatingToolbar
 import com.woocommerce.android.ui.woopos.home.totals.WooPosTotalsScreen

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/scanningsetup/WooPosScannerDetectionServiceForTracking.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/scanningsetup/WooPosScannerDetectionServiceForTracking.kt
@@ -1,8 +1,8 @@
-package com.woocommerce.android.ui.woopos.home.scanningsetup
+package com.woocommerce.android.ui.woopos.scanningsetup
 
 import com.woocommerce.android.ui.woopos.common.util.ScannerInfo
 import com.woocommerce.android.ui.woopos.common.util.WooPosScannerDetectionUtil
-import com.woocommerce.android.ui.woopos.home.scanningsetup.WooPosScanningSetupState.BarcodeReaderDevice
+import com.woocommerce.android.ui.woopos.scanningsetup.WooPosScanningSetupState.BarcodeReaderDevice
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.delay

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/scanningsetup/WooPosScannerSetupNavigator.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/scanningsetup/WooPosScannerSetupNavigator.kt
@@ -1,8 +1,8 @@
-package com.woocommerce.android.ui.woopos.home.scanningsetup
+package com.woocommerce.android.ui.woopos.scanningsetup
 
-import com.woocommerce.android.ui.woopos.home.scanningsetup.WooPosScanningSetupState.BarcodeReaderDevice
-import com.woocommerce.android.ui.woopos.home.scanningsetup.WooPosScanningSetupState.ScannerConfigurations
-import com.woocommerce.android.ui.woopos.home.scanningsetup.WooPosScanningSetupState.ScanningSetupStep
+import com.woocommerce.android.ui.woopos.scanningsetup.WooPosScanningSetupState.BarcodeReaderDevice
+import com.woocommerce.android.ui.woopos.scanningsetup.WooPosScanningSetupState.ScannerConfigurations
+import com.woocommerce.android.ui.woopos.scanningsetup.WooPosScanningSetupState.ScanningSetupStep
 import javax.inject.Inject
 
 class WooPosScannerSetupNavigator @Inject constructor() {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/scanningsetup/WooPosScanningSetupAnalyticsTracker.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/scanningsetup/WooPosScanningSetupAnalyticsTracker.kt
@@ -1,7 +1,7 @@
-package com.woocommerce.android.ui.woopos.home.scanningsetup
+package com.woocommerce.android.ui.woopos.scanningsetup
 
-import com.woocommerce.android.ui.woopos.home.scanningsetup.WooPosScanningSetupState.BarcodeReaderDevice
-import com.woocommerce.android.ui.woopos.home.scanningsetup.WooPosScanningSetupState.ScanningSetupStep
+import com.woocommerce.android.ui.woopos.scanningsetup.WooPosScanningSetupState.BarcodeReaderDevice
+import com.woocommerce.android.ui.woopos.scanningsetup.WooPosScanningSetupState.ScanningSetupStep
 import com.woocommerce.android.ui.woopos.util.analytics.WooPosAnalyticsEvent
 import com.woocommerce.android.ui.woopos.util.analytics.WooPosAnalyticsTracker
 import javax.inject.Inject

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/scanningsetup/WooPosScanningSetupDialog.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/scanningsetup/WooPosScanningSetupDialog.kt
@@ -1,6 +1,7 @@
-package com.woocommerce.android.ui.woopos.home.scanningsetup
+package com.woocommerce.android.ui.woopos.scanningsetup
 
 import android.content.ActivityNotFoundException
+import android.content.Context
 import android.content.Intent
 import android.provider.Settings
 import androidx.annotation.DrawableRes
@@ -86,8 +87,8 @@ import com.woocommerce.android.ui.woopos.common.composeui.designsystem.WooPosTyp
 import com.woocommerce.android.ui.woopos.common.composeui.designsystem.toAdaptivePadding
 import com.woocommerce.android.ui.woopos.common.composeui.modifier.listenForBarcodes
 import com.woocommerce.android.ui.woopos.common.data.WOO_POS_BARCODE_DOC_URL
-import com.woocommerce.android.ui.woopos.home.scanningsetup.WooPosScanningSetupState.BarcodeReaderDevice
-import com.woocommerce.android.ui.woopos.home.scanningsetup.WooPosScanningSetupState.ScanningSetupStep
+import com.woocommerce.android.ui.woopos.scanningsetup.WooPosScanningSetupState.BarcodeReaderDevice
+import com.woocommerce.android.ui.woopos.scanningsetup.WooPosScanningSetupState.ScanningSetupStep
 import com.woocommerce.android.util.ChromeCustomTabUtils
 import com.woocommerce.android.util.WooLog
 import kotlinx.coroutines.delay
@@ -808,7 +809,7 @@ private fun ScannerSetupInfoContent(
 @Composable
 private fun EventListeners(
     viewModel: WooPosScanningSetupViewModel,
-    context: android.content.Context,
+    context: Context,
     onDismissRequestWrapper: () -> Unit
 ) {
     LaunchedEffect(Unit) {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/scanningsetup/WooPosScanningSetupState.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/scanningsetup/WooPosScanningSetupState.kt
@@ -1,4 +1,4 @@
-package com.woocommerce.android.ui.woopos.home.scanningsetup
+package com.woocommerce.android.ui.woopos.scanningsetup
 
 import android.os.Parcelable
 import androidx.annotation.DrawableRes

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/scanningsetup/WooPosScanningSetupUiEvent.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/scanningsetup/WooPosScanningSetupUiEvent.kt
@@ -1,7 +1,7 @@
-package com.woocommerce.android.ui.woopos.home.scanningsetup
+package com.woocommerce.android.ui.woopos.scanningsetup
 
 import com.woocommerce.android.ui.woopos.common.composeui.modifier.BarcodeInputDetector
-import com.woocommerce.android.ui.woopos.home.scanningsetup.WooPosScanningSetupState.BarcodeReaderDevice
+import com.woocommerce.android.ui.woopos.scanningsetup.WooPosScanningSetupState.BarcodeReaderDevice
 
 sealed class WooPosScanningSetupUiEvent {
     data object OnDialogShown : WooPosScanningSetupUiEvent()

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/scanningsetup/WooPosScanningSetupViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/scanningsetup/WooPosScanningSetupViewModel.kt
@@ -1,10 +1,10 @@
-package com.woocommerce.android.ui.woopos.home.scanningsetup
+package com.woocommerce.android.ui.woopos.scanningsetup
 
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.woocommerce.android.ui.woopos.common.composeui.modifier.BarcodeInputDetector
-import com.woocommerce.android.ui.woopos.home.scanningsetup.WooPosScanningSetupState.Companion.TEST_BARCODE_EAN13
-import com.woocommerce.android.ui.woopos.home.scanningsetup.WooPosScanningSetupState.ScanningSetupStep
+import com.woocommerce.android.ui.woopos.scanningsetup.WooPosScanningSetupState.Companion.TEST_BARCODE_EAN13
+import com.woocommerce.android.ui.woopos.scanningsetup.WooPosScanningSetupState.ScanningSetupStep
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.delay

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/settings/WooPosSettingsScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/settings/WooPosSettingsScreen.kt
@@ -17,8 +17,8 @@ import com.woocommerce.android.R
 import com.woocommerce.android.ui.woopos.common.composeui.WooPosPreview
 import com.woocommerce.android.ui.woopos.common.composeui.component.WooPosToolbar
 import com.woocommerce.android.ui.woopos.common.composeui.designsystem.WooPosTheme
-import com.woocommerce.android.ui.woopos.scanningsetup.WooPosScanningSetupDialog
 import com.woocommerce.android.ui.woopos.root.navigation.WooPosNavigationEvent
+import com.woocommerce.android.ui.woopos.scanningsetup.WooPosScanningSetupDialog
 import com.woocommerce.android.ui.woopos.settings.categories.WooPosSettingsCategoriesPaneScreen
 import com.woocommerce.android.ui.woopos.settings.categories.WooPosSettingsCategory
 import com.woocommerce.android.ui.woopos.settings.details.WooPosSettingsDetailPaneScreen

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/settings/WooPosSettingsScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/settings/WooPosSettingsScreen.kt
@@ -17,7 +17,7 @@ import com.woocommerce.android.R
 import com.woocommerce.android.ui.woopos.common.composeui.WooPosPreview
 import com.woocommerce.android.ui.woopos.common.composeui.component.WooPosToolbar
 import com.woocommerce.android.ui.woopos.common.composeui.designsystem.WooPosTheme
-import com.woocommerce.android.ui.woopos.home.scanningsetup.WooPosScanningSetupDialog
+import com.woocommerce.android.ui.woopos.scanningsetup.WooPosScanningSetupDialog
 import com.woocommerce.android.ui.woopos.root.navigation.WooPosNavigationEvent
 import com.woocommerce.android.ui.woopos.settings.categories.WooPosSettingsCategoriesPaneScreen
 import com.woocommerce.android.ui.woopos.settings.categories.WooPosSettingsCategory

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/scanningsetup/WooPosScannerSetupNavigatorTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/scanningsetup/WooPosScannerSetupNavigatorTest.kt
@@ -1,8 +1,8 @@
-package com.woocommerce.android.ui.woopos.home.scanningsetup
+package com.woocommerce.android.ui.woopos.scanningsetup
 
 import com.woocommerce.android.R
-import com.woocommerce.android.ui.woopos.home.scanningsetup.WooPosScanningSetupState.BarcodeReaderDevice
-import com.woocommerce.android.ui.woopos.home.scanningsetup.WooPosScanningSetupState.ScanningSetupStep
+import com.woocommerce.android.ui.woopos.scanningsetup.WooPosScanningSetupState.BarcodeReaderDevice
+import com.woocommerce.android.ui.woopos.scanningsetup.WooPosScanningSetupState.ScanningSetupStep
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.Test
 

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/scanningsetup/WooPosScanningSetupViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/scanningsetup/WooPosScanningSetupViewModelTest.kt
@@ -4,14 +4,9 @@ import app.cash.turbine.test
 import com.woocommerce.android.R
 import com.woocommerce.android.model.UiString
 import com.woocommerce.android.ui.woopos.common.composeui.modifier.BarcodeInputDetector
-import com.woocommerce.android.ui.woopos.scanningsetup.WooPosScannerDetectionServiceForTracking
-import com.woocommerce.android.ui.woopos.scanningsetup.WooPosScannerSetupNavigator
-import com.woocommerce.android.ui.woopos.scanningsetup.WooPosScanningSetupAnalyticsTracker
 import com.woocommerce.android.ui.woopos.scanningsetup.WooPosScanningSetupState.BarcodeReaderDevice
 import com.woocommerce.android.ui.woopos.scanningsetup.WooPosScanningSetupState.Companion.TEST_BARCODE_EAN13
 import com.woocommerce.android.ui.woopos.scanningsetup.WooPosScanningSetupState.ScanningSetupStep
-import com.woocommerce.android.ui.woopos.scanningsetup.WooPosScanningSetupUiEvent
-import com.woocommerce.android.ui.woopos.scanningsetup.WooPosScanningSetupViewModel
 import com.woocommerce.android.ui.woopos.util.WooPosCoroutineTestRule
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.advanceTimeBy

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/scanningsetup/WooPosScanningSetupViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/scanningsetup/WooPosScanningSetupViewModelTest.kt
@@ -1,12 +1,17 @@
-package com.woocommerce.android.ui.woopos.home.scanningsetup
+package com.woocommerce.android.ui.woopos.scanningsetup
 
 import app.cash.turbine.test
 import com.woocommerce.android.R
 import com.woocommerce.android.model.UiString
 import com.woocommerce.android.ui.woopos.common.composeui.modifier.BarcodeInputDetector
-import com.woocommerce.android.ui.woopos.home.scanningsetup.WooPosScanningSetupState.BarcodeReaderDevice
-import com.woocommerce.android.ui.woopos.home.scanningsetup.WooPosScanningSetupState.Companion.TEST_BARCODE_EAN13
-import com.woocommerce.android.ui.woopos.home.scanningsetup.WooPosScanningSetupState.ScanningSetupStep
+import com.woocommerce.android.ui.woopos.scanningsetup.WooPosScannerDetectionServiceForTracking
+import com.woocommerce.android.ui.woopos.scanningsetup.WooPosScannerSetupNavigator
+import com.woocommerce.android.ui.woopos.scanningsetup.WooPosScanningSetupAnalyticsTracker
+import com.woocommerce.android.ui.woopos.scanningsetup.WooPosScanningSetupState.BarcodeReaderDevice
+import com.woocommerce.android.ui.woopos.scanningsetup.WooPosScanningSetupState.Companion.TEST_BARCODE_EAN13
+import com.woocommerce.android.ui.woopos.scanningsetup.WooPosScanningSetupState.ScanningSetupStep
+import com.woocommerce.android.ui.woopos.scanningsetup.WooPosScanningSetupUiEvent
+import com.woocommerce.android.ui.woopos.scanningsetup.WooPosScanningSetupViewModel
 import com.woocommerce.android.ui.woopos.util.WooPosCoroutineTestRule
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.advanceTimeBy


### PR DESCRIPTION
WOOMOB-1043

### Description
Moved the scanning setup dialog from the home package to the root POS package to make it placed correctly as it's used from both the home screen and settings screen now

### Steps to reproduce
1. Open POS home screen
2. Verify scanning setup dialog works as before
3. Navigate to POS settings
4. Verify scanning setup dialog is accessible from settings

### Testing information
Tested on tablet and phone devices. Both home and settings screens can now access the scanning setup dialog.

### The tests that have been performed
- Unit tests pass for the moved components
- Manual testing of scanning setup from both entry points

- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.