### PR TITLE
[WOOMOB-1378] "Trash Product" option invisible after creating the product

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/stock/DashboardProductStockCard.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/stock/DashboardProductStockCard.kt
@@ -85,7 +85,6 @@ private fun HandleEvents(event: LiveData<Event>) {
                 is OpenProductDetail -> navController.navigateSafely(
                     NavGraphMainDirections.actionGlobalProductDetailFragment(
                         mode = ShowProduct(event.productId),
-                        isTrashEnabled = false
                     )
                 )
             }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/topperformers/DashboardTopPerformersWidgetCard.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/topperformers/DashboardTopPerformersWidgetCard.kt
@@ -165,7 +165,6 @@ private fun HandleEvents(
                 is OpenTopPerformer -> navController.navigateSafely(
                     NavGraphMainDirections.actionGlobalProductDetailFragment(
                         mode = ShowProduct(event.productId),
-                        isTrashEnabled = false
                     )
                 )
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/main/MainActivity.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/main/MainActivity.kt
@@ -1021,27 +1021,24 @@ class MainActivity :
         restart()
     }
 
-    override fun showProductDetail(remoteProductId: Long, enableTrash: Boolean, popUpToProductList: Boolean) {
+    override fun showProductDetail(remoteProductId: Long, popUpToProductList: Boolean) {
         val action = when (popUpToProductList) {
             true -> NavGraphMainDirections.actionGlobalProductDetailFragmentPopUpToProductList(
                 mode = ProductDetailFragment.Mode.ShowProduct(remoteProductId),
-                isTrashEnabled = enableTrash
             )
             else -> NavGraphMainDirections.actionGlobalProductDetailFragment(
                 mode = ProductDetailFragment.Mode.ShowProduct(remoteProductId),
-                isTrashEnabled = enableTrash
             )
         }
         navController.navigateSafely(action)
     }
 
-    override fun showProductDetailWithSharedTransition(remoteProductId: Long, sharedView: View, enableTrash: Boolean) {
+    override fun showProductDetailWithSharedTransition(remoteProductId: Long, sharedView: View) {
         val productCardDetailTransitionName = getString(R.string.product_card_detail_transition_name)
         val extras = FragmentNavigatorExtras(sharedView to productCardDetailTransitionName)
 
         val action = NavGraphMainDirections.actionGlobalProductDetailFragment(
             mode = ProductDetailFragment.Mode.ShowProduct(remoteProductId),
-            isTrashEnabled = enableTrash
         )
         navController.navigateSafely(directions = action, extras = extras)
     }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/main/MainNavigationRouter.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/main/MainNavigationRouter.kt
@@ -7,11 +7,10 @@ interface MainNavigationRouter {
     fun isAtNavigationRoot(): Boolean
     fun isChildFragmentShowing(): Boolean
 
-    fun showProductDetail(remoteProductId: Long, enableTrash: Boolean = false, popUpToProductList: Boolean = false)
+    fun showProductDetail(remoteProductId: Long, popUpToProductList: Boolean = false)
     fun showProductDetailWithSharedTransition(
         remoteProductId: Long,
         sharedView: View,
-        enableTrash: Boolean = false
     )
     fun showProductVariationDetail(remoteProductId: Long, remoteVariationId: Long)
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/details/ProductDetailFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/details/ProductDetailFragment.kt
@@ -132,8 +132,7 @@ class ProductDetailFragment :
     override val activityAppBarStatus: AppBarStatus
         get() = AppBarStatus.Hidden
 
-    @Inject
-    lateinit var crashLogging: CrashLogging
+    @Inject lateinit var crashLogging: CrashLogging
 
     private val productsCommunicationViewModel: ProductsCommunicationViewModel by activityViewModels()
 
@@ -400,7 +399,6 @@ class ProductDetailFragment :
                 is LaunchUrlInChromeTab -> ChromeCustomTabUtils.launchUrl(requireContext(), event.url)
                 is Event.LaunchUrlInAuthenticatedWebView -> findNavController(R.id.nav_host_fragment_main)
                     .navigateSafely(NavGraphMainDirections.actionGlobalAuthenticatedWebViewFragment(event.url))
-
                 is RefreshMenu -> toolbarHelper.setupToolbar()
 
                 is TrashProduct -> {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/details/ProductDetailFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/details/ProductDetailFragment.kt
@@ -132,7 +132,8 @@ class ProductDetailFragment :
     override val activityAppBarStatus: AppBarStatus
         get() = AppBarStatus.Hidden
 
-    @Inject lateinit var crashLogging: CrashLogging
+    @Inject
+    lateinit var crashLogging: CrashLogging
 
     private val productsCommunicationViewModel: ProductsCommunicationViewModel by activityViewModels()
 
@@ -399,6 +400,7 @@ class ProductDetailFragment :
                 is LaunchUrlInChromeTab -> ChromeCustomTabUtils.launchUrl(requireContext(), event.url)
                 is Event.LaunchUrlInAuthenticatedWebView -> findNavController(R.id.nav_host_fragment_main)
                     .navigateSafely(NavGraphMainDirections.actionGlobalAuthenticatedWebViewFragment(event.url))
+
                 is RefreshMenu -> toolbarHelper.setupToolbar()
 
                 is TrashProduct -> {
@@ -483,7 +485,6 @@ class ProductDetailFragment :
         hideProgressDialog()
         (activity as? MainNavigationRouter)?.showProductDetail(
             remoteProductId = productRemoteId,
-            enableTrash = true,
             popUpToProductList = true
         )
     }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/details/ProductDetailFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/details/ProductDetailFragment.kt
@@ -154,6 +154,9 @@ class ProductDetailFragment :
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
 
+        val isTrashEnabled = findNavController().previousBackStackEntry?.destination?.id == R.id.products
+        viewModel.setTrashActionPossible(isTrashEnabled)
+
         blazeCampaignCreationDispatcher.attachFragment(this, BlazeFlowSource.PRODUCT_DETAIL_PROMOTE_BUTTON)
 
         _binding = FragmentProductDetailBinding.bind(view)

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/details/ProductDetailFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/details/ProductDetailFragment.kt
@@ -47,6 +47,7 @@ import com.woocommerce.android.ui.blaze.creation.BlazeCampaignCreationDispatcher
 import com.woocommerce.android.ui.compose.theme.WooThemeWithBackground
 import com.woocommerce.android.ui.dialog.WooDialog
 import com.woocommerce.android.ui.main.AppBarStatus
+import com.woocommerce.android.ui.main.BottomNavigationPosition
 import com.woocommerce.android.ui.main.MainNavigationRouter
 import com.woocommerce.android.ui.products.BaseProductEditorFragment
 import com.woocommerce.android.ui.products.BaseProductFragment
@@ -132,7 +133,8 @@ class ProductDetailFragment :
     override val activityAppBarStatus: AppBarStatus
         get() = AppBarStatus.Hidden
 
-    @Inject lateinit var crashLogging: CrashLogging
+    @Inject
+    lateinit var crashLogging: CrashLogging
 
     private val productsCommunicationViewModel: ProductsCommunicationViewModel by activityViewModels()
 
@@ -154,7 +156,8 @@ class ProductDetailFragment :
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
 
-        val isTrashEnabled = findNavController().previousBackStackEntry?.destination?.id == R.id.products
+        val isTrashEnabled =
+            findNavController().previousBackStackEntry?.destination?.id == BottomNavigationPosition.PRODUCTS.id
         viewModel.setTrashActionPossible(isTrashEnabled)
 
         blazeCampaignCreationDispatcher.attachFragment(this, BlazeFlowSource.PRODUCT_DETAIL_PROMOTE_BUTTON)
@@ -399,6 +402,7 @@ class ProductDetailFragment :
                 is LaunchUrlInChromeTab -> ChromeCustomTabUtils.launchUrl(requireContext(), event.url)
                 is Event.LaunchUrlInAuthenticatedWebView -> findNavController(R.id.nav_host_fragment_main)
                     .navigateSafely(NavGraphMainDirections.actionGlobalAuthenticatedWebViewFragment(event.url))
+
                 is RefreshMenu -> toolbarHelper.setupToolbar()
 
                 is TrashProduct -> {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/details/ProductDetailViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/details/ProductDetailViewModel.kt
@@ -393,13 +393,6 @@ class ProductDetailViewModel @Inject constructor(
         get() = isAddNewProductFlow && isProductStoredAtSite.not()
 
     /**
-     * Returns boolean value of [navArgs.isTrashEnabled] to determine if the detail fragment should enable
-     * trash menu. Always returns false when we're in the add flow.
-     */
-    val isTrashEnabled: Boolean
-        get() = !isProductUnderCreation && isTrashActionPossibleFlow.value
-
-    /**
      * Provides the currencyCode for views who requires display prices
      */
     val currencyCode: String

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/details/ProductDetailViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/details/ProductDetailViewModel.kt
@@ -181,6 +181,8 @@ class ProductDetailViewModel @Inject constructor(
         parameterRepository.getParameters(KEY_PRODUCT_PARAMETERS, savedState)
     }
 
+    private val isTrashActionPossibleFlow: MutableStateFlow<Boolean> = MutableStateFlow(false)
+
     /**
      * Saving more data than necessary into the SavedState has associated risks which were not known at the time this
      * field was implemented - after we ensure we don't save unnecessary data, we can replace @Suppress("OPT_IN_USAGE")
@@ -325,7 +327,10 @@ class ProductDetailViewModel @Inject constructor(
         .filterNotNull()
         .combine(_hasChanges) { draft, hasChanges ->
             Pair(draft.product, hasChanges)
-        }.map { (productDraft, hasChanges) ->
+        }
+        .combine(isTrashActionPossibleFlow) { (draft, hasChanges), isTrashEnabled ->
+            Triple(draft, hasChanges, isTrashEnabled)
+        }.map { (productDraft, hasChanges, isTrashEnabled) ->
             val canBeSavedAsDraft = this.isAddNewProductFlow &&
                 !isProductStoredAtSite &&
                 productDraft.status != DRAFT
@@ -357,7 +362,7 @@ class ProductDetailViewModel @Inject constructor(
                 viewProductOption = showViewProductOption,
                 shareOption = showShareOption,
                 showShareOptionAsActionWithText = showShareOptionAsActionWithText,
-                trashOption = !isProductUnderCreation && navArgs.isTrashEnabled
+                trashOption = !isProductUnderCreation && isTrashEnabled
             )
         }.asLiveData()
 
@@ -392,7 +397,7 @@ class ProductDetailViewModel @Inject constructor(
      * trash menu. Always returns false when we're in the add flow.
      */
     val isTrashEnabled: Boolean
-        get() = !isProductUnderCreation && navArgs.isTrashEnabled
+        get() = !isProductUnderCreation && isTrashActionPossibleFlow.value
 
     /**
      * Provides the currencyCode for views who requires display prices
@@ -2669,6 +2674,10 @@ class ProductDetailViewModel @Inject constructor(
 
     fun openUploadScreen() {
         triggerEvent(ProductNavigationTarget.ViewMediaUploadErrors(getRemoteProductId()))
+    }
+
+    fun setTrashActionPossible(isTrashActionPossible: Boolean) {
+        isTrashActionPossibleFlow.value = isTrashActionPossible
     }
 
     /**

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/list/ProductListFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/list/ProductListFragment.kt
@@ -375,7 +375,6 @@ class ProductListFragment :
                             productAdapter.notifyItemChanged(event.newPosition)
                             R.id.nav_graph_products to ProductDetailFragmentArgs(
                                 mode = ProductDetailFragment.Mode.ShowProduct(event.productId),
-                                isTrashEnabled = true,
                             ).toBundle()
                         },
                         navigateWithPhoneNavigation = {
@@ -390,7 +389,6 @@ class ProductListFragment :
                         tabletNavigateTo = {
                             R.id.nav_graph_products to ProductDetailFragmentArgs(
                                 mode = ProductDetailFragment.Mode.Empty,
-                                isTrashEnabled = true,
                             ).toBundle()
                         },
                         navigateWithPhoneNavigation = {
@@ -673,9 +671,9 @@ class ProductListFragment :
         productListToolbar.disableSearchListeners()
         (activity as? MainNavigationRouter)?.let { router ->
             if (sharedView == null) {
-                router.showProductDetail(remoteProductId, enableTrash = true)
+                router.showProductDetail(remoteProductId)
             } else {
-                router.showProductDetailWithSharedTransition(remoteProductId, sharedView, enableTrash = true)
+                router.showProductDetailWithSharedTransition(remoteProductId, sharedView)
             }
         }
     }

--- a/WooCommerce/src/main/res/navigation/nav_graph_main.xml
+++ b/WooCommerce/src/main/res/navigation/nav_graph_main.xml
@@ -405,10 +405,6 @@
             android:name="mode"
             app:argType="com.woocommerce.android.ui.products.details.ProductDetailFragment$Mode" />
         <argument
-            android:name="isTrashEnabled"
-            android:defaultValue="false"
-            app:argType="boolean" />
-        <argument
             android:name="images"
             android:defaultValue="@null"
             app:argType="string[]"
@@ -425,10 +421,6 @@
         <argument
             android:name="mode"
             app:argType="com.woocommerce.android.ui.products.details.ProductDetailFragment$Mode" />
-        <argument
-            android:name="isTrashEnabled"
-            android:defaultValue="false"
-            app:argType="boolean" />
         <argument
             android:name="images"
             android:defaultValue="@null"

--- a/WooCommerce/src/main/res/navigation/nav_graph_products.xml
+++ b/WooCommerce/src/main/res/navigation/nav_graph_products.xml
@@ -19,10 +19,6 @@
             android:name="mode"
             app:argType="com.woocommerce.android.ui.products.details.ProductDetailFragment$Mode" />
         <argument
-            android:name="isTrashEnabled"
-            android:defaultValue="false"
-            app:argType="boolean" />
-        <argument
             android:name="images"
             android:defaultValue="@null"
             app:argType="string[]"

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/products/details/ProductDetailViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/products/details/ProductDetailViewModelTest.kt
@@ -1486,4 +1486,33 @@ class ProductDetailViewModelTest : BaseUnitTest() {
         // THEN
         Assertions.assertThat(menuButtonsState.trashOption).isTrue()
     }
+
+    @Test
+    fun `given add new product flow, when product gets stored later and trash possible, then trashOption shown`() = testBlocking {
+        // GIVEN: start in AddNewProduct mode (product under creation)
+        savedState = ProductDetailFragmentArgs(ProductDetailFragment.Mode.AddNewProduct).toSavedStateHandle()
+        // Ensure default product type preferences are provided for the add flow
+        whenever(prefsWrapper.getSelectedProductType()).thenReturn(ProductType.SIMPLE.value)
+        whenever(prefsWrapper.isSelectedProductVirtual()).thenReturn(false)
+        setup()
+
+        // Simulate successful creation on server returning a new remote id
+        val newRemoteId = 1234L
+        val storedAggregate = ProductAggregate(ProductTestUtils.generateProduct(newRemoteId))
+        given(productRepository.addProduct(any<ProductAggregate>())).willReturn(Pair(true, newRemoteId))
+        whenever(productRepository.getProductAggregate(eq(newRemoteId))).thenReturn(storedAggregate)
+        whenever(productRepository.fetchAndGetProductAggregate(eq(newRemoteId))).thenReturn(storedAggregate)
+
+        val menuButtonsStates = viewModel.menuButtonsState.runAndCaptureValues {
+            viewModel.setTrashActionPossible(true)
+            viewModel.start()
+            // Observe the view state to trigger menu buttons state emissions
+            viewModel.productDetailViewStateData.observeForever { _, _ -> }
+            // When: user saves as draft so the product is posted to the server
+            viewModel.onSaveAsDraftButtonClicked()
+        }
+
+        // THEN: once the product is stored, trash option should be visible
+        Assertions.assertThat(menuButtonsStates.last().trashOption).isTrue()
+    }
 }

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/products/details/ProductDetailViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/products/details/ProductDetailViewModelTest.kt
@@ -1434,4 +1434,62 @@ class ProductDetailViewModelTest : BaseUnitTest() {
 
     private val productsDraft
         get() = viewModel.productDetailViewStateData.liveData.value?.productDraft
+
+    @Test
+    fun `given add new product flow, when trash action becomes possible, then trashOption remains hidden`() = testBlocking {
+        // GIVEN: start in AddNewProduct mode (product under creation)
+        savedState = ProductDetailFragmentArgs(ProductDetailFragment.Mode.AddNewProduct).toSavedStateHandle()
+        // Ensure default product type preferences are provided
+        whenever(prefsWrapper.getSelectedProductType()).thenReturn(ProductType.SIMPLE.value)
+        whenever(prefsWrapper.isSelectedProductVirtual()).thenReturn(false)
+        // Recreate VM with the new SavedState
+        setup()
+        // WHEN: start and mark trash action as possible
+        val menuButtonsStates = viewModel.menuButtonsState.runAndCaptureValues {
+            viewModel.start()
+            // Observe the view state to trigger menu buttons state emissions
+            viewModel.productDetailViewStateData.observeForever { _, _ -> }
+            viewModel.setTrashActionPossible(true)
+        }
+        // THEN: trash option must be hidden in add flow regardless of isTrashActionPossible
+        Assertions.assertThat(menuButtonsStates.last().trashOption).isFalse()
+    }
+
+    @Test
+    fun `given existing product, when trash action not possible, then trashOption hidden`() = testBlocking {
+        // GIVEN: existing product (ShowProduct mode)
+        savedState = ProductDetailFragmentArgs(ProductDetailFragment.Mode.ShowProduct(PRODUCT_REMOTE_ID))
+            .toSavedStateHandle()
+        setup()
+        given(productRepository.getProductAggregate(any())).willReturn(productAggregate)
+
+        val menuButtonsState = viewModel.menuButtonsState.runAndCaptureValues {
+            viewModel.start()
+            viewModel.productDetailViewStateData.observeForever { _, _ -> }
+            // Ensure trash action is not possible
+            viewModel.setTrashActionPossible(false)
+        }.last()
+
+        // THEN
+        Assertions.assertThat(menuButtonsState.trashOption).isFalse()
+    }
+
+    @Test
+    fun `given existing product, when trash action possible, then trashOption shown`() = testBlocking {
+        // GIVEN: existing product (ShowProduct mode)
+        savedState = ProductDetailFragmentArgs(ProductDetailFragment.Mode.ShowProduct(PRODUCT_REMOTE_ID))
+            .toSavedStateHandle()
+        setup()
+        given(productRepository.getProductAggregate(any())).willReturn(productAggregate)
+
+        val menuButtonsState = viewModel.menuButtonsState.runAndCaptureValues {
+            viewModel.start()
+            viewModel.productDetailViewStateData.observeForever { _, _ -> }
+            // Make trash action possible
+            viewModel.setTrashActionPossible(true)
+        }.last()
+
+        // THEN
+        Assertions.assertThat(menuButtonsState.trashOption).isTrue()
+    }
 }

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/products/details/ProductDetailViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/products/details/ProductDetailViewModelTest.kt
@@ -659,13 +659,6 @@ class ProductDetailViewModelTest : BaseUnitTest() {
     }
 
     @Test
-    fun `Do not enable trashing a product when in add product flow`() {
-        viewModel.start()
-        doReturn(true).whenever(viewModel).isProductUnderCreation
-        Assertions.assertThat(viewModel.isTrashEnabled).isFalse()
-    }
-
-    @Test
     fun `Display offline message and don't show trash confirmation dialog when not connected`() {
         doReturn(false).whenever(networkStatus).isConnected()
 
@@ -1436,24 +1429,25 @@ class ProductDetailViewModelTest : BaseUnitTest() {
         get() = viewModel.productDetailViewStateData.liveData.value?.productDraft
 
     @Test
-    fun `given add new product flow, when trash action becomes possible, then trashOption remains hidden`() = testBlocking {
-        // GIVEN: start in AddNewProduct mode (product under creation)
-        savedState = ProductDetailFragmentArgs(ProductDetailFragment.Mode.AddNewProduct).toSavedStateHandle()
-        // Ensure default product type preferences are provided
-        whenever(prefsWrapper.getSelectedProductType()).thenReturn(ProductType.SIMPLE.value)
-        whenever(prefsWrapper.isSelectedProductVirtual()).thenReturn(false)
-        // Recreate VM with the new SavedState
-        setup()
-        // WHEN: start and mark trash action as possible
-        val menuButtonsStates = viewModel.menuButtonsState.runAndCaptureValues {
-            viewModel.start()
-            // Observe the view state to trigger menu buttons state emissions
-            viewModel.productDetailViewStateData.observeForever { _, _ -> }
-            viewModel.setTrashActionPossible(true)
+    fun `given add new product flow, when trash action becomes possible, then trashOption remains hidden`() =
+        testBlocking {
+            // GIVEN: start in AddNewProduct mode (product under creation)
+            savedState = ProductDetailFragmentArgs(ProductDetailFragment.Mode.AddNewProduct).toSavedStateHandle()
+            // Ensure default product type preferences are provided
+            whenever(prefsWrapper.getSelectedProductType()).thenReturn(ProductType.SIMPLE.value)
+            whenever(prefsWrapper.isSelectedProductVirtual()).thenReturn(false)
+            // Recreate VM with the new SavedState
+            setup()
+            // WHEN: start and mark trash action as possible
+            val menuButtonsStates = viewModel.menuButtonsState.runAndCaptureValues {
+                viewModel.start()
+                // Observe the view state to trigger menu buttons state emissions
+                viewModel.productDetailViewStateData.observeForever { _, _ -> }
+                viewModel.setTrashActionPossible(true)
+            }
+            // THEN: trash option must be hidden in add flow regardless of isTrashActionPossible
+            Assertions.assertThat(menuButtonsStates.last().trashOption).isFalse()
         }
-        // THEN: trash option must be hidden in add flow regardless of isTrashActionPossible
-        Assertions.assertThat(menuButtonsStates.last().trashOption).isFalse()
-    }
 
     @Test
     fun `given existing product, when trash action not possible, then trashOption hidden`() = testBlocking {

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/products/details/ProductDetailViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/products/details/ProductDetailViewModelTest.kt
@@ -1450,7 +1450,7 @@ class ProductDetailViewModelTest : BaseUnitTest() {
         }
 
     @Test
-    fun `given existing product, when trash action not possible, then trashOption hidden`() = testBlocking {
+    fun `given add new product flow, when product not yet created on server, then trashOption is hidden`() = testBlocking {
         // GIVEN: existing product (ShowProduct mode)
         savedState = ProductDetailFragmentArgs(ProductDetailFragment.Mode.ShowProduct(PRODUCT_REMOTE_ID))
             .toSavedStateHandle()


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

<!-- Id number of the Linear issue this PR addresses, e.g., WOOMOB-373. -->
Closes WOOMOB-1378

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

From the issue description:

>After creating a new product, the “Trash product” button isn’t visible. It only appears after navigating back and reopening the product.

This is cause becase the `trashEnabled` destination argument defaulted to false when the fragment was opened from the bottom sheet. We can't simply change it to `true` because the same bottom sheet is used in other places, and we can only enable that option when the product details screen is opened from the product list screen.
Adding the same value as a bottom sheet destination argument would be an option, but that would create a long chain of passing arguments, because the above-mentioned bottom sheet is opened from yet another bottom sheet.  It would be a pain to write and maintain.

As proposed by @hichamboushaba this PR removed the destination argument completely, and instead checked whether the product list is in the backstack. 


### Steps to reproduce
<!-- Step-by-step testing instructions. For new user flows, consider instead stating the goal of the workflow and see if your PR reviewer can accomplish the workflow without specific steps! -->
1. Open the product list screen
2. Tap on the FAB to create a new product
3. Tap `Add manually`
4. Pick a product type
5. Tap publish
6. Tap on the `...` menu icon 
7. Verify `Trash product` option visibility

### Testing information
The above steps are good to reproduce the bug and verify it's fixed. 

Additionally, it's good to test other entry points for the Product details screen. One example is shown below, where the product is created from the onboarding checklist. 

### The tests that have been performed

1. New product from product list.
2. New product from onboarding checklist.
3. Opening a product from the product list and verifying the option is visible.

### Images/gif
<!-- Include before and after images or gifs when appropriate. -->
Bug

| Before | After |
|---|---|
| ![product_list_flow_before](https://github.com/user-attachments/assets/b5a7a203-57e5-43df-b632-bf2289179124) | ![product_list_flow_after](https://github.com/user-attachments/assets/2183b441-9e97-4aaa-b482-04a3e4d8d6b6) |

Regression test (should be the same):

| Before | After |
|---|---|
| ![onboarding_flow_before](https://github.com/user-attachments/assets/ebb5dd5e-a88c-4751-8f82-fd6676bcca4a) | ![onboarding_flow_after](https://github.com/user-attachments/assets/b9b7160b-773d-4d1f-90c3-cb9eb6e45663) |
| ![existing_product_before](https://github.com/user-attachments/assets/b97852ff-c0cf-485a-938f-17bca06a3f8b) | ![existing_product_after](https://github.com/user-attachments/assets/c5f75d87-b866-463b-a12b-eaf0aaa08fbb) |

- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->