### PR TITLE
[WOOMOB-1421] List-Details layout for bookings on tablet

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/bookings/BookingsCommunicationViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/bookings/BookingsCommunicationViewModel.kt
@@ -1,0 +1,21 @@
+package com.woocommerce.android.ui.bookings
+
+import androidx.lifecycle.SavedStateHandle
+import com.woocommerce.android.viewmodel.MultiLiveEvent
+import com.woocommerce.android.viewmodel.ScopedViewModel
+import javax.inject.Inject
+
+/**
+ * Activity-scoped ViewModel used to communicate between Booking list and details in split-pane mode.
+ */
+class BookingsCommunicationViewModel @Inject constructor(
+    savedState: SavedStateHandle
+) : ScopedViewModel(savedState) {
+    fun pushEvent(event: CommunicationEvent) {
+        triggerEvent(event)
+    }
+
+    sealed class CommunicationEvent : MultiLiveEvent.Event() {
+        data class BookingSelected(val bookingId: Long) : CommunicationEvent()
+    }
+}

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/bookings/details/BookingDetailsFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/bookings/details/BookingDetailsFragment.kt
@@ -45,7 +45,7 @@ class BookingDetailsFragment : BaseFragment() {
                     requireActivity().findNavController(R.id.nav_host_fragment_main).navigate(
                         NavGraphMainDirections.actionGlobalOrderDetailFragment(
                             orderId = orderId,
-                            ignoreTwoPaneLayout = true
+                            ignoreTwoPaneLayoutLogic = true
                         )
                     )
                 },

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/bookings/details/BookingDetailsFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/bookings/details/BookingDetailsFragment.kt
@@ -5,11 +5,15 @@ import android.os.Parcelable
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
+import androidx.fragment.app.activityViewModels
 import androidx.fragment.app.viewModels
 import androidx.navigation.fragment.findNavController
 import androidx.navigation.fragment.navArgs
+import com.woocommerce.android.R
+import com.woocommerce.android.extensions.isTwoPanesShouldBeUsed
 import com.woocommerce.android.ui.base.BaseFragment
 import com.woocommerce.android.ui.base.UIMessageResolver
+import com.woocommerce.android.ui.bookings.BookingsCommunicationViewModel
 import com.woocommerce.android.ui.compose.composeView
 import com.woocommerce.android.ui.main.AppBarStatus
 import com.woocommerce.android.viewmodel.MultiLiveEvent
@@ -25,6 +29,7 @@ class BookingDetailsFragment : BaseFragment() {
 
     private val viewModel: BookingDetailsViewModel by viewModels()
     private val args: BookingDetailsFragmentArgs by navArgs()
+    private val bookingsCommunicationViewModel: BookingsCommunicationViewModel by activityViewModels()
 
     override val activityAppBarStatus: AppBarStatus
         get() = AppBarStatus.Hidden
@@ -55,6 +60,7 @@ class BookingDetailsFragment : BaseFragment() {
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
         handleEvents()
+        handleOnePaneToTwoPaneConversion()
     }
 
     private fun handleEvents() {
@@ -62,6 +68,26 @@ class BookingDetailsFragment : BaseFragment() {
             when (event) {
                 is MultiLiveEvent.Event.ShowSnackbar -> {
                     uiMessageResolver.showSnack(event.message)
+                }
+            }
+        }
+    }
+
+    private fun handleOnePaneToTwoPaneConversion() {
+        val isScreenLargerThanCompact = requireContext().isTwoPanesShouldBeUsed
+        val isBookingListFragmentUpInBackStack =
+            findNavController().previousBackStackEntry?.destination?.id == R.id.bookingListFragment
+        if (isScreenLargerThanCompact && isBookingListFragmentUpInBackStack) {
+            when (val mode = args.mode) {
+                is Mode.ShowBooking -> {
+                    findNavController().popBackStack()
+                    bookingsCommunicationViewModel.pushEvent(
+                        BookingsCommunicationViewModel.CommunicationEvent.BookingSelected(mode.bookingId)
+                    )
+                }
+
+                is Mode.Empty -> {
+                    findNavController().popBackStack()
                 }
             }
         }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/bookings/details/BookingDetailsFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/bookings/details/BookingDetailsFragment.kt
@@ -7,8 +7,10 @@ import android.view.View
 import android.view.ViewGroup
 import androidx.fragment.app.activityViewModels
 import androidx.fragment.app.viewModels
+import androidx.navigation.findNavController
 import androidx.navigation.fragment.findNavController
 import androidx.navigation.fragment.navArgs
+import com.woocommerce.android.NavGraphMainDirections
 import com.woocommerce.android.R
 import com.woocommerce.android.extensions.isTwoPanesShouldBeUsed
 import com.woocommerce.android.ui.base.BaseFragment
@@ -40,9 +42,11 @@ class BookingDetailsFragment : BaseFragment() {
                 viewModel = viewModel,
                 onBack = { findNavController().popBackStack() },
                 onViewOrder = { orderId ->
-                    findNavController().navigate(
-                        BookingDetailsFragmentDirections
-                            .actionBookingDetailsFragmentToOrderDetailFragment(orderId)
+                    requireActivity().findNavController(R.id.nav_host_fragment_main).navigate(
+                        NavGraphMainDirections.actionGlobalOrderDetailFragment(
+                            orderId = orderId,
+                            ignoreTwoPaneLayout = true
+                        )
                     )
                 },
                 onViewNotes = {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/bookings/details/BookingDetailsFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/bookings/details/BookingDetailsFragment.kt
@@ -43,7 +43,7 @@ class BookingDetailsFragment : BaseFragment() {
                         BookingDetailsFragmentDirections
                             .actionBookingDetailsFragmentToBookingNoteFragment(args.bookingId)
                     )
-                }
+                },
             )
         }
     }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/bookings/details/BookingDetailsFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/bookings/details/BookingDetailsFragment.kt
@@ -1,6 +1,7 @@
 package com.woocommerce.android.ui.bookings.details
 
 import android.os.Bundle
+import android.os.Parcelable
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
@@ -13,6 +14,7 @@ import com.woocommerce.android.ui.compose.composeView
 import com.woocommerce.android.ui.main.AppBarStatus
 import com.woocommerce.android.viewmodel.MultiLiveEvent
 import dagger.hilt.android.AndroidEntryPoint
+import kotlinx.parcelize.Parcelize
 import javax.inject.Inject
 
 @AndroidEntryPoint
@@ -39,10 +41,12 @@ class BookingDetailsFragment : BaseFragment() {
                     )
                 },
                 onViewNotes = {
-                    findNavController().navigate(
-                        BookingDetailsFragmentDirections
-                            .actionBookingDetailsFragmentToBookingNoteFragment(args.bookingId)
-                    )
+                    (args.mode as? Mode.ShowBooking)?.bookingId?.let {
+                        findNavController().navigate(
+                            BookingDetailsFragmentDirections
+                                .actionBookingDetailsFragmentToBookingNoteFragment(it)
+                        )
+                    }
                 },
             )
         }
@@ -61,5 +65,14 @@ class BookingDetailsFragment : BaseFragment() {
                 }
             }
         }
