### PR TITLE
[Woo POS][Historical Orders] Add refund data to model and screen

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/common/data/WooPosGetOrderRefundsByOrderId.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/common/data/WooPosGetOrderRefundsByOrderId.kt
@@ -1,0 +1,21 @@
+package com.woocommerce.android.ui.woopos.common.data
+
+import com.woocommerce.android.model.Refund
+import com.woocommerce.android.model.toAppModel
+import com.woocommerce.android.tools.SelectedSite
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+import org.wordpress.android.fluxc.store.WCRefundStore
+import javax.inject.Inject
+
+class WooPosGetOrderRefundsByOrderId @Inject constructor(
+    private val refundStore: WCRefundStore,
+    private val selectedSite: SelectedSite
+) {
+    suspend operator fun invoke(orderId: Long): List<Refund> {
+        return withContext(Dispatchers.IO) {
+            refundStore.getAllRefunds(selectedSite.get(), orderId)
+                .map { it.toAppModel() }
+        }
+    }
+}

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/orders/WooPosOrdersDetails.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/orders/WooPosOrdersDetails.kt
@@ -251,6 +251,42 @@ fun OrderDetails(
                     )
                 }
             }
+
+            if (details.breakdown.refunds.isNotEmpty()) {
+                Column {
+                    details.breakdown.refunds.forEach { refundAmount ->
+                        Row(Modifier.fillMaxWidth()) {
+                            WooPosText(
+                                text = stringResource(R.string.woopos_orders_details_refunded_label),
+                                style = WooPosTypography.BodySmall,
+                                modifier = Modifier.weight(1f)
+                            )
+                            WooPosText(
+                                text = refundAmount,
+                                style = WooPosTypography.BodySmall
+                            )
+                        }
+                        Spacer(Modifier.height(WooPosSpacing.XSmall.value))
+                    }
+                }
+            }
+
+            details.breakdown.netPayment?.let { netPayment ->
+                Spacer(Modifier.height(WooPosSpacing.Small.value))
+                Row(Modifier.fillMaxWidth()) {
+                    WooPosText(
+                        text = stringResource(R.string.woopos_orders_details_net_payment_label),
+                        style = WooPosTypography.BodySmall,
+                        fontWeight = FontWeight.Bold,
+                        modifier = Modifier.weight(1f)
+                    )
+                    WooPosText(
+                        text = netPayment,
+                        style = WooPosTypography.BodySmall,
+                        fontWeight = FontWeight.Bold
+                    )
+                }
+            }
         }
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/orders/WooPosOrdersDetails.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/orders/WooPosOrdersDetails.kt
@@ -32,6 +32,7 @@ import androidx.compose.ui.unit.dp
 import coil.compose.AsyncImage
 import coil.request.ImageRequest
 import com.woocommerce.android.R
+import com.woocommerce.android.ui.woopos.common.composeui.WooPosPreview
 import com.woocommerce.android.ui.woopos.common.composeui.component.WooPosButton
 import com.woocommerce.android.ui.woopos.common.composeui.component.WooPosCard
 import com.woocommerce.android.ui.woopos.common.composeui.component.WooPosText
@@ -42,7 +43,7 @@ import com.woocommerce.android.ui.woopos.common.composeui.designsystem.WooPosThe
 import com.woocommerce.android.ui.woopos.common.composeui.designsystem.WooPosTypography
 
 @Composable
-fun OrderDetails(
+fun WooPosOrderDetails(
     modifier: Modifier = Modifier,
     details: OrderDetailsViewState,
     onEmailReceiptButtonClicked: (Long) -> Unit = {}
@@ -227,64 +228,73 @@ fun OrderDetails(
                             fontWeight = FontWeight.Bold
                         )
                     }
-                }
-            }
 
