### PR TITLE
Auto-merge `PATCH` Dependabot updates

### DIFF
--- a/.github/workflows/dependabot_automerge.yml
+++ b/.github/workflows/dependabot_automerge.yml
@@ -44,8 +44,12 @@ jobs:
 
       - name: Approve the PR
         if: steps.metadata.outputs.update-type == 'version-update:semver-patch'
-        run: gh pr review --approve "$PR_URL"
+        run: |
+          set -e
+          gh pr review --approve "$PR_URL"
 
       - name: Enable auto-merge for Dependabot PRs
         if: steps.metadata.outputs.update-type == 'version-update:semver-patch'
-        run: gh pr merge --auto --merge "$PR_URL"
+        run: |
+          set -e
+          gh pr merge --auto --merge "$PR_URL"

--- a/.github/workflows/dependabot_automerge.yml
+++ b/.github/workflows/dependabot_automerge.yml
@@ -16,7 +16,7 @@ jobs:
       PR_URL: ${{ github.event.pull_request.html_url }}
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v5
 
       - name: Fetch Dependabot metadata
         id: metadata

--- a/.github/workflows/dependabot_automerge.yml
+++ b/.github/workflows/dependabot_automerge.yml
@@ -11,7 +11,7 @@ permissions:
 jobs:
   auto-merge:
     runs-on: ubuntu-latest
-    if: github.event.pull_request.user.login == 'dependabot[bot]' && github.repository == 'wzieba/woocommerce-android'
+    if: github.event.pull_request.user.login == 'dependabot[bot]' && github.repository == 'woocommerce/woocommerce-android'
     env:
       PR_URL: ${{ github.event.pull_request.html_url }}
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/dependabot_automerge.yml
+++ b/.github/workflows/dependabot_automerge.yml
@@ -1,0 +1,48 @@
+name: Automerge Dependabot PATCH updates
+
+on:
+  pull_request:
+    types: [opened]
+
+jobs:
+  assign-milestone:
+    runs-on: ubuntu-latest
+    if: github.event.pull_request.user.login == 'dependabot[bot]' && github.repository == 'woocommerce/woocommerce-android'
+    env:
+      PR_URL: ${{ github.event.pull_request.html_url }}
+      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    steps:
+      - name: Fetch Dependabot metadata
+        id: metadata
+        uses: dependabot/fetch-metadata@v2
+        with:
+          github-token: "${{ secrets.GITHUB_TOKEN }}"
+
+      - name: Exit if no Dependabot metadata found
+        if: steps.metadata.outputs.update-type != 'version-update:semver-patch'
+        run: |
+          echo "The update is not PATCH. Exiting."
+          exit 0
+
+      - name: Assign closest open milestone to PR
+        run: |
+          set -e
+          number=$(gh api repos/$GITHUB_REPOSITORY/milestones \
+            --jq '[.[]
+              | select(.state=="open" and .due_on!=null and (.due_on | fromdateiso8601) >= now)
+            ]
+            | sort_by(.due_on)
+            | .[0].number')
+
+          if [ -n "$number" ]; then
+            echo "Assigning milestone #$number to PR #${{ github.event.pull_request.number }}"
+            gh pr edit "${{ github.event.pull_request.number }}" --milestone "$number"
+          else
+            echo "No future open milestones found."
+          fi
+
+      - name: Approve the PR
+        run: gh pr review --approve "$PR_URL"
+
+      - name: Enable auto-merge for Dependabot PRs
+        run: gh pr merge --auto --merge "$PR_URL"

--- a/.github/workflows/dependabot_automerge.yml
+++ b/.github/workflows/dependabot_automerge.yml
@@ -1,30 +1,31 @@
-name: Automerge Dependabot PATCH updates
+name: Auto-merge Dependabot PATCH updates
 
 on:
   pull_request:
-    types: [opened]
+    types: [opened, reopened]
+
+permissions:
+  contents: write
+  pull-requests: write
 
 jobs:
-  assign-milestone:
+  auto-merge:
     runs-on: ubuntu-latest
-    if: github.event.pull_request.user.login == 'dependabot[bot]' && github.repository == 'woocommerce/woocommerce-android'
+    if: github.event.pull_request.user.login == 'dependabot[bot]' && github.repository == 'wzieba/woocommerce-android'
     env:
       PR_URL: ${{ github.event.pull_request.html_url }}
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:
+      - uses: actions/checkout@v3
+
       - name: Fetch Dependabot metadata
         id: metadata
         uses: dependabot/fetch-metadata@v2
         with:
           github-token: "${{ secrets.GITHUB_TOKEN }}"
 
-      - name: Exit if no Dependabot metadata found
-        if: steps.metadata.outputs.update-type != 'version-update:semver-patch'
-        run: |
-          echo "The update is not PATCH. Exiting."
-          exit 0
-
       - name: Assign closest open milestone to PR
+        if: steps.metadata.outputs.update-type == 'version-update:semver-patch'
         run: |
           set -e
           number=$(gh api repos/$GITHUB_REPOSITORY/milestones \
@@ -42,7 +43,9 @@ jobs:
           fi
 
       - name: Approve the PR
+        if: steps.metadata.outputs.update-type == 'version-update:semver-patch'
         run: gh pr review --approve "$PR_URL"
 
       - name: Enable auto-merge for Dependabot PRs
+        if: steps.metadata.outputs.update-type == 'version-update:semver-patch'
         run: gh pr merge --auto --merge "$PR_URL"


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

<!-- Id number of the Linear issue this PR addresses, e.g., WOOMOB-373. -->

Closes: AINFRA-1224

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

This PR enables auto-merge of `PATCH` updates from Dependabot. Before merging, it'll also:
- assign the closest milestone (that is not `due`)
- approve the PR

### Testing information
<!-- This is your opportunity to break out individual scenarios that need testing (when necessary) and/or include a checklist for the reviewer to go through. Consider documenting the following from your own completed testing: devices used, alternate workflows, edge cases, affected areas, critical flows, areas not tested, and any remaining unknowns. Provide feedback on this new section of the PR template through Sept 30, 2024 to Apps Quality; additional context here: p91TBi-b8z-p2#comment-12036 -->

I've tested this on my fork:

#### 1. When the update is `PATCH`

- https://github.com/wzieba/woocommerce-android/pull/35
- Action: https://github.com/wzieba/woocommerce-android/actions/runs/17430367838/job/49487171350

#### 2. When the update is not `PATCH`

- https://github.com/wzieba/woocommerce-android/pull/56
- Action: https://github.com/wzieba/woocommerce-android/actions/runs/17430265089/job/49486859570

- [ ] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->