### PR TITLE
[WOOMOB-1443] Filter out unsupported products and variations in Local Catalog

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/common/data/WooPosProductsTypesFilterConfig.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/common/data/WooPosProductsTypesFilterConfig.kt
@@ -6,6 +6,7 @@ import org.wordpress.android.fluxc.store.WCProductStore.DownloadableOptions
 import org.wordpress.android.fluxc.store.WCProductStore.ProductFilterOption
 import javax.inject.Inject
 
+// Note: For the Local Catalog feature, the filtering is done locally in WooPosProductsDao.
 class WooPosProductsTypesFilterConfig @Inject constructor() {
     val filters: Map<ProductFilterOption, String> =
         mapOf(

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/common/data/WooPosVariationsTypesFilterConfig.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/common/data/WooPosVariationsTypesFilterConfig.kt
@@ -4,6 +4,7 @@ import org.wordpress.android.fluxc.store.WCProductStore.DownloadableOptions
 import org.wordpress.android.fluxc.store.WCProductStore.VariationFilterOption
 import javax.inject.Inject
 
+// Note: For the Local Catalog feature, the filtering is done locally in WooPosVariationsDao.
 class WooPosVariationsTypesFilterConfig @Inject constructor() {
     val filters: Map<VariationFilterOption, String> =
         mapOf(

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/items/variations/WooPosVariationsInDbDataSource.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/items/variations/WooPosVariationsInDbDataSource.kt
@@ -36,15 +36,11 @@ class WooPosVariationsInDbDataSource @Inject constructor(
         forceRefresh: Boolean
     ): Flow<FetchResult> = getVariationsFromDatabaseFlow(productId)
         .map { variations ->
-            FetchResult.Remote(Result.success(variations.applyFilter()))
+            FetchResult.Remote(Result.success(variations))
         }
         .flowOn(Dispatchers.IO)
 
     override suspend fun loadMore(productId: Long): Result<List<WooPosVariation>> = withContext(Dispatchers.IO) {
         Result.success(emptyList())
     }
-}
-
-private fun List<WooPosVariation>.applyFilter(): List<WooPosVariation> {
-    return filter { !it.isDownloadable }
 }

--- a/libs/fluxc-plugin/src/main/kotlin/org/wordpress/android/fluxc/persistence/dao/pos/WooPosProductsDao.kt
+++ b/libs/fluxc-plugin/src/main/kotlin/org/wordpress/android/fluxc/persistence/dao/pos/WooPosProductsDao.kt
@@ -10,8 +10,21 @@ import org.wordpress.android.fluxc.persistence.entity.pos.WooPosProductEntity
 
 @Dao
 abstract class WooPosProductsDao {
-    @Query("SELECT * FROM PosProductEntity WHERE localSiteId = :localSiteId AND status = 'publish' " +
-        "AND (type = 'simple' OR type = 'variable') AND downloadable = 0 ORDER BY LOWER(name)")
+    companion object {
+        private const val PRODUCT_STATUS_PUBLISH = "publish"
+        private const val PRODUCT_TYPE_SIMPLE = "simple"
+        private const val PRODUCT_TYPE_VARIABLE = "variable"
+        private const val DOWNLOADABLE_FALSE = 0
+    }
+
+    @Query(
+        "SELECT * FROM PosProductEntity " +
+            "WHERE localSiteId = :localSiteId " +
+            "AND status = '$PRODUCT_STATUS_PUBLISH' " +
+            "AND (type = '$PRODUCT_TYPE_SIMPLE' OR type = '$PRODUCT_TYPE_VARIABLE') " +
+            "AND downloadable = '$DOWNLOADABLE_FALSE' " +
+            "ORDER BY LOWER(name)"
+    )
     abstract fun observeAllProducts(localSiteId: LocalId): Flow<List<WooPosProductEntity>>
 
     @Query("SELECT * FROM PosProductEntity WHERE localSiteId = :localSiteId AND remoteId = :remoteId")

--- a/libs/fluxc-plugin/src/main/kotlin/org/wordpress/android/fluxc/persistence/dao/pos/WooPosProductsDao.kt
+++ b/libs/fluxc-plugin/src/main/kotlin/org/wordpress/android/fluxc/persistence/dao/pos/WooPosProductsDao.kt
@@ -10,7 +10,8 @@ import org.wordpress.android.fluxc.persistence.entity.pos.WooPosProductEntity
 
 @Dao
 abstract class WooPosProductsDao {
-    @Query("SELECT * FROM PosProductEntity WHERE localSiteId = :localSiteId ORDER BY LOWER(name)")
+    @Query("SELECT * FROM PosProductEntity WHERE localSiteId = :localSiteId AND status = 'publish' " +
+        "AND (type = 'simple' OR type = 'variable') AND downloadable = 0 ORDER BY LOWER(name)")
     abstract fun observeAllProducts(localSiteId: LocalId): Flow<List<WooPosProductEntity>>
 
     @Query("SELECT * FROM PosProductEntity WHERE localSiteId = :localSiteId AND remoteId = :remoteId")

--- a/libs/fluxc-plugin/src/main/kotlin/org/wordpress/android/fluxc/persistence/dao/pos/WooPosVariationsDao.kt
+++ b/libs/fluxc-plugin/src/main/kotlin/org/wordpress/android/fluxc/persistence/dao/pos/WooPosVariationsDao.kt
@@ -10,9 +10,19 @@ import org.wordpress.android.fluxc.persistence.entity.pos.WooPosVariationEntity
 
 @Dao
 abstract class WooPosVariationsDao {
+    companion object {
+        private const val VARIATION_STATUS_PUBLISH = "publish"
+        private const val DOWNLOADABLE_FALSE = 0
+    }
 
-    @Query("SELECT * FROM PosVariationEntity WHERE localSiteId = :localSiteId AND remoteProductId = :productId " +
-        "AND status = 'publish' AND downloadable = 0 ORDER BY variationName ASC")
+    @Query(
+        "SELECT * FROM PosVariationEntity " +
+            "WHERE localSiteId = :localSiteId " +
+            "AND remoteProductId = :productId " +
+            "AND status = '$VARIATION_STATUS_PUBLISH' " +
+            "AND downloadable = '$DOWNLOADABLE_FALSE' " +
+            "ORDER BY variationName ASC"
+    )
     abstract fun observeVariationsForProduct(
         localSiteId: Int,
         productId: Long

--- a/libs/fluxc-plugin/src/main/kotlin/org/wordpress/android/fluxc/persistence/dao/pos/WooPosVariationsDao.kt
+++ b/libs/fluxc-plugin/src/main/kotlin/org/wordpress/android/fluxc/persistence/dao/pos/WooPosVariationsDao.kt
@@ -11,7 +11,8 @@ import org.wordpress.android.fluxc.persistence.entity.pos.WooPosVariationEntity
 @Dao
 abstract class WooPosVariationsDao {
 
-    @Query("SELECT * FROM PosVariationEntity WHERE localSiteId = :localSiteId AND remoteProductId = :productId ORDER BY variationName ASC")
+    @Query("SELECT * FROM PosVariationEntity WHERE localSiteId = :localSiteId AND remoteProductId = :productId " +
+        "AND status = 'publish' AND downloadable = 0 ORDER BY variationName ASC")
     abstract fun observeVariationsForProduct(
         localSiteId: Int,
         productId: Long


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

<!-- Id number of the Linear issue this PR addresses, e.g., WOOMOB-373. -->

#WOOMOB-1443

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

This PR filters out unsupported products and variations in the Local Catalog. Variations were filtered out even before, but they are filtered out on the database layer now.

### Testing information
<!-- This is your opportunity to break out individual scenarios that need testing (when necessary) and/or include a checklist for the reviewer to go through. Consider documenting the following from your own completed testing: devices used, alternate workflows, edge cases, affected areas, critical flows, areas not tested, and any remaining unknowns. Provide feedback on this new section of the PR template through Sept 30, 2024 to Apps Quality; additional context here: p91TBi-b8z-p2#comment-12036 -->

1. Verify downloadable products are not visible in the POS
2. Verify downloadable variation isn't visible in the POS
3. Verify product with non-published status isn't visible in the POS

### The tests that have been performed
<!-- To give the reviewer an idea of what could be missed in terms of testing -->

The above

### Images/gif
<!-- Include before and after images or gifs when appropriate. -->
N/A

- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->