### PR TITLE
Update milestone assignment logic in auto-merge workflow

### DIFF
--- a/.github/workflows/dependabot_automerge.yml
+++ b/.github/workflows/dependabot_automerge.yml
@@ -28,16 +28,16 @@ jobs:
         if: steps.metadata.outputs.update-type == 'version-update:semver-patch'
         run: |
           set -e
-          number=$(gh api repos/$GITHUB_REPOSITORY/milestones \
+          title=$(gh api repos/$GITHUB_REPOSITORY/milestones \
             --jq '[.[]
               | select(.state=="open" and .due_on!=null and (.due_on | fromdateiso8601) >= now)
             ]
             | sort_by(.due_on)
-            | .[0].number')
+            | .[0].title')
 
-          if [ -n "$number" ]; then
-            echo "Assigning milestone #$number to PR #${{ github.event.pull_request.number }}"
-            gh pr edit "${{ github.event.pull_request.number }}" --milestone "$number"
+          if [ -n "$title" ]; then
+            echo "Assigning milestone '$title' to PR #${{ github.event.pull_request.number }}"
+            gh pr edit "${{ github.event.pull_request.number }}" --milestone "$title"
           else
             echo "No future open milestones found."
           fi


### PR DESCRIPTION
Related to: AINFRA-1224

### Description

This little PR is a follow-up to #14556 . The `gh pr edit --milestone` expects milestone name: 

```
  -m, --milestone name          Edit the milestone the pull request belongs to by name
```

I missed this on my fork, because the milestone was not found there.