### PR TITLE
[WOOMOB-1312] Fix localSiteId mapping for WooPosProductEntity

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/common/data/WooPosVariationMapper.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/common/data/WooPosVariationMapper.kt
@@ -74,7 +74,7 @@ class WooPosVariationMapper @Inject constructor(
     }
 
     @Suppress("SwallowedException")
-    fun fromWCPosVariationModel(model: WooPosVariationEntity): WooPosVariation {
+    fun fromWooPosVariationEntity(model: WooPosVariationEntity): WooPosVariation {
         val attributesList = parseAttributesJson(model.attributesJson)
 
         return WooPosVariation(
@@ -163,7 +163,7 @@ fun WCProductVariationModel.toWooPosVariation(mapper: WooPosVariationMapper): Wo
     mapper.fromWCProductVariationModel(this)
 
 fun WooPosVariationEntity.toWooPosVariation(mapper: WooPosVariationMapper): WooPosVariation =
-    mapper.fromWCPosVariationModel(this)
+    mapper.fromWooPosVariationEntity(this)
 
 fun WooPosVariation.getNameForPOS(
     mapper: WooPosVariationMapper,

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/common/data/WooPosVariationMapper.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/common/data/WooPosVariationMapper.kt
@@ -9,7 +9,7 @@ import com.woocommerce.android.ui.woopos.common.data.models.WooPosProductModel
 import com.woocommerce.android.util.WooLog
 import com.woocommerce.android.viewmodel.ResourceProvider
 import org.wordpress.android.fluxc.model.WCProductVariationModel
-import org.wordpress.android.fluxc.persistence.entity.pos.WCPosVariationModel
+import org.wordpress.android.fluxc.persistence.entity.pos.WooPosVariationEntity
 import javax.inject.Inject
 import javax.inject.Singleton
 
@@ -74,7 +74,7 @@ class WooPosVariationMapper @Inject constructor(
     }
 
     @Suppress("SwallowedException")
-    fun fromWCPosVariationModel(model: WCPosVariationModel): WooPosVariation {
+    fun fromWCPosVariationModel(model: WooPosVariationEntity): WooPosVariation {
         val attributesList = parseAttributesJson(model.attributesJson)
 
         return WooPosVariation(
@@ -162,7 +162,7 @@ fun ProductVariation.toWooPosVariation(mapper: WooPosVariationMapper): WooPosVar
 fun WCProductVariationModel.toWooPosVariation(mapper: WooPosVariationMapper): WooPosVariation =
     mapper.fromWCProductVariationModel(this)
 
-fun WCPosVariationModel.toWooPosVariation(mapper: WooPosVariationMapper): WooPosVariation =
+fun WooPosVariationEntity.toWooPosVariation(mapper: WooPosVariationMapper): WooPosVariation =
     mapper.fromWCPosVariationModel(this)
 
 fun WooPosVariation.getNameForPOS(

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/common/data/models/WooPosProductModelMapper.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/common/data/models/WooPosProductModelMapper.kt
@@ -5,7 +5,7 @@ import com.google.gson.JsonSyntaxException
 import com.google.gson.reflect.TypeToken
 import com.woocommerce.android.ui.woopos.common.util.WooPosLogWrapper
 import dagger.Reusable
-import org.wordpress.android.fluxc.persistence.entity.pos.WCPosProductEntity
+import org.wordpress.android.fluxc.persistence.entity.pos.WooPosProductEntity
 import java.math.BigDecimal
 import javax.inject.Inject
 
@@ -18,7 +18,7 @@ import javax.inject.Inject
 @Reusable
 class WooPosProductModelMapper @Inject constructor(val logger: WooPosLogWrapper) {
     private val gson = Gson()
-    fun fromEntity(entity: WCPosProductEntity): WooPosProductModel {
+    fun fromEntity(entity: WooPosProductEntity): WooPosProductModel {
         return WooPosProductModel(
             remoteId = entity.remoteId.value,
             parentId = entity.parentId,
@@ -45,7 +45,7 @@ class WooPosProductModelMapper @Inject constructor(val logger: WooPosLogWrapper)
         )
     }
 
-    fun fromEntities(entities: List<WCPosProductEntity>): List<WooPosProductModel> {
+    fun fromEntities(entities: List<WooPosProductEntity>): List<WooPosProductModel> {
         return entities.map { fromEntity(it) }
     }
 

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/common/data/models/WooPosProductModelMapperTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/common/data/models/WooPosProductModelMapperTest.kt
@@ -7,7 +7,7 @@ import org.assertj.core.api.Assertions.assertThat
 import org.junit.Test
 import org.mockito.Mockito.mock
 import org.wordpress.android.fluxc.model.LocalOrRemoteId
-import org.wordpress.android.fluxc.persistence.entity.pos.WCPosProductEntity
+import org.wordpress.android.fluxc.persistence.entity.pos.WooPosProductEntity
 import java.math.BigDecimal
 
 @ExperimentalCoroutinesApi
@@ -44,7 +44,7 @@ class WooPosProductModelMapperTest : BaseUnitTest() {
     @Test
     fun `given entity with pricing information, when mapping to model, then pricing is handled correctly`() {
         // Regular pricing only
-        var entity = WCPosProductEntity(
+        var entity = WooPosProductEntity(
             remoteId = LocalOrRemoteId.RemoteId(123),
             regularPrice = "25.99",
             onSale = false
@@ -55,7 +55,7 @@ class WooPosProductModelMapperTest : BaseUnitTest() {
         assertThat(regularPricing.price).isEqualTo(BigDecimal("25.99"))
 
         // Sale pricing
-        entity = WCPosProductEntity(
+        entity = WooPosProductEntity(
             remoteId = LocalOrRemoteId.RemoteId(123),
             regularPrice = "29.99",
             salePrice = "19.99",
@@ -68,7 +68,7 @@ class WooPosProductModelMapperTest : BaseUnitTest() {
         assertThat(salePricing.salePrice).isEqualTo(BigDecimal("19.99"))
 
         // No pricing
-        entity = WCPosProductEntity(
+        entity = WooPosProductEntity(
             remoteId = LocalOrRemoteId.RemoteId(123),
             price = "",
             regularPrice = "",
@@ -82,7 +82,7 @@ class WooPosProductModelMapperTest : BaseUnitTest() {
 
     @Test
     fun `given entity with invalid price format, when mapping to model, then pricing defaults to NoPricing`() {
-        val entity = WCPosProductEntity(
+        val entity = WooPosProductEntity(
             remoteId = LocalOrRemoteId.RemoteId(123),
             price = "invalid",
             regularPrice = "not-a-number",
@@ -99,7 +99,7 @@ class WooPosProductModelMapperTest : BaseUnitTest() {
     @Test
     fun `given entity with JSON images, when mapping to model, then images are parsed correctly`() {
         val imagesJson = """[{"id": 1, "src": "https://example.com/image.jpg", "name": "Image 1", "alt": "Alt text"}]"""
-        val entity = WCPosProductEntity(
+        val entity = WooPosProductEntity(
             remoteId = LocalOrRemoteId.RemoteId(123),
             images = imagesJson
         )
@@ -117,7 +117,7 @@ class WooPosProductModelMapperTest : BaseUnitTest() {
 
     @Test
     fun `given entity with malformed JSON, when mapping to model, then returns empty collections gracefully`() {
-        val entity = WCPosProductEntity(
+        val entity = WooPosProductEntity(
             remoteId = LocalOrRemoteId.RemoteId(123),
             images = "malformed json",
             attributes = "invalid json",
@@ -135,7 +135,7 @@ class WooPosProductModelMapperTest : BaseUnitTest() {
 
     @Test
     fun `given entity with empty JSON collections, when mapping to model, then returns empty lists`() {
-        val entity = WCPosProductEntity(
+        val entity = WooPosProductEntity(
             remoteId = LocalOrRemoteId.RemoteId(123),
             images = "",
             attributes = "",
@@ -155,7 +155,7 @@ class WooPosProductModelMapperTest : BaseUnitTest() {
     fun `given entity with valid JSON attributes, when mapping to model, then attributes are parsed correctly`() {
         val attributesJson =
             """[{"id": 1, "name": "Color", "options": ["Red", "Blue"], "visible": true, "variation": false}]"""
-        val entity = WCPosProductEntity(
+        val entity = WooPosProductEntity(
             remoteId = LocalOrRemoteId.RemoteId(123),
             attributes = attributesJson
         )
@@ -174,7 +174,7 @@ class WooPosProductModelMapperTest : BaseUnitTest() {
 
     @Test
     fun `given product model with JSON collections, when accessing multiple times, then returns same parsed data`() {
-        val entity = WCPosProductEntity(
+        val entity = WooPosProductEntity(
             remoteId = LocalOrRemoteId.RemoteId(123),
             images = """[{"id": 1, "src": "test.jpg"}]""",
             attributes = """[{"id": 2, "name": "Size"}]"""
@@ -232,7 +232,7 @@ class WooPosProductModelMapperTest : BaseUnitTest() {
         )
 
         testCases.forEach { (typeString, expectedType) ->
-            val entity = WCPosProductEntity(
+            val entity = WooPosProductEntity(
                 remoteId = LocalOrRemoteId.RemoteId(123),
                 type = typeString
             )
@@ -255,7 +255,7 @@ class WooPosProductModelMapperTest : BaseUnitTest() {
         )
 
         testCases.forEach { (statusString, expectedStatus) ->
-            val entity = WCPosProductEntity(
+            val entity = WooPosProductEntity(
                 remoteId = LocalOrRemoteId.RemoteId(123),
                 status = statusString
             )
@@ -317,7 +317,7 @@ class WooPosProductModelMapperTest : BaseUnitTest() {
         assertThat(mapper.mapProductStatus("unknown")).isEqualTo(WooPosProductModel.WooPosProductStatus.UNKNOWN)
     }
 
-    private fun createCompleteEntity() = WCPosProductEntity(
+    private fun createCompleteEntity() = WooPosProductEntity(
         localSiteId = LocalOrRemoteId.LocalId(1),
         remoteId = LocalOrRemoteId.RemoteId(123),
         name = "Test Product",
@@ -342,7 +342,7 @@ class WooPosProductModelMapperTest : BaseUnitTest() {
         dateModified = "2023-01-01T00:00:00"
     )
 
-    private fun createMinimalEntity(id: Long) = WCPosProductEntity(
+    private fun createMinimalEntity(id: Long) = WooPosProductEntity(
         remoteId = LocalOrRemoteId.RemoteId(id)
     )
 }

--- a/libs/fluxc-plugin/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/product/ProductApiResponse.kt
+++ b/libs/fluxc-plugin/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/product/ProductApiResponse.kt
@@ -11,7 +11,6 @@ typealias ProductDto = ProductApiResponse
 @Suppress("ConstructorParameterNaming")
 data class ProductApiResponse(
     val id: Long? = null,
-    val localSiteId: Int = 0,
     val name: String? = null,
     val slug: String? = null,
     val permalink: String? = null,

--- a/libs/fluxc-plugin/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/product/pos/WooPosProductResponseToEntityMapper.kt
+++ b/libs/fluxc-plugin/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/product/pos/WooPosProductResponseToEntityMapper.kt
@@ -7,9 +7,9 @@ import org.wordpress.android.fluxc.persistence.entity.pos.WCPosProductEntity
 import org.wordpress.android.fluxc.persistence.entity.pos.WCPosVariationModel
 
 @Suppress("CyclomaticComplexMethod")
-fun ProductApiResponse.mapToPOSEntity(): WCPosProductEntity =
+fun ProductApiResponse.mapToPOSEntity(localSiteId: LocalOrRemoteId.LocalId): WCPosProductEntity =
     WCPosProductEntity(
-        localSiteId = LocalOrRemoteId.LocalId(this.localSiteId),
+        localSiteId = localSiteId,
         remoteId = LocalOrRemoteId.RemoteId(this.id ?: 0),
         name = this.name ?: "",
         dateModified = this.date_modified ?: "",

--- a/libs/fluxc-plugin/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/product/pos/WooPosProductResponseToEntityMapper.kt
+++ b/libs/fluxc-plugin/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/product/pos/WooPosProductResponseToEntityMapper.kt
@@ -3,8 +3,8 @@ package org.wordpress.android.fluxc.network.rest.wpcom.wc.product.pos
 import org.wordpress.android.fluxc.model.LocalOrRemoteId
 import org.wordpress.android.fluxc.model.pos.WooPosVariationApiResponse
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.product.ProductApiResponse
-import org.wordpress.android.fluxc.persistence.entity.pos.WCPosVariationModel
 import org.wordpress.android.fluxc.persistence.entity.pos.WooPosProductEntity
+import org.wordpress.android.fluxc.persistence.entity.pos.WooPosVariationEntity
 
 @Suppress("CyclomaticComplexMethod")
 fun ProductApiResponse.mapToWooPOSEntity(localSiteId: LocalOrRemoteId.LocalId): WooPosProductEntity =
@@ -40,8 +40,8 @@ fun ProductApiResponse.mapToWooPOSEntity(localSiteId: LocalOrRemoteId.LocalId): 
 
 fun WooPosVariationApiResponse.mapToPosVariationModel(
     localSiteId: LocalOrRemoteId.LocalId
-): WCPosVariationModel {
-    return WCPosVariationModel(
+): WooPosVariationEntity {
+    return WooPosVariationEntity(
         localSiteId = localSiteId,
         remoteProductId = LocalOrRemoteId.RemoteId(this.productId),
         remoteVariationId = LocalOrRemoteId.RemoteId(this.id),

--- a/libs/fluxc-plugin/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/product/pos/WooPosProductResponseToEntityMapper.kt
+++ b/libs/fluxc-plugin/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/product/pos/WooPosProductResponseToEntityMapper.kt
@@ -3,12 +3,12 @@ package org.wordpress.android.fluxc.network.rest.wpcom.wc.product.pos
 import org.wordpress.android.fluxc.model.LocalOrRemoteId
 import org.wordpress.android.fluxc.model.pos.WooPosVariationApiResponse
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.product.ProductApiResponse
-import org.wordpress.android.fluxc.persistence.entity.pos.WCPosProductEntity
 import org.wordpress.android.fluxc.persistence.entity.pos.WCPosVariationModel
+import org.wordpress.android.fluxc.persistence.entity.pos.WooPosProductEntity
 
 @Suppress("CyclomaticComplexMethod")
-fun ProductApiResponse.mapToPOSEntity(localSiteId: LocalOrRemoteId.LocalId): WCPosProductEntity =
-    WCPosProductEntity(
+fun ProductApiResponse.mapToWooPOSEntity(localSiteId: LocalOrRemoteId.LocalId): WooPosProductEntity =
+    WooPosProductEntity(
         localSiteId = localSiteId,
         remoteId = LocalOrRemoteId.RemoteId(this.id ?: 0),
         name = this.name ?: "",

--- a/libs/fluxc-plugin/src/main/kotlin/org/wordpress/android/fluxc/persistence/WCAndroidDatabase.kt
+++ b/libs/fluxc-plugin/src/main/kotlin/org/wordpress/android/fluxc/persistence/WCAndroidDatabase.kt
@@ -88,8 +88,8 @@ import org.wordpress.android.fluxc.persistence.entity.WooPaymentsManualDepositEn
 import org.wordpress.android.fluxc.persistence.entity.WooShippingLabelEntity
 import org.wordpress.android.fluxc.persistence.entity.WooShippingPackagesEntity
 import org.wordpress.android.fluxc.persistence.entity.WooShippingShipmentEntity
-import org.wordpress.android.fluxc.persistence.entity.pos.WCPosVariationModel
 import org.wordpress.android.fluxc.persistence.entity.pos.WooPosProductEntity
+import org.wordpress.android.fluxc.persistence.entity.pos.WooPosVariationEntity
 import org.wordpress.android.fluxc.persistence.migrations.AutoMigration13to14
 import org.wordpress.android.fluxc.persistence.migrations.AutoMigration14to15
 import org.wordpress.android.fluxc.persistence.migrations.AutoMigration16to17
@@ -146,7 +146,7 @@ const val WC_DATABASE_VERSION = 64
         CustomerFromAnalyticsEntity::class,
         WCProductModel::class,
         WooPosProductEntity::class,
-        WCPosVariationModel::class,
+        WooPosVariationEntity::class,
         WCProductCategoryModel::class,
         WCProductVariationModel::class,
         WCProductTagModel::class,

--- a/libs/fluxc-plugin/src/main/kotlin/org/wordpress/android/fluxc/persistence/WCAndroidDatabase.kt
+++ b/libs/fluxc-plugin/src/main/kotlin/org/wordpress/android/fluxc/persistence/WCAndroidDatabase.kt
@@ -88,8 +88,8 @@ import org.wordpress.android.fluxc.persistence.entity.WooPaymentsManualDepositEn
 import org.wordpress.android.fluxc.persistence.entity.WooShippingLabelEntity
 import org.wordpress.android.fluxc.persistence.entity.WooShippingPackagesEntity
 import org.wordpress.android.fluxc.persistence.entity.WooShippingShipmentEntity
-import org.wordpress.android.fluxc.persistence.entity.pos.WCPosProductEntity
 import org.wordpress.android.fluxc.persistence.entity.pos.WCPosVariationModel
+import org.wordpress.android.fluxc.persistence.entity.pos.WooPosProductEntity
 import org.wordpress.android.fluxc.persistence.migrations.AutoMigration13to14
 import org.wordpress.android.fluxc.persistence.migrations.AutoMigration14to15
 import org.wordpress.android.fluxc.persistence.migrations.AutoMigration16to17
@@ -145,7 +145,7 @@ const val WC_DATABASE_VERSION = 64
         ShippingMethodEntity::class,
         CustomerFromAnalyticsEntity::class,
         WCProductModel::class,
-        WCPosProductEntity::class,
+        WooPosProductEntity::class,
         WCPosVariationModel::class,
         WCProductCategoryModel::class,
         WCProductVariationModel::class,

--- a/libs/fluxc-plugin/src/main/kotlin/org/wordpress/android/fluxc/persistence/dao/pos/WooPosProductsDao.kt
+++ b/libs/fluxc-plugin/src/main/kotlin/org/wordpress/android/fluxc/persistence/dao/pos/WooPosProductsDao.kt
@@ -6,18 +6,18 @@ import androidx.room.Upsert
 import kotlinx.coroutines.flow.Flow
 import org.wordpress.android.fluxc.model.LocalOrRemoteId.LocalId
 import org.wordpress.android.fluxc.model.LocalOrRemoteId.RemoteId
-import org.wordpress.android.fluxc.persistence.entity.pos.WCPosProductEntity
+import org.wordpress.android.fluxc.persistence.entity.pos.WooPosProductEntity
 
 @Dao
 abstract class WooPosProductsDao {
     @Query("SELECT * FROM PosProductEntity WHERE localSiteId = :localSiteId")
-    abstract fun observeAllProducts(localSiteId: LocalId): Flow<List<WCPosProductEntity>>
+    abstract fun observeAllProducts(localSiteId: LocalId): Flow<List<WooPosProductEntity>>
 
     @Query("SELECT * FROM PosProductEntity WHERE localSiteId = :localSiteId AND remoteId = :remoteId")
-    abstract suspend fun getProduct(localSiteId: LocalId, remoteId: RemoteId): WCPosProductEntity?
+    abstract suspend fun getProduct(localSiteId: LocalId, remoteId: RemoteId): WooPosProductEntity?
 
     @Upsert
-    abstract suspend fun upsertProducts(products: List<WCPosProductEntity>)
+    abstract suspend fun upsertProducts(products: List<WooPosProductEntity>)
 
     @Query("DELETE FROM PosProductEntity WHERE localSiteId = :localSiteId AND remoteId = :remoteId")
     abstract suspend fun deleteProduct(localSiteId: LocalId, remoteId: RemoteId)

--- a/libs/fluxc-plugin/src/main/kotlin/org/wordpress/android/fluxc/persistence/dao/pos/WooPosVariationsDao.kt
+++ b/libs/fluxc-plugin/src/main/kotlin/org/wordpress/android/fluxc/persistence/dao/pos/WooPosVariationsDao.kt
@@ -6,26 +6,26 @@ import androidx.room.Upsert
 import kotlinx.coroutines.flow.Flow
 import org.wordpress.android.fluxc.model.LocalOrRemoteId.LocalId
 import org.wordpress.android.fluxc.model.LocalOrRemoteId.RemoteId
-import org.wordpress.android.fluxc.persistence.entity.pos.WCPosVariationModel
+import org.wordpress.android.fluxc.persistence.entity.pos.WooPosVariationEntity
 
 @Dao
 abstract class WooPosVariationsDao {
 
     @Query("SELECT * FROM PosVariationEntity WHERE localSiteId = :localSiteId AND remoteProductId = :productId ORDER BY variationName ASC")
-    abstract fun observeVariationsForProduct(localSiteId: LocalId, productId: RemoteId): Flow<List<WCPosVariationModel>>
+    abstract fun observeVariationsForProduct(localSiteId: LocalId, productId: RemoteId): Flow<List<WooPosVariationEntity>>
 
     @Query("SELECT * FROM PosVariationEntity WHERE localSiteId = :localSiteId AND remoteProductId = :productId AND remoteVariationId = :variationId")
     abstract suspend fun getVariation(
         localSiteId: LocalId,
         productId: RemoteId,
         variationId: RemoteId
-    ): WCPosVariationModel?
+    ): WooPosVariationEntity?
 
     @Upsert
-    abstract suspend fun upsertVariations(variations: List<WCPosVariationModel>)
+    abstract suspend fun upsertVariations(variations: List<WooPosVariationEntity>)
 
     @Upsert
-    abstract suspend fun upsertVariation(variation: WCPosVariationModel)
+    abstract suspend fun upsertVariation(variation: WooPosVariationEntity)
 
     @Query("DELETE FROM PosVariationEntity WHERE localSiteId = :localSiteId AND remoteProductId = :productId AND remoteVariationId = :variationId")
     abstract suspend fun deleteVariation(localSiteId: LocalId, productId: RemoteId, variationId: RemoteId)

--- a/libs/fluxc-plugin/src/main/kotlin/org/wordpress/android/fluxc/persistence/dao/pos/WooPosVariationsDao.kt
+++ b/libs/fluxc-plugin/src/main/kotlin/org/wordpress/android/fluxc/persistence/dao/pos/WooPosVariationsDao.kt
@@ -12,7 +12,10 @@ import org.wordpress.android.fluxc.persistence.entity.pos.WooPosVariationEntity
 abstract class WooPosVariationsDao {
 
     @Query("SELECT * FROM PosVariationEntity WHERE localSiteId = :localSiteId AND remoteProductId = :productId ORDER BY variationName ASC")
-    abstract fun observeVariationsForProduct(localSiteId: LocalId, productId: RemoteId): Flow<List<WooPosVariationEntity>>
+    abstract fun observeVariationsForProduct(
+        localSiteId: LocalId,
+        productId: RemoteId
+    ): Flow<List<WooPosVariationEntity>>
 
     @Query("SELECT * FROM PosVariationEntity WHERE localSiteId = :localSiteId AND remoteProductId = :productId AND remoteVariationId = :variationId")
     abstract suspend fun getVariation(

--- a/libs/fluxc-plugin/src/main/kotlin/org/wordpress/android/fluxc/persistence/entity/pos/WooPosProductEntity.kt
+++ b/libs/fluxc-plugin/src/main/kotlin/org/wordpress/android/fluxc/persistence/entity/pos/WooPosProductEntity.kt
@@ -11,7 +11,7 @@ import org.wordpress.android.fluxc.model.LocalOrRemoteId.RemoteId
     tableName = "PosProductEntity",
     primaryKeys = ["localSiteId", "remoteId"],
 )
-data class WCPosProductEntity(
+data class WooPosProductEntity(
     val localSiteId: LocalId = LocalId(0),
     val remoteId: RemoteId = RemoteId(0),
     val name: String = "",

--- a/libs/fluxc-plugin/src/main/kotlin/org/wordpress/android/fluxc/persistence/entity/pos/WooPosVariationEntity.kt
+++ b/libs/fluxc-plugin/src/main/kotlin/org/wordpress/android/fluxc/persistence/entity/pos/WooPosVariationEntity.kt
@@ -11,7 +11,7 @@ import org.wordpress.android.fluxc.model.LocalOrRemoteId.RemoteId
     tableName = "PosVariationEntity",
     primaryKeys = ["localSiteId", "remoteProductId", "remoteVariationId"],
 )
-data class WCPosVariationModel(
+data class WooPosVariationEntity(
     val localSiteId: LocalId = LocalId(0),
     val remoteProductId: RemoteId = RemoteId(0),
     val remoteVariationId: RemoteId = RemoteId(0),

--- a/libs/fluxc-plugin/src/main/kotlin/org/wordpress/android/fluxc/store/pos/localcatalog/WooPosLocalCatalogStore.kt
+++ b/libs/fluxc-plugin/src/main/kotlin/org/wordpress/android/fluxc/store/pos/localcatalog/WooPosLocalCatalogStore.kt
@@ -128,7 +128,7 @@ class WooPosLocalCatalogStore @Inject constructor(
                 )
 
                 else -> {
-                    val products = response.model.map { it.mapToPOSEntity() }
+                    val products = response.model.map { it.mapToPOSEntity(site.localId()) }
 
                     if (storeInDb) {
                         val upsertResult = runCatching { posProductDao.upsertProducts(products) }

--- a/libs/fluxc-plugin/src/main/kotlin/org/wordpress/android/fluxc/store/pos/localcatalog/WooPosLocalCatalogStore.kt
+++ b/libs/fluxc-plugin/src/main/kotlin/org/wordpress/android/fluxc/store/pos/localcatalog/WooPosLocalCatalogStore.kt
@@ -7,13 +7,13 @@ import org.wordpress.android.fluxc.model.SiteModel
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.WooError
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.WooErrorType
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.product.pos.WooPosProductRestClient
-import org.wordpress.android.fluxc.network.rest.wpcom.wc.product.pos.mapToPOSEntity
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.product.pos.mapToPosVariationModel
+import org.wordpress.android.fluxc.network.rest.wpcom.wc.product.pos.mapToWooPOSEntity
 import org.wordpress.android.fluxc.persistence.WCAndroidDatabase
 import org.wordpress.android.fluxc.persistence.dao.pos.WooPosProductsDao
 import org.wordpress.android.fluxc.persistence.dao.pos.WooPosVariationsDao
-import org.wordpress.android.fluxc.persistence.entity.pos.WCPosProductEntity
 import org.wordpress.android.fluxc.persistence.entity.pos.WCPosVariationModel
+import org.wordpress.android.fluxc.persistence.entity.pos.WooPosProductEntity
 import org.wordpress.android.fluxc.tools.CoroutineEngine
 import org.wordpress.android.fluxc.utils.HeadersParser
 import org.wordpress.android.util.AppLog.T.API
@@ -42,7 +42,7 @@ class WooPosLocalCatalogStore @Inject constructor(
      */
     fun observeProducts(
         siteId: LocalOrRemoteId.LocalId
-    ): Flow<Result<List<WCPosProductEntity>>> =
+    ): Flow<Result<List<WooPosProductEntity>>> =
         posProductDao.observeAllProducts(siteId)
             .map { products ->
                 Result.success(products)
@@ -58,7 +58,7 @@ class WooPosLocalCatalogStore @Inject constructor(
     suspend fun getProduct(
         siteId: LocalOrRemoteId.LocalId,
         remoteProductId: LocalOrRemoteId.RemoteId
-    ): Result<WCPosProductEntity?> =
+    ): Result<WooPosProductEntity?> =
         coroutineEngine.withDefaultContext(API, this, "getProduct") {
             val product = posProductDao.getProduct(siteId, remoteProductId)
             Result.success(product)
@@ -128,7 +128,7 @@ class WooPosLocalCatalogStore @Inject constructor(
                 )
 
                 else -> {
-                    val products = response.model.map { it.mapToPOSEntity(site.localId()) }
+                    val products = response.model.map { it.mapToWooPOSEntity(site.localId()) }
 
                     if (storeInDb) {
                         val upsertResult = runCatching { posProductDao.upsertProducts(products) }

--- a/libs/fluxc-plugin/src/main/kotlin/org/wordpress/android/fluxc/store/pos/localcatalog/WooPosLocalCatalogStore.kt
+++ b/libs/fluxc-plugin/src/main/kotlin/org/wordpress/android/fluxc/store/pos/localcatalog/WooPosLocalCatalogStore.kt
@@ -12,8 +12,8 @@ import org.wordpress.android.fluxc.network.rest.wpcom.wc.product.pos.mapToWooPOS
 import org.wordpress.android.fluxc.persistence.WCAndroidDatabase
 import org.wordpress.android.fluxc.persistence.dao.pos.WooPosProductsDao
 import org.wordpress.android.fluxc.persistence.dao.pos.WooPosVariationsDao
-import org.wordpress.android.fluxc.persistence.entity.pos.WCPosVariationModel
 import org.wordpress.android.fluxc.persistence.entity.pos.WooPosProductEntity
+import org.wordpress.android.fluxc.persistence.entity.pos.WooPosVariationEntity
 import org.wordpress.android.fluxc.tools.CoroutineEngine
 import org.wordpress.android.fluxc.utils.HeadersParser
 import org.wordpress.android.util.AppLog.T.API
@@ -178,7 +178,7 @@ class WooPosLocalCatalogStore @Inject constructor(
     fun observeVariationsForProduct(
         siteId: LocalOrRemoteId.LocalId,
         productId: LocalOrRemoteId.RemoteId
-    ): Flow<Result<List<WCPosVariationModel>>> =
+    ): Flow<Result<List<WooPosVariationEntity>>> =
         posVariationsDao.observeVariationsForProduct(siteId, productId)
             .map { variations ->
                 Result.success(variations)
@@ -196,7 +196,7 @@ class WooPosLocalCatalogStore @Inject constructor(
         siteId: LocalOrRemoteId.LocalId,
         productId: LocalOrRemoteId.RemoteId,
         variationId: LocalOrRemoteId.RemoteId
-    ): Result<WCPosVariationModel?> =
+    ): Result<WooPosVariationEntity?> =
         coroutineEngine.withDefaultContext(API, this, "getVariation") {
             val variation = posVariationsDao.getVariation(siteId, productId, variationId)
             Result.success(variation)

--- a/libs/fluxc-plugin/src/test/java/org/wordpress/android/fluxc/persistence/dao/pos/WooPosProductsDaoTest.kt
+++ b/libs/fluxc-plugin/src/test/java/org/wordpress/android/fluxc/persistence/dao/pos/WooPosProductsDaoTest.kt
@@ -12,7 +12,7 @@ import org.robolectric.RobolectricTestRunner
 import org.wordpress.android.fluxc.model.LocalOrRemoteId.LocalId
 import org.wordpress.android.fluxc.model.LocalOrRemoteId.RemoteId
 import org.wordpress.android.fluxc.persistence.DatabaseTestRule
-import org.wordpress.android.fluxc.persistence.entity.pos.WCPosProductEntity
+import org.wordpress.android.fluxc.persistence.entity.pos.WooPosProductEntity
 import kotlin.test.assertEquals
 import kotlin.test.assertNotNull
 import kotlin.test.assertNull
@@ -265,7 +265,7 @@ class WooPosProductsDaoTest {
         attributes: String = "",
         images: String = "",
         dateModified: String = "2024-01-01T10:00:00Z"
-    ) = WCPosProductEntity(
+    ) = WooPosProductEntity(
         localSiteId = LocalId(siteId),
         remoteId = RemoteId(remoteId),
         name = name,

--- a/libs/fluxc-plugin/src/test/java/org/wordpress/android/fluxc/persistence/dao/pos/WooPosVariationsDaoTest.kt
+++ b/libs/fluxc-plugin/src/test/java/org/wordpress/android/fluxc/persistence/dao/pos/WooPosVariationsDaoTest.kt
@@ -12,7 +12,7 @@ import org.robolectric.RobolectricTestRunner
 import org.wordpress.android.fluxc.model.LocalOrRemoteId.LocalId
 import org.wordpress.android.fluxc.model.LocalOrRemoteId.RemoteId
 import org.wordpress.android.fluxc.persistence.DatabaseTestRule
-import org.wordpress.android.fluxc.persistence.entity.pos.WCPosVariationModel
+import org.wordpress.android.fluxc.persistence.entity.pos.WooPosVariationEntity
 import kotlin.test.assertEquals
 import kotlin.test.assertNotNull
 import kotlin.test.assertNull
@@ -440,7 +440,7 @@ class WooPosVariationsDaoTest {
         status: String = "publish",
         lastUpdated: String = "2024-01-01T10:00:00Z",
         downloadable: Boolean = false
-    ) = WCPosVariationModel(
+    ) = WooPosVariationEntity(
         localSiteId = LocalId(siteId),
         remoteProductId = RemoteId(productId),
         remoteVariationId = RemoteId(variationId),

--- a/libs/fluxc-plugin/src/test/java/org/wordpress/android/fluxc/store/pos/WooPosLocalCatalogStoreTest.kt
+++ b/libs/fluxc-plugin/src/test/java/org/wordpress/android/fluxc/store/pos/WooPosLocalCatalogStoreTest.kt
@@ -26,8 +26,8 @@ import org.wordpress.android.fluxc.network.rest.wpcom.wc.product.pos.WooPosProdu
 import org.wordpress.android.fluxc.persistence.WCAndroidDatabase
 import org.wordpress.android.fluxc.persistence.dao.pos.WooPosProductsDao
 import org.wordpress.android.fluxc.persistence.dao.pos.WooPosVariationsDao
-import org.wordpress.android.fluxc.persistence.entity.pos.WCPosProductEntity
 import org.wordpress.android.fluxc.persistence.entity.pos.WCPosVariationModel
+import org.wordpress.android.fluxc.persistence.entity.pos.WooPosProductEntity
 import org.wordpress.android.fluxc.store.pos.localcatalog.WooPosLocalCatalogError
 import org.wordpress.android.fluxc.store.pos.localcatalog.WooPosLocalCatalogStore
 import org.wordpress.android.fluxc.utils.HeadersParser
@@ -827,7 +827,7 @@ class WooPosLocalCatalogStoreTest {
     )
 
     object ProductTestData {
-        fun coffeMug(siteId: LocalId) = WCPosProductEntity(
+        fun coffeMug(siteId: LocalId) = WooPosProductEntity(
             localSiteId = siteId,
             remoteId = RemoteId(1L),
             name = "Coffee Mug",
@@ -836,7 +836,7 @@ class WooPosLocalCatalogStoreTest {
             images = ""
         )
 
-        fun laptopStand(siteId: LocalId) = WCPosProductEntity(
+        fun laptopStand(siteId: LocalId) = WooPosProductEntity(
             localSiteId = siteId,
             remoteId = RemoteId(2L),
             name = "Laptop Stand",
@@ -850,7 +850,7 @@ class WooPosLocalCatalogStoreTest {
             remoteId: Long,
             name: String,
             price: String = "29.99"
-        ) = WCPosProductEntity(
+        ) = WooPosProductEntity(
             localSiteId = siteId,
             remoteId = RemoteId(remoteId),
             name = name,

--- a/libs/fluxc-plugin/src/test/java/org/wordpress/android/fluxc/store/pos/WooPosLocalCatalogStoreTest.kt
+++ b/libs/fluxc-plugin/src/test/java/org/wordpress/android/fluxc/store/pos/WooPosLocalCatalogStoreTest.kt
@@ -26,8 +26,8 @@ import org.wordpress.android.fluxc.network.rest.wpcom.wc.product.pos.WooPosProdu
 import org.wordpress.android.fluxc.persistence.WCAndroidDatabase
 import org.wordpress.android.fluxc.persistence.dao.pos.WooPosProductsDao
 import org.wordpress.android.fluxc.persistence.dao.pos.WooPosVariationsDao
-import org.wordpress.android.fluxc.persistence.entity.pos.WCPosVariationModel
 import org.wordpress.android.fluxc.persistence.entity.pos.WooPosProductEntity
+import org.wordpress.android.fluxc.persistence.entity.pos.WooPosVariationEntity
 import org.wordpress.android.fluxc.store.pos.localcatalog.WooPosLocalCatalogError
 import org.wordpress.android.fluxc.store.pos.localcatalog.WooPosLocalCatalogStore
 import org.wordpress.android.fluxc.utils.HeadersParser
@@ -817,7 +817,7 @@ class WooPosLocalCatalogStoreTest {
         variationId: Long,
         name: String,
         price: String = "19.99"
-    ) = WCPosVariationModel(
+    ) = WooPosVariationEntity(
         localSiteId = testSiteId,
         remoteProductId = testRemoteId,
         remoteVariationId = RemoteId(variationId),


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

<!-- Id number of the Linear issue this PR addresses, e.g., WOOMOB-373. -->

#WOOMOB-1312

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

This PR
- fixes mapping of localSiteId for WooPosProductEntity
- adds WooPos prefix to product and variation entities

### Testing information
<!-- This is your opportunity to break out individual scenarios that need testing (when necessary) and/or include a checklist for the reviewer to go through. Consider documenting the following from your own completed testing: devices used, alternate workflows, edge cases, affected areas, critical flows, areas not tested, and any remaining unknowns. Provide feedback on this new section of the PR template through Sept 30, 2024 to Apps Quality; additional context here: p91TBi-b8z-p2#comment-12036 -->

This the code isn't used in this branch, there isn't much to test. If you'd like to test it, you can add apply the following patch. The sync will start when you access the POS - you can test switching site to see different ids in the DB.

```
Subject: [PATCH] Add WooPos prefix
---
Index: WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/items/WooPosItemsViewModel.kt
IDEA additional info:
Subsystem: com.intellij.openapi.diff.impl.patch.CharsetEP
<+>UTF-8
===================================================================
diff --git a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/items/WooPosItemsViewModel.kt b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/items/WooPosItemsViewModel.kt
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/items/WooPosItemsViewModel.kt	(revision eedfeaec0309403fe79318716478cf5efd690f27)
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/items/WooPosItemsViewModel.kt	(date 1757588112196)
@@ -3,6 +3,7 @@
 import android.os.Parcelable
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import com.woocommerce.android.tools.SelectedSite
 import com.woocommerce.android.ui.woopos.common.composeui.component.WooPosSearchInputState
 import com.woocommerce.android.ui.woopos.home.ChildToParentEvent
 import com.woocommerce.android.ui.woopos.home.ParentToChildrenEvent
@@ -12,6 +13,7 @@
 import com.woocommerce.android.ui.woopos.home.items.WooPosItemsToolbarViewState.Tab
 import com.woocommerce.android.ui.woopos.home.items.coupons.creation.WooPosCouponCreationFacade
 import com.woocommerce.android.ui.woopos.home.items.variations.WooPosVariationsNavigationData
+import com.woocommerce.android.ui.woopos.localcatalog.PosLocalCatalogSyncRepository
 import com.woocommerce.android.ui.woopos.util.analytics.WooPosAnalyticsEvent
 import com.woocommerce.android.ui.woopos.util.analytics.WooPosAnalyticsEvent.Event.SearchButtonTapped
 import com.woocommerce.android.ui.woopos.util.analytics.WooPosAnalyticsEventConstant
@@ -33,6 +35,8 @@
     private val fromChildToParentEventSender: WooPosChildrenToParentEventSender,
     private val parentToChildrenEventReceiver: WooPosParentToChildrenEventReceiver,
     private val analyticsTracker: WooPosAnalyticsTracker,
+    private val localCatalogSyncRepository: PosLocalCatalogSyncRepository,
+    private val selectedSite: SelectedSite,
 ) : ViewModel() {
     private var preservedStateBeforeOpeningVariations: WooPosItemsToolbarViewState? = null
     private val _viewState = MutableStateFlow<WooPosItemsToolbarViewState>(initialState())
@@ -49,6 +53,7 @@
             coroutineScope = viewModelScope,
             viewStateFlow = _viewState
         )
+        viewModelScope.launch { localCatalogSyncRepository.syncLocalCatalogFull(selectedSite.get()) }
     }
 
     fun onUIEvent(event: WooPosItemsUIEvent) {

```

### The tests that have been performed
<!-- To give the reviewer an idea of what could be missed in terms of testing -->
The above

### Images/gif
<!-- Include before and after images or gifs when appropriate. -->

<img width="350" height="286" alt="Screenshot 2025-09-11 at 12 56 25" src="https://github.com/user-attachments/assets/887c5bee-520c-4e56-8ed5-9db95806dda8" />


- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->