### PR TITLE
[Jetpack Performance] Handle KeyStore errors and fallback to Jetpack if they occur

### DIFF
--- a/libs/fluxc-plugin/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/WooNetwork.kt
+++ b/libs/fluxc-plugin/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/WooNetwork.kt
@@ -1,16 +1,19 @@
 package org.wordpress.android.fluxc.network.rest.wpcom.wc
 
 import org.wordpress.android.fluxc.model.SiteModel
+import org.wordpress.android.fluxc.network.BaseRequest
 import org.wordpress.android.fluxc.network.rest.wpapi.WPAPINetwork
 import org.wordpress.android.fluxc.network.rest.wpapi.WPAPINetworkError
 import org.wordpress.android.fluxc.network.rest.wpapi.WPAPINetworkingMode
 import org.wordpress.android.fluxc.network.rest.wpapi.WPAPIResponse
 import org.wordpress.android.fluxc.network.rest.wpapi.applicationpasswords.ApplicationPasswordsConfiguration
 import org.wordpress.android.fluxc.network.rest.wpapi.applicationpasswords.ApplicationPasswordsNetwork
+import org.wordpress.android.fluxc.network.rest.wpapi.applicationpasswords.ApplicationPasswordsStore
 import org.wordpress.android.fluxc.network.rest.wpapi.applicationpasswords.JetpackApplicationPasswordsErrorHandler
 import org.wordpress.android.fluxc.network.rest.wpapi.applicationpasswords.JetpackApplicationPasswordsSupport
 import org.wordpress.android.fluxc.network.rest.wpcom.JetpackTunnelWPAPINetwork
 import org.wordpress.android.util.AppLog
+import java.security.GeneralSecurityException
 import javax.inject.Inject
 import javax.inject.Singleton
 
@@ -140,7 +143,19 @@ class WooNetwork @Inject constructor(
             )
         }
 
