### PR TITLE
[Tooling] [AINFRA-1332] Annotate builds with Sentry mapping UUID

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -20,21 +20,6 @@ steps:
   # Wait for Gradle Wrapper to be validated before running any other jobs
   - wait
 
-  - label: "🛠 Build {{matrix}} Bundle"
-    command: |
-      echo "--- :rubygems: Setting up Gems"
-      install_gems
-
-      echo "--- :closed_lock_with_key: Installing Secrets"
-      bundle exec fastlane run configure_apply
-
-      echo "--- :hammer_and_wrench: Building app"
-      bundle exec fastlane build_bundle app:"{{matrix}}"
-    plugins: [$CI_TOOLKIT]
-    matrix:
-      - WooCommerce
-      - WooCommerce-Wear
-
   ########################################
   - group: "🕵️ Linters"
     steps:

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -20,6 +20,21 @@ steps:
   # Wait for Gradle Wrapper to be validated before running any other jobs
   - wait
 
+  - label: "🛠 Build {{matrix}} Bundle"
+    command: |
+      echo "--- :rubygems: Setting up Gems"
+      install_gems
+
+      echo "--- :closed_lock_with_key: Installing Secrets"
+      bundle exec fastlane run configure_apply
+
+      echo "--- :hammer_and_wrench: Building app"
+      bundle exec fastlane build_bundle app:"{{matrix}}"
+    plugins: [$CI_TOOLKIT]
+    matrix:
+      - WooCommerce
+      - WooCommerce-Wear
+
   ########################################
   - group: "🕵️ Linters"
     steps:

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -897,6 +897,9 @@ platform :android do
       FileUtils.cp(File.join(output_dir, "#{flavor.downcase}Release", output_aab_file), artifact_final_path)
       UI.message("Bundle ready: #{artifact_final_path}")
     end
+
+    annotate_sentry_mapping_uuid(app: app, aab_file: artifact_final_path)
+
     artifact_final_path
   end
 
@@ -1246,6 +1249,25 @@ platform :android do
     key_file_secrets = JSON.parse(File.read(GOOGLE_FIREBASE_SECRETS_PATH))
     UI.user_error!("Unable to find key `#{name}` in #{GOOGLE_FIREBASE_SECRETS_PATH}") if key_file_secrets[name].nil?
     key_file_secrets[name]
+  end
+
+  def annotate_sentry_mapping_uuid(app:, aab_file:)
+    sentry_props = sh('unzip', '-p', aab_file, 'base/assets/sentry-debug-meta.properties', step_name: 'Extract sentry-debug-meta.properties') do |status, result, _|
+      status.success? ? result : nil
+    end
+    if sentry_props.nil?
+      UI.important("Unable to extract Sentry properties file from #{aab_file}. Skipping annotating the build with the mapping UUID.")
+      return
+    end
+
+    line = sentry_props.split("\n").find { |l| l.start_with?('io.sentry.ProguardUuids=') }
+    if line.nil?
+      UI.error("`io.sentry.ProguardUuids` line not found in #{aab_file}'s `sentry-debug-meta.properties` file")
+      return
+    end
+
+    uuid = line.split('=', 2).last.strip
+    buildkite_annotate(style: 'info', context: "sentry-mapping-uuid-#{app}", message: "Sentry mapping UUID for #{app}: #{uuid}")
   end
 
   # This function is Buildkite-specific


### PR DESCRIPTION
Closes [AINFRA-1332](https://linear.app/a8c/issue/AINFRA-1332/update-releasesv2-instructions-for-checking-mappings)
See: p1759078113521129-slack-C06CKSPHYA1

### Why

Sentry has updated their web UI and no longer show the list of releases associated with each Proguard Mapping file.
This made [the instructions in the ReleasesV2 step (about checking that the mapping file was uploaded) inconsistent](https://mc.a8c.com/releases-v2/release.php?product=WCAndroid&version=23.3#task-064b8aaa-8f60-4640-a017-d20fa03f0bc0-fragment), and means we no longer had a consistent way of validating if the mapping file was available in Sentry.

### How

This PR extracts the Sentry mapping UUID generated by the Sentry Gradle Plugin from the `assets/sentry-debug-meta.properties` file found within the produced `.aab` bundle, and exposes this information as a Buildkite annotation.

### What's Next

Once this is merged, we'll be able to update the wording of the ReleasesV2 scenario instructions to suggest to verify that the UUID in that annotation is present in Sentry.

### Testing Steps

See [annotations on this test build](https://buildkite.com/automattic/woocommerce-android/builds/32374/annotations)
<img width="664" height="140" alt="image" src="https://github.com/user-attachments/assets/1f0839d4-ffbe-4205-9dd6-e234b0fbd060" />

Compare with [Sentry's latests mapping files on their web UI](https://a8c.sentry.io/settings/projects/woocommerce-android/proguard/):
<img width="583" height="346" alt="image" src="https://github.com/user-attachments/assets/a64af611-54b4-49a9-9f5b-1a900437ff81" />
