### PR TITLE
[Blaze] Fix campaign creation when products use a PDF file thumbnail as image

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -3,11 +3,7 @@
 *** For entries which are touching the Android Wear app's, start entry with `[WEAR]` too.
 23.4
 -----
-
-
-23.4
------
-
+- [*] Fixed an issue where Blaze campaign creation could fail for products using PDF thumbnails as images [https://github.com/woocommerce/woocommerce-android/pull/14642]
 
 23.3
 -----

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/media/MediaFilesRepository.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/media/MediaFilesRepository.kt
@@ -87,7 +87,7 @@ class MediaFilesRepository @Inject constructor(
         }
     }
 
-    suspend fun getImageDimensions(uri: String): ImageDimensions {
+    suspend fun getImageDetails(uri: String): ImageDetails {
         return withContext(dispatchers.io) {
             try {
                 val options = Options().apply { inJustDecodeBounds = true }
@@ -99,11 +99,11 @@ class MediaFilesRepository @Inject constructor(
                     BitmapFactory.decodeFileDescriptor(fileDescriptor, null, options)
                     parcelFileDescriptor.close()
                 }
-                return@withContext ImageDimensions(options.outWidth, options.outHeight)
+                return@withContext ImageDetails(options.outWidth, options.outHeight, options.outMimeType)
             } catch (e: IOException) {
-                WooLog.e(T.MEDIA, "MediaFilesRepository > Error getting image dimensions", e)
+                WooLog.e(T.MEDIA, "MediaFilesRepository > Error getting image details from uri: $uri", e)
+                return@withContext ImageDetails(width = 0, height = 0, mimeType = "")
             }
-            return@withContext ImageDimensions(width = 0, height = 0)
         }
     }
 
@@ -249,5 +249,9 @@ class MediaFilesRepository @Inject constructor(
         data class UploadFailure(val error: MediaUploadException) : UploadResult()
     }
 
-    data class ImageDimensions(val width: Int, val height: Int)
+    data class ImageDetails(
+        val width: Int,
+        val height: Int,
+        val mimeType: String
+    )
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/blaze/BlazeRepository.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/blaze/BlazeRepository.kt
@@ -19,11 +19,11 @@ import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.retry
 import kotlinx.coroutines.flow.transform
 import kotlinx.parcelize.Parcelize
-import org.wordpress.android.fluxc.model.MediaModel
 import org.wordpress.android.fluxc.model.blaze.BlazeAdForecast
 import org.wordpress.android.fluxc.model.blaze.BlazeAdSuggestion
 import org.wordpress.android.fluxc.model.blaze.BlazeCampaignCreationRequest
 import org.wordpress.android.fluxc.model.blaze.BlazeCampaignCreationRequestBudget
+import org.wordpress.android.fluxc.model.blaze.BlazeCampaignCreationRequestImage
 import org.wordpress.android.fluxc.model.blaze.BlazeCampaignType
 import org.wordpress.android.fluxc.model.blaze.BlazePaymentMethod.PaymentMethodInfo
 import org.wordpress.android.fluxc.model.blaze.BlazeTargetingParameters
@@ -183,8 +183,9 @@ class BlazeRepository @Inject constructor(
             tagLine = product.name,
             description = description.fastStripHtml(),
             campaignImage = product.images.firstOrNull().let {
-                if (it != null && isValidAdImage(it.source)) {
-                    BlazeCampaignImage.RemoteImage(it.id, it.source)
+                val imageDetails = it?.source?.let { uri -> getImageDetails(uri) }
+                if (imageDetails?.isValidAdImage() == true) {
+                    BlazeCampaignImage.RemoteImage(it.id, it.source, imageDetails.mimeType)
                 } else {
                     BlazeCampaignImage.None
                 }
@@ -345,13 +346,20 @@ class BlazeRepository @Inject constructor(
         }
     }
 
-    private suspend fun prepareCampaignImage(image: BlazeCampaignImage): Result<MediaModel> {
+    private suspend fun prepareCampaignImage(image: BlazeCampaignImage): Result<BlazeCampaignCreationRequestImage> {
         val result = when (image) {
             is BlazeCampaignImage.LocalImage -> {
                 mediaFilesRepository.uploadFile(image.uri)
                     .transform {
                         when (it) {
-                            is MediaFilesRepository.UploadResult.UploadSuccess -> emit(Result.success(it.media))
+                            is MediaFilesRepository.UploadResult.UploadSuccess -> {
+                                val requestImage = BlazeCampaignCreationRequestImage(
+                                    url = it.media.url,
+                                    mimeType = it.media.mimeType.orEmpty()
+                                )
+                                emit(Result.success(requestImage))
+                            }
+
                             is MediaFilesRepository.UploadResult.UploadFailure -> throw it.error
                             else -> {
                                 /* Do nothing */
@@ -363,7 +371,13 @@ class BlazeRepository @Inject constructor(
                     .first()
             }
 
-            is BlazeCampaignImage.RemoteImage -> mediaFilesRepository.fetchWordPressMedia(image.mediaId)
+            is BlazeCampaignImage.RemoteImage -> Result.success(
+                BlazeCampaignCreationRequestImage(
+                    url = image.uri,
+                    mimeType = image.mimeType
+                )
+            )
+
             is BlazeCampaignImage.None -> error("No image provided for Blaze Campaign Creation")
         }
 
@@ -372,15 +386,12 @@ class BlazeRepository @Inject constructor(
         }
     }
 
-    suspend fun isValidAdImage(uri: String): Boolean {
-        val (width, height) = mediaFilesRepository.getImageDimensions(uri)
-        return when {
-            width == 0 || height == 0 -> {
-                WooLog.w(WooLog.T.BLAZE, "isValidAdImage uri: Failed to get image dimens from uri: $uri")
-                false
-            }
+    suspend fun getImageDetails(uri: String) = mediaFilesRepository.getImageDetails(uri)
 
+    fun MediaFilesRepository.ImageDetails.isValidAdImage(): Boolean {
+        return when {
             width < BLAZE_IMAGE_MINIMUM_SIZE_IN_PIXELS || height < BLAZE_IMAGE_MINIMUM_SIZE_IN_PIXELS -> false
+            !mimeType.startsWith("image/") -> false
             else -> true
         }
     }
@@ -422,7 +433,7 @@ class BlazeRepository @Inject constructor(
         data class LocalImage(override val uri: String) : BlazeCampaignImage
 
         @Parcelize
-        data class RemoteImage(val mediaId: Long, override val uri: String) : BlazeCampaignImage
+        data class RemoteImage(val mediaId: Long, override val uri: String, val mimeType: String) : BlazeCampaignImage
     }
 
     @Parcelize

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/blaze/BlazeRepository.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/blaze/BlazeRepository.kt
@@ -185,7 +185,7 @@ class BlazeRepository @Inject constructor(
             campaignImage = product.images.firstOrNull().let {
                 val imageDetails = it?.source?.let { uri -> getImageDetails(uri) }
                 if (imageDetails?.isValidAdImage() == true) {
-                    BlazeCampaignImage.RemoteImage(it.id, it.source, imageDetails.mimeType)
+                    BlazeCampaignImage.RemoteImage(it.source, imageDetails.mimeType)
                 } else {
                     BlazeCampaignImage.None
                 }
@@ -433,7 +433,7 @@ class BlazeRepository @Inject constructor(
         data class LocalImage(override val uri: String) : BlazeCampaignImage
 
         @Parcelize
-        data class RemoteImage(val mediaId: Long, override val uri: String, val mimeType: String) : BlazeCampaignImage
+        data class RemoteImage(override val uri: String, val mimeType: String) : BlazeCampaignImage
     }
 
     @Parcelize

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/blaze/creation/ad/BlazeCampaignCreationEditAdScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/blaze/creation/ad/BlazeCampaignCreationEditAdScreen.kt
@@ -429,7 +429,7 @@ fun PreviewCampaignEditAdContent() {
     WooThemeWithBackground {
         CampaignEditAdContent(
             viewState = ViewState(
-                adImage = BlazeCampaignImage.RemoteImage(0, "https://rb.gy/gmjuwb")
+                adImage = BlazeCampaignImage.RemoteImage(0, "https://rb.gy/gmjuwb", "image/jpeg")
             ),
             onTagLineChanged = { },
             onDescriptionChanged = { },

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/blaze/creation/ad/BlazeCampaignCreationEditAdScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/blaze/creation/ad/BlazeCampaignCreationEditAdScreen.kt
@@ -429,7 +429,7 @@ fun PreviewCampaignEditAdContent() {
     WooThemeWithBackground {
         CampaignEditAdContent(
             viewState = ViewState(
-                adImage = BlazeCampaignImage.RemoteImage(0, "https://rb.gy/gmjuwb", "image/jpeg")
+                adImage = BlazeCampaignImage.RemoteImage("https://rb.gy/gmjuwb", "image/jpeg")
             ),
             onTagLineChanged = { },
             onDescriptionChanged = { },

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/blaze/creation/ad/BlazeCampaignCreationEditAdViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/blaze/creation/ad/BlazeCampaignCreationEditAdViewModel.kt
@@ -149,7 +149,6 @@ class BlazeCampaignCreationEditAdViewModel @Inject constructor(
                 _viewState.update {
                     it.copy(
                         adImage = BlazeRepository.BlazeCampaignImage.RemoteImage(
-                            mediaId = image.id,
                             uri = image.source,
                             mimeType = imageDetails.mimeType
                         )

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/blaze/creation/ad/BlazeCampaignCreationEditAdViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/blaze/creation/ad/BlazeCampaignCreationEditAdViewModel.kt
@@ -130,7 +130,8 @@ class BlazeCampaignCreationEditAdViewModel @Inject constructor(
 
     fun onLocalImageSelected(uri: String) {
         launch {
-            if (blazeRepository.isValidAdImage(uri)) {
+            val imageDetails = blazeRepository.getImageDetails(uri)
+            if (with(blazeRepository) { imageDetails.isValidAdImage() }) {
                 _viewState.update {
                     it.copy(adImage = BlazeRepository.BlazeCampaignImage.LocalImage(uri))
                 }
@@ -142,12 +143,14 @@ class BlazeCampaignCreationEditAdViewModel @Inject constructor(
 
     fun onWPMediaSelected(image: Product.Image) {
         launch {
-            if (blazeRepository.isValidAdImage(image.source)) {
+            val imageDetails = blazeRepository.getImageDetails(image.source)
+            if (with(blazeRepository) { imageDetails.isValidAdImage() }) {
                 _viewState.update {
                     it.copy(
                         adImage = BlazeRepository.BlazeCampaignImage.RemoteImage(
                             mediaId = image.id,
-                            uri = image.source
+                            uri = image.source,
+                            mimeType = imageDetails.mimeType
                         )
                     )
                 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/blaze/creation/ad/BlazeCampaignCreationEditAdViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/blaze/creation/ad/BlazeCampaignCreationEditAdViewModel.kt
@@ -8,6 +8,7 @@ import com.woocommerce.android.R
 import com.woocommerce.android.analytics.AnalyticsEvent.BLAZE_CREATION_EDIT_AD_AI_SUGGESTION_TAPPED
 import com.woocommerce.android.analytics.AnalyticsEvent.BLAZE_CREATION_EDIT_AD_SAVE_TAPPED
 import com.woocommerce.android.analytics.AnalyticsTrackerWrapper
+import com.woocommerce.android.media.MediaFilesRepository
 import com.woocommerce.android.model.Product
 import com.woocommerce.android.ui.blaze.BlazeRepository
 import com.woocommerce.android.ui.blaze.BlazeRepository.AiSuggestionForAd
@@ -131,7 +132,7 @@ class BlazeCampaignCreationEditAdViewModel @Inject constructor(
     fun onLocalImageSelected(uri: String) {
         launch {
             val imageDetails = blazeRepository.getImageDetails(uri)
-            if (with(blazeRepository) { imageDetails.isValidAdImage() }) {
+            if (imageDetails.isValidAdImage()) {
                 _viewState.update {
                     it.copy(adImage = BlazeRepository.BlazeCampaignImage.LocalImage(uri))
                 }
@@ -144,7 +145,7 @@ class BlazeCampaignCreationEditAdViewModel @Inject constructor(
     fun onWPMediaSelected(image: Product.Image) {
         launch {
             val imageDetails = blazeRepository.getImageDetails(image.source)
-            if (with(blazeRepository) { imageDetails.isValidAdImage() }) {
+            if (imageDetails.isValidAdImage()) {
                 _viewState.update {
                     it.copy(
                         adImage = BlazeRepository.BlazeCampaignImage.RemoteImage(
@@ -159,6 +160,8 @@ class BlazeCampaignCreationEditAdViewModel @Inject constructor(
             }
         }
     }
+
+    private fun MediaFilesRepository.ImageDetails.isValidAdImage() = with(blazeRepository) { isValidAdImage() }
 
     private fun showInvalidImageSizeDialog() {
         triggerEvent(

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/blaze/BlazeRepositoryTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/blaze/BlazeRepositoryTest.kt
@@ -2,7 +2,7 @@ package com.woocommerce.android.ui.blaze
 
 import com.woocommerce.android.AppPrefsWrapper
 import com.woocommerce.android.media.MediaFilesRepository
-import com.woocommerce.android.media.MediaFilesRepository.ImageDimensions
+import com.woocommerce.android.media.MediaFilesRepository.ImageDetails
 import com.woocommerce.android.tools.SelectedSite
 import com.woocommerce.android.ui.blaze.BlazeRepository.BlazeCampaignImage.RemoteImage
 import com.woocommerce.android.ui.blaze.BlazeRepository.Budget
@@ -131,7 +131,7 @@ class BlazeRepositoryTest : BaseUnitTest() {
 
             whenever(appPrefsWrapper.blazeCampaignSelectedObjective).thenReturn(objective)
             whenever(productDetailRepository.getProduct(productId)).thenReturn(product)
-            whenever(mediaFilesRepository.getImageDimensions(imageUrl)).thenReturn(ImageDimensions(0, 0))
+            whenever(mediaFilesRepository.getImageDetails(imageUrl)).thenReturn(ImageDetails(0, 0))
 
             val before = Date()
             val details = repository.generateDefaultCampaignDetails(productId)

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/blaze/BlazeRepositoryTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/blaze/BlazeRepositoryTest.kt
@@ -26,7 +26,6 @@ import org.mockito.kotlin.doReturn
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
-import org.wordpress.android.fluxc.model.MediaModel
 import org.wordpress.android.fluxc.model.SiteModel
 import org.wordpress.android.fluxc.model.blaze.BlazeCampaignCreationRequest
 import org.wordpress.android.fluxc.model.blaze.BlazeCampaignModel
@@ -61,11 +60,7 @@ class BlazeRepositoryTest : BaseUnitTest() {
             BlazeResult(blazeModel)
     }
     private val productDetailRepository: ProductDetailRepository = mock()
-    private val mediaModel: MediaModel = mock()
-    private val mediaFilesRepository: MediaFilesRepository = mock {
-        onBlocking { fetchWordPressMedia(AD_IMAGE.mediaId) } doReturn
-            Result.success(mediaModel)
-    }
+    private val mediaFilesRepository: MediaFilesRepository = mock()
     private val appPrefsWrapper: AppPrefsWrapper = mock()
 
     private val createCampaignRequestCaptor = argumentCaptor<BlazeCampaignCreationRequest>()
@@ -131,7 +126,7 @@ class BlazeRepositoryTest : BaseUnitTest() {
 
             whenever(appPrefsWrapper.blazeCampaignSelectedObjective).thenReturn(objective)
             whenever(productDetailRepository.getProduct(productId)).thenReturn(product)
-            whenever(mediaFilesRepository.getImageDetails(imageUrl)).thenReturn(ImageDetails(0, 0))
+            whenever(mediaFilesRepository.getImageDetails(imageUrl)).thenReturn(ImageDetails(0, 0, ""))
 
             val before = Date()
             val details = repository.generateDefaultCampaignDetails(productId)
@@ -191,12 +186,34 @@ class BlazeRepositoryTest : BaseUnitTest() {
             assertThat(details.description).isEqualTo("Main \n Description")
         }
 
+    @Test
+    fun `given a product with invalid image, when generateDefaultCampaignDetails invoked, then CampaignDetails with no image created`() =
+        testBlocking {
+            val productId = 456L
+            val objective = "sales"
+            val imageUrl = "https://example.com/image-400.jpg"
+            val product = ProductTestUtils.generateProduct(
+                productId = productId,
+                productName = "Another Product",
+                imageUrl = imageUrl
+            )
+
+            whenever(appPrefsWrapper.blazeCampaignSelectedObjective).thenReturn(objective)
+            whenever(productDetailRepository.getProduct(productId)).thenReturn(product)
+            whenever(mediaFilesRepository.getImageDetails(imageUrl)).thenReturn(ImageDetails(0, 0, ""))
+
+            val details = repository.generateDefaultCampaignDetails(productId)
+
+            // Only focus on campaign image behavior
+            assertThat(details.campaignImage).isInstanceOf(BlazeRepository.BlazeCampaignImage.None::class.java)
+        }
+
     companion object {
         private const val TOTAL_BUDGET = 35f
         private const val PAYMENT_METHOD_ID = "132435"
         private val AD_IMAGE = RemoteImage(
-            mediaId = 1,
             uri = "https://example.com/image.jpg",
+            mimeType = "image/jpeg",
         )
         private val DEFAULT_START_DATE = Date()
         private val EMPTY_TARGETING_PARAMETERS = TargetingParameters(

--- a/libs/fluxc/src/main/java/org/wordpress/android/fluxc/model/blaze/BlazeCampaignCreationRequest.kt
+++ b/libs/fluxc/src/main/java/org/wordpress/android/fluxc/model/blaze/BlazeCampaignCreationRequest.kt
@@ -1,6 +1,5 @@
 package org.wordpress.android.fluxc.model.blaze
 
-import org.wordpress.android.fluxc.model.MediaModel
 import java.util.Date
 import java.util.TimeZone
 
@@ -18,12 +17,17 @@ data class BlazeCampaignCreationRequest(
     val budget: BlazeCampaignCreationRequestBudget,
     val targetUrl: String,
     val urlParams: Map<String, String>,
-    val mainImage: MediaModel,
+    val mainImage: BlazeCampaignCreationRequestImage,
     val targetingParameters: BlazeTargetingParameters?,
     val timeZoneId: String = TimeZone.getDefault().id,
     val isEndlessCampaign: Boolean,
     val objectiveId: String?,
     val acceptedTos: Boolean,
+)
+
+data class BlazeCampaignCreationRequestImage(
+    val url: String,
+    val mimeType: String
 )
 
 data class BlazeCampaignCreationRequestBudget(


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

<!-- Id number of the Linear issue this PR addresses, e.g., WOOMOB-373. -->
Closes WOOMOB-1348

### Description
This PR fixes an issue where the app could send a PDF URL in the `main_image.url` field when creating a campaign, and `main_image.mime_type` set to `application/pdf`.

For more information on how this happens, check out the details here: pe5sF9-4CI-p2. In short, the product image is set to a thumbnail of a PDF file uploaded to the store, and the app uses the PDF URL and not the thumbnail URL, this was caused by the fact that we fetch the Media object to get its mime type, resulting in using a different URL. To fix this, this PR updates the logic to infer the MIME type when fetching image dimensions, so we no longer need to fetch the Media object. This also optimizes the campaign creation process by eliminating one API request.

To explain this more, for the test store that we'll use for reproducing the issue, the details are shown below:

##### Product details:
```json
{
  "id": 62,
  "name": "PDF Image Product",
  "slug": "pdf-image-product",
  "permalink": "https:\/\/fortunately-square.jurassic.ninja\/product\/pdf-image-product\/",
  "images": [
    {
      "id": 61,
      "date_created": "2025-09-19T15:12:06",
      "date_created_gmt": "2025-09-19T15:12:06",
      "date_modified": "2025-09-19T15:12:06",
      "date_modified_gmt": "2025-09-19T15:12:06",
      "src": "https:\/\/fortunately-square.jurassic.ninja\/wp-content\/uploads\/2025\/09\/pdf-61-full.jpg",
      "name": "sample",
      "alt": ""
    }
  ],
  ...
}
```

##### Blaze campaign creation request before
```json
{
  "origin": "wc-android",
  "origin_version": "23.2",
  "target_urn": "urn:wpcom:post:248546480:62",
  "type": "product",
  "payment_method_id": "PW-15849315",
  "start_date": "2025-09-19",
  "end_date": "2025-09-26",
  "time_zone": "Africa/Casablanca",
  "budget": {
    "mode": "daily",
    "amount": 5.0,
    "currency": "USD"
  },
  "site_name": "Transform Your PDFs!",
  "text_snippet": "Unlock the power of PDF images like never before. Explore now!",
  "cta_text": "Discover More",
  "target_url": "https://fortunately-square.jurassic.ninja/product/pdf-image-product/",
  "url_params": "",
  "main_image": {
    "url": "https://fortunately-square.jurassic.ninja/wp-content/uploads/2025/09/sample.pdf",
    "mime_type": "application/pdf"
  },
  "targeting": {
    "locations": [],
    "languages": [],
    "devices": [],
    "page_topics": []
  },
  "is_evergreen": true,
  "objective": "sales",
  "accepted_tos": true
}
```

##### Blaze campaign creation request after the fix
```json
{
  "origin": "wc-android",
  "origin_version": "23.2",
  "target_urn": "urn:wpcom:post:248546480:62",
  "type": "product",
  "payment_method_id": "PW-15849315",
  "start_date": "2025-09-19",
  "end_date": "2025-09-26",
  "time_zone": "Africa/Casablanca",
  "budget": {
    "mode": "daily",
    "amount": 5.0,
    "currency": "USD"
  },
  "site_name": "Transform Your PDFs!",
  "text_snippet": "Unlock the power of PDF images like never before. Explore now!",
  "cta_text": "Discover More",
  "target_url": "https://fortunately-square.jurassic.ninja/product/pdf-image-product/",
  "url_params": "",
  "main_image": {
    "url": "https://fortunately-square.jurassic.ninja/wp-content/uploads/2025/09/pdf-61-full.jpg",
    "mime_type": "image/jpeg"
  },
  "targeting": {
    "locations": [],
    "languages": [],
    "devices": [],
    "page_topics": []
  },
  "is_evergreen": true,
  "objective": "sales",
  "accepted_tos": true
}
```

### Steps to reproduce
1. Creating a website with the issue is not a straightforward process, so ping me in a DM to share a test store.
2. Open the app.
3. Create a Blaze campaign using the default AD image.

### Testing information
- Confirm the PR fixes the issue.

### The tests that have been performed
The above.

- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->