+    }
+
+    @Parcelize
+    sealed class Mode : Parcelable {
+        @Parcelize
+        data object Empty : Mode()
+
+        @Parcelize
+        data class ShowBooking(val bookingId: Long) : Mode()
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/bookings/details/BookingDetailsScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/bookings/details/BookingDetailsScreen.kt
@@ -14,6 +14,8 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.MaterialTheme
@@ -28,12 +30,14 @@ import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.shadow
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.dimensionResource
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.times
 import com.woocommerce.android.R
+import com.woocommerce.android.extensions.isTwoPanesShouldBeUsed
 import com.woocommerce.android.ui.bookings.compose.BookingAppointmentDetails
 import com.woocommerce.android.ui.bookings.compose.BookingAppointmentDetailsModel
 import com.woocommerce.android.ui.bookings.compose.BookingAttendanceSection
@@ -85,11 +89,13 @@ fun BookingDetailsScreen(
     onViewOrder: (Long) -> Unit,
     onViewNotes: () -> Unit,
 ) {
+    val context = LocalContext.current
     val showAttendanceSheet = remember { mutableStateOf(false) }
     Scaffold(
         topBar = {
             Toolbar(
                 title = viewState.toolbarTitle,
+                navigationIcon = if (context.isTwoPanesShouldBeUsed) null else Icons.AutoMirrored.Filled.ArrowBack,
                 onNavigationButtonClick = onBack,
                 modifier = Modifier.shadow(4.dp)
             )

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/bookings/details/BookingDetailsScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/bookings/details/BookingDetailsScreen.kt
@@ -4,6 +4,7 @@ import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
@@ -101,34 +102,37 @@ fun BookingDetailsScreen(
             )
         }
     ) { innerPadding ->
-        WCPullToRefreshBox(
-            isRefreshing = viewState.loadingState == BookingDetailsLoadingState.Refreshing,
-            onRefresh = viewState.onRefresh,
-            state = rememberPullToRefreshState(),
-            modifier = Modifier
-                .fillMaxSize()
-                .padding(innerPadding)
-                .detailsPanePadding(),
-        ) {
-            Column(
+        if (viewState.shouldShowEmptyState) {
+            BookingDetailsEmptyScreen()
+        } else {
+            WCPullToRefreshBox(
+                isRefreshing = viewState.loadingState == BookingDetailsLoadingState.Refreshing,
+                onRefresh = viewState.onRefresh,
+                state = rememberPullToRefreshState(),
                 modifier = Modifier
-                    .verticalScroll(rememberScrollState())
+                    .fillMaxSize()
+                    .padding(innerPadding)
+                    .detailsPanePadding(),
             ) {
-                when {
-                    viewState.shouldShowSkeleton -> BookingDetailsLoading()
-                    viewState.bookingUiState != null -> {
-                        BookingDetailsContent(
-                            booking = viewState.bookingUiState,
-                            onCancelBooking = viewState.onCancelBooking,
-                            onViewOrder = onViewOrder,
-                            onAttendanceStatusClicked = { showAttendanceSheet.value = true },
-                            onViewNotes = onViewNotes,
-                            onMarkAsPaid = viewState.onMarkAsPaid,
-                            markAsPaidInProgress = viewState.paymentUpdateStatus == PaymentUpdateStatus.InProgress,
-                        )
+                Column(
+                    modifier = Modifier
+                        .fillMaxSize()
+                        .verticalScroll(rememberScrollState())
+                ) {
+                    when {
+                        viewState.shouldShowSkeleton -> BookingDetailsLoading()
+                        viewState.bookingUiState != null -> {
+                            BookingDetailsContent(
+                                booking = viewState.bookingUiState,
+                                onCancelBooking = viewState.onCancelBooking,
+                                onViewOrder = onViewOrder,
+                                onAttendanceStatusClicked = { showAttendanceSheet.value = true },
+                                onViewNotes = onViewNotes,
+                                onMarkAsPaid = viewState.onMarkAsPaid,
+                                markAsPaidInProgress = viewState.paymentUpdateStatus == PaymentUpdateStatus.InProgress,
+                            )
+                        }
                     }
-
-                    else -> BookingDetailsEmptyScreen()
                 }
             }
         }
@@ -235,18 +239,24 @@ private fun BookingDetailsLoading() {
 }
 
 @Composable
-fun BookingDetailsEmptyScreen() {
-    Column(
-        modifier = Modifier.fillMaxSize(),
-        horizontalAlignment = Alignment.CenterHorizontally,
-        verticalArrangement = Arrangement.Center
+fun BookingDetailsEmptyScreen(
+    modifier: Modifier = Modifier
+) {
+    Box(
+        modifier = modifier.fillMaxSize(),
     ) {
-        Image(
-            painter = painterResource(id = R.drawable.img_woo_generic_error),
-            contentDescription = null
-        )
-        Spacer(modifier = Modifier.height(dimensionResource(id = R.dimen.major_200)))
-        Text(text = stringResource(R.string.booking_not_selected))
+        Column(
+            modifier = Modifier.fillMaxSize(),
+            horizontalAlignment = Alignment.CenterHorizontally,
+            verticalArrangement = Arrangement.Center
+        ) {
+            Image(
+                painter = painterResource(id = R.drawable.img_woo_generic_error),
+                contentDescription = null
+            )
+            Spacer(modifier = Modifier.height(dimensionResource(id = R.dimen.major_200)))
+            Text(text = stringResource(R.string.booking_not_selected))
+        }
     }
 }
 
@@ -312,6 +322,7 @@ private fun BookingDetailsLoadingPreview() {
             viewState = BookingDetailsViewState(
                 toolbarTitle = "",
                 bookingUiState = null,
+                loadingState = BookingDetailsLoadingState.Refreshing,
             ),
             onBack = {},
             onViewOrder = {},

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/bookings/details/BookingDetailsScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/bookings/details/BookingDetailsScreen.kt
@@ -46,6 +46,7 @@ import com.woocommerce.android.ui.compose.Render
 import com.woocommerce.android.ui.compose.animations.SkeletonView
 import com.woocommerce.android.ui.compose.component.Toolbar
 import com.woocommerce.android.ui.compose.component.WCPullToRefreshBox
+import com.woocommerce.android.ui.compose.modifier.detailsPanePadding
 import com.woocommerce.android.ui.compose.preview.LightDarkThemePreviews
 import com.woocommerce.android.ui.compose.theme.WooThemeWithBackground
 
@@ -94,6 +95,7 @@ fun BookingDetailsScreen(
             modifier = Modifier
                 .fillMaxSize()
                 .padding(innerPadding)
+                .detailsPanePadding(),
         ) {
             Column(
                 modifier = Modifier

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/bookings/details/BookingDetailsScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/bookings/details/BookingDetailsScreen.kt
@@ -1,6 +1,7 @@
 package com.woocommerce.android.ui.bookings.details
 
 import androidx.compose.animation.AnimatedVisibility
+import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
@@ -17,16 +18,22 @@ import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
 import androidx.compose.material3.pulltorefresh.rememberPullToRefreshState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.livedata.observeAsState
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.shadow
+import androidx.compose.ui.res.dimensionResource
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.times
+import com.woocommerce.android.R
 import com.woocommerce.android.ui.bookings.compose.BookingAppointmentDetails
 import com.woocommerce.android.ui.bookings.compose.BookingAppointmentDetailsModel
 import com.woocommerce.android.ui.bookings.compose.BookingAttendanceSection
@@ -114,6 +121,8 @@ fun BookingDetailsScreen(
                             markAsPaidInProgress = viewState.paymentUpdateStatus == PaymentUpdateStatus.InProgress,
                         )
                     }
+
+                    else -> BookingDetailsEmptyScreen()
                 }
             }
         }
@@ -219,6 +228,22 @@ private fun BookingDetailsLoading() {
     }
 }
 
+@Composable
+fun BookingDetailsEmptyScreen() {
+    Column(
+        modifier = Modifier.fillMaxSize(),
+        horizontalAlignment = Alignment.CenterHorizontally,
+        verticalArrangement = Arrangement.Center
+    ) {
+        Image(
+            painter = painterResource(id = R.drawable.img_woo_generic_error),
+            contentDescription = null
+        )
+        Spacer(modifier = Modifier.height(dimensionResource(id = R.dimen.major_200)))
+        Text(text = stringResource(R.string.booking_not_selected))
+    }
+}
+
 @LightDarkThemePreviews
 @Composable
 private fun BookingDetailsPreview() {
@@ -276,6 +301,22 @@ private fun BookingDetailsPreview() {
 @LightDarkThemePreviews
 @Composable
 private fun BookingDetailsLoadingPreview() {
+    WooThemeWithBackground {
+        BookingDetailsScreen(
+            viewState = BookingDetailsViewState(
+                toolbarTitle = "",
+                bookingUiState = null,
+            ),
+            onBack = {},
+            onViewOrder = {},
+            onViewNotes = {},
+        )
+    }
+}
+
+@LightDarkThemePreviews
+@Composable
+private fun BookingDetailsEmptyPreview() {
     WooThemeWithBackground {
         BookingDetailsScreen(
             viewState = BookingDetailsViewState(

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/bookings/details/BookingDetailsScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/bookings/details/BookingDetailsScreen.kt
@@ -255,7 +255,10 @@ fun BookingDetailsEmptyScreen(
                 contentDescription = null
             )
             Spacer(modifier = Modifier.height(dimensionResource(id = R.dimen.major_200)))
-            Text(text = stringResource(R.string.booking_not_selected))
+            Text(
+                text = stringResource(R.string.booking_not_selected),
+                style = MaterialTheme.typography.titleLarge
+            )
         }
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/bookings/details/BookingDetailsViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/bookings/details/BookingDetailsViewModel.kt
@@ -20,14 +20,18 @@ import com.woocommerce.android.viewmodel.ScopedViewModel
 import com.woocommerce.android.viewmodel.navArgs
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.Job
 import kotlinx.coroutines.async
 import kotlinx.coroutines.awaitAll
+import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.flatMapLatest
 import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.flow.shareIn
 import kotlinx.coroutines.launch
 import org.wordpress.android.fluxc.persistence.entity.BookingEntity
@@ -44,11 +48,19 @@ class BookingDetailsViewModel @Inject constructor(
     private val networkStatus: NetworkStatus,
 ) : ScopedViewModel(savedState) {
 
+    private var bookingFetchJob: Job? = null
+
     private val navArgs: BookingDetailsFragmentArgs by savedState.navArgs()
 
     private val bookingId: Long? = (navArgs.mode as? BookingDetailsFragment.Mode.ShowBooking)?.bookingId
     private val booking = if (bookingId != null) {
         bookingsRepository.observeBooking(bookingId)
+            .distinctUntilChanged()
+            .onEach {
+                if (it == null) {
+                    fetchBooking(BookingDetailsLoadingState.Loading)
+                }
+            }
             .shareIn(scope = viewModelScope, started = SharingStarted.WhileSubscribed(), replay = 1)
     } else {
         flowOf(null)
@@ -137,7 +149,8 @@ class BookingDetailsViewModel @Inject constructor(
     }
 
     private fun fetchBooking(initialLoadingState: BookingDetailsLoadingState = BookingDetailsLoadingState.Refreshing) {
-        launch {
+        bookingFetchJob?.cancel()
+        bookingFetchJob = launch {
             if (navArgs.mode !is BookingDetailsFragment.Mode.ShowBooking) {
                 return@launch
             }
@@ -147,19 +160,20 @@ class BookingDetailsViewModel @Inject constructor(
             }
             loadingState.value = initialLoadingState
 
-            val bookingTask = async {
-                bookingsRepository.fetchBooking(bookingId ?: 0L)
-            }
-            val resourceTask = async {
-                val booking = booking.first() ?: bookingTask.await().getOrNull()
-                val resourceId = booking?.resourceId?.takeIf { it != 0L } ?: return@async Result.success(Unit)
-                bookingsRepository.fetchResource(resourceId)
-            }
+            coroutineScope {
+                val bookingTask = async {
+                    bookingsRepository.fetchBooking(bookingId ?: 0L)
+                }
+                val resourceTask = async {
+                    val booking = booking.first() ?: bookingTask.await().getOrNull()
+                    val resourceId = booking?.resourceId?.takeIf { it != 0L } ?: return@async Result.success(Unit)
+                    bookingsRepository.fetchResource(resourceId)
+                }
 
-            if (awaitAll(bookingTask, resourceTask).any { it.isFailure }) {
-                triggerEvent(MultiLiveEvent.Event.ShowSnackbar(R.string.bookings_fetch_error))
+                if (awaitAll(bookingTask, resourceTask).any { it.isFailure }) {
+                    triggerEvent(MultiLiveEvent.Event.ShowSnackbar(R.string.bookings_fetch_error))
+                }
             }
-
             loadingState.value = BookingDetailsLoadingState.Idle
         }
     }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/bookings/details/BookingDetailsViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/bookings/details/BookingDetailsViewModel.kt
@@ -25,6 +25,7 @@ import kotlinx.coroutines.awaitAll
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.flow.emptyFlow
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.flatMapLatest
 import kotlinx.coroutines.flow.flowOf
@@ -46,8 +47,13 @@ class BookingDetailsViewModel @Inject constructor(
 
     private val navArgs: BookingDetailsFragmentArgs by savedState.navArgs()
 
-    private val booking = bookingsRepository.observeBooking(navArgs.bookingId)
-        .shareIn(scope = viewModelScope, started = SharingStarted.WhileSubscribed(), replay = 1)
+    private val bookingId: Long? = (navArgs.mode as? BookingDetailsFragment.Mode.ShowBooking)?.bookingId
+    private val booking = if (bookingId != null) {
+        bookingsRepository.observeBooking(bookingId)
+            .shareIn(scope = viewModelScope, started = SharingStarted.WhileSubscribed(), replay = 1)
+    } else {
+        flowOf(null)
+    }
 
     private val resource = booking.flatMapLatest { booking ->
         booking?.resourceId?.let { bookingsRepository.observeResource(it) } ?: flowOf(null)
@@ -131,19 +137,16 @@ class BookingDetailsViewModel @Inject constructor(
         fetchBooking(BookingDetailsLoadingState.Loading)
     }
 
-    private fun fetchBooking(
-        initialLoadingState: BookingDetailsLoadingState = BookingDetailsLoadingState.Refreshing
-    ) {
+    private fun fetchBooking(initialLoadingState: BookingDetailsLoadingState = BookingDetailsLoadingState.Refreshing) {
         launch {
             if (!networkStatus.isConnected()) {
                 triggerEvent(MultiLiveEvent.Event.ShowSnackbar(R.string.offline_error))
                 return@launch
             }
-
             loadingState.value = initialLoadingState
 
             val bookingTask = async {
-                bookingsRepository.fetchBooking(navArgs.bookingId)
+                bookingsRepository.fetchBooking(bookingId ?: 0L)
             }
             val resourceTask = async {
                 val booking = booking.first() ?: bookingTask.await().getOrNull()
@@ -168,7 +171,7 @@ class BookingDetailsViewModel @Inject constructor(
             attendanceUpdateStatus.value = AttendanceUpdateStatus.InProgress
             val attendanceStatus = status.toDataModel() ?: return@launch
             bookingsRepository.updateAttendanceStatus(
-                bookingId = navArgs.bookingId,
+                bookingId = bookingId ?: 0L,
                 attendanceStatus = attendanceStatus
             ).onFailure {
                 triggerEvent(MultiLiveEvent.Event.ShowSnackbar(R.string.booking_attendance_status_error))
@@ -195,7 +198,7 @@ class BookingDetailsViewModel @Inject constructor(
     private fun onConfirmCancelBooking() = launch {
         showCancelBookingDialog.value = false
         cancelStatusState.value = CancelStatus.InProgress
-        bookingsRepository.cancelBooking(navArgs.bookingId)
+        bookingsRepository.cancelBooking(bookingId ?: 0L)
             .onFailure {
                 triggerEvent(MultiLiveEvent.Event.ShowSnackbar(R.string.booking_cancel_error))
             }
@@ -208,7 +211,7 @@ class BookingDetailsViewModel @Inject constructor(
             return@launch
         }
         paymentUpdateStatus.value = PaymentUpdateStatus.InProgress
-        bookingsRepository.markAsPaid(navArgs.bookingId)
+        bookingsRepository.markAsPaid(bookingId ?: 0L)
             .onFailure {
                 triggerEvent(MultiLiveEvent.Event.ShowSnackbar(R.string.booking_mark_as_paid_error))
             }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/bookings/details/BookingDetailsViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/bookings/details/BookingDetailsViewModel.kt
@@ -25,7 +25,6 @@ import kotlinx.coroutines.awaitAll
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.combine
-import kotlinx.coroutines.flow.emptyFlow
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.flatMapLatest
 import kotlinx.coroutines.flow.flowOf
@@ -139,6 +138,9 @@ class BookingDetailsViewModel @Inject constructor(
 
     private fun fetchBooking(initialLoadingState: BookingDetailsLoadingState = BookingDetailsLoadingState.Refreshing) {
         launch {
+            if (navArgs.mode !is BookingDetailsFragment.Mode.ShowBooking) {
+                return@launch
+            }
             if (!networkStatus.isConnected()) {
                 triggerEvent(MultiLiveEvent.Event.ShowSnackbar(R.string.offline_error))
                 return@launch

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/bookings/details/BookingDetailsViewState.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/bookings/details/BookingDetailsViewState.kt
@@ -18,7 +18,7 @@ data class BookingDetailsViewState(
     val dialogState: DialogState? = null,
     val onRefresh: () -> Unit = {},
 ) {
-    val shouldShowSkeleton: Boolean = bookingUiState == null && loadingState == BookingDetailsLoadingState.Refreshing
+    val shouldShowSkeleton: Boolean = bookingUiState == null && loadingState == BookingDetailsLoadingState.Loading
     val shouldShowEmptyState: Boolean = bookingUiState == null && loadingState == BookingDetailsLoadingState.Idle
 }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/bookings/details/BookingDetailsViewState.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/bookings/details/BookingDetailsViewState.kt
@@ -19,6 +19,7 @@ data class BookingDetailsViewState(
     val onRefresh: () -> Unit = {},
 ) {
     val shouldShowSkeleton: Boolean = bookingUiState == null && loadingState == BookingDetailsLoadingState.Refreshing
+    val shouldShowEmptyState: Boolean = bookingUiState == null && loadingState == BookingDetailsLoadingState.Idle
 }
 
 data class BookingUiState(

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/bookings/list/BookingListFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/bookings/list/BookingListFragment.kt
@@ -8,9 +8,11 @@ import androidx.core.view.isVisible
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.activityViewModels
 import androidx.fragment.app.viewModels
+import androidx.navigation.fragment.NavHostFragment
 import androidx.navigation.fragment.findNavController
 import com.woocommerce.android.R
 import com.woocommerce.android.databinding.FragmentBookingListBinding
+import com.woocommerce.android.extensions.isTwoPanesShouldBeUsed
 import com.woocommerce.android.ui.base.TopLevelFragment
 import com.woocommerce.android.ui.base.UIMessageResolver
 import com.woocommerce.android.ui.bookings.BookingsCommunicationViewModel
@@ -41,6 +43,7 @@ class BookingListFragment : TopLevelFragment(), TabletLayoutSetupHelper.Screen {
     override val detailPaneContainer: View
         get() = binding.detailNavContainer
     override var twoPanesWereShownBeforeConfigChange: Boolean = false
+    override val automaticallyAdjustLayoutAfterConfigChange: Boolean = false
     override val listFragment: Fragment
         get() = this
     override val navigation
@@ -88,6 +91,7 @@ class BookingListFragment : TopLevelFragment(), TabletLayoutSetupHelper.Screen {
         super.onViewCreated(view, savedInstanceState)
         handleEvents()
         handleBottomNavigationVisibility()
+        handleTwoPaneToOnePaneConversionIfNeeded()
     }
 
     override fun onDestroyView() {
@@ -146,6 +150,39 @@ class BookingListFragment : TopLevelFragment(), TabletLayoutSetupHelper.Screen {
                 (activity as? MainActivity)?.hideBottomNav()
             } else {
                 (activity as? MainActivity)?.showBottomNav()
+            }
+        }
+    }
+
+    private fun handleTwoPaneToOnePaneConversionIfNeeded() {
+        val isNowSinglePane = !requireContext().isTwoPanesShouldBeUsed
+        if (isNowSinglePane && twoPanesWereShownBeforeConfigChange) {
+            // Reset the flag to avoid re-triggering on future recreations
+            twoPanesWereShownBeforeConfigChange = false
+
+            // Show the list pane only in this fragment
+            tabletLayoutSetupHelper.displayListPaneOnly(this)
+
+            // Read the current state of the details NavHost to get the booking being displayed (if any)
+            val navHost = childFragmentManager.findFragmentById(R.id.detail_nav_container) as? NavHostFragment
+            val argsBundle = navHost?.navController?.currentBackStackEntry?.arguments
+            if (argsBundle != null) {
+                val args = BookingDetailsFragmentArgs.fromBundle(argsBundle)
+                when (val mode = args.mode) {
+                    is BookingDetailsFragment.Mode.ShowBooking -> {
+                        // Re-open details with phone navigation to ensure full-screen and proper back behavior
+                        findNavController().navigate(
+                            BookingListFragmentDirections
+                                .actionBookingListFragmentToBookingDetailsFragment(
+                                    BookingDetailsFragment.Mode.ShowBooking(mode.bookingId)
+                                )
+                        )
+                    }
+
+                    is BookingDetailsFragment.Mode.Empty -> {
+                        // No booking was selected; nothing to re-open
+                    }
+                }
             }
         }
     }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/bookings/list/BookingListFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/bookings/list/BookingListFragment.kt
@@ -13,6 +13,8 @@ import com.woocommerce.android.R
 import com.woocommerce.android.databinding.FragmentBookingListBinding
 import com.woocommerce.android.ui.base.TopLevelFragment
 import com.woocommerce.android.ui.base.UIMessageResolver
+import com.woocommerce.android.ui.bookings.details.BookingDetailsFragment
+import com.woocommerce.android.ui.bookings.details.BookingDetailsFragmentArgs
 import com.woocommerce.android.ui.compose.theme.WooTheme
 import com.woocommerce.android.ui.main.AppBarStatus
 import com.woocommerce.android.ui.main.MainActivity
@@ -43,7 +45,9 @@ class BookingListFragment : TopLevelFragment(), TabletLayoutSetupHelper.Screen {
     override val navigation
         get() = TabletLayoutSetupHelper.Screen.Navigation(
             detailsNavGraphId = R.navigation.nav_graph_bookings_details,
-            detailsInitialBundle = null
+            detailsInitialBundle = BookingDetailsFragmentArgs(
+                mode = BookingDetailsFragment.Mode.Empty
+            ).toBundle()
         )
     override val activityAppBarStatus: AppBarStatus
         get() = AppBarStatus.Hidden
@@ -98,12 +102,16 @@ class BookingListFragment : TopLevelFragment(), TabletLayoutSetupHelper.Screen {
                 is BookingListViewModel.NavigateToBookingDetails -> {
                     tabletLayoutSetupHelper.openItemDetails(
                         tabletNavigateTo = {
-                            R.id.nav_graph_bookings_details to bundleOf("bookingId" to event.bookingId)
+                            R.id.nav_graph_bookings_details to bundleOf(
+                                "mode" to BookingDetailsFragment.Mode.ShowBooking(event.bookingId)
+                            )
                         },
                         navigateWithPhoneNavigation = {
                             findNavController().navigate(
                                 BookingListFragmentDirections
-                                    .actionBookingListFragmentToBookingDetailsFragment(event.bookingId)
+                                    .actionBookingListFragmentToBookingDetailsFragment(
+                                        BookingDetailsFragment.Mode.ShowBooking(event.bookingId)
+                                    )
                             )
                         }
                     )

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/bookings/list/BookingListFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/bookings/list/BookingListFragment.kt
@@ -4,15 +4,16 @@ import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
-import androidx.core.os.bundleOf
 import androidx.core.view.isVisible
 import androidx.fragment.app.Fragment
+import androidx.fragment.app.activityViewModels
 import androidx.fragment.app.viewModels
 import androidx.navigation.fragment.findNavController
 import com.woocommerce.android.R
 import com.woocommerce.android.databinding.FragmentBookingListBinding
 import com.woocommerce.android.ui.base.TopLevelFragment
 import com.woocommerce.android.ui.base.UIMessageResolver
+import com.woocommerce.android.ui.bookings.BookingsCommunicationViewModel
 import com.woocommerce.android.ui.bookings.details.BookingDetailsFragment
 import com.woocommerce.android.ui.bookings.details.BookingDetailsFragmentArgs
 import com.woocommerce.android.ui.compose.theme.WooTheme
@@ -53,6 +54,7 @@ class BookingListFragment : TopLevelFragment(), TabletLayoutSetupHelper.Screen {
         get() = AppBarStatus.Hidden
 
     private val viewModel: BookingListViewModel by viewModels()
+    private val bookingsCommunicationViewModel: BookingsCommunicationViewModel by activityViewModels()
 
     @Inject
     lateinit var uiMessageResolver: UIMessageResolver
@@ -102,9 +104,9 @@ class BookingListFragment : TopLevelFragment(), TabletLayoutSetupHelper.Screen {
                 is BookingListViewModel.NavigateToBookingDetails -> {
                     tabletLayoutSetupHelper.openItemDetails(
                         tabletNavigateTo = {
-                            R.id.nav_graph_bookings_details to bundleOf(
-                                "mode" to BookingDetailsFragment.Mode.ShowBooking(event.bookingId)
-                            )
+                            R.id.nav_graph_bookings_details to BookingDetailsFragmentArgs(
+                                mode = BookingDetailsFragment.Mode.ShowBooking(event.bookingId)
+                            ).toBundle()
                         },
                         navigateWithPhoneNavigation = {
                             findNavController().navigate(
@@ -117,6 +119,23 @@ class BookingListFragment : TopLevelFragment(), TabletLayoutSetupHelper.Screen {
                     )
                 }
                 is MultiLiveEvent.Event.ShowSnackbar -> uiMessageResolver.showSnack(event.message)
+            }
+        }
+
+        bookingsCommunicationViewModel.event.observe(viewLifecycleOwner) { event ->
+            when (event) {
+                is BookingsCommunicationViewModel.CommunicationEvent.BookingSelected -> {
+                    tabletLayoutSetupHelper.openItemDetails(
+                        tabletNavigateTo = {
+                            R.id.nav_graph_bookings_details to BookingDetailsFragmentArgs(
+                                mode = BookingDetailsFragment.Mode.ShowBooking(event.bookingId)
+                            ).toBundle()
+                        },
+                        navigateWithPhoneNavigation = { /* No-op, won't happen */ }
+                    )
+                }
+
+                else -> event.isHandled = false
             }
         }
     }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/bookings/list/BookingListFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/bookings/list/BookingListFragment.kt
@@ -4,21 +4,47 @@ import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
+import androidx.core.os.bundleOf
+import androidx.core.view.isVisible
+import androidx.fragment.app.Fragment
 import androidx.fragment.app.viewModels
 import androidx.navigation.fragment.findNavController
 import com.woocommerce.android.R
+import com.woocommerce.android.databinding.FragmentBookingListBinding
 import com.woocommerce.android.ui.base.TopLevelFragment
 import com.woocommerce.android.ui.base.UIMessageResolver
-import com.woocommerce.android.ui.compose.composeView
+import com.woocommerce.android.ui.compose.theme.WooTheme
 import com.woocommerce.android.ui.main.AppBarStatus
 import com.woocommerce.android.ui.main.MainActivity
+import com.woocommerce.android.util.TabletLayoutSetupHelper
 import com.woocommerce.android.viewmodel.MultiLiveEvent
 import dagger.hilt.android.AndroidEntryPoint
 import javax.inject.Inject
 
-@AndroidEntryPoint
-class BookingListFragment : TopLevelFragment() {
+private const val TWO_PANES_WERE_SHOWN_BEFORE_CONFIG_CHANGE_KEY = "non_root_navigation_in_detail_pane"
 
+@AndroidEntryPoint
+class BookingListFragment : TopLevelFragment(), TabletLayoutSetupHelper.Screen {
+    @Inject
+    lateinit var tabletLayoutSetupHelper: TabletLayoutSetupHelper
+
+    private var _binding: FragmentBookingListBinding? = null
+    private val binding get() = _binding!!
+
+    override val twoPaneLayoutGuideline
+        get() = binding.twoPaneLayoutGuideline
+    override val listPaneContainer: View
+        get() = binding.listPaneContainer
+    override val detailPaneContainer: View
+        get() = binding.detailNavContainer
+    override var twoPanesWereShownBeforeConfigChange: Boolean = false
+    override val listFragment: Fragment
+        get() = this
+    override val navigation
+        get() = TabletLayoutSetupHelper.Screen.Navigation(
+            detailsNavGraphId = R.navigation.nav_graph_bookings_details,
+            detailsInitialBundle = null
+        )
     override val activityAppBarStatus: AppBarStatus
         get() = AppBarStatus.Hidden
 
@@ -34,14 +60,33 @@ class BookingListFragment : TopLevelFragment() {
     }
 
     override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View {
-        return composeView {
-            BookingListScreen(viewModel)
+        _binding = FragmentBookingListBinding.inflate(inflater, container, false)
+        binding.bookingListCompose.setContent {
+            WooTheme {
+                BookingListScreen(viewModel)
+            }
         }
+        return binding.root
+    }
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        twoPanesWereShownBeforeConfigChange = savedInstanceState?.getBoolean(
+            TWO_PANES_WERE_SHOWN_BEFORE_CONFIG_CHANGE_KEY,
+            false
+        ) ?: false
+        tabletLayoutSetupHelper.onRootFragmentCreated(this)
     }
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
         handleEvents()
         handleBottomNavigationVisibility()
+    }
+
+    override fun onDestroyView() {
+        super.onDestroyView()
+        _binding = null
     }
 
     private fun handleEvents() {
@@ -50,11 +95,19 @@ class BookingListFragment : TopLevelFragment() {
                 is BookingListViewModel.NavigateToFilters -> findNavController().navigate(
                     BookingListFragmentDirections.actionBookingListFragmentToBookingFilterList()
                 )
-
-                is BookingListViewModel.NavigateToBookingDetails -> findNavController().navigate(
-                    BookingListFragmentDirections.actionBookingListFragmentToBookingDetailsFragment(event.bookingId)
-                )
-
+                is BookingListViewModel.NavigateToBookingDetails -> {
+                    tabletLayoutSetupHelper.openItemDetails(
+                        tabletNavigateTo = {
+                            R.id.nav_graph_bookings_details to bundleOf("bookingId" to event.bookingId)
+                        },
+                        navigateWithPhoneNavigation = {
+                            findNavController().navigate(
+                                BookingListFragmentDirections
+                                    .actionBookingListFragmentToBookingDetailsFragment(event.bookingId)
+                            )
+                        }
+                    )
+                }
                 is MultiLiveEvent.Event.ShowSnackbar -> uiMessageResolver.showSnack(event.message)
             }
         }
@@ -68,5 +121,13 @@ class BookingListFragment : TopLevelFragment() {
                 (activity as? MainActivity)?.showBottomNav()
             }
         }
+    }
+
+    override fun onSaveInstanceState(outState: Bundle) {
+        outState.putBoolean(
+            TWO_PANES_WERE_SHOWN_BEFORE_CONFIG_CHANGE_KEY,
+            _binding?.detailNavContainer?.isVisible == true && _binding?.listPaneContainer?.isVisible == true
+        )
+        super.onSaveInstanceState(outState)
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/bookings/list/BookingListViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/bookings/list/BookingListViewModel.kt
@@ -76,14 +76,10 @@ class BookingListViewModel @Inject constructor(
     private var bookingsLoadMoreJob: Job? = null
 
     private fun openFirstLoadedBookingOnTablet(bookings: List<BookingEntity>) {
-        if (isWindowClassLargeThanCompact()) {
-            if (bookings.isNotEmpty()) {
-                if (selectedBookingIdOnBigScreen == null) {
-                    val firstId = bookings.first().id.value
-                    selectedBookingIdOnBigScreen = firstId
-                    triggerEvent(NavigateToBookingDetails(firstId))
-                }
-            }
+        if (isWindowClassLargeThanCompact() && bookings.isNotEmpty() && selectedBookingIdOnBigScreen == null) {
+            val firstId = bookings.first().id.value
+            selectedBookingIdOnBigScreen = firstId
+            triggerEvent(NavigateToBookingDetails(firstId))
         }
     }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/bookings/list/BookingListViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/bookings/list/BookingListViewModel.kt
@@ -8,6 +8,7 @@ import com.woocommerce.android.AppConstants
 import com.woocommerce.android.R
 import com.woocommerce.android.ui.bookings.BookingMapper
 import com.woocommerce.android.ui.bookings.filter.data.BookingFilterRepository
+import com.woocommerce.android.util.IsWindowClassLargeThanCompact
 import com.woocommerce.android.viewmodel.MultiLiveEvent
 import com.woocommerce.android.viewmodel.ScopedViewModel
 import com.woocommerce.android.viewmodel.getNullableStateFlow
@@ -30,6 +31,7 @@ import kotlinx.coroutines.flow.withIndex
 import kotlinx.coroutines.launch
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.bookings.BookingFilters
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.bookings.BookingsFilterOption
+import org.wordpress.android.fluxc.persistence.entity.BookingEntity
 import javax.inject.Inject
 
 @OptIn(FlowPreview::class, ExperimentalCoroutinesApi::class)
@@ -40,7 +42,7 @@ class BookingListViewModel @Inject constructor(
     private val bookingListHandler: BookingListHandler,
     private val filtersBuilder: BookingListFiltersBuilder,
     private val bookingMapper: BookingMapper,
-    private val isWindowClassLargeThanCompact: com.woocommerce.android.util.IsWindowClassLargeThanCompact,
+    private val isWindowClassLargeThanCompact: IsWindowClassLargeThanCompact,
 ) : ScopedViewModel(savedStateHandle) {
 
     companion object {
@@ -73,7 +75,7 @@ class BookingListViewModel @Inject constructor(
     private var bookingsFetchJob: Job? = null
     private var bookingsLoadMoreJob: Job? = null
 
-    private fun openFirstLoadedBookingOnTablet(bookings: List<com.woocommerce.android.ui.bookings.Booking>) {
+    private fun openFirstLoadedBookingOnTablet(bookings: List<BookingEntity>) {
         if (isWindowClassLargeThanCompact()) {
             if (bookings.isNotEmpty()) {
                 if (selectedBookingIdOnBigScreen == null) {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/bookings/list/BookingListViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/bookings/list/BookingListViewModel.kt
@@ -75,14 +75,6 @@ class BookingListViewModel @Inject constructor(
     private var bookingsFetchJob: Job? = null
     private var bookingsLoadMoreJob: Job? = null
 
-    private fun openFirstLoadedBookingOnTablet(bookings: List<BookingEntity>) {
-        if (isWindowClassLargeThanCompact() && bookings.isNotEmpty() && selectedBookingIdOnBigScreen == null) {
-            val firstId = bookings.first().id.value
-            selectedBookingIdOnBigScreen = firstId
-            triggerEvent(NavigateToBookingDetails(firstId))
-        }
-    }
-
     private val contentState = combine(
         bookingListHandler.bookingsFlow.map { bookings ->
             openFirstLoadedBookingOnTablet(bookings)
@@ -279,6 +271,14 @@ class BookingListViewModel @Inject constructor(
     private fun onClearFiltersClicked() {
         launch {
             bookingFilterRepository.save(BookingFilters.EMPTY)
+        }
+    }
+
+    private fun openFirstLoadedBookingOnTablet(bookings: List<BookingEntity>) {
+        if (isWindowClassLargeThanCompact() && bookings.isNotEmpty() && selectedBookingIdOnBigScreen == null) {
+            val firstId = bookings.first().id.value
+            selectedBookingIdOnBigScreen = firstId
+            triggerEvent(NavigateToBookingDetails(firstId))
         }
     }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/bookings/list/BookingListViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/bookings/list/BookingListViewModel.kt
@@ -1,5 +1,6 @@
 package com.woocommerce.android.ui.bookings.list
 
+import androidx.annotation.VisibleForTesting
 import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.asLiveData
 import androidx.lifecycle.viewModelScope
@@ -39,7 +40,15 @@ class BookingListViewModel @Inject constructor(
     private val bookingListHandler: BookingListHandler,
     private val filtersBuilder: BookingListFiltersBuilder,
     private val bookingMapper: BookingMapper,
+    private val isWindowClassLargeThanCompact: com.woocommerce.android.util.IsWindowClassLargeThanCompact,
 ) : ScopedViewModel(savedStateHandle) {
+
+    companion object {
+        @VisibleForTesting
+        const val KEY_BOOKING_SELECTED_ON_BIG_SCREEN = "key_booking_selected_on_big_screen"
+    }
+
+    private val stateHandle = savedStateHandle
     private val loadingState = MutableStateFlow(BookingListLoadingState.Idle)
     private val selectedTab = savedStateHandle.getStateFlow(viewModelScope, BookingListTab.Today)
     private val searchQuery = savedStateHandle.getNullableStateFlow(
@@ -55,13 +64,30 @@ class BookingListViewModel @Inject constructor(
 
     private val sortOption = savedStateHandle.getStateFlow(viewModelScope, BookingListSortOption.NewestToOldest)
 
+    private var selectedBookingIdOnBigScreen: Long?
+        get() = stateHandle[KEY_BOOKING_SELECTED_ON_BIG_SCREEN]
+        set(value) = stateHandle.set(KEY_BOOKING_SELECTED_ON_BIG_SCREEN, value)
+
     private val isSortSheetVisible = MutableStateFlow(false)
 
     private var bookingsFetchJob: Job? = null
     private var bookingsLoadMoreJob: Job? = null
 
+    private fun openFirstLoadedBookingOnTablet(bookings: List<com.woocommerce.android.ui.bookings.Booking>) {
+        if (isWindowClassLargeThanCompact()) {
+            if (bookings.isNotEmpty()) {
+                if (selectedBookingIdOnBigScreen == null) {
+                    val firstId = bookings.first().id.value
+                    selectedBookingIdOnBigScreen = firstId
+                    triggerEvent(NavigateToBookingDetails(firstId))
+                }
+            }
+        }
+    }
+
     private val contentState = combine(
         bookingListHandler.bookingsFlow.map { bookings ->
+            openFirstLoadedBookingOnTablet(bookings)
             with(bookingMapper) { bookings.map { it.toListItem() } }
         },
         loadingState
@@ -225,6 +251,9 @@ class BookingListViewModel @Inject constructor(
     }
 
     private fun onBookingClick(bookingId: Long) {
+        if (isWindowClassLargeThanCompact()) {
+            selectedBookingIdOnBigScreen = bookingId
+        }
         triggerEvent(NavigateToBookingDetails(bookingId))
     }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/bookings/note/BookingNoteScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/bookings/note/BookingNoteScreen.kt
@@ -32,6 +32,7 @@ import com.woocommerce.android.R
 import com.woocommerce.android.ui.compose.Render
 import com.woocommerce.android.ui.compose.component.Toolbar
 import com.woocommerce.android.ui.compose.component.WCTextButton
+import com.woocommerce.android.ui.compose.modifier.detailsPanePadding
 
 @Composable
 fun BookingNoteScreen(
@@ -87,8 +88,9 @@ fun BookingNoteScreen(
     ) { innerPadding ->
         Box(
             modifier = Modifier
-                .background(MaterialTheme.colorScheme.surface)
+                .background(MaterialTheme.colorScheme.background)
                 .padding(top = innerPadding.calculateTopPadding())
+                .detailsPanePadding()
         ) {
             viewState.editedNote?.let {
                 NoteTextField(
@@ -96,6 +98,7 @@ fun BookingNoteScreen(
                     onValueChange = viewState.onNoteChange,
                     enabled = viewState.noteEditable,
                     modifier = Modifier
+                        .background(MaterialTheme.colorScheme.surface)
                         .fillMaxSize()
                         .padding(horizontal = 16.dp, vertical = 12.dp)
                         .focusRequester(focusRequester)

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/compose/modifier/DetailsPanePadding.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/compose/modifier/DetailsPanePadding.kt
@@ -1,0 +1,43 @@
+package com.woocommerce.android.ui.compose.modifier
+
+import androidx.compose.foundation.layout.padding
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.res.dimensionResource
+import androidx.compose.ui.unit.dp
+import com.woocommerce.android.R
+import com.woocommerce.android.extensions.WindowSizeClass
+import com.woocommerce.android.extensions.isTwoPanesShouldBeUsed
+import com.woocommerce.android.extensions.windowWidthSizeClass
+import org.wordpress.android.util.DisplayUtils
+
+/**
+ * Adds horizontal padding to detail screens when shown in a split-pane layout (tablets).
+ * The padding mirrors the margin calculations used in TabletLayoutSetupHelper.setDetailsMargins.
+ */
+@Composable
+fun Modifier.detailsPanePadding(): Modifier {
+    val context = LocalContext.current
+    val density = LocalDensity.current
+
+    val isTwoPanes = context.isTwoPanesShouldBeUsed
+
+    return if (isTwoPanes) {
+        val marginDp = when (context.windowWidthSizeClass) {
+            WindowSizeClass.Medium -> dimensionResource(id = R.dimen.major_100)
+            WindowSizeClass.ExpandedAndBigger -> {
+                val windowWidth = DisplayUtils.getWindowPixelWidth(context)
+                with(density) { (windowWidth * MARGINS_FOR_TABLET).toDp() }
+            }
+
+            WindowSizeClass.Compact -> 0.dp
+        }
+        this.padding(horizontal = marginDp)
+    } else {
+        this
+    }
+}
+
+private const val MARGINS_FOR_TABLET: Float = 0.1F

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/OrderDetailFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/OrderDetailFragment.kt
@@ -209,12 +209,14 @@ class OrderDetailFragment :
          * during the payment collection process. If this is the case, it navigates to the
          * Select Payment screen on both phone and tablet devices.
          */
-        if (isOrderListFragmentNotVisible() && isScreenLargerThanCompact && !navArgs.startPaymentFlow) {
-            navigateBackWithResult(KEY_ORDER_ID, navArgs.orderId)
-            return
-        } else if (isOrderListFragmentNotVisible() && isScreenLargerThanCompact && navArgs.startPaymentFlow) {
-            navigateBackWithResult(KEY_START_PAYMENT_FLOW, navArgs.orderId)
-            return
+        if (!navArgs.ignoreTwoPaneLayout) {
+            if (isOrderListFragmentNotVisible() && isScreenLargerThanCompact && !navArgs.startPaymentFlow) {
+                navigateBackWithResult(KEY_ORDER_ID, navArgs.orderId)
+                return
+            } else if (isOrderListFragmentNotVisible() && isScreenLargerThanCompact && navArgs.startPaymentFlow) {
+                navigateBackWithResult(KEY_START_PAYMENT_FLOW, navArgs.orderId)
+                return
+            }
         }
 
         if (navArgs.startPaymentFlow) {
@@ -298,7 +300,7 @@ class OrderDetailFragment :
 
     private fun setupToolbarMenu(menu: Menu) {
         onPrepareMenu(menu)
-        if (requireContext().isTwoPanesShouldBeUsed) {
+        if (requireContext().isTwoPanesShouldBeUsed && !navArgs.ignoreTwoPaneLayout) {
             binding.toolbar.navigationIcon = null
         } else {
             binding.toolbar.navigationIcon = AppCompatResources.getDrawable(requireActivity(), R.drawable.ic_back_24dp)

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/OrderDetailFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/OrderDetailFragment.kt
@@ -209,7 +209,7 @@ class OrderDetailFragment :
          * during the payment collection process. If this is the case, it navigates to the
          * Select Payment screen on both phone and tablet devices.
          */
-        if (!navArgs.ignoreTwoPaneLayout) {
+        if (!navArgs.ignoreTwoPaneLayoutLogic) {
             if (isOrderListFragmentNotVisible() && isScreenLargerThanCompact && !navArgs.startPaymentFlow) {
                 navigateBackWithResult(KEY_ORDER_ID, navArgs.orderId)
                 return
@@ -300,7 +300,7 @@ class OrderDetailFragment :
 
     private fun setupToolbarMenu(menu: Menu) {
         onPrepareMenu(menu)
-        if (requireContext().isTwoPanesShouldBeUsed && !navArgs.ignoreTwoPaneLayout) {
+        if (requireContext().isTwoPanesShouldBeUsed && !navArgs.ignoreTwoPaneLayoutLogic) {
             binding.toolbar.navigationIcon = null
         } else {
             binding.toolbar.navigationIcon = AppCompatResources.getDrawable(requireActivity(), R.drawable.ic_back_24dp)

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/OrderDetailFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/OrderDetailFragment.kt
@@ -63,6 +63,7 @@ import com.woocommerce.android.ui.base.BaseFragment
 import com.woocommerce.android.ui.base.UIMessageResolver
 import com.woocommerce.android.ui.compose.theme.WooThemeWithBackground
 import com.woocommerce.android.ui.main.AppBarStatus
+import com.woocommerce.android.ui.main.BottomNavigationPosition
 import com.woocommerce.android.ui.main.MainNavigationRouter
 import com.woocommerce.android.ui.orders.CustomAmountCard
 import com.woocommerce.android.ui.orders.Header
@@ -657,7 +658,8 @@ class OrderDetailFragment :
         binding.orderDetailCustomerInfo.updateCustomerInfo(
             order = order,
             isVirtualOrder = viewModel.hasVirtualProductsOnly(),
-            isReadOnly = false
+            isReadOnly = false,
+            viewOrdersButtonVissible = shouldShowViewCustomerOrdersButton()
         )
         binding.orderDetailPaymentInfo.updatePaymentInfo(
             order = order,
@@ -674,6 +676,14 @@ class OrderDetailFragment :
                 viewModel.onPrintingInstructionsClicked()
             }
         )
+    }
+
+    private fun shouldShowViewCustomerOrdersButton(): Boolean {
+        val orderListInBackstack =
+            findNavController().previousBackStackEntry?.destination?.id == BottomNavigationPosition.ORDERS.id
+        val isInDetailPane =
+            requireContext().isTwoPanesShouldBeUsed && (parentFragment?.id == R.id.detailPaneContainer)
+        return orderListInBackstack || isInDetailPane
     }
 
     private fun showOrderStatus(orderStatus: OrderStatus) {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/views/OrderDetailCustomerInfoView.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/views/OrderDetailCustomerInfoView.kt
@@ -64,7 +64,8 @@ class OrderDetailCustomerInfoView @JvmOverloads constructor(
     fun updateCustomerInfo(
         order: Order,
         isVirtualOrder: Boolean, // don't display shipping section for virtual products
-        isReadOnly: Boolean
+        isReadOnly: Boolean,
+        viewOrdersButtonVissible: Boolean = false,
     ) {
         val noBillingInfo = order.billingAddress.hasInfo().not() && order.formatBillingInformationForDisplay().isEmpty()
         val noShippingInfo = order.formatShippingInformationForDisplay().isEmpty()
@@ -80,7 +81,7 @@ class OrderDetailCustomerInfoView @JvmOverloads constructor(
         showCustomerNote(order, isReadOnly)
         showShippingAddress(order, isVirtualOrder, isReadOnly)
         showBillingInfo(order, isReadOnly)
-        showViewOrdersButton(order)
+        showViewOrdersButton(order, viewOrdersButtonVissible)
         restoreCustomerInfoViewExpandedOrCollapsedState()
     }
 
@@ -192,10 +193,10 @@ class OrderDetailCustomerInfoView @JvmOverloads constructor(
         }
     }
 
-    private fun showViewOrdersButton(order: Order) {
+    private fun showViewOrdersButton(order: Order, viewOrdersButtonVisible: Boolean) {
         val hasCustomerId = order.customer?.customerId != null && order.customer.customerId > 0
 
-        if (hasCustomerId) {
+        if (hasCustomerId && viewOrdersButtonVisible) {
             binding.customerInfoViewOrdersBtn.visibility = VISIBLE
             binding.customerInfoViewOrdersBtn.setOnClickListener {
                 viewCustomerOrdersListener?.invoke(order)

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/list/ProductListFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/list/ProductListFragment.kt
@@ -135,6 +135,7 @@ class ProductListFragment :
     override val detailPaneContainer: View
         get() = binding.detailNavContainer
     override var twoPanesWereShownBeforeConfigChange: Boolean = false
+    override val automaticallyAdjustLayoutAfterConfigChange: Boolean = true
     override val listFragment: Fragment
         get() = this
     override val navigation

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/util/TabletLayoutSetupHelper.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/util/TabletLayoutSetupHelper.kt
@@ -161,7 +161,7 @@ class TabletLayoutSetupHelper @Inject constructor(private val context: Context) 
     }
 
     private fun adjustLayoutForNonTablet(screen: Screen) {
-        if (screen.twoPanesWereShownBeforeConfigChange) {
+        if (screen.twoPanesWereShownBeforeConfigChange && screen.automaticallyAdjustLayoutAfterConfigChange) {
             displayDetailPaneOnly(screen)
         } else {
             displayListPaneOnly(screen)
@@ -195,6 +195,7 @@ class TabletLayoutSetupHelper @Inject constructor(private val context: Context) 
         val navigation: Navigation
 
         val twoPanesWereShownBeforeConfigChange: Boolean
+        val automaticallyAdjustLayoutAfterConfigChange: Boolean
 
         val listFragment: Fragment
 

--- a/WooCommerce/src/main/res/layout/fragment_booking_list.xml
+++ b/WooCommerce/src/main/res/layout/fragment_booking_list.xml
@@ -1,0 +1,43 @@
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    tools:context=".ui.bookings.list.BookingListFragment">
+
+    <!-- List pane (left) -->
+    <FrameLayout
+        android:id="@+id/listPaneContainer"
+        android:layout_width="0dp"
+        android:layout_height="0dp"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintEnd_toStartOf="@id/two_pane_layout_guideline"
+        app:layout_constraintTop_toTopOf="parent"
+        app:layout_constraintBottom_toBottomOf="parent">
+
+        <androidx.compose.ui.platform.ComposeView
+            android:id="@+id/bookingListCompose"
+            android:layout_width="match_parent"
+            android:layout_height="match_parent" />
+    </FrameLayout>
+
+    <!-- Guideline to split list/details on tablets -->
+    <androidx.constraintlayout.widget.Guideline
+        android:id="@+id/two_pane_layout_guideline"
+        android:layout_width="wrap_content"
+        android:layout_height="0dp"
+        android:orientation="vertical"
+        app:layout_constraintGuide_percent="0.0" />
+
+    <!-- Details pane (right) -->
+    <androidx.fragment.app.FragmentContainerView
+        android:id="@+id/detail_nav_container"
+        android:layout_width="0dp"
+        android:layout_height="0dp"
+        app:layout_constraintStart_toEndOf="@id/two_pane_layout_guideline"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintTop_toTopOf="parent"
+        app:layout_constraintBottom_toBottomOf="parent"
+        tools:visibility="gone" />
+
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/WooCommerce/src/main/res/navigation/nav_graph_bookings.xml
+++ b/WooCommerce/src/main/res/navigation/nav_graph_bookings.xml
@@ -4,48 +4,28 @@
     android:id="@+id/bookings"
     app:startDestination="@id/bookingListFragment">
 
+    <include app:graph="@navigation/nav_graph_bookings_details" />
+
     <fragment
         android:id="@+id/bookingListFragment"
         android:name="com.woocommerce.android.ui.bookings.list.BookingListFragment"
         android:label="fragment_bookings">
         <action
             android:id="@+id/action_bookingListFragment_to_bookingDetailsFragment"
-            app:destination="@id/bookingDetailsFragment" />
+            app:destination="@id/nav_graph_bookings_details">
+            <argument
+                android:name="bookingId"
+                android:defaultValue="-1L"
+                app:argType="long" />
+        </action>
         <action
             android:id="@+id/action_bookingListFragment_to_bookingFilterList"
             app:destination="@id/bookingFilterListFragment" />
     </fragment>
-    <fragment
-        android:id="@+id/bookingDetailsFragment"
-        android:name="com.woocommerce.android.ui.bookings.details.BookingDetailsFragment"
-        android:label="BookingDetailsFragment">
-        <argument
-            android:name="bookingId"
-            android:defaultValue="-1L"
-            app:argType="long" />
-        <action
-            android:id="@+id/action_bookingDetailsFragment_to_orderDetailFragment"
-            app:destination="@id/nav_graph_orders">
-            <argument
-                android:name="orderId"
-                app:argType="long" />
-        </action>
-        <action
-            android:id="@+id/action_bookingDetailsFragment_to_bookingNoteFragment"
-            app:destination="@id/bookingNoteFragment" />
-    </fragment>
+
     <fragment
         android:id="@+id/bookingFilterListFragment"
         android:name="com.woocommerce.android.ui.bookings.filter.BookingFilterListFragment"
         android:label="BookingFilterListFragment" />
-    <fragment
-        android:id="@+id/bookingNoteFragment"
-        android:name="com.woocommerce.android.ui.bookings.note.BookingNoteFragment"
-        android:label="BookingNoteFragment">
-        <argument
-            android:name="bookingId"
-            android:defaultValue="-1L"
-            app:argType="long" />
-    </fragment>
 
 </navigation>

--- a/WooCommerce/src/main/res/navigation/nav_graph_bookings.xml
+++ b/WooCommerce/src/main/res/navigation/nav_graph_bookings.xml
@@ -14,9 +14,8 @@
             android:id="@+id/action_bookingListFragment_to_bookingDetailsFragment"
             app:destination="@id/nav_graph_bookings_details">
             <argument
-                android:name="bookingId"
-                android:defaultValue="-1L"
-                app:argType="long" />
+                android:name="mode"
+                app:argType="com.woocommerce.android.ui.bookings.details.BookingDetailsFragment$Mode" />
         </action>
         <action
             android:id="@+id/action_bookingListFragment_to_bookingFilterList"

--- a/WooCommerce/src/main/res/navigation/nav_graph_bookings_details.xml
+++ b/WooCommerce/src/main/res/navigation/nav_graph_bookings_details.xml
@@ -11,9 +11,8 @@
         android:name="com.woocommerce.android.ui.bookings.details.BookingDetailsFragment"
         android:label="BookingDetailsFragment">
         <argument
-            android:name="bookingId"
-            android:defaultValue="-1L"
-            app:argType="long" />
+            android:name="mode"
+            app:argType="com.woocommerce.android.ui.bookings.details.BookingDetailsFragment$Mode" />
         <action
             android:id="@+id/action_bookingDetailsFragment_to_orderDetailFragment"
             app:destination="@id/nav_graph_orders">

--- a/WooCommerce/src/main/res/navigation/nav_graph_bookings_details.xml
+++ b/WooCommerce/src/main/res/navigation/nav_graph_bookings_details.xml
@@ -4,8 +4,6 @@
     android:id="@+id/nav_graph_bookings_details"
     app:startDestination="@id/bookingDetailsFragment">
 
-    <include app:graph="@navigation/nav_graph_orders" />
-
     <fragment
         android:id="@+id/bookingDetailsFragment"
         android:name="com.woocommerce.android.ui.bookings.details.BookingDetailsFragment"
@@ -13,13 +11,6 @@
         <argument
             android:name="mode"
             app:argType="com.woocommerce.android.ui.bookings.details.BookingDetailsFragment$Mode" />
-        <action
-            android:id="@+id/action_bookingDetailsFragment_to_orderDetailFragment"
-            app:destination="@id/nav_graph_orders">
-            <argument
-                android:name="orderId"
-                app:argType="long" />
-        </action>
         <action
             android:id="@+id/action_bookingDetailsFragment_to_bookingNoteFragment"
             app:destination="@id/bookingNoteFragment" />

--- a/WooCommerce/src/main/res/navigation/nav_graph_bookings_details.xml
+++ b/WooCommerce/src/main/res/navigation/nav_graph_bookings_details.xml
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="utf-8"?>
+<navigation xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:id="@+id/nav_graph_bookings_details"
+    app:startDestination="@id/bookingDetailsFragment">
+
+    <include app:graph="@navigation/nav_graph_orders" />
+
+    <fragment
+        android:id="@+id/bookingDetailsFragment"
+        android:name="com.woocommerce.android.ui.bookings.details.BookingDetailsFragment"
+        android:label="BookingDetailsFragment">
+        <argument
+            android:name="bookingId"
+            android:defaultValue="-1L"
+            app:argType="long" />
+        <action
+            android:id="@+id/action_bookingDetailsFragment_to_orderDetailFragment"
+            app:destination="@id/nav_graph_orders">
+            <argument
+                android:name="orderId"
+                app:argType="long" />
+        </action>
+        <action
+            android:id="@+id/action_bookingDetailsFragment_to_bookingNoteFragment"
+            app:destination="@id/bookingNoteFragment" />
+    </fragment>
+
+    <fragment
+        android:id="@+id/bookingNoteFragment"
+        android:name="com.woocommerce.android.ui.bookings.note.BookingNoteFragment"
+        android:label="BookingNoteFragment">
+        <argument
+            android:name="bookingId"
+            android:defaultValue="-1L"
+            app:argType="long" />
+    </fragment>
+</navigation>

--- a/WooCommerce/src/main/res/navigation/nav_graph_main.xml
+++ b/WooCommerce/src/main/res/navigation/nav_graph_main.xml
@@ -411,6 +411,17 @@
             app:argType="com.woocommerce.android.ui.products.AddProductSource" />
     </action>
     <action
+        android:id="@+id/action_global_orderDetailFragment"
+        app:destination="@id/nav_graph_orders">
+        <argument
+            android:name="orderId"
+            app:argType="long" />
+        <argument
+            android:name="ignoreTwoPaneLayout"
+            android:defaultValue="false"
+            app:argType="boolean" />
+    </action>
+    <action
         android:id="@+id/action_global_reviewDetailFragment"
         app:destination="@id/reviewDetailFragment" />
     <fragment

--- a/WooCommerce/src/main/res/navigation/nav_graph_main.xml
+++ b/WooCommerce/src/main/res/navigation/nav_graph_main.xml
@@ -417,7 +417,7 @@
             android:name="orderId"
             app:argType="long" />
         <argument
-            android:name="ignoreTwoPaneLayout"
+            android:name="ignoreTwoPaneLayoutLogic"
             android:defaultValue="false"
             app:argType="boolean" />
     </action>

--- a/WooCommerce/src/main/res/navigation/nav_graph_orders.xml
+++ b/WooCommerce/src/main/res/navigation/nav_graph_orders.xml
@@ -181,6 +181,10 @@
             android:name="startPaymentFlow"
             android:defaultValue="false"
             app:argType="boolean" />
+        <argument
+            android:name="ignoreTwoPaneLayout"
+            android:defaultValue="false"
+            app:argType="boolean" />
         <action
             android:id="@+id/action_orderDetailFragment_to_orderDetailFragment"
             app:destination="@+id/orderDetailFragment"

--- a/WooCommerce/src/main/res/navigation/nav_graph_orders.xml
+++ b/WooCommerce/src/main/res/navigation/nav_graph_orders.xml
@@ -182,7 +182,7 @@
             android:defaultValue="false"
             app:argType="boolean" />
         <argument
-            android:name="ignoreTwoPaneLayout"
+            android:name="ignoreTwoPaneLayoutLogic"
             android:defaultValue="false"
             app:argType="boolean" />
         <action

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -4303,6 +4303,7 @@
     <string name="booking_note_screen_update_error">Error saving booking note</string>
     <string name="booking_cancel_error">Error cancelling the booking</string>
     <string name="booking_mark_as_paid_error">Error marking the booking as paid</string>
+    <string name="booking_not_selected">Booking not selected</string>
 
     <string name="or_use_password" a8c-src-lib="module:login">Use password to sign in</string>
     <string name="about_automattic_main_page_title">About %1$s</string>

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/bookings/details/BookingDetailsViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/bookings/details/BookingDetailsViewModelTest.kt
@@ -41,7 +41,7 @@ class BookingDetailsViewModelTest : BaseUnitTest() {
     private val bookingId = 1L
     private val initialBooking = getSampleBooking(bookingId)
     private val bookingFlow = MutableStateFlow(initialBooking)
-    private val savedStateHandle = SavedStateHandle(mapOf("bookingId" to bookingId))
+    private val savedStateHandle = SavedStateHandle(mapOf("mode" to BookingDetailsFragment.Mode.ShowBooking(bookingId)))
 
     private val currencyFormatter = mock<CurrencyFormatter>()
     private val resourceProvider = mock<ResourceProvider>()
@@ -354,6 +354,20 @@ class BookingDetailsViewModelTest : BaseUnitTest() {
         advanceUntilIdle()
         val after = viewModel.state.getOrAwaitValue()
         assertThat(after.paymentUpdateStatus).isEqualTo(PaymentUpdateStatus.Idle)
+    }
+
+    @Test
+    fun `given Empty mode, when ViewModel created, then state is empty`() = testBlocking {
+        // Given
+        val savedState = SavedStateHandle(mapOf("mode" to BookingDetailsFragment.Mode.Empty))
+
+        // When
+        val viewModel = createViewModel(savedState)
+
+        // Then
+        val state = viewModel.state.getOrAwaitValue()
+        assertThat(state.bookingUiState).isNull()
+        assertThat(state.toolbarTitle).isEmpty()
     }
 
     private fun createViewModel(

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/bookings/list/BookingListViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/bookings/list/BookingListViewModelTest.kt
@@ -7,6 +7,7 @@ import com.woocommerce.android.ui.bookings.Booking
 import com.woocommerce.android.ui.bookings.BookingMapper
 import com.woocommerce.android.ui.bookings.filter.data.BookingFilterRepository
 import com.woocommerce.android.util.CurrencyFormatter
+import com.woocommerce.android.util.IsWindowClassLargeThanCompact
 import com.woocommerce.android.util.captureValues
 import com.woocommerce.android.util.getOrAwaitValue
 import com.woocommerce.android.viewmodel.BaseUnitTest
@@ -59,21 +60,26 @@ class BookingListViewModelTest : BaseUnitTest() {
     private val bookingFilterRepository: BookingFilterRepository = mock {
         on { bookingFiltersFlow } doReturn bookingFiltersFlow
     }
+    private val isWindowClassLargeThanCompact: IsWindowClassLargeThanCompact = mock()
 
     private lateinit var viewModel: BookingListViewModel
+    private lateinit var savedStateHandle: SavedStateHandle
 
     suspend fun setup(
         bookings: List<Booking> = emptyList(),
         prepareMocks: suspend () -> Unit = {}
     ) {
-        prepareMocks()
         whenever(bookingListHandler.bookingsFlow).thenReturn(flowOf(bookings))
+        whenever(isWindowClassLargeThanCompact()).thenReturn(false)
+        prepareMocks()
+        savedStateHandle = SavedStateHandle()
         viewModel = BookingListViewModel(
-            savedStateHandle = SavedStateHandle(),
             bookingFilterRepository = bookingFilterRepository,
+            savedStateHandle = savedStateHandle,
             bookingListHandler = bookingListHandler,
             filtersBuilder = filtersBuilder,
             bookingMapper = bookingMapper,
+            isWindowClassLargeThanCompact = isWindowClassLargeThanCompact,
         )
     }
 
@@ -346,6 +352,61 @@ class BookingListViewModelTest : BaseUnitTest() {
         // THEN
         val controlsState = viewModel.state.getOrAwaitValue().controlsState
         assertThat(controlsState.enabledFiltersCount).isEqualTo(1)
+    }
+
+    @Test
+    fun `given tablet, when bookings are loaded and none selected yet, then first is auto opened`() = testBlocking {
+        // GIVEN
+        val booking1 = getSampleBooking(11)
+        val booking2 = getSampleBooking(22)
+        setup(bookings = listOf(booking1, booking2)) {
+            whenever(isWindowClassLargeThanCompact()).thenReturn(true)
+        }
+
+        // WHEN
+        val events = viewModel.event.captureValues()
+        viewModel.state.getOrAwaitValue()
+        advanceUntilIdle()
+
+        // THEN
+        val navigations = events.filterIsInstance<BookingListViewModel.NavigateToBookingDetails>()
+        assertThat(navigations).hasSize(1)
+        assertThat(navigations.first().bookingId).isEqualTo(booking1.id.value)
+    }
+
+    @Test
+    fun `given phone, when bookings are loaded, then no auto navigation happens`() = testBlocking {
+        // GIVEN
+        val booking = getSampleBooking(33)
+        setup(bookings = listOf(booking))
+
+        // WHEN
+        val events = viewModel.event.captureValues()
+        viewModel.state.getOrAwaitValue()
+        advanceUntilIdle()
+
+        // THEN
+        val navigations = events.filterIsInstance<BookingListViewModel.NavigateToBookingDetails>()
+        assertThat(navigations).isEmpty()
+    }
+
+    @Test
+    fun `given tablet, when booking is clicked, then selection is saved and navigation emitted`() = testBlocking {
+        // GIVEN
+        setup(bookings = emptyList()) {
+            whenever(isWindowClassLargeThanCompact()).thenReturn(true)
+        }
+        val events = viewModel.event.captureValues()
+        val state = viewModel.state.getOrAwaitValue()
+
+        // WHEN
+        state.contentState.onBookingClick(1234L)
+        advanceUntilIdle()
+
+        // THEN
+        val navigations = events.filterIsInstance<BookingListViewModel.NavigateToBookingDetails>()
+        assertThat(navigations.last().bookingId).isEqualTo(1234L)
+        assertThat(savedStateHandle.get<Long>(BookingListViewModel.KEY_BOOKING_SELECTED_ON_BIG_SCREEN)).isEqualTo(1234L)
     }
 
     private fun getSampleBooking(id: Int): Booking {


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Part of WOOMOB-1421

<!-- Id number of the Linear issue this PR addresses, e.g., WOOMOB-373. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

This PR adds support for split pane layout on the bookings tab for bigger screens. The implementation mostly follows the Products tab logic. I highly recommend reviewing commit by commit, where I tried to fix issues one by one.

**About the `View Order` navigation logic.** 

The `OrderDetailFragment` has some logic that pretty much makes it impossible to show this Fragment outside the main graph with the Order list in the backstack. I've added an option to ignore it https://github.com/woocommerce/woocommerce-android/pull/14720/commits/dc55081626eff082eacb159c7158b0555d55bb35. Additionally, I've decided to show the Order details in full screen when in Split Pane. While this may not be the best, it's something we already do when opening a Product from Order.

### Testing
<!-- Step-by-step testing instructions. For new user flows, consider instead stating the goal of the workflow and see if your PR reviewer can accomplish the workflow without specific steps! -->
1. Launch the app on a tablet or a resizable emulator
2. Go to the Bookings tab
3. Play with it


### Images/gif
<!-- Include before and after images or gifs when appropriate. -->


https://github.com/user-attachments/assets/03842b1a-b4ec-4406-be12-763251e8bc9e


- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->