### PR TITLE
[CIAB] Bookings search

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/bookings/BookingsRepository.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/bookings/BookingsRepository.kt
@@ -14,12 +14,14 @@ class BookingsRepository @Inject constructor(
     suspend fun fetchBookings(
         page: Int,
         perPage: Int,
+        query: String? = null,
         filters: List<BookingsFilterOption> = emptyList()
     ): Result<Boolean> {
         val result = bookingsStore.fetchBookings(
             site = selectedSite.get(),
             perPage = perPage,
             page = page,
+            query = query,
             filters = filters
         )
         return if (result.isError) {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/bookings/BookingsRepository.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/bookings/BookingsRepository.kt
@@ -16,7 +16,7 @@ class BookingsRepository @Inject constructor(
         perPage: Int,
         query: String? = null,
         filters: List<BookingsFilterOption> = emptyList()
-    ): Result<Boolean> {
+    ): Result<FetchResult> {
         val result = bookingsStore.fetchBookings(
             site = selectedSite.get(),
             perPage = perPage,
@@ -27,7 +27,14 @@ class BookingsRepository @Inject constructor(
         return if (result.isError) {
             Result.failure(WooException(result.error))
         } else {
-            Result.success(result.model!!)
+            Result.success(
+                result.model!!.let {
+                    FetchResult(
+                        bookings = it.bookings,
+                        hasMorePages = it.hasMorePages
+                    )
+                }
+            )
         }
     }
 
@@ -40,6 +47,11 @@ class BookingsRepository @Inject constructor(
             limit = limit,
             filters = filters
         )
+
+    data class FetchResult(
+        val bookings: List<Booking>,
+        val hasMorePages: Boolean
+    )
 }
 
 typealias Booking = org.wordpress.android.fluxc.persistence.entity.BookingEntity

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/bookings/list/BookingListFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/bookings/list/BookingListFragment.kt
@@ -11,6 +11,7 @@ import com.woocommerce.android.ui.base.TopLevelFragment
 import com.woocommerce.android.ui.base.UIMessageResolver
 import com.woocommerce.android.ui.compose.composeView
 import com.woocommerce.android.ui.main.AppBarStatus
+import com.woocommerce.android.ui.main.MainActivity
 import com.woocommerce.android.viewmodel.MultiLiveEvent
 import dagger.hilt.android.AndroidEntryPoint
 import javax.inject.Inject
@@ -39,6 +40,7 @@ class BookingListFragment : TopLevelFragment() {
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         handleEvents()
+        handleBottomNavigationVisibility()
     }
 
     private fun handleEvents() {
@@ -52,6 +54,16 @@ class BookingListFragment : TopLevelFragment() {
                 }
 
                 is MultiLiveEvent.Event.ShowSnackbar -> uiMessageResolver.showSnack(event.message)
+            }
+        }
+    }
+
+    private fun handleBottomNavigationVisibility() {
+        viewModel.bottomNavigationVisible.observe(viewLifecycleOwner) { isVisible ->
+            if (!isVisible) {
+                (activity as? MainActivity)?.hideBottomNav()
+            } else {
+                (activity as? MainActivity)?.showBottomNav()
             }
         }
     }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/bookings/list/BookingListHandler.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/bookings/list/BookingListHandler.kt
@@ -67,34 +67,31 @@ class BookingListHandler @Inject constructor(
                 canLoadMore.set(false)
                 Result.success(Unit)
             } else {
-                searchBookings()
+                fetchBookings()
             }
         }
     }
 
     suspend fun loadMore(): Result<Unit> = mutex.withLock {
         if (!canLoadMore.get()) return@withLock Result.success(Unit)
-        return if (searchQuery.value == null) {
-            fetchBookings()
-        } else {
-            searchBookings()
-        }
+        return fetchBookings()
     }
 
     private suspend fun fetchBookings(): Result<Unit> {
+        val isSearching = !searchQuery.value.isNullOrEmpty()
         return bookingsRepository.fetchBookings(
             page = page.value,
             perPage = PAGE_SIZE,
+            query = searchQuery.value,
             filters = filters.value
-        ).onSuccess { hasMorePages ->
-            canLoadMore.set(hasMorePages)
-            if (hasMorePages) {
+        ).onSuccess { result ->
+            canLoadMore.set(result.hasMorePages)
+            if (result.hasMorePages) {
                 page.update { it + 1 }
             }
+            if (isSearching) {
+                searchResults.update { it + result.bookings }
+            }
         }.map { }
-    }
-
-    private suspend fun searchBookings(): Result<Unit> {
-        TODO("Not yet implemented")
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/bookings/list/BookingListHandler.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/bookings/list/BookingListHandler.kt
@@ -43,7 +43,6 @@ class BookingListHandler @Inject constructor(
 
     suspend fun loadBookings(
         searchQuery: String? = null,
-        forceRefresh: Boolean = false,
         filters: List<BookingsFilterOption> = emptyList()
     ): Result<Unit> = mutex.withLock {
         // Reset pagination attributes
@@ -54,12 +53,7 @@ class BookingListHandler @Inject constructor(
         this.filters.value = filters
 
         return@withLock if (searchQuery == null) {
-            if (forceRefresh) {
-                fetchBookings()
-            } else {
-                // Load from DB only
-                Result.success(Unit)
-            }
+            fetchBookings()
         } else {
             searchResults.value = emptyList()
             if (searchQuery.isEmpty()) {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/bookings/list/BookingListHandler.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/bookings/list/BookingListHandler.kt
@@ -34,7 +34,7 @@ class BookingListHandler @Inject constructor(
 
     @OptIn(ExperimentalCoroutinesApi::class)
     val bookingsFlow: Flow<List<Booking>> = combine(searchQuery, filters, page) { query, filters, page ->
-        if (query == null) {
+        if (query.isNullOrEmpty()) {
             bookingsRepository.observeBookings(limit = page * PAGE_SIZE, filters)
         } else {
             searchResults
@@ -57,7 +57,7 @@ class BookingListHandler @Inject constructor(
         } else {
             searchResults.value = emptyList()
             if (searchQuery.isEmpty()) {
-                // If the query is empty, clear search results directly
+                // If the query is empty, return cached results directly
                 canLoadMore.set(false)
                 Result.success(Unit)
             } else {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/bookings/list/BookingListScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/bookings/list/BookingListScreen.kt
@@ -1,5 +1,6 @@
 package com.woocommerce.android.ui.bookings.list
 
+import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Column
@@ -91,19 +92,22 @@ fun BookingListScreen(state: BookingListViewState) {
         val lazyListState = rememberLazyListState()
 
         Column(modifier = Modifier.padding(paddingValues)) {
-            WCPrimaryTabRow(
-                tabs = BookingListTab.entries,
-                selectedTab = state.tabState.selectedTab,
-                tabName = { it.name() },
-                onTabSelected = {
-                    // Scroll to top when tab changes
-                    coroutineScope.launch {
-                        lazyListState.scrollToItem(0)
-                    }
-                    state.tabState.onTabChanged(it)
-                },
-                modifier = Modifier
-            )
+            AnimatedVisibility(!state.searchState.isSearchActive) {
+                WCPrimaryTabRow(
+                    tabs = BookingListTab.entries,
+                    selectedTab = state.tabState.selectedTab,
+                    tabName = { it.name() },
+                    onTabSelected = {
+                        // Scroll to top when tab changes
+                        coroutineScope.launch {
+                            lazyListState.scrollToItem(0)
+                        }
+                        state.tabState.onTabChanged(it)
+                    },
+                    modifier = Modifier
+                )
+            }
+
             when {
                 state.contentState.isNotEmpty() -> {
                     BookingList(

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/bookings/list/BookingListScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/bookings/list/BookingListScreen.kt
@@ -12,9 +12,13 @@ import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.LazyListState
 import androidx.compose.foundation.lazy.itemsIndexed
 import androidx.compose.foundation.lazy.rememberLazyListState
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material.icons.filled.Search
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
@@ -31,6 +35,7 @@ import com.woocommerce.android.ui.compose.component.InfiniteListHandler
 import com.woocommerce.android.ui.compose.component.Toolbar
 import com.woocommerce.android.ui.compose.component.WCPrimaryTabRow
 import com.woocommerce.android.ui.compose.component.WCPullToRefreshBox
+import com.woocommerce.android.ui.compose.component.WCSearchField
 import com.woocommerce.android.ui.compose.preview.LightDarkThemePreviews
 import com.woocommerce.android.ui.compose.theme.WooThemeWithBackground
 import kotlinx.coroutines.launch
@@ -48,7 +53,37 @@ fun BookingListScreen(state: BookingListViewState) {
         topBar = {
             Toolbar(
                 title = stringResource(R.string.bookings_tab_title),
-                navigationIcon = null
+                navigationIcon = null,
+                actions = {
+                    if (!state.searchState.isSearchActive) {
+                        Icon(
+                            imageVector = Icons.Default.Search,
+                            contentDescription = stringResource(R.string.search),
+                            tint = MaterialTheme.colorScheme.onSurface,
+                            modifier = Modifier
+                                .clickable(onClick = {
+                                    state.searchState.onQueryChanged("")
+                                })
+                                .padding(12.dp)
+                        )
+                    } else {
+                        Icon(
+                            imageVector = Icons.AutoMirrored.Default.ArrowBack,
+                            contentDescription = stringResource(R.string.back),
+                            tint = MaterialTheme.colorScheme.onSurface,
+                            modifier = Modifier
+                                .clickable(onClick = {
+                                    state.searchState.onQueryChanged(null)
+                                })
+                                .padding(12.dp)
+                        )
+                        WCSearchField(
+                            value = state.searchState.query ?: "",
+                            onValueChange = { state.searchState.onQueryChanged(it) },
+                            hint = "Search bookings"
+                        )
+                    }
+                }
             )
         }
     ) { paddingValues ->
@@ -184,6 +219,10 @@ private fun BookingListPreview() {
                 tabState = BookingListTabState(
                     selectedTab = BookingListTab.Today,
                     onTabChanged = {}
+                ),
+                searchState = BookingListSearchState(
+                    query = null,
+                    onQueryChanged = {}
                 )
             )
         )

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/bookings/list/BookingListScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/bookings/list/BookingListScreen.kt
@@ -1,6 +1,5 @@
 package com.woocommerce.android.ui.bookings.list
 
-import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Column
@@ -77,20 +76,18 @@ fun BookingListScreen(state: BookingListViewState) {
         val lazyListState = rememberLazyListState()
 
         Column(modifier = Modifier.padding(paddingValues)) {
-            AnimatedVisibility(true) {
-                WCPrimaryTabRow(
-                    tabs = BookingListTab.entries,
-                    selectedTab = state.tabState.selectedTab,
-                    tabName = { it.name() },
-                    onTabSelected = {
-                        // Scroll to top when tab changes
-                        coroutineScope.launch {
-                            lazyListState.scrollToItem(0)
-                        }
-                        state.tabState.onTabChanged(it)
+            WCPrimaryTabRow(
+                tabs = BookingListTab.entries,
+                selectedTab = state.tabState.selectedTab,
+                tabName = { it.name() },
+                onTabSelected = {
+                    // Scroll to top when tab changes
+                    coroutineScope.launch {
+                        lazyListState.scrollToItem(0)
                     }
-                )
-            }
+                    state.tabState.onTabChanged(it)
+                }
+            )
 
             when {
                 state.contentState.isNotEmpty() -> {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/bookings/list/BookingListScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/bookings/list/BookingListScreen.kt
@@ -4,6 +4,7 @@ import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
@@ -21,6 +22,7 @@ import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
@@ -30,6 +32,7 @@ import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.livedata.observeAsState
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.focus.FocusRequester
 import androidx.compose.ui.focus.focusRequester
@@ -61,49 +64,10 @@ fun BookingListScreen(state: BookingListViewState) {
                 title = stringResource(R.string.bookings_tab_title),
                 navigationIcon = null,
                 actions = {
-                    val focusRequester = remember { FocusRequester() }
-
-                    LaunchedEffect(state.searchState.isSearchActive) {
-                        if (state.searchState.isSearchActive) {
-                            focusRequester.requestFocus()
-                        }
-                    }
-
-                    if (!state.searchState.isSearchActive) {
-                        Icon(
-                            imageVector = Icons.Default.Search,
-                            contentDescription = stringResource(R.string.search),
-                            modifier = Modifier
-                                .clickable(onClick = {
-                                    state.searchState.onQueryChanged("")
-                                })
-                                .padding(12.dp)
-                        )
-                    } else {
-                        Icon(
-                            imageVector = Icons.AutoMirrored.Default.ArrowBack,
-                            contentDescription = stringResource(R.string.back),
-                            tint = MaterialTheme.colorScheme.onSurface,
-                            modifier = Modifier
-                                .clickable(onClick = {
-                                    state.searchState.onQueryChanged(null)
-                                })
-                                .padding(start = 16.dp)
-                        )
-                        WCSearchField(
-                            value = state.searchState.query ?: "",
-                            onValueChange = { state.searchState.onQueryChanged(it) },
-                            hint = if (state.areFiltersActive) {
-                                stringResource(R.string.bookings_search_with_filters_hint)
-                            } else {
-                                stringResource(R.string.bookings_search_hint)
-                            },
-                            modifier = Modifier
-                                .focusRequester(focusRequester)
-                                .fillMaxWidth()
-                                .padding(horizontal = 16.dp)
-                        )
-                    }
+                    SearchSection(
+                        searchState = state.searchState,
+                        areFiltersActive = state.areFiltersActive
+                    )
                 }
             )
         },
@@ -157,6 +121,61 @@ fun BookingListScreen(state: BookingListViewState) {
                     )
                 }
             }
+        }
+    }
+}
+
+@Composable
+private fun SearchSection(
+    searchState: BookingListSearchState,
+    areFiltersActive: Boolean,
+    modifier: Modifier = Modifier
+) {
+    val focusRequester = remember { FocusRequester() }
+
+    LaunchedEffect(searchState.isSearchActive) {
+        if (searchState.isSearchActive) {
+            focusRequester.requestFocus()
+        }
+    }
+
+    Row(
+        verticalAlignment = Alignment.CenterVertically,
+        modifier = modifier,
+    ) {
+        if (!searchState.isSearchActive) {
+            IconButton(onClick = {
+                searchState.onQueryChanged("")
+            }) {
+                Icon(
+                    imageVector = Icons.Default.Search,
+                    contentDescription = stringResource(R.string.search)
+                )
+            }
+        } else {
+            IconButton(onClick = {
+                searchState.onQueryChanged(null)
+            }) {
+                Icon(
+                    imageVector = Icons.AutoMirrored.Default.ArrowBack,
+                    contentDescription = stringResource(R.string.back),
+                    tint = MaterialTheme.colorScheme.onSurface
+                )
+            }
+
+            WCSearchField(
+                value = searchState.query ?: "",
+                onValueChange = { searchState.onQueryChanged(it) },
+                hint = if (areFiltersActive) {
+                    stringResource(R.string.bookings_search_with_filters_hint)
+                } else {
+                    stringResource(R.string.bookings_search_hint)
+                },
+                modifier = Modifier
+                    .focusRequester(focusRequester)
+                    .fillMaxWidth()
+                    .padding(horizontal = 16.dp)
+            )
         }
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/bookings/list/BookingListScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/bookings/list/BookingListScreen.kt
@@ -76,7 +76,7 @@ fun BookingListScreen(state: BookingListViewState) {
                                 .clickable(onClick = {
                                     state.searchState.onQueryChanged(null)
                                 })
-                                .padding(12.dp)
+                                .padding(start = 16.dp)
                         )
                         WCSearchField(
                             value = state.searchState.query ?: "",
@@ -85,7 +85,10 @@ fun BookingListScreen(state: BookingListViewState) {
                                 stringResource(R.string.bookings_search_with_filters_hint)
                             } else {
                                 stringResource(R.string.bookings_search_hint)
-                            }
+                            },
+                            modifier = Modifier
+                                .fillMaxWidth()
+                                .padding(horizontal = 16.dp)
                         )
                     }
                 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/bookings/list/BookingListScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/bookings/list/BookingListScreen.kt
@@ -26,9 +26,13 @@ import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
 import androidx.compose.material3.pulltorefresh.rememberPullToRefreshState
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.livedata.observeAsState
+import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.focus.FocusRequester
+import androidx.compose.ui.focus.focusRequester
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import com.woocommerce.android.R
@@ -57,6 +61,14 @@ fun BookingListScreen(state: BookingListViewState) {
                 title = stringResource(R.string.bookings_tab_title),
                 navigationIcon = null,
                 actions = {
+                    val focusRequester = remember { FocusRequester() }
+
+                    LaunchedEffect(state.searchState.isSearchActive) {
+                        if (state.searchState.isSearchActive) {
+                            focusRequester.requestFocus()
+                        }
+                    }
+
                     if (!state.searchState.isSearchActive) {
                         Icon(
                             imageVector = Icons.Default.Search,
@@ -87,6 +99,7 @@ fun BookingListScreen(state: BookingListViewState) {
                                 stringResource(R.string.bookings_search_hint)
                             },
                             modifier = Modifier
+                                .focusRequester(focusRequester)
                                 .fillMaxWidth()
                                 .padding(horizontal = 16.dp)
                         )

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/bookings/list/BookingListScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/bookings/list/BookingListScreen.kt
@@ -82,7 +82,8 @@ fun BookingListScreen(state: BookingListViewState) {
                         WCSearchField(
                             value = state.searchState.query ?: "",
                             onValueChange = { state.searchState.onQueryChanged(it) },
-                            hint = "Search bookings"
+                            // TODO use a specific hint when filters are applied like what we do on other screens
+                            hint = stringResource(R.string.bookings_search_hint)
                         )
                     }
                 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/bookings/list/BookingListScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/bookings/list/BookingListScreen.kt
@@ -61,7 +61,6 @@ fun BookingListScreen(state: BookingListViewState) {
                         Icon(
                             imageVector = Icons.Default.Search,
                             contentDescription = stringResource(R.string.search),
-                            tint = MaterialTheme.colorScheme.onSurface,
                             modifier = Modifier
                                 .clickable(onClick = {
                                     state.searchState.onQueryChanged("")
@@ -98,7 +97,7 @@ fun BookingListScreen(state: BookingListViewState) {
         val lazyListState = rememberLazyListState()
 
         Column(modifier = Modifier.padding(paddingValues)) {
-            AnimatedVisibility(!state.searchState.isSearchActive) {
+            AnimatedVisibility(true) {
                 WCPrimaryTabRow(
                     tabs = BookingListTab.entries,
                     selectedTab = state.tabState.selectedTab,

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/bookings/list/BookingListScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/bookings/list/BookingListScreen.kt
@@ -4,6 +4,7 @@ import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
@@ -86,7 +87,8 @@ fun BookingListScreen(state: BookingListViewState) {
                     }
                 }
             )
-        }
+        },
+        contentWindowInsets = WindowInsets()
     ) { paddingValues ->
         val coroutineScope = rememberCoroutineScope()
         val lazyListState = rememberLazyListState()
@@ -103,8 +105,7 @@ fun BookingListScreen(state: BookingListViewState) {
                             lazyListState.scrollToItem(0)
                         }
                         state.tabState.onTabChanged(it)
-                    },
-                    modifier = Modifier
+                    }
                 )
             }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/bookings/list/BookingListScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/bookings/list/BookingListScreen.kt
@@ -82,8 +82,11 @@ fun BookingListScreen(state: BookingListViewState) {
                         WCSearchField(
                             value = state.searchState.query ?: "",
                             onValueChange = { state.searchState.onQueryChanged(it) },
-                            // TODO use a specific hint when filters are applied like what we do on other screens
-                            hint = stringResource(R.string.bookings_search_hint)
+                            hint = if (state.areFiltersActive) {
+                                stringResource(R.string.bookings_search_with_filters_hint)
+                            } else {
+                                stringResource(R.string.bookings_search_hint)
+                            }
                         )
                     }
                 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/bookings/list/BookingListViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/bookings/list/BookingListViewModel.kt
@@ -3,17 +3,22 @@ package com.woocommerce.android.ui.bookings.list
 import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.asLiveData
 import androidx.lifecycle.viewModelScope
+import com.woocommerce.android.AppConstants
 import com.woocommerce.android.R
 import com.woocommerce.android.viewmodel.MultiLiveEvent
 import com.woocommerce.android.viewmodel.ScopedViewModel
 import com.woocommerce.android.viewmodel.getNullableStateFlow
 import com.woocommerce.android.viewmodel.getStateFlow
 import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.FlowPreview
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.flow.debounce
+import kotlinx.coroutines.flow.drop
 import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.merge
 import kotlinx.coroutines.launch
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.bookings.BookingsFilterOption
 import javax.inject.Inject
@@ -73,24 +78,33 @@ class BookingListViewModel @Inject constructor(
     }.asLiveData()
 
     init {
-        monitorFilterChanges()
+        monitorSearchAndFilterChanges()
     }
 
-    private fun monitorFilterChanges() {
+    @OptIn(FlowPreview::class)
+    private fun monitorSearchAndFilterChanges() {
         launch {
-            selectedTab.collectLatest {
-                // Cancel any ongoing fetch or load more operations
-                bookingsFetchJob?.cancel()
-                bookingsLoadMoreJob?.cancel()
+            val queryFlow = searchQuery
+                .drop(1) // Skip the initial value to avoid double fetch on init
+                .debounce {
+                    if (it.isNullOrEmpty()) 0L else AppConstants.SEARCH_TYPING_DELAY_MS
+                }
 
-                bookingsFetchJob = fetchBookings(BookingListLoadingState.Loading)
-            }
+            merge(selectedTab, queryFlow)
+                .collectLatest {
+                    // Cancel any ongoing fetch or load more operations
+                    bookingsFetchJob?.cancel()
+                    bookingsLoadMoreJob?.cancel()
+
+                    bookingsFetchJob = fetchBookings(BookingListLoadingState.Loading)
+                }
         }
     }
 
     private fun fetchBookings(initialLoadingState: BookingListLoadingState) = launch {
         loadingState.value = initialLoadingState
         bookingListHandler.loadBookings(
+            searchQuery = searchQuery.value,
             forceRefresh = true,
             filters = prepareFilters()
         ).onFailure {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/bookings/list/BookingListViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/bookings/list/BookingListViewModel.kt
@@ -77,6 +77,9 @@ class BookingListViewModel @Inject constructor(
         )
     }.asLiveData()
 
+    val bottomNavigationVisible = searchState.map { !it.isSearchActive }
+        .asLiveData()
+
     init {
         monitorSearchAndFilterChanges()
     }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/bookings/list/BookingListViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/bookings/list/BookingListViewModel.kt
@@ -6,6 +6,7 @@ import androidx.lifecycle.viewModelScope
 import com.woocommerce.android.R
 import com.woocommerce.android.viewmodel.MultiLiveEvent
 import com.woocommerce.android.viewmodel.ScopedViewModel
+import com.woocommerce.android.viewmodel.getNullableStateFlow
 import com.woocommerce.android.viewmodel.getStateFlow
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.Job
@@ -25,6 +26,12 @@ class BookingListViewModel @Inject constructor(
 ) : ScopedViewModel(savedStateHandle) {
     private val loadingState = MutableStateFlow(BookingListLoadingState.Idle)
     private val selectedTab = savedStateHandle.getStateFlow(viewModelScope, BookingListTab.Today)
+    private val searchQuery = savedStateHandle.getNullableStateFlow(
+        scope = viewModelScope,
+        initialValue = null,
+        clazz = String::class.java,
+        key = "searchQuery"
+    )
 
     private var bookingsFetchJob: Job? = null
     private var bookingsLoadMoreJob: Job? = null
@@ -41,17 +48,27 @@ class BookingListViewModel @Inject constructor(
             onBookingClick = ::onBookingClick
         )
     }
+    private val searchState = searchQuery.map {
+        BookingListSearchState(
+            query = it,
+            onQueryChanged = { newQuery ->
+                searchQuery.value = newQuery
+            }
+        )
+    }
 
     val state = combine(
         contentState,
-        selectedTab
-    ) { contentState, selectedTab ->
+        selectedTab,
+        searchState
+    ) { contentState, selectedTab, searchState ->
         BookingListViewState(
             contentState = contentState,
             tabState = BookingListTabState(
                 selectedTab = selectedTab,
                 onTabChanged = ::onTabChanged
-            )
+            ),
+            searchState = searchState
         )
     }.asLiveData()
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/bookings/list/BookingListViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/bookings/list/BookingListViewModel.kt
@@ -105,7 +105,6 @@ class BookingListViewModel @Inject constructor(
         loadingState.value = initialLoadingState
         bookingListHandler.loadBookings(
             searchQuery = searchQuery.value,
-            forceRefresh = true,
             filters = prepareFilters()
         ).onFailure {
             triggerEvent(MultiLiveEvent.Event.ShowSnackbar(R.string.bookings_fetch_error))

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/bookings/list/BookingListViewState.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/bookings/list/BookingListViewState.kt
@@ -12,7 +12,11 @@ data class BookingListViewState(
     val contentState: BookingListContentState,
     val tabState: BookingListTabState,
     val searchState: BookingListSearchState
-)
+) {
+    // TODO combine with other filters when available
+    val areFiltersActive: Boolean
+        get() = tabState.selectedTab != BookingListTab.All
+}
 
 data class BookingListContentState(
     val bookings: List<BookingListItem>,

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/bookings/list/BookingListViewState.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/bookings/list/BookingListViewState.kt
@@ -10,7 +10,8 @@ import java.time.format.FormatStyle
 
 data class BookingListViewState(
     val contentState: BookingListContentState,
-    val tabState: BookingListTabState
+    val tabState: BookingListTabState,
+    val searchState: BookingListSearchState
 )
 
 data class BookingListContentState(
@@ -21,6 +22,14 @@ data class BookingListContentState(
     val onBookingClick: (Long) -> Unit,
 ) {
     fun isNotEmpty() = bookings.isNotEmpty()
+}
+
+data class BookingListSearchState(
+    val query: String?,
+    val onQueryChanged: (String?) -> Unit
+) {
+    val isSearchActive: Boolean
+        get() = query != null
 }
 
 data class BookingListTabState(

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/compose/component/TextFields.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/compose/component/TextFields.kt
@@ -31,6 +31,8 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberUpdatedState
+import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -204,9 +206,20 @@ fun WCSearchField(
     keyboardOptions: KeyboardOptions = KeyboardOptions.Default,
     keyboardActions: KeyboardActions = KeyboardActions.Default,
 ) {
+    var textFieldValueState by rememberSaveable(stateSaver = TextFieldValue.Saver) {
+        mutableStateOf(TextFieldValue(text = value))
+    }
+    val lastValue by rememberUpdatedState(value)
+
     BasicTextField(
-        value = value,
-        onValueChange = onValueChange,
+        value = textFieldValueState,
+        onValueChange = {
+            textFieldValueState = it
+            if (it.text != lastValue) {
+                // Update external value when changed
+                onValueChange(it.text)
+            }
+        },
         textStyle = TextStyle(
             color = colorResource(id = R.color.color_on_surface),
             textDirection = ContentOrLtr

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -4862,6 +4862,7 @@
     <string name="bookings_tab_upcoming">Upcoming</string>
     <string name="bookings_tab_all">All</string>
     <string name="bookings_search_hint">Search bookings</string>
+    <string name="bookings_search_with_filters_hint">Search filtered bookings</string>
 
     <!-- Booking details view-->
     <string name="booking_details_title">Booking #%s</string>

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -4861,6 +4861,7 @@
     <string name="bookings_tab_today">Today</string>
     <string name="bookings_tab_upcoming">Upcoming</string>
     <string name="bookings_tab_all">All</string>
+    <string name="bookings_search_hint">Search bookings</string>
 
     <!-- Booking details view-->
     <string name="booking_details_title">Booking #%s</string>

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/bookings/list/BookingListHandlerTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/bookings/list/BookingListHandlerTest.kt
@@ -64,7 +64,7 @@ class BookingListHandlerTest : BaseUnitTest() {
     @Test
     fun `given no search query and force refresh, when loading bookings, then fetches from repository`() =
         testBlocking {
-            val result = bookingListHandler.loadBookings(searchQuery = null, forceRefresh = true)
+            val result = bookingListHandler.loadBookings(searchQuery = null)
             val bookings = bookingListHandler.bookingsFlow.first()
 
             assertThat(result.isSuccess).isTrue()
@@ -78,7 +78,7 @@ class BookingListHandlerTest : BaseUnitTest() {
             given(bookingsRepository.fetchBookings(page = any(), perPage = any(), filters = any()))
                 .willReturn(Result.failure(exception))
 
-            val result = bookingListHandler.loadBookings(searchQuery = null, forceRefresh = true)
+            val result = bookingListHandler.loadBookings(searchQuery = null)
 
             assertThat(result.isFailure).isTrue()
             assertThat(result.exceptionOrNull()).isEqualTo(exception)
@@ -95,7 +95,7 @@ class BookingListHandlerTest : BaseUnitTest() {
 
     @Test
     fun `when load more is called and can load more is true, then fetches next page`() = testBlocking {
-        bookingListHandler.loadBookings(forceRefresh = true)
+        bookingListHandler.loadBookings()
 
         val result = bookingListHandler.loadMore()
         val bookings = bookingListHandler.bookingsFlow.first()
@@ -106,7 +106,7 @@ class BookingListHandlerTest : BaseUnitTest() {
 
     @Test
     fun `when last page is reached, then can load more becomes false`() = testBlocking {
-        bookingListHandler.loadBookings(forceRefresh = true)
+        bookingListHandler.loadBookings()
 
         var result: Result<Unit>? = null
         repeat(availablePages - 1) {
@@ -124,11 +124,11 @@ class BookingListHandlerTest : BaseUnitTest() {
     @Test
     fun `when load bookings is called, then pagination resets`() = testBlocking {
         // First load and load more to advance page
-        bookingListHandler.loadBookings(forceRefresh = true)
+        bookingListHandler.loadBookings()
         bookingListHandler.loadMore()
 
         // Load bookings again - should reset to page 1
-        bookingListHandler.loadBookings(forceRefresh = true)
+        bookingListHandler.loadBookings()
         val bookings = bookingListHandler.bookingsFlow.first()
 
         assertThat(bookings).hasSize(BookingListHandler.PAGE_SIZE)
@@ -136,7 +136,7 @@ class BookingListHandlerTest : BaseUnitTest() {
 
     @Test
     fun `when bookings flow is observed with pagination, then limit increases correctly`() = testBlocking {
-        bookingListHandler.loadBookings(forceRefresh = true)
+        bookingListHandler.loadBookings()
 
         val initialBookings = bookingListHandler.bookingsFlow.first()
         assertThat(initialBookings).hasSize(BookingListHandler.PAGE_SIZE)
@@ -152,8 +152,8 @@ class BookingListHandlerTest : BaseUnitTest() {
     @Test
     fun `when concurrent load operations occur, then operations are synchronized`() = testBlocking {
         // Launch multiple concurrent load operations
-        val job1 = launch { bookingListHandler.loadBookings(forceRefresh = true) }
-        val job2 = launch { bookingListHandler.loadBookings(forceRefresh = true) }
+        val job1 = launch { bookingListHandler.loadBookings() }
+        val job2 = launch { bookingListHandler.loadBookings() }
         val job3 = launch { bookingListHandler.loadMore() }
 
         job1.join()

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/bookings/list/BookingListHandlerTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/bookings/list/BookingListHandlerTest.kt
@@ -14,6 +14,7 @@ import kotlinx.coroutines.launch
 import org.assertj.core.api.Assertions.assertThat
 import org.mockito.ArgumentMatchers.intThat
 import org.mockito.kotlin.any
+import org.mockito.kotlin.anyOrNull
 import org.mockito.kotlin.doAnswer
 import org.mockito.kotlin.eq
 import org.mockito.kotlin.given
@@ -36,16 +37,18 @@ class BookingListHandlerTest : BaseUnitTest() {
             val limit = invocation.getArgument<Int>(0)
             results.map { it.take(limit) }
         }
-        onBlocking { fetchBookings(any(), any(), any()) } doAnswer InlineClassesAnswer { invocation ->
+        onBlocking { fetchBookings(any(), any(), anyOrNull(), any()) } doAnswer InlineClassesAnswer { invocation ->
             val page = invocation.getArgument<Int>(0)
             val perPage = invocation.getArgument<Int>(1)
             val canLoadMore = page < availablePages
-            when (page) {
-                1 -> results.update { List(perPage) { getSampleBooking(it) } }
-                availablePages -> results.update { list -> list + List(5) { getSampleBooking(it + perPage) } }
-                else -> results.update { list -> list + List(perPage) { getSampleBooking(it + perPage) } }
+            val bookings = when (page) {
+                1 -> List(perPage) { getSampleBooking(it) }
+                availablePages -> List(5) { getSampleBooking(it + (page - 1) * perPage) }
+                else -> List(perPage) { getSampleBooking(it + (page - 1) * perPage) }
             }
-            Result.success(canLoadMore)
+            if (page == 1) results.update { emptyList() }
+            results.update { it + bookings }
+            Result.success(BookingsRepository.FetchResult(bookings, canLoadMore))
         }
     }
 
@@ -75,7 +78,7 @@ class BookingListHandlerTest : BaseUnitTest() {
     fun `given repository fetch fails, when loading bookings with force refresh, then returns failure`() =
         testBlocking {
             val exception = Exception("Network error")
-            given(bookingsRepository.fetchBookings(page = any(), perPage = any(), filters = any()))
+            given(bookingsRepository.fetchBookings(page = any(), perPage = any(), query = anyOrNull(), filters = any()))
                 .willReturn(Result.failure(exception))
 
             val result = bookingListHandler.loadBookings(searchQuery = null)
@@ -90,7 +93,12 @@ class BookingListHandlerTest : BaseUnitTest() {
             val result = bookingListHandler.loadMore()
 
             assertThat(result.isSuccess).isTrue()
-            verify(bookingsRepository, never()).fetchBookings(any(), any(), any())
+            verify(bookingsRepository, never()).fetchBookings(
+                page = any(),
+                perPage = any(),
+                query = anyOrNull(),
+                filters = any()
+            )
         }
 
     @Test
@@ -117,6 +125,7 @@ class BookingListHandlerTest : BaseUnitTest() {
         verify(bookingsRepository, never()).fetchBookings(
             page = intThat { it > availablePages },
             perPage = any(),
+            query = anyOrNull(),
             filters = any()
         )
     }

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/bookings/list/BookingListViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/bookings/list/BookingListViewModelTest.kt
@@ -34,7 +34,6 @@ class BookingListViewModelTest : BaseUnitTest() {
         onBlocking {
             loadBookings(
                 searchQuery = anyOrNull(),
-                forceRefresh = any(),
                 filters = any()
             )
         } doReturn Result.success(Unit)
@@ -68,7 +67,7 @@ class BookingListViewModelTest : BaseUnitTest() {
         advanceUntilIdle()
 
         // THEN
-        verify(bookingListHandler).loadBookings(searchQuery = eq(null), forceRefresh = eq(true), filters = any())
+        verify(bookingListHandler).loadBookings(searchQuery = eq(null), filters = any())
 
         val state = viewModel.state.getOrAwaitValue().contentState
         assertThat(state.bookings).hasSize(1)
@@ -107,7 +106,6 @@ class BookingListViewModelTest : BaseUnitTest() {
         // THEN
         verify(bookingListHandler, times(2)).loadBookings(
             searchQuery = eq(null),
-            forceRefresh = eq(true),
             filters = any()
         )
     }
@@ -148,7 +146,7 @@ class BookingListViewModelTest : BaseUnitTest() {
     fun `when booking handler fails to load, then show error snackbar`() = testBlocking {
         // GIVEN
         setup {
-            whenever(bookingListHandler.loadBookings(searchQuery = anyOrNull(), forceRefresh = any(), filters = any()))
+            whenever(bookingListHandler.loadBookings(searchQuery = anyOrNull(), filters = any()))
                 .thenReturn(Result.failure(Exception("Network error")))
         }
 
@@ -209,7 +207,6 @@ class BookingListViewModelTest : BaseUnitTest() {
         // THEN
         verify(bookingListHandler).loadBookings(
             searchQuery = eq(null),
-            forceRefresh = eq(true),
             filters = eq(
                 listOfNotNull(
                     with(filtersBuilder) {

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/bookings/list/BookingListViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/bookings/list/BookingListViewModelTest.kt
@@ -217,6 +217,60 @@ class BookingListViewModelTest : BaseUnitTest() {
         )
     }
 
+    @Test
+    fun `when search query is changed, then state is updated`() = testBlocking {
+        // GIVEN
+        setup()
+
+        // WHEN
+        val initialState = viewModel.state.getOrAwaitValue()
+        initialState.searchState.onQueryChanged("test query")
+
+        // THEN
+        val updatedState = viewModel.state.getOrAwaitValue()
+        assertThat(updatedState.searchState.query).isEqualTo("test query")
+        assertThat(updatedState.searchState.isSearchActive).isTrue()
+    }
+
+    @Test
+    fun `when search query is changed, then bookings are refetched`() = testBlocking {
+        // GIVEN
+        setup()
+
+        // WHEN
+        val initialState = viewModel.state.getOrAwaitValue()
+        initialState.searchState.onQueryChanged("test query")
+        advanceUntilIdle()
+
+        // THEN
+        verify(bookingListHandler).loadBookings(
+            searchQuery = eq("test query"),
+            filters = any()
+        )
+    }
+
+    @Test
+    fun `when search query is cleared, then isSearchActive becomes false and bookings are refetched`() = testBlocking {
+        // GIVEN
+        setup()
+
+        // WHEN
+        val initialState = viewModel.state.getOrAwaitValue()
+        initialState.searchState.onQueryChanged("test query")
+        val stateWithQuery = viewModel.state.getOrAwaitValue()
+        stateWithQuery.searchState.onQueryChanged(null)
+        advanceUntilIdle()
+
+        // THEN
+        val clearedState = viewModel.state.getOrAwaitValue()
+        assertThat(clearedState.searchState.query).isNull()
+        assertThat(clearedState.searchState.isSearchActive).isFalse()
+        verify(bookingListHandler, times(2)).loadBookings(
+            searchQuery = eq(null),
+            filters = any()
+        )
+    }
+
     private fun getSampleBooking(id: Int): Booking {
         return BookingEntity(
             id = LocalOrRemoteId.RemoteId(id.toLong()),

--- a/libs/fluxc-plugin/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/bookings/BookingsFetchResult.kt
+++ b/libs/fluxc-plugin/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/bookings/BookingsFetchResult.kt
@@ -1,0 +1,8 @@
+package org.wordpress.android.fluxc.network.rest.wpcom.wc.bookings
+
+import org.wordpress.android.fluxc.persistence.entity.BookingEntity
+
+data class BookingsFetchResult(
+    val bookings: List<BookingEntity>,
+    val hasMorePages: Boolean
+)

--- a/libs/fluxc-plugin/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/bookings/BookingsRestClient.kt
+++ b/libs/fluxc-plugin/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/bookings/BookingsRestClient.kt
@@ -7,6 +7,7 @@ import org.wordpress.android.fluxc.network.rest.wpapi.WPAPIResponse.Success
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.WooNetwork
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.WooPayload
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.toWooError
+import org.wordpress.android.fluxc.utils.extensions.filterNotNull
 import javax.inject.Inject
 import javax.inject.Singleton
 
@@ -22,6 +23,7 @@ class BookingsRestClient @Inject constructor(
         site: SiteModel,
         perPage: Int,
         page: Int,
+        query: String?,
         filters: List<BookingsFilterOption>
     ): WooPayload<Array<BookingDto>> {
         val endpoint = WOOCOMMERCE.bookings.pathV2Bookings
@@ -32,8 +34,9 @@ class BookingsRestClient @Inject constructor(
             clazz = Array<BookingDto>::class.java,
             params = mapOf(
                 "per_page" to perPage.toString(),
-                "page" to page.toString()
-            ) + filters.toQueryParams()
+                "page" to page.toString(),
+                "search" to query
+            ).filterNotNull() + filters.toQueryParams()
         )
         return when (response) {
             is Success -> WooPayload(response.data)

--- a/libs/fluxc-plugin/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/bookings/BookingsStore.kt
+++ b/libs/fluxc-plugin/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/bookings/BookingsStore.kt
@@ -36,7 +36,7 @@ class BookingsStore @Inject constructor(
             when {
                 response.isError -> WooResult(response.error)
                 response.result != null -> {
-                    if (page == 1 && filters.isEmpty()) {
+                    if (page == 1 && filters.isEmpty() && query.isNullOrEmpty()) {
                         // Clear existing bookings when fetching the first page
                         // TODO when we support text search, we should only clear if no search is applied
                         bookingsDao.deleteAllForSite(site.localId())

--- a/libs/fluxc-plugin/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/bookings/BookingsStore.kt
+++ b/libs/fluxc-plugin/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/bookings/BookingsStore.kt
@@ -28,10 +28,11 @@ class BookingsStore @Inject constructor(
         site: SiteModel,
         perPage: Int = BookingsRestClient.DEFAULT_PER_PAGE,
         page: Int = 1,
+        query: String? = null,
         filters: List<BookingsFilterOption> = emptyList()
     ): WooResult<Boolean> {
         return coroutineEngine.withDefaultContext(AppLog.T.API, this, "fetchBookings") {
-            val response = bookingsRestClient.fetchBookings(site, perPage, page, filters)
+            val response = bookingsRestClient.fetchBookings(site, perPage, page, query, filters)
             when {
                 response.isError -> WooResult(response.error)
                 response.result != null -> {

--- a/libs/fluxc-plugin/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/bookings/BookingsStore.kt
+++ b/libs/fluxc-plugin/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/bookings/BookingsStore.kt
@@ -30,7 +30,7 @@ class BookingsStore @Inject constructor(
         page: Int = 1,
         query: String? = null,
         filters: List<BookingsFilterOption> = emptyList()
-    ): WooResult<Boolean> {
+    ): WooResult<BookingsFetchResult> {
         return coroutineEngine.withDefaultContext(AppLog.T.API, this, "fetchBookings") {
             val response = bookingsRestClient.fetchBookings(site, perPage, page, query, filters)
             when {
@@ -38,7 +38,6 @@ class BookingsStore @Inject constructor(
                 response.result != null -> {
                     if (page == 1 && filters.isEmpty() && query.isNullOrEmpty()) {
                         // Clear existing bookings when fetching the first page
-                        // TODO when we support text search, we should only clear if no search is applied
                         bookingsDao.deleteAllForSite(site.localId())
                     }
                     val entities = response.result.map { it.toEntity(site.localId()) }
@@ -46,8 +45,13 @@ class BookingsStore @Inject constructor(
                     val totalPages = headersParser.getTotalPages(response.headers)
                     // Determine if we can load more from the total pages header if available, otherwise
                     // infer it from the number of items returned
-                    val canLoadMore = (totalPages?.let { it > page }) ?: (entities.size == perPage)
-                    WooResult(canLoadMore)
+                    val hasMorePages = (totalPages?.let { it > page }) ?: (entities.size == perPage)
+                    WooResult(
+                        BookingsFetchResult(
+                            bookings = entities,
+                            hasMorePages = hasMorePages
+                        )
+                    )
                 }
 
                 else -> WooResult(WooError(GENERIC_ERROR, UNKNOWN))


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

<!-- Id number of the Linear issue this PR addresses, e.g., WOOMOB-373. -->
Closes WOOMOB-1402

### Description
This PR adds UI and logic for the search feature, and some notes about the implementation:
- Like what we do in orders and products, the selected filters are also applied during the search.
- To align with the design, and to follow what we do with products and orders, the tabs bar is hidden when search is active.

I have some concerns with the above approach as it can be confusing as to why the search is not returning results, I started a discussion about this in Slack p1759333433022899-slack-C09FHQNQERG, and I'll update the implementation when we make a final decision.

### Steps to reproduce
1. Use a CIAB site.
2. Manually install the bookings plugin from this ZIP file: p1758531103469849/1758101141.913349-slack-C03L1NF1EA3
3. You'll need to enable bookings v2 on your CIAB testing site. You can do that by installing the Code [Snippets plugin](https://wordpress.org/plugins/code-snippets/) to your site and adding the following PHP snippet: `define( 'WC_BOOKINGS_NEXT_ENABLED', true );`
4. Create some bookings.
5. Test searching.

### Testing information
- From my testing, searching will check against the product name and the customer, so check this. And note that the data displayed is just mocked, so check the actual product name on your store.

### The tests that have been performed
The above.

### Images/gif

For the video, ignore the wrong tint color of the search icon, and the wrong paddings, I recorded this before finishing the final UI, the screenshots show the final UI.

https://github.com/user-attachments/assets/bf0b25f1-ce71-42fa-b139-9e107fcb6fa6

| Light | Dark |
| --- | --- |
| <img width="1080" height="2400" alt="Screenshot_20251001_225752" src="https://github.com/user-attachments/assets/c17d393b-123c-444a-b1e8-887248ecc055" /> | <img width="1080" height="2400" alt="Screenshot_20251001_225736" src="https://github.com/user-attachments/assets/2850b392-c1db-472c-a2d7-acc653b5218f" /> |

- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->