### PR TITLE
[WOOMOB-445] UI glitches

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/plugins/PluginsScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/plugins/PluginsScreen.kt
@@ -1,16 +1,9 @@
 package com.woocommerce.android.ui.prefs.plugins
 
 import androidx.compose.animation.Crossfade
-import androidx.compose.animation.core.LinearEasing
-import androidx.compose.animation.core.RepeatMode
-import androidx.compose.animation.core.animateFloat
-import androidx.compose.animation.core.infiniteRepeatable
-import androidx.compose.animation.core.rememberInfiniteTransition
-import androidx.compose.animation.core.tween
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
-import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxSize
@@ -34,9 +27,6 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.livedata.observeAsState
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.geometry.Offset
-import androidx.compose.ui.graphics.Brush
-import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.res.colorResource
 import androidx.compose.ui.res.dimensionResource
 import androidx.compose.ui.res.stringResource
@@ -45,6 +35,7 @@ import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import com.woocommerce.android.R
 import com.woocommerce.android.extensions.isNotNullOrEmpty
+import com.woocommerce.android.ui.compose.animations.SkeletonView
 import com.woocommerce.android.ui.compose.component.Toolbar
 import com.woocommerce.android.ui.compose.component.WCColoredButton
 import com.woocommerce.android.ui.compose.preview.LightDarkThemePreviews
@@ -199,32 +190,9 @@ private fun PluginItem(
 
 @Composable
 fun ShimmerPluginsList() {
-    val colors = listOf(
-        Color.LightGray.copy(alpha = 0.9f),
-        Color.LightGray.copy(alpha = 0.2f),
-        Color.LightGray.copy(alpha = 0.9f)
-    )
-
-    val transition = rememberInfiniteTransition(label = "")
-    val animation = transition.animateFloat(
-        initialValue = 0f,
-        targetValue = 1000f,
-        animationSpec = infiniteRepeatable(
-            animation = tween(600, easing = LinearEasing, delayMillis = 500),
-            repeatMode = RepeatMode.Restart
-        ),
-        label = ""
-    )
-
-    val brush = Brush.linearGradient(
-        colors = colors,
-        start = Offset(animation.value - 500f, animation.value - 500f),
-        end = Offset(animation.value, animation.value)
-    )
-
     LazyColumn {
         items(10) {
-            ShimmerPluginItem(brush = brush)
+            ShimmerPluginItem()
 
             if (it < 10) {
                 Divider()
@@ -234,7 +202,7 @@ fun ShimmerPluginsList() {
 }
 
 @Composable
-fun ShimmerPluginItem(brush: Brush) {
+fun ShimmerPluginItem() {
     Row(
         modifier = Modifier
             .fillMaxWidth()
@@ -245,16 +213,14 @@ fun ShimmerPluginItem(brush: Brush) {
                 .weight(1f),
             verticalArrangement = Arrangement.spacedBy(8.dp)
         ) {
-            Box(
+            SkeletonView(
                 modifier = Modifier
                     .fillMaxWidth()
-                    .background(brush)
                     .height(18.dp)
                     .width(200.dp)
             )
-            Box(
+            SkeletonView(
                 modifier = Modifier
-                    .background(brush)
                     .height(18.dp)
                     .width(150.dp)
             )
@@ -265,17 +231,15 @@ fun ShimmerPluginItem(brush: Brush) {
                 .width(100.dp),
             verticalArrangement = Arrangement.spacedBy(8.dp)
         ) {
-            Box(
+            SkeletonView(
                 modifier = Modifier
                     .align(Alignment.End)
-                    .background(brush)
                     .height(18.dp)
                     .width(40.dp)
             )
-            Box(
+            SkeletonView(
                 modifier = Modifier
                     .align(Alignment.End)
-                    .background(brush)
                     .height(16.dp)
                     .width(70.dp)
             )

--- a/WooCommerce/src/main/res/layout/fragment_product_shipping_class_list.xml
+++ b/WooCommerce/src/main/res/layout/fragment_product_shipping_class_list.xml
@@ -29,7 +29,7 @@
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:layout_gravity="center"
-            android:layout_marginBottom="@dimen/margin_large"
+            android:layout_marginVertical="@dimen/margin_large"
             android:visibility="gone"
             tools:visibility="visible" />
 


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->
Closes WOOMOB-445
<!-- Id number of the Linear issue this PR addresses, e.g., WOOMOB-373. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

When testing 22.2 two UI glitches were found:

**Loading Spinner cut off when opening shipping class**

Fix by replacing the bottom margin with a vertical margin to keep it symetrical.

| Before | After |
|---|---|
| <img width="320" height="714" alt="Screenshot_20250912_114911" src="https://github.com/user-attachments/assets/d09aa2b6-c75a-48b6-a98a-1920a5014423" /> | <img width="320" height="714" alt="Screenshot_20250912_115232" src="https://github.com/user-attachments/assets/87f14374-adc3-452b-8404-cb81629ef085" /> |

**Wrong skeletons color in the Plugins screen**

The custom composable used a fixed color there. After looking around, I noticed there's a `SkeletonView` for such a scenario, so I replaced the custom one with it completely. This should ensure the shimmer effect is consistent across the screens.

| Before | After |
|---|---|
| <img width="320" height="714" alt="shim_before" src="https://github.com/user-attachments/assets/93e4ecc7-0999-4907-8236-46ae1ffe1a99" /> | <img width="320" height="714" alt="shim_after" src="https://github.com/user-attachments/assets/96326a88-3bf6-4523-9375-e2a7b599e733" /> |
| <img width="320" height="714" alt="shim_light_before" src="https://github.com/user-attachments/assets/be467f72-d8e2-42b2-9a2b-a7b756c1ef09" /> | <img width="320" height="714" alt="shim_light_after" src="https://github.com/user-attachments/assets/9ecf2dac-8152-4543-9689-37a844ee147d" /> |

### Steps to reproduce / Testing information

**Loading Spinner cut off when opening shipping class**
1. Make sure you have no shipping classes (this loading is shown only when the list is empty, otherwise cached values are used)
2. Go to product 
3. Tap "Shipping" or if it's not there tap "Add more details"
4. Tap "Shipping class"
5. Observe the progress indicator

**Wrong skeletons color in the Plugins screen**
1. Enable dark theme
2. Go to "Settings"
3. Tap "Installed plugins"
4. Notice the shimmer effect color
5. Switch theme and re-enter the screen to verify the shimmer again

### The tests that have been performed

The above


- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
