### PR TITLE
Fix UI tests after introducing logic to fetch app passwords on app launch

### DIFF
--- a/WooCommerce/src/androidTest/assets/mocks/mappings/jetpack-blogs/rest_api.json
+++ b/WooCommerce/src/androidTest/assets/mocks/mappings/jetpack-blogs/rest_api.json
@@ -6,8 +6,8 @@
       "json": {
         "equalTo": "true"
       },
-      "query": {
-        "matches": "(.*)fields(.*)authentication,namespaces(.*)"
+      "path": {
+        "equalTo": "/&_method=get"
       },
       "locale": {
         "matches": "(.*)"
@@ -19,13 +19,6 @@
     "jsonBody": {
       "data": {
         "namespaces": ["oembed\/1.0", "wpcomsh\/v1", "akismet\/v1", "jetpack\/v4", "wc\/v1", "wc\/v2", "amp\/v1", "wc-admin", "wc-analytics", "wc-product-add-ons\/v1", "wpcom\/v2", "wc\/v3", "wc\/store", "wccom-site\/v1", "wc-calypso-bridge\/v1", "wp\/v2", "wp-site-health\/v1"],
-        "authentication": {
-          "application-passwords": {
-            "endpoints": {
-              "authorization": "https:\/\/automatticwidgets.wpcomstaging.com\/wp-admin\/authorize-application.php"
-            }
-          }
-        },
         "_links": {
           "help": [{
             "href": "https:\/\/developer.wordpress.org\/rest-api\/"


### PR DESCRIPTION
### Description
The changes I introduced in #14538 seem to cause an intermittent UI tests failure because of an umatched request, this PR updates the UI tests to improve the matching of the root endpoint to fix the tests.

### Steps to reproduce
Green CI.

- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->