### PR TITLE
[WOOMOB-1411][Woo POS][Surveys] Add local notification infrastructure for Woo POS surveys

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/AppPrefs.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/AppPrefs.kt
@@ -310,6 +310,14 @@ object AppPrefs {
         get() = getBoolean(DeletablePrefKey.JETPACK_APP_PASSWORDS_ENABLED, true)
         set(value) = setBoolean(DeletablePrefKey.JETPACK_APP_PASSWORDS_ENABLED, value)
 
+    var isWooPosSurveyNotificationCurrentUserShown: Boolean
+        get() = getBoolean(UndeletablePrefKey.WOO_POS_SURVEY_NOTIFICATION_CURRENT_USER_SHOWN, false)
+        set(value) = setBoolean(UndeletablePrefKey.WOO_POS_SURVEY_NOTIFICATION_CURRENT_USER_SHOWN, value)
+
+    var isWooPosSurveyNotificationPotentialUserShown: Boolean
+        get() = getBoolean(UndeletablePrefKey.WOO_POS_SURVEY_NOTIFICATION_POTENTIAL_USER_SHOWN, false)
+        set(value) = setBoolean(UndeletablePrefKey.WOO_POS_SURVEY_NOTIFICATION_POTENTIAL_USER_SHOWN, value)
+
     fun getProductSortingChoice(currentSiteId: Int) = getString(getProductSortingKey(currentSiteId)).orNullIfEmpty()
 
     fun setProductSortingChoice(currentSiteId: Int, value: String) {
@@ -1356,14 +1364,6 @@ object AppPrefs {
             Context.MODE_PRIVATE
         )
     }
-
-    var isWooPosSurveyNotificationCurrentUserShown: Boolean
-        get() = getBoolean(UndeletablePrefKey.WOO_POS_SURVEY_NOTIFICATION_CURRENT_USER_SHOWN, false)
-        set(value) = setBoolean(UndeletablePrefKey.WOO_POS_SURVEY_NOTIFICATION_CURRENT_USER_SHOWN, value)
-
-    var isWooPosSurveyNotificationPotentialUserShown: Boolean
-        get() = getBoolean(UndeletablePrefKey.WOO_POS_SURVEY_NOTIFICATION_POTENTIAL_USER_SHOWN, false)
-        set(value) = setBoolean(UndeletablePrefKey.WOO_POS_SURVEY_NOTIFICATION_POTENTIAL_USER_SHOWN, value)
 
     enum class CardReaderOnboardingStatus {
         CARD_READER_ONBOARDING_COMPLETED,

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/AppPrefsWrapper.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/AppPrefsWrapper.kt
@@ -41,6 +41,8 @@ open class AppPrefsWrapper @Inject constructor() {
 
     var isWooPosSurveyNotificationPotentialUserShown by AppPrefs::isWooPosSurveyNotificationPotentialUserShown
 
+    var isWooPosSurveyNotificationCurrentUserShown by AppPrefs::isWooPosSurveyNotificationCurrentUserShown
+
     open var orderSummaryMigrated by AppPrefs::orderSummaryMigrated
     open var gatewayMigrated by AppPrefs::gatewayMigrated
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/AppPrefsWrapper.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/AppPrefsWrapper.kt
@@ -39,6 +39,8 @@ open class AppPrefsWrapper @Inject constructor() {
 
     var isSiteWPComSuspended by AppPrefs::isSiteWPComSuspended
 
+    var isWooPosSurveyNotificationPotentialUserShown by AppPrefs::isWooPosSurveyNotificationPotentialUserShown
+
     open var orderSummaryMigrated by AppPrefs::orderSummaryMigrated
     open var gatewayMigrated by AppPrefs::gatewayMigrated
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/notifications/local/LocalNotification.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/notifications/local/LocalNotification.kt
@@ -52,4 +52,16 @@ sealed class LocalNotification(
         delay = delay,
         delayUnit = TimeUnit.MILLISECONDS
     )
+
+    data class WooPosSurveyCurrentUserNotification(
+        override val siteId: Long,
+        override val delay: Long = 0,
+    ) : LocalNotification(
+        siteId = siteId,
+        title = R.string.local_notification_woo_pos_survey_current_user_title,
+        description = R.string.local_notification_woo_pos_survey_current_user_description,
+        type = LocalNotificationType.WOO_POS_SURVEY_CURRENT_USER_REMINDER,
+        delay = delay,
+        delayUnit = TimeUnit.MILLISECONDS
+    )
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/notifications/local/LocalNotification.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/notifications/local/LocalNotification.kt
@@ -40,4 +40,16 @@ sealed class LocalNotification(
         delay = 1,
         delayUnit = TimeUnit.DAYS
     )
+
+    data class WooPosSurveyPotentialUserNotification(
+        override val siteId: Long,
+        override val delay: Long = 0,
+    ) : LocalNotification(
+        siteId = siteId,
+        title = R.string.local_notification_woo_pos_survey_potential_user_title,
+        description = R.string.local_notification_woo_pos_survey_potential_user_description,
+        type = LocalNotificationType.WOO_POS_SURVEY_POTENTIAL_USER_REMINDER,
+        delay = delay,
+        delayUnit = TimeUnit.MILLISECONDS
+    )
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/notifications/local/LocalNotificationType.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/notifications/local/LocalNotificationType.kt
@@ -3,7 +3,8 @@ package com.woocommerce.android.notifications.local
 enum class LocalNotificationType(val value: String) {
     BLAZE_NO_CAMPAIGN_REMINDER("blaze_no_campaign_reminder"),
     BLAZE_ABANDONED_CAMPAIGN_REMINDER("blaze_abandoned_campaign_reminder"),
-    WOO_POS_SURVEY_POTENTIAL_USER_REMINDER("woo_pos_survey_potential_user_reminder");
+    WOO_POS_SURVEY_POTENTIAL_USER_REMINDER("woo_pos_survey_potential_user_reminder"),
+    WOO_POS_SURVEY_CURRENT_USER_REMINDER("woo_pos_survey_current_user_reminder");
     override fun toString() = value
 
     companion object {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/notifications/local/LocalNotificationType.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/notifications/local/LocalNotificationType.kt
@@ -2,7 +2,8 @@ package com.woocommerce.android.notifications.local
 
 enum class LocalNotificationType(val value: String) {
     BLAZE_NO_CAMPAIGN_REMINDER("blaze_no_campaign_reminder"),
-    BLAZE_ABANDONED_CAMPAIGN_REMINDER("blaze_abandoned_campaign_reminder");
+    BLAZE_ABANDONED_CAMPAIGN_REMINDER("blaze_abandoned_campaign_reminder"),
+    WOO_POS_SURVEY_POTENTIAL_USER_REMINDER("woo_pos_survey_potential_user_reminder");
     override fun toString() = value
 
     companion object {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/notifications/local/LocalNotificationWorker.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/notifications/local/LocalNotificationWorker.kt
@@ -84,6 +84,10 @@ class LocalNotificationWorker @AssistedInject constructor(
                 appsPrefsWrapper.isBlazeAbandonedCampaignReminderShown = true
             }
 
+            LocalNotificationType.WOO_POS_SURVEY_POTENTIAL_USER_REMINDER -> {
+                appsPrefsWrapper.isWooPosSurveyNotificationPotentialUserShown = true
+            }
+
             else -> {}
         }
     }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/notifications/local/LocalNotificationWorker.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/notifications/local/LocalNotificationWorker.kt
@@ -88,6 +88,10 @@ class LocalNotificationWorker @AssistedInject constructor(
                 appsPrefsWrapper.isWooPosSurveyNotificationPotentialUserShown = true
             }
 
+            LocalNotificationType.WOO_POS_SURVEY_CURRENT_USER_REMINDER -> {
+                appsPrefsWrapper.isWooPosSurveyNotificationCurrentUserShown = true
+            }
+
             else -> {}
         }
     }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/notifications/local/PreconditionCheckWorker.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/notifications/local/PreconditionCheckWorker.kt
@@ -38,6 +38,8 @@ class PreconditionCheckWorker @AssistedInject constructor(
             LocalNotificationType.BLAZE_NO_CAMPAIGN_REMINDER,
             LocalNotificationType.BLAZE_ABANDONED_CAMPAIGN_REMINDER -> proceedIfValidSiteAndBlazeAvailable(siteId)
 
+            LocalNotificationType.WOO_POS_SURVEY_POTENTIAL_USER_REMINDER -> proceedIfValidSite(siteId)
+
             null -> cancelWork("Notification type is null. Cancelling work.")
         }
     }
@@ -54,6 +56,23 @@ class PreconditionCheckWorker @AssistedInject constructor(
 
         observeBlazeWidgetStatus().first() != DashboardWidget.Status.Available -> {
             cancelWork("Blaze is not available. Cancelling local notification work.")
+        }
+
+        siteStore.getSiteBySiteId(siteId) == null -> {
+            cancelWork("The site linked to the notifications doesn't exist in the db. Cancelling work.")
+        }
+
+        else -> Result.success()
+    }
+
+    private fun proceedIfValidSite(siteId: Long) = when {
+        siteId == 0L -> {
+            val message = "Site id is missing. Cancelling local notification work."
+            crashLogging.sendReport(
+                exception = Exception(message),
+                message = "PreconditionCheckWorker: cancelling work"
+            )
+            cancelWork(message)
         }
 
         siteStore.getSiteBySiteId(siteId) == null -> {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/notifications/local/PreconditionCheckWorker.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/notifications/local/PreconditionCheckWorker.kt
@@ -38,7 +38,8 @@ class PreconditionCheckWorker @AssistedInject constructor(
             LocalNotificationType.BLAZE_NO_CAMPAIGN_REMINDER,
             LocalNotificationType.BLAZE_ABANDONED_CAMPAIGN_REMINDER -> proceedIfValidSiteAndBlazeAvailable(siteId)
 
-            LocalNotificationType.WOO_POS_SURVEY_POTENTIAL_USER_REMINDER -> proceedIfValidSite(siteId)
+            LocalNotificationType.WOO_POS_SURVEY_POTENTIAL_USER_REMINDER,
+            LocalNotificationType.WOO_POS_SURVEY_CURRENT_USER_REMINDER -> proceedIfValidSite(siteId)
 
             null -> cancelWork("Notification type is null. Cancelling work.")
         }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/main/MainActivityViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/main/MainActivityViewModel.kt
@@ -19,6 +19,8 @@ import com.woocommerce.android.notifications.WooNotificationType
 import com.woocommerce.android.notifications.local.LocalNotificationType
 import com.woocommerce.android.notifications.local.LocalNotificationType.BLAZE_ABANDONED_CAMPAIGN_REMINDER
 import com.woocommerce.android.notifications.local.LocalNotificationType.BLAZE_NO_CAMPAIGN_REMINDER
+import com.woocommerce.android.notifications.local.LocalNotificationType.WOO_POS_SURVEY_CURRENT_USER_REMINDER
+import com.woocommerce.android.notifications.local.LocalNotificationType.WOO_POS_SURVEY_POTENTIAL_USER_REMINDER
 import com.woocommerce.android.notifications.push.NotificationMessageHandler
 import com.woocommerce.android.tools.SelectedSite
 import com.woocommerce.android.tools.SiteConnectionType.Jetpack
@@ -286,6 +288,9 @@ class MainActivityViewModel @Inject constructor(
                 when (it) {
                     BLAZE_NO_CAMPAIGN_REMINDER,
                     BLAZE_ABANDONED_CAMPAIGN_REMINDER -> triggerEvent(LaunchBlazeCampaignCreation)
+
+                    WOO_POS_SURVEY_POTENTIAL_USER_REMINDER,
+                    WOO_POS_SURVEY_CURRENT_USER_REMINDER -> error("POS Survey notifications are not implemented yet")
                 }
             }
         }

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -3211,7 +3211,7 @@
     <string name="local_notification_blaze_abandoned_campaign_reminder_title">Thinking about boosting your sales?</string>
     <string name="local_notification_blaze_abandoned_campaign_reminder_description">Get your products seen by millions with Blaze and boost your sales</string>
     <string name="local_notification_woo_pos_survey_potential_user_title">Thinking about in-person sales?</string>
-    <string name="local_notification_woo_pos_survey_potential_user_description">Help us build tools you\'d actually use. 2 minutes.</string>
+    <string name="local_notification_woo_pos_survey_potential_user_description">Help us build tools you\'d actually use. 2-minute survey to build tools you'll love.</string>
     <string name="local_notification_woo_pos_survey_current_user_title">How\'s POS working for you?</string>
     <string name="local_notification_woo_pos_survey_current_user_description">Share your experience in 2 minutes and help us improve.</string>
 

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -3210,6 +3210,8 @@
     <string name="local_notification_blaze_no_campaign_reminder_description">Promote your products with Blaze Ads and increase your sales now.</string>
     <string name="local_notification_blaze_abandoned_campaign_reminder_title">Thinking about boosting your sales?</string>
     <string name="local_notification_blaze_abandoned_campaign_reminder_description">Get your products seen by millions with Blaze and boost your sales</string>
+    <string name="local_notification_woo_pos_survey_potential_user_title">Thinking about in-person sales?</string>
+    <string name="local_notification_woo_pos_survey_potential_user_description">Help us build tools you\'d actually use. 2 minutes.</string>
 
     <!--
     First product published congratulatory feature

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -3211,7 +3211,7 @@
     <string name="local_notification_blaze_abandoned_campaign_reminder_title">Thinking about boosting your sales?</string>
     <string name="local_notification_blaze_abandoned_campaign_reminder_description">Get your products seen by millions with Blaze and boost your sales</string>
     <string name="local_notification_woo_pos_survey_potential_user_title">Thinking about in-person sales?</string>
-    <string name="local_notification_woo_pos_survey_potential_user_description">Help us build tools you\'d actually use. 2-minute survey to build tools you'll love.</string>
+    <string name="local_notification_woo_pos_survey_potential_user_description">Help us build tools you\'d actually use. 2-minute survey to build tools you\'ll love.</string>
     <string name="local_notification_woo_pos_survey_current_user_title">How\'s POS working for you?</string>
     <string name="local_notification_woo_pos_survey_current_user_description">Share your experience in 2 minutes and help us improve.</string>
 

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -3212,6 +3212,8 @@
     <string name="local_notification_blaze_abandoned_campaign_reminder_description">Get your products seen by millions with Blaze and boost your sales</string>
     <string name="local_notification_woo_pos_survey_potential_user_title">Thinking about in-person sales?</string>
     <string name="local_notification_woo_pos_survey_potential_user_description">Help us build tools you\'d actually use. 2 minutes.</string>
+    <string name="local_notification_woo_pos_survey_current_user_title">How\'s POS working for you?</string>
+    <string name="local_notification_woo_pos_survey_current_user_description">Share your experience in 2 minutes and help us improve.</string>
 
     <!--
     First product published congratulatory feature


### PR DESCRIPTION
WOOMOB-1411

### Description
Adds the base infrastructure for local push notifications for Woo POS surveys. This PR creates two notification types:

1. **Potential users survey** - targets merchants who haven't used POS yet
   - Title: "Thinking about in-person sales?"
   - Description: "Help us build tools you'd actually use. 2 minutes."

2. **Current users survey** - targets merchants actively using POS
   - Title: "How's POS working for you?"
   - Description: "Share your experience in 2 minutes and help us improve."

The implementation includes:
- New notification type enums for both survey types
- Notification data classes with titles and descriptions
- String resources for notification content
- Precondition check worker updates to validate site before showing notifications
- AppPrefs flags to track if notifications have been shown (one-time display)
- LocalNotificationWorker updates to set flags when notifications are displayed

This PR does not include the triggering logic - that will be added in a follow-up PR.

### Steps to reproduce
This is infrastructure only. No user-facing changes yet.

### Testing information
- Verify the code compiles successfully
- Review the notification infrastructure follows existing patterns (Blaze notifications)
- Confirm AppPrefs flags are properly integrated

### The tests that have been performed
- Build verification
- Code review of infrastructure components

- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.