### PR TITLE
[Bookings] Add appointment details section UI

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/bookings/compose/BookingAppointmentDetails.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/bookings/compose/BookingAppointmentDetails.kt
@@ -1,0 +1,126 @@
+package com.woocommerce.android.ui.bookings.compose
+
+import androidx.annotation.StringRes
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.ButtonDefaults
+import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.dp
+import com.woocommerce.android.R
+import com.woocommerce.android.ui.compose.component.WCOutlinedButton
+import com.woocommerce.android.ui.compose.preview.LightDarkThemePreviews
+import com.woocommerce.android.ui.compose.theme.WooThemeWithBackground
+
+@Composable
+fun BookingAppointmentDetails(
+    model: BookingAppointmentDetailsModel,
+    onCancelBooking: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    Column(modifier = modifier) {
+        BookingSectionHeader(R.string.booking_appointment_details_header)
+        Column(modifier = Modifier.background(color = MaterialTheme.colorScheme.surfaceContainer)) {
+            HorizontalDivider(thickness = 0.5.dp)
+            AppointmentDetailsRow(
+                label = R.string.booking_appointment_label_date,
+                value = model.date
+            )
+            AppointmentDetailsRow(
+                label = R.string.booking_appointment_label_time,
+                value = model.time
+            )
+            AppointmentDetailsRow(
+                label = R.string.booking_appointment_label_staff,
+                value = model.staff
+            )
+            AppointmentDetailsRow(
+                label = R.string.booking_appointment_label_location,
+                value = model.location
+            )
+            AppointmentDetailsRow(
+                label = R.string.booking_appointment_label_duration,
+                value = model.duration
+            )
+            AppointmentDetailsRow(
+                label = R.string.booking_appointment_label_price,
+                value = model.price
+            )
+            WCOutlinedButton(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(16.dp),
+                colors = ButtonDefaults.outlinedButtonColors(
+                    contentColor = MaterialTheme.colorScheme.onSurface
+                ),
+                onClick = onCancelBooking
+            ) {
+                Text(text = stringResource(R.string.booking_details_cancel_booking_button))
+            }
+            HorizontalDivider(thickness = 0.5.dp)
+        }
+    }
+}
+
+@Composable
+fun AppointmentDetailsRow(@StringRes label: Int, value: String) {
+    Column {
+        Row(
+            horizontalArrangement = Arrangement.SpaceBetween,
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(horizontal = 16.dp, vertical = 11.dp)
+        ) {
+            BookingDetailsLabel(label)
+            Text(
+                modifier = Modifier.padding(start = 8.dp),
+                text = value,
+                style = MaterialTheme.typography.bodyMedium,
+                color = MaterialTheme.colorScheme.surfaceVariant,
+                maxLines = 1,
+                overflow = TextOverflow.Ellipsis
+            )
+        }
+        HorizontalDivider(
+            modifier = Modifier.padding(start = 16.dp),
+            thickness = 0.5.dp
+        )
+    }
+}
+
+data class BookingAppointmentDetailsModel(
+    val date: String,
+    val time: String,
+    val staff: String,
+    val location: String,
+    val duration: String,
+    val price: String
+)
+
+@LightDarkThemePreviews
+@Composable
+private fun BookingAppointmentDetailsPreview() {
+    WooThemeWithBackground {
+        BookingAppointmentDetails(
+            model = BookingAppointmentDetailsModel(
+                date = "05/07/2025, 11:00 AM",
+                time = "11:00 am - 12:00 pm",
+                staff = "Marianne Renoir",
+                location = "238 Willow Creek Drive, Montgomery AL 36109",
+                duration = "60 min",
+                price = "$55.00"
+            ),
+            onCancelBooking = {},
+            modifier = Modifier.fillMaxWidth()
+        )
+    }
+}

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/bookings/compose/BookingDetailsLabel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/bookings/compose/BookingDetailsLabel.kt
@@ -1,0 +1,16 @@
+package com.woocommerce.android.ui.bookings.compose
+
+import androidx.annotation.StringRes
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.res.stringResource
+
+@Composable
+fun BookingDetailsLabel(@StringRes label: Int) {
+    Text(
+        text = stringResource(label),
+        style = MaterialTheme.typography.labelLarge,
+        color = MaterialTheme.colorScheme.onSurface
+    )
+}

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/bookings/compose/BookingSectionHeader.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/bookings/compose/BookingSectionHeader.kt
@@ -1,0 +1,21 @@
+package com.woocommerce.android.ui.bookings.compose
+
+import androidx.annotation.StringRes
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+
+@Composable
+fun BookingSectionHeader(@StringRes header: Int) {
+    Text(
+        text = stringResource(header),
+        fontWeight = FontWeight.Medium,
+        style = MaterialTheme.typography.titleMedium,
+        modifier = Modifier.padding(start = 16.dp, top = 16.dp, end = 16.dp, bottom = 8.dp)
+    )
+}

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/bookings/compose/BookingSummary.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/bookings/compose/BookingSummary.kt
@@ -23,7 +23,7 @@ import com.woocommerce.android.ui.compose.theme.WooThemeWithBackground
 
 @Composable
 fun BookingSummary(
-    model: BookingSummary,
+    model: BookingSummaryModel,
     modifier: Modifier = Modifier,
 ) {
     Column(
@@ -66,7 +66,7 @@ fun BookingSummary(
     }
 }
 
-data class BookingSummary(
+data class BookingSummaryModel(
     val date: String,
     val name: String,
     val customerName: String,
@@ -79,7 +79,7 @@ data class BookingSummary(
 private fun BookingSummaryPreview() {
     WooThemeWithBackground {
         BookingSummary(
-            model = BookingSummary(
+            model = BookingSummaryModel(
                 date = "05/07/2025, 11:00 AM",
                 name = "Women’s Haircut",
                 customerName = "Margarita Nikolaevna",
@@ -96,7 +96,7 @@ private fun BookingSummaryPreview() {
 private fun BookingSummaryDarkPreview() {
     WooThemeWithBackground {
         BookingSummary(
-            model = BookingSummary(
+            model = BookingSummaryModel(
                 date = "05/07/2025, 11:00 AM",
                 name = "Women’s Haircut",
                 customerName = "Margarita Nikolaevna",

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/bookings/compose/BookingSummary.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/bookings/compose/BookingSummary.kt
@@ -1,6 +1,7 @@
 package com.woocommerce.android.ui.bookings.compose
 
 import android.content.res.Configuration
+import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.FlowRow
@@ -28,6 +29,7 @@ fun BookingSummary(
     Column(
         horizontalAlignment = Alignment.Start,
         modifier = modifier
+            .background(color = MaterialTheme.colorScheme.surfaceContainer)
             .padding(16.dp)
     ) {
         Text(

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/bookings/details/BookingDetailsScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/bookings/details/BookingDetailsScreen.kt
@@ -12,9 +12,12 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.livedata.observeAsState
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.shadow
+import androidx.compose.ui.res.colorResource
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
+import com.woocommerce.android.R
 import com.woocommerce.android.ui.bookings.compose.AttendanceStatus
+import com.woocommerce.android.ui.bookings.compose.BookingAppointmentDetails
 import com.woocommerce.android.ui.bookings.compose.BookingPaymentStatus
 import com.woocommerce.android.ui.bookings.compose.BookingSummary
 import com.woocommerce.android.ui.compose.component.Toolbar
@@ -31,7 +34,8 @@ fun BookingDetailsScreen(
     viewState?.let {
         BookingDetailsScreen(
             viewState = it,
-            onBack = onBack
+            onBack = onBack,
+            onCancelBooking = viewModel::onCancelBooking
         )
     }
 }
@@ -39,7 +43,8 @@ fun BookingDetailsScreen(
 @Composable
 fun BookingDetailsScreen(
     viewState: BookingDetailsViewState,
-    onBack: () -> Unit
+    onBack: () -> Unit,
+    onCancelBooking: () -> Unit
 ) {
     Scaffold(
         topBar = {
@@ -51,6 +56,7 @@ fun BookingDetailsScreen(
         }
     ) { innerPadding ->
         Surface(
+            color = colorResource(R.color.default_window_background),
             modifier = Modifier.fillMaxSize()
         ) {
             Column(
@@ -58,6 +64,11 @@ fun BookingDetailsScreen(
             ) {
                 BookingSummary(
                     model = viewState.bookingSummary,
+                    modifier = Modifier.fillMaxWidth()
+                )
+                BookingAppointmentDetails(
+                    model = viewState.bookingsAppointmentDetails,
+                    onCancelBooking = onCancelBooking,
                     modifier = Modifier.fillMaxWidth()
                 )
             }
@@ -80,7 +91,8 @@ private fun BookingDetailsPreview() {
                     paymentStatus = BookingPaymentStatus.PAID
                 )
             ),
-            onBack = {}
+            onBack = {},
+            onCancelBooking = {}
         )
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/bookings/details/BookingDetailsScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/bookings/details/BookingDetailsScreen.kt
@@ -4,6 +4,8 @@ import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Surface
@@ -62,7 +64,9 @@ fun BookingDetailsScreen(
             modifier = Modifier.fillMaxSize()
         ) {
             Column(
-                modifier = Modifier.padding(innerPadding)
+                modifier = Modifier
+                    .verticalScroll(rememberScrollState())
+                    .padding(innerPadding)
             ) {
                 BookingSummary(
                     model = viewState.bookingSummary,

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/bookings/details/BookingDetailsScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/bookings/details/BookingDetailsScreen.kt
@@ -18,6 +18,7 @@ import androidx.compose.ui.unit.dp
 import com.woocommerce.android.R
 import com.woocommerce.android.ui.bookings.compose.AttendanceStatus
 import com.woocommerce.android.ui.bookings.compose.BookingAppointmentDetails
+import com.woocommerce.android.ui.bookings.compose.BookingAppointmentDetailsModel
 import com.woocommerce.android.ui.bookings.compose.BookingPaymentStatus
 import com.woocommerce.android.ui.bookings.compose.BookingSummary
 import com.woocommerce.android.ui.compose.component.Toolbar
@@ -89,6 +90,14 @@ private fun BookingDetailsPreview() {
                     customerName = "Margarita Nikolaevna",
                     attendanceStatus = AttendanceStatus.CHECKED_IN,
                     paymentStatus = BookingPaymentStatus.PAID
+                ),
+                bookingsAppointmentDetails = BookingAppointmentDetailsModel(
+                    date = "Monday, 05 July 2025",
+                    time = "11:00 am - 12:00 pm",
+                    staff = "Marianne Renoir",
+                    location = "238 Willow Creek Drive, Montgomery AL 36109",
+                    duration = "60 min",
+                    price = "$55.00"
                 )
             ),
             onBack = {},

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/bookings/details/BookingDetailsScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/bookings/details/BookingDetailsScreen.kt
@@ -21,6 +21,7 @@ import com.woocommerce.android.ui.bookings.compose.BookingAppointmentDetails
 import com.woocommerce.android.ui.bookings.compose.BookingAppointmentDetailsModel
 import com.woocommerce.android.ui.bookings.compose.BookingPaymentStatus
 import com.woocommerce.android.ui.bookings.compose.BookingSummary
+import com.woocommerce.android.ui.bookings.compose.BookingSummaryModel
 import com.woocommerce.android.ui.compose.component.Toolbar
 import com.woocommerce.android.ui.compose.theme.WooThemeWithBackground
 
@@ -84,7 +85,7 @@ private fun BookingDetailsPreview() {
         BookingDetailsScreen(
             viewState = BookingDetailsViewState(
                 toolbarTitle = "Booking #12345",
-                bookingSummary = BookingSummary(
+                bookingSummary = BookingSummaryModel(
                     date = "05/07/2025, 11:00 AM",
                     name = "Women’s Haircut",
                     customerName = "Margarita Nikolaevna",

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/bookings/details/BookingDetailsViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/bookings/details/BookingDetailsViewModel.kt
@@ -30,4 +30,8 @@ class BookingDetailsViewModel @Inject constructor(
             )
         }
     }
+
+    fun onCancelBooking() {
+        // TODO Add logic to Cancel booking
+    }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/bookings/details/BookingDetailsViewState.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/bookings/details/BookingDetailsViewState.kt
@@ -1,6 +1,7 @@
 package com.woocommerce.android.ui.bookings.details
 
 import com.woocommerce.android.ui.bookings.compose.AttendanceStatus
+import com.woocommerce.android.ui.bookings.compose.BookingAppointmentDetailsModel
 import com.woocommerce.android.ui.bookings.compose.BookingPaymentStatus
 import com.woocommerce.android.ui.bookings.compose.BookingSummary
 
@@ -13,4 +14,12 @@ data class BookingDetailsViewState(
         attendanceStatus = AttendanceStatus.CHECKED_IN,
         paymentStatus = BookingPaymentStatus.PAID
     ),
+    val bookingsAppointmentDetails: BookingAppointmentDetailsModel = BookingAppointmentDetailsModel(
+        date = "Monday, 05 July 2025",
+        time = "11:00 am - 12:00 pm",
+        staff = "Marianne Renoir",
+        location = "238 Willow Creek Drive, Montgomery AL 36109",
+        duration = "60 min",
+        price = "$55.00"
+    )
 )

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/bookings/details/BookingDetailsViewState.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/bookings/details/BookingDetailsViewState.kt
@@ -3,11 +3,11 @@ package com.woocommerce.android.ui.bookings.details
 import com.woocommerce.android.ui.bookings.compose.AttendanceStatus
 import com.woocommerce.android.ui.bookings.compose.BookingAppointmentDetailsModel
 import com.woocommerce.android.ui.bookings.compose.BookingPaymentStatus
-import com.woocommerce.android.ui.bookings.compose.BookingSummary
+import com.woocommerce.android.ui.bookings.compose.BookingSummaryModel
 
 data class BookingDetailsViewState(
     val toolbarTitle: String = "",
-    val bookingSummary: BookingSummary = BookingSummary(
+    val bookingSummary: BookingSummaryModel = BookingSummaryModel(
         date = "05/07/2025, 11:00 AM",
         name = "Women’s Haircut",
         customerName = "Margarita Nikolaevna",

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -4860,6 +4860,13 @@
 
     <!-- Booking details view-->
     <string name="booking_details_title">Booking #%s</string>
+    <string name="booking_appointment_details_header">APPOINTMENT DETAILS</string>
+    <string name="booking_appointment_label_date">Date</string>
+    <string name="booking_appointment_label_time">Time</string>
+    <string name="booking_appointment_label_staff">Assigned staff</string>
+    <string name="booking_appointment_label_location">Location</string>
+    <string name="booking_appointment_label_duration">Duration</string>
+    <string name="booking_appointment_label_price">Price</string>
     <string name="booking_payment_status_unpaid">Unpaid</string>
     <string name="booking_payment_status_paid">Paid</string>
     <string name="booking_payment_status_pending_confirmation">Pending Confirmation</string>
@@ -4870,5 +4877,6 @@
     <string name="booking_attendance_status_checked_in">Checked-in</string>
     <string name="booking_attendance_status_cancelled">Cancelled</string>
     <string name="booking_attendance_status_no_show">No-show</string>
+    <string name="booking_details_cancel_booking_button">Cancel booking</string>
 
 </resources>


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

<!-- Id number of the Linear issue this PR addresses, e.g., WOOMOB-373. -->
Part of WOOMOB-1343

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
This adds the APPOINTMENT DETAILS section to the booking details screen.
This PR includes only the UI and is not a closing PR.

It also updates the background color of the booking details screen and its sections to match the order details screen. As a result, you may notice some differences from the design, for example, the section header is black to stay consistent with the order details screen.

### Steps to reproduce
<!-- Step-by-step testing instructions. For new user flows, consider instead stating the goal of the workflow and see if your PR reviewer can accomplish the workflow without specific steps! -->
1. Log in.
2. Go to Menu → Settings → Developer Options → Show booking details

### The tests that have been performed
<!-- To give the reviewer an idea of what could be missed in terms of testing -->
Screens below

### Images/gif
<!-- Include before and after images or gifs when appropriate. -->
|Light|Dark|Large font|
|-|-|-|
|<img width="1280" height="2856" alt="light" src="https://github.com/user-attachments/assets/38382d21-6418-4c06-b959-afd6d2ec221c" />|<img width="1280" height="2856" alt="dark" src="https://github.com/user-attachments/assets/a9351269-9749-4a72-bda2-21dca505f523" />|<img width="1280" height="2856" alt="large" src="https://github.com/user-attachments/assets/4967747c-0a12-43ff-a43d-ce4d80940b23" />|

|landscape|
|-|
|<img width="2856" height="1280" alt="land" src="https://github.com/user-attachments/assets/fa94c9a8-5642-486b-bd1f-4f863012fdfc" />|

- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->