### PR TITLE
Add `cooldown` of Dependabot PRs for minor & major updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -15,6 +15,9 @@ updates:
           - "com.google.devtools.ksp*"
         exclude-patterns:
           - "org.jetbrains.kotlinx*"
+    cooldown:
+      semver-major-days: 30
+      semver-minor-days: 30
     ignore:
       # Bumping 2.26.3 to 2.27.2 will break the mocks. For more details, see
       # https://github.com/wiremock/wiremock/issues/1345#issuecomment-656060968


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->
Closes: AINFRA-1233

<!-- Id number of the Linear issue this PR addresses, e.g., WOOMOB-373. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

This PR introduces a 30-day cooldown period for minor & major updates, as discussed with the team internally (p91TBi-dpu-p2#comment-14339 .

The documentation for this feature is available here: https://docs.github.com/en/code-security/dependabot/working-with-dependabot/dependabot-options-reference

### Testing information
<!-- This is your opportunity to break out individual scenarios that need testing (when necessary) and/or include a checklist for the reviewer to go through. Consider documenting the following from your own completed testing: devices used, alternate workflows, edge cases, affected areas, critical flows, areas not tested, and any remaining unknowns. Provide feedback on this new section of the PR template through Sept 30, 2024 to Apps Quality; additional context here: p91TBi-b8z-p2#comment-12036 -->

1. Create a fork
2. Downgrade a random dependency with minor version
3. Wait 30 days...
4. Just kidding :) This is just a configuration option, there's no way to meaningfully test it.

- [ ] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->