### PR TITLE
[WOOMOB-1569] - Rename Pay at location to Pay on site

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/bookings/BookingMapper.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/bookings/BookingMapper.kt
@@ -113,7 +113,7 @@ class BookingMapper @Inject constructor(
         paymentMethod: String?,
     ): BookingStatus {
         return if (orderStatus != "completed" && paymentMethod == "cod") {
-            BookingStatus.PayAtLocation
+            BookingStatus.PayOnSite
         } else {
             when (this) {
                 BookingEntity.Status.Paid -> BookingStatus.Paid

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/bookings/compose/BookingStatusTag.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/bookings/compose/BookingStatusTag.kt
@@ -26,7 +26,7 @@ fun BookingStatusTag(
 }
 
 sealed interface BookingStatus {
-    data object PayAtLocation : BookingStatus
+    data object PayOnSite : BookingStatus
     data object Unpaid : BookingStatus
     data object PendingConfirmation : BookingStatus
     data object Confirmed : BookingStatus
@@ -45,7 +45,7 @@ private fun BookingStatus.text(): String {
         BookingStatus.Paid -> stringResource(R.string.booking_payment_status_paid)
         BookingStatus.Cancelled -> stringResource(R.string.booking_payment_status_cancelled)
         BookingStatus.Complete -> stringResource(R.string.booking_payment_status_complete)
-        BookingStatus.PayAtLocation -> stringResource(R.string.booking_payment_status_pay_at_location)
+        BookingStatus.PayOnSite -> stringResource(R.string.booking_payment_status_pay_on_site)
         is BookingStatus.Unknown -> key
     }
 }
@@ -53,7 +53,7 @@ private fun BookingStatus.text(): String {
 @Composable
 fun BookingStatus.backgroundColor(): Color {
     return when (this) {
-        BookingStatus.PayAtLocation -> R.color.tag_bg_booking_yellow
+        BookingStatus.PayOnSite -> R.color.tag_bg_booking_yellow
         else -> R.color.tagView_bg
     }.let { colorResource(it) }
 }
@@ -70,10 +70,10 @@ private fun PaymentStatusTagPreview() {
 
 @LightDarkThemePreviews
 @Composable
-private fun PaymentStatusTagPayAtLocationPreview() {
+private fun PaymentStatusTagPayOnSitePreview() {
     WooThemeWithBackground {
         BookingStatusTag(
-            state = BookingStatus.PayAtLocation
+            state = BookingStatus.PayOnSite
         )
     }
 }

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -4246,7 +4246,7 @@
     <string name="booking_payment_status_cancelled">Cancelled</string>
     <string name="booking_payment_status_confirmed">Confirmed</string>
     <string name="booking_payment_status_complete">Complete</string>
-    <string name="booking_payment_status_pay_at_location">Pay at location</string>
+    <string name="booking_payment_status_pay_on_site">Pay on site</string>
     <string name="booking_attendance_status_booked">Booked</string>
     <string name="booking_attendance_status_checked_in">Checked-in</string>
     <string name="booking_attendance_status_cancelled">Cancelled</string>

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/bookings/BookingMapperTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/bookings/BookingMapperTest.kt
@@ -255,7 +255,7 @@ class BookingMapperTest : BaseUnitTest() {
     }
 
     @Test
-    fun `given processing order with COD payment method, when mapped to summary model, then status is PayAtLocation`() {
+    fun `given processing order with COD payment method, when mapped to summary model, then status is PayOnSite`() {
         // GIVEN
         val booking = sampleBooking().let { original ->
             val paymentInfo = BookingPaymentInfo(
@@ -274,7 +274,7 @@ class BookingMapperTest : BaseUnitTest() {
         val model = mapper.run { booking.toBookingSummaryModel(AttendanceUpdateStatus.Idle) }
 
         // THEN
-        assertThat(model.status).isEqualTo(BookingStatus.PayAtLocation)
+        assertThat(model.status).isEqualTo(BookingStatus.PayOnSite)
     }
 
     private fun sampleBooking(


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

<!-- Id number of the Linear issue this PR addresses, e.g., WOOMOB-373. -->

WOOMOB-1569

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

I've noticed that the badge copy was changed from `Pay at location` to `Pay on site`. This PR implements that change.

### Test Steps
<!-- Describe how to test your changes. Include only what’s needed for the reviewer to validate the behavior.
For new features, outline the main user flow or goal rather than every tap or click — the reviewer should be able to complete the flow naturally.
If applicable, mention key devices, scenarios, or edge cases to verify. -->

1. Make sure you have a booking with `cash on delivery` payment method and the order is not completed
2. Launch the booking tab
3. Verify you see `Pay on site` badge in the list

### Images/gif
<!-- Include before and after images or gifs when appropriate. -->

<img width="1280" height="2856" alt="Screenshot_20251023_164114" src="https://github.com/user-attachments/assets/6cabd455-5967-4701-a5f7-589e5fcc3e38" />


- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
