### PR TITLE
[CIAB] BookingListViewModel refactoring and some fixes

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/bookings/list/BookingListHandler.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/bookings/list/BookingListHandler.kt
@@ -8,6 +8,7 @@ import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.flatMapLatest
+import kotlinx.coroutines.flow.take
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
@@ -48,7 +49,7 @@ class BookingListHandler @Inject constructor(
                 order = sortBy.toBookingsOrderOption()
             )
         } else {
-            searchResults
+            searchResults.take(page * PAGE_SIZE)
         }
     }.flatMapLatest { it }
 
@@ -61,6 +62,7 @@ class BookingListHandler @Inject constructor(
         page.value = 1
         canLoadMore.set(true)
 
+        val previousQuery = this.searchQuery.value
         this.searchQuery.value = searchQuery
         this.filters.value = filters
         this.sortBy.value = sortBy
@@ -68,7 +70,9 @@ class BookingListHandler @Inject constructor(
         return@withLock if (searchQuery == null) {
             fetchBookings()
         } else {
-            searchResults.value = emptyList()
+            if (searchQuery != previousQuery) {
+                searchResults.value = emptyList()
+            }
             if (searchQuery.isEmpty()) {
                 // If the query is empty, return cached results directly
                 canLoadMore.set(false)
@@ -85,10 +89,11 @@ class BookingListHandler @Inject constructor(
     }
 
     private suspend fun fetchBookings(): Result<Unit> {
+        val pageToFetch = page.value
         val isSearching = !searchQuery.value.isNullOrEmpty()
         val order = sortBy.value.toBookingsOrderOption()
         return bookingsRepository.fetchBookings(
-            page = page.value,
+            page = pageToFetch,
             perPage = PAGE_SIZE,
             query = searchQuery.value,
             filters = filters.value,
@@ -99,7 +104,11 @@ class BookingListHandler @Inject constructor(
                 page.update { it + 1 }
             }
             if (isSearching) {
-                searchResults.update { it + result.bookings }
+                if (pageToFetch == 1) {
+                    searchResults.value = result.bookings
+                } else {
+                    searchResults.update { it + result.bookings }
+                }
             }
         }.map { }
     }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/bookings/list/BookingListHandler.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/bookings/list/BookingListHandler.kt
@@ -4,6 +4,7 @@ import androidx.annotation.VisibleForTesting
 import com.woocommerce.android.ui.bookings.Booking
 import com.woocommerce.android.ui.bookings.BookingsRepository
 import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.combine
@@ -23,6 +24,7 @@ class BookingListHandler @Inject constructor(
     companion object {
         @VisibleForTesting
         const val PAGE_SIZE = 25
+        private const val MIN_FETCH_DURATION_MS = 100L
     }
 
     private val mutex = Mutex()
@@ -75,7 +77,8 @@ class BookingListHandler @Inject constructor(
             }
             if (searchQuery.isEmpty()) {
                 // If the query is empty, return cached results directly
-                canLoadMore.set(false)
+                // Mimic network delay to allow the UI to show then hide the refreshing indicator
+                delay(MIN_FETCH_DURATION_MS)
                 Result.success(Unit)
             } else {
                 fetchBookings()

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/bookings/list/BookingListHandler.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/bookings/list/BookingListHandler.kt
@@ -9,7 +9,7 @@ import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.flatMapLatest
-import kotlinx.coroutines.flow.take
+import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
@@ -51,7 +51,7 @@ class BookingListHandler @Inject constructor(
                 order = sortBy.toBookingsOrderOption()
             )
         } else {
-            searchResults.take(page * PAGE_SIZE)
+            searchResults.map { it.take(page * PAGE_SIZE) }
         }
     }.flatMapLatest { it }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/bookings/list/BookingListViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/bookings/list/BookingListViewModel.kt
@@ -12,6 +12,7 @@ import com.woocommerce.android.viewmodel.ScopedViewModel
 import com.woocommerce.android.viewmodel.getNullableStateFlow
 import com.woocommerce.android.viewmodel.getStateFlow
 import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.FlowPreview
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.flow.MutableSharedFlow
@@ -19,7 +20,9 @@ import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.debounce
+import kotlinx.coroutines.flow.flatMapLatest
 import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.onStart
 import kotlinx.coroutines.flow.withIndex
 import kotlinx.coroutines.launch
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.bookings.BookingFilters
@@ -113,7 +116,7 @@ class BookingListViewModel @Inject constructor(
         monitorSearchAndFilterChanges()
     }
 
-    @OptIn(FlowPreview::class)
+    @OptIn(FlowPreview::class, ExperimentalCoroutinesApi::class)
     private fun monitorSearchAndFilterChanges() {
         launch {
             var lastFetchParams: FetchParams? = null
@@ -137,17 +140,25 @@ class BookingListViewModel @Inject constructor(
                     selectedTab = tab,
                     filters = filters
                 )
-            }.collectLatest { fetchParams ->
+            }.flatMapLatest { fetchParams ->
+                refreshTrigger.map { true }
+                    .onStart { emit(false) }
+                    .map { isRefreshing -> Pair(fetchParams, isRefreshing) }
+            }.collectLatest { (fetchParams, isRefreshing) ->
                 // Cancel any ongoing fetch or load more operations
                 bookingsFetchJob?.cancel()
                 bookingsLoadMoreJob?.cancel()
 
-                val initialLoadingState = lastFetchParams.let { lastFetchParams ->
-                    if (lastFetchParams != null && lastFetchParams.sortOption != fetchParams.sortOption) {
-                        // When sort option changes, force refreshing state to indicate data reload
-                        BookingListLoadingState.Refreshing
-                    } else {
-                        BookingListLoadingState.Loading
+                val initialLoadingState = if (isRefreshing) {
+                    BookingListLoadingState.Refreshing
+                } else {
+                    lastFetchParams.let { lastFetchParams ->
+                        if (lastFetchParams != null && lastFetchParams.sortOption != fetchParams.sortOption) {
+                            // When sort option changes, force refreshing state to indicate data reload
+                            BookingListLoadingState.Refreshing
+                        } else {
+                            BookingListLoadingState.Loading
+                        }
                     }
                 }
 
@@ -156,13 +167,6 @@ class BookingListViewModel @Inject constructor(
                     initialLoadingState = initialLoadingState,
                     fetchParams = fetchParams
                 )
-
-                refreshTrigger.collect {
-                    fetchBookings(
-                        initialLoadingState = BookingListLoadingState.Refreshing,
-                        fetchParams = fetchParams
-                    )
-                }
             }
         }
     }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/bookings/list/BookingListViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/bookings/list/BookingListViewModel.kt
@@ -14,15 +14,15 @@ import com.woocommerce.android.viewmodel.getStateFlow
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.FlowPreview
 import kotlinx.coroutines.Job
+import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.debounce
-import kotlinx.coroutines.flow.drop
-import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.map
-import kotlinx.coroutines.flow.merge
+import kotlinx.coroutines.flow.withIndex
 import kotlinx.coroutines.launch
+import org.wordpress.android.fluxc.network.rest.wpcom.wc.bookings.BookingFilters
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.bookings.BookingsFilterOption
 import javax.inject.Inject
 
@@ -42,6 +42,7 @@ class BookingListViewModel @Inject constructor(
         clazz = String::class.java,
         key = "searchQuery"
     )
+    private val refreshTrigger = MutableSharedFlow<Unit>(extraBufferCapacity = 1)
 
     private val sortOption = savedStateHandle.getStateFlow(viewModelScope, BookingListSortOption.NewestToOldest)
 
@@ -59,7 +60,7 @@ class BookingListViewModel @Inject constructor(
         BookingListContentState(
             bookings = bookings,
             loadingState = loadingState,
-            onRefresh = { fetchBookings(BookingListLoadingState.Refreshing) },
+            onRefresh = { refreshTrigger.tryEmit(Unit) },
             onLoadMore = ::loadMore,
             onBookingClick = ::onBookingClick
         )
@@ -115,37 +116,66 @@ class BookingListViewModel @Inject constructor(
     @OptIn(FlowPreview::class)
     private fun monitorSearchAndFilterChanges() {
         launch {
+            var lastFetchParams: FetchParams? = null
             val queryFlow = searchQuery
-                .drop(1) // Skip the initial value to avoid double fetch on init
-                .debounce {
-                    if (it.isNullOrEmpty()) 0L else AppConstants.SEARCH_TYPING_DELAY_MS
+                .withIndex()
+                .debounce { (index, query) ->
+                    // Skip debounce for the initial value or when the query is cleared
+                    if (index == 0 || query.isNullOrEmpty()) 0L else AppConstants.SEARCH_TYPING_DELAY_MS
                 }
-            val sortFlow = sortOption.drop(1) // Skip the initial value to avoid double fetch on init
-            val bookingFilterFlow =
-                bookingFilterRepository.bookingFiltersFlow.drop(1) // Skip initial to avoid double fetch on init
+                .map { it.value }
 
-            merge(selectedTab, queryFlow, sortFlow, bookingFilterFlow).collectLatest {
+            combine(
+                selectedTab,
+                queryFlow,
+                sortOption,
+                bookingFilterRepository.bookingFiltersFlow
+            ) { tab, query, sort, filters ->
+                FetchParams(
+                    searchQuery = query,
+                    sortOption = sort,
+                    selectedTab = tab,
+                    filters = filters
+                )
+            }.collectLatest { fetchParams ->
                 // Cancel any ongoing fetch or load more operations
                 bookingsFetchJob?.cancel()
                 bookingsLoadMoreJob?.cancel()
 
-                bookingsFetchJob = fetchBookings(
-                    initialLoadingState = if (it is BookingListSortOption) {
+                val initialLoadingState = lastFetchParams.let { lastFetchParams ->
+                    if (lastFetchParams != null && lastFetchParams.sortOption != fetchParams.sortOption) {
+                        // When sort option changes, force refreshing state to indicate data reload
                         BookingListLoadingState.Refreshing
                     } else {
                         BookingListLoadingState.Loading
                     }
+                }
+
+                lastFetchParams = fetchParams
+                fetchBookings(
+                    initialLoadingState = initialLoadingState,
+                    fetchParams = fetchParams
                 )
+
+                refreshTrigger.collect {
+                    fetchBookings(
+                        initialLoadingState = BookingListLoadingState.Refreshing,
+                        fetchParams = fetchParams
+                    )
+                }
             }
         }
     }
 
-    private fun fetchBookings(initialLoadingState: BookingListLoadingState) = launch {
+    private suspend fun fetchBookings(
+        initialLoadingState: BookingListLoadingState,
+        fetchParams: FetchParams,
+    ) {
         loadingState.value = initialLoadingState
         bookingListHandler.loadBookings(
-            searchQuery = searchQuery.value,
-            filters = prepareFilters(),
-            sortBy = sortOption.value
+            searchQuery = fetchParams.searchQuery,
+            filters = fetchParams.prepareFilters(),
+            sortBy = fetchParams.sortOption
         ).onFailure {
             triggerEvent(MultiLiveEvent.Event.ShowSnackbar(R.string.bookings_fetch_error))
         }
@@ -192,16 +222,23 @@ class BookingListViewModel @Inject constructor(
         triggerEvent(NavigateToFilters)
     }
 
-    private suspend fun prepareFilters(): List<BookingsFilterOption> = with(filtersBuilder) {
-        when (selectedTab.value) {
+    private fun FetchParams.prepareFilters(): List<BookingsFilterOption> = with(filtersBuilder) {
+        when (selectedTab) {
             BookingListTab.Today,
             BookingListTab.Upcoming -> listOfNotNull(
-                selectedTab.value.asDateRangeFilter()
+                selectedTab.asDateRangeFilter()
             )
 
-            BookingListTab.All -> bookingFilterRepository.bookingFiltersFlow.first().asList()
+            BookingListTab.All -> filters.asList()
         }
     }
+
+    private data class FetchParams(
+        val searchQuery: String?,
+        val sortOption: BookingListSortOption,
+        val selectedTab: BookingListTab,
+        val filters: BookingFilters
+    )
 
     data class NavigateToBookingDetails(val bookingId: Long) : MultiLiveEvent.Event()
     object NavigateToFilters : MultiLiveEvent.Event()

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/compose/component/TextFields.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/compose/component/TextFields.kt
@@ -209,10 +209,13 @@ fun WCSearchField(
     var textFieldValueState by rememberSaveable(stateSaver = TextFieldValue.Saver) {
         mutableStateOf(TextFieldValue(text = value))
     }
+    // Keep TextFieldValue in sync with external value
+    val textFieldValue = textFieldValueState.copy(text = value)
+
     val lastValue by rememberUpdatedState(value)
 
     BasicTextField(
-        value = textFieldValueState,
+        value = textFieldValue,
         onValueChange = {
             textFieldValueState = it
             if (it.text != lastValue) {

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/bookings/list/BookingListHandlerTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/bookings/list/BookingListHandlerTest.kt
@@ -5,6 +5,7 @@ import com.woocommerce.android.ui.bookings.BookingsRepository
 import com.woocommerce.android.util.InlineClassesAnswer
 import com.woocommerce.android.viewmodel.BaseUnitTest
 import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.flowOf
@@ -21,6 +22,7 @@ import org.mockito.kotlin.given
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.never
 import org.mockito.kotlin.verify
+import org.mockito.kotlin.willSuspendableAnswer
 import org.wordpress.android.fluxc.model.LocalOrRemoteId.LocalId
 import org.wordpress.android.fluxc.model.LocalOrRemoteId.RemoteId
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.bookings.BookingOrderInfo
@@ -200,6 +202,87 @@ class BookingListHandlerTest : BaseUnitTest() {
 
         val bookings = bookingListHandler.bookingsFlow.first()
         assertThat(bookings).hasSize(BookingListHandler.PAGE_SIZE * 2)
+    }
+
+    @Test
+    fun `given search, when refreshing, then keep previous search results during the fetch`() = testBlocking {
+        val searchQuery = "Sample"
+        val firstResults = List(BookingListHandler.PAGE_SIZE) { getSampleBooking(it) }
+        val refreshedResults = List(BookingListHandler.PAGE_SIZE - 2) { getSampleBooking(it) }
+        given(bookingsRepository.fetchBookings(any(), any(), eq(searchQuery), any(), any()))
+            .willReturn(
+                Result.success(
+                    BookingsRepository.FetchResult(firstResults, false)
+                )
+            )
+            .willSuspendableAnswer {
+                delay(10) // To allow checking intermediate state
+                Result.success(
+                    BookingsRepository.FetchResult(refreshedResults, false)
+                )
+            }
+
+        bookingListHandler.loadBookings(
+            searchQuery = searchQuery,
+            sortBy = BookingListSortOption.NewestToOldest
+        )
+        val bookingsAfterFirstLoad = bookingListHandler.bookingsFlow.first()
+        val refreshJob = launch {
+            bookingListHandler.loadBookings(
+                searchQuery = searchQuery,
+                sortBy = BookingListSortOption.NewestToOldest
+            )
+        }
+        val bookingsDuringRefresh = bookingListHandler.bookingsFlow.first()
+        refreshJob.join()
+        val bookingsAfterRefresh = bookingListHandler.bookingsFlow.first()
+
+        assertThat(bookingsAfterFirstLoad).isEqualTo(firstResults)
+        assertThat(bookingsDuringRefresh).isEqualTo(firstResults)
+        assertThat(bookingsAfterRefresh).isEqualTo(refreshedResults)
+    }
+
+    @Test
+    fun `given search, when changing search query, then reset search results`() = testBlocking {
+        val initialQuery = "Initial"
+        val newQuery = "New"
+
+        val firstResults = List(BookingListHandler.PAGE_SIZE) { getSampleBooking(it) }
+        val newResults = List(BookingListHandler.PAGE_SIZE - 3) { getSampleBooking(it) }
+
+        given(bookingsRepository.fetchBookings(any(), any(), eq(initialQuery), any(), any()))
+            .willReturn(
+                Result.success(
+                    BookingsRepository.FetchResult(firstResults, false)
+                )
+            )
+        given(bookingsRepository.fetchBookings(any(), any(), eq(newQuery), any(), any()))
+            .willSuspendableAnswer {
+                delay(10) // To allow checking intermediate state
+                Result.success(
+                    BookingsRepository.FetchResult(newResults, false)
+                )
+            }
+
+        bookingListHandler.loadBookings(
+            searchQuery = initialQuery,
+            sortBy = BookingListSortOption.NewestToOldest
+        )
+        val bookingsAfterInitialSearch = bookingListHandler.bookingsFlow.first()
+
+        val refreshJob = launch {
+            bookingListHandler.loadBookings(
+                searchQuery = newQuery,
+                sortBy = BookingListSortOption.NewestToOldest
+            )
+        }
+        val bookingsDuringNewSearch = bookingListHandler.bookingsFlow.first()
+        refreshJob.join()
+        val bookingsAfterNewSearch = bookingListHandler.bookingsFlow.first()
+
+        assertThat(bookingsAfterInitialSearch).isEqualTo(firstResults)
+        assertThat(bookingsDuringNewSearch).isEmpty()
+        assertThat(bookingsAfterNewSearch).isEqualTo(newResults)
     }
 
     private fun getSampleBooking(id: Int) = BookingEntity(


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

<!-- Id number of the Linear issue this PR addresses, e.g., WOOMOB-373. -->

### Description
This PR has three main changes:

- Implement the approach [discussed](https://github.com/woocommerce/woocommerce-android/pull/14735#discussion_r2420675966) previously to make the ViewModel more reactive, and avoid reading the fetch parameters from `StateFlow#value`.
- Fix an issue with pull-to-refresh and search (check the comments for more details)
- Fix an issue with the WCSearchView composable (check the comments for more details)

### Steps to reproduce
1. Use a CIAB site that has multiple bookings, multiple pages.
2. Open bookings list.

### Testing information
- Test changing tabs, searching.
- Test changing the sorting order, and confirm it shows the refresh status.
- Check for any regressions.

### The tests that have been performed
The above.

- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->