### PR TITLE
[POS Orders] Details State + View Model

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/orders/WooPosOrdersDetails.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/orders/WooPosOrdersDetails.kt
@@ -1,0 +1,283 @@
+package com.woocommerce.android.ui.woopos.orders
+
+import androidx.compose.foundation.Image
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxHeight
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.heightIn
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.outlined.Inventory2
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.ColorFilter
+import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import coil.compose.AsyncImage
+import coil.request.ImageRequest
+import com.woocommerce.android.R
+import com.woocommerce.android.ui.woopos.common.composeui.component.WooPosButton
+import com.woocommerce.android.ui.woopos.common.composeui.component.WooPosCard
+import com.woocommerce.android.ui.woopos.common.composeui.component.WooPosText
+import com.woocommerce.android.ui.woopos.common.composeui.component.WooPosToolbar
+import com.woocommerce.android.ui.woopos.common.composeui.designsystem.WooPosElevation
+import com.woocommerce.android.ui.woopos.common.composeui.designsystem.WooPosSpacing
+import com.woocommerce.android.ui.woopos.common.composeui.designsystem.WooPosTheme
+import com.woocommerce.android.ui.woopos.common.composeui.designsystem.WooPosTypography
+
+@Composable
+fun OrderDetails(
+    modifier: Modifier = Modifier,
+    details: OrderDetailsViewState,
+    onEmailReceiptButtonClicked: (Long) -> Unit = {}
+) {
+    Column(modifier = modifier.fillMaxSize()) {
+        WooPosToolbar(
+            modifier = Modifier.fillMaxWidth(),
+            titleText = details.number,
+            onBackClicked = null
+        )
+
+        Column(
+            modifier = Modifier
+                .fillMaxSize()
+                .verticalScroll(rememberScrollState())
+                .padding(
+                    start = WooPosSpacing.Large.value,
+                    end = WooPosSpacing.Large.value,
+                    top = WooPosSpacing.Medium.value,
+                    bottom = WooPosSpacing.XLarge.value
+                ),
+            verticalArrangement = Arrangement.spacedBy(WooPosSpacing.Large.value)
+        ) {
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                verticalAlignment = Alignment.CenterVertically
+            ) {
+                Column(modifier = Modifier.weight(1f)) {
+                    WooPosText(
+                        text = details.dateTime,
+                        style = WooPosTypography.BodySmall,
+                        color = WooPosTheme.colors.onSurfaceVariantHighest
+                    )
+                    details.customerEmail?.takeIf { it.isNotBlank() }?.let {
+                        Spacer(Modifier.height(WooPosSpacing.XSmall.value))
+                        WooPosText(
+                            text = it,
+                            style = WooPosTypography.BodySmall,
+                            color = WooPosTheme.colors.onSurfaceVariantHighest
+                        )
+                    }
+                    Spacer(Modifier.height(WooPosSpacing.Small.value))
+                    OrderStatusBadge(details.status)
+                }
+
+                WooPosButton(
+                    text = stringResource(R.string.woopos_orders_email_receipt),
+                    onClick = { onEmailReceiptButtonClicked(details.id) }
+                )
+            }
+
+            WooPosCard(
+                shape = MaterialTheme.shapes.medium,
+                backgroundColor = MaterialTheme.colorScheme.surface,
+                elevation = WooPosElevation.Medium,
+                shadowType = com.woocommerce.android.ui.woopos.common.composeui.component.ShadowType.Soft
+            ) {
+                Column(Modifier.padding(WooPosSpacing.Medium.value)) {
+                    WooPosText(
+                        text = stringResource(R.string.woopos_orders_details_products_title),
+                        style = WooPosTypography.Heading
+                    )
+                    Spacer(Modifier.height(WooPosSpacing.Small.value))
+
+                    details.lineItems.forEach { row ->
+                        Row(
+                            modifier = Modifier
+                                .fillMaxWidth()
+                                .padding(vertical = WooPosSpacing.Small.value),
+                            verticalAlignment = Alignment.CenterVertically
+                        ) {
+                            OrderLineItemImage(imageUrl = row.imageUrl)
+
+                            Column(Modifier.weight(1f)) {
+                                WooPosText(
+                                    text = row.name,
+                                    style = WooPosTypography.BodySmall,
+                                    fontWeight = FontWeight.Medium
+                                )
+                                Spacer(Modifier.height(WooPosSpacing.XSmall.value))
+                                WooPosText(
+                                    text = row.qtyAndUnitPrice,
+                                    style = WooPosTypography.BodySmall,
+                                    color = WooPosTheme.colors.onSurfaceVariantHighest
+                                )
+                            }
+                            WooPosText(
+                                text = row.lineTotal,
+                                style = WooPosTypography.BodySmall
+                            )
+                        }
+                    }
+                }
+            }
+
+            WooPosCard(
+                shape = MaterialTheme.shapes.medium,
+                backgroundColor = MaterialTheme.colorScheme.surface,
+                elevation = WooPosElevation.Medium,
+                shadowType = com.woocommerce.android.ui.woopos.common.composeui.component.ShadowType.Soft
+            ) {
+                Column(Modifier.padding(WooPosSpacing.Medium.value)) {
+                    WooPosText(
+                        text = stringResource(R.string.woopos_orders_details_totals_title),
+                        style = WooPosTypography.Heading
+                    )
+                    Spacer(Modifier.height(WooPosSpacing.Small.value))
+
+                    @Composable
+                    fun RowLine(label: String, value: String) {
+                        Row(
+                            Modifier
+                                .fillMaxWidth()
+                                .padding(vertical = WooPosSpacing.XSmall.value)
+                        ) {
+                            WooPosText(
+                                text = label,
+                                style = WooPosTypography.BodySmall,
+                                color = WooPosTheme.colors.onSurfaceVariantHighest,
+                                modifier = Modifier.weight(1f)
+                            )
+                            WooPosText(
+                                text = value,
+                                style = WooPosTypography.BodySmall
+                            )
+                        }
+                    }
+
+                    val b = details.breakdown
+                    RowLine(
+                        label = stringResource(R.string.woopos_orders_details_breakdown_products_label),
+                        value = b.products
+                    )
+
+                    b.discount?.let { d ->
+                        val label =
+                            if (b.discountCode.isNullOrBlank()) {
+                                stringResource(R.string.woopos_orders_details_breakdown_discount_label)
+                            } else {
+                                stringResource(
+                                    R.string.woopos_orders_details_breakdown_discount_with_code_label,
+                                    b.discountCode
+                                )
+                            }
+                        RowLine(label, d)
+                    }
+
+                    RowLine(
+                        label = stringResource(R.string.woopos_orders_details_breakdown_taxes_label),
+                        value = b.taxes
+                    )
+
+                    b.shipping?.let {
+                        RowLine(
+                            label = stringResource(R.string.woopos_orders_details_breakdown_shipping_label),
+                            value = it
+                        )
+                    }
+
+                    Spacer(Modifier.height(WooPosSpacing.Small.value))
+                    Box(
+                        Modifier
+                            .fillMaxWidth()
+                            .height(1.dp)
+                            .background(MaterialTheme.colorScheme.surfaceContainerHighest)
+                    )
+
+                    Row(
+                        Modifier
+                            .fillMaxWidth()
+                            .padding(vertical = WooPosSpacing.Small.value)
+                    ) {
+                        WooPosText(
+                            text = stringResource(R.string.woopos_orders_details_total_label),
+                            style = WooPosTypography.BodySmall,
+                            fontWeight = FontWeight.Bold,
+                            modifier = Modifier.weight(1f)
+                        )
+                        WooPosText(
+                            text = details.total,
+                            style = WooPosTypography.BodySmall,
+                            fontWeight = FontWeight.Bold
+                        )
+                    }
+                }
+            }
+
+            Column {
+                Row(Modifier.fillMaxWidth()) {
+                    WooPosText(
+                        text = stringResource(R.string.woopos_orders_details_total_paid_label),
+                        style = WooPosTypography.BodySmall,
+                        modifier = Modifier.weight(1f)
+                    )
+                    WooPosText(
+                        text = details.totalPaid,
+                        style = WooPosTypography.BodySmall
+                    )
+                }
+                details.paymentMethodTitle?.let {
+                    Spacer(Modifier.height(WooPosSpacing.XSmall.value))
+                    WooPosText(
+                        text = it,
+                        style = WooPosTypography.BodySmall,
+                        color = WooPosTheme.colors.onSurfaceVariantHighest
+                    )
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun OrderLineItemImage(imageUrl: String?) {
+    Box(
+        modifier = Modifier
+            .width(56.dp)
+            .fillMaxHeight()
+            .heightIn(min = 56.dp)
+            .background(MaterialTheme.colorScheme.surfaceDim),
+        contentAlignment = Alignment.Center
+    ) {
+        Image(
+            imageVector = Icons.Outlined.Inventory2,
+            contentDescription = null,
+            colorFilter = ColorFilter.tint(WooPosTheme.colors.onSurfaceVariantLowest),
+            modifier = Modifier.size(24.dp)
+        )
+        AsyncImage(
+            model = ImageRequest.Builder(LocalContext.current)
+                .data(imageUrl)
+                .crossfade(true)
+                .build(),
+            contentDescription = null,
+            contentScale = ContentScale.Crop
+        )
+    }
+}

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/orders/WooPosOrdersScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/orders/WooPosOrdersScreen.kt
@@ -23,7 +23,9 @@ import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.layout.wrapContentHeight
 import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.lazy.rememberLazyListState
+import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.ExperimentalMaterialApi
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.outlined.Inventory2
@@ -391,202 +393,30 @@ fun OrderDetails(
             onBackClicked = null
         )
 
-        WooPosLazyColumn(
-            modifier = Modifier.fillMaxSize(),
-            verticalArrangement = Arrangement.spacedBy(WooPosSpacing.Large.value),
-            contentPadding = PaddingValues(
-                start = WooPosSpacing.Large.value,
-                end = WooPosSpacing.Large.value,
-                top = WooPosSpacing.Medium.value,
-                bottom = WooPosSpacing.XLarge.value
-            )
+        Column(
+            modifier = Modifier
+                .fillMaxSize()
+                .verticalScroll(rememberScrollState())
+                .padding(
+                    start = WooPosSpacing.Large.value,
+                    end = WooPosSpacing.Large.value,
+                    top = WooPosSpacing.Medium.value,
+                    bottom = WooPosSpacing.XLarge.value
+                ),
+            verticalArrangement = Arrangement.spacedBy(WooPosSpacing.Large.value)
         ) {
-            item {
-                Row(
-                    modifier = Modifier.fillMaxWidth(),
-                    verticalAlignment = Alignment.CenterVertically
-                ) {
-                    Column(modifier = Modifier.weight(1f)) {
-                        WooPosText(
-                            text = details.dateTime,
-                            style = WooPosTypography.BodySmall,
-                            color = WooPosTheme.colors.onSurfaceVariantHighest
-                        )
-                        details.customerEmail?.takeIf { it.isNotBlank() }?.let {
-                            Spacer(Modifier.height(WooPosSpacing.XSmall.value))
-                            WooPosText(
-                                text = it,
-                                style = WooPosTypography.BodySmall,
-                                color = WooPosTheme.colors.onSurfaceVariantHighest
-                            )
-                        }
-                        Spacer(Modifier.height(WooPosSpacing.Small.value))
-                        OrderStatusBadge(details.status)
-                    }
-
-                    WooPosButton(
-                        text = stringResource(R.string.woopos_orders_email_receipt),
-                        onClick = { onEmailReceiptButtonClicked(details.id) }
+            // Header: date, email, status, email receipt button
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                verticalAlignment = Alignment.CenterVertically
+            ) {
+                Column(modifier = Modifier.weight(1f)) {
+                    WooPosText(
+                        text = details.dateTime,
+                        style = WooPosTypography.BodySmall,
+                        color = WooPosTheme.colors.onSurfaceVariantHighest
                     )
-                }
-            }
-
-            item {
-                WooPosCard(
-                    shape = RoundedCornerShape(WooPosCornerRadius.Medium.value),
-                    backgroundColor = MaterialTheme.colorScheme.surface,
-                    elevation = WooPosElevation.Medium,
-                    shadowType = ShadowType.Soft
-                ) {
-                    Column(Modifier.padding(WooPosSpacing.Medium.value)) {
-                        WooPosText(
-                            text = stringResource(R.string.woopos_orders_details_products_title),
-                            style = WooPosTypography.Heading
-                        )
-                        Spacer(Modifier.height(WooPosSpacing.Small.value))
-
-                        details.lineItems.forEach { row ->
-                            Row(
-                                modifier = Modifier
-                                    .fillMaxWidth()
-                                    .padding(vertical = WooPosSpacing.Small.value),
-                                verticalAlignment = Alignment.CenterVertically
-                            ) {
-                                OrderLineItemImage(
-                                    imageUrl = row.imageUrl
-                                )
-
-                                Column(Modifier.weight(1f)) {
-                                    WooPosText(
-                                        text = row.name,
-                                        style = WooPosTypography.BodySmall,
-                                        fontWeight = FontWeight.Medium
-                                    )
-                                    Spacer(Modifier.height(WooPosSpacing.XSmall.value))
-                                    WooPosText(
-                                        text = row.qtyAndUnitPrice,
-                                        style = WooPosTypography.BodySmall,
-                                        color = WooPosTheme.colors.onSurfaceVariantHighest
-                                    )
-                                }
-                                WooPosText(
-                                    text = row.lineTotal,
-                                    style = WooPosTypography.BodySmall
-                                )
-                            }
-                        }
-                    }
-                }
-            }
-
-            item {
-                WooPosCard(
-                    shape = RoundedCornerShape(WooPosCornerRadius.Medium.value),
-                    backgroundColor = MaterialTheme.colorScheme.surface,
-                    elevation = WooPosElevation.Medium,
-                    shadowType = ShadowType.Soft
-                ) {
-                    Column(Modifier.padding(WooPosSpacing.Medium.value)) {
-                        WooPosText(
-                            text = stringResource(R.string.woopos_orders_details_totals_title),
-                            style = WooPosTypography.Heading
-                        )
-                        Spacer(Modifier.height(WooPosSpacing.Small.value))
-
-                        @Composable
-                        fun RowLine(label: String, value: String) {
-                            Row(
-                                Modifier
-                                    .fillMaxWidth()
-                                    .padding(vertical = WooPosSpacing.XSmall.value)
-                            ) {
-                                WooPosText(
-                                    text = label,
-                                    style = WooPosTypography.BodySmall,
-                                    color = WooPosTheme.colors.onSurfaceVariantHighest,
-                                    modifier = Modifier.weight(1f)
-                                )
-                                WooPosText(
-                                    text = value,
-                                    style = WooPosTypography.BodySmall
-                                )
-                            }
-                        }
-
-                        val b = details.breakdown
-                        RowLine(
-                            label = stringResource(R.string.woopos_orders_details_breakdown_products_label),
-                            value = b.products
-                        )
-
-                        b.discount?.let { d ->
-                            val label =
-                                if (b.discountCode.isNullOrBlank()) {
-                                    stringResource(R.string.woopos_orders_details_breakdown_discount_label)
-                                } else {
-                                    stringResource(
-                                        R.string.woopos_orders_details_breakdown_discount_with_code_label,
-                                        b.discountCode
-                                    )
-                                }
-                            RowLine(label, d)
-                        }
-
-                        RowLine(
-                            label = stringResource(R.string.woopos_orders_details_breakdown_taxes_label),
-                            value = b.taxes
-                        )
-
-                        b.shipping?.let {
-                            RowLine(
-                                label = stringResource(R.string.woopos_orders_details_breakdown_shipping_label),
-                                value = it
-                            )
-                        }
-
-                        Spacer(Modifier.height(WooPosSpacing.Small.value))
-                        Box(
-                            Modifier
-                                .fillMaxWidth()
-                                .height(1.dp)
-                                .background(MaterialTheme.colorScheme.surfaceContainerHighest)
-                        )
-
-                        Row(
-                            Modifier
-                                .fillMaxWidth()
-                                .padding(vertical = WooPosSpacing.Small.value)
-                        ) {
-                            WooPosText(
-                                text = stringResource(R.string.woopos_orders_details_total_label),
-                                style = WooPosTypography.BodySmall,
-                                fontWeight = FontWeight.Bold,
-                                modifier = Modifier.weight(1f)
-                            )
-                            WooPosText(
-                                text = details.total,
-                                style = WooPosTypography.BodySmall,
-                                fontWeight = FontWeight.Bold
-                            )
-                        }
-                    }
-                }
-            }
-
-            item {
-                Column {
-                    Row(Modifier.fillMaxWidth()) {
-                        WooPosText(
-                            text = stringResource(R.string.woopos_orders_details_total_paid_label),
-                            style = WooPosTypography.BodySmall,
-                            modifier = Modifier.weight(1f)
-                        )
-                        WooPosText(
-                            text = details.totalPaid,
-                            style = WooPosTypography.BodySmall
-                        )
-                    }
-                    details.paymentMethodTitle?.let {
+                    details.customerEmail?.takeIf { it.isNotBlank() }?.let {
                         Spacer(Modifier.height(WooPosSpacing.XSmall.value))
                         WooPosText(
                             text = it,
@@ -594,6 +424,174 @@ fun OrderDetails(
                             color = WooPosTheme.colors.onSurfaceVariantHighest
                         )
                     }
+                    Spacer(Modifier.height(WooPosSpacing.Small.value))
+                    OrderStatusBadge(details.status)
+                }
+
+                WooPosButton(
+                    text = stringResource(R.string.woopos_orders_email_receipt),
+                    onClick = { onEmailReceiptButtonClicked(details.id) }
+                )
+            }
+
+            // Products card
+            WooPosCard(
+                shape = RoundedCornerShape(WooPosCornerRadius.Medium.value),
+                backgroundColor = MaterialTheme.colorScheme.surface,
+                elevation = WooPosElevation.Medium,
+                shadowType = ShadowType.Soft
+            ) {
+                Column(Modifier.padding(WooPosSpacing.Medium.value)) {
+                    WooPosText(
+                        text = stringResource(R.string.woopos_orders_details_products_title),
+                        style = WooPosTypography.Heading
+                    )
+                    Spacer(Modifier.height(WooPosSpacing.Small.value))
+
+                    details.lineItems.forEach { row ->
+                        Row(
+                            modifier = Modifier
+                                .fillMaxWidth()
+                                .padding(vertical = WooPosSpacing.Small.value),
+                            verticalAlignment = Alignment.CenterVertically
+                        ) {
+                            OrderLineItemImage(imageUrl = row.imageUrl)
+
+                            Column(Modifier.weight(1f)) {
+                                WooPosText(
+                                    text = row.name,
+                                    style = WooPosTypography.BodySmall,
+                                    fontWeight = FontWeight.Medium
+                                )
+                                Spacer(Modifier.height(WooPosSpacing.XSmall.value))
+                                WooPosText(
+                                    text = row.qtyAndUnitPrice,
+                                    style = WooPosTypography.BodySmall,
+                                    color = WooPosTheme.colors.onSurfaceVariantHighest
+                                )
+                            }
+                            WooPosText(
+                                text = row.lineTotal,
+                                style = WooPosTypography.BodySmall
+                            )
+                        }
+                    }
+                }
+            }
+
+            // Totals card
+            WooPosCard(
+                shape = RoundedCornerShape(WooPosCornerRadius.Medium.value),
+                backgroundColor = MaterialTheme.colorScheme.surface,
+                elevation = WooPosElevation.Medium,
+                shadowType = ShadowType.Soft
+            ) {
+                Column(Modifier.padding(WooPosSpacing.Medium.value)) {
+                    WooPosText(
+                        text = stringResource(R.string.woopos_orders_details_totals_title),
+                        style = WooPosTypography.Heading
+                    )
+                    Spacer(Modifier.height(WooPosSpacing.Small.value))
+
+                    @Composable
+                    fun RowLine(label: String, value: String) {
+                        Row(
+                            Modifier
+                                .fillMaxWidth()
+                                .padding(vertical = WooPosSpacing.XSmall.value)
+                        ) {
+                            WooPosText(
+                                text = label,
+                                style = WooPosTypography.BodySmall,
+                                color = WooPosTheme.colors.onSurfaceVariantHighest,
+                                modifier = Modifier.weight(1f)
+                            )
+                            WooPosText(
+                                text = value,
+                                style = WooPosTypography.BodySmall
+                            )
+                        }
+                    }
+
+                    val b = details.breakdown
+                    RowLine(
+                        label = stringResource(R.string.woopos_orders_details_breakdown_products_label),
+                        value = b.products
+                    )
+
+                    b.discount?.let { d ->
+                        val label =
+                            if (b.discountCode.isNullOrBlank()) {
+                                stringResource(R.string.woopos_orders_details_breakdown_discount_label)
+                            } else {
+                                stringResource(
+                                    R.string.woopos_orders_details_breakdown_discount_with_code_label,
+                                    b.discountCode
+                                )
+                            }
+                        RowLine(label, d)
+                    }
+
+                    RowLine(
+                        label = stringResource(R.string.woopos_orders_details_breakdown_taxes_label),
+                        value = b.taxes
+                    )
+
+                    b.shipping?.let {
+                        RowLine(
+                            label = stringResource(R.string.woopos_orders_details_breakdown_shipping_label),
+                            value = it
+                        )
+                    }
+
+                    Spacer(Modifier.height(WooPosSpacing.Small.value))
+                    Box(
+                        Modifier
+                            .fillMaxWidth()
+                            .height(1.dp)
+                            .background(MaterialTheme.colorScheme.surfaceContainerHighest)
+                    )
+
+                    Row(
+                        Modifier
+                            .fillMaxWidth()
+                            .padding(vertical = WooPosSpacing.Small.value)
+                    ) {
+                        WooPosText(
+                            text = stringResource(R.string.woopos_orders_details_total_label),
+                            style = WooPosTypography.BodySmall,
+                            fontWeight = FontWeight.Bold,
+                            modifier = Modifier.weight(1f)
+                        )
+                        WooPosText(
+                            text = details.total,
+                            style = WooPosTypography.BodySmall,
+                            fontWeight = FontWeight.Bold
+                        )
+                    }
+                }
+            }
+
+            // Payment section
+            Column {
+                Row(Modifier.fillMaxWidth()) {
+                    WooPosText(
+                        text = stringResource(R.string.woopos_orders_details_total_paid_label),
+                        style = WooPosTypography.BodySmall,
+                        modifier = Modifier.weight(1f)
+                    )
+                    WooPosText(
+                        text = details.totalPaid,
+                        style = WooPosTypography.BodySmall
+                    )
+                }
+                details.paymentMethodTitle?.let {
+                    Spacer(Modifier.height(WooPosSpacing.XSmall.value))
+                    WooPosText(
+                        text = it,
+                        style = WooPosTypography.BodySmall,
+                        color = WooPosTheme.colors.onSurfaceVariantHighest
+                    )
                 }
             }
         }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/orders/WooPosOrdersScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/orders/WooPosOrdersScreen.kt
@@ -88,7 +88,8 @@ fun WooPosOrdersScreen(
         onPaginationErrorTryAgain = viewModel::onPaginationErrorTryAgain,
         onSearchEvent = viewModel::onSearchEvent,
         onOrdersEmptyActionClicked = viewModel::onOrdersEmptyActionClicked,
-        onOrdersLoadingErrorRetryButtonClicked = viewModel::onOrdersLoadingErrorRetryButtonClicked
+        onOrdersLoadingErrorRetryButtonClicked = viewModel::onOrdersLoadingErrorRetryButtonClicked,
+        onEmailReceiptButtonClicked = viewModel::onEmailReceiptButtonClicked
     )
 }
 
@@ -103,7 +104,8 @@ private fun WooPosOrdersScreen(
     onPaginationErrorTryAgain: () -> Unit,
     onSearchEvent: (WooPosSearchUIEvent) -> Unit,
     onOrdersEmptyActionClicked: () -> Unit,
-    onOrdersLoadingErrorRetryButtonClicked: () -> Unit
+    onOrdersLoadingErrorRetryButtonClicked: () -> Unit,
+    onEmailReceiptButtonClicked: (Long) -> Unit,
 ) {
     BackHandler { onBackClicked() }
 
@@ -115,7 +117,8 @@ private fun WooPosOrdersScreen(
                 onOrderSelected = onOrderSelected,
                 onEndOfOrdersListReached = onEndOfOrdersListReached,
                 onPaginationErrorTryAgain = onPaginationErrorTryAgain,
-                onSearchEvent = onSearchEvent
+                onSearchEvent = onSearchEvent,
+                onEmailReceiptButtonClicked = onEmailReceiptButtonClicked
             )
             is WooPosOrdersState.Empty -> OrdersEmpty(
                 onActionClicked = onOrdersEmptyActionClicked
@@ -145,7 +148,8 @@ private fun OrdersContent(
     onOrderSelected: (Long) -> Unit,
     onEndOfOrdersListReached: () -> Unit,
     onPaginationErrorTryAgain: () -> Unit,
-    onSearchEvent: (WooPosSearchUIEvent) -> Unit
+    onSearchEvent: (WooPosSearchUIEvent) -> Unit,
+    onEmailReceiptButtonClicked: (Long) -> Unit
 ) {
     Row(modifier = Modifier.fillMaxSize()) {
         OrdersListPane(
@@ -168,6 +172,8 @@ private fun OrdersContent(
                 .fillMaxHeight()
                 .background(MaterialTheme.colorScheme.surfaceContainerLow),
             order = state.items.find { it.isSelected },
+            details = state.selectedOrderDetails,
+            onEmailReceiptButtonClicked = onEmailReceiptButtonClicked
         )
     }
 }
@@ -363,26 +369,250 @@ private fun OrdersList(
 }
 
 @Composable
-private fun OrderDetails(
+fun OrderDetails(
     modifier: Modifier = Modifier,
     order: OrderItemViewState?,
+    details: OrderDetailsViewState?,
+    onEmailReceiptButtonClicked: (Long) -> Unit = {}
 ) {
     Column(modifier = modifier.fillMaxSize()) {
         WooPosToolbar(
             modifier = Modifier.fillMaxWidth(),
-            titleText = order?.title ?: "--",
-            titleFontWeight = FontWeight.Bold
+            titleText = details?.number ?: order?.title ?: "--",
+            onBackClicked = null
         )
-        Column(
-            modifier = Modifier
-                .fillMaxSize()
-                .padding(start = WooPosSpacing.Large.value, end = WooPosSpacing.Large.value)
-        ) {
-            WooPosText(
-                text = "Order details goes here",
-                style = WooPosTypography.BodyMedium,
-                color = MaterialTheme.colorScheme.onSurfaceVariant
+
+        // Placeholder when nothing is selected
+        if (details == null) {
+            Column(
+                Modifier
+                    .fillMaxSize()
+                    .padding(WooPosSpacing.Large.value),
+                verticalArrangement = Arrangement.Center,
+                horizontalAlignment = Alignment.CenterHorizontally
+            ) {
+                WooPosText(
+                    text = stringResource(R.string.woopos_orders_details_placeholder_title),
+                    style = WooPosTypography.Heading,
+                    fontWeight = FontWeight.SemiBold,
+                    color = MaterialTheme.colorScheme.onSurface
+                )
+                Spacer(Modifier.height(WooPosSpacing.Small.value))
+                WooPosText(
+                    text = stringResource(R.string.woopos_orders_details_placeholder_message),
+                    style = WooPosTypography.BodySmall,
+                    color = WooPosTheme.colors.onSurfaceVariantHighest
+                )
+            }
+            return
+        }
+
+        WooPosLazyColumn(
+            modifier = Modifier.fillMaxSize(),
+            verticalArrangement = Arrangement.spacedBy(WooPosSpacing.Large.value),
+            contentPadding = PaddingValues(
+                start = WooPosSpacing.Large.value,
+                end = WooPosSpacing.Large.value,
+                top = WooPosSpacing.Medium.value,
+                bottom = WooPosSpacing.XLarge.value
             )
+        ) {
+            item {
+                Row(
+                    modifier = Modifier.fillMaxWidth(),
+                    verticalAlignment = Alignment.CenterVertically
+                ) {
+                    Column(modifier = Modifier.weight(1f)) {
+                        WooPosText(
+                            text = details.dateTime,
+                            style = WooPosTypography.BodySmall,
+                            color = WooPosTheme.colors.onSurfaceVariantHighest
+                        )
+                        details.customerEmail?.takeIf { it.isNotBlank() }?.let {
+                            Spacer(Modifier.height(WooPosSpacing.XSmall.value))
+                            WooPosText(
+                                text = it,
+                                style = WooPosTypography.BodySmall,
+                                color = WooPosTheme.colors.onSurfaceVariantHighest
+                            )
+                        }
+                        Spacer(Modifier.height(WooPosSpacing.Small.value))
+                        OrderStatusBadge(details.status)
+                    }
+
+                    androidx.compose.material3.Button(
+                        onClick = { onEmailReceiptButtonClicked(details.id) }
+                    ) {
+                        WooPosText(
+                            text = stringResource(R.string.woopos_orders_email_receipt),
+                            style = WooPosTypography.BodySmall
+                        )
+                    }
+                }
+            }
+
+            // Products card
+            item {
+                WooPosCard(
+                    shape = RoundedCornerShape(WooPosCornerRadius.Medium.value),
+                    backgroundColor = MaterialTheme.colorScheme.surface,
+                    elevation = WooPosElevation.Medium,
+                    shadowType = ShadowType.Soft
+                ) {
+                    Column(Modifier.padding(WooPosSpacing.Medium.value)) {
+                        WooPosText(
+                            text = stringResource(R.string.woopos_orders_details_products_title),
+                            style = WooPosTypography.Heading
+                        )
+                        Spacer(Modifier.height(WooPosSpacing.Small.value))
+
+                        details.lineItems.forEach { row ->
+                            Row(
+                                modifier = Modifier
+                                    .fillMaxWidth()
+                                    .padding(vertical = WooPosSpacing.Small.value),
+                                verticalAlignment = Alignment.CenterVertically
+                            ) {
+                                Column(Modifier.weight(1f)) {
+                                    WooPosText(
+                                        text = row.name,
+                                        style = WooPosTypography.BodySmall,
+                                        fontWeight = FontWeight.Medium
+                                    )
+                                    Spacer(Modifier.height(WooPosSpacing.XSmall.value))
+                                    WooPosText(
+                                        text = row.qtyAndUnitPrice,
+                                        style = WooPosTypography.BodySmall,
+                                        color = WooPosTheme.colors.onSurfaceVariantHighest
+                                    )
+                                }
+                                WooPosText(
+                                    text = row.lineTotal,
+                                    style = WooPosTypography.BodySmall
+                                )
+                            }
+                        }
+                    }
+                }
+            }
+
+            item {
+                WooPosCard(
+                    shape = RoundedCornerShape(WooPosCornerRadius.Medium.value),
+                    backgroundColor = MaterialTheme.colorScheme.surface,
+                    elevation = WooPosElevation.Medium,
+                    shadowType = ShadowType.Soft
+                ) {
+                    Column(Modifier.padding(WooPosSpacing.Medium.value)) {
+                        WooPosText(
+                            text = stringResource(R.string.woopos_orders_details_totals_title),
+                            style = WooPosTypography.Heading
+                        )
+                        Spacer(Modifier.height(WooPosSpacing.Small.value))
+
+                        @Composable
+                        fun RowLine(label: String, value: String) {
+                            Row(
+                                Modifier
+                                    .fillMaxWidth()
+                                    .padding(vertical = WooPosSpacing.XSmall.value)
+                            ) {
+                                WooPosText(
+                                    text = label,
+                                    style = WooPosTypography.BodySmall,
+                                    color = WooPosTheme.colors.onSurfaceVariantHighest,
+                                    modifier = Modifier.weight(1f)
+                                )
+                                WooPosText(
+                                    text = value,
+                                    style = WooPosTypography.BodySmall
+                                )
+                            }
+                        }
+
+                        val b = details.breakdown
+                        RowLine(
+                            label = stringResource(R.string.woopos_orders_details_breakdown_products_label),
+                            value = b.products
+                        )
+
+                        b.discount?.let { d ->
+                            val label =
+                                if (b.discountCode.isNullOrBlank()) {
+                                    stringResource(R.string.woopos_orders_details_breakdown_discount_label)
+                                } else {
+                                    stringResource(
+                                        R.string.woopos_orders_details_breakdown_discount_with_code_label,
+                                        b.discountCode
+                                    )
+                                }
+                            RowLine(label, d)
+                        }
+
+                        RowLine(
+                            label = stringResource(R.string.woopos_orders_details_breakdown_taxes_label),
+                            value = b.taxes
+                        )
+
+                        b.shipping?.let {
+                            RowLine(
+                                label = stringResource(R.string.woopos_orders_details_breakdown_shipping_label),
+                                value = it
+                            )
+                        }
+
+                        Spacer(Modifier.height(WooPosSpacing.Small.value))
+                        Box(
+                            Modifier
+                                .fillMaxWidth()
+                                .height(1.dp)
+                                .background(MaterialTheme.colorScheme.surfaceContainerHighest)
+                        )
+
+                        Row(
+                            Modifier
+                                .fillMaxWidth()
+                                .padding(vertical = WooPosSpacing.Small.value)
+                        ) {
+                            WooPosText(
+                                text = stringResource(R.string.woopos_orders_details_total_label),
+                                style = WooPosTypography.BodySmall,
+                                fontWeight = FontWeight.Bold,
+                                modifier = Modifier.weight(1f)
+                            )
+                            WooPosText(
+                                text = details.total,
+                                style = WooPosTypography.BodySmall,
+                                fontWeight = FontWeight.Bold
+                            )
+                        }
+                    }
+                }
+            }
+
+            item {
+                Column {
+                    Row(Modifier.fillMaxWidth()) {
+                        WooPosText(
+                            text = stringResource(R.string.woopos_orders_details_total_paid_label),
+                            style = WooPosTypography.BodySmall,
+                            modifier = Modifier.weight(1f)
+                        )
+                        WooPosText(
+                            text = details.totalPaid,
+                            style = WooPosTypography.BodySmall
+                        )
+                    }
+                    details.paymentMethodTitle?.let {
+                        Spacer(Modifier.height(WooPosSpacing.XSmall.value))
+                        WooPosText(
+                            text = it,
+                            style = WooPosTypography.BodySmall,
+                            color = WooPosTheme.colors.onSurfaceVariantHighest
+                        )
+                    }
+                }
+            }
         }
     }
 }
@@ -469,10 +699,10 @@ fun WooPosOrdersScreenPreview() {
                 items = listOf(
                     OrderItemViewState(
                         id = 1,
-                        title = "#1234",
-                        date = "Jan 15, 2025 at 10:30 AM",
-                        total = "$125.00",
-                        customerEmail = "customer@example.com",
+                        title = "#014",
+                        date = "Aug 28, 2025 at 10:31 AM",
+                        total = "$17.00",
+                        customerEmail = "johndoe@mail.com",
                         isSelected = true,
                         status = PosOrderStatus(
                             text = "Completed",
@@ -481,10 +711,10 @@ fun WooPosOrdersScreenPreview() {
                     ),
                     OrderItemViewState(
                         id = 2,
-                        title = "#1235",
-                        date = "Jan 16, 2025 at 2:45 PM",
-                        total = "$89.50",
-                        customerEmail = "another@example.com",
+                        title = "#013",
+                        date = "Jul 28, 2025 at 10:31 AM",
+                        total = "$43.90",
+                        customerEmail = "johndoe@mail.com",
                         isSelected = false,
                         status = PosOrderStatus(
                             text = "Processing",
@@ -495,7 +725,8 @@ fun WooPosOrdersScreenPreview() {
                 pullToRefreshState = WooPosPullToRefreshState.Enabled,
                 searchInputState = WooPosSearchInputState.Closed,
                 paginationState = WooPosPaginationState.None,
-                selectedOrderId = 1
+                selectedOrderId = 1,
+                selectedOrderDetails = sampleOrderDetails()
             ),
             onBackClicked = {},
             onRefresh = {},
@@ -504,7 +735,32 @@ fun WooPosOrdersScreenPreview() {
             onPaginationErrorTryAgain = {},
             onSearchEvent = {},
             onOrdersEmptyActionClicked = {},
-            onOrdersLoadingErrorRetryButtonClicked = {}
+            onOrdersLoadingErrorRetryButtonClicked = {},
+            onEmailReceiptButtonClicked = {} // ✅ required by the current signature
         )
     }
 }
+
+@Suppress("MagicNumber")
+private fun sampleOrderDetails() = OrderDetailsViewState(
+    id = 1L,
+    number = "#014",
+    dateTime = "Aug 28, 2025 at 10:31 AM",
+    customerEmail = "johndoe@mail.com",
+    status = PosOrderStatus(text = "Completed", colorKey = OrderStatusColorKey.COMPLETED),
+    lineItems = listOf(
+        OrderDetailsViewState.LineItemRow(101, "Cup", "1 x $8.50", "$15.00", null),
+        OrderDetailsViewState.LineItemRow(102, "Coffee Container", "1 x $10.00", "$8.00", null),
+        OrderDetailsViewState.LineItemRow(103, "Paper Filter", "1 x $4.50", "$8.00", null)
+    ),
+    breakdown = OrderDetailsViewState.TotalsBreakdown(
+        products = "$23.00",
+        discount = "-$5.00",
+        discountCode = "8qew4mnq",
+        taxes = "$0.00",
+        shipping = null
+    ),
+    total = "$17.00",
+    totalPaid = "$17.00",
+    paymentMethodTitle = "WooCommerce In-Person Payments"
+)

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/orders/WooPosOrdersScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/orders/WooPosOrdersScreen.kt
@@ -451,7 +451,6 @@ fun OrderDetails(
                 }
             }
 
-            // Products card
             item {
                 WooPosCard(
                     shape = RoundedCornerShape(WooPosCornerRadius.Medium.value),

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/orders/WooPosOrdersScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/orders/WooPosOrdersScreen.kt
@@ -57,6 +57,7 @@ import coil.request.ImageRequest
 import com.woocommerce.android.R
 import com.woocommerce.android.ui.woopos.common.composeui.WooPosPreview
 import com.woocommerce.android.ui.woopos.common.composeui.component.ShadowType
+import com.woocommerce.android.ui.woopos.common.composeui.component.WooPosButton
 import com.woocommerce.android.ui.woopos.common.composeui.component.WooPosCard
 import com.woocommerce.android.ui.woopos.common.composeui.component.WooPosEmptyScreen
 import com.woocommerce.android.ui.woopos.common.composeui.component.WooPosErrorScreen
@@ -425,14 +426,10 @@ fun OrderDetails(
                         OrderStatusBadge(details.status)
                     }
 
-                    androidx.compose.material3.Button(
+                    WooPosButton(
+                        text = stringResource(R.string.woopos_orders_email_receipt),
                         onClick = { onEmailReceiptButtonClicked(details.id) }
-                    ) {
-                        WooPosText(
-                            text = stringResource(R.string.woopos_orders_email_receipt),
-                            style = WooPosTypography.BodySmall
-                        )
-                    }
+                    )
                 }
             }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/orders/WooPosOrdersScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/orders/WooPosOrdersScreen.kt
@@ -1,7 +1,6 @@
 package com.woocommerce.android.ui.woopos.orders
 
 import androidx.activity.compose.BackHandler
-import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
 import androidx.compose.foundation.border
 import androidx.compose.foundation.clickable
@@ -17,18 +16,13 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.heightIn
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.statusBarsPadding
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.layout.wrapContentHeight
 import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.lazy.rememberLazyListState
-import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.RoundedCornerShape
-import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.ExperimentalMaterialApi
-import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.outlined.Inventory2
 import androidx.compose.material.pullrefresh.PullRefreshIndicator
 import androidx.compose.material.pullrefresh.pullRefresh
 import androidx.compose.material.pullrefresh.rememberPullRefreshState
@@ -44,9 +38,6 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.graphics.ColorFilter
-import androidx.compose.ui.layout.ContentScale
-import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.semantics.selected
 import androidx.compose.ui.semantics.semantics
@@ -54,12 +45,9 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
-import coil.compose.AsyncImage
-import coil.request.ImageRequest
 import com.woocommerce.android.R
 import com.woocommerce.android.ui.woopos.common.composeui.WooPosPreview
 import com.woocommerce.android.ui.woopos.common.composeui.component.ShadowType
-import com.woocommerce.android.ui.woopos.common.composeui.component.WooPosButton
 import com.woocommerce.android.ui.woopos.common.composeui.component.WooPosCard
 import com.woocommerce.android.ui.woopos.common.composeui.component.WooPosEmptyScreen
 import com.woocommerce.android.ui.woopos.common.composeui.component.WooPosErrorScreen
@@ -377,251 +365,6 @@ private fun OrdersList(
                 OrdersPaginationErrorRow(onPaginationErrorTryAgain)
             }
         }
-    }
-}
-
-@Composable
-fun OrderDetails(
-    modifier: Modifier = Modifier,
-    details: OrderDetailsViewState,
-    onEmailReceiptButtonClicked: (Long) -> Unit = {}
-) {
-    Column(modifier = modifier.fillMaxSize()) {
-        WooPosToolbar(
-            modifier = Modifier.fillMaxWidth(),
-            titleText = details.number,
-            onBackClicked = null
-        )
-
-        Column(
-            modifier = Modifier
-                .fillMaxSize()
-                .verticalScroll(rememberScrollState())
-                .padding(
-                    start = WooPosSpacing.Large.value,
-                    end = WooPosSpacing.Large.value,
-                    top = WooPosSpacing.Medium.value,
-                    bottom = WooPosSpacing.XLarge.value
-                ),
-            verticalArrangement = Arrangement.spacedBy(WooPosSpacing.Large.value)
-        ) {
-            // Header: date, email, status, email receipt button
-            Row(
-                modifier = Modifier.fillMaxWidth(),
-                verticalAlignment = Alignment.CenterVertically
-            ) {
-                Column(modifier = Modifier.weight(1f)) {
-                    WooPosText(
-                        text = details.dateTime,
-                        style = WooPosTypography.BodySmall,
-                        color = WooPosTheme.colors.onSurfaceVariantHighest
-                    )
-                    details.customerEmail?.takeIf { it.isNotBlank() }?.let {
-                        Spacer(Modifier.height(WooPosSpacing.XSmall.value))
-                        WooPosText(
-                            text = it,
-                            style = WooPosTypography.BodySmall,
-                            color = WooPosTheme.colors.onSurfaceVariantHighest
-                        )
-                    }
-                    Spacer(Modifier.height(WooPosSpacing.Small.value))
-                    OrderStatusBadge(details.status)
-                }
-
-                WooPosButton(
-                    text = stringResource(R.string.woopos_orders_email_receipt),
-                    onClick = { onEmailReceiptButtonClicked(details.id) }
-                )
-            }
-
-            // Products card
-            WooPosCard(
-                shape = RoundedCornerShape(WooPosCornerRadius.Medium.value),
-                backgroundColor = MaterialTheme.colorScheme.surface,
-                elevation = WooPosElevation.Medium,
-                shadowType = ShadowType.Soft
-            ) {
-                Column(Modifier.padding(WooPosSpacing.Medium.value)) {
-                    WooPosText(
-                        text = stringResource(R.string.woopos_orders_details_products_title),
-                        style = WooPosTypography.Heading
-                    )
-                    Spacer(Modifier.height(WooPosSpacing.Small.value))
-
-                    details.lineItems.forEach { row ->
-                        Row(
-                            modifier = Modifier
-                                .fillMaxWidth()
-                                .padding(vertical = WooPosSpacing.Small.value),
-                            verticalAlignment = Alignment.CenterVertically
-                        ) {
-                            OrderLineItemImage(imageUrl = row.imageUrl)
-
-                            Column(Modifier.weight(1f)) {
-                                WooPosText(
-                                    text = row.name,
-                                    style = WooPosTypography.BodySmall,
-                                    fontWeight = FontWeight.Medium
-                                )
-                                Spacer(Modifier.height(WooPosSpacing.XSmall.value))
-                                WooPosText(
-                                    text = row.qtyAndUnitPrice,
-                                    style = WooPosTypography.BodySmall,
-                                    color = WooPosTheme.colors.onSurfaceVariantHighest
-                                )
-                            }
-                            WooPosText(
-                                text = row.lineTotal,
-                                style = WooPosTypography.BodySmall
-                            )
-                        }
-                    }
-                }
-            }
-
-            // Totals card
-            WooPosCard(
-                shape = RoundedCornerShape(WooPosCornerRadius.Medium.value),
-                backgroundColor = MaterialTheme.colorScheme.surface,
-                elevation = WooPosElevation.Medium,
-                shadowType = ShadowType.Soft
-            ) {
-                Column(Modifier.padding(WooPosSpacing.Medium.value)) {
-                    WooPosText(
-                        text = stringResource(R.string.woopos_orders_details_totals_title),
-                        style = WooPosTypography.Heading
-                    )
-                    Spacer(Modifier.height(WooPosSpacing.Small.value))
-
-                    @Composable
-                    fun RowLine(label: String, value: String) {
-                        Row(
-                            Modifier
-                                .fillMaxWidth()
-                                .padding(vertical = WooPosSpacing.XSmall.value)
-                        ) {
-                            WooPosText(
-                                text = label,
-                                style = WooPosTypography.BodySmall,
-                                color = WooPosTheme.colors.onSurfaceVariantHighest,
-                                modifier = Modifier.weight(1f)
-                            )
-                            WooPosText(
-                                text = value,
-                                style = WooPosTypography.BodySmall
-                            )
-                        }
-                    }
-
-                    val b = details.breakdown
-                    RowLine(
-                        label = stringResource(R.string.woopos_orders_details_breakdown_products_label),
-                        value = b.products
-                    )
-
-                    b.discount?.let { d ->
-                        val label =
-                            if (b.discountCode.isNullOrBlank()) {
-                                stringResource(R.string.woopos_orders_details_breakdown_discount_label)
-                            } else {
-                                stringResource(
-                                    R.string.woopos_orders_details_breakdown_discount_with_code_label,
-                                    b.discountCode
-                                )
-                            }
-                        RowLine(label, d)
-                    }
-
-                    RowLine(
-                        label = stringResource(R.string.woopos_orders_details_breakdown_taxes_label),
-                        value = b.taxes
-                    )
-
-                    b.shipping?.let {
-                        RowLine(
-                            label = stringResource(R.string.woopos_orders_details_breakdown_shipping_label),
-                            value = it
-                        )
-                    }
-
-                    Spacer(Modifier.height(WooPosSpacing.Small.value))
-                    Box(
-                        Modifier
-                            .fillMaxWidth()
-                            .height(1.dp)
-                            .background(MaterialTheme.colorScheme.surfaceContainerHighest)
-                    )
-
-                    Row(
-                        Modifier
-                            .fillMaxWidth()
-                            .padding(vertical = WooPosSpacing.Small.value)
-                    ) {
-                        WooPosText(
-                            text = stringResource(R.string.woopos_orders_details_total_label),
-                            style = WooPosTypography.BodySmall,
-                            fontWeight = FontWeight.Bold,
-                            modifier = Modifier.weight(1f)
-                        )
-                        WooPosText(
-                            text = details.total,
-                            style = WooPosTypography.BodySmall,
-                            fontWeight = FontWeight.Bold
-                        )
-                    }
-                }
-            }
-
-            // Payment section
-            Column {
-                Row(Modifier.fillMaxWidth()) {
-                    WooPosText(
-                        text = stringResource(R.string.woopos_orders_details_total_paid_label),
-                        style = WooPosTypography.BodySmall,
-                        modifier = Modifier.weight(1f)
-                    )
-                    WooPosText(
-                        text = details.totalPaid,
-                        style = WooPosTypography.BodySmall
-                    )
-                }
-                details.paymentMethodTitle?.let {
-                    Spacer(Modifier.height(WooPosSpacing.XSmall.value))
-                    WooPosText(
-                        text = it,
-                        style = WooPosTypography.BodySmall,
-                        color = WooPosTheme.colors.onSurfaceVariantHighest
-                    )
-                }
-            }
-        }
-    }
-}
-
-@Composable
-private fun OrderLineItemImage(imageUrl: String?) {
-    Box(
-        modifier = Modifier
-            .width(56.dp)
-            .fillMaxHeight()
-            .heightIn(min = 56.dp)
-            .background(MaterialTheme.colorScheme.surfaceDim),
-        contentAlignment = Alignment.Center
-    ) {
-        Image(
-            imageVector = Icons.Outlined.Inventory2,
-            contentDescription = null,
-            colorFilter = ColorFilter.tint(WooPosTheme.colors.onSurfaceVariantLowest),
-            modifier = Modifier.size(24.dp)
-        )
-        AsyncImage(
-            model = ImageRequest.Builder(LocalContext.current)
-                .data(imageUrl)
-                .crossfade(true)
-                .build(),
-            contentDescription = null,
-            contentScale = ContentScale.Crop
-        )
     }
 }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/orders/WooPosOrdersScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/orders/WooPosOrdersScreen.kt
@@ -182,7 +182,6 @@ private fun OrdersContent(
                 .weight(0.7f)
                 .fillMaxHeight()
                 .background(MaterialTheme.colorScheme.surfaceContainerLow),
-            order = state.items.find { it.isSelected },
             details = state.selectedOrderDetails,
             onEmailReceiptButtonClicked = onEmailReceiptButtonClicked
         )

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/orders/WooPosOrdersScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/orders/WooPosOrdersScreen.kt
@@ -736,7 +736,7 @@ fun WooPosOrdersScreenPreview() {
             onSearchEvent = {},
             onOrdersEmptyActionClicked = {},
             onOrdersLoadingErrorRetryButtonClicked = {},
-            onEmailReceiptButtonClicked = {} // ✅ required by the current signature
+            onEmailReceiptButtonClicked = {}
         )
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/orders/WooPosOrdersScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/orders/WooPosOrdersScreen.kt
@@ -382,14 +382,13 @@ private fun OrdersList(
 @Composable
 fun OrderDetails(
     modifier: Modifier = Modifier,
-    order: OrderItemViewState?,
     details: OrderDetailsViewState,
     onEmailReceiptButtonClicked: (Long) -> Unit = {}
 ) {
     Column(modifier = modifier.fillMaxSize()) {
         WooPosToolbar(
             modifier = Modifier.fillMaxWidth(),
-            titleText = details?.number ?: order?.title ?: "--",
+            titleText = details.number,
             onBackClicked = null
         )
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/orders/WooPosOrdersScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/orders/WooPosOrdersScreen.kt
@@ -1,6 +1,7 @@
 package com.woocommerce.android.ui.woopos.orders
 
 import androidx.activity.compose.BackHandler
+import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
 import androidx.compose.foundation.border
 import androidx.compose.foundation.clickable
@@ -16,12 +17,16 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.heightIn
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.statusBarsPadding
+import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.layout.wrapContentHeight
 import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.ExperimentalMaterialApi
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.outlined.Inventory2
 import androidx.compose.material.pullrefresh.PullRefreshIndicator
 import androidx.compose.material.pullrefresh.pullRefresh
 import androidx.compose.material.pullrefresh.rememberPullRefreshState
@@ -37,6 +42,9 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.ColorFilter
+import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.semantics.selected
 import androidx.compose.ui.semantics.semantics
@@ -44,6 +52,8 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
+import coil.compose.AsyncImage
+import coil.request.ImageRequest
 import com.woocommerce.android.R
 import com.woocommerce.android.ui.woopos.common.composeui.WooPosPreview
 import com.woocommerce.android.ui.woopos.common.composeui.component.ShadowType
@@ -382,7 +392,6 @@ fun OrderDetails(
             onBackClicked = null
         )
 
-        // Placeholder when nothing is selected
         if (details == null) {
             Column(
                 Modifier
@@ -472,6 +481,10 @@ fun OrderDetails(
                                     .padding(vertical = WooPosSpacing.Small.value),
                                 verticalAlignment = Alignment.CenterVertically
                             ) {
+                                OrderLineItemImage(
+                                    imageUrl = row.imageUrl
+                                )
+
                                 Column(Modifier.weight(1f)) {
                                     WooPosText(
                                         text = row.name,
@@ -613,6 +626,33 @@ fun OrderDetails(
                 }
             }
         }
+    }
+}
+
+@Composable
+private fun OrderLineItemImage(imageUrl: String?) {
+    Box(
+        modifier = Modifier
+            .width(56.dp)
+            .fillMaxHeight()
+            .heightIn(min = 56.dp)
+            .background(MaterialTheme.colorScheme.surfaceDim),
+        contentAlignment = Alignment.Center
+    ) {
+        Image(
+            imageVector = Icons.Outlined.Inventory2,
+            contentDescription = null,
+            colorFilter = ColorFilter.tint(WooPosTheme.colors.onSurfaceVariantLowest),
+            modifier = Modifier.size(24.dp)
+        )
+        AsyncImage(
+            model = ImageRequest.Builder(LocalContext.current)
+                .data(imageUrl)
+                .crossfade(true)
+                .build(),
+            contentDescription = null,
+            contentScale = ContentScale.Crop
+        )
     }
 }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/orders/WooPosOrdersScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/orders/WooPosOrdersScreen.kt
@@ -172,7 +172,7 @@ private fun OrdersContent(
                 .weight(0.7f)
                 .fillMaxHeight()
                 .background(MaterialTheme.colorScheme.surfaceContainerLow),
-            details = state.selectedOrderDetails,
+            details = state.selectedDetails,
             onEmailReceiptButtonClicked = onEmailReceiptButtonClicked
         )
     }
@@ -274,7 +274,7 @@ private fun OrdersList(
         contentPadding = PaddingValues(WooPosSpacing.Medium.value),
         state = listState,
     ) {
-        items(state.items, key = { it.id }) { item ->
+        items(state.items.keys.toList(), key = { it.id }) { item ->
             WooPosCard(
                 modifier = modifier
                     .wrapContentHeight(),
@@ -444,40 +444,45 @@ fun OrderStatusBadge(status: PosOrderStatus) {
 @WooPosPreview
 @Composable
 fun WooPosOrdersScreenPreview() {
+    val item1 = OrderItemViewState(
+        id = 1,
+        title = "#014",
+        date = "Aug 28, 2025 at 10:31 AM",
+        total = "$17.00",
+        customerEmail = "johndoe@mail.com",
+        isSelected = true,
+        status = PosOrderStatus(
+            text = "Completed",
+            colorKey = OrderStatusColorKey.COMPLETED
+        )
+    )
+    val item2 = OrderItemViewState(
+        id = 2,
+        title = "#013",
+        date = "Jul 28, 2025 at 10:31 AM",
+        total = "$43.90",
+        customerEmail = "johndoe@mail.com",
+        isSelected = false,
+        status = PosOrderStatus(
+            text = "Processing",
+            colorKey = OrderStatusColorKey.PROCESSING
+        )
+    )
+
+    val details1 = sampleOrderDetails(id = 1L, number = "#014")
+    val details2 = sampleOrderDetails(id = 2L, number = "#013")
+
     WooPosTheme {
         WooPosOrdersScreen(
             state = WooPosOrdersState.Content(
-                items = listOf(
-                    OrderItemViewState(
-                        id = 1,
-                        title = "#014",
-                        date = "Aug 28, 2025 at 10:31 AM",
-                        total = "$17.00",
-                        customerEmail = "johndoe@mail.com",
-                        isSelected = true,
-                        status = PosOrderStatus(
-                            text = "Completed",
-                            colorKey = OrderStatusColorKey.COMPLETED
-                        )
-                    ),
-                    OrderItemViewState(
-                        id = 2,
-                        title = "#013",
-                        date = "Jul 28, 2025 at 10:31 AM",
-                        total = "$43.90",
-                        customerEmail = "johndoe@mail.com",
-                        isSelected = false,
-                        status = PosOrderStatus(
-                            text = "Processing",
-                            colorKey = OrderStatusColorKey.PROCESSING
-                        )
-                    )
+                items = mapOf(
+                    item1 to details1,
+                    item2 to details2
                 ),
+                selectedDetails = details1,
                 pullToRefreshState = WooPosPullToRefreshState.Enabled,
                 searchInputState = WooPosSearchInputState.Closed,
-                paginationState = WooPosPaginationState.None,
-                selectedOrderId = 1,
-                selectedOrderDetails = sampleOrderDetails()
+                paginationState = WooPosPaginationState.None
             ),
             onBackClicked = {},
             onRefresh = {},
@@ -493,9 +498,12 @@ fun WooPosOrdersScreenPreview() {
 }
 
 @Suppress("MagicNumber")
-private fun sampleOrderDetails() = OrderDetailsViewState(
-    id = 1L,
-    number = "#014",
+private fun sampleOrderDetails(
+    id: Long = 1L,
+    number: String = "#014"
+) = OrderDetailsViewState(
+    id = id,
+    number = number,
     dateTime = "Aug 28, 2025 at 10:31 AM",
     customerEmail = "johndoe@mail.com",
     status = PosOrderStatus(text = "Completed", colorKey = OrderStatusColorKey.COMPLETED),

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/orders/WooPosOrdersScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/orders/WooPosOrdersScreen.kt
@@ -382,7 +382,7 @@ private fun OrdersList(
 fun OrderDetails(
     modifier: Modifier = Modifier,
     order: OrderItemViewState?,
-    details: OrderDetailsViewState?,
+    details: OrderDetailsViewState,
     onEmailReceiptButtonClicked: (Long) -> Unit = {}
 ) {
     Column(modifier = modifier.fillMaxSize()) {
@@ -391,30 +391,6 @@ fun OrderDetails(
             titleText = details?.number ?: order?.title ?: "--",
             onBackClicked = null
         )
-
-        if (details == null) {
-            Column(
-                Modifier
-                    .fillMaxSize()
-                    .padding(WooPosSpacing.Large.value),
-                verticalArrangement = Arrangement.Center,
-                horizontalAlignment = Alignment.CenterHorizontally
-            ) {
-                WooPosText(
-                    text = stringResource(R.string.woopos_orders_details_placeholder_title),
-                    style = WooPosTypography.Heading,
-                    fontWeight = FontWeight.SemiBold,
-                    color = MaterialTheme.colorScheme.onSurface
-                )
-                Spacer(Modifier.height(WooPosSpacing.Small.value))
-                WooPosText(
-                    text = stringResource(R.string.woopos_orders_details_placeholder_message),
-                    style = WooPosTypography.BodySmall,
-                    color = WooPosTheme.colors.onSurfaceVariantHighest
-                )
-            }
-            return
-        }
 
         WooPosLazyColumn(
             modifier = Modifier.fillMaxSize(),

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/orders/WooPosOrdersState.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/orders/WooPosOrdersState.kt
@@ -61,9 +61,9 @@ sealed class WooPosOrdersState {
         override val pullToRefreshState: WooPosPullToRefreshState,
         override val searchInputState: WooPosSearchInputState,
         val paginationState: WooPosPaginationState,
-        val selectedOrderId: Long?,
+        val selectedOrderId: Long,
 
-        val selectedOrderDetails: OrderDetailsViewState? = null
+        val selectedOrderDetails: OrderDetailsViewState
     ) : WooPosOrdersState()
 
     @Immutable

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/orders/WooPosOrdersState.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/orders/WooPosOrdersState.kt
@@ -26,7 +26,7 @@ data class OrderDetailsViewState(
         val name: String,
         val qtyAndUnitPrice: String,
         val lineTotal: String,
-        val thumbnailUrl: String?,
+        val imageUrl: String?,
     )
 
     @Immutable

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/orders/WooPosOrdersState.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/orders/WooPosOrdersState.kt
@@ -7,6 +7,39 @@ import com.woocommerce.android.ui.woopos.home.items.WooPosPaginationState
 import com.woocommerce.android.ui.woopos.home.items.WooPosPullToRefreshState
 
 @Immutable
+data class OrderDetailsViewState(
+    val id: Long,
+    val number: String,
+    val dateTime: String,
+    val customerEmail: String?,
+    val status: PosOrderStatus,
+
+    val lineItems: List<LineItemRow>,
+    val breakdown: TotalsBreakdown,
+    val total: String,
+    val totalPaid: String,
+    val paymentMethodTitle: String?,
+) {
+    @Immutable
+    data class LineItemRow(
+        val id: Long,
+        val name: String,
+        val qtyAndUnitPrice: String,
+        val lineTotal: String,
+        val thumbnailUrl: String?,
+    )
+
+    @Immutable
+    data class TotalsBreakdown(
+        val products: String,
+        val discount: String?,
+        val discountCode: String?,
+        val taxes: String,
+        val shipping: String?
+    )
+}
+
+@Immutable
 data class OrderItemViewState(
     val id: Long,
     val title: String,
@@ -28,7 +61,9 @@ sealed class WooPosOrdersState {
         override val pullToRefreshState: WooPosPullToRefreshState,
         override val searchInputState: WooPosSearchInputState,
         val paginationState: WooPosPaginationState,
-        val selectedOrderId: Long?
+        val selectedOrderId: Long?,
+
+        val selectedOrderDetails: OrderDetailsViewState? = null
     ) : WooPosOrdersState()
 
     @Immutable

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/orders/WooPosOrdersState.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/orders/WooPosOrdersState.kt
@@ -57,13 +57,11 @@ sealed class WooPosOrdersState {
 
     @Immutable
     data class Content(
-        val items: List<OrderItemViewState>,
+        val items: Map<OrderItemViewState, OrderDetailsViewState>,
+        val selectedDetails: OrderDetailsViewState,
         override val pullToRefreshState: WooPosPullToRefreshState,
         override val searchInputState: WooPosSearchInputState,
         val paginationState: WooPosPaginationState,
-        val selectedOrderId: Long,
-
-        val selectedOrderDetails: OrderDetailsViewState
     ) : WooPosOrdersState()
 
     @Immutable

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/orders/WooPosOrdersViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/orders/WooPosOrdersViewModel.kt
@@ -4,6 +4,8 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.woocommerce.android.R
 import com.woocommerce.android.model.Order
+import com.woocommerce.android.tools.ProductImageMap
+import com.woocommerce.android.tools.ProductImageMap.OnProductFetchedListener
 import com.woocommerce.android.tools.SelectedSite
 import com.woocommerce.android.ui.woopos.common.composeui.component.WooPosSearchInputState
 import com.woocommerce.android.ui.woopos.common.composeui.component.WooPosSearchUIEvent
@@ -29,8 +31,9 @@ class WooPosOrdersViewModel @Inject constructor(
     private val wooCommerceStore: WooCommerceStore,
     private val selectedSite: SelectedSite,
     private val resourceProvider: ResourceProvider,
-    private val locale: Locale
-) : ViewModel() {
+    private val locale: Locale,
+    private val productImageMap: ProductImageMap,
+) : ViewModel(), OnProductFetchedListener {
 
     private val _state = MutableStateFlow<WooPosOrdersState>(
         WooPosOrdersState.Loading(searchInputState = WooPosSearchInputState.Closed)
@@ -56,6 +59,27 @@ class WooPosOrdersViewModel @Inject constructor(
 
     init {
         loadOrders()
+        productImageMap.subscribeToOnProductFetchedEvents(this)
+    }
+
+    override fun onCleared() {
+        super.onCleared()
+        productImageMap.unsubscribeFromOnProductFetchedEvents(this)
+    }
+
+    @Suppress("ReturnCount")
+    override fun onProductFetched(remoteProductId: Long) {
+        val current = _state.value as? WooPosOrdersState.Content ?: return
+        val selectedId = current.selectedOrderId ?: return
+        val selectedOrder = ordersById[selectedId] ?: return
+
+        // Only refresh if the selected order uses that product
+        val affectsSelected = selectedOrder.items.any { it.productId == remoteProductId }
+        if (!affectsSelected) return
+
+        _state.value = current.copy(
+            selectedOrderDetails = mapDetails(selectedOrder)
+        )
     }
 
     fun onOrderSelected(orderId: Long) {
@@ -285,7 +309,8 @@ class WooPosOrdersViewModel @Inject constructor(
             selectedOrderId = newSelectedId,
             pullToRefreshState = WooPosPullToRefreshState.Enabled,
             paginationState = paginationState,
-            searchInputState = _state.value.searchInputState
+            searchInputState = _state.value.searchInputState,
+            selectedOrderDetails = newSelectedId?.let { ordersById[it] }?.let(::mapDetails)
         )
     }
 
@@ -349,6 +374,7 @@ class WooPosOrdersViewModel @Inject constructor(
             text = statusText,
             colorKey = OrderStatusColorKey.fromStatus(order.status)
         )
+        fun imageFor(item: Order.Item): String? = productImageMap.get(item.productId)
 
         val lineItems = order.items.map { item ->
             val unitPrice = if (item.quantity == 0f) item.total else item.total / item.quantity.toBigDecimal()
@@ -357,7 +383,7 @@ class WooPosOrdersViewModel @Inject constructor(
                 name = item.name,
                 qtyAndUnitPrice = "${item.quantity.toInt()} x ${fmt(unitPrice)}",
                 lineTotal = fmt(item.total),
-                thumbnailUrl = null
+                imageUrl = imageFor(item)
             )
         }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/orders/WooPosOrdersViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/orders/WooPosOrdersViewModel.kt
@@ -307,22 +307,31 @@ class WooPosOrdersViewModel @Inject constructor(
         _state.value = WooPosOrdersState.Content(
             items = newItems,
             selectedOrderId = newSelectedId,
+            selectedOrderDetails = newSelectedId?.let { id -> ordersById[id]?.let(::mapDetails) },
             pullToRefreshState = WooPosPullToRefreshState.Enabled,
             paginationState = paginationState,
-            searchInputState = _state.value.searchInputState,
-            selectedOrderDetails = newSelectedId?.let { ordersById[it] }?.let(::mapDetails)
+            searchInputState = _state.value.searchInputState
         )
     }
 
-    private fun appendOrders(orders: List<Order>, paginationState: WooPosPaginationState = WooPosPaginationState.None) {
+    private fun appendOrders(
+        orders: List<Order>,
+        paginationState: WooPosPaginationState = WooPosPaginationState.None
+    ) {
+        orders.forEach { ordersById[it.id] = it }
+
         val current = _state.value as? WooPosOrdersState.Content
         val existingItems = current?.items.orEmpty()
-        val selectedId = current?.selectedOrderId ?: existingItems.firstOrNull()?.id ?: orders.firstOrNull()?.id
+        val selectedId = current?.selectedOrderId
+            ?: existingItems.firstOrNull()?.id
+            ?: orders.firstOrNull()?.id
+
         val newItems = mapOrders(orders, selectedId)
 
         _state.value = WooPosOrdersState.Content(
             items = existingItems + newItems,
             selectedOrderId = selectedId,
+            selectedOrderDetails = selectedId?.let { id -> ordersById[id]?.let(::mapDetails) },
             pullToRefreshState = WooPosPullToRefreshState.Enabled,
             paginationState = paginationState,
             searchInputState = _state.value.searchInputState

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/orders/WooPosOrdersViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/orders/WooPosOrdersViewModel.kt
@@ -19,6 +19,7 @@ import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.launch
 import org.wordpress.android.fluxc.store.WooCommerceStore
+import java.math.BigDecimal
 import java.util.Locale
 import javax.inject.Inject
 
@@ -40,6 +41,8 @@ class WooPosOrdersViewModel @Inject constructor(
     private var loadingJob: Job? = null
     private var loadingMoreOrdersJob: Job? = null
 
+    private val ordersById = linkedMapOf<Long, Order>()
+
     private val currentSearchQuery: String?
         get() = (
             (
@@ -60,7 +63,8 @@ class WooPosOrdersViewModel @Inject constructor(
         if (currentState is WooPosOrdersState.Content) {
             _state.value = currentState.copy(
                 items = currentState.items.map { it.copy(isSelected = it.id == orderId) },
-                selectedOrderId = orderId
+                selectedOrderId = orderId,
+                selectedOrderDetails = ordersById[orderId]?.let(::mapDetails)
             )
         }
     }
@@ -113,6 +117,11 @@ class WooPosOrdersViewModel @Inject constructor(
     fun onOrdersLoadingErrorRetryButtonClicked() {
         _state.value = WooPosOrdersState.Loading(searchInputState = WooPosSearchInputState.Closed)
         loadOrders()
+    }
+
+    @Suppress("UnusedParameter")
+    fun onEmailReceiptButtonClicked(orderId: Long) {
+        // Action to be implemented
     }
 
     @Suppress("ReturnCount")
@@ -265,6 +274,9 @@ class WooPosOrdersViewModel @Inject constructor(
         orders: List<Order>,
         paginationState: WooPosPaginationState = WooPosPaginationState.None
     ) {
+        ordersById.clear()
+        orders.forEach { ordersById[it.id] = it }
+
         val newSelectedId = orders.firstOrNull()?.id
         val newItems = mapOrders(orders, newSelectedId)
 
@@ -304,19 +316,7 @@ class WooPosOrdersViewModel @Inject constructor(
                 applyDecimalFormatting = true
             )
 
-            val formattedStatus = when (order.status) {
-                Order.Status.Cancelled -> resourceProvider.getString(R.string.woopos_orders_status_cancelled)
-                Order.Status.Completed -> resourceProvider.getString(R.string.woopos_orders_status_completed)
-                is Order.Status.Custom ->
-                    order.status.value
-                        .replaceFirstChar { it.titlecase(locale) }
-                        .replace("-", " ") // cannot localize at runtime
-                Order.Status.Failed -> resourceProvider.getString(R.string.woopos_orders_status_failed)
-                Order.Status.OnHold -> resourceProvider.getString(R.string.woopos_orders_status_on_hold)
-                Order.Status.Pending -> resourceProvider.getString(R.string.woopos_orders_status_pending)
-                Order.Status.Processing -> resourceProvider.getString(R.string.woopos_orders_status_processing)
-                Order.Status.Refunded -> resourceProvider.getString(R.string.woopos_orders_status_refunded)
-            }
+            val statusText = order.status.localizedLabel(resourceProvider, locale)
 
             OrderItemViewState(
                 id = order.id,
@@ -328,10 +328,75 @@ class WooPosOrdersViewModel @Inject constructor(
                 customerEmail = order.customer?.email,
                 isSelected = order.id == selectedId,
                 status = PosOrderStatus(
-                    text = formattedStatus,
+                    text = statusText,
                     colorKey = OrderStatusColorKey.fromStatus(order.status)
                 )
             )
         }
+    }
+
+    private fun mapDetails(order: Order): OrderDetailsViewState {
+        fun fmt(amount: BigDecimal) = wooCommerceStore.formatCurrencyForDisplay(
+            amount = amount.toDouble(),
+            site = selectedSite.get(),
+            currencyCode = null,
+            applyDecimalFormatting = true
+        )
+
+        val statusText = order.status.localizedLabel(resourceProvider, locale)
+
+        val status = PosOrderStatus(
+            text = statusText,
+            colorKey = OrderStatusColorKey.fromStatus(order.status)
+        )
+
+        val lineItems = order.items.map { item ->
+            val unitPrice = if (item.quantity == 0f) item.total else item.total / item.quantity.toBigDecimal()
+            OrderDetailsViewState.LineItemRow(
+                id = item.itemId,
+                name = item.name,
+                qtyAndUnitPrice = "${item.quantity.toInt()} x ${fmt(unitPrice)}",
+                lineTotal = fmt(item.total),
+                thumbnailUrl = null
+            )
+        }
+
+        val discountCode = order.couponLines.firstOrNull()?.code
+        val breakdown = OrderDetailsViewState.TotalsBreakdown(
+            products = fmt(order.productsTotal),
+            discount = order.discountTotal.takeIf { it != BigDecimal.ZERO }?.let { "-${fmt(it)}" },
+            discountCode = discountCode,
+            taxes = fmt(order.totalTax),
+            shipping = order.shippingTotal.takeIf { it != BigDecimal.ZERO }?.let { fmt(it) }
+        )
+
+        return OrderDetailsViewState(
+            id = order.id,
+            number = "#${order.number}",
+            dateTime = order.dateCreated.formatToMMMddYYYYAtHHmm(
+                atWord = resourceProvider.getString(R.string.date_time_connector)
+            ),
+            customerEmail = order.customer?.email,
+            status = status,
+            lineItems = lineItems,
+            breakdown = breakdown,
+            total = fmt(order.total),
+            totalPaid = fmt(order.total),
+            paymentMethodTitle = order.paymentMethodTitle.takeIf { it.isNotBlank() }
+        )
+    }
+}
+
+private fun Order.Status.localizedLabel(resourceProvider: ResourceProvider, locale: Locale): String {
+    return when (this) {
+        Order.Status.Cancelled -> resourceProvider.getString(R.string.woopos_orders_status_cancelled)
+        Order.Status.Completed -> resourceProvider.getString(R.string.woopos_orders_status_completed)
+        is Order.Status.Custom ->
+            value.replaceFirstChar { it.titlecase(locale) }.replace("-", " ")
+        Order.Status.Failed -> resourceProvider.getString(R.string.woopos_orders_status_failed)
+        Order.Status.OnHold -> resourceProvider.getString(R.string.woopos_orders_status_on_hold)
+        Order.Status.Pending -> resourceProvider.getString(R.string.woopos_orders_status_pending)
+        Order.Status.Processing -> resourceProvider.getString(R.string.woopos_orders_status_processing)
+        Order.Status.Refunded -> resourceProvider.getString(R.string.woopos_orders_status_refunded)
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/orders/WooPosOrdersViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/orders/WooPosOrdersViewModel.kt
@@ -83,14 +83,14 @@ class WooPosOrdersViewModel @Inject constructor(
     }
 
     fun onOrderSelected(orderId: Long) {
-        val currentState = _state.value
-        if (currentState is WooPosOrdersState.Content) {
-            _state.value = currentState.copy(
-                items = currentState.items.map { it.copy(isSelected = it.id == orderId) },
-                selectedOrderId = orderId,
-                selectedOrderDetails = ordersById[orderId]?.let(::mapDetails)
-            )
-        }
+        val current = _state.value as? WooPosOrdersState.Content ?: return
+        val details = ordersById[orderId]?.let(::mapDetails) ?: return
+
+        _state.value = current.copy(
+            items = current.items.map { it.copy(isSelected = it.id == orderId) },
+            selectedOrderId = orderId,
+            selectedOrderDetails = details
+        )
     }
 
     fun onRefresh() {
@@ -271,7 +271,13 @@ class WooPosOrdersViewModel @Inject constructor(
                     }
 
                     is LoadOrdersResult.SuccessCache -> {
-                        replaceOrders(result.orders)
+                        if (result.orders.isEmpty()) {
+                            _state.value = WooPosOrdersState.Loading(
+                                searchInputState = WooPosSearchInputState.Closed
+                            )
+                        } else {
+                            replaceOrders(result.orders)
+                        }
                     }
 
                     is LoadOrdersResult.SuccessRemote -> {
@@ -301,13 +307,14 @@ class WooPosOrdersViewModel @Inject constructor(
         ordersById.clear()
         orders.forEach { ordersById[it.id] = it }
 
-        val newSelectedId = orders.firstOrNull()?.id
+        val newSelectedId = requireNotNull(orders.firstOrNull()?.id) { "Content requires at least one order" }
         val newItems = mapOrders(orders, newSelectedId)
+        val details = mapDetails(requireNotNull(ordersById[newSelectedId]))
 
         _state.value = WooPosOrdersState.Content(
             items = newItems,
             selectedOrderId = newSelectedId,
-            selectedOrderDetails = newSelectedId?.let { id -> ordersById[id]?.let(::mapDetails) },
+            selectedOrderDetails = details,
             pullToRefreshState = WooPosPullToRefreshState.Enabled,
             paginationState = paginationState,
             searchInputState = _state.value.searchInputState
@@ -320,18 +327,16 @@ class WooPosOrdersViewModel @Inject constructor(
     ) {
         orders.forEach { ordersById[it.id] = it }
 
-        val current = _state.value as? WooPosOrdersState.Content
-        val existingItems = current?.items.orEmpty()
-        val selectedId = current?.selectedOrderId
-            ?: existingItems.firstOrNull()?.id
-            ?: orders.firstOrNull()?.id
+        val current = _state.value as WooPosOrdersState.Content
+        val items = current.items + mapOrders(orders, current.selectedOrderId)
 
-        val newItems = mapOrders(orders, selectedId)
+        // Selection doesn’t change on append
+        val details = mapDetails(requireNotNull(ordersById[current.selectedOrderId]))
 
         _state.value = WooPosOrdersState.Content(
-            items = existingItems + newItems,
-            selectedOrderId = selectedId,
-            selectedOrderDetails = selectedId?.let { id -> ordersById[id]?.let(::mapDetails) },
+            items = items,
+            selectedOrderId = current.selectedOrderId,
+            selectedOrderDetails = details,
             pullToRefreshState = WooPosPullToRefreshState.Enabled,
             paginationState = paginationState,
             searchInputState = _state.value.searchInputState

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/orders/WooPosOrdersViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/orders/WooPosOrdersViewModel.kt
@@ -4,11 +4,10 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.woocommerce.android.R
 import com.woocommerce.android.model.Order
-import com.woocommerce.android.tools.ProductImageMap
-import com.woocommerce.android.tools.ProductImageMap.OnProductFetchedListener
 import com.woocommerce.android.tools.SelectedSite
 import com.woocommerce.android.ui.woopos.common.composeui.component.WooPosSearchInputState
 import com.woocommerce.android.ui.woopos.common.composeui.component.WooPosSearchUIEvent
+import com.woocommerce.android.ui.woopos.common.data.WooPosGetProductById
 import com.woocommerce.android.ui.woopos.home.items.WooPosPaginationState
 import com.woocommerce.android.ui.woopos.home.items.WooPosPullToRefreshState
 import com.woocommerce.android.ui.woopos.util.ext.formatToMMMddYYYYAtHHmm
@@ -32,8 +31,8 @@ class WooPosOrdersViewModel @Inject constructor(
     private val selectedSite: SelectedSite,
     private val resourceProvider: ResourceProvider,
     private val locale: Locale,
-    private val productImageMap: ProductImageMap,
-) : ViewModel(), OnProductFetchedListener {
+    private val getProductById: WooPosGetProductById,
+) : ViewModel() {
 
     private val _state = MutableStateFlow<WooPosOrdersState>(
         WooPosOrdersState.Loading(searchInputState = WooPosSearchInputState.Closed)
@@ -43,8 +42,6 @@ class WooPosOrdersViewModel @Inject constructor(
     private var searchJob: Job? = null
     private var loadingJob: Job? = null
     private var loadingMoreOrdersJob: Job? = null
-
-    private val ordersById = linkedMapOf<Long, Order>()
 
     private val currentSearchQuery: String?
         get() = (
@@ -59,37 +56,20 @@ class WooPosOrdersViewModel @Inject constructor(
 
     init {
         loadOrders()
-        productImageMap.subscribeToOnProductFetchedEvents(this)
-    }
-
-    override fun onCleared() {
-        super.onCleared()
-        productImageMap.unsubscribeFromOnProductFetchedEvents(this)
-    }
-
-    @Suppress("ReturnCount")
-    override fun onProductFetched(remoteProductId: Long) {
-        val current = _state.value as? WooPosOrdersState.Content ?: return
-        val selectedId = current.selectedOrderId ?: return
-        val selectedOrder = ordersById[selectedId] ?: return
-
-        // Only refresh if the selected order uses that product
-        val affectsSelected = selectedOrder.items.any { it.productId == remoteProductId }
-        if (!affectsSelected) return
-
-        _state.value = current.copy(
-            selectedOrderDetails = mapDetails(selectedOrder)
-        )
     }
 
     fun onOrderSelected(orderId: Long) {
         val current = _state.value as? WooPosOrdersState.Content ?: return
-        val details = ordersById[orderId]?.let(::mapDetails) ?: return
+
+        val updatedItems = current.items.mapKeys { (item, _) ->
+            item.copy(isSelected = item.id == orderId)
+        }
+
+        val selectedEntry = updatedItems.entries.first { (item, _) -> item.isSelected }
 
         _state.value = current.copy(
-            items = current.items.map { it.copy(isSelected = it.id == orderId) },
-            selectedOrderId = orderId,
-            selectedOrderDetails = details
+            items = updatedItems,
+            selectedDetails = selectedEntry.value
         )
     }
 
@@ -300,81 +280,79 @@ class WooPosOrdersViewModel @Inject constructor(
         loadingMoreOrdersJob?.cancel()
     }
 
-    private fun replaceOrders(
+    private suspend fun replaceOrders(
         orders: List<Order>,
         paginationState: WooPosPaginationState = WooPosPaginationState.None
     ) {
-        ordersById.clear()
-        orders.forEach { ordersById[it.id] = it }
-
         val newSelectedId = requireNotNull(orders.firstOrNull()?.id) { "Content requires at least one order" }
-        val newItems = mapOrders(orders, newSelectedId)
-        val details = mapDetails(requireNotNull(ordersById[newSelectedId]))
-
-        _state.value = WooPosOrdersState.Content(
-            items = newItems,
-            selectedOrderId = newSelectedId,
-            selectedOrderDetails = details,
-            pullToRefreshState = WooPosPullToRefreshState.Enabled,
-            paginationState = paginationState,
-            searchInputState = _state.value.searchInputState
-        )
-    }
-
-    private fun appendOrders(
-        orders: List<Order>,
-        paginationState: WooPosPaginationState = WooPosPaginationState.None
-    ) {
-        orders.forEach { ordersById[it.id] = it }
-
-        val current = _state.value as WooPosOrdersState.Content
-        val items = current.items + mapOrders(orders, current.selectedOrderId)
-
-        // Selection doesn’t change on append
-        val details = mapDetails(requireNotNull(ordersById[current.selectedOrderId]))
+        val items = buildItemsMap(orders, newSelectedId)
+        val selectedEntry = items.entries.first { (item, _) -> item.isSelected }
 
         _state.value = WooPosOrdersState.Content(
             items = items,
-            selectedOrderId = current.selectedOrderId,
-            selectedOrderDetails = details,
+            selectedDetails = selectedEntry.value,
             pullToRefreshState = WooPosPullToRefreshState.Enabled,
             paginationState = paginationState,
             searchInputState = _state.value.searchInputState
         )
     }
 
-    private fun mapOrders(
+    private suspend fun appendOrders(
+        orders: List<Order>,
+        paginationState: WooPosPaginationState = WooPosPaginationState.None
+    ) {
+        val current = _state.value as WooPosOrdersState.Content
+        val currentSelectedId = current.items.entries.firstOrNull { it.key.isSelected }?.key?.id
+        val newItems = buildItemsMap(orders, currentSelectedId)
+        val items = current.items + newItems
+
+        _state.value = WooPosOrdersState.Content(
+            items = items,
+            selectedDetails = current.selectedDetails,
+            pullToRefreshState = WooPosPullToRefreshState.Enabled,
+            paginationState = paginationState,
+            searchInputState = _state.value.searchInputState
+        )
+    }
+
+    private suspend fun buildItemsMap(
         orders: List<Order>,
         selectedId: Long?
-    ): List<OrderItemViewState> {
-        return orders.map { order ->
-            val formattedOrderTotals = wooCommerceStore.formatCurrencyForDisplay(
-                amount = order.total.toDouble(),
-                site = selectedSite.get(),
-                currencyCode = null,
-                applyDecimalFormatting = true
-            )
-
-            val statusText = order.status.localizedLabel(resourceProvider, locale)
-
-            OrderItemViewState(
-                id = order.id,
-                title = "#${order.number}",
-                date = order.dateCreated.formatToMMMddYYYYAtHHmm(
-                    atWord = resourceProvider.getString(R.string.date_time_connector)
-                ),
-                total = formattedOrderTotals,
-                customerEmail = order.customer?.email,
-                isSelected = order.id == selectedId,
-                status = PosOrderStatus(
-                    text = statusText,
-                    colorKey = OrderStatusColorKey.fromStatus(order.status)
-                )
-            )
+    ): Map<OrderItemViewState, OrderDetailsViewState> {
+        return orders.associate { order ->
+            val item = mapOrderItem(order, selectedId)
+            val details = mapOrderDetails(order)
+            item to details
         }
     }
 
-    private fun mapDetails(order: Order): OrderDetailsViewState {
+    private fun mapOrderItem(order: Order, selectedId: Long?): OrderItemViewState {
+        val formattedOrderTotals = wooCommerceStore.formatCurrencyForDisplay(
+            amount = order.total.toDouble(),
+            site = selectedSite.get(),
+            currencyCode = null,
+            applyDecimalFormatting = true
+        )
+
+        val statusText = order.status.localizedLabel(resourceProvider, locale)
+
+        return OrderItemViewState(
+            id = order.id,
+            title = "#${order.number}",
+            date = order.dateCreated.formatToMMMddYYYYAtHHmm(
+                atWord = resourceProvider.getString(R.string.date_time_connector)
+            ),
+            total = formattedOrderTotals,
+            customerEmail = order.customer?.email,
+            isSelected = order.id == selectedId,
+            status = PosOrderStatus(
+                text = statusText,
+                colorKey = OrderStatusColorKey.fromStatus(order.status)
+            )
+        )
+    }
+
+    private suspend fun mapOrderDetails(order: Order): OrderDetailsViewState {
         fun fmt(amount: BigDecimal) = wooCommerceStore.formatCurrencyForDisplay(
             amount = amount.toDouble(),
             site = selectedSite.get(),
@@ -388,16 +366,16 @@ class WooPosOrdersViewModel @Inject constructor(
             text = statusText,
             colorKey = OrderStatusColorKey.fromStatus(order.status)
         )
-        fun imageFor(item: Order.Item): String? = productImageMap.get(item.productId)
 
         val lineItems = order.items.map { item ->
             val unitPrice = if (item.quantity == 0f) item.total else item.total / item.quantity.toBigDecimal()
+            val product = getProductById(item.productId)
             OrderDetailsViewState.LineItemRow(
                 id = item.itemId,
                 name = item.name,
                 qtyAndUnitPrice = "${item.quantity.toInt()} x ${fmt(unitPrice)}",
                 lineTotal = fmt(item.total),
-                imageUrl = imageFor(item)
+                imageUrl = product?.firstImageUrl
             )
         }
 

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -3794,6 +3794,23 @@
     <string name="woopos_orders_pagination_error_title">Unable to load more orders</string>
     <string name="woopos_orders_pagination_error_content_description">Please try again.</string>
 
+    <string name="woopos_orders_email_receipt">Issue refund</string>
+    <string name="woopos_orders_issue_refund_content_description">Issue a refund for this order</string>
+    <string name="woopos_orders_details_placeholder_title">Select an order</string>
+    <string name="woopos_orders_details_placeholder_message">Choose an order from the list to view details.</string>
+    <string name="woopos_orders_details_products_title">Products</string>
+    <string name="woopos_orders_details_totals_title">Totals</string>
+    <string name="woopos_orders_details_qty_unit_price_format">%1$d x %2$s</string>
+    <string name="woopos_orders_details_breakdown_products_label">Products</string>
+    <string name="woopos_orders_details_breakdown_discount_label">Discount</string>
+    <string name="woopos_orders_details_breakdown_discount_with_code_label">Discount (%1$s)</string>
+    <string name="woopos_orders_details_breakdown_taxes_label">Taxes</string>
+    <string name="woopos_orders_details_breakdown_shipping_label">Shipping</string>
+    <string name="woopos_orders_details_total_label">Total</string>
+    <string name="woopos_orders_details_total_paid_label">Total paid</string>
+    <string name="woopos_orders_details_products_list_content_description">Order products list</string>
+    <string name="woopos_orders_details_totals_card_content_description">Order totals breakdown</string>
+
     <string name="woopos_orders_status_auto_draft">Draft</string>
     <string name="woopos_orders_status_pending">Pending Payment</string>
     <string name="woopos_orders_status_processing">Processing</string>

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -3794,7 +3794,7 @@
     <string name="woopos_orders_pagination_error_title">Unable to load more orders</string>
     <string name="woopos_orders_pagination_error_content_description">Please try again.</string>
 
-    <string name="woopos_orders_email_receipt">Issue refund</string>
+    <string name="woopos_orders_email_receipt">Email receipt</string>
     <string name="woopos_orders_issue_refund_content_description">Issue a refund for this order</string>
     <string name="woopos_orders_details_placeholder_title">Select an order</string>
     <string name="woopos_orders_details_placeholder_message">Choose an order from the list to view details.</string>

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/orders/WooPosOrdersViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/orders/WooPosOrdersViewModelTest.kt
@@ -650,4 +650,70 @@ class WooPosOrdersViewModelTest {
         val details = content.selectedOrderDetails!!
         assertThat(details.lineItems.any { it.imageUrl == "https://example.com/img.png" }).isTrue()
     }
+
+    @Test
+    fun `given orders loaded, when selecting an order, then selectedOrderDetails is populated`() = runTest {
+        // GIVEN
+        whenever(dataSource.loadOrders()).thenReturn(
+            flow { emit(LoadOrdersResult.SuccessRemote(listOf(order(1), order(2)))) }
+        )
+
+        viewModel = createViewModel()
+        advanceUntilIdle()
+
+        // WHEN
+        viewModel.onOrderSelected(2L)
+        advanceUntilIdle()
+
+        // THEN
+        val content = viewModel.state.value as WooPosOrdersState.Content
+        assertThat(content.selectedOrderId).isEqualTo(2L)
+        assertThat(content.selectedOrderDetails?.id).isEqualTo(2L)
+        assertThat(content.selectedOrderDetails?.lineItems).isNotEmpty
+        assertThat(content.selectedOrderDetails?.total).isEqualTo("$0.00")
+    }
+
+    @Test
+    fun `given selected order, when appending next page, then selectedOrderDetails content remains correct`() = runTest {
+        whenever(dataSource.loadOrders()).thenReturn(
+            flow { emit(LoadOrdersResult.SuccessRemote(listOf(order(10), order(20)))) }
+        )
+        whenever(dataSource.hasMorePages).thenReturn(true)
+        whenever(dataSource.loadMore()).thenReturn(Result.success(listOf(order(30), order(40))))
+
+        viewModel = createViewModel()
+        advanceUntilIdle()
+
+        viewModel.onOrderSelected(20L)
+        advanceUntilIdle()
+
+        viewModel.onEndOfOrdersListReached()
+        advanceUntilIdle()
+
+        val content = viewModel.state.value as WooPosOrdersState.Content
+        val details = content.selectedOrderDetails
+        assertThat(details).isNotNull
+        assertThat(details?.id).isEqualTo(20L)
+        assertThat(details?.totalPaid).isEqualTo("$0.00")
+    }
+
+    @Test
+    fun `given orders reloaded, when refreshing, then first order details are auto-populated`() = runTest {
+        whenever(dataSource.loadOrders()).thenReturn(
+            flow { emit(LoadOrdersResult.SuccessRemote(listOf(order(100), order(200)))) }
+        )
+        viewModel = createViewModel()
+        advanceUntilIdle()
+
+        whenever(dataSource.loadOrders()).thenReturn(
+            flow { emit(LoadOrdersResult.SuccessRemote(listOf(order(300), order(400)))) }
+        )
+
+        viewModel.onRefresh()
+        advanceUntilIdle()
+
+        val content = viewModel.state.value as WooPosOrdersState.Content
+        assertThat(content.selectedOrderId).isEqualTo(300L)
+        assertThat(content.selectedOrderDetails?.id).isEqualTo(300L)
+    }
 }

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/orders/WooPosOrdersViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/orders/WooPosOrdersViewModelTest.kt
@@ -113,8 +113,7 @@ class WooPosOrdersViewModelTest {
         assertThat(content.pullToRefreshState).isEqualTo(WooPosPullToRefreshState.Enabled)
         assertThat(content.paginationState).isEqualTo(WooPosPaginationState.None)
         verify(dataSource).loadOrders()
-
-        assertThat(content.selectedOrderDetails?.id).isEqualTo(2L)
+        assertThat(content.selectedOrderDetails.id).isEqualTo(2L)
     }
 
     @Test
@@ -123,8 +122,8 @@ class WooPosOrdersViewModelTest {
         val network = listOf(order(10))
         whenever(dataSource.loadOrders()).thenReturn(
             flow {
-                emit(LoadOrdersResult.SuccessCache(emptyList())) // cache → VM sets Loading
-                emit(LoadOrdersResult.SuccessRemote(network)) // remote → Content
+                emit(LoadOrdersResult.SuccessCache(emptyList()))
+                emit(LoadOrdersResult.SuccessRemote(network))
             }
         )
 
@@ -138,7 +137,7 @@ class WooPosOrdersViewModelTest {
         val content = state as WooPosOrdersState.Content
         assertThat(content.items.map { it.id }).containsExactly(10L)
         assertThat(content.pullToRefreshState).isEqualTo(WooPosPullToRefreshState.Enabled)
-        assertThat(content.selectedOrderDetails?.id).isEqualTo(10L)
+        assertThat(content.selectedOrderDetails.id).isEqualTo(10L)
     }
 
     @Test
@@ -146,8 +145,8 @@ class WooPosOrdersViewModelTest {
         // GIVEN
         whenever(dataSource.loadOrders()).thenReturn(
             flow {
-                emit(LoadOrdersResult.SuccessCache(emptyList())) // cache → Loading
-                emit(LoadOrdersResult.SuccessRemote(emptyList())) // remote → Empty
+                emit(LoadOrdersResult.SuccessCache(emptyList()))
+                emit(LoadOrdersResult.SuccessRemote(emptyList()))
             }
         )
 
@@ -205,11 +204,11 @@ class WooPosOrdersViewModelTest {
         assertThat(after.items.map { it.id }).containsExactly(5L, 6L)
         assertThat(after.pullToRefreshState).isEqualTo(WooPosPullToRefreshState.Enabled)
         verify(dataSource).clearCache()
-        verify(dataSource, times(2)).loadOrders() // init + refresh
+        verify(dataSource, times(2)).loadOrders()
     }
 
     @Test
-    fun `given orders loaded, when selecting an order, then selected id and flags update`() = runTest {
+    fun `given orders loaded, when selecting an order, then selected id, flags and details update`() = runTest {
         // GIVEN
         whenever(dataSource.loadOrders()).thenReturn(
             flow { emit(LoadOrdersResult.SuccessRemote(listOf(order(1), order(2), order(3)))) }
@@ -228,12 +227,11 @@ class WooPosOrdersViewModelTest {
         assertThat(selectedFlags[1L]).isFalse()
         assertThat(selectedFlags[2L]).isFalse()
         assertThat(selectedFlags[3L]).isTrue()
-
-        assertThat(state.selectedOrderDetails?.id).isEqualTo(3L)
+        assertThat(state.selectedOrderDetails.id).isEqualTo(3L)
     }
 
     @Test
-    fun `given selection removed after reload, when refreshing, then first item is auto selected`() = runTest {
+    fun `given selection removed after reload, when refreshing, then first item is auto selected with details`() = runTest {
         // GIVEN
         whenever(dataSource.loadOrders()).thenReturn(
             flow { emit(LoadOrdersResult.SuccessRemote(listOf(order(100), order(200)))) }
@@ -258,7 +256,7 @@ class WooPosOrdersViewModelTest {
         val state = viewModel.state.value as WooPosOrdersState.Content
         assertThat(state.items.map { it.id }).containsExactly(300L, 400L)
         assertThat(state.selectedOrderId).isEqualTo(300L)
-        assertThat(state.selectedOrderDetails?.id).isEqualTo(300L)
+        assertThat(state.selectedOrderDetails.id).isEqualTo(300L)
     }
 
     @Test
@@ -299,7 +297,6 @@ class WooPosOrdersViewModelTest {
         val content = state as WooPosOrdersState.Content
         assertThat(content.items.map { it.id }).containsExactly(10L, 20L)
         assertThat(content.searchInputState).isInstanceOf(WooPosSearchInputState.Open::class.java)
-
         verify(dataSource).searchOrders(query)
     }
 
@@ -314,26 +311,7 @@ class WooPosOrdersViewModelTest {
         advanceUntilIdle()
 
         // THEN
-        verify(dataSource, times(2)).loadOrders() // init + search with empty query
-    }
-
-    @Test
-    fun `given search input is open, when onSearchEvent Close, then search input state closes and loadOrders is called`() = runTest {
-        // GIVEN
-        viewModel = createViewModel()
-        advanceUntilIdle()
-
-        viewModel.onSearchEvent(WooPosSearchUIEvent.SearchIconClicked)
-        advanceUntilIdle()
-
-        // WHEN
-        viewModel.onSearchEvent(WooPosSearchUIEvent.Close)
-        advanceUntilIdle()
-
-        // THEN
-        val state = viewModel.state.value
-        assertThat(state.searchInputState).isEqualTo(WooPosSearchInputState.Closed)
-        verify(dataSource, times(2)).loadOrders() // init + close search
+        verify(dataSource, times(2)).loadOrders()
     }
 
     @Test
@@ -372,7 +350,6 @@ class WooPosOrdersViewModelTest {
         // WHEN
         viewModel = createViewModel()
         advanceUntilIdle()
-
         viewModel.onEndOfOrdersListReached()
         advanceUntilIdle()
 
@@ -384,26 +361,28 @@ class WooPosOrdersViewModelTest {
 
     @Test
     fun `given more pages, when end reached and loadMore fails, then keep items and show pagination error`() = runTest {
+        // GIVEN
         whenever(dataSource.loadOrders()).thenReturn(
             flow { emit(LoadOrdersResult.SuccessRemote(listOf(order(1), order(2)))) }
         )
         whenever(dataSource.hasMorePages).thenReturn(true)
         whenever(dataSource.loadMore()).thenReturn(Result.failure(RuntimeException("boom")))
 
+        // WHEN
         viewModel = createViewModel()
         advanceUntilIdle()
-
         viewModel.onEndOfOrdersListReached()
         advanceUntilIdle()
 
+        // THEN
         val content = viewModel.state.value as WooPosOrdersState.Content
-        assertThat(content.items.map { it.id }).containsExactly(1L, 2L) // unchanged
+        assertThat(content.items.map { it.id }).containsExactly(1L, 2L)
         assertThat(content.paginationState).isEqualTo(WooPosPaginationState.Error)
     }
 
     @Test
     fun `given initial load active, when end reached, then do nothing`() = runTest {
-        // GIVEN: cache -> Content; remote never completes (keeps loadingJob active)
+        // GIVEN
         whenever(dataSource.loadOrders()).thenReturn(
             flow {
                 emit(LoadOrdersResult.SuccessCache(listOf(order(1))))
@@ -424,7 +403,7 @@ class WooPosOrdersViewModelTest {
     }
 
     @Test
-    fun `given selected order, when appending next page, then selection is preserved`() = runTest {
+    fun `given selected order, when appending next page, then selection and details are preserved`() = runTest {
         // GIVEN
         whenever(dataSource.loadOrders()).thenReturn(
             flow { emit(LoadOrdersResult.SuccessRemote(listOf(order(10), order(20)))) }
@@ -435,10 +414,8 @@ class WooPosOrdersViewModelTest {
         // WHEN
         viewModel = createViewModel()
         advanceUntilIdle()
-
         viewModel.onOrderSelected(20L)
         advanceUntilIdle()
-
         viewModel.onEndOfOrdersListReached()
         advanceUntilIdle()
 
@@ -448,7 +425,7 @@ class WooPosOrdersViewModelTest {
         assertThat(content.selectedOrderId).isEqualTo(20L)
         val selectedFlags = content.items.associate { it.id to it.isSelected }
         assertThat(selectedFlags[20L]).isTrue()
-        assertThat(content.selectedOrderDetails?.id).isEqualTo(20L)
+        assertThat(content.selectedOrderDetails.id).isEqualTo(20L)
     }
 
     @Test
@@ -472,7 +449,6 @@ class WooPosOrdersViewModelTest {
         viewModel.onSearchEvent(WooPosSearchUIEvent.SearchIconClicked)
         viewModel.onSearchEvent(WooPosSearchUIEvent.Search(query, query.length))
         advanceUntilIdle()
-
         viewModel.onEndOfOrdersListReached()
         advanceUntilIdle()
 
@@ -490,10 +466,7 @@ class WooPosOrdersViewModelTest {
             flow { emit(LoadOrdersResult.SuccessRemote(listOf(order(1), order(2)))) }
         )
         whenever(dataSource.hasMorePages).thenReturn(true)
-
-        whenever(dataSource.loadMore()).thenReturn(
-            Result.failure(RuntimeException("boom"))
-        )
+        whenever(dataSource.loadMore()).thenReturn(Result.failure(RuntimeException("boom")))
 
         viewModel = createViewModel()
         advanceUntilIdle()
@@ -502,11 +475,15 @@ class WooPosOrdersViewModelTest {
         viewModel.onEndOfOrdersListReached()
         advanceUntilIdle()
 
+        // THEN (pagination shows error)
         var content = viewModel.state.value as WooPosOrdersState.Content
         assertThat(content.items.map { it.id }).containsExactly(1L, 2L)
         assertThat(content.paginationState).isEqualTo(WooPosPaginationState.Error)
 
+        // GIVEN (next call will succeed)
         whenever(dataSource.loadMore()).thenReturn(Result.success(listOf(order(3), order(4))))
+
+        // WHEN
         viewModel.onPaginationErrorTryAgain()
         advanceUntilIdle()
 
@@ -514,39 +491,8 @@ class WooPosOrdersViewModelTest {
         content = viewModel.state.value as WooPosOrdersState.Content
         assertThat(content.items.map { it.id }).containsExactly(1L, 2L, 3L, 4L)
         assertThat(content.paginationState).isEqualTo(WooPosPaginationState.None)
-
         verify(dataSource).loadOrders()
         verify(dataSource, times(2)).loadMore()
-    }
-
-    @Test
-    fun `given Error, when retry tapped, then load orders again`() = runTest {
-        // GIVEN
-        whenever(dataSource.loadOrders()).thenReturn(
-            flow { emit(LoadOrdersResult.Error("boom")) }
-        )
-
-        viewModel = createViewModel()
-        advanceUntilIdle()
-
-        whenever(dataSource.loadOrders()).thenReturn(
-            flow {
-                emit(LoadOrdersResult.SuccessCache(emptyList()))
-                emit(LoadOrdersResult.SuccessRemote(listOf(order(7), order(8))))
-            }
-        )
-
-        // WHEN
-        viewModel.onOrdersLoadingErrorRetryButtonClicked()
-        advanceUntilIdle()
-
-        // THEN
-        val after = viewModel.state.value as WooPosOrdersState.Content
-        assertThat(after.items.map { it.id }).containsExactly(7L, 8L)
-        assertThat(after.pullToRefreshState).isEqualTo(WooPosPullToRefreshState.Enabled)
-        assertThat(after.paginationState).isEqualTo(WooPosPaginationState.None)
-
-        verify(dataSource, times(2)).loadOrders()
     }
 
     @Test
@@ -620,7 +566,7 @@ class WooPosOrdersViewModelTest {
 
         // THEN
         val state = viewModel.state.value as WooPosOrdersState.Content
-        val details = state.selectedOrderDetails!!
+        val details = state.selectedOrderDetails
         assertThat(details.lineItems).isNotEmpty
         assertThat(details.lineItems.all { it.imageUrl == "https://example.com/image.jpg" }).isTrue()
     }
@@ -632,7 +578,6 @@ class WooPosOrdersViewModelTest {
         whenever(dataSource.loadOrders()).thenReturn(
             flow { emit(LoadOrdersResult.SuccessRemote(listOf(ord))) }
         )
-
         whenever(productImageMap.get(any()))
             .thenReturn(null)
             .thenReturn("https://example.com/img.png")
@@ -640,14 +585,13 @@ class WooPosOrdersViewModelTest {
         // WHEN
         viewModel = createViewModel()
         advanceUntilIdle()
-
         val affectedProductId = ord.items.firstOrNull()?.productId ?: 0L
         viewModel.onProductFetched(affectedProductId)
         advanceUntilIdle()
 
         // THEN
         val content = viewModel.state.value as WooPosOrdersState.Content
-        val details = content.selectedOrderDetails!!
+        val details = content.selectedOrderDetails
         assertThat(details.lineItems.any { it.imageUrl == "https://example.com/img.png" }).isTrue()
     }
 
@@ -658,62 +602,63 @@ class WooPosOrdersViewModelTest {
             flow { emit(LoadOrdersResult.SuccessRemote(listOf(order(1), order(2)))) }
         )
 
+        // WHEN
         viewModel = createViewModel()
         advanceUntilIdle()
-
-        // WHEN
         viewModel.onOrderSelected(2L)
         advanceUntilIdle()
 
         // THEN
         val content = viewModel.state.value as WooPosOrdersState.Content
         assertThat(content.selectedOrderId).isEqualTo(2L)
-        assertThat(content.selectedOrderDetails?.id).isEqualTo(2L)
-        assertThat(content.selectedOrderDetails?.lineItems).isNotEmpty
-        assertThat(content.selectedOrderDetails?.total).isEqualTo("$0.00")
+        assertThat(content.selectedOrderDetails.id).isEqualTo(2L)
+        assertThat(content.selectedOrderDetails.lineItems).isNotEmpty
+        assertThat(content.selectedOrderDetails.total).isEqualTo("$0.00")
     }
 
     @Test
     fun `given selected order, when appending next page, then selectedOrderDetails content remains correct`() = runTest {
+        // GIVEN
         whenever(dataSource.loadOrders()).thenReturn(
             flow { emit(LoadOrdersResult.SuccessRemote(listOf(order(10), order(20)))) }
         )
         whenever(dataSource.hasMorePages).thenReturn(true)
         whenever(dataSource.loadMore()).thenReturn(Result.success(listOf(order(30), order(40))))
 
+        // WHEN
         viewModel = createViewModel()
         advanceUntilIdle()
-
         viewModel.onOrderSelected(20L)
         advanceUntilIdle()
-
         viewModel.onEndOfOrdersListReached()
         advanceUntilIdle()
 
+        // THEN
         val content = viewModel.state.value as WooPosOrdersState.Content
         val details = content.selectedOrderDetails
-        assertThat(details).isNotNull
-        assertThat(details?.id).isEqualTo(20L)
-        assertThat(details?.totalPaid).isEqualTo("$0.00")
+        assertThat(details.id).isEqualTo(20L)
+        assertThat(details.totalPaid).isEqualTo("$0.00")
     }
 
     @Test
     fun `given orders reloaded, when refreshing, then first order details are auto-populated`() = runTest {
+        // GIVEN
         whenever(dataSource.loadOrders()).thenReturn(
             flow { emit(LoadOrdersResult.SuccessRemote(listOf(order(100), order(200)))) }
         )
         viewModel = createViewModel()
         advanceUntilIdle()
-
         whenever(dataSource.loadOrders()).thenReturn(
             flow { emit(LoadOrdersResult.SuccessRemote(listOf(order(300), order(400)))) }
         )
 
+        // WHEN
         viewModel.onRefresh()
         advanceUntilIdle()
 
+        // THEN
         val content = viewModel.state.value as WooPosOrdersState.Content
         assertThat(content.selectedOrderId).isEqualTo(300L)
-        assertThat(content.selectedOrderDetails?.id).isEqualTo(300L)
+        assertThat(content.selectedOrderDetails.id).isEqualTo(300L)
     }
 }

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/orders/WooPosOrdersViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/orders/WooPosOrdersViewModelTest.kt
@@ -2,6 +2,7 @@ package com.woocommerce.android.ui.woopos.orders
 
 import com.woocommerce.android.R
 import com.woocommerce.android.model.Order
+import com.woocommerce.android.tools.ProductImageMap
 import com.woocommerce.android.tools.SelectedSite
 import com.woocommerce.android.ui.orders.OrderTestUtils
 import com.woocommerce.android.ui.woopos.common.composeui.component.WooPosSearchInputState
@@ -42,7 +43,19 @@ class WooPosOrdersViewModelTest {
     private val wooStore: WooCommerceStore = org.mockito.kotlin.mock()
     private val selectedSite: SelectedSite = org.mockito.kotlin.mock()
     private val resourceProvider: ResourceProvider = org.mockito.kotlin.mock()
+    private val productImageMap: ProductImageMap = org.mockito.kotlin.mock()
     private val providedLocale: Locale = Locale.US
+
+    private fun createViewModel(): WooPosOrdersViewModel {
+        return WooPosOrdersViewModel(
+            ordersDataSource = dataSource,
+            wooCommerceStore = wooStore,
+            selectedSite = selectedSite,
+            resourceProvider = resourceProvider,
+            locale = providedLocale,
+            productImageMap = productImageMap
+        )
+    }
 
     @Before
     fun setUp() {
@@ -72,6 +85,8 @@ class WooPosOrdersViewModelTest {
         whenever(resourceProvider.getString(R.string.woopos_orders_status_cancelled)).thenReturn("Cancelled")
         whenever(resourceProvider.getString(R.string.woopos_orders_status_completed)).thenReturn("Completed")
         whenever(resourceProvider.getString(R.string.woopos_orders_status_refunded)).thenReturn("Refunded")
+
+        whenever(productImageMap.get(any())).thenReturn(null)
     }
 
     @Test
@@ -87,7 +102,7 @@ class WooPosOrdersViewModelTest {
         )
 
         // WHEN
-        viewModel = WooPosOrdersViewModel(dataSource, wooStore, selectedSite, resourceProvider, providedLocale)
+        viewModel = createViewModel()
         advanceUntilIdle()
 
         // THEN
@@ -98,6 +113,8 @@ class WooPosOrdersViewModelTest {
         assertThat(content.pullToRefreshState).isEqualTo(WooPosPullToRefreshState.Enabled)
         assertThat(content.paginationState).isEqualTo(WooPosPaginationState.None)
         verify(dataSource).loadOrders()
+
+        assertThat(content.selectedOrderDetails?.id).isEqualTo(2L)
     }
 
     @Test
@@ -112,7 +129,7 @@ class WooPosOrdersViewModelTest {
         )
 
         // WHEN
-        viewModel = WooPosOrdersViewModel(dataSource, wooStore, selectedSite, resourceProvider, providedLocale)
+        viewModel = createViewModel()
         advanceUntilIdle()
 
         // THEN
@@ -121,6 +138,7 @@ class WooPosOrdersViewModelTest {
         val content = state as WooPosOrdersState.Content
         assertThat(content.items.map { it.id }).containsExactly(10L)
         assertThat(content.pullToRefreshState).isEqualTo(WooPosPullToRefreshState.Enabled)
+        assertThat(content.selectedOrderDetails?.id).isEqualTo(10L)
     }
 
     @Test
@@ -134,7 +152,7 @@ class WooPosOrdersViewModelTest {
         )
 
         // WHEN
-        viewModel = WooPosOrdersViewModel(dataSource, wooStore, selectedSite, resourceProvider, providedLocale)
+        viewModel = createViewModel()
         advanceUntilIdle()
 
         // THEN
@@ -150,7 +168,7 @@ class WooPosOrdersViewModelTest {
         )
 
         // WHEN
-        viewModel = WooPosOrdersViewModel(dataSource, wooStore, selectedSite, resourceProvider, providedLocale)
+        viewModel = createViewModel()
         advanceUntilIdle()
 
         // THEN
@@ -166,7 +184,7 @@ class WooPosOrdersViewModelTest {
         whenever(dataSource.loadOrders()).thenReturn(
             flow { emit(LoadOrdersResult.SuccessRemote(listOf(order(1)))) }
         )
-        viewModel = WooPosOrdersViewModel(dataSource, wooStore, selectedSite, resourceProvider, providedLocale)
+        viewModel = createViewModel()
         advanceUntilIdle()
         val before = viewModel.state.value as WooPosOrdersState.Content
         assertThat(before.items.map { it.id }).containsExactly(1L)
@@ -198,7 +216,7 @@ class WooPosOrdersViewModelTest {
         )
 
         // WHEN
-        viewModel = WooPosOrdersViewModel(dataSource, wooStore, selectedSite, resourceProvider, providedLocale)
+        viewModel = createViewModel()
         advanceUntilIdle()
         viewModel.onOrderSelected(3L)
         advanceUntilIdle()
@@ -210,6 +228,8 @@ class WooPosOrdersViewModelTest {
         assertThat(selectedFlags[1L]).isFalse()
         assertThat(selectedFlags[2L]).isFalse()
         assertThat(selectedFlags[3L]).isTrue()
+
+        assertThat(state.selectedOrderDetails?.id).isEqualTo(3L)
     }
 
     @Test
@@ -218,7 +238,7 @@ class WooPosOrdersViewModelTest {
         whenever(dataSource.loadOrders()).thenReturn(
             flow { emit(LoadOrdersResult.SuccessRemote(listOf(order(100), order(200)))) }
         )
-        viewModel = WooPosOrdersViewModel(dataSource, wooStore, selectedSite, resourceProvider, providedLocale)
+        viewModel = createViewModel()
         advanceUntilIdle()
         viewModel.onOrderSelected(200L)
         advanceUntilIdle()
@@ -238,12 +258,13 @@ class WooPosOrdersViewModelTest {
         val state = viewModel.state.value as WooPosOrdersState.Content
         assertThat(state.items.map { it.id }).containsExactly(300L, 400L)
         assertThat(state.selectedOrderId).isEqualTo(300L)
+        assertThat(state.selectedOrderDetails?.id).isEqualTo(300L)
     }
 
     @Test
     fun `given ViewModel initialized, when onSearchEvent SearchIconClicked, then search input state opens`() = runTest {
         // GIVEN
-        viewModel = WooPosOrdersViewModel(dataSource, wooStore, selectedSite, resourceProvider, providedLocale)
+        viewModel = createViewModel()
         advanceUntilIdle()
 
         // WHEN
@@ -265,7 +286,7 @@ class WooPosOrdersViewModelTest {
         val searchResult = listOf(order(10), order(20))
         whenever(dataSource.searchOrders(query)).thenReturn(SearchOrdersResult.Success(searchResult))
 
-        viewModel = WooPosOrdersViewModel(dataSource, wooStore, selectedSite, resourceProvider, providedLocale)
+        viewModel = createViewModel()
         advanceUntilIdle()
 
         // WHEN
@@ -285,7 +306,7 @@ class WooPosOrdersViewModelTest {
     @Test
     fun `given ViewModel initialized, when onSearchEvent Search with empty query, then loadOrders is called`() = runTest {
         // GIVEN
-        viewModel = WooPosOrdersViewModel(dataSource, wooStore, selectedSite, resourceProvider, providedLocale)
+        viewModel = createViewModel()
         advanceUntilIdle()
 
         // WHEN
@@ -299,7 +320,7 @@ class WooPosOrdersViewModelTest {
     @Test
     fun `given search input is open, when onSearchEvent Close, then search input state closes and loadOrders is called`() = runTest {
         // GIVEN
-        viewModel = WooPosOrdersViewModel(dataSource, wooStore, selectedSite, resourceProvider, providedLocale)
+        viewModel = createViewModel()
         advanceUntilIdle()
 
         viewModel.onSearchEvent(WooPosSearchUIEvent.SearchIconClicked)
@@ -321,7 +342,7 @@ class WooPosOrdersViewModelTest {
         val query = "test query"
         whenever(dataSource.searchOrders(query)).thenReturn(SearchOrdersResult.Error("search failed"))
 
-        viewModel = WooPosOrdersViewModel(dataSource, wooStore, selectedSite, resourceProvider, providedLocale)
+        viewModel = createViewModel()
         advanceUntilIdle()
 
         viewModel.onSearchEvent(WooPosSearchUIEvent.SearchIconClicked)
@@ -349,7 +370,7 @@ class WooPosOrdersViewModelTest {
         whenever(dataSource.loadMore()).thenReturn(Result.success(listOf(order(3), order(4))))
 
         // WHEN
-        viewModel = WooPosOrdersViewModel(dataSource, wooStore, selectedSite, resourceProvider, providedLocale)
+        viewModel = createViewModel()
         advanceUntilIdle()
 
         viewModel.onEndOfOrdersListReached()
@@ -369,7 +390,7 @@ class WooPosOrdersViewModelTest {
         whenever(dataSource.hasMorePages).thenReturn(true)
         whenever(dataSource.loadMore()).thenReturn(Result.failure(RuntimeException("boom")))
 
-        viewModel = WooPosOrdersViewModel(dataSource, wooStore, selectedSite, resourceProvider, providedLocale)
+        viewModel = createViewModel()
         advanceUntilIdle()
 
         viewModel.onEndOfOrdersListReached()
@@ -390,7 +411,7 @@ class WooPosOrdersViewModelTest {
             }
         )
 
-        viewModel = WooPosOrdersViewModel(dataSource, wooStore, selectedSite, resourceProvider, providedLocale)
+        viewModel = createViewModel()
         advanceUntilIdle()
 
         // WHEN
@@ -412,7 +433,7 @@ class WooPosOrdersViewModelTest {
         whenever(dataSource.loadMore()).thenReturn(Result.success(listOf(order(30), order(40))))
 
         // WHEN
-        viewModel = WooPosOrdersViewModel(dataSource, wooStore, selectedSite, resourceProvider, providedLocale)
+        viewModel = createViewModel()
         advanceUntilIdle()
 
         viewModel.onOrderSelected(20L)
@@ -427,6 +448,7 @@ class WooPosOrdersViewModelTest {
         assertThat(content.selectedOrderId).isEqualTo(20L)
         val selectedFlags = content.items.associate { it.id to it.isSelected }
         assertThat(selectedFlags[20L]).isTrue()
+        assertThat(content.selectedOrderDetails?.id).isEqualTo(20L)
     }
 
     @Test
@@ -445,7 +467,7 @@ class WooPosOrdersViewModelTest {
         )
 
         // WHEN
-        viewModel = WooPosOrdersViewModel(dataSource, wooStore, selectedSite, resourceProvider, providedLocale)
+        viewModel = createViewModel()
         advanceUntilIdle()
         viewModel.onSearchEvent(WooPosSearchUIEvent.SearchIconClicked)
         viewModel.onSearchEvent(WooPosSearchUIEvent.Search(query, query.length))
@@ -473,7 +495,7 @@ class WooPosOrdersViewModelTest {
             Result.failure(RuntimeException("boom"))
         )
 
-        viewModel = WooPosOrdersViewModel(dataSource, wooStore, selectedSite, resourceProvider, providedLocale)
+        viewModel = createViewModel()
         advanceUntilIdle()
 
         // WHEN
@@ -504,7 +526,7 @@ class WooPosOrdersViewModelTest {
             flow { emit(LoadOrdersResult.Error("boom")) }
         )
 
-        viewModel = WooPosOrdersViewModel(dataSource, wooStore, selectedSite, resourceProvider, providedLocale)
+        viewModel = createViewModel()
         advanceUntilIdle()
 
         whenever(dataSource.loadOrders()).thenReturn(
@@ -531,13 +553,13 @@ class WooPosOrdersViewModelTest {
     fun `given on-hold status, when mapped, then status text is titlecased and hyphen replaced`() = runTest {
         // GIVEN
         val base = OrderTestUtils.generateTestOrder(orderId = 42L)
-        val withOnHold = base.copy(status = Order.Status.OnHold) // domain has "on-hold" value
+        val withOnHold = base.copy(status = Order.Status.OnHold)
         whenever(dataSource.loadOrders()).thenReturn(
             flow { emit(LoadOrdersResult.SuccessRemote(listOf(withOnHold))) }
         )
 
         // WHEN
-        viewModel = WooPosOrdersViewModel(dataSource, wooStore, selectedSite, resourceProvider, providedLocale)
+        viewModel = createViewModel()
         advanceUntilIdle()
 
         // THEN
@@ -556,7 +578,7 @@ class WooPosOrdersViewModelTest {
         )
 
         // WHEN
-        viewModel = WooPosOrdersViewModel(dataSource, wooStore, selectedSite, resourceProvider, providedLocale)
+        viewModel = createViewModel()
         advanceUntilIdle()
 
         // THEN
@@ -574,12 +596,58 @@ class WooPosOrdersViewModelTest {
         )
 
         // WHEN
-        viewModel = WooPosOrdersViewModel(dataSource, wooStore, selectedSite, resourceProvider, providedLocale)
+        viewModel = createViewModel()
         advanceUntilIdle()
 
         // THEN
         val content = viewModel.state.value as WooPosOrdersState.Content
         val item = content.items.single { it.id == 11L }
         assertThat(item.date).contains(" at ")
+    }
+
+    @Test
+    fun `given product image map returns url, when mapping selected details, then line item uses that url`() = runTest {
+        // GIVEN
+        val ord = order(101)
+        whenever(dataSource.loadOrders()).thenReturn(
+            flow { emit(LoadOrdersResult.SuccessRemote(listOf(ord))) }
+        )
+        whenever(productImageMap.get(any())).thenReturn("https://example.com/image.jpg")
+
+        // WHEN
+        viewModel = createViewModel()
+        advanceUntilIdle()
+
+        // THEN
+        val state = viewModel.state.value as WooPosOrdersState.Content
+        val details = state.selectedOrderDetails!!
+        assertThat(details.lineItems).isNotEmpty
+        assertThat(details.lineItems.all { it.imageUrl == "https://example.com/image.jpg" }).isTrue()
+    }
+
+    @Test
+    fun `given product fetch completes, when onProductFetched called, then selected details refresh and show image`() = runTest {
+        // GIVEN
+        val ord = order(202)
+        whenever(dataSource.loadOrders()).thenReturn(
+            flow { emit(LoadOrdersResult.SuccessRemote(listOf(ord))) }
+        )
+
+        whenever(productImageMap.get(any()))
+            .thenReturn(null)
+            .thenReturn("https://example.com/img.png")
+
+        // WHEN
+        viewModel = createViewModel()
+        advanceUntilIdle()
+
+        val affectedProductId = ord.items.firstOrNull()?.productId ?: 0L
+        viewModel.onProductFetched(affectedProductId)
+        advanceUntilIdle()
+
+        // THEN
+        val content = viewModel.state.value as WooPosOrdersState.Content
+        val details = content.selectedOrderDetails!!
+        assertThat(details.lineItems.any { it.imageUrl == "https://example.com/img.png" }).isTrue()
     }
 }

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/orders/WooPosOrdersViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/orders/WooPosOrdersViewModelTest.kt
@@ -2,17 +2,18 @@ package com.woocommerce.android.ui.woopos.orders
 
 import com.woocommerce.android.R
 import com.woocommerce.android.model.Order
-import com.woocommerce.android.tools.ProductImageMap
 import com.woocommerce.android.tools.SelectedSite
 import com.woocommerce.android.ui.orders.OrderTestUtils
 import com.woocommerce.android.ui.woopos.common.composeui.component.WooPosSearchInputState
 import com.woocommerce.android.ui.woopos.common.composeui.component.WooPosSearchUIEvent
+import com.woocommerce.android.ui.woopos.common.data.WooPosGetProductById
 import com.woocommerce.android.ui.woopos.home.items.WooPosPaginationState
 import com.woocommerce.android.ui.woopos.home.items.WooPosPullToRefreshState
 import com.woocommerce.android.ui.woopos.util.WooPosCoroutineTestRule
 import com.woocommerce.android.viewmodel.ResourceProvider
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.flow
+import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.test.advanceUntilIdle
 import kotlinx.coroutines.test.runTest
 import org.assertj.core.api.Assertions.assertThat
@@ -43,7 +44,7 @@ class WooPosOrdersViewModelTest {
     private val wooStore: WooCommerceStore = org.mockito.kotlin.mock()
     private val selectedSite: SelectedSite = org.mockito.kotlin.mock()
     private val resourceProvider: ResourceProvider = org.mockito.kotlin.mock()
-    private val productImageMap: ProductImageMap = org.mockito.kotlin.mock()
+    private val getProductById: WooPosGetProductById = org.mockito.kotlin.mock()
     private val providedLocale: Locale = Locale.US
 
     private fun createViewModel(): WooPosOrdersViewModel {
@@ -53,7 +54,7 @@ class WooPosOrdersViewModelTest {
             selectedSite = selectedSite,
             resourceProvider = resourceProvider,
             locale = providedLocale,
-            productImageMap = productImageMap
+            getProductById = getProductById
         )
     }
 
@@ -86,7 +87,9 @@ class WooPosOrdersViewModelTest {
         whenever(resourceProvider.getString(R.string.woopos_orders_status_completed)).thenReturn("Completed")
         whenever(resourceProvider.getString(R.string.woopos_orders_status_refunded)).thenReturn("Refunded")
 
-        whenever(productImageMap.get(any())).thenReturn(null)
+        runBlocking {
+            whenever(getProductById.invoke(any())).thenReturn(null)
+        }
     }
 
     @Test
@@ -109,11 +112,11 @@ class WooPosOrdersViewModelTest {
         val state = viewModel.state.value
         assertThat(state).isInstanceOf(WooPosOrdersState.Content::class.java)
         val content = state as WooPosOrdersState.Content
-        assertThat(content.items.map { it.id }).containsExactly(2L, 3L)
+        assertThat(content.items.keys.map { it.id }).containsExactly(2L, 3L)
         assertThat(content.pullToRefreshState).isEqualTo(WooPosPullToRefreshState.Enabled)
         assertThat(content.paginationState).isEqualTo(WooPosPaginationState.None)
         verify(dataSource).loadOrders()
-        assertThat(content.selectedOrderDetails.id).isEqualTo(2L)
+        assertThat(content.selectedDetails.id).isEqualTo(2L)
     }
 
     @Test
@@ -135,9 +138,9 @@ class WooPosOrdersViewModelTest {
         val state = viewModel.state.value
         assertThat(state).isInstanceOf(WooPosOrdersState.Content::class.java)
         val content = state as WooPosOrdersState.Content
-        assertThat(content.items.map { it.id }).containsExactly(10L)
+        assertThat(content.items.keys.map { it.id }).containsExactly(10L)
         assertThat(content.pullToRefreshState).isEqualTo(WooPosPullToRefreshState.Enabled)
-        assertThat(content.selectedOrderDetails.id).isEqualTo(10L)
+        assertThat(content.selectedDetails.id).isEqualTo(10L)
     }
 
     @Test
@@ -186,7 +189,7 @@ class WooPosOrdersViewModelTest {
         viewModel = createViewModel()
         advanceUntilIdle()
         val before = viewModel.state.value as WooPosOrdersState.Content
-        assertThat(before.items.map { it.id }).containsExactly(1L)
+        assertThat(before.items.keys.map { it.id }).containsExactly(1L)
 
         whenever(dataSource.loadOrders()).thenReturn(
             flow {
@@ -201,7 +204,7 @@ class WooPosOrdersViewModelTest {
 
         // THEN
         val after = viewModel.state.value as WooPosOrdersState.Content
-        assertThat(after.items.map { it.id }).containsExactly(5L, 6L)
+        assertThat(after.items.keys.map { it.id }).containsExactly(5L, 6L)
         assertThat(after.pullToRefreshState).isEqualTo(WooPosPullToRefreshState.Enabled)
         verify(dataSource).clearCache()
         verify(dataSource, times(2)).loadOrders()
@@ -222,12 +225,11 @@ class WooPosOrdersViewModelTest {
 
         // THEN
         val state = viewModel.state.value as WooPosOrdersState.Content
-        assertThat(state.selectedOrderId).isEqualTo(3L)
-        val selectedFlags = state.items.associate { it.id to it.isSelected }
+        val selectedFlags = state.items.keys.associate { it.id to it.isSelected }
         assertThat(selectedFlags[1L]).isFalse()
         assertThat(selectedFlags[2L]).isFalse()
         assertThat(selectedFlags[3L]).isTrue()
-        assertThat(state.selectedOrderDetails.id).isEqualTo(3L)
+        assertThat(state.selectedDetails.id).isEqualTo(3L)
     }
 
     @Test
@@ -254,9 +256,9 @@ class WooPosOrdersViewModelTest {
 
         // THEN
         val state = viewModel.state.value as WooPosOrdersState.Content
-        assertThat(state.items.map { it.id }).containsExactly(300L, 400L)
-        assertThat(state.selectedOrderId).isEqualTo(300L)
-        assertThat(state.selectedOrderDetails.id).isEqualTo(300L)
+        assertThat(state.items.keys.map { it.id }).containsExactly(300L, 400L)
+        // first item should be auto-selected after reload
+        assertThat(state.selectedDetails.id).isEqualTo(300L)
     }
 
     @Test
@@ -295,7 +297,7 @@ class WooPosOrdersViewModelTest {
         val state = viewModel.state.value
         assertThat(state).isInstanceOf(WooPosOrdersState.Content::class.java)
         val content = state as WooPosOrdersState.Content
-        assertThat(content.items.map { it.id }).containsExactly(10L, 20L)
+        assertThat(content.items.keys.map { it.id }).containsExactly(10L, 20L)
         assertThat(content.searchInputState).isInstanceOf(WooPosSearchInputState.Open::class.java)
         verify(dataSource).searchOrders(query)
     }
@@ -355,7 +357,7 @@ class WooPosOrdersViewModelTest {
 
         // THEN
         val content = viewModel.state.value as WooPosOrdersState.Content
-        assertThat(content.items.map { it.id }).containsExactly(1L, 2L, 3L, 4L)
+        assertThat(content.items.keys.map { it.id }).containsExactly(1L, 2L, 3L, 4L)
         assertThat(content.paginationState).isEqualTo(WooPosPaginationState.None)
     }
 
@@ -376,7 +378,7 @@ class WooPosOrdersViewModelTest {
 
         // THEN
         val content = viewModel.state.value as WooPosOrdersState.Content
-        assertThat(content.items.map { it.id }).containsExactly(1L, 2L)
+        assertThat(content.items.keys.map { it.id }).containsExactly(1L, 2L)
         assertThat(content.paginationState).isEqualTo(WooPosPaginationState.Error)
     }
 
@@ -421,11 +423,10 @@ class WooPosOrdersViewModelTest {
 
         // THEN
         val content = viewModel.state.value as WooPosOrdersState.Content
-        assertThat(content.items.map { it.id }).containsExactly(10L, 20L, 30L, 40L)
-        assertThat(content.selectedOrderId).isEqualTo(20L)
-        val selectedFlags = content.items.associate { it.id to it.isSelected }
+        assertThat(content.items.keys.map { it.id }).containsExactly(10L, 20L, 30L, 40L)
+        val selectedFlags = content.items.keys.associate { it.id to it.isSelected }
         assertThat(selectedFlags[20L]).isTrue()
-        assertThat(content.selectedOrderDetails.id).isEqualTo(20L)
+        assertThat(content.selectedDetails.id).isEqualTo(20L)
     }
 
     @Test
@@ -454,7 +455,7 @@ class WooPosOrdersViewModelTest {
 
         // THEN
         val content = viewModel.state.value as WooPosOrdersState.Content
-        assertThat(content.items.map { it.id }).containsExactly(10L, 20L, 30L, 40L)
+        assertThat(content.items.keys.map { it.id }).containsExactly(10L, 20L, 30L, 40L)
         assertThat(content.paginationState).isEqualTo(WooPosPaginationState.None)
         verify(dataSource).loadMore(query)
     }
@@ -477,7 +478,7 @@ class WooPosOrdersViewModelTest {
 
         // THEN (pagination shows error)
         var content = viewModel.state.value as WooPosOrdersState.Content
-        assertThat(content.items.map { it.id }).containsExactly(1L, 2L)
+        assertThat(content.items.keys.map { it.id }).containsExactly(1L, 2L)
         assertThat(content.paginationState).isEqualTo(WooPosPaginationState.Error)
 
         // GIVEN (next call will succeed)
@@ -489,7 +490,7 @@ class WooPosOrdersViewModelTest {
 
         // THEN
         content = viewModel.state.value as WooPosOrdersState.Content
-        assertThat(content.items.map { it.id }).containsExactly(1L, 2L, 3L, 4L)
+        assertThat(content.items.keys.map { it.id }).containsExactly(1L, 2L, 3L, 4L)
         assertThat(content.paginationState).isEqualTo(WooPosPaginationState.None)
         verify(dataSource).loadOrders()
         verify(dataSource, times(2)).loadMore()
@@ -510,7 +511,7 @@ class WooPosOrdersViewModelTest {
 
         // THEN
         val content = viewModel.state.value as WooPosOrdersState.Content
-        val item = content.items.single { it.id == 42L }
+        val item = content.items.keys.single { it.id == 42L }
         assertThat(item.status.text).isEqualTo("On hold")
     }
 
@@ -529,7 +530,7 @@ class WooPosOrdersViewModelTest {
 
         // THEN
         val content = viewModel.state.value as WooPosOrdersState.Content
-        val item = content.items.single { it.id == 77L }
+        val item = content.items.keys.single { it.id == 77L }
         assertThat(item.status.text).isEqualTo("Awaiting payment")
     }
 
@@ -547,52 +548,8 @@ class WooPosOrdersViewModelTest {
 
         // THEN
         val content = viewModel.state.value as WooPosOrdersState.Content
-        val item = content.items.single { it.id == 11L }
+        val item = content.items.keys.single { it.id == 11L }
         assertThat(item.date).contains(" at ")
-    }
-
-    @Test
-    fun `given product image map returns url, when mapping selected details, then line item uses that url`() = runTest {
-        // GIVEN
-        val ord = order(101)
-        whenever(dataSource.loadOrders()).thenReturn(
-            flow { emit(LoadOrdersResult.SuccessRemote(listOf(ord))) }
-        )
-        whenever(productImageMap.get(any())).thenReturn("https://example.com/image.jpg")
-
-        // WHEN
-        viewModel = createViewModel()
-        advanceUntilIdle()
-
-        // THEN
-        val state = viewModel.state.value as WooPosOrdersState.Content
-        val details = state.selectedOrderDetails
-        assertThat(details.lineItems).isNotEmpty
-        assertThat(details.lineItems.all { it.imageUrl == "https://example.com/image.jpg" }).isTrue()
-    }
-
-    @Test
-    fun `given product fetch completes, when onProductFetched called, then selected details refresh and show image`() = runTest {
-        // GIVEN
-        val ord = order(202)
-        whenever(dataSource.loadOrders()).thenReturn(
-            flow { emit(LoadOrdersResult.SuccessRemote(listOf(ord))) }
-        )
-        whenever(productImageMap.get(any()))
-            .thenReturn(null)
-            .thenReturn("https://example.com/img.png")
-
-        // WHEN
-        viewModel = createViewModel()
-        advanceUntilIdle()
-        val affectedProductId = ord.items.firstOrNull()?.productId ?: 0L
-        viewModel.onProductFetched(affectedProductId)
-        advanceUntilIdle()
-
-        // THEN
-        val content = viewModel.state.value as WooPosOrdersState.Content
-        val details = content.selectedOrderDetails
-        assertThat(details.lineItems.any { it.imageUrl == "https://example.com/img.png" }).isTrue()
     }
 
     @Test
@@ -610,10 +567,12 @@ class WooPosOrdersViewModelTest {
 
         // THEN
         val content = viewModel.state.value as WooPosOrdersState.Content
-        assertThat(content.selectedOrderId).isEqualTo(2L)
-        assertThat(content.selectedOrderDetails.id).isEqualTo(2L)
-        assertThat(content.selectedOrderDetails.lineItems).isNotEmpty
-        assertThat(content.selectedOrderDetails.total).isEqualTo("$0.00")
+        // selected item should be 2, and selectedDetails should match
+        val selectedItemId = content.items.keys.single { it.isSelected }.id
+        assertThat(selectedItemId).isEqualTo(2L)
+        assertThat(content.selectedDetails.id).isEqualTo(2L)
+        assertThat(content.selectedDetails.lineItems).isNotEmpty
+        assertThat(content.selectedDetails.total).isEqualTo("$0.00")
     }
 
     @Test
@@ -635,7 +594,8 @@ class WooPosOrdersViewModelTest {
 
         // THEN
         val content = viewModel.state.value as WooPosOrdersState.Content
-        val details = content.selectedOrderDetails
+        val details = content.selectedDetails
+        assertThat(content.items.keys.map { it.id }).containsExactly(10L, 20L, 30L, 40L)
         assertThat(details.id).isEqualTo(20L)
         assertThat(details.totalPaid).isEqualTo("$0.00")
     }
@@ -658,7 +618,7 @@ class WooPosOrdersViewModelTest {
 
         // THEN
         val content = viewModel.state.value as WooPosOrdersState.Content
-        assertThat(content.selectedOrderId).isEqualTo(300L)
-        assertThat(content.selectedOrderDetails.id).isEqualTo(300L)
+        assertThat(content.items.keys.map { it.id }).containsExactly(300L, 400L)
+        assertThat(content.selectedDetails.id).isEqualTo(300L)
     }
 }


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

<!-- Id number of the Linear issue this PR addresses, e.g., WOOMOB-373. -->

Part of: WOOMOB-1157

Sorry for the long PR, _dummy_ UI and tests are quite long.

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
With this PR, we add the view model and state for the POS order details, plus a non-final UI to show it. Refunded information, final design, and Email receipt action are coming in the following PRs.

### Steps to reproduce
<!-- Step-by-step testing instructions. For new user flows, consider instead stating the goal of the workflow and see if your PR reviewer can accomplish the workflow without specific steps! -->

1. Go to POS
2. Tap on the ... Menu
3. Tap on Orders
4. Wait until orders are loaded. Once that happens, check the order details, selecting different orders for better appraisal.

### Images/gif
<!-- Include before and after images or gifs when appropriate. -->

https://github.com/user-attachments/assets/f761510b-f16d-43e1-a66a-4bec946a785d




- [X] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
