### PR TITLE
[WOOMOB-1453] Booking details - refresh API call

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/bookings/BookingsRepository.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/bookings/BookingsRepository.kt
@@ -60,6 +60,20 @@ class BookingsRepository @Inject constructor(
             bookingId = bookingId
         )
 
+    suspend fun fetchBooking(
+        bookingId: Long
+    ): Result<Unit> {
+        val result = bookingsStore.fetchBooking(
+            site = selectedSite.get(),
+            bookingId = bookingId
+        )
+        return if (result.isError) {
+            Result.failure(WooException(result.error))
+        } else {
+            Result.success(Unit)
+        }
+    }
+
     data class FetchResult(
         val bookings: List<Booking>,
         val hasMorePages: Boolean

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/bookings/details/BookingDetailsFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/bookings/details/BookingDetailsFragment.kt
@@ -7,12 +7,18 @@ import android.view.ViewGroup
 import androidx.fragment.app.viewModels
 import androidx.navigation.fragment.findNavController
 import com.woocommerce.android.ui.base.BaseFragment
+import com.woocommerce.android.ui.base.UIMessageResolver
 import com.woocommerce.android.ui.compose.composeView
 import com.woocommerce.android.ui.main.AppBarStatus
+import com.woocommerce.android.viewmodel.MultiLiveEvent
 import dagger.hilt.android.AndroidEntryPoint
+import javax.inject.Inject
 
 @AndroidEntryPoint
 class BookingDetailsFragment : BaseFragment() {
+
+    @Inject
+    lateinit var uiMessageResolver: UIMessageResolver
 
     private val viewModel: BookingDetailsViewModel by viewModels()
 
@@ -31,6 +37,21 @@ class BookingDetailsFragment : BaseFragment() {
                     )
                 }
             )
