### PR TITLE
[CIAB Bookings] Handle navigation from list to details

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/bookings/list/BookingListFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/bookings/list/BookingListFragment.kt
@@ -5,6 +5,7 @@ import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import androidx.fragment.app.viewModels
+import androidx.navigation.fragment.findNavController
 import com.woocommerce.android.R
 import com.woocommerce.android.ui.base.TopLevelFragment
 import com.woocommerce.android.ui.base.UIMessageResolver
@@ -12,7 +13,6 @@ import com.woocommerce.android.ui.compose.composeView
 import com.woocommerce.android.ui.main.AppBarStatus
 import com.woocommerce.android.viewmodel.MultiLiveEvent
 import dagger.hilt.android.AndroidEntryPoint
-import org.wordpress.android.util.ToastUtils
 import javax.inject.Inject
 
 @AndroidEntryPoint
@@ -45,9 +45,12 @@ class BookingListFragment : TopLevelFragment() {
         viewModel.event.observe(viewLifecycleOwner) { event ->
             when (event) {
                 is BookingListViewModel.NavigateToBookingDetails -> {
-                    // TODO navigate to booking details screen
-                    ToastUtils.showToast(requireContext(), "Navigate to booking ${event.bookingId}")
+                    findNavController().navigate(
+                        BookingListFragmentDirections
+                            .actionBookingListFragmentToBookingDetailsFragment(event.bookingId)
+                    )
                 }
+
                 is MultiLiveEvent.Event.ShowSnackbar -> uiMessageResolver.showSnack(event.message)
             }
         }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/bookings/tab/BookingsTabController.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/bookings/tab/BookingsTabController.kt
@@ -1,8 +1,8 @@
 package com.woocommerce.android.ui.bookings.tab
 
 import androidx.lifecycle.lifecycleScope
-import com.woocommerce.android.R
 import com.woocommerce.android.databinding.ActivityMainBinding
+import com.woocommerce.android.ui.main.BottomNavigationPosition
 import com.woocommerce.android.ui.main.MainActivity
 import kotlinx.coroutines.launch
 import javax.inject.Inject
@@ -26,7 +26,7 @@ class BookingsTabController @Inject constructor(
         activity.lifecycleScope.launch {
             observeBookingsTabVisibility()
                 .collect { isVisible ->
-                    binding.bottomNav.menu.findItem(R.id.bookings)?.isVisible = isVisible
+                    binding.bottomNav.menu.findItem(BottomNavigationPosition.BOOKINGS.id)?.isVisible = isVisible
                 }
         }
     }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/developer/DeveloperOptionsFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/developer/DeveloperOptionsFragment.kt
@@ -64,14 +64,6 @@ class DeveloperOptionsFragment : BaseFragment() {
                         DeveloperOptionsFragmentDirections.actionDeveloperOptionsFragmentToApiFaker()
                     )
                 }
-
-                is DeveloperOptionsViewModel.DeveloperOptionsEvents.OpenBookingDetails -> {
-                    // Temporary navigation to Booking Details screen with a hardcoded booking ID
-                    val action = DeveloperOptionsFragmentDirections
-                        .actionDeveloperOptionsFragmentToBookingDetailsFragment()
-                    val args = action.arguments.apply { putLong("bookingId", 123L) }
-                    findNavController().navigate(action.actionId, args)
-                }
             }
         }
     }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/developer/DeveloperOptionsViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/developer/DeveloperOptionsViewModel.kt
@@ -90,25 +90,12 @@ class DeveloperOptionsViewModel @Inject constructor(
         )
     )
 
