### PR TITLE
Issue/woomob 1499 woo poslocal catalog perform incremental sync after each

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/localcatalog/WooPosLocalCatalogSyncWorker.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/localcatalog/WooPosLocalCatalogSyncWorker.kt
@@ -73,7 +73,7 @@ constructor(
 
             is PosLocalCatalogSyncResult.Failure.CatalogTooLarge -> {
                 // TBD Local Catalog - stop future syncs for this site if catalog too large
-                logger.e("Local catalog FULL  sync failed: ${fullSyncResult.error}.")
+                logger.e("Local catalog FULL sync failed: ${fullSyncResult.error}.")
                 Result.failure()
             }
         }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/localcatalog/WooPosLocalCatalogSyncWorker.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/localcatalog/WooPosLocalCatalogSyncWorker.kt
@@ -46,26 +46,33 @@ constructor(
             return Result.failure()
         }
 
-        logger.d("Starting full local catalog sync")
+        logger.d("Starting FULL local catalog sync")
 
-        val syncResult = syncRepository.syncLocalCatalogFull(site)
+        val fullSyncResult = syncRepository.syncLocalCatalogFull(site)
 
-        return when (syncResult) {
+        return when (fullSyncResult) {
             is PosLocalCatalogSyncResult.Success -> {
                 logger.d(
-                    "Local catalog sync completed successfully. Products: ${syncResult.productsSynced}, " +
-                        "Variations: ${syncResult.variationsSynced}, Duration: ${syncResult.syncDurationMs}ms"
+                    "Local catalog FULL sync completed successfully. Products: ${fullSyncResult.productsSynced}, " +
+                        "Variations: ${fullSyncResult.variationsSynced}, Duration: ${fullSyncResult.syncDurationMs}ms"
                 )
+                val incrementalSyncResult = syncRepository.syncLocalCatalogIncremental(site)
+                if (incrementalSyncResult is PosLocalCatalogSyncResult.Failure) {
+                    logger.d(
+                        "Local catalog INCREMENTAL sync failed."
+                    )
+                }
                 Result.success()
             }
 
             is PosLocalCatalogSyncResult.Failure.UnexpectedError -> {
-                logger.e("Local catalog sync failed: ${syncResult.error}. Retrying ...")
+                logger.e("Local catalog FULL sync failed: ${fullSyncResult.error}. Retrying ...")
                 Result.retry()
             }
+
             is PosLocalCatalogSyncResult.Failure.CatalogTooLarge -> {
                 // TBD Local Catalog - stop future syncs for this site if catalog too large
-                logger.e("Local catalog sync failed: ${syncResult.error}.")
+                logger.e("Local catalog FULL  sync failed: ${fullSyncResult.error}.")
                 Result.failure()
             }
         }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/localcatalog/WooPosLocalCatalogSyncWorker.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/localcatalog/WooPosLocalCatalogSyncWorker.kt
@@ -56,6 +56,7 @@ constructor(
                     "Local catalog FULL sync completed successfully. Products: ${fullSyncResult.productsSynced}, " +
                         "Variations: ${fullSyncResult.variationsSynced}, Duration: ${fullSyncResult.syncDurationMs}ms"
                 )
+                logger.d("Starting Local catalog INCREMENTAL sync.")
                 val incrementalSyncResult = syncRepository.syncLocalCatalogIncremental(site)
                 if (incrementalSyncResult is PosLocalCatalogSyncResult.Failure) {
                     logger.d(

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/localcatalog/WooPosLocalCatalogSyncWorkerTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/localcatalog/WooPosLocalCatalogSyncWorkerTest.kt
@@ -41,6 +41,12 @@ class WooPosLocalCatalogSyncWorkerTest : BaseUnitTest() {
         totalPages = 29,
         maxPages = 10
     )
+    private val incrementalSuccessResponse = PosLocalCatalogSyncResult.Success(
+        productsSynced = 5,
+        variationsSynced = 2,
+        syncDurationMs = 500
+    )
+    private val incrementalFailureResponse = PosLocalCatalogSyncResult.Failure.UnexpectedError("Incremental sync error")
 
     @Before
     fun setup() = testBlocking {
@@ -55,6 +61,8 @@ class WooPosLocalCatalogSyncWorkerTest : BaseUnitTest() {
         whenever(featureFlagM1Enabled.invoke()).thenReturn(true)
         whenever(syncRepository.syncLocalCatalogFull(site))
             .thenReturn(successResponse)
+        whenever(syncRepository.syncLocalCatalogIncremental(site))
+            .thenReturn(incrementalSuccessResponse)
     }
 
     private fun createWorker(): WooPosLocalCatalogSyncWorker {
@@ -79,6 +87,8 @@ class WooPosLocalCatalogSyncWorkerTest : BaseUnitTest() {
 
         // THEN
         assertThat(result).isEqualTo(ListenableWorker.Result.success())
+        verify(syncRepository).syncLocalCatalogFull(eq(site))
+        verify(syncRepository).syncLocalCatalogIncremental(eq(site))
     }
 
     @Test
@@ -174,6 +184,8 @@ class WooPosLocalCatalogSyncWorkerTest : BaseUnitTest() {
                     syncDurationMs = 1000L
                 )
             )
+        whenever(syncRepository.syncLocalCatalogIncremental(site))
+            .thenReturn(incrementalSuccessResponse)
         val result3 = worker.doWork()
 
         // THEN
@@ -205,6 +217,8 @@ class WooPosLocalCatalogSyncWorkerTest : BaseUnitTest() {
                     syncDurationMs = 800L
                 )
             )
+        whenever(syncRepository.syncLocalCatalogIncremental(any()))
+            .thenReturn(incrementalSuccessResponse)
 
         val worker = createWorker()
 
@@ -219,5 +233,71 @@ class WooPosLocalCatalogSyncWorkerTest : BaseUnitTest() {
         assertThat(result2).isEqualTo(ListenableWorker.Result.success())
         verify(syncRepository).syncLocalCatalogFull(eq(site1))
         verify(syncRepository).syncLocalCatalogFull(eq(site2))
+    }
+
+    @Test
+    fun `given full sync succeeds, when incremental sync succeeds, then returns success and calls both syncs`() = testBlocking {
+        // GIVEN
+        val worker = createWorker()
+
+        // WHEN
+        val result = worker.doWork()
+
+        // THEN
+        assertThat(result).isEqualTo(ListenableWorker.Result.success())
+        verify(syncRepository).syncLocalCatalogFull(eq(site))
+        verify(syncRepository).syncLocalCatalogIncremental(eq(site))
+    }
+
+    @Test
+    fun `given full sync succeeds, when incremental sync fails, then returns success but logs error`() = testBlocking {
+        // GIVEN
+        whenever(syncRepository.syncLocalCatalogIncremental(site))
+            .thenReturn(incrementalFailureResponse)
+
+        val worker = createWorker()
+
+        // WHEN
+        val result = worker.doWork()
+
+        // THEN
+        assertThat(result).isEqualTo(ListenableWorker.Result.success())
+        verify(syncRepository).syncLocalCatalogFull(eq(site))
+        verify(syncRepository).syncLocalCatalogIncremental(eq(site))
+        verify(logger).d("Local catalog INCREMENTAL sync failed.")
+    }
+
+    @Test
+    fun `given full sync fails, when worker executes, then incremental sync is not called`() = testBlocking {
+        // GIVEN
+        whenever(syncRepository.syncLocalCatalogFull(site))
+            .thenReturn(PosLocalCatalogSyncResult.Failure.UnexpectedError("Full sync failed"))
+
+        val worker = createWorker()
+
+        // WHEN
+        val result = worker.doWork()
+
+        // THEN
+        assertThat(result).isEqualTo(ListenableWorker.Result.retry())
+        verify(syncRepository).syncLocalCatalogFull(eq(site))
+        verify(syncRepository, org.mockito.kotlin.never()).syncLocalCatalogIncremental(any())
+    }
+
+    @Test
+    fun `given full sync fails with catalog too large, when worker executes, then incremental sync is not called`() = testBlocking {
+        // GIVEN
+        whenever(syncRepository.syncLocalCatalogFull(site))
+            .thenReturn(catalogTooLargeResponse)
+
+        val worker = createWorker()
+
+        // WHEN
+        val result = worker.doWork()
+
+        // THEN
+        assertThat(result).isEqualTo(ListenableWorker.Result.failure())
+        verify(syncRepository).syncLocalCatalogFull(eq(site))
+        verify(syncRepository, org.mockito.kotlin.never()).syncLocalCatalogIncremental(any())
     }
 }


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

<!-- Id number of the Linear issue this PR addresses, e.g., WOOMOB-373. -->

#WOOMOB-1499

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

This PR adds an incremental local catalog sync after each full local catalog sync. This ensure that even when the full sync downloads a file that was generated several hours ago, the local catalog remains up to date.

Failure of the incremental sync isn't so vital, since the POS runs incremental sync
- on startup
- on completed order
- on PTR
- every 60 minutes
So failed incremental update is logged but doesn't result in a failure of the whole worker.

### Testing information
<!-- This is your opportunity to break out individual scenarios that need testing (when necessary) and/or include a checklist for the reviewer to go through. Consider documenting the following from your own completed testing: devices used, alternate workflows, edge cases, affected areas, critical flows, areas not tested, and any remaining unknowns. Provide feedback on this new section of the PR template through Sept 30, 2024 to Apps Quality; additional context here: p91TBi-b8z-p2#comment-12036 -->


1. Clear app data
2. Log in
3. Wait and observe logs
4. Notice both full sync and incremental syncs are performed
5. Open POS and notice data are available

### The tests that have been performed
<!-- To give the reviewer an idea of what could be missed in terms of testing -->

the above
### Images/gif
<!-- Include before and after images or gifs when appropriate. -->
N/A

- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->