### PR TITLE
[WOOMOB-1401] - Booking details - loading skeleton

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/bookings/details/BookingDetailsScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/bookings/details/BookingDetailsScreen.kt
@@ -1,13 +1,16 @@
 package com.woocommerce.android.ui.bookings.details
 
 import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.ExperimentalMaterial3Api
@@ -20,11 +23,11 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.livedata.observeAsState
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
-import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.shadow
 import androidx.compose.ui.res.colorResource
 import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.times
 import com.woocommerce.android.R
 import com.woocommerce.android.ui.bookings.compose.BookingAppointmentDetails
 import com.woocommerce.android.ui.bookings.compose.BookingAppointmentDetailsModel
@@ -167,14 +170,23 @@ private fun BookingDetailsLoading() {
                 .background(MaterialTheme.colorScheme.surfaceContainer)
         ) {
             repeat(6) {
-                SkeletonView(
+                Row(
+                    horizontalArrangement = Arrangement.SpaceBetween,
                     modifier = Modifier
-                        .padding(start = 16.dp)
-                        .padding(vertical = 10.dp)
+                        .padding(vertical = 10.dp, horizontal = 16.dp)
                         .fillMaxWidth()
-                        .height(20.dp)
-                        .align(Alignment.End)
-                )
+                ) {
+                    SkeletonView(
+                        modifier = Modifier
+                            .height(20.dp)
+                            .width(50.dp + 10 * (it % 3).dp)
+                    )
+                    SkeletonView(
+                        modifier = Modifier
+                            .height(20.dp)
+                            .width(100.dp + 10 * (it % 5).dp)
+                    )
+                }
                 HorizontalDivider(
                     Modifier.padding(start = 16.dp)
                 )

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/bookings/details/BookingDetailsScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/bookings/details/BookingDetailsScreen.kt
@@ -1,12 +1,18 @@
 package com.woocommerce.android.ui.bookings.details
 
+import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Surface
 import androidx.compose.runtime.Composable
@@ -14,10 +20,10 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.livedata.observeAsState
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.shadow
 import androidx.compose.ui.res.colorResource
-import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import com.woocommerce.android.R
 import com.woocommerce.android.ui.bookings.compose.BookingAppointmentDetails
@@ -32,7 +38,9 @@ import com.woocommerce.android.ui.bookings.compose.BookingPaymentSection
 import com.woocommerce.android.ui.bookings.compose.BookingStatus
 import com.woocommerce.android.ui.bookings.compose.BookingSummary
 import com.woocommerce.android.ui.bookings.compose.BookingSummaryModel
+import com.woocommerce.android.ui.compose.animations.SkeletonView
 import com.woocommerce.android.ui.compose.component.Toolbar
+import com.woocommerce.android.ui.compose.preview.LightDarkThemePreviews
 import com.woocommerce.android.ui.compose.theme.WooThemeWithBackground
 
 @OptIn(ExperimentalMaterial3Api::class)
@@ -78,33 +86,16 @@ fun BookingDetailsScreen(
                     .verticalScroll(rememberScrollState())
                     .padding(innerPadding)
             ) {
-                viewState.bookingUiState?.let {
-                    BookingSummary(
-                        model = viewState.bookingUiState.bookingSummary,
-                        modifier = Modifier.fillMaxWidth()
-                    )
-                    BookingAppointmentDetails(
-                        model = viewState.bookingUiState.bookingsAppointmentDetails,
-                        onCancelBooking = viewState.onCancelBooking,
-                        modifier = Modifier.fillMaxWidth()
-                    )
-                    BookingCustomerDetails(
-                        model = viewState.bookingUiState.bookingCustomerDetails,
-                        modifier = Modifier.fillMaxWidth()
-                    )
-                    BookingAttendanceSection(
-                        status = viewState.bookingUiState.bookingSummary.attendanceStatus,
-                        onClick = { showAttendanceSheet.value = true },
-                        modifier = Modifier.fillMaxWidth()
-                    )
-                    BookingPaymentSection(
-                        model = viewState.bookingUiState.bookingPaymentDetails,
-                        status = viewState.bookingUiState.bookingSummary.status,
-                        onMarkAsPaid = { onViewOrder(viewState.orderId) },
-                        onViewOrder = { onViewOrder(viewState.orderId) },
-                        onMarkAsRefunded = { onViewOrder(viewState.orderId) },
-                        modifier = Modifier.fillMaxWidth()
-                    )
+                when {
+                    viewState.shouldShowSkeleton -> BookingDetailsLoading()
+                    viewState.bookingUiState != null -> {
+                        BookingDetailsContent(
+                            booking = viewState.bookingUiState,
+                            onCancelBooking = viewState.onCancelBooking,
+                            onViewOrder = onViewOrder,
+                            onAttendanceStatusClicked = { showAttendanceSheet.value = true },
+                        )
+                    }
                 }
             }
         }
@@ -119,7 +110,86 @@ fun BookingDetailsScreen(
     }
 }
 
-@Preview(showBackground = true)
+@Composable
+private fun BookingDetailsContent(
+    booking: BookingUiState,
+    onCancelBooking: () -> Unit,
+    onViewOrder: (Long) -> Unit,
+    onAttendanceStatusClicked: () -> Unit,
+) {
+    BookingSummary(
+        model = booking.bookingSummary,
+        modifier = Modifier.fillMaxWidth()
+    )
+    BookingAppointmentDetails(
+        model = booking.bookingsAppointmentDetails,
+        onCancelBooking = onCancelBooking,
+        modifier = Modifier.fillMaxWidth()
+    )
+    BookingCustomerDetails(
+        model = booking.bookingCustomerDetails,
+        modifier = Modifier.fillMaxWidth()
+    )
+    BookingAttendanceSection(
+        status = booking.bookingSummary.attendanceStatus,
+        onClick = onAttendanceStatusClicked,
+        modifier = Modifier.fillMaxWidth()
+    )
+    BookingPaymentSection(
+        model = booking.bookingPaymentDetails,
+        status = booking.bookingSummary.status,
+        onMarkAsPaid = { onViewOrder(booking.orderId) },
+        onViewOrder = { onViewOrder(booking.orderId) },
+        onMarkAsRefunded = { onViewOrder(booking.orderId) },
+        modifier = Modifier.fillMaxWidth()
+    )
+}
+
+@Composable
+private fun BookingDetailsLoading() {
+    Column {
+        Column(
+            modifier = Modifier
+                .fillMaxWidth()
+                .background(MaterialTheme.colorScheme.surfaceContainer)
+                .padding(16.dp)
+        ) {
+            SkeletonView(Modifier.size(200.dp, 20.dp))
+            Spacer(Modifier.height(4.dp))
+            SkeletonView(Modifier.size(250.dp, 15.dp))
+            Spacer(Modifier.height(8.dp))
+            SkeletonView(Modifier.size(150.dp, 25.dp))
+        }
+        Spacer(Modifier.height(40.dp))
+        Column(
+            modifier = Modifier
+                .fillMaxWidth()
+                .background(MaterialTheme.colorScheme.surfaceContainer)
+        ) {
+            repeat(6) {
+                SkeletonView(
+                    modifier = Modifier
+                        .padding(start = 16.dp)
+                        .padding(vertical = 10.dp)
+                        .fillMaxWidth()
+                        .height(20.dp)
+                        .align(Alignment.End)
+                )
+                HorizontalDivider(
+                    Modifier.padding(start = 16.dp)
+                )
+            }
+            SkeletonView(
+                Modifier
+                    .fillMaxWidth()
+                    .padding(16.dp)
+                    .height(40.dp)
+            )
+        }
+    }
+}
+
+@LightDarkThemePreviews
 @Composable
 private fun BookingDetailsPreview() {
     WooThemeWithBackground {
@@ -127,6 +197,7 @@ private fun BookingDetailsPreview() {
             viewState = BookingDetailsViewState(
                 toolbarTitle = "Booking #12345",
                 bookingUiState = BookingUiState(
+                    orderId = 1L,
                     bookingSummary = BookingSummaryModel(
                         date = "05/07/2025, 11:00 AM",
                         name = "Women’s Haircut",
@@ -162,6 +233,21 @@ private fun BookingDetailsPreview() {
             ),
             onBack = {},
             onViewOrder = {}
+        )
+    }
+}
+
+@LightDarkThemePreviews
+@Composable
+private fun BookingDetailsLoadingPreview() {
+    WooThemeWithBackground {
+        BookingDetailsScreen(
+            viewState = BookingDetailsViewState(
+                toolbarTitle = "",
+                bookingUiState = null,
+            ),
+            onBack = {},
+            onViewOrder = {},
         )
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/bookings/details/BookingDetailsViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/bookings/details/BookingDetailsViewModel.kt
@@ -15,7 +15,6 @@ import com.woocommerce.android.viewmodel.navArgs
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.combine
-import kotlinx.coroutines.flow.filterNotNull
 import javax.inject.Inject
 
 @HiltViewModel
@@ -34,14 +33,15 @@ class BookingDetailsViewModel @Inject constructor(
     private val bookingAttendanceStatus = MutableStateFlow<BookingAttendanceStatus?>(null)
 
     val state: LiveData<BookingDetailsViewState> = combine(
-        booking.filterNotNull(),
+        booking,
         bookingAttendanceStatus
     ) { booking, attendanceStatus ->
         with(bookingMapper) {
             BookingDetailsViewState(
-                toolbarTitle = resourceProvider.getString(R.string.booking_details_title, booking.id.value),
-                orderId = booking.orderId,
-                bookingUiState = buildBookingUiState(booking, attendanceStatus),
+                toolbarTitle = booking?.id?.value?.let { id ->
+                    resourceProvider.getString(R.string.booking_details_title, id)
+                } ?: "",
+                bookingUiState = if (booking != null) buildBookingUiState(booking, attendanceStatus) else null,
                 onCancelBooking = ::onCancelBooking,
                 onAttendanceStatusSelected = ::onAttendanceStatusSelected
             )
@@ -61,6 +61,7 @@ class BookingDetailsViewModel @Inject constructor(
         booking: Booking,
         attendanceStatus: BookingAttendanceStatus?
     ): BookingUiState = BookingUiState(
+        orderId = booking.orderId,
         bookingSummary = booking.toBookingSummaryModel().let {
             if (attendanceStatus != null) {
                 it.copy(attendanceStatus = attendanceStatus)

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/bookings/details/BookingDetailsViewState.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/bookings/details/BookingDetailsViewState.kt
@@ -8,13 +8,16 @@ import com.woocommerce.android.ui.bookings.compose.BookingSummaryModel
 
 data class BookingDetailsViewState(
     val toolbarTitle: String = "",
-    val orderId: Long = 0L,
     val bookingUiState: BookingUiState? = null,
     val onCancelBooking: () -> Unit = {},
     val onAttendanceStatusSelected: (BookingAttendanceStatus) -> Unit = { _ -> }
-)
+) {
+
+    val shouldShowSkeleton: Boolean = bookingUiState == null
+}
 
 data class BookingUiState(
+    val orderId: Long,
     val bookingSummary: BookingSummaryModel,
     val bookingsAppointmentDetails: BookingAppointmentDetailsModel,
     val bookingCustomerDetails: BookingCustomerDetailsModel,

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/bookings/details/BookingDetailsViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/bookings/details/BookingDetailsViewModelTest.kt
@@ -89,7 +89,7 @@ class BookingDetailsViewModelTest : BaseUnitTest() {
         // Then
         val state = viewModel.state.getOrAwaitValue()
         assertThat(state.bookingUiState).isNotNull
-        assertThat(state.orderId).isEqualTo(2L)
+        assertThat(state.bookingUiState?.orderId).isEqualTo(2L)
     }
 
     private fun createViewModel(


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

<!-- Id number of the Linear issue this PR addresses, e.g., WOOMOB-373. -->

WOOMOB-1401

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs, try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

This PR implements the loading skeleton for the booking details screen. I tried to replicate roughly the first two sections of the screen: booking summary and appointment details. 

### Steps to reproduce
<!-- Step-by-step testing instructions. For new user flows, consider instead stating the goal of the workflow and see if your PR reviewer can accomplish the workflow without specific steps! -->

Not possible now, because the booking entity is never null. For now, the easiest is to apply [details_skeleton.patch](https://github.com/user-attachments/files/22885764/details_skeleton.patch) to foce null in the UI state.

### Testing information
<!-- This is your opportunity to break out individual scenarios that need testing (when necessary) and/or include a checklist for the reviewer to go through. Consider documenting the following from your own completed testing: devices used, alternate workflows, edge cases, affected areas, critical flows, areas not tested, and any remaining unknowns. Provide feedback on this new section of the PR template through Sept 30, 2024 to Apps Quality; additional context here: p91TBi-b8z-p2#comment-12036 -->

Test Dark/Light theme.

### The tests that have been performed
<!-- To give the reviewer an idea of what could be missed in terms of testing -->

The above.

### Images/gif
<!-- Include before and after images or gifs when appropriate. -->


https://github.com/user-attachments/assets/4a42164c-b9e9-415b-aeef-09e7bba23bff



- [ ] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->