### PR TITLE
[WOOMOB-1242][Woo POS][Settings] Add error state handling for receipt information in POS settings

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/settings/details/store/WooPosSettingsStoreScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/settings/details/store/WooPosSettingsStoreScreen.kt
@@ -27,6 +27,8 @@ import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import com.woocommerce.android.R
 import com.woocommerce.android.ui.woopos.common.composeui.WooPosPreview
+import com.woocommerce.android.ui.woopos.common.composeui.component.Button
+import com.woocommerce.android.ui.woopos.common.composeui.component.WooPosErrorScreen
 import com.woocommerce.android.ui.woopos.common.composeui.component.WooPosShimmerBox
 import com.woocommerce.android.ui.woopos.common.composeui.component.WooPosText
 import com.woocommerce.android.ui.woopos.common.composeui.designsystem.WooPosSpacing
@@ -42,6 +44,7 @@ fun WooPosSettingsStoreScreen(
     val state by viewModel.state.collectAsState()
     WooPosSettingsStoreScreen(
         state = state,
+        onRetryReceiptDataLoad = { viewModel.retryLoadReceiptData() },
         modifier = modifier
     )
 }
@@ -49,6 +52,7 @@ fun WooPosSettingsStoreScreen(
 @Composable
 private fun WooPosSettingsStoreScreen(
     state: WooPosSettingsStoreState,
+    onRetryReceiptDataLoad: () -> Unit,
     modifier: Modifier = Modifier
 ) {
     Column(
@@ -68,8 +72,12 @@ private fun WooPosSettingsStoreScreen(
         }
 
         when (val receiptState = state.receiptState) {
-            is WooPosSettingsStoreState.ReceiptState.NotSupported,
+            is WooPosSettingsStoreState.ReceiptState.NotSupported -> {
+            }
+
             is WooPosSettingsStoreState.ReceiptState.Error -> {
+                Spacer(modifier = Modifier.height(WooPosSpacing.Large.value))
+                ReceiptErrorSection(onRetryReceiptDataLoad)
             }
 
             is WooPosSettingsStoreState.ReceiptState.Loading -> {
@@ -195,6 +203,20 @@ private fun ReceiptInformationSection(receiptInfo: WooPosSettingsStoreState.Rece
     )
 }
 
+@Composable
+private fun ReceiptErrorSection(onRetry: () -> Unit) {
+    WooPosErrorScreen(
+        modifier = Modifier
+            .padding(WooPosSpacing.Large.value),
+        message = stringResource(R.string.woopos_settings_receipt_error_title),
+        reason = stringResource(R.string.woopos_settings_receipt_error_message),
+        primaryButton = Button(
+            text = stringResource(R.string.retry),
+            click = onRetry
+        )
+    )
+}
+
 @WooPosPreview
 @Composable
 fun WooPosSettingsStoreScreenPreview() {
@@ -216,7 +238,10 @@ fun WooPosSettingsStoreScreenPreview() {
             )
         )
 
-        WooPosSettingsStoreScreen(state = state)
+        WooPosSettingsStoreScreen(
+            state = state,
+            onRetryReceiptDataLoad = {}
+        )
     }
 }
 
@@ -234,6 +259,30 @@ fun WooPosSettingsStoreScreenLoadingPreview() {
             receiptState = WooPosSettingsStoreState.ReceiptState.Loading
         )
 
-        WooPosSettingsStoreScreen(state = state)
+        WooPosSettingsStoreScreen(
+            state = state,
+            onRetryReceiptDataLoad = {}
+        )
+    }
+}
+
+@WooPosPreview
+@Composable
+fun WooPosSettingsStoreScreenErrorPreview() {
+    WooPosTheme {
+        val state = WooPosSettingsStoreState(
+            storeInfoState = WooPosSettingsStoreState.StoreState.Loaded(
+                WooPosSettingsStoreState.StoreInfo(
+                    storeName = "My WooCommerce Store",
+                    address = "123 Main Street, City, State 12345, US"
+                )
+            ),
+            receiptState = WooPosSettingsStoreState.ReceiptState.Error
+        )
+
+        WooPosSettingsStoreScreen(
+            state = state,
+            onRetryReceiptDataLoad = {}
+        )
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/settings/details/store/WooPosSettingsStoreViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/settings/details/store/WooPosSettingsStoreViewModel.kt
@@ -51,4 +51,9 @@ class WooPosSettingsStoreViewModel @Inject constructor(
             _state.value = _state.value.copy(receiptState = newReceiptState)
         }
     }
+
+    fun retryLoadReceiptData() {
+        _state.value = _state.value.copy(receiptState = WooPosSettingsStoreState.ReceiptState.Loading)
+        loadReceiptData()
+    }
 }

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -4577,6 +4577,8 @@
 
     <string name="woopos_settings_store_information_title">Store information</string>
     <string name="woopos_settings_receipt_information_title">Receipt information</string>
+    <string name="woopos_settings_receipt_error_title">Unable to load receipt information</string>
+    <string name="woopos_settings_receipt_error_message">There was an error loading receipt information. Please check your connection and try again.</string>
     <string name="woopos_settings_store_name_label">Store name</string>
     <string name="woopos_settings_store_address_label">Address</string>
     <string name="woopos_settings_store_phone_label">Phone</string>


### PR DESCRIPTION
WOOMOB-1242

### Description
Add proper error handling with retry functionality when receipt information fails to load in the WooPos Settings Store screen. The implementation displays POS standard error screen which may not be ideal, but I guess better than nothing

### Steps to reproduce
1. Navigate to POS Settings > Store
2. Simulate a network error or server issue when fetching receipt information
3. Verify error screen is displayed with retry option
4. Tap retry button to attempt loading again

### Testing information
- Error screen displays appropriate message and retry button
- Retry functionality properly reloads receipt data
- Loading state is shown during retry attempts
- Success state displays receipt information correctly

### The tests that have been performed
- Manual testing of error state display
- Retry functionality verification
- UI layout and spacing validation


https://github.com/user-attachments/assets/b548729e-d9da-4996-ab59-a4d9c176ddd6

- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.