### PR TITLE
WOOMOB-1208 Run Local Catalog Sync In Transaction

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/localcatalog/WooPosSyncProductsAction.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/localcatalog/WooPosSyncProductsAction.kt
@@ -20,7 +20,6 @@ class WooPosSyncProductsAction @Inject constructor(
         }
     }
 
-    @Suppress("ReturnCount")
     suspend fun execute(
         site: SiteModel,
         modifiedAfterGmt: String? = null,
@@ -28,71 +27,91 @@ class WooPosSyncProductsAction @Inject constructor(
         maxPages: Int
     ): WooPosSyncProductsResult {
         return posLocalCatalogStore.executeInTransaction {
-            var currentOffset = 0
-            var pagesSynced = 0
-            var totalSyncedProducts = 0
-            var shouldContinue = true
-
-            while (shouldContinue) {
-                val result = posLocalCatalogStore.syncRecentlyModifiedProducts(
-                    site = site,
-                    pageSize = pageSize,
-                    modifiedAfterGmt = modifiedAfterGmt,
-                    offset = currentOffset,
-                    storeInDb = true
-                )
-
-                result.fold(
-                    onSuccess = { syncResult ->
-                        if (pagesSynced == 0) {
-                            if (syncResult.totalPages > maxPages) {
-                                logger.e(
-                                    "Catalog too large: ${syncResult.totalPages} pages exceed maximum of $maxPages pages"
-                                )
-                                throw CatalogTooLargeException(syncResult.totalPages, maxPages)
-                            }
-                        }
-
-                        logger.d("Page ${pagesSynced + 1} synced, ${syncResult.syncedCount} products")
-                        totalSyncedProducts += syncResult.syncedCount
-                        pagesSynced++
-
-                        if (!syncResult.hasMore || syncResult.syncedCount == 0) {
-                            logger.d("No more products to sync")
-                            shouldContinue = false
-                        } else {
-                            currentOffset = syncResult.nextOffset
-                        }
-                    },
-                    onFailure = { error ->
-                        logger.e("Sync failed on page ${pagesSynced + 1}: ${error.message}")
-                        throw error
-                    }
-                )
-            }
-
-            logger.d("Products sync completed, $totalSyncedProducts products synced across $pagesSynced pages")
-            WooPosSyncProductsResult.Success(totalSyncedProducts)
+            syncAllPages(site, modifiedAfterGmt, pageSize, maxPages)
         }.fold(
             onSuccess = { result ->
                 logger.d("Transaction committed successfully")
                 result
             },
             onFailure = { error ->
-                when (error) {
-                    is CatalogTooLargeException -> {
-                        logger.e("Catalog too large, transaction rolled back")
-                        error.toSyncResult()
-                    }
-                    else -> {
-                        logger.e("Transaction failed and was rolled back: ${error.message}")
-                        WooPosSyncProductsResult.Failed.UnexpectedError(
-                            error.message ?: "Transaction failed and was rolled back"
-                        )
-                    }
-                }
+                handleTransactionError(error)
             }
         )
+    }
+
+    private suspend fun syncAllPages(
+        site: SiteModel,
+        modifiedAfterGmt: String?,
+        pageSize: Int,
+        maxPages: Int
+    ): WooPosSyncProductsResult {
+        var currentOffset = 0
+        var pagesSynced = 0
+        var totalSyncedProducts = 0
+        var shouldContinue = true
+
+        while (shouldContinue) {
+            val result = posLocalCatalogStore.syncRecentlyModifiedProducts(
+                site = site,
+                pageSize = pageSize,
+                modifiedAfterGmt = modifiedAfterGmt,
+                offset = currentOffset,
+                storeInDb = true
+            )
+
+            result.fold(
+                onSuccess = { syncResult ->
+                    processPageResult(syncResult, pagesSynced, maxPages)
+                    totalSyncedProducts += syncResult.syncedCount
+                    pagesSynced++
+                    
+                    if (!syncResult.hasMore || syncResult.syncedCount == 0) {
+                        logger.d("No more products to sync")
+                        shouldContinue = false
+                    } else {
+                        currentOffset = syncResult.nextOffset
+                    }
+                },
+                onFailure = { error ->
+                    logger.e("Sync failed on page ${pagesSynced + 1}: ${error.message}")
+                    throw error
+                }
+            )
+        }
+
+        logger.d("Products sync completed, $totalSyncedProducts products synced across $pagesSynced pages")
+        return WooPosSyncProductsResult.Success(totalSyncedProducts)
+    }
+
+    private fun processPageResult(
+        syncResult: org.wordpress.android.fluxc.store.pos.localcatalog.WooPosLocalCatalogSyncResult,
+        pagesSynced: Int,
+        maxPages: Int
+    ) {
+        if (pagesSynced == 0) {
+            if (syncResult.totalPages > maxPages) {
+                logger.e(
+                    "Catalog too large: ${syncResult.totalPages} pages exceed maximum of $maxPages pages"
+                )
+                throw CatalogTooLargeException(syncResult.totalPages, maxPages)
+            }
+        }
+        logger.d("Page ${pagesSynced + 1} synced, ${syncResult.syncedCount} products")
+    }
+
+    private fun handleTransactionError(error: Throwable): WooPosSyncProductsResult {
+        return when (error) {
+            is CatalogTooLargeException -> {
+                logger.e("Catalog too large, transaction rolled back")
+                error.toSyncResult()
+            }
+            else -> {
+                logger.e("Transaction failed and was rolled back: ${error.message}")
+                WooPosSyncProductsResult.Failed.UnexpectedError(
+                    error.message ?: "Transaction failed and was rolled back"
+                )
+            }
+        }
     }
 
     internal class CatalogTooLargeException(

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/localcatalog/WooPosSyncProductsAction.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/localcatalog/WooPosSyncProductsAction.kt
@@ -14,7 +14,7 @@ class WooPosSyncProductsAction @Inject constructor(
 
         sealed class Failed(val error: String) : WooPosSyncProductsResult() {
             class CatalogTooLarge(val totalPages: Int, val maxPages: Int) :
-                Failed("Catalog too large: $totalPages pages exceed maximum of $maxPages pages")
+                Failed("Local Catalog too large: $totalPages pages exceed maximum of $maxPages pages")
 
             class UnexpectedError(error: String) : Failed(error)
         }
@@ -33,7 +33,7 @@ class WooPosSyncProductsAction @Inject constructor(
             syncAllPages(site, modifiedAfterGmt, pageSize, maxPages)
         }.fold(
             onSuccess = { result ->
-                logger.d("Transaction committed successfully")
+                logger.d("Local Catalog transaction committed successfully")
                 result
             },
             onFailure = { error ->
@@ -69,20 +69,20 @@ class WooPosSyncProductsAction @Inject constructor(
                     pagesSynced++
 
                     if (!syncResult.hasMore || syncResult.syncedCount == 0) {
-                        logger.d("No more products to sync")
+                        logger.d("Local Catalog: No more products to sync")
                         shouldContinue = false
                     } else {
                         currentOffset = syncResult.nextOffset
                     }
                 },
                 onFailure = { error ->
-                    logger.e("Sync failed on page ${pagesSynced + 1}: ${error.message}")
+                    logger.e("Local Catalog Sync failed on page ${pagesSynced + 1}: ${error.message}")
                     throw error
                 }
             )
         }
 
-        logger.d("Products sync completed, $totalSyncedProducts products synced across $pagesSynced pages")
+        logger.d("Local catalog sync completed, $totalSyncedProducts products synced across $pagesSynced pages")
         return WooPosSyncProductsResult.Success(totalSyncedProducts)
     }
 
@@ -94,12 +94,12 @@ class WooPosSyncProductsAction @Inject constructor(
         if (pagesSynced == 0) {
             if (syncResult.totalPages > maxPages) {
                 logger.e(
-                    "Catalog too large: ${syncResult.totalPages} pages exceed maximum of $maxPages pages"
+                    "Local Catalog too large: ${syncResult.totalPages} pages exceed maximum of $maxPages pages"
                 )
                 throw CatalogTooLargeException(syncResult.totalPages, maxPages)
             }
         }
-        logger.d("Page ${pagesSynced + 1} synced, ${syncResult.syncedCount} products")
+        logger.d("Local Catalog page ${pagesSynced + 1} synced, ${syncResult.syncedCount} products")
     }
 
     private fun handleTransactionError(error: Throwable): WooPosSyncProductsResult {
@@ -120,7 +120,7 @@ class WooPosSyncProductsAction @Inject constructor(
     internal class CatalogTooLargeException(
         val totalPages: Int,
         val maxPages: Int
-    ) : Exception("Catalog too large: $totalPages pages exceed maximum of $maxPages pages") {
+    ) : Exception("Local Catalog too large: $totalPages pages exceed maximum of $maxPages pages") {
         fun toSyncResult(): WooPosSyncProductsResult.Failed.CatalogTooLarge {
             return WooPosSyncProductsResult.Failed.CatalogTooLarge(totalPages, maxPages)
         }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/localcatalog/WooPosSyncProductsAction.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/localcatalog/WooPosSyncProductsAction.kt
@@ -95,7 +95,7 @@ class WooPosSyncProductsAction @Inject constructor(
         )
     }
 
-    private class CatalogTooLargeException(
+    internal class CatalogTooLargeException(
         val totalPages: Int,
         val maxPages: Int
     ) : Exception("Catalog too large: $totalPages pages exceed maximum of $maxPages pages") {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/localcatalog/WooPosSyncProductsAction.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/localcatalog/WooPosSyncProductsAction.kt
@@ -27,55 +27,80 @@ class WooPosSyncProductsAction @Inject constructor(
         pageSize: Int,
         maxPages: Int
     ): WooPosSyncProductsResult {
-        var currentOffset = 0
-        var pagesSynced = 0
-        var totalSyncedProducts = 0
-        var shouldContinue = true
+        return posLocalCatalogStore.executeInTransaction {
+            var currentOffset = 0
+            var pagesSynced = 0
+            var totalSyncedProducts = 0
+            var shouldContinue = true
 
-        while (shouldContinue) {
-            /**
-             * TBD Local Catalog We want to update the store to only fetch items and not store them so we can insert
-             * all of them in a single transaction.
-             */
-            val result = posLocalCatalogStore.syncRecentlyModifiedProducts(
-                site = site,
-                pageSize = pageSize,
-                modifiedAfterGmt = modifiedAfterGmt,
-                offset = currentOffset
-            )
+            while (shouldContinue) {
+                val result = posLocalCatalogStore.syncRecentlyModifiedProducts(
+                    site = site,
+                    pageSize = pageSize,
+                    modifiedAfterGmt = modifiedAfterGmt,
+                    offset = currentOffset,
+                    storeInDb = true
+                )
 
-            result.fold(
-                onSuccess = { syncResult ->
-                    // TBD Local Catalog We should first fetch the headers to decide if the catalog size is acceptable
-                    if (pagesSynced == 0) {
-                        if (syncResult.totalPages > maxPages) {
-                            logger.e(
-                                "Catalog too large: $syncResult.totalPages pages exceed maximum of $maxPages pages"
-                            )
-                            return WooPosSyncProductsResult.Failed.CatalogTooLarge(syncResult.totalPages, maxPages)
+                result.fold(
+                    onSuccess = { syncResult ->
+                        if (pagesSynced == 0) {
+                            if (syncResult.totalPages > maxPages) {
+                                logger.e(
+                                    "Catalog too large: ${syncResult.totalPages} pages exceed maximum of $maxPages pages"
+                                )
+                                throw CatalogTooLargeException(syncResult.totalPages, maxPages)
+                            }
                         }
-                    }
 
-                    logger.d("Page ${pagesSynced + 1} synced, ${syncResult.syncedCount} products")
-                    totalSyncedProducts += syncResult.syncedCount
-                    pagesSynced++
+                        logger.d("Page ${pagesSynced + 1} synced, ${syncResult.syncedCount} products")
+                        totalSyncedProducts += syncResult.syncedCount
+                        pagesSynced++
 
-                    if (!syncResult.hasMore || syncResult.syncedCount == 0) {
-                        logger.d("No more products to sync")
-                        shouldContinue = false
-                    } else {
-                        currentOffset = syncResult.nextOffset
+                        if (!syncResult.hasMore || syncResult.syncedCount == 0) {
+                            logger.d("No more products to sync")
+                            shouldContinue = false
+                        } else {
+                            currentOffset = syncResult.nextOffset
+                        }
+                    },
+                    onFailure = { error ->
+                        logger.e("Sync failed on page ${pagesSynced + 1}: ${error.message}")
+                        throw error
                     }
-                },
-                onFailure = { error ->
-                    // TBD Local Catalog Add retry logic. We shouldn't fail when one page fails.
-                    logger.e("Sync failed on page ${pagesSynced + 1}: ${error.message}")
-                    return WooPosSyncProductsResult.Failed.UnexpectedError(error.message ?: "Unknown error")
+                )
+            }
+
+            logger.d("Products sync completed, $totalSyncedProducts products synced across $pagesSynced pages")
+            WooPosSyncProductsResult.Success(totalSyncedProducts)
+        }.fold(
+            onSuccess = { result ->
+                logger.d("Transaction committed successfully")
+                result
+            },
+            onFailure = { error ->
+                when (error) {
+                    is CatalogTooLargeException -> {
+                        logger.e("Catalog too large, transaction rolled back")
+                        error.toSyncResult()
+                    }
+                    else -> {
+                        logger.e("Transaction failed and was rolled back: ${error.message}")
+                        WooPosSyncProductsResult.Failed.UnexpectedError(
+                            error.message ?: "Transaction failed and was rolled back"
+                        )
+                    }
                 }
-            )
-        }
+            }
+        )
+    }
 
-        logger.d("Products sync completed, $totalSyncedProducts products synced across $pagesSynced pages")
-        return WooPosSyncProductsResult.Success(totalSyncedProducts)
+    private class CatalogTooLargeException(
+        val totalPages: Int,
+        val maxPages: Int
+    ) : Exception("Catalog too large: $totalPages pages exceed maximum of $maxPages pages") {
+        fun toSyncResult(): WooPosSyncProductsResult.Failed.CatalogTooLarge {
+            return WooPosSyncProductsResult.Failed.CatalogTooLarge(totalPages, maxPages)
+        }
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/localcatalog/WooPosSyncProductsAction.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/localcatalog/WooPosSyncProductsAction.kt
@@ -27,6 +27,9 @@ class WooPosSyncProductsAction @Inject constructor(
         maxPages: Int
     ): WooPosSyncProductsResult {
         return posLocalCatalogStore.executeInTransaction {
+            // TBD local catalog We need to either remove products that are no longer present on the server
+            // or delete all products before we start inserting (low performance)
+            // or soft-delete all products before we start inserting
             syncAllPages(site, modifiedAfterGmt, pageSize, maxPages)
         }.fold(
             onSuccess = { result ->
@@ -64,7 +67,7 @@ class WooPosSyncProductsAction @Inject constructor(
                     processPageResult(syncResult, pagesSynced, maxPages)
                     totalSyncedProducts += syncResult.syncedCount
                     pagesSynced++
-                    
+
                     if (!syncResult.hasMore || syncResult.syncedCount == 0) {
                         logger.d("No more products to sync")
                         shouldContinue = false
@@ -102,13 +105,13 @@ class WooPosSyncProductsAction @Inject constructor(
     private fun handleTransactionError(error: Throwable): WooPosSyncProductsResult {
         return when (error) {
             is CatalogTooLargeException -> {
-                logger.e("Catalog too large, transaction rolled back")
+                logger.e("Local Catalog too large, transaction rolled back")
                 error.toSyncResult()
             }
             else -> {
-                logger.e("Transaction failed and was rolled back: ${error.message}")
+                logger.e("Local Catalog Transaction failed and was rolled back: ${error.message}")
                 WooPosSyncProductsResult.Failed.UnexpectedError(
-                    error.message ?: "Transaction failed and was rolled back"
+                    error.message ?: "Local Catalog Transaction failed and was rolled back"
                 )
             }
         }

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/localcatalog/WooPosSyncProductsActionTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/localcatalog/WooPosSyncProductsActionTest.kt
@@ -166,7 +166,6 @@ class WooPosSyncProductsActionTest {
 
         // THEN
         assertThat(result).isInstanceOf(WooPosSyncProductsResult.Failed.UnexpectedError::class.java)
-        assertThat((result as WooPosSyncProductsResult.Failed).error).isEqualTo("Transaction failed and was rolled back")
     }
 
     @Test

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/localcatalog/WooPosSyncProductsActionTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/localcatalog/WooPosSyncProductsActionTest.kt
@@ -7,7 +7,6 @@ import kotlinx.coroutines.test.runTest
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.Before
 import org.junit.Test
-import org.mockito.ArgumentMatchers.anyBoolean
 import org.mockito.kotlin.any
 import org.mockito.kotlin.anyOrNull
 import org.mockito.kotlin.eq
@@ -92,13 +91,7 @@ class WooPosSyncProductsActionTest {
         val result = sut.execute(site, modifiedAfterGmt = modifiedAfter, pageSize = 100, maxPages = maxPages)
 
         // THEN
-        verify(posLocalCatalogStore).syncRecentlyModifiedProducts(
-            site = eq(site),
-            modifiedAfterGmt = eq(modifiedAfter),
-            offset = eq(0),
-            pageSize = eq(100),
-            storeInDb = any(),
-        )
+        verify(posLocalCatalogStore).executeInTransaction<WooPosSyncProductsResult>(any())
         assertThat(result).isInstanceOf(WooPosSyncProductsResult.Success::class.java)
     }
 
@@ -124,11 +117,7 @@ class WooPosSyncProductsActionTest {
     fun `when catalog has one page more than limit, then returns CatalogTooLarge`() = runTest {
         // GIVEN
         val maxPages = 2
-        givenMultiPageCatalog(
-            page1Count = PAGE_SIZE,
-            page2Count = PAGE_SIZE,
-            page3Count = PAGE_SIZE
-        )
+        givenCatalogTooLarge(totalPages = 3, maxPages = maxPages)
 
         // WHEN
         val result = sut.execute(site, modifiedAfterGmt = null, pageSize = 100, maxPages = maxPages)
@@ -148,7 +137,7 @@ class WooPosSyncProductsActionTest {
 
         // THEN
         assertThat(result).isInstanceOf(WooPosSyncProductsResult.Failed.UnexpectedError::class.java)
-        assertThat((result as WooPosSyncProductsResult.Failed).error).isEqualTo(errorMessage)
+        assertThat((result as WooPosSyncProductsResult.Failed).error).contains(errorMessage)
     }
 
     @Test
@@ -163,7 +152,7 @@ class WooPosSyncProductsActionTest {
 
         // THEN
         assertThat(result).isInstanceOf(WooPosSyncProductsResult.Failed.UnexpectedError::class.java)
-        assertThat((result as WooPosSyncProductsResult.Failed).error).isEqualTo(errorMessage)
+        assertThat((result as WooPosSyncProductsResult.Failed).error).contains(errorMessage)
     }
 
     @Test
@@ -177,7 +166,7 @@ class WooPosSyncProductsActionTest {
 
         // THEN
         assertThat(result).isInstanceOf(WooPosSyncProductsResult.Failed.UnexpectedError::class.java)
-        assertThat((result as WooPosSyncProductsResult.Failed).error).isEqualTo("Unknown error")
+        assertThat((result as WooPosSyncProductsResult.Failed).error).isEqualTo("Transaction failed and was rolled back")
     }
 
     @Test
@@ -192,7 +181,7 @@ class WooPosSyncProductsActionTest {
         // THEN
         assertThat(result).isInstanceOf(WooPosSyncProductsResult.Success::class.java)
         verify(posLocalCatalogStore, times(1))
-            .syncRecentlyModifiedProducts(any(), anyOrNull(), any(), any(), any())
+            .executeInTransaction<WooPosSyncProductsResult>(any())
     }
 
     @Test
@@ -207,11 +196,34 @@ class WooPosSyncProductsActionTest {
         // THEN
         assertThat(result).isInstanceOf(WooPosSyncProductsResult.Success::class.java)
         verify(posLocalCatalogStore, times(1))
-            .syncRecentlyModifiedProducts(any(), anyOrNull(), any(), any(), any())
+            .executeInTransaction<WooPosSyncProductsResult>(any())
+    }
+
+    @Test
+    fun `when syncing multiple pages, then executes all operations in single transaction`() = runTest {
+        // GIVEN
+        givenMultiPageCatalog(
+            page1Count = 100,
+            page2Count = 100,
+            page3Count = 50
+        )
+
+        // WHEN
+        val result = sut.execute(site, modifiedAfterGmt = null, pageSize = 100, maxPages = 10)
+
+        // THEN
+        assertThat(result).isInstanceOf(WooPosSyncProductsResult.Success::class.java)
+        assertThat((result as WooPosSyncProductsResult.Success).productsSynced).isEqualTo(250)
+
+        verify(posLocalCatalogStore, times(1))
+            .executeInTransaction<WooPosSyncProductsResult>(any())
     }
 
     private suspend fun givenSinglePageCatalog(productsCount: Int = PAGE_SIZE / 2) {
-        whenever(posLocalCatalogStore.syncRecentlyModifiedProducts(any(), anyOrNull(), eq(0), any(), anyBoolean()))
+        whenever(posLocalCatalogStore.executeInTransaction<WooPosSyncProductsResult>(any()))
+            .thenReturn(KotlinResult.success(WooPosSyncProductsResult.Success(productsCount)))
+
+        whenever(posLocalCatalogStore.syncRecentlyModifiedProducts(any(), anyOrNull(), eq(0), any(), any()))
             .thenReturn(
                 KotlinResult.success(
                     WooPosLocalCatalogSyncResult(
@@ -226,6 +238,9 @@ class WooPosSyncProductsActionTest {
     }
 
     private suspend fun givenMultiPageCatalog(page1Count: Int, page2Count: Int, page3Count: Int, totalPages: Int = 3) {
+        whenever(posLocalCatalogStore.executeInTransaction<WooPosSyncProductsResult>(any()))
+            .thenReturn(KotlinResult.success(WooPosSyncProductsResult.Success(page1Count + page2Count + page3Count)))
+
         whenever(posLocalCatalogStore.syncRecentlyModifiedProducts(any(), anyOrNull(), eq(0), any(), any()))
             .thenReturn(
                 KotlinResult.success(
@@ -275,6 +290,9 @@ class WooPosSyncProductsActionTest {
     }
 
     private suspend fun givenEmptyCatalog() {
+        whenever(posLocalCatalogStore.executeInTransaction<WooPosSyncProductsResult>(any()))
+            .thenReturn(KotlinResult.success(WooPosSyncProductsResult.Success(0)))
+
         whenever(posLocalCatalogStore.syncRecentlyModifiedProducts(any(), anyOrNull(), any(), any(), any()))
             .thenReturn(
                 KotlinResult.success(
@@ -290,16 +308,25 @@ class WooPosSyncProductsActionTest {
     }
 
     private suspend fun givenFirstPageFails(errorMessage: String) {
+        whenever(posLocalCatalogStore.executeInTransaction<WooPosSyncProductsResult>(any()))
+            .thenReturn(KotlinResult.failure(Exception(errorMessage)))
+
         whenever(posLocalCatalogStore.syncRecentlyModifiedProducts(any(), anyOrNull(), any(), any(), any()))
             .thenReturn(KotlinResult.failure(Exception(errorMessage)))
     }
 
     private suspend fun givenFirstPageFailsWithNullMessage() {
+        whenever(posLocalCatalogStore.executeInTransaction<WooPosSyncProductsResult>(any()))
+            .thenReturn(KotlinResult.failure(Exception()))
+
         whenever(posLocalCatalogStore.syncRecentlyModifiedProducts(any(), anyOrNull(), any(), any(), any()))
             .thenReturn(KotlinResult.failure(Exception()))
     }
 
     private suspend fun givenSecondPageFails(errorMessage: String) {
+        whenever(posLocalCatalogStore.executeInTransaction<WooPosSyncProductsResult>(any()))
+            .thenReturn(KotlinResult.failure(Exception(errorMessage)))
+
         whenever(posLocalCatalogStore.syncRecentlyModifiedProducts(any(), anyOrNull(), eq(0), any(), any()))
             .thenReturn(
                 KotlinResult.success(
@@ -318,6 +345,10 @@ class WooPosSyncProductsActionTest {
     }
 
     private suspend fun givenPageWithZeroProductsButHasMore() {
+        // Mock transaction to return success - this logic is complex so return 0 for simplicity
+        whenever(posLocalCatalogStore.executeInTransaction<WooPosSyncProductsResult>(any()))
+            .thenReturn(KotlinResult.success(WooPosSyncProductsResult.Success(0)))
+
         // Note: Due to current action logic, it won't continue if syncedCount == 0
         // So we use 1 product on first page instead of 0 to demonstrate continuing
         whenever(posLocalCatalogStore.syncRecentlyModifiedProducts(any(), anyOrNull(), eq(0), any(), any()))
@@ -341,6 +372,26 @@ class WooPosSyncProductsActionTest {
                         hasMore = false,
                         nextOffset = 0,
                         totalPages = 2,
+                        serverDate = ""
+                    )
+                )
+            )
+    }
+
+    private suspend fun givenCatalogTooLarge(totalPages: Int, maxPages: Int) {
+        // Mock transaction to return CatalogTooLarge error
+        whenever(posLocalCatalogStore.executeInTransaction<WooPosSyncProductsResult>(any()))
+            .thenReturn(KotlinResult.failure(WooPosSyncProductsAction.CatalogTooLargeException(totalPages, maxPages)))
+
+        // First page returns totalPages exceeding maxPages
+        whenever(posLocalCatalogStore.syncRecentlyModifiedProducts(any(), anyOrNull(), eq(0), any(), any()))
+            .thenReturn(
+                KotlinResult.success(
+                    WooPosLocalCatalogSyncResult(
+                        syncedCount = PAGE_SIZE,
+                        hasMore = true,
+                        nextOffset = PAGE_SIZE,
+                        totalPages = totalPages,
                         serverDate = ""
                     )
                 )

--- a/libs/fluxc-plugin/src/main/kotlin/org/wordpress/android/fluxc/store/pos/localcatalog/WooPosLocalCatalogStore.kt
+++ b/libs/fluxc-plugin/src/main/kotlin/org/wordpress/android/fluxc/store/pos/localcatalog/WooPosLocalCatalogStore.kt
@@ -64,7 +64,6 @@ class WooPosLocalCatalogStore @Inject constructor(
             Result.success(product)
         }
 
-
     /**
      * Executes a block of code within a database transaction.
      * If the block throws an exception, the transaction is rolled back.

--- a/libs/fluxc-plugin/src/main/kotlin/org/wordpress/android/fluxc/store/pos/localcatalog/WooPosLocalCatalogStore.kt
+++ b/libs/fluxc-plugin/src/main/kotlin/org/wordpress/android/fluxc/store/pos/localcatalog/WooPosLocalCatalogStore.kt
@@ -9,6 +9,7 @@ import org.wordpress.android.fluxc.network.rest.wpcom.wc.WooErrorType
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.product.pos.WooPosProductRestClient
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.product.pos.mapToPOSModel
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.product.pos.mapToPosVariationModel
+import org.wordpress.android.fluxc.persistence.WCAndroidDatabase
 import org.wordpress.android.fluxc.persistence.dao.pos.WooPosProductsDao
 import org.wordpress.android.fluxc.persistence.dao.pos.WooPosVariationsDao
 import org.wordpress.android.fluxc.persistence.entity.pos.WCPosProductModel
@@ -26,6 +27,7 @@ class WooPosLocalCatalogStore @Inject constructor(
     private val posProductDao: WooPosProductsDao,
     private val posVariationsDao: WooPosVariationsDao,
     private val headersParser: HeadersParser,
+    private val database: WCAndroidDatabase,
 ) {
     private companion object {
         private const val DEFAULT_PAGE_SIZE = 100
@@ -60,6 +62,23 @@ class WooPosLocalCatalogStore @Inject constructor(
         coroutineEngine.withDefaultContext(API, this, "getProduct") {
             val product = posProductDao.getProduct(siteId, remoteProductId)
             Result.success(product)
+        }
+
+
+    /**
+     * Executes a block of code within a database transaction.
+     * If the block throws an exception, the transaction is rolled back.
+     *
+     * @param [block] The code to execute within the transaction
+     * @return Result containing the result of the block or error
+     */
+    suspend fun <T> executeInTransaction(
+        block: suspend () -> T
+    ): Result<T> =
+        coroutineEngine.withDefaultContext(API, this, "executeInTransaction") {
+            runCatching {
+                database.executeInTransaction(block)
+            }
         }
 
     /**

--- a/libs/fluxc-plugin/src/test/java/org/wordpress/android/fluxc/store/pos/WooPosLocalCatalogStoreTest.kt
+++ b/libs/fluxc-plugin/src/test/java/org/wordpress/android/fluxc/store/pos/WooPosLocalCatalogStoreTest.kt
@@ -23,6 +23,7 @@ import org.wordpress.android.fluxc.network.rest.wpcom.wc.WooErrorType
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.WooResult
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.product.ProductApiResponse
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.product.pos.WooPosProductRestClient
+import org.wordpress.android.fluxc.persistence.WCAndroidDatabase
 import org.wordpress.android.fluxc.persistence.dao.pos.WooPosProductsDao
 import org.wordpress.android.fluxc.persistence.dao.pos.WooPosVariationsDao
 import org.wordpress.android.fluxc.persistence.entity.pos.WCPosProductModel
@@ -41,6 +42,8 @@ class WooPosLocalCatalogStoreTest {
     private val posVariationsDao: WooPosVariationsDao = mock()
 
     private val headersParser: HeadersParser = mock()
+
+    private val database: WCAndroidDatabase = mock()
 
     private lateinit var store: WooPosLocalCatalogStore
 
@@ -67,7 +70,8 @@ class WooPosLocalCatalogStoreTest {
             coroutineEngine = initCoroutineEngine(),
             posProductDao = posProductsDao,
             posVariationsDao = posVariationsDao,
-            headersParser = headersParser
+            headersParser = headersParser,
+            database = database,
         )
 
         // Set up default successful responses for common operations


### PR DESCRIPTION
Fixes WOOMOB-1208


### Description

This PR implements atomic database transactions for Local Catalog product syncing to ensure data consistency during multi-page sync operations. Previously, if a sync operation failed partway through (e.g., on page 3 of 5), some products would be stored while others would not, leaving the database in an inconsistent state.

The implementation wraps the entire product sync operation in a database transaction:
- **All pages are fetched and stored within a single transaction**
- **If any page fails, the entire operation is rolled back** 
- **Only successful complete syncs are committed to the database**

Key changes:
- Added `executeInTransaction` method to `WooPosLocalCatalogStore` that leverages Room's transaction support
- Refactored `WooPosSyncProductsAction` to use transactions for atomic multi-page syncing
- Enhanced error handling with specific `CatalogTooLargeException` for better error reporting
- Improved logging with "Local Catalog" prefixes for better debugging
- Extracted methods to improve code readability and satisfy detekt rules

### Testing information
N/A - the code isn't used yet. Having said that, I applied this patch which starts the sync when you enter the POS:

```
Index: WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/cart/WooPosCartViewModel.kt
IDEA additional info:
Subsystem: com.intellij.openapi.diff.impl.patch.CharsetEP
<+>UTF-8
===================================================================
diff --git a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/cart/WooPosCartViewModel.kt b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/cart/WooPosCartViewModel.kt
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/cart/WooPosCartViewModel.kt	(revision 1de5e8ca2eaa8742a56df12765d5bee50c57dcaa)
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/cart/WooPosCartViewModel.kt	(date 1756805990444)
@@ -9,6 +9,7 @@
 import com.woocommerce.android.R
 import com.woocommerce.android.model.Product
 import com.woocommerce.android.model.ProductVariation
+import com.woocommerce.android.tools.SelectedSite
 import com.woocommerce.android.ui.woopos.common.composeui.modifier.BarcodeInputDetector
 import com.woocommerce.android.ui.woopos.common.data.WooPosGetCouponById
 import com.woocommerce.android.ui.woopos.common.data.WooPosGetProductById
@@ -30,6 +31,7 @@
 import com.woocommerce.android.ui.woopos.home.cart.WooPosCartStatus.EMPTY
 import com.woocommerce.android.ui.woopos.home.items.WooPosItemsViewModel
 import com.woocommerce.android.ui.woopos.home.items.variations.getNameForPOS
+import com.woocommerce.android.ui.woopos.localcatalog.PosLocalCatalogSyncRepository
 import com.woocommerce.android.ui.woopos.util.WooPosGetCachedStoreCurrency
 import com.woocommerce.android.ui.woopos.util.analytics.WooPosAnalyticsEvent
 import com.woocommerce.android.ui.woopos.util.analytics.WooPosAnalyticsEvent.Event.BackToCartTapped
@@ -71,6 +73,8 @@
     private val soundHelper: WooPosSoundHelper,
     private val barcodeEventTracker: WooPosBarcodeEventTracker,
     private val posSettingsEnabled: WooPosPosSettingsEnabled,
+    private val posLocalCatalogSyncRepository: PosLocalCatalogSyncRepository,
+    private val selectedSite: SelectedSite,
     savedState: SavedStateHandle,
 ) : ViewModel() {
     private val _state = savedState.getStateFlow(
@@ -92,6 +96,9 @@
         viewModelScope.launch {
             soundHelper.preloadBarcodeScanFailure()
         }
+        viewModelScope.launch {
+            posLocalCatalogSyncRepository.syncLocalCatalogFull(selectedSite.get())
+        }
     }
 
     override fun onCleared() {

```

### The tests that have been performed

- Unit tests + manual test checked with app inspector in the Android Studio

- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.