### PR TITLE
[CIAB] Integrate the garden arch API and add a helper class for deciding features to be disabled for CIAB sites

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ciab/CIABAffectedFeature.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ciab/CIABAffectedFeature.kt
@@ -1,0 +1,11 @@
+package com.woocommerce.android.ciab
+
+enum class CIABAffectedFeature {
+    Blaze,
+    Payments,
+    WooShippingSplitShipments,
+    GroupedProducts,
+    VariableProducts,
+    GiftCardEditing,
+    ProductsStockDashboardCard
+}

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ciab/CIABSiteGateKeeper.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ciab/CIABSiteGateKeeper.kt
@@ -19,7 +19,8 @@ class CIABSiteGateKeeper @Inject constructor(private val selectedSite: SelectedS
     }
 
     private fun isCurrentSiteCIAB(): Boolean {
-        TODO()
+        val site = selectedSite.getOrNull() ?: return false
+        return site.isGardenSite && site.gardenName == CIAB_GARDEN_NAME
     }
 
     companion object Companion {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ciab/CIABSiteGateKeeper.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ciab/CIABSiteGateKeeper.kt
@@ -1,0 +1,29 @@
+package com.woocommerce.android.ciab
+
+import androidx.annotation.VisibleForTesting
+import com.woocommerce.android.tools.SelectedSite
+import javax.inject.Inject
+
+class CIABSiteGateKeeper @Inject constructor(private val selectedSite: SelectedSite) {
+    fun isFeatureSupported(
+        @Suppress("unused")
+        feature: CIABAffectedFeature
+    ): Boolean {
+        // For now, all affected features are unsupported in CIAB.
+        // If there are exceptions in the future, we can handle them here.
+        return !isCurrentSiteCIAB()
+    }
+
+    fun isFeatureUnsupported(feature: CIABAffectedFeature): Boolean {
+        return !isFeatureSupported(feature)
+    }
+
+    private fun isCurrentSiteCIAB(): Boolean {
+        TODO()
+    }
+
+    companion object Companion {
+        @VisibleForTesting
+        const val CIAB_GARDEN_NAME = "commerce"
+    }
+}

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ciab/CIABSiteGateKeeperTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ciab/CIABSiteGateKeeperTest.kt
@@ -1,0 +1,44 @@
+package com.woocommerce.android.ciab
+
+import com.woocommerce.android.tools.SelectedSite
+import com.woocommerce.android.viewmodel.BaseUnitTest
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.mockito.Mockito.mock
+import org.mockito.kotlin.given
+import org.wordpress.android.fluxc.model.SiteModel
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class CIABSiteGateKeeperTest : BaseUnitTest() {
+    private val selectedSite: SelectedSite = mock()
+    private val ciabSiteGateKeeper = CIABSiteGateKeeper(selectedSite)
+
+    @Test
+    fun `given current site is CIAB, when checking feature support, then feature is unsupported`() {
+        val site = createSite(isCIAB = true)
+        given(selectedSite.getOrNull()).willReturn(site)
+
+        CIABAffectedFeature.entries.forEach {
+            assertFalse(ciabSiteGateKeeper.isFeatureSupported(it))
+        }
+    }
+
+    @Test
+    fun `given current site is not CIAB, when checking feature support, then feature is supported`() {
+        val site = createSite(isCIAB = false)
+        given(selectedSite.getOrNull()).willReturn(site)
+
+        CIABAffectedFeature.entries.forEach {
+            assertTrue(ciabSiteGateKeeper.isFeatureSupported(it))
+        }
+    }
+
+    private fun createSite(isCIAB: Boolean): SiteModel {
+        return SiteModel().apply {
+            setIsGardenSite(isCIAB)
+            this.gardenName = if (isCIAB) CIABSiteGateKeeper.CIAB_GARDEN_NAME else null
+        }
+    }
+}

--- a/libs/fluxc/src/main/java/org/wordpress/android/fluxc/model/SiteModel.java
+++ b/libs/fluxc/src/main/java/org/wordpress/android/fluxc/model/SiteModel.java
@@ -265,6 +265,14 @@ public class SiteModel extends Payload<BaseNetworkError> implements Identifiable
     private Boolean mWasEcommerceTrial;
     @Column
     private Boolean mIsSingleUserSite;
+    @Column
+    private boolean mIsGardenSite;
+    @Column
+    @Nullable
+    private String mGardenName;
+    @Column
+    @Nullable
+    private String mGardenPartner;
 
     @Override
     public int getId() {
@@ -1137,6 +1145,32 @@ public class SiteModel extends Payload<BaseNetworkError> implements Identifiable
         mIsSingleUserSite = isSingleUserSite;
     }
 
+    public boolean isGardenSite() {
+        return mIsGardenSite;
+    }
+
+    public void setIsGardenSite(boolean mIsGardenSite) {
+        this.mIsGardenSite = mIsGardenSite;
+    }
+
+    @Nullable
+    public String getGardenName() {
+        return mGardenName;
+    }
+
+    public void setGardenName(@Nullable String mGardenName) {
+        this.mGardenName = mGardenName;
+    }
+
+    @Nullable
+    public String getGardenPartner() {
+        return mGardenPartner;
+    }
+
+    public void setGardenPartner(@Nullable String mGardenPartner) {
+        this.mGardenPartner = mGardenPartner;
+    }
+
     @Override
     public boolean equals(Object o) {
         if (!(o instanceof SiteModel)) return false;
@@ -1236,7 +1270,10 @@ public class SiteModel extends Payload<BaseNetworkError> implements Identifiable
                 Objects.equals(mCanBlaze, siteModel.mCanBlaze) &&
                 Objects.equals(mPlanActiveFeatures, siteModel.mPlanActiveFeatures) &&
                 Objects.equals(mWasEcommerceTrial, siteModel.mWasEcommerceTrial) &&
-                Objects.equals(mIsSingleUserSite, siteModel.mIsSingleUserSite);
+                Objects.equals(mIsSingleUserSite, siteModel.mIsSingleUserSite) &&
+                mIsGardenSite == siteModel.mIsGardenSite &&
+                Objects.equals(mGardenName, siteModel.mGardenName) &&
+                Objects.equals(mGardenPartner, siteModel.mGardenPartner);
     }
 
     @Override
@@ -1336,6 +1373,9 @@ public class SiteModel extends Payload<BaseNetworkError> implements Identifiable
                 mCanBlaze,
                 mPlanActiveFeatures,
                 mWasEcommerceTrial,
-                mIsSingleUserSite);
+                mIsSingleUserSite,
+                mIsGardenSite,
+                mGardenName,
+                mGardenPartner);
     }
 }

