### PR TITLE
[WOOMOB-1410][Woo POS][Surveys] Implement persistent flags

### DIFF
--- a/WooCommerce/src/androidTest/kotlin/com/woocommerce/android/AppPrefsTest.kt
+++ b/WooCommerce/src/androidTest/kotlin/com/woocommerce/android/AppPrefsTest.kt
@@ -10,7 +10,6 @@ import org.assertj.core.api.Assertions.assertThat
 import org.junit.Before
 import org.junit.Test
 
-@Suppress("UnitTestNamingRule")
 class AppPrefsTest {
     @Before
     fun setup() {
@@ -592,5 +591,45 @@ class AppPrefsTest {
         AppPrefs.clearPOSLaunchableForSite(siteId)
 
         assertThat(AppPrefs.isPOSLaunchableForSite(siteId)).isFalse
+    }
+
+    @Test
+    fun givenWooPosSurveyNotificationCurrentUserShownNotSetThenReturnFalseByDefault() {
+        assertThat(AppPrefs.isWooPosSurveyNotificationCurrentUserShown).isFalse
+    }
+
+    @Test
+    fun givenWooPosSurveyNotificationCurrentUserShownSetToTrueThenReturnTrue() {
+        AppPrefs.isWooPosSurveyNotificationCurrentUserShown = true
+
+        assertThat(AppPrefs.isWooPosSurveyNotificationCurrentUserShown).isTrue
+    }
+
+    @Test
+    fun givenWooPosSurveyNotificationCurrentUserShownSetToFalseThenReturnFalse() {
+        AppPrefs.isWooPosSurveyNotificationCurrentUserShown = true
+        AppPrefs.isWooPosSurveyNotificationCurrentUserShown = false
+
+        assertThat(AppPrefs.isWooPosSurveyNotificationCurrentUserShown).isFalse
+    }
+
+    @Test
+    fun givenWooPosSurveyNotificationPotentialUserShownNotSetThenReturnFalseByDefault() {
+        assertThat(AppPrefs.isWooPosSurveyNotificationPotentialUserShown).isFalse
+    }
+
+    @Test
+    fun givenWooPosSurveyNotificationPotentialUserShownSetToTrueThenReturnTrue() {
+        AppPrefs.isWooPosSurveyNotificationPotentialUserShown = true
+
+        assertThat(AppPrefs.isWooPosSurveyNotificationPotentialUserShown).isTrue
+    }
+
+    @Test
+    fun givenWooPosSurveyNotificationPotentialUserShownSetToFalseThenReturnFalse() {
+        AppPrefs.isWooPosSurveyNotificationPotentialUserShown = true
+        AppPrefs.isWooPosSurveyNotificationPotentialUserShown = false
+
+        assertThat(AppPrefs.isWooPosSurveyNotificationPotentialUserShown).isFalse
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/AppPrefs.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/AppPrefs.kt
@@ -213,7 +213,11 @@ object AppPrefs {
 
         POS_TAB_VISIBILITY,
 
-        POS_LAUNCHABLE
+        POS_LAUNCHABLE,
+
+        WOO_POS_SURVEY_NOTIFICATION_CURRENT_USER_SHOWN,
+
+        WOO_POS_SURVEY_NOTIFICATION_POTENTIAL_USER_SHOWN
     }
 
     fun init(context: Context) {
@@ -1352,6 +1356,14 @@ object AppPrefs {
             Context.MODE_PRIVATE
         )
     }
+
+    var isWooPosSurveyNotificationCurrentUserShown: Boolean
+        get() = getBoolean(UndeletablePrefKey.WOO_POS_SURVEY_NOTIFICATION_CURRENT_USER_SHOWN, false)
+        set(value) = setBoolean(UndeletablePrefKey.WOO_POS_SURVEY_NOTIFICATION_CURRENT_USER_SHOWN, value)
+
+    var isWooPosSurveyNotificationPotentialUserShown: Boolean
+        get() = getBoolean(UndeletablePrefKey.WOO_POS_SURVEY_NOTIFICATION_POTENTIAL_USER_SHOWN, false)
+        set(value) = setBoolean(UndeletablePrefKey.WOO_POS_SURVEY_NOTIFICATION_POTENTIAL_USER_SHOWN, value)
 
     enum class CardReaderOnboardingStatus {
         CARD_READER_ONBOARDING_COMPLETED,

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/items/WooPosItemsViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/items/WooPosItemsViewModel.kt
@@ -16,6 +16,7 @@ import com.woocommerce.android.ui.woopos.util.analytics.WooPosAnalyticsEvent
 import com.woocommerce.android.ui.woopos.util.analytics.WooPosAnalyticsEvent.Event.SearchButtonTapped
 import com.woocommerce.android.ui.woopos.util.analytics.WooPosAnalyticsEventConstant
 import com.woocommerce.android.ui.woopos.util.analytics.WooPosAnalyticsTracker
+import com.woocommerce.android.ui.woopos.util.datastore.WooPosPreferencesRepository
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharingStarted
@@ -32,6 +33,7 @@ class WooPosItemsViewModel @Inject constructor(
     private val couponCreationFacade: WooPosCouponCreationFacade,
     private val fromChildToParentEventSender: WooPosChildrenToParentEventSender,
     private val parentToChildrenEventReceiver: WooPosParentToChildrenEventReceiver,
+    private val preferencesRepository: WooPosPreferencesRepository,
     private val analyticsTracker: WooPosAnalyticsTracker,
 ) : ViewModel() {
     private var preservedStateBeforeOpeningVariations: WooPosItemsToolbarViewState? = null
@@ -49,6 +51,10 @@ class WooPosItemsViewModel @Inject constructor(
             coroutineScope = viewModelScope,
             viewStateFlow = _viewState
         )
+
+        viewModelScope.launch {
+            preferencesRepository.setWasOpenedOnce(true)
+        }
     }
 
     fun onUIEvent(event: WooPosItemsUIEvent) {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/util/datastore/WooPosPreferencesRepository.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/util/datastore/WooPosPreferencesRepository.kt
@@ -2,6 +2,7 @@ package com.woocommerce.android.ui.woopos.util.datastore
 
 import androidx.datastore.core.DataStore
 import androidx.datastore.preferences.core.Preferences
+import androidx.datastore.preferences.core.booleanPreferencesKey
 import androidx.datastore.preferences.core.edit
 import androidx.datastore.preferences.core.stringPreferencesKey
 import com.woocommerce.android.tools.SelectedSite
@@ -15,6 +16,7 @@ class WooPosPreferencesRepository @Inject constructor(
 ) {
     private val recentProductSearchesSiteSpecificKey = buildSiteSpecificKey(RECENT_PRODUCT_SEARCHES_KEY)
     private val recentCouponSearchesSiteSpecificKey = buildSiteSpecificKey(RECENT_COUPON_SEARCHES_KEY)
+    private val wasOpenedOnceKey = booleanPreferencesKey(POS_WAS_OPENED_ONCE_KEY)
 
     val recentProductSearches: Flow<List<String>> = dataStore.data
         .map { preferences ->
@@ -26,6 +28,11 @@ class WooPosPreferencesRepository @Inject constructor(
         .map { preferences ->
             val searchesString = preferences[recentCouponSearchesSiteSpecificKey] ?: ""
             if (searchesString.isEmpty()) emptyList() else searchesString.split(",")
+        }
+
+    val wasOpenedOnce: Flow<Boolean> = dataStore.data
+        .map { preferences ->
+            preferences[wasOpenedOnceKey] ?: false
         }
 
     suspend fun addRecentProductSearch(search: String) {
@@ -56,12 +63,19 @@ class WooPosPreferencesRepository @Inject constructor(
         }
     }
 
+    suspend fun setWasOpenedOnce(wasOpened: Boolean) {
+        dataStore.edit { preferences ->
+            preferences[wasOpenedOnceKey] = wasOpened
+        }
+    }
+
     private fun buildSiteSpecificKey(key: String): Preferences.Key<String> =
         stringPreferencesKey("${selectedSite.getOrNull()?.siteId}-$key")
 
     private companion object {
         const val RECENT_PRODUCT_SEARCHES_KEY = "recent_product_searches_key"
         const val RECENT_COUPON_SEARCHES_KEY = "recent_coupon_searches_key"
+        const val POS_WAS_OPENED_ONCE_KEY = "pos_was_opened_once_key"
 
         const val MAX_RECENT_SEARCHES_COUNT = 10
     }

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/home/items/WooPosItemsViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/home/items/WooPosItemsViewModelTest.kt
@@ -14,6 +14,7 @@ import com.woocommerce.android.ui.woopos.util.analytics.WooPosAnalyticsEvent
 import com.woocommerce.android.ui.woopos.util.analytics.WooPosAnalyticsEvent.Event.SearchButtonTapped
 import com.woocommerce.android.ui.woopos.util.analytics.WooPosAnalyticsEventConstant
 import com.woocommerce.android.ui.woopos.util.analytics.WooPosAnalyticsTracker
+import com.woocommerce.android.ui.woopos.util.datastore.WooPosPreferencesRepository
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.test.runTest
@@ -53,6 +54,7 @@ class WooPosItemsViewModelTest {
     private val couponCreationFacade: WooPosCouponCreationFacade = mock()
     private val fromChildToParentEventSender: WooPosChildrenToParentEventSender = mock()
     private val parentToChildrenEventReceiver: WooPosParentToChildrenEventReceiver = mock()
+    private val preferencesRepository: WooPosPreferencesRepository = mock()
 
     @Before
     fun setup() {
@@ -435,6 +437,17 @@ class WooPosItemsViewModelTest {
         verify(searchHelper).updateLoadingState(isLoading = false)
     }
 
+    @Test
+    fun `when view model created, then wasOpenedOnce is set to true`() = runTest {
+        // GIVEN
+
+        // WHEN
+        createViewModel()
+
+        // THEN
+        verify(preferencesRepository).setWasOpenedOnce(true)
+    }
+
     private fun createViewModel(): WooPosItemsViewModel {
         return WooPosItemsViewModel(
             searchHelper = searchHelper,
@@ -442,6 +455,7 @@ class WooPosItemsViewModelTest {
             couponCreationFacade = couponCreationFacade,
             fromChildToParentEventSender = fromChildToParentEventSender,
             parentToChildrenEventReceiver = parentToChildrenEventReceiver,
+            preferencesRepository = preferencesRepository,
             analyticsTracker = analyticsTracker,
         )
     }


### PR DESCRIPTION
WOOMOB-1410

### Description
Implements persistent flags to support Woo POS survey notifications. This adds infrastructure to track:
- Whether the POS has been opened at least once
- Whether survey notifications have been shown to current users
- Whether survey notifications have been shown to potential users

The implementation includes:
- `wasOpenedOnce` flag in `WooPosPreferencesRepository` using DataStore (global, not site-specific)
- Survey notification visibility flags in `AppPrefs` (persist after logout)
- Integration with `WooPosItemsViewModel` to automatically set the POS opened flag

### Steps to reproduce
Not in use yet

### Testing information
- Unit tests verify flag persistence and default values
- Tests confirm the POS opened flag is set on ViewModel initialization
- Survey notification flags are tested for both current and potential users

### The tests that have been performed
- Unit tests

- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.