### PR TITLE
[WOOMOB-1385] Booking Pay at location status

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/bookings/BookingMapper.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/bookings/BookingMapper.kt
@@ -104,7 +104,7 @@ class BookingMapper @Inject constructor(
         orderStatus: String?,
         paymentMethod: String?,
     ): BookingStatus {
-        return if (orderStatus == "completed" && paymentMethod == "cod") {
+        return if (orderStatus != "completed" && paymentMethod == "cod") {
             BookingStatus.PayAtLocation
         } else {
             when (this) {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/bookings/BookingMapper.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/bookings/BookingMapper.kt
@@ -47,7 +47,7 @@ class BookingMapper @Inject constructor(
             name = order.productInfo?.name ?: "-",
             customerName = order.customerInfo?.fullName(),
             attendanceStatus = BookingAttendanceStatus.BOOKED,
-            status = status.toUiModel()
+            status = status.toUiModel(order.status, order.paymentInfo?.paymentMethodId)
         )
     }
 
@@ -100,14 +100,23 @@ class BookingMapper @Inject constructor(
         )
     }
 
-    private fun BookingEntity.Status.toUiModel(): BookingStatus = when (this) {
-        BookingEntity.Status.Paid -> BookingStatus.Paid
-        BookingEntity.Status.PendingConfirmation -> BookingStatus.PendingConfirmation
-        BookingEntity.Status.Cancelled -> BookingStatus.Cancelled
-        BookingEntity.Status.Complete -> BookingStatus.Complete
-        BookingEntity.Status.Confirmed -> BookingStatus.Confirmed
-        BookingEntity.Status.Unpaid -> BookingStatus.Unpaid
-        is BookingEntity.Status.Unknown -> BookingStatus.Unknown(this.key)
+    private fun BookingEntity.Status.toUiModel(
+        orderStatus: String?,
+        paymentMethod: String?,
+    ): BookingStatus {
+        return if (orderStatus == "completed" && paymentMethod == "cod") {
+            BookingStatus.PayAtLocation
+        } else {
+            when (this) {
+                BookingEntity.Status.Paid -> BookingStatus.Paid
+                BookingEntity.Status.PendingConfirmation -> BookingStatus.PendingConfirmation
+                BookingEntity.Status.Cancelled -> BookingStatus.Cancelled
+                BookingEntity.Status.Complete -> BookingStatus.Complete
+                BookingEntity.Status.Confirmed -> BookingStatus.Confirmed
+                BookingEntity.Status.Unpaid -> BookingStatus.Unpaid
+                is BookingEntity.Status.Unknown -> BookingStatus.Unknown(this.key)
+            }
+        }
     }
 
     private fun BookingCustomerInfo.fullName(): String? {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/bookings/compose/BookingStatusTag.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/bookings/compose/BookingStatusTag.kt
@@ -25,6 +25,7 @@ fun BookingStatusTag(
 }
 
 sealed interface BookingStatus {
+    data object PayAtLocation : BookingStatus
     data object Unpaid : BookingStatus
     data object PendingConfirmation : BookingStatus
     data object Confirmed : BookingStatus
@@ -43,6 +44,7 @@ private fun BookingStatus.text(): String {
         BookingStatus.Paid -> stringResource(R.string.booking_payment_status_paid)
         BookingStatus.Cancelled -> stringResource(R.string.booking_payment_status_cancelled)
         BookingStatus.Complete -> stringResource(R.string.booking_payment_status_complete)
+        BookingStatus.PayAtLocation -> stringResource(R.string.booking_payment_status_pay_at_location)
         is BookingStatus.Unknown -> key
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/bookings/compose/BookingStatusTag.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/bookings/compose/BookingStatusTag.kt
@@ -2,12 +2,13 @@ package com.woocommerce.android.ui.bookings.compose
 
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.res.colorResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
-import androidx.compose.ui.tooling.preview.Preview
 import com.woocommerce.android.R
 import com.woocommerce.android.ui.compose.component.WCTag
+import com.woocommerce.android.ui.compose.preview.LightDarkThemePreviews
 import com.woocommerce.android.ui.compose.theme.WooThemeWithBackground
 
 @Composable
@@ -17,7 +18,7 @@ fun BookingStatusTag(
 ) {
     WCTag(
         text = state.text(),
-        backgroundColor = colorResource(R.color.tagView_bg),
+        backgroundColor = state.backgroundColor(),
         textColor = colorResource(R.color.tagView_text),
         fontWeight = FontWeight.Normal,
         modifier = modifier
@@ -49,7 +50,15 @@ private fun BookingStatus.text(): String {
     }
 }
 
-@Preview
+@Composable
+fun BookingStatus.backgroundColor(): Color {
+    return when (this) {
+        BookingStatus.PayAtLocation -> R.color.tag_bg_booking_yellow
+        else -> R.color.tagView_bg
+    }.let { colorResource(it) }
+}
+
+@LightDarkThemePreviews
 @Composable
 private fun PaymentStatusTagPreview() {
     WooThemeWithBackground {
@@ -59,12 +68,12 @@ private fun PaymentStatusTagPreview() {
     }
 }
 
-@Preview(uiMode = android.content.res.Configuration.UI_MODE_NIGHT_YES)
+@LightDarkThemePreviews
 @Composable
-private fun PaymentStatusTagDarkPreview() {
+private fun PaymentStatusTagPayAtLocationPreview() {
     WooThemeWithBackground {
         BookingStatusTag(
-            state = BookingStatus.Complete
+            state = BookingStatus.PayAtLocation
         )
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/bookings/list/BookingListFiltersBuilder.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/bookings/list/BookingListFiltersBuilder.kt
@@ -19,7 +19,8 @@ class BookingListFiltersBuilder @Inject constructor(
      * See p1759398245019489-slack-C09FHQNQERG
      */
     fun BookingListTab.asDateRangeFilter(): BookingsFilterOption.DateRange? {
-        fun todayAtMidnight() = LocalDate.now(clock).atTime(LocalTime.MIDNIGHT).atOffset(ZoneOffset.UTC).toInstant()
+        fun todayAtMidnight() = LocalDate.now(clock).minusDays(1).atTime(LocalTime.MAX)
+            .atOffset(ZoneOffset.UTC).toInstant()
         fun todayAtEndOfDay() = LocalDate.now(clock).atTime(LocalTime.MAX).atOffset(ZoneOffset.UTC).toInstant()
 
         return when (this) {

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -4212,6 +4212,7 @@
     <string name="booking_payment_status_cancelled">Cancelled</string>
     <string name="booking_payment_status_confirmed">Confirmed</string>
     <string name="booking_payment_status_complete">Complete</string>
+    <string name="booking_payment_status_pay_at_location">Pay at location</string>
     <string name="booking_attendance_status_booked">Booked</string>
     <string name="booking_attendance_status_checked_in">Checked-in</string>
     <string name="booking_attendance_status_cancelled">Cancelled</string>

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/bookings/BookingMapperTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/bookings/BookingMapperTest.kt
@@ -228,7 +228,7 @@ class BookingMapperTest : BaseUnitTest() {
     }
 
     @Test
-    fun `given completed order with COD payment method, when mapped to summary model, then status is PayAtLocation`() {
+    fun `given processing order with COD payment method, when mapped to summary model, then status is PayAtLocation`() {
         // GIVEN
         val booking = sampleBooking().let { original ->
             val paymentInfo = BookingPaymentInfo(
@@ -239,7 +239,7 @@ class BookingMapperTest : BaseUnitTest() {
                 total = BigDecimal("55.00"),
                 totalTax = BigDecimal("0.00")
             )
-            val orderWithPayment = original.order.copy(paymentInfo = paymentInfo, status = "completed")
+            val orderWithPayment = original.order.copy(paymentInfo = paymentInfo, status = "processing")
             original.copy(order = orderWithPayment)
         }
 

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/bookings/BookingMapperTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/bookings/BookingMapperTest.kt
@@ -227,6 +227,29 @@ class BookingMapperTest : BaseUnitTest() {
             )
     }
 
+    @Test
+    fun `given completed order with COD payment method, when mapped to summary model, then status is PayAtLocation`() {
+        // GIVEN
+        val booking = sampleBooking().let { original ->
+            val paymentInfo = BookingPaymentInfo(
+                paymentMethodId = "cod",
+                paymentMethodTitle = "Cash on Delivery",
+                subtotal = BigDecimal("55.00"),
+                subtotalTax = BigDecimal("0.00"),
+                total = BigDecimal("55.00"),
+                totalTax = BigDecimal("0.00")
+            )
+            val orderWithPayment = original.order.copy(paymentInfo = paymentInfo, status = "completed")
+            original.copy(order = orderWithPayment)
+        }
+
+        // WHEN
+        val model = mapper.run { booking.toBookingSummaryModel() }
+
+        // THEN
+        assertThat(model.status).isEqualTo(BookingStatus.PayAtLocation)
+    }
+
     private fun sampleBooking(
         status: BookingEntity.Status = BookingEntity.Status.Confirmed,
         start: Instant = Instant.parse("2025-07-05T11:00:00Z"),

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/bookings/list/BookingListFilterBuilderTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/bookings/list/BookingListFilterBuilderTest.kt
@@ -21,7 +21,7 @@ class BookingListFilterBuilderTest {
         }
 
         assertThat(filter).isNotNull()
-        assertThat(filter?.after).isEqualTo(Instant.parse("2025-01-01T00:00:00+00:00"))
+        assertThat(filter?.after).isEqualTo(Instant.parse("2024-12-31T23:59:59.999999999Z"))
         assertThat(filter?.before).isEqualTo(Instant.parse("2025-01-01T23:59:59.999999999+00:00"))
     }
 


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

<!-- Id number of the Linear issue this PR addresses, e.g., WOOMOB-373. -->

WOOMOB-1385

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

As per the discussion p1760521762369029/1760520041.270299-slack-C09FHQNQERG, this PR adds the `Pay at location` status for the booking based on the order status and the payment method. 

> [!NOTE]
> There's an extra commit https://github.com/woocommerce/woocommerce-android/commit/b5a61e62161343300cef1cf8212a2694fb031fcf that fixes a bug in the Today tab filtering logic. The `start_date_after` is not inclusive, so Bookings that start at 12:00 AM are not included in the response.

### Steps to reproduce
<!-- Step-by-step testing instructions. For new user flows, consider instead stating the goal of the workflow and see if your PR reviewer can accomplish the workflow without specific steps! -->

1. Create a booking 
2. Make sure the order is not completed and set the payment method to Cash on delivery
3. Open the app
4. Go to the bookings tab and find your booking
5. Confirm the badge shows `Pay at location`

### Testing information
<!-- This is your opportunity to break out individual scenarios that need testing (when necessary) and/or include a checklist for the reviewer to go through. Consider documenting the following from your own completed testing: devices used, alternate workflows, edge cases, affected areas, critical flows, areas not tested, and any remaining unknowns. Provide feedback on this new section of the PR template through Sept 30, 2024 to Apps Quality; additional context here: p91TBi-b8z-p2#comment-12036 -->

To test the bug with date filtering, create a booking that starts today at 12:00 AM - I used the room rental template for that. Open the Today tab and verify the booking is there.

### The tests that have been performed
<!-- To give the reviewer an idea of what could be missed in terms of testing -->

The above.

### Images/gif
<!-- Include before and after images or gifs when appropriate. -->

<img width="1280" height="2856" alt="Screenshot_20251015_130950" src="https://github.com/user-attachments/assets/28ee394c-335d-49e5-90f0-3e89a48afa09" />


- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->