-            Column {
-                Row(Modifier.fillMaxWidth()) {
-                    WooPosText(
-                        text = stringResource(R.string.woopos_orders_details_total_paid_label),
-                        style = WooPosTypography.BodySmall,
-                        modifier = Modifier.weight(1f)
-                    )
-                    WooPosText(
-                        text = details.totalPaid,
-                        style = WooPosTypography.BodySmall
-                    )
-                }
-                details.paymentMethodTitle?.let {
-                    Spacer(Modifier.height(WooPosSpacing.XSmall.value))
-                    WooPosText(
-                        text = it,
-                        style = WooPosTypography.BodySmall,
-                        color = WooPosTheme.colors.onSurfaceVariantHighest
-                    )
-                }
-            }
+                    Row(
+                        Modifier
+                            .fillMaxWidth()
+                    ) {
+                        WooPosText(
+                            text = stringResource(R.string.woopos_orders_details_total_paid_label),
+                            style = WooPosTypography.BodySmall,
+                            modifier = Modifier.weight(1f)
+                        )
+                        WooPosText(
+                            text = details.totalPaid,
+                            style = WooPosTypography.BodySmall
+                        )
+                    }
+                    details.paymentMethodTitle?.let {
+                        Spacer(Modifier.height(WooPosSpacing.XSmall.value))
+                        WooPosText(
+                            text = it,
+                            style = WooPosTypography.BodySmall,
+                            color = WooPosTheme.colors.onSurfaceVariantHighest,
+                        )
+                    }
 
