### PR TITLE
[WOOMOB-1342] Booking details header/list item component

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/bookings/compose/AttendanceStatusTag.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/bookings/compose/AttendanceStatusTag.kt
@@ -1,0 +1,59 @@
+package com.woocommerce.android.ui.bookings.compose
+
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.colorResource
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.tooling.preview.Preview
+import com.woocommerce.android.R
+import com.woocommerce.android.ui.compose.component.WCTag
+import com.woocommerce.android.ui.compose.theme.WooThemeWithBackground
+
+@Composable
+fun AttendanceStatusTag(
+    state: AttendanceStatus,
+    modifier: Modifier = Modifier,
+) {
+    WCTag(
+        text = state.text(),
+        backgroundColor = colorResource(R.color.tagView_bg),
+        textColor = colorResource(R.color.tagView_text),
+        fontWeight = FontWeight.Normal,
+        modifier = modifier
+    )
+}
+
+enum class AttendanceStatus {
+    BOOKED, CHECKED_IN, CANCELLED, NO_SHOW
+}
+
+@Composable
+private fun AttendanceStatus.text(): String {
+    return when (this) {
+        AttendanceStatus.BOOKED -> R.string.booking_attendance_status_booked
+        AttendanceStatus.CHECKED_IN -> R.string.booking_attendance_status_checked_in
+        AttendanceStatus.CANCELLED -> R.string.booking_attendance_status_cancelled
+        AttendanceStatus.NO_SHOW -> R.string.booking_attendance_status_no_show
+    }.let { stringResource(it) }
+}
+
+@Preview
+@Composable
+private fun AttendanceStatusTagPreview() {
+    WooThemeWithBackground {
+        AttendanceStatusTag(
+            state = AttendanceStatus.BOOKED
+        )
+    }
+}
+
+@Preview(uiMode = android.content.res.Configuration.UI_MODE_NIGHT_YES)
+@Composable
+private fun AttendanceStatusTagDarkPreview() {
+    WooThemeWithBackground {
+        AttendanceStatusTag(
+            state = AttendanceStatus.CHECKED_IN
+        )
+    }
+}

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/bookings/compose/BookingSummary.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/bookings/compose/BookingSummary.kt
@@ -44,7 +44,7 @@ fun BookingSummary(
                 style = MaterialTheme.typography.labelMedium.copy(fontSize = 13.sp),
             )
             Text(
-                text = model.staff,
+                text = model.customerName,
                 color = colorResource(id = R.color.color_surface_variant),
                 style = MaterialTheme.typography.labelMedium.copy(fontSize = 13.sp),
             )
