### PR TITLE
[WOOMOB-1543] Propagate network errors instead of missing server date

### DIFF
--- a/libs/fluxc-plugin/src/main/kotlin/org/wordpress/android/fluxc/store/pos/localcatalog/WooPosLocalCatalogStore.kt
+++ b/libs/fluxc-plugin/src/main/kotlin/org/wordpress/android/fluxc/store/pos/localcatalog/WooPosLocalCatalogStore.kt
@@ -121,14 +121,12 @@ class WooPosLocalCatalogStore @Inject constructor(
 
             val serverDate = headersParser.getServerDate(response)
 
-            if (serverDate == null) {
-                return@withDefaultContext Result.failure(
-                    WooPosLocalCatalogError.InvalidResponse("Missing required header in response: Server Date.")
-                )
-            }
-
             when {
                 response.isError -> Result.failure(mapResponseError(response.error))
+
+                serverDate == null -> return@withDefaultContext Result.failure(
+                    WooPosLocalCatalogError.InvalidResponse("Missing required header in response: Server Date.")
+                )
 
                 response.model.isNullOrEmpty() -> Result.success(
                     WooPosLocalCatalogFetchProductsResult(
@@ -249,18 +247,16 @@ class WooPosLocalCatalogStore @Inject constructor(
 
             val serverDate = headersParser.getServerDate(response)
 
-            if (serverDate == null) {
-                return@withDefaultContext Result.failure(
-                    WooPosLocalCatalogError.InvalidResponse("Missing required header in response: Server Date.")
-                )
-            }
-
             when {
                 response.isError -> {
                     Result.failure(
                         mapResponseError(response.error)
                     )
                 }
+
+                serverDate == null -> return@withDefaultContext Result.failure(
+                    WooPosLocalCatalogError.InvalidResponse("Missing required header in response: Server Date.")
+                )
 
                 response.model.isNullOrEmpty() -> {
                     Result.success(

--- a/libs/fluxc-plugin/src/test/java/org/wordpress/android/fluxc/store/pos/WooPosLocalCatalogStoreTest.kt
+++ b/libs/fluxc-plugin/src/test/java/org/wordpress/android/fluxc/store/pos/WooPosLocalCatalogStoreTest.kt
@@ -609,14 +609,14 @@ class WooPosLocalCatalogStoreTest {
     }
 
     @Test
-    fun `when server date header is missing, then sync returns invalid response error`() = runTest {
+    fun `given sucessful response, when server date header is missing, then sync returns invalid response error`() = runTest {
         // GIVEN
         val remoteProducts = arrayOf(createTestApiResponse(id = 1L, name = "Product"))
         val response = WooResult(remoteProducts)
         whenever(posProductRestClient.fetchProducts(testSite, validDateString, 0, 100))
             .thenReturn(response)
         whenever(headersParser.getServerDate(response))
-            .thenReturn(null) // Missing server date
+            .thenReturn(null)
 
         // WHEN
         val result = store.fetchRecentlyModifiedProducts(testSite, validDateString, 0, 100)
@@ -624,6 +624,30 @@ class WooPosLocalCatalogStoreTest {
         // THEN
         assertThat(result.isFailure).isTrue()
         val error = result.exceptionOrNull() as WooPosLocalCatalogError.InvalidResponse
+        assertThat(error).isNotNull
+    }
+
+    @Test
+    fun `given error response, when server date header is missing, then sync returns error response`() = runTest {
+        // GIVEN
+        val response = WooResult<Array<ProductApiResponse>> (
+            WooError(
+                type = WooErrorType.API_ERROR,
+                original = org.wordpress.android.fluxc.network.BaseRequest.GenericErrorType.NETWORK_ERROR,
+                message = "API error"
+            )
+        )
+        whenever(posProductRestClient.fetchProducts(testSite, validDateString, 0, 100))
+            .thenReturn(response)
+        whenever(headersParser.getServerDate(response))
+            .thenReturn(null)
+
+        // WHEN
+        val result = store.fetchRecentlyModifiedProducts(testSite, validDateString, 0, 100)
+
+        // THEN
+        assertThat(result.isFailure).isTrue()
+        val error = result.exceptionOrNull() as WooPosLocalCatalogError.NetworkError
         assertThat(error).isNotNull
     }
 

--- a/libs/fluxc-plugin/src/test/java/org/wordpress/android/fluxc/store/pos/WooPosLocalCatalogStoreTest.kt
+++ b/libs/fluxc-plugin/src/test/java/org/wordpress/android/fluxc/store/pos/WooPosLocalCatalogStoreTest.kt
@@ -609,7 +609,7 @@ class WooPosLocalCatalogStoreTest {
     }
 
     @Test
-    fun `given sucessful response, when server date header is missing, then sync returns invalid response error`() = runTest {
+    fun `given successful response, when server date header is missing, then sync returns invalid response error`() = runTest {
         // GIVEN
         val remoteProducts = arrayOf(createTestApiResponse(id = 1L, name = "Product"))
         val response = WooResult(remoteProducts)


### PR DESCRIPTION
Fixes WOOMOB-1543

### Description
This PR fixes an issue where network errors were being logged as "missing server date" instead of properly propagating the actual network error. Previously, when network requests failed, the error handling was incorrectly attributing all failures to missing server date, making debugging and error tracking difficult.

The fix ensures that network errors are properly propagated through the error handling chain, allowing for more accurate error reporting and better debugging capabilities in the WooCommerce POS local catalog functionality.

### To test
1. Simulate a network error scenario in WooCommerce POS local catalog
2. Observe that the error was previously logged as "missing server date" instead of the actual network error (in the logs)
3. With this fix, the proper network error should now be reported

### Images/gif
N/A - This is a backend error handling improvement

- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.