### PR TITLE
[WOOMOB-1209] Disable periodic worker for sites with too large catalog

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/localcatalog/WooPosLocalCatalogSyncWorker.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/localcatalog/WooPosLocalCatalogSyncWorker.kt
@@ -8,6 +8,7 @@ import com.woocommerce.android.tools.SelectedSite
 import com.woocommerce.android.ui.login.AccountRepository
 import com.woocommerce.android.ui.woopos.common.util.WooPosLogWrapper
 import com.woocommerce.android.ui.woopos.featureflags.WooPosLocalCatalogM1Enabled
+import com.woocommerce.android.ui.woopos.util.datastore.WooPosPreferencesRepository
 import dagger.assisted.Assisted
 import dagger.assisted.AssistedInject
 
@@ -23,6 +24,7 @@ constructor(
     private val syncRepository: WooPosLocalCatalogSyncRepository,
     private val logger: WooPosLogWrapper,
     private val featureFlagM1Enabled: WooPosLocalCatalogM1Enabled,
+    private val preferencesRepository: WooPosPreferencesRepository,
 ) : CoroutineWorker(appContext, workerParams) {
 
     companion object {
@@ -43,6 +45,11 @@ constructor(
         val site = selectedSite.getOrNull()
         if (site == null) {
             logger.e("No selected WooCommerce site found, skipping local catalog sync")
+            return Result.failure()
+        }
+
+        if (!preferencesRepository.isPeriodicSyncEnabledForSite(site.siteId)) {
+            logger.e("Periodic sync permanently disabled for site ${site.url}, skipping local catalog sync.")
             return Result.failure()
         }
 
@@ -72,8 +79,11 @@ constructor(
             }
 
             is PosLocalCatalogSyncResult.Failure.CatalogTooLarge -> {
-                // TBD Local Catalog - stop future syncs for this site if catalog too large
-                logger.e("Local catalog FULL sync failed: ${fullSyncResult.error}.")
+                preferencesRepository.disablePeriodicSyncForSite(site.siteId)
+                logger.e(
+                    "Local catalog FULL sync failed: ${fullSyncResult.error}. Permanently " +
+                        "disabling periodic sync for site ${site.siteId}."
+                )
                 Result.failure()
             }
         }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/localcatalog/WooPosLocalCatalogSyncWorker.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/localcatalog/WooPosLocalCatalogSyncWorker.kt
@@ -82,7 +82,7 @@ constructor(
                 preferencesRepository.disablePeriodicSyncForSite(site.siteId)
                 logger.e(
                     "Local catalog FULL sync failed: ${fullSyncResult.error}. Permanently " +
-                        "disabling periodic sync for site ${site.siteId}."
+                        "disabling periodic sync for site ${site.url}."
                 )
                 Result.failure()
             }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/localcatalog/WooPosLocalCatalogSyncWorker.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/localcatalog/WooPosLocalCatalogSyncWorker.kt
@@ -44,12 +44,12 @@ constructor(
 
         val site = selectedSite.getOrNull()
         if (site == null) {
-            logger.e("No selected WooCommerce site found, skipping local catalog sync")
+            logger.w("No selected WooCommerce site found, skipping local catalog sync")
             return Result.failure()
         }
 
         if (!preferencesRepository.isPeriodicSyncEnabledForSite(site.siteId)) {
-            logger.e("Periodic sync permanently disabled for site ${site.url}, skipping local catalog sync.")
+            logger.w("Periodic sync permanently disabled for site ${site.url}, skipping local catalog sync.")
             return Result.failure()
         }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/util/datastore/WooPosPreferencesRepository.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/util/datastore/WooPosPreferencesRepository.kt
@@ -7,6 +7,7 @@ import androidx.datastore.preferences.core.edit
 import androidx.datastore.preferences.core.stringPreferencesKey
 import com.woocommerce.android.tools.SelectedSite
 import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.map
 import javax.inject.Inject
 
@@ -78,6 +79,19 @@ class WooPosPreferencesRepository @Inject constructor(
     suspend fun setAllowCellularDataUpdate(allow: Boolean) {
         dataStore.edit { preferences ->
             preferences[allowCellularDataUpdateKey] = allow
+        }
+    }
+
+    suspend fun isPeriodicSyncEnabledForSite(siteId: Long): Boolean {
+        val key = booleanPreferencesKey("pos_periodic_sync_enabled_$siteId")
+        val preferences = dataStore.data.map { it[key] ?: true }.first()
+        return preferences
+    }
+
+    suspend fun disablePeriodicSyncForSite(siteId: Long) {
+        val key = booleanPreferencesKey("pos_periodic_sync_enabled_$siteId")
+        dataStore.edit { preferences ->
+            preferences[key] = false
         }
     }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/util/datastore/WooPosPreferencesRepository.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/util/datastore/WooPosPreferencesRepository.kt
@@ -83,18 +83,20 @@ class WooPosPreferencesRepository @Inject constructor(
     }
 
     suspend fun isPeriodicSyncEnabledForSite(siteId: Long): Boolean {
-        val key = booleanPreferencesKey("pos_periodic_sync_enabled_$siteId")
+        val key = buildPeriodicSyncEnabledKey(siteId)
         val preferences = dataStore.data.map { it[key] ?: true }.first()
         return preferences
     }
 
     suspend fun disablePeriodicSyncForSite(siteId: Long) {
-        val key = booleanPreferencesKey("pos_periodic_sync_enabled_$siteId")
+        val key = buildPeriodicSyncEnabledKey(siteId)
         dataStore.edit { preferences ->
             preferences[key] = false
         }
     }
 
+    private fun buildPeriodicSyncEnabledKey(siteId: Long): Preferences.Key<Boolean> =
+        booleanPreferencesKey("pos_periodic_sync_enabled_$siteId")
     private fun buildSiteSpecificKey(key: String): Preferences.Key<String> =
         stringPreferencesKey("${selectedSite.getOrNull()?.siteId}-$key")
 

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/localcatalog/WooPosLocalCatalogSyncWorkerTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/localcatalog/WooPosLocalCatalogSyncWorkerTest.kt
@@ -16,6 +16,7 @@ import org.junit.Test
 import org.mockito.kotlin.any
 import org.mockito.kotlin.eq
 import org.mockito.kotlin.mock
+import org.mockito.kotlin.never
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
 import org.wordpress.android.fluxc.model.SiteModel
@@ -150,8 +151,8 @@ class WooPosLocalCatalogSyncWorkerTest : BaseUnitTest() {
 
         // THEN
         assertThat(result).isEqualTo(ListenableWorker.Result.failure())
-        verify(syncRepository, org.mockito.kotlin.never()).syncLocalCatalogFull(any())
-        verify(syncRepository, org.mockito.kotlin.never()).syncLocalCatalogIncremental(any())
+        verify(syncRepository, never()).syncLocalCatalogFull(any())
+        verify(syncRepository, never()).syncLocalCatalogIncremental(any())
     }
 
     @Test
@@ -301,7 +302,7 @@ class WooPosLocalCatalogSyncWorkerTest : BaseUnitTest() {
         // THEN
         assertThat(result).isEqualTo(ListenableWorker.Result.retry())
         verify(syncRepository).syncLocalCatalogFull(eq(site))
-        verify(syncRepository, org.mockito.kotlin.never()).syncLocalCatalogIncremental(any())
+        verify(syncRepository, never()).syncLocalCatalogIncremental(any())
     }
 
     @Test
@@ -318,7 +319,7 @@ class WooPosLocalCatalogSyncWorkerTest : BaseUnitTest() {
         // THEN
         assertThat(result).isEqualTo(ListenableWorker.Result.failure())
         verify(syncRepository).syncLocalCatalogFull(eq(site))
-        verify(syncRepository, org.mockito.kotlin.never()).syncLocalCatalogIncremental(any())
+        verify(syncRepository, never()).syncLocalCatalogIncremental(any())
     }
 
     @Test
@@ -348,7 +349,7 @@ class WooPosLocalCatalogSyncWorkerTest : BaseUnitTest() {
         worker.doWork()
 
         // THEN
-        verify(preferencesRepository, org.mockito.kotlin.never()).disablePeriodicSyncForSite(any())
+        verify(preferencesRepository, never()).disablePeriodicSyncForSite(any())
     }
 
     @Test
@@ -365,6 +366,6 @@ class WooPosLocalCatalogSyncWorkerTest : BaseUnitTest() {
         worker.doWork()
 
         // THEN
-        verify(preferencesRepository, org.mockito.kotlin.never()).disablePeriodicSyncForSite(any())
+        verify(preferencesRepository, never()).disablePeriodicSyncForSite(any())
     }
 }

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/localcatalog/WooPosLocalCatalogSyncWorkerTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/localcatalog/WooPosLocalCatalogSyncWorkerTest.kt
@@ -61,6 +61,7 @@ class WooPosLocalCatalogSyncWorkerTest : BaseUnitTest() {
         whenever(accountRepository.isUserLoggedIn()).thenReturn(true)
         whenever(selectedSite.getOrNull()).thenReturn(site)
         whenever(featureFlagM1Enabled.invoke()).thenReturn(true)
+        whenever(preferencesRepository.isPeriodicSyncEnabledForSite(any())).thenReturn(true)
         whenever(syncRepository.syncLocalCatalogFull(site))
             .thenReturn(successResponse)
         whenever(syncRepository.syncLocalCatalogIncremental(site))
@@ -135,6 +136,22 @@ class WooPosLocalCatalogSyncWorkerTest : BaseUnitTest() {
 
         // THEN
         assertThat(result).isEqualTo(ListenableWorker.Result.failure())
+    }
+
+    @Test
+    fun `when periodic sync is disabled for site, then returns failure and skips sync`() = testBlocking {
+        // GIVEN
+        whenever(preferencesRepository.isPeriodicSyncEnabledForSite(site.siteId)).thenReturn(false)
+
+        val worker = createWorker()
+
+        // WHEN
+        val result = worker.doWork()
+
+        // THEN
+        assertThat(result).isEqualTo(ListenableWorker.Result.failure())
+        verify(syncRepository, org.mockito.kotlin.never()).syncLocalCatalogFull(any())
+        verify(syncRepository, org.mockito.kotlin.never()).syncLocalCatalogIncremental(any())
     }
 
     @Test
@@ -302,5 +319,52 @@ class WooPosLocalCatalogSyncWorkerTest : BaseUnitTest() {
         assertThat(result).isEqualTo(ListenableWorker.Result.failure())
         verify(syncRepository).syncLocalCatalogFull(eq(site))
         verify(syncRepository, org.mockito.kotlin.never()).syncLocalCatalogIncremental(any())
+    }
+
+    @Test
+    fun `when sync fails with catalog too large, then disables periodic sync for site`() = testBlocking {
+        // GIVEN
+        whenever(syncRepository.syncLocalCatalogFull(site))
+            .thenReturn(catalogTooLargeResponse)
+
+        val worker = createWorker()
+
+        // WHEN
+        worker.doWork()
+
+        // THEN
+        verify(preferencesRepository).disablePeriodicSyncForSite(site.siteId)
+    }
+
+    @Test
+    fun `when sync fails with unexpected error, then does not disable periodic sync`() = testBlocking {
+        // GIVEN
+        whenever(syncRepository.syncLocalCatalogFull(site))
+            .thenReturn(PosLocalCatalogSyncResult.Failure.UnexpectedError("Network error"))
+
+        val worker = createWorker()
+
+        // WHEN
+        worker.doWork()
+
+        // THEN
+        verify(preferencesRepository, org.mockito.kotlin.never()).disablePeriodicSyncForSite(any())
+    }
+
+    @Test
+    fun `when sync succeeds, then does not disable periodic sync`() = testBlocking {
+        // GIVEN
+        whenever(syncRepository.syncLocalCatalogFull(site))
+            .thenReturn(successResponse)
+        whenever(syncRepository.syncLocalCatalogIncremental(site))
+            .thenReturn(incrementalSuccessResponse)
+
+        val worker = createWorker()
+
+        // WHEN
+        worker.doWork()
+
+        // THEN
+        verify(preferencesRepository, org.mockito.kotlin.never()).disablePeriodicSyncForSite(any())
     }
 }

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/localcatalog/WooPosLocalCatalogSyncWorkerTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/localcatalog/WooPosLocalCatalogSyncWorkerTest.kt
@@ -7,6 +7,7 @@ import com.woocommerce.android.tools.SelectedSite
 import com.woocommerce.android.ui.login.AccountRepository
 import com.woocommerce.android.ui.woopos.common.util.WooPosLogWrapper
 import com.woocommerce.android.ui.woopos.featureflags.WooPosLocalCatalogM1Enabled
+import com.woocommerce.android.ui.woopos.util.datastore.WooPosPreferencesRepository
 import com.woocommerce.android.viewmodel.BaseUnitTest
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import org.assertj.core.api.Assertions.assertThat
@@ -30,6 +31,7 @@ class WooPosLocalCatalogSyncWorkerTest : BaseUnitTest() {
     private lateinit var site: SiteModel
     private var logger: WooPosLogWrapper = mock()
     private var featureFlagM1Enabled: WooPosLocalCatalogM1Enabled = mock()
+    private var preferencesRepository: WooPosPreferencesRepository = mock()
 
     private val successResponse = PosLocalCatalogSyncResult.Success(
         productsSynced = 10,
@@ -74,6 +76,7 @@ class WooPosLocalCatalogSyncWorkerTest : BaseUnitTest() {
             syncRepository = syncRepository,
             logger = logger,
             featureFlagM1Enabled = featureFlagM1Enabled,
+            preferencesRepository = preferencesRepository,
         )
     }
 


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

<!-- Id number of the Linear issue this PR addresses, e.g., WOOMOB-373. -->

#WOOMOB-1209

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

This PR adds logic that disables periodic Local catalog sync for sites with a catalog that is too large. We simply store a flag when the catalog sync fails with `CatalogTooLarge` exception and skip all future syncs.

I considered cancelling the scheduled job in these cases, but since we use a single worker for all sites, I opted for this approach instead.


### Testing information
<!-- This is your opportunity to break out individual scenarios that need testing (when necessary) and/or include a checklist for the reviewer to go through. Consider documenting the following from your own completed testing: devices used, alternate workflows, edge cases, affected areas, critical flows, areas not tested, and any remaining unknowns. Provide feedback on this new section of the PR template through Sept 30, 2024 to Apps Quality; additional context here: p91TBi-b8z-p2#comment-12036 -->

1. Clear app data
2. Login with a store that has more than 1000 products.
3. Observe logcat and notice the sync fails
4. Check shared preferences and verify the flag is `false` for the site - alternatively, you can modify how often is the worker run and wait until it runs again. Having said that, keep in mind that usually the OS won't let you run the worker more often than once in 15 minutes.

### The tests that have been performed
<!-- To give the reviewer an idea of what could be missed in terms of testing -->

I have tested the above - using the approach where I reduced the period for the worker from 24 hours to 15 minutes and I waited.

### Images/gif
<!-- Include before and after images or gifs when appropriate. -->
N/A

- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->