### PR TITLE
[CIAB] Hide split shipments feature for CIAB sites

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/WooShippingLabelCreationViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/WooShippingLabelCreationViewModel.kt
@@ -1295,12 +1295,11 @@ class WooShippingLabelCreationViewModel @Inject constructor(
             val shouldShowSplitShipmentButton: Boolean
                 get() {
                     val unpurchasedShipments = shipmentUIList.filterNot { it.isPurchased }
+                    val hasMultipleUnfulfilledItems = unpurchasedShipments.size > 1 ||
+                        (unpurchasedShipments.firstOrNull()?.totalItemQuantity ?: 0) > 1
                     return isSplitShipmentsSupported &&
                         shipmentUIList.none { it.isPurchaseInProgress } &&
-                        (
-                            unpurchasedShipments.size > 1 ||
-                                (unpurchasedShipments.firstOrNull()?.totalItemQuantity ?: 0) > 1
-                            )
+                        hasMultipleUnfulfilledItems
                 }
         }
     }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/WooShippingLabelCreationViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/WooShippingLabelCreationViewModel.kt
@@ -16,6 +16,8 @@ import com.woocommerce.android.analytics.AnalyticsTracker.Companion.KEY_ERROR
 import com.woocommerce.android.analytics.AnalyticsTracker.Companion.KEY_STATE
 import com.woocommerce.android.analytics.AnalyticsTracker.Companion.VALUE_STARTED
 import com.woocommerce.android.analytics.AnalyticsTrackerWrapper
+import com.woocommerce.android.ciab.CIABAffectedFeature
+import com.woocommerce.android.ciab.CIABSiteGateKeeper
 import com.woocommerce.android.extensions.combine
 import com.woocommerce.android.extensions.sumByFloat
 import com.woocommerce.android.model.Address
