### PR TITLE
[WOOMOB-1487] - Booking filter internal navigation

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/bookings/filter/BookingFilterListScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/bookings/filter/BookingFilterListScreen.kt
@@ -1,14 +1,18 @@
 package com.woocommerce.android.ui.bookings.filter
 
+import androidx.compose.animation.AnimatedContent
+import androidx.compose.animation.ContentTransform
+import androidx.compose.animation.core.tween
+import androidx.compose.animation.fadeIn
+import androidx.compose.animation.fadeOut
+import androidx.compose.animation.slideInHorizontally
+import androidx.compose.animation.slideOutHorizontally
+import androidx.compose.animation.togetherWith
 import androidx.compose.foundation.background
-import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.defaultMinSize
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.lazy.LazyColumn
-import androidx.compose.foundation.lazy.items
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
@@ -22,7 +26,6 @@ import androidx.compose.ui.unit.dp
 import com.woocommerce.android.R
 import com.woocommerce.android.ui.compose.component.Toolbar
 import com.woocommerce.android.ui.compose.component.WCColoredButton
-import com.woocommerce.android.ui.compose.component.WCListItemWithInlineSubtitle
 import com.woocommerce.android.ui.compose.preview.LightDarkThemePreviews
 import com.woocommerce.android.ui.compose.theme.WooThemeWithBackground
 
@@ -58,29 +61,53 @@ fun BookingFilterListScreen(state: BookingFilterListUiState) {
         },
         containerColor = MaterialTheme.colorScheme.surface,
     ) { innerPadding ->
-        LazyColumn(
+        AnimatedContent(
+            targetState = state.currentPage,
+            transitionSpec = {
+                if (targetState is BookingFilterPage.List) {
+                    slideOut()
+                } else {
+                    slideIn()
+                }
+            },
+            label = "BookingFiltersAnimatedContent",
             modifier = Modifier
                 .fillMaxSize()
                 .padding(innerPadding)
-        ) {
-            items(state.items) { item -> BookingFilterListRow(item) }
+        ) { page ->
+            when (page) {
+                is BookingFilterPage.List -> {
+                    BookingFilterRootPage(state.items)
+                }
+
+                is BookingFilterPage.DateTimePicker -> {
+                    DateTimeFilterPicker()
+                }
+            }
         }
     }
 }
 
