### PR TITLE
Fix protolayout warning by updating its version

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -11,6 +11,7 @@
 - [Internal] Remove unused dependencies and optimize dependency scopes [https://github.com/woocommerce/woocommerce-android/pull/14710]
 - [*] Fix a rare crash in order refund flow [https://github.com/woocommerce/woocommerce-android/pull/14742]
 - [*] Fix customer name display when filtering orders from order details  [https://github.com/woocommerce/woocommerce-android/pull/14761]
+- [Internal][Wear] Override Horologist’s transitive protolayout-expression dependency to fix known issues [https://github.com/woocommerce/woocommerce-android/pull/14797]
 
 23.4
 -----

--- a/WooCommerce-Wear/build.gradle
+++ b/WooCommerce-Wear/build.gradle
@@ -191,6 +191,12 @@ dependencies {
         exclude group: 'com.android.support', module: 'support-annotations'
         exclude group: 'com.android.support', module: 'support-core-utils'
     }
+
+    constraints {
+        implementation(libs.androidx.wear.protolayout.expression) {
+            because("Horologist 0.7.15 uses Wear ProtoLayout 1.0.0-beta01, which has known issues.")
+        }
+    }
 }
 
 android.buildTypes.all { buildType ->

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -34,7 +34,6 @@ androidx-test-orchestrator = '1.5.1'
 androidx-test-uiautomator = '2.3.0'
 androidx-transition = '1.6.0'
 androidx-wear-compose = '1.4.0'
-androidx-wear-tiles = '1.3.0'
 androidx-wear-protolayout = '1.2.1'
 androidx-wear-tooling = '1.0.0'
 androidx-wear-watchface = '1.2.1'
@@ -178,8 +177,6 @@ androidx-test-uiautomator = { group = "androidx.test.uiautomator", name = "uiaut
 androidx-transition = { group = "androidx.transition", name = "transition", version.ref = "androidx-transition" }
 androidx-wear-compose-material = { group = "androidx.wear.compose", name = "compose-material", version.ref = "androidx-wear-compose" }
 androidx-wear-compose-foundation = { group = "androidx.wear.compose", name = "compose-foundation", version.ref = "androidx-wear-compose" }
-androidx-wear-tiles-main = { group = "androidx.wear.tiles", name = "tiles", version.ref = "androidx-wear-tiles" }
-androidx-wear-tiles-material = { group = "androidx.wear.tiles", name = "tiles-material", version.ref = "androidx-wear-tiles" }
 androidx-wear-protolayout-expression = { group = "androidx.wear.protolayout", name = "protolayout-expression", version.ref = "androidx-wear-protolayout" }
 androidx-wear-tooling-preview = { group = "androidx.wear", name = "wear-tooling-preview", version.ref = "androidx-wear-tooling" }
 androidx-wear-watchface-complications-data-source-ktx = { group = "androidx.wear.watchface", name = "watchface-complications-data-source-ktx", version.ref = "androidx-wear-watchface" }
@@ -222,8 +219,6 @@ google-firebase-messaging = { group = "com.google.firebase", name = "firebase-me
 google-gson = { group = "com.google.code.gson", name = "gson", version.ref = "google-gson" }
 google-guava = { group = "com.google.guava", name = "guava", version.ref = "google-guava" }
 google-horologist-compose-layout = { group = "com.google.android.horologist", name = "horologist-compose-layout", version.ref = "google-horologist" }
-google-horologist-compose-tools = { group = "com.google.android.horologist", name = "horologist-compose-tools", version.ref = "google-horologist" }
-google-horologist-tiles = { group = "com.google.android.horologist", name = "horologist-tiles", version.ref = "google-horologist" }
 google-material = { group = "com.google.android.material", name = "material", version.ref = "google-material" }
 google-compose-material3 = { group = "androidx.compose.material3", name = "material3", version.ref = "google-compose-material3" }
 google-mlkit-barcode-scanning = { group = "com.google.mlkit", name = "barcode-scanning", version.ref = "google-mlkit-barcode-scanning" }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -35,6 +35,7 @@ androidx-test-uiautomator = '2.3.0'
 androidx-transition = '1.6.0'
 androidx-wear-compose = '1.4.0'
 androidx-wear-tiles = '1.3.0'
+androidx-wear-protolayout = '1.2.1'
 androidx-wear-tooling = '1.0.0'
 androidx-wear-watchface = '1.2.1'
 androidx-work = '2.10.5'
@@ -179,6 +180,7 @@ androidx-wear-compose-material = { group = "androidx.wear.compose", name = "comp
 androidx-wear-compose-foundation = { group = "androidx.wear.compose", name = "compose-foundation", version.ref = "androidx-wear-compose" }
 androidx-wear-tiles-main = { group = "androidx.wear.tiles", name = "tiles", version.ref = "androidx-wear-tiles" }
 androidx-wear-tiles-material = { group = "androidx.wear.tiles", name = "tiles-material", version.ref = "androidx-wear-tiles" }
+androidx-wear-protolayout-expression = { group = "androidx.wear.protolayout", name = "protolayout-expression", version.ref = "androidx-wear-protolayout" }
 androidx-wear-tooling-preview = { group = "androidx.wear", name = "wear-tooling-preview", version.ref = "androidx-wear-tooling" }
 androidx-wear-watchface-complications-data-source-ktx = { group = "androidx.wear.watchface", name = "watchface-complications-data-source-ktx", version.ref = "androidx-wear-watchface" }
 androidx-work-runtime-ktx = { group = "androidx.work", name = "work-runtime-ktx", version.ref = "androidx-work" }


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

<!-- Id number of the Linear issue this PR addresses, e.g., WOOMOB-373. -->
Closes WOOMOB-1552

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
This PR updates the `protolayout-expression` version used transitively by the Wear app through the Horologist library. See WOOMOB-1552 for more details about the known issues with `protolayout-expression:1.0.0-beta01`.

### Steps to reproduce
<!-- Step-by-step testing instructions. For new user flows, consider instead stating the goal of the workflow and see if your PR reviewer can accomplish the workflow without specific steps! -->
- Launch Wear app.
- Run `./gradlew assembleDebug --scan` and in the result report, check dependencies and verify that `androidx.wear.protolayout:protolayout-expression:1.0.0-beta01` is forced to
`1.2.1`.

### The tests that have been performed
<!-- To give the reviewer an idea of what could be missed in terms of testing -->
Tested the Wear app to ensure it compiles and launches without any issues.

### Images/gif
<!-- Include before and after images or gifs when appropriate. -->

- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->