### PR TITLE
[WOOMOB-1501] Replace wc-analytics/variations with v3/variations endpoint

### DIFF
--- a/libs/fluxc-plugin/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/product/pos/WooPosProductRestClient.kt
+++ b/libs/fluxc-plugin/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/product/pos/WooPosProductRestClient.kt
@@ -64,7 +64,7 @@ class WooPosProductRestClient @Inject constructor(
         page: Int,
         pageSize: Int,
     ): WooResult<Array<WooPosVariationApiResponse>> {
-        val url = "/wc-analytics/variations"
+        val url = WOOCOMMERCE.variations.pathV3
         val params = mutableMapOf(
             "per_page" to pageSize.toString(),
             "page" to page.toString(),

--- a/libs/fluxc-processor/src/main/resources/wc-wp-api-endpoints.txt
+++ b/libs/fluxc-processor/src/main/resources/wc-wp-api-endpoints.txt
@@ -33,6 +33,8 @@
 /products/tags/<id>/
 /products/tags/batch/
 
+/variations/
+
 /catalog/
 /catalog/status/<id>#String/
 


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

<!-- Id number of the Linear issue this PR addresses, e.g., WOOMOB-373. -->

#WOOMOB-1501

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

This PR replaces `/wc-analytics/variations` with `/v3/variations` endpoint. 

**Note: WooCommerce 10.3+ is required as the new endpoint isn't available on the previous versions.**

### Testing information
<!-- This is your opportunity to break out individual scenarios that need testing (when necessary) and/or include a checklist for the reviewer to go through. Consider documenting the following from your own completed testing: devices used, alternate workflows, edge cases, affected areas, critical flows, areas not tested, and any remaining unknowns. Provide feedback on this new section of the PR template through Sept 30, 2024 to Apps Quality; additional context here: p91TBi-b8z-p2#comment-12036 -->

1. Clear apps data 
2. Login
3. Wait until the Local Catalog worker finishes (you can observe logs)
4. Verify it completes successfully and use app inspector to check the PosVariations table contains data

### The tests that have been performed
<!-- To give the reviewer an idea of what could be missed in terms of testing -->

The above

### Images/gif
<!-- Include before and after images or gifs when appropriate. -->
N/A

- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->