### PR TITLE
Remove buggy orderby parameter

### DIFF
--- a/libs/fluxc-plugin/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/product/pos/WooPosProductRestClient.kt
+++ b/libs/fluxc-plugin/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/product/pos/WooPosProductRestClient.kt
@@ -69,7 +69,6 @@ class WooPosProductRestClient @Inject constructor(
             "per_page" to pageSize.toString(),
             "page" to page.toString(),
             "_fields" to VARIATIONS_FIELDS,
-            "orderby" to "modified",
             ).also {
             if (modifiedAfter.isNullOrBlank().not()) {
                 it["modified_after"] = modifiedAfter
@@ -157,7 +156,6 @@ class WooPosProductRestClient @Inject constructor(
             "per_page" to pageSize.toString(),
             "offset" to offset.toString(),
             "_fields" to fields,
-            "orderby" to "modified",
             ).also {
             modifiedAfter?.let { modified ->
                 it["modified_after"] = modified


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

<!-- Id number of the Linear issue this PR addresses, e.g., WOOMOB-373. -->

#WOOMOB-1520

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

This PR removes the `orderby` parameter from /products and /variations requests. The orderby parameter on these endpoints contains a bug - more info pdfdoF-8dQ-p2#comment-9528. However, as we found out, we are unnecessarily adding `orderby` parameter to our requests and this parameter isn't necessary - we always fetch all products so the order doesn't matter. This change also brings platform consistency with iOS.

### Steps to reproduce
<!-- Step-by-step testing instructions. For new user flows, consider instead stating the goal of the workflow and see if your PR reviewer can accomplish the workflow without specific steps! -->

Before this PR
1. Use WooCommerce 10.2.2 or **older** (like 9.9 or so).
2. Make sure you there are variations with identical `modified` date (e.g. generate them using Smooth Generator)
3. Login
4. Wait for the Local Catalog worker to run
5. Check database and verify the number of variations in the local database is lower than the number of variations on the store.

Let me know and I can invite you to my store where the bug is 100% reproducible.

### Testing information
<!-- This is your opportunity to break out individual scenarios that need testing (when necessary) and/or include a checklist for the reviewer to go through. Consider documenting the following from your own completed testing: devices used, alternate workflows, edge cases, affected areas, critical flows, areas not tested, and any remaining unknowns. Provide feedback on this new section of the PR template through Sept 30, 2024 to Apps Quality; additional context here: p91TBi-b8z-p2#comment-12036 -->

Repeat the above steps and verify the number in the local database matches the store.

### The tests that have been performed
<!-- To give the reviewer an idea of what could be missed in terms of testing -->

The above.

### Images/gif
<!-- Include before and after images or gifs when appropriate. -->

- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->