### PR TITLE
[WOOMOB-1146][Woo POS][Orders] Add search functionality to Woo POS orders

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/orders/WooPosOrdersDataSource.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/orders/WooPosOrdersDataSource.kt
@@ -16,6 +16,11 @@ sealed class LoadOrdersResult {
     data class Error(val message: String) : LoadOrdersResult()
 }
 
+sealed class SearchOrdersResult {
+    data class Success(val orders: List<Order>) : SearchOrdersResult()
+    data class Error(val message: String) : SearchOrdersResult()
+}
+
 class WooPosOrdersDataSource @Inject constructor(
     private val restClient: OrderRestClient,
     private val selectedSite: SelectedSite,
@@ -43,14 +48,13 @@ class WooPosOrdersDataSource @Inject constructor(
         }
     }
 
-    suspend fun searchOrders(searchQuery: String): LoadOrdersResult {
+    suspend fun searchOrders(searchQuery: String): SearchOrdersResult {
         val result = fetchOrdersFromRemote(searchQuery = searchQuery, page = 1)
 
         return if (result.isError) {
-            LoadOrdersResult.Error(result.error?.message ?: "Unknown error")
+            SearchOrdersResult.Error(result.error?.message ?: "Unknown error")
         } else {
-            val mapped = result.orders.toAppModels()
-            LoadOrdersResult.SuccessRemote(mapped)
+            SearchOrdersResult.Success(result.orders.toAppModels())
         }
     }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/orders/WooPosOrdersDataSource.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/orders/WooPosOrdersDataSource.kt
@@ -25,30 +25,46 @@ class WooPosOrdersDataSource @Inject constructor(
     companion object {
         const val POS_ORDERS_PAGE_SIZE = 25
     }
+
     fun loadOrders(): Flow<LoadOrdersResult> = flow {
         val cached = ordersCache.getAll()
         if (cached.isNotEmpty()) {
             emit(LoadOrdersResult.SuccessCache(cached))
         }
 
-        val result = restClient.fetchOrders(
+        val result = fetchOrdersFromRemote(searchQuery = null)
+
+        if (result.isError) {
+            emit(LoadOrdersResult.Error(result.error?.message ?: "Unknown error"))
+        } else {
+            val mapped = result.orders.toAppModels()
+            ordersCache.setAll(mapped)
+            emit(LoadOrdersResult.SuccessRemote(mapped))
+        }
+    }
+
+    suspend fun searchOrders(searchQuery: String): LoadOrdersResult {
+        val result = fetchOrdersFromRemote(searchQuery = searchQuery)
+
+        return if (result.isError) {
+            LoadOrdersResult.Error(result.error?.message ?: "Unknown error")
+        } else {
+            val mapped = result.orders.toAppModels()
+            LoadOrdersResult.SuccessRemote(mapped)
+        }
+    }
+
+    private suspend fun fetchOrdersFromRemote(searchQuery: String?) =
+        restClient.fetchOrders(
             site = selectedSite.get(),
             count = POS_ORDERS_PAGE_SIZE,
             page = 1,
             orderBy = OrderBy.DATE,
             sortOrder = OrderRestClient.SortOrder.DESCENDING,
             statusFilter = null,
-            createdVia = "pos-rest-api"
+            createdVia = "pos-rest-api",
+            searchQuery = searchQuery,
         )
-
-        if (result.isError) {
-            emit(LoadOrdersResult.Error(result.error.message))
-        } else {
-            val mapped = result.orders.toAppModels()
-            ordersCache.setAll(mapped)
-            emit(LoadOrdersResult.SuccessRemote(result.orders.toAppModels()))
-        }
-    }
 
     fun clearCache() = ordersCache.clear()
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/orders/WooPosOrdersDataSource.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/orders/WooPosOrdersDataSource.kt
@@ -32,7 +32,7 @@ class WooPosOrdersDataSource @Inject constructor(
             emit(LoadOrdersResult.SuccessCache(cached))
         }
 
-        val result = fetchOrdersFromRemote(searchQuery = null)
+        val result = fetchOrdersFromRemote(searchQuery = null, page = 1)
 
         if (result.isError) {
             emit(LoadOrdersResult.Error(result.error?.message ?: "Unknown error"))
@@ -44,7 +44,7 @@ class WooPosOrdersDataSource @Inject constructor(
     }
 
     suspend fun searchOrders(searchQuery: String): LoadOrdersResult {
-        val result = fetchOrdersFromRemote(searchQuery = searchQuery)
+        val result = fetchOrdersFromRemote(searchQuery = searchQuery, page = 1)
 
         return if (result.isError) {
             LoadOrdersResult.Error(result.error?.message ?: "Unknown error")
@@ -54,17 +54,19 @@ class WooPosOrdersDataSource @Inject constructor(
         }
     }
 
-    private suspend fun fetchOrdersFromRemote(searchQuery: String?) =
-        restClient.fetchOrders(
-            site = selectedSite.get(),
-            count = POS_ORDERS_PAGE_SIZE,
-            page = 1,
-            orderBy = OrderBy.DATE,
-            sortOrder = OrderRestClient.SortOrder.DESCENDING,
-            statusFilter = null,
-            createdVia = "pos-rest-api",
-            searchQuery = searchQuery,
-        )
+    private suspend fun fetchOrdersFromRemote(
+        page: Int,
+        searchQuery: String?
+    ) = restClient.fetchOrders(
+        site = selectedSite.get(),
+        count = POS_ORDERS_PAGE_SIZE,
+        page = page,
+        orderBy = OrderBy.DATE,
+        sortOrder = OrderRestClient.SortOrder.DESCENDING,
+        statusFilter = null,
+        createdVia = "pos-rest-api",
+        searchQuery = searchQuery,
+    )
 
     fun clearCache() = ordersCache.clear()
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/orders/WooPosOrdersScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/orders/WooPosOrdersScreen.kt
@@ -12,7 +12,10 @@ import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.heightIn
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.statusBarsPadding
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.material.ExperimentalMaterialApi
@@ -30,6 +33,8 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.semantics.selected
 import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import androidx.constraintlayout.compose.ConstraintLayout
 import androidx.hilt.navigation.compose.hiltViewModel
 import com.woocommerce.android.R
 import com.woocommerce.android.ui.woopos.common.composeui.WooPosPreview
@@ -43,6 +48,8 @@ import com.woocommerce.android.ui.woopos.common.composeui.designsystem.WooPosThe
 import com.woocommerce.android.ui.woopos.common.composeui.designsystem.WooPosTypography
 import com.woocommerce.android.ui.woopos.home.items.WooPosPullToRefreshState
 import com.woocommerce.android.ui.woopos.root.navigation.WooPosNavigationEvent
+
+private val WOO_POS_ORDERS_TOOLBAR_HEIGHT = 56.dp
 
 @OptIn(ExperimentalMaterialApi::class)
 @Composable
@@ -91,31 +98,44 @@ private fun OrdersList(
     modifier: Modifier = Modifier
 ) {
     Column(modifier = modifier) {
-        when (state.searchInputState) {
-            is WooPosSearchInputState.Open -> {
-                WooPosSearchInput(
-                    state = state.searchInputState,
-                    onEvent = onSearchEvent,
-                    modifier = Modifier.fillMaxWidth()
+        ConstraintLayout(
+            modifier = Modifier
+                .fillMaxWidth()
+                .heightIn(min = WOO_POS_ORDERS_TOOLBAR_HEIGHT),
+        ) {
+            val (toolbar, searchInput) = createRefs()
+
+            if (state.searchInputState is WooPosSearchInputState.Closed) {
+                WooPosToolbar(
+                    titleText = stringResource(R.string.woopos_orders_title),
+                    onBackClicked = onBackClicked,
+                    modifier = Modifier.constrainAs(toolbar) {
+                        start.linkTo(parent.start)
+                        top.linkTo(parent.top)
+                        bottom.linkTo(parent.bottom)
+                    }
                 )
             }
-            is WooPosSearchInputState.Closed -> {
-                Row(
-                    modifier = Modifier.fillMaxWidth(),
-                    verticalAlignment = Alignment.CenterVertically
-                ) {
-                    WooPosToolbar(
-                        titleText = stringResource(R.string.woopos_orders_title),
-                        onBackClicked = onBackClicked,
-                        modifier = Modifier.weight(1f)
-                    )
-                    WooPosSearchInput(
-                        state = state.searchInputState,
-                        onEvent = onSearchEvent
-                    )
-                }
-            }
+            WooPosSearchInput(
+                state = state.searchInputState,
+                onEvent = onSearchEvent,
+                modifier = Modifier
+                    .statusBarsPadding()
+                    .constrainAs(searchInput) {
+                        if (state.searchInputState is WooPosSearchInputState.Open) {
+                            start.linkTo(parent.start)
+                            end.linkTo(parent.end)
+                            width = androidx.constraintlayout.compose.Dimension.fillToConstraints
+                        } else {
+                            end.linkTo(parent.end)
+                        }
+                        top.linkTo(parent.top)
+                        bottom.linkTo(parent.bottom)
+                    }
+            )
         }
+
+        Spacer(modifier = Modifier.height(WooPosSpacing.Small.value))
 
         val pullRefreshState = rememberPullRefreshState(
             refreshing = isRefreshing,

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/orders/WooPosOrdersScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/orders/WooPosOrdersScreen.kt
@@ -33,6 +33,9 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.hilt.navigation.compose.hiltViewModel
 import com.woocommerce.android.R
 import com.woocommerce.android.ui.woopos.common.composeui.WooPosPreview
+import com.woocommerce.android.ui.woopos.common.composeui.component.WooPosSearchInput
+import com.woocommerce.android.ui.woopos.common.composeui.component.WooPosSearchInputState
+import com.woocommerce.android.ui.woopos.common.composeui.component.WooPosSearchUIEvent
 import com.woocommerce.android.ui.woopos.common.composeui.component.WooPosText
 import com.woocommerce.android.ui.woopos.common.composeui.component.WooPosToolbar
 import com.woocommerce.android.ui.woopos.common.composeui.designsystem.WooPosSpacing
@@ -59,6 +62,7 @@ fun WooPosOrdersScreen(
             onRefresh = viewModel::onRefresh,
             isRefreshing = state.pullToRefreshState == WooPosPullToRefreshState.Refreshing,
             onOrderSelected = viewModel::onOrderSelected,
+            onSearchEvent = viewModel::onSearchEvent,
             modifier = Modifier
                 .weight(0.3f)
                 .fillMaxHeight()
@@ -83,13 +87,35 @@ private fun OrdersList(
     onRefresh: () -> Unit,
     isRefreshing: Boolean,
     onOrderSelected: (Long) -> Unit,
+    onSearchEvent: (WooPosSearchUIEvent) -> Unit,
     modifier: Modifier = Modifier
 ) {
     Column(modifier = modifier) {
-        WooPosToolbar(
-            titleText = stringResource(R.string.woopos_orders_title),
-            onBackClicked = onBackClicked,
-        )
+        when (state.searchInputState) {
+            is WooPosSearchInputState.Open -> {
+                WooPosSearchInput(
+                    state = state.searchInputState,
+                    onEvent = onSearchEvent,
+                    modifier = Modifier.fillMaxWidth()
+                )
+            }
+            is WooPosSearchInputState.Closed -> {
+                Row(
+                    modifier = Modifier.fillMaxWidth(),
+                    verticalAlignment = Alignment.CenterVertically
+                ) {
+                    WooPosToolbar(
+                        titleText = stringResource(R.string.woopos_orders_title),
+                        onBackClicked = onBackClicked,
+                        modifier = Modifier.weight(1f)
+                    )
+                    WooPosSearchInput(
+                        state = state.searchInputState,
+                        onEvent = onSearchEvent
+                    )
+                }
+            }
+        }
 
         val pullRefreshState = rememberPullRefreshState(
             refreshing = isRefreshing,

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/orders/WooPosOrdersState.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/orders/WooPosOrdersState.kt
@@ -1,6 +1,7 @@
 package com.woocommerce.android.ui.woopos.orders
 
 import androidx.compose.runtime.Immutable
+import com.woocommerce.android.ui.woopos.common.composeui.component.WooPosSearchInputState
 import com.woocommerce.android.ui.woopos.home.items.WooPosPaginationState
 import com.woocommerce.android.ui.woopos.home.items.WooPosPullToRefreshState
 
@@ -16,11 +17,13 @@ data class OrderItemViewState(
 @Immutable
 sealed class WooPosOrdersState {
     abstract val pullToRefreshState: WooPosPullToRefreshState
+    abstract val searchInputState: WooPosSearchInputState
 
     @Immutable
     data class Content(
         val items: List<OrderItemViewState>,
         override val pullToRefreshState: WooPosPullToRefreshState,
+        override val searchInputState: WooPosSearchInputState,
         val paginationState: WooPosPaginationState,
         val selectedOrderId: Long?
     ) : WooPosOrdersState()
@@ -28,18 +31,19 @@ sealed class WooPosOrdersState {
     @Immutable
     data class Error(
         val message: String,
+        override val searchInputState: WooPosSearchInputState
     ) : WooPosOrdersState() {
         override val pullToRefreshState: WooPosPullToRefreshState = WooPosPullToRefreshState.Disabled
     }
 
     @Immutable
-    data object Loading : WooPosOrdersState() {
+    data class Loading(override val searchInputState: WooPosSearchInputState) : WooPosOrdersState() {
         override val pullToRefreshState: WooPosPullToRefreshState = WooPosPullToRefreshState.Disabled
     }
 
     @Immutable
     data class Empty(
-        override val pullToRefreshState: WooPosPullToRefreshState =
-            WooPosPullToRefreshState.Enabled
+        override val pullToRefreshState: WooPosPullToRefreshState = WooPosPullToRefreshState.Enabled,
+        override val searchInputState: WooPosSearchInputState,
     ) : WooPosOrdersState()
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/orders/WooPosOrdersViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/orders/WooPosOrdersViewModel.kt
@@ -4,9 +4,13 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.woocommerce.android.extensions.formatToDDMMMYYYY
 import com.woocommerce.android.model.Order
+import com.woocommerce.android.ui.woopos.common.composeui.component.WooPosSearchInputState
+import com.woocommerce.android.ui.woopos.common.composeui.component.WooPosSearchUIEvent
 import com.woocommerce.android.ui.woopos.home.items.WooPosPaginationState
 import com.woocommerce.android.ui.woopos.home.items.WooPosPullToRefreshState
 import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
@@ -18,8 +22,20 @@ class WooPosOrdersViewModel @Inject constructor(
     private val ordersDataSource: WooPosOrdersDataSource
 ) : ViewModel() {
 
-    private val _state = MutableStateFlow<WooPosOrdersState>(WooPosOrdersState.Loading)
+    private val _state = MutableStateFlow<WooPosOrdersState>(
+        WooPosOrdersState.Loading(searchInputState = WooPosSearchInputState.Closed)
+    )
     val state: StateFlow<WooPosOrdersState> = _state.asStateFlow()
+
+    private var searchJob: Job? = null
+
+    private val currentSearchQuery: String?
+        get() = ((_state.value.searchInputState as? WooPosSearchInputState.Open)?.input
+            as? WooPosSearchInputState.Open.Input.Query)?.query
+
+    companion object {
+        private const val SEARCH_DEBOUNCE_DELAY_MS = 300L
+    }
 
     init {
         loadOrders()
@@ -51,15 +67,104 @@ class WooPosOrdersViewModel @Inject constructor(
         }
 
         ordersDataSource.clearCache()
-        loadOrders()
+
+        val query = currentSearchQuery
+        if (query.isNullOrEmpty()) {
+            loadOrders()
+        } else {
+            performSearch(query)
+        }
+    }
+
+    fun onSearchEvent(event: WooPosSearchUIEvent) {
+        when (event) {
+            is WooPosSearchUIEvent.SearchIconClicked -> {
+                updateSearchState(
+                    WooPosSearchInputState.Open(
+                        input = WooPosSearchInputState.Open.Input.Query("", 0),
+                        isLoading = false,
+                        requestFocus = true
+                    )
+                )
+            }
+
+            is WooPosSearchUIEvent.Search -> {
+                updateSearchState(
+                    WooPosSearchInputState.Open(
+                        input = WooPosSearchInputState.Open.Input.Query(
+                            event.query,
+                            event.cursorPosition
+                        ),
+                        isLoading = false,
+                    )
+                )
+                performSearch(event.query)
+            }
+
+            is WooPosSearchUIEvent.Clear -> {
+                updateSearchState(
+                    WooPosSearchInputState.Open(
+                        input = WooPosSearchInputState.Open.Input.Query("", 0),
+                        isLoading = false,
+                        requestFocus = true
+                    )
+                )
+                performSearch("")
+            }
+
+            is WooPosSearchUIEvent.Close -> {
+                updateSearchState(WooPosSearchInputState.Closed)
+                loadOrders()
+            }
+        }
+    }
+
+    private fun updateSearchState(searchState: WooPosSearchInputState) {
+        _state.value = when (val currentState = _state.value) {
+            is WooPosOrdersState.Content -> currentState.copy(searchInputState = searchState)
+            is WooPosOrdersState.Empty -> currentState.copy(searchInputState = searchState)
+            is WooPosOrdersState.Error -> currentState.copy(searchInputState = searchState)
+            is WooPosOrdersState.Loading -> currentState.copy(searchInputState = searchState)
+        }
+    }
+
+    private fun performSearch(query: String) {
+        searchJob?.cancel()
+        searchJob = viewModelScope.launch {
+            _state.value = WooPosOrdersState.Loading(searchInputState = _state.value.searchInputState)
+            delay(SEARCH_DEBOUNCE_DELAY_MS)
+            val result = ordersDataSource.searchOrders(query)
+            when (result) {
+                is SearchOrdersResult.Error -> {
+                    _state.value = WooPosOrdersState.Error(
+                        message = result.message,
+                        searchInputState = _state.value.searchInputState
+                    )
+                }
+
+                is SearchOrdersResult.Success -> {
+                    if (result.orders.isEmpty()) {
+                        _state.value = WooPosOrdersState.Empty(
+                            searchInputState = _state.value.searchInputState
+                        )
+                    } else {
+                        updateContentState(result.orders)
+                    }
+                }
+            }
+        }
     }
 
     private fun loadOrders() {
         viewModelScope.launch {
+            _state.value = WooPosOrdersState.Loading(searchInputState = WooPosSearchInputState.Closed)
             ordersDataSource.loadOrders().collect { result ->
                 when (result) {
                     is LoadOrdersResult.Error -> {
-                        _state.value = WooPosOrdersState.Error(message = result.message)
+                        _state.value = WooPosOrdersState.Error(
+                            message = result.message,
+                            searchInputState = WooPosSearchInputState.Closed
+                        )
                     }
 
                     is LoadOrdersResult.SuccessCache -> {
@@ -68,7 +173,9 @@ class WooPosOrdersViewModel @Inject constructor(
 
                     is LoadOrdersResult.SuccessRemote -> {
                         if (result.orders.isEmpty()) {
-                            _state.value = WooPosOrdersState.Empty()
+                            _state.value = WooPosOrdersState.Empty(
+                                searchInputState = WooPosSearchInputState.Closed
+                            )
                         } else {
                             updateContentState(result.orders)
                         }
@@ -79,7 +186,8 @@ class WooPosOrdersViewModel @Inject constructor(
     }
 
     private fun updateContentState(orders: List<Order>) {
-        val currentSelectedId = (_state.value as? WooPosOrdersState.Content)?.selectedOrderId
+        val currentState = _state.value
+        val currentSelectedId = (currentState as? WooPosOrdersState.Content)?.selectedOrderId
         val newSelectedId = currentSelectedId?.takeIf { id -> orders.any { it.id == id } }
             ?: orders.firstOrNull()?.id
 
@@ -95,7 +203,8 @@ class WooPosOrdersViewModel @Inject constructor(
             },
             selectedOrderId = newSelectedId,
             pullToRefreshState = WooPosPullToRefreshState.Enabled,
-            paginationState = WooPosPaginationState.None
+            paginationState = WooPosPaginationState.None,
+            searchInputState = currentState.searchInputState,
         )
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/orders/WooPosOrdersViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/orders/WooPosOrdersViewModel.kt
@@ -28,6 +28,7 @@ class WooPosOrdersViewModel @Inject constructor(
     val state: StateFlow<WooPosOrdersState> = _state.asStateFlow()
 
     private var searchJob: Job? = null
+    private var loadingJob: Job? = null
 
     private val currentSearchQuery: String?
         get() = (
@@ -137,7 +138,8 @@ class WooPosOrdersViewModel @Inject constructor(
     }
 
     private fun performSearch(query: String) {
-        searchJob?.cancel()
+        cancelJobs()
+
         searchJob = viewModelScope.launch {
             delay(SEARCH_DEBOUNCE_DELAY_MS)
             _state.value = WooPosOrdersState.Loading(searchInputState = _state.value.searchInputState)
@@ -164,7 +166,8 @@ class WooPosOrdersViewModel @Inject constructor(
     }
 
     private fun loadOrders() {
-        viewModelScope.launch {
+        cancelJobs()
+        loadingJob = viewModelScope.launch {
             val currentState = _state.value
             _state.value = WooPosOrdersState.Loading(searchInputState = currentState.searchInputState)
             ordersDataSource.loadOrders().collect { result ->
@@ -192,6 +195,11 @@ class WooPosOrdersViewModel @Inject constructor(
                 }
             }
         }
+    }
+
+    private fun cancelJobs() {
+        searchJob?.cancel()
+        loadingJob?.cancel()
     }
 
     private fun updateContentState(orders: List<Order>) {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/orders/WooPosOrdersViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/orders/WooPosOrdersViewModel.kt
@@ -98,7 +98,12 @@ class WooPosOrdersViewModel @Inject constructor(
                         isLoading = false,
                     )
                 )
-                performSearch(event.query)
+
+                if (event.query.isEmpty()) {
+                    loadOrders()
+                } else {
+                    performSearch(event.query)
+                }
             }
 
             is WooPosSearchUIEvent.Clear -> {
@@ -109,7 +114,7 @@ class WooPosOrdersViewModel @Inject constructor(
                         requestFocus = true
                     )
                 )
-                performSearch("")
+                loadOrders()
             }
 
             is WooPosSearchUIEvent.Close -> {
@@ -131,8 +136,8 @@ class WooPosOrdersViewModel @Inject constructor(
     private fun performSearch(query: String) {
         searchJob?.cancel()
         searchJob = viewModelScope.launch {
-            _state.value = WooPosOrdersState.Loading(searchInputState = _state.value.searchInputState)
             delay(SEARCH_DEBOUNCE_DELAY_MS)
+            _state.value = WooPosOrdersState.Loading(searchInputState = _state.value.searchInputState)
             val result = ordersDataSource.searchOrders(query)
             when (result) {
                 is SearchOrdersResult.Error -> {
@@ -157,7 +162,8 @@ class WooPosOrdersViewModel @Inject constructor(
 
     private fun loadOrders() {
         viewModelScope.launch {
-            _state.value = WooPosOrdersState.Loading(searchInputState = WooPosSearchInputState.Closed)
+            val currentState = _state.value
+            _state.value = WooPosOrdersState.Loading(searchInputState = currentState.searchInputState)
             ordersDataSource.loadOrders().collect { result ->
                 when (result) {
                     is LoadOrdersResult.Error -> {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/orders/WooPosOrdersViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/orders/WooPosOrdersViewModel.kt
@@ -30,8 +30,11 @@ class WooPosOrdersViewModel @Inject constructor(
     private var searchJob: Job? = null
 
     private val currentSearchQuery: String?
-        get() = ((_state.value.searchInputState as? WooPosSearchInputState.Open)?.input
-            as? WooPosSearchInputState.Open.Input.Query)?.query
+        get() = (
+            (
+                _state.value.searchInputState as? WooPosSearchInputState.Open
+                )?.input as? WooPosSearchInputState.Open.Input.Query
+            )?.query
 
     companion object {
         private const val SEARCH_DEBOUNCE_DELAY_MS = 300L

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/orders/WooPosOrdersDataSourceTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/orders/WooPosOrdersDataSourceTest.kt
@@ -188,4 +188,117 @@ class WooPosOrdersDataSourceTest {
             createdVia = eq("pos-rest-api")
         )
     }
+
+    @Test
+    fun `given search query, when searchOrders succeeds, then return SearchOrdersResult Success with mapped orders`() = runTest {
+        // GIVEN
+        val query = "test order"
+        val e1 = OrderEntity(localSiteId = LocalOrRemoteId.LocalId(1), 11)
+        val e2 = OrderEntity(localSiteId = LocalOrRemoteId.LocalId(1), 22)
+        val entities = listOf(e1 to emptyList<WCMetaData>(), e2 to emptyList())
+        val mapped1 = OrderTestUtils.generateTestOrder()
+        val mapped2 = OrderTestUtils.generateTestOrder()
+        whenever(orderMapper.toAppModel(e1)).thenReturn(mapped1)
+        whenever(orderMapper.toAppModel(e2)).thenReturn(mapped2)
+
+        val payload = WCOrderStore.FetchOrdersResponsePayload(
+            site = siteModel,
+            ordersWithMeta = entities
+        )
+        whenever(
+            orderRestClient.fetchOrders(
+                site = siteModel,
+                count = WooPosOrdersDataSource.POS_ORDERS_PAGE_SIZE,
+                page = 1,
+                orderBy = OrderRestClient.OrderBy.DATE,
+                sortOrder = OrderRestClient.SortOrder.DESCENDING,
+                statusFilter = null,
+                createdVia = "pos-rest-api",
+                searchQuery = query
+            )
+        ).thenReturn(payload)
+
+        // WHEN
+        val result = sut.searchOrders(query)
+
+        // THEN
+        assertThat(result).isInstanceOf(SearchOrdersResult.Success::class.java)
+        val success = result as SearchOrdersResult.Success
+        assertThat(success.orders).containsExactly(mapped1, mapped2)
+
+        verify(orderRestClient).fetchOrders(
+            site = siteModel,
+            count = WooPosOrdersDataSource.POS_ORDERS_PAGE_SIZE,
+            page = 1,
+            orderBy = OrderRestClient.OrderBy.DATE,
+            sortOrder = OrderRestClient.SortOrder.DESCENDING,
+            statusFilter = null,
+            createdVia = "pos-rest-api",
+            searchQuery = query
+        )
+    }
+
+    @Test
+    fun `given search query, when searchOrders fails, then return SearchOrdersResult Error`() = runTest {
+        // GIVEN
+        val query = "test order"
+        val orderError = WCOrderStore.OrderError(
+            type = WCOrderStore.OrderErrorType.GENERIC_ERROR,
+            message = "search error"
+        )
+        val payload = WCOrderStore.FetchOrdersResponsePayload(
+            error = orderError,
+            site = siteModel
+        )
+        whenever(
+            orderRestClient.fetchOrders(
+                site = siteModel,
+                count = WooPosOrdersDataSource.POS_ORDERS_PAGE_SIZE,
+                page = 1,
+                orderBy = OrderRestClient.OrderBy.DATE,
+                sortOrder = OrderRestClient.SortOrder.DESCENDING,
+                statusFilter = null,
+                createdVia = "pos-rest-api",
+                searchQuery = query
+            )
+        ).thenReturn(payload)
+
+        // WHEN
+        val result = sut.searchOrders(query)
+
+        // THEN
+        assertThat(result).isInstanceOf(SearchOrdersResult.Error::class.java)
+        val error = result as SearchOrdersResult.Error
+        assertThat(error.message).isEqualTo("search error")
+    }
+
+    @Test
+    fun `given empty search query, when searchOrders returns no results, then return SearchOrdersResult Success with empty list`() = runTest {
+        // GIVEN
+        val query = ""
+        val payload = WCOrderStore.FetchOrdersResponsePayload(
+            site = siteModel,
+            ordersWithMeta = emptyList()
+        )
+        whenever(
+            orderRestClient.fetchOrders(
+                site = siteModel,
+                count = WooPosOrdersDataSource.POS_ORDERS_PAGE_SIZE,
+                page = 1,
+                orderBy = OrderRestClient.OrderBy.DATE,
+                sortOrder = OrderRestClient.SortOrder.DESCENDING,
+                statusFilter = null,
+                createdVia = "pos-rest-api",
+                searchQuery = query
+            )
+        ).thenReturn(payload)
+
+        // WHEN
+        val result = sut.searchOrders(query)
+
+        // THEN
+        assertThat(result).isInstanceOf(SearchOrdersResult.Success::class.java)
+        val success = result as SearchOrdersResult.Success
+        assertThat(success.orders).isEmpty()
+    }
 }

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/orders/WooPosOrdersDataSourceTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/orders/WooPosOrdersDataSourceTest.kt
@@ -62,13 +62,14 @@ class WooPosOrdersDataSourceTest {
         )
         whenever(
             orderRestClient.fetchOrders(
-                site = eq(siteModel),
-                count = eq(WooPosOrdersDataSource.POS_ORDERS_PAGE_SIZE),
-                page = eq(1),
+                site = any(),
+                count = any(),
+                page = any(),
                 orderBy = any(),
                 sortOrder = any(),
                 statusFilter = anyOrNull(),
-                createdVia = eq("pos-rest-api")
+                createdVia = any(),
+                searchQuery = anyOrNull()
             )
         ).thenReturn(payload)
 
@@ -88,13 +89,14 @@ class WooPosOrdersDataSourceTest {
         verify(ordersCache).getAll()
         verify(ordersCache).setAll(listOf(mapped1, mapped2))
         verify(orderRestClient).fetchOrders(
-            site = eq(siteModel),
-            count = eq(WooPosOrdersDataSource.POS_ORDERS_PAGE_SIZE),
-            page = eq(1),
+            site = any(),
+            count = any(),
+            page = any(),
             orderBy = any(),
             sortOrder = any(),
             statusFilter = anyOrNull(),
-            createdVia = eq("pos-rest-api")
+            createdVia = any(),
+            searchQuery = anyOrNull()
         )
     }
 
@@ -113,13 +115,14 @@ class WooPosOrdersDataSourceTest {
         )
         whenever(
             orderRestClient.fetchOrders(
-                site = eq(siteModel),
-                count = eq(WooPosOrdersDataSource.POS_ORDERS_PAGE_SIZE),
-                page = eq(1),
+                site = any(),
+                count = any(),
+                page = any(),
                 orderBy = any(),
                 sortOrder = any(),
                 statusFilter = anyOrNull(),
-                createdVia = eq("pos-rest-api")
+                createdVia = any(),
+                searchQuery = anyOrNull()
             )
         ).thenReturn(payload)
 
@@ -138,13 +141,14 @@ class WooPosOrdersDataSourceTest {
         verify(ordersCache).getAll()
         verify(ordersCache, never()).setAll(any())
         verify(orderRestClient).fetchOrders(
-            site = eq(siteModel),
-            count = eq(WooPosOrdersDataSource.POS_ORDERS_PAGE_SIZE),
-            page = eq(1),
+            site = any(),
+            count = any(),
+            page = any(),
             orderBy = any(),
             sortOrder = any(),
             statusFilter = anyOrNull(),
-            createdVia = eq("pos-rest-api")
+            createdVia = any(),
+            searchQuery = anyOrNull()
         )
     }
 
@@ -158,13 +162,14 @@ class WooPosOrdersDataSourceTest {
         )
         whenever(
             orderRestClient.fetchOrders(
-                site = eq(siteModel),
-                count = eq(WooPosOrdersDataSource.POS_ORDERS_PAGE_SIZE),
-                page = eq(1),
+                site = any(),
+                count = any(),
+                page = any(),
                 orderBy = any(),
                 sortOrder = any(),
                 statusFilter = anyOrNull(),
-                createdVia = eq("pos-rest-api")
+                createdVia = any(),
+                searchQuery = anyOrNull()
             )
         ).thenReturn(payload)
 
@@ -179,13 +184,14 @@ class WooPosOrdersDataSourceTest {
         verify(ordersCache).getAll()
         verify(ordersCache).setAll(emptyList())
         verify(orderRestClient).fetchOrders(
-            site = eq(siteModel),
-            count = eq(WooPosOrdersDataSource.POS_ORDERS_PAGE_SIZE),
-            page = eq(1),
+            site = any(),
+            count = any(),
+            page = any(),
             orderBy = any(),
             sortOrder = any(),
             statusFilter = anyOrNull(),
-            createdVia = eq("pos-rest-api")
+            createdVia = any(),
+            searchQuery = anyOrNull()
         )
     }
 

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/orders/WooPosOrdersDataSourceTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/orders/WooPosOrdersDataSourceTest.kt
@@ -11,7 +11,6 @@ import org.assertj.core.api.Assertions.assertThat
 import org.junit.Rule
 import org.mockito.kotlin.any
 import org.mockito.kotlin.anyOrNull
-import org.mockito.kotlin.eq
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.never
 import org.mockito.kotlin.verify

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/orders/WooPosOrdersViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/orders/WooPosOrdersViewModelTest.kt
@@ -16,7 +16,6 @@ import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
 import org.mockito.Mockito.mock
-import org.mockito.kotlin.eq
 import org.mockito.kotlin.times
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/orders/WooPosOrdersViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/orders/WooPosOrdersViewModelTest.kt
@@ -2,6 +2,8 @@ package com.woocommerce.android.ui.woopos.orders
 
 import com.woocommerce.android.model.Order
 import com.woocommerce.android.ui.orders.OrderTestUtils
+import com.woocommerce.android.ui.woopos.common.composeui.component.WooPosSearchInputState
+import com.woocommerce.android.ui.woopos.common.composeui.component.WooPosSearchUIEvent
 import com.woocommerce.android.ui.woopos.home.items.WooPosPaginationState
 import com.woocommerce.android.ui.woopos.home.items.WooPosPullToRefreshState
 import com.woocommerce.android.ui.woopos.util.WooPosCoroutineTestRule
@@ -14,6 +16,7 @@ import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
 import org.mockito.Mockito.mock
+import org.mockito.kotlin.eq
 import org.mockito.kotlin.times
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
@@ -202,5 +205,104 @@ class WooPosOrdersViewModelTest {
         val state = viewModel.state.value as WooPosOrdersState.Content
         assertThat(state.items.map { it.id }).containsExactly(300L, 400L)
         assertThat(state.selectedOrderId).isEqualTo(300L)
+    }
+
+    @Test
+    fun `given ViewModel initialized, when onSearchEvent SearchIconClicked, then search input state opens`() = runTest {
+        // GIVEN
+        viewModel = WooPosOrdersViewModel(dataSource)
+        advanceUntilIdle()
+
+        // WHEN
+        viewModel.onSearchEvent(WooPosSearchUIEvent.SearchIconClicked)
+        advanceUntilIdle()
+
+        // THEN
+        val state = viewModel.state.value
+        assertThat(state.searchInputState).isInstanceOf(WooPosSearchInputState.Open::class.java)
+        val openState = state.searchInputState as WooPosSearchInputState.Open
+        assertThat(openState.input.text).isEmpty()
+        assertThat(openState.requestFocus).isTrue()
+    }
+
+    @Test
+    fun `given search data available, when onSearchEvent Search with query, then searchOrders is called and state updates`() = runTest {
+        // GIVEN
+        val query = "test query"
+        val searchResult = listOf(order(10), order(20))
+        whenever(dataSource.searchOrders(query)).thenReturn(SearchOrdersResult.Success(searchResult))
+
+        viewModel = WooPosOrdersViewModel(dataSource)
+        advanceUntilIdle()
+
+        // WHEN
+        viewModel.onSearchEvent(WooPosSearchUIEvent.Search(query, query.length))
+        advanceUntilIdle()
+
+        // THEN
+        val state = viewModel.state.value
+        assertThat(state).isInstanceOf(WooPosOrdersState.Content::class.java)
+        val content = state as WooPosOrdersState.Content
+        assertThat(content.items.map { it.id }).containsExactly(10L, 20L)
+        assertThat(content.searchInputState).isInstanceOf(WooPosSearchInputState.Open::class.java)
+
+        verify(dataSource).searchOrders(query)
+    }
+
+    @Test
+    fun `given ViewModel initialized, when onSearchEvent Search with empty query, then loadOrders is called`() = runTest {
+        // GIVEN
+        viewModel = WooPosOrdersViewModel(dataSource)
+        advanceUntilIdle()
+
+        // WHEN
+        viewModel.onSearchEvent(WooPosSearchUIEvent.Search("", 0))
+        advanceUntilIdle()
+
+        // THEN
+        verify(dataSource, times(2)).loadOrders() // init + search with empty query
+    }
+
+    @Test
+    fun `given search input is open, when onSearchEvent Close, then search input state closes and loadOrders is called`() = runTest {
+        // GIVEN
+        viewModel = WooPosOrdersViewModel(dataSource)
+        advanceUntilIdle()
+
+        viewModel.onSearchEvent(WooPosSearchUIEvent.SearchIconClicked)
+        advanceUntilIdle()
+
+        // WHEN
+        viewModel.onSearchEvent(WooPosSearchUIEvent.Close)
+        advanceUntilIdle()
+
+        // THEN
+        val state = viewModel.state.value
+        assertThat(state.searchInputState).isEqualTo(WooPosSearchInputState.Closed)
+        verify(dataSource, times(2)).loadOrders() // init + close search
+    }
+
+    @Test
+    fun `given search will fail, when search is performed, then Error state is shown with search input state preserved`() = runTest {
+        // GIVEN
+        val query = "test query"
+        whenever(dataSource.searchOrders(query)).thenReturn(SearchOrdersResult.Error("search failed"))
+
+        viewModel = WooPosOrdersViewModel(dataSource)
+        advanceUntilIdle()
+
+        viewModel.onSearchEvent(WooPosSearchUIEvent.SearchIconClicked)
+        advanceUntilIdle()
+
+        // WHEN
+        viewModel.onSearchEvent(WooPosSearchUIEvent.Search(query, query.length))
+        advanceUntilIdle()
+
+        // THEN
+        val state = viewModel.state.value
+        assertThat(state).isInstanceOf(WooPosOrdersState.Error::class.java)
+        val error = state as WooPosOrdersState.Error
+        assertThat(error.message).isEqualTo("search failed")
+        assertThat(error.searchInputState).isInstanceOf(WooPosSearchInputState.Open::class.java)
     }
 }

--- a/libs/fluxc-plugin/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/order/OrderRestClient.kt
+++ b/libs/fluxc-plugin/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/order/OrderRestClient.kt
@@ -177,6 +177,7 @@ class OrderRestClient @Inject constructor(
         sortOrder: SortOrder,
         statusFilter: String?,
         createdVia: String? = null,
+        searchQuery: String? = null,
     ): FetchOrdersResponsePayload {
         val url = WOOCOMMERCE.orders.pathV3
         val params = mutableMapOf(
@@ -187,7 +188,8 @@ class OrderRestClient @Inject constructor(
             "_fields" to ORDER_FIELDS
         ).putIfNotEmpty(
             "status" to statusFilter,
-            "created_via" to createdVia
+            "created_via" to createdVia,
+            "search" to searchQuery,
         )
 
         val response = wooNetwork.executeGetGsonRequest(


### PR DESCRIPTION
WOOMOB-1146

### Description
Implemented search functionality for orders in Woo POS. The enhancement allows users to search through orders using a search query, with proper handling of empty queries to load all orders. The implementation includes UI updates with a search bar integrated into the toolbar and state management for search operations. The UI is mocked and not final. There is no pagination, and only 1 page is loaded yet.

### Steps to reproduce
1. Navigate to Woo POS orders screen
2. Use the search bar in the toolbar to enter a search query
3. Observe filtered orders appear based on the search
4. Clear the search to see all orders reload

### Testing information
- Tested search functionality with various queries
- Verified empty query behavior reloads all orders
- Verified error state

### Images/gif


https://github.com/user-attachments/assets/55debae6-f1af-41e4-8315-c64ece78267c



- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.