### PR TITLE
[Jetpack Performance] Add a preference toggle for enabling app passwords for Jetpack sites

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/AppPrefs.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/AppPrefs.kt
@@ -133,7 +133,8 @@ object AppPrefs {
         CUSTOM_FIELDS_TOP_BANNER_DISMISSED,
         BLAZE_CAMPAIGN_SELECTED_OBJECTIVE,
         BLAZE_CAMPAIGN_OBJECTIVE_SWITCH_CHECKED,
-        IS_SITE_WPCOM_SUSPENDED
+        IS_SITE_WPCOM_SUSPENDED,
+        JETPACK_APP_PASSWORDS_ENABLED
     }
 
     /**
@@ -295,6 +296,10 @@ object AppPrefs {
     var orderSummaryMigrated: Boolean
         get() = getBoolean(DeletablePrefKey.ORDER_SUMMARY_MIGRATED, false)
         set(value) = setBoolean(DeletablePrefKey.ORDER_SUMMARY_MIGRATED, value)
+
+    var jetpackAppPasswordsEnabled: Boolean
+        get() = getBoolean(DeletablePrefKey.JETPACK_APP_PASSWORDS_ENABLED, true)
+        set(value) = setBoolean(DeletablePrefKey.JETPACK_APP_PASSWORDS_ENABLED, value)
 
     fun getProductSortingChoice(currentSiteId: Int) = getString(getProductSortingKey(currentSiteId)).orNullIfEmpty()
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/AppPrefsWrapper.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/AppPrefsWrapper.kt
@@ -41,6 +41,8 @@ open class AppPrefsWrapper @Inject constructor() {
 
     open var orderSummaryMigrated by AppPrefs::orderSummaryMigrated
 
+    var jetpackAppPasswordsEnabled by AppPrefs::jetpackAppPasswordsEnabled
+
     fun getAppInstallationDate() = AppPrefs.installationDate
 
     fun getReceiptUrl(localSiteId: Int, remoteSiteId: Long, selfHostedSiteId: Long, orderId: Long) =

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/applicationpasswords/WooApplicationPasswordsConfiguration.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/applicationpasswords/WooApplicationPasswordsConfiguration.kt
@@ -1,14 +1,18 @@
 package com.woocommerce.android.applicationpasswords
 
+import com.woocommerce.android.AppPrefsWrapper
 import com.woocommerce.android.BuildConfig
 import com.woocommerce.android.util.DeviceInfo
 import com.woocommerce.android.util.FeatureFlag.APP_PASSWORDS_FOR_JETPACK_SITES
 import jakarta.inject.Inject
 import org.wordpress.android.fluxc.network.rest.wpapi.applicationpasswords.ApplicationPasswordsConfiguration
 
-class WooApplicationPasswordsConfiguration @Inject constructor() : ApplicationPasswordsConfiguration {
+class WooApplicationPasswordsConfiguration @Inject constructor(
+    private val appPrefs: AppPrefsWrapper
+) : ApplicationPasswordsConfiguration {
     override val applicationName: String =
         "${BuildConfig.APPLICATION_ID}.app-client.${DeviceInfo.name.replace(' ', '-')}"
 
-    override suspend fun isEnabledForJetpackAccess(): Boolean = APP_PASSWORDS_FOR_JETPACK_SITES.isEnabled()
+    override suspend fun isEnabledForJetpackAccess(): Boolean =
+        APP_PASSWORDS_FOR_JETPACK_SITES.isEnabled() && appPrefs.jetpackAppPasswordsEnabled
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/BetaFeaturesFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/BetaFeaturesFragment.kt
@@ -3,6 +3,7 @@ package com.woocommerce.android.ui.prefs
 import android.os.Bundle
 import android.view.View
 import android.widget.CompoundButton
+import androidx.core.view.isVisible
 import androidx.fragment.app.Fragment
 import com.google.android.material.snackbar.BaseTransientBottomBar
 import com.google.android.material.snackbar.Snackbar
@@ -11,15 +12,22 @@ import com.woocommerce.android.R
 import com.woocommerce.android.analytics.AnalyticsEvent.PRODUCT_ADDONS_BETA_FEATURES_SWITCH_TOGGLED
 import com.woocommerce.android.analytics.AnalyticsTracker
 import com.woocommerce.android.databinding.FragmentSettingsBetaBinding
+import com.woocommerce.android.tools.SelectedSite
+import com.woocommerce.android.tools.SiteConnectionType
 import com.woocommerce.android.ui.prefs.MainSettingsFragment.AppSettingsListener
 import com.woocommerce.android.util.AnalyticsUtils
+import com.woocommerce.android.util.FeatureFlag
 import dagger.hilt.android.AndroidEntryPoint
+import javax.inject.Inject
 
 @AndroidEntryPoint
 class BetaFeaturesFragment : Fragment(R.layout.fragment_settings_beta) {
     companion object {
         const val TAG = "beta-features"
     }
+
+    @Inject
+    lateinit var selectedSite: SelectedSite
 
     private val settingsListener by lazy {
         activity as? AppSettingsListener
@@ -30,6 +38,7 @@ class BetaFeaturesFragment : Fragment(R.layout.fragment_settings_beta) {
 
         with(FragmentSettingsBetaBinding.bind(view)) {
             bindProductAddonsToggle()
+            bindJetpackAppPasswordsToggle()
         }
     }
 
@@ -46,6 +55,17 @@ class BetaFeaturesFragment : Fragment(R.layout.fragment_settings_beta) {
 
             settingsListener?.onProductAddonsOptionChanged(isChecked)
                 ?: handleToggleChangeFailure(switch, isChecked)
+        }
+    }
+
+    private fun FragmentSettingsBetaBinding.bindJetpackAppPasswordsToggle() {
+        // TODO check the remote feature flag state once available
+        val isJetpackSite = selectedSite.connectionType != SiteConnectionType.ApplicationPasswords
+        jetpackAppPasswordsToggle.isVisible = FeatureFlag.APP_PASSWORDS_FOR_JETPACK_SITES.isEnabled() && isJetpackSite
+
+        jetpackAppPasswordsToggle.isChecked = AppPrefs.jetpackAppPasswordsEnabled
+        jetpackAppPasswordsToggle.setOnCheckedChangeListener { _, isChecked ->
+            AppPrefs.jetpackAppPasswordsEnabled = isChecked
         }
     }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/BetaFeaturesFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/BetaFeaturesFragment.kt
@@ -73,7 +73,7 @@ class BetaFeaturesFragment : Fragment(R.layout.fragment_settings_beta) {
         super.onResume()
         AnalyticsTracker.trackViewShown(this)
 
-        activity?.setTitle(R.string.beta_features)
+        activity?.setTitle(R.string.experimental_features)
     }
 
     private fun FragmentSettingsBetaBinding.handleToggleChangeFailure(switch: CompoundButton, isChecked: Boolean) {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/MainSettingsFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/MainSettingsFragment.kt
@@ -121,8 +121,6 @@ class MainSettingsFragment : Fragment(R.layout.fragment_settings_main), MainSett
             AppPrefs.setImageOptimizationEnabled(isChecked)
         }
 
-        updateStoreSettings()
-
         binding.optionHelpAndSupport.setOnClickListener {
             AnalyticsTracker.track(AnalyticsEvent.MAIN_MENU_CONTACT_SUPPORT_TAPPED)
             startActivity(HelpActivity.createIntent(requireActivity(), HelpOrigin.SETTINGS, null))
@@ -303,18 +301,6 @@ class MainSettingsFragment : Fragment(R.layout.fragment_settings_main), MainSett
     override fun handleApplicationPasswordsSettings() {
         binding.optionNotifications.hide()
     }
-
-    private fun updateStoreSettings() {
-        generateBetaFeaturesTitleList()
-            .joinToString(", ")
-            .takeIf { it.isNotEmpty() }
-            ?.let { binding.optionBetaFeatures.optionValue = it }
-    }
-
-    private fun generateBetaFeaturesTitleList() =
-        mutableListOf<String>().apply {
-            add(getString(R.string.beta_features_add_ons))
-        }
 
     private fun showThemeChooser() {
         val currentTheme = AppPrefs.getAppTheme()

--- a/WooCommerce/src/main/res/layout/fragment_settings_beta.xml
+++ b/WooCommerce/src/main/res/layout/fragment_settings_beta.xml
@@ -14,6 +14,13 @@
         app:toggleOptionDesc="@string/settings_enable_product_addons_teaser_message"
         app:toggleOptionTitle="@string/settings_enable_product_addons_teaser_title" />
 
+    <com.woocommerce.android.ui.prefs.WCSettingsToggleOptionView
+        android:id="@+id/jetpackAppPasswordsToggle"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        app:toggleOptionDesc="@string/settings_enable_jetpack_app_passwords_message"
+        app:toggleOptionTitle="@string/settings_enable_jetpack_app_passwords_title" />
+
     <View style="@style/Woo.Divider" />
 
 </LinearLayout>

--- a/WooCommerce/src/main/res/layout/fragment_settings_main.xml
+++ b/WooCommerce/src/main/res/layout/fragment_settings_main.xml
@@ -203,8 +203,7 @@
             android:id="@+id/option_beta_features"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            app:optionTitle="@string/beta_features"
-            app:optionValue="@string/beta_features_add_ons" />
+            app:optionTitle="@string/experimental_features" />
 
         <!--
             Send Feedback

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -2610,6 +2610,8 @@
     <string name="plugin_state_inactive">Inactive</string>
     <string name="plugin_state_auto_managed">Auto-managed</string>
     <string name="plugins_error_message">An error occurred while loading installed plugins</string>
+    <string name="settings_enable_jetpack_app_passwords_title">Application Passwords</string>
+    <string name="settings_enable_jetpack_app_passwords_message">Enable application passwords to let the app directly fetch data from your WooCommerce site instead of doing so through Jetpack connection.</string>
 
     <!--
         Developer Options Screen

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -2503,9 +2503,7 @@
     <string name="settings">Settings</string>
     <string name="privacy_settings">Privacy settings</string>
     <string name="send_feedback">Send feedback</string>
-    <string name="beta_features">Beta features</string>
-    <string name="beta_features_add_ons">View Add-ons</string>
-    <string name="beta_features_simple_payments">Simple payments</string>
+    <string name="experimental_features">Experimental features</string>
     <string name="settings_signout">Log out</string>
     <string name="settings_close_account">Close Account</string>
     <string name="settings_close_account_dialog_title">Confirm Close Account</string>


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

<!-- Id number of the Linear issue this PR addresses, e.g., WOOMOB-373. -->
Closes WOOMOB-1183

### Description
This PR adds a toggle that allows disabling using Application Passwords for Jetpack sites, it's meant as a temporary solution for any potential issues that we may miss.
The toggle is displayed when the feature flag (will be replaced with a remote feature flag in a future PR) is enabled, and when the current connection is using a WordPress.com account.

I also renamed the section from "Beta features" to "Experimental features" to match iOS platform, and to make the section more suitable for this toggle.

### Steps to reproduce
1. Open the app settings.
2. Tap on Experimental features.
3. Notice the toggle.

### Testing information
- Confirm the toggle is enabled by default.
- Inspect network calls, and change the value if the toggle and confirm it works as expected.

### The tests that have been performed
The above.

- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->