-    private val bookingDetailsFlow = flowOf(
-        NonToggleableListItem(
-            icon = R.drawable.ic_calendar_16,
-            iconTint = R.color.color_primary,
-            label = UiString.UiStringText("Show booking details"),
-            isEnabled = true,
-            onClick = {
-                triggerEvent(DeveloperOptionsEvents.OpenBookingDetails)
-            }
-        )
-    )
-
     val viewState = combine(
         simulatedCardReaderFlow,
         readerUpdateFrequencyFlow,
         interacPaymentEnabledFlow,
         savedPrivacySettingsOnDialogFlow,
-        apiFakerFlow,
-        bookingDetailsFlow
+        apiFakerFlow
     ) { items ->
         DeveloperOptionsViewState(
             rows = items.filterNotNull()
@@ -152,7 +139,6 @@ class DeveloperOptionsViewModel @Inject constructor(
         ) : DeveloperOptionsEvents()
 
         data object OpenApiFaker : DeveloperOptionsEvents()
-        data object OpenBookingDetails : DeveloperOptionsEvents()
     }
 
     data class DeveloperOptionsViewState(

--- a/WooCommerce/src/main/res/navigation/nav_graph_bookings.xml
+++ b/WooCommerce/src/main/res/navigation/nav_graph_bookings.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="utf-8"?>
+<navigation xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:id="@+id/bookings"
+    app:startDestination="@id/bookingListFragment">
+
+    <fragment
+        android:id="@+id/bookingListFragment"
+        android:name="com.woocommerce.android.ui.bookings.list.BookingListFragment"
+        android:label="fragment_bookings" />
+
+</navigation>

--- a/WooCommerce/src/main/res/navigation/nav_graph_bookings.xml
+++ b/WooCommerce/src/main/res/navigation/nav_graph_bookings.xml
@@ -7,6 +7,19 @@
     <fragment
         android:id="@+id/bookingListFragment"
         android:name="com.woocommerce.android.ui.bookings.list.BookingListFragment"
-        android:label="fragment_bookings" />
+        android:label="fragment_bookings" >
+        <action
+            android:id="@+id/action_bookingListFragment_to_bookingDetailsFragment"
+            app:destination="@id/bookingDetailsFragment" />
+    </fragment>
+    <fragment
+        android:id="@+id/bookingDetailsFragment"
+        android:name="com.woocommerce.android.ui.bookings.details.BookingDetailsFragment"
+        android:label="BookingDetailsFragment">
+        <argument
+            android:name="bookingId"
+            android:defaultValue="-1L"
+            app:argType="long" />
+    </fragment>
 
 </navigation>

--- a/WooCommerce/src/main/res/navigation/nav_graph_main.xml
+++ b/WooCommerce/src/main/res/navigation/nav_graph_main.xml
@@ -17,6 +17,7 @@
     <include app:graph="@navigation/nav_graph_domain_change" />
     <include app:graph="@navigation/nav_graph_blaze_campaign_creation" />
     <include app:graph="@navigation/nav_graph_order_creations" />
+    <include app:graph="@navigation/nav_graph_bookings" />
 
     <fragment
         android:id="@+id/dashboard"
@@ -217,11 +218,6 @@
             app:popEnterAnim="@null"
             app:popExitAnim="@anim/activity_fade_out" />
     </fragment>
-    <fragment
-        android:id="@+id/bookings"
-        android:name="com.woocommerce.android.ui.bookings.list.BookingListFragment"
-        android:label="fragment_bookings"
-        tools:layout="@layout/fragment_bookings" />
     <dialog
         android:id="@+id/updateStockStatusFragment"
         android:name="com.woocommerce.android.ui.products.UpdateProductStockStatusFragment"

--- a/WooCommerce/src/main/res/navigation/nav_graph_settings.xml
+++ b/WooCommerce/src/main/res/navigation/nav_graph_settings.xml
@@ -174,9 +174,6 @@
         <action
             android:id="@+id/action_developerOptionsFragment_to_ApiFaker"
             app:destination="@id/apiFakerHostFragment" />
-        <action
-            android:id="@+id/action_developerOptionsFragment_to_bookingDetailsFragment"
-            app:destination="@id/bookingDetailsFragment" />
     </fragment>
     <fragment
         android:id="@+id/accountSettingsFragment"
@@ -190,15 +187,6 @@
         android:id="@+id/closeAccountDialogFragment"
         android:name="com.woocommerce.android.ui.prefs.account.CloseAccountDialogFragment"
         android:label="CloseAccountDialogFragment" />
-    <fragment
-        android:id="@+id/bookingDetailsFragment"
-        android:name="com.woocommerce.android.ui.bookings.details.BookingDetailsFragment"
-        android:label="BookingDetailsFragment">
-        <argument
-            android:name="bookingId"
-            android:defaultValue="-1L"
-            app:argType="long" />
-    </fragment>
     <dialog
         android:id="@+id/nameYourStoreDialogFragment"
         android:name="com.woocommerce.android.ui.onboarding.NameYourStoreDialogFragment"


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

<!-- Id number of the Linear issue this PR addresses, e.g., WOOMOB-373. -->
Closes WOOMOB-1358

### Description
This PR adds navigation logic from the list to the booking details screen. For this, I decided to move both the `BookingListFragment` and `BookingDetailsFragment` to a new navgraph, which differs from our other top-level screens. However, it's the correct approach that the Navigation component expects if we want to support multiple back stacks. We haven't used it for the other tabs because they were added before the Navigation component supported it (https://github.com/woocommerce/woocommerce-android/issues/7183). Anyway, since this also improves organization by preventing more destinations from being added to the already large `nav_graph_main`, I think it's a win-win situation.

### Steps to reproduce
1. Follow steps of #14658
2. Tap on one of the bookings.

### Testing information
- Confirm the navigation works correctly.

### The tests that have been performed
The above.

- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->