### PR TITLE
[CIAB Bookings] Update logic of tabs filtering

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/bookings/list/BookingListFiltersBuilder.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/bookings/list/BookingListFiltersBuilder.kt
@@ -3,18 +3,26 @@ package com.woocommerce.android.ui.bookings.list
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.bookings.BookingsFilterOption
 import java.time.Clock
 import java.time.Instant
+import java.time.LocalDate
 import java.time.LocalTime
-import java.time.ZonedDateTime
+import java.time.ZoneOffset
 import javax.inject.Inject
 
 class BookingListFiltersBuilder @Inject constructor(
     private val clock: Clock
 ) {
+    /**
+     * Returns a [BookingsFilterOption.DateRange] based on the selected [BookingListTab].
+     *
+     * We use UTC for the API calls, as the API stores the dates without timezone information, which means that
+     * when comparing dates, they are treated as UTC times.
+     * See p1759398245019489-slack-C09FHQNQERG
+     */
     fun BookingListTab.asDateRangeFilter(): BookingsFilterOption.DateRange? {
         return when (this) {
             BookingListTab.Today -> BookingsFilterOption.DateRange(
-                before = ZonedDateTime.now(clock).with(LocalTime.MAX).toInstant(),
-                after = ZonedDateTime.now(clock).with(LocalTime.MIN).toInstant()
+                before = LocalDate.now(clock).atTime(LocalTime.MAX).atOffset(ZoneOffset.UTC).toInstant(),
+                after = LocalDate.now(clock).atTime(LocalTime.MIDNIGHT).atOffset(ZoneOffset.UTC).toInstant()
             )
 
             BookingListTab.Upcoming -> BookingsFilterOption.DateRange(

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/bookings/list/BookingListFiltersBuilder.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/bookings/list/BookingListFiltersBuilder.kt
@@ -18,15 +18,18 @@ class BookingListFiltersBuilder @Inject constructor(
      * See p1759398245019489-slack-C09FHQNQERG
      */
     fun BookingListTab.asDateRangeFilter(): BookingsFilterOption.DateRange? {
+        fun todayAtMidnight() = LocalDate.now(clock).atTime(LocalTime.MIDNIGHT).atOffset(ZoneOffset.UTC).toInstant()
+        fun todayAtEndOfDay() = LocalDate.now(clock).atTime(LocalTime.MAX).atOffset(ZoneOffset.UTC).toInstant()
+
         return when (this) {
             BookingListTab.Today -> BookingsFilterOption.DateRange(
-                before = LocalDate.now(clock).atTime(LocalTime.MAX).atOffset(ZoneOffset.UTC).toInstant(),
-                after = LocalDate.now(clock).atTime(LocalTime.MIDNIGHT).atOffset(ZoneOffset.UTC).toInstant()
+                before = todayAtEndOfDay(),
+                after = todayAtMidnight()
             )
 
             BookingListTab.Upcoming -> BookingsFilterOption.DateRange(
                 before = null,
-                after = LocalDate.now(clock).atTime(LocalTime.MAX).atOffset(ZoneOffset.UTC).toInstant()
+                after = todayAtEndOfDay()
             )
 
             BookingListTab.All -> null

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/bookings/list/BookingListFiltersBuilder.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/bookings/list/BookingListFiltersBuilder.kt
@@ -2,7 +2,6 @@ package com.woocommerce.android.ui.bookings.list
 
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.bookings.BookingsFilterOption
 import java.time.Clock
-import java.time.Instant
 import java.time.LocalDate
 import java.time.LocalTime
 import java.time.ZoneOffset
@@ -27,7 +26,7 @@ class BookingListFiltersBuilder @Inject constructor(
 
             BookingListTab.Upcoming -> BookingsFilterOption.DateRange(
                 before = null,
-                after = Instant.now(clock)
+                after = LocalDate.now(clock).atTime(LocalTime.MAX).atOffset(ZoneOffset.UTC).toInstant()
             )
 
             BookingListTab.All -> null

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/bookings/list/BookingListFilterBuilderTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/bookings/list/BookingListFilterBuilderTest.kt
@@ -21,8 +21,8 @@ class BookingListFilterBuilderTest {
         }
 
         assertThat(filter).isNotNull()
-        assertThat(filter?.after).isEqualTo(Instant.parse("2025-01-01T00:00:00+02:00"))
-        assertThat(filter?.before).isEqualTo(Instant.parse("2025-01-01T23:59:59.999999999+02:00"))
+        assertThat(filter?.after).isEqualTo(Instant.parse("2025-01-01T00:00:00+00:00"))
+        assertThat(filter?.before).isEqualTo(Instant.parse("2025-01-01T23:59:59.999999999+00:00"))
     }
 
     @Test

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/bookings/list/BookingListFilterBuilderTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/bookings/list/BookingListFilterBuilderTest.kt
@@ -32,7 +32,7 @@ class BookingListFilterBuilderTest {
         }
 
         assertThat(filter).isNotNull()
-        assertThat(filter?.after).isEqualTo(mockedNow)
+        assertThat(filter?.after).isEqualTo(Instant.parse("2025-01-01T23:59:59.999999999+00:00"))
         assertThat(filter?.before).isNull()
     }
 


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

<!-- Id number of the Linear issue this PR addresses, e.g., WOOMOB-373. -->
Closes WOOMOB-1404

### Description
This PR updates the logic of filtering to match what the API expects, because the API stores dates without timezone information (dates stored as strings), it ignores any timezone information when filtering, so to get the correct results for date filtering, we need to send the dates as UTC.

### Steps to reproduce
1. Prepare a CIAB site with bookings (check previous PRs for steps if needed).
2. Create some bookings.
3. Confirm Today and Upcoming behave as expected.

### Testing information
- Check the bookings times listed on the server, and confirm that Today lists all bookings for today, and Upcoming lists all future bookings (from tomorrow midnight).

### The tests that have been performed
- The above.
- Also I created a booking at `11:30pm` on the server, and confirmed that the logic now works well, as this booking wasn't shown before for today (my local timezone is UTC+1).

### Images/gif
| Before (missing one booking) | After |
| --- | --- |
| <img width="360" alt="Screenshot_20251002_181303" src="https://github.com/user-attachments/assets/b8724e43-189c-4ec3-8b71-b5e5dd9104ea" /> | <img width="360" alt="Screenshot_20251002_182207" src="https://github.com/user-attachments/assets/07d601a3-c381-41b1-b7e4-6e366bf7060f" /> |

- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->