### PR TITLE
[CIAB Bookings] List UI

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/bookings/compose/PaymentStatusTag.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/bookings/compose/PaymentStatusTag.kt
@@ -24,8 +24,19 @@ fun BookingPaymentStatusTag(
     )
 }
 
-enum class BookingPaymentStatus {
-    UNPAID, PENDING_CONFIRMATION, CONFIRMED, PAID, CANCELLED, COMPLETE
+enum class BookingPaymentStatus(val key: String) {
+    UNPAID("unpaid"),
+    PENDING_CONFIRMATION("pending-confirmation"),
+    CONFIRMED("confirmed"),
+    PAID("paid"),
+    CANCELLED("cancelled"),
+    COMPLETE("complete");
+
+    companion object {
+        fun fromKey(key: String): BookingPaymentStatus {
+            return entries.firstOrNull { it.key == key } ?: UNPAID
+        }
+    }
 }
 
 @Composable

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/bookings/list/BookingListFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/bookings/list/BookingListFragment.kt
@@ -10,6 +10,7 @@ import com.woocommerce.android.ui.base.TopLevelFragment
 import com.woocommerce.android.ui.compose.composeView
 import com.woocommerce.android.ui.main.AppBarStatus
 import dagger.hilt.android.AndroidEntryPoint
+import org.wordpress.android.util.ToastUtils
 
 @AndroidEntryPoint
 class BookingListFragment : TopLevelFragment() {
@@ -27,6 +28,21 @@ class BookingListFragment : TopLevelFragment() {
     override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View {
         return composeView {
             BookingListScreen(viewModel)
+        }
+    }
+
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        handleEvents()
+    }
+
+    private fun handleEvents() {
+        viewModel.event.observe(viewLifecycleOwner) { event ->
+            when (event) {
+                is BookingListViewModel.NavigateToBookingDetails -> {
+                    // TODO navigate to booking details screen
+                    ToastUtils.showToast(requireContext(), "Navigate to booking ${event.bookingId}")
+                }
+            }
         }
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/bookings/list/BookingListFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/bookings/list/BookingListFragment.kt
@@ -1,4 +1,4 @@
-package com.woocommerce.android.ui.bookings
+package com.woocommerce.android.ui.bookings.list
 
 import android.os.Bundle
 import android.view.LayoutInflater

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/bookings/list/BookingListFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/bookings/list/BookingListFragment.kt
@@ -7,23 +7,29 @@ import android.view.ViewGroup
 import androidx.fragment.app.viewModels
 import com.woocommerce.android.R
 import com.woocommerce.android.ui.base.TopLevelFragment
+import com.woocommerce.android.ui.base.UIMessageResolver
 import com.woocommerce.android.ui.compose.composeView
 import com.woocommerce.android.ui.main.AppBarStatus
+import com.woocommerce.android.viewmodel.MultiLiveEvent
 import dagger.hilt.android.AndroidEntryPoint
 import org.wordpress.android.util.ToastUtils
+import javax.inject.Inject
 
 @AndroidEntryPoint
 class BookingListFragment : TopLevelFragment() {
     override val activityAppBarStatus: AppBarStatus
         get() = AppBarStatus.Hidden
 
+    private val viewModel: BookingListViewModel by viewModels()
+
+    @Inject
+    lateinit var uiMessageResolver: UIMessageResolver
+
     override fun getFragmentTitle() = getString(R.string.bookings_tab_title)
     override fun shouldExpandToolbar(): Boolean = false
     override fun scrollToTop() {
         return
     }
-
-    private val viewModel: BookingListViewModel by viewModels()
 
     override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View {
         return composeView {
@@ -42,6 +48,7 @@ class BookingListFragment : TopLevelFragment() {
                     // TODO navigate to booking details screen
                     ToastUtils.showToast(requireContext(), "Navigate to booking ${event.bookingId}")
                 }
+                is MultiLiveEvent.Event.ShowSnackbar -> uiMessageResolver.showSnack(event.message)
             }
         }
     }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/bookings/list/BookingListHandler.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/bookings/list/BookingListHandler.kt
@@ -1,6 +1,8 @@
-package com.woocommerce.android.ui.bookings
+package com.woocommerce.android.ui.bookings.list
 
 import androidx.annotation.VisibleForTesting
+import com.woocommerce.android.ui.bookings.Booking
+import com.woocommerce.android.ui.bookings.BookingsRepository
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/bookings/list/BookingListScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/bookings/list/BookingListScreen.kt
@@ -1,6 +1,5 @@
 package com.woocommerce.android.ui.bookings.list
 
-import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
@@ -13,7 +12,6 @@ import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.HorizontalDivider
-import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
 import androidx.compose.material3.pulltorefresh.rememberPullToRefreshState
@@ -51,7 +49,9 @@ fun BookingListScreen(state: BookingListViewState) {
             state.bookings.isNotEmpty() -> {
                 BookingList(
                     state = state,
-                    modifier = Modifier.padding(paddingValues)
+                    modifier = Modifier
+                        .padding(paddingValues)
+                        .fillMaxSize()
                 )
             }
 
@@ -94,7 +94,7 @@ private fun BookingList(
         LazyColumn(
             state = listState,
             modifier = Modifier
-                .background(color = MaterialTheme.colorScheme.surface)
+                .fillMaxSize()
         ) {
             itemsIndexed(state.bookings) { _, booking ->
                 BookingSummary(
@@ -130,7 +130,7 @@ private fun BookingListPreview() {
     WooThemeWithBackground {
         BookingListScreen(
             state = BookingListViewState(
-                bookings = List(20) {
+                bookings = List(3) {
                     BookingListItem(
                         id = it.toLong(),
                         summary = com.woocommerce.android.ui.bookings.compose.BookingSummaryModel(

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/bookings/list/BookingListScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/bookings/list/BookingListScreen.kt
@@ -1,4 +1,4 @@
-package com.woocommerce.android.ui.bookings
+package com.woocommerce.android.ui.bookings.list
 
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.fillMaxSize
@@ -20,6 +20,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.livedata.observeAsState
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
+import com.woocommerce.android.ui.bookings.Booking
 import com.woocommerce.android.ui.compose.component.InfiniteListHandler
 
 @Composable

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/bookings/list/BookingListScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/bookings/list/BookingListScreen.kt
@@ -13,14 +13,18 @@ import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
 import androidx.compose.material3.pulltorefresh.PullToRefreshBox
 import androidx.compose.material3.pulltorefresh.rememberPullToRefreshState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.livedata.observeAsState
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
+import com.woocommerce.android.R
 import com.woocommerce.android.ui.compose.component.InfiniteListHandler
+import com.woocommerce.android.ui.compose.component.Toolbar
 
 @Composable
 fun BookingListScreen(viewModel: BookingListViewModel) {
@@ -31,33 +35,44 @@ fun BookingListScreen(viewModel: BookingListViewModel) {
 
 @Composable
 fun BookingListScreen(state: BookingListViewState) {
-    when {
-        state.bookings.isNotEmpty() -> {
-            BookingList(
-                bookings = state.bookings,
-                onRefresh = state.onRefresh,
-                onLoadMore = state.onLoadMore,
-                loadingState = state.loadingState,
+    Scaffold(
+        topBar = {
+            Toolbar(
+                title = stringResource(R.string.bookings_tab_title),
+                navigationIcon = null
             )
         }
+    ) { paddingValues ->
+        when {
+            state.bookings.isNotEmpty() -> {
+                BookingList(
+                    bookings = state.bookings,
+                    onRefresh = state.onRefresh,
+                    onLoadMore = state.onLoadMore,
+                    loadingState = state.loadingState,
+                    modifier = Modifier.padding(paddingValues)
+                )
+            }
 
-        state.loadingState == BookingListViewState.LoadingState.Loading -> {
-            // TODO replace with shimmer
-            CircularProgressIndicator(
-                modifier = Modifier
-                    .fillMaxSize()
-                    .wrapContentSize()
-            )
-        }
+            state.loadingState == BookingListViewState.LoadingState.Loading -> {
+                // TODO replace with shimmer
+                CircularProgressIndicator(
+                    modifier = Modifier
+                        .padding(paddingValues)
+                        .fillMaxSize()
+                        .wrapContentSize()
+                )
+            }
 
-        else -> {
-            // TODO replace with empty state
-            Text(
-                text = "No bookings found",
-                modifier = Modifier
-                    .fillMaxSize()
-                    .wrapContentSize()
-            )
+            else -> {
+                // TODO replace with empty state
+                Text(
+                    text = "No bookings found",
+                    modifier = Modifier
+                        .padding(paddingValues)
+                        .wrapContentSize()
+                )
+            }
         }
     }
 }
@@ -68,12 +83,14 @@ private fun BookingList(
     bookings: List<BookingListItem>,
     onRefresh: () -> Unit,
     onLoadMore: () -> Unit,
-    loadingState: BookingListViewState.LoadingState
+    loadingState: BookingListViewState.LoadingState,
+    modifier: Modifier = Modifier
 ) {
     PullToRefreshBox(
         isRefreshing = loadingState == BookingListViewState.LoadingState.Refreshing,
         onRefresh = onRefresh,
-        state = rememberPullToRefreshState()
+        state = rememberPullToRefreshState(),
+        modifier = modifier
     ) {
         val listState = rememberLazyListState()
         LazyColumn(

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/bookings/list/BookingListScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/bookings/list/BookingListScreen.kt
@@ -103,7 +103,9 @@ private fun BookingList(
                         .fillMaxWidth()
                         .clickable(onClick = { state.onBookingClick(booking.id) })
                 )
-                HorizontalDivider()
+                HorizontalDivider(
+                    Modifier.padding(start = 16.dp)
+                )
             }
 
             if (state.loadingState == BookingListViewState.LoadingState.Appending) {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/bookings/list/BookingListScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/bookings/list/BookingListScreen.kt
@@ -15,7 +15,6 @@ import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
-import androidx.compose.material3.pulltorefresh.PullToRefreshBox
 import androidx.compose.material3.pulltorefresh.rememberPullToRefreshState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.livedata.observeAsState
@@ -26,6 +25,7 @@ import com.woocommerce.android.R
 import com.woocommerce.android.ui.bookings.compose.BookingSummary
 import com.woocommerce.android.ui.compose.component.InfiniteListHandler
 import com.woocommerce.android.ui.compose.component.Toolbar
+import com.woocommerce.android.ui.compose.component.WCPullToRefreshBox
 import com.woocommerce.android.ui.compose.preview.LightDarkThemePreviews
 import com.woocommerce.android.ui.compose.theme.WooThemeWithBackground
 
@@ -89,7 +89,7 @@ private fun BookingList(
     loadingState: BookingListViewState.LoadingState,
     modifier: Modifier = Modifier
 ) {
-    PullToRefreshBox(
+    WCPullToRefreshBox(
         isRefreshing = loadingState == BookingListViewState.LoadingState.Refreshing,
         onRefresh = onRefresh,
         state = rememberPullToRefreshState(),

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/bookings/list/BookingListScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/bookings/list/BookingListScreen.kt
@@ -1,6 +1,7 @@
 package com.woocommerce.android.ui.bookings.list
 
 import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
@@ -49,10 +50,7 @@ fun BookingListScreen(state: BookingListViewState) {
         when {
             state.bookings.isNotEmpty() -> {
                 BookingList(
-                    bookings = state.bookings,
-                    onRefresh = state.onRefresh,
-                    onLoadMore = state.onLoadMore,
-                    loadingState = state.loadingState,
+                    state = state,
                     modifier = Modifier.padding(paddingValues)
                 )
             }
@@ -83,15 +81,12 @@ fun BookingListScreen(state: BookingListViewState) {
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 private fun BookingList(
-    bookings: List<BookingListItem>,
-    onRefresh: () -> Unit,
-    onLoadMore: () -> Unit,
-    loadingState: BookingListViewState.LoadingState,
+    state: BookingListViewState,
     modifier: Modifier = Modifier
 ) {
     WCPullToRefreshBox(
-        isRefreshing = loadingState == BookingListViewState.LoadingState.Refreshing,
-        onRefresh = onRefresh,
+        isRefreshing = state.loadingState == BookingListViewState.LoadingState.Refreshing,
+        onRefresh = state.onRefresh,
         state = rememberPullToRefreshState(),
         modifier = modifier
     ) {
@@ -101,15 +96,17 @@ private fun BookingList(
             modifier = Modifier
                 .background(color = MaterialTheme.colorScheme.surface)
         ) {
-            itemsIndexed(bookings) { _, booking ->
+            itemsIndexed(state.bookings) { _, booking ->
                 BookingSummary(
                     model = booking.summary,
-                    modifier = Modifier.fillMaxWidth()
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .clickable(onClick = { state.onBookingClick(booking.id) })
                 )
                 HorizontalDivider()
             }
 
-            if (loadingState == BookingListViewState.LoadingState.Appending) {
+            if (state.loadingState == BookingListViewState.LoadingState.Appending) {
                 item {
                     CircularProgressIndicator(
                         modifier = Modifier
@@ -121,9 +118,7 @@ private fun BookingList(
             }
         }
 
-        InfiniteListHandler(listState = listState) {
-            onLoadMore()
-        }
+        InfiniteListHandler(listState = listState, onLoadMore = state.onLoadMore)
     }
 }
 
@@ -147,7 +142,8 @@ private fun BookingListPreview() {
                 },
                 loadingState = BookingListViewState.LoadingState.Idle,
                 onRefresh = {},
-                onLoadMore = {}
+                onLoadMore = {},
+                onBookingClick = {}
             )
         )
     }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/bookings/list/BookingListScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/bookings/list/BookingListScreen.kt
@@ -23,8 +23,11 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import com.woocommerce.android.R
+import com.woocommerce.android.ui.bookings.compose.BookingSummary
 import com.woocommerce.android.ui.compose.component.InfiniteListHandler
 import com.woocommerce.android.ui.compose.component.Toolbar
+import com.woocommerce.android.ui.compose.preview.LightDarkThemePreviews
+import com.woocommerce.android.ui.compose.theme.WooThemeWithBackground
 
 @Composable
 fun BookingListScreen(viewModel: BookingListViewModel) {
@@ -99,9 +102,9 @@ private fun BookingList(
                 .background(color = MaterialTheme.colorScheme.surface)
         ) {
             itemsIndexed(bookings) { _, booking ->
-                Text(
-                    text = "Booking #${booking.id}",
-                    modifier = Modifier.padding(16.dp)
+                BookingSummary(
+                    model = booking.summary,
+                    modifier = Modifier.fillMaxWidth()
                 )
                 HorizontalDivider()
             }
@@ -121,5 +124,31 @@ private fun BookingList(
         InfiniteListHandler(listState = listState) {
             onLoadMore()
         }
+    }
+}
+
+@Composable
+@LightDarkThemePreviews
+private fun BookingListPreview() {
+    WooThemeWithBackground {
+        BookingListScreen(
+            state = BookingListViewState(
+                bookings = List(20) {
+                    BookingListItem(
+                        id = it.toLong(),
+                        summary = com.woocommerce.android.ui.bookings.compose.BookingSummaryModel(
+                            date = "Aug 20, 2024",
+                            name = "Women’s Haircut",
+                            customerName = "Margarita Nikolaevna",
+                            attendanceStatus = com.woocommerce.android.ui.bookings.compose.AttendanceStatus.BOOKED,
+                            paymentStatus = com.woocommerce.android.ui.bookings.compose.BookingPaymentStatus.PAID
+                        )
+                    )
+                },
+                loadingState = BookingListViewState.LoadingState.Idle,
+                onRefresh = {},
+                onLoadMore = {}
+            )
+        )
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/bookings/list/BookingListScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/bookings/list/BookingListScreen.kt
@@ -20,7 +20,6 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.livedata.observeAsState
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
-import com.woocommerce.android.ui.bookings.Booking
 import com.woocommerce.android.ui.compose.component.InfiniteListHandler
 
 @Composable
@@ -31,7 +30,7 @@ fun BookingListScreen(viewModel: BookingListViewModel) {
 }
 
 @Composable
-fun BookingListScreen(state: BookingListViewModel.State) {
+fun BookingListScreen(state: BookingListViewState) {
     when {
         state.bookings.isNotEmpty() -> {
             BookingList(
@@ -42,7 +41,7 @@ fun BookingListScreen(state: BookingListViewModel.State) {
             )
         }
 
-        state.loadingState == BookingListViewModel.LoadingState.Loading -> {
+        state.loadingState == BookingListViewState.LoadingState.Loading -> {
             // TODO replace with shimmer
             CircularProgressIndicator(
                 modifier = Modifier
@@ -66,13 +65,13 @@ fun BookingListScreen(state: BookingListViewModel.State) {
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 private fun BookingList(
-    bookings: List<Booking>,
+    bookings: List<BookingListItem>,
     onRefresh: () -> Unit,
     onLoadMore: () -> Unit,
-    loadingState: BookingListViewModel.LoadingState
+    loadingState: BookingListViewState.LoadingState
 ) {
     PullToRefreshBox(
-        isRefreshing = loadingState == BookingListViewModel.LoadingState.Refreshing,
+        isRefreshing = loadingState == BookingListViewState.LoadingState.Refreshing,
         onRefresh = onRefresh,
         state = rememberPullToRefreshState()
     ) {
@@ -84,13 +83,13 @@ private fun BookingList(
         ) {
             itemsIndexed(bookings) { _, booking ->
                 Text(
-                    text = "Booking #${booking.id.value}",
+                    text = "Booking #${booking.id}",
                     modifier = Modifier.padding(16.dp)
                 )
                 HorizontalDivider()
             }
 
-            if (loadingState == BookingListViewModel.LoadingState.Appending) {
+            if (loadingState == BookingListViewState.LoadingState.Appending) {
                 item {
                     CircularProgressIndicator(
                         modifier = Modifier

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/bookings/list/BookingListViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/bookings/list/BookingListViewModel.kt
@@ -2,6 +2,7 @@ package com.woocommerce.android.ui.bookings.list
 
 import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.asLiveData
+import com.woocommerce.android.viewmodel.MultiLiveEvent
 import com.woocommerce.android.viewmodel.ScopedViewModel
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.Job
@@ -28,7 +29,8 @@ class BookingListViewModel @Inject constructor(
             bookings = bookings,
             loadingState = loadingState,
             onRefresh = { fetchBookings(BookingListViewState.LoadingState.Refreshing) },
-            onLoadMore = { loadMore() }
+            onLoadMore = ::loadMore,
+            onBookingClick = ::onBookingClick
         )
     }.asLiveData()
 
@@ -61,4 +63,10 @@ class BookingListViewModel @Inject constructor(
             loadingState.value = BookingListViewState.LoadingState.Idle
         }
     }
+
+    private fun onBookingClick(bookingId: Long) {
+        triggerEvent(NavigateToBookingDetails(bookingId))
+    }
+
+    data class NavigateToBookingDetails(val bookingId: Long) : MultiLiveEvent.Event()
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/bookings/list/BookingListViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/bookings/list/BookingListViewModel.kt
@@ -1,7 +1,8 @@
-package com.woocommerce.android.ui.bookings
+package com.woocommerce.android.ui.bookings.list
 
 import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.asLiveData
+import com.woocommerce.android.ui.bookings.Booking
 import com.woocommerce.android.viewmodel.ScopedViewModel
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.Job

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/bookings/list/BookingListViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/bookings/list/BookingListViewModel.kt
@@ -2,6 +2,7 @@ package com.woocommerce.android.ui.bookings.list
 
 import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.asLiveData
+import com.woocommerce.android.R
 import com.woocommerce.android.viewmodel.MultiLiveEvent
 import com.woocommerce.android.viewmodel.ScopedViewModel
 import dagger.hilt.android.lifecycle.HiltViewModel
@@ -44,7 +45,7 @@ class BookingListViewModel @Inject constructor(
             loadingState.value = initialLoadingState
             bookingListHandler.loadBookings(forceRefresh = true)
                 .onFailure {
-                    // Show error message
+                    triggerEvent(MultiLiveEvent.Event.ShowSnackbar(R.string.bookings_fetch_error))
                 }
             loadingState.value = BookingListViewState.LoadingState.Idle
         }
@@ -58,7 +59,7 @@ class BookingListViewModel @Inject constructor(
             loadingState.value = BookingListViewState.LoadingState.Appending
             bookingListHandler.loadMore()
                 .onFailure {
-                    // Show error message
+                    triggerEvent(MultiLiveEvent.Event.ShowSnackbar(R.string.bookings_fetch_error))
                 }
             loadingState.value = BookingListViewState.LoadingState.Idle
         }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/bookings/list/BookingListViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/bookings/list/BookingListViewModel.kt
@@ -2,12 +2,12 @@ package com.woocommerce.android.ui.bookings.list
 
 import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.asLiveData
-import com.woocommerce.android.ui.bookings.Booking
 import com.woocommerce.android.viewmodel.ScopedViewModel
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.launch
 import javax.inject.Inject
 
@@ -16,27 +16,27 @@ class BookingListViewModel @Inject constructor(
     savedStateHandle: SavedStateHandle,
     private val bookingListHandler: BookingListHandler
 ) : ScopedViewModel(savedStateHandle) {
-    private val loadingState = MutableStateFlow(LoadingState.Idle)
+    private val loadingState = MutableStateFlow(BookingListViewState.LoadingState.Idle)
 
     private var bookingsFetchJob: Job? = null
 
     val state = combine(
-        bookingListHandler.bookingsFlow,
+        bookingListHandler.bookingsFlow.map { bookings -> bookings.map { it.toUiModel() } },
         loadingState,
     ) { bookings, loadingState ->
-        State(
+        BookingListViewState(
             bookings = bookings,
             loadingState = loadingState,
-            onRefresh = { fetchBookings(LoadingState.Refreshing) },
+            onRefresh = { fetchBookings(BookingListViewState.LoadingState.Refreshing) },
             onLoadMore = { loadMore() }
         )
     }.asLiveData()
 
     init {
-        fetchBookings(initialLoadingState = LoadingState.Loading)
+        fetchBookings(initialLoadingState = BookingListViewState.LoadingState.Loading)
     }
 
-    private fun fetchBookings(initialLoadingState: LoadingState) {
+    private fun fetchBookings(initialLoadingState: BookingListViewState.LoadingState) {
         bookingsFetchJob?.cancel()
         bookingsFetchJob = launch {
             loadingState.value = initialLoadingState
@@ -44,7 +44,7 @@ class BookingListViewModel @Inject constructor(
                 .onFailure {
                     // Show error message
                 }
-            loadingState.value = LoadingState.Idle
+            loadingState.value = BookingListViewState.LoadingState.Idle
         }
     }
 
@@ -53,23 +53,12 @@ class BookingListViewModel @Inject constructor(
             // If a fetch is already in progress, wait for it to complete before loading more
             bookingsFetchJob?.join()
 
-            loadingState.value = LoadingState.Appending
+            loadingState.value = BookingListViewState.LoadingState.Appending
             bookingListHandler.loadMore()
                 .onFailure {
                     // Show error message
                 }
-            loadingState.value = LoadingState.Idle
+            loadingState.value = BookingListViewState.LoadingState.Idle
         }
-    }
-
-    data class State(
-        val bookings: List<Booking>, // To be replaced with Ui model
-        val loadingState: LoadingState,
-        val onRefresh: () -> Unit,
-        val onLoadMore: () -> Unit
-    )
-
-    enum class LoadingState {
-        Idle, Loading, Refreshing, Appending
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/bookings/list/BookingListViewState.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/bookings/list/BookingListViewState.kt
@@ -1,0 +1,42 @@
+package com.woocommerce.android.ui.bookings.list
+
+import com.woocommerce.android.ui.bookings.Booking
+import com.woocommerce.android.ui.bookings.compose.AttendanceStatus
+import com.woocommerce.android.ui.bookings.compose.BookingPaymentStatus
+import com.woocommerce.android.ui.bookings.compose.BookingSummaryModel
+import java.text.SimpleDateFormat
+import java.util.Date
+
+data class BookingListViewState(
+    val bookings: List<BookingListItem>,
+    val loadingState: LoadingState,
+    val onRefresh: () -> Unit,
+    val onLoadMore: () -> Unit
+) {
+    enum class LoadingState {
+        Idle, Loading, Refreshing, Appending
+    }
+}
+
+data class BookingListItem(
+    val id: Long,
+    val summary: BookingSummaryModel
+)
+
+fun Booking.toUiModel(): BookingListItem {
+    val dateFormatter = SimpleDateFormat.getDateTimeInstance(
+        SimpleDateFormat.MEDIUM,
+        SimpleDateFormat.SHORT
+    )
+
+    return BookingListItem(
+        id = id.value,
+        summary = BookingSummaryModel(
+            date = dateFormatter.format(Date(start * 1000)),
+            name = "Women’s Haircut",
+            customerName = "Margarita Nikolaevna",
+            attendanceStatus = AttendanceStatus.BOOKED,
+            paymentStatus = BookingPaymentStatus.valueOf(status.uppercase())
+        )
+    )
+}

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/bookings/list/BookingListViewState.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/bookings/list/BookingListViewState.kt
@@ -11,7 +11,8 @@ data class BookingListViewState(
     val bookings: List<BookingListItem>,
     val loadingState: LoadingState,
     val onRefresh: () -> Unit,
-    val onLoadMore: () -> Unit
+    val onLoadMore: () -> Unit,
+    val onBookingClick: (Long) -> Unit
 ) {
     enum class LoadingState {
         Idle, Loading, Refreshing, Appending

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/bookings/list/BookingListViewState.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/bookings/list/BookingListViewState.kt
@@ -39,7 +39,7 @@ fun Booking.toUiModel(): BookingListItem {
             name = "Women’s Haircut",
             customerName = "Margarita Nikolaevna",
             attendanceStatus = AttendanceStatus.BOOKED,
-            paymentStatus = BookingPaymentStatus.valueOf(status.uppercase())
+            paymentStatus = BookingPaymentStatus.fromKey(status)
         )
     )
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/bookings/list/BookingListViewState.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/bookings/list/BookingListViewState.kt
@@ -31,6 +31,7 @@ fun Booking.toUiModel(): BookingListItem {
         FormatStyle.SHORT
     ).withZone(ZoneId.systemDefault())
 
+    // TODO replace the mocked details with real data when available from the API
     return BookingListItem(
         id = id.value,
         summary = BookingSummaryModel(

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/bookings/list/BookingListViewState.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/bookings/list/BookingListViewState.kt
@@ -4,8 +4,9 @@ import com.woocommerce.android.ui.bookings.Booking
 import com.woocommerce.android.ui.bookings.compose.AttendanceStatus
 import com.woocommerce.android.ui.bookings.compose.BookingPaymentStatus
 import com.woocommerce.android.ui.bookings.compose.BookingSummaryModel
-import java.text.SimpleDateFormat
-import java.util.Date
+import java.time.ZoneId
+import java.time.format.DateTimeFormatter
+import java.time.format.FormatStyle
 
 data class BookingListViewState(
     val bookings: List<BookingListItem>,
@@ -25,15 +26,15 @@ data class BookingListItem(
 )
 
 fun Booking.toUiModel(): BookingListItem {
-    val dateFormatter = SimpleDateFormat.getDateTimeInstance(
-        SimpleDateFormat.MEDIUM,
-        SimpleDateFormat.SHORT
-    )
+    val dateFormatter = DateTimeFormatter.ofLocalizedDateTime(
+        FormatStyle.MEDIUM,
+        FormatStyle.SHORT
+    ).withZone(ZoneId.systemDefault())
 
     return BookingListItem(
         id = id.value,
         summary = BookingSummaryModel(
-            date = dateFormatter.format(Date(start * 1000)),
+            date = dateFormatter.format(start),
             name = "Women’s Haircut",
             customerName = "Margarita Nikolaevna",
             attendanceStatus = AttendanceStatus.BOOKED,

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/compose/component/WCPullToRefreshBox.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/compose/component/WCPullToRefreshBox.kt
@@ -1,0 +1,38 @@
+package com.woocommerce.android.ui.compose.component
+
+import androidx.compose.foundation.layout.BoxScope
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.pulltorefresh.PullToRefreshBox
+import androidx.compose.material3.pulltorefresh.PullToRefreshDefaults.Indicator
+import androidx.compose.material3.pulltorefresh.PullToRefreshState
+import androidx.compose.material3.pulltorefresh.rememberPullToRefreshState
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun WCPullToRefreshBox(
+    isRefreshing: Boolean,
+    onRefresh: () -> Unit,
+    modifier: Modifier = Modifier,
+    state: PullToRefreshState = rememberPullToRefreshState(),
+    content: @Composable BoxScope.() -> Unit
+) {
+    PullToRefreshBox(
+        isRefreshing = isRefreshing,
+        onRefresh = onRefresh,
+        state = state,
+        indicator = {
+            Indicator(
+                modifier = Modifier.align(Alignment.TopCenter),
+                state = state,
+                isRefreshing = isRefreshing,
+                color = MaterialTheme.colorScheme.primary
+            )
+        },
+        modifier = modifier,
+        content = content
+    )
+}

--- a/WooCommerce/src/main/res/navigation/nav_graph_main.xml
+++ b/WooCommerce/src/main/res/navigation/nav_graph_main.xml
@@ -219,7 +219,7 @@
     </fragment>
     <fragment
         android:id="@+id/bookings"
-        android:name="com.woocommerce.android.ui.bookings.BookingListFragment"
+        android:name="com.woocommerce.android.ui.bookings.list.BookingListFragment"
         android:label="fragment_bookings"
         tools:layout="@layout/fragment_bookings" />
     <dialog

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -4857,6 +4857,7 @@
     Bookings
     -->
     <string name="bookings_tab_title">Bookings</string>
+    <string name="bookings_fetch_error">Error fetching bookings</string>
 
     <!-- Booking details view-->
     <string name="booking_details_title">Booking #%s</string>

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/bookings/list/BookingListHandlerTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/bookings/list/BookingListHandlerTest.kt
@@ -1,5 +1,7 @@
 package com.woocommerce.android.ui.bookings.list
 
+import com.woocommerce.android.ui.bookings.Booking
+import com.woocommerce.android.ui.bookings.BookingsRepository
 import com.woocommerce.android.util.InlineClassesAnswer
 import com.woocommerce.android.viewmodel.BaseUnitTest
 import kotlinx.coroutines.ExperimentalCoroutinesApi

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/bookings/list/BookingListHandlerTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/bookings/list/BookingListHandlerTest.kt
@@ -1,4 +1,4 @@
-package com.woocommerce.android.ui.bookings
+package com.woocommerce.android.ui.bookings.list
 
 import com.woocommerce.android.util.InlineClassesAnswer
 import com.woocommerce.android.viewmodel.BaseUnitTest

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/bookings/list/BookingListHandlerTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/bookings/list/BookingListHandlerTest.kt
@@ -23,6 +23,8 @@ import org.mockito.kotlin.verify
 import org.wordpress.android.fluxc.model.LocalOrRemoteId.LocalId
 import org.wordpress.android.fluxc.model.LocalOrRemoteId.RemoteId
 import org.wordpress.android.fluxc.persistence.entity.BookingEntity
+import java.time.Duration
+import java.time.Instant
 import kotlin.test.Test
 
 @OptIn(ExperimentalCoroutinesApi::class)
@@ -161,8 +163,8 @@ class BookingListHandlerTest : BaseUnitTest() {
     private fun getSampleBooking(id: Int) = BookingEntity(
         id = RemoteId(id.toLong()),
         localSiteId = LocalId(1),
-        start = System.currentTimeMillis(),
-        end = System.currentTimeMillis() + 3600000,
+        start = Instant.now(),
+        end = Instant.now() + Duration.ofDays(1),
         allDay = false,
         status = "confirmed",
         cost = "100.00",
@@ -170,13 +172,13 @@ class BookingListHandlerTest : BaseUnitTest() {
         customerId = 1L,
         productId = 1L,
         resourceId = 1L,
-        dateCreated = System.currentTimeMillis(),
-        dateModified = System.currentTimeMillis(),
+        dateCreated = Instant.now(),
+        dateModified = Instant.now(),
         googleCalendarEventId = "",
         orderId = 1L,
         orderItemId = 1L,
         parentId = 0L,
         personCounts = listOf(1L),
-        localTimezone = "UTC"
+        localTimezone = ""
     )
 }

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/bookings/list/BookingListViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/bookings/list/BookingListViewModelTest.kt
@@ -1,0 +1,222 @@
+package com.woocommerce.android.ui.bookings.list
+
+import androidx.lifecycle.SavedStateHandle
+import com.woocommerce.android.R
+import com.woocommerce.android.ui.bookings.Booking
+import com.woocommerce.android.util.captureValues
+import com.woocommerce.android.util.getOrAwaitValue
+import com.woocommerce.android.viewmodel.BaseUnitTest
+import com.woocommerce.android.viewmodel.MultiLiveEvent
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.test.advanceUntilIdle
+import org.assertj.core.api.Assertions.assertThat
+import org.mockito.kotlin.any
+import org.mockito.kotlin.anyOrNull
+import org.mockito.kotlin.doReturn
+import org.mockito.kotlin.eq
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.times
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
+import org.wordpress.android.fluxc.model.LocalOrRemoteId
+import org.wordpress.android.fluxc.persistence.entity.BookingEntity
+import kotlin.test.Test
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class BookingListViewModelTest : BaseUnitTest() {
+    private val bookingListHandler: BookingListHandler = mock {
+        on { bookingsFlow } doReturn flowOf(emptyList())
+        onBlocking { loadBookings(searchQuery = anyOrNull(), forceRefresh = any()) } doReturn Result.success(Unit)
+        onBlocking { loadMore() } doReturn Result.success(Unit)
+    }
+
+    private val savedStateHandle: SavedStateHandle = SavedStateHandle()
+
+    suspend fun setup(
+        bookings: List<Booking> = emptyList(),
+        prepareMocks: suspend () -> Unit = {}
+    ) {
+        prepareMocks()
+        whenever(bookingListHandler.bookingsFlow).thenReturn(flowOf(bookings))
+    }
+
+    @Test
+    fun `when viewmodel is initialized, then bookings are fetched`() = testBlocking {
+        // GIVEN
+        val bookings = listOf(getSampleBooking(1))
+        setup(bookings = bookings)
+
+        // WHEN
+        val viewModel = BookingListViewModel(
+            savedStateHandle = savedStateHandle,
+            bookingListHandler = bookingListHandler
+        )
+        advanceUntilIdle()
+
+        // THEN
+        verify(bookingListHandler).loadBookings(searchQuery = eq(null), forceRefresh = eq(true))
+
+        val state = viewModel.state.getOrAwaitValue()
+        assertThat(state.bookings).hasSize(1)
+        assertThat(state.loadingState).isEqualTo(BookingListViewState.LoadingState.Idle)
+    }
+
+    @Test
+    fun `given multiple bookings, when state is observed, then bookings are converted to UI models`() =
+        testBlocking {
+            // GIVEN
+            val booking1 = getSampleBooking(1)
+            val booking2 = getSampleBooking(2)
+            val bookings = listOf(booking1, booking2)
+            setup(bookings = bookings)
+
+            // WHEN
+            val viewModel = BookingListViewModel(
+                savedStateHandle = savedStateHandle,
+                bookingListHandler = bookingListHandler
+            )
+            advanceUntilIdle()
+
+            // THEN
+            val state = viewModel.state.getOrAwaitValue()
+            assertThat(state.bookings).hasSize(2)
+            assertThat(state.bookings[0].id).isEqualTo(booking1.id.value)
+            assertThat(state.bookings[1].id).isEqualTo(booking2.id.value)
+        }
+
+    @Test
+    fun `when onRefresh is called, then bookings are refreshed`() = testBlocking {
+        // GIVEN
+        setup()
+        val viewModel = BookingListViewModel(
+            savedStateHandle = savedStateHandle,
+            bookingListHandler = bookingListHandler
+        )
+        advanceUntilIdle()
+
+        // WHEN
+        val state = viewModel.state.getOrAwaitValue()
+        state.onRefresh()
+        advanceUntilIdle()
+
+        // THEN
+        verify(bookingListHandler, times(2)).loadBookings(
+            searchQuery = eq(null),
+            forceRefresh = eq(true)
+        )
+    }
+
+    @Test
+    fun `when onLoadMore is called, then handler loadMore is invoked`() = testBlocking {
+        // GIVEN
+        setup()
+        val viewModel = BookingListViewModel(
+            savedStateHandle = savedStateHandle,
+            bookingListHandler = bookingListHandler
+        )
+        advanceUntilIdle()
+
+        // WHEN
+        val state = viewModel.state.getOrAwaitValue()
+        state.onLoadMore()
+        advanceUntilIdle()
+
+        // THEN
+        verify(bookingListHandler).loadMore()
+    }
+
+    @Test
+    fun `when onBookingClick is called, then NavigateToBookingDetails event is triggered`() = testBlocking {
+        // GIVEN
+        val bookingId = 123L
+        setup()
+        val viewModel = BookingListViewModel(
+            savedStateHandle = savedStateHandle,
+            bookingListHandler = bookingListHandler
+        )
+        advanceUntilIdle()
+
+        // WHEN
+        val state = viewModel.state.getOrAwaitValue()
+        val events = viewModel.event.captureValues()
+        state.onBookingClick(bookingId)
+
+        // THEN
+        assertThat(events).hasSize(1)
+        val event = events.first()
+        assertThat(event).isInstanceOf(BookingListViewModel.NavigateToBookingDetails::class.java)
+        assertThat((event as BookingListViewModel.NavigateToBookingDetails).bookingId).isEqualTo(bookingId)
+    }
+
+    @Test
+    fun `when booking handler fails to load, then show error snackbar`() = testBlocking {
+        // GIVEN
+        setup {
+            whenever(bookingListHandler.loadBookings(searchQuery = anyOrNull(), forceRefresh = any()))
+                .thenReturn(Result.failure(Exception("Network error")))
+        }
+
+        // WHEN
+        val viewModel = BookingListViewModel(
+            savedStateHandle = savedStateHandle,
+            bookingListHandler = bookingListHandler
+        )
+        advanceUntilIdle()
+
+        // THEN
+        val state = viewModel.state.getOrAwaitValue()
+        val event = viewModel.event.getOrAwaitValue()
+        assertThat(state.loadingState).isEqualTo(BookingListViewState.LoadingState.Idle)
+        assertThat(event).isEqualTo(MultiLiveEvent.Event.ShowSnackbar(R.string.bookings_fetch_error))
+    }
+
+    @Test
+    fun `when load more fails, then show error snackbar`() = testBlocking {
+        // GIVEN
+        setup {
+            whenever(bookingListHandler.loadMore())
+                .thenReturn(Result.failure(Exception("Network error")))
+        }
+        val viewModel = BookingListViewModel(
+            savedStateHandle = savedStateHandle,
+            bookingListHandler = bookingListHandler
+        )
+        advanceUntilIdle()
+
+        // WHEN
+        val state = viewModel.state.getOrAwaitValue()
+        state.onLoadMore()
+        advanceUntilIdle()
+
+        // THEN
+        val finalState = viewModel.state.getOrAwaitValue()
+        val event = viewModel.event.getOrAwaitValue()
+        assertThat(finalState.loadingState).isEqualTo(BookingListViewState.LoadingState.Idle)
+        assertThat(event).isEqualTo(MultiLiveEvent.Event.ShowSnackbar(R.string.bookings_fetch_error))
+    }
+
+    private fun getSampleBooking(id: Int): Booking {
+        return BookingEntity(
+            id = LocalOrRemoteId.RemoteId(id.toLong()),
+            localSiteId = LocalOrRemoteId.LocalId(1),
+            start = System.currentTimeMillis(),
+            end = System.currentTimeMillis() + 3600000,
+            allDay = false,
+            status = "confirmed",
+            cost = "100.00",
+            currency = "USD",
+            customerId = 1L,
+            productId = 1L,
+            resourceId = 1L,
+            dateCreated = System.currentTimeMillis(),
+            dateModified = System.currentTimeMillis(),
+            googleCalendarEventId = "",
+            orderId = 1L,
+            orderItemId = 1L,
+            parentId = 0L,
+            personCounts = listOf(1L),
+            localTimezone = "UTC"
+        )
+    }
+}

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/bookings/list/BookingListViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/bookings/list/BookingListViewModelTest.kt
@@ -21,6 +21,8 @@ import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
 import org.wordpress.android.fluxc.model.LocalOrRemoteId
 import org.wordpress.android.fluxc.persistence.entity.BookingEntity
+import java.time.Duration
+import java.time.Instant
 import kotlin.test.Test
 
 @OptIn(ExperimentalCoroutinesApi::class)
@@ -200,8 +202,8 @@ class BookingListViewModelTest : BaseUnitTest() {
         return BookingEntity(
             id = LocalOrRemoteId.RemoteId(id.toLong()),
             localSiteId = LocalOrRemoteId.LocalId(1),
-            start = System.currentTimeMillis(),
-            end = System.currentTimeMillis() + 3600000,
+            start = Instant.now(),
+            end = Instant.now() + Duration.ofDays(1),
             allDay = false,
             status = "confirmed",
             cost = "100.00",
@@ -209,14 +211,14 @@ class BookingListViewModelTest : BaseUnitTest() {
             customerId = 1L,
             productId = 1L,
             resourceId = 1L,
-            dateCreated = System.currentTimeMillis(),
-            dateModified = System.currentTimeMillis(),
+            dateCreated = Instant.now(),
+            dateModified = Instant.now(),
             googleCalendarEventId = "",
             orderId = 1L,
             orderItemId = 1L,
             parentId = 0L,
             personCounts = listOf(1L),
-            localTimezone = "UTC"
+            localTimezone = ""
         )
     }
 }

--- a/libs/fluxc-plugin/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/bookings/BookingsStore.kt
+++ b/libs/fluxc-plugin/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/bookings/BookingsStore.kt
@@ -13,6 +13,7 @@ import org.wordpress.android.fluxc.persistence.entity.BookingEntity
 import org.wordpress.android.fluxc.tools.CoroutineEngine
 import org.wordpress.android.fluxc.utils.HeadersParser
 import org.wordpress.android.util.AppLog
+import java.time.Instant
 import javax.inject.Inject
 import javax.inject.Singleton
 
@@ -58,8 +59,8 @@ class BookingsStore @Inject constructor(
     private fun BookingDto.toEntity(localSiteId: LocalId): BookingEntity = BookingEntity(
         id = RemoteId(id),
         localSiteId = localSiteId,
-        start = start,
-        end = end,
+        start = Instant.ofEpochSecond(start),
+        end = Instant.ofEpochSecond(end),
         allDay = allDay,
         status = status,
         cost = cost,
@@ -67,8 +68,8 @@ class BookingsStore @Inject constructor(
         customerId = customerId,
         productId = productId,
         resourceId = resourceId,
-        dateCreated = dateCreated,
-        dateModified = dateModified,
+        dateCreated = Instant.ofEpochSecond(dateCreated),
+        dateModified = Instant.ofEpochSecond(dateModified),
         googleCalendarEventId = googleCalendarEventId,
         orderId = orderId,
         orderItemId = orderItemId,

--- a/libs/fluxc-plugin/src/main/kotlin/org/wordpress/android/fluxc/persistence/entity/BookingEntity.kt
+++ b/libs/fluxc-plugin/src/main/kotlin/org/wordpress/android/fluxc/persistence/entity/BookingEntity.kt
@@ -1,18 +1,22 @@
 package org.wordpress.android.fluxc.persistence.entity
 
 import androidx.room.Entity
+import androidx.room.TypeConverter
+import androidx.room.TypeConverters
 import org.wordpress.android.fluxc.model.LocalOrRemoteId.LocalId
 import org.wordpress.android.fluxc.model.LocalOrRemoteId.RemoteId
+import java.time.Instant
 
 @Entity(
     tableName = "Bookings",
     primaryKeys = ["id", "localSiteId"]
 )
+@TypeConverters(BookingEntityConverters::class)
 data class BookingEntity(
     val id: RemoteId,
     val localSiteId: LocalId,
-    val start: Long,
-    val end: Long,
+    val start: Instant,
+    val end: Instant,
     val allDay: Boolean,
     val status: String,
     val cost: String,
@@ -20,8 +24,8 @@ data class BookingEntity(
     val customerId: Long,
     val productId: Long,
     val resourceId: Long,
-    val dateCreated: Long,
-    val dateModified: Long,
+    val dateCreated: Instant,
+    val dateModified: Instant,
     val googleCalendarEventId: String,
     val orderId: Long,
     val orderItemId: Long,
@@ -29,3 +33,11 @@ data class BookingEntity(
     val personCounts: List<Long>?,
     val localTimezone: String
 )
+
+internal class BookingEntityConverters {
+    @TypeConverter
+    fun instantToEpochSeconds(instant: Instant) = instant.epochSecond
+
+    @TypeConverter
+    fun epochSecondsToInstant(epochSeconds: Long) = Instant.ofEpochSecond(epochSeconds)
+}


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

<!-- Id number of the Linear issue this PR addresses, e.g., WOOMOB-373. -->
Part of WOOMOB-1358

> [!TIP]
> For an easier review, exclude the commit af89c46, this commit just moves the list specific files to a new package, and this caused Github to mark some files as new files.

### Description
This PR adds basic UI for the bookings list, it includes the following changes:
- Introduces a new ViewState class, that uses the `BookingSummaryModel` for the items.
- Handles basic mapping from the `Booking` class to the view state.
- Updates the UI in the BookingListScreen to use the `BookingSummary` composable.

The navigation to booking details is not included yet, it will be added in another PR.

### Steps to reproduce
1. Use a CIAB site.
2. Manually install the bookings plugin from this ZIP file: p1758531103469849/1758101141.913349-slack-C03L1NF1EA3
3. You'll need to enable bookings v2 on your CIAB testing site. You can do that by installing the Code [Snippets plugin](https://wordpress.org/plugins/code-snippets/) to your site and adding the following PHP snippet: `define( 'WC_BOOKINGS_NEXT_ENABLED', true );`
4. Create some bookings.
5. Open the Bookings tab in the app.
6. Check the UI.

### Testing information
- Confirm the UI works as expected.
- Confirm the booking `id`, `date` and `payment status` are shown correctly, the other details are mocked now.

### The tests that have been performed
The above.

### Images/gif
| Light | Dark |
| --- | --- |
| <img width="1080" height="2400" alt="Screenshot_20250926_095810" src="https://github.com/user-attachments/assets/dbc71e3b-220f-4bcd-b9c9-9885b8967b96" /> | <img width="1080" height="2400" alt="Screenshot_20250926_095905" src="https://github.com/user-attachments/assets/931fe8d9-79b4-4123-9416-68170a85584a" /> |


- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->