### PR TITLE
[WOOMOB-1561] Booking details - cancel booking action

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/bookings/BookingMapper.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/bookings/BookingMapper.kt
@@ -112,7 +112,7 @@ class BookingMapper @Inject constructor(
         orderStatus: String?,
         paymentMethod: String?,
     ): BookingStatus {
-        return if (orderStatus != "completed" && paymentMethod == "cod") {
+        return if (orderStatus == "on-hold" && paymentMethod == "cod") {
             BookingStatus.PayOnSite
         } else {
             when (this) {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/bookings/BookingMapper.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/bookings/BookingMapper.kt
@@ -79,6 +79,7 @@ class BookingMapper @Inject constructor(
             location = "238 Willow Creek Drive, Montgomery AL 36109",
             price = currencyFormatter.formatCurrency(cost, currency),
             cancelStatus = cancelStatus,
+            cancelButtonVisible = isCancellable,
             duration = duration,
         )
     }
@@ -122,6 +123,7 @@ class BookingMapper @Inject constructor(
                 BookingEntity.Status.Complete -> BookingStatus.Complete
                 BookingEntity.Status.Confirmed -> BookingStatus.Confirmed
                 BookingEntity.Status.Unpaid -> BookingStatus.Unpaid
+                BookingEntity.Status.InCart -> BookingStatus.InCart
                 is BookingEntity.Status.Unknown -> BookingStatus.Unknown(this.key)
             }
         }
@@ -175,3 +177,10 @@ class BookingMapper @Inject constructor(
         )
     }
 }
+
+private val BookingEntity.isCancellable: Boolean
+    get() = status !in listOf(
+        BookingEntity.Status.Cancelled,
+        BookingEntity.Status.InCart,
+        BookingEntity.Status.Complete
+    )

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/bookings/BookingMapper.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/bookings/BookingMapper.kt
@@ -24,6 +24,7 @@ import kotlinx.coroutines.withContext
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.bookings.BookingCustomerInfo
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.bookings.BookingPaymentInfo
 import org.wordpress.android.fluxc.persistence.entity.BookingEntity
+import org.wordpress.android.fluxc.persistence.entity.isCancellable
 import java.math.BigDecimal
 import java.time.Duration
 import java.time.ZoneOffset
@@ -177,10 +178,3 @@ class BookingMapper @Inject constructor(
         )
     }
 }
