### PR TITLE
Fix permissions for the dependabot contraintlayout check

### DIFF
--- a/.github/workflows/dependabot-constraintlayout-check.yml
+++ b/.github/workflows/dependabot-constraintlayout-check.yml
@@ -1,13 +1,15 @@
 name: Dependabot POS Reminder
 
 on:
-  pull_request:
+  pull_request_target:
     types: [opened, reopened]
 
 jobs:
   add-pos-reminder:
     runs-on: ubuntu-latest
     if: github.actor == 'dependabot[bot]'
+    permissions:
+      pull-requests: write
 
     steps:
       # Check if PR contains the constraintlayout dependency


### PR DESCRIPTION
This PR is[ an attempt at fixing the github action](https://github.com/woocommerce/woocommerce-android/actions/runs/17070557868/job/48398077981#step:3:99) that drops a warning comment on dependabot contraint-layout updates. Since there is no way how to verify it works, I believe we just need to merge it and then test it on https://github.com/woocommerce/woocommerce-android/pull/14400.