@@ -67,7 +67,7 @@ fun BookingSummary(
 data class BookingSummary(
     val date: String,
     val name: String,
-    val staff: String,
+    val customerName: String,
     val attendanceStatus: AttendanceStatus,
     val paymentStatus: BookingPaymentStatus,
 )
@@ -80,7 +80,7 @@ private fun BookingSummaryPreview() {
             model = BookingSummary(
                 date = "05/07/2025, 11:00 AM",
                 name = "Women’s Haircut",
-                staff = "Margarita Nikolaevna",
+                customerName = "Margarita Nikolaevna",
                 attendanceStatus = AttendanceStatus.CHECKED_IN,
                 paymentStatus = BookingPaymentStatus.PAID
             ),
@@ -97,7 +97,7 @@ private fun BookingSummaryDarkPreview() {
             model = BookingSummary(
                 date = "05/07/2025, 11:00 AM",
                 name = "Women’s Haircut",
-                staff = "Margarita Nikolaevna",
+                customerName = "Margarita Nikolaevna",
                 attendanceStatus = AttendanceStatus.BOOKED,
                 paymentStatus = BookingPaymentStatus.PENDING_CONFIRMATION
             ),

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/bookings/compose/BookingSummary.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/bookings/compose/BookingSummary.kt
@@ -1,0 +1,107 @@
+package com.woocommerce.android.ui.bookings.compose
+
+import android.content.res.Configuration
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.FlowRow
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.colorResource
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import com.woocommerce.android.R
+import com.woocommerce.android.ui.compose.theme.WooThemeWithBackground
+
+@Composable
+fun BookingSummary(
+    model: BookingSummary,
+    modifier: Modifier = Modifier,
+) {
+    Column(
+        horizontalAlignment = Alignment.Start,
+        modifier = modifier
+            .padding(16.dp)
+    ) {
+        Text(
+            text = model.date,
+            color = MaterialTheme.colorScheme.onSurface,
+            style = MaterialTheme.typography.bodyLarge.copy(fontWeight = FontWeight.Medium),
+        )
+        FlowRow(
+            modifier = Modifier.padding(top = 2.dp),
+        ) {
+            Text(
+                text = "${model.name} • ",
+                color = colorResource(id = R.color.color_surface_variant),
+                style = MaterialTheme.typography.labelMedium.copy(fontSize = 13.sp),
+            )
+            Text(
+                text = model.staff,
+                color = colorResource(id = R.color.color_surface_variant),
+                style = MaterialTheme.typography.labelMedium.copy(fontSize = 13.sp),
+            )
+        }
+        Row(
+            horizontalArrangement = Arrangement.spacedBy(8.dp),
+            modifier = Modifier
+                .padding(top = 8.dp)
+        ) {
+            AttendanceStatusTag(
+                state = model.attendanceStatus
+            )
+            BookingPaymentStatusTag(
+                state = model.paymentStatus
+            )
+        }
+    }
+}
+
+data class BookingSummary(
+    val date: String,
+    val name: String,
+    val staff: String,
+    val attendanceStatus: AttendanceStatus,
+    val paymentStatus: BookingPaymentStatus,
+)
+
+@Preview
+@Composable
+private fun BookingSummaryPreview() {
+    WooThemeWithBackground {
+        BookingSummary(
+            model = BookingSummary(
+                date = "05/07/2025, 11:00 AM",
+                name = "Women’s Haircut",
+                staff = "Margarita Nikolaevna",
+                attendanceStatus = AttendanceStatus.CHECKED_IN,
+                paymentStatus = BookingPaymentStatus.PAID
+            ),
+            modifier = Modifier.fillMaxWidth()
+        )
+    }
+}
+
+@Preview(uiMode = Configuration.UI_MODE_NIGHT_YES)
+@Composable
+private fun BookingSummaryDarkPreview() {
+    WooThemeWithBackground {
+        BookingSummary(
+            model = BookingSummary(
+                date = "05/07/2025, 11:00 AM",
+                name = "Women’s Haircut",
+                staff = "Margarita Nikolaevna",
+                attendanceStatus = AttendanceStatus.BOOKED,
+                paymentStatus = BookingPaymentStatus.PENDING_CONFIRMATION
+            ),
+            modifier = Modifier.fillMaxWidth()
+        )
+    }
+}

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/bookings/compose/PaymentStatusTag.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/bookings/compose/PaymentStatusTag.kt
@@ -1,0 +1,61 @@
+package com.woocommerce.android.ui.bookings.compose
+
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.colorResource
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.tooling.preview.Preview
+import com.woocommerce.android.R
+import com.woocommerce.android.ui.compose.component.WCTag
+import com.woocommerce.android.ui.compose.theme.WooThemeWithBackground
+
+@Composable
+fun BookingPaymentStatusTag(
+    state: BookingPaymentStatus,
+    modifier: Modifier = Modifier,
+) {
+    WCTag(
+        text = state.text(),
+        backgroundColor = colorResource(R.color.tagView_bg),
+        textColor = colorResource(R.color.tagView_text),
+        fontWeight = FontWeight.Normal,
+        modifier = modifier
+    )
+}
+
+enum class BookingPaymentStatus {
+    UNPAID, PENDING_CONFIRMATION, CONFIRMED, PAID, CANCELLED, COMPLETE
+}
+
+@Composable
+private fun BookingPaymentStatus.text(): String {
+    return when (this) {
+        BookingPaymentStatus.UNPAID -> R.string.booking_payment_status_unpaid
+        BookingPaymentStatus.PENDING_CONFIRMATION -> R.string.booking_payment_status_pending_confirmation
+        BookingPaymentStatus.CONFIRMED -> R.string.booking_payment_status_confirmed
+        BookingPaymentStatus.PAID -> R.string.booking_payment_status_paid
+        BookingPaymentStatus.CANCELLED -> R.string.booking_payment_status_cancelled
+        BookingPaymentStatus.COMPLETE -> R.string.booking_payment_status_complete
+    }.let { stringResource(it) }
+}
+
+@Preview
+@Composable
+private fun PaymentStatusTagPreview() {
+    WooThemeWithBackground {
+        BookingPaymentStatusTag(
+            state = BookingPaymentStatus.PAID
+        )
+    }
+}
+
+@Preview(uiMode = android.content.res.Configuration.UI_MODE_NIGHT_YES)
+@Composable
+private fun PaymentStatusTagDarkPreview() {
+    WooThemeWithBackground {
+        BookingPaymentStatusTag(
+            state = BookingPaymentStatus.COMPLETE
+        )
+    }
+}

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/bookings/details/BookingDetailsScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/bookings/details/BookingDetailsScreen.kt
@@ -1,14 +1,22 @@
 package com.woocommerce.android.ui.bookings.details
 
-import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Surface
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.livedata.observeAsState
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.shadow
 import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import com.woocommerce.android.ui.bookings.compose.AttendanceStatus
+import com.woocommerce.android.ui.bookings.compose.BookingPaymentStatus
+import com.woocommerce.android.ui.bookings.compose.BookingSummary
 import com.woocommerce.android.ui.compose.component.Toolbar
 import com.woocommerce.android.ui.compose.theme.WooThemeWithBackground
 
@@ -38,10 +46,22 @@ fun BookingDetailsScreen(
             Toolbar(
                 title = viewState.toolbarTitle,
                 onNavigationButtonClick = onBack,
+                modifier = Modifier.shadow(4.dp)
             )
         }
     ) { innerPadding ->
-        Box(modifier = Modifier.padding(innerPadding))
+        Surface(
+            modifier = Modifier.fillMaxSize()
+        ) {
+            Column(
+                modifier = Modifier.padding(innerPadding)
+            ) {
+                BookingSummary(
+                    model = viewState.bookingSummary,
+                    modifier = Modifier.fillMaxWidth()
+                )
+            }
+        }
     }
 }
 
@@ -52,6 +72,13 @@ private fun BookingDetailsPreview() {
         BookingDetailsScreen(
             viewState = BookingDetailsViewState(
                 toolbarTitle = "Booking #12345",
+                bookingSummary = BookingSummary(
+                    date = "05/07/2025, 11:00 AM",
+                    name = "Women’s Haircut",
+                    staff = "Margarita Nikolaevna",
+                    attendanceStatus = AttendanceStatus.CHECKED_IN,
+                    paymentStatus = BookingPaymentStatus.PAID
+                )
             ),
             onBack = {}
         )

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/bookings/details/BookingDetailsScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/bookings/details/BookingDetailsScreen.kt
@@ -75,7 +75,7 @@ private fun BookingDetailsPreview() {
                 bookingSummary = BookingSummary(
                     date = "05/07/2025, 11:00 AM",
                     name = "Women’s Haircut",
-                    staff = "Margarita Nikolaevna",
+                    customerName = "Margarita Nikolaevna",
                     attendanceStatus = AttendanceStatus.CHECKED_IN,
                     paymentStatus = BookingPaymentStatus.PAID
                 )

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/bookings/details/BookingDetailsViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/bookings/details/BookingDetailsViewModel.kt
@@ -26,7 +26,7 @@ class BookingDetailsViewModel @Inject constructor(
     init {
         _state.update {
             it.copy(
-                toolbarTitle = resourceProvider.getString(R.string.booking_details_title, navArgs.bookingId)
+                toolbarTitle = resourceProvider.getString(R.string.booking_details_title, navArgs.bookingId),
             )
         }
     }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/bookings/details/BookingDetailsViewState.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/bookings/details/BookingDetailsViewState.kt
@@ -9,7 +9,7 @@ data class BookingDetailsViewState(
     val bookingSummary: BookingSummary = BookingSummary(
         date = "05/07/2025, 11:00 AM",
         name = "Women’s Haircut",
-        staff = "Margarita Nikolaevna",
+        customerName = "Margarita Nikolaevna",
         attendanceStatus = AttendanceStatus.CHECKED_IN,
         paymentStatus = BookingPaymentStatus.PAID
     ),

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/bookings/details/BookingDetailsViewState.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/bookings/details/BookingDetailsViewState.kt
@@ -1,5 +1,16 @@
 package com.woocommerce.android.ui.bookings.details
 
+import com.woocommerce.android.ui.bookings.compose.AttendanceStatus
+import com.woocommerce.android.ui.bookings.compose.BookingPaymentStatus
+import com.woocommerce.android.ui.bookings.compose.BookingSummary
+
 data class BookingDetailsViewState(
     val toolbarTitle: String = "",
+    val bookingSummary: BookingSummary = BookingSummary(
+        date = "05/07/2025, 11:00 AM",
+        name = "Women’s Haircut",
+        staff = "Margarita Nikolaevna",
+        attendanceStatus = AttendanceStatus.CHECKED_IN,
+        paymentStatus = BookingPaymentStatus.PAID
+    ),
 )

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -4860,4 +4860,15 @@
 
     <!-- Booking details view-->
     <string name="booking_details_title">Booking #%s</string>
+    <string name="booking_payment_status_unpaid">Unpaid</string>
+    <string name="booking_payment_status_paid">Paid</string>
+    <string name="booking_payment_status_pending_confirmation">Pending Confirmation</string>
+    <string name="booking_payment_status_cancelled">Cancelled</string>
+    <string name="booking_payment_status_confirmed">Confirmed</string>
+    <string name="booking_payment_status_complete">Complete</string>
+    <string name="booking_attendance_status_booked">Booked</string>
+    <string name="booking_attendance_status_checked_in">Checked-in</string>
+    <string name="booking_attendance_status_cancelled">Cancelled</string>
+    <string name="booking_attendance_status_no_show">No-show</string>
+
 </resources>


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

<!-- Id number of the Linear issue this PR addresses, e.g., WOOMOB-373. -->

WOOMOB-1342

### Description

This PR creates the top/header Composable component for the Booking details screen. It's also the same component that can be reused on the Booking list screen. 

I will leave some extra comments below.

### Steps to reproduce

1. Log in
2. Go to Settings -> Developer Options
3. Tap "Show booking details"
4. Verify the UI matches the designs

### Testing information

Test with different font/display scaling and dark/light mode.

### The tests that have been performed

The above

### Images/gif
<!-- Include before and after images or gifs when appropriate. -->

| Light | Dark |
|---|---|
| <img width="400" height="241" alt="Screenshot 2025-09-23 at 09 48 50" src="https://github.com/user-attachments/assets/ec31b897-abf2-417a-a038-09e923540322" /> | <img width="401" height="220" alt="Screenshot 2025-09-23 at 09 49 06" src="https://github.com/user-attachments/assets/d0334d8f-0959-4848-866b-b1a0f4275b77" /> |

- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->