### PR TITLE
[WOOMOB-1347] - Booking details note - discard changes dialog

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/bookings/note/BookingNoteFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/bookings/note/BookingNoteFragment.kt
@@ -29,7 +29,6 @@ class BookingNoteFragment : BaseFragment() {
         return composeView {
             BookingNoteScreen(
                 viewModel = viewModel,
-                onBack = { findNavController().popBackStack() },
             )
         }
     }
@@ -45,6 +44,7 @@ class BookingNoteFragment : BaseFragment() {
                 is MultiLiveEvent.Event.ShowSnackbar -> {
                     uiMessageResolver.showSnack(event.message)
                 }
+
                 is MultiLiveEvent.Event.Exit -> {
                     findNavController().navigateUp()
                 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/bookings/note/BookingNoteScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/bookings/note/BookingNoteScreen.kt
@@ -29,19 +29,18 @@ import androidx.compose.ui.text.TextRange
 import androidx.compose.ui.text.input.TextFieldValue
 import androidx.compose.ui.unit.dp
 import com.woocommerce.android.R
+import com.woocommerce.android.ui.compose.Render
 import com.woocommerce.android.ui.compose.component.Toolbar
 import com.woocommerce.android.ui.compose.component.WCTextButton
 
 @Composable
 fun BookingNoteScreen(
     viewModel: BookingNoteViewModel,
-    onBack: () -> Unit,
 ) {
     val viewState by viewModel.state.observeAsState()
     viewState?.let {
         BookingNoteScreen(
             viewState = it,
-            onBack = onBack,
         )
     }
 }
@@ -49,7 +48,6 @@ fun BookingNoteScreen(
 @Composable
 fun BookingNoteScreen(
     viewState: BookingNoteViewState,
-    onBack: () -> Unit,
 ) {
     val focusRequester = remember { FocusRequester() }
 
@@ -62,7 +60,7 @@ fun BookingNoteScreen(
         topBar = {
             Toolbar(
                 title = stringResource(R.string.booking_note_screen_title),
-                onNavigationButtonClick = onBack,
+                onNavigationButtonClick = viewState.onBackPressed,
                 actions = {
                     if (viewState.isSaveVisible) {
                         WCTextButton(
@@ -105,6 +103,8 @@ fun BookingNoteScreen(
             }
         }
     }
+
+    viewState.dialogState?.Render()
 }
 
 @Composable

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/bookings/note/BookingNoteViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/bookings/note/BookingNoteViewModel.kt
@@ -5,6 +5,7 @@ import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.asLiveData
 import com.woocommerce.android.R
 import com.woocommerce.android.ui.bookings.BookingsRepository
+import com.woocommerce.android.ui.compose.DialogState
 import com.woocommerce.android.viewmodel.MultiLiveEvent
 import com.woocommerce.android.viewmodel.ScopedViewModel
 import com.woocommerce.android.viewmodel.navArgs
@@ -25,18 +26,22 @@ class BookingNoteViewModel @Inject constructor(
     private val initialNoteState = MutableStateFlow("")
     private val editedNoteState = MutableStateFlow<String?>(null)
     private val noteSaveStatusFlow = MutableStateFlow<NoteSaveStatus>(NoteSaveStatus.Idle)
+    private val dialogStateFlow = MutableStateFlow<DialogState?>(null)
 
     val state: LiveData<BookingNoteViewState> = combine(
         initialNoteState,
         editedNoteState,
-        noteSaveStatusFlow
-    ) { initialNote, editedNote, noteSaveStatus ->
+        noteSaveStatusFlow,
+        dialogStateFlow,
+    ) { initialNote, editedNote, noteSaveStatus, dialogState ->
         BookingNoteViewState(
             initialNote = initialNote,
             editedNote = editedNote,
             noteSaveStatus = noteSaveStatus,
             onNoteChange = ::onNoteChange,
             onSaveClicked = ::saveNote,
+            onBackPressed = ::onBackPressed,
+            dialogState = dialogState,
         )
     }.asLiveData()
 
@@ -55,6 +60,40 @@ class BookingNoteViewModel @Inject constructor(
 
     private fun onNoteChange(value: String) {
         editedNoteState.value = value
+    }
+
+    private fun onBackPressed() {
+        if (noteSaveStatusFlow.value == NoteSaveStatus.InProgress) {
+            return
+        }
+        val initial = initialNoteState.value.trim()
+        val current = editedNoteState.value.orEmpty().trim()
+        val noteHasChanged = initial != current
+        if (noteHasChanged) {
+            dialogStateFlow.value = DialogState(
+                message = R.string.booking_note_discard_changes_message,
+                positiveButton = DialogState.DialogButton(
+                    text = R.string.booking_note_discard_changes_discard,
+                    onClick = ::onDiscardChanges
+                ),
+                negativeButton = DialogState.DialogButton(
+                    text = R.string.cancel,
+                    onClick = ::onDismissDialog
+                ),
+                onDismiss = ::onDismissDialog,
+            )
+        } else {
+            triggerEvent(MultiLiveEvent.Event.Exit)
+        }
+    }
+
+    private fun onDiscardChanges() {
+        dialogStateFlow.value = null
+        triggerEvent(MultiLiveEvent.Event.Exit)
+    }
+
+    private fun onDismissDialog() {
+        dialogStateFlow.value = null
     }
 
     private fun saveNote() {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/bookings/note/BookingNoteViewState.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/bookings/note/BookingNoteViewState.kt
@@ -1,11 +1,15 @@
 package com.woocommerce.android.ui.bookings.note
 
+import com.woocommerce.android.ui.compose.DialogState
+
 data class BookingNoteViewState(
     val initialNote: String = "",
     val editedNote: String? = null,
     val noteSaveStatus: NoteSaveStatus = NoteSaveStatus.Idle,
     val onNoteChange: (String) -> Unit = {},
     val onSaveClicked: () -> Unit = {},
+    val onBackPressed: () -> Unit = {},
+    val dialogState: DialogState? = null,
 ) {
 
     val isSaveVisible: Boolean

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -61,6 +61,9 @@
     <string name="this_month">This Month</string>
     <string name="this_year">This Year</string>
     <string name="discard">Discard</string>
+    <!-- Booking note discard changes dialog -->
+    <string name="booking_note_discard_changes_message">Are you sure you want to discard these changes?</string>
+    <string name="booking_note_discard_changes_discard">Discard changes</string>
     <string name="products">Products</string>
     <string name="point_of_sale">Point of Sale</string>
     <string name="custom_amounts">Custom Amounts</string>

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/bookings/note/BookingNoteViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/bookings/note/BookingNoteViewModelTest.kt
@@ -2,6 +2,7 @@ package com.woocommerce.android.ui.bookings.note
 
 import androidx.lifecycle.SavedStateHandle
 import com.woocommerce.android.R
+import com.woocommerce.android.model.UiString
 import com.woocommerce.android.ui.bookings.BookingsRepository
 import com.woocommerce.android.util.getOrAwaitValue
 import com.woocommerce.android.viewmodel.BaseUnitTest
@@ -178,6 +179,103 @@ class BookingNoteViewModelTest : BaseUnitTest() {
         assertThat(event).isEqualTo(MultiLiveEvent.Event.ShowSnackbar(R.string.booking_note_screen_update_error))
         val finalState = viewModel.state.getOrAwaitValue()
         assertThat(finalState.noteSaveStatus).isEqualTo(NoteSaveStatus.Idle)
+    }
+
+    @Test
+    fun `given no changes, when back pressed, then exit is triggered and no dialog`() = testBlocking {
+        // Given
+        val viewModel = createViewModel()
+        val state = viewModel.state.getOrAwaitValue()
+
+        // When
+        state.onBackPressed()
+
+        // Then
+        val event = viewModel.event.getOrAwaitValue()
+        assertThat(event).isEqualTo(MultiLiveEvent.Event.Exit)
+        val latestState = viewModel.state.getOrAwaitValue()
+        assertThat(latestState.dialogState).isNull()
+    }
+
+    @Test
+    fun `given changed note, when back pressed, then show discard dialog with correct copy and buttons`() = testBlocking {
+        // Given
+        val viewModel = createViewModel()
+        val state = viewModel.state.getOrAwaitValue()
+        state.onNoteChange("Changed note")
+        viewModel.state.getOrAwaitValue()
+
+        // When
+        state.onBackPressed()
+
+        // Then
+        val withDialog = viewModel.state.getOrAwaitValue()
+        val dialog = withDialog.dialogState
+        check(dialog != null)
+        // Verify message and buttons types/ids
+        assertThat(dialog.message).isInstanceOf(UiString.UiStringRes::class.java)
+        assertThat((dialog.message as UiString.UiStringRes).stringRes)
+            .isEqualTo(R.string.booking_note_discard_changes_message)
+        val positive = dialog.positiveButton
+        val negative = dialog.negativeButton
+        check(positive != null && negative != null)
+        assertThat((positive.text as UiString.UiStringRes).stringRes)
+            .isEqualTo(R.string.booking_note_discard_changes_discard)
+        assertThat((negative.text as UiString.UiStringRes).stringRes)
+            .isEqualTo(R.string.cancel)
+
+        // Clicking negative should dismiss dialog and not exit
+        negative.onClick()
+        val afterDismiss = viewModel.state.getOrAwaitValue()
+        assertThat(afterDismiss.dialogState).isNull()
+    }
+
+    @Test
+    fun `when confirm discard in dialog, then exit is triggered`() = testBlocking {
+        // Given
+        val viewModel = createViewModel()
+        val state = viewModel.state.getOrAwaitValue()
+        state.onNoteChange("Changed note")
+        viewModel.state.getOrAwaitValue()
+        state.onBackPressed()
+        val withDialog = viewModel.state.getOrAwaitValue()
+        val positive = withDialog.dialogState?.positiveButton
+        check(positive != null)
+
+        // When
+        positive.onClick()
+
+        // Then
+        val event = viewModel.event.getOrAwaitValue()
+        assertThat(event).isEqualTo(MultiLiveEvent.Event.Exit)
+    }
+
+    @Test
+    fun `when save in progress and back pressed, then do nothing (no dialog, no exit)`() = testBlocking {
+        // Given a slow repository update to keep InProgress state
+        whenever(bookingsRepository.updateNote(any(), any())).doSuspendableAnswer {
+            delay(200)
+            Result.success(Unit)
+        }
+        val viewModel = createViewModel()
+        val state = viewModel.state.getOrAwaitValue()
+        state.onNoteChange("Changed")
+        viewModel.state.getOrAwaitValue()
+
+        // Start save
+        state.onSaveClicked()
+        val inProgress = viewModel.state.getOrAwaitValue()
+        assertThat(inProgress.noteSaveStatus).isEqualTo(NoteSaveStatus.InProgress)
+
+        // When
+        inProgress.onBackPressed()
+
+        // Then: dialog remains null while in progress
+        val stillInProgress = viewModel.state.getOrAwaitValue()
+        assertThat(stillInProgress.dialogState).isNull()
+
+        // Clean up
+        advanceUntilIdle()
     }
 
     private fun createViewModel(


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

<!-- Id number of the Linear issue this PR addresses, e.g., WOOMOB-373. -->

Closes WOOMOB-1347

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

This PR adds the `Discard changes` dialog to the `BookingNoteScreen` after tapping the back button. 

If there are unsaved changes, the dialog is presented with the option to discard them. 

### Test Steps
<!-- Describe how to test your changes. Include only what’s needed for the reviewer to validate the behavior.
For new features, outline the main user flow or goal rather than every tap or click — the reviewer should be able to complete the flow naturally.
If applicable, mention key devices, scenarios, or edge cases to verify. -->


1. Make sure you have the latest booking plugin installed
2. Launch the app
3. Bo to bookings tab
4. Tap on a booking
5. Scroll down to the notes section
6. Tap on it
7. Tap back button
8. Confirm the screen was closed
9. Open the note again
10. Add changes
11. Tap back button
12. Confirm the dialog was shown

### Images/gif
<!-- Include before and after images or gifs when appropriate. -->


https://github.com/user-attachments/assets/c5759885-da81-487f-9b51-c5ffdb7e2b5a



- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
