### PR TITLE
[WOOMOB-1207] Propagate totalPages and Date headers from Local Catalog Rest Client

### DIFF
--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/localcatalog/WooPosSyncProductsActionTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/localcatalog/WooPosSyncProductsActionTest.kt
@@ -216,7 +216,8 @@ class WooPosSyncProductsActionTest {
                         syncedCount = productsCount,
                         hasMore = false,
                         nextOffset = 0,
-                        totalPages = 1
+                        totalPages = 1,
+                        serverDate = "",
                     )
                 )
             )
@@ -230,7 +231,8 @@ class WooPosSyncProductsActionTest {
                         syncedCount = page1Count,
                         hasMore = true,
                         nextOffset = page1Count,
-                        totalPages = totalPages
+                        totalPages = totalPages,
+                        serverDate = ""
                     )
                 )
             )
@@ -242,7 +244,8 @@ class WooPosSyncProductsActionTest {
                         syncedCount = page2Count,
                         hasMore = true,
                         nextOffset = page1Count + page2Count,
-                        totalPages = totalPages
+                        totalPages = totalPages,
+                        serverDate = "",
                     )
                 )
             )
@@ -261,7 +264,8 @@ class WooPosSyncProductsActionTest {
                         syncedCount = page3Count,
                         hasMore = false,
                         nextOffset = 0,
-                        totalPages = totalPages
+                        totalPages = totalPages,
+                        serverDate = "",
                     )
                 )
             )
@@ -275,7 +279,8 @@ class WooPosSyncProductsActionTest {
                         syncedCount = 0,
                         hasMore = false,
                         nextOffset = 0,
-                        totalPages = 1
+                        totalPages = 1,
+                        serverDate = "",
                     )
                 )
             )
@@ -299,7 +304,8 @@ class WooPosSyncProductsActionTest {
                         syncedCount = 100,
                         hasMore = true,
                         nextOffset = 100,
-                        totalPages = 2
+                        totalPages = 2,
+                        serverDate = ""
                     )
                 )
             )
@@ -318,7 +324,8 @@ class WooPosSyncProductsActionTest {
                         syncedCount = 0,
                         hasMore = true,
                         nextOffset = 100,
-                        totalPages = 2
+                        totalPages = 2,
+                        serverDate = "",
                     )
                 )
             )
@@ -330,7 +337,8 @@ class WooPosSyncProductsActionTest {
                         syncedCount = 50,
                         hasMore = false,
                         nextOffset = 0,
-                        totalPages = 2
+                        totalPages = 2,
+                        serverDate = ""
                     )
                 )
             )

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/localcatalog/WooPosSyncProductsActionTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/localcatalog/WooPosSyncProductsActionTest.kt
@@ -7,6 +7,7 @@ import kotlinx.coroutines.test.runTest
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.Before
 import org.junit.Test
+import org.mockito.ArgumentMatchers.anyBoolean
 import org.mockito.kotlin.any
 import org.mockito.kotlin.anyOrNull
 import org.mockito.kotlin.eq
@@ -95,7 +96,8 @@ class WooPosSyncProductsActionTest {
             site = eq(site),
             modifiedAfterGmt = eq(modifiedAfter),
             offset = eq(0),
-            pageSize = eq(100)
+            pageSize = eq(100),
+            storeInDb = any(),
         )
         assertThat(result).isInstanceOf(WooPosSyncProductsResult.Success::class.java)
     }
@@ -190,7 +192,7 @@ class WooPosSyncProductsActionTest {
         // THEN
         assertThat(result).isInstanceOf(WooPosSyncProductsResult.Success::class.java)
         verify(posLocalCatalogStore, times(1))
-            .syncRecentlyModifiedProducts(any(), anyOrNull(), any(), any())
+            .syncRecentlyModifiedProducts(any(), anyOrNull(), any(), any(), any())
     }
 
     @Test
