### PR TITLE
[WOOMOB-1386] Update the attendance tag background color based on the state

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/bookings/compose/BookingAttendanceStatusTag.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/bookings/compose/BookingAttendanceStatusTag.kt
@@ -45,7 +45,7 @@ fun BookingAttendanceStatus.text(): String {
 @Composable
 fun BookingAttendanceStatus.backgroundColor(): Color {
     return when (this) {
-        BookingAttendanceStatus.NO_SHOW -> R.color.tag_bg_no_show
+        BookingAttendanceStatus.NO_SHOW -> R.color.tag_bg_booking_yellow
         BookingAttendanceStatus.BOOKED,
         BookingAttendanceStatus.CHECKED_IN,
         BookingAttendanceStatus.CANCELLED -> R.color.tagView_bg

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/bookings/compose/BookingAttendanceStatusTag.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/bookings/compose/BookingAttendanceStatusTag.kt
@@ -1,13 +1,17 @@
 package com.woocommerce.android.ui.bookings.compose
 
+import androidx.compose.foundation.layout.padding
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.res.colorResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
 import com.woocommerce.android.R
 import com.woocommerce.android.ui.compose.component.WCTag
+import com.woocommerce.android.ui.compose.preview.LightDarkThemePreviews
 import com.woocommerce.android.ui.compose.theme.WooThemeWithBackground
 
 @Composable
@@ -17,7 +21,7 @@ fun BookingAttendanceStatusTag(
 ) {
     WCTag(
         text = state.text(),
-        backgroundColor = colorResource(R.color.tagView_bg),
+        backgroundColor = state.backgroundColor(),
         textColor = colorResource(R.color.tagView_text),
         fontWeight = FontWeight.Normal,
         modifier = modifier
@@ -38,6 +42,16 @@ fun BookingAttendanceStatus.text(): String {
     }.let { stringResource(it) }
 }
 
+@Composable
+fun BookingAttendanceStatus.backgroundColor(): Color {
+    return when (this) {
+        BookingAttendanceStatus.NO_SHOW -> R.color.tag_bg_no_show
+        BookingAttendanceStatus.BOOKED,
+        BookingAttendanceStatus.CHECKED_IN,
+        BookingAttendanceStatus.CANCELLED -> R.color.tagView_bg
+    }.let { colorResource(it) }
+}
+
 @Preview
 @Composable
 private fun AttendanceStatusTagPreview() {
@@ -54,6 +68,17 @@ private fun AttendanceStatusTagDarkPreview() {
     WooThemeWithBackground {
         BookingAttendanceStatusTag(
             state = BookingAttendanceStatus.CHECKED_IN
+        )
+    }
+}
+
+@LightDarkThemePreviews
+@Composable
+private fun AttendanceStatusTagNoShowPreview() {
+    WooThemeWithBackground {
+        BookingAttendanceStatusTag(
+            state = BookingAttendanceStatus.NO_SHOW,
+            modifier = Modifier.padding(10.dp)
         )
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/bookings/details/BookingDetailsViewState.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/bookings/details/BookingDetailsViewState.kt
@@ -12,7 +12,7 @@ data class BookingDetailsViewState(
         date = "05/07/2025, 11:00 AM",
         name = "Women’s Haircut",
         customerName = "Margarita Nikolaevna",
-        attendanceStatus = BookingAttendanceStatus.CHECKED_IN,
+        attendanceStatus = BookingAttendanceStatus.NO_SHOW,
         status = BookingStatus.Paid
     ),
     val bookingsAppointmentDetails: BookingAppointmentDetailsModel = BookingAppointmentDetailsModel(

--- a/WooCommerce/src/main/res/values/colors_base.xml
+++ b/WooCommerce/src/main/res/values/colors_base.xml
@@ -130,7 +130,7 @@
     <color name="tag_bg_other">@color/woo_gray_5</color>
     <color name="tag_bg_main">@color/woo_purple_0</color>
     <color name="tag_bg_pos">@color/woo_purple_5</color>
-    <color name="tag_bg_no_show">#FFE365</color>
+    <color name="tag_bg_booking_yellow">#FFE365</color>
     <color name="tag_text_main">@color/color_primary</color>
     <color name="tag_text_pos">@color/woo_purple_60</color>
     <color name="tag_task_label">@color/woo_gray_6</color>

--- a/WooCommerce/src/main/res/values/colors_base.xml
+++ b/WooCommerce/src/main/res/values/colors_base.xml
@@ -130,6 +130,7 @@
     <color name="tag_bg_other">@color/woo_gray_5</color>
     <color name="tag_bg_main">@color/woo_purple_0</color>
     <color name="tag_bg_pos">@color/woo_purple_5</color>
+    <color name="tag_bg_no_show">#FFE365</color>
     <color name="tag_text_main">@color/color_primary</color>
     <color name="tag_text_pos">@color/woo_purple_60</color>
     <color name="tag_task_label">@color/woo_gray_6</color>


### PR DESCRIPTION
<!-- Remember about a good descriptive title.  -->

<!-- Id number of the Linear issue this PR addresses, e.g., WOOMOB-373. -->

Closes WOOMOB-1386

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

This PR updates the background color of the attendance tag based on the state. The `no show` should have a yellow background. 

### Steps to reproduce
<!-- Step-by-step testing instructions. For new user flows, consider instead stating the goal of the workflow and see if your PR reviewer can accomplish the workflow without specific steps! -->

1. Go to the bookings tab
2. Tap on any booking 


### Testing information
<!-- This is your opportunity to break out individual scenarios that need testing (when necessary) and/or include a checklist for the reviewer to go through. Consider documenting the following from your own completed testing: devices used, alternate workflows, edge cases, affected areas, critical flows, areas not tested, and any remaining unknowns. Provide feedback on this new section of the PR template through Sept 30, 2024 to Apps Quality; additional context here: p91TBi-b8z-p2#comment-12036 -->

Check light and dark theme

### The tests that have been performed
The above

### Images/gif
<!-- Include before and after images or gifs when appropriate. -->

| Light | Dark |
|---|---|
| <img width="439" height="318" alt="Screenshot 2025-10-01 at 11 59 26" src="https://github.com/user-attachments/assets/6716f175-b543-4d23-97d4-a2139c18df94" /> | <img width="434" height="310" alt="Screenshot 2025-10-01 at 11 59 35" src="https://github.com/user-attachments/assets/ff509410-619b-4b20-bb2c-a36d1a18530a" /> |

- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->