### PR TITLE
[CIAB] Hide variable and grouped product types

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/typesbottomsheet/ProductTypeBottomSheetBuilder.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/typesbottomsheet/ProductTypeBottomSheetBuilder.kt
@@ -5,12 +5,16 @@ import com.woocommerce.android.ciab.CIABAffectedFeature
 import com.woocommerce.android.ciab.CIABSiteGateKeeper
 import com.woocommerce.android.ui.products.ProductType
 import com.woocommerce.android.ui.products.typesbottomsheet.ProductTypesBottomSheetViewModel.ProductTypesBottomSheetUiItem
+import com.woocommerce.android.ui.subscriptions.IsEligibleForSubscriptions
 import javax.inject.Inject
 
 class ProductTypeBottomSheetBuilder @Inject constructor(
+    private val isEligibleForSubscriptions: IsEligibleForSubscriptions,
     private val ciabSiteGateKeeper: CIABSiteGateKeeper
 ) {
-    fun buildBottomSheetList(areSubscriptionsSupported: Boolean): List<ProductTypesBottomSheetUiItem> {
+    suspend fun buildBottomSheetList(): List<ProductTypesBottomSheetUiItem> {
+        val isEligibleForSubscriptions = isEligibleForSubscriptions()
+
         return listOf(
             ProductTypesBottomSheetUiItem(
                 type = ProductType.SIMPLE,
@@ -30,7 +34,7 @@ class ProductTypeBottomSheetBuilder @Inject constructor(
                 titleResource = R.string.product_type_simple_subscription_title,
                 descResource = R.string.product_type_simple_subscription_desc,
                 iconResource = R.drawable.ic_event_repeat,
-                isVisible = areSubscriptionsSupported
+                isVisible = isEligibleForSubscriptions
             ),
             ProductTypesBottomSheetUiItem(
                 type = ProductType.VARIABLE,
@@ -45,7 +49,7 @@ class ProductTypeBottomSheetBuilder @Inject constructor(
                 titleResource = R.string.product_type_variable_subscription_title,
                 descResource = R.string.product_type_variable_subscription_desc,
                 iconResource = R.drawable.ic_event_repeat,
-                isVisible = areSubscriptionsSupported
+                isVisible = isEligibleForSubscriptions
             ),
             ProductTypesBottomSheetUiItem(
                 type = ProductType.GROUPED,

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/typesbottomsheet/ProductTypeBottomSheetBuilder.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/typesbottomsheet/ProductTypeBottomSheetBuilder.kt
@@ -1,11 +1,15 @@
 package com.woocommerce.android.ui.products.typesbottomsheet
 
 import com.woocommerce.android.R
+import com.woocommerce.android.ciab.CIABAffectedFeature
+import com.woocommerce.android.ciab.CIABSiteGateKeeper
 import com.woocommerce.android.ui.products.ProductType
 import com.woocommerce.android.ui.products.typesbottomsheet.ProductTypesBottomSheetViewModel.ProductTypesBottomSheetUiItem
 import javax.inject.Inject
 
-class ProductTypeBottomSheetBuilder @Inject constructor() {
+class ProductTypeBottomSheetBuilder @Inject constructor(
+    private val ciabSiteGateKeeper: CIABSiteGateKeeper
+) {
     fun buildBottomSheetList(areSubscriptionsSupported: Boolean): List<ProductTypesBottomSheetUiItem> {
         return listOf(
             ProductTypesBottomSheetUiItem(
@@ -33,6 +37,7 @@ class ProductTypeBottomSheetBuilder @Inject constructor() {
                 titleResource = R.string.product_type_variable_title,
                 descResource = R.string.product_type_variable_desc,
                 iconResource = R.drawable.ic_gridicons_types,
+                isVisible = ciabSiteGateKeeper.isFeatureSupported(CIABAffectedFeature.VariableProducts)
             ),
 
             ProductTypesBottomSheetUiItem(

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/typesbottomsheet/ProductTypeBottomSheetBuilder.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/typesbottomsheet/ProductTypeBottomSheetBuilder.kt
@@ -51,7 +51,8 @@ class ProductTypeBottomSheetBuilder @Inject constructor(
                 type = ProductType.GROUPED,
                 titleResource = R.string.product_type_grouped_title,
                 descResource = R.string.product_type_grouped_desc,
-                iconResource = R.drawable.ic_widgets
+                iconResource = R.drawable.ic_widgets,
+                isVisible = ciabSiteGateKeeper.isFeatureSupported(CIABAffectedFeature.GroupedProducts)
             ),
             ProductTypesBottomSheetUiItem(
                 type = ProductType.EXTERNAL,

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/typesbottomsheet/ProductTypesBottomSheetViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/typesbottomsheet/ProductTypesBottomSheetViewModel.kt
@@ -13,7 +13,6 @@ import com.woocommerce.android.analytics.AnalyticsEvent
 import com.woocommerce.android.analytics.AnalyticsTracker
 import com.woocommerce.android.ui.products.ProductNavigationTarget
 import com.woocommerce.android.ui.products.ProductType
-import com.woocommerce.android.ui.subscriptions.IsEligibleForSubscriptions
 import com.woocommerce.android.viewmodel.MultiLiveEvent
 import com.woocommerce.android.viewmodel.ScopedViewModel
 import com.woocommerce.android.viewmodel.navArgs
@@ -26,8 +25,7 @@ import javax.inject.Inject
 @HiltViewModel
 class ProductTypesBottomSheetViewModel @Inject constructor(
     savedState: SavedStateHandle,
-    private val productTypeBottomSheetBuilder: ProductTypeBottomSheetBuilder,
-    private val isEligibleForSubscriptions: IsEligibleForSubscriptions
+    private val productTypeBottomSheetBuilder: ProductTypeBottomSheetBuilder
 ) : ScopedViewModel(savedState) {
     private val navArgs: ProductTypesBottomSheetFragmentArgs by savedState.navArgs()
 
@@ -41,12 +39,11 @@ class ProductTypesBottomSheetViewModel @Inject constructor(
     }
 
     private suspend fun loadProductTypes() {
-        val areSubscriptionsSupported = isEligibleForSubscriptions()
         _productTypesBottomSheetList.value = if (navArgs.isAddProduct) {
-            productTypeBottomSheetBuilder.buildBottomSheetList(areSubscriptionsSupported)
+            productTypeBottomSheetBuilder.buildBottomSheetList()
                 .filter { it.isVisible }
         } else {
-            productTypeBottomSheetBuilder.buildBottomSheetList(areSubscriptionsSupported)
+            productTypeBottomSheetBuilder.buildBottomSheetList()
                 .filter {
                     val currentProductType = navArgs.currentProductType
                         ?.let { nonNullProductType -> ProductType.fromString(nonNullProductType) }

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/products/typesbottomsheet/ProductTypeBottomSheetBuilderTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/products/typesbottomsheet/ProductTypeBottomSheetBuilderTest.kt
@@ -1,0 +1,99 @@
+package com.woocommerce.android.ui.products.typesbottomsheet
+
+import com.woocommerce.android.ciab.CIABAffectedFeature
+import com.woocommerce.android.ciab.CIABSiteGateKeeper
+import com.woocommerce.android.ui.products.ProductType
+import com.woocommerce.android.ui.subscriptions.IsEligibleForSubscriptions
+import com.woocommerce.android.viewmodel.BaseUnitTest
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.Test
+import org.mockito.kotlin.any
+import org.mockito.kotlin.doReturn
+import org.mockito.kotlin.given
+import org.mockito.kotlin.mock
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class ProductTypeBottomSheetBuilderTest : BaseUnitTest() {
+    private val isEligibleForSubscriptions: IsEligibleForSubscriptions = mock {
+        onBlocking { invoke() } doReturn true
+    }
+    private val ciabSiteGateKeeper: CIABSiteGateKeeper = mock {
+        on { isFeatureSupported(any()) } doReturn true
+    }
+
+    private val sut = ProductTypeBottomSheetBuilder(
+        isEligibleForSubscriptions = isEligibleForSubscriptions,
+        ciabSiteGateKeeper = ciabSiteGateKeeper
+    )
+
+    @Test
+    fun `given eligible for subscriptions, when building bottom sheet list, then subscription products are visible`() =
+        testBlocking {
+            given(isEligibleForSubscriptions()).willReturn(true)
+
+            val result = sut.buildBottomSheetList()
+
+            val subscriptionProduct = result.find { it.type == ProductType.SUBSCRIPTION }
+            val variableSubscriptionProduct = result.find { it.type == ProductType.VARIABLE_SUBSCRIPTION }
+            assertThat(subscriptionProduct?.isVisible).isTrue
+            assertThat(variableSubscriptionProduct?.isVisible).isTrue
+        }
+
+    @Test
+    fun `given not eligible for subscriptions, when building bottom sheet list, then subscription products are not visible`() =
+        testBlocking {
+            given(isEligibleForSubscriptions()).willReturn(false)
+
+            val result = sut.buildBottomSheetList()
+
+            val subscriptionProduct = result.find { it.type == ProductType.SUBSCRIPTION }
+            val variableSubscriptionProduct = result.find { it.type == ProductType.VARIABLE_SUBSCRIPTION }
+            assertThat(subscriptionProduct?.isVisible).isFalse()
+            assertThat(variableSubscriptionProduct?.isVisible).isFalse()
+        }
+
+    @Test
+    fun `given variable products are supported, when building bottom sheet list, then variable products are visible`() =
+        testBlocking {
+            given(ciabSiteGateKeeper.isFeatureSupported(CIABAffectedFeature.VariableProducts)).willReturn(true)
+
+            val result = sut.buildBottomSheetList()
+
+            val variableProduct = result.find { it.type == ProductType.VARIABLE }
+            assertThat(variableProduct?.isVisible).isTrue
+        }
+
+    @Test
+    fun `given variable products not supported, when building bottom sheet list, then variable and grouped products are not visible`() =
+        testBlocking {
+            given(ciabSiteGateKeeper.isFeatureSupported(CIABAffectedFeature.VariableProducts)).willReturn(false)
+
+            val result = sut.buildBottomSheetList()
+
+            val variableProduct = result.find { it.type == ProductType.VARIABLE }
+            assertThat(variableProduct?.isVisible).isFalse()
+        }
+
+    @Test
+    fun `given grouped products are supported, when building bottom sheet list, then grouped products are visible`() =
+        testBlocking {
+            given(ciabSiteGateKeeper.isFeatureSupported(CIABAffectedFeature.GroupedProducts)).willReturn(true)
+
+            val result = sut.buildBottomSheetList()
+
+            val groupedProduct = result.find { it.type == ProductType.GROUPED }
+            assertThat(groupedProduct?.isVisible).isTrue
+        }
+
+    @Test
+    fun `given grouped products not supported, when building bottom sheet list, then grouped products are not visible`() =
+        testBlocking {
+            given(ciabSiteGateKeeper.isFeatureSupported(CIABAffectedFeature.GroupedProducts)).willReturn(false)
+
+            val result = sut.buildBottomSheetList()
+
+            val groupedProduct = result.find { it.type == ProductType.GROUPED }
+            assertThat(groupedProduct?.isVisible).isFalse()
+        }
+}

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/products/typesbottomsheet/ProductTypesBottomSheetViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/products/typesbottomsheet/ProductTypesBottomSheetViewModelTest.kt
@@ -1,7 +1,6 @@
 package com.woocommerce.android.ui.products.typesbottomsheet
 
 import com.woocommerce.android.ui.products.ProductType
-import com.woocommerce.android.ui.subscriptions.IsEligibleForSubscriptions
 import com.woocommerce.android.viewmodel.BaseUnitTest
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import org.assertj.core.api.Assertions.assertThat
@@ -14,12 +13,10 @@ import org.mockito.kotlin.whenever
 class ProductTypesBottomSheetViewModelTest : BaseUnitTest() {
     private lateinit var viewModel: ProductTypesBottomSheetViewModel
     private val bottomSheetBuilder: ProductTypeBottomSheetBuilder = mock()
-    private val isEligibleForSubscriptions: IsEligibleForSubscriptions = mock()
 
     @Before
     fun setUp() = testBlocking {
-        whenever(isEligibleForSubscriptions()).thenReturn(false)
-        whenever(bottomSheetBuilder.buildBottomSheetList(false)).thenReturn(uiItems)
+        whenever(bottomSheetBuilder.buildBottomSheetList()).thenReturn(uiItems)
     }
 
     @Test
@@ -27,7 +24,6 @@ class ProductTypesBottomSheetViewModelTest : BaseUnitTest() {
         viewModel = ProductTypesBottomSheetViewModel(
             ProductTypesBottomSheetFragmentArgs(isAddProduct = true).toSavedStateHandle(),
             bottomSheetBuilder,
-            isEligibleForSubscriptions,
         )
 
         assertThat(viewModel.productTypesBottomSheetList.value).isEqualTo(uiItems)
@@ -42,7 +38,6 @@ class ProductTypesBottomSheetViewModelTest : BaseUnitTest() {
                 isCurrentProductVirtual = false
             ).toSavedStateHandle(),
             bottomSheetBuilder,
-            isEligibleForSubscriptions
         )
 
         assertThat(viewModel.productTypesBottomSheetList.value!!.size).isEqualTo(uiItems.size - 1)
@@ -57,7 +52,6 @@ class ProductTypesBottomSheetViewModelTest : BaseUnitTest() {
                 isCurrentProductVirtual = true
             ).toSavedStateHandle(),
             bottomSheetBuilder,
-            isEligibleForSubscriptions
         )
 
         assertThat(viewModel.productTypesBottomSheetList.value!!.size).isEqualTo(uiItems.size - 1)


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

<!-- Id number of the Linear issue this PR addresses, e.g., WOOMOB-373. -->
Closes WOOMOB-1276

### Description
This PR updates logic of the product types bottom sheet to make sure we hide Variable and Grouped product types for CIAB sites.

### Steps to reproduce
1. Sign in using a CIAB site (Check this for creating a demo site pdpAdu-29A-p2)
2. Navigate to the products tab.
3. Tap on add new product
4. Check the product type bottom sheet.
5. Create a new product (make sure to save it before next step) or open an existing one.
6. Tap on "Product Type" row.
7. Check the product type bottom sheet. 

### Testing information
- Confirm Variable and Grouped products are not shown.
- Confirm there is no impact for other sites.

### The tests that have been performed
The above.

### Images/gif
<img width="360" alt="image" src="https://github.com/user-attachments/assets/d02da54c-b7fd-4064-9da8-547fce92be64" />

- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->