### PR TITLE
[Jetpack Performance] Delete app passwords of all sites on logout

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/AccountRepository.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/AccountRepository.kt
@@ -9,11 +9,13 @@ import com.woocommerce.android.support.zendesk.ZendeskSettings
 import com.woocommerce.android.tools.SelectedSite
 import com.woocommerce.android.tools.SiteConnectionType
 import com.woocommerce.android.ui.sitepicker.sitevisibility.VisibleWooSitesDataStore
+import com.woocommerce.android.util.CoroutineDispatchers
 import com.woocommerce.android.util.WooLog
 import com.woocommerce.android.util.WooLog.T.LOGIN
 import com.woocommerce.android.util.dispatchAndAwait
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
 import org.wordpress.android.fluxc.Dispatcher
 import org.wordpress.android.fluxc.generated.AccountActionBuilder
 import org.wordpress.android.fluxc.generated.NotificationActionBuilder
@@ -37,7 +39,8 @@ class AccountRepository @Inject constructor(
     private val zendeskSettings: ZendeskSettings,
     private val prefs: AppPrefs,
     @AppCoroutineScope private val appCoroutineScope: CoroutineScope,
-    private val siteVisibilityDataStore: VisibleWooSitesDataStore
+    private val siteVisibilityDataStore: VisibleWooSitesDataStore,
+    private val dispatchers: CoroutineDispatchers
 ) {
     fun getUserAccount(): AccountModel? = accountStore.account.takeIf { it.userId != 0L }
 
@@ -72,6 +75,7 @@ class AccountRepository @Inject constructor(
                 false
             } else {
                 AnalyticsTracker.track(AnalyticsEvent.ACCOUNT_LOGOUT)
+                deleteApplicationPasswordsOfUserSites()
                 cleanup()
                 true
             }
@@ -125,6 +129,17 @@ class AccountRepository @Inject constructor(
         dispatcher.dispatchAndAwait<Void, OnDeviceUnregistered>(
             NotificationActionBuilder.newUnregisterDeviceAction()
         )
+    }
+
+    private suspend fun deleteApplicationPasswordsOfUserSites() {
+        val sites = withContext(dispatchers.io) {
+            siteStore.sitesAccessedViaWPComRest
+        }
+
+        // Start deleting passwords asynchronously in the background
+        sites.forEach { site ->
+            deleteApplicationPassword(site)
+        }
     }
 
     private fun deleteApplicationPassword(site: SiteModel) {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/AccountRepository.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/AccountRepository.kt
@@ -19,6 +19,7 @@ import org.wordpress.android.fluxc.generated.AccountActionBuilder
 import org.wordpress.android.fluxc.generated.NotificationActionBuilder
 import org.wordpress.android.fluxc.generated.SiteActionBuilder
 import org.wordpress.android.fluxc.model.AccountModel
+import org.wordpress.android.fluxc.model.SiteModel
 import org.wordpress.android.fluxc.store.AccountStore
 import org.wordpress.android.fluxc.store.AccountStore.OnAccountChanged
 import org.wordpress.android.fluxc.store.NotificationStore.OnDeviceUnregistered
@@ -76,18 +77,7 @@ class AccountRepository @Inject constructor(
             }
         } else {
             // Application passwords logout
-            val site = selectedSite.get()
-            appCoroutineScope.launch {
-                val result = siteStore.deleteApplicationPassword(site)
-                if (result.isError) {
-                    WooLog.e(
-                        LOGIN,
-                        "Error deleting application password: ${result.error.errorCode} > ${result.error.message}"
-                    )
-                } else {
-                    WooLog.i(LOGIN, "Application password deleted")
-                }
-            }
+            deleteApplicationPassword(selectedSite.get())
             AnalyticsTracker.track(AnalyticsEvent.ACCOUNT_LOGOUT)
             cleanup()
             true
@@ -135,6 +125,22 @@ class AccountRepository @Inject constructor(
         dispatcher.dispatchAndAwait<Void, OnDeviceUnregistered>(
             NotificationActionBuilder.newUnregisterDeviceAction()
         )
+    }
+
+    private fun deleteApplicationPassword(site: SiteModel) {
+        appCoroutineScope.launch {
+            val result = siteStore.deleteApplicationPassword(site)
+            val siteId = site.siteId.takeIf { it != 0L }
+            if (result.isError) {
+                WooLog.e(
+                    LOGIN,
+                    "Error deleting application password: ${siteId?.let { "Site Id: $it - " }.orEmpty()}" +
+                        "${result.error.errorCode} > ${result.error.message}"
+                )
+            } else {
+                WooLog.i(LOGIN, "Application password deleted${siteId?.let { " for site Id: $it" }.orEmpty()}" )
+            }
+        }
     }
 
     sealed class CloseAccountResult {

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/login/AccountRepositoryTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/login/AccountRepositoryTest.kt
@@ -9,13 +9,16 @@ import com.woocommerce.android.viewmodel.BaseUnitTest
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.TestScope
 import org.assertj.core.api.Assertions.assertThat
+import org.mockito.kotlin.any
 import org.mockito.kotlin.given
 import org.mockito.kotlin.mock
 import org.wordpress.android.fluxc.action.AccountAction
 import org.wordpress.android.fluxc.action.NotificationAction
+import org.wordpress.android.fluxc.model.SiteModel
 import org.wordpress.android.fluxc.store.AccountStore
 import org.wordpress.android.fluxc.store.NotificationStore
 import org.wordpress.android.fluxc.store.SiteStore
+import org.wordpress.android.fluxc.store.SiteStore.OnApplicationPasswordDeleted
 import org.wordpress.android.fluxc.store.account.CloseAccountStore
 import kotlin.test.Test
 
@@ -32,6 +35,9 @@ class AccountRepositoryTest : BaseUnitTest() {
         registerActionHandler(AccountAction.SIGN_OUT) {
             emitChange(AccountStore.OnAccountChanged())
         }
+        registerActionHandler(NotificationAction.UNREGISTER_DEVICE) {
+            emitChange(NotificationStore.OnDeviceUnregistered())
+        }
     }
     private val appCoroutineScope = TestScope(coroutinesTestRule.testDispatcher)
 
@@ -44,7 +50,8 @@ class AccountRepositoryTest : BaseUnitTest() {
         zendeskSettings = zendeskSettings,
         prefs = appPrefs,
         appCoroutineScope = appCoroutineScope,
-        siteVisibilityDataStore = visibleWooSitesDataStore
+        siteVisibilityDataStore = visibleWooSitesDataStore,
+        dispatchers = coroutinesTestRule.testDispatchers
     )
 
     @Test
@@ -60,4 +67,22 @@ class AccountRepositoryTest : BaseUnitTest() {
 
         assertThat(deviceUnregistered).isTrue()
     }
+
+    @Test
+    fun `given signed in using wordpress_com, when logout is called, then remove app passwords of user sites`() =
+        testBlocking {
+            given(accountStore.hasAccessToken()).willReturn(true)
+            val sites = List(3) { SiteModel().apply { siteId = it.toLong() } }
+            given(siteStore.sitesAccessedViaWPComRest).willReturn(sites)
+            val sitesDeleted = mutableListOf<SiteModel>()
+            given(siteStore.deleteApplicationPassword(any())).willAnswer {
+                val site = it.getArgument(0) as SiteModel
+                sitesDeleted.add(site)
+                return@willAnswer OnApplicationPasswordDeleted(site)
+            }
+
+            repository.logout()
+
+            assertThat(sitesDeleted).containsExactlyElementsOf(sites)
+        }
 }

--- a/libs/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpapi/applicationpasswords/ApplicationPasswordsManager.kt
+++ b/libs/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpapi/applicationpasswords/ApplicationPasswordsManager.kt
@@ -152,8 +152,8 @@ internal class ApplicationPasswordsManager @Inject constructor(
                 }
                 when {
                     statusCode == CONFLICT -> {
-                        appLogWrapper.w(MAIN, "Application Password already exists")
-                        when (val deletionResult = deleteApplicationCredentials(site)) {
+                        appLogWrapper.w(AppLog.T.MAIN, "Application Password already exists")
+                        when (val deletionResult = deleteConflictedApplicationPassword(site)) {
                             ApplicationPasswordDeletionResult.Success ->
                                 createApplicationPassword(site, username)
 
@@ -175,7 +175,7 @@ internal class ApplicationPasswordsManager @Inject constructor(
 
                     else -> {
                         appLogWrapper.w(
-                            MAIN,
+                            AppLog.T.MAIN,
                             "Application Password creation failed ${payload.error.type}"
                         )
                         ApplicationPasswordCreationResult.Failure(payload.error)
@@ -189,70 +189,28 @@ internal class ApplicationPasswordsManager @Inject constructor(
         site: SiteModel
     ): ApplicationPasswordDeletionResult {
         val credentials = applicationPasswordsStore.getCredentials(site)
+        if (credentials == null) return ApplicationPasswordDeletionResult.Success
 
-        val payload = if (credentials == null) {
-            // If we don't have any saved credentials, let's fetch the UUID then delete the password using
-            // either the WP.com token or the self-hosted credentials.
-            val uuid = fetchApplicationPasswordUUID(site).let {
-                if (it.isError) return ApplicationPasswordDeletionResult.Failure(it.error)
-                it.uuid
-            }
+        val payload = wpApiApplicationPasswordsRestClient.deleteApplicationPassword(
+            site = site,
+            credentials = credentials
+        )
 
-            if (site.origin == SiteModel.ORIGIN_WPCOM_REST) {
-                jetpackApplicationPasswordsRestClient.deleteApplicationPassword(
-                    site = site,
-                    uuid = uuid
-                )
-            } else {
-                wpApiApplicationPasswordsRestClient.deleteApplicationPassword(
-                    site = site,
-                    uuid = uuid
-                )
-            }
-        } else {
-            // If we have an Application Password, we can use it itself for the delete request.
-            wpApiApplicationPasswordsRestClient.deleteApplicationPassword(
-                site = site,
-                credentials = credentials
-            )
-        }
-
-        return when {
-            !payload.isError -> {
-                if (payload.isDeleted) {
+        return payload.toResult().also {
+            when (it) {
+                is ApplicationPasswordDeletionResult.Success -> {
                     appLogWrapper.d(AppLog.T.MAIN, "Application password deleted")
                     applicationPasswordsStore.deleteCredentials(site)
-                    ApplicationPasswordDeletionResult.Success
-                } else {
-                    appLogWrapper.w(AppLog.T.MAIN, "Application password deletion failed")
-                    ApplicationPasswordDeletionResult.Failure(
-                        BaseNetworkError(
-                            GenericErrorType.UNKNOWN,
-                            "Deletion not confirmed by API"
-                        )
+                }
+
+                is ApplicationPasswordDeletionResult.Failure -> {
+                    appLogWrapper.w(
+                        AppLog.T.MAIN, "Application password deletion failed, error: " +
+                                "${it.error.type} ${it.error.message}\n" +
+                                "${it.error.volleyError?.toString()}"
                     )
                 }
             }
-
-            else -> {
-                val error = payload.error
-                appLogWrapper.w(
-                    AppLog.T.MAIN, "Application password deletion failed, error: " +
-                        "${error.type} ${error.message}\n" +
-                        "${error.volleyError?.toString()}"
-                )
-                ApplicationPasswordDeletionResult.Failure(error)
-            }
-        }
-    }
-
-    private suspend fun fetchApplicationPasswordUUID(
-        site: SiteModel
-    ): ApplicationPasswordUUIDFetchPayload {
-        return if (site.origin == SiteModel.ORIGIN_WPCOM_REST) {
-            jetpackApplicationPasswordsRestClient.fetchApplicationPasswordUUID(site, applicationName)
-        } else {
-            wpApiApplicationPasswordsRestClient.fetchApplicationPasswordUUID(site, applicationName)
         }
     }
 
@@ -261,4 +219,61 @@ internal class ApplicationPasswordsManager @Inject constructor(
             applicationPasswordsStore.deleteCredentials(site)
         }
     }
+
+    private suspend fun deleteConflictedApplicationPassword(
+        site: SiteModel
+    ): ApplicationPasswordDeletionResult {
+        suspend fun fetchApplicationPasswordUUID(
+            site: SiteModel
+        ): ApplicationPasswordUUIDFetchPayload {
+            return if (site.origin == SiteModel.ORIGIN_WPCOM_REST) {
+                jetpackApplicationPasswordsRestClient.fetchApplicationPasswordUUID(site, applicationName)
+            } else {
+                wpApiApplicationPasswordsRestClient.fetchApplicationPasswordUUID(site, applicationName)
+            }
+        }
+
+        val uuid = fetchApplicationPasswordUUID(site).let {
+            if (it.isError) return ApplicationPasswordDeletionResult.Failure(it.error)
+            it.uuid
+        }
+
+        val result = if (site.origin == SiteModel.ORIGIN_WPCOM_REST) {
+            jetpackApplicationPasswordsRestClient.deleteApplicationPassword(
+                site = site,
+                uuid = uuid
+            )
+        } else {
+            wpApiApplicationPasswordsRestClient.deleteApplicationPassword(
+                site = site,
+                uuid = uuid
+            )
+        }
+
+        return result.toResult().also {
+            if (it is ApplicationPasswordDeletionResult.Failure) {
+                appLogWrapper.w(
+                    AppLog.T.MAIN, "Conflicted application password deletion failed, error: " +
+                        "${it.error.type} ${it.error.message}\n" +
+                        "${it.error.volleyError?.toString()}"
+                )
+            } else {
+                appLogWrapper.d(AppLog.T.MAIN, "Conflicted application password deleted")
+            }
+        }
+    }
+
+    private fun ApplicationPasswordDeletionPayload.toResult(): ApplicationPasswordDeletionResult =
+        if (isError) {
+            ApplicationPasswordDeletionResult.Failure(error)
+        } else if (isDeleted) {
+            ApplicationPasswordDeletionResult.Success
+        } else {
+            ApplicationPasswordDeletionResult.Failure(
+                BaseNetworkError(
+                    GenericErrorType.UNKNOWN,
+                    "Deletion not confirmed by API"
+                )
+            )
+        }
 }

--- a/libs/fluxc/src/test/java/org/wordpress/android/fluxc/network/rest/wpapi/applicationpasswords/ApplicationPasswordManagerTests.kt
+++ b/libs/fluxc/src/test/java/org/wordpress/android/fluxc/network/rest/wpapi/applicationpasswords/ApplicationPasswordManagerTests.kt
@@ -259,26 +259,6 @@ class ApplicationPasswordManagerTests {
         }
 
     @Test
-    fun `given application password doesn't exist locally, when deleting a password, then fetch the UUID`() =
-        runTest {
-            val site = testSite.apply {
-                origin = SiteModel.ORIGIN_XMLRPC
-                username = testCredentials.userName
-            }
-            whenever(applicationPasswordsStore.getCredentials(testSite)).thenReturn(null)
-            whenever(mWpApiApplicationPasswordsRestClient.fetchApplicationPasswordUUID(site, applicationName))
-                .thenReturn(ApplicationPasswordUUIDFetchPayload(uuid))
-            whenever(mWpApiApplicationPasswordsRestClient.deleteApplicationPassword(site, uuid))
-                .thenReturn(ApplicationPasswordDeletionPayload(isDeleted = true))
-
-            val result = mApplicationPasswordsManager.deleteApplicationCredentials(site)
-
-            assertEquals(ApplicationPasswordDeletionResult.Success, result)
-            verify(mWpApiApplicationPasswordsRestClient).fetchApplicationPasswordUUID(site, applicationName)
-            verify(mWpApiApplicationPasswordsRestClient).deleteApplicationPassword(site, uuid)
-        }
-
-    @Test
     fun `given application password exists locally, when deleting a password, then delete it using it itself`() =
         runTest {
             val site = testSite.apply {


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

<!-- Id number of the Linear issue this PR addresses, e.g., WOOMOB-373. -->
Closes WOOMOB-1178

### Description
This PR adds handling of deleting app passwords on logout for Jetpack sites.
Similar to what we do with site credentials login, the deletion happens asynchronously, and we ignore any eventual failures.

### Steps to reproduce
1. Sign in using a WordPress.com account (preferably connected to multiple sites).
2. Switch sites (if possible).
3. Inspect network requests.
4. Log out of the app.

### Testing information
- Confirm the app sent requests to delete passwords for all sites that were used (assuming they support app passwords).


### The tests that have been performed
The above

- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->