### PR TITLE
Refactor AddressUtils to handle full country names

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/util/AddressUtils.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/util/AddressUtils.kt
@@ -5,35 +5,36 @@ import java.util.Locale
 
 object AddressUtils {
     /**
-     * Translates a two-character country code into a human
-     * readable label. If a full country name is provided instead of
-     * a code, returns a best-effort display label without crashing.
+     * Returns a human-readable country label for the given input.
      *
-     * Examples:
-     * - "US" -> "United States"
-     * - "India " -> "India"
+     * Behavior:
+     * - If input is blank -> returns empty string.
+     * - If input looks like a 2-letter ISO country code (e.g., "US", "gb") ->
+     *   returns the localized display name (e.g., "United States"). Falls back
+     *   to the original input if it cannot be resolved.
+     * - Otherwise (e.g., full country name like "India") -> returns the trimmed input.
      */
     fun getCountryLabelByCountryCode(countryCode: String): String {
-        if (countryCode.isBlank()) return ""
+        val value = countryCode.trim()
+        if (value.isEmpty() || !isIsoLikeCountryCode(value)) return value
 
-        val trimmed = countryCode.trim()
-
-        // If it looks like a 2-letter country code, try to resolve safely
-        if (trimmed.length == 2 && trimmed.all { it.isLetter() }) {
-            val region = trimmed.uppercase(Locale.ROOT)
-            return try {
-                val locale = Locale.Builder()
-                    .setLanguage(Locale.getDefault().language)
-                    .setRegion(region)
-                    .build()
-                locale.displayCountry.ifBlank { region }
-            } catch (_: IllformedLocaleException) {
-                // Fall back to the original input if region is ill-formed
-                trimmed
-            }
-        }
-
-        // As a last resort, return the input as-is to avoid crashes
-        return trimmed
+        val region = value.uppercase(Locale.ROOT)
+        return resolveDisplayCountry(region, fallback = value)
     }
+
+    private fun isIsoLikeCountryCode(input: String): Boolean =
+        input.length == 2 && input.all { it.isLetter() }
+
+    private fun resolveDisplayCountry(region: String, fallback: String): String =
+        try {
+            val locale = Locale.Builder()
+                .setLanguage(Locale.getDefault().language)
+                .setRegion(region)
+                .build()
+            val display = locale.displayCountry
+            display.ifBlank { fallback }
+        } catch (_: IllformedLocaleException) {
+            // If the region is ill-formed, return the safest fallback (original input)
+            fallback
+        }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/util/AddressUtils.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/util/AddressUtils.kt
@@ -1,19 +1,39 @@
 package com.woocommerce.android.util
 
+import java.util.IllformedLocaleException
 import java.util.Locale
 
 object AddressUtils {
     /**
      * Translates a two-character country code into a human
-     * readable label.
+     * readable label. If a full country name is provided instead of
+     * a code, returns a best-effort display label without crashing.
      *
-     * Example: US -> United States
+     * Examples:
+     * - "US" -> "United States"
+     * - "India " -> "India"
      */
     fun getCountryLabelByCountryCode(countryCode: String): String {
-        val locale = Locale.Builder()
-            .setLanguage(Locale.getDefault().language)
-            .setRegion(countryCode)
-            .build()
-        return locale.displayCountry
+        if (countryCode.isBlank()) return ""
+
+        val trimmed = countryCode.trim()
+
+        // If it looks like a 2-letter country code, try to resolve safely
+        if (trimmed.length == 2 && trimmed.all { it.isLetter() }) {
+            val region = trimmed.uppercase(Locale.ROOT)
+            return try {
+                val locale = Locale.Builder()
+                    .setLanguage(Locale.getDefault().language)
+                    .setRegion(region)
+                    .build()
+                locale.displayCountry.ifBlank { region }
+            } catch (_: IllformedLocaleException) {
+                // Fall back to the original input if region is ill-formed
+                trimmed
+            }
+        }
+
+        // As a last resort, return the input as-is to avoid crashes
+        return trimmed
     }
 }

--- a/WooCommerce/src/test/java/com/woocommerce/android/util/AddressUtilsTest.kt
+++ b/WooCommerce/src/test/java/com/woocommerce/android/util/AddressUtilsTest.kt
@@ -1,0 +1,72 @@
+package com.woocommerce.android.util
+
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Before
+import org.junit.Test
+import java.util.Locale
+
+class AddressUtilsTest {
+
+    private lateinit var originalDefault: Locale
+
+    @Before
+    fun setUp() {
+        // Use a stable default locale so display names are deterministic in tests
+        originalDefault = Locale.getDefault()
+        Locale.setDefault(Locale.US)
+    }
+
+    @After
+    fun tearDown() {
+        Locale.setDefault(originalDefault)
+    }
+
+    @Test
+    fun `blank input returns empty string`() {
+        assertEquals("", AddressUtils.getCountryLabelByCountryCode(""))
+        assertEquals("", AddressUtils.getCountryLabelByCountryCode("   "))
+    }
+
+    @Test
+    fun `2-letter uppercase code resolves to display name`() {
+        val expected = Locale.Builder().setRegion("US").build().getDisplayCountry(Locale.getDefault())
+        val result = AddressUtils.getCountryLabelByCountryCode("US")
+        assertEquals(expected, result)
+    }
+
+    @Test
+    fun `2-letter lowercase code resolves to display name`() {
+        val expected = Locale.Builder().setRegion("GB").build().getDisplayCountry(Locale.getDefault())
+        val result = AddressUtils.getCountryLabelByCountryCode("gb")
+        assertEquals(expected, result)
+    }
+
+    @Test
+    fun `full country name returns the same name (best effort)`() {
+        val result = AddressUtils.getCountryLabelByCountryCode("India")
+        // In US locale, display name for IN is "India"
+        assertEquals("India", result)
+    }
+
+    @Test
+    fun `ill-formed 2-letter code falls back to input`() {
+        val result = AddressUtils.getCountryLabelByCountryCode("ZZ")
+        assertEquals("ZZ", result)
+    }
+
+    @Test
+    fun `trims surrounding whitespace`() {
+        val expected = Locale.Builder().setRegion("CA").build().getDisplayCountry(Locale.getDefault())
+        val result = AddressUtils.getCountryLabelByCountryCode("  CA  ")
+        assertEquals(expected, result)
+    }
+
+    @Test
+    fun `non-2-letter arbitrary input is returned as-is when not matched`() {
+        val input = "Neverland"
+        val result = AddressUtils.getCountryLabelByCountryCode(input)
+        // There is no ISO country with display name "Neverland"; should echo input
+        assertEquals(input, result)
+    }
+}

--- a/WooCommerce/src/test/java/com/woocommerce/android/util/AddressUtilsTest.kt
+++ b/WooCommerce/src/test/java/com/woocommerce/android/util/AddressUtilsTest.kt
@@ -50,7 +50,7 @@ class AddressUtilsTest {
     }
 
     @Test
-    fun ` when non-2-letter arbitrary input, then it is returned as-is`() {
+    fun `when non-2-letter arbitrary input, then it is returned as-is`() {
         val input = "Neverland"
         val result = AddressUtils.getCountryLabelByCountryCode(input)
         // There is no ISO country with display name "Neverland"; should echo input

--- a/WooCommerce/src/test/java/com/woocommerce/android/util/AddressUtilsTest.kt
+++ b/WooCommerce/src/test/java/com/woocommerce/android/util/AddressUtilsTest.kt
@@ -44,7 +44,7 @@ class AddressUtilsTest {
     }
 
     @Test
-    fun `when ill-formed 2-letter code, then returns "Unknown Region" value`() {
+    fun `when ill-formed 2-letter code, then returns Unknown Region value`() {
         val result = AddressUtils.getCountryLabelByCountryCode("ZZ")
         assertEquals("Unknown Region", result)
     }

--- a/WooCommerce/src/test/java/com/woocommerce/android/util/AddressUtilsTest.kt
+++ b/WooCommerce/src/test/java/com/woocommerce/android/util/AddressUtilsTest.kt
@@ -1,6 +1,5 @@
 package com.woocommerce.android.util
 
-import org.junit.After
 import org.junit.Assert.assertEquals
 import org.junit.Before
 import org.junit.Test
@@ -17,53 +16,41 @@ class AddressUtilsTest {
         Locale.setDefault(Locale.US)
     }
 
-    @After
-    fun tearDown() {
-        Locale.setDefault(originalDefault)
-    }
-
     @Test
-    fun `blank input returns empty string`() {
+    fun `when blank input, then returns empty string`() {
         assertEquals("", AddressUtils.getCountryLabelByCountryCode(""))
         assertEquals("", AddressUtils.getCountryLabelByCountryCode("   "))
     }
 
     @Test
-    fun `2-letter uppercase code resolves to display name`() {
+    fun `when 2-letter uppercase code, then resolves to display name`() {
         val expected = Locale.Builder().setRegion("US").build().getDisplayCountry(Locale.getDefault())
         val result = AddressUtils.getCountryLabelByCountryCode("US")
         assertEquals(expected, result)
     }
 
     @Test
-    fun `2-letter lowercase code resolves to display name`() {
+    fun `when 2-letter lowercase code, then resolves to display name`() {
         val expected = Locale.Builder().setRegion("GB").build().getDisplayCountry(Locale.getDefault())
         val result = AddressUtils.getCountryLabelByCountryCode("gb")
         assertEquals(expected, result)
     }
 
     @Test
-    fun `full country name returns the same name (best effort)`() {
+    fun `when full country name, then returns the same name`() {
         val result = AddressUtils.getCountryLabelByCountryCode("India")
         // In US locale, display name for IN is "India"
         assertEquals("India", result)
     }
 
     @Test
-    fun `ill-formed 2-letter code falls back to input`() {
+    fun `when ill-formed 2-letter code, then returns "Unknown Region" value`() {
         val result = AddressUtils.getCountryLabelByCountryCode("ZZ")
-        assertEquals("ZZ", result)
+        assertEquals("Unknown Region", result)
     }
 
     @Test
-    fun `trims surrounding whitespace`() {
-        val expected = Locale.Builder().setRegion("CA").build().getDisplayCountry(Locale.getDefault())
-        val result = AddressUtils.getCountryLabelByCountryCode("  CA  ")
-        assertEquals(expected, result)
-    }
-
-    @Test
-    fun `non-2-letter arbitrary input is returned as-is when not matched`() {
+    fun ` when non-2-letter arbitrary input, then it is returned as-is`() {
         val input = "Neverland"
         val result = AddressUtils.getCountryLabelByCountryCode(input)
         // There is no ISO country with display name "Neverland"; should echo input


### PR DESCRIPTION
Fixes WOOMOB-1257

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
After recent change to remove deprecated usages of Locale() constructor a new crash was accidentally introduce in `AddressUtils` class. The following code: 

```kotlin
    fun getCountryLabelByCountryCode(countryCode: String): String {
        val locale = Locale.Builder()
            .setLanguage(Locale.getDefault().language)
            .setRegion(countryCode)
            .build()
        return locale.displayCountry
    }
```
Would lead to a crash when the passed value for `countryCode` is a country name al ready. 
```
java.util.IllformedLocaleException: Ill-formed region: India [at index 0]
	at java.util.Locale$Builder.setRegion(Locale.java:3316)
	at com.woocommerce.android.util.AddressUtils.getCountryLabelByCountryCode(AddressUtils.kt:15)
	at com.woocommerce.android.model.Order.formatShippingInformationForDisplay(Order.kt:310)
```

### Testing information
The unit tests added should be enough to ensure the function works as expected. 
