### PR TITLE
Convert mCanBlaze field to primitive value to avoid npe when unboxing

### DIFF
--- a/libs/fluxc/src/main/java/org/wordpress/android/fluxc/model/SiteModel.java
+++ b/libs/fluxc/src/main/java/org/wordpress/android/fluxc/model/SiteModel.java
@@ -6,12 +6,6 @@ import androidx.annotation.IntDef;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 
-import com.yarolegovich.wellsql.core.Identifiable;
-import com.yarolegovich.wellsql.core.annotation.Column;
-import com.yarolegovich.wellsql.core.annotation.PrimaryKey;
-import com.yarolegovich.wellsql.core.annotation.RawConstraints;
-import com.yarolegovich.wellsql.core.annotation.Table;
-
 import org.wordpress.android.fluxc.Payload;
 import org.wordpress.android.fluxc.model.LocalOrRemoteId.LocalId;
 import org.wordpress.android.fluxc.model.LocalOrRemoteId.RemoteId;
@@ -25,6 +19,12 @@ import java.net.URI;
 import java.net.URISyntaxException;
 import java.util.Arrays;
 import java.util.Objects;
+
+import com.yarolegovich.wellsql.core.Identifiable;
+import com.yarolegovich.wellsql.core.annotation.Column;
+import com.yarolegovich.wellsql.core.annotation.PrimaryKey;
+import com.yarolegovich.wellsql.core.annotation.RawConstraints;
+import com.yarolegovich.wellsql.core.annotation.Table;
 
 // WARN: This class is used within WordPress-MediaPicker-Android, do not remove!
 @Table
@@ -257,7 +257,7 @@ public class SiteModel extends Payload<BaseNetworkError> implements Identifiable
     @Column
     private String mApplicationPasswordsAuthorizeUrl;
     @Column
-    private Boolean mCanBlaze;
+    private boolean mCanBlaze;
     // Comma-separated list of active features in the site's plan
     @Column
     private String mPlanActiveFeatures;
@@ -1109,11 +1109,11 @@ public class SiteModel extends Payload<BaseNetworkError> implements Identifiable
         this.mPublishedStatus = publishedStatus;
     }
 
-    public Boolean getCanBlaze() {
+    public boolean getCanBlaze() {
         return mCanBlaze;
     }
 
-    public void setCanBlaze(Boolean canBlaze) {
+    public void setCanBlaze(boolean canBlaze) {
         this.mCanBlaze = canBlaze;
     }
 


### PR DESCRIPTION
Fixes WOOMOB-1442

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
Coming from this PR, we are aplying this as a beta fix. 

Migrates `mCanBlaze` to primitive boolean value to avoid npe when persited value is NULL and we try to unbox a `Boolean` object. 

### Testing information
PR reviewer can accomplish the workflow without specific steps! -->
1. Install tha app from `trunk`
2. Log into a site with Blaze enabled
3. Inspect DB value from AS and override `CAN_BLAZE` value for the current site and set it to `NULL`. 
4. Kill the app and restart it. It should crash
5. Run the app from this PR branch using `./gradlew :WooCommerce:assembleWasabiDebug --rerun-tasks` first and check it doesn't crash when opening it.
