### PR TITLE
[HACK] Migrate NotificationSettingsScreen to Material 3

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/notifications/NotificationSettingsScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/notifications/NotificationSettingsScreen.kt
@@ -7,9 +7,9 @@ import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
-import androidx.compose.material.MaterialTheme
-import androidx.compose.material.Scaffold
-import androidx.compose.material.Text
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.livedata.observeAsState
 import androidx.compose.ui.Modifier
@@ -41,7 +41,7 @@ private fun NotificationSettingsScreen(
         Column(
             modifier = Modifier
                 .fillMaxWidth()
-                .background(MaterialTheme.colors.surface)
+                .background(MaterialTheme.colorScheme.surface)
                 .padding(paddingValues)
         ) {
             NotificationSettingsItem(
@@ -81,11 +81,11 @@ private fun NotificationSettingsItem(
     ) {
         Text(
             text = title,
-            style = MaterialTheme.typography.subtitle1
+            style = MaterialTheme.typography.titleMedium
         )
         Text(
             text = subtitle,
-            style = MaterialTheme.typography.body2
+            style = MaterialTheme.typography.bodyMedium
         )
     }
 }


### PR DESCRIPTION
## Description
Migrates the NotificationSettingsScreen from Material 2 to Material 3 components and theming.

## Changes
- Updated imports from `androidx.compose.material` to `androidx.compose.material3`
- Changed `MaterialTheme.colors` to `MaterialTheme.colorScheme`
- Updated typography references:
  - `MaterialTheme.typography.subtitle1` → `MaterialTheme.typography.titleMedium`
  - `MaterialTheme.typography.body2` → `MaterialTheme.typography.bodyMedium`

## Steps to reproduce
1. Open the app and navigate to Settings → Notifications
2. To see the "Enable cha-ching sound" option, first change the notification sound:
   - Go to device Settings → Apps → WooCommerce → Notifications
   - Find "New order" notification channel and change its sound to something other than default
   - Return to the app settings to see the option appear

### Before
<img width="680" height="424" alt="Screenshot 2025-09-17 at 15 35 26" src="https://github.com/user-attachments/assets/bcfe1672-7536-46ed-ad9a-4eb461e688e8" />

### After
<img width="680" height="423" alt="Screenshot 2025-09-17 at 15 33 32" src="https://github.com/user-attachments/assets/43c57ad3-7ca1-4dc1-9659-fa2d7049bea6" />