### PR TITLE
Ensure getCanBlaze is non nullable even when canBlaze is not set

### DIFF
--- a/libs/fluxc/src/main/java/org/wordpress/android/fluxc/model/SiteModel.java
+++ b/libs/fluxc/src/main/java/org/wordpress/android/fluxc/model/SiteModel.java
@@ -6,12 +6,6 @@ import androidx.annotation.IntDef;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 
-import com.yarolegovich.wellsql.core.Identifiable;
-import com.yarolegovich.wellsql.core.annotation.Column;
-import com.yarolegovich.wellsql.core.annotation.PrimaryKey;
-import com.yarolegovich.wellsql.core.annotation.RawConstraints;
-import com.yarolegovich.wellsql.core.annotation.Table;
-
 import org.wordpress.android.fluxc.Payload;
 import org.wordpress.android.fluxc.model.LocalOrRemoteId.LocalId;
 import org.wordpress.android.fluxc.model.LocalOrRemoteId.RemoteId;
@@ -25,6 +19,12 @@ import java.net.URI;
 import java.net.URISyntaxException;
 import java.util.Arrays;
 import java.util.Objects;
+
+import com.yarolegovich.wellsql.core.Identifiable;
+import com.yarolegovich.wellsql.core.annotation.Column;
+import com.yarolegovich.wellsql.core.annotation.PrimaryKey;
+import com.yarolegovich.wellsql.core.annotation.RawConstraints;
+import com.yarolegovich.wellsql.core.annotation.Table;
 
 // WARN: This class is used within WordPress-MediaPicker-Android, do not remove!
 @Table
@@ -1110,7 +1110,7 @@ public class SiteModel extends Payload<BaseNetworkError> implements Identifiable
     }
 
     public Boolean getCanBlaze() {
-        return mCanBlaze;
+        return mCanBlaze == true;
     }
 
     public void setCanBlaze(Boolean canBlaze) {


### PR DESCRIPTION
Fixes WOOMOB-1442

<!-- Id number of the Linear issue this PR addresses, e.g., WOOMOB-373. -->

### Description
I couldn't reproduce this crash, but the fix ensures `mCanBlaze` is never null. 
I've attempted migrating the field from `Boolean` to primitive value `boolean` as suggested in Linear issue, but it does require migration. So the simplest approach was to handle nullability at `getCanBlaze()` function level. 

### Steps to reproduce
<!-- Step-by-step testing instructions. For new user flows, consider instead stating the goal of the workflow and see if your PR reviewer can accomplish the workflow without specific steps! -->
Couldn't reproduce this either. 

### Testing information
1. Switch back and forth between 2 sites, one where Blaze is enabled and the other where Blaze is disabled. Check that the feature is shown or hidden accordingly.
