### PR TITLE
Fix trash product button visibility on tablets

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/details/ProductDetailFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/details/ProductDetailFragment.kt
@@ -156,8 +156,11 @@ class ProductDetailFragment :
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
 
-        val isTrashEnabled =
+        val productListInBackstack =
             findNavController().previousBackStackEntry?.destination?.id == BottomNavigationPosition.PRODUCTS.id
+        val isInDetailPane =
+            requireContext().isTwoPanesShouldBeUsed && (parentFragment?.id == R.id.detail_nav_container)
+        val isTrashEnabled = productListInBackstack || isInDetailPane
         viewModel.setTrashActionPossible(isTrashEnabled)
 
         blazeCampaignCreationDispatcher.attachFragment(this, BlazeFlowSource.PRODUCT_DETAIL_PROMOTE_BUTTON)


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

<!-- Id number of the Linear issue this PR addresses, e.g., WOOMOB-373. -->

WOOMOB-1484

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

While fixing a bug related to the `Trash product` button visibility (https://github.com/woocommerce/woocommerce-android/pull/14657) I introduced this bug where the trash button is not visible in the split pane layout. 

This PR adds an additional check to make sure it's enabled in split pane even if the product list is not in the backstack.

### Steps to reproduce
<!-- Step-by-step testing instructions. For new user flows, consider instead stating the goal of the workflow and see if your PR reviewer can accomplish the workflow without specific steps! -->

1. Open the app on tablet
2. Go to products
3. Tap on the `...` menu button
4. Verify the `Trash product` is visible

### Testing information
<!-- This is your opportunity to break out individual scenarios that need testing (when necessary) and/or include a checklist for the reviewer to go through. Consider documenting the following from your own completed testing: devices used, alternate workflows, edge cases, affected areas, critical flows, areas not tested, and any remaining unknowns. Provide feedback on this new section of the PR template through Sept 30, 2024 to Apps Quality; additional context here: p91TBi-b8z-p2#comment-12036 -->

The above plus:

Using a tablet
2. Go to order 
3. Tap on a product
4. Verify the `Trash product` is gone

Using a phone
1. Go to products
2. Tap on a product
3. Tap on the `...` menu button
4. Verify the `Trash product` is visible

### The tests that have been performed
<!-- To give the reviewer an idea of what could be missed in terms of testing -->

The above

### Images/gif
<!-- Include before and after images or gifs when appropriate. -->

| Before | After |
|---|---|
| <img width="1920" height="1200" alt="trash_unavailable" src="https://github.com/user-attachments/assets/a3796ce6-3d71-4e32-a116-f7828c9335f8" /> | <img width="1920" height="1200" alt="trash_visible" src="https://github.com/user-attachments/assets/28921f87-99db-48d5-84d3-282dec20d9e4" /> |

- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->