### PR TITLE
Move a release note to the correct version section

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -3,7 +3,7 @@
 *** For entries which are touching the Android Wear app's, start entry with `[WEAR]` too.
 23.3
 -----
-
+- [*] Enhance the shipping label creation screen by making the selected hazardous box tappable [https://github.com/woocommerce/woocommerce-android/pull/14576]
 
 23.2
 -----
@@ -20,7 +20,6 @@
 - [*] Automatically populate the weight field in the create shipment flow [https://github.com/woocommerce/woocommerce-android/pull/14525]
 - [*] [Shipping Labels] Fixed displaying incorrect hazardous material option for purchased labels [https://github.com/woocommerce/woocommerce-android/pull/14571]
 - [*] Shipping Labels: Updated the disabled button text on the package selection screen [https://github.com/woocommerce/woocommerce-android/pull/14558]
-- [*] Enhance the shipping label creation screen by making the selected hazardous box tappable [https://github.com/woocommerce/woocommerce-android/pull/14576]
 
 23.1
 -----


### PR DESCRIPTION
This moves a release note that was incorrectly added in 23.2 to the 23.3 section.
[Release notes in 23.2](https://github.com/woocommerce/woocommerce-android/pull/14582/files) don’t include this specific incorrect item, so no changes are needed in the 23.2 release.