@@ -124,6 +126,7 @@ class WooShippingLabelCreationViewModel @Inject constructor(
     private val fetchShippingLabelFile: FetchShippingLabelFile,
     private val observeShippingLabelStatus: ObserveShippingLabelStatus,
     private val downloadAndPrintInvoiceUseCase: DownloadAndPrintInvoiceUseCase,
+    private val ciabSiteGateKeeper: CIABSiteGateKeeper,
     private val analyticsTracker: AnalyticsTrackerWrapper,
 ) : ScopedViewModel(savedState) {
     private val navArgs: WooShippingLabelCreationFragmentArgs by savedState.navArgs()
@@ -779,6 +782,9 @@ class WooShippingLabelCreationViewModel @Inject constructor(
                     formattedPrice = shipmentUIList[uiState.selectedIndex].shipmentCostUI?.formattedTotalPrice,
                     onMarkOrderCompleteChange = ::onMarkOrderCompleteChange,
                     onPurchaseShippingLabel = ::onPurchaseShippingLabel
+                ),
+                isSplitShipmentsSupported = ciabSiteGateKeeper.isFeatureSupported(
+                    feature = CIABAffectedFeature.WooShippingSplitShipments
                 )
             )
         }.combine(loadTrigger.onStart { emit(Unit) }) { viewState, _ ->
@@ -1283,12 +1289,14 @@ class WooShippingLabelCreationViewModel @Inject constructor(
             val uiState: UIControlsState,
             val destinationStatus: AddressStatus,
             val paymentsSectionUI: PaymentsSectionUI,
-            val purchaseSectionUI: PurchaseSectionUI
+            val purchaseSectionUI: PurchaseSectionUI,
+            val isSplitShipmentsSupported: Boolean
         ) : WooShippingViewState() {
             val shouldShowSplitShipmentButton: Boolean
                 get() {
                     val unpurchasedShipments = shipmentUIList.filterNot { it.isPurchased }
-                    return shipmentUIList.none { it.isPurchaseInProgress } &&
+                    return isSplitShipmentsSupported &&
+                        shipmentUIList.none { it.isPurchaseInProgress } &&
                         (
                             unpurchasedShipments.size > 1 ||
                                 (unpurchasedShipments.firstOrNull()?.totalItemQuantity ?: 0) > 1

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/WooShippingLabelCreationViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/WooShippingLabelCreationViewModelTest.kt
@@ -9,6 +9,8 @@ import com.woocommerce.android.analytics.AnalyticsTracker
 import com.woocommerce.android.analytics.AnalyticsTracker.Companion.KEY_ERROR
 import com.woocommerce.android.analytics.AnalyticsTracker.Companion.KEY_STATE
 import com.woocommerce.android.analytics.AnalyticsTrackerWrapper
+import com.woocommerce.android.ciab.CIABAffectedFeature
+import com.woocommerce.android.ciab.CIABSiteGateKeeper
 import com.woocommerce.android.model.Address
 import com.woocommerce.android.model.AmbiguousLocation
 import com.woocommerce.android.model.Location
@@ -330,6 +332,9 @@ class WooShippingLabelCreationViewModelTest : BaseUnitTest() {
     private val file: File = mock()
     private val analyticsTracker: AnalyticsTrackerWrapper = mock()
     private val createDefaultCustomsData = CreateDefaultCustomsData(mock())
+    private val ciabSiteGateKeeper: CIABSiteGateKeeper = mock {
+        on { isFeatureSupported(CIABAffectedFeature.WooShippingSplitShipments) } doReturn true
+    }
 
     private lateinit var sut: WooShippingLabelCreationViewModel
 
@@ -355,6 +360,7 @@ class WooShippingLabelCreationViewModelTest : BaseUnitTest() {
             observeShippingLabelStatus = observeShippingLabelStatus,
             downloadAndPrintInvoiceUseCase = mock(),
             analyticsTracker = analyticsTracker,
+            ciabSiteGateKeeper = ciabSiteGateKeeper,
             savedState = savedState
         )
     }
@@ -1808,5 +1814,31 @@ class WooShippingLabelCreationViewModelTest : BaseUnitTest() {
         assertThat(currentViewState.shipmentUIList[0].isPurchased).isTrue
         @Suppress("UnusedFlow")
         verify(observeShippingLabelStatus).invoke(orderId, inProgressLabel.labelId)
+    }
+
+    @Test
+    fun `given split shipments unsupported, when displaying shipments, then hide split option`() = testBlocking {
+        // The default `getShipments` mock already returns a shipment with multiple items
+        given(ciabSiteGateKeeper.isFeatureSupported(CIABAffectedFeature.WooShippingSplitShipments))
+            .willReturn(false)
+
+        createViewModel()
+
+        val currentViewState = sut.viewState.value as DataState
+
+        assertThat(currentViewState.shouldShowSplitShipmentButton).isFalse
+    }
+
+    @Test
+    fun `given split shipments supported, when displaying shipments, then hide split option`() = testBlocking {
+        // The default `getShipments` mock already returns a shipment with multiple items
+        given(ciabSiteGateKeeper.isFeatureSupported(CIABAffectedFeature.WooShippingSplitShipments))
+            .willReturn(true)
+
+        createViewModel()
+
+        val currentViewState = sut.viewState.value as DataState
+
+        assertThat(currentViewState.shouldShowSplitShipmentButton).isTrue
     }
 }


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

<!-- Id number of the Linear issue this PR addresses, e.g., WOOMOB-373. -->
Closes WOOMOB-1278

### Description
This PR adds logic to hide split shipments feature for CIAB sites.

### Steps to reproduce
1. Use a CIAB site (Check this for creating a demo site pdpAdu-29A-p2)
2. Install WooCommerce Shipping plugin, and connect it to WordPress.com (using the banner that appears after installing it)
3. Open the app, and open or create an order with multiple items.
4. Tap on Create shipping labels.
5. Check that the "Split shipment" button is hidden.
6. Open the order in **wp-admin**, then tap on "Create shipping labels", then split it to multiple shipments.
7. Re-open the order in the mobile app (you would need to go back to order details and refresh to fetch the new shipments list)
8. Check that the "pencil" button is hidden.

### Testing information
- Confirm that split shipments feature is hidden for both orders with single shipments and multiple shipments.
- Good to test: confirm there is no impact for other sites.

### The tests that have been performed
The above.

### Images/gif
| Before | After |
| --- | --- |
| <img width="360" alt="Screenshot_20250918_114010" src="https://github.com/user-attachments/assets/40863b99-5892-44e6-9d52-e832e5315429" /> | <img width="360" alt="Screenshot_20250918_113852" src="https://github.com/user-attachments/assets/cf84df90-7982-40b2-ad34-202ca63d2acf" /> |
| <img width="360" alt="Screenshot_20250918_114045" src="https://github.com/user-attachments/assets/c909a278-1378-424f-a108-84586a2dcc6d" /> | <img width="360" alt="Screenshot_20250918_114132" src="https://github.com/user-attachments/assets/e56aabf3-03d5-4812-a6d1-33529b7d82eb" /> |

- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->