### PR TITLE
[WOOMOB-1346] Booking details - payment section

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/bookings/compose/BookingPaymentSection.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/bookings/compose/BookingPaymentSection.kt
@@ -26,7 +26,7 @@ import com.woocommerce.android.ui.compose.theme.WooThemeWithBackground
 @Composable
 fun BookingPaymentSection(
     model: BookingPaymentDetailsModel,
-    paymentStatus: BookingPaymentStatus,
+    status: BookingStatus,
     onMarkAsPaid: () -> Unit,
     onMarkAsRefunded: () -> Unit,
     onViewOrder: () -> Unit,
@@ -56,7 +56,7 @@ fun BookingPaymentSection(
                 thickness = 0.5.dp,
                 modifier = Modifier.padding(start = 16.dp)
             )
-            if (paymentStatus == BookingPaymentStatus.PAID) {
+            if (status == BookingStatus.Paid) {
                 WCOutlinedButton(
                     onClick = onMarkAsRefunded,
                     colors = ButtonDefaults.outlinedButtonColors(
@@ -140,7 +140,7 @@ private fun BookingPaymentSectionPreview() {
                 discount = "-",
                 total = "$59.50"
             ),
-            paymentStatus = BookingPaymentStatus.COMPLETE,
+            status = BookingStatus.Complete,
             onMarkAsPaid = {},
             onViewOrder = {},
             onMarkAsRefunded = {},
@@ -160,7 +160,7 @@ private fun BookingPaymentSectionWithRefundOptionPreview() {
                 discount = "-",
                 total = "$59.50"
             ),
-            paymentStatus = BookingPaymentStatus.PAID,
+            status = BookingStatus.Paid,
             onMarkAsPaid = {},
             onViewOrder = {},
             onMarkAsRefunded = {},

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/bookings/compose/BookingPaymentSection.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/bookings/compose/BookingPaymentSection.kt
@@ -26,7 +26,9 @@ import com.woocommerce.android.ui.compose.theme.WooThemeWithBackground
 @Composable
 fun BookingPaymentSection(
     model: BookingPaymentDetailsModel,
+    paymentStatus: BookingPaymentStatus,
     onMarkAsPaid: () -> Unit,
+    onMarkAsRefunded: () -> Unit,
     onViewOrder: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
@@ -54,13 +56,26 @@ fun BookingPaymentSection(
                 thickness = 0.5.dp,
                 modifier = Modifier.padding(start = 16.dp)
             )
-            WCColoredButton(
-                onClick = onMarkAsPaid,
-                text = stringResource(id = R.string.booking_payment_mark_as_paid),
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .padding(horizontal = 16.dp)
-            )
+            if (paymentStatus == BookingPaymentStatus.PAID) {
+                WCOutlinedButton(
+                    onClick = onMarkAsRefunded,
+                    colors = ButtonDefaults.outlinedButtonColors(
+                        contentColor = MaterialTheme.colorScheme.onSurface
+                    ),
+                    text = stringResource(id = R.string.booking_payment_mark_as_refunded),
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .padding(horizontal = 16.dp)
+                )
+            } else {
+                WCColoredButton(
+                    onClick = onMarkAsPaid,
+                    text = stringResource(id = R.string.booking_payment_mark_as_paid),
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .padding(horizontal = 16.dp)
+                )
+            }
             WCOutlinedButton(
                 onClick = onViewOrder,
                 colors = ButtonDefaults.outlinedButtonColors(
@@ -125,8 +140,30 @@ private fun BookingPaymentSectionPreview() {
                 discount = "-",
                 total = "$59.50"
             ),
+            paymentStatus = BookingPaymentStatus.COMPLETE,
             onMarkAsPaid = {},
             onViewOrder = {},
+            onMarkAsRefunded = {},
+            modifier = Modifier.fillMaxWidth()
+        )
+    }
+}
+
+@LightDarkThemePreviews
+@Composable
+private fun BookingPaymentSectionWithRefundOptionPreview() {
+    WooThemeWithBackground {
+        BookingPaymentSection(
+            model = BookingPaymentDetailsModel(
+                service = "$55.00",
+                tax = "$4.50",
+                discount = "-",
+                total = "$59.50"
+            ),
+            paymentStatus = BookingPaymentStatus.PAID,
+            onMarkAsPaid = {},
+            onViewOrder = {},
+            onMarkAsRefunded = {},
             modifier = Modifier.fillMaxWidth()
         )
     }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/bookings/compose/BookingPaymentSection.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/bookings/compose/BookingPaymentSection.kt
@@ -59,13 +59,14 @@ fun BookingPaymentSection(
                 modifier = Modifier.padding(start = 16.dp)
             )
             Spacer(modifier = Modifier.height(16.dp))
+            // TODO Change the logic and use Order info when available
             if (status == BookingStatus.Paid) {
                 WCOutlinedButton(
                     onClick = onMarkAsRefunded,
                     colors = ButtonDefaults.outlinedButtonColors(
                         contentColor = MaterialTheme.colorScheme.onSurface
                     ),
-                    text = stringResource(id = R.string.booking_payment_mark_as_refunded),
+                    text = stringResource(id = R.string.orderdetail_issue_refund_button),
                     modifier = Modifier
                         .fillMaxWidth()
                         .padding(horizontal = 16.dp)

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/bookings/compose/BookingPaymentSection.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/bookings/compose/BookingPaymentSection.kt
@@ -1,0 +1,133 @@
+package com.woocommerce.android.ui.bookings.compose
+
+import androidx.annotation.StringRes
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.ButtonDefaults
+import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.dp
+import com.woocommerce.android.R
+import com.woocommerce.android.ui.compose.component.WCColoredButton
+import com.woocommerce.android.ui.compose.component.WCOutlinedButton
+import com.woocommerce.android.ui.compose.preview.LightDarkThemePreviews
+import com.woocommerce.android.ui.compose.theme.WooThemeWithBackground
+
+@Composable
+fun BookingPaymentSection(
+    model: BookingPaymentDetailsModel,
+    onMarkAsPaid: () -> Unit,
+    onViewOrder: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    Column(modifier = modifier) {
+        BookingSectionHeader(R.string.booking_payment_header)
+        HorizontalDivider(thickness = 0.5.dp)
+        Column(
+            verticalArrangement = Arrangement.spacedBy(16.dp),
+            modifier = Modifier
+                .background(color = MaterialTheme.colorScheme.surfaceContainer)
+                .padding(vertical = 16.dp)
+        ) {
+            Column(
+                verticalArrangement = Arrangement.spacedBy(4.dp),
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(horizontal = 16.dp)
+            ) {
+                PaymentRow(label = R.string.booking_payment_label_service, value = model.service)
+                PaymentRow(label = R.string.tax, value = model.tax)
+                PaymentRow(label = R.string.discount, value = model.discount)
+                PaymentRow(label = R.string.total, value = model.total, fontWeight = FontWeight.Medium)
+            }
+            HorizontalDivider(
+                thickness = 0.5.dp,
+                modifier = Modifier.padding(start = 16.dp)
+            )
+            WCColoredButton(
+                onClick = onMarkAsPaid,
+                text = stringResource(id = R.string.booking_payment_mark_as_paid),
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(horizontal = 16.dp)
+            )
+            WCOutlinedButton(
+                onClick = onViewOrder,
+                colors = ButtonDefaults.outlinedButtonColors(
+                    contentColor = MaterialTheme.colorScheme.onSurface
+                ),
+                text = stringResource(id = R.string.booking_payment_view_order),
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(horizontal = 16.dp)
+            )
+        }
+    }
+}
+
+@Composable
+private fun PaymentRow(
+    @StringRes label: Int,
+    value: String,
+    fontWeight: FontWeight = FontWeight.Normal,
+) {
+    Row(
+        horizontalArrangement = Arrangement.SpaceBetween,
+        modifier = Modifier
+            .fillMaxWidth()
+    ) {
+        PaymentText(stringResource(label), fontWeight = fontWeight)
+        PaymentText(value, modifier = Modifier.padding(start = 8.dp), fontWeight = fontWeight)
+    }
+}
+
+@Composable
+private fun PaymentText(
+    text: String,
+    fontWeight: FontWeight,
+    modifier: Modifier = Modifier,
+) {
+    Text(
+        text = text,
+        style = MaterialTheme.typography.bodyMedium.copy(fontWeight = fontWeight),
+        color = MaterialTheme.colorScheme.onSurface,
+        maxLines = 1,
+        overflow = TextOverflow.Ellipsis,
+        modifier = modifier
+    )
+}
+
+data class BookingPaymentDetailsModel(
+    val service: String,
+    val tax: String,
+    val discount: String,
+    val total: String
+)
+
+@LightDarkThemePreviews
+@Composable
+private fun BookingPaymentSectionPreview() {
+    WooThemeWithBackground {
+        BookingPaymentSection(
+            model = BookingPaymentDetailsModel(
+                service = "$55.00",
+                tax = "$4.50",
+                discount = "-",
+                total = "$59.50"
+            ),
+            onMarkAsPaid = {},
+            onViewOrder = {},
+            modifier = Modifier.fillMaxWidth()
+        )
+    }
+}

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/bookings/compose/BookingPaymentSection.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/bookings/compose/BookingPaymentSection.kt
@@ -5,7 +5,9 @@ import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.ButtonDefaults
 import androidx.compose.material3.HorizontalDivider
@@ -36,7 +38,6 @@ fun BookingPaymentSection(
         BookingSectionHeader(R.string.booking_payment_header)
         HorizontalDivider(thickness = 0.5.dp)
         Column(
-            verticalArrangement = Arrangement.spacedBy(16.dp),
             modifier = Modifier
                 .background(color = MaterialTheme.colorScheme.surfaceContainer)
                 .padding(vertical = 16.dp)
@@ -52,10 +53,12 @@ fun BookingPaymentSection(
                 PaymentRow(label = R.string.discount, value = model.discount)
                 PaymentRow(label = R.string.total, value = model.total, fontWeight = FontWeight.Medium)
             }
+            Spacer(modifier = Modifier.height(16.dp))
             HorizontalDivider(
                 thickness = 0.5.dp,
                 modifier = Modifier.padding(start = 16.dp)
             )
+            Spacer(modifier = Modifier.height(16.dp))
             if (status == BookingStatus.Paid) {
                 WCOutlinedButton(
                     onClick = onMarkAsRefunded,
@@ -76,6 +79,7 @@ fun BookingPaymentSection(
                         .padding(horizontal = 16.dp)
                 )
             }
+            Spacer(modifier = Modifier.height(8.dp))
             WCOutlinedButton(
                 onClick = onViewOrder,
                 colors = ButtonDefaults.outlinedButtonColors(

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/bookings/details/BookingDetailsFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/bookings/details/BookingDetailsFragment.kt
@@ -23,7 +23,13 @@ class BookingDetailsFragment : BaseFragment() {
         return composeView {
             BookingDetailsScreen(
                 viewModel = viewModel,
-                onBack = { findNavController().popBackStack() }
+                onBack = { findNavController().popBackStack() },
+                onViewOrder = { orderId ->
+                    findNavController().navigate(
+                        BookingDetailsFragmentDirections
+                            .actionBookingDetailsFragmentToOrderDetailFragment(orderId)
+                    )
+                }
             )
         }
     }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/bookings/details/BookingDetailsScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/bookings/details/BookingDetailsScreen.kt
@@ -46,7 +46,6 @@ fun BookingDetailsScreen(
         BookingDetailsScreen(
             viewState = it,
             onBack = onBack,
-            onCancelBooking = viewModel::onCancelBooking,
             onAttendanceStatusSelected = viewModel::onAttendanceStatusSelected,
             onViewOrder = onViewOrder,
         )
@@ -57,7 +56,6 @@ fun BookingDetailsScreen(
 fun BookingDetailsScreen(
     viewState: BookingDetailsViewState,
     onBack: () -> Unit,
-    onCancelBooking: () -> Unit,
     onAttendanceStatusSelected: (BookingAttendanceStatus) -> Unit,
     onViewOrder: (Long) -> Unit,
 ) {
@@ -86,7 +84,7 @@ fun BookingDetailsScreen(
                 )
                 BookingAppointmentDetails(
                     model = viewState.bookingsAppointmentDetails,
-                    onCancelBooking = onCancelBooking,
+                    onCancelBooking = viewState.onCancelBooking,
                     modifier = Modifier.fillMaxWidth()
                 )
                 BookingCustomerDetails(
@@ -145,7 +143,6 @@ private fun BookingDetailsPreview() {
                 )
             ),
             onBack = {},
-            onCancelBooking = {},
             onAttendanceStatusSelected = {},
             onViewOrder = {}
         )

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/bookings/details/BookingDetailsScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/bookings/details/BookingDetailsScreen.kt
@@ -26,6 +26,7 @@ import com.woocommerce.android.ui.bookings.compose.BookingAttendanceSection
 import com.woocommerce.android.ui.bookings.compose.BookingAttendanceStatus
 import com.woocommerce.android.ui.bookings.compose.BookingAttendanceStatusBottomSheet
 import com.woocommerce.android.ui.bookings.compose.BookingCustomerDetails
+import com.woocommerce.android.ui.bookings.compose.BookingPaymentSection
 import com.woocommerce.android.ui.bookings.compose.BookingStatus
 import com.woocommerce.android.ui.bookings.compose.BookingSummary
 import com.woocommerce.android.ui.bookings.compose.BookingSummaryModel
@@ -94,6 +95,12 @@ fun BookingDetailsScreen(
                 BookingAttendanceSection(
                     status = viewState.bookingSummary.attendanceStatus,
                     onClick = { showAttendanceSheet.value = true },
+                    modifier = Modifier.fillMaxWidth()
+                )
+                BookingPaymentSection(
+                    model = viewState.bookingPaymentDetails,
+                    onMarkAsPaid = {},
+                    onViewOrder = {},
                     modifier = Modifier.fillMaxWidth()
                 )
             }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/bookings/details/BookingDetailsScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/bookings/details/BookingDetailsScreen.kt
@@ -46,7 +46,6 @@ fun BookingDetailsScreen(
         BookingDetailsScreen(
             viewState = it,
             onBack = onBack,
-            onAttendanceStatusSelected = viewModel::onAttendanceStatusSelected,
             onViewOrder = onViewOrder,
         )
     }
@@ -56,7 +55,6 @@ fun BookingDetailsScreen(
 fun BookingDetailsScreen(
     viewState: BookingDetailsViewState,
     onBack: () -> Unit,
-    onAttendanceStatusSelected: (BookingAttendanceStatus) -> Unit,
     onViewOrder: (Long) -> Unit,
 ) {
     val showAttendanceSheet = remember { mutableStateOf(false) }
@@ -110,7 +108,7 @@ fun BookingDetailsScreen(
             if (showAttendanceSheet.value) {
                 BookingAttendanceStatusBottomSheet(
                     onSelect = { status ->
-                        onAttendanceStatusSelected(status)
+                        viewState.onAttendanceStatusSelected(status)
                     },
                     onDismiss = { showAttendanceSheet.value = false }
                 )
@@ -143,7 +141,6 @@ private fun BookingDetailsPreview() {
                 )
             ),
             onBack = {},
-            onAttendanceStatusSelected = {},
             onViewOrder = {}
         )
     }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/bookings/details/BookingDetailsScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/bookings/details/BookingDetailsScreen.kt
@@ -98,7 +98,7 @@ fun BookingDetailsScreen(
                 )
                 BookingPaymentSection(
                     model = viewState.bookingPaymentDetails,
-                    paymentStatus = viewState.bookingSummary.status,
+                    status = viewState.bookingSummary.status,
                     onMarkAsPaid = viewState.onMarkAsPaid,
                     onViewOrder = { onViewOrder(viewState.orderId) },
                     onMarkAsRefunded = viewState.onMarkAsRefunded,

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/bookings/details/BookingDetailsScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/bookings/details/BookingDetailsScreen.kt
@@ -99,8 +99,10 @@ fun BookingDetailsScreen(
                 )
                 BookingPaymentSection(
                     model = viewState.bookingPaymentDetails,
+                    paymentStatus = viewState.bookingSummary.paymentStatus,
                     onMarkAsPaid = {},
                     onViewOrder = {},
+                    onMarkAsRefunded = {},
                     modifier = Modifier.fillMaxWidth()
                 )
             }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/bookings/details/BookingDetailsScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/bookings/details/BookingDetailsScreen.kt
@@ -48,7 +48,7 @@ fun BookingDetailsScreen(
             onBack = onBack,
             onCancelBooking = viewModel::onCancelBooking,
             onAttendanceStatusSelected = viewModel::onAttendanceStatusSelected,
-            onViewOrder = onViewOrder
+            onViewOrder = onViewOrder,
         )
     }
 }
@@ -59,7 +59,7 @@ fun BookingDetailsScreen(
     onBack: () -> Unit,
     onCancelBooking: () -> Unit,
     onAttendanceStatusSelected: (BookingAttendanceStatus) -> Unit,
-    onViewOrder: (Long) -> Unit
+    onViewOrder: (Long) -> Unit,
 ) {
     val showAttendanceSheet = remember { mutableStateOf(false) }
     Scaffold(
@@ -103,9 +103,9 @@ fun BookingDetailsScreen(
                 BookingPaymentSection(
                     model = viewState.bookingPaymentDetails,
                     paymentStatus = viewState.bookingSummary.status,
-                    onMarkAsPaid = {},
+                    onMarkAsPaid = viewState.onMarkAsPaid,
                     onViewOrder = { onViewOrder(viewState.orderId) },
-                    onMarkAsRefunded = {},
+                    onMarkAsRefunded = viewState.onMarkAsRefunded,
                     modifier = Modifier.fillMaxWidth()
                 )
             }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/bookings/details/BookingDetailsScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/bookings/details/BookingDetailsScreen.kt
@@ -99,9 +99,9 @@ fun BookingDetailsScreen(
                 BookingPaymentSection(
                     model = viewState.bookingPaymentDetails,
                     status = viewState.bookingSummary.status,
-                    onMarkAsPaid = viewState.onMarkAsPaid,
+                    onMarkAsPaid = { onViewOrder(viewState.orderId) },
                     onViewOrder = { onViewOrder(viewState.orderId) },
-                    onMarkAsRefunded = viewState.onMarkAsRefunded,
+                    onMarkAsRefunded = { onViewOrder(viewState.orderId) },
                     modifier = Modifier.fillMaxWidth()
                 )
             }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/bookings/details/BookingDetailsScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/bookings/details/BookingDetailsScreen.kt
@@ -37,7 +37,8 @@ import com.woocommerce.android.ui.compose.theme.WooThemeWithBackground
 @Composable
 fun BookingDetailsScreen(
     viewModel: BookingDetailsViewModel,
-    onBack: () -> Unit
+    onBack: () -> Unit,
+    onViewOrder: (Long) -> Unit
 ) {
     val viewState by viewModel.state.observeAsState()
 
@@ -46,7 +47,8 @@ fun BookingDetailsScreen(
             viewState = it,
             onBack = onBack,
             onCancelBooking = viewModel::onCancelBooking,
-            onAttendanceStatusSelected = viewModel::onAttendanceStatusSelected
+            onAttendanceStatusSelected = viewModel::onAttendanceStatusSelected,
+            onViewOrder = onViewOrder
         )
     }
 }
@@ -56,7 +58,8 @@ fun BookingDetailsScreen(
     viewState: BookingDetailsViewState,
     onBack: () -> Unit,
     onCancelBooking: () -> Unit,
-    onAttendanceStatusSelected: (BookingAttendanceStatus) -> Unit
+    onAttendanceStatusSelected: (BookingAttendanceStatus) -> Unit,
+    onViewOrder: (Long) -> Unit
 ) {
     val showAttendanceSheet = remember { mutableStateOf(false) }
     Scaffold(
@@ -99,9 +102,9 @@ fun BookingDetailsScreen(
                 )
                 BookingPaymentSection(
                     model = viewState.bookingPaymentDetails,
-                    paymentStatus = viewState.bookingSummary.paymentStatus,
+                    paymentStatus = viewState.bookingSummary.status,
                     onMarkAsPaid = {},
-                    onViewOrder = {},
+                    onViewOrder = { onViewOrder(viewState.orderId) },
                     onMarkAsRefunded = {},
                     modifier = Modifier.fillMaxWidth()
                 )
@@ -143,7 +146,8 @@ private fun BookingDetailsPreview() {
             ),
             onBack = {},
             onCancelBooking = {},
-            onAttendanceStatusSelected = {}
+            onAttendanceStatusSelected = {},
+            onViewOrder = {}
         )
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/bookings/details/BookingDetailsViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/bookings/details/BookingDetailsViewModel.kt
@@ -27,6 +27,7 @@ class BookingDetailsViewModel @Inject constructor(
             onMarkAsPaid = ::onMarkAsPaid,
             onMarkAsRefunded = ::onMarkAsRefunded,
             onCancelBooking = ::onCancelBooking,
+            onAttendanceStatusSelected = ::onAttendanceStatusSelected,
         )
     )
     val state: LiveData<BookingDetailsViewState> = _state.asLiveData()
@@ -39,7 +40,7 @@ class BookingDetailsViewModel @Inject constructor(
         }
     }
 
-    fun onAttendanceStatusSelected(status: BookingAttendanceStatus) {
+    private fun onAttendanceStatusSelected(status: BookingAttendanceStatus) {
         _state.update { current ->
             current.copy(
                 bookingSummary = current.bookingSummary.copy(attendanceStatus = status)

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/bookings/details/BookingDetailsViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/bookings/details/BookingDetailsViewModel.kt
@@ -26,6 +26,7 @@ class BookingDetailsViewModel @Inject constructor(
         BookingDetailsViewState(
             onMarkAsPaid = ::onMarkAsPaid,
             onMarkAsRefunded = ::onMarkAsRefunded,
+            onCancelBooking = ::onCancelBooking,
         )
     )
     val state: LiveData<BookingDetailsViewState> = _state.asLiveData()
@@ -62,7 +63,7 @@ class BookingDetailsViewModel @Inject constructor(
         }
     }
 
-    fun onCancelBooking() {
+    private fun onCancelBooking() {
         // TODO Add logic to Cancel booking
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/bookings/details/BookingDetailsViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/bookings/details/BookingDetailsViewModel.kt
@@ -5,7 +5,6 @@ import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.asLiveData
 import com.woocommerce.android.R
 import com.woocommerce.android.ui.bookings.compose.BookingAttendanceStatus
-import com.woocommerce.android.ui.bookings.compose.BookingStatus
 import com.woocommerce.android.viewmodel.ResourceProvider
 import com.woocommerce.android.viewmodel.ScopedViewModel
 import com.woocommerce.android.viewmodel.navArgs
@@ -24,8 +23,6 @@ class BookingDetailsViewModel @Inject constructor(
 
     private val _state = MutableStateFlow(
         BookingDetailsViewState(
-            onMarkAsPaid = ::onMarkAsPaid,
-            onMarkAsRefunded = ::onMarkAsRefunded,
             onCancelBooking = ::onCancelBooking,
             onAttendanceStatusSelected = ::onAttendanceStatusSelected,
         )
@@ -44,22 +41,6 @@ class BookingDetailsViewModel @Inject constructor(
         _state.update { current ->
             current.copy(
                 bookingSummary = current.bookingSummary.copy(attendanceStatus = status)
-            )
-        }
-    }
-
-    private fun onMarkAsPaid() {
-        _state.update { current ->
-            current.copy(
-                bookingSummary = current.bookingSummary.copy(status = BookingStatus.Paid)
-            )
-        }
-    }
-
-    private fun onMarkAsRefunded() {
-        _state.update { current ->
-            current.copy(
-                bookingSummary = current.bookingSummary.copy(status = BookingStatus.Unpaid)
             )
         }
     }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/bookings/details/BookingDetailsViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/bookings/details/BookingDetailsViewModel.kt
@@ -5,6 +5,7 @@ import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.asLiveData
 import com.woocommerce.android.R
 import com.woocommerce.android.ui.bookings.compose.BookingAttendanceStatus
+import com.woocommerce.android.ui.bookings.compose.BookingStatus
 import com.woocommerce.android.viewmodel.ResourceProvider
 import com.woocommerce.android.viewmodel.ScopedViewModel
 import com.woocommerce.android.viewmodel.navArgs
@@ -21,7 +22,12 @@ class BookingDetailsViewModel @Inject constructor(
 
     private val navArgs: BookingDetailsFragmentArgs by savedState.navArgs()
 
-    private val _state = MutableStateFlow(BookingDetailsViewState())
+    private val _state = MutableStateFlow(
+        BookingDetailsViewState(
+            onMarkAsPaid = ::onMarkAsPaid,
+            onMarkAsRefunded = ::onMarkAsRefunded,
+        )
+    )
     val state: LiveData<BookingDetailsViewState> = _state.asLiveData()
 
     init {
@@ -36,6 +42,22 @@ class BookingDetailsViewModel @Inject constructor(
         _state.update { current ->
             current.copy(
                 bookingSummary = current.bookingSummary.copy(attendanceStatus = status)
+            )
+        }
+    }
+
+    private fun onMarkAsPaid() {
+        _state.update { current ->
+            current.copy(
+                bookingSummary = current.bookingSummary.copy(status = BookingStatus.Paid)
+            )
+        }
+    }
+
+    private fun onMarkAsRefunded() {
+        _state.update { current ->
+            current.copy(
+                bookingSummary = current.bookingSummary.copy(status = BookingStatus.Unpaid)
             )
         }
     }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/bookings/details/BookingDetailsViewState.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/bookings/details/BookingDetailsViewState.kt
@@ -41,8 +41,6 @@ data class BookingDetailsViewState(
         discount = "-",
         total = "$59.50"
     ),
-    val onMarkAsPaid: () -> Unit = {},
-    val onMarkAsRefunded: () -> Unit = {},
     val onCancelBooking: () -> Unit = {},
     val onAttendanceStatusSelected: (BookingAttendanceStatus) -> Unit = { _ -> }
 )

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/bookings/details/BookingDetailsViewState.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/bookings/details/BookingDetailsViewState.kt
@@ -9,6 +9,7 @@ import com.woocommerce.android.ui.bookings.compose.BookingSummaryModel
 
 data class BookingDetailsViewState(
     val toolbarTitle: String = "",
+    val orderId: Long = 0L,
     val bookingSummary: BookingSummaryModel = BookingSummaryModel(
         date = "05/07/2025, 11:00 AM",
         name = "Women’s Haircut",

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/bookings/details/BookingDetailsViewState.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/bookings/details/BookingDetailsViewState.kt
@@ -44,4 +44,5 @@ data class BookingDetailsViewState(
     val onMarkAsPaid: () -> Unit = {},
     val onMarkAsRefunded: () -> Unit = {},
     val onCancelBooking: () -> Unit = {},
+    val onAttendanceStatusSelected: (BookingAttendanceStatus) -> Unit = { _ -> }
 )

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/bookings/details/BookingDetailsViewState.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/bookings/details/BookingDetailsViewState.kt
@@ -43,4 +43,5 @@ data class BookingDetailsViewState(
     ),
     val onMarkAsPaid: () -> Unit = {},
     val onMarkAsRefunded: () -> Unit = {},
+    val onCancelBooking: () -> Unit = {},
 )

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/bookings/details/BookingDetailsViewState.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/bookings/details/BookingDetailsViewState.kt
@@ -3,6 +3,7 @@ package com.woocommerce.android.ui.bookings.details
 import com.woocommerce.android.ui.bookings.compose.BookingAppointmentDetailsModel
 import com.woocommerce.android.ui.bookings.compose.BookingAttendanceStatus
 import com.woocommerce.android.ui.bookings.compose.BookingCustomerDetailsModel
+import com.woocommerce.android.ui.bookings.compose.BookingPaymentDetailsModel
 import com.woocommerce.android.ui.bookings.compose.BookingStatus
 import com.woocommerce.android.ui.bookings.compose.BookingSummaryModel
 
@@ -32,5 +33,11 @@ data class BookingDetailsViewState(
             "Montgomery AL 36109",
             "United States"
         )
+    ),
+    val bookingPaymentDetails: BookingPaymentDetailsModel = BookingPaymentDetailsModel(
+        service = "$55.00",
+        tax = "$4.50",
+        discount = "-",
+        total = "$59.50"
     )
 )

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/bookings/details/BookingDetailsViewState.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/bookings/details/BookingDetailsViewState.kt
@@ -40,5 +40,7 @@ data class BookingDetailsViewState(
         tax = "$4.50",
         discount = "-",
         total = "$59.50"
-    )
+    ),
+    val onMarkAsPaid: () -> Unit = {},
+    val onMarkAsRefunded: () -> Unit = {},
 )

--- a/WooCommerce/src/main/res/navigation/nav_graph_bookings.xml
+++ b/WooCommerce/src/main/res/navigation/nav_graph_bookings.xml
@@ -7,7 +7,7 @@
     <fragment
         android:id="@+id/bookingListFragment"
         android:name="com.woocommerce.android.ui.bookings.list.BookingListFragment"
-        android:label="fragment_bookings" >
+        android:label="fragment_bookings">
         <action
             android:id="@+id/action_bookingListFragment_to_bookingDetailsFragment"
             app:destination="@id/bookingDetailsFragment" />
@@ -20,6 +20,13 @@
             android:name="bookingId"
             android:defaultValue="-1L"
             app:argType="long" />
+        <action
+            android:id="@+id/action_bookingDetailsFragment_to_orderDetailFragment"
+            app:destination="@id/nav_graph_orders">
+            <argument
+                android:name="orderId"
+                app:argType="long" />
+        </action>
     </fragment>
 
 </navigation>

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -4899,6 +4899,5 @@
     <string name="booking_payment_label_service">Service</string>
     <string name="booking_payment_mark_as_paid">Mark as paid</string>
     <string name="booking_payment_view_order">View order</string>
-    <string name="booking_payment_mark_as_refunded">Mark as refunded</string>
 
 </resources>

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -4899,5 +4899,6 @@
     <string name="booking_payment_label_service">Service</string>
     <string name="booking_payment_mark_as_paid">Mark as paid</string>
     <string name="booking_payment_view_order">View order</string>
+    <string name="booking_payment_mark_as_refunded">Mark as refunded</string>
 
 </resources>

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -4895,5 +4895,9 @@
     <string name="booking_attendance_status_checked_in_desc">The customer arrived and the session took place as planned.</string>
     <string name="booking_attendance_status_cancelled_desc">The client will no longer be able to attend.</string>
     <string name="booking_attendance_status_no_show_desc">The client missed the appointment without canceling in advance.</string>
+    <string name="booking_payment_header">PAYMENT</string>
+    <string name="booking_payment_label_service">Service</string>
+    <string name="booking_payment_mark_as_paid">Mark as paid</string>
+    <string name="booking_payment_view_order">View order</string>
 
 </resources>

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/bookings/details/BookingDetailsViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/bookings/details/BookingDetailsViewModelTest.kt
@@ -2,11 +2,8 @@ package com.woocommerce.android.ui.bookings.details
 
 import androidx.lifecycle.SavedStateHandle
 import com.woocommerce.android.R
-<<<<<<< HEAD
 import com.woocommerce.android.ui.bookings.compose.BookingAttendanceStatus
-=======
 import com.woocommerce.android.util.getOrAwaitValue
->>>>>>> a4e6bd3632f (Move onAttendanceStatusSelected to BookingDetailsViewState)
 import com.woocommerce.android.viewmodel.BaseUnitTest
 import com.woocommerce.android.viewmodel.ResourceProvider
 import kotlinx.coroutines.ExperimentalCoroutinesApi
@@ -46,12 +43,8 @@ class BookingDetailsViewModelTest : BaseUnitTest() {
         val viewModel = createViewModel(savedState, resourceProvider)
 
         // When
-<<<<<<< HEAD
-        viewModel.onAttendanceStatusSelected(BookingAttendanceStatus.CANCELLED)
-=======
         val state = viewModel.state.getOrAwaitValue()
-        state.onAttendanceStatusSelected(com.woocommerce.android.ui.bookings.compose.AttendanceStatus.CANCELLED)
->>>>>>> a4e6bd3632f (Move onAttendanceStatusSelected to BookingDetailsViewState)
+        state.onAttendanceStatusSelected(BookingAttendanceStatus.CANCELLED)
 
         // Then
         val updated = viewModel.state.value?.bookingSummary?.attendanceStatus

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/bookings/details/BookingDetailsViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/bookings/details/BookingDetailsViewModelTest.kt
@@ -2,7 +2,11 @@ package com.woocommerce.android.ui.bookings.details
 
 import androidx.lifecycle.SavedStateHandle
 import com.woocommerce.android.R
+<<<<<<< HEAD
 import com.woocommerce.android.ui.bookings.compose.BookingAttendanceStatus
+=======
+import com.woocommerce.android.util.getOrAwaitValue
+>>>>>>> a4e6bd3632f (Move onAttendanceStatusSelected to BookingDetailsViewState)
 import com.woocommerce.android.viewmodel.BaseUnitTest
 import com.woocommerce.android.viewmodel.ResourceProvider
 import kotlinx.coroutines.ExperimentalCoroutinesApi
@@ -42,7 +46,12 @@ class BookingDetailsViewModelTest : BaseUnitTest() {
         val viewModel = createViewModel(savedState, resourceProvider)
 
         // When
+<<<<<<< HEAD
         viewModel.onAttendanceStatusSelected(BookingAttendanceStatus.CANCELLED)
+=======
+        val state = viewModel.state.getOrAwaitValue()
+        state.onAttendanceStatusSelected(com.woocommerce.android.ui.bookings.compose.AttendanceStatus.CANCELLED)
+>>>>>>> a4e6bd3632f (Move onAttendanceStatusSelected to BookingDetailsViewState)
 
         // Then
         val updated = viewModel.state.value?.bookingSummary?.attendanceStatus


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

<!-- Id number of the Linear issue this PR addresses, e.g., WOOMOB-373. -->
Closes WOOMOB-1346

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

This PR adds the payment section to the `BookingDetailsScreen` with a working `View order` button and not fully implemented `mark as paid/mark as refunded` buttons.

There are two extra commits that move the view model callback to the view state to limit the growing number of parameters - https://github.com/woocommerce/woocommerce-android/pull/14666/commits/fc1ae2f99091cc43f5bc2332f2832a56a424ff54 and https://github.com/woocommerce/woocommerce-android/pull/14666/commits/a4e6bd3632f7c4ce4924bcdd9702282b7e1ef8d3.

### Steps to reproduce
<!-- Step-by-step testing instructions. For new user flows, consider instead stating the goal of the workflow and see if your PR reviewer can accomplish the workflow without specific steps! -->

1. Use a CIAB site.
2. Manually install the bookings plugin from this ZIP file: p1758531103469849/1758101141.913349-slack-C03L1NF1EA3
3. You'll need to enable bookings v2 on your CIAB testing site. You can do that by installing the Code [Snippets plugin](https://wordpress.org/plugins/code-snippets/) to your site and adding the following PHP snippet: define( 'WC_BOOKINGS_NEXT_ENABLED', true );
4. Create some bookings.
5. Open the bookings tab
6. Tap on any booking
7. Scroll down and notice the payment section (data is hardcoded for now)
8. Tap on `View order` 
9. Confirm the order details screen was opened (the ID is hardcoded, so don't expect real data yet)

### Testing information
<!-- This is your opportunity to break out individual scenarios that need testing (when necessary) and/or include a checklist for the reviewer to go through. Consider documenting the following from your own completed testing: devices used, alternate workflows, edge cases, affected areas, critical flows, areas not tested, and any remaining unknowns. Provide feedback on this new section of the PR template through Sept 30, 2024 to Apps Quality; additional context here: p91TBi-b8z-p2#comment-12036 -->

You can verify with different font/view scaling and light/dark theme.
Tapping on the `Mark as paid`/`Mark as refunded` should also update the temp in-memory state.

### The tests that have been performed
<!-- To give the reviewer an idea of what could be missed in terms of testing -->

The above.

### Images/gif
<!-- Include before and after images or gifs when appropriate. -->

<img width="744" height="652" alt="Screenshot 2025-09-29 at 15 52 53" src="https://github.com/user-attachments/assets/73d002b8-7b42-4893-b59b-4141ff9ae70c" />

https://github.com/user-attachments/assets/f7bc8d3d-50a7-4585-b187-05f54911c2ac



- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->