### PR TITLE
Fix UI flickering when fetching bookings for the first time

### DIFF
--- a/libs/fluxc-plugin/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/bookings/BookingsStore.kt
+++ b/libs/fluxc-plugin/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/bookings/BookingsStore.kt
@@ -46,11 +46,6 @@ class BookingsStore @Inject internal constructor(
                         return@withDefaultContext WooResult(ordersResult.error)
                     }
 
-                    if (page == 1 && filters.isEmpty() && query.isNullOrEmpty()) {
-                        // Clear existing bookings when fetching the first page
-                        bookingsDao.deleteAllForSite(site.localId())
-                    }
-
                     val entities = response.result.map {
                         with(bookingDtoMapper) {
                             it.toEntity(
@@ -59,7 +54,12 @@ class BookingsStore @Inject internal constructor(
                             )
                         }
                     }
-                    bookingsDao.insertOrReplace(entities)
+                    if (page == 1 && filters.isEmpty() && query.isNullOrEmpty()) {
+                        // Clear existing bookings and insert new ones when fetching the first page
+                        bookingsDao.replaceAllForSite(site.localId(), entities)
+                    } else {
+                        bookingsDao.insertOrReplace(entities)
+                    }
                     val totalPages = headersParser.getTotalPages(response.headers)
                     // Determine if we can load more from the total pages header if available, otherwise
                     // infer it from the number of items returned

--- a/libs/fluxc-plugin/src/main/kotlin/org/wordpress/android/fluxc/persistence/dao/BookingsDao.kt
+++ b/libs/fluxc-plugin/src/main/kotlin/org/wordpress/android/fluxc/persistence/dao/BookingsDao.kt
@@ -4,6 +4,7 @@ import androidx.room.Dao
 import androidx.room.Insert
 import androidx.room.OnConflictStrategy
 import androidx.room.Query
+import androidx.room.Transaction
 import kotlinx.coroutines.flow.Flow
 import org.wordpress.android.fluxc.model.LocalOrRemoteId.LocalId
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.bookings.BookingsFilterOption
@@ -60,6 +61,12 @@ interface BookingsDao {
 
     @Query("DELETE FROM Bookings WHERE localSiteId = :localSiteId")
     suspend fun deleteAllForSite(localSiteId: LocalId)
+
+    @Transaction
+    suspend fun replaceAllForSite(siteId: LocalId, entities: List<BookingEntity>) {
+        deleteAllForSite(siteId)
+        insertOrReplace(entities)
+    }
 
     fun observeBookings(
         localSiteId: LocalId,


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

<!-- Id number of the Linear issue this PR addresses, e.g., WOOMOB-373. -->
Closes WOOMOB-1559

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
When fetching the first page of the bookings list, we were deleting existing bookings and inserting new ones in two separate database transactions. This caused the UI to briefly display an empty list, resulting in flickering. This PR combines these two operations into a single transaction to resolve the issue.

### Steps to reproduce
<!-- Step-by-step testing instructions. For new user flows, consider instead stating the goal of the workflow and see if your PR reviewer can accomplish the workflow without specific steps! -->
1. Open the bookings screen and wait for a moment to ensure the list does not flicker.
2. Kill the app and relaunch it.
3. Quickly repeat the steps: open bookings, select the All tab, and choose a booking. Scroll to the bottom, wait for a while, and verify that the screen does not flicker.

### The tests that have been performed
<!-- To give the reviewer an idea of what could be missed in terms of testing -->
Steps above

### Images/gif
<!-- Include before and after images or gifs when appropriate. -->

- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->