### PR TITLE
[CIAB] Hide Blaze and Payments in the More menu screen

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/blaze/IsBlazeEnabled.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/blaze/IsBlazeEnabled.kt
@@ -1,9 +1,12 @@
 package com.woocommerce.android.ui.blaze
 
+import androidx.annotation.VisibleForTesting
 import com.woocommerce.android.ciab.CIABAffectedFeature
 import com.woocommerce.android.ciab.CIABSiteGateKeeper
 import com.woocommerce.android.tools.SelectedSite
 import com.woocommerce.android.tools.SiteConnectionType.Jetpack
+import com.woocommerce.android.tools.connectionType
+import org.wordpress.android.fluxc.model.SiteModel
 import javax.inject.Inject
 
 class IsBlazeEnabled @Inject constructor(
@@ -11,13 +14,14 @@ class IsBlazeEnabled @Inject constructor(
     private val ciabSiteGateKeeper: CIABSiteGateKeeper
 ) {
     companion object {
-        private const val BLAZE_FOR_WOOCOMMERCE_PLUGIN_SLUG = "blaze-ads"
+        @VisibleForTesting
+        const val BLAZE_FOR_WOOCOMMERCE_PLUGIN_SLUG = "blaze-ads"
     }
 
     operator fun invoke(): Boolean {
         val site = selectedSite.getOrNull() ?: return false
         return site.isAdmin &&
-            hasAValidJetpackConnectionForBlaze() &&
+            site.hasAValidJetpackConnectionForBlaze() &&
             site.canBlaze &&
             ciabSiteGateKeeper.isFeatureSupported(CIABAffectedFeature.Blaze)
     }
@@ -27,9 +31,9 @@ class IsBlazeEnabled @Inject constructor(
      * Jetpack connection will work. For now, Blaze will only be enabled for sites with Jetpack plugin installed and
      * active, or for sites with Blaze for WooCommerce plugin installed and connected.
      */
-    private fun hasAValidJetpackConnectionForBlaze() =
-        selectedSite.connectionType == Jetpack || isBlazeForWooCommercePluginActive()
+    private fun SiteModel.hasAValidJetpackConnectionForBlaze() =
+        connectionType == Jetpack || isBlazeForWooCommercePluginActive()
 
-    private fun isBlazeForWooCommercePluginActive(): Boolean =
-        selectedSite.get().activeJetpackConnectionPlugins?.contains(BLAZE_FOR_WOOCOMMERCE_PLUGIN_SLUG) == true
+    private fun SiteModel.isBlazeForWooCommercePluginActive(): Boolean =
+        activeJetpackConnectionPlugins?.contains(BLAZE_FOR_WOOCOMMERCE_PLUGIN_SLUG) == true
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/blaze/IsBlazeEnabled.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/blaze/IsBlazeEnabled.kt
@@ -1,19 +1,26 @@
 package com.woocommerce.android.ui.blaze
 
+import com.woocommerce.android.ciab.CIABAffectedFeature
+import com.woocommerce.android.ciab.CIABSiteGateKeeper
 import com.woocommerce.android.tools.SelectedSite
 import com.woocommerce.android.tools.SiteConnectionType.Jetpack
 import javax.inject.Inject
 
 class IsBlazeEnabled @Inject constructor(
-    private val selectedSite: SelectedSite
+    private val selectedSite: SelectedSite,
+    private val ciabSiteGateKeeper: CIABSiteGateKeeper
 ) {
     companion object {
         private const val BLAZE_FOR_WOOCOMMERCE_PLUGIN_SLUG = "blaze-ads"
     }
 
-    operator fun invoke(): Boolean = selectedSite.getIfExists()?.isAdmin ?: false &&
-        hasAValidJetpackConnectionForBlaze() &&
-        selectedSite.getIfExists()?.canBlaze ?: false
+    operator fun invoke(): Boolean {
+        val site = selectedSite.getOrNull() ?: return false
+        return site.isAdmin &&
+            hasAValidJetpackConnectionForBlaze() &&
+            site.canBlaze &&
+            ciabSiteGateKeeper.isFeatureSupported(CIABAffectedFeature.Blaze)
+    }
 
     /**
      * In order for Blaze to work, the site requires the Jetpack Sync module to be enabled. This means not all

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/moremenu/MoreMenuState.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/moremenu/MoreMenuState.kt
@@ -53,7 +53,7 @@ data class MoreMenuItemButton(
     }
 
     enum class Type {
-        Blaze, GoogleForWoo, Inbox, Settings,
+        Blaze, GoogleForWoo, Inbox, Settings, Payments
     }
 }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/moremenu/MoreMenuViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/moremenu/MoreMenuViewModel.kt
@@ -19,6 +19,8 @@ import com.woocommerce.android.analytics.AnalyticsTracker.Companion.VALUE_MORE_M
 import com.woocommerce.android.analytics.AnalyticsTracker.Companion.VALUE_MORE_MENU_UPGRADES
 import com.woocommerce.android.analytics.AnalyticsTracker.Companion.VALUE_MORE_MENU_VIEW_STORE
 import com.woocommerce.android.analytics.AnalyticsTrackerWrapper
+import com.woocommerce.android.ciab.CIABAffectedFeature
+import com.woocommerce.android.ciab.CIABSiteGateKeeper
 import com.woocommerce.android.extensions.adminUrlOrDefault
 import com.woocommerce.android.notifications.UnseenReviewsCountHandler
 import com.woocommerce.android.tools.SelectedSite
@@ -69,6 +71,7 @@ class MoreMenuViewModel @Inject constructor(
     private val isGoogleForWooEnabled: IsGoogleForWooEnabled,
     private val hasGoogleAdsCampaigns: HasGoogleAdsCampaigns,
     private val analyticsTrackerWrapper: AnalyticsTrackerWrapper,
+    private val ciabSiteGateKeeper: CIABSiteGateKeeper,
 ) : ScopedViewModel(savedState) {
     private var storeHasGoogleAdsCampaigns = false
 
@@ -119,6 +122,7 @@ class MoreMenuViewModel @Inject constructor(
             googleForWooState = buttonsStates[MoreMenuItemButton.Type.GoogleForWoo]!!,
             blazeState = buttonsStates[MoreMenuItemButton.Type.Blaze]!!,
             inboxState = buttonsStates[MoreMenuItemButton.Type.Inbox]!!,
+            paymentsState = buttonsStates[MoreMenuItemButton.Type.Payments]!!
         )
     )
 
@@ -137,6 +141,7 @@ class MoreMenuViewModel @Inject constructor(
         googleForWooState: MoreMenuItemButton.State,
         blazeState: MoreMenuItemButton.State,
         inboxState: MoreMenuItemButton.State,
+        paymentsState: MoreMenuItemButton.State
     ) = MoreMenuItemSection(
         title = R.string.more_menu_general_section_title,
         items = listOf(
@@ -146,6 +151,7 @@ class MoreMenuViewModel @Inject constructor(
                 icon = R.drawable.ic_more_menu_payments,
                 badgeState = buildPaymentsBadgeState(paymentsFeatureWasClicked),
                 onClick = ::onPaymentsButtonClick,
+                state = paymentsState
             ),
             MoreMenuItemButton(
                 title = R.string.more_menu_button_google,
@@ -444,7 +450,10 @@ class MoreMenuViewModel @Inject constructor(
             doCheckAvailability(MoreMenuItemButton.Type.Blaze) { isBlazeEnabled() },
             doCheckAvailability(MoreMenuItemButton.Type.GoogleForWoo) { isGoogleForWooEnabled() },
             doCheckAvailability(MoreMenuItemButton.Type.Inbox) { moreMenuRepository.isInboxEnabled() },
-            doCheckAvailability(MoreMenuItemButton.Type.Settings) { moreMenuRepository.isUpgradesEnabled() }
+            doCheckAvailability(MoreMenuItemButton.Type.Settings) { moreMenuRepository.isUpgradesEnabled() },
+            doCheckAvailability(MoreMenuItemButton.Type.Payments) {
+                ciabSiteGateKeeper.isFeatureSupported(CIABAffectedFeature.Payments)
+            }
         ).merge()
             .map { update ->
                 initialState[update.first] = update.second

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/blaze/IsBlazeEnabledTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/blaze/IsBlazeEnabledTest.kt
@@ -1,0 +1,107 @@
+package com.woocommerce.android.ui.blaze
+
+import com.woocommerce.android.ciab.CIABAffectedFeature
+import com.woocommerce.android.ciab.CIABSiteGateKeeper
+import com.woocommerce.android.tools.SelectedSite
+import com.woocommerce.android.viewmodel.BaseUnitTest
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import org.assertj.core.api.Assertions.assertThat
+import org.mockito.kotlin.doReturn
+import org.mockito.kotlin.given
+import org.mockito.kotlin.mock
+import org.wordpress.android.fluxc.model.SiteModel
+import kotlin.test.Test
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class IsBlazeEnabledTest : BaseUnitTest() {
+    private val selectedSite: SelectedSite = mock()
+    private val ciabSiteGateKeeper: CIABSiteGateKeeper = mock {
+        on { isFeatureSupported(CIABAffectedFeature.Blaze) } doReturn true
+    }
+
+    val sut = IsBlazeEnabled(selectedSite, ciabSiteGateKeeper)
+
+    @Test
+    fun `given Blaze is supported, when feature is disabled by CIAB gate keepe, then Blaze is disabled`() {
+        val site = createSite()
+        given(selectedSite.getOrNull()).willReturn(site)
+        given(ciabSiteGateKeeper.isFeatureSupported(CIABAffectedFeature.Blaze)).willReturn(false)
+
+        val result = sut.invoke()
+
+        assertThat(result).isFalse()
+    }
+
+    @Test
+    fun `given Blaze is supported, when feature is enabled by CIAB gate keeper, then Blaze is enabled`() {
+        val site = createSite()
+        given(selectedSite.getOrNull()).willReturn(site)
+        given(ciabSiteGateKeeper.isFeatureSupported(CIABAffectedFeature.Blaze)).willReturn(true)
+
+        val result = sut.invoke()
+
+        assertThat(result).isTrue()
+    }
+
+    @Test
+    fun `given site without admin capabilities, when checking if Blaze is enabled, then Blaze is disabled`() {
+        val site = createSite(isAdmin = false)
+        given(selectedSite.getOrNull()).willReturn(site)
+
+        val result = sut.invoke()
+
+        assertThat(result).isFalse()
+    }
+
+    @Test
+    fun `given site without Jetpack connection, when checking if Blaze is enabled, then Blaze is disabled`() {
+        val site = createSite(isJetpackConnected = false)
+        given(selectedSite.getOrNull()).willReturn(site)
+
+        val result = sut.invoke()
+
+        assertThat(result).isFalse()
+    }
+
+    @Test
+    fun `given site without Blaze capability, when checking if Blaze is enabled, then Blaze is disabled`() {
+        val site = createSite(canBlaze = false)
+        given(selectedSite.getOrNull()).willReturn(site)
+
+        val result = sut.invoke()
+
+        assertThat(result).isFalse()
+    }
+
+    @Test
+    fun `given site with Blaze for WooCommerce plugin active, when checking if Blaze is enabled, then Blaze is enabled`() {
+        val site = createSite(
+            isJetpackConnected = false,
+            jetpackConnectionActivePlugins = IsBlazeEnabled.BLAZE_FOR_WOOCOMMERCE_PLUGIN_SLUG
+        )
+        given(selectedSite.getOrNull()).willReturn(site)
+
+        val result = sut.invoke()
+
+        assertThat(result).isTrue()
+    }
+
+    private fun createSite(
+        isAdmin: Boolean = true,
+        canBlaze: Boolean = true,
+        isJetpackConnected: Boolean = true,
+        jetpackConnectionActivePlugins: String? = null,
+    ): SiteModel {
+        return SiteModel().apply {
+            this.hasCapabilityManageOptions = isAdmin
+            this.canBlaze = canBlaze
+
+            if (isJetpackConnected) {
+                origin = SiteModel.ORIGIN_WPCOM_REST
+                setIsJetpackConnected(isJetpackConnected)
+            }
+
+            activeJetpackConnectionPlugins = jetpackConnectionActivePlugins
+        }
+    }
+}

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/moremenu/MoreMenuViewModelTests.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/moremenu/MoreMenuViewModelTests.kt
@@ -3,6 +3,8 @@ package com.woocommerce.android.ui.moremenu
 import androidx.lifecycle.SavedStateHandle
 import com.woocommerce.android.R
 import com.woocommerce.android.analytics.AnalyticsTrackerWrapper
+import com.woocommerce.android.ciab.CIABAffectedFeature
+import com.woocommerce.android.ciab.CIABSiteGateKeeper
 import com.woocommerce.android.notifications.UnseenReviewsCountHandler
 import com.woocommerce.android.tools.SelectedSite
 import com.woocommerce.android.ui.blaze.IsBlazeEnabled
@@ -86,6 +88,10 @@ class MoreMenuViewModelTests : BaseUnitTest() {
 
     private val blazeCampaignsStore: BlazeCampaignsStore = mock()
 
+    private val ciabSiteGateKeeper: CIABSiteGateKeeper = mock {
+        on { isFeatureSupported(any()) } doReturn true
+    }
+
     private lateinit var viewModel: MoreMenuViewModel
     private val tapToPayAvailabilityStatus: TapToPayAvailabilityStatus = mock()
 
@@ -105,7 +111,8 @@ class MoreMenuViewModelTests : BaseUnitTest() {
             isBlazeEnabled = isBlazeEnabled,
             isGoogleForWooEnabled = isGoogleForWooEnabled,
             hasGoogleAdsCampaigns = hasGoogleAdsCampaigns,
-            analyticsTrackerWrapper = analyticsTrackerWrapper
+            analyticsTrackerWrapper = analyticsTrackerWrapper,
+            ciabSiteGateKeeper = ciabSiteGateKeeper
         )
     }
 
@@ -445,5 +452,21 @@ class MoreMenuViewModelTests : BaseUnitTest() {
             .isEqualTo(MoreMenuItemButton.State.Loading)
         assertThat(items.first { it.title == R.string.more_menu_button_inbox }.state)
             .isEqualTo(MoreMenuItemButton.State.Loading)
+    }
+
+    @Test
+    fun `given CIAB reports payments disabled, when building state, then payments button is hidden`() = testBlocking {
+        // GIVEN
+        setup {
+            whenever(ciabSiteGateKeeper.isFeatureSupported(CIABAffectedFeature.Payments))
+                .thenReturn(false)
+        }
+
+        // WHEN
+        val state = viewModel.moreMenuViewState.captureValues().last()
+
+        // THEN
+        val items = state.menuSections.flatMap { it.items }
+        assertThat(items.none { it.title == R.string.more_menu_button_payments }).isTrue()
     }
 }


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

<!-- Id number of the Linear issue this PR addresses, e.g., WOOMOB-373. -->
Closes WOOMOB-1275

### Description
This PR adds logic to hide Blaze and Payments entries in the More menu screen for CIAB sites.

With these changes, Blaze will also be hidden from all other spots (Dashboard and Product details), that's a wanted behavior.

### Steps to reproduce
1. Sign in using a CIAB site (Check this for creating a demo site pdpAdu-29A-p2)
2. Tap on Menu tab.

### Testing information
- Confirm Blaze and payments are hidden for CIAB sites, and confirm there is no change for other sites.

### The tests that have been performed
The above.

### Images/gif
<img width="360" src="https://github.com/user-attachments/assets/7fc10015-76a1-4a76-b9ab-e6ef5deb921e" />

- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->