-@Composable
-private fun BookingFilterListRow(item: BookingFilterListItem) {
-    Column(modifier = Modifier.fillMaxWidth()) {
-        WCListItemWithInlineSubtitle(
-            text = stringResource(item.title),
-            subtitle = item.value ?: stringResource(id = R.string.bookings_filter_default),
-            modifier = Modifier
-                .defaultMinSize(minHeight = 64.dp)
-                .clickable { item.onClick() }
-                .padding(vertical = 8.dp)
+private const val TRANSITION_DURATION = 250
+
+private fun slideIn(duration: Int = TRANSITION_DURATION): ContentTransform {
+    return (
+        slideInHorizontally(animationSpec = tween(durationMillis = duration)) { fullWidth -> fullWidth } +
+            fadeIn(animationSpec = tween(durationMillis = duration))
+        ) togetherWith (
+        slideOutHorizontally(animationSpec = tween(durationMillis = duration)) { fullWidth -> -fullWidth } +
+            fadeOut(animationSpec = tween(durationMillis = duration))
         )
-        HorizontalDivider(thickness = 0.5.dp)
-    }
+}
+
+private fun slideOut(duration: Int = TRANSITION_DURATION): ContentTransform {
+    return (
+        slideInHorizontally(animationSpec = tween(durationMillis = duration)) { fullWidth -> -fullWidth } +
+            fadeIn(animationSpec = tween(durationMillis = duration))
+        ) togetherWith (
+        slideOutHorizontally(animationSpec = tween(durationMillis = duration)) { fullWidth -> fullWidth } +
+            fadeOut(animationSpec = tween(durationMillis = duration))
+        )
 }
 
 @LightDarkThemePreviews

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/bookings/filter/BookingFilterListScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/bookings/filter/BookingFilterListScreen.kt
@@ -1,5 +1,6 @@
 package com.woocommerce.android.ui.bookings.filter
 
+import androidx.activity.compose.BackHandler
 import androidx.compose.animation.AnimatedContent
 import androidx.compose.animation.ContentTransform
 import androidx.compose.animation.core.tween
@@ -31,6 +32,10 @@ import com.woocommerce.android.ui.compose.theme.WooThemeWithBackground
 
 @Composable
 fun BookingFilterListScreen(state: BookingFilterListUiState) {
+    BackHandler {
+        state.onClose()
+    }
+
     Scaffold(
         topBar = {
             Column {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/bookings/filter/BookingFilterListScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/bookings/filter/BookingFilterListScreen.kt
@@ -85,7 +85,14 @@ fun BookingFilterListScreen(state: BookingFilterListUiState) {
                     BookingFilterRootPage(state.items)
                 }
 
-                is BookingFilterPage.DateTimePicker -> {
+                BookingFilterPage.AttendanceStatus,
+                BookingFilterPage.BookingType,
+                BookingFilterPage.Customer,
+                BookingFilterPage.Location,
+                BookingFilterPage.PaymentStatus,
+                BookingFilterPage.ServiceEvent,
+                BookingFilterPage.TeamMember,
+                is BookingFilterPage.DateTime -> {
                     DateTimeFilterPicker()
                 }
             }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/bookings/filter/BookingFilterListScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/bookings/filter/BookingFilterListScreen.kt
@@ -35,9 +35,9 @@ fun BookingFilterListScreen(state: BookingFilterListUiState) {
         topBar = {
             Column {
                 Toolbar(
-                    title = stringResource(id = R.string.bookings_filters_default_title),
+                    title = stringResource(state.currentPage.titleRes),
                     onNavigationButtonClick = state.onClose,
-                    navigationIcon = ImageVector.vectorResource(id = R.drawable.ic_gridicons_cross_24dp)
+                    navigationIcon = ImageVector.vectorResource(id = state.navigationIcon)
                 )
                 HorizontalDivider(thickness = 0.5.dp)
             }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/bookings/filter/BookingFilterListUiState.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/bookings/filter/BookingFilterListUiState.kt
@@ -6,9 +6,16 @@ import com.woocommerce.android.R
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.bookings.BookingFilters
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.bookings.BookingsFilterOption
 
-sealed class BookingFilterPage(@StringRes val titleRes: Int) {
-    data object List : BookingFilterPage(R.string.bookings_filters_default_title)
-    data object DateTimePicker : BookingFilterPage(R.string.bookings_filter_title_date)
+sealed interface BookingFilterPage {
+    data object List : BookingFilterPage
+    data object DateTime : BookingFilterPage
+    data object TeamMember : BookingFilterPage
+    data object AttendanceStatus : BookingFilterPage
+    data object PaymentStatus : BookingFilterPage
+    data object BookingType : BookingFilterPage
+    data object Customer : BookingFilterPage
+    data object ServiceEvent : BookingFilterPage
+    data object Location : BookingFilterPage
 }
 
 data class BookingFilterListUiState(
@@ -20,11 +27,11 @@ data class BookingFilterListUiState(
     val openPage: (BookingFilterPage) -> Unit = {},
 ) {
 
-    val items: List<BookingFilterListItem> = initialBookingFilters.defaultBookingFilters().map { option ->
+    val items: List<BookingFilterListItem> = availableBookingFilters().map { page ->
         BookingFilterListItem(
-            title = option.titleRes(),
-            value = option.value,
-            onClick = { openPage(option.page) },
+            title = page.titleRes,
+            value = page.filterValue,
+            onClick = { openPage(page) },
         )
     }
 
@@ -33,6 +40,24 @@ data class BookingFilterListUiState(
         is BookingFilterPage.List -> R.drawable.ic_gridicons_cross_24dp
         else -> R.drawable.ic_back_24dp
     }
+
+    val BookingFilterPage.filterValue: String?
+        get() = when (this) {
+            BookingFilterPage.Customer -> {
+                newBookingFilters.getOrDefault<BookingsFilterOption.Customer>(
+                    initialBookingFilters?.customer
+                )?.customerName
+            }
+
+            BookingFilterPage.DateTime,
+            BookingFilterPage.Location,
+            BookingFilterPage.AttendanceStatus,
+            BookingFilterPage.BookingType,
+            BookingFilterPage.PaymentStatus,
+            BookingFilterPage.ServiceEvent,
+            BookingFilterPage.TeamMember,
+            BookingFilterPage.List -> null
+        }
 }
 
 data class BookingFilterListItem(
@@ -41,50 +66,30 @@ data class BookingFilterListItem(
     val onClick: () -> Unit = {}
 )
 
-@StringRes
-fun BookingsFilterOption.titleRes(): Int = when (this) {
-    BookingsFilterOption.TeamMember -> R.string.bookings_filter_title_team_member
-    BookingsFilterOption.AttendanceStatus -> R.string.bookings_filter_title_attendance_status
-    BookingsFilterOption.PaymentStatus -> R.string.bookings_filter_title_payment_status
-    BookingsFilterOption.BookingType -> R.string.bookings_filter_title_type
-    is BookingsFilterOption.Customer -> R.string.bookings_filter_customer_name
-    BookingsFilterOption.Category -> R.string.bookings_filter_category
-    is BookingsFilterOption.DateRange -> R.string.bookings_filter_title_date
-    BookingsFilterOption.ServiceEvent -> R.string.bookings_filter_title_service_event
-}
-
-private val BookingsFilterOption.value: String?
-    get() = when (this) {
-        BookingsFilterOption.TeamMember,
-        BookingsFilterOption.AttendanceStatus,
-        BookingsFilterOption.PaymentStatus,
-        BookingsFilterOption.BookingType,
-        BookingsFilterOption.Category,
-        BookingsFilterOption.ServiceEvent,
-        is BookingsFilterOption.Customer,
-        is BookingsFilterOption.DateRange -> null
+val BookingFilterPage.titleRes: Int
+    @StringRes get() = when (this) {
+        BookingFilterPage.TeamMember -> R.string.bookings_filter_title_team_member
+        BookingFilterPage.AttendanceStatus -> R.string.bookings_filter_title_attendance_status
+        BookingFilterPage.PaymentStatus -> R.string.bookings_filter_title_payment_status
+        BookingFilterPage.BookingType -> R.string.bookings_filter_title_type
+        BookingFilterPage.Customer -> R.string.bookings_filter_customer_name
+        BookingFilterPage.Location -> R.string.bookings_filter_location
+        BookingFilterPage.DateTime -> R.string.bookings_filter_title_date
+        BookingFilterPage.ServiceEvent -> R.string.bookings_filter_title_service_event
+        BookingFilterPage.List -> R.string.bookings_filters_default_title
     }
 
-private fun BookingFilters?.defaultBookingFilters(): List<BookingsFilterOption> = listOf(
-    BookingsFilterOption.TeamMember,
-    BookingsFilterOption.AttendanceStatus,
-    BookingsFilterOption.PaymentStatus,
-    BookingsFilterOption.BookingType,
-    BookingsFilterOption.Customer(customerId = this?.customer?.customerId, customerName = this?.customer?.customerName),
-    BookingsFilterOption.Category,
-    BookingsFilterOption.DateRange(before = this?.dateRange?.before, after = this?.dateRange?.after),
-    BookingsFilterOption.ServiceEvent,
+private fun availableBookingFilters(): List<BookingFilterPage> = listOf(
+    BookingFilterPage.TeamMember,
+    BookingFilterPage.BookingType,
+    BookingFilterPage.ServiceEvent,
+    BookingFilterPage.AttendanceStatus,
+    BookingFilterPage.PaymentStatus,
+    BookingFilterPage.Customer,
+    BookingFilterPage.DateTime,
+    BookingFilterPage.Location,
 )
 
-// TODO map to new pages as we add them
-private val BookingsFilterOption.page: BookingFilterPage
-    get() = when (this) {
-        BookingsFilterOption.TeamMember,
-        BookingsFilterOption.AttendanceStatus,
-        BookingsFilterOption.PaymentStatus,
-        BookingsFilterOption.BookingType,
-        BookingsFilterOption.Category,
-        BookingsFilterOption.ServiceEvent,
-        is BookingsFilterOption.Customer,
-        is BookingsFilterOption.DateRange -> BookingFilterPage.DateTimePicker
-    }
+inline fun <reified T> Set<BookingsFilterOption>.getOrDefault(default: T?): T? {
+    return this.filterIsInstance<T>().firstOrNull() ?: default
+}

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/bookings/filter/BookingFilterListUiState.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/bookings/filter/BookingFilterListUiState.kt
@@ -5,17 +5,25 @@ import com.woocommerce.android.R
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.bookings.BookingFilters
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.bookings.BookingsFilterOption
 
+sealed interface BookingFilterPage {
+    data object List : BookingFilterPage
+    data object DateTimePicker : BookingFilterPage
+}
+
 data class BookingFilterListUiState(
     val initialBookingFilters: BookingFilters? = null,
     val newBookingFilters: Set<BookingsFilterOption> = emptySet(),
+    val currentPage: BookingFilterPage = BookingFilterPage.List,
     val onClose: () -> Unit = {},
     val onShowBookings: () -> Unit = {},
+    val openPage: (BookingFilterPage) -> Unit = {},
 ) {
 
     val items: List<BookingFilterListItem> = initialBookingFilters.defaultBookingFilters().map { option ->
         BookingFilterListItem(
             title = option.titleRes(),
             value = option.value,
+            onClick = { openPage(option.page) },
         )
     }
 }
@@ -60,3 +68,16 @@ private fun BookingFilters?.defaultBookingFilters(): List<BookingsFilterOption> 
     BookingsFilterOption.DateRange(before = this?.dateRange?.before, after = this?.dateRange?.after),
     BookingsFilterOption.ServiceEvent,
 )
+
+// TODO map to new pages as we add them
+private val BookingsFilterOption.page: BookingFilterPage
+    get() = when (this) {
+        BookingsFilterOption.TeamMember,
+        BookingsFilterOption.AttendanceStatus,
+        BookingsFilterOption.PaymentStatus,
+        BookingsFilterOption.BookingType,
+        BookingsFilterOption.Category,
+        BookingsFilterOption.ServiceEvent,
+        is BookingsFilterOption.Customer,
+        is BookingsFilterOption.DateRange -> BookingFilterPage.DateTimePicker
+    }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/bookings/filter/BookingFilterListUiState.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/bookings/filter/BookingFilterListUiState.kt
@@ -1,13 +1,14 @@
 package com.woocommerce.android.ui.bookings.filter
 
+import androidx.annotation.DrawableRes
 import androidx.annotation.StringRes
 import com.woocommerce.android.R
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.bookings.BookingFilters
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.bookings.BookingsFilterOption
 
-sealed interface BookingFilterPage {
-    data object List : BookingFilterPage
-    data object DateTimePicker : BookingFilterPage
+sealed class BookingFilterPage(@StringRes val titleRes: Int) {
+    data object List : BookingFilterPage(R.string.bookings_filters_default_title)
+    data object DateTimePicker : BookingFilterPage(R.string.bookings_filter_title_date)
 }
 
 data class BookingFilterListUiState(
@@ -25,6 +26,12 @@ data class BookingFilterListUiState(
             value = option.value,
             onClick = { openPage(option.page) },
         )
+    }
+
+    @DrawableRes
+    val navigationIcon: Int = when (currentPage) {
+        is BookingFilterPage.List -> R.drawable.ic_gridicons_cross_24dp
+        else -> R.drawable.ic_back_24dp
     }
 }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/bookings/filter/BookingFilterListViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/bookings/filter/BookingFilterListViewModel.kt
@@ -23,13 +23,20 @@ class BookingFilterListViewModel @Inject constructor(
     private val _uiState = MutableStateFlow(
         BookingFilterListUiState(
             onClose = ::onClose,
-            onShowBookings = ::onShowBookings
+            onShowBookings = ::onShowBookings,
+            openPage = ::onOpenPage,
         )
     )
     val uiState = _uiState.asLiveData()
 
     init {
         getBookingFilter()
+    }
+
+    private fun onOpenPage(page: BookingFilterPage) {
+        _uiState.update { current ->
+            current.copy(currentPage = page)
+        }
     }
 
     private fun getBookingFilter() {
@@ -43,8 +50,14 @@ class BookingFilterListViewModel @Inject constructor(
     }
 
     private fun onClose() {
-        // TODO Verify unsaved changes and close
-        triggerEvent(MultiLiveEvent.Event.Exit)
+        if (_uiState.value.currentPage != BookingFilterPage.List) {
+            _uiState.update { current ->
+                current.copy(currentPage = BookingFilterPage.List)
+            }
+        } else {
+            // TODO Verify unsaved changes and close
+            triggerEvent(MultiLiveEvent.Event.Exit)
+        }
     }
 
     private fun onShowBookings() {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/bookings/filter/BookingFilterListViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/bookings/filter/BookingFilterListViewModel.kt
@@ -76,7 +76,8 @@ private val BookingFilterListUiState.updatedBookingFilters: BookingFilters
             dateRange = updates.getOrDefault(initial.dateRange),
             customer = updates.getOrDefault(initial.customer),
             teamMember = updates.getOrDefault(
-                initial.teamMember),
+                initial.teamMember
+            ),
             attendanceStatus = updates.getOrDefault(initial.attendanceStatus),
             paymentStatus = updates.getOrDefault(initial.paymentStatus),
             bookingType = updates.getOrDefault(initial.bookingType),

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/bookings/filter/BookingFilterListViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/bookings/filter/BookingFilterListViewModel.kt
@@ -11,7 +11,6 @@ import kotlinx.coroutines.flow.firstOrNull
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.bookings.BookingFilters
-import org.wordpress.android.fluxc.network.rest.wpcom.wc.bookings.BookingsFilterOption
 import javax.inject.Inject
 
 @HiltViewModel
@@ -80,11 +79,7 @@ private val BookingFilterListUiState.updatedBookingFilters: BookingFilters
             attendanceStatus = updates.getOrDefault(initial.attendanceStatus),
             paymentStatus = updates.getOrDefault(initial.paymentStatus),
             bookingType = updates.getOrDefault(initial.bookingType),
-            category = updates.getOrDefault(initial.category),
+            location = updates.getOrDefault(initial.location),
             serviceEvent = updates.getOrDefault(initial.serviceEvent),
         )
     }
-
-private inline fun <reified T> Set<BookingsFilterOption>.getOrDefault(default: T?): T? {
-    return this.filterIsInstance<T>().firstOrNull() ?: default
-}

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/bookings/filter/BookingFilterListViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/bookings/filter/BookingFilterListViewModel.kt
@@ -75,7 +75,8 @@ private val BookingFilterListUiState.updatedBookingFilters: BookingFilters
         return BookingFilters(
             dateRange = updates.getOrDefault(initial.dateRange),
             customer = updates.getOrDefault(initial.customer),
-            teamMember = updates.getOrDefault(initial.teamMember),
+            teamMember = updates.getOrDefault(
+                initial.teamMember),
             attendanceStatus = updates.getOrDefault(initial.attendanceStatus),
             paymentStatus = updates.getOrDefault(initial.paymentStatus),
             bookingType = updates.getOrDefault(initial.bookingType),

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/bookings/filter/BookingFilterRootPage.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/bookings/filter/BookingFilterRootPage.kt
@@ -1,0 +1,45 @@
+package com.woocommerce.android.ui.bookings.filter
+
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.defaultMinSize
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.material3.HorizontalDivider
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.unit.dp
+import com.woocommerce.android.R
+import com.woocommerce.android.ui.compose.component.WCListItemWithInlineSubtitle
+
+@Composable
+fun BookingFilterRootPage(
+    items: List<BookingFilterListItem>,
+    modifier: Modifier = Modifier,
+) {
+    LazyColumn(
+        modifier = modifier
+            .fillMaxSize()
+    ) {
+        items(items) { item -> BookingFilterListRow(item) }
+    }
+}
+
+@Composable
+private fun BookingFilterListRow(item: BookingFilterListItem) {
+    Column(modifier = Modifier.fillMaxWidth()) {
+        WCListItemWithInlineSubtitle(
+            text = stringResource(item.title),
+            subtitle = item.value ?: stringResource(id = R.string.bookings_filter_default),
+            modifier = Modifier
+                .defaultMinSize(minHeight = 64.dp)
+                .clickable { item.onClick() }
+                .padding(vertical = 8.dp)
+        )
+        HorizontalDivider(thickness = 0.5.dp)
+    }
+}

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/bookings/filter/DateTimeFilterPicker.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/bookings/filter/DateTimeFilterPicker.kt
@@ -1,0 +1,24 @@
+package com.woocommerce.android.ui.bookings.filter
+
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+
+/**
+ * Placeholder for the upcoming Date/Time filter picker screen.
+ * Only navigation and structure are implemented for now.
+ */
+@Composable
+fun DateTimeFilterPicker() {
+    Box(modifier = Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
+        Text(
+            text = "Date & Time Filter Picker",
+            style = MaterialTheme.typography.titleMedium,
+            color = MaterialTheme.colorScheme.onSurface
+        )
+    }
+}

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/bookings/filter/data/BookingFilterRepository.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/bookings/filter/data/BookingFilterRepository.kt
@@ -50,8 +50,8 @@ class BookingFilterRepository @Inject constructor(
             if (customer != null) {
                 val id = customer.customerId
                 val name = customer.customerName
-                if (id != null) prefs[customerIdKey] = id else prefs.remove(customerIdKey)
-                if (name != null) prefs[customerNameKey] = name else prefs.remove(customerNameKey)
+                prefs[customerIdKey] = id
+                prefs[customerNameKey] = name
             } else {
                 // Clear if not provided
                 prefs.remove(customerIdKey)
@@ -80,7 +80,7 @@ class BookingFilterRepository @Inject constructor(
     private fun Preferences.getCustomerValue(siteId: Int): BookingsFilterOption.Customer? {
         val customerId = this[customerIdKey(siteId)]
         val customerName = this[customerNameKey(siteId)]
-        return if (customerId != null || customerName != null) {
+        return if (customerId != null && customerName != null) {
             BookingsFilterOption.Customer(customerId = customerId, customerName = customerName)
         } else {
             null

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/bookings/list/BookingListFiltersBuilder.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/bookings/list/BookingListFiltersBuilder.kt
@@ -45,7 +45,7 @@ class BookingListFiltersBuilder @Inject constructor(
         attendanceStatus?.let { filters.add(it) }
         paymentStatus?.let { filters.add(it) }
         bookingType?.let { filters.add(it) }
-        category?.let { filters.add(it) }
+        location?.let { filters.add(it) }
         serviceEvent?.let { filters.add(it) }
         return filters
     }

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -4181,7 +4181,7 @@
     <string name="bookings_filter_title_payment_status">Payment status</string>
     <string name="bookings_filter_title_type">Booking type</string>
     <string name="bookings_filter_customer_name">Customer name</string>
-    <string name="bookings_filter_category">Category</string>
+    <string name="bookings_filter_location">Location</string>
     <string name="bookings_filter_title_date">Date &amp; time</string>
     <string name="bookings_filter_title_service_event">Service / Event</string>
     <string name="bookings_filter_default">Any</string>

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -4182,7 +4182,7 @@
     <string name="bookings_filter_title_type">Booking type</string>
     <string name="bookings_filter_customer_name">Customer name</string>
     <string name="bookings_filter_category">Category</string>
-    <string name="bookings_filter_title_date">Date</string>
+    <string name="bookings_filter_title_date">Date &amp; time</string>
     <string name="bookings_filter_title_service_event">Service / Event</string>
     <string name="bookings_filter_default">Any</string>
 

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/bookings/filter/BookingFilterListViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/bookings/filter/BookingFilterListViewModelTest.kt
@@ -1,0 +1,87 @@
+package com.woocommerce.android.ui.bookings.filter
+
+import androidx.lifecycle.SavedStateHandle
+import com.woocommerce.android.ui.bookings.filter.data.BookingFilterRepository
+import com.woocommerce.android.util.getOrAwaitValue
+import com.woocommerce.android.viewmodel.BaseUnitTest
+import com.woocommerce.android.viewmodel.MultiLiveEvent
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.flowOf
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.Before
+import org.junit.Test
+import org.mockito.kotlin.doReturn
+import org.mockito.kotlin.mock
+import org.wordpress.android.fluxc.network.rest.wpcom.wc.bookings.BookingFilter
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class BookingFilterListViewModelTest : BaseUnitTest() {
+
+    private lateinit var viewModel: BookingFilterListViewModel
+    private val bookingFilterRepository: BookingFilterRepository = mock {
+        on { bookingFilterFlow } doReturn flowOf(BookingFilter())
+    }
+
+    @Before
+    fun setup() {
+        viewModel = BookingFilterListViewModel(
+            savedStateHandle = SavedStateHandle(),
+            bookingFilterRepository = bookingFilterRepository,
+        )
+    }
+
+    @Test
+    fun `when init, then current page is List`() {
+        // WHEN
+        val state = viewModel.uiState.value!!
+
+        // THEN
+        assertThat(state.currentPage).isInstanceOf(BookingFilterPage.List::class.java)
+    }
+
+    @Test
+    fun `given DateTimePicker page, when openPage, then current page is DateTimePicker`() {
+        // GIVEN
+        val initial = viewModel.uiState.getOrAwaitValue()
+        assertThat(initial.currentPage).isInstanceOf(BookingFilterPage.List::class.java)
+
+        // WHEN
+        initial.openPage(BookingFilterPage.DateTimePicker)
+
+        // THEN
+        val updated = viewModel.uiState.getOrAwaitValue()
+        assertThat(updated.currentPage).isInstanceOf(BookingFilterPage.DateTimePicker::class.java)
+    }
+
+    @Test
+    fun `given current page is DateTimePicker, when onClose, then current page set to List`() {
+        // GIVEN
+        val initial = viewModel.uiState.getOrAwaitValue()
+        initial.openPage(BookingFilterPage.DateTimePicker)
+        val afterOpen = viewModel.uiState.getOrAwaitValue()
+        assertThat(afterOpen.currentPage).isInstanceOf(BookingFilterPage.DateTimePicker::class.java)
+
+        // WHEN
+        afterOpen.onClose()
+
+        // THEN
+        val afterClose = viewModel.uiState.getOrAwaitValue()
+        assertThat(afterClose.currentPage).isInstanceOf(BookingFilterPage.List::class.java)
+    }
+
+    @Test
+    fun `given current page is List, when onClose, then Exit event is emitted`() {
+        // GIVEN
+        val events = mutableListOf<MultiLiveEvent.Event>()
+        viewModel.event.observeForever { events.add(it) }
+        val initial = viewModel.uiState.value!!
+        assertThat(initial.currentPage).isInstanceOf(BookingFilterPage.List::class.java)
+
+        // WHEN
+        initial.onClose()
+
+        // THEN
+        assertThat(events).isNotEmpty
+        assertThat(events.last()).isEqualTo(MultiLiveEvent.Event.Exit)
+    }
+}

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/bookings/filter/BookingFilterListViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/bookings/filter/BookingFilterListViewModelTest.kt
@@ -12,14 +12,14 @@ import org.junit.Before
 import org.junit.Test
 import org.mockito.kotlin.doReturn
 import org.mockito.kotlin.mock
-import org.wordpress.android.fluxc.network.rest.wpcom.wc.bookings.BookingFilter
+import org.wordpress.android.fluxc.network.rest.wpcom.wc.bookings.BookingFilters
 
 @OptIn(ExperimentalCoroutinesApi::class)
 class BookingFilterListViewModelTest : BaseUnitTest() {
 
     private lateinit var viewModel: BookingFilterListViewModel
     private val bookingFilterRepository: BookingFilterRepository = mock {
-        on { bookingFilterFlow } doReturn flowOf(BookingFilter())
+        on { bookingFiltersFlow } doReturn flowOf(BookingFilters())
     }
 
     @Before

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/bookings/filter/BookingFilterListViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/bookings/filter/BookingFilterListViewModelTest.kt
@@ -46,20 +46,20 @@ class BookingFilterListViewModelTest : BaseUnitTest() {
         assertThat(initial.currentPage).isInstanceOf(BookingFilterPage.List::class.java)
 
         // WHEN
-        initial.openPage(BookingFilterPage.DateTimePicker)
+        initial.openPage(BookingFilterPage.DateTime)
 
         // THEN
         val updated = viewModel.uiState.getOrAwaitValue()
-        assertThat(updated.currentPage).isInstanceOf(BookingFilterPage.DateTimePicker::class.java)
+        assertThat(updated.currentPage).isInstanceOf(BookingFilterPage.DateTime::class.java)
     }
 
     @Test
     fun `given current page is DateTimePicker, when onClose, then current page set to List`() {
         // GIVEN
         val initial = viewModel.uiState.getOrAwaitValue()
-        initial.openPage(BookingFilterPage.DateTimePicker)
+        initial.openPage(BookingFilterPage.DateTime)
         val afterOpen = viewModel.uiState.getOrAwaitValue()
-        assertThat(afterOpen.currentPage).isInstanceOf(BookingFilterPage.DateTimePicker::class.java)
+        assertThat(afterOpen.currentPage).isInstanceOf(BookingFilterPage.DateTime::class.java)
 
         // WHEN
         afterOpen.onClose()

--- a/libs/fluxc-plugin/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/bookings/BookingsFilterOption.kt
+++ b/libs/fluxc-plugin/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/bookings/BookingsFilterOption.kt
@@ -11,9 +11,9 @@ sealed interface BookingsFilterOption {
 
     object BookingType : BookingsFilterOption
 
-    data class Customer(val customerId: Long?, val customerName: String?) : BookingsFilterOption
+    data class Customer(val customerId: Long, val customerName: String) : BookingsFilterOption
 
-    object Category : BookingsFilterOption
+    object Location : BookingsFilterOption
 
     data class DateRange(
         val before: Instant?,
@@ -30,6 +30,6 @@ data class BookingFilters(
     val attendanceStatus: BookingsFilterOption.AttendanceStatus? = null,
     val paymentStatus: BookingsFilterOption.PaymentStatus? = null,
     val bookingType: BookingsFilterOption.BookingType? = null,
-    val category: BookingsFilterOption.Category? = null,
+    val location: BookingsFilterOption.Location? = null,
     val serviceEvent: BookingsFilterOption.ServiceEvent? = null,
 )

--- a/libs/fluxc-plugin/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/bookings/BookingsRestClient.kt
+++ b/libs/fluxc-plugin/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/bookings/BookingsRestClient.kt
@@ -57,7 +57,7 @@ class BookingsRestClient @Inject constructor(
                 BookingsFilterOption.BookingType -> TODO()
                 is BookingsFilterOption.Customer -> filter.customerId?.let { set("customer", it.toString()) }
 
-                BookingsFilterOption.Category -> TODO()
+                BookingsFilterOption.Location -> TODO()
                 is BookingsFilterOption.DateRange -> {
                     filter.before?.let { set("start_date_before", it.toString()) }
                     filter.after?.let { set("start_date_after", it.toString()) }


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

<!-- Id number of the Linear issue this PR addresses, e.g., WOOMOB-373. -->

WOOMOB-1487

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

This PR implements the internal navigation in the BookingFilter screen. It handled going into a specific filer view (for example, date picker) and updates the Toolbar (title and the icon). For now, the content is always the same (Empty date&time picker composable).

Additionally, in the last commit (https://github.com/woocommerce/woocommerce-android/commit/f832e2cf3b7189d79c4d66974d754ac8639d353d), I updated the `BookingFilterOption.Customer` by making the fields non-nullable. This requried some updates to how we built the UI state for the booking filter screen.

### Steps to reproduce
<!-- Step-by-step testing instructions. For new user flows, consider instead stating the goal of the workflow and see if your PR reviewer can accomplish the workflow without specific steps! -->

1. Launch the app 
2. Go to the booking tab
3. Tap `All`
4. Tap `Filters`
5. Select any of the options
6. Confirm the toolbar is updated and the content switched
7. Tap back or use the system back button
8. Confirm the list of available filters is visible

### Testing information
<!-- This is your opportunity to break out individual scenarios that need testing (when necessary) and/or include a checklist for the reviewer to go through. Consider documenting the following from your own completed testing: devices used, alternate workflows, edge cases, affected areas, critical flows, areas not tested, and any remaining unknowns. Provide feedback on this new section of the PR template through Sept 30, 2024 to Apps Quality; additional context here: p91TBi-b8z-p2#comment-12036 -->


### The tests that have been performed
<!-- To give the reviewer an idea of what could be missed in terms of testing -->
The above

### Images/gif
<!-- Include before and after images or gifs when appropriate. -->

https://github.com/user-attachments/assets/cd47c960-0e5e-43f1-8f62-3445e1b44301



- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->