### PR TITLE
[WOOMOB-1445] Use full sync timestamp in WooPos settings

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/localcatalog/WooPosLocalCatalogSyncRepository.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/localcatalog/WooPosLocalCatalogSyncRepository.kt
@@ -38,7 +38,11 @@ class WooPosLocalCatalogSyncRepository @Inject constructor(
     }
 
     suspend fun syncLocalCatalogFull(site: SiteModel): PosLocalCatalogSyncResult = withContext(dispatchers.io) {
-        return@withContext performSync(site = site, pageSize = PAGE_SIZE, maxPages = MAX_PAGES_PER_FULL_SYNC)
+        return@withContext performSync(site = site, pageSize = PAGE_SIZE, maxPages = MAX_PAGES_PER_FULL_SYNC).also {
+            if (it is PosLocalCatalogSyncResult.Success) {
+                syncTimestampManager.storeFullSyncLastCompletedTimestamp(System.currentTimeMillis())
+            }
+        }
     }
 
     suspend fun syncLocalCatalogIncremental(site: SiteModel): PosLocalCatalogSyncResult = withContext(dispatchers.io) {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/localcatalog/WooPosLocalCatalogSyncWorker.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/localcatalog/WooPosLocalCatalogSyncWorker.kt
@@ -9,7 +9,6 @@ import com.woocommerce.android.ui.login.AccountRepository
 import com.woocommerce.android.ui.woopos.common.util.WooPosLogWrapper
 import com.woocommerce.android.ui.woopos.featureflags.WooPosLocalCatalogM1Enabled
 import com.woocommerce.android.ui.woopos.util.datastore.WooPosPreferencesRepository
-import com.woocommerce.android.ui.woopos.util.datastore.WooPosSyncTimestampManager
 import dagger.assisted.Assisted
 import dagger.assisted.AssistedInject
 
@@ -23,7 +22,6 @@ constructor(
     private val accountRepository: AccountRepository,
     private val selectedSite: SelectedSite,
     private val syncRepository: WooPosLocalCatalogSyncRepository,
-    private val timestampManager: WooPosSyncTimestampManager,
     private val logger: WooPosLogWrapper,
     private val featureFlagM1Enabled: WooPosLocalCatalogM1Enabled,
     private val preferencesRepository: WooPosPreferencesRepository,
@@ -65,7 +63,6 @@ constructor(
                     "Local catalog FULL sync completed successfully. Products: ${fullSyncResult.productsSynced}, " +
                         "Variations: ${fullSyncResult.variationsSynced}, Duration: ${fullSyncResult.syncDurationMs}ms"
                 )
-                timestampManager.storeFullSyncLastCompletedTimestamp(System.currentTimeMillis())
                 logger.d("Starting Local catalog INCREMENTAL sync.")
                 val incrementalSyncResult = syncRepository.syncLocalCatalogIncremental(site)
                 if (incrementalSyncResult is PosLocalCatalogSyncResult.Failure) {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/settings/details/localcatalog/WooPosSettingsLocalCatalogViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/settings/details/localcatalog/WooPosSettingsLocalCatalogViewModel.kt
@@ -39,18 +39,21 @@ class WooPosSettingsLocalCatalogViewModel @Inject constructor(
         viewModelScope.launch {
             _state.update { it.copy(catalogStatus = WooPosSettingsLocalCatalogState.CatalogStatus.LoadingStatus) }
 
-            val productsTimestamp = syncTimestampManager.getProductsLastSyncTimestamp()
-            val variationsTimestamp = syncTimestampManager.getVariationsLastSyncTimestamp()
+            val productsLastSyncTimestamp = syncTimestampManager.getProductsLastSyncTimestamp()
+            val variationsLastSyncTimestamp = syncTimestampManager.getVariationsLastSyncTimestamp()
+            val fullSyncTimestamp = syncTimestampManager.getFullSyncLastCompletedTimestamp()
 
-            val formattedTimestamp = dateFormatter.formatCatalogLastUpdate(
-                productsTimestamp,
-                variationsTimestamp
+            val formattedLastSyncTimestamp = dateFormatter.formatCatalogLastUpdate(
+                productsLastSyncTimestamp,
+                variationsLastSyncTimestamp
             )
+
+            val formattedLastFullSyncTimestamp = dateFormatter.formatCatalogLastFullSync(fullSyncTimestamp)
 
             val catalogStatus = WooPosSettingsLocalCatalogState.CatalogStatus.Available(
                 catalogSize = "8.3 MB", // TBD local catalog: Replace with actual catalog size
-                lastUpdate = formattedTimestamp,
-                lastFullUpdate = formattedTimestamp // TBD local catalog: Replace with full sync timestamp
+                lastUpdate = formattedLastSyncTimestamp,
+                lastFullUpdate = formattedLastFullSyncTimestamp
             )
 
             _state.update {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/util/format/WooPosDateFormatter.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/util/format/WooPosDateFormatter.kt
@@ -51,6 +51,15 @@ class WooPosDateFormatter @Inject constructor(
     }
 
     /**
+     * Formats the date into a user-friendly string. Returns "Never" if timestamps is null.
+     */
+    fun formatCatalogLastFullSync(fullSyncTimestamp: Long?): String {
+        return fullSyncTimestamp?.let {
+            formatLastUpdateTimestamp(it)
+        } ?: context.getString(R.string.woopos_date_never)
+    }
+
+    /**
      * Formats a timestamp into a user-friendly string representation.
      * Shows:
      * - "Just now" for very recent updates (< 1 minute)

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/util/format/WooPosDateFormatter.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/util/format/WooPosDateFormatter.kt
@@ -51,7 +51,7 @@ class WooPosDateFormatter @Inject constructor(
     }
 
     /**
-     * Formats the date into a user-friendly string. Returns "Never" if timestamps is null.
+     * Formats the date into a user-friendly string. Returns "Never" if timestamp is null.
      */
     fun formatCatalogLastFullSync(fullSyncTimestamp: Long?): String {
         return fullSyncTimestamp?.let {

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/localcatalog/WooPosLocalCatalogSyncRepositoryTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/localcatalog/WooPosLocalCatalogSyncRepositoryTest.kt
@@ -67,7 +67,7 @@ class WooPosLocalCatalogSyncRepositoryTest : BaseUnitTest() {
     }
 
     @Test
-    fun `when full sync succeeds, then stores timestamp`() = testBlocking {
+    fun `when full sync succeeds, then stores both last sync and last full sync timestamps`() = testBlocking {
         // GIVEN
         val productsSynced = 150
         whenever(posSyncProductsAction.execute(any(), anyOrNull(), any(), any()))
@@ -82,6 +82,7 @@ class WooPosLocalCatalogSyncRepositoryTest : BaseUnitTest() {
 
         // THEN
         verify(syncTimestampManager).storeProductsLastSyncTimestamp(any())
+        verify(syncTimestampManager).storeFullSyncLastCompletedTimestamp(any())
     }
 
     @Test

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/localcatalog/WooPosLocalCatalogSyncWorkerTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/localcatalog/WooPosLocalCatalogSyncWorkerTest.kt
@@ -8,7 +8,6 @@ import com.woocommerce.android.ui.login.AccountRepository
 import com.woocommerce.android.ui.woopos.common.util.WooPosLogWrapper
 import com.woocommerce.android.ui.woopos.featureflags.WooPosLocalCatalogM1Enabled
 import com.woocommerce.android.ui.woopos.util.datastore.WooPosPreferencesRepository
-import com.woocommerce.android.ui.woopos.util.datastore.WooPosSyncTimestampManager
 import com.woocommerce.android.viewmodel.BaseUnitTest
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import org.assertj.core.api.Assertions.assertThat
@@ -30,7 +29,6 @@ class WooPosLocalCatalogSyncWorkerTest : BaseUnitTest() {
     private var accountRepository: AccountRepository = mock()
     private var selectedSite: SelectedSite = mock()
     private var syncRepository: WooPosLocalCatalogSyncRepository = mock()
-    private var timestampManager: WooPosSyncTimestampManager = mock()
     private lateinit var site: SiteModel
     private var logger: WooPosLogWrapper = mock()
     private var featureFlagM1Enabled: WooPosLocalCatalogM1Enabled = mock()
@@ -78,7 +76,6 @@ class WooPosLocalCatalogSyncWorkerTest : BaseUnitTest() {
             accountRepository = accountRepository,
             selectedSite = selectedSite,
             syncRepository = syncRepository,
-            timestampManager = timestampManager,
             logger = logger,
             featureFlagM1Enabled = featureFlagM1Enabled,
             preferencesRepository = preferencesRepository,
@@ -97,19 +94,6 @@ class WooPosLocalCatalogSyncWorkerTest : BaseUnitTest() {
         assertThat(result).isEqualTo(ListenableWorker.Result.success())
         verify(syncRepository).syncLocalCatalogFull(eq(site))
         verify(syncRepository).syncLocalCatalogIncremental(eq(site))
-    }
-
-    @Test
-    fun `given successful sync, when doWork completes, then stores full sync completion timestamp`() = testBlocking {
-        // GIVEN
-        val worker = createWorker()
-
-        // WHEN
-        val result = worker.doWork()
-
-        // THEN
-        assertThat(result).isEqualTo(ListenableWorker.Result.success())
-        verify(timestampManager).storeFullSyncLastCompletedTimestamp(any())
     }
 
     @Test

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/settings/details/localcatalog/WooPosSettingsLocalCatalogViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/settings/details/localcatalog/WooPosSettingsLocalCatalogViewModelTest.kt
@@ -1,0 +1,176 @@
+package com.woocommerce.android.ui.woopos.settings.details.localcatalog
+
+import com.woocommerce.android.tools.SelectedSite
+import com.woocommerce.android.ui.woopos.localcatalog.PosLocalCatalogSyncResult
+import com.woocommerce.android.ui.woopos.localcatalog.WooPosLocalCatalogSyncRepository
+import com.woocommerce.android.ui.woopos.localcatalog.WooPosLocalCatalogSyncScheduler
+import com.woocommerce.android.ui.woopos.util.WooPosCoroutineTestRule
+import com.woocommerce.android.ui.woopos.util.datastore.WooPosPreferencesRepository
+import com.woocommerce.android.ui.woopos.util.datastore.WooPosSyncTimestampManager
+import com.woocommerce.android.ui.woopos.util.format.WooPosDateFormatter
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.runTest
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.mockito.kotlin.any
+import org.mockito.kotlin.anyOrNull
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.times
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
+import org.wordpress.android.fluxc.model.SiteModel
+
+@ExperimentalCoroutinesApi
+class WooPosSettingsLocalCatalogViewModelTest {
+
+    @Rule
+    @JvmField
+    val coroutineTestRule = WooPosCoroutineTestRule()
+
+    private val syncTimestampManager: WooPosSyncTimestampManager = mock()
+    private val localCatalogSyncRepository: WooPosLocalCatalogSyncRepository = mock()
+    private val selectedSite: SelectedSite = mock()
+    private val dateFormatter: WooPosDateFormatter = mock()
+    private val preferencesRepository: WooPosPreferencesRepository = mock()
+    private val syncScheduler: WooPosLocalCatalogSyncScheduler = mock()
+
+    private val mockSite: SiteModel = mock()
+    private val allowCellularDataFlow = MutableStateFlow(false)
+
+    private lateinit var sut: WooPosSettingsLocalCatalogViewModel
+
+    @Before
+    fun setUp() = runTest {
+        whenever(selectedSite.get()).thenReturn(mockSite)
+        whenever(preferencesRepository.allowCellularDataUpdate).thenReturn(allowCellularDataFlow)
+        whenever(localCatalogSyncRepository.syncLocalCatalogFull(any()))
+            .thenReturn(
+                PosLocalCatalogSyncResult.Success(
+                    productsSynced = 10,
+                    variationsSynced = 5,
+                    syncDurationMs = 1000L
+                )
+            )
+
+        whenever(syncTimestampManager.getProductsLastSyncTimestamp()).thenReturn(1000L)
+        whenever(syncTimestampManager.getVariationsLastSyncTimestamp()).thenReturn(1000L)
+        whenever(syncTimestampManager.getFullSyncLastCompletedTimestamp()).thenReturn(1000L)
+        whenever(dateFormatter.formatCatalogLastUpdate(anyOrNull(), anyOrNull())).thenReturn("Never")
+        whenever(dateFormatter.formatCatalogLastFullSync(anyOrNull())).thenReturn("Never")
+    }
+
+    @Test
+    fun `given cellular data is disabled, when init, then state reflects disabled preference`() = runTest {
+        // GIVEN
+        allowCellularDataFlow.value = false
+
+        // WHEN
+        sut = createViewModel()
+        advanceUntilIdle()
+
+        // THEN
+        assertThat(sut.state.value.allowCellularDataUpdate).isFalse()
+    }
+
+    @Test
+    fun `given cellular data is enabled, when init, then state reflects enabled preference`() = runTest {
+        // GIVEN
+        allowCellularDataFlow.value = true
+
+        // WHEN
+        sut = createViewModel()
+        advanceUntilIdle()
+
+        // THEN
+        assertThat(sut.state.value.allowCellularDataUpdate).isTrue()
+    }
+
+    @Test
+    fun `when toggling cellular data, then updates preferences and notifies scheduler`() = runTest {
+        // GIVEN
+        sut = createViewModel()
+
+        // WHEN
+        sut.toggleCellularDataUpdate(true)
+        advanceUntilIdle()
+
+        // THEN
+        verify(preferencesRepository).setAllowCellularDataUpdate(true)
+        verify(syncScheduler).updateWorkConstraints()
+    }
+
+    @Test
+    fun `when cellular data preference changes, then state is updated`() = runTest {
+        // GIVEN
+        sut = createViewModel()
+        advanceUntilIdle()
+        assertThat(sut.state.value.allowCellularDataUpdate).isFalse()
+
+        // WHEN
+        allowCellularDataFlow.value = true
+        advanceUntilIdle()
+
+        // THEN
+        assertThat(sut.state.value.allowCellularDataUpdate).isTrue()
+    }
+
+    @Test
+    fun `when default state is created, then initial state is Loading`() {
+        // GIVEN & WHEN
+        val initialState = WooPosSettingsLocalCatalogState()
+
+        // THEN
+        assertThat(initialState.catalogStatus).isEqualTo(WooPosSettingsLocalCatalogState.CatalogStatus.LoadingStatus)
+    }
+
+    @Test
+    fun `when init, then loading state gets replaced when data loads`() = runTest {
+        // WHEN
+        sut = createViewModel()
+        advanceUntilIdle()
+
+        // THEN
+        val catalogStatus = sut.state.value.catalogStatus
+        assertThat(catalogStatus).isInstanceOf(WooPosSettingsLocalCatalogState.CatalogStatus.Available::class.java)
+
+        val availableStatus = catalogStatus as WooPosSettingsLocalCatalogState.CatalogStatus.Available
+        assertThat(availableStatus.catalogSize).isEqualTo("8.3 MB")
+        assertThat(availableStatus.lastUpdate).isEqualTo("Never")
+        assertThat(availableStatus.lastFullUpdate).isEqualTo("Never")
+    }
+
+    @Test
+    fun `when manual refresh completes, then state is refreshed`() = runTest {
+        // GIVEN
+        sut = createViewModel()
+        advanceUntilIdle()
+
+        val initialStatus = sut.state.value.catalogStatus
+        assertThat(initialStatus).isInstanceOf(WooPosSettingsLocalCatalogState.CatalogStatus.Available::class.java)
+
+        // WHEN
+        sut.runFullCatalogSync()
+        advanceUntilIdle()
+
+        // THEN
+        val finalStatus = sut.state.value.catalogStatus
+        assertThat(finalStatus).isInstanceOf(WooPosSettingsLocalCatalogState.CatalogStatus.Available::class.java)
+        verify(localCatalogSyncRepository).syncLocalCatalogFull(mockSite)
+        verify(syncTimestampManager, times(2)).getProductsLastSyncTimestamp()
+        verify(syncTimestampManager, times(2)).getVariationsLastSyncTimestamp()
+        verify(syncTimestampManager, times(2)).getFullSyncLastCompletedTimestamp()
+    }
+
+    private fun createViewModel() = WooPosSettingsLocalCatalogViewModel(
+        syncTimestampManager = syncTimestampManager,
+        localCatalogSyncRepository = localCatalogSyncRepository,
+        selectedSite = selectedSite,
+        dateFormatter = dateFormatter,
+        preferencesRepository = preferencesRepository,
+        syncScheduler = syncScheduler
+    )
+}


### PR DESCRIPTION
Fixes WOOMOB-1445

### Description
Updated WooPos local catalog settings to properly use the full sync timestamp instead of incremental sync timestamps. This ensures that the "Last full update" field in the settings displays the actual time of the last full catalog synchronization.

Note: This PR also ensures the full sync timestamp is stored even when the sync is invoked manually from the settings.

This PR also introduces tests for the VM.

### Changes Made
- Updated `WooPosSettingsLocalCatalogViewModel` to use `getFullSyncLastCompletedTimestamp()` for the last full update display
- Updated `WooPosDateFormatter` to include `formatCatalogLastFullSync()` method for proper full sync timestamp formatting
- Added comprehensive unit tests for `WooPosSettingsLocalCatalogViewModel` to ensure proper state management and timestamp handling

### Steps to reproduce
1. Navigate to WooPos settings
2. Go to Local Catalog settings
3. Verify that "Last full update" shows the correct timestamp from the last full sync operation (if both rows display "Just now" -> wait a minute, then go to the list and pull to refresh -> go back to settings and verify the Last full update remains at 1minutes, but Last Update says "Just now")

### Images/gif
N/A - Internal data handling improvement.

- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.