### PR TITLE
Adds a skeleton loading animation to the Bookings list

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/bookings/list/BookingListScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/bookings/list/BookingListScreen.kt
@@ -17,7 +17,6 @@ import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
-import androidx.compose.foundation.layout.wrapContentSize
 import androidx.compose.foundation.layout.wrapContentWidth
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.LazyListState
@@ -59,6 +58,7 @@ import com.woocommerce.android.ui.bookings.compose.BookingStatus
 import com.woocommerce.android.ui.bookings.compose.BookingSummary
 import com.woocommerce.android.ui.bookings.compose.BookingSummaryModel
 import com.woocommerce.android.ui.bookings.details.AttendanceUpdateStatus
+import com.woocommerce.android.ui.compose.animations.SkeletonView
 import com.woocommerce.android.ui.compose.component.InfiniteListHandler
 import com.woocommerce.android.ui.compose.component.Toolbar
 import com.woocommerce.android.ui.compose.component.WCColoredButton
@@ -124,13 +124,7 @@ fun BookingListScreen(state: BookingListViewState) {
                 }
 
                 state.contentState.loadingState == BookingListLoadingState.Loading -> {
-                    // TODO replace with shimmer
-                    CircularProgressIndicator(
-                        modifier = Modifier
-                            .padding(paddingValues)
-                            .fillMaxSize()
-                            .wrapContentSize()
-                    )
+                    BookingListIsLoading(state.controlsState)
                 }
 
                 else -> {
@@ -251,6 +245,32 @@ private fun BookingList(
         }
 
         InfiniteListHandler(listState = listState, onLoadMore = state.onLoadMore)
+    }
+}
+
+@Composable
+private fun BookingListIsLoading(controlsState: BookingListControlsState) {
+    Column(
+        modifier = Modifier
+            .fillMaxWidth()
+            .verticalScroll(rememberScrollState())
+            .background(MaterialTheme.colorScheme.surfaceContainer)
+    ) {
+        BookingListControls(controlsState)
+        repeat(7) {
+            Column(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(16.dp)
+            ) {
+                SkeletonView(Modifier.size(173.dp, 22.dp))
+                Spacer(Modifier.height(2.dp))
+                SkeletonView(Modifier.size(256.dp, 18.dp))
+                Spacer(Modifier.height(8.dp))
+                SkeletonView(Modifier.size(138.dp, 22.dp))
+            }
+            HorizontalDivider(Modifier.padding(start = 16.dp))
+        }
     }
 }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/bookings/list/BookingListScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/bookings/list/BookingListScreen.kt
@@ -124,7 +124,7 @@ fun BookingListScreen(state: BookingListViewState) {
                 }
 
                 state.contentState.loadingState == BookingListLoadingState.Loading -> {
-                    BookingListIsLoading(state.controlsState)
+                    BookingListLoading(state.controlsState)
                 }
 
                 else -> {
@@ -249,7 +249,7 @@ private fun BookingList(
 }
 
 @Composable
-private fun BookingListIsLoading(controlsState: BookingListControlsState) {
+private fun BookingListLoading(controlsState: BookingListControlsState) {
     Column(
         modifier = Modifier
             .fillMaxWidth()


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

<!-- Id number of the Linear issue this PR addresses, e.g., WOOMOB-373. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
This adds a skeleton (shimmer) loading animation to the Bookings list, displayed when there’s no data and it’s being fetched.

### Test Steps
<!-- Describe how to test your changes. Include only what’s needed for the reviewer to validate the behavior.
For new features, outline the main user flow or goal rather than every tap or click — the reviewer should be able to complete the flow naturally.
If applicable, mention key devices, scenarios, or edge cases to verify. -->
You need to make a fresh install to reproduce the no-data case.
1. Install the app.
2. Launch it.
3. Log in with a site that has bookings available.
4. Open the Bookings tab.

### Images/gif
<!-- Include before and after images or gifs when appropriate. -->
<img width="400" alt="Screenshot_20251023_143100" src="https://github.com/user-attachments/assets/70a13c10-ed7d-4def-bd87-3e98adc63152" />

- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