-
-private val BookingEntity.isCancellable: Boolean
-    get() = status !in listOf(
-        BookingEntity.Status.Cancelled,
-        BookingEntity.Status.InCart,
-        BookingEntity.Status.Complete
-    )

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/bookings/BookingsRepository.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/bookings/BookingsRepository.kt
@@ -148,7 +148,7 @@ class BookingsRepository @Inject constructor(
             site = selectedSite.get(),
             bookingId = bookingId,
             bookingUpdatePayload = BookingUpdatePayload(status = BookingEntity.Status.Cancelled),
-            refreshBooking = true,
+            refreshOrder = true,
         )
         return if (result.isError) {
             Result.failure(WooException(result.error))

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/bookings/BookingsRepository.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/bookings/BookingsRepository.kt
@@ -147,7 +147,8 @@ class BookingsRepository @Inject constructor(
         val result = bookingsStore.updateBooking(
             site = selectedSite.get(),
             bookingId = bookingId,
-            bookingUpdatePayload = BookingUpdatePayload(status = BookingEntity.Status.Cancelled)
+            bookingUpdatePayload = BookingUpdatePayload(status = BookingEntity.Status.Cancelled),
+            refreshBooking = true,
         )
         return if (result.isError) {
             Result.failure(WooException(result.error))

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/bookings/BookingsRepository.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/bookings/BookingsRepository.kt
@@ -141,6 +141,21 @@ class BookingsRepository @Inject constructor(
         }
     }
 
+    suspend fun cancelBooking(
+        bookingId: Long,
+    ): Result<Unit> {
+        val result = bookingsStore.updateBooking(
+            site = selectedSite.get(),
+            bookingId = bookingId,
+            bookingUpdatePayload = BookingUpdatePayload(status = BookingEntity.Status.Cancelled)
+        )
+        return if (result.isError) {
+            Result.failure(WooException(result.error))
+        } else {
+            Result.success(Unit)
+        }
+    }
+
     data class FetchResult(
         val bookings: List<Booking>,
         val hasMorePages: Boolean

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/bookings/compose/BookingAppointmentDetails.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/bookings/compose/BookingAppointmentDetails.kt
@@ -1,6 +1,7 @@
 package com.woocommerce.android.ui.bookings.compose
 
 import androidx.annotation.StringRes
+import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
@@ -79,20 +80,23 @@ fun BookingAppointmentDetails(
             )
             AppointmentDetailsRow(
                 label = R.string.booking_appointment_label_price,
-                value = model.price
+                value = model.price,
+                withDivider = model.cancelButtonVisible,
             )
-            WCOutlinedButton(
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .padding(16.dp),
-                colors = ButtonDefaults.outlinedButtonColors(
-                    contentColor = MaterialTheme.colorScheme.onSurface
-                ),
-                onClick = onCancelBooking,
-                enabled = model.cancelButtonEnabled,
-                text = stringResource(R.string.booking_details_cancel_booking_button),
-                loading = model.cancelInProgressShown,
-            )
+            AnimatedVisibility(model.cancelButtonVisible) {
+                WCOutlinedButton(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .padding(16.dp),
+                    colors = ButtonDefaults.outlinedButtonColors(
+                        contentColor = MaterialTheme.colorScheme.onSurface
+                    ),
+                    onClick = onCancelBooking,
+                    enabled = model.cancelButtonEnabled,
+                    text = stringResource(R.string.booking_details_cancel_booking_button),
+                    loading = model.cancelInProgressShown,
+                )
+            }
             HorizontalDivider(thickness = 0.5.dp)
         }
     }
@@ -101,6 +105,7 @@ fun BookingAppointmentDetails(
 @Composable
 private fun AppointmentDetailsRow(
     @StringRes label: Int,
+    withDivider: Boolean = true,
     value: @Composable () -> Unit
 ) {
     Column {
@@ -115,16 +120,22 @@ private fun AppointmentDetailsRow(
                 value()
             }
         }
-        HorizontalDivider(
-            modifier = Modifier.padding(start = 16.dp),
-            thickness = 0.5.dp
-        )
+        if (withDivider) {
+            HorizontalDivider(
+                modifier = Modifier.padding(start = 16.dp),
+                thickness = 0.5.dp
+            )
+        }
     }
 }
 
 @Composable
-private fun AppointmentDetailsRow(@StringRes label: Int, value: String) {
-    AppointmentDetailsRow(label = label) {
+private fun AppointmentDetailsRow(
+    @StringRes label: Int,
+    withDivider: Boolean = true,
+    value: String,
+) {
+    AppointmentDetailsRow(label = label, withDivider = withDivider) {
         Text(
             text = value,
             style = MaterialTheme.typography.bodyMedium,
@@ -142,10 +153,11 @@ data class BookingAppointmentDetailsModel(
     val location: String,
     val duration: String,
     val price: String,
+    val cancelButtonVisible: Boolean,
     val cancelStatus: CancelStatus,
 ) {
-    val cancelButtonEnabled: Boolean = cancelStatus != CancelStatus.InProgress
-    val cancelInProgressShown: Boolean = cancelStatus == CancelStatus.InProgress
+    val cancelButtonEnabled: Boolean = cancelButtonVisible && cancelStatus != CancelStatus.InProgress
+    val cancelInProgressShown: Boolean = cancelButtonVisible && cancelStatus == CancelStatus.InProgress
 }
 
 sealed interface BookingStaffMemberStatus {
@@ -166,6 +178,28 @@ private fun BookingAppointmentDetailsPreview() {
                 location = "238 Willow Creek Drive, Montgomery AL 36109",
                 duration = "60 min",
                 price = "$55.00",
+                cancelButtonVisible = true,
+                cancelStatus = CancelStatus.Idle,
+            ),
+            onCancelBooking = {},
+            modifier = Modifier.fillMaxWidth()
+        )
+    }
+}
+
+@LightDarkThemePreviews
+@Composable
+private fun BookingAppointmentDetailsCancelHiddenPreview() {
+    WooThemeWithBackground {
+        BookingAppointmentDetails(
+            model = BookingAppointmentDetailsModel(
+                date = "05/07/2025, 11:00 AM",
+                time = "11:00 am - 12:00 pm",
+                staff = BookingStaffMemberStatus.Loading,
+                location = "238 Willow Creek Drive, Montgomery AL 36109",
+                duration = "60 min",
+                price = "$55.00",
+                cancelButtonVisible = false,
                 cancelStatus = CancelStatus.Idle,
             ),
             onCancelBooking = {},

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/bookings/compose/BookingStatusTag.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/bookings/compose/BookingStatusTag.kt
@@ -33,6 +33,7 @@ sealed interface BookingStatus {
     data object Paid : BookingStatus
     data object Cancelled : BookingStatus
     data object Complete : BookingStatus
+    data object InCart : BookingStatus
     data class Unknown(val key: String) : BookingStatus
 }
 
@@ -46,6 +47,7 @@ private fun BookingStatus.text(): String {
         BookingStatus.Cancelled -> stringResource(R.string.booking_payment_status_cancelled)
         BookingStatus.Complete -> stringResource(R.string.booking_payment_status_complete)
         BookingStatus.PayOnSite -> stringResource(R.string.booking_payment_status_pay_on_site)
+        BookingStatus.InCart -> stringResource(R.string.booking_payment_status_in_cart)
         is BookingStatus.Unknown -> key
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/bookings/details/BookingDetailsScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/bookings/details/BookingDetailsScreen.kt
@@ -1,5 +1,6 @@
 package com.woocommerce.android.ui.bookings.details
 
+import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
@@ -145,12 +146,14 @@ private fun BookingDetailsContent(
         model = booking.bookingCustomerDetails,
         modifier = Modifier.fillMaxWidth()
     )
-    BookingAttendanceSection(
-        status = booking.bookingSummary.attendanceStatus,
-        attendanceUpdateStatus = booking.bookingSummary.attendanceUpdateStatus,
-        onClick = onAttendanceStatusClicked,
-        modifier = Modifier.fillMaxWidth()
-    )
+    AnimatedVisibility(booking.isAttendanceStatusEditable) {
+        BookingAttendanceSection(
+            status = booking.bookingSummary.attendanceStatus,
+            attendanceUpdateStatus = booking.bookingSummary.attendanceUpdateStatus,
+            onClick = onAttendanceStatusClicked,
+            modifier = Modifier.fillMaxWidth()
+        )
+    }
     booking.bookingPaymentDetails?.let {
         BookingPaymentSection(
             model = it,
@@ -245,6 +248,7 @@ private fun BookingDetailsPreview() {
                         location = "238 Willow Creek Drive, Montgomery AL 36109",
                         duration = "60 min",
                         price = "$55.00",
+                        cancelButtonVisible = true,
                         cancelStatus = CancelStatus.Idle,
                     ),
                     bookingCustomerDetails = BookingCustomerDetailsModel(
@@ -263,7 +267,8 @@ private fun BookingDetailsPreview() {
                         discount = "-",
                         total = "$59.50"
                     ),
-                    note = ""
+                    note = "",
+                    isAttendanceStatusEditable = true
                 ),
             ),
             onBack = {},

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/bookings/details/BookingDetailsViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/bookings/details/BookingDetailsViewModel.kt
@@ -31,6 +31,7 @@ import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.flow.shareIn
 import kotlinx.coroutines.launch
 import org.wordpress.android.fluxc.persistence.entity.BookingEntity
+import org.wordpress.android.fluxc.persistence.entity.isAttendanceStatusEditable
 import javax.inject.Inject
 
 @OptIn(ExperimentalCoroutinesApi::class)
@@ -215,7 +216,8 @@ class BookingDetailsViewModel @Inject constructor(
         ),
         bookingCustomerDetails = booking.order.customerInfo.toCustomerDetailsModel(),
         bookingPaymentDetails = booking.order.paymentInfo?.toPaymentDetailsModel(booking.currency),
-        note = booking.note
+        note = booking.note,
+        isAttendanceStatusEditable = booking.isAttendanceStatusEditable
     )
 
     private fun buildStaffMemberStatus(

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/bookings/details/BookingDetailsViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/bookings/details/BookingDetailsViewModel.kt
@@ -22,7 +22,6 @@ import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.async
 import kotlinx.coroutines.awaitAll
-import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.combine
@@ -32,7 +31,6 @@ import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.flow.shareIn
 import kotlinx.coroutines.launch
 import org.wordpress.android.fluxc.persistence.entity.BookingEntity
-import java.time.Duration
 import javax.inject.Inject
 
 @OptIn(ExperimentalCoroutinesApi::class)
@@ -189,10 +187,12 @@ class BookingDetailsViewModel @Inject constructor(
     }
 
     private fun onConfirmCancelBooking() = launch {
-        // TODO Add logic to Cancel booking action
         showCancelBookingDialog.value = false
         cancelStatusState.value = CancelStatus.InProgress
-        delay(Duration.ofSeconds(1).toMillis())
+        bookingsRepository.cancelBooking(navArgs.bookingId)
+            .onFailure {
+                triggerEvent(MultiLiveEvent.Event.ShowSnackbar(R.string.booking_cancel_error))
+            }
         cancelStatusState.value = CancelStatus.Idle
     }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/bookings/details/BookingDetailsViewState.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/bookings/details/BookingDetailsViewState.kt
@@ -26,6 +26,7 @@ data class BookingUiState(
     val bookingCustomerDetails: BookingCustomerDetailsModel,
     val bookingPaymentDetails: BookingPaymentDetailsModel?,
     val note: String,
+    val isAttendanceStatusEditable: Boolean
 )
 
 sealed interface BookingDetailsLoadingState {

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -4296,6 +4296,7 @@
     <string name="booking_note_screen_title">Booking note</string>
     <string name="booking_note_screen_done">DONE</string>
     <string name="booking_note_screen_update_error">Error saving booking note</string>
+    <string name="booking_cancel_error">Error cancelling the booking</string>
 
     <string name="or_use_password" a8c-src-lib="module:login">Use password to sign in</string>
     <string name="about_automattic_main_page_title">About %1$s</string>

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -4252,6 +4252,7 @@
     <string name="booking_payment_status_paid">Paid</string>
     <string name="booking_payment_status_pending_confirmation">Pending Confirmation</string>
     <string name="booking_payment_status_cancelled">Cancelled</string>
+    <string name="booking_payment_status_in_cart">In Cart</string>
     <string name="booking_payment_status_confirmed">Confirmed</string>
     <string name="booking_payment_status_complete">Complete</string>
     <string name="booking_payment_status_pay_on_site">Pay on site</string>

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/bookings/BookingMapperTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/bookings/BookingMapperTest.kt
@@ -277,6 +277,48 @@ class BookingMapperTest : BaseUnitTest() {
         assertThat(model.status).isEqualTo(BookingStatus.PayOnSite)
     }
 
+    @Test
+    fun `given cancellable statuses, when mapped to appointment details, then cancel button visible`() {
+        whenever(currencyFormatter.formatCurrency(any<String>(), any(), eq(true))).thenAnswer {
+            val amount = it.getArgument<String>(0)
+            val currency = it.getArgument<String>(1)
+            "$currency$amount"
+        }
+        val statuses = listOf(
+            BookingEntity.Status.Confirmed,
+            BookingEntity.Status.Paid,
+            BookingEntity.Status.Unpaid,
+            BookingEntity.Status.PendingConfirmation,
+            BookingEntity.Status.Unknown("some-new-status")
+        )
+        statuses.forEach { status ->
+            val booking = sampleBooking(status = status, cost = "55.00", currency = "USD")
+            val model =
+                mapper.run { booking.toAppointmentDetailsModel(BookingStaffMemberStatus.Loading, CancelStatus.Idle) }
+            assertThat(model.cancelButtonVisible).describedAs("status $status").isTrue()
+        }
+    }
+
+    @Test
+    fun `given non-cancellable statuses, when mapped to appointment details, then cancel button hidden`() {
+        whenever(currencyFormatter.formatCurrency(any<String>(), any(), eq(true))).thenAnswer {
+            val amount = it.getArgument<String>(0)
+            val currency = it.getArgument<String>(1)
+            "$currency$amount"
+        }
+        val statuses = listOf(
+            BookingEntity.Status.Cancelled,
+            BookingEntity.Status.InCart,
+            BookingEntity.Status.Complete
+        )
+        statuses.forEach { status ->
+            val booking = sampleBooking(status = status, cost = "55.00", currency = "USD")
+            val model =
+                mapper.run { booking.toAppointmentDetailsModel(BookingStaffMemberStatus.Loading, CancelStatus.Idle) }
+            assertThat(model.cancelButtonVisible).describedAs("status $status").isFalse()
+        }
+    }
+
     private fun sampleBooking(
         status: BookingEntity.Status = BookingEntity.Status.Confirmed,
         start: Instant = Instant.parse("2025-07-05T11:00:00Z"),

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/bookings/BookingMapperTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/bookings/BookingMapperTest.kt
@@ -255,7 +255,7 @@ class BookingMapperTest : BaseUnitTest() {
     }
 
     @Test
-    fun `given processing order with COD payment method, when mapped to summary model, then status is PayOnSite`() {
+    fun `given on-hold order with COD payment method, when mapped to summary model, then status is PayOnSite`() {
         // GIVEN
         val booking = sampleBooking().let { original ->
             val paymentInfo = BookingPaymentInfo(
@@ -266,7 +266,7 @@ class BookingMapperTest : BaseUnitTest() {
                 total = BigDecimal("55.00"),
                 totalTax = BigDecimal("0.00")
             )
-            val orderWithPayment = original.order.copy(paymentInfo = paymentInfo, status = "processing")
+            val orderWithPayment = original.order.copy(paymentInfo = paymentInfo, status = "on-hold")
             original.copy(order = orderWithPayment)
         }
 

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/bookings/details/BookingDetailsViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/bookings/details/BookingDetailsViewModelTest.kt
@@ -252,6 +252,52 @@ class BookingDetailsViewModelTest : BaseUnitTest() {
         assertThat(updated.dialogState).isNull()
     }
 
+    @Test
+    fun `given cancel dialog shown, when confirm, then repository cancelBooking called and cancel status shows progress then idle`() = testBlocking {
+        // Given
+        whenever(bookingsRepository.cancelBooking(any())).doSuspendableAnswer {
+            delay(100)
+            Result.success(Unit)
+        }
+        val viewModel = createViewModel()
+        val state = viewModel.state.getOrAwaitValue()
+        state.onCancelBooking()
+        val stateWithDialog = viewModel.state.getOrAwaitValue()
+
+        // When
+        stateWithDialog.dialogState?.positiveButton?.onClick()
+
+        // Then: immediately after click (operation in progress)
+        val during = viewModel.state.getOrAwaitValue()
+        assertThat(during.bookingUiState?.bookingsAppointmentDetails?.cancelInProgressShown).isTrue()
+        verify(bookingsRepository, times(1)).cancelBooking(bookingId)
+
+        // And after operation completes, status returns to idle
+        advanceUntilIdle()
+        val after = viewModel.state.getOrAwaitValue()
+        assertThat(after.bookingUiState?.bookingsAppointmentDetails?.cancelInProgressShown).isFalse()
+    }
+
+    @Test
+    fun `given cancel fails, when confirm, then show error snackbar and status returns idle`() = testBlocking {
+        // Given
+        whenever(bookingsRepository.cancelBooking(any())).thenReturn(Result.failure(Exception("Cancel failed")))
+        val viewModel = createViewModel()
+        val state = viewModel.state.getOrAwaitValue()
+        state.onCancelBooking()
+        val stateWithDialog = viewModel.state.getOrAwaitValue()
+
+        // When
+        stateWithDialog.dialogState?.positiveButton?.onClick()
+
+        // Then
+        val event = viewModel.event.getOrAwaitValue()
+        assertThat(event).isEqualTo(MultiLiveEvent.Event.ShowSnackbar(R.string.booking_cancel_error))
+        advanceUntilIdle()
+        val after = viewModel.state.getOrAwaitValue()
+        assertThat(after.bookingUiState?.bookingsAppointmentDetails?.cancelInProgressShown).isFalse()
+    }
+
     private fun createViewModel(
         savedState: SavedStateHandle = savedStateHandle,
     ): BookingDetailsViewModel {

--- a/libs/fluxc-plugin/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/bookings/BookingDtoMapper.kt
+++ b/libs/fluxc-plugin/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/bookings/BookingDtoMapper.kt
@@ -71,7 +71,7 @@ internal class BookingDtoMapper @Inject constructor(
         description = description,
     )
 
-    private suspend fun OrderEntity.toBookingOrderInfo(
+    suspend fun OrderEntity.toBookingOrderInfo(
         orderItemId: Long
     ): BookingOrderInfo {
         val lineItem = getLineItemList().firstOrNull { it.id == orderItemId }

--- a/libs/fluxc-plugin/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/bookings/BookingUpdatePayload.kt
+++ b/libs/fluxc-plugin/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/bookings/BookingUpdatePayload.kt
@@ -4,5 +4,6 @@ import org.wordpress.android.fluxc.persistence.entity.BookingEntity
 
 data class BookingUpdatePayload(
     val attendanceStatus: BookingEntity.AttendanceStatus? = null,
-    val note: String? = null
+    val note: String? = null,
+    val status: BookingEntity.Status? = null
 )

--- a/libs/fluxc-plugin/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/bookings/BookingsRestClient.kt
+++ b/libs/fluxc-plugin/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/bookings/BookingsRestClient.kt
@@ -131,4 +131,7 @@ private val BookingUpdatePayload.asMap: Map<String, Any>
         note?.let {
             put("note", it)
         }
+        status?.let {
+            put("status", it.key)
+        }
     }

--- a/libs/fluxc-plugin/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/bookings/BookingsRestClient.kt
+++ b/libs/fluxc-plugin/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/bookings/BookingsRestClient.kt
@@ -8,6 +8,7 @@ import org.wordpress.android.fluxc.network.rest.wpcom.wc.WooNetwork
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.WooPayload
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.toWooError
 import org.wordpress.android.fluxc.utils.extensions.filterNotNull
+import org.wordpress.android.fluxc.utils.extensions.putIfNotNull
 import javax.inject.Inject
 import javax.inject.Singleton
 
@@ -124,14 +125,8 @@ class BookingsRestClient @Inject constructor(
 }
 
 private val BookingUpdatePayload.asMap: Map<String, Any>
-    get() = buildMap {
-        attendanceStatus?.let {
-            put("attendance_status", it.key)
-        }
-        note?.let {
-            put("note", it)
-        }
-        status?.let {
-            put("status", it.key)
-        }
-    }
+    get() = mutableMapOf<String, Any>().putIfNotNull(
+        "attendance_status" to attendanceStatus?.key,
+        "note" to note,
+        "status" to status?.key
+    )

--- a/libs/fluxc-plugin/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/bookings/BookingsStore.kt
+++ b/libs/fluxc-plugin/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/bookings/BookingsStore.kt
@@ -164,18 +164,17 @@ class BookingsStore @Inject internal constructor(
                 response.result != null -> {
                     val bookingDto = response.result
 
-                    val updatedBookingEntityResult = if (refreshOrder) {
+                    val updatedBookingEntity = if (refreshOrder) {
                         getBookingEntityWithRefreshedOrder(site, bookingDto)
+                            ?: getBookingEntityWithLocalOrder(site, bookingDto) // Fallback to local
                     } else {
                         getBookingEntityWithLocalOrder(site, bookingDto)
                     }
-                    if (updatedBookingEntityResult.isError) {
-                        return@withDefaultContext WooResult(updatedBookingEntityResult.error)
+                    if (updatedBookingEntity == null) {
+                        return@withDefaultContext WooResult(WooError(GENERIC_ERROR, UNKNOWN))
                     } else {
-                        updatedBookingEntityResult.model?.let {
-                            bookingsDao.insertOrReplace(it)
-                        }
-                        return@withDefaultContext WooResult(updatedBookingEntityResult.model)
+                        bookingsDao.insertOrReplace(updatedBookingEntity)
+                        return@withDefaultContext WooResult(updatedBookingEntity)
                     }
                 }
 
@@ -203,10 +202,10 @@ class BookingsStore @Inject internal constructor(
     private suspend fun getBookingEntityWithRefreshedOrder(
         site: SiteModel,
         bookingDto: BookingDto
-    ): WooResult<BookingEntity> {
+    ): BookingEntity? {
         val orderResult = orderStore.fetchSingleOrderSync(site, bookingDto.orderId)
         if (orderResult.isError) {
-            return WooResult(orderResult.error)
+            return null
         } else {
             val entity = with(bookingDtoMapper) {
                 bookingDto.toEntity(
@@ -214,20 +213,20 @@ class BookingsStore @Inject internal constructor(
                     orderEntity = orderResult.model,
                 )
             }
-            return WooResult(entity)
+            return entity
         }
     }
 
     private suspend fun getBookingEntityWithLocalOrder(
         site: SiteModel,
         bookingDto: BookingDto
-    ): WooResult<BookingEntity> {
+    ): BookingEntity? {
         val storedBooking = bookingsDao.getBooking(
             localSiteId = site.localId(),
             bookingId = bookingDto.id,
         )
         if (storedBooking == null) {
-            return WooResult(WooError(GENERIC_ERROR, UNKNOWN))
+            return null
         }
         val entity = with(bookingDtoMapper) {
             bookingDto.toEntity(
@@ -238,6 +237,6 @@ class BookingsStore @Inject internal constructor(
                 order = storedBooking.order,
             )
         }
-        return WooResult(entity)
+        return entity
     }
 }

--- a/libs/fluxc-plugin/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/bookings/BookingsStore.kt
+++ b/libs/fluxc-plugin/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/bookings/BookingsStore.kt
@@ -155,6 +155,7 @@ class BookingsStore @Inject internal constructor(
         site: SiteModel,
         bookingId: Long,
         bookingUpdatePayload: BookingUpdatePayload,
+        refreshBooking: Boolean = false,
     ): WooResult<BookingEntity> {
         return coroutineEngine.withDefaultContext(AppLog.T.API, this, "updateBooking") {
             val response = bookingsRestClient.updateBooking(site, bookingId, bookingUpdatePayload)
@@ -163,24 +164,18 @@ class BookingsStore @Inject internal constructor(
                 response.result != null -> {
                     val bookingDto = response.result
 
-                    val storedBooking = bookingsDao.getBooking(
-                        localSiteId = site.localId(),
-                        bookingId = bookingId
-                    )
-                    if (storedBooking == null) {
-                        return@withDefaultContext WooResult(WooError(GENERIC_ERROR, UNKNOWN))
+                    val updatedBookingEntityResult = if (refreshBooking) {
+                        getBookingEntityWithRefreshedOrder(site, bookingDto)
+                    } else {
+                        getBookingEntityWithLocalOrder(site, bookingDto)
                     }
-
-                    with(bookingDtoMapper) {
-                        val updatedBooking = bookingDto.toEntity(
-                            localSiteId = site.localId(),
-                            orderEntity = null,
-                        ).copy(
-                            // Preserve fields not returned by the API
-                            order = storedBooking.order,
-                        )
-                        bookingsDao.insertOrReplace(updatedBooking)
-                        return@withDefaultContext WooResult(updatedBooking)
+                    if (updatedBookingEntityResult.isError) {
+                        return@withDefaultContext WooResult(updatedBookingEntityResult.error)
+                    } else {
+                        updatedBookingEntityResult.model?.let {
+                            bookingsDao.insertOrReplace(it)
+                        }
+                        return@withDefaultContext WooResult(updatedBookingEntityResult.model)
                     }
                 }
 
@@ -203,5 +198,46 @@ class BookingsStore @Inject internal constructor(
         } else {
             WooResult(result.fetchedOrders.map { (order, _) -> order }.associateBy { it.orderId })
         }
+    }
+
+    private suspend fun getBookingEntityWithRefreshedOrder(
+        site: SiteModel,
+        bookingDto: BookingDto
+    ): WooResult<BookingEntity> {
+        val orderResult = orderStore.fetchSingleOrderSync(site, bookingDto.orderId)
+        if (orderResult.isError) {
+            return WooResult(orderResult.error)
+        } else {
+            val entity = with(bookingDtoMapper) {
+                bookingDto.toEntity(
+                    localSiteId = site.localId(),
+                    orderEntity = orderResult.model,
+                )
+            }
+            return WooResult(entity)
+        }
+    }
+
+    private suspend fun getBookingEntityWithLocalOrder(
+        site: SiteModel,
+        bookingDto: BookingDto
+    ): WooResult<BookingEntity> {
+        val storedBooking = bookingsDao.getBooking(
+            localSiteId = site.localId(),
+            bookingId = bookingDto.id,
+        )
+        if (storedBooking == null) {
+            return WooResult(WooError(GENERIC_ERROR, UNKNOWN))
+        }
+        val entity = with(bookingDtoMapper) {
+            bookingDto.toEntity(
+                localSiteId = site.localId(),
+                orderEntity = null,
+            ).copy(
+                // Preserve fields not returned by the API
+                order = storedBooking.order,
+            )
+        }
+        return WooResult(entity)
     }
 }

--- a/libs/fluxc-plugin/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/bookings/BookingsStore.kt
+++ b/libs/fluxc-plugin/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/bookings/BookingsStore.kt
@@ -155,7 +155,7 @@ class BookingsStore @Inject internal constructor(
         site: SiteModel,
         bookingId: Long,
         bookingUpdatePayload: BookingUpdatePayload,
-        refreshBooking: Boolean = false,
+        refreshOrder: Boolean = false,
     ): WooResult<BookingEntity> {
         return coroutineEngine.withDefaultContext(AppLog.T.API, this, "updateBooking") {
             val response = bookingsRestClient.updateBooking(site, bookingId, bookingUpdatePayload)
@@ -164,7 +164,7 @@ class BookingsStore @Inject internal constructor(
                 response.result != null -> {
                     val bookingDto = response.result
 
-                    val updatedBookingEntityResult = if (refreshBooking) {
+                    val updatedBookingEntityResult = if (refreshOrder) {
                         getBookingEntityWithRefreshedOrder(site, bookingDto)
                     } else {
                         getBookingEntityWithLocalOrder(site, bookingDto)

--- a/libs/fluxc-plugin/src/main/kotlin/org/wordpress/android/fluxc/persistence/entity/BookingEntity.kt
+++ b/libs/fluxc-plugin/src/main/kotlin/org/wordpress/android/fluxc/persistence/entity/BookingEntity.kt
@@ -66,6 +66,10 @@ data class BookingEntity(
             override val key = "complete"
         }
 
+        data object InCart : Status {
+            override val key = "in-cart"
+        }
+
         data class Unknown(override val key: String) : Status
 
         companion object Companion {
@@ -77,6 +81,7 @@ data class BookingEntity(
                     Paid.key -> Paid
                     Cancelled.key -> Cancelled
                     Complete.key -> Complete
+                    InCart.key -> InCart
                     else -> Unknown(key)
                 }
             }

--- a/libs/fluxc-plugin/src/main/kotlin/org/wordpress/android/fluxc/persistence/entity/BookingEntity.kt
+++ b/libs/fluxc-plugin/src/main/kotlin/org/wordpress/android/fluxc/persistence/entity/BookingEntity.kt
@@ -139,3 +139,13 @@ internal class BookingEntityConverters {
         return BookingEntity.AttendanceStatus.fromKey(key)
     }
 }
+
+val BookingEntity.isCancellable: Boolean
+    get() = status !in listOf(
+        BookingEntity.Status.Cancelled,
+        BookingEntity.Status.InCart,
+        BookingEntity.Status.Complete
+    )
+
+val BookingEntity.isAttendanceStatusEditable: Boolean
+    get() = status != BookingEntity.Status.Cancelled

--- a/libs/fluxc-plugin/src/test/java/org/wordpress/android/fluxc/network/rest/wpcom/wc/bookings/BookingsStoreTest.kt
+++ b/libs/fluxc-plugin/src/test/java/org/wordpress/android/fluxc/network/rest/wpcom/wc/bookings/BookingsStoreTest.kt
@@ -16,6 +16,7 @@ import org.wordpress.android.fluxc.model.SiteModel
 import org.wordpress.android.fluxc.network.BaseRequest.GenericErrorType.UNKNOWN
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.WooError
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.WooErrorType.GENERIC_ERROR
+import org.wordpress.android.fluxc.network.rest.wpcom.wc.WooPayload
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.WooResult
 import org.wordpress.android.fluxc.persistence.dao.BookingsDao
 import org.wordpress.android.fluxc.persistence.entity.BookingEntity
@@ -58,7 +59,7 @@ class BookingsStoreTest {
         val storedBooking = sampleBookingEntity(order = BookingOrderInfo(productInfo = null))
         whenever(bookingsDao.getBooking(TEST_LOCAL_SITE_ID, dto.id)).thenReturn(storedBooking)
         whenever(bookingsRestClient.updateBooking(site, dto.id, BookingUpdatePayload(note = "n")))
-            .thenReturn(org.wordpress.android.fluxc.network.rest.wpcom.wc.WooPayload(dto))
+            .thenReturn(WooPayload(dto))
         whenever(bookingsDao.insertOrReplace(any<BookingEntity>())).thenReturn(1L)
 
         // when
@@ -85,7 +86,7 @@ class BookingsStoreTest {
         val fetchedOrder = OrderEntity(orderId = dto.orderId, localSiteId = TEST_LOCAL_SITE_ID)
         whenever(orderStore.fetchSingleOrderSync(site, dto.orderId)).thenReturn(WooResult(fetchedOrder))
         whenever(bookingsRestClient.updateBooking(site, dto.id, BookingUpdatePayload(status = Status.Confirmed)))
-            .thenReturn(org.wordpress.android.fluxc.network.rest.wpcom.wc.WooPayload(dto))
+            .thenReturn(WooPayload(dto))
         whenever(bookingsDao.insertOrReplace(any<BookingEntity>())).thenReturn(1L)
 
         // when
@@ -101,6 +102,7 @@ class BookingsStoreTest {
         val expected = with(bookingDtoMapper) { dto.toEntity(TEST_LOCAL_SITE_ID, fetchedOrder) }
         assertThat(result.model).isEqualTo(expected)
         verify(bookingsDao).insertOrReplace(expected)
+        verify(bookingsDao, never()).getBooking(TEST_LOCAL_SITE_ID, dto.id)
     }
 
     @Test
@@ -109,7 +111,7 @@ class BookingsStoreTest {
         val site = SiteModel().apply { id = TEST_LOCAL_SITE_ID.value }
         val error = WooError(GENERIC_ERROR, UNKNOWN)
         whenever(bookingsRestClient.updateBooking(site, TEST_BOOKING_ID, BookingUpdatePayload(note = "n")))
-            .thenReturn(org.wordpress.android.fluxc.network.rest.wpcom.wc.WooPayload(error))
+            .thenReturn(WooPayload(error))
 
         // when
         val result = sut.updateBooking(
@@ -125,38 +127,47 @@ class BookingsStoreTest {
     }
 
     @Test
-    fun `given order refresh fails, when updateBooking with refreshOrder true, then returns error and does not insert`(): Unit = runBlocking {
-        // given
-        val site = SiteModel().apply { id = TEST_LOCAL_SITE_ID.value }
-        val dto = sampleBookingDto()
-        whenever(
-            bookingsRestClient.updateBooking(
-                site,
-                dto.id,
-                BookingUpdatePayload(attendanceStatus = AttendanceStatus.CheckedIn)
+    fun `given order refresh fails, when updateBooking with refreshOrder true, then fallbacks to local entity and inserts it`(): Unit =
+        runBlocking {
+            // given
+            val site = SiteModel().apply { id = TEST_LOCAL_SITE_ID.value }
+            val dto = sampleBookingDto()
+            val storedBooking = sampleBookingEntity(
+                order = BookingOrderInfo(
+                    productInfo = null,
+                    status = "paid",
+                )
             )
-        )
-            .thenReturn(org.wordpress.android.fluxc.network.rest.wpcom.wc.WooPayload(dto))
+            whenever(bookingsDao.getBooking(TEST_LOCAL_SITE_ID, dto.id)).thenReturn(storedBooking)
+            whenever(
+                bookingsRestClient.updateBooking(
+                    site,
+                    dto.id,
+                    BookingUpdatePayload(attendanceStatus = AttendanceStatus.CheckedIn)
+                )
+            ).thenReturn(WooPayload(dto))
 
-        whenever(
-            orderStore.fetchSingleOrderSync(
-                site,
-                dto.orderId
+            whenever(
+                orderStore.fetchSingleOrderSync(
+                    site,
+                    dto.orderId
+                )
+            ).thenReturn(WooResult(error = WooError(GENERIC_ERROR, UNKNOWN)))
+
+            // when
+            val result = sut.updateBooking(
+                site = site,
+                bookingId = dto.id,
+                bookingUpdatePayload = BookingUpdatePayload(attendanceStatus = AttendanceStatus.CheckedIn),
+                refreshOrder = true
             )
-        ).thenReturn(WooResult(error = WooError(GENERIC_ERROR, UNKNOWN)))
 
-        // when
-        val result = sut.updateBooking(
-            site = site,
-            bookingId = dto.id,
-            bookingUpdatePayload = BookingUpdatePayload(attendanceStatus = AttendanceStatus.CheckedIn),
-            refreshOrder = true
-        )
-
-        // then
-        assertThat(result.isError).isTrue()
-        verify(bookingsDao, never()).insertOrReplace(any<BookingEntity>())
-    }
+            // then
+            assertThat(result.isError).isFalse
+            verify(bookingsDao).getBooking(TEST_LOCAL_SITE_ID, dto.id)
+            // The store preserves the stored order on the mapped entity
+            verify(bookingsDao).insertOrReplace(argThat<BookingEntity> { this.order == storedBooking.order })
+        }
 
     private fun sampleBookingDto(): BookingDto = BookingDto(
         id = TEST_BOOKING_ID,

--- a/libs/fluxc-plugin/src/test/java/org/wordpress/android/fluxc/network/rest/wpcom/wc/bookings/BookingsStoreTest.kt
+++ b/libs/fluxc-plugin/src/test/java/org/wordpress/android/fluxc/network/rest/wpcom/wc/bookings/BookingsStoreTest.kt
@@ -51,7 +51,7 @@ class BookingsStoreTest {
     }
 
     @Test
-    fun `given refreshBooking is false, when updateBooking succeeds, then inserts mapped entity and returns it`(): Unit = runBlocking {
+    fun `given refreshOrder is false, when updateBooking succeeds, then inserts mapped entity and returns it`(): Unit = runBlocking {
         // given
         val site = SiteModel().apply { id = TEST_LOCAL_SITE_ID.value }
         val dto = sampleBookingDto()
@@ -77,7 +77,7 @@ class BookingsStoreTest {
     }
 
     @Test
-    fun `given refreshBooking is true, when updateBooking succeeds, then refreshes order and inserts mapped entity`(): Unit = runBlocking {
+    fun `given refreshOrder is true, when updateBooking succeeds, then refreshes order and inserts mapped entity`(): Unit = runBlocking {
         // given
         val site = SiteModel().apply { id = TEST_LOCAL_SITE_ID.value }
         val dto = sampleBookingDto()
@@ -125,7 +125,7 @@ class BookingsStoreTest {
     }
 
     @Test
-    fun `given order refresh fails, when updateBooking with refreshBooking true, then returns error and does not insert`(): Unit = runBlocking {
+    fun `given order refresh fails, when updateBooking with refreshOrder true, then returns error and does not insert`(): Unit = runBlocking {
         // given
         val site = SiteModel().apply { id = TEST_LOCAL_SITE_ID.value }
         val dto = sampleBookingDto()

--- a/libs/fluxc-plugin/src/test/java/org/wordpress/android/fluxc/network/rest/wpcom/wc/bookings/BookingsStoreTest.kt
+++ b/libs/fluxc-plugin/src/test/java/org/wordpress/android/fluxc/network/rest/wpcom/wc/bookings/BookingsStoreTest.kt
@@ -66,7 +66,7 @@ class BookingsStoreTest {
             site = site,
             bookingId = dto.id,
             bookingUpdatePayload = BookingUpdatePayload(note = "n"),
-            refreshBooking = false
+            refreshOrder = false
         )
 
         // then
@@ -93,7 +93,7 @@ class BookingsStoreTest {
             site = site,
             bookingId = dto.id,
             bookingUpdatePayload = BookingUpdatePayload(status = Status.Confirmed),
-            refreshBooking = true
+            refreshOrder = true
         )
 
         // then
@@ -116,7 +116,7 @@ class BookingsStoreTest {
             site = site,
             bookingId = TEST_BOOKING_ID,
             bookingUpdatePayload = BookingUpdatePayload(note = "n"),
-            refreshBooking = false
+            refreshOrder = false
         )
 
         // then
@@ -150,7 +150,7 @@ class BookingsStoreTest {
             site = site,
             bookingId = dto.id,
             bookingUpdatePayload = BookingUpdatePayload(attendanceStatus = AttendanceStatus.CheckedIn),
-            refreshBooking = true
+            refreshOrder = true
         )
 
         // then

--- a/libs/fluxc-plugin/src/test/java/org/wordpress/android/fluxc/network/rest/wpcom/wc/bookings/BookingsStoreTest.kt
+++ b/libs/fluxc-plugin/src/test/java/org/wordpress/android/fluxc/network/rest/wpcom/wc/bookings/BookingsStoreTest.kt
@@ -1,0 +1,213 @@
+package org.wordpress.android.fluxc.network.rest.wpcom.wc.bookings
+
+import kotlinx.coroutines.runBlocking
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.Before
+import org.junit.Test
+import org.mockito.kotlin.any
+import org.mockito.kotlin.argThat
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.never
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
+import org.wordpress.android.fluxc.model.LocalOrRemoteId.LocalId
+import org.wordpress.android.fluxc.model.LocalOrRemoteId.RemoteId
+import org.wordpress.android.fluxc.model.SiteModel
+import org.wordpress.android.fluxc.network.BaseRequest.GenericErrorType.UNKNOWN
+import org.wordpress.android.fluxc.network.rest.wpcom.wc.WooError
+import org.wordpress.android.fluxc.network.rest.wpcom.wc.WooErrorType.GENERIC_ERROR
+import org.wordpress.android.fluxc.network.rest.wpcom.wc.WooResult
+import org.wordpress.android.fluxc.persistence.dao.BookingsDao
+import org.wordpress.android.fluxc.persistence.entity.BookingEntity
+import org.wordpress.android.fluxc.persistence.entity.BookingEntity.AttendanceStatus
+import org.wordpress.android.fluxc.persistence.entity.BookingEntity.Status
+import org.wordpress.android.fluxc.persistence.entity.OrderEntity
+import org.wordpress.android.fluxc.store.WCOrderStore
+import org.wordpress.android.fluxc.tools.CoroutineEngine
+import org.wordpress.android.fluxc.utils.HeadersParser
+import java.time.Instant
+import kotlin.coroutines.EmptyCoroutineContext
+
+class BookingsStoreTest {
+
+    private lateinit var sut: BookingsStore
+
+    private val bookingsRestClient: BookingsRestClient = mock()
+    private val orderStore: WCOrderStore = mock()
+    private val bookingsDao: BookingsDao = mock()
+    private val bookingDtoMapper: BookingDtoMapper = BookingDtoMapper(mock())
+    private val headersParser: HeadersParser = mock()
+
+    @Before
+    fun setUp() {
+        sut = BookingsStore(
+            bookingsRestClient = bookingsRestClient,
+            orderStore = orderStore,
+            bookingsDao = bookingsDao,
+            bookingDtoMapper = bookingDtoMapper,
+            headersParser = headersParser,
+            coroutineEngine = CoroutineEngine(EmptyCoroutineContext, mock())
+        )
+    }
+
+    @Test
+    fun `given refreshBooking is false, when updateBooking succeeds, then inserts mapped entity and returns it`(): Unit = runBlocking {
+        // given
+        val site = SiteModel().apply { id = TEST_LOCAL_SITE_ID.value }
+        val dto = sampleBookingDto()
+        val storedBooking = sampleBookingEntity(order = BookingOrderInfo(productInfo = null))
+        whenever(bookingsDao.getBooking(TEST_LOCAL_SITE_ID, dto.id)).thenReturn(storedBooking)
+        whenever(bookingsRestClient.updateBooking(site, dto.id, BookingUpdatePayload(note = "n")))
+            .thenReturn(org.wordpress.android.fluxc.network.rest.wpcom.wc.WooPayload(dto))
+        whenever(bookingsDao.insertOrReplace(any<BookingEntity>())).thenReturn(1L)
+
+        // when
+        val result = sut.updateBooking(
+            site = site,
+            bookingId = dto.id,
+            bookingUpdatePayload = BookingUpdatePayload(note = "n"),
+            refreshBooking = false
+        )
+
+        // then
+        assertThat(result.isError).isFalse()
+        assertThat(result.model).isNotNull
+        // The store preserves the stored order on the mapped entity
+        verify(bookingsDao).insertOrReplace(argThat<BookingEntity> { this.order == storedBooking.order })
+    }
+
+    @Test
+    fun `given refreshBooking is true, when updateBooking succeeds, then refreshes order and inserts mapped entity`(): Unit = runBlocking {
+        // given
+        val site = SiteModel().apply { id = TEST_LOCAL_SITE_ID.value }
+        val dto = sampleBookingDto()
+
+        val fetchedOrder = OrderEntity(orderId = dto.orderId, localSiteId = TEST_LOCAL_SITE_ID)
+        whenever(orderStore.fetchSingleOrderSync(site, dto.orderId)).thenReturn(WooResult(fetchedOrder))
+        whenever(bookingsRestClient.updateBooking(site, dto.id, BookingUpdatePayload(status = Status.Confirmed)))
+            .thenReturn(org.wordpress.android.fluxc.network.rest.wpcom.wc.WooPayload(dto))
+        whenever(bookingsDao.insertOrReplace(any<BookingEntity>())).thenReturn(1L)
+
+        // when
+        val result = sut.updateBooking(
+            site = site,
+            bookingId = dto.id,
+            bookingUpdatePayload = BookingUpdatePayload(status = Status.Confirmed),
+            refreshBooking = true
+        )
+
+        // then
+        assertThat(result.isError).isFalse()
+        val expected = with(bookingDtoMapper) { dto.toEntity(TEST_LOCAL_SITE_ID, fetchedOrder) }
+        assertThat(result.model).isEqualTo(expected)
+        verify(bookingsDao).insertOrReplace(expected)
+    }
+
+    @Test
+    fun `given rest client fails, when updateBooking, then returns error and does not insert`(): Unit = runBlocking {
+        // given
+        val site = SiteModel().apply { id = TEST_LOCAL_SITE_ID.value }
+        val error = WooError(GENERIC_ERROR, UNKNOWN)
+        whenever(bookingsRestClient.updateBooking(site, TEST_BOOKING_ID, BookingUpdatePayload(note = "n")))
+            .thenReturn(org.wordpress.android.fluxc.network.rest.wpcom.wc.WooPayload(error))
+
+        // when
+        val result = sut.updateBooking(
+            site = site,
+            bookingId = TEST_BOOKING_ID,
+            bookingUpdatePayload = BookingUpdatePayload(note = "n"),
+            refreshBooking = false
+        )
+
+        // then
+        assertThat(result.isError).isTrue()
+        verify(bookingsDao, never()).insertOrReplace(any<BookingEntity>())
+    }
+
+    @Test
+    fun `given order refresh fails, when updateBooking with refreshBooking true, then returns error and does not insert`(): Unit = runBlocking {
+        // given
+        val site = SiteModel().apply { id = TEST_LOCAL_SITE_ID.value }
+        val dto = sampleBookingDto()
+        whenever(
+            bookingsRestClient.updateBooking(
+                site,
+                dto.id,
+                BookingUpdatePayload(attendanceStatus = AttendanceStatus.CheckedIn)
+            )
+        )
+            .thenReturn(org.wordpress.android.fluxc.network.rest.wpcom.wc.WooPayload(dto))
+
+        whenever(
+            orderStore.fetchSingleOrderSync(
+                site,
+                dto.orderId
+            )
+        ).thenReturn(WooResult(error = WooError(GENERIC_ERROR, UNKNOWN)))
+
+        // when
+        val result = sut.updateBooking(
+            site = site,
+            bookingId = dto.id,
+            bookingUpdatePayload = BookingUpdatePayload(attendanceStatus = AttendanceStatus.CheckedIn),
+            refreshBooking = true
+        )
+
+        // then
+        assertThat(result.isError).isTrue()
+        verify(bookingsDao, never()).insertOrReplace(any<BookingEntity>())
+    }
+
+    private fun sampleBookingDto(): BookingDto = BookingDto(
+        id = TEST_BOOKING_ID,
+        start = Instant.now().epochSecond,
+        end = Instant.now().plusSeconds(3600).epochSecond,
+        allDay = false,
+        status = Status.Unpaid.key,
+        cost = "10.00",
+        currency = "USD",
+        customerId = 1L,
+        productId = 2L,
+        resourceId = 3L,
+        dateCreated = Instant.now().epochSecond,
+        dateModified = Instant.now().epochSecond,
+        googleCalendarEventId = "",
+        orderId = 100L,
+        orderItemId = 200L,
+        parentId = 0L,
+        personCounts = null,
+        localTimezone = "UTC",
+        attendanceStatus = AttendanceStatus.Booked.key,
+        note = null
+    )
+
+    private fun sampleBookingEntity(order: BookingOrderInfo): BookingEntity = BookingEntity(
+        id = RemoteId(TEST_BOOKING_ID),
+        localSiteId = TEST_LOCAL_SITE_ID,
+        start = Instant.now(),
+        end = Instant.now().plusSeconds(3600),
+        allDay = false,
+        status = Status.Unpaid,
+        cost = "10.00",
+        currency = "USD",
+        customerId = 1L,
+        productId = 2L,
+        resourceId = 3L,
+        dateCreated = Instant.now(),
+        dateModified = Instant.now(),
+        googleCalendarEventId = "",
+        orderId = 100L,
+        orderItemId = 200L,
+        parentId = 0L,
+        personCounts = null,
+        localTimezone = "UTC",
+        attendanceStatus = AttendanceStatus.Booked,
+        note = "",
+        order = order
+    )
+
+    companion object {
+        private const val TEST_BOOKING_ID = 42L
+        private val TEST_LOCAL_SITE_ID = LocalId(999)
+    }
+}


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

<!-- Id number of the Linear issue this PR addresses, e.g., WOOMOB-373. -->

WOOMOB-1561

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

This PR implements the Cancel booking action (REST API part). There were some extra things that had to updated to make the whole Cancel work as expected:
- Update the logic to determine `Pay on site` badge. The previous `order.status != "completed"` didn't work well for `cancelled` bookings/orders`. This also follows the latest changes to the web logic. - p1761223364429439/1761044767.213429-slack-C09FHQNQERG. https://github.com/woocommerce/woocommerce-android/commit/d762e9a58f5a3c6952812a22260f46fdeed6a497
- Cancell button visibility - https://github.com/woocommerce/woocommerce-android/pull/14808/commits/7f131b1bc9a6293bf7a8f490cc1072f327d382b5
- Attendance section visibility - https://github.com/woocommerce/woocommerce-android/pull/14808/commits/5486a2703a6a4b756c441fdac02768c35185a671

Additionally, there's an extra commit that adds an option to refresh the underlying order when updating the booking https://github.com/woocommerce/woocommerce-android/pull/14808/commits/800901648935e63318d5ad601548779ff2de2a81. Up untill now, updating the booking was not affecting the order, but the new cancel booking is different as it also marks the order as cancelled. The order status is used to determine the badge so we need it updated. 

### Test Steps
<!-- Describe how to test your changes. Include only what’s needed for the reviewer to validate the behavior.
For new features, outline the main user flow or goal rather than every tap or click — the reviewer should be able to complete the flow naturally.
If applicable, mention key devices, scenarios, or edge cases to verify. -->

1. Launch the app
2. Open the bookings tab
3. Find a booking that wasn't cancelled
4. Tap `Cancel` 
5. If successful, make sure that the button and the attendance section were hidden and the badge status changed
6. You can also verify that a request to refresh an order was made

Please, try changing the attendance status, saving a new note and verify network requests to make sure we are not refreshing the order.

### Images/gif
<!-- Include before and after images or gifs when appropriate. -->


https://github.com/user-attachments/assets/2e82dc97-e56c-4790-b988-82232dd5276b



- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->