### PR TITLE
Fix overlap issue in the receipt preview screen

### DIFF
--- a/WooCommerce/src/main/res/layout/fragment_receipt_preview.xml
+++ b/WooCommerce/src/main/res/layout/fragment_receipt_preview.xml
@@ -37,7 +37,7 @@
     <WebView
         android:id="@+id/receipt_preview_preview_webview"
         android:layout_width="match_parent"
-        android:layout_height="match_parent"
+        android:layout_height="0dp"
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

<!-- Id number of the Linear issue this PR addresses, e.g., WOOMOB-373. -->
Closes WOOMOB-1296

### Description
This PR fixes an overlap issue in the receipt preview screen that caused the top section of the receipt to be hidden by the toolbar.

### Steps to reproduce
1. Open a completed order in the app.
2. Tap on view receipt.

### Testing information
Confirm the receipt is shown correctly.

### The tests that have been performed
The above.

### Images/gif
| Before | After |
| --- | --- |
| <img width="1080" height="2400" alt="Screenshot_20250908_132953" src="https://github.com/user-attachments/assets/5fac73ed-171c-4136-957a-9f88f008e557" /> | <img width="1080" height="2400" alt="Screenshot_20250908_133027" src="https://github.com/user-attachments/assets/9e0fa134-3d28-4975-90fc-56b1597a8a67" /> |

- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->