### PR TITLE
[Jetpack Performance] Refresh site status periodically

### DIFF
--- a/libs/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpapi/applicationpasswords/JetpackApplicationPasswordsSupport.kt
+++ b/libs/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpapi/applicationpasswords/JetpackApplicationPasswordsSupport.kt
@@ -18,6 +18,7 @@ class JetpackApplicationPasswordsSupport @Inject constructor(
 ) {
     private val fluxCPreferences by lazy { PreferenceUtils.getFluxCPreferences(context) }
 
+    @Synchronized
     fun supportsAppPasswords(siteModel: SiteModel): Boolean {
         val siteFlag = fluxCPreferences.getStringSet(UNSUPPORTED_JETPACK_APP_PASSWORDS_SITES, null)
             ?.firstOrNull { it.startsWith("${siteModel.siteId}:") }
@@ -38,6 +39,7 @@ class JetpackApplicationPasswordsSupport @Inject constructor(
         return siteModel.isApplicationPasswordsSupported
     }
 
+    @Synchronized
     fun flagAsUnsupported(siteModel: SiteModel) {
         val unsupportedSites = fluxCPreferences.getStringSet(UNSUPPORTED_JETPACK_APP_PASSWORDS_SITES, null) ?: setOf()
         if (unsupportedSites.any { it.startsWith("${siteModel.siteId}:") }) {

--- a/libs/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpapi/applicationpasswords/JetpackApplicationPasswordsSupport.kt
+++ b/libs/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpapi/applicationpasswords/JetpackApplicationPasswordsSupport.kt
@@ -64,7 +64,7 @@ class JetpackApplicationPasswordsSupport @Inject constructor(
 
     companion object {
         @VisibleForTesting
-        internal const val FLAG_REFRESH_DURATION_DAYS = 7
+        internal const val FLAG_REFRESH_DURATION_DAYS = 14
 
         @VisibleForTesting
         internal const val UNSUPPORTED_JETPACK_APP_PASSWORDS_SITES = "unsupported_jetpack_app_passwords_sites"

--- a/libs/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpapi/applicationpasswords/JetpackApplicationPasswordsSupport.kt
+++ b/libs/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpapi/applicationpasswords/JetpackApplicationPasswordsSupport.kt
@@ -1,28 +1,70 @@
 package org.wordpress.android.fluxc.network.rest.wpapi.applicationpasswords
 
 import android.content.Context
+import androidx.annotation.VisibleForTesting
 import androidx.core.content.edit
 import org.wordpress.android.fluxc.model.SiteModel
+import org.wordpress.android.fluxc.utils.AppLogWrapper
 import org.wordpress.android.fluxc.utils.PreferenceUtils
+import org.wordpress.android.util.AppLog
 import javax.inject.Inject
+import javax.inject.Singleton
+import kotlin.time.Duration.Companion.days
 
-class JetpackApplicationPasswordsSupport @Inject constructor(context: Context) {
+@Singleton
+class JetpackApplicationPasswordsSupport @Inject constructor(
+    context: Context,
+    private val appLog: AppLogWrapper
+) {
     private val fluxCPreferences by lazy { PreferenceUtils.getFluxCPreferences(context) }
 
     fun supportsAppPasswords(siteModel: SiteModel): Boolean {
-        return siteModel.isApplicationPasswordsSupported &&
-            fluxCPreferences.getStringSet(UNSUPPORTED_JETPACK_APP_PASSWORDS_SITES, null)
-                ?.contains(siteModel.siteId.toString()) != true
+        val siteFlag = fluxCPreferences.getStringSet(UNSUPPORTED_JETPACK_APP_PASSWORDS_SITES, null)
+            ?.firstOrNull { it.startsWith("${siteModel.siteId}:") }
+
+        if (siteFlag != null) {
+            val flagTimestamp = siteFlag.substringAfter(":").toLongOrNull() ?: 0L
+            if (System.currentTimeMillis() - flagTimestamp < FLAG_REFRESH_DURATION_DAYS.days.inWholeMilliseconds) {
+                return false
+            } else {
+                appLog.d(
+                    AppLog.T.API,
+                    "Clearing Jetpack Application Passwords unsupported flag for site ${siteModel.siteId} after refresh period"
+                )
+                clearFlag(siteModel)
+            }
+        }
+
+        return siteModel.isApplicationPasswordsSupported
     }
 
     fun flagAsUnsupported(siteModel: SiteModel) {
         val unsupportedSites = fluxCPreferences.getStringSet(UNSUPPORTED_JETPACK_APP_PASSWORDS_SITES, null) ?: setOf()
+        if (unsupportedSites.any { it.startsWith("${siteModel.siteId}:") }) {
+            // Already flagged
+            return
+        }
         fluxCPreferences.edit {
-            putStringSet(UNSUPPORTED_JETPACK_APP_PASSWORDS_SITES, unsupportedSites + siteModel.siteId.toString())
+            putStringSet(
+                UNSUPPORTED_JETPACK_APP_PASSWORDS_SITES,
+                unsupportedSites + "${siteModel.siteId}:${System.currentTimeMillis()}"
+            )
+        }
+    }
+
+    private fun clearFlag(siteModel: SiteModel) {
+        val unsupportedSites = fluxCPreferences.getStringSet(UNSUPPORTED_JETPACK_APP_PASSWORDS_SITES, null) ?: setOf()
+        val updatedSites = unsupportedSites.filterNot { it.startsWith("${siteModel.siteId}:") }.toSet()
+        fluxCPreferences.edit {
+            putStringSet(UNSUPPORTED_JETPACK_APP_PASSWORDS_SITES, updatedSites)
         }
     }
 
     companion object {
-        private const val UNSUPPORTED_JETPACK_APP_PASSWORDS_SITES = "unsupported_jetpack_app_passwords_sites"
+        @VisibleForTesting
+        internal const val FLAG_REFRESH_DURATION_DAYS = 7
+
+        @VisibleForTesting
+        internal const val UNSUPPORTED_JETPACK_APP_PASSWORDS_SITES = "unsupported_jetpack_app_passwords_sites"
     }
 }

--- a/libs/fluxc/src/test/java/org/wordpress/android/fluxc/network/rest/wpapi/applicationpasswords/JetpackApplicationPasswordsSupportTest.kt
+++ b/libs/fluxc/src/test/java/org/wordpress/android/fluxc/network/rest/wpapi/applicationpasswords/JetpackApplicationPasswordsSupportTest.kt
@@ -198,7 +198,7 @@ class JetpackApplicationPasswordsSupportTest {
         // Given
         val testSite = createSite()
         val currentTime = System.currentTimeMillis()
-        val flagTime = currentTime - 8.days.inWholeMilliseconds
+        val flagTime = currentTime - (FLAG_REFRESH_DURATION_DAYS + 1).days.inWholeMilliseconds
         sharedPreferences.edit()
             .putStringSet(UNSUPPORTED_JETPACK_APP_PASSWORDS_SITES, setOf("$testSiteId:$flagTime"))
             .apply()

--- a/libs/fluxc/src/test/java/org/wordpress/android/fluxc/network/rest/wpapi/applicationpasswords/JetpackApplicationPasswordsSupportTest.kt
+++ b/libs/fluxc/src/test/java/org/wordpress/android/fluxc/network/rest/wpapi/applicationpasswords/JetpackApplicationPasswordsSupportTest.kt
@@ -1,0 +1,233 @@
+package org.wordpress.android.fluxc.network.rest.wpapi.applicationpasswords
+
+import android.content.Context
+import android.content.SharedPreferences
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.joinAll
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.test.runTest
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.After
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.mockito.kotlin.mock
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.RuntimeEnvironment
+import org.wordpress.android.fluxc.model.SiteModel
+import org.wordpress.android.fluxc.network.rest.wpapi.applicationpasswords.JetpackApplicationPasswordsSupport.Companion.FLAG_REFRESH_DURATION_DAYS
+import org.wordpress.android.fluxc.network.rest.wpapi.applicationpasswords.JetpackApplicationPasswordsSupport.Companion.UNSUPPORTED_JETPACK_APP_PASSWORDS_SITES
+import org.wordpress.android.fluxc.utils.PreferenceUtils
+import kotlin.time.Duration.Companion.days
+
+@RunWith(RobolectricTestRunner::class)
+class JetpackApplicationPasswordsSupportTest {
+    private lateinit var context: Context
+    private lateinit var sharedPreferences: SharedPreferences
+    private lateinit var jetpackApplicationPasswordsSupport: JetpackApplicationPasswordsSupport
+
+    private val testSiteId = 123L
+
+    @Before
+    fun setup() {
+        context = RuntimeEnvironment.getApplication().applicationContext
+        sharedPreferences = PreferenceUtils.getFluxCPreferences(context)
+        jetpackApplicationPasswordsSupport = JetpackApplicationPasswordsSupport(context = context, appLog = mock())
+    }
+
+    @After
+    fun tearDown() {
+        sharedPreferences.edit().remove(UNSUPPORTED_JETPACK_APP_PASSWORDS_SITES).apply()
+    }
+
+    @Test
+    fun `given site with no flag and app passwords supported, when checking support, then return true`() {
+        // Given
+        val testSite = createSite(supportsAppPasswords = true)
+        // SharedPreferences is empty by default
+
+        // When
+        val result = jetpackApplicationPasswordsSupport.supportsAppPasswords(testSite)
+
+        // Then
+        assertThat(result).isTrue()
+    }
+
+    @Test
+    fun `given site with no flag but app passwords not supported, when checking support, then return false`() {
+        // Given
+        val siteWithoutAppPasswordsSupport = createSite(supportsAppPasswords = false)
+
+        // When
+        val result = jetpackApplicationPasswordsSupport.supportsAppPasswords(siteWithoutAppPasswordsSupport)
+
+        // Then
+        assertThat(result).isFalse()
+    }
+
+    @Test
+    fun `given site flagged as unsupported within refresh duration, when checking support, then return false`() {
+        // Given
+        val testSite = createSite(supportsAppPasswords = true)
+        val currentTime = System.currentTimeMillis()
+        val flagTime = currentTime - (FLAG_REFRESH_DURATION_DAYS.days - 1.days).inWholeMilliseconds
+        val unsupportedSites = setOf("$testSiteId:$flagTime")
+
+        // Pre-populate SharedPreferences with the flag
+        sharedPreferences.edit()
+            .putStringSet(UNSUPPORTED_JETPACK_APP_PASSWORDS_SITES, unsupportedSites)
+            .apply()
+
+        // When
+        val result = jetpackApplicationPasswordsSupport.supportsAppPasswords(testSite)
+
+        // Then
+        assertThat(result).isFalse()
+    }
+
+    @Test
+    fun `given site flagged as unsupported beyond refresh duration, when checking support, then clear flag and return site support status`() {
+        // Given
+        val testSite = createSite(supportsAppPasswords = true)
+        val currentTime = System.currentTimeMillis()
+        val flagTime = currentTime - (FLAG_REFRESH_DURATION_DAYS.days + 1.days).inWholeMilliseconds
+        val unsupportedSites = setOf("$testSiteId:$flagTime", "456:$currentTime")
+
+        // Pre-populate SharedPreferences with the flags
+        sharedPreferences.edit()
+            .putStringSet(UNSUPPORTED_JETPACK_APP_PASSWORDS_SITES, unsupportedSites)
+            .apply()
+
+        // When
+        val result = jetpackApplicationPasswordsSupport.supportsAppPasswords(testSite)
+
+        // Then
+        assertThat(result).isTrue() // Returns site's isApplicationPasswordsSupported value
+
+        // Verify that the expired flag was removed but the other flag remains
+        val remainingFlags = sharedPreferences.getStringSet(UNSUPPORTED_JETPACK_APP_PASSWORDS_SITES, null)
+        assertThat(remainingFlags).containsExactly("456:$currentTime")
+    }
+
+    @Test
+    fun `given multiple sites in unsupported list, when checking support for different site, then return site support status`() {
+        // Given
+        val differentSiteId = 999L
+        val differentSite = createSite(siteId = differentSiteId, supportsAppPasswords = true)
+        val currentTime = System.currentTimeMillis()
+        val flagTime = currentTime - (FLAG_REFRESH_DURATION_DAYS.days - 1.days).inWholeMilliseconds
+        val unsupportedSites = setOf("$testSiteId:$flagTime", "456:$currentTime")
+
+        // Pre-populate SharedPreferences with the flags
+        sharedPreferences.edit()
+            .putStringSet(UNSUPPORTED_JETPACK_APP_PASSWORDS_SITES, unsupportedSites)
+            .apply()
+
+        // When
+        val result = jetpackApplicationPasswordsSupport.supportsAppPasswords(differentSite)
+
+        // Then
+        assertThat(result).isTrue()
+
+        // Verify that the existing flags were not modified
+        val remainingFlags = sharedPreferences.getStringSet(UNSUPPORTED_JETPACK_APP_PASSWORDS_SITES, null)
+        assertThat(remainingFlags).containsExactlyInAnyOrder("$testSiteId:$flagTime", "456:$currentTime")
+    }
+
+    @Test
+    fun `given site not yet flagged, when flagging as unsupported, then add site to unsupported list`() {
+        // Given
+        val testSite = createSite()
+        val existingUnsupportedSites = setOf("456:1234567890")
+
+        // Pre-populate SharedPreferences with existing flags
+        sharedPreferences.edit()
+            .putStringSet(UNSUPPORTED_JETPACK_APP_PASSWORDS_SITES, existingUnsupportedSites)
+            .apply()
+
+        // When
+        jetpackApplicationPasswordsSupport.flagAsUnsupported(testSite)
+
+        // Then
+        val updatedFlags = sharedPreferences.getStringSet(UNSUPPORTED_JETPACK_APP_PASSWORDS_SITES, null)
+        assertThat(updatedFlags).hasSize(2)
+        assertThat(updatedFlags).contains("456:1234567890")
+        assertThat(updatedFlags!!.any { it.startsWith("$testSiteId:") }).isTrue()
+    }
+
+    @Test
+    fun `given site already flagged, when flagging as unsupported again, then do not modify the list`() {
+        // Given
+        val testSite = createSite()
+        val currentTime = System.currentTimeMillis()
+        val existingUnsupportedSites = setOf("$testSiteId:$currentTime", "456:1234567890")
+
+        // Pre-populate SharedPreferences with existing flags
+        sharedPreferences.edit()
+            .putStringSet(UNSUPPORTED_JETPACK_APP_PASSWORDS_SITES, existingUnsupportedSites)
+            .apply()
+
+        // When
+        jetpackApplicationPasswordsSupport.flagAsUnsupported(testSite)
+
+        // Then
+        val updatedFlags = sharedPreferences.getStringSet(UNSUPPORTED_JETPACK_APP_PASSWORDS_SITES, null)
+        assertThat(updatedFlags).isEqualTo(existingUnsupportedSites)
+    }
+
+    @Test
+    fun `given malformed flag entry, when checking support, then handle gracefully`() {
+        // Given
+        val testSite = createSite(supportsAppPasswords = true)
+        val unsupportedSites = setOf("$testSiteId:invalid_timestamp", "456:1234567890")
+        sharedPreferences.edit()
+            .putStringSet(UNSUPPORTED_JETPACK_APP_PASSWORDS_SITES, unsupportedSites)
+            .apply()
+
+        // When
+        val result = jetpackApplicationPasswordsSupport.supportsAppPasswords(testSite)
+
+        // Then
+        assertThat(result).isTrue()
+        val remainingFlags = sharedPreferences.getStringSet(UNSUPPORTED_JETPACK_APP_PASSWORDS_SITES, null)
+        assertThat(remainingFlags).noneMatch { it.startsWith("$testSiteId:") }
+    }
+
+    @Test
+    fun `given concurrent access, when flagging and checking support, then maintain data integrity`() = runTest {
+        // Given
+        val testSite = createSite()
+        val currentTime = System.currentTimeMillis()
+        val flagTime = currentTime - 8.days.inWholeMilliseconds
+        sharedPreferences.edit()
+            .putStringSet(UNSUPPORTED_JETPACK_APP_PASSWORDS_SITES, setOf("$testSiteId:$flagTime"))
+            .apply()
+
+        // When
+        val accessJobs = (0..4).map {
+            launch(Dispatchers.Default) {
+                jetpackApplicationPasswordsSupport.supportsAppPasswords(testSite)
+            }
+        }
+        val updateJobs = (0..4).map {
+            launch(Dispatchers.Default) {
+                jetpackApplicationPasswordsSupport.flagAsUnsupported(testSite)
+            }
+        }
+        joinAll(*accessJobs.toTypedArray(), *updateJobs.toTypedArray())
+
+        // Then
+        val updatedFlags = sharedPreferences.getStringSet(UNSUPPORTED_JETPACK_APP_PASSWORDS_SITES, null)
+        val siteFlag = updatedFlags?.firstOrNull { it.startsWith("$testSiteId:") }
+        assertThat(siteFlag).isNotNull
+        val timestamp = siteFlag!!.substringAfter(":").toLongOrNull()
+        assertThat(timestamp).isGreaterThanOrEqualTo(currentTime)
+    }
+
+    private fun createSite(siteId: Long = testSiteId, supportsAppPasswords: Boolean = true): SiteModel {
+        val site = SiteModel()
+        site.siteId = siteId
+        site.applicationPasswordsAuthorizeUrl = if (supportsAppPasswords) "https://example.com/authorize" else null
+        return site
+    }
+}


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

<!-- Id number of the Linear issue this PR addresses, e.g., WOOMOB-373. -->
Closes WOOMOB-1182

### Description
This PR adds logic to make sure we refresh site status periodically, it implements the approach suggested here pe5sF9-4ye-p2#comment-4801:
- Store the timestamp when flagging a website as not supporting app passwords.
- When the timestamp is older than 7 days, we ignore it.

### Steps to reproduce
Follow the TC7 test steps from here pe5sF9-4Am-p2

### Testing information
- Confirm that after the duration, we check the site again, and we can use app passwords.

### The tests that have been performed
The above.

- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->