### PR TITLE
Replace margin right with margin end

### DIFF
--- a/WooCommerce/src/main/res/layout/skeleton_analytics_list_item.xml
+++ b/WooCommerce/src/main/res/layout/skeleton_analytics_list_item.xml
@@ -19,7 +19,7 @@
         android:id="@+id/value"
         android:layout_width="@dimen/major_275"
         android:layout_height="@dimen/skeleton_text_height_75"
-        android:layout_marginRight="@dimen/major_100"
+        android:layout_marginEnd="@dimen/major_100"
         android:background="@drawable/skeleton_background"
         app:layout_constraintBottom_toBottomOf="@+id/subtitle"
         app:layout_constraintEnd_toEndOf="parent"


### PR DESCRIPTION
This is a quick follow up for this merged PR - https://github.com/woocommerce/woocommerce-android/pull/14740.

I accidentally didn't push the last commit which replaces `marginRight` with `marginEnd` to ensure RTL support.