-            if (details.breakdown.refunds.isNotEmpty()) {
-                Column {
-                    details.breakdown.refunds.forEach { refundAmount ->
-                        Row(Modifier.fillMaxWidth()) {
+                    if (details.breakdown.refunds.isNotEmpty()) {
+                        Spacer(Modifier.height(WooPosSpacing.Small.value))
+                        details.breakdown.refunds.forEachIndexed { index, refundAmount ->
+                            Row(
+                                Modifier
+                                    .fillMaxWidth()
+                            ) {
+                                WooPosText(
+                                    text = stringResource(R.string.woopos_orders_details_refunded_label),
+                                    style = WooPosTypography.BodySmall,
+                                    modifier = Modifier.weight(1f)
+                                )
+                                WooPosText(
+                                    text = refundAmount,
+                                    style = WooPosTypography.BodySmall
+                                )
+                            }
+                            if (index < details.breakdown.refunds.size - 1) {
+                                Spacer(Modifier.height(WooPosSpacing.XSmall.value))
+                            }
+                        }
+                    }
+
+                    details.breakdown.netPayment?.let { netPayment ->
+                        Spacer(Modifier.height(WooPosSpacing.Small.value))
+                        Row(
+                            Modifier
+                                .fillMaxWidth()
+                                .padding(bottom = WooPosSpacing.Medium.value)
+                        ) {
                             WooPosText(
-                                text = stringResource(R.string.woopos_orders_details_refunded_label),
+                                text = stringResource(R.string.woopos_orders_details_net_payment_label),
                                 style = WooPosTypography.BodySmall,
+                                fontWeight = FontWeight.Bold,
                                 modifier = Modifier.weight(1f)
                             )
                             WooPosText(
-                                text = refundAmount,
-                                style = WooPosTypography.BodySmall
+                                text = netPayment,
+                                style = WooPosTypography.BodySmall,
+                                fontWeight = FontWeight.Bold
                             )
                         }
-                        Spacer(Modifier.height(WooPosSpacing.XSmall.value))
                     }
-                }
-            }
-
-            details.breakdown.netPayment?.let { netPayment ->
-                Spacer(Modifier.height(WooPosSpacing.Small.value))
-                Row(Modifier.fillMaxWidth()) {
-                    WooPosText(
-                        text = stringResource(R.string.woopos_orders_details_net_payment_label),
-                        style = WooPosTypography.BodySmall,
-                        fontWeight = FontWeight.Bold,
-                        modifier = Modifier.weight(1f)
-                    )
-                    WooPosText(
-                        text = netPayment,
-                        style = WooPosTypography.BodySmall,
-                        fontWeight = FontWeight.Bold
-                    )
                 }
             }
         }
@@ -314,6 +324,42 @@ private fun OrderLineItemImage(imageUrl: String?) {
                 .build(),
             contentDescription = null,
             contentScale = ContentScale.Crop
+        )
+    }
+}
+
+@WooPosPreview
+@Composable
+fun WooPosOrderDetailsPreview() {
+    val orderDetails = OrderDetailsViewState(
+        id = 1L,
+        number = "#014",
+        dateTime = "Aug 28, 2025 at 10:31 AM",
+        customerEmail = "johndoe@mail.com",
+        status = PosOrderStatus(text = "Completed", colorKey = OrderStatusColorKey.COMPLETED),
+        lineItems = listOf(
+            OrderDetailsViewState.LineItemRow(101, "Cup", "1 x $8.50", "$15.00", null),
+            OrderDetailsViewState.LineItemRow(102, "Coffee Container", "1 x $10.00", "$8.00", null),
+            OrderDetailsViewState.LineItemRow(103, "Paper Filter", "1 x $4.50", "$8.00", null)
+        ),
+        breakdown = OrderDetailsViewState.TotalsBreakdown(
+            products = "$23.00",
+            discount = "-$5.00",
+            discountCode = "8qew4mnq",
+            taxes = "$0.00",
+            shipping = null,
+            refunds = listOf("-$3.00", "-$2.00"),
+            netPayment = "$12.00"
+        ),
+        total = "$17.00",
+        totalPaid = "$17.00",
+        paymentMethodTitle = "WooCommerce In-Person Payments"
+    )
+
+    WooPosTheme {
+        WooPosOrderDetails(
+            details = orderDetails,
+            onEmailReceiptButtonClicked = {}
         )
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/orders/WooPosOrdersScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/orders/WooPosOrdersScreen.kt
@@ -17,7 +17,6 @@ import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.heightIn
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.statusBarsPadding
-import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.layout.wrapContentHeight
 import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.lazy.rememberLazyListState
@@ -167,7 +166,7 @@ private fun OrdersContent(
                 .background(MaterialTheme.colorScheme.surface)
         )
 
-        OrderDetails(
+        WooPosOrderDetails(
             modifier = Modifier
                 .weight(0.7f)
                 .fillMaxHeight()

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/orders/WooPosOrdersScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/orders/WooPosOrdersScreen.kt
@@ -518,8 +518,8 @@ private fun sampleOrderDetails(
         discountCode = "8qew4mnq",
         taxes = "$0.00",
         shipping = null,
-        refunds = emptyList(),
-        netPayment = null
+        refunds = listOf("-$3.00", "-$2.00"),
+        netPayment = "$12.00"
     ),
     total = "$17.00",
     totalPaid = "$17.00",

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/orders/WooPosOrdersScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/orders/WooPosOrdersScreen.kt
@@ -517,7 +517,9 @@ private fun sampleOrderDetails(
         discount = "-$5.00",
         discountCode = "8qew4mnq",
         taxes = "$0.00",
-        shipping = null
+        shipping = null,
+        refunds = emptyList(),
+        netPayment = null
     ),
     total = "$17.00",
     totalPaid = "$17.00",

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/orders/WooPosOrdersState.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/orders/WooPosOrdersState.kt
@@ -35,7 +35,9 @@ data class OrderDetailsViewState(
         val discount: String?,
         val discountCode: String?,
         val taxes: String,
-        val shipping: String?
+        val shipping: String?,
+        val refunds: List<String>,
+        val netPayment: String?
     )
 }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/orders/WooPosOrdersViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/orders/WooPosOrdersViewModel.kt
@@ -4,13 +4,13 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.woocommerce.android.R
 import com.woocommerce.android.model.Order
-import com.woocommerce.android.tools.SelectedSite
 import com.woocommerce.android.ui.woopos.common.composeui.component.WooPosSearchInputState
 import com.woocommerce.android.ui.woopos.common.composeui.component.WooPosSearchUIEvent
 import com.woocommerce.android.ui.woopos.common.data.WooPosGetProductById
 import com.woocommerce.android.ui.woopos.home.items.WooPosPaginationState
 import com.woocommerce.android.ui.woopos.home.items.WooPosPullToRefreshState
 import com.woocommerce.android.ui.woopos.util.ext.formatToMMMddYYYYAtHHmm
+import com.woocommerce.android.ui.woopos.util.format.WooPosFormatPrice
 import com.woocommerce.android.viewmodel.ResourceProvider
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.Job
@@ -19,7 +19,6 @@ import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.launch
-import org.wordpress.android.fluxc.store.WooCommerceStore
 import java.math.BigDecimal
 import java.util.Locale
 import javax.inject.Inject
@@ -27,11 +26,10 @@ import javax.inject.Inject
 @HiltViewModel
 class WooPosOrdersViewModel @Inject constructor(
     private val ordersDataSource: WooPosOrdersDataSource,
-    private val wooCommerceStore: WooCommerceStore,
-    private val selectedSite: SelectedSite,
     private val resourceProvider: ResourceProvider,
     private val locale: Locale,
     private val getProductById: WooPosGetProductById,
+    private val formatPrice: WooPosFormatPrice,
 ) : ViewModel() {
 
     private val _state = MutableStateFlow<WooPosOrdersState>(
@@ -326,14 +324,7 @@ class WooPosOrdersViewModel @Inject constructor(
         }
     }
 
-    private fun mapOrderItem(order: Order, selectedId: Long?): OrderItemViewState {
-        val formattedOrderTotals = wooCommerceStore.formatCurrencyForDisplay(
-            amount = order.total.toDouble(),
-            site = selectedSite.get(),
-            currencyCode = null,
-            applyDecimalFormatting = true
-        )
-
+    private suspend fun mapOrderItem(order: Order, selectedId: Long?): OrderItemViewState {
         val statusText = order.status.localizedLabel(resourceProvider, locale)
 
         return OrderItemViewState(
@@ -342,7 +333,7 @@ class WooPosOrdersViewModel @Inject constructor(
             date = order.dateCreated.formatToMMMddYYYYAtHHmm(
                 atWord = resourceProvider.getString(R.string.date_time_connector)
             ),
-            total = formattedOrderTotals,
+            total = formatPrice(order.total),
             customerEmail = order.customer?.email,
             isSelected = order.id == selectedId,
             status = PosOrderStatus(
@@ -353,13 +344,6 @@ class WooPosOrdersViewModel @Inject constructor(
     }
 
     private suspend fun mapOrderDetails(order: Order): OrderDetailsViewState {
-        fun fmt(amount: BigDecimal) = wooCommerceStore.formatCurrencyForDisplay(
-            amount = amount.toDouble(),
-            site = selectedSite.get(),
-            currencyCode = null,
-            applyDecimalFormatting = true
-        )
-
         val statusText = order.status.localizedLabel(resourceProvider, locale)
 
         val status = PosOrderStatus(
@@ -373,19 +357,19 @@ class WooPosOrdersViewModel @Inject constructor(
             OrderDetailsViewState.LineItemRow(
                 id = item.itemId,
                 name = item.name,
-                qtyAndUnitPrice = "${item.quantity.toInt()} x ${fmt(unitPrice)}",
-                lineTotal = fmt(item.total),
+                qtyAndUnitPrice = "${item.quantity.toInt()} x ${formatPrice(unitPrice)}",
+                lineTotal = formatPrice(item.total),
                 imageUrl = product?.firstImageUrl
             )
         }
 
         val discountCode = order.couponLines.firstOrNull()?.code
         val breakdown = OrderDetailsViewState.TotalsBreakdown(
-            products = fmt(order.productsTotal),
-            discount = order.discountTotal.takeIf { it != BigDecimal.ZERO }?.let { "-${fmt(it)}" },
+            products = formatPrice(order.productsTotal),
+            discount = order.discountTotal.takeIf { it != BigDecimal.ZERO }?.let { "-${formatPrice(it)}" },
             discountCode = discountCode,
-            taxes = fmt(order.totalTax),
-            shipping = order.shippingTotal.takeIf { it != BigDecimal.ZERO }?.let { fmt(it) }
+            taxes = formatPrice(order.totalTax),
+            shipping = order.shippingTotal.takeIf { it != BigDecimal.ZERO }?.let { formatPrice(it) }
         )
 
         return OrderDetailsViewState(
@@ -398,8 +382,8 @@ class WooPosOrdersViewModel @Inject constructor(
             status = status,
             lineItems = lineItems,
             breakdown = breakdown,
-            total = fmt(order.total),
-            totalPaid = fmt(order.total),
+            total = formatPrice(order.total),
+            totalPaid = formatPrice(order.total),
             paymentMethodTitle = order.paymentMethodTitle.takeIf { it.isNotBlank() }
         )
     }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/orders/WooPosOrdersViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/orders/WooPosOrdersViewModel.kt
@@ -6,6 +6,7 @@ import com.woocommerce.android.R
 import com.woocommerce.android.model.Order
 import com.woocommerce.android.ui.woopos.common.composeui.component.WooPosSearchInputState
 import com.woocommerce.android.ui.woopos.common.composeui.component.WooPosSearchUIEvent
+import com.woocommerce.android.ui.woopos.common.data.WooPosGetOrderRefundsByOrderId
 import com.woocommerce.android.ui.woopos.common.data.WooPosGetProductById
 import com.woocommerce.android.ui.woopos.home.items.WooPosPaginationState
 import com.woocommerce.android.ui.woopos.home.items.WooPosPullToRefreshState
@@ -30,6 +31,7 @@ class WooPosOrdersViewModel @Inject constructor(
     private val locale: Locale,
     private val getProductById: WooPosGetProductById,
     private val formatPrice: WooPosFormatPrice,
+    private val getOrderRefunds: WooPosGetOrderRefundsByOrderId,
 ) : ViewModel() {
 
     private val _state = MutableStateFlow<WooPosOrdersState>(
@@ -364,12 +366,24 @@ class WooPosOrdersViewModel @Inject constructor(
         }
 
         val discountCode = order.couponLines.firstOrNull()?.code
+
+        val refunds = getOrderRefunds(order.id)
+        val refundAmounts = refunds.map { "-${formatPrice(it.amount)}" }
+        val totalRefunded = refunds.sumOf { it.amount }
+        val netPayment = if (totalRefunded > BigDecimal.ZERO) {
+            formatPrice(order.total - totalRefunded)
+        } else {
+            null
+        }
+
         val breakdown = OrderDetailsViewState.TotalsBreakdown(
             products = formatPrice(order.productsTotal),
             discount = order.discountTotal.takeIf { it != BigDecimal.ZERO }?.let { "-${formatPrice(it)}" },
             discountCode = discountCode,
             taxes = formatPrice(order.totalTax),
-            shipping = order.shippingTotal.takeIf { it != BigDecimal.ZERO }?.let { formatPrice(it) }
+            shipping = order.shippingTotal.takeIf { it != BigDecimal.ZERO }?.let { formatPrice(it) },
+            refunds = refundAmounts,
+            netPayment = netPayment
         )
 
         return OrderDetailsViewState(

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -3809,6 +3809,8 @@
     <string name="woopos_orders_details_breakdown_shipping_label">Shipping</string>
     <string name="woopos_orders_details_total_label">Total</string>
     <string name="woopos_orders_details_total_paid_label">Total paid</string>
+    <string name="woopos_orders_details_refunded_label">Refunded</string>
+    <string name="woopos_orders_details_net_payment_label">Net Payment</string>
     <string name="woopos_orders_details_products_list_content_description">Order products list</string>
     <string name="woopos_orders_details_totals_card_content_description">Order totals breakdown</string>
 

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/common/data/WooPosGetOrderRefundsByOrderIdTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/common/data/WooPosGetOrderRefundsByOrderIdTest.kt
@@ -1,0 +1,102 @@
+package com.woocommerce.android.ui.woopos.common.data
+
+import com.woocommerce.android.tools.SelectedSite
+import kotlinx.coroutines.test.runTest
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.Before
+import org.junit.Test
+import org.mockito.kotlin.any
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
+import org.wordpress.android.fluxc.model.SiteModel
+import org.wordpress.android.fluxc.model.refunds.WCRefundModel
+import org.wordpress.android.fluxc.store.WCRefundStore
+import java.math.BigDecimal
+import java.util.Date
+
+class WooPosGetOrderRefundsByOrderIdTest {
+    private lateinit var refundStore: WCRefundStore
+    private lateinit var selectedSite: SelectedSite
+    private lateinit var sut: WooPosGetOrderRefundsByOrderId
+    private lateinit var site: SiteModel
+
+    @Before
+    fun setup() {
+        refundStore = mock()
+        selectedSite = mock()
+        site = mock()
+
+        whenever(selectedSite.get()).thenReturn(site)
+
+        sut = WooPosGetOrderRefundsByOrderId(
+            refundStore = refundStore,
+            selectedSite = selectedSite
+        )
+    }
+
+    @Test
+    fun `given refunds exist, when invoke called, then returns mapped refunds`() = runTest {
+        // GIVEN
+        val orderId = 123L
+        val fluxCRefunds = listOf(
+            WCRefundModel(
+                id = 1L,
+                dateCreated = Date(),
+                amount = BigDecimal.TEN,
+                reason = "Test refund",
+                automaticGatewayRefund = true,
+                items = emptyList(),
+                shippingLineItems = emptyList(),
+                feeLineItems = emptyList()
+            ),
+            WCRefundModel(
+                id = 2L,
+                dateCreated = Date(),
+                amount = BigDecimal.valueOf(5),
+                reason = "Another refund",
+                automaticGatewayRefund = false,
+                items = emptyList(),
+                shippingLineItems = emptyList(),
+                feeLineItems = emptyList()
+            )
+        )
+        whenever(refundStore.getAllRefunds(site, orderId)).thenReturn(fluxCRefunds)
+
+        // WHEN
+        val result = sut.invoke(orderId)
+
+        // THEN
+        assertThat(result).hasSize(2)
+        assertThat(result[0].id).isEqualTo(1L)
+        assertThat(result[0].amount).isEqualTo(BigDecimal.TEN)
+        assertThat(result[1].id).isEqualTo(2L)
+        assertThat(result[1].amount).isEqualTo(BigDecimal.valueOf(5))
+    }
+
+    @Test
+    fun `given no refunds exist, when invoke called, then returns empty list`() = runTest {
+        // GIVEN
+        val orderId = 123L
+        whenever(refundStore.getAllRefunds(site, orderId)).thenReturn(emptyList())
+
+        // WHEN
+        val result = sut.invoke(orderId)
+
+        // THEN
+        assertThat(result).isEmpty()
+    }
+
+    @Test
+    fun `given orderId provided, when invoke called, then passes correct orderId to store`() = runTest {
+        // GIVEN
+        val orderId = 456L
+        whenever(refundStore.getAllRefunds(any(), any())).thenReturn(emptyList())
+
+        // WHEN
+        sut.invoke(orderId)
+
+        // THEN
+        verify(refundStore).getAllRefunds(site, orderId)
+    }
+}

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/orders/WooPosOrdersViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/orders/WooPosOrdersViewModelTest.kt
@@ -612,4 +612,69 @@ class WooPosOrdersViewModelTest {
         assertThat(content.items.keys.map { it.id }).containsExactly(300L, 400L)
         assertThat(content.selectedDetails.id).isEqualTo(300L)
     }
+
+    @Test
+    fun `given order with no refunds, when mapped, then breakdown has empty refunds and null net payment`() = runTest {
+        // GIVEN
+        whenever(dataSource.loadOrders()).thenReturn(
+            flow { emit(LoadOrdersResult.SuccessRemote(listOf(order(1)))) }
+        )
+        runBlocking {
+            whenever(getOrderRefunds.invoke(1L)).thenReturn(emptyList())
+        }
+
+        // WHEN
+        viewModel = createViewModel()
+        advanceUntilIdle()
+
+        // THEN
+        val content = viewModel.state.value as WooPosOrdersState.Content
+        assertThat(content.selectedDetails.breakdown.refunds).isEmpty()
+        assertThat(content.selectedDetails.breakdown.netPayment).isNull()
+    }
+
+    @Test
+    fun `given order with refunds, when mapped, then breakdown includes refund amounts and net payment`() = runTest {
+        // GIVEN
+        val testOrder = order(1)
+        whenever(dataSource.loadOrders()).thenReturn(
+            flow { emit(LoadOrdersResult.SuccessRemote(listOf(testOrder))) }
+        )
+
+        val refund1 = com.woocommerce.android.model.Refund(
+            id = 1,
+            dateCreated = java.util.Date(),
+            amount = java.math.BigDecimal("10.00"),
+            reason = null,
+            automaticGatewayRefund = false,
+            items = emptyList(),
+            shippingLines = emptyList(),
+            feeLines = emptyList()
+        )
+        val refund2 = com.woocommerce.android.model.Refund(
+            id = 2,
+            dateCreated = java.util.Date(),
+            amount = java.math.BigDecimal("5.00"),
+            reason = null,
+            automaticGatewayRefund = false,
+            items = emptyList(),
+            shippingLines = emptyList(),
+            feeLines = emptyList()
+        )
+
+        runBlocking {
+            whenever(getOrderRefunds.invoke(1L)).thenReturn(listOf(refund1, refund2))
+            whenever(formatPrice.invoke(java.math.BigDecimal("10.00"))).thenReturn("$10.00")
+            whenever(formatPrice.invoke(java.math.BigDecimal("5.00"))).thenReturn("$5.00")
+        }
+
+        // WHEN
+        viewModel = createViewModel()
+        advanceUntilIdle()
+
+        // THEN
+        val content = viewModel.state.value as WooPosOrdersState.Content
+        assertThat(content.selectedDetails.breakdown.refunds).containsExactly("-$10.00", "-$5.00")
+        assertThat(content.selectedDetails.breakdown.netPayment).isNotNull()
+    }
 }

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/orders/WooPosOrdersViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/orders/WooPosOrdersViewModelTest.kt
@@ -5,6 +5,7 @@ import com.woocommerce.android.model.Order
 import com.woocommerce.android.ui.orders.OrderTestUtils
 import com.woocommerce.android.ui.woopos.common.composeui.component.WooPosSearchInputState
 import com.woocommerce.android.ui.woopos.common.composeui.component.WooPosSearchUIEvent
+import com.woocommerce.android.ui.woopos.common.data.WooPosGetOrderRefundsByOrderId
 import com.woocommerce.android.ui.woopos.common.data.WooPosGetProductById
 import com.woocommerce.android.ui.woopos.home.items.WooPosPaginationState
 import com.woocommerce.android.ui.woopos.home.items.WooPosPullToRefreshState
@@ -41,6 +42,7 @@ class WooPosOrdersViewModelTest {
     private val resourceProvider: ResourceProvider = org.mockito.kotlin.mock()
     private val getProductById: WooPosGetProductById = org.mockito.kotlin.mock()
     private val formatPrice: WooPosFormatPrice = org.mockito.kotlin.mock()
+    private val getOrderRefunds: WooPosGetOrderRefundsByOrderId = org.mockito.kotlin.mock()
     private val providedLocale: Locale = Locale.US
 
     private fun createViewModel(): WooPosOrdersViewModel {
@@ -49,7 +51,8 @@ class WooPosOrdersViewModelTest {
             resourceProvider = resourceProvider,
             locale = providedLocale,
             getProductById = getProductById,
-            formatPrice = formatPrice
+            formatPrice = formatPrice,
+            getOrderRefunds = getOrderRefunds
         )
     }
 
@@ -76,6 +79,7 @@ class WooPosOrdersViewModelTest {
 
         runBlocking {
             whenever(getProductById.invoke(any())).thenReturn(null)
+            whenever(getOrderRefunds.invoke(any())).thenReturn(emptyList())
         }
     }
 

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/orders/WooPosOrdersViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/orders/WooPosOrdersViewModelTest.kt
@@ -2,7 +2,6 @@ package com.woocommerce.android.ui.woopos.orders
 
 import com.woocommerce.android.R
 import com.woocommerce.android.model.Order
-import com.woocommerce.android.tools.SelectedSite
 import com.woocommerce.android.ui.orders.OrderTestUtils
 import com.woocommerce.android.ui.woopos.common.composeui.component.WooPosSearchInputState
 import com.woocommerce.android.ui.woopos.common.composeui.component.WooPosSearchUIEvent
@@ -10,6 +9,7 @@ import com.woocommerce.android.ui.woopos.common.data.WooPosGetProductById
 import com.woocommerce.android.ui.woopos.home.items.WooPosPaginationState
 import com.woocommerce.android.ui.woopos.home.items.WooPosPullToRefreshState
 import com.woocommerce.android.ui.woopos.util.WooPosCoroutineTestRule
+import com.woocommerce.android.ui.woopos.util.format.WooPosFormatPrice
 import com.woocommerce.android.viewmodel.ResourceProvider
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.flow
@@ -22,12 +22,9 @@ import org.junit.Rule
 import org.junit.Test
 import org.mockito.Mockito.mock
 import org.mockito.kotlin.any
-import org.mockito.kotlin.anyOrNull
 import org.mockito.kotlin.times
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
-import org.wordpress.android.fluxc.model.SiteModel
-import org.wordpress.android.fluxc.store.WooCommerceStore
 import java.util.Locale
 
 @OptIn(ExperimentalCoroutinesApi::class)
@@ -41,20 +38,18 @@ class WooPosOrdersViewModelTest {
     private lateinit var viewModel: WooPosOrdersViewModel
 
     private fun order(id: Long = 1L): Order = OrderTestUtils.generateTestOrder(orderId = id)
-    private val wooStore: WooCommerceStore = org.mockito.kotlin.mock()
-    private val selectedSite: SelectedSite = org.mockito.kotlin.mock()
     private val resourceProvider: ResourceProvider = org.mockito.kotlin.mock()
     private val getProductById: WooPosGetProductById = org.mockito.kotlin.mock()
+    private val formatPrice: WooPosFormatPrice = org.mockito.kotlin.mock()
     private val providedLocale: Locale = Locale.US
 
     private fun createViewModel(): WooPosOrdersViewModel {
         return WooPosOrdersViewModel(
             ordersDataSource = dataSource,
-            wooCommerceStore = wooStore,
-            selectedSite = selectedSite,
             resourceProvider = resourceProvider,
             locale = providedLocale,
-            getProductById = getProductById
+            getProductById = getProductById,
+            formatPrice = formatPrice
         )
     }
 
@@ -62,17 +57,9 @@ class WooPosOrdersViewModelTest {
     fun setUp() {
         whenever(resourceProvider.getString(R.string.date_time_connector)).thenReturn("at")
 
-        whenever(
-            wooStore.formatCurrencyForDisplay(
-                amount = any(),
-                site = any(),
-                currencyCode = anyOrNull(),
-                applyDecimalFormatting = any()
-            )
-        ).thenReturn("$0.00")
-
-        val site: SiteModel = mock()
-        whenever(selectedSite.get()).thenReturn(site)
+        runBlocking {
+            whenever(formatPrice.invoke(any())).thenReturn("$0.00")
+        }
 
         whenever(dataSource.loadOrders()).thenReturn(
             flow { emit(LoadOrdersResult.SuccessCache(listOf(order(1), order(2)))) }


### PR DESCRIPTION
WOOMOB-1533

### Description
Adds refund information to the historical orders details screen in Woo POS. The order details now display individual refund line items and calculate net payment (total paid minus refunds).

Changes:
- Added `WooPosGetOrderRefundsByOrderId` utility to fetch refund data for orders
- Updated `OrderDetailsViewState.TotalsBreakdown` to include refunds list and net payment
- Modified `WooPosOrdersViewModel` to fetch and format refund amounts
- Updated `WooPosOrderDetails` UI to display refunds and net payment sections
- Added string resources for "Refunded" and "Net Payment" labels

Note: The UI layout is not final and will be refined in subsequent iterations.

### Steps to reproduce
1. Open Woo POS
2. Navigate to Historical Orders
3. Select an order that has refunds
4. Observe the order details screen showing:
   - Total paid with payment method
   - Individual refund line items (if any)
   - Net payment calculation (if refunds exist)

### Testing information
- Verified orders without refunds display correctly (no refund section shown)
- Verified orders with single refund show refund amount and net payment
- Verified orders with multiple refunds show all refunds separately
- Confirmed refund amounts are formatted with negative signs
- Confirmed net payment calculation is correct (total - sum of refunds)

### Images/gif
<img width="1064" height="663" alt="image" src="https://github.com/user-attachments/assets/27397f17-c56b-42b3-87b1-2d5e2e8c5588" />


- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.