### PR TITLE
[WOOMOB-1448] Fix a rare uninitialized property crash in refund flow

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -5,6 +5,7 @@
 -----
 - [Internal][Wear] Remove unused dependencies and optimize dependency scopes [https://github.com/woocommerce/woocommerce-android/pull/14710]
 - [Internal] Remove unused dependencies and optimize dependency scopes [https://github.com/woocommerce/woocommerce-android/pull/14710]
+- [*] Fix a rare crash in order refund flow [https://github.com/woocommerce/woocommerce-android/pull/14742]
 
 23.4
 -----

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/refunds/RefundSummaryViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/refunds/RefundSummaryViewModel.kt
@@ -92,14 +92,14 @@ class RefundSummaryViewModel @Inject constructor(
         get() = refundJob?.isActive ?: false
 
     init {
-        viewModelScope.launch {
+        launch {
             val order = orderFlow.first()
             gateway = loadPaymentGateway(order)
             initRefundSummaryState(order)
         }
     }
 
-    fun onRefundIssued(reason: String) = viewModelScope.launch {
+    fun onRefundIssued(reason: String) = launch {
         val order = orderFlow.first()
         analyticsTrackerWrapper.track(
             CREATE_ORDER_REFUND_SUMMARY_REFUND_BUTTON_TAPPED,
@@ -127,7 +127,7 @@ class RefundSummaryViewModel @Inject constructor(
     fun onRefundConfirmed(wasConfirmed: Boolean) {
         if (wasConfirmed) {
             if (networkStatus.isConnected()) {
-                refundJob = viewModelScope.launch {
+                refundJob = launch {
                     val order = orderFlow.first()
                     refundSummaryState = refundSummaryState.copy(
                         isFormEnabled = false
@@ -205,7 +205,7 @@ class RefundSummaryViewModel @Inject constructor(
     }
 
     private fun loadCardDetails(chargeId: String, refundMethod: String) {
-        viewModelScope.launch {
+        launch {
             refundSummaryState = refundSummaryState.copy(isFetchingCardData = true)
             val result = paymentChargeRepository.fetchCardDataUsedForOrderPayment(chargeId)
             refundSummaryState = refundSummaryState.copy(isFetchingCardData = false)
@@ -254,7 +254,7 @@ class RefundSummaryViewModel @Inject constructor(
    For Interac refund -> Update the backend of the successful refund. The actual refund happens on the client-side */
     fun refund() {
         triggerUIMessageIfRefundIsInterac()
-        viewModelScope.launch {
+        launch {
             val order = orderFlow.first()
             val result = initiateRefund(order)
             if (result.isError) {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/refunds/RefundSummaryViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/refunds/RefundSummaryViewModel.kt
@@ -255,14 +255,14 @@ class RefundSummaryViewModel @Inject constructor(
     fun refund() {
         triggerUIMessageIfRefundIsInterac()
         viewModelScope.launch {
-            val orderToUse = orderFlow.first()
-            val result = initiateRefund(orderToUse)
+            val order = orderFlow.first()
+            val result = initiateRefund(order)
             if (result.isError) {
-                trackRefundError(orderToUse, result)
+                trackRefundError(order, result)
                 triggerUIMessage()
             } else {
-                trackRefundSuccess(orderToUse, result)
-                updateRefundSummaryStateWithOrderNote(orderToUse)
+                trackRefundSuccess(order, result)
+                updateRefundSummaryStateWithOrderNote(order)
                 triggerEvent(ShowSnackbar(R.string.order_refunds_amount_refund_successful))
                 triggerEvent(Exit)
             }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/refunds/RefundSummaryViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/refunds/RefundSummaryViewModel.kt
@@ -35,6 +35,11 @@ import com.woocommerce.android.viewmodel.ScopedViewModel
 import com.woocommerce.android.viewmodel.navArgs
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.Job
+import kotlinx.coroutines.flow.SharedFlow
+import kotlinx.coroutines.flow.SharingStarted
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.flow
+import kotlinx.coroutines.flow.shareIn
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 import kotlinx.parcelize.Parcelize
@@ -74,25 +79,28 @@ class RefundSummaryViewModel @Inject constructor(
     val refundSummaryStateLiveData = LiveDataDelegate(savedState, RefundSummaryViewState())
     private var refundSummaryState by refundSummaryStateLiveData
 
-    private lateinit var order: Order
+    private val orderFlow: SharedFlow<Order> = flow {
+        val order = requireNotNull(orderDetailRepository.getOrderById(navArgs.orderId))
+        emit(order)
+    }.shareIn(viewModelScope, SharingStarted.Lazily, replay = 1)
+
     private lateinit var gateway: PaymentGateway
 
     private var cardType = PaymentMethodType.CARD_PRESENT
     private var refundJob: Job? = null
     val isRefundInProgress: Boolean
         get() = refundJob?.isActive ?: false
-    private val formatCurrency: (BigDecimal) -> String
-        get() = currencyFormatter.buildBigDecimalFormatter(order.currency)
 
     init {
         viewModelScope.launch {
-            order = requireNotNull(orderDetailRepository.getOrderById(navArgs.orderId))
-            gateway = loadPaymentGateway()
-            initRefundSummaryState()
+            val order = orderFlow.first()
+            gateway = loadPaymentGateway(order)
+            initRefundSummaryState(order)
         }
     }
 
     fun onRefundIssued(reason: String) = viewModelScope.launch {
+        val order = orderFlow.first()
         analyticsTrackerWrapper.track(
             CREATE_ORDER_REFUND_SUMMARY_REFUND_BUTTON_TAPPED,
             mapOf(
@@ -108,7 +116,7 @@ class RefundSummaryViewModel @Inject constructor(
             ShowRefundConfirmation(
                 resourceProvider.getString(
                     R.string.order_refunds_title_with_amount,
-                    formatCurrency(refundSummaryState.refundAmount!!)
+                    formatCurrency(refundSummaryState.refundAmount!!, order.currency)
                 ),
                 resourceProvider.getString(R.string.order_refunds_confirmation),
                 resourceProvider.getString(R.string.order_refunds_refund)
@@ -119,17 +127,19 @@ class RefundSummaryViewModel @Inject constructor(
     fun onRefundConfirmed(wasConfirmed: Boolean) {
         if (wasConfirmed) {
             if (networkStatus.isConnected()) {
-                refundJob = launch {
+                refundJob = viewModelScope.launch {
+                    val order = orderFlow.first()
                     refundSummaryState = refundSummaryState.copy(
                         isFormEnabled = false
                     )
                     if (isInteracRefund()) {
                         triggerEvent(NavigateToCardReaderScreen(order.id, refundSummaryState.refundAmount!!))
                     } else {
+                        val formattedAmount = formatCurrency(refundSummaryState.refundAmount!!, order.currency)
                         triggerEvent(
                             ShowSnackbar(
                                 R.string.order_refunds_amount_refund_progress_message,
-                                arrayOf(formatCurrency(refundSummaryState.refundAmount!!))
+                                arrayOf(formattedAmount)
                             )
                         )
                         refund()
@@ -161,13 +171,13 @@ class RefundSummaryViewModel @Inject constructor(
         refundSummaryState = refundSummaryState.copy(isSummaryTextTooLong = currLength > maxLength)
     }
 
-    private fun initRefundSummaryState() {
+    private fun initRefundSummaryState(order: Order) {
         if (refundSummaryStateLiveData.hasInitialValue) {
             val refundAmount = navArgs.refundAmount.toBigDecimal()
             refundSummaryState = refundSummaryState.copy(
                 refundAmount = refundAmount,
-                refundAmountFormatted = formatCurrency(refundAmount),
-                previouslyRefunded = formatCurrency(order.refundTotal),
+                refundAmountFormatted = formatCurrency(refundAmount, order.currency),
+                previouslyRefunded = formatCurrency(order.refundTotal, order.currency),
                 isFormEnabled = true
             )
 
@@ -180,12 +190,12 @@ class RefundSummaryViewModel @Inject constructor(
                 }
                 updateRefundSummaryState(paymentTitle, isMethodDescriptionVisible = true)
             } else {
-                enrichRefundMethodWithCardDetails(gateway.title.ifBlank { gateway.methodTitle })
+                enrichRefundMethodWithCardDetails(order, gateway.title.ifBlank { gateway.methodTitle })
             }
         }
     }
 
-    private fun enrichRefundMethodWithCardDetails(refundMethod: String) {
+    private fun enrichRefundMethodWithCardDetails(order: Order, refundMethod: String) {
         val chargeId = order.chargeId
         if (chargeId != null) {
             loadCardDetails(chargeId, refundMethod)
@@ -195,7 +205,7 @@ class RefundSummaryViewModel @Inject constructor(
     }
 
     private fun loadCardDetails(chargeId: String, refundMethod: String) {
-        launch {
+        viewModelScope.launch {
             refundSummaryState = refundSummaryState.copy(isFetchingCardData = true)
             val result = paymentChargeRepository.fetchCardDataUsedForOrderPayment(chargeId)
             refundSummaryState = refundSummaryState.copy(isFetchingCardData = false)
@@ -227,7 +237,7 @@ class RefundSummaryViewModel @Inject constructor(
         )
     }
 
-    private suspend fun loadPaymentGateway(): PaymentGateway = withContext(coroutineDispatchers.io) {
+    private suspend fun loadPaymentGateway(order: Order): PaymentGateway = withContext(coroutineDispatchers.io) {
         val paymentGateway = gatewayStore.getGateway(selectedSite.get(), order.paymentMethod)?.toAppModel()
         return@withContext if (paymentGateway != null && paymentGateway.isEnabled) {
             paymentGateway
@@ -244,14 +254,15 @@ class RefundSummaryViewModel @Inject constructor(
    For Interac refund -> Update the backend of the successful refund. The actual refund happens on the client-side */
     fun refund() {
         triggerUIMessageIfRefundIsInterac()
-        launch {
-            val result = initiateRefund()
+        viewModelScope.launch {
+            val orderToUse = orderFlow.first()
+            val result = initiateRefund(orderToUse)
             if (result.isError) {
-                trackRefundError(result)
+                trackRefundError(orderToUse, result)
                 triggerUIMessage()
             } else {
-                trackRefundSuccess(result)
-                updateRefundSummaryStateWithOrderNote()
+                trackRefundSuccess(orderToUse, result)
+                updateRefundSummaryStateWithOrderNote(orderToUse)
                 triggerEvent(ShowSnackbar(R.string.order_refunds_amount_refund_successful))
                 triggerEvent(Exit)
             }
@@ -264,7 +275,7 @@ class RefundSummaryViewModel @Inject constructor(
         }
     }
 
-    private suspend fun initiateRefund(): WooResult<WCRefundModel> {
+    private suspend fun initiateRefund(order: Order): WooResult<WCRefundModel> {
         return refundStore.createItemsRefund(
             site = selectedSite.get(),
             orderId = order.id,
@@ -276,7 +287,7 @@ class RefundSummaryViewModel @Inject constructor(
         )
     }
 
-    private fun trackRefundError(result: WooResult<WCRefundModel>) {
+    private fun trackRefundError(order: Order, result: WooResult<WCRefundModel>) {
         analyticsTrackerWrapper.track(
             REFUND_CREATE_FAILED,
             mapOf(
@@ -300,7 +311,7 @@ class RefundSummaryViewModel @Inject constructor(
         }
     }
 
-    private fun trackRefundSuccess(result: WooResult<WCRefundModel>) {
+    private fun trackRefundSuccess(order: Order, result: WooResult<WCRefundModel>) {
         analyticsTrackerWrapper.track(
             REFUND_CREATE_SUCCESS,
             mapOf(
@@ -310,15 +321,15 @@ class RefundSummaryViewModel @Inject constructor(
         )
     }
 
-    private suspend fun updateRefundSummaryStateWithOrderNote() {
+    private suspend fun updateRefundSummaryStateWithOrderNote(order: Order) {
         refundSummaryState.refundReason?.let { reason ->
             if (reason.isNotBlank()) {
-                addOrderNote(reason)
+                addOrderNote(order, reason)
             }
         }
     }
 
-    private suspend fun addOrderNote(reason: String) {
+    private suspend fun addOrderNote(order: Order, reason: String) {
         val note = OrderNote(note = reason, isCustomerNote = false)
         orderDetailRepository.addOrderNote(order.id, note).fold(
             onSuccess = {
@@ -331,6 +342,10 @@ class RefundSummaryViewModel @Inject constructor(
                 )
             }
         )
+    }
+
+    private fun formatCurrency(amount: BigDecimal, currency: String): String {
+        return currencyFormatter.buildBigDecimalFormatter(currency)(amount)
     }
 
     private fun prepareTracksEventsDetails(exception: WooException) = mapOf(

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/refunds/RefundSummaryViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/refunds/RefundSummaryViewModel.kt
@@ -34,12 +34,9 @@ import com.woocommerce.android.viewmodel.ResourceProvider
 import com.woocommerce.android.viewmodel.ScopedViewModel
 import com.woocommerce.android.viewmodel.navArgs
 import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.Deferred
 import kotlinx.coroutines.Job
-import kotlinx.coroutines.flow.SharedFlow
-import kotlinx.coroutines.flow.SharingStarted
-import kotlinx.coroutines.flow.first
-import kotlinx.coroutines.flow.flow
-import kotlinx.coroutines.flow.shareIn
+import kotlinx.coroutines.async
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 import kotlinx.parcelize.Parcelize
@@ -79,10 +76,11 @@ class RefundSummaryViewModel @Inject constructor(
     val refundSummaryStateLiveData = LiveDataDelegate(savedState, RefundSummaryViewState())
     private var refundSummaryState by refundSummaryStateLiveData
 
-    private val orderFlow: SharedFlow<Order> = flow {
-        val order = requireNotNull(orderDetailRepository.getOrderById(navArgs.orderId))
-        emit(order)
-    }.shareIn(viewModelScope, SharingStarted.Lazily, replay = 1)
+    private val order: Deferred<Order> by lazy {
+        viewModelScope.async {
+            requireNotNull(orderDetailRepository.getOrderById(navArgs.orderId))
+        }
+    }
 
     private lateinit var gateway: PaymentGateway
 
@@ -93,14 +91,14 @@ class RefundSummaryViewModel @Inject constructor(
 
     init {
         launch {
-            val order = orderFlow.first()
+            val order = order.await()
             gateway = loadPaymentGateway(order)
             initRefundSummaryState(order)
         }
     }
 
     fun onRefundIssued(reason: String) = launch {
-        val order = orderFlow.first()
+        val order = order.await()
         analyticsTrackerWrapper.track(
             CREATE_ORDER_REFUND_SUMMARY_REFUND_BUTTON_TAPPED,
             mapOf(
@@ -128,7 +126,7 @@ class RefundSummaryViewModel @Inject constructor(
         if (wasConfirmed) {
             if (networkStatus.isConnected()) {
                 refundJob = launch {
-                    val order = orderFlow.first()
+                    val order = order.await()
                     refundSummaryState = refundSummaryState.copy(
                         isFormEnabled = false
                     )
@@ -255,7 +253,7 @@ class RefundSummaryViewModel @Inject constructor(
     fun refund() {
         triggerUIMessageIfRefundIsInterac()
         launch {
-            val order = orderFlow.first()
+            val order = order.await()
             val result = initiateRefund(order)
             if (result.isError) {
                 trackRefundError(order, result)


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

<!-- Id number of the Linear issue this PR addresses, e.g., WOOMOB-373. -->

#WOOMOB-1448


### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

Fixes `lateinit property order has not been initialized` by replacing `order` variable with a flow.

  - Replaced `lateinit var order: Order` with `SharedFlow<Order>` for async initialization
  - Refactored `formatCurrency` to accept currency parameter instead of accessing order property
  - Updated methods to use reactive pattern with `orderFlow.first()` for safe order access
  - Optimized Flow usage by passing order from public methods to private methods



### Steps to reproduce
<!-- Step-by-step testing instructions. For new user flows, consider instead stating the goal of the workflow and see if your PR reviewer can accomplish the workflow without specific steps! -->

Unknown

### Testing information
<!-- This is your opportunity to break out individual scenarios that need testing (when necessary) and/or include a checklist for the reviewer to go through. Consider documenting the following from your own completed testing: devices used, alternate workflows, edge cases, affected areas, critical flows, areas not tested, and any remaining unknowns. Provide feedback on this new section of the PR template through Sept 30, 2024 to Apps Quality; additional context here: p91TBi-b8z-p2#comment-12036 -->

Smoke test refund order flow.

### The tests that have been performed
<!-- To give the reviewer an idea of what could be missed in terms of testing -->

I've tried refunding an order

### Images/gif
<!-- Include before and after images or gifs when appropriate. -->

N/A

- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->