### PR TITLE
[WOOMOB-1577] Booking details - mark as paid action

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/bookings/BookingsRepository.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/bookings/BookingsRepository.kt
@@ -157,6 +157,22 @@ class BookingsRepository @Inject constructor(
         }
     }
 
+    suspend fun markAsPaid(
+        bookingId: Long,
+    ): Result<Unit> {
+        val result = bookingsStore.updateBooking(
+            site = selectedSite.get(),
+            bookingId = bookingId,
+            bookingUpdatePayload = BookingUpdatePayload(status = BookingEntity.Status.Paid),
+            refreshBooking = true,
+        )
+        return if (result.isError) {
+            Result.failure(WooException(result.error))
+        } else {
+            Result.success(Unit)
+        }
+    }
+
     data class FetchResult(
         val bookings: List<Booking>,
         val hasMorePages: Boolean

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/bookings/BookingsRepository.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/bookings/BookingsRepository.kt
@@ -1,7 +1,10 @@
 package com.woocommerce.android.ui.bookings
 
 import com.woocommerce.android.WooException
+import com.woocommerce.android.di.AppCoroutineScope
 import com.woocommerce.android.tools.SelectedSite
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.async
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.flowOf
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.bookings.BookingUpdatePayload
@@ -14,7 +17,8 @@ import javax.inject.Inject
 
 class BookingsRepository @Inject constructor(
     private val selectedSite: SelectedSite,
-    private val bookingsStore: BookingsStore
+    private val bookingsStore: BookingsStore,
+    @AppCoroutineScope private val appCoroutineScope: CoroutineScope,
 ) {
     suspend fun fetchBookings(
         page: Int,
@@ -112,66 +116,66 @@ class BookingsRepository @Inject constructor(
     suspend fun updateAttendanceStatus(
         bookingId: Long,
         attendanceStatus: BookingEntity.AttendanceStatus,
-    ): Result<Unit> {
+    ): Result<Unit> = appCoroutineScope.async {
         val result = bookingsStore.updateBooking(
             site = selectedSite.get(),
             bookingId = bookingId,
             bookingUpdatePayload = BookingUpdatePayload(attendanceStatus = attendanceStatus)
         )
-        return if (result.isError) {
+        if (result.isError) {
             Result.failure(WooException(result.error))
         } else {
             Result.success(Unit)
         }
-    }
+    }.await()
 
     suspend fun updateNote(
         bookingId: Long,
         note: String,
-    ): Result<Unit> {
+    ): Result<Unit> = appCoroutineScope.async {
         val result = bookingsStore.updateBooking(
             site = selectedSite.get(),
             bookingId = bookingId,
             bookingUpdatePayload = BookingUpdatePayload(note = note)
         )
-        return if (result.isError) {
+        if (result.isError) {
             Result.failure(WooException(result.error))
         } else {
             Result.success(Unit)
         }
-    }
+    }.await()
 
     suspend fun cancelBooking(
         bookingId: Long,
-    ): Result<Unit> {
+    ): Result<Unit> = appCoroutineScope.async {
         val result = bookingsStore.updateBooking(
             site = selectedSite.get(),
             bookingId = bookingId,
             bookingUpdatePayload = BookingUpdatePayload(status = BookingEntity.Status.Cancelled),
             refreshOrder = true,
         )
-        return if (result.isError) {
+        if (result.isError) {
             Result.failure(WooException(result.error))
         } else {
             Result.success(Unit)
         }
-    }
+    }.await()
 
     suspend fun markAsPaid(
         bookingId: Long,
-    ): Result<Unit> {
+    ): Result<Unit> = appCoroutineScope.async {
         val result = bookingsStore.updateBooking(
             site = selectedSite.get(),
             bookingId = bookingId,
             bookingUpdatePayload = BookingUpdatePayload(status = BookingEntity.Status.Paid),
-            refreshBooking = true,
+            refreshOrder = true,
         )
-        return if (result.isError) {
+        if (result.isError) {
             Result.failure(WooException(result.error))
         } else {
             Result.success(Unit)
         }
-    }
+    }.await()
 
     data class FetchResult(
         val bookings: List<Booking>,

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/bookings/compose/BookingPaymentSection.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/bookings/compose/BookingPaymentSection.kt
@@ -33,6 +33,7 @@ fun BookingPaymentSection(
     onMarkAsRefunded: () -> Unit,
     onViewOrder: () -> Unit,
     modifier: Modifier = Modifier,
+    markAsPaidInProgress: Boolean = false,
 ) {
     Column(modifier = modifier) {
         BookingSectionHeader(R.string.booking_payment_header)
@@ -77,7 +78,9 @@ fun BookingPaymentSection(
                     text = stringResource(id = R.string.booking_payment_mark_as_paid),
                     modifier = Modifier
                         .fillMaxWidth()
-                        .padding(horizontal = 16.dp)
+                        .padding(horizontal = 16.dp),
+                    loading = markAsPaidInProgress,
+                    enabled = !markAsPaidInProgress,
                 )
             }
             Spacer(modifier = Modifier.height(8.dp))

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/bookings/compose/BookingPaymentSection.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/bookings/compose/BookingPaymentSection.kt
@@ -30,7 +30,6 @@ fun BookingPaymentSection(
     model: BookingPaymentDetailsModel,
     status: BookingStatus,
     onMarkAsPaid: () -> Unit,
-    onMarkAsRefunded: () -> Unit,
     onViewOrder: () -> Unit,
     modifier: Modifier = Modifier,
     markAsPaidInProgress: Boolean = false,
@@ -60,19 +59,7 @@ fun BookingPaymentSection(
                 modifier = Modifier.padding(start = 16.dp)
             )
             Spacer(modifier = Modifier.height(16.dp))
-            // TODO Change the logic and use Order info when available
-            if (status == BookingStatus.Paid) {
-                WCOutlinedButton(
-                    onClick = onMarkAsRefunded,
-                    colors = ButtonDefaults.outlinedButtonColors(
-                        contentColor = MaterialTheme.colorScheme.onSurface
-                    ),
-                    text = stringResource(id = R.string.orderdetail_issue_refund_button),
-                    modifier = Modifier
-                        .fillMaxWidth()
-                        .padding(horizontal = 16.dp)
-                )
-            } else {
+            if (status == BookingStatus.Unpaid) {
                 WCColoredButton(
                     onClick = onMarkAsPaid,
                     text = stringResource(id = R.string.booking_payment_mark_as_paid),
@@ -82,8 +69,8 @@ fun BookingPaymentSection(
                     loading = markAsPaidInProgress,
                     enabled = !markAsPaidInProgress,
                 )
+                Spacer(modifier = Modifier.height(8.dp))
             }
-            Spacer(modifier = Modifier.height(8.dp))
             WCOutlinedButton(
                 onClick = onViewOrder,
                 colors = ButtonDefaults.outlinedButtonColors(
@@ -148,10 +135,9 @@ private fun BookingPaymentSectionPreview() {
                 discount = "-",
                 total = "$59.50"
             ),
-            status = BookingStatus.Complete,
+            status = BookingStatus.Unpaid,
             onMarkAsPaid = {},
             onViewOrder = {},
-            onMarkAsRefunded = {},
             modifier = Modifier.fillMaxWidth()
         )
     }
@@ -159,7 +145,7 @@ private fun BookingPaymentSectionPreview() {
 
 @LightDarkThemePreviews
 @Composable
-private fun BookingPaymentSectionWithRefundOptionPreview() {
+private fun BookingPaymentSectionWithPaidBookingPreview() {
     WooThemeWithBackground {
         BookingPaymentSection(
             model = BookingPaymentDetailsModel(
@@ -171,7 +157,6 @@ private fun BookingPaymentSectionWithRefundOptionPreview() {
             status = BookingStatus.Paid,
             onMarkAsPaid = {},
             onViewOrder = {},
-            onMarkAsRefunded = {},
             modifier = Modifier.fillMaxWidth()
         )
     }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/bookings/details/BookingDetailsScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/bookings/details/BookingDetailsScreen.kt
@@ -108,6 +108,8 @@ fun BookingDetailsScreen(
                             onViewOrder = onViewOrder,
                             onAttendanceStatusClicked = { showAttendanceSheet.value = true },
                             onViewNotes = onViewNotes,
+                            onMarkAsPaid = viewState.onMarkAsPaid,
+                            markAsPaidInProgress = viewState.paymentUpdateStatus == PaymentUpdateStatus.InProgress,
                         )
                     }
                 }
@@ -132,6 +134,8 @@ private fun BookingDetailsContent(
     onViewOrder: (Long) -> Unit,
     onAttendanceStatusClicked: () -> Unit,
     onViewNotes: () -> Unit,
+    onMarkAsPaid: () -> Unit,
+    markAsPaidInProgress: Boolean,
 ) {
     BookingSummary(
         model = booking.bookingSummary,
@@ -158,10 +162,11 @@ private fun BookingDetailsContent(
         BookingPaymentSection(
             model = it,
             status = booking.bookingSummary.status,
-            onMarkAsPaid = { onViewOrder(booking.orderId) },
+            onMarkAsPaid = onMarkAsPaid,
             onViewOrder = { onViewOrder(booking.orderId) },
             onMarkAsRefunded = { onViewOrder(booking.orderId) },
-            modifier = Modifier.fillMaxWidth()
+            modifier = Modifier.fillMaxWidth(),
+            markAsPaidInProgress = markAsPaidInProgress,
         )
     }
     BookingNoteSection(

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/bookings/details/BookingDetailsScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/bookings/details/BookingDetailsScreen.kt
@@ -164,7 +164,6 @@ private fun BookingDetailsContent(
             status = booking.bookingSummary.status,
             onMarkAsPaid = onMarkAsPaid,
             onViewOrder = { onViewOrder(booking.orderId) },
-            onMarkAsRefunded = { onViewOrder(booking.orderId) },
             modifier = Modifier.fillMaxWidth(),
             markAsPaidInProgress = markAsPaidInProgress,
         )

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/bookings/details/BookingDetailsViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/bookings/details/BookingDetailsViewModel.kt
@@ -60,6 +60,8 @@ class BookingDetailsViewModel @Inject constructor(
     private val cancelStatusState = MutableStateFlow<CancelStatus>(CancelStatus.Idle)
     private val showCancelBookingDialog = MutableStateFlow(false)
 
+    private val paymentUpdateStatus = MutableStateFlow<PaymentUpdateStatus>(PaymentUpdateStatus.Idle)
+
     private val cancelBookingDialogState = combine(
         booking,
         showCancelBookingDialog,
@@ -102,7 +104,8 @@ class BookingDetailsViewModel @Inject constructor(
         bookingUiStateFlow,
         loadingState,
         cancelBookingDialogState,
-    ) { booking, bookingUiState, loadingState, cancelBookingDialog ->
+        paymentUpdateStatus,
+    ) { booking, bookingUiState, loadingState, cancelBookingDialog, paymentUpdateStatus ->
         with(bookingMapper) {
             BookingDetailsViewState(
                 toolbarTitle = booking?.id?.value?.let { id ->
@@ -115,6 +118,8 @@ class BookingDetailsViewModel @Inject constructor(
                         onAttendanceStatusSelected(attendanceStatus)
                     }
                 },
+                onMarkAsPaid = ::onMarkAsPaid,
+                paymentUpdateStatus = paymentUpdateStatus,
                 dialogState = cancelBookingDialog,
                 loadingState = loadingState,
                 onRefresh = ::fetchBooking,
@@ -195,6 +200,19 @@ class BookingDetailsViewModel @Inject constructor(
                 triggerEvent(MultiLiveEvent.Event.ShowSnackbar(R.string.booking_cancel_error))
             }
         cancelStatusState.value = CancelStatus.Idle
+    }
+
+    private fun onMarkAsPaid() = launch {
+        if (!networkStatus.isConnected()) {
+            triggerEvent(MultiLiveEvent.Event.ShowSnackbar(R.string.offline_error))
+            return@launch
+        }
+        paymentUpdateStatus.value = PaymentUpdateStatus.InProgress
+        bookingsRepository.markAsPaid(navArgs.bookingId)
+            .onFailure {
+                triggerEvent(MultiLiveEvent.Event.ShowSnackbar(R.string.booking_mark_as_paid_error))
+            }
+        paymentUpdateStatus.value = PaymentUpdateStatus.Idle
     }
 
     private suspend fun BookingMapper.buildBookingUiState(

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/bookings/details/BookingDetailsViewState.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/bookings/details/BookingDetailsViewState.kt
@@ -13,6 +13,8 @@ data class BookingDetailsViewState(
     val loadingState: BookingDetailsLoadingState = BookingDetailsLoadingState.Idle,
     val onCancelBooking: () -> Unit = {},
     val onAttendanceStatusSelected: (BookingAttendanceStatus) -> Unit = { _ -> },
+    val onMarkAsPaid: () -> Unit = {},
+    val paymentUpdateStatus: PaymentUpdateStatus = PaymentUpdateStatus.Idle,
     val dialogState: DialogState? = null,
     val onRefresh: () -> Unit = {},
 ) {
@@ -43,4 +45,9 @@ sealed interface CancelStatus {
 sealed interface AttendanceUpdateStatus {
     data object Idle : AttendanceUpdateStatus
     data object InProgress : AttendanceUpdateStatus
+}
+
+sealed interface PaymentUpdateStatus {
+    data object Idle : PaymentUpdateStatus
+    data object InProgress : PaymentUpdateStatus
 }

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -4298,6 +4298,7 @@
     <string name="booking_note_screen_done">DONE</string>
     <string name="booking_note_screen_update_error">Error saving booking note</string>
     <string name="booking_cancel_error">Error cancelling the booking</string>
+    <string name="booking_mark_as_paid_error">Error marking the booking as paid</string>
 
     <string name="or_use_password" a8c-src-lib="module:login">Use password to sign in</string>
     <string name="about_automattic_main_page_title">About %1$s</string>

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/bookings/details/BookingDetailsViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/bookings/details/BookingDetailsViewModelTest.kt
@@ -298,6 +298,64 @@ class BookingDetailsViewModelTest : BaseUnitTest() {
         assertThat(after.bookingUiState?.bookingsAppointmentDetails?.cancelInProgressShown).isFalse()
     }
 
+    @Test
+    fun `when onMarkAsPaid invoked, then repository markAsPaid called and payment status shows progress then idle`() = testBlocking {
+        // Given
+        whenever(bookingsRepository.markAsPaid(any())).doSuspendableAnswer {
+            delay(100)
+            Result.success(Unit)
+        }
+        val viewModel = createViewModel()
+        val state = viewModel.state.getOrAwaitValue()
+
+        // When
+        state.onMarkAsPaid()
+
+        // Then: immediately after click (operation in progress)
+        val during = viewModel.state.getOrAwaitValue()
+        assertThat(during.paymentUpdateStatus).isEqualTo(PaymentUpdateStatus.InProgress)
+        verify(bookingsRepository, times(1)).markAsPaid(bookingId)
+
+        // And after operation completes, status returns to idle
+        advanceUntilIdle()
+        val after = viewModel.state.getOrAwaitValue()
+        assertThat(after.paymentUpdateStatus).isEqualTo(PaymentUpdateStatus.Idle)
+    }
+
+    @Test
+    fun `when offline and onMarkAsPaid invoked, then offline snackbar shown and repo not called`() = testBlocking {
+        // Given
+        whenever(networkStatus.isConnected()).thenReturn(false)
+        val viewModel = createViewModel()
+        val state = viewModel.state.getOrAwaitValue()
+
+        // When
+        state.onMarkAsPaid()
+
+        // Then
+        val event = viewModel.event.getOrAwaitValue()
+        assertThat(event).isEqualTo(MultiLiveEvent.Event.ShowSnackbar(R.string.offline_error))
+        verify(bookingsRepository, times(0)).markAsPaid(any())
+    }
+
+    @Test
+    fun `given markAsPaid fails, when called, then show error snackbar and status returns idle`() = testBlocking {
+        // Given
+        whenever(bookingsRepository.markAsPaid(any())).thenReturn(Result.failure(Exception("Mark as paid failed")))
+        val viewModel = createViewModel()
+        val state = viewModel.state.getOrAwaitValue()
+
+        // When
+        state.onMarkAsPaid()
+
+        // Then
+        val event = viewModel.event.getOrAwaitValue()
+        assertThat(event).isEqualTo(MultiLiveEvent.Event.ShowSnackbar(R.string.booking_mark_as_paid_error))
+        advanceUntilIdle()
+        val after = viewModel.state.getOrAwaitValue()
+        assertThat(after.paymentUpdateStatus).isEqualTo(PaymentUpdateStatus.Idle)
+    }
+
     private fun createViewModel(
         savedState: SavedStateHandle = savedStateHandle,
     ): BookingDetailsViewModel {


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

<!-- Id number of the Linear issue this PR addresses, e.g., WOOMOB-373. -->

WOOMOB-1577

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

_Targeting https://github.com/woocommerce/woocommerce-android/pull/14808 as that PR has some changes that are helpful to update the Booking via API call._

As it was recently discovered, we can mark the booking as paid and the server should properly handle the underlying order object. 

This PR updates the code, and now instead of opening the order we mark the booking as paid directly from the bookings screen.

Additionally, the `Issue refund` was removed to align with CIAB admin.

### Test Steps
<!-- Describe how to test your changes. Include only what’s needed for the reviewer to validate the behavior.
For new features, outline the main user flow or goal rather than every tap or click — the reviewer should be able to complete the flow naturally.
If applicable, mention key devices, scenarios, or edge cases to verify. -->

1. Make sure you have some bookings with`unpaid` status
2. Launch the app
3. Go to bookings
4. Tap on booking with `unpaid` status
5. Scroll down
6. Tap `Mark  as paid`
7. Verify the booking status was change
8. Verify the `Issue refund` button is no longer there

### Images/gif
<!-- Include before and after images or gifs when appropriate. -->

Marking as paid

https://github.com/user-attachments/assets/b149c22e-a304-4406-bf27-f60efba45489

| Unpaid | Other |
|---|---|
| <img width="1280" height="2856" alt="Screenshot_20251024_135405" src="https://github.com/user-attachments/assets/9ff1a6dd-d3b5-4c3b-8514-ec1c306df0bb" /> | <img width="1280" height="2856" alt="Screenshot_20251024_135413" src="https://github.com/user-attachments/assets/cada9e21-0895-466e-93ea-d4a8bff08d5c" /> |

- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
