### PR TITLE
Fix broken skeleton layout

### DIFF
--- a/WooCommerce/src/main/res/layout/skeleton_analytics_list_item.xml
+++ b/WooCommerce/src/main/res/layout/skeleton_analytics_list_item.xml
@@ -19,10 +19,11 @@
         android:id="@+id/value"
         android:layout_width="@dimen/major_275"
         android:layout_height="@dimen/skeleton_text_height_75"
-        android:layout_marginStart="352dp"
+        android:layout_marginRight="@dimen/major_100"
         android:background="@drawable/skeleton_background"
         app:layout_constraintBottom_toBottomOf="@+id/subtitle"
-        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintLeft_toRightOf="@id/guideline"
         app:layout_constraintTop_toTopOf="@+id/title" />
 
     <View


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

<!-- Id number of the Linear issue this PR addresses, e.g., WOOMOB-373. -->

#WOOMOB-1424

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

This PR fixes a minor UI glitch on the skeleton loading view in analytics.

### Steps to reproduce
<!-- Step-by-step testing instructions. For new user flows, consider instead stating the goal of the workflow and see if your PR reviewer can accomplish the workflow without specific steps! -->
1. Open dashboard
2. Tap on 'View all store analytics on one of the cards
3. Scroll down and notice a broken (overlapping) skeleton

### Testing information
<!-- This is your opportunity to break out individual scenarios that need testing (when necessary) and/or include a checklist for the reviewer to go through. Consider documenting the following from your own completed testing: devices used, alternate workflows, edge cases, affected areas, critical flows, areas not tested, and any remaining unknowns. Provide feedback on this new section of the PR template through Sept 30, 2024 to Apps Quality; additional context here: p91TBi-b8z-p2#comment-12036 -->

- Repeat the above steps and verify it's fixed

### The tests that have been performed
<!-- To give the reviewer an idea of what could be missed in terms of testing -->

The above

### Images/gif
<!-- Include before and after images or gifs when appropriate. -->
| Before | After |
| -- | -- |
| <img width="400" alt="image" src="https://github.com/user-attachments/assets/dd7cd2b0-9c65-40e3-b3fb-7ff80ebe85c8" /> | <img width="400" alt="image" src="https://github.com/user-attachments/assets/eadb0d08-2c0d-4e33-b054-14e45255e2d5" /> |

- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->