### PR TITLE
[HACK] Migrate MediaPickerDialogScreen to Material 3

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -3,7 +3,6 @@
 *** For entries which are touching the Android Wear app's, start entry with `[WEAR]` too.
 23.4
 -----
-- [*] It's possible to see all the orders made by a specific customer from the order details screen [https://github.com/woocommerce/woocommerce-android/pull/14615]
 
 
 23.3
@@ -14,6 +13,7 @@
 - [*] Fixed the incorrect size of the notification icon [https://github.com/woocommerce/woocommerce-android/pull/14586]
 - [***] Performance improvements for users logging in with WordPress.com accounts [https://github.com/woocommerce/woocommerce-android/pull/14610]
 - [*] Fix an issue where there is delay before displaying the continue button in Site Picker screen [https://github.com/woocommerce/woocommerce-android/pull/14611]
+- [*] It's possible to see all the orders made by a specific customer from the order details screen [https://github.com/woocommerce/woocommerce-android/pull/14615]
 
 23.2
 -----

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/mediapicker/MediaPickerDialogScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/mediapicker/MediaPickerDialogScreen.kt
@@ -11,9 +11,9 @@ import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
-import androidx.compose.material.Card
-import androidx.compose.material.MaterialTheme
-import androidx.compose.material.Text
+import androidx.compose.material3.Card
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -43,7 +43,7 @@ fun MediaPickerDialog(
         Card(
             modifier = Modifier
                 .fillMaxWidth()
-                .background(MaterialTheme.colors.surface, MaterialTheme.shapes.medium)
+                .background(MaterialTheme.colorScheme.surface, MaterialTheme.shapes.medium)
                 .shadow(elevation = dimensionResource(id = dimen.major_75)),
         ) {
             Column(
@@ -58,7 +58,7 @@ fun MediaPickerDialog(
                             bottom = dimensionResource(id = dimen.minor_100)
                         ),
                     text = stringResource(id = string.media_picker_dialog_title),
-                    style = MaterialTheme.typography.h6
+                    style = MaterialTheme.typography.titleLarge
                 )
 
                 DialogButton(
@@ -116,8 +116,8 @@ private fun DialogButton(@DrawableRes image: Int, @StringRes title: Int, onClick
                     .align(alignment = Alignment.CenterVertically)
                     .padding(start = dimensionResource(id = dimen.major_100)),
                 text = stringResource(id = title),
-                color = MaterialTheme.colors.onSurface,
-                style = MaterialTheme.typography.body2
+                color = MaterialTheme.colorScheme.onSurface,
+                style = MaterialTheme.typography.bodyMedium
             )
         }
     }


### PR DESCRIPTION
### Description
Migrate MediaPickerDialogScreen from Material 2 to Material 3 components to align with the design system migration. Updates the dialog components to use Material 3 styling while maintaining the same functionality.

### Steps to reproduce
1. Navigate to products. Start product creation. Select Create with AI
2. Tap on an image upload option to open the media picker dialog
3. Verify the dialog is the same as before the change

### Images/gif
##### Before
<img width="801" height="500" alt="Screenshot 2025-09-16 at 13 55 17" src="https://github.com/user-attachments/assets/f9b8e6a6-5d6c-4b37-83d6-4137a3f425b4" />


##### After
<img width="805" height="502" alt="Screenshot 2025-09-16 at 14 22 49" src="https://github.com/user-attachments/assets/c6d15203-7689-4d43-9506-1d3fd41caeb0" />

- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.