### PR TITLE
Fix compilation issues in BookingListScreen preview functions

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/bookings/list/BookingListScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/bookings/list/BookingListScreen.kt
@@ -491,7 +491,8 @@ private fun EmptyViewPreview() {
                 controlsState = BookingListControlsState(
                     selectedSortOption = BookingListSortOption.NewestToOldest,
                     onSortClick = {},
-                    onFilterClick = {}
+                    onFilterClick = {},
+                    isFilterButtonVisible = true
                 ),
                 sortBottomSheetState = null,
                 searchState = BookingListSearchState(
@@ -523,7 +524,8 @@ private fun EmptySearchResultsViewPreview() {
                 controlsState = BookingListControlsState(
                     selectedSortOption = BookingListSortOption.NewestToOldest,
                     onSortClick = {},
-                    onFilterClick = {}
+                    onFilterClick = {},
+                    isFilterButtonVisible = true
                 ),
                 sortBottomSheetState = null,
                 searchState = BookingListSearchState(


### PR DESCRIPTION
### Description
Fixed compilation issues in the BookingListScreen preview functions by adding the missing `isFilterButtonVisible` parameter to the `BookingListControlsState` in both `EmptyViewPreview` and `EmptySearchResultsViewPreview` functions.

### Steps to reproduce
1. Build the project
2. Verify compilation succeeds

### Testing information
- Verified the app compiles successfully
- Preview functions now match the updated `BookingListControlsState` signature

### The tests that have been performed
- Build verification

- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.