### PR TITLE
[WOOMOB-28] Use product details for default Blaze campaign values

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/media/MediaFilesRepository.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/media/MediaFilesRepository.kt
@@ -101,7 +101,7 @@ class MediaFilesRepository @Inject constructor(
                 }
                 return@withContext ImageDimensions(options.outWidth, options.outHeight)
             } catch (e: IOException) {
-                e.printStackTrace()
+                WooLog.e(T.MEDIA, "MediaFilesRepository > Error getting image dimensions", e)
             }
             return@withContext ImageDimensions(width = 0, height = 0)
         }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/media/MediaFilesRepository.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/media/MediaFilesRepository.kt
@@ -5,8 +5,6 @@ import android.graphics.BitmapFactory
 import android.graphics.BitmapFactory.Options
 import android.net.Uri
 import android.util.Patterns
-import coil.annotation.ExperimentalCoilApi
-import coil.imageLoader
 import com.woocommerce.android.OnChangedException
 import com.woocommerce.android.R
 import com.woocommerce.android.extensions.isNotNullOrEmpty
@@ -44,7 +42,6 @@ import java.io.File
 import java.io.FileDescriptor
 import java.io.IOException
 import java.net.URL
-import java.net.UnknownHostException
 import javax.inject.Inject
 
 class MediaFilesRepository @Inject constructor(
@@ -90,7 +87,6 @@ class MediaFilesRepository @Inject constructor(
         }
     }
 