-        return when (val appPasswordsResponse = applicationPasswordsNetwork.request()) {
+        val appPasswordsResponse = try {
+            applicationPasswordsNetwork.request()
+        } catch (e: GeneralSecurityException) {
+            AppLog.e(AppLog.T.API, "Error setting up Application Passwords encryption", e)
+            WPAPIResponse.Error(
+                error = WPAPINetworkError(
+                    baseError = BaseRequest.BaseNetworkError(BaseRequest.GenericErrorType.UNKNOWN),
+                    errorCode = ApplicationPasswordsStore.APPLICATION_PASSWORDS_KEYSTORE_ENCRYPTION_ERROR
+                )
+            )
+        }
+
+        return when (appPasswordsResponse) {
             is WPAPIResponse.Success<*> -> {
                 (appPasswordsResponse as WPAPIResponse<T>).copyWith(
                     networkingMode = WPAPINetworkingMode.ApplicationPasswordsWithJetpack

--- a/libs/fluxc-tests/src/test/java/org/wordpress/android/fluxc/network/rest/wpcom/wc/WooNetworkTest.kt
+++ b/libs/fluxc-tests/src/test/java/org/wordpress/android/fluxc/network/rest/wpcom/wc/WooNetworkTest.kt
@@ -3,6 +3,8 @@ package org.wordpress.android.fluxc.network.rest.wpcom.wc
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.Test
 import org.junit.runner.RunWith
+import org.mockito.kotlin.argThat
+import org.mockito.kotlin.eq
 import org.mockito.kotlin.given
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.never
@@ -14,10 +16,12 @@ import org.wordpress.android.fluxc.network.rest.wpapi.WPAPINetworkError
 import org.wordpress.android.fluxc.network.rest.wpapi.WPAPIResponse
 import org.wordpress.android.fluxc.network.rest.wpapi.applicationpasswords.ApplicationPasswordsConfiguration
 import org.wordpress.android.fluxc.network.rest.wpapi.applicationpasswords.ApplicationPasswordsNetwork
+import org.wordpress.android.fluxc.network.rest.wpapi.applicationpasswords.ApplicationPasswordsStore
 import org.wordpress.android.fluxc.network.rest.wpapi.applicationpasswords.JetpackApplicationPasswordsErrorHandler
 import org.wordpress.android.fluxc.network.rest.wpapi.applicationpasswords.JetpackApplicationPasswordsSupport
 import org.wordpress.android.fluxc.network.rest.wpcom.JetpackTunnelWPAPINetwork
 import org.wordpress.android.fluxc.test
+import java.security.GeneralSecurityException
 
 @RunWith(RobolectricTestRunner::class)
 class WooNetworkTest {
@@ -136,6 +140,33 @@ class WooNetworkTest {
         )
 
         verify(jetpackApplicationPasswordsErrorHandler).handleError(testSite, appPasswordsNetworkError)
+    }
+
+    @Test
+    fun `when a KeyStore error occurs, then fallback to Jetpack Tunnel`() = test {
+        given(jetpackApplicationPasswordsSupport.supportsAppPasswords(testSite)).willReturn(true)
+        given(
+            applicationPasswordsNetwork.executeGetGsonRequest(
+                testSite,
+                testPath,
+                SampleResponse::class.java
+            )
+        ).willAnswer {
+            throw GeneralSecurityException()
+        }
+        givenJetpackTunnelResponse(WPAPIResponse.Success(SampleResponse("value"), emptyList()))
+
+        val response = sut.executeGetGsonRequest(
+            site = testSite,
+            path = testPath,
+            clazz = SampleResponse::class.java
+        )
+
+        assertThat((response as WPAPIResponse.Success).data).isEqualTo(SampleResponse("value"))
+        verify(jetpackApplicationPasswordsErrorHandler).handleError(
+            eq(testSite),
+            argThat { errorCode == ApplicationPasswordsStore.APPLICATION_PASSWORDS_KEYSTORE_ENCRYPTION_ERROR }
+        )
     }
 
     private suspend fun givenAppPasswordsResponse(response: WPAPIResponse<SampleResponse>) {

--- a/libs/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpapi/applicationpasswords/ApplicationPasswordsStore.kt
+++ b/libs/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpapi/applicationpasswords/ApplicationPasswordsStore.kt
@@ -19,6 +19,7 @@ class ApplicationPasswordsStore @Inject constructor(
         private const val USERNAME_PREFERENCE_KEY_PREFIX = "username_"
         private const val PASSWORD_PREFERENCE_KEY_PREFIX = "app_password_"
         private const val UUID_PREFERENCE_KEY_PREFIX = "app_password_uuid_"
+        const val APPLICATION_PASSWORDS_KEYSTORE_ENCRYPTION_ERROR = "application_passwords_keystore_encryption_error"
     }
 
     @Inject internal lateinit var configuration: ApplicationPasswordsConfiguration

--- a/libs/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpapi/applicationpasswords/JetpackApplicationPasswordsErrorHandler.kt
+++ b/libs/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpapi/applicationpasswords/JetpackApplicationPasswordsErrorHandler.kt
@@ -39,7 +39,8 @@ class JetpackApplicationPasswordsErrorHandler @Inject constructor(
             httpStatusCode == TOO_MANY_REQUESTS ||
             apiErrorCode == "incorrect_password" ||
             apiErrorCode == ApplicationPasswordsManager.APPLICATION_PASSWORDS_DISABLED_ERROR_CODE ||
-            apiErrorCode == ApplicationPasswordsManager.APPLICATION_PASSWORDS_DISABLED_USER_ERROR_CODE
+            apiErrorCode == ApplicationPasswordsManager.APPLICATION_PASSWORDS_DISABLED_USER_ERROR_CODE ||
+            apiErrorCode == ApplicationPasswordsStore.APPLICATION_PASSWORDS_KEYSTORE_ENCRYPTION_ERROR
         ) {
             appLogWrapper.w(
                 AppLog.T.API,

--- a/libs/fluxc/src/test/java/org/wordpress/android/fluxc/network/rest/wpapi/applicationpasswords/JetpackApplicationPasswordsErrorHandlerTests.kt
+++ b/libs/fluxc/src/test/java/org/wordpress/android/fluxc/network/rest/wpapi/applicationpasswords/JetpackApplicationPasswordsErrorHandlerTests.kt
@@ -175,4 +175,20 @@ class JetpackApplicationPasswordsErrorHandlerTests {
             )
         )
     }
+
+    @Test
+    fun `given KeyStore error, when handling error, then flag site as unsupported`() {
+        // Given
+        val baseError = BaseNetworkError(mock<VolleyError>())
+        val networkError = WPAPINetworkError(
+            baseError,
+            ApplicationPasswordsStore.APPLICATION_PASSWORDS_KEYSTORE_ENCRYPTION_ERROR
+        )
+
+        // When
+        errorHandler.handleError(testSite, networkError)
+
+        // Then
+        verify(jetpackApplicationPasswordsSupport).flagAsUnsupported(testSite)
+    }
 }


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

<!-- Id number of the Linear issue this PR addresses, e.g., WOOMOB-373. -->
Closes WOOMOB-1451

> [!NOTE]
> I'm making this a beta test since the feature could break the app for some users, I checked and the number of cases is still flat with no spikes, but it's better to get this to production ASAP. 

### Description
This PR adds logic to handle any potential failures from `EncryptedSharedPreferences` to avoid blocking users who could be impacted by the issue, the app will now gracefully recover from them, and flag the site as not supporting app passwords.

For some context, since introducing Application Passwords, we've had some crashes related to `EncryptedSharedPreferences`, they were never frequent enough to warrant migrating to another solution (See WOOMOB-1423 and peaMlT-wX-p2). For Jetpack users, though, if they occur, it's better to switch back to Jetpack.

### Steps to reproduce
1. Sign in using WordPress.com, and make sure your site supports app passwords.
2. Apply this patch:

<details>
<summary>Patch</summary>

```patch
Index: libs/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpapi/applicationpasswords/ApplicationPasswordsStore.kt
IDEA additional info:
Subsystem: com.intellij.openapi.diff.impl.patch.CharsetEP
<+>UTF-8
===================================================================
diff --git a/libs/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpapi/applicationpasswords/ApplicationPasswordsStore.kt b/libs/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpapi/applicationpasswords/ApplicationPasswordsStore.kt
--- a/libs/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpapi/applicationpasswords/ApplicationPasswordsStore.kt	(revision 8e8e74a4291c3a3016bb0ecdbfc2ef399632390c)
+++ b/libs/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpapi/applicationpasswords/ApplicationPasswordsStore.kt	(date 1760012513397)
@@ -7,6 +7,7 @@
 import org.wordpress.android.fluxc.model.SiteModel
 import org.wordpress.android.util.AppLog
 import org.wordpress.android.util.UrlUtils
+import java.security.GeneralSecurityException
 import java.security.KeyStore
 import javax.inject.Inject
 import javax.inject.Singleton
@@ -70,6 +71,7 @@
     }
 
     private fun initEncryptedPrefs(): SharedPreferences {
+        throw GeneralSecurityException()
         val keySpec = MasterKeys.AES256_GCM_SPEC
         val filename = "$applicationName-encrypted-prefs"
 
```
</details>
2. Launch the app.

### Testing information
- Confirm the app doesn't crash.
- Check logcat and confirm the message `Error setting up Application Passwords encryption` was logged with the thrown exception.
- Use AS network inspector and confirm the app uses Jetpack Proxy (ie calling `public-api.wordpress.com` as the host).

### The tests that have been performed
The above.

- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->