### PR TITLE
Fix parsing error on media upload

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -8,6 +8,7 @@
 23.4
 -----
 - [*] Fixed an issue where Blaze campaign creation could fail for products using PDF thumbnails as images [https://github.com/woocommerce/woocommerce-android/pull/14642]
+- [*] Fixed a rare media upload error [https://github.com/woocommerce/woocommerce-android/pull/14716]
 
 23.3.1
 -----

--- a/libs/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpapi/media/MediaWPRESTResponse.kt
+++ b/libs/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpapi/media/MediaWPRESTResponse.kt
@@ -40,7 +40,7 @@ data class MediaWPRESTResponse(
         val height: Int,
         val file: String?,
         val sizes: Sizes?
-    )
+    ) : JsonObjectOrEmptyArray()
 
     data class Sizes(
         val medium: ImageSize?,
@@ -80,9 +80,9 @@ fun MediaWPRESTResponse.toMediaModel(localSiteId: Int) = MediaModel(
     StringEscapeUtils.unescapeHtml4(altText),
     mediaDetails.width,
     mediaDetails.height,
-        0,
-        null,
-        false,
+    0,
+    null,
+    false,
     if (MediaWPComRestResponse.DELETED_STATUS == status) {
         MediaUploadState.DELETED
     } else {


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

<!-- Id number of the Linear issue this PR addresses, e.g., WOOMOB-373. -->
Closes WOOMOB-1037

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
Media endpoints sometimes return `"media_details": []` instead og `"media_details": {...}`. This causes a `ParseError` and results in media upload failure.

Slack discussion: p1759829978621259/1759367883.081929-slack-C013AAPA4G0

### Steps to reproduce
<!-- Step-by-step testing instructions. For new user flows, consider instead stating the goal of the workflow and see if your PR reviewer can accomplish the workflow without specific steps! -->
I suggest you follow these steps on `trunk` first to reproduce the error, and then on the PR to verify the solution:

1. Go to Products.
2. Select a product.
3. Tap the Add photo button.
4. Tap Take a photo.
5. Capture a photo.
6. Open Network Inspector and find the response from the `https://public-api.wordpress.com/wp/v2/sites/.../media/...` endpoint.
7. Create a fake response by modifying the `"media_details": {...}"` part in the response to `"media_details": []`.
8. Use this fake response with your preferred tool.
9. Repeat steps 1-5.

### Testing information
<!-- This is your opportunity to break out individual scenarios that need testing (when necessary) and/or include a checklist for the reviewer to go through. Consider documenting the following from your own completed testing: devices used, alternate workflows, edge cases, affected areas, critical flows, areas not tested, and any remaining unknowns. Provide feedback on this new section of the PR template through Sept 30, 2024 to Apps Quality; additional context here: p91TBi-b8z-p2#comment-12036 -->
I used Android Studio’s Network Inspector tool to fake the endpoint result. You can also use API Faker.

### The tests that have been performed
<!-- To give the reviewer an idea of what could be missed in terms of testing -->
Steps above

### Images/gif
<!-- Include before and after images or gifs when appropriate. -->
|Before|After|
|-|-|
|<img width="1280" height="2856" alt="Screenshot_20251007_190859" src="https://github.com/user-attachments/assets/a22ea50b-8bf0-433f-9e08-a0615822f284" />|<img width="1280" height="2856" alt="Screenshot_20251007_192914" src="https://github.com/user-attachments/assets/98bd7be4-236d-4c94-8e1a-decdbb24c68c" />|

- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->