### PR TITLE
[Booings] Show filter button only for All tab

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/bookings/list/BookingListScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/bookings/list/BookingListScreen.kt
@@ -268,18 +268,20 @@ private fun BookingListControls(
                 tint = MaterialTheme.colorScheme.onSurfaceVariant
             )
         }
-        OutlinedButton(
-            modifier = Modifier.defaultMinSize(minWidth = 88.dp, minHeight = 36.dp),
-            contentPadding = PaddingValues(horizontal = 16.dp),
-            colors = ButtonDefaults.outlinedButtonColors().copy(
-                contentColor = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.6f)
-            ),
-            onClick = state.onFilterClick,
-        ) {
-            Text(
-                text = stringResource(R.string.bookings_filters_default_title),
-                style = MaterialTheme.typography.bodyMedium,
-            )
+        if (state.isFilterButtonVisible) {
+            OutlinedButton(
+                modifier = Modifier.defaultMinSize(minWidth = 88.dp, minHeight = 36.dp),
+                contentPadding = PaddingValues(horizontal = 16.dp),
+                colors = ButtonDefaults.outlinedButtonColors().copy(
+                    contentColor = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.6f)
+                ),
+                onClick = state.onFilterClick,
+            ) {
+                Text(
+                    text = stringResource(R.string.bookings_filters_default_title),
+                    style = MaterialTheme.typography.bodyMedium,
+                )
+            }
         }
     }
 }
@@ -321,6 +323,7 @@ private fun BookingListPreview() {
                 ),
                 controlsState = BookingListControlsState(
                     selectedSortOption = BookingListSortOption.NewestToOldest,
+                    isFilterButtonVisible = true,
                     onSortClick = {},
                     onFilterClick = {}
                 ),

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/bookings/list/BookingListViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/bookings/list/BookingListViewModel.kt
@@ -81,6 +81,7 @@ class BookingListViewModel @Inject constructor(
             ),
             controlsState = BookingListControlsState(
                 selectedSortOption = sortOption,
+                isFilterButtonVisible = selectedTab == BookingListTab.All,
                 onSortClick = ::onSortClicked,
                 onFilterClick = ::onFilterClicked
             ),

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/bookings/list/BookingListViewState.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/bookings/list/BookingListViewState.kt
@@ -46,6 +46,7 @@ data class BookingListTabState(
 
 data class BookingListControlsState(
     val selectedSortOption: BookingListSortOption,
+    val isFilterButtonVisible: Boolean,
     val onSortClick: () -> Unit,
     val onFilterClick: () -> Unit
 )


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

<!-- Id number of the Linear issue this PR addresses, e.g., WOOMOB-373. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
This updates the logic for the visibility of the Filter button based on the Slack discussion (p1759766247634389/1759505490.361729-slack-C09FHQNQERG).

### Steps to reproduce
<!-- Step-by-step testing instructions. For new user flows, consider instead stating the goal of the workflow and see if your PR reviewer can accomplish the workflow without specific steps! -->
1. Use a CIAB site.
2. Manually install the bookings plugin from this ZIP file: p1758531103469849/1758101141.913349-slack-C03L1NF1EA3
3. You'll need to enable bookings v2 on your CIAB testing site. You can do that by installing the Code [Snippets plugin](https://wordpress.org/plugins/code-snippets/) to your site and adding the following PHP snippet: `define( 'WC_BOOKINGS_NEXT_ENABLED', true );`
4. Navigate to Bookings.
5. Change the tab.

### The tests that have been performed
<!-- To give the reviewer an idea of what could be missed in terms of testing -->
Tested Screens below

### Images/gif
<!-- Include before and after images or gifs when appropriate. -->
|Before|After|
|-|-|
|<img width="1280" height="2856" alt="Screenshot_20251007_003630" src="https://github.com/user-attachments/assets/c5cec58e-5aed-4d90-83d2-7f4565efaf49" />|<img width="1280" height="2856" alt="Screenshot_20251007_000955" src="https://github.com/user-attachments/assets/8c7f9bf9-2061-4ae2-92e7-f6b31e853e24" />|

- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->