### PR TITLE
[WOOMOB-1309] Fix WooPos local catalog API response parsing

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/util/datastore/WooPosSyncTimestampManager.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/util/datastore/WooPosSyncTimestampManager.kt
@@ -2,10 +2,10 @@ package com.woocommerce.android.ui.woopos.util.datastore
 
 import com.woocommerce.android.ui.woopos.common.util.WooPosLogWrapper
 import java.time.Instant
-import java.time.LocalDateTime
 import java.time.ZoneOffset
 import java.time.format.DateTimeFormatter
 import java.time.format.DateTimeParseException
+import java.time.temporal.TemporalAccessor
 import java.util.Locale
 import javax.inject.Inject
 
@@ -13,7 +13,6 @@ class WooPosSyncTimestampManager @Inject constructor(
     private val timestampRepository: WooPosSyncTimestampRepository,
     private val logger: WooPosLogWrapper
 ) {
-    private val gmtFormatter = DateTimeFormatter.ofPattern(GMT_DATE_FORMAT, Locale.US).withZone(ZoneOffset.UTC)
 
     suspend fun storeProductsLastSyncTimestamp(timestamp: Long) {
         timestampRepository.storeProductsLastSyncTimestamp(timestamp)
@@ -37,7 +36,7 @@ class WooPosSyncTimestampManager @Inject constructor(
     }
 
     fun formatTimestampForApi(timestamp: Long): String {
-        return gmtFormatter.format(Instant.ofEpochMilli(timestamp))
+        return defaultApiDateFormatter.format(Instant.ofEpochMilli(timestamp))
     }
 
     fun parseTimestampFromApi(dateFromApi: String): Long? {
@@ -45,16 +44,33 @@ class WooPosSyncTimestampManager @Inject constructor(
     }
 
     private fun parseGmtTimestamp(dateFromApi: String): Long? {
-        return try {
-            val localDateTime = LocalDateTime.parse(dateFromApi, gmtFormatter)
-            return localDateTime.toInstant(ZoneOffset.UTC).toEpochMilli()
-        } catch (e: DateTimeParseException) {
-            logger.e("Failed to parse GMT timestamp: '$dateFromApi'", e)
-            null
+        for (formatter in PARSING_FORMATTERS) {
+            try {
+                val temporal: TemporalAccessor = formatter.parse(dateFromApi)
+                return Instant.from(temporal).toEpochMilli()
+            } catch (_: Exception) {
+                continue
+            }
         }
+
+        logger.e(
+            "Failed to parse GMT timestamp: '$dateFromApi' with any supported format",
+            DateTimeParseException("None of the supported formats could parse the date", dateFromApi, 0)
+        )
+        return null
     }
 
     private companion object {
-        const val GMT_DATE_FORMAT = "yyyy-MM-dd'T'HH:mm:ss"
+        private const val DEFAULT_API_DATE_FORMAT = "yyyy-MM-dd'T'HH:mm:ss"
+        private val defaultApiDateFormatter = DateTimeFormatter.ofPattern(DEFAULT_API_DATE_FORMAT, Locale.US)
+            .withZone(ZoneOffset.UTC)
+
+        private val PARSING_FORMATTERS = listOf(
+            defaultApiDateFormatter,
+            DateTimeFormatter.ofPattern("EEE, dd MMM yyyy HH:mm:ss 'GMT'", Locale.US).withZone(ZoneOffset.UTC),
+            DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss'Z'", Locale.US).withZone(ZoneOffset.UTC),
+            DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss.SSS", Locale.US).withZone(ZoneOffset.UTC),
+            DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss.SSS'Z'", Locale.US).withZone(ZoneOffset.UTC)
+        )
     }
 }

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/util/datastore/WooPosSyncTimestampManagerTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/util/datastore/WooPosSyncTimestampManagerTest.kt
@@ -20,7 +20,8 @@ class WooPosSyncTimestampManagerTest {
     private val logger: WooPosLogWrapper = mock()
 
     private lateinit var manager: WooPosSyncTimestampManager
-    private val gmtFormatter = DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss", Locale.US).withZone(ZoneOffset.UTC)
+    private val gmtFormatter = DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss", Locale.US)
+        .withZone(ZoneOffset.UTC)
 
     @Before
     fun setup() {
@@ -187,7 +188,7 @@ class WooPosSyncTimestampManagerTest {
 
         // THEN
         assertThat(result).isNull()
-        verify(logger).e(eq("Failed to parse GMT timestamp: '2024-15-45T25:70:90'"), any())
+        verify(logger).e(eq("Failed to parse GMT timestamp: '2024-15-45T25:70:90' with any supported format"), any())
     }
 
     @Test
@@ -214,7 +215,7 @@ class WooPosSyncTimestampManagerTest {
 
         // THEN
         assertThat(result).isNull()
-        verify(logger).e(eq("Failed to parse GMT timestamp: ''"), any())
+        verify(logger).e(eq("Failed to parse GMT timestamp: '' with any supported format"), any())
     }
 
     @Test
@@ -227,19 +228,78 @@ class WooPosSyncTimestampManagerTest {
 
         // THEN
         assertThat(result).isNull()
-        verify(logger).e(eq("Failed to parse GMT timestamp: '   '"), any())
+        verify(logger).e(eq("Failed to parse GMT timestamp: '   ' with any supported format"), any())
     }
 
     @Test
-    fun `given timestamp with timezone suffix, when parsing from API, then null is returned`() {
+    fun `given timestamp with timezone suffix Z, when parsing from API, then correct timestamp is returned`() {
         // GIVEN
         val timestampWithTZ = "2024-01-15T10:30:00Z"
+        val expectedTimestamp = LocalDateTime.parse("2024-01-15T10:30:00", gmtFormatter)
+            .toInstant(ZoneOffset.UTC).toEpochMilli()
 
         // WHEN
         val result = manager.parseTimestampFromApi(timestampWithTZ)
 
         // THEN
+        assertThat(result).isEqualTo(expectedTimestamp)
+    }
+
+    @Test
+    fun `given RFC 2822 format timestamp, when parsing from API, then correct timestamp is returned`() {
+        // GIVEN
+        val rfc2822Timestamp = "Tue, 09 Sep 2025 08:40:42 GMT"
+        // Create expected timestamp: September 9, 2025 08:40:42 GMT
+        val expectedTimestamp = LocalDateTime.of(2025, 9, 9, 8, 40, 42)
+            .toInstant(ZoneOffset.UTC).toEpochMilli()
+
+        // WHEN
+        val result = manager.parseTimestampFromApi(rfc2822Timestamp)
+
+        // THEN
+        assertThat(result).isEqualTo(expectedTimestamp)
+    }
+
+    @Test
+    fun `given timestamp with milliseconds, when parsing from API, then correct timestamp is returned`() {
+        // GIVEN
+        val timestampWithMillis = "2024-01-15T10:30:00.123"
+        // Expected timestamp should preserve milliseconds
+        val expectedTimestamp = LocalDateTime.of(2024, 1, 15, 10, 30, 0, 123_000_000)
+            .toInstant(ZoneOffset.UTC).toEpochMilli()
+
+        // WHEN
+        val result = manager.parseTimestampFromApi(timestampWithMillis)
+
+        // THEN
+        assertThat(result).isEqualTo(expectedTimestamp)
+    }
+
+    @Test
+    fun `given timestamp with milliseconds and Z, when parsing from API, then correct timestamp is returned`() {
+        // GIVEN
+        val timestampWithMillisAndZ = "2024-01-15T10:30:00.456Z"
+        // Expected timestamp should preserve milliseconds
+        val expectedTimestamp = LocalDateTime.of(2024, 1, 15, 10, 30, 0, 456_000_000)
+            .toInstant(ZoneOffset.UTC).toEpochMilli()
+
+        // WHEN
+        val result = manager.parseTimestampFromApi(timestampWithMillisAndZ)
+
+        // THEN
+        assertThat(result).isEqualTo(expectedTimestamp)
+    }
+
+    @Test
+    fun `given completely invalid format, when parsing from API, then null is returned and error logged`() {
+        // GIVEN
+        val invalidFormat = "not-a-valid-timestamp"
+
+        // WHEN
+        val result = manager.parseTimestampFromApi(invalidFormat)
+
+        // THEN
         assertThat(result).isNull()
-        verify(logger).e(eq("Failed to parse GMT timestamp: '2024-01-15T10:30:00Z'"), any())
+        verify(logger).e(eq("Failed to parse GMT timestamp: 'not-a-valid-timestamp' with any supported format"), any())
     }
 }

--- a/libs/fluxc-plugin/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/product/pos/WooPosProductRestClient.kt
+++ b/libs/fluxc-plugin/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/product/pos/WooPosProductRestClient.kt
@@ -67,7 +67,7 @@ class WooPosProductRestClient @Inject constructor(
         val url = "/wc-analytics/variations"
         val params = mutableMapOf(
             "per_page" to pageSize.toString(),
-            "paged" to page.toString(),
+            "page" to page.toString(),
             "_fields" to VARIATIONS_FIELDS
         ).also {
             if (modifiedAfter.isNullOrBlank().not()) {


### PR DESCRIPTION
Fixes WOOMOB-1309

### Description
This PR fixes API response parsing issues in the WooPos local catalog functionality. The changes include updating the WooPosSyncTimestampManager to handle different timestamp formats properly and fixing a typo in query parameters that was affecting API responses.

### Testing information
- Green CI is enough for this PR, since the code isn't used yet.

### Images/gif
<!-- Include before and after images or gifs when appropriate. -->
N/A

- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.