### PR TITLE
Add SqLite 2.6.1 dependency

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -25,6 +25,7 @@ androidx-recyclerview-main = '1.4.0'
 androidx-recyclerview-selection = '1.1.0'
 androidx-room = "2.7.2"
 androidx-security-crypto = "1.1.0"
+androidx-sqlite = "2.6.1"
 androidx-test-core = '1.6.1'
 androidx-test-espresso = '3.6.1'
 androidx-test-ext = '1.2.1'
@@ -256,6 +257,8 @@ mockito-kotlin = { group = "org.mockito.kotlin", name = "mockito-kotlin", versio
 mpandroidchart = { group = "com.github.PhilJay", name = "MPAndroidChart", version.ref = "mpandroidchart" }
 photoview = { group = "com.github.chrisbanes", name = "PhotoView", version.ref = "photoview" }
 robolectric = { module = "org.robolectric:robolectric", version.ref = "robolectric" }
+sqlite = { module = "androidx.sqlite:sqlite", version.ref = "androidx-sqlite" }
+sqlite-framework = { module = "androidx.sqlite:sqlite-framework", version.ref = "androidx-sqlite" }
 squareup-javapoet = { module = "com.squareup:javapoet", version.ref = "squareup-javapoet" }
 squareup-leakcanary-android = { group = "com.squareup.leakcanary", name = "leakcanary-android", version.ref = "squareup-leakcanary" }
 squareup-okhttp3 = { module = "com.squareup.okhttp3:okhttp", version.ref = "squareup-okhttp3" }

--- a/libs/fluxc/build.gradle
+++ b/libs/fluxc/build.gradle
@@ -95,6 +95,8 @@ dependencies {
     implementation libs.androidx.room.runtime
     ksp libs.androidx.room.compiler
     implementation libs.androidx.room.ktx
+    implementation(libs.sqlite)
+    implementation(libs.sqlite.framework)
 
     // Dagger
     implementation libs.google.dagger


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

<!-- Id number of the Linear issue this PR addresses, e.g., WOOMOB-373. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
This upgrades SQLite to version 2.6.1, which includes fixes for several issues. See the Slack discussion for details: p1759486799743309/1759469754.623059-slack-C6H8C3G23.

### Steps to reproduce
<!-- Step-by-step testing instructions. For new user flows, consider instead stating the goal of the workflow and see if your PR reviewer can accomplish the workflow without specific steps! -->
Run `./gradlew assembleDebug --scan`, and in the generated report, check the dependencies section to verify that SqLite 2.6.1 is being used.

### The tests that have been performed
<!-- To give the reviewer an idea of what could be missed in terms of testing -->
I compared the assembleDebug reports between `trunk` and this PR, and verified that SQLite has been upgraded from version 2.5.1 to 2.6.1.

### Images/gif
<!-- Include before and after images or gifs when appropriate. -->

- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->