### PR TITLE
[WOOMOB-1258][Woo POS][Settings] Fix minor findings from the CFT

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/settings/WooPosSettingsState.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/settings/WooPosSettingsState.kt
@@ -51,7 +51,7 @@ sealed class WooPosSettingsDetailDestination {
 
     sealed class Help : WooPosSettingsDetailDestination() {
         data object Overview : Help() {
-            override val titleRes: Int = R.string.woopos_get_support_title
+            override val titleRes: Int = R.string.woopos_settings_help_category
             override val parentDestination: WooPosSettingsDetailDestination? = null
             override val childDestinations: List<WooPosSettingsDetailDestination> = emptyList()
         }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/settings/categories/WooPosSettingsCategoriesState.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/settings/categories/WooPosSettingsCategoriesState.kt
@@ -29,7 +29,7 @@ enum class WooPosSettingsCategory(
         WooPosSettingsDetailDestination.Hardware.Overview
     ),
     HELP(
-        R.string.woopos_get_support_title,
+        R.string.woopos_settings_help_category,
         R.string.woopos_settings_help_category_subtitle,
         Icons.AutoMirrored.Filled.Help,
         WooPosSettingsDetailDestination.Help.Overview,

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/settings/details/store/WooPosSettingsReceiptRepository.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/settings/details/store/WooPosSettingsReceiptRepository.kt
@@ -30,7 +30,7 @@ class WooPosSettingsReceiptRepository @Inject constructor(
                 val settings = response.model ?: emptyMap()
                 val receiptInfo = WooPosSettingsStoreState.ReceiptInfo(
                     storeName = settings["woocommerce_pos_store_name"] ?: "",
-                    address = settings["woocommerce_pos_store_address"] ?: "",
+                    address = formatReceiptAddress(settings["woocommerce_pos_store_address"] ?: ""),
                     phone = settings["woocommerce_pos_store_phone"] ?: "",
                     email = settings["woocommerce_pos_store_email"] ?: "",
                     refundPolicy = settings["woocommerce_pos_refund_returns_policy"] ?: ""
@@ -41,6 +41,10 @@ class WooPosSettingsReceiptRepository @Inject constructor(
                 WooPosReceiptDataResult.Error
             }
         }
+
+    private fun formatReceiptAddress(address: String): String {
+        return address.replace("\n", ", ").replace(Regex(",\\s*,"), ",").trim()
+    }
 
     private fun isWooCommerceVersionAtLeast10(): Boolean {
         val wooCoreVersion = getWooCoreVersion() ?: return false

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/settings/details/store/WooPosSettingsReceiptRepository.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/settings/details/store/WooPosSettingsReceiptRepository.kt
@@ -32,6 +32,7 @@ class WooPosSettingsReceiptRepository @Inject constructor(
                     storeName = settings["woocommerce_pos_store_name"] ?: "",
                     address = settings["woocommerce_pos_store_address"] ?: "",
                     phone = settings["woocommerce_pos_store_phone"] ?: "",
+                    email = settings["woocommerce_pos_store_email"] ?: "",
                     refundPolicy = settings["woocommerce_pos_refund_returns_policy"] ?: ""
                 )
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/settings/details/store/WooPosSettingsStoreScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/settings/details/store/WooPosSettingsStoreScreen.kt
@@ -11,6 +11,7 @@ import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Email
 import androidx.compose.material.icons.filled.Home
 import androidx.compose.material.icons.filled.Phone
 import androidx.compose.material.icons.filled.Receipt
@@ -189,6 +190,12 @@ private fun ReceiptInformationSection(receiptInfo: WooPosSettingsStoreState.Rece
     )
 
     WooPosSettingsDetailsMenuItem(
+        icon = Icons.Default.Email,
+        title = stringResource(R.string.woopos_settings_store_email_label),
+        subtitle = receiptInfo.email.ifBlank { stringResource(R.string.woopos_settings_store_not_set) }
+    )
+
+    WooPosSettingsDetailsMenuItem(
         icon = Icons.Default.Receipt,
         title = stringResource(R.string.woopos_settings_refund_policy_label),
         subtitle = receiptInfo.refundPolicy.ifBlank { stringResource(R.string.woopos_settings_store_not_set) }
@@ -211,6 +218,7 @@ fun WooPosSettingsStoreScreenPreview() {
                     storeName = "My WooCommerce Store",
                     address = "123 Main Street, City, State 12345, US",
                     phone = "+1 555 1234 1234",
+                    email = "store@example.com",
                     refundPolicy = "Returns accepted within 30 days"
                 )
             )

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/settings/details/store/WooPosSettingsStoreScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/settings/details/store/WooPosSettingsStoreScreen.kt
@@ -133,11 +133,14 @@ private fun ReceiptMenuItemShimmer() {
     Row(
         modifier = Modifier
             .fillMaxWidth()
-            .padding(WooPosSpacing.Large.value),
+            .padding(
+                vertical = WooPosSpacing.Medium.value,
+                horizontal = WooPosSpacing.Large.value
+            ),
         verticalAlignment = Alignment.CenterVertically
     ) {
         WooPosShimmerBox(
-            modifier = Modifier.size(28.dp)
+            modifier = Modifier.size(24.dp)
         )
 
         Column(
@@ -148,7 +151,7 @@ private fun ReceiptMenuItemShimmer() {
             WooPosShimmerBox(
                 modifier = Modifier
                     .fillMaxWidth(0.4f)
-                    .height(24.dp)
+                    .height(28.dp)
             )
 
             Spacer(modifier = Modifier.height(WooPosSpacing.Small.value))
@@ -156,7 +159,7 @@ private fun ReceiptMenuItemShimmer() {
             WooPosShimmerBox(
                 modifier = Modifier
                     .fillMaxWidth(0.7f)
-                    .height(14.dp)
+                    .height(16.dp)
             )
         }
     }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/settings/details/store/WooPosSettingsStoreScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/settings/details/store/WooPosSettingsStoreScreen.kt
@@ -121,12 +121,7 @@ private fun StoreInformationSection(storeInfo: WooPosSettingsStoreState.StoreInf
 
 @Composable
 private fun ReceiptLoadingSection() {
-    WooPosShimmerBox(
-        modifier = Modifier
-            .fillMaxWidth(0.3f)
-            .height(32.dp)
-            .padding(start = WooPosSpacing.Large.value, bottom = WooPosSpacing.Small.value)
-    )
+    SectionTitle(stringResource(R.string.woopos_settings_receipt_information_title))
 
     repeat(5) {
         ReceiptMenuItemShimmer()

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/settings/details/store/WooPosSettingsStoreState.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/settings/details/store/WooPosSettingsStoreState.kt
@@ -13,6 +13,7 @@ data class WooPosSettingsStoreState(
         val storeName: String,
         val address: String,
         val phone: String,
+        val email: String,
         val refundPolicy: String
     )
 

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -4370,6 +4370,7 @@
     <string name="woopos_settings_card_reader_documentation_title">Documentation</string>
     <string name="woopos_settings_card_reader_documentation_subtitle">Learn more about accepting mobile payments</string>
     <string name="woopos_settings_card_reader_connected_reader">Connected reader</string>
+    <string name="woopos_settings_help_category">Help</string>
     <string name="woopos_settings_help_category_subtitle">Get help and support</string>
     <string name="woopos_settings_help_product_limitations_subtitle">Learn about which products are supported in POS</string>
     <string name="woopos_settings_help_documentation_subtitle">View guides and tutorials</string>

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -4580,6 +4580,7 @@
     <string name="woopos_settings_store_name_label">Store name</string>
     <string name="woopos_settings_store_address_label">Address</string>
     <string name="woopos_settings_store_phone_label">Phone</string>
+    <string name="woopos_settings_store_email_label">Email</string>
     <string name="woopos_settings_refund_policy_label">Refund &amp; Returns Policy</string>
     <string name="woopos_settings_store_not_set">Not set</string>
 

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/settings/details/store/WooPosSettingsStoreViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/settings/details/store/WooPosSettingsStoreViewModelTest.kt
@@ -31,6 +31,7 @@ class WooPosSettingsStoreViewModelTest {
             storeName = "Test Store",
             address = "123 Test St",
             phone = "+1234567890",
+            email = "test@example.com",
             refundPolicy = "30 day returns"
         )
         whenever(storeRepository.getStoreInfo()).thenReturn(storeInfo)


### PR DESCRIPTION
WOOMOB-1258

### Description
Fixed several UI and consistency issues identified during the Woo POS settings CFT:
- Added email field to receipt information in store settings
- Fixed address formatting inconsistency between Store Information and Receipt Information sections
- Updated receipt loading state to show section title while content is loading
- Updated help section titles for consistency

### Steps to reproduce
1. Open the Woo POS app
2. Navigate to Settings > Store
3. Observe the Store Information and Receipt Information sections
4. Check that email field appears after phone number
5. Verify addresses are formatted consistently with commas
6. Note that section title appears while receipt information is loading

### Images/gif

https://github.com/user-attachments/assets/cc3fcddd-1914-4c4a-ba16-e88be13c45c7



- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.