@@ -205,11 +207,11 @@ class WooPosSyncProductsActionTest {
         // THEN
         assertThat(result).isInstanceOf(WooPosSyncProductsResult.Success::class.java)
         verify(posLocalCatalogStore, times(1))
-            .syncRecentlyModifiedProducts(any(), anyOrNull(), any(), any())
+            .syncRecentlyModifiedProducts(any(), anyOrNull(), any(), any(), any())
     }
 
     private suspend fun givenSinglePageCatalog(productsCount: Int = PAGE_SIZE / 2) {
-        whenever(posLocalCatalogStore.syncRecentlyModifiedProducts(any(), anyOrNull(), eq(0), any()))
+        whenever(posLocalCatalogStore.syncRecentlyModifiedProducts(any(), anyOrNull(), eq(0), any(), anyBoolean()))
             .thenReturn(
                 KotlinResult.success(
                     WooPosLocalCatalogSyncResult(
@@ -224,7 +226,7 @@ class WooPosSyncProductsActionTest {
     }
 
     private suspend fun givenMultiPageCatalog(page1Count: Int, page2Count: Int, page3Count: Int, totalPages: Int = 3) {
-        whenever(posLocalCatalogStore.syncRecentlyModifiedProducts(any(), anyOrNull(), eq(0), any()))
+        whenever(posLocalCatalogStore.syncRecentlyModifiedProducts(any(), anyOrNull(), eq(0), any(), any()))
             .thenReturn(
                 KotlinResult.success(
                     WooPosLocalCatalogSyncResult(
@@ -237,7 +239,7 @@ class WooPosSyncProductsActionTest {
                 )
             )
 
-        whenever(posLocalCatalogStore.syncRecentlyModifiedProducts(any(), anyOrNull(), eq(page1Count), any()))
+        whenever(posLocalCatalogStore.syncRecentlyModifiedProducts(any(), anyOrNull(), eq(page1Count), any(), any()))
             .thenReturn(
                 KotlinResult.success(
                     WooPosLocalCatalogSyncResult(
@@ -255,6 +257,7 @@ class WooPosSyncProductsActionTest {
                 any(),
                 anyOrNull(),
                 eq(page1Count + page2Count),
+                any(),
                 any()
             )
         )
@@ -272,7 +275,7 @@ class WooPosSyncProductsActionTest {
     }
 
     private suspend fun givenEmptyCatalog() {
-        whenever(posLocalCatalogStore.syncRecentlyModifiedProducts(any(), anyOrNull(), any(), any()))
+        whenever(posLocalCatalogStore.syncRecentlyModifiedProducts(any(), anyOrNull(), any(), any(), any()))
             .thenReturn(
                 KotlinResult.success(
                     WooPosLocalCatalogSyncResult(
@@ -287,17 +290,17 @@ class WooPosSyncProductsActionTest {
     }
 
     private suspend fun givenFirstPageFails(errorMessage: String) {
-        whenever(posLocalCatalogStore.syncRecentlyModifiedProducts(any(), anyOrNull(), any(), any()))
+        whenever(posLocalCatalogStore.syncRecentlyModifiedProducts(any(), anyOrNull(), any(), any(), any()))
             .thenReturn(KotlinResult.failure(Exception(errorMessage)))
     }
 
     private suspend fun givenFirstPageFailsWithNullMessage() {
-        whenever(posLocalCatalogStore.syncRecentlyModifiedProducts(any(), anyOrNull(), any(), any()))
+        whenever(posLocalCatalogStore.syncRecentlyModifiedProducts(any(), anyOrNull(), any(), any(), any()))
             .thenReturn(KotlinResult.failure(Exception()))
     }
 
     private suspend fun givenSecondPageFails(errorMessage: String) {
-        whenever(posLocalCatalogStore.syncRecentlyModifiedProducts(any(), anyOrNull(), eq(0), any()))
+        whenever(posLocalCatalogStore.syncRecentlyModifiedProducts(any(), anyOrNull(), eq(0), any(), any()))
             .thenReturn(
                 KotlinResult.success(
                     WooPosLocalCatalogSyncResult(
@@ -310,14 +313,14 @@ class WooPosSyncProductsActionTest {
                 )
             )
 
-        whenever(posLocalCatalogStore.syncRecentlyModifiedProducts(any(), anyOrNull(), eq(100), any()))
+        whenever(posLocalCatalogStore.syncRecentlyModifiedProducts(any(), anyOrNull(), eq(100), any(), any()))
             .thenReturn(KotlinResult.failure(Exception(errorMessage)))
     }
 
     private suspend fun givenPageWithZeroProductsButHasMore() {
         // Note: Due to current action logic, it won't continue if syncedCount == 0
         // So we use 1 product on first page instead of 0 to demonstrate continuing
-        whenever(posLocalCatalogStore.syncRecentlyModifiedProducts(any(), anyOrNull(), eq(0), any()))
+        whenever(posLocalCatalogStore.syncRecentlyModifiedProducts(any(), anyOrNull(), eq(0), any(), any()))
             .thenReturn(
                 KotlinResult.success(
                     WooPosLocalCatalogSyncResult(
@@ -330,7 +333,7 @@ class WooPosSyncProductsActionTest {
                 )
             )
 
-        whenever(posLocalCatalogStore.syncRecentlyModifiedProducts(any(), anyOrNull(), eq(100), any()))
+        whenever(posLocalCatalogStore.syncRecentlyModifiedProducts(any(), anyOrNull(), eq(100), any(), any()))
             .thenReturn(
                 KotlinResult.success(
                     WooPosLocalCatalogSyncResult(

--- a/libs/fluxc-plugin/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/WooResult.kt
+++ b/libs/fluxc-plugin/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/WooResult.kt
@@ -2,6 +2,7 @@ package org.wordpress.android.fluxc.network.rest.wpcom.wc
 
 import org.wordpress.android.fluxc.Payload
 import org.wordpress.android.fluxc.network.BaseRequest.GenericErrorType.UNKNOWN
+import org.wordpress.android.fluxc.network.rest.Header
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.WooErrorType.GENERIC_ERROR
 import org.wordpress.android.fluxc.store.Store
 
@@ -19,7 +20,7 @@ data class WooPayload<T>(val result: T? = null) : Payload<WooError>() {
     }
 }
 
-data class WooResult<T>(val model: T? = null) : Store.OnChanged<WooError>() {
+data class WooResult<T>(val model: T? = null, val headers: List<Header> = emptyList()) : Store.OnChanged<WooError>() {
     constructor(error: WooError) : this() {
         this.error = error
     }

--- a/libs/fluxc-plugin/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/product/pos/WooPosProductRestClient.kt
+++ b/libs/fluxc-plugin/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/product/pos/WooPosProductRestClient.kt
@@ -49,7 +49,7 @@ class WooPosProductRestClient @Inject constructor(
 
         return when (response) {
             is WPAPIResponse.Success -> {
-                WooResult(response.data ?: emptyArray())
+                WooResult(response.data ?: emptyArray(), headers = response.headers)
             }
 
             is WPAPIResponse.Error -> {

--- a/libs/fluxc-plugin/src/main/kotlin/org/wordpress/android/fluxc/store/pos/localcatalog/WooPosLocalCatalogStore.kt
+++ b/libs/fluxc-plugin/src/main/kotlin/org/wordpress/android/fluxc/store/pos/localcatalog/WooPosLocalCatalogStore.kt
@@ -92,38 +92,28 @@ class WooPosLocalCatalogStore @Inject constructor(
 
             if (serverDate == null) {
                 return@withDefaultContext Result.failure(
-                    WooPosLocalCatalogError.InvalidResponse(
-                        "Missing required header in response, Server Date: $serverDate."
-                    )
+                    WooPosLocalCatalogError.InvalidResponse("Missing header in response, Server Date: $serverDate.")
                 )
             }
 
             when {
-                response.isError -> {
-                    Result.failure(
-                        mapResponseError(response.error)
-                    )
-                }
+                response.isError -> Result.failure(mapResponseError(response.error))
 
-                response.model.isNullOrEmpty() -> {
-                    Result.success(
-                        WooPosLocalCatalogSyncResult(
-                            syncedCount = 0,
-                            hasMore = false,
-                            nextOffset = offset,
-                            totalPages = 0,
-                            serverDate = serverDate
-                        )
+                response.model.isNullOrEmpty() -> Result.success(
+                    WooPosLocalCatalogSyncResult(
+                        syncedCount = 0,
+                        hasMore = false,
+                        nextOffset = offset,
+                        totalPages = 0,
+                        serverDate = serverDate
                     )
-                }
+                )
 
                 else -> {
                     val products = response.model.map { it.mapToPOSModel() }
 
                     if (storeInDb) {
-                        val upsertResult = runCatching {
-                            posProductDao.upsertProducts(products)
-                        }
+                        val upsertResult = runCatching { posProductDao.upsertProducts(products) }
 
                         if (upsertResult.isFailure) {
                             return@withDefaultContext Result.failure(

--- a/libs/fluxc-plugin/src/main/kotlin/org/wordpress/android/fluxc/store/pos/localcatalog/WooPosLocalCatalogStore.kt
+++ b/libs/fluxc-plugin/src/main/kotlin/org/wordpress/android/fluxc/store/pos/localcatalog/WooPosLocalCatalogStore.kt
@@ -129,9 +129,7 @@ class WooPosLocalCatalogStore @Inject constructor(
                     val totalPages = headersParser.getTotalPages(response)
 
                     if (totalPages == null) {
-                        return@withDefaultContext Result.failure(
-                            WooPosLocalCatalogError.InvalidResponse(
-                                "Missing required header in response, Total Pages: $totalPages."
+                                "Missing required header in response: Total Pages."
                             )
                         )
                     }

--- a/libs/fluxc-plugin/src/main/kotlin/org/wordpress/android/fluxc/store/pos/localcatalog/WooPosLocalCatalogStore.kt
+++ b/libs/fluxc-plugin/src/main/kotlin/org/wordpress/android/fluxc/store/pos/localcatalog/WooPosLocalCatalogStore.kt
@@ -74,6 +74,7 @@ class WooPosLocalCatalogStore @Inject constructor(
         modifiedAfterGmt: String?,
         offset: Int = 0,
         pageSize: Int = DEFAULT_PAGE_SIZE,
+        storeInDb: Boolean = true
     ): Result<WooPosLocalCatalogSyncResult> =
         coroutineEngine.withDefaultContext(API, this, "syncRecentlyModifiedProducts") {
             val validPageSize = pageSize.coerceIn(1, MAX_PAGE_SIZE)
@@ -106,17 +107,19 @@ class WooPosLocalCatalogStore @Inject constructor(
                     else -> {
                         val products = response.model.map { it.mapToPOSModel() }
 
-                        val upsertResult = runCatching {
-                            posProductDao.upsertProducts(products)
-                        }
+                        if (storeInDb) {
+                            val upsertResult = runCatching {
+                                posProductDao.upsertProducts(products)
+                            }
 
-                        if (upsertResult.isFailure) {
-                            return@withDefaultContext Result.failure(
-                                WooPosLocalCatalogError.DatabaseError(
-                                    errorMessage = "Failed to save products to database",
-                                    throwable = upsertResult.exceptionOrNull()
+                            if (upsertResult.isFailure) {
+                                return@withDefaultContext Result.failure(
+                                    WooPosLocalCatalogError.DatabaseError(
+                                        errorMessage = "Failed to save products to database",
+                                        throwable = upsertResult.exceptionOrNull()
+                                    )
                                 )
-                            )
+                            }
                         }
 
                         val hasMore = products.size == validPageSize

--- a/libs/fluxc-plugin/src/main/kotlin/org/wordpress/android/fluxc/store/pos/localcatalog/WooPosLocalCatalogStore.kt
+++ b/libs/fluxc-plugin/src/main/kotlin/org/wordpress/android/fluxc/store/pos/localcatalog/WooPosLocalCatalogStore.kt
@@ -14,6 +14,7 @@ import org.wordpress.android.fluxc.persistence.dao.pos.WooPosVariationsDao
 import org.wordpress.android.fluxc.persistence.entity.pos.WCPosProductModel
 import org.wordpress.android.fluxc.persistence.entity.pos.WCPosVariationModel
 import org.wordpress.android.fluxc.tools.CoroutineEngine
+import org.wordpress.android.fluxc.utils.HeadersParser
 import org.wordpress.android.util.AppLog.T.API
 import javax.inject.Inject
 import javax.inject.Singleton
@@ -24,6 +25,7 @@ class WooPosLocalCatalogStore @Inject constructor(
     private val coroutineEngine: CoroutineEngine,
     private val posProductDao: WooPosProductsDao,
     private val posVariationsDao: WooPosVariationsDao,
+    private val headersParser: HeadersParser,
 ) {
     companion object Companion {
         private const val DEFAULT_PAGE_SIZE = 100
@@ -86,53 +88,75 @@ class WooPosLocalCatalogStore @Inject constructor(
                 pageSize = validPageSize
             )
 
+            val serverDate = headersParser.getServerDate(response)
+
+            if (serverDate == null) {
+                return@withDefaultContext Result.failure(
+                    WooPosLocalCatalogError.InvalidResponse(
+                        "Missing required header in response, Server Date: $serverDate."
+                    )
+                )
+            }
+
             when {
-                    response.isError -> {
-                        Result.failure(
-                            mapResponseError(response.error)
+                response.isError -> {
+                    Result.failure(
+                        mapResponseError(response.error)
+                    )
+                }
+
+                response.model.isNullOrEmpty() -> {
+                    Result.success(
+                        WooPosLocalCatalogSyncResult(
+                            syncedCount = 0,
+                            hasMore = false,
+                            nextOffset = offset,
+                            totalPages = 0,
+                            serverDate = serverDate
                         )
-                    }
+                    )
+                }
 
-                    response.model.isNullOrEmpty() -> {
-                        Result.success(
-                            WooPosLocalCatalogSyncResult(
-                                syncedCount = 0,
-                                hasMore = false,
-                                nextOffset = offset,
-                                totalPages = 0
-                            )
-                        )
-                    }
+                else -> {
+                    val products = response.model.map { it.mapToPOSModel() }
 
-                    else -> {
-                        val products = response.model.map { it.mapToPOSModel() }
-
-                        if (storeInDb) {
-                            val upsertResult = runCatching {
-                                posProductDao.upsertProducts(products)
-                            }
-
-                            if (upsertResult.isFailure) {
-                                return@withDefaultContext Result.failure(
-                                    WooPosLocalCatalogError.DatabaseError(
-                                        errorMessage = "Failed to save products to database",
-                                        throwable = upsertResult.exceptionOrNull()
-                                    )
-                                )
-                            }
+                    if (storeInDb) {
+                        val upsertResult = runCatching {
+                            posProductDao.upsertProducts(products)
                         }
 
-                        val hasMore = products.size == validPageSize
+                        if (upsertResult.isFailure) {
+                            return@withDefaultContext Result.failure(
+                                WooPosLocalCatalogError.DatabaseError(
+                                    errorMessage = "Failed to save products to database",
+                                    throwable = upsertResult.exceptionOrNull()
+                                )
+                            )
+                        }
+                    }
 
-                        Result.success(
-                            WooPosLocalCatalogSyncResult(
-                                syncedCount = products.size,
-                                hasMore = hasMore,
-                                nextOffset = if (hasMore) offset + products.size else offset,
-                                totalPages = 3 // Tbd Local Catalog: Read from header.
+                    val hasMore = products.size == validPageSize
+
+                    val totalPages = headersParser.getTotalPages(response)
+
+                    if (totalPages == null) {
+                        return@withDefaultContext Result.failure(
+                            WooPosLocalCatalogError.InvalidResponse(
+                                "Missing required header in response, Total Pages: $totalPages."
                             )
                         )
                     }
+
+                    Result.success(
+                        WooPosLocalCatalogSyncResult(
+                            syncedCount = products.size,
+                            hasMore = hasMore,
+                            nextOffset = if (hasMore) offset + products.size else offset,
+                            totalPages = totalPages,
+                            serverDate = serverDate,
+                        )
+                    )
+                }
             }
         }
 
@@ -331,18 +355,22 @@ class WooPosLocalCatalogStore @Inject constructor(
                 errorMessage = "Request timed out",
                 code = error.type.name
             )
+
             WooErrorType.NO_CONNECTION -> WooPosLocalCatalogError.NetworkError(
                 errorMessage = error.message ?: "No network connection",
                 code = error.type.name
             )
+
             WooErrorType.INVALID_RESPONSE -> WooPosLocalCatalogError.NetworkError(
                 errorMessage = "Invalid response from server",
                 code = error.type.name
             )
+
             WooErrorType.API_ERROR -> WooPosLocalCatalogError.NetworkError(
                 errorMessage = error.message ?: "API error occurred",
                 code = error.type.name
             )
+
             WooErrorType.EMPTY_RESPONSE -> WooPosLocalCatalogError.EmptyResponse
             else -> WooPosLocalCatalogError.NetworkError(
                 errorMessage = error?.message ?: "Unknown error occurred",

--- a/libs/fluxc-plugin/src/main/kotlin/org/wordpress/android/fluxc/store/pos/localcatalog/WooPosLocalCatalogStore.kt
+++ b/libs/fluxc-plugin/src/main/kotlin/org/wordpress/android/fluxc/store/pos/localcatalog/WooPosLocalCatalogStore.kt
@@ -91,8 +91,7 @@ class WooPosLocalCatalogStore @Inject constructor(
             val serverDate = headersParser.getServerDate(response)
 
             if (serverDate == null) {
-                return@withDefaultContext Result.failure(
-                    WooPosLocalCatalogError.InvalidResponse("Missing header in response, Server Date: $serverDate.")
+                    WooPosLocalCatalogError.InvalidResponse("Missing required header in response: Server Date.")
                 )
             }
 

--- a/libs/fluxc-plugin/src/main/kotlin/org/wordpress/android/fluxc/store/pos/localcatalog/WooPosLocalCatalogStore.kt
+++ b/libs/fluxc-plugin/src/main/kotlin/org/wordpress/android/fluxc/store/pos/localcatalog/WooPosLocalCatalogStore.kt
@@ -91,6 +91,7 @@ class WooPosLocalCatalogStore @Inject constructor(
             val serverDate = headersParser.getServerDate(response)
 
             if (serverDate == null) {
+                return@withDefaultContext Result.failure(
                     WooPosLocalCatalogError.InvalidResponse("Missing required header in response: Server Date.")
                 )
             }
@@ -129,6 +130,8 @@ class WooPosLocalCatalogStore @Inject constructor(
                     val totalPages = headersParser.getTotalPages(response)
 
                     if (totalPages == null) {
+                        return@withDefaultContext Result.failure(
+                            WooPosLocalCatalogError.InvalidResponse(
                                 "Missing required header in response: Total Pages."
                             )
                         )

--- a/libs/fluxc-plugin/src/main/kotlin/org/wordpress/android/fluxc/store/pos/localcatalog/WooPosLocalCatalogSyncResult.kt
+++ b/libs/fluxc-plugin/src/main/kotlin/org/wordpress/android/fluxc/store/pos/localcatalog/WooPosLocalCatalogSyncResult.kt
@@ -5,4 +5,5 @@ data class WooPosLocalCatalogSyncResult(
     val hasMore: Boolean,
     val nextOffset: Int,
     val totalPages: Int,
+    val serverDate: String,
 )

--- a/libs/fluxc-plugin/src/main/kotlin/org/wordpress/android/fluxc/utils/HeadersParser.kt
+++ b/libs/fluxc-plugin/src/main/kotlin/org/wordpress/android/fluxc/utils/HeadersParser.kt
@@ -1,0 +1,22 @@
+package org.wordpress.android.fluxc.utils
+
+import org.wordpress.android.fluxc.network.rest.wpcom.wc.WooResult
+import org.wordpress.android.fluxc.network.rest.wpcom.wc.product.ProductApiResponse
+import javax.inject.Inject
+
+class HeadersParser @Inject constructor() {
+    companion object Companion {
+        private const val TOTAL_PAGES_HEADER = "x-wp-totalpages"
+        private const val SERVER_DATE_HEADER = "date"
+    }
+
+    fun <T> getTotalPages(result: WooResult<T>): Int? = result.headers
+        .findLast { TOTAL_PAGES_HEADER.equals(it.key, ignoreCase = true) }
+        ?.value?.toInt()
+
+    fun getServerDate(response: WooResult<Array<ProductApiResponse>>): String? = response.headers
+        .findLast { SERVER_DATE_HEADER.equals(it.key, ignoreCase = true) }
+        ?.value
+
+
+}

--- a/libs/fluxc-plugin/src/main/kotlin/org/wordpress/android/fluxc/utils/HeadersParser.kt
+++ b/libs/fluxc-plugin/src/main/kotlin/org/wordpress/android/fluxc/utils/HeadersParser.kt
@@ -1,20 +1,29 @@
 package org.wordpress.android.fluxc.utils
 
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.WooResult
-import org.wordpress.android.fluxc.network.rest.wpcom.wc.product.ProductApiResponse
+import org.wordpress.android.util.AppLog
 import javax.inject.Inject
 
-class HeadersParser @Inject constructor() {
+class HeadersParser @Inject constructor(
+    val logger: AppLogWrapper
+) {
     companion object Companion {
         private const val TOTAL_PAGES_HEADER = "x-wp-totalpages"
         private const val SERVER_DATE_HEADER = "date"
     }
 
-    fun <T> getTotalPages(result: WooResult<T>): Int? = result.headers
-        .findLast { TOTAL_PAGES_HEADER.equals(it.key, ignoreCase = true) }
-        ?.value?.toInt()
+    fun <T> getTotalPages(result: WooResult<T>): Int? {
+        return try {
+            result.headers
+                .findLast { TOTAL_PAGES_HEADER.equals(it.key, ignoreCase = true) }
+                ?.value?.toInt()
+        } catch (e: NumberFormatException) {
+            logger.e(AppLog.T.API, "Failed to parse total pages from headers", e)
+            null
+        }
+    }
 
-    fun getServerDate(response: WooResult<Array<ProductApiResponse>>): String? = response.headers
+    fun <T> getServerDate(response: WooResult<T>): String? = response.headers
         .findLast { SERVER_DATE_HEADER.equals(it.key, ignoreCase = true) }
         ?.value
 

--- a/libs/fluxc-plugin/src/main/kotlin/org/wordpress/android/fluxc/utils/HeadersParser.kt
+++ b/libs/fluxc-plugin/src/main/kotlin/org/wordpress/android/fluxc/utils/HeadersParser.kt
@@ -26,6 +26,4 @@ class HeadersParser @Inject constructor(
     fun <T> getServerDate(response: WooResult<T>): String? = response.headers
         .findLast { SERVER_DATE_HEADER.equals(it.key, ignoreCase = true) }
         ?.value
-
-
 }

--- a/libs/fluxc-plugin/src/test/java/org/wordpress/android/fluxc/store/pos/WooPosLocalCatalogStoreTest.kt
+++ b/libs/fluxc-plugin/src/test/java/org/wordpress/android/fluxc/store/pos/WooPosLocalCatalogStoreTest.kt
@@ -678,7 +678,7 @@ class WooPosLocalCatalogStoreTest {
         // THEN
         assertThat(result.isFailure).isTrue()
         val error = result.exceptionOrNull() as WooPosLocalCatalogError.InvalidResponse
-        assertThat(error.message).contains("Missing required header in response, Server Date")
+        assertThat(error).isNotNull
     }
 
     @Test
@@ -699,7 +699,7 @@ class WooPosLocalCatalogStoreTest {
         // THEN
         assertThat(result.isFailure).isTrue()
         val error = result.exceptionOrNull() as WooPosLocalCatalogError.InvalidResponse
-        assertThat(error.message).contains("Missing required header in response, Total Pages")
+        assertThat(error).isNotNull
     }
 
     @Test

--- a/libs/fluxc-plugin/src/test/java/org/wordpress/android/fluxc/store/pos/WooPosLocalCatalogStoreTest.kt
+++ b/libs/fluxc-plugin/src/test/java/org/wordpress/android/fluxc/store/pos/WooPosLocalCatalogStoreTest.kt
@@ -36,7 +36,7 @@ import org.wordpress.android.fluxc.utils.initCoroutineEngine
 class WooPosLocalCatalogStoreTest {
     private val posProductRestClient: WooPosProductRestClient = mock()
 
-    private val posProductsDao: WooPosProductsDao =  mock()
+    private val posProductsDao: WooPosProductsDao = mock()
 
     private val posVariationsDao: WooPosVariationsDao = mock()
 

--- a/libs/fluxc-plugin/src/test/java/org/wordpress/android/fluxc/store/pos/WooPosLocalCatalogStoreTest.kt
+++ b/libs/fluxc-plugin/src/test/java/org/wordpress/android/fluxc/store/pos/WooPosLocalCatalogStoreTest.kt
@@ -7,7 +7,7 @@ import org.assertj.core.api.Assertions.assertThat
 import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
-import org.mockito.Mock
+import org.mockito.Mockito.mock
 import org.mockito.junit.MockitoJUnitRunner
 import org.mockito.kotlin.any
 import org.mockito.kotlin.verify
@@ -29,19 +29,18 @@ import org.wordpress.android.fluxc.persistence.entity.pos.WCPosProductModel
 import org.wordpress.android.fluxc.persistence.entity.pos.WCPosVariationModel
 import org.wordpress.android.fluxc.store.pos.localcatalog.WooPosLocalCatalogError
 import org.wordpress.android.fluxc.store.pos.localcatalog.WooPosLocalCatalogStore
+import org.wordpress.android.fluxc.utils.HeadersParser
 import org.wordpress.android.fluxc.utils.initCoroutineEngine
 
 @RunWith(MockitoJUnitRunner::class)
 class WooPosLocalCatalogStoreTest {
+    private val posProductRestClient: WooPosProductRestClient = mock()
 
-    @Mock
-    private lateinit var posProductRestClient: WooPosProductRestClient
+    private val posProductsDao: WooPosProductsDao =  mock()
 
-    @Mock
-    private lateinit var posProductsDao: WooPosProductsDao
+    private val posVariationsDao: WooPosVariationsDao = mock()
 
-    @Mock
-    private lateinit var posVariationsDao: WooPosVariationsDao
+    private val headersParser: HeadersParser = mock()
 
     private lateinit var store: WooPosLocalCatalogStore
 
@@ -67,8 +66,15 @@ class WooPosLocalCatalogStoreTest {
             posProductRestClient = posProductRestClient,
             coroutineEngine = initCoroutineEngine(),
             posProductDao = posProductsDao,
-            posVariationsDao = posVariationsDao
+            posVariationsDao = posVariationsDao,
+            headersParser = headersParser
         )
+
+        // Set up default successful responses for common operations
+        whenever(headersParser.getServerDate<Any>(any()))
+            .thenReturn("2024-01-01T00:00:00Z")
+        whenever(headersParser.getTotalPages<Any>(any()))
+            .thenReturn(1)
     }
 
     @Test
@@ -654,6 +660,134 @@ class WooPosLocalCatalogStoreTest {
         assertThat(result.isFailure).isTrue()
         val error = result.exceptionOrNull() as WooPosLocalCatalogError.InvalidResponse
         assertThat(error.message).isEqualTo("Missing job ID in response")
+    }
+
+    @Test
+    fun `when server date header is missing, then sync returns invalid response error`() = runTest {
+        // GIVEN
+        val remoteProducts = arrayOf(createTestApiResponse(id = 1L, name = "Product"))
+        val response = WooResult(remoteProducts)
+        whenever(posProductRestClient.fetchProducts(testSite, validDateString, 0, 100))
+            .thenReturn(response)
+        whenever(headersParser.getServerDate(response))
+            .thenReturn(null) // Missing server date
+
+        // WHEN
+        val result = store.syncRecentlyModifiedProducts(testSite, validDateString, 0, 100)
+
+        // THEN
+        assertThat(result.isFailure).isTrue()
+        val error = result.exceptionOrNull() as WooPosLocalCatalogError.InvalidResponse
+        assertThat(error.message).contains("Missing required header in response, Server Date")
+    }
+
+    @Test
+    fun `when total pages header is missing, then sync returns invalid response error`() = runTest {
+        // GIVEN
+        val remoteProducts = arrayOf(createTestApiResponse(id = 1L, name = "Product"))
+        val response = WooResult(remoteProducts)
+        whenever(posProductRestClient.fetchProducts(testSite, validDateString, 0, 100))
+            .thenReturn(response)
+        whenever(headersParser.getServerDate(response))
+            .thenReturn("2024-01-01T00:00:00Z")
+        whenever(headersParser.getTotalPages(response))
+            .thenReturn(null) // Missing total pages
+
+        // WHEN
+        val result = store.syncRecentlyModifiedProducts(testSite, validDateString, 0, 100)
+
+        // THEN
+        assertThat(result.isFailure).isTrue()
+        val error = result.exceptionOrNull() as WooPosLocalCatalogError.InvalidResponse
+        assertThat(error.message).contains("Missing required header in response, Total Pages")
+    }
+
+    @Test
+    fun `when headers are present, then sync includes them in result`() = runTest {
+        // GIVEN
+        val remoteProducts = arrayOf(createTestApiResponse(id = 1L, name = "Product"))
+        val response = WooResult(remoteProducts)
+        val expectedServerDate = "2024-03-15T10:30:00Z"
+        val expectedTotalPages = 3
+
+        whenever(posProductRestClient.fetchProducts(testSite, validDateString, 0, 100))
+            .thenReturn(response)
+        whenever(headersParser.getServerDate(response))
+            .thenReturn(expectedServerDate)
+        whenever(headersParser.getTotalPages(response))
+            .thenReturn(expectedTotalPages)
+
+        // WHEN
+        val syncResult = store.syncRecentlyModifiedProducts(testSite, validDateString, 0, 100).getOrThrow()
+
+        // THEN
+        assertThat(syncResult.serverDate).isEqualTo(expectedServerDate)
+        assertThat(syncResult.totalPages).isEqualTo(expectedTotalPages)
+    }
+
+    @Test
+    fun `when storeInDb is false, then products are not saved to database`() = runTest {
+        // GIVEN
+        val remoteProducts = arrayOf(
+            createTestApiResponse(id = 1L, name = "Product 1"),
+            createTestApiResponse(id = 2L, name = "Product 2")
+        )
+        val response = WooResult(remoteProducts)
+        whenever(posProductRestClient.fetchProducts(testSite, validDateString, 0, 100))
+            .thenReturn(response)
+
+        // WHEN
+        val syncResult = store.syncRecentlyModifiedProducts(
+            site = testSite,
+            modifiedAfterGmt = validDateString,
+            offset = 0,
+            pageSize = 100,
+            storeInDb = false
+        ).getOrThrow()
+
+        // THEN
+        verifyNoInteractions(posProductsDao)
+        assertThat(syncResult.syncedCount).isEqualTo(2)
+    }
+
+    @Test
+    fun `when storeInDb is true, then products are saved to database`() = runTest {
+        // GIVEN
+        val remoteProducts = arrayOf(
+            createTestApiResponse(id = 1L, name = "Product 1"),
+            createTestApiResponse(id = 2L, name = "Product 2")
+        )
+        val response = WooResult(remoteProducts)
+        whenever(posProductRestClient.fetchProducts(testSite, validDateString, 0, 100))
+            .thenReturn(response)
+
+        // WHEN
+        val syncResult = store.syncRecentlyModifiedProducts(
+            site = testSite,
+            modifiedAfterGmt = validDateString,
+            offset = 0,
+            pageSize = 100,
+            storeInDb = true
+        ).getOrThrow()
+
+        // THEN
+        verify(posProductsDao).upsertProducts(any())
+        assertThat(syncResult.syncedCount).isEqualTo(2)
+    }
+
+    @Test
+    fun `when storeInDb is not specified, then defaults to storing in database`() = runTest {
+        // GIVEN
+        val remoteProducts = arrayOf(createTestApiResponse(id = 1L, name = "Product"))
+        val response = WooResult(remoteProducts)
+        whenever(posProductRestClient.fetchProducts(testSite, validDateString, 0, 100))
+            .thenReturn(response)
+
+        // WHEN
+        store.syncRecentlyModifiedProducts(testSite, validDateString, 0, 100).getOrThrow()
+
+        // THEN
+        verify(posProductsDao).upsertProducts(any())
     }
 
     private fun createTestVariationApiResponse(

--- a/libs/fluxc-plugin/src/test/java/org/wordpress/android/fluxc/utils/HeadersParserTest.kt
+++ b/libs/fluxc-plugin/src/test/java/org/wordpress/android/fluxc/utils/HeadersParserTest.kt
@@ -1,0 +1,175 @@
+package org.wordpress.android.fluxc.utils
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.mockito.Mockito.mock
+import org.mockito.junit.MockitoJUnitRunner
+import org.wordpress.android.fluxc.network.rest.Header
+import org.wordpress.android.fluxc.network.rest.wpcom.wc.WooResult
+
+@RunWith(MockitoJUnitRunner::class)
+class HeadersParserTest {
+    private val parser = HeadersParser(mock())
+
+    @Test
+    fun `when total pages header is present, then returns correct value`() {
+        // GIVEN
+        val headers = listOf(
+            Header("x-wp-totalpages", "5"),
+            Header("content-type", "application/json")
+        )
+        val result = WooResult("test", headers)
+
+        // WHEN
+        val totalPages = parser.getTotalPages(result)
+
+        // THEN
+        assertThat(totalPages).isEqualTo(5)
+    }
+
+    @Test
+    fun `when total pages header has different case, then returns correct value`() {
+        // GIVEN
+        val headers = listOf(
+            Header("X-WP-TOTALPAGES", "3"),
+            Header("content-type", "application/json")
+        )
+        val result = WooResult("test", headers)
+
+        // WHEN
+        val totalPages = parser.getTotalPages(result)
+
+        // THEN
+        assertThat(totalPages).isEqualTo(3)
+    }
+
+    @Test
+    fun `when total pages header is missing, then returns null`() {
+        // GIVEN
+        val headers = listOf(
+            Header("content-type", "application/json"),
+            Header("cache-control", "no-cache")
+        )
+        val result = WooResult("test", headers)
+
+        // WHEN
+        val totalPages = parser.getTotalPages(result)
+
+        // THEN
+        assertThat(totalPages).isNull()
+    }
+
+    @Test
+    fun `when multiple total pages headers exist, then returns last one`() {
+        // GIVEN
+        val headers = listOf(
+            Header("x-wp-totalpages", "2"),
+            Header("x-wp-totalpages", "7")
+        )
+        val result = WooResult("test", headers)
+
+        // WHEN
+        val totalPages = parser.getTotalPages(result)
+
+        // THEN
+        assertThat(totalPages).isEqualTo(7)
+    }
+
+    @Test
+    fun `when server date header is present, then returns correct value`() {
+        // GIVEN
+        val expectedDate = "Wed, 21 Oct 2024 07:28:00 GMT"
+        val headers = listOf(
+            Header("date", expectedDate),
+            Header("content-type", "application/json")
+        )
+        val result = WooResult("test", headers)
+
+        // WHEN
+        val serverDate = parser.getServerDate(result)
+
+        // THEN
+        assertThat(serverDate).isEqualTo(expectedDate)
+    }
+
+    @Test
+    fun `when server date header has different case, then returns correct value`() {
+        // GIVEN
+        val expectedDate = "Wed, 21 Oct 2024 07:28:00 GMT"
+        val headers = listOf(
+            Header("DATE", expectedDate),
+            Header("content-type", "application/json")
+        )
+        val result = WooResult("test", headers)
+
+        // WHEN
+        val serverDate = parser.getServerDate(result)
+
+        // THEN
+        assertThat(serverDate).isEqualTo(expectedDate)
+    }
+
+    @Test
+    fun `when server date header is missing, then returns null`() {
+        // GIVEN
+        val headers = listOf(
+            Header("content-type", "application/json"),
+            Header("cache-control", "no-cache")
+        )
+        val result = WooResult("test", headers)
+
+        // WHEN
+        val serverDate = parser.getServerDate(result)
+
+        // THEN
+        assertThat(serverDate).isNull()
+    }
+
+    @Test
+    fun `when multiple date headers exist, then returns last one`() {
+        // GIVEN
+        val oldDate = "Wed, 20 Oct 2024 07:28:00 GMT"
+        val newDate = "Wed, 21 Oct 2024 07:28:00 GMT"
+        val headers = listOf(
+            Header("date", oldDate),
+            Header("date", newDate)
+        )
+        val result = WooResult("test", headers)
+
+        // WHEN
+        val serverDate = parser.getServerDate(result)
+
+        // THEN
+        assertThat(serverDate).isEqualTo(newDate)
+    }
+
+    @Test
+    fun `when headers list is empty, then both methods return null`() {
+        // GIVEN
+        val result = WooResult("test", emptyList())
+
+        // WHEN
+        val totalPages = parser.getTotalPages(result)
+        val serverDate = parser.getServerDate(result)
+
+        // THEN
+        assertThat(totalPages).isNull()
+        assertThat(serverDate).isNull()
+    }
+
+    @Test
+    fun `when total pages header has invalid value, then returns null`() {
+        // GIVEN
+        val headers = listOf(
+            Header("x-wp-totalpages", "not-a-number")
+        )
+        val result = WooResult("test", headers)
+
+        // WHEN
+        val totalPages = parser.getTotalPages(result)
+
+        // THEN
+        assertThat(totalPages).isNull()
+    }
+}


### PR DESCRIPTION
Fixes WOOMOB-1207


### Description
This PR enhances the Local Catalog sync functionality by propagating response headers from the REST client to the store layer. The changes enable the store to extract and use the `X-WP-Total-Pages` and `Date` headers from the API responses, which are critical for pagination logic and sync timestamp tracking.

Key changes:
- Extended `WooResult` to include headers from API responses
- Added `HeadersParser` utility class to safely extract and parse headers
- Updated `WooPosLocalCatalogStore` to parse and validate required headers during sync
- Added `serverDate` field to `WooPosLocalCatalogSyncResult` for timestamp tracking
- Made product database storage optional via `storeInDb` parameter

### Steps to reproduce
N/A - This is an internal improvement to header propagation, not a bug fix.

### Testing information
The code isn't used yet - green CI is enough.

### The tests that have been performed
- ✅ Unit tests pass for `HeadersParser`
- ✅ Unit tests pass for `WooPosLocalCatalogStore` 
- ✅ Verified header extraction by invoking sync on app start

### Images/gif
N/A - Backend changes only, no UI impact.

- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.