### PR TITLE
[CIAB] Update search empty state message to match the current design

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/bookings/list/BookingListScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/bookings/list/BookingListScreen.kt
@@ -58,7 +58,6 @@ import com.woocommerce.android.ui.bookings.compose.BookingAttendanceStatus
 import com.woocommerce.android.ui.bookings.compose.BookingStatus
 import com.woocommerce.android.ui.bookings.compose.BookingSummary
 import com.woocommerce.android.ui.bookings.compose.BookingSummaryModel
-import com.woocommerce.android.ui.compose.annotatedStringRes
 import com.woocommerce.android.ui.compose.component.InfiniteListHandler
 import com.woocommerce.android.ui.compose.component.Toolbar
 import com.woocommerce.android.ui.compose.component.WCColoredButton
@@ -319,7 +318,7 @@ private fun EmptyView(
 
         if (state.searchState.query?.isNotEmpty() == true) {
             EmptySearchResultsView(
-                query = state.searchState.query,
+                areFiltersActive = state.areFiltersActive,
                 modifier = innerEmptyViewModifier
             )
         } else {
@@ -398,7 +397,10 @@ private fun EmptyListView(
 }
 
 @Composable
-private fun EmptySearchResultsView(query: String, modifier: Modifier) {
+private fun EmptySearchResultsView(
+    areFiltersActive: Boolean,
+    modifier: Modifier
+) {
     Column(
         horizontalAlignment = Alignment.CenterHorizontally,
         verticalArrangement = Arrangement.Center,
@@ -412,7 +414,13 @@ private fun EmptySearchResultsView(query: String, modifier: Modifier) {
         Spacer(modifier = Modifier.height(24.dp))
 
         Text(
-            text = annotatedStringRes(R.string.bookings_search_no_results, query),
+            text = stringResource(
+                id = if (areFiltersActive) {
+                    R.string.bookings_search_no_results_with_filters
+                } else {
+                    R.string.bookings_search_no_results_without_filters
+                }
+            ),
             style = MaterialTheme.typography.titleLarge,
             fontWeight = FontWeight.Normal,
             textAlign = TextAlign.Center

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -4179,7 +4179,8 @@
     <string name="bookings_empty_state_description_default">Incoming bookings will appear here, where you can view and manage them.</string>
     <string name="bookings_empty_state_description_today">You don’t have any appointments or events scheduled for today.</string>
     <string name="bookings_empty_state_description_upcoming">You don’t have any future appointments or events scheduled scheduled yet.</string>
-    <string name="bookings_search_no_results"><![CDATA[We’re sorry, we couldn’t find results for <b>\"%s\"</b>]]></string>
+    <string name="bookings_search_no_results_without_filters">We couldn’t find any bookings with that name — try adjusting your search term to see more results.</string>
+    <string name="bookings_search_no_results_with_filters">We couldn’t find any bookings with that name — try adjusting your search term or your filters to see more results.</string>
     <string name="bookings_empty_state_description_with_filters">No bookings match your filters. Try adjusting them to see more results.</string>
     <string name="bookings_empty_state_change_filters_button">Change filters</string>
     <string name="bookings_empty_state_clear_filters_button">Clear filters</string>


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

<!-- Id number of the Linear issue this PR addresses, e.g., WOOMOB-373. -->
Closes WOOMOB-1361

### Description
After merging the previous PR about empty state, the design was updated with a minor change, and this PR aligns with the new update.

### Steps to reproduce
As this is a small change, code review should be sufficient, along with checking the attached screenshots.

### Testing information
- 

### The tests that have been performed
Tested the search empty to take the screenshots

### Images/gif
| Without filters | With filters |
| --- | --- |
| <img width="1080" height="2400" alt="Screenshot_20251015_141110" src="https://github.com/user-attachments/assets/9a7a0dcf-47b1-44c6-a84b-d6b94e00bc2e" /> | <img width="1080" height="2400" alt="Screenshot_20251015_141622" src="https://github.com/user-attachments/assets/6c10f8c9-22e2-4ac8-bb1b-1d96323611e3" /> |


- [ ] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->