### PR TITLE
[Compose component] - Add loading param to WCOutlinedButton

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/bookings/compose/BookingAppointmentDetails.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/bookings/compose/BookingAppointmentDetails.kt
@@ -8,11 +8,8 @@ import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.size
 import androidx.compose.material3.ButtonDefaults
-import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.HorizontalDivider
-import androidx.compose.material3.LocalContentColor
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
@@ -93,16 +90,9 @@ fun BookingAppointmentDetails(
                 ),
                 onClick = onCancelBooking,
                 enabled = model.cancelButtonEnabled,
-            ) {
-                if (model.cancelInProgressShown) {
-                    CircularProgressIndicator(
-                        color = LocalContentColor.current,
-                        modifier = Modifier.size(24.dp)
-                    )
-                } else {
-                    Text(text = stringResource(R.string.booking_details_cancel_booking_button))
-                }
-            }
+                text = stringResource(R.string.booking_details_cancel_booking_button),
+                loading = model.cancelInProgressShown,
+            )
             HorizontalDivider(thickness = 0.5.dp)
         }
     }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/compose/component/Buttons.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/compose/component/Buttons.kt
@@ -191,9 +191,9 @@ fun WCOutlinedButton(
     interactionSource: MutableInteractionSource? = null,
 ) {
     WCOutlinedButton(
-        onClick = onClick,
+        onClick = { if (!loading) onClick() },
         modifier = modifier,
-        enabled = enabled && !loading,
+        enabled = enabled,
         shape = shape,
         colors = colors,
         border = border,

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/compose/component/Buttons.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/compose/component/Buttons.kt
@@ -123,10 +123,8 @@ fun WCColoredButton(
     ) {
         Box {
             if (loading) {
-                CircularProgressIndicator(
-                    color = LocalContentColor.current,
+                ButtonCircularProgressIndicator(
                     modifier = Modifier
-                        .size(24.dp)
                         .align(Alignment.Center)
                 )
             }
@@ -185,6 +183,7 @@ fun WCOutlinedButton(
     leadingIcon: @Composable (() -> Unit)? = null,
     trailingIcon: @Composable (() -> Unit)? = null,
     enabled: Boolean = true,
+    loading: Boolean = false,
     shape: Shape = MaterialTheme.shapes.small,
     colors: ButtonColors = ButtonDefaults.wcOutlinedButtonColors(),
     border: BorderStroke? = ButtonDefaults.wcOutlinedButtonBorder(enabled),
@@ -194,21 +193,28 @@ fun WCOutlinedButton(
     WCOutlinedButton(
         onClick = onClick,
         modifier = modifier,
-        enabled = enabled,
+        enabled = enabled && !loading,
         shape = shape,
         colors = colors,
         border = border,
         contentPadding = contentPadding,
         interactionSource = interactionSource
     ) {
-        if (leadingIcon != null) {
-            leadingIcon()
-            Spacer(modifier = Modifier.width(dimensionResource(id = R.dimen.minor_100)))
-        }
-        Text(text = text)
-        if (trailingIcon != null) {
-            Spacer(modifier = Modifier.width(dimensionResource(id = R.dimen.minor_100)))
-            trailingIcon()
+        if (loading) {
+            ButtonCircularProgressIndicator(
+                modifier = Modifier
+                    .align(Alignment.CenterVertically)
+            )
+        } else {
+            if (leadingIcon != null) {
+                leadingIcon()
+                Spacer(modifier = Modifier.width(dimensionResource(id = R.dimen.minor_100)))
+            }
+            Text(text = text)
+            if (trailingIcon != null) {
+                Spacer(modifier = Modifier.width(dimensionResource(id = R.dimen.minor_100)))
+                trailingIcon()
+            }
         }
     }
 }
@@ -415,6 +421,15 @@ private fun ProvideMaterial3CompositionForMaterial2(
     }
 }
 
+@Composable
+private fun ButtonCircularProgressIndicator(modifier: Modifier = Modifier) {
+    CircularProgressIndicator(
+        color = LocalContentColor.current,
+        modifier = modifier
+            .size(24.dp)
+    )
+}
+
 @LightDarkThemePreviews
 @Composable
 private fun ButtonsPreview() {
@@ -459,6 +474,11 @@ private fun ButtonsPreview() {
                     )
                 }
             )
+            WCColoredButton(
+                text = "Button Loading",
+                loading = true,
+                onClick = {},
+            )
 
             WCOutlinedButton(onClick = {}) {
                 Text(text = "Outlined Button")
@@ -474,6 +494,11 @@ private fun ButtonsPreview() {
                 trailingIcon = {
                     Icon(imageVector = Icons.Default.Check, contentDescription = null, modifier = Modifier.size(16.dp))
                 }
+            )
+            WCOutlinedButton(
+                text = "Outlined Button Loading",
+                loading = true,
+                onClick = {},
             )
 
             WCTextButton(onClick = {}) {


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

<!-- Id number of the Linear issue this PR addresses, e.g., WOOMOB-373. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

As per the [request](https://github.com/woocommerce/woocommerce-android/pull/14752#discussion_r2432557675) this PR add the `loading` param to the WCOutlinedButton. 

>If you do, please also make sure to update WCColoredButton's implementation to pass enabled = enabled && !loading, to make sure we disable button during loading.

I didn't do that, because this changes the button appearance in loading state, here's the comparison:

| Current | Disabled |
|---|---|
| <img width="225" height="57" alt="Screenshot 2025-10-16 at 11 23 49" src="https://github.com/user-attachments/assets/1e598fa2-1890-4ed3-bb97-b7ddc9c1d428" /> | <img width="227" height="59" alt="Screenshot 2025-10-16 at 11 24 35" src="https://github.com/user-attachments/assets/2cb4da02-1c7f-44f0-8108-e778d170c11c" /> |

I can do it, but this feels like a bigger decision.

### Steps to reproduce
<!-- Step-by-step testing instructions. For new user flows, consider instead stating the goal of the workflow and see if your PR reviewer can accomplish the workflow without specific steps! -->

Follow the steps from https://github.com/woocommerce/woocommerce-android/pull/14752 to test the button in the app. You can also launch the Preview with all the buttons.

### Testing information

The default loading param value is false, so this should be a safe change.

### The tests that have been performed
<!-- To give the reviewer an idea of what could be missed in terms of testing -->
The above.

### Images/gif
<!-- Include before and after images or gifs when appropriate. -->
<img width="408" height="92" alt="Screenshot 2025-10-16 at 11 35 14" src="https://github.com/user-attachments/assets/acc63f46-d025-47e2-b603-dac49a72b8d6" />


- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->