--- a/libs/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/site/SiteRestClient.kt
+++ b/libs/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/site/SiteRestClient.kt
@@ -1136,6 +1136,11 @@ class SiteRestClient @Inject constructor(
         site.planActiveFeatures = (from.plan?.features?.active?.joinToString(",")).orEmpty()
         site.wasEcommerceTrial = from.was_ecommerce_trial
         site.setIsSingleUserSite(from.single_user_site)
+
+        site.setIsGardenSite(from.is_garden)
+        site.gardenName = from.garden_name
+        site.gardenPartner = from.garden_partner
+
         return site
     }
 
@@ -1186,7 +1191,7 @@ class SiteRestClient @Inject constructor(
         @VisibleForTesting
         const val SITE_FIELDS = "ID,URL,name,description,jetpack,jetpack_connection,visible,is_private," +
             "options,plan,capabilities,quota,icon,meta,zendesk_site_meta,organization_id," +
-            "was_ecommerce_trial,single_user_site,jetpack_modules"
+            "was_ecommerce_trial,single_user_site,jetpack_modules,is_garden,garden_name,garden_partner"
         private const val ROOT_ENDPOINT_FIELDS = "name,description,gmt_offset,namespaces,authentication"
         private const val WOO_API_NAMESPACE_PREFIX = "wc/"
         private const val FIELDS = "fields"

--- a/libs/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/site/SiteWPComRestResponse.java
+++ b/libs/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/site/SiteWPComRestResponse.java
@@ -127,4 +127,7 @@ public class SiteWPComRestResponse implements Response {
     public boolean was_ecommerce_trial;
     public boolean single_user_site;
     public List<String> jetpack_modules;
+    public boolean is_garden;
+    public String garden_name;
+    public String garden_partner;
 }

--- a/libs/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/WellSqlConfig.kt
+++ b/libs/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/WellSqlConfig.kt
@@ -40,7 +40,7 @@ open class WellSqlConfig : DefaultWellConfig {
     annotation class AddOn
 
     override fun getDbVersion(): Int {
-        return 230
+        return 231
     }
 
     override fun getDbName(): String {
@@ -2245,6 +2245,12 @@ open class WellSqlConfig : DefaultWellConfig {
 
                 229 -> migrateAddOn(ADDON_WOOCOMMERCE, version) {
                     db.execSQL("DROP TABLE IF EXISTS WCNewVisitorStatsModel")
+                }
+
+                230 -> migrate(version) {
+                    db.execSQL("ALTER TABLE SiteModel ADD IS_GARDEN_SITE BOOLEAN NOT NULL DEFAULT 0")
+                    db.execSQL("ALTER TABLE SiteModel ADD GARDEN_NAME TEXT")
+                    db.execSQL("ALTER TABLE SiteModel ADD GARDEN_PARTNER TEXT")
                 }
             }
         }


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

<!-- Id number of the Linear issue this PR addresses, e.g., WOOMOB-373. -->
Closes WOOMOB-1274

### Description
This is the first PR for updating the app to allow adjusting the experience for CIAB sites, the PR introduces the following changes:
- It updates the `SiteModel` DB table to include the new fields added for the garden architecture.
- It updates the SiteRestClient to make sure we read the new fields from the API (Check https://developer.wordpress.com/docs/api/1.1/get/sites/%24site/)
- Adds the `CIABSiteGateKeeper` class for controlling which features we'll disable for CIAB sites.

**Note:** The `CIABSiteGateKeeper` and `CIABAffectedFeature` architecture is modeled after what the iOS team [did](https://github.com/woocommerce/woocommerce-ios/pull/16095), just with different names. I think the architecture makes sense, even though we'll disable all features of the enum `CIABAffectedFeature` initially. Also, even though I'm not sure we'll ever need this, the flexibility could be helpful in the future if we need to offer different features to the different partners.
For some context on the Garden Architecture, check this PdpAdu-2ai-p2

### Steps to reproduce
#### For the `CIABSiteGateKeeper` just check the unit tests, as it's not used now.
#### For the sites API
1. Apply the following patch
<details>
<summary> Patch </summary>

```patch
Index: WooCommerce/src/main/kotlin/com/woocommerce/android/ui/main/MainActivity.kt
IDEA additional info:
Subsystem: com.intellij.openapi.diff.impl.patch.CharsetEP
<+>UTF-8
===================================================================
diff --git a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/main/MainActivity.kt b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/main/MainActivity.kt
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/main/MainActivity.kt	(revision 0acce60e28a92556603847c978a3940811087867)
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/main/MainActivity.kt	(date 1757956052483)
@@ -117,6 +117,7 @@
 import org.wordpress.android.login.LoginAnalyticsListener
 import org.wordpress.android.login.LoginMode
 import org.wordpress.android.util.NetworkUtils
+import org.wordpress.android.util.ToastUtils
 import java.lang.ref.WeakReference
 import java.math.BigDecimal
 import java.util.Locale
@@ -363,6 +364,12 @@
             viewModel.handleShortcutAction(intent?.action?.lowercase(Locale.ROOT))
             handleIncomingImages()
         }
+
+        selectedSite.get().let {
+            if (it.isGardenSite) {
+                ToastUtils.showToast(this, "Detected a Garden site:\nGarden Name: ${it.gardenName}\nGarden Partner: ${it.gardenPartner}")
+            }
+        }
     }
 
     private fun handleIncomingImages() {
```

</details>

2. Create a CIAB site using this guide and tool pdpAdu-29A-p2
3. Open the app and sign in to your account.
4. Confirm a toast is shown with the garden name and partner when opening the app.

### Testing information
- Test the API integration.
- Review the unit tests and logic.

### The tests that have been performed
The above.

- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->