### PR TITLE
Fix Room crash in 23.3

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/applicationpasswords/WooApplicationPasswordsConfiguration.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/applicationpasswords/WooApplicationPasswordsConfiguration.kt
@@ -2,21 +2,34 @@ package com.woocommerce.android.applicationpasswords
 
 import com.woocommerce.android.AppPrefsWrapper
 import com.woocommerce.android.BuildConfig
+import com.woocommerce.android.di.AppCoroutineScope
 import com.woocommerce.android.util.DeviceInfo
 import com.woocommerce.android.util.IsRemoteFeatureFlagEnabled
 import com.woocommerce.android.util.RemoteFeatureFlag
 import jakarta.inject.Inject
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.CoroutineStart
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.async
 import org.wordpress.android.fluxc.network.rest.wpapi.applicationpasswords.ApplicationPasswordsConfiguration
 
 class WooApplicationPasswordsConfiguration @Inject constructor(
     private val appPrefs: AppPrefsWrapper,
-    private val isRemoteFeatureFlagEnabled: IsRemoteFeatureFlagEnabled
+    private val isRemoteFeatureFlagEnabled: IsRemoteFeatureFlagEnabled,
+    @AppCoroutineScope private val appCoroutineScope: CoroutineScope
 ) : ApplicationPasswordsConfiguration {
+    private val remoteFeatureFlagDeferred = appCoroutineScope.async(
+        start = CoroutineStart.LAZY,
+        context = Dispatchers.IO
+    ) {
+        isRemoteFeatureFlagEnabled(RemoteFeatureFlag.APP_PASSWORDS_FOR_JETPACK_SITES)
+    }
+
     override val applicationName: String =
         "${BuildConfig.APPLICATION_ID}.app-client.${DeviceInfo.name.replace(' ', '-')}"
 
     override suspend fun isEnabledForJetpackAccess(): Boolean {
         return appPrefs.jetpackAppPasswordsEnabled &&
-            isRemoteFeatureFlagEnabled(RemoteFeatureFlag.APP_PASSWORDS_FOR_JETPACK_SITES)
+            remoteFeatureFlagDeferred.await()
     }
 }

--- a/libs/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/FeatureFlagConfigDao.kt
+++ b/libs/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/FeatureFlagConfigDao.kt
@@ -12,11 +12,9 @@ import org.wordpress.android.fluxc.persistence.FeatureFlagConfigDao.FeatureFlagV
 
 @Dao
 abstract class FeatureFlagConfigDao {
-    @Transaction
     @Query("SELECT * from FeatureFlagConfigurations")
     abstract fun getFeatureFlagList(): List<FeatureFlag>
 
-    @Transaction
     @Query("SELECT * from FeatureFlagConfigurations WHERE `key` = :key")
     abstract fun getFeatureFlag(key: String): List<FeatureFlag>
 
@@ -36,7 +34,6 @@ abstract class FeatureFlagConfigDao {
         }
     }
 
-    @Transaction
     @Query("DELETE FROM FeatureFlagConfigurations")
     abstract fun clear()
 


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

<!-- Id number of the Linear issue this PR addresses, e.g., WOOMOB-373. -->

### Description
This PR fixes the crash discussed here p1759469754623059-slack-C6H8C3G23, the PR includes the following changes:

- Removes the `@Transaction` annotation from the `FeatureFlagConfigDao` functions, the Dao functions involve a single table, so the transaction usage wasn't needed anyway, and it's most probably what's causing the crash here (more details in the above thread).
- Just for more safety, we cache the feature flag in memory, and we ensure we call the DB just once.

### Steps to reproduce
1. Add a `print` statement in this [line](https://github.com/woocommerce/woocommerce-android/blob/c787f89e663a2b2545e6350819947679606f15fe/WooCommerce/src/main/kotlin/com/woocommerce/android/applicationpasswords/WooApplicationPasswordsConfiguration.kt#L25)
2. Sign in using WordPress.com
3. Open the app, and check that the print statement is invoked only once.
4. Confirm the app uses app passwords (by inspecting network).


### The tests that have been performed
The above.

- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->