-    @OptIn(ExperimentalCoilApi::class)
     suspend fun getImageDimensions(uri: String): ImageDimensions {
         return withContext(dispatchers.io) {
             try {
@@ -104,16 +100,6 @@ class MediaFilesRepository @Inject constructor(
                     parcelFileDescriptor.close()
                 }
                 return@withContext ImageDimensions(options.outWidth, options.outHeight)
-            } catch (e: UnknownHostException) {
-                e.printStackTrace()
-                // Image could not be loaded from internet, let's try to load a cached version
-                context.imageLoader.diskCache?.openSnapshot(uri)?.let { snapshot ->
-                    val source = snapshot.data.toFile()
-                    val options = Options().apply { inJustDecodeBounds = true }
-                    BitmapFactory.decodeStream(source.inputStream(), null, options)
-                    snapshot.close()
-                    return@withContext ImageDimensions(options.outWidth, options.outHeight)
-                }
             } catch (e: IOException) {
                 e.printStackTrace()
             }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/media/MediaFilesRepository.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/media/MediaFilesRepository.kt
@@ -5,6 +5,8 @@ import android.graphics.BitmapFactory
 import android.graphics.BitmapFactory.Options
 import android.net.Uri
 import android.util.Patterns
+import coil.annotation.ExperimentalCoilApi
+import coil.imageLoader
 import com.woocommerce.android.OnChangedException
 import com.woocommerce.android.R
 import com.woocommerce.android.extensions.isNotNullOrEmpty
@@ -42,6 +44,7 @@ import java.io.File
 import java.io.FileDescriptor
 import java.io.IOException
 import java.net.URL
+import java.net.UnknownHostException
 import javax.inject.Inject
 
 class MediaFilesRepository @Inject constructor(
@@ -87,6 +90,7 @@ class MediaFilesRepository @Inject constructor(
         }
     }
 
+    @OptIn(ExperimentalCoilApi::class)
     suspend fun getImageDimensions(uri: String): ImageDimensions {
         return withContext(dispatchers.io) {
             try {
@@ -100,6 +104,16 @@ class MediaFilesRepository @Inject constructor(
                     parcelFileDescriptor.close()
                 }
                 return@withContext ImageDimensions(options.outWidth, options.outHeight)
+            } catch (e: UnknownHostException) {
+                e.printStackTrace()
+                // Image could not be loaded from internet, let's try to load a cached version
+                context.imageLoader.diskCache?.openSnapshot(uri)?.let { snapshot ->
+                    val source = snapshot.data.toFile()
+                    val options = Options().apply { inJustDecodeBounds = true }
+                    BitmapFactory.decodeStream(source.inputStream(), null, options)
+                    snapshot.close()
+                    return@withContext ImageDimensions(options.outWidth, options.outHeight)
+                }
             } catch (e: IOException) {
                 e.printStackTrace()
             }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/blaze/BlazeRepository.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/blaze/BlazeRepository.kt
@@ -6,6 +6,7 @@ import com.woocommerce.android.AppUrls.FETCH_PAYMENT_METHOD_URL_PATH
 import com.woocommerce.android.AppUrls.WPCOM_ADD_PAYMENT_METHOD
 import com.woocommerce.android.BuildConfig
 import com.woocommerce.android.OnChangedException
+import com.woocommerce.android.extensions.fastStripHtml
 import com.woocommerce.android.media.MediaFilesRepository
 import com.woocommerce.android.model.CreditCardType
 import com.woocommerce.android.tools.SelectedSite
@@ -176,10 +177,11 @@ class BlazeRepository @Inject constructor(
         val product = productDetailRepository.getProduct(productId)
             ?: productDetailRepository.fetchAndGetProduct(productId)!!
 
+        val description = product.shortDescription.takeIf { product.hasShortDescription } ?: product.description
         return CampaignDetails(
             productId = productId,
-            tagLine = "",
-            description = "",
+            tagLine = product.name,
+            description = description.fastStripHtml(),
             campaignImage = product.images.firstOrNull().let {
                 if (it != null && isValidAdImage(it.source)) {
                     BlazeCampaignImage.RemoteImage(it.id, it.source)

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/blaze/BlazeRepositoryTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/blaze/BlazeRepositoryTest.kt
@@ -2,15 +2,19 @@ package com.woocommerce.android.ui.blaze
 
 import com.woocommerce.android.AppPrefsWrapper
 import com.woocommerce.android.media.MediaFilesRepository
+import com.woocommerce.android.media.MediaFilesRepository.ImageDimensions
 import com.woocommerce.android.tools.SelectedSite
 import com.woocommerce.android.ui.blaze.BlazeRepository.BlazeCampaignImage.RemoteImage
 import com.woocommerce.android.ui.blaze.BlazeRepository.Budget
 import com.woocommerce.android.ui.blaze.BlazeRepository.CampaignDetails
 import com.woocommerce.android.ui.blaze.BlazeRepository.Companion.CAMPAIGN_BUDGET_MODE_DAILY
 import com.woocommerce.android.ui.blaze.BlazeRepository.Companion.CAMPAIGN_BUDGET_MODE_TOTAL
+import com.woocommerce.android.ui.blaze.BlazeRepository.Companion.CAMPAIGN_MINIMUM_DAILY_SPEND
+import com.woocommerce.android.ui.blaze.BlazeRepository.Companion.DEFAULT_CAMPAIGN_DURATION
 import com.woocommerce.android.ui.blaze.BlazeRepository.Companion.WEEKLY_DURATION
 import com.woocommerce.android.ui.blaze.BlazeRepository.DestinationParameters
 import com.woocommerce.android.ui.blaze.BlazeRepository.TargetingParameters
+import com.woocommerce.android.ui.products.ProductTestUtils
 import com.woocommerce.android.ui.products.details.ProductDetailRepository
 import com.woocommerce.android.viewmodel.BaseUnitTest
 import kotlinx.coroutines.ExperimentalCoroutinesApi
@@ -21,6 +25,7 @@ import org.mockito.kotlin.argumentCaptor
 import org.mockito.kotlin.doReturn
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
 import org.wordpress.android.fluxc.model.MediaModel
 import org.wordpress.android.fluxc.model.SiteModel
 import org.wordpress.android.fluxc.model.blaze.BlazeCampaignCreationRequest
@@ -37,7 +42,20 @@ class BlazeRepositoryTest : BaseUnitTest() {
             url = "https://example.com"
         }
     }
-    private val blazeModel: BlazeCampaignModel = mock()
+    private val blazeModel: BlazeCampaignModel = BlazeCampaignModel(
+        campaignId = "1",
+        title = "",
+        imageUrl = null,
+        startTime = Date(),
+        durationInDays = 0,
+        uiStatus = "",
+        impressions = 0,
+        clicks = 0,
+        targetUrn = null,
+        totalBudget = 0.0,
+        spentBudget = 0.0,
+        isEndlessCampaign = false
+    )
     private val blazeCampaignsStore: BlazeCampaignsStore = mock {
         onBlocking { createCampaign(any(), any()) } doReturn
             BlazeResult(blazeModel)
@@ -89,12 +107,79 @@ class BlazeRepositoryTest : BaseUnitTest() {
         }
 
     @Test
-    fun `given a campaign with end date, when creating it, budget should equal totalBudget`() =
+    fun `given productId, when generateDefaultCampaignDetails invoked, then default CampaignDetails created`() =
         testBlocking {
-            repository.createCampaign(NON_ENDLESS_CAMPAIGN_DETAILS, PAYMENT_METHOD_ID)
+            val productId = 123L
+            val objective = "sales"
+            val imageUrl = "https://example.com/image-400.jpg"
+            val product = ProductTestUtils.generateProduct(
+                productId = productId,
+                productName = "My Product",
+                imageUrl = imageUrl
+            ).copy(
+                shortDescription = "<p>Hello<br>World</p>"
+            )
 
-            verify(blazeCampaignsStore).createCampaign(any(), createCampaignRequestCaptor.capture())
-            assertThat(createCampaignRequestCaptor.firstValue.budget.amount).isEqualTo(TOTAL_BUDGET.toDouble())
+            whenever(appPrefsWrapper.blazeCampaignSelectedObjective).thenReturn(objective)
+            whenever(productDetailRepository.getProduct(productId)).thenReturn(product)
+            whenever(mediaFilesRepository.getImageDimensions(imageUrl)).thenReturn(ImageDimensions(0, 0))
+
+            val before = Date()
+            val details = repository.generateDefaultCampaignDetails(productId)
+
+            // Basic fields
+            assertThat(details.productId).isEqualTo(productId)
+            assertThat(details.tagLine).isEqualTo("My Product")
+            assertThat(details.description).isEqualTo("Hello\nWorld")
+            assertThat(details.ctaText).isEmpty()
+            assertThat(details.objectiveId).isEqualTo(objective)
+            assertThat(details.acceptedTos).isFalse()
+
+            // Destination
+            assertThat(details.destinationParameters.targetUrl).isEqualTo(product.permalink)
+            assertThat(details.destinationParameters.parameters).isEmpty()
+
+            // Targeting
+            assertThat(details.targetingParameters.locations).isEmpty()
+            assertThat(details.targetingParameters.languages).isEmpty()
+            assertThat(details.targetingParameters.devices).isEmpty()
+            assertThat(details.targetingParameters.interests).isEmpty()
+
+            // Campaign Image
+            assertThat(details.campaignImage).isInstanceOf(BlazeRepository.BlazeCampaignImage.None::class.java)
+
+            // Budget defaults
+            val expectedTotal = DEFAULT_CAMPAIGN_DURATION * CAMPAIGN_MINIMUM_DAILY_SPEND
+            assertThat(details.budget.totalBudget).isEqualTo(expectedTotal)
+            assertThat(details.budget.spentBudget).isEqualTo(0f)
+            assertThat(details.budget.currencyCode).isEqualTo("USD")
+            assertThat(details.budget.durationInDays).isEqualTo(DEFAULT_CAMPAIGN_DURATION)
+            assertThat(details.budget.isEndlessCampaign).isTrue()
+            // Start date should be roughly tomorrow: after 'before' and not too far in the future
+            assertThat(details.budget.startDate.time).isGreaterThanOrEqualTo(before.time)
+        }
+
+    @Test
+    fun `given a product with no short description, when generateDefaultCampaignDetails invoked, then CampaignDetails with description created`() =
+        testBlocking {
+            val productId = 456L
+            val objective = "sales"
+            val product = ProductTestUtils.generateProduct(
+                productId = productId,
+                productName = "Another Product",
+                imageUrl = null
+            ).copy(
+                shortDescription = "",
+                description = "<p>Main <br> Description</p>"
+            )
+
+            whenever(appPrefsWrapper.blazeCampaignSelectedObjective).thenReturn(objective)
+            whenever(productDetailRepository.getProduct(productId)).thenReturn(product)
+
+            val details = repository.generateDefaultCampaignDetails(productId)
+
+            // Only focus on description defaulting behavior
+            assertThat(details.description).isEqualTo("Main \n Description")
         }
 
     companion object {

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/blaze/BlazeRepositoryTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/blaze/BlazeRepositoryTest.kt
@@ -107,6 +107,15 @@ class BlazeRepositoryTest : BaseUnitTest() {
         }
 
     @Test
+    fun `given a campaign with end date, when creating it, budget should equal totalBudget`() =
+        testBlocking {
+            repository.createCampaign(NON_ENDLESS_CAMPAIGN_DETAILS, PAYMENT_METHOD_ID)
+
+            verify(blazeCampaignsStore).createCampaign(any(), createCampaignRequestCaptor.capture())
+            assertThat(createCampaignRequestCaptor.firstValue.budget.amount).isEqualTo(TOTAL_BUDGET.toDouble())
+        }
+
+    @Test
     fun `given productId, when generateDefaultCampaignDetails invoked, then default CampaignDetails created`() =
         testBlocking {
             val productId = 123L


### PR DESCRIPTION
Closes WOOMOB-28

### Description

When the request to get the Blaze campaign values fails, the Android app shows an empty Ad preview. We can prepopulate some fields based on the product details in such cases. 

From the issue description:
- Use product name for ad title
- Use product short description if available or Description for ad description.

This was done in https://github.com/woocommerce/woocommerce-android/commit/aa3e0e55fdc5cec81b85c2024fba418a2b05884b

Additionally, [I looked at iOS and noticed they do shows the product image without the network](https://github.com/woocommerce/woocommerce-ios/pull/14868). The Android app logic didn't allow for that, becuase there's an extra check if the image is valid (certain minimum size), and without the internet the image couldn't be loaded.

In https://github.com/woocommerce/woocommerce-android/commit/9e272ef30cc40aa81742d0c3d0e10c820fb286e9 I've added an extra check to use an already cached image as a backup. 

It uses some experimental Coil functions, but I think this is mostly because we use a pretty old Coil version. Also, I'm not entirely sure if that is enough given the app uses Glide as well.

Alternatively, we could remove the `isValidAdImage()` check from the `BlazeRepository.generateDefaultCampaignDetails()`. After all, this is just a default, which should be treated as backup, so maybe not doing this check is better than not displaying an image at all. 

Thoughts?

One more thing:

The iOS app sets the default `ctaText` as `Shop now`. Due to where the `CampaignDetails` is created, we can't do that. We would have to pass the translated string from the View. But given that this text should match the language of the shop, I'm not sure that using the device's language is the way to go. At this point, I kept this as empty.

### Steps to reproduce

1. Open the app
2. Go to products
3. Tap on a product
5. Disable the internet connection
6. Tap "Promote with Blaze"
7. Tap "Start your campaign"

### Testing information
<!-- This is your opportunity to break out individual scenarios that need testing (when necessary) and/or include a checklist for the reviewer to go through. Consider documenting the following from your own completed testing: devices used, alternate workflows, edge cases, affected areas, critical flows, areas not tested, and any remaining unknowns. Provide feedback on this new section of the PR template through Sept 30, 2024 to Apps Quality; additional context here: https://woomobilep2.wordpress.com/2024/05/06/woocommerce-mobile-quality-report-march-april/#comment-12036 -->

Follow the steps above with different products, some with short description and some without.

### The tests that have been performed

I performed the above tests with different products.

### Images/gif
| Before | After |
|---|---|
| <img width="320" height="714" alt="Screenshot_20250911_123736" src="https://github.com/user-attachments/assets/67972c25-42d3-41c4-befb-e88033b97e94" /> | <img width="320" height="714" alt="Screenshot_20250911_123207" src="https://github.com/user-attachments/assets/bb7ac811-9b47-40e5-9672-3013528263cd" /> |


- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.

Technically, this is visible, but it's a "backup" so I'm not sure it's worth mentioning.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
