### PR TITLE
[Site Picker] Fix issue with the visibility of the Continue button

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -6,6 +6,7 @@
 - [Internal] Migration to POS specific product model [https://github.com/woocommerce/woocommerce-android/pull/14598]
 - [*] Enhance the shipping label creation screen by making the selected hazardous box tappable [https://github.com/woocommerce/woocommerce-android/pull/14576]
 - [*] Shipping Labels: Enhance selected package UI in the create shipping label flow [https://github.com/woocommerce/woocommerce-android/pull/14579]
+- [*] Fix an issue where there is delay before displaying the continue button in Site Picker screen [https://github.com/woocommerce/woocommerce-android/pull/14611]
 
 23.2
 -----

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/sitepicker/SitePickerViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/sitepicker/SitePickerViewModel.kt
@@ -153,7 +153,7 @@ class SitePickerViewModel @Inject constructor(
     private suspend fun fetchSitesFromApi(showSkeleton: Boolean) {
         sitePickerViewState = sitePickerViewState.copy(
             isSkeletonViewVisible = showSkeleton,
-            isPrimaryBtnVisible = false
+            isPrimaryBtnVisible = !showSkeleton
         )
 
         val startTime = System.currentTimeMillis()

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/sitepicker/SitePickerViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/sitepicker/SitePickerViewModelTest.kt
@@ -61,6 +61,7 @@ import org.wordpress.android.fluxc.network.rest.wpcom.wc.WooErrorType
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.WooResult
 import org.wordpress.android.fluxc.store.SiteStore.ConnectSiteInfoPayload
 import kotlin.test.assertFalse
+import kotlin.test.assertTrue
 
 @ExperimentalCoroutinesApi
 class SitePickerViewModelTest : BaseUnitTest() {
@@ -809,7 +810,7 @@ class SitePickerViewModelTest : BaseUnitTest() {
         }
 
     @Test
-    fun `given initiated, when isPrimaryBtnVisible and loading state, then primary button view is not displayed`() =
+    fun `given initiated, when fetching sites, then primary button view is not displayed when showing skeleton`() =
         runTest {
             Dispatchers.setMain(StandardTestDispatcher())
             val expectedSites = defaultExpectedSiteList.map { it.apply { setIsJetpackCPConnected(true) } }
@@ -817,15 +818,29 @@ class SitePickerViewModelTest : BaseUnitTest() {
             whenViewModelIsCreated()
             val states = viewModel.sitePickerViewStateData.liveData.captureValues()
 
-            // Make primary button visible after initialization. This may happen in low memory condition.
-            viewModel.sitePickerViewState = viewModel.sitePickerViewState.copy(isPrimaryBtnVisible = true)
-
             advanceUntilIdle()
 
             states.forEach { state ->
                 if (state.isSkeletonViewVisible) {
                     assertFalse(state.isPrimaryBtnVisible)
                 }
+            }
+            Dispatchers.resetMain()
+        }
+
+    @Test
+    fun `given initiated, when fetching sites, then primary button view is shown during loading`() =
+        runTest {
+            Dispatchers.setMain(StandardTestDispatcher())
+            val expectedSites = defaultExpectedSiteList
+            whenSitesAreFetched(sitesFromDb = expectedSites)
+            whenViewModelIsCreated()
+            val states = viewModel.sitePickerViewStateData.liveData.captureValues().drop(1)
+
+            advanceUntilIdle()
+
+            states.forEach { state ->
+                assertTrue(state.isPrimaryBtnVisible)
             }
             Dispatchers.resetMain()
         }


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

<!-- Id number of the Linear issue this PR addresses, e.g., WOOMOB-373. -->
Closes WOOMOB-1337

### Description
This PR fixes an issue with the visibility of the Continue button: The button is not shown when fetching sites from the API, even when we already have sites cached.

The issue started happening after this PR https://github.com/woocommerce/woocommerce-android/pull/12603, when we added logic to hide the button during the fetch in an attempt to fix a crash, the issue with that change is that it was too broad, as there are cases when the button should still be shown. This PR adjustes the logic so that the button is hidden only when we need to show the skeleton loading view, which means the cache is empty or we need to enforce a refresh.

### Steps to reproduce
1. To better see the issue, sign in using your A8C account to the app.
2. Ensure your account is not connected to any Jetpack CP sites, as we enforce a refresh for those sites.
3. Open the site picker.

### Testing information
- Confirm the continue button is shown at the start.
- Good to test: add a Jetpack CP site to your account and confirm that the button is hidden when we open the screen, and the skeleton is shown.

### The tests that have been performed
The above.

- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->