### PR TITLE
[HACK] Migrate DeveloperOptionsScreen to Material 3

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/developer/DeveloperOptionsScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/developer/DeveloperOptionsScreen.kt
@@ -11,12 +11,11 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
-import androidx.compose.material.Divider
-import androidx.compose.material.Icon
-import androidx.compose.material.MaterialTheme
-import androidx.compose.material.Switch
-import androidx.compose.material.SwitchDefaults
-import androidx.compose.material.Text
+import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Switch
+import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.livedata.observeAsState
 import androidx.compose.ui.Alignment
@@ -61,7 +60,6 @@ private fun ToggleableListItem(
         Switch(
             checked = item.isChecked,
             onCheckedChange = item.onToggled,
-            colors = SwitchDefaults.colors(checkedThumbColor = MaterialTheme.colors.primary)
         )
     }
 }
@@ -90,7 +88,7 @@ private fun CommonItemLayout(
     Column(
         modifier = modifier
             .fillMaxWidth()
-            .background(MaterialTheme.colors.surface)
+            .background(MaterialTheme.colorScheme.surface)
     ) {
         Row(
             horizontalArrangement = Arrangement.spacedBy(16.dp),
@@ -113,6 +111,6 @@ private fun CommonItemLayout(
             additionalContent?.invoke()
         }
 
-        Divider()
+        HorizontalDivider()
     }
 }


### PR DESCRIPTION
### Description
Migrated the DeveloperOptionsScreen from Material 2 to Material 3 components as part of the app-wide Material 3 migration effort.

### Steps to reproduce
1. Open the app
2. Navigate to Settings > Developer Options
3. Verify the switches and UI components display correctly
4. Toggle the switches to ensure functionality remains intact

### Images/gif
The Material 3 switches have a different visual appearance compared to Material 2, which is expected as part of the Material 3 design language update.
##### Before
<img width="797" height="501" alt="Screenshot 2025-09-16 at 15 05 17" src="https://github.com/user-attachments/assets/06013025-a76e-4cba-b43a-6d14e2f60d29" />


##### After
<img width="800" height="501" alt="Screenshot 2025-09-16 at 15 12 42" src="https://github.com/user-attachments/assets/a58048b3-b433-4437-aea1-f6a33bc8a39f" />

- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.