+        }
+    }
+
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
+        handleEvents()
+    }
+
+    private fun handleEvents() {
+        viewModel.event.observe(viewLifecycleOwner) { event ->
+            when (event) {
+                is MultiLiveEvent.Event.ShowSnackbar -> {
+                    uiMessageResolver.showSnack(event.message)
+                }
+            }
         }
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/bookings/details/BookingDetailsScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/bookings/details/BookingDetailsScreen.kt
@@ -17,7 +17,6 @@ import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
-import androidx.compose.material3.Surface
 import androidx.compose.material3.pulltorefresh.rememberPullToRefreshState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
@@ -26,10 +25,8 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.shadow
-import androidx.compose.ui.res.colorResource
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.times
-import com.woocommerce.android.R
 import com.woocommerce.android.ui.bookings.compose.BookingAppointmentDetails
 import com.woocommerce.android.ui.bookings.compose.BookingAppointmentDetailsModel
 import com.woocommerce.android.ui.bookings.compose.BookingAttendanceSection
@@ -83,44 +80,39 @@ fun BookingDetailsScreen(
             )
         }
     ) { innerPadding ->
-        Surface(
-            color = colorResource(R.color.default_window_background),
+        WCPullToRefreshBox(
+            isRefreshing = viewState.loadingState == BookingDetailsLoadingState.Refreshing,
+            onRefresh = viewState.onRefresh,
+            state = rememberPullToRefreshState(),
             modifier = Modifier
                 .fillMaxSize()
                 .padding(innerPadding)
         ) {
-            WCPullToRefreshBox(
-                isRefreshing = viewState.loadingState == BookingDetailsLoadingState.Refreshing,
-                onRefresh = viewState.onRefresh,
-                state = rememberPullToRefreshState(),
-                modifier = Modifier.fillMaxSize()
+            Column(
+                modifier = Modifier
+                    .verticalScroll(rememberScrollState())
             ) {
-                Column(
-                    modifier = Modifier
-                        .verticalScroll(rememberScrollState())
-                ) {
-                    when {
-                        viewState.shouldShowSkeleton -> BookingDetailsLoading()
-                        viewState.bookingUiState != null -> {
-                            BookingDetailsContent(
-                                booking = viewState.bookingUiState,
-                                onCancelBooking = viewState.onCancelBooking,
-                                onViewOrder = onViewOrder,
-                                onAttendanceStatusClicked = { showAttendanceSheet.value = true },
-                            )
-                        }
+                when {
+                    viewState.shouldShowSkeleton -> BookingDetailsLoading()
+                    viewState.bookingUiState != null -> {
+                        BookingDetailsContent(
+                            booking = viewState.bookingUiState,
+                            onCancelBooking = viewState.onCancelBooking,
+                            onViewOrder = onViewOrder,
+                            onAttendanceStatusClicked = { showAttendanceSheet.value = true },
+                        )
                     }
                 }
             }
         }
-        if (showAttendanceSheet.value) {
-            BookingAttendanceStatusBottomSheet(
-                onSelect = { status ->
-                    viewState.onAttendanceStatusSelected(status)
-                },
-                onDismiss = { showAttendanceSheet.value = false }
-            )
-        }
+    }
+    if (showAttendanceSheet.value) {
+        BookingAttendanceStatusBottomSheet(
+            onSelect = { status ->
+                viewState.onAttendanceStatusSelected(status)
+            },
+            onDismiss = { showAttendanceSheet.value = false }
+        )
     }
 }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/bookings/details/BookingDetailsScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/bookings/details/BookingDetailsScreen.kt
@@ -18,6 +18,7 @@ import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Surface
+import androidx.compose.material3.pulltorefresh.rememberPullToRefreshState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.livedata.observeAsState
@@ -43,6 +44,7 @@ import com.woocommerce.android.ui.bookings.compose.BookingSummary
 import com.woocommerce.android.ui.bookings.compose.BookingSummaryModel
 import com.woocommerce.android.ui.compose.animations.SkeletonView
 import com.woocommerce.android.ui.compose.component.Toolbar
+import com.woocommerce.android.ui.compose.component.WCPullToRefreshBox
 import com.woocommerce.android.ui.compose.preview.LightDarkThemePreviews
 import com.woocommerce.android.ui.compose.theme.WooThemeWithBackground
 
@@ -64,6 +66,7 @@ fun BookingDetailsScreen(
     }
 }
 
+@OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun BookingDetailsScreen(
     viewState: BookingDetailsViewState,
@@ -82,22 +85,30 @@ fun BookingDetailsScreen(
     ) { innerPadding ->
         Surface(
             color = colorResource(R.color.default_window_background),
-            modifier = Modifier.fillMaxSize()
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(innerPadding)
         ) {
-            Column(
-                modifier = Modifier
-                    .verticalScroll(rememberScrollState())
-                    .padding(innerPadding)
+            WCPullToRefreshBox(
+                isRefreshing = viewState.loadingState == BookingDetailsLoadingState.Refreshing,
+                onRefresh = viewState.onRefresh,
+                state = rememberPullToRefreshState(),
+                modifier = Modifier.fillMaxSize()
             ) {
-                when {
-                    viewState.shouldShowSkeleton -> BookingDetailsLoading()
-                    viewState.bookingUiState != null -> {
-                        BookingDetailsContent(
-                            booking = viewState.bookingUiState,
-                            onCancelBooking = viewState.onCancelBooking,
-                            onViewOrder = onViewOrder,
-                            onAttendanceStatusClicked = { showAttendanceSheet.value = true },
-                        )
+                Column(
+                    modifier = Modifier
+                        .verticalScroll(rememberScrollState())
+                ) {
+                    when {
+                        viewState.shouldShowSkeleton -> BookingDetailsLoading()
+                        viewState.bookingUiState != null -> {
+                            BookingDetailsContent(
+                                booking = viewState.bookingUiState,
+                                onCancelBooking = viewState.onCancelBooking,
+                                onViewOrder = onViewOrder,
+                                onAttendanceStatusClicked = { showAttendanceSheet.value = true },
+                            )
+                        }
                     }
                 }
             }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/bookings/details/BookingDetailsViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/bookings/details/BookingDetailsViewModel.kt
@@ -50,22 +50,23 @@ class BookingDetailsViewModel @Inject constructor(
                 bookingUiState = if (booking != null) buildBookingUiState(booking, attendanceStatus) else null,
                 loadingState = loadingState,
                 onCancelBooking = ::onCancelBooking,
-                onAttendanceStatusSelected = ::onAttendanceStatusSelected
+                onAttendanceStatusSelected = ::onAttendanceStatusSelected,
+                onRefresh = ::fetchBooking,
             )
         }
     }.asLiveData()
 
     init {
-        refreshBooking()
+        fetchBooking(BookingDetailsLoadingState.Loading)
     }
 
-    private fun refreshBooking() {
+    private fun fetchBooking(state: BookingDetailsLoadingState = BookingDetailsLoadingState.Refreshing) {
         launch {
             if (!networkStatus.isConnected()) {
                 triggerEvent(MultiLiveEvent.Event.ShowSnackbar(R.string.offline_error))
                 return@launch
             }
-            loadingState.value = BookingDetailsLoadingState.Refreshing
+            loadingState.value = state
             bookingsRepository.fetchBooking(navArgs.bookingId)
                 .onFailure {
                     triggerEvent(MultiLiveEvent.Event.ShowSnackbar(R.string.bookings_fetch_error))

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/bookings/details/BookingDetailsViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/bookings/details/BookingDetailsViewModel.kt
@@ -4,11 +4,13 @@ import androidx.lifecycle.LiveData
 import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.asLiveData
 import com.woocommerce.android.R
+import com.woocommerce.android.tools.NetworkStatus
 import com.woocommerce.android.ui.bookings.Booking
 import com.woocommerce.android.ui.bookings.BookingMapper
 import com.woocommerce.android.ui.bookings.BookingsRepository
 import com.woocommerce.android.ui.bookings.compose.BookingAttendanceStatus
 import com.woocommerce.android.ui.bookings.compose.BookingPaymentDetailsModel
+import com.woocommerce.android.viewmodel.MultiLiveEvent
 import com.woocommerce.android.viewmodel.ResourceProvider
 import com.woocommerce.android.viewmodel.ScopedViewModel
 import com.woocommerce.android.viewmodel.navArgs
@@ -24,6 +26,7 @@ class BookingDetailsViewModel @Inject constructor(
     private val resourceProvider: ResourceProvider,
     private val bookingsRepository: BookingsRepository,
     private val bookingMapper: BookingMapper,
+    private val networkStatus: NetworkStatus,
 ) : ScopedViewModel(savedState) {
 
     private val navArgs: BookingDetailsFragmentArgs by savedState.navArgs()
@@ -59,8 +62,15 @@ class BookingDetailsViewModel @Inject constructor(
 
     private fun refreshBooking() {
         launch {
+            if (!networkStatus.isConnected()) {
+                triggerEvent(MultiLiveEvent.Event.ShowSnackbar(R.string.offline_error))
+                return@launch
+            }
             loadingState.value = BookingDetailsLoadingState.Refreshing
             bookingsRepository.fetchBooking(navArgs.bookingId)
+                .onFailure {
+                    triggerEvent(MultiLiveEvent.Event.ShowSnackbar(R.string.bookings_fetch_error))
+                }
             loadingState.value = BookingDetailsLoadingState.Idle
         }
     }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/bookings/details/BookingDetailsViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/bookings/details/BookingDetailsViewModel.kt
@@ -15,13 +15,14 @@ import com.woocommerce.android.viewmodel.navArgs
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.launch
 import javax.inject.Inject
 
 @HiltViewModel
 class BookingDetailsViewModel @Inject constructor(
     savedState: SavedStateHandle,
-    resourceProvider: ResourceProvider,
-    bookingsRepository: BookingsRepository,
+    private val resourceProvider: ResourceProvider,
+    private val bookingsRepository: BookingsRepository,
     private val bookingMapper: BookingMapper,
 ) : ScopedViewModel(savedState) {
 
@@ -29,24 +30,40 @@ class BookingDetailsViewModel @Inject constructor(
 
     private val booking = bookingsRepository.observeBooking(navArgs.bookingId)
 
+    private val loadingState = MutableStateFlow<BookingDetailsLoadingState>(BookingDetailsLoadingState.Idle)
+
     // Temporary, the booking status should come from the stored object
     private val bookingAttendanceStatus = MutableStateFlow<BookingAttendanceStatus?>(null)
 
     val state: LiveData<BookingDetailsViewState> = combine(
         booking,
-        bookingAttendanceStatus
-    ) { booking, attendanceStatus ->
+        bookingAttendanceStatus,
+        loadingState
+    ) { booking, attendanceStatus, loadingState ->
         with(bookingMapper) {
             BookingDetailsViewState(
                 toolbarTitle = booking?.id?.value?.let { id ->
                     resourceProvider.getString(R.string.booking_details_title, id)
                 } ?: "",
                 bookingUiState = if (booking != null) buildBookingUiState(booking, attendanceStatus) else null,
+                loadingState = loadingState,
                 onCancelBooking = ::onCancelBooking,
                 onAttendanceStatusSelected = ::onAttendanceStatusSelected
             )
         }
     }.asLiveData()
+
+    init {
+        refreshBooking()
+    }
+
+    private fun refreshBooking() {
+        launch {
+            loadingState.value = BookingDetailsLoadingState.Refreshing
+            bookingsRepository.fetchBooking(navArgs.bookingId)
+            loadingState.value = BookingDetailsLoadingState.Idle
+        }
+    }
 
     private fun onAttendanceStatusSelected(status: BookingAttendanceStatus) {
         // Temporary, the booking status should come from the stored object

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/bookings/details/BookingDetailsViewState.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/bookings/details/BookingDetailsViewState.kt
@@ -6,14 +6,19 @@ import com.woocommerce.android.ui.bookings.compose.BookingCustomerDetailsModel
 import com.woocommerce.android.ui.bookings.compose.BookingPaymentDetailsModel
 import com.woocommerce.android.ui.bookings.compose.BookingSummaryModel
 
+sealed interface BookingDetailsLoadingState {
+    data object Idle : BookingDetailsLoadingState
+    data object Refreshing : BookingDetailsLoadingState
+}
+
 data class BookingDetailsViewState(
     val toolbarTitle: String = "",
     val bookingUiState: BookingUiState? = null,
+    val loadingState: BookingDetailsLoadingState = BookingDetailsLoadingState.Idle,
     val onCancelBooking: () -> Unit = {},
     val onAttendanceStatusSelected: (BookingAttendanceStatus) -> Unit = { _ -> }
 ) {
-
-    val shouldShowSkeleton: Boolean = bookingUiState == null
+    val shouldShowSkeleton: Boolean = bookingUiState == null && loadingState == BookingDetailsLoadingState.Refreshing
 }
 
 data class BookingUiState(

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/bookings/details/BookingDetailsViewState.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/bookings/details/BookingDetailsViewState.kt
@@ -8,6 +8,7 @@ import com.woocommerce.android.ui.bookings.compose.BookingSummaryModel
 
 sealed interface BookingDetailsLoadingState {
     data object Idle : BookingDetailsLoadingState
+    data object Loading : BookingDetailsLoadingState
     data object Refreshing : BookingDetailsLoadingState
 }
 
@@ -16,7 +17,8 @@ data class BookingDetailsViewState(
     val bookingUiState: BookingUiState? = null,
     val loadingState: BookingDetailsLoadingState = BookingDetailsLoadingState.Idle,
     val onCancelBooking: () -> Unit = {},
-    val onAttendanceStatusSelected: (BookingAttendanceStatus) -> Unit = { _ -> }
+    val onAttendanceStatusSelected: (BookingAttendanceStatus) -> Unit = { _ -> },
+    val onRefresh: () -> Unit = {},
 ) {
     val shouldShowSkeleton: Boolean = bookingUiState == null && loadingState == BookingDetailsLoadingState.Refreshing
 }

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -4223,6 +4223,8 @@
     <string name="booking_payment_label_service">Service</string>
     <string name="booking_payment_mark_as_paid">Mark as paid</string>
     <string name="booking_payment_view_order">View order</string>
+    <string name="booking_fetch_error">Error fetching booking</string>
+
     <string name="or_use_password" a8c-src-lib="module:login">Use password to sign in</string>
     <string name="about_automattic_main_page_title">About %1$s</string>
     <string name="about_automattic_legal_page_title">Legal and More</string>

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/bookings/details/BookingDetailsViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/bookings/details/BookingDetailsViewModelTest.kt
@@ -19,6 +19,8 @@ import org.mockito.kotlin.any
 import org.mockito.kotlin.doReturn
 import org.mockito.kotlin.eq
 import org.mockito.kotlin.mock
+import org.mockito.kotlin.times
+import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
 import org.wordpress.android.fluxc.model.LocalOrRemoteId
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.bookings.BookingOrderInfo
@@ -92,11 +94,33 @@ class BookingDetailsViewModelTest : BaseUnitTest() {
         assertThat(state.bookingUiState?.orderId).isEqualTo(2L)
     }
 
+    @Test
+    fun `when init, then fetchBooking is triggered`() = testBlocking {
+        // Given
+        val bookingId = 321L
+        val savedState = SavedStateHandle(mapOf("bookingId" to bookingId))
+        val bookingsRepository = mock<BookingsRepository> {
+            on { observeBooking(any()) } doReturn bookingFlow
+            onBlocking { fetchBooking(any()) } doReturn Result.success(Unit)
+        }
+        // When
+        BookingDetailsViewModel(
+            savedState = savedState,
+            resourceProvider = resourceProvider,
+            bookingsRepository = bookingsRepository,
+            bookingMapper = bookingMapper
+        ).apply { state.observeForever { } }
+
+        // Then
+        verify(bookingsRepository, times(1)).fetchBooking(bookingId)
+    }
+
     private fun createViewModel(
         savedState: SavedStateHandle,
     ): BookingDetailsViewModel {
         val bookingsRepository = mock<BookingsRepository> {
             on { observeBooking(any()) } doReturn bookingFlow
+            onBlocking { fetchBooking(any()) } doReturn Result.success(Unit)
         }
         return BookingDetailsViewModel(
             savedState = savedState,

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/bookings/details/BookingDetailsViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/bookings/details/BookingDetailsViewModelTest.kt
@@ -177,6 +177,34 @@ class BookingDetailsViewModelTest : BaseUnitTest() {
         assertThat(event).isEqualTo(MultiLiveEvent.Event.ShowSnackbar(R.string.bookings_fetch_error))
     }
 
+    @Test
+    fun `when onRefresh called, then fetchBooking is triggered again`() = testBlocking {
+        // Given
+        val bookingId = 654L
+        val savedState = SavedStateHandle(mapOf("bookingId" to bookingId))
+        val bookingsRepository = mock<BookingsRepository> {
+            on { observeBooking(any()) } doReturn bookingFlow
+            onBlocking { fetchBooking(any()) } doReturn Result.success(Unit)
+        }
+        val networkStatus = mock<NetworkStatus> {
+            on { isConnected() } doReturn true
+        }
+        val viewModel = BookingDetailsViewModel(
+            savedState = savedState,
+            resourceProvider = resourceProvider,
+            bookingsRepository = bookingsRepository,
+            bookingMapper = bookingMapper,
+            networkStatus = networkStatus
+        ).apply { state.observeForever { } }
+
+        // When
+        val state = viewModel.state.getOrAwaitValue()
+        state.onRefresh()
+
+        // Then
+        verify(bookingsRepository, times(2)).fetchBooking(bookingId)
+    }
+
     private fun createViewModel(
         savedState: SavedStateHandle,
     ): BookingDetailsViewModel {

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/bookings/details/BookingDetailsViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/bookings/details/BookingDetailsViewModelTest.kt
@@ -2,6 +2,7 @@ package com.woocommerce.android.ui.bookings.details
 
 import androidx.lifecycle.SavedStateHandle
 import com.woocommerce.android.R
+import com.woocommerce.android.tools.NetworkStatus
 import com.woocommerce.android.ui.bookings.Booking
 import com.woocommerce.android.ui.bookings.BookingMapper
 import com.woocommerce.android.ui.bookings.BookingsRepository
@@ -9,6 +10,7 @@ import com.woocommerce.android.ui.bookings.compose.BookingAttendanceStatus
 import com.woocommerce.android.util.CurrencyFormatter
 import com.woocommerce.android.util.getOrAwaitValue
 import com.woocommerce.android.viewmodel.BaseUnitTest
+import com.woocommerce.android.viewmodel.MultiLiveEvent
 import com.woocommerce.android.viewmodel.ResourceProvider
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -104,15 +106,73 @@ class BookingDetailsViewModelTest : BaseUnitTest() {
             onBlocking { fetchBooking(any()) } doReturn Result.success(Unit)
         }
         // When
+        val networkStatus = mock<NetworkStatus> {
+            on { isConnected() } doReturn true
+        }
         BookingDetailsViewModel(
             savedState = savedState,
             resourceProvider = resourceProvider,
             bookingsRepository = bookingsRepository,
-            bookingMapper = bookingMapper
+            bookingMapper = bookingMapper,
+            networkStatus = networkStatus
         ).apply { state.observeForever { } }
 
         // Then
         verify(bookingsRepository, times(1)).fetchBooking(bookingId)
+    }
+
+    @Test
+    fun `when offline on init, then offline snackbar shown and fetch not called`() = testBlocking {
+        // Given
+        val bookingId = 999L
+        val savedState = SavedStateHandle(mapOf("bookingId" to bookingId))
+        val bookingsRepository = mock<BookingsRepository> {
+            on { observeBooking(any()) } doReturn bookingFlow
+        }
+        val networkStatus = mock<NetworkStatus> {
+            on { isConnected() } doReturn false
+        }
+        val viewModel = BookingDetailsViewModel(
+            savedState = savedState,
+            resourceProvider = resourceProvider,
+            bookingsRepository = bookingsRepository,
+            bookingMapper = bookingMapper,
+            networkStatus = networkStatus
+        ).apply { event.observeForever { } }
+
+        // When
+        val event = viewModel.event.getOrAwaitValue()
+
+        // Then
+        assertThat(event).isEqualTo(MultiLiveEvent.Event.ShowSnackbar(R.string.offline_error))
+        verify(bookingsRepository, times(0)).fetchBooking(any())
+    }
+
+    @Test
+    fun `when fetchBooking fails, then error snackbar shown`() = testBlocking {
+        // Given
+        val bookingId = 111L
+        val savedState = SavedStateHandle(mapOf("bookingId" to bookingId))
+        val bookingsRepository = mock<BookingsRepository> {
+            on { observeBooking(any()) } doReturn bookingFlow
+            onBlocking { fetchBooking(any()) } doReturn Result.failure(Exception("boom"))
+        }
+        val networkStatus = mock<NetworkStatus> {
+            on { isConnected() } doReturn true
+        }
+        val viewModel = BookingDetailsViewModel(
+            savedState = savedState,
+            resourceProvider = resourceProvider,
+            bookingsRepository = bookingsRepository,
+            bookingMapper = bookingMapper,
+            networkStatus = networkStatus
+        ).apply { event.observeForever { } }
+
+        // When
+        val event = viewModel.event.getOrAwaitValue()
+
+        // Then
+        assertThat(event).isEqualTo(MultiLiveEvent.Event.ShowSnackbar(R.string.bookings_fetch_error))
     }
 
     private fun createViewModel(
@@ -122,11 +182,15 @@ class BookingDetailsViewModelTest : BaseUnitTest() {
             on { observeBooking(any()) } doReturn bookingFlow
             onBlocking { fetchBooking(any()) } doReturn Result.success(Unit)
         }
+        val networkStatus = mock<NetworkStatus> {
+            on { isConnected() } doReturn true
+        }
         return BookingDetailsViewModel(
             savedState = savedState,
             resourceProvider = resourceProvider,
             bookingsRepository = bookingsRepository,
-            bookingMapper = bookingMapper
+            bookingMapper = bookingMapper,
+            networkStatus = networkStatus
         ).apply {
             state.observeForever { }
         }

--- a/libs/fluxc-plugin/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/bookings/BookingsRestClient.kt
+++ b/libs/fluxc-plugin/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/bookings/BookingsRestClient.kt
@@ -1,6 +1,5 @@
 package org.wordpress.android.fluxc.network.rest.wpcom.wc.bookings
 
-import org.wordpress.android.fluxc.annotations.endpoint.WCWPAPIEndpoint
 import org.wordpress.android.fluxc.generated.endpoint.WOOCOMMERCE
 import org.wordpress.android.fluxc.model.SiteModel
 import org.wordpress.android.fluxc.network.rest.wpapi.WPAPIResponse.Error
@@ -24,9 +23,7 @@ class BookingsRestClient @Inject constructor(
         site: SiteModel,
         bookingId: Long
     ): WooPayload<BookingDto> {
-        val endpoint = WCWPAPIEndpoint(
-            WOOCOMMERCE.bookings.id(bookingId).endpoint
-        ).pathV2Bookings
+        val endpoint = WOOCOMMERCE.bookings.id(bookingId).pathV2Bookings
         val response = wooNetwork.executeGetGsonRequest(
             site = site,
             path = endpoint,

--- a/libs/fluxc-plugin/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/bookings/BookingsRestClient.kt
+++ b/libs/fluxc-plugin/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/bookings/BookingsRestClient.kt
@@ -1,5 +1,6 @@
 package org.wordpress.android.fluxc.network.rest.wpcom.wc.bookings
 
+import org.wordpress.android.fluxc.annotations.endpoint.WCWPAPIEndpoint
 import org.wordpress.android.fluxc.generated.endpoint.WOOCOMMERCE
 import org.wordpress.android.fluxc.model.SiteModel
 import org.wordpress.android.fluxc.network.rest.wpapi.WPAPIResponse.Error
@@ -17,6 +18,25 @@ class BookingsRestClient @Inject constructor(
 ) {
     companion object {
         const val DEFAULT_PER_PAGE = 25 // Number of items to fetch in a single request
+    }
+
+    suspend fun fetchBooking(
+        site: SiteModel,
+        bookingId: Long
+    ): WooPayload<BookingDto> {
+        val endpoint = WCWPAPIEndpoint(
+            WOOCOMMERCE.bookings.id(bookingId).endpoint
+        ).pathV2Bookings
+        val response = wooNetwork.executeGetGsonRequest(
+            site = site,
+            path = endpoint,
+            clazz = BookingDto::class.java,
+            params = emptyMap()
+        )
+        return when (response) {
+            is Success -> WooPayload(response.data)
+            is Error -> WooPayload(response.error.toWooError())
+        }
     }
 
     @Suppress("LongParameterList")

--- a/libs/fluxc-plugin/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/bookings/BookingsStore.kt
+++ b/libs/fluxc-plugin/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/bookings/BookingsStore.kt
@@ -97,16 +97,15 @@ class BookingsStore @Inject internal constructor(
             when {
                 response.isError -> WooResult(response.error)
                 response.result != null -> {
-                    val dto = response.result
-                    val orderIds = listOf(dto.orderId).filterNot { it == 0L }
-                    val ordersResult = fetchOrders(site, orderIds)
-                    if (ordersResult.isError) {
-                        return@withDefaultContext WooResult(ordersResult.error)
+                    val bookingDto = response.result
+                    val orderResult = orderStore.fetchSingleOrderSync(site, bookingDto.orderId)
+                    if (orderResult.isError) {
+                        return@withDefaultContext WooResult(orderResult.error)
                     }
                     val entity = with(bookingDtoMapper) {
-                        dto.toEntity(
+                        bookingDto.toEntity(
                             localSiteId = site.localId(),
-                            orderEntity = ordersResult.model?.get(dto.orderId)
+                            orderEntity = orderResult.model,
                         )
                     }
                     bookingsDao.insertOrReplace(listOf(entity))

--- a/libs/fluxc-plugin/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/bookings/BookingsStore.kt
+++ b/libs/fluxc-plugin/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/bookings/BookingsStore.kt
@@ -88,6 +88,36 @@ class BookingsStore @Inject internal constructor(
         bookingId: Long
     ): Flow<BookingEntity?> = bookingsDao.observeBooking(site.localId(), bookingId)
 
+    suspend fun fetchBooking(
+        site: SiteModel,
+        bookingId: Long
+    ): WooResult<BookingEntity> {
+        return coroutineEngine.withDefaultContext(AppLog.T.API, this, "fetchBooking") {
+            val response = bookingsRestClient.fetchBooking(site, bookingId)
+            when {
+                response.isError -> WooResult(response.error)
+                response.result != null -> {
+                    val dto = response.result
+                    val orderIds = listOf(dto.orderId).filterNot { it == 0L }
+                    val ordersResult = fetchOrders(site, orderIds)
+                    if (ordersResult.isError) {
+                        return@withDefaultContext WooResult(ordersResult.error)
+                    }
+                    val entity = with(bookingDtoMapper) {
+                        dto.toEntity(
+                            localSiteId = site.localId(),
+                            orderEntity = ordersResult.model?.get(dto.orderId)
+                        )
+                    }
+                    bookingsDao.insertOrReplace(listOf(entity))
+                    WooResult(entity)
+                }
+
+                else -> WooResult(WooError(GENERIC_ERROR, UNKNOWN))
+            }
+        }
+    }
+
     private suspend fun fetchOrders(
         site: SiteModel,
         orderIds: List<Long>

--- a/libs/fluxc-processor/src/main/resources/wc-wp-api-endpoints.txt
+++ b/libs/fluxc-processor/src/main/resources/wc-wp-api-endpoints.txt
@@ -134,3 +134,4 @@
 /gla/ads/reports/programs
 
 /bookings
+/bookings/<id>/


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

<!-- Id number of the Linear issue this PR addresses, e.g., WOOMOB-373. -->

WOOMOB-1453

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

This PR implements the refresh logic on the Booking details screen. 
It follows the Booking List logic - so first the booking is retrieved and then the corresponding order.

Additionally, I've added a basic error handling to show a snack when the call fails or when there's no network conneciton.

### Steps to reproduce
<!-- Step-by-step testing instructions. For new user flows, consider instead stating the goal of the workflow and see if your PR reviewer can accomplish the workflow without specific steps! -->

1. Monitor network calls via Android Studio or any other tool you like
2. Launch the app
3. Go to bookings tab
4. Tap on the booking
5. Confirm two endpoints were made to fetch the booking and the order

### Testing information
<!-- This is your opportunity to break out individual scenarios that need testing (when necessary) and/or include a checklist for the reviewer to go through. Consider documenting the following from your own completed testing: devices used, alternate workflows, edge cases, affected areas, critical flows, areas not tested, and any remaining unknowns. Provide feedback on this new section of the PR template through Sept 30, 2024 to Apps Quality; additional context here: p91TBi-b8z-p2#comment-12036 -->

Repeat the above with disabled network. 
Repeat the above with network but this time mock the API responses to fail.

### The tests that have been performed
<!-- To give the reviewer an idea of what could be missed in terms of testing -->
The above.

### Images/gif
<!-- Include before and after images or gifs when appropriate. -->

- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->