### PR TITLE
[CIAB Bookings] Add pagination logic

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/bookings/BookingListFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/bookings/BookingListFragment.kt
@@ -4,8 +4,6 @@ import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
-import androidx.compose.material3.Text
-import androidx.compose.runtime.livedata.observeAsState
 import androidx.fragment.app.viewModels
 import com.woocommerce.android.R
 import com.woocommerce.android.ui.base.TopLevelFragment
@@ -28,9 +26,7 @@ class BookingListFragment : TopLevelFragment() {
 
     override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View {
         return composeView {
-            viewModel.state.observeAsState().value?.let { state ->
-                Text("Empty Booking List screen: WIP")
-            }
+            BookingListScreen(viewModel)
         }
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/bookings/BookingListHandler.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/bookings/BookingListHandler.kt
@@ -1,5 +1,6 @@
 package com.woocommerce.android.ui.bookings
 
+import androidx.annotation.VisibleForTesting
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -15,7 +16,8 @@ class BookingListHandler @Inject constructor(
     private val bookingsRepository: BookingsRepository
 ) {
     companion object {
-        private const val PAGE_SIZE = 25
+        @VisibleForTesting
+        const val PAGE_SIZE = 25
     }
 
     private val mutex = Mutex()

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/bookings/BookingListHandler.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/bookings/BookingListHandler.kt
@@ -1,0 +1,88 @@
+package com.woocommerce.android.ui.bookings
+
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.flow.flatMapLatest
+import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
+import java.util.concurrent.atomic.AtomicBoolean
+import javax.inject.Inject
+
+class BookingListHandler @Inject constructor(
+    private val bookingsRepository: BookingsRepository
+) {
+    companion object {
+        private const val PAGE_SIZE = 25
+    }
+
+    private val mutex = Mutex()
+    private var page = MutableStateFlow(1)
+    private val canLoadMore = AtomicBoolean(false)
+
+    private val searchQuery = MutableStateFlow<String?>(null)
+    private val searchResults = MutableStateFlow(emptyList<Booking>())
+
+    @OptIn(ExperimentalCoroutinesApi::class)
+    val bookingsFlow: Flow<List<Booking>> = combine(searchQuery, page) { query, page ->
+        if (query == null) {
+            bookingsRepository.observeBookings(limit = page * PAGE_SIZE)
+        } else {
+            searchResults
+        }
+    }.flatMapLatest { it }
+
+    suspend fun loadBookings(
+        searchQuery: String? = null,
+        forceRefresh: Boolean = false,
+    ): Result<Unit> = mutex.withLock {
+        // Reset pagination attributes
+        page.value = 1
+        canLoadMore.set(true)
+
+        this.searchQuery.value = searchQuery
+        return if (searchQuery == null) {
+            if (forceRefresh) {
+                fetchBookings()
+            } else {
+                Result.success(Unit)
+            }
+        } else {
+            searchResults.value = emptyList()
+            if (searchQuery.isEmpty()) {
+                // If the query is empty, clear search results directly
+                canLoadMore.set(false)
+                Result.success(Unit)
+            } else {
+                searchBookings()
+            }
+        }
+    }
+
+    suspend fun loadMore(): Result<Unit> = mutex.withLock {
+        if (!canLoadMore.get()) return@withLock Result.success(Unit)
+        return if (searchQuery.value == null) {
+            fetchBookings()
+        } else {
+            searchBookings()
+        }
+    }
+
+    private suspend fun fetchBookings(): Result<Unit> {
+        return bookingsRepository.fetchBookings(
+            page = page.value,
+            perPage = PAGE_SIZE
+        ).onSuccess { hasMorePages ->
+            canLoadMore.set(hasMorePages)
+            if (hasMorePages) {
+                page.update { it + 1 }
+            }
+        }.map { }
+    }
+
+    private suspend fun searchBookings(): Result<Unit> {
+        TODO("Not yet implemented")
+    }
+}

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/bookings/BookingListScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/bookings/BookingListScreen.kt
@@ -1,0 +1,108 @@
+package com.woocommerce.android.ui.bookings
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.wrapContentSize
+import androidx.compose.foundation.layout.wrapContentWidth
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.itemsIndexed
+import androidx.compose.foundation.lazy.rememberLazyListState
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.material3.pulltorefresh.PullToRefreshBox
+import androidx.compose.material3.pulltorefresh.rememberPullToRefreshState
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.livedata.observeAsState
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import com.woocommerce.android.ui.compose.component.InfiniteListHandler
+
+@Composable
+fun BookingListScreen(viewModel: BookingListViewModel) {
+    viewModel.state.observeAsState().value?.let {
+        BookingListScreen(it)
+    }
+}
+
+@Composable
+fun BookingListScreen(state: BookingListViewModel.State) {
+    when {
+        state.bookings.isNotEmpty() -> {
+            BookingList(
+                bookings = state.bookings,
+                onRefresh = state.onRefresh,
+                onLoadMore = state.onLoadMore,
+                loadingState = state.loadingState,
+            )
+        }
+
+        state.loadingState == BookingListViewModel.LoadingState.Loading -> {
+            // TODO replace with shimmer
+            CircularProgressIndicator(
+                modifier = Modifier
+                    .fillMaxSize()
+                    .wrapContentSize()
+            )
+        }
+
+        else -> {
+            // TODO replace with empty state
+            Text(
+                text = "No bookings found",
+                modifier = Modifier
+                    .fillMaxSize()
+                    .wrapContentSize()
+            )
+        }
+    }
+}
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+private fun BookingList(
+    bookings: List<Booking>,
+    onRefresh: () -> Unit,
+    onLoadMore: () -> Unit,
+    loadingState: BookingListViewModel.LoadingState
+) {
+    PullToRefreshBox(
+        isRefreshing = loadingState == BookingListViewModel.LoadingState.Refreshing,
+        onRefresh = onRefresh,
+        state = rememberPullToRefreshState()
+    ) {
+        val listState = rememberLazyListState()
+        LazyColumn(
+            state = listState,
+            modifier = Modifier
+                .background(color = MaterialTheme.colorScheme.surface)
+        ) {
+            itemsIndexed(bookings) { _, booking ->
+                Text(
+                    text = "Booking #${booking.id.value}",
+                    modifier = Modifier.padding(16.dp)
+                )
+                HorizontalDivider()
+            }
+
+            if (loadingState == BookingListViewModel.LoadingState.Appending) {
+                item {
+                    CircularProgressIndicator(
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .wrapContentWidth()
+                            .padding(vertical = 8.dp)
+                    )
+                }
+            }
+        }
+
+        InfiniteListHandler(listState = listState) {
+            onLoadMore()
+        }
+    }
+}

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/bookings/BookingListViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/bookings/BookingListViewModel.kt
@@ -2,57 +2,53 @@ package com.woocommerce.android.ui.bookings
 
 import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.asLiveData
-import com.woocommerce.android.R
-import com.woocommerce.android.tools.SelectedSite
-import com.woocommerce.android.viewmodel.MultiLiveEvent.Event
 import com.woocommerce.android.viewmodel.ScopedViewModel
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.launch
-import org.wordpress.android.fluxc.network.rest.wpcom.wc.bookings.BookingsStore
-import org.wordpress.android.fluxc.persistence.entity.BookingEntity
 import javax.inject.Inject
 
 @HiltViewModel
 class BookingListViewModel @Inject constructor(
     savedStateHandle: SavedStateHandle,
-    private val bookingsStore: BookingsStore,
-    private val selectedSite: SelectedSite,
+    private val bookingListHandler: BookingListHandler
 ) : ScopedViewModel(savedStateHandle) {
-    private val isLoading = MutableStateFlow(false)
+    private val loadingState = MutableStateFlow(LoadingState.Idle)
 
     val state = combine(
-        bookingsStore.observeBookings(selectedSite.get()),
-        isLoading
-    ) { bookings, loading ->
+        bookingListHandler.bookingsFlow,
+        loadingState
+    ) { bookings, loadingState ->
         State(
             bookings = bookings,
-            isLoading = loading,
-            onRefresh = { fetchBookings() }
+            loadingState = loadingState,
+            onRefresh = { fetchBookings(LoadingState.Refreshing) }
         )
     }.asLiveData()
 
     init {
-        launch { fetchBookings() }
+        fetchBookings(initialLoadingState = LoadingState.Loading)
     }
 
-    fun fetchBookings() {
-        if (isLoading.value) return
+    private fun fetchBookings(initialLoadingState: LoadingState) {
         launch {
-            isLoading.value = true
-            val result = bookingsStore.fetchBookings(selectedSite.get())
-            if (result.isError) {
-                // Surface a generic error
-                triggerEvent(Event.ShowSnackbar(R.string.error_generic))
-            }
-            isLoading.value = false
+            loadingState.value = initialLoadingState
+            bookingListHandler.loadBookings(forceRefresh = true)
+                .onFailure {
+                    // Show error message
+                }
+            loadingState.value = LoadingState.Idle
         }
     }
 
     data class State(
-        val bookings: List<BookingEntity>, // To be replaced with Ui model
-        val isLoading: Boolean,
+        val bookings: List<Booking>, // To be replaced with Ui model
+        val loadingState: LoadingState,
         val onRefresh: () -> Unit,
     )
+
+    enum class LoadingState {
+        Idle, Loading, Refreshing, Appending
+    }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/bookings/BookingListViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/bookings/BookingListViewModel.kt
@@ -4,6 +4,7 @@ import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.asLiveData
 import com.woocommerce.android.viewmodel.ScopedViewModel
 import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.Job
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.launch
@@ -16,14 +17,17 @@ class BookingListViewModel @Inject constructor(
 ) : ScopedViewModel(savedStateHandle) {
     private val loadingState = MutableStateFlow(LoadingState.Idle)
 
+    private var bookingsFetchJob: Job? = null
+
     val state = combine(
         bookingListHandler.bookingsFlow,
-        loadingState
+        loadingState,
     ) { bookings, loadingState ->
         State(
             bookings = bookings,
             loadingState = loadingState,
-            onRefresh = { fetchBookings(LoadingState.Refreshing) }
+            onRefresh = { fetchBookings(LoadingState.Refreshing) },
+            onLoadMore = { loadMore() }
         )
     }.asLiveData()
 
@@ -32,9 +36,24 @@ class BookingListViewModel @Inject constructor(
     }
 
     private fun fetchBookings(initialLoadingState: LoadingState) {
-        launch {
+        bookingsFetchJob?.cancel()
+        bookingsFetchJob = launch {
             loadingState.value = initialLoadingState
             bookingListHandler.loadBookings(forceRefresh = true)
+                .onFailure {
+                    // Show error message
+                }
+            loadingState.value = LoadingState.Idle
+        }
+    }
+
+    private fun loadMore() {
+        launch {
+            // If a fetch is already in progress, wait for it to complete before loading more
+            bookingsFetchJob?.join()
+
+            loadingState.value = LoadingState.Appending
+            bookingListHandler.loadMore()
                 .onFailure {
                     // Show error message
                 }
@@ -46,6 +65,7 @@ class BookingListViewModel @Inject constructor(
         val bookings: List<Booking>, // To be replaced with Ui model
         val loadingState: LoadingState,
         val onRefresh: () -> Unit,
+        val onLoadMore: () -> Unit
     )
 
     enum class LoadingState {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/bookings/BookingsRepository.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/bookings/BookingsRepository.kt
@@ -1,0 +1,33 @@
+package com.woocommerce.android.ui.bookings
+
+import com.woocommerce.android.WooException
+import com.woocommerce.android.tools.SelectedSite
+import kotlinx.coroutines.flow.Flow
+import org.wordpress.android.fluxc.network.rest.wpcom.wc.bookings.BookingsStore
+import javax.inject.Inject
+
+class BookingsRepository @Inject constructor(
+    private val selectedSite: SelectedSite,
+    private val bookingsStore: BookingsStore
+) {
+    suspend fun fetchBookings(
+        page: Int,
+        perPage: Int
+    ): Result<Boolean> {
+        val result = bookingsStore.fetchBookings(
+            site = selectedSite.get(),
+            page = page,
+            perPage = perPage
+        )
+        return if (result.isError) {
+            Result.failure(WooException(result.error))
+        } else {
+            Result.success(result.model!!)
+        }
+    }
+
+    fun observeBookings(limit: Int? = null): Flow<List<Booking>> =
+        bookingsStore.observeBookings(selectedSite.get(), limit)
+}
+
+typealias Booking = org.wordpress.android.fluxc.persistence.entity.BookingEntity

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/bookings/BookingListHandlerTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/bookings/BookingListHandlerTest.kt
@@ -1,0 +1,180 @@
+package com.woocommerce.android.ui.bookings
+
+import com.woocommerce.android.util.InlineClassesAnswer
+import com.woocommerce.android.viewmodel.BaseUnitTest
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.launch
+import org.assertj.core.api.Assertions.assertThat
+import org.mockito.ArgumentMatchers.intThat
+import org.mockito.kotlin.any
+import org.mockito.kotlin.doAnswer
+import org.mockito.kotlin.eq
+import org.mockito.kotlin.given
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.never
+import org.mockito.kotlin.verify
+import org.wordpress.android.fluxc.model.LocalOrRemoteId.LocalId
+import org.wordpress.android.fluxc.model.LocalOrRemoteId.RemoteId
+import org.wordpress.android.fluxc.persistence.entity.BookingEntity
+import kotlin.test.Test
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class BookingListHandlerTest : BaseUnitTest() {
+    private val availablePages = 3
+    private val bookingsRepository: BookingsRepository = mock {
+        val results = MutableStateFlow(emptyList<Booking>())
+        on { observeBookings(any()) } doAnswer { invocation ->
+            val limit = invocation.getArgument<Int>(0)
+            results.map { it.take(limit) }
+        }
+        onBlocking { fetchBookings(any(), any()) } doAnswer InlineClassesAnswer { invocation ->
+            val page = invocation.getArgument<Int>(0)
+            val perPage = invocation.getArgument<Int>(1)
+            val canLoadMore = page < availablePages
+            when (page) {
+                1 -> results.update { List(perPage) { getSampleBooking(it) } }
+                availablePages -> results.update { list -> list + List(5) { getSampleBooking(it + perPage) } }
+                else -> results.update { list -> list + List(perPage) { getSampleBooking(it + perPage) } }
+            }
+            Result.success(canLoadMore)
+        }
+    }
+
+    private val bookingListHandler: BookingListHandler = BookingListHandler(bookingsRepository)
+
+    @Test
+    fun `given repository returns bookings, when observing bookings flow, then returns bookings`() = testBlocking {
+        val sampleBookings = List(10) { getSampleBooking(it) }
+        given(bookingsRepository.observeBookings(any())).willReturn(flowOf(sampleBookings))
+
+        val bookings = bookingListHandler.bookingsFlow.first()
+
+        assertThat(bookings).isEqualTo(sampleBookings)
+    }
+
+    @Test
+    fun `given no search query and force refresh, when loading bookings, then fetches from repository`() =
+        testBlocking {
+            val result = bookingListHandler.loadBookings(searchQuery = null, forceRefresh = true)
+            val bookings = bookingListHandler.bookingsFlow.first()
+
+            assertThat(result.isSuccess).isTrue()
+            assertThat(bookings).hasSize(BookingListHandler.PAGE_SIZE)
+        }
+
+    @Test
+    fun `given repository fetch fails, when loading bookings with force refresh, then returns failure`() =
+        testBlocking {
+            val exception = Exception("Network error")
+            given(bookingsRepository.fetchBookings(page = any(), perPage = any()))
+                .willReturn(Result.failure(exception))
+
+            val result = bookingListHandler.loadBookings(searchQuery = null, forceRefresh = true)
+
+            assertThat(result.isFailure).isTrue()
+            assertThat(result.exceptionOrNull()).isEqualTo(exception)
+        }
+
+    @Test
+    fun `when load more is called and can load more is false, then returns success without fetching`() =
+        testBlocking {
+            val result = bookingListHandler.loadMore()
+
+            assertThat(result.isSuccess).isTrue()
+            verify(bookingsRepository, never()).fetchBookings(any(), any())
+        }
+
+    @Test
+    fun `when load more is called and can load more is true, then fetches next page`() = testBlocking {
+        bookingListHandler.loadBookings(forceRefresh = true)
+
+        val result = bookingListHandler.loadMore()
+        val bookings = bookingListHandler.bookingsFlow.first()
+
+        assertThat(result.isSuccess).isTrue()
+        assertThat(bookings).hasSize(2 * BookingListHandler.PAGE_SIZE)
+    }
+
+    @Test
+    fun `when last page is reached, then can load more becomes false`() = testBlocking {
+        bookingListHandler.loadBookings(forceRefresh = true)
+
+        var result: Result<Unit>? = null
+        repeat(availablePages - 1) {
+            result = bookingListHandler.loadMore()
+        }
+
+        assertThat(result?.isSuccess).isTrue()
+        verify(bookingsRepository, never()).fetchBookings(page = intThat { it > availablePages }, perPage = any())
+    }
+
+    @Test
+    fun `when load bookings is called, then pagination resets`() = testBlocking {
+        // First load and load more to advance page
+        bookingListHandler.loadBookings(forceRefresh = true)
+        bookingListHandler.loadMore()
+
+        // Load bookings again - should reset to page 1
+        bookingListHandler.loadBookings(forceRefresh = true)
+        val bookings = bookingListHandler.bookingsFlow.first()
+
+        assertThat(bookings).hasSize(BookingListHandler.PAGE_SIZE)
+    }
+
+    @Test
+    fun `when bookings flow is observed with pagination, then limit increases correctly`() = testBlocking {
+        bookingListHandler.loadBookings(forceRefresh = true)
+
+        val initialBookings = bookingListHandler.bookingsFlow.first()
+        assertThat(initialBookings).hasSize(BookingListHandler.PAGE_SIZE)
+
+        bookingListHandler.loadMore()
+        val moreBookings = bookingListHandler.bookingsFlow.first()
+
+        @Suppress("UnusedFlow")
+        verify(bookingsRepository).observeBookings(limit = eq(2 * BookingListHandler.PAGE_SIZE))
+        assertThat(moreBookings).hasSize(2 * BookingListHandler.PAGE_SIZE)
+    }
+
+    @Test
+    fun `when concurrent load operations occur, then operations are synchronized`() = testBlocking {
+        // Launch multiple concurrent load operations
+        val job1 = launch { bookingListHandler.loadBookings(forceRefresh = true) }
+        val job2 = launch { bookingListHandler.loadBookings(forceRefresh = true) }
+        val job3 = launch { bookingListHandler.loadMore() }
+
+        job1.join()
+        job2.join()
+        job3.join()
+
+        val bookings = bookingListHandler.bookingsFlow.first()
+        assertThat(bookings).hasSize(BookingListHandler.PAGE_SIZE * 2)
+    }
+
+    private fun getSampleBooking(id: Int) = BookingEntity(
+        id = RemoteId(id.toLong()),
+        localSiteId = LocalId(1),
+        start = System.currentTimeMillis(),
+        end = System.currentTimeMillis() + 3600000,
+        allDay = false,
+        status = "confirmed",
+        cost = "100.00",
+        currency = "USD",
+        customerId = 1L,
+        productId = 1L,
+        resourceId = 1L,
+        dateCreated = System.currentTimeMillis(),
+        dateModified = System.currentTimeMillis(),
+        googleCalendarEventId = "",
+        orderId = 1L,
+        orderItemId = 1L,
+        parentId = 0L,
+        personCounts = listOf(1L),
+        localTimezone = "UTC"
+    )
+}

--- a/libs/fluxc-plugin/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/WooResult.kt
+++ b/libs/fluxc-plugin/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/WooResult.kt
@@ -6,7 +6,10 @@ import org.wordpress.android.fluxc.network.rest.Header
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.WooErrorType.GENERIC_ERROR
 import org.wordpress.android.fluxc.store.Store
 
-data class WooPayload<T>(val result: T? = null) : Payload<WooError>() {
+data class WooPayload<T>(
+    val result: T? = null,
+    val headers: List<Header> = emptyList()
+) : Payload<WooError>() {
     constructor(error: WooError) : this() {
         this.error = error
     }
@@ -15,7 +18,7 @@ data class WooPayload<T>(val result: T? = null) : Payload<WooError>() {
 
     fun <R> asWooResult(mapper: (T) -> R): WooResult<R> = when {
         isError -> WooResult(error)
-        result != null -> WooResult(mapper(result))
+        result != null -> WooResult(mapper(result), headers)
         else -> WooResult(WooError(GENERIC_ERROR, UNKNOWN))
     }
 }

--- a/libs/fluxc-plugin/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/bookings/BookingsStore.kt
+++ b/libs/fluxc-plugin/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/bookings/BookingsStore.kt
@@ -52,8 +52,8 @@ class BookingsStore @Inject constructor(
         }
     }
 
-    fun observeBookings(site: SiteModel): Flow<List<BookingEntity>> =
-        bookingsDao.observeBookings(site.localId())
+    fun observeBookings(site: SiteModel, limit: Int? = null): Flow<List<BookingEntity>> =
+        bookingsDao.observeBookings(site.localId(), limit)
 
     private fun BookingDto.toEntity(localSiteId: LocalId): BookingEntity = BookingEntity(
         id = RemoteId(id),

--- a/libs/fluxc-plugin/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/bookings/BookingsStore.kt
+++ b/libs/fluxc-plugin/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/bookings/BookingsStore.kt
@@ -33,6 +33,11 @@ class BookingsStore @Inject constructor(
             when {
                 response.isError -> WooResult(response.error)
                 response.result != null -> {
+                    if (page == 1) {
+                        // Clear existing bookings when fetching the first page
+                        // TODO when supporting filters, we should only clear bookings if no filters are applied
+                        bookingsDao.deleteAllForSite(site.localId())
+                    }
                     val entities = response.result.map { it.toEntity(site.localId()) }
                     bookingsDao.insertOrReplace(entities)
                     val totalPages = headersParser.getTotalPages(response.headers)

--- a/libs/fluxc-plugin/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/bookings/BookingsStore.kt
+++ b/libs/fluxc-plugin/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/bookings/BookingsStore.kt
@@ -11,6 +11,7 @@ import org.wordpress.android.fluxc.network.rest.wpcom.wc.WooResult
 import org.wordpress.android.fluxc.persistence.dao.BookingsDao
 import org.wordpress.android.fluxc.persistence.entity.BookingEntity
 import org.wordpress.android.fluxc.tools.CoroutineEngine
+import org.wordpress.android.fluxc.utils.HeadersParser
 import org.wordpress.android.util.AppLog
 import javax.inject.Inject
 import javax.inject.Singleton
@@ -19,13 +20,14 @@ import javax.inject.Singleton
 class BookingsStore @Inject constructor(
     private val bookingsRestClient: BookingsRestClient,
     private val bookingsDao: BookingsDao,
+    private val headersParser: HeadersParser,
     private val coroutineEngine: CoroutineEngine,
 ) {
     suspend fun fetchBookings(
         site: SiteModel,
         perPage: Int = BookingsRestClient.DEFAULT_PER_PAGE,
         page: Int = 1
-    ): WooResult<List<BookingEntity>> {
+    ): WooResult<Boolean> {
         return coroutineEngine.withDefaultContext(AppLog.T.API, this, "fetchBookings") {
             val response = bookingsRestClient.fetchBookings(site, perPage, page)
             when {
@@ -33,7 +35,11 @@ class BookingsStore @Inject constructor(
                 response.result != null -> {
                     val entities = response.result.map { it.toEntity(site.localId()) }
                     bookingsDao.insertOrReplace(entities)
-                    WooResult(entities)
+                    val totalPages = headersParser.getTotalPages(response.headers)
+                    // Determine if we can load more from the total pages header if available, otherwise
+                    // infer it from the number of items returned
+                    val canLoadMore = (totalPages?.let { it > page }) ?: (entities.size == perPage)
+                    WooResult(canLoadMore)
                 }
 
                 else -> WooResult(WooError(GENERIC_ERROR, UNKNOWN))

--- a/libs/fluxc-plugin/src/main/kotlin/org/wordpress/android/fluxc/persistence/dao/BookingsDao.kt
+++ b/libs/fluxc-plugin/src/main/kotlin/org/wordpress/android/fluxc/persistence/dao/BookingsDao.kt
@@ -10,8 +10,10 @@ import org.wordpress.android.fluxc.persistence.entity.BookingEntity
 
 @Dao
 interface BookingsDao {
-    @Query("SELECT * FROM Bookings WHERE localSiteId = :localSiteId ORDER BY dateCreated DESC")
-    fun observeBookings(localSiteId: LocalId): Flow<List<BookingEntity>>
+    @Query("""SELECT * FROM Bookings WHERE localSiteId = :localSiteId
+        ORDER BY dateCreated DESC
+        LIMIT CASE WHEN :limit IS NULL THEN -1 ELSE :limit END""")
+    fun observeBookings(localSiteId: LocalId, limit: Int?): Flow<List<BookingEntity>>
 
     @Query("SELECT * FROM Bookings WHERE localSiteId = :localSiteId ORDER BY dateCreated DESC")
     suspend fun getBookings(localSiteId: LocalId): List<BookingEntity>

--- a/libs/fluxc-plugin/src/main/kotlin/org/wordpress/android/fluxc/persistence/dao/BookingsDao.kt
+++ b/libs/fluxc-plugin/src/main/kotlin/org/wordpress/android/fluxc/persistence/dao/BookingsDao.kt
@@ -21,4 +21,7 @@ interface BookingsDao {
 
     @Insert(onConflict = OnConflictStrategy.REPLACE)
     suspend fun insertOrReplace(entities: List<BookingEntity>)
+
+    @Query("DELETE FROM Bookings WHERE localSiteId = :localSiteId")
+    suspend fun deleteAllForSite(localSiteId: LocalId)
 }

--- a/libs/fluxc-plugin/src/main/kotlin/org/wordpress/android/fluxc/utils/HeadersParser.kt
+++ b/libs/fluxc-plugin/src/main/kotlin/org/wordpress/android/fluxc/utils/HeadersParser.kt
@@ -1,5 +1,6 @@
 package org.wordpress.android.fluxc.utils
 
+import org.wordpress.android.fluxc.network.rest.Header
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.WooResult
 import org.wordpress.android.util.AppLog
 import javax.inject.Inject
@@ -12,15 +13,19 @@ class HeadersParser @Inject constructor(
         private const val SERVER_DATE_HEADER = "date"
     }
 
-    fun <T> getTotalPages(result: WooResult<T>): Int? {
+    fun getTotalPages(headers: List<Header>): Int? {
         return try {
-            result.headers
+            headers
                 .findLast { TOTAL_PAGES_HEADER.equals(it.key, ignoreCase = true) }
                 ?.value?.toInt()
         } catch (e: NumberFormatException) {
             logger.e(AppLog.T.API, "Failed to parse total pages from headers", e)
             null
         }
+    }
+
+    fun <T> getTotalPages(result: WooResult<T>): Int? {
+        return getTotalPages(result.headers)
     }
 
     fun <T> getServerDate(response: WooResult<T>): String? = response.headers


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

<!-- Id number of the Linear issue this PR addresses, e.g., WOOMOB-373. -->
Closes WOOMOB-1359

### Description
This PR adds logic to handle the pagination for bookings, to keep things simple, I followed the same approach we used for the other Compose screens, so I added a new component `BookingListHandler` that encapsulates the pagination logic, for now it supports basic fetching, with a stub function for search, and when supporting sorting and filtering, we'll update it as needed.

### Steps to reproduce
1. Use a CIAB site.
2. Manually install the bookings plugin from this ZIP file: p1758531103469849/1758101141.913349-slack-C03L1NF1EA3
3. You'll need to enable bookings v2 on your CIAB testing site. You can do that by installing the Code [Snippets plugin](https://wordpress.org/plugins/code-snippets/) to your site and adding the following PHP snippet: `define( 'WC_BOOKINGS_NEXT_ENABLED', true );`
4. Create at least 30 bookings (Sorry, but I'm not aware of any way to generate them, so you need to do it manually, the only tip I can share to make this easier, is that when adding a booking from `wp-admin`, on the second step where we choose the date and duration, you can command + click the "Add booking" button to offload the creation to a new tab, and stay on the screen to create another one, then repeat)
5. Optionally: modify the code to reduce the `BookingListHandler#PAGE_SIZE` to a smaller number, just make sure the number is big enough to fill the screen to make sure the basic Compose logic we use in `InfiniteListHandler` still works.
6. Open the bookings tab.

### Testing information
- Confirm the bookings are fetched, and pagination works.
- Confirm that we show the first page from the DB cache when re-opening the screen, while refreshing the data in background.

### The tests that have been performed
The above.

### Images/gif

https://github.com/user-attachments/assets/01e8de00-8612-4aa4-8682-2ad481ac1d13


- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->