### PR TITLE
[CIAB] Hide POS

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ciab/CIABAffectedFeature.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ciab/CIABAffectedFeature.kt
@@ -7,5 +7,6 @@ enum class CIABAffectedFeature {
     GroupedProducts,
     VariableProducts,
     GiftCardEditing,
-    ProductsStockDashboardCard
+    ProductsStockDashboardCard,
+    POS
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/tab/WooPosTabShouldBeVisible.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/tab/WooPosTabShouldBeVisible.kt
@@ -1,5 +1,7 @@
 package com.woocommerce.android.ui.woopos.tab
 
+import com.woocommerce.android.ciab.CIABAffectedFeature
+import com.woocommerce.android.ciab.CIABSiteGateKeeper
 import com.woocommerce.android.tools.SelectedSite
 import com.woocommerce.android.ui.woopos.WooPosIsScreenSizeAllowed
 import com.woocommerce.android.ui.woopos.common.util.WooPosCouldNotDetermineValueException
@@ -16,11 +18,18 @@ class WooPosTabShouldBeVisible @Inject constructor(
     private val isScreenSizeAllowed: WooPosIsScreenSizeAllowed,
     private val wooCommerceStore: WooCommerceStore,
     private val isRemoteFeatureFlagEnabled: IsRemoteFeatureFlagEnabled,
+    private val ciabSiteGateKeeper: CIABSiteGateKeeper,
     private val wooPosLog: WooPosLogWrapper,
 ) {
     suspend operator fun invoke(): Result<Boolean> = withContext(Dispatchers.IO) {
         val selectedSite = selectedSite.getOrNull()
             ?: return@withContext Result.failure(WooPosCouldNotDetermineValueException())
+
+        if (ciabSiteGateKeeper.isFeatureUnsupported(CIABAffectedFeature.POS)) {
+            return@withContext Result.success(false).also {
+                wooPosLog.i("POS Tab Not visible reason: Site is CIAB")
+            }
+        }
 
         if (!isRemoteFeatureFlagEnabled(WOO_POS)) {
             return@withContext Result.success(false).also {

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/tab/WooPosTabShouldBeVisibleTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/tab/WooPosTabShouldBeVisibleTest.kt
@@ -1,5 +1,7 @@
 package com.woocommerce.android.ui.woopos.tab
 
+import com.woocommerce.android.ciab.CIABAffectedFeature
+import com.woocommerce.android.ciab.CIABSiteGateKeeper
 import com.woocommerce.android.tools.SelectedSite
 import com.woocommerce.android.ui.woopos.WooPosIsScreenSizeAllowed
 import com.woocommerce.android.ui.woopos.common.util.WooPosCouldNotDetermineValueException
@@ -9,6 +11,7 @@ import com.woocommerce.android.viewmodel.BaseUnitTest
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import org.junit.Before
 import org.mockito.kotlin.any
+import org.mockito.kotlin.doReturn
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
@@ -28,6 +31,9 @@ class WooPosTabShouldBeVisibleTest : BaseUnitTest() {
     private val wooCommerceStore: WooCommerceStore = mock()
     private val isScreenSizeAllowed: WooPosIsScreenSizeAllowed = mock()
     private val isRemoteFeatureFlagEnabled: IsRemoteFeatureFlagEnabled = mock()
+    private val ciabSiteGateKeeper: CIABSiteGateKeeper = mock {
+        on { isFeatureUnsupported(CIABAffectedFeature.POS) } doReturn false
+    }
 
     private lateinit var sut: WooPosTabShouldBeVisible
     private lateinit var siteModel: SiteModel
@@ -46,6 +52,7 @@ class WooPosTabShouldBeVisibleTest : BaseUnitTest() {
             isScreenSizeAllowed = isScreenSizeAllowed,
             wooCommerceStore = wooCommerceStore,
             isRemoteFeatureFlagEnabled = isRemoteFeatureFlagEnabled,
+            ciabSiteGateKeeper = ciabSiteGateKeeper,
             wooPosLog = mock()
         )
     }
@@ -116,6 +123,16 @@ class WooPosTabShouldBeVisibleTest : BaseUnitTest() {
         whenever(wooCommerceStore.fetchSiteGeneralSettings(any())).thenReturn(WooResult(fetchedSettings))
 
         val r = sut()
+        assertTrue(r.isSuccess)
+        assertFalse(r.getOrThrow())
+    }
+
+    @Test
+    fun `given feature unsupported for CIAB site, when invoked, then return success false`() = testBlocking {
+        whenever(ciabSiteGateKeeper.isFeatureUnsupported(CIABAffectedFeature.POS)).thenReturn(true)
+
+        val r = sut()
+
         assertTrue(r.isSuccess)
         assertFalse(r.getOrThrow())
     }


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

<!-- Id number of the Linear issue this PR addresses, e.g., WOOMOB-373. -->
Closes WOOMOB-1364

### Description
This PR adds logic to hide the POS tab for CIAB sites.

### Steps to reproduce
1. Use a tablet.
2. Sign in using a CIAB site (Check this for creating a demo site pdpAdu-29A-p2)
3. Confirm the POS tab is now shown.
4. Switch to a different site (site that supports POS, it should have US or UK country, and shouldn't have disabled the POS feature explicitly)
5. Confirm the POS tab is shown.

### Testing information
- Confirm POS is now shown for CIAB sites.
- Confirm there is no impact for other sites.

### The tests that have been performed
The above.

### Images/gif
| CIAB site | Non-CIAB site |
| --- | --- |
| <img width="2560" height="1600" alt="Screenshot_20250918_151425" src="https://github.com/user-attachments/assets/4538d0e3-08f8-42d4-a408-8cefa48d5a71" /> | <img width="2560" height="1600" alt="Screenshot_20250918_145001" src="https://github.com/user-attachments/assets/32c8852c-587d-44c4-84b1-afbfcc364a86" /> |

**Remark:** The bookings tab is shown for the non-CIAB site in the above screenshot, this is just temporary, later the tab would be hidden for non-CIAB sites.

- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
