### PR TITLE
[CIAB] Hide unsupported dashboard cards

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/data/ObserveStockWidgetStatus.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/data/ObserveStockWidgetStatus.kt
@@ -6,35 +6,33 @@ import com.woocommerce.android.ciab.CIABSiteGateKeeper
 import com.woocommerce.android.model.DashboardWidget
 import com.woocommerce.android.tools.SelectedSite
 import kotlinx.coroutines.ExperimentalCoroutinesApi
-import kotlinx.coroutines.flow.emitAll
 import kotlinx.coroutines.flow.filterNotNull
+import kotlinx.coroutines.flow.flatMapLatest
+import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.flow.map
-import kotlinx.coroutines.flow.transformLatest
 import javax.inject.Inject
 
-@OptIn(ExperimentalCoroutinesApi::class)
 class ObserveStockWidgetStatus @Inject constructor(
     private val selectedSite: SelectedSite,
     private val observePublishedProductsCount: ObservePublishedProductsCount,
     private val ciabSiteGateKeeper: CIABSiteGateKeeper
 ) {
+    @OptIn(ExperimentalCoroutinesApi::class)
     operator fun invoke() = selectedSite.observe()
         .filterNotNull()
-        .transformLatest { site ->
+        .flatMapLatest { site ->
             if (ciabSiteGateKeeper.isFeatureUnsupported(CIABAffectedFeature.ProductsStockDashboardCard)) {
-                emit(DashboardWidget.Status.Hidden)
+                flowOf(DashboardWidget.Status.Hidden)
             } else {
-                emitAll(
-                    observePublishedProductsCount().map { hasPublishedProducts ->
-                        if (hasPublishedProducts) {
-                            DashboardWidget.Status.Available
-                        } else {
-                            DashboardWidget.Status.Unavailable(
-                                badgeText = R.string.my_store_widget_unavailable
-                            )
-                        }
+                observePublishedProductsCount().map { hasPublishedProducts ->
+                    if (hasPublishedProducts) {
+                        DashboardWidget.Status.Available
+                    } else {
+                        DashboardWidget.Status.Unavailable(
+                            badgeText = R.string.my_store_widget_unavailable
+                        )
                     }
-                )
+                }
             }
         }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/data/ObserveStockWidgetStatus.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/data/ObserveStockWidgetStatus.kt
@@ -1,28 +1,39 @@
 package com.woocommerce.android.ui.dashboard.data
 
 import com.woocommerce.android.R
+import com.woocommerce.android.ciab.CIABAffectedFeature
+import com.woocommerce.android.ciab.CIABSiteGateKeeper
 import com.woocommerce.android.model.DashboardWidget
 import com.woocommerce.android.tools.SelectedSite
 import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.emitAll
 import kotlinx.coroutines.flow.filterNotNull
-import kotlinx.coroutines.flow.flatMapLatest
 import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.transformLatest
 import javax.inject.Inject
 
 @OptIn(ExperimentalCoroutinesApi::class)
 class ObserveStockWidgetStatus @Inject constructor(
     private val selectedSite: SelectedSite,
-    private val observePublishedProductsCount: ObservePublishedProductsCount
+    private val observePublishedProductsCount: ObservePublishedProductsCount,
+    private val ciabSiteGateKeeper: CIABSiteGateKeeper
 ) {
     operator fun invoke() = selectedSite.observe()
         .filterNotNull()
-        .flatMapLatest { observePublishedProductsCount() }
-        .map { hasPublishedProducts ->
-            if (hasPublishedProducts) {
-                DashboardWidget.Status.Available
+        .transformLatest { site ->
+            if (ciabSiteGateKeeper.isFeatureUnsupported(CIABAffectedFeature.ProductsStockDashboardCard)) {
+                emit(DashboardWidget.Status.Hidden)
             } else {
-                DashboardWidget.Status.Unavailable(
-                    badgeText = R.string.my_store_widget_unavailable
+                emitAll(
+                    observePublishedProductsCount().map { hasPublishedProducts ->
+                        if (hasPublishedProducts) {
+                            DashboardWidget.Status.Available
+                        } else {
+                            DashboardWidget.Status.Unavailable(
+                                badgeText = R.string.my_store_widget_unavailable
+                            )
+                        }
+                    }
                 )
             }
         }

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/dashboard/data/ObserveStockWidgetStatusTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/dashboard/data/ObserveStockWidgetStatusTest.kt
@@ -1,0 +1,72 @@
+package com.woocommerce.android.ui.dashboard.data
+
+import com.woocommerce.android.ciab.CIABAffectedFeature
+import com.woocommerce.android.ciab.CIABSiteGateKeeper
+import com.woocommerce.android.model.DashboardWidget
+import com.woocommerce.android.tools.SelectedSite
+import com.woocommerce.android.viewmodel.BaseUnitTest
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.flowOf
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.Test
+import org.mockito.kotlin.any
+import org.mockito.kotlin.doReturn
+import org.mockito.kotlin.given
+import org.mockito.kotlin.mock
+import org.wordpress.android.fluxc.model.SiteModel
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class ObserveStockWidgetStatusTest : BaseUnitTest() {
+    private val ciabSiteGateKeeper: CIABSiteGateKeeper = mock {
+        on { isFeatureUnsupported(any()) } doReturn false
+    }
+    private val observePublishedProductsCount: ObservePublishedProductsCount = mock()
+    private val selectedSite: SelectedSite = mock {
+        on { observe() } doReturn flowOf(SiteModel())
+    }
+
+    private val sut = ObserveStockWidgetStatus(
+        selectedSite,
+        observePublishedProductsCount,
+        ciabSiteGateKeeper
+    )
+
+    @Test
+    fun `given CIAB feature unsupported, when observing stock widget status, then status is Hidden`() = testBlocking {
+        given(ciabSiteGateKeeper.isFeatureUnsupported(CIABAffectedFeature.ProductsStockDashboardCard))
+            .willReturn(true)
+
+        val status = sut().first()
+
+        assertThat(status).isEqualTo(DashboardWidget.Status.Hidden)
+    }
+
+    @Test
+    fun `given CIAB feature supported and has published products, when observing stock widget status, then status is Available`() =
+        testBlocking {
+            given(ciabSiteGateKeeper.isFeatureUnsupported(CIABAffectedFeature.ProductsStockDashboardCard))
+                .willReturn(false)
+            given(observePublishedProductsCount()).willReturn(flowOf(true))
+
+            val status = sut().first()
+
+            assertThat(status).isEqualTo(DashboardWidget.Status.Available)
+        }
+
+    @Test
+    fun `given CIAB feature supported and has no published products, when observing stock widget status, then status is Unavailable`(): Unit =
+        testBlocking {
+            given(ciabSiteGateKeeper.isFeatureUnsupported(CIABAffectedFeature.ProductsStockDashboardCard))
+                .willReturn(false)
+            given(observePublishedProductsCount()).willReturn(flowOf(false))
+
+            val status = sut().first()
+
+            assertThat(status).isEqualTo(
+                DashboardWidget.Status.Unavailable(
+                    badgeText = com.woocommerce.android.R.string.my_store_widget_unavailable
+                )
+            )
+        }
+}


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

<!-- Id number of the Linear issue this PR addresses, e.g., WOOMOB-373. -->
Closes WOOMOB-1267

### Description
This PR adds logic to hide the Product Stock card in the dashboard for CIAB sites.
We also need to hide the Blaze card, but this was already done in the previous PR #14618 

### Steps to reproduce
1. Sign in using a CIAB site (Check this for creating a demo site pdpAdu-29A-p2)
2. Open the app.
3. Tap on the edit button (Pencil) in the dashboard.

### Testing information
- Confirm the Stock card is not shown.
- Confirm Blaze is not shown.
- Confirm there is no change for other sites.

### The tests that have been performed
The above.

### Images/gif
<img width="360" alt="image" src="https://github.com/user-attachments/assets/e30c0864-28d9-4d7d-a57b-fbed229d175d" />


- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->