### PR TITLE
[CIAB] Bookings tabs - UI

### DIFF
--- a/.idea/inspectionProfiles/Project_Default.xml
+++ b/.idea/inspectionProfiles/Project_Default.xml
@@ -75,6 +75,10 @@
       <option name="composableFile" value="true" />
       <option name="previewFile" value="true" />
     </inspection_tool>
+    <inspection_tool class="PreviewParameterProviderOnFirstParameter" enabled="true" level="ERROR" enabled_by_default="true">
+      <option name="composableFile" value="true" />
+      <option name="previewFile" value="true" />
+    </inspection_tool>
     <inspection_tool class="PreviewPickerAnnotation" enabled="true" level="ERROR" enabled_by_default="true">
       <option name="composableFile" value="true" />
       <option name="previewFile" value="true" />

--- a/.idea/inspectionProfiles/Project_Default.xml
+++ b/.idea/inspectionProfiles/Project_Default.xml
@@ -75,10 +75,6 @@
       <option name="composableFile" value="true" />
       <option name="previewFile" value="true" />
     </inspection_tool>
-    <inspection_tool class="PreviewParameterProviderOnFirstParameter" enabled="true" level="ERROR" enabled_by_default="true">
-      <option name="composableFile" value="true" />
-      <option name="previewFile" value="true" />
-    </inspection_tool>
     <inspection_tool class="PreviewPickerAnnotation" enabled="true" level="ERROR" enabled_by_default="true">
       <option name="composableFile" value="true" />
       <option name="previewFile" value="true" />

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/bookings/list/BookingListScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/bookings/list/BookingListScreen.kt
@@ -172,7 +172,7 @@ private fun BookingListPreview() {
         BookingListScreen(
             state = BookingListViewState(
                 contentState = BookingListContentState(
-                    bookings = List(3) {
+                    bookings = List(20) {
                         BookingListItem(
                             id = it.toLong(),
                             summary = com.woocommerce.android.ui.bookings.compose.BookingSummaryModel(

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/bookings/list/BookingListScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/bookings/list/BookingListScreen.kt
@@ -15,22 +15,19 @@ import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.PrimaryTabRow
 import androidx.compose.material3.Scaffold
-import androidx.compose.material3.Tab
 import androidx.compose.material3.Text
 import androidx.compose.material3.pulltorefresh.rememberPullToRefreshState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.livedata.observeAsState
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.res.colorResource
 import androidx.compose.ui.res.stringResource
-import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import com.woocommerce.android.R
 import com.woocommerce.android.ui.bookings.compose.BookingSummary
 import com.woocommerce.android.ui.compose.component.InfiniteListHandler
 import com.woocommerce.android.ui.compose.component.Toolbar
+import com.woocommerce.android.ui.compose.component.WCPrimaryTabRow
 import com.woocommerce.android.ui.compose.component.WCPullToRefreshBox
 import com.woocommerce.android.ui.compose.preview.LightDarkThemePreviews
 import com.woocommerce.android.ui.compose.theme.WooThemeWithBackground
@@ -53,8 +50,11 @@ fun BookingListScreen(state: BookingListViewState) {
         }
     ) { paddingValues ->
         Column(modifier = Modifier.padding(paddingValues)) {
-            BookingListTabs(
-                tabState = state.tabState,
+            WCPrimaryTabRow(
+                tabs = BookingListTab.entries,
+                selectedTab = state.tabState.selectedTab,
+                tabName = { it.name() },
+                onTabSelected = state.tabState.onTabChanged,
                 modifier = Modifier
             )
             when {
@@ -137,39 +137,11 @@ private fun BookingList(
     }
 }
 
-@OptIn(ExperimentalMaterial3Api::class)
 @Composable
-private fun BookingListTabs(
-    tabState: BookingListTabState,
-    modifier: Modifier = Modifier
-) {
-    @Composable
-    fun BookingListTab.name(): String = when (this) {
-        BookingListTab.Today -> stringResource(R.string.bookings_tab_today)
-        BookingListTab.Upcoming -> stringResource(R.string.bookings_tab_upcoming)
-        BookingListTab.All -> stringResource(R.string.bookings_tab_all)
-    }
-
-    val selectedTabIndex = BookingListTab.entries.indexOf(tabState.selectedTab)
-    PrimaryTabRow(
-        selectedTabIndex = selectedTabIndex,
-        containerColor = colorResource(id = R.color.color_toolbar),
-        modifier = modifier
-    ) {
-        BookingListTab.entries.forEach { tab ->
-            Tab(
-                selected = tab == tabState.selectedTab,
-                onClick = { tabState.onTabChanged(tab) },
-                text = {
-                    Text(
-                        text = tab.name(),
-                        maxLines = 2,
-                        overflow = TextOverflow.Ellipsis
-                    )
-                }
-            )
-        }
-    }
+private fun BookingListTab.name(): String = when (this) {
+    BookingListTab.Today -> stringResource(R.string.bookings_tab_today)
+    BookingListTab.Upcoming -> stringResource(R.string.bookings_tab_upcoming)
+    BookingListTab.All -> stringResource(R.string.bookings_tab_all)
 }
 
 @Composable

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/bookings/list/BookingListScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/bookings/list/BookingListScreen.kt
@@ -143,6 +143,13 @@ private fun BookingListTabs(
     tabState: BookingListTabState,
     modifier: Modifier = Modifier
 ) {
+    @Composable
+    fun BookingListTab.name(): String = when (this) {
+        BookingListTab.Today -> stringResource(R.string.bookings_tab_today)
+        BookingListTab.Upcoming -> stringResource(R.string.bookings_tab_upcoming)
+        BookingListTab.All -> stringResource(R.string.bookings_tab_all)
+    }
+
     val selectedTabIndex = BookingListTab.entries.indexOf(tabState.selectedTab)
     PrimaryTabRow(
         selectedTabIndex = selectedTabIndex,
@@ -155,7 +162,7 @@ private fun BookingListTabs(
                 onClick = { tabState.onTabChanged(tab) },
                 text = {
                     Text(
-                        text = tab.name,
+                        text = tab.name(),
                         maxLines = 2,
                         overflow = TextOverflow.Ellipsis
                     )

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/bookings/list/BookingListScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/bookings/list/BookingListScreen.kt
@@ -183,7 +183,8 @@ private fun BookingListPreview() {
                     loadingState = BookingListLoadingState.Idle,
                     onRefresh = {},
                     onLoadMore = {},
-                    onBookingClick = {}),
+                    onBookingClick = {}
+                ),
                 tabState = BookingListTabState(
                     selectedTab = BookingListTab.Today,
                     onTabChanged = {}

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/bookings/list/BookingListScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/bookings/list/BookingListScreen.kt
@@ -1,5 +1,6 @@
 package com.woocommerce.android.ui.bookings.list
 
+import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxSize
@@ -13,6 +14,7 @@ import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.PrimaryTabRow
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Tab
@@ -103,7 +105,9 @@ private fun BookingList(
         LazyColumn(
             state = listState,
             modifier = Modifier
+                .background(MaterialTheme.colorScheme.surfaceContainer)
                 .fillMaxSize()
+                .background(MaterialTheme.colorScheme.background)
         ) {
             itemsIndexed(state.bookings) { _, booking ->
                 BookingSummary(
@@ -168,7 +172,7 @@ private fun BookingListPreview() {
         BookingListScreen(
             state = BookingListViewState(
                 contentState = BookingListContentState(
-                    bookings = List(20) {
+                    bookings = List(3) {
                         BookingListItem(
                             id = it.toLong(),
                             summary = com.woocommerce.android.ui.bookings.compose.BookingSummaryModel(

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/bookings/list/BookingListScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/bookings/list/BookingListScreen.kt
@@ -1,6 +1,7 @@
 package com.woocommerce.android.ui.bookings.list
 
 import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
@@ -12,13 +13,17 @@ import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.PrimaryTabRow
 import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Tab
 import androidx.compose.material3.Text
 import androidx.compose.material3.pulltorefresh.rememberPullToRefreshState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.livedata.observeAsState
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.colorResource
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import com.woocommerce.android.R
 import com.woocommerce.android.ui.bookings.compose.BookingSummary
@@ -45,34 +50,38 @@ fun BookingListScreen(state: BookingListViewState) {
             )
         }
     ) { paddingValues ->
-        when {
-            state.contentState.isNotEmpty() -> {
-                BookingList(
-                    state = state.contentState,
-                    modifier = Modifier
-                        .padding(paddingValues)
-                        .fillMaxSize()
-                )
-            }
+        Column(modifier = Modifier.padding(paddingValues)) {
+            BookingListTabs(
+                tabState = state.tabState,
+                modifier = Modifier
+            )
+            when {
+                state.contentState.isNotEmpty() -> {
+                    BookingList(
+                        state = state.contentState,
+                        modifier = Modifier.fillMaxSize()
+                    )
+                }
 
-            state.contentState.loadingState == BookingListLoadingState.Loading -> {
-                // TODO replace with shimmer
-                CircularProgressIndicator(
-                    modifier = Modifier
-                        .padding(paddingValues)
-                        .fillMaxSize()
-                        .wrapContentSize()
-                )
-            }
+                state.contentState.loadingState == BookingListLoadingState.Loading -> {
+                    // TODO replace with shimmer
+                    CircularProgressIndicator(
+                        modifier = Modifier
+                            .padding(paddingValues)
+                            .fillMaxSize()
+                            .wrapContentSize()
+                    )
+                }
 
-            else -> {
-                // TODO replace with empty state
-                Text(
-                    text = "No bookings found",
-                    modifier = Modifier
-                        .padding(paddingValues)
-                        .wrapContentSize()
-                )
+                else -> {
+                    // TODO replace with empty state
+                    Text(
+                        text = "No bookings found",
+                        modifier = Modifier
+                            .padding(paddingValues)
+                            .wrapContentSize()
+                    )
+                }
             }
         }
     }
@@ -121,6 +130,34 @@ private fun BookingList(
         }
 
         InfiniteListHandler(listState = listState, onLoadMore = state.onLoadMore)
+    }
+}
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+private fun BookingListTabs(
+    tabState: BookingListTabState,
+    modifier: Modifier = Modifier
+) {
+    val selectedTabIndex = BookingListTab.entries.indexOf(tabState.selectedTab)
+    PrimaryTabRow(
+        selectedTabIndex = selectedTabIndex,
+        containerColor = colorResource(id = R.color.color_toolbar),
+        modifier = modifier
+    ) {
+        BookingListTab.entries.forEach { tab ->
+            Tab(
+                selected = tab == tabState.selectedTab,
+                onClick = { tabState.onTabChanged(tab) },
+                text = {
+                    Text(
+                        text = tab.name,
+                        maxLines = 2,
+                        overflow = TextOverflow.Ellipsis
+                    )
+                }
+            )
+        }
     }
 }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/bookings/list/BookingListScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/bookings/list/BookingListScreen.kt
@@ -105,20 +105,20 @@ private fun BookingList(
         LazyColumn(
             state = listState,
             modifier = Modifier
-                .background(MaterialTheme.colorScheme.surfaceContainer)
                 .fillMaxSize()
-                .background(MaterialTheme.colorScheme.background)
         ) {
             itemsIndexed(state.bookings) { _, booking ->
-                BookingSummary(
-                    model = booking.summary,
-                    modifier = Modifier
-                        .fillMaxWidth()
-                        .clickable(onClick = { state.onBookingClick(booking.id) })
-                )
-                HorizontalDivider(
-                    Modifier.padding(start = 16.dp)
-                )
+                Column(modifier = Modifier.background(MaterialTheme.colorScheme.surfaceContainer)) {
+                    BookingSummary(
+                        model = booking.summary,
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .clickable(onClick = { state.onBookingClick(booking.id) })
+                    )
+                    HorizontalDivider(
+                        Modifier.padding(start = 16.dp)
+                    )
+                }
             }
 
             if (state.loadingState == BookingListLoadingState.Appending) {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/bookings/list/BookingListScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/bookings/list/BookingListScreen.kt
@@ -46,16 +46,16 @@ fun BookingListScreen(state: BookingListViewState) {
         }
     ) { paddingValues ->
         when {
-            state.bookings.isNotEmpty() -> {
+            state.contentState.isNotEmpty() -> {
                 BookingList(
-                    state = state,
+                    state = state.contentState,
                     modifier = Modifier
                         .padding(paddingValues)
                         .fillMaxSize()
                 )
             }
 
-            state.loadingState == BookingListViewState.LoadingState.Loading -> {
+            state.contentState.loadingState == BookingListLoadingState.Loading -> {
                 // TODO replace with shimmer
                 CircularProgressIndicator(
                     modifier = Modifier
@@ -81,11 +81,11 @@ fun BookingListScreen(state: BookingListViewState) {
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 private fun BookingList(
-    state: BookingListViewState,
+    state: BookingListContentState,
     modifier: Modifier = Modifier
 ) {
     WCPullToRefreshBox(
-        isRefreshing = state.loadingState == BookingListViewState.LoadingState.Refreshing,
+        isRefreshing = state.loadingState == BookingListLoadingState.Refreshing,
         onRefresh = state.onRefresh,
         state = rememberPullToRefreshState(),
         modifier = modifier
@@ -108,7 +108,7 @@ private fun BookingList(
                 )
             }
 
-            if (state.loadingState == BookingListViewState.LoadingState.Appending) {
+            if (state.loadingState == BookingListLoadingState.Appending) {
                 item {
                     CircularProgressIndicator(
                         modifier = Modifier
@@ -130,22 +130,27 @@ private fun BookingListPreview() {
     WooThemeWithBackground {
         BookingListScreen(
             state = BookingListViewState(
-                bookings = List(3) {
-                    BookingListItem(
-                        id = it.toLong(),
-                        summary = com.woocommerce.android.ui.bookings.compose.BookingSummaryModel(
-                            date = "Aug 20, 2024",
-                            name = "Women’s Haircut",
-                            customerName = "Margarita Nikolaevna",
-                            attendanceStatus = com.woocommerce.android.ui.bookings.compose.AttendanceStatus.BOOKED,
-                            paymentStatus = com.woocommerce.android.ui.bookings.compose.BookingPaymentStatus.PAID
+                contentState = BookingListContentState(
+                    bookings = List(20) {
+                        BookingListItem(
+                            id = it.toLong(),
+                            summary = com.woocommerce.android.ui.bookings.compose.BookingSummaryModel(
+                                date = "Aug 20, 2024",
+                                name = "Women’s Haircut",
+                                customerName = "Margarita Nikolaevna",
+                                attendanceStatus = com.woocommerce.android.ui.bookings.compose.AttendanceStatus.BOOKED,
+                                paymentStatus = com.woocommerce.android.ui.bookings.compose.BookingPaymentStatus.PAID
+                            )
                         )
-                    )
-                },
-                loadingState = BookingListViewState.LoadingState.Idle,
-                onRefresh = {},
-                onLoadMore = {},
-                onBookingClick = {}
+                    },
+                    loadingState = BookingListLoadingState.Idle,
+                    onRefresh = {},
+                    onLoadMore = {},
+                    onBookingClick = {}),
+                tabState = BookingListTabState(
+                    selectedTab = BookingListTab.Today,
+                    onTabChanged = {}
+                )
             )
         )
     }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/bookings/list/BookingListViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/bookings/list/BookingListViewModel.kt
@@ -2,9 +2,11 @@ package com.woocommerce.android.ui.bookings.list
 
 import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.asLiveData
+import androidx.lifecycle.viewModelScope
 import com.woocommerce.android.R
 import com.woocommerce.android.viewmodel.MultiLiveEvent
 import com.woocommerce.android.viewmodel.ScopedViewModel
+import com.woocommerce.android.viewmodel.getStateFlow
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -18,28 +20,42 @@ class BookingListViewModel @Inject constructor(
     savedStateHandle: SavedStateHandle,
     private val bookingListHandler: BookingListHandler
 ) : ScopedViewModel(savedStateHandle) {
-    private val loadingState = MutableStateFlow(BookingListViewState.LoadingState.Idle)
+    private val loadingState = MutableStateFlow(BookingListLoadingState.Idle)
+    private val selectedTab = savedStateHandle.getStateFlow(viewModelScope, BookingListTab.Today)
 
     private var bookingsFetchJob: Job? = null
 
-    val state = combine(
+    private val contentState = combine(
         bookingListHandler.bookingsFlow.map { bookings -> bookings.map { it.toUiModel() } },
-        loadingState,
+        loadingState
     ) { bookings, loadingState ->
-        BookingListViewState(
+        BookingListContentState(
             bookings = bookings,
             loadingState = loadingState,
-            onRefresh = { fetchBookings(BookingListViewState.LoadingState.Refreshing) },
+            onRefresh = { fetchBookings(BookingListLoadingState.Refreshing) },
             onLoadMore = ::loadMore,
             onBookingClick = ::onBookingClick
+        )
+    }
+
+    val state = combine(
+        contentState,
+        selectedTab
+    ) { contentState, selectedTab ->
+        BookingListViewState(
+            contentState = contentState,
+            tabState = BookingListTabState(
+                selectedTab = selectedTab,
+                onTabChanged = ::onTabChanged
+            )
         )
     }.asLiveData()
 
     init {
-        fetchBookings(initialLoadingState = BookingListViewState.LoadingState.Loading)
+        fetchBookings(initialLoadingState = BookingListLoadingState.Loading)
     }
 
-    private fun fetchBookings(initialLoadingState: BookingListViewState.LoadingState) {
+    private fun fetchBookings(initialLoadingState: BookingListLoadingState) {
         bookingsFetchJob?.cancel()
         bookingsFetchJob = launch {
             loadingState.value = initialLoadingState
@@ -47,7 +63,7 @@ class BookingListViewModel @Inject constructor(
                 .onFailure {
                     triggerEvent(MultiLiveEvent.Event.ShowSnackbar(R.string.bookings_fetch_error))
                 }
-            loadingState.value = BookingListViewState.LoadingState.Idle
+            loadingState.value = BookingListLoadingState.Idle
         }
     }
 
@@ -56,17 +72,21 @@ class BookingListViewModel @Inject constructor(
             // If a fetch is already in progress, wait for it to complete before loading more
             bookingsFetchJob?.join()
 
-            loadingState.value = BookingListViewState.LoadingState.Appending
+            loadingState.value = BookingListLoadingState.Appending
             bookingListHandler.loadMore()
                 .onFailure {
                     triggerEvent(MultiLiveEvent.Event.ShowSnackbar(R.string.bookings_fetch_error))
                 }
-            loadingState.value = BookingListViewState.LoadingState.Idle
+            loadingState.value = BookingListLoadingState.Idle
         }
     }
 
     private fun onBookingClick(bookingId: Long) {
         triggerEvent(NavigateToBookingDetails(bookingId))
+    }
+
+    private fun onTabChanged(tab: BookingListTab) {
+        selectedTab.value = tab
     }
 
     data class NavigateToBookingDetails(val bookingId: Long) : MultiLiveEvent.Event()

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/bookings/list/BookingListViewState.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/bookings/list/BookingListViewState.kt
@@ -9,21 +9,37 @@ import java.time.format.DateTimeFormatter
 import java.time.format.FormatStyle
 
 data class BookingListViewState(
+    val contentState: BookingListContentState,
+    val tabState: BookingListTabState
+)
+
+data class BookingListContentState(
     val bookings: List<BookingListItem>,
-    val loadingState: LoadingState,
+    val loadingState: BookingListLoadingState,
     val onRefresh: () -> Unit,
     val onLoadMore: () -> Unit,
-    val onBookingClick: (Long) -> Unit
+    val onBookingClick: (Long) -> Unit,
 ) {
-    enum class LoadingState {
-        Idle, Loading, Refreshing, Appending
-    }
+    fun isNotEmpty() = bookings.isNotEmpty()
 }
+
+data class BookingListTabState(
+    val selectedTab: BookingListTab,
+    val onTabChanged: (BookingListTab) -> Unit
+)
 
 data class BookingListItem(
     val id: Long,
     val summary: BookingSummaryModel
 )
+
+enum class BookingListLoadingState {
+    Idle, Loading, Refreshing, Appending
+}
+
+enum class BookingListTab {
+    Today, Upcoming, All
+}
 
 fun Booking.toUiModel(): BookingListItem {
     val dateFormatter = DateTimeFormatter.ofLocalizedDateTime(

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/compose/component/WCPrimaryTabRow.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/compose/component/WCPrimaryTabRow.kt
@@ -1,0 +1,58 @@
+package com.woocommerce.android.ui.compose.component
+
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.PrimaryTabRow
+import androidx.compose.material3.Tab
+import androidx.compose.material3.TabRowDefaults
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.colorResource
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.Dp
+import com.woocommerce.android.R
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun <T> WCPrimaryTabRow(
+    tabs: List<T>,
+    selectedTab: T,
+    tabName: @Composable (T) -> String,
+    onTabSelected: (T) -> Unit,
+    modifier: Modifier = Modifier
+) {
+    val selectedTabIndex = tabs.indexOf(selectedTab)
+
+    PrimaryTabRow(
+        selectedTabIndex = selectedTabIndex,
+        containerColor = colorResource(R.color.color_toolbar),
+        indicator = {
+            TabRowDefaults.PrimaryIndicator(
+                modifier = Modifier
+                    .tabIndicatorOffset(selectedTabIndex, matchContentSize = false),
+                width = Dp.Unspecified
+            )
+        },
+        modifier = modifier,
+    ) {
+        tabs.forEach { tab ->
+            Tab(
+                selected = selectedTab == tab,
+                onClick = { onTabSelected(tab) },
+                text = {
+                    Text(
+                        text = tabName(tab),
+                        maxLines = 2,
+                        overflow = TextOverflow.Ellipsis,
+                        color = if (selectedTab == tab) {
+                            MaterialTheme.colorScheme.primary
+                        } else {
+                            MaterialTheme.colorScheme.onSurface
+                        }
+                    )
+                }
+            )
+        }
+    }
+}

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -4858,6 +4858,9 @@
     -->
     <string name="bookings_tab_title">Bookings</string>
     <string name="bookings_fetch_error">Error fetching bookings</string>
+    <string name="bookings_tab_today">Today</string>
+    <string name="bookings_tab_upcoming">Upcoming</string>
+    <string name="bookings_tab_all">All</string>
 
     <!-- Booking details view-->
     <string name="booking_details_title">Booking #%s</string>

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/bookings/list/BookingListViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/bookings/list/BookingListViewModelTest.kt
@@ -33,7 +33,7 @@ class BookingListViewModelTest : BaseUnitTest() {
         onBlocking { loadMore() } doReturn Result.success(Unit)
     }
 
-    private val savedStateHandle: SavedStateHandle = SavedStateHandle()
+    private lateinit var viewModel: BookingListViewModel
 
     suspend fun setup(
         bookings: List<Booking> = emptyList(),
@@ -41,6 +41,10 @@ class BookingListViewModelTest : BaseUnitTest() {
     ) {
         prepareMocks()
         whenever(bookingListHandler.bookingsFlow).thenReturn(flowOf(bookings))
+        viewModel = BookingListViewModel(
+            savedStateHandle = SavedStateHandle(),
+            bookingListHandler = bookingListHandler
+        )
     }
 
     @Test
@@ -50,18 +54,14 @@ class BookingListViewModelTest : BaseUnitTest() {
         setup(bookings = bookings)
 
         // WHEN
-        val viewModel = BookingListViewModel(
-            savedStateHandle = savedStateHandle,
-            bookingListHandler = bookingListHandler
-        )
-        advanceUntilIdle()
+       advanceUntilIdle()
 
         // THEN
         verify(bookingListHandler).loadBookings(searchQuery = eq(null), forceRefresh = eq(true))
 
-        val state = viewModel.state.getOrAwaitValue()
+        val state = viewModel.state.getOrAwaitValue().contentState
         assertThat(state.bookings).hasSize(1)
-        assertThat(state.loadingState).isEqualTo(BookingListViewState.LoadingState.Idle)
+        assertThat(state.loadingState).isEqualTo(BookingListLoadingState.Idle)
     }
 
     @Test
@@ -74,14 +74,10 @@ class BookingListViewModelTest : BaseUnitTest() {
             setup(bookings = bookings)
 
             // WHEN
-            val viewModel = BookingListViewModel(
-                savedStateHandle = savedStateHandle,
-                bookingListHandler = bookingListHandler
-            )
             advanceUntilIdle()
 
             // THEN
-            val state = viewModel.state.getOrAwaitValue()
+            val state = viewModel.state.getOrAwaitValue().contentState
             assertThat(state.bookings).hasSize(2)
             assertThat(state.bookings[0].id).isEqualTo(booking1.id.value)
             assertThat(state.bookings[1].id).isEqualTo(booking2.id.value)
@@ -91,14 +87,9 @@ class BookingListViewModelTest : BaseUnitTest() {
     fun `when onRefresh is called, then bookings are refreshed`() = testBlocking {
         // GIVEN
         setup()
-        val viewModel = BookingListViewModel(
-            savedStateHandle = savedStateHandle,
-            bookingListHandler = bookingListHandler
-        )
-        advanceUntilIdle()
 
         // WHEN
-        val state = viewModel.state.getOrAwaitValue()
+        val state = viewModel.state.getOrAwaitValue().contentState
         state.onRefresh()
         advanceUntilIdle()
 
@@ -113,14 +104,9 @@ class BookingListViewModelTest : BaseUnitTest() {
     fun `when onLoadMore is called, then handler loadMore is invoked`() = testBlocking {
         // GIVEN
         setup()
-        val viewModel = BookingListViewModel(
-            savedStateHandle = savedStateHandle,
-            bookingListHandler = bookingListHandler
-        )
-        advanceUntilIdle()
 
         // WHEN
-        val state = viewModel.state.getOrAwaitValue()
+        val state = viewModel.state.getOrAwaitValue().contentState
         state.onLoadMore()
         advanceUntilIdle()
 
@@ -133,14 +119,9 @@ class BookingListViewModelTest : BaseUnitTest() {
         // GIVEN
         val bookingId = 123L
         setup()
-        val viewModel = BookingListViewModel(
-            savedStateHandle = savedStateHandle,
-            bookingListHandler = bookingListHandler
-        )
-        advanceUntilIdle()
 
         // WHEN
-        val state = viewModel.state.getOrAwaitValue()
+        val state = viewModel.state.getOrAwaitValue().contentState
         val events = viewModel.event.captureValues()
         state.onBookingClick(bookingId)
 
@@ -160,16 +141,12 @@ class BookingListViewModelTest : BaseUnitTest() {
         }
 
         // WHEN
-        val viewModel = BookingListViewModel(
-            savedStateHandle = savedStateHandle,
-            bookingListHandler = bookingListHandler
-        )
         advanceUntilIdle()
 
         // THEN
-        val state = viewModel.state.getOrAwaitValue()
+        val state = viewModel.state.getOrAwaitValue().contentState
         val event = viewModel.event.getOrAwaitValue()
-        assertThat(state.loadingState).isEqualTo(BookingListViewState.LoadingState.Idle)
+        assertThat(state.loadingState).isEqualTo(BookingListLoadingState.Idle)
         assertThat(event).isEqualTo(MultiLiveEvent.Event.ShowSnackbar(R.string.bookings_fetch_error))
     }
 
@@ -180,22 +157,31 @@ class BookingListViewModelTest : BaseUnitTest() {
             whenever(bookingListHandler.loadMore())
                 .thenReturn(Result.failure(Exception("Network error")))
         }
-        val viewModel = BookingListViewModel(
-            savedStateHandle = savedStateHandle,
-            bookingListHandler = bookingListHandler
-        )
-        advanceUntilIdle()
 
         // WHEN
-        val state = viewModel.state.getOrAwaitValue()
+        val state = viewModel.state.getOrAwaitValue().contentState
         state.onLoadMore()
         advanceUntilIdle()
 
         // THEN
-        val finalState = viewModel.state.getOrAwaitValue()
+        val finalState = viewModel.state.getOrAwaitValue().contentState
         val event = viewModel.event.getOrAwaitValue()
-        assertThat(finalState.loadingState).isEqualTo(BookingListViewState.LoadingState.Idle)
+        assertThat(finalState.loadingState).isEqualTo(BookingListLoadingState.Idle)
         assertThat(event).isEqualTo(MultiLiveEvent.Event.ShowSnackbar(R.string.bookings_fetch_error))
+    }
+
+    @Test
+    fun `when tab is changed, then state is updated`() = testBlocking {
+        // GIVEN
+        setup()
+
+        // WHEN
+        val initialState = viewModel.state.getOrAwaitValue()
+        initialState.tabState.onTabChanged(BookingListTab.Upcoming)
+
+        // THEN
+        val updatedState = viewModel.state.getOrAwaitValue()
+        assertThat(updatedState.tabState.selectedTab).isEqualTo(BookingListTab.Upcoming)
     }
 
     private fun getSampleBooking(id: Int): Booking {

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/bookings/list/BookingListViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/bookings/list/BookingListViewModelTest.kt
@@ -54,7 +54,7 @@ class BookingListViewModelTest : BaseUnitTest() {
         setup(bookings = bookings)
 
         // WHEN
-       advanceUntilIdle()
+        advanceUntilIdle()
 
         // THEN
         verify(bookingListHandler).loadBookings(searchQuery = eq(null), forceRefresh = eq(true))


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

<!-- Id number of the Linear issue this PR addresses, e.g., WOOMOB-373. -->
Part of WOOMOB-1360

### Description
This PR adds UI for the bookings tabs, the logic will be handled in separated PR.

### Steps to reproduce
1. Use a CIAB site.
2. Manually install the bookings plugin from this ZIP file: p1758531103469849/1758101141.913349-slack-C03L1NF1EA3
3. You'll need to enable bookings v2 on your CIAB testing site. You can do that by installing the Code [Snippets plugin](https://wordpress.org/plugins/code-snippets/) to your site and adding the following PHP snippet: `define( 'WC_BOOKINGS_NEXT_ENABLED', true );`
4. Create some bookings.
5. Notice the tabs.

### Testing information
Confirm the UI looks good in both light and dark theme.

### The tests that have been performed
The above

### Images/gif
| Light | Dark |
| --- | --- |
| <img width="1080" height="2400" alt="Screenshot_20250929_191727" src="https://github.com/user-attachments/assets/3078e15b-a1d1-491f-8c36-1fbccb50baa5" /> | <img width="1080" height="2400" alt="Screenshot_20250929_215941" src="https://github.com/user-attachments/assets/acc7e554-880b-4399-8d21-8d07e3c4aad4" /> |


- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
