### PR TITLE
[Bookings] Update the path of the resources endpoint

### DIFF
--- a/libs/fluxc-plugin/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/bookings/BookingsRestClient.kt
+++ b/libs/fluxc-plugin/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/bookings/BookingsRestClient.kt
@@ -69,7 +69,7 @@ class BookingsRestClient @Inject constructor(
         site: SiteModel,
         resourceId: Long
     ): WooPayload<BookingResourceDto> {
-        val endpoint = WOOCOMMERCE.resources.id(resourceId).pathV2Bookings
+        val endpoint = WOOCOMMERCE.resources.team_members.id(resourceId).pathV2Bookings
 
         val response = wooNetwork.executeGetGsonRequest(
             site = site,

--- a/libs/fluxc-plugin/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/bookings/BookingsRestClient.kt
+++ b/libs/fluxc-plugin/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/bookings/BookingsRestClient.kt
@@ -90,7 +90,7 @@ class BookingsRestClient @Inject constructor(
                 BookingsFilterOption.AttendanceStatus -> TODO()
                 BookingsFilterOption.PaymentStatus -> TODO()
                 BookingsFilterOption.BookingType -> TODO()
-                is BookingsFilterOption.Customer -> filter.customerId?.let { set("customer", it.toString()) }
+                is BookingsFilterOption.Customer -> set("customer", filter.customerId.toString())
 
                 BookingsFilterOption.Location -> TODO()
                 is BookingsFilterOption.DateRange -> {

--- a/libs/fluxc-plugin/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/bookings/BookingsStore.kt
+++ b/libs/fluxc-plugin/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/bookings/BookingsStore.kt
@@ -99,14 +99,16 @@ class BookingsStore @Inject internal constructor(
                 response.isError -> WooResult(response.error)
                 response.result != null -> {
                     val bookingDto = response.result
-                    val orderResult = orderStore.fetchSingleOrderSync(site, bookingDto.orderId)
-                    if (orderResult.isError) {
+                    val orderResult = bookingDto.orderId.takeIf { it != 0L }?.let {
+                        orderStore.fetchSingleOrderSync(site, bookingDto.orderId)
+                    }
+                    if (orderResult?.isError == true) {
                         return@withDefaultContext WooResult(orderResult.error)
                     }
                     val entity = with(bookingDtoMapper) {
                         bookingDto.toEntity(
                             localSiteId = site.localId(),
-                            orderEntity = orderResult.model,
+                            orderEntity = orderResult?.model,
                         )
                     }
                     bookingsDao.insertOrReplace(listOf(entity))

--- a/libs/fluxc-processor/src/main/resources/wc-wp-api-endpoints.txt
+++ b/libs/fluxc-processor/src/main/resources/wc-wp-api-endpoints.txt
@@ -137,4 +137,4 @@
 
 /bookings
 /bookings/<id>/
-/resources/<id>/
+/resources/team-members/<id>/


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

<!-- Id number of the Linear issue this PR addresses, e.g., WOOMOB-373. -->
Closes WOOMOB-1526

### Description
This PR updates the path of the bookings resources endpoint to align with the last update woocommerce/woocommerce-bookings#4069.
I kept the table name `BookingResource`, if I knew about the plan to change the endpoint path I would have opted for a more specific name in the table, but now I prefer to avoid another DB migration, let me know what you think about this.

The PR also includes two minor improvements:
- Simplify the code of filters since `customerId` is not nullable anymore.
- Skips fetching the order when the `booking#orderId` is `0L`

### Steps to reproduce
1. Use a CIAB test with last bookings version (p1760617545633669-slack-C03L1NF1EA3)
2. After updating the plugin, use the plugin SQL Buddy to remove the the keys `wc_bookings_version` and `wc_bookings_db_version` options from the `wp_options` table.
3. Refresh the resources page in wp-admin.
4. Open a booking that has a linked resource, and confirm there are no errors.

### Testing information
- Confirm resources are loaded correctly.

### The tests that have been performed
The above.

- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->