### PR TITLE
Add release notes for version 23.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 <!--
 Contains editorialized release notes. Raw release notes should go into `RELEASE-NOTES.txt`.
 -->
+## 23.4
+We've improved the Blaze campaign experience! Creating campaigns now works smoothly for all products, including those with PDF thumbnails. Update today for a more reliable advertising experience.
+
 ## 23.3
 This update brings smoother performance for WordPress.com users, clearer shipping label creation with improved package and hazardous item selection, and easier access to all orders from a customer. We also fixed small UI glitches like notification icon sizing and delays on the site picker screen.
 

--- a/fastlane/metadata/android/en-US/changelogs/default.txt
+++ b/fastlane/metadata/android/en-US/changelogs/default.txt
@@ -1,1 +1,1 @@
-- [*] Fixed an issue where Blaze campaign creation could fail for products using PDF thumbnails as images [https://github.com/woocommerce/woocommerce-android/pull/14642]
+We've improved the Blaze campaign experience! Creating campaigns now works smoothly for all products, including those with PDF thumbnails. Update today for a more reliable advertising experience.


### PR DESCRIPTION
Added release notes for version 23.4 highlighting improvements to the Blaze campaign experience.
