### PR TITLE
Use Authenticated WebView for IPP setup

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -4,6 +4,7 @@
 23.6
 -----
 - [Internal] Improve WebView experience by using Authenticated WebView for more scenarios [https://github.com/woocommerce/woocommerce-android/pull/14826]
+- [Internal] Update In-Person Payments setup flow to use Authenticated WebView [https://github.com/woocommerce/woocommerce-android/pull/14827]
 
 23.5
 -----

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/compose/component/web/WCWebChromeClient.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/compose/component/web/WCWebChromeClient.kt
@@ -1,11 +1,14 @@
 package com.woocommerce.android.ui.compose.component.web
 
 import android.net.Uri
+import android.os.Message
 import android.webkit.ValueCallback
 import android.webkit.WebChromeClient
 import android.webkit.WebView
+import android.widget.FrameLayout
 import androidx.activity.ComponentActivity
 import androidx.activity.result.contract.ActivityResultContracts
+import androidx.core.view.isVisible
 import com.woocommerce.android.extensions.findActivity
 
 open class WCWebChromeClient : WebChromeClient() {
@@ -47,5 +50,43 @@ open class WCWebChromeClient : WebChromeClient() {
 
     override fun onProgressChanged(view: WebView?, newProgress: Int) {
         onProgressChanged(newProgress)
+    }
+
+    override fun onCreateWindow(
+        view: WebView,
+        isDialog: Boolean,
+        isUserGesture: Boolean,
+        resultMsg: Message
+    ): Boolean {
+        require(view.parent is FrameLayout) {
+            "Ensure the WebView is added to a FrameLayout to support popups. Check WCWebView implementation."
+        }
+
+        val popupContainer = view.parent as FrameLayout
+
+        val popupWebView = WebView(view.context).apply {
+            settings.useWideViewPort = view.settings.useWideViewPort
+            settings.loadWithOverviewMode = view.settings.loadWithOverviewMode
+            settings.javaScriptEnabled = view.settings.javaScriptEnabled
+            settings.domStorageEnabled = view.settings.domStorageEnabled
+            settings.setSupportMultipleWindows(true)
+        }
+
+        popupWebView.webViewClient = view.webViewClient
+        popupWebView.webChromeClient = object : WebChromeClient() {
+            override fun onCloseWindow(window: WebView) {
+                popupContainer.removeView(popupWebView)
+                view.isVisible = true
+            }
+        }
+
+        popupContainer.layoutParams = view.layoutParams
+        popupContainer.addView(popupWebView)
+        view.isVisible = false
+
+        (resultMsg.obj as WebView.WebViewTransport).webView = popupWebView
+        resultMsg.sendToTarget()
+
+        return true
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/compose/component/web/WCWebView.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/compose/component/web/WCWebView.kt
@@ -3,6 +3,7 @@ package com.woocommerce.android.ui.compose.component.web
 import android.annotation.SuppressLint
 import android.view.ViewGroup
 import android.webkit.WebView
+import android.widget.FrameLayout
 import androidx.activity.compose.BackHandler
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -104,6 +105,7 @@ fun WCWebView(
             webView.settings.loadWithOverviewMode = settings.loadWithOverviewMode
             webView.settings.javaScriptEnabled = settings.isJavaScriptEnabled
             webView.settings.domStorageEnabled = settings.isDomStorageEnabled
+            webView.settings.setSupportMultipleWindows(true)
         }
     }
 
@@ -127,7 +129,7 @@ fun WCWebView(
 
         AndroidView(
             factory = { context ->
-                WebView(context).apply {
+                val webView = WebView(context).apply {
                     layoutParams = ViewGroup.LayoutParams(
                         ViewGroup.LayoutParams.MATCH_PARENT,
                         ViewGroup.LayoutParams.MATCH_PARENT
@@ -140,6 +142,10 @@ fun WCWebView(
 
                     this.settings.userAgentString = userAgent.webViewUserAgent
                 }.also { webView = it }
+
+                FrameLayout(context).apply {
+                    addView(webView)
+                }
             },
             modifier = Modifier
                 .alpha(webViewAlpha)

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/cardreader/onboarding/CardReaderOnboardingEvent.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/cardreader/onboarding/CardReaderOnboardingEvent.kt
@@ -4,9 +4,6 @@ import com.woocommerce.android.viewmodel.MultiLiveEvent
 
 sealed class CardReaderOnboardingEvent : MultiLiveEvent.Event() {
     object NavigateToSupport : MultiLiveEvent.Event()
-
-    data class NavigateToUrlInBrowser(val url: String) : MultiLiveEvent.Event()
-
     data class ContinueToHub(val cardReaderFlowParam: CardReaderFlowParam) : MultiLiveEvent.Event()
     data class ContinueToConnection(
         val cardReaderFlowParam: CardReaderFlowParam,

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/cardreader/onboarding/CardReaderOnboardingFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/cardreader/onboarding/CardReaderOnboardingFragment.kt
@@ -28,6 +28,7 @@ import com.woocommerce.android.extensions.startHelpActivity
 import com.woocommerce.android.support.help.HelpOrigin
 import com.woocommerce.android.ui.base.BaseFragment
 import com.woocommerce.android.ui.base.UIMessageResolver
+import com.woocommerce.android.ui.common.webview.AuthenticatedWebViewLauncher
 import com.woocommerce.android.ui.main.AppBarStatus
 import com.woocommerce.android.util.ChromeCustomTabUtils
 import com.woocommerce.android.util.UiHelpers
@@ -42,6 +43,9 @@ import javax.inject.Inject
 class CardReaderOnboardingFragment : BaseFragment(R.layout.fragment_card_reader_onboarding) {
     @Inject
     lateinit var uiMessageResolver: UIMessageResolver
+
+    @Inject
+    lateinit var authenticatedWebViewLauncher: AuthenticatedWebViewLauncher
 
     val viewModel: CardReaderOnboardingViewModel by viewModels()
 
@@ -92,9 +96,7 @@ class CardReaderOnboardingFragment : BaseFragment(R.layout.fragment_card_reader_
                 is CardReaderOnboardingEvent.NavigateToSupport -> {
                     requireActivity().startHelpActivity(HelpOrigin.CARD_READER_ONBOARDING)
                 }
-                is CardReaderOnboardingEvent.NavigateToUrlInBrowser -> {
-                    ChromeCustomTabUtils.launchUrl(requireContext(), event.url)
-                }
+
                 is CardReaderOnboardingEvent.ContinueToHub -> {
                     findNavController().navigate(
                         CardReaderOnboardingFragmentDirections
@@ -103,6 +105,7 @@ class CardReaderOnboardingFragment : BaseFragment(R.layout.fragment_card_reader_
                             )
                     )
                 }
+
                 is CardReaderOnboardingEvent.ContinueToConnection -> {
                     findNavController().navigate(
                         CardReaderOnboardingFragmentDirections
@@ -112,6 +115,15 @@ class CardReaderOnboardingFragment : BaseFragment(R.layout.fragment_card_reader_
                             )
                     )
                 }
+
+                is MultiLiveEvent.Event.LaunchUrlInAuthenticatedWebView -> {
+                    authenticatedWebViewLauncher.showAuthenticatedWebView(event)
+                }
+
+                is MultiLiveEvent.Event.LaunchUrlInChromeTab -> {
+                    ChromeCustomTabUtils.launchUrl(requireContext(), event.url)
+                }
+
                 is MultiLiveEvent.Event.ShowUiStringSnackbar -> uiMessageResolver.showSnack(event.message)
                 is MultiLiveEvent.Event.Exit -> findNavController().popBackStack()
                 else -> event.isHandled = false
@@ -148,20 +160,28 @@ class CardReaderOnboardingFragment : BaseFragment(R.layout.fragment_card_reader_
         when (state) {
             is CardReaderOnboardingViewState.GenericErrorState ->
                 showGenericErrorState(layout, state)
+
             is CardReaderOnboardingViewState.NoConnectionErrorState ->
                 showNetworkErrorState(layout, state)
+
             is CardReaderOnboardingViewState.LoadingState ->
                 showLoadingState(layout, state)
+
             is CardReaderOnboardingViewState.UnsupportedErrorState ->
                 showCountryNotSupportedState(layout, state)
+
             is CardReaderOnboardingViewState.WCPayError ->
                 showWCPayErrorState(layout, state)
+
             is CardReaderOnboardingViewState.StripeAccountError ->
                 showStripeAccountError(layout, state)
+
             is CardReaderOnboardingViewState.StripeExtensionError ->
                 showStripeExtensionErrorState(layout, state)
+
             is CardReaderOnboardingViewState.SelectPaymentPluginState ->
                 showPaymentPluginSelectionState(layout, state)
+
             is CardReaderOnboardingViewState.CashOnDeliveryDisabledState ->
                 showCashOnDeliveryDisabledState(layout, state)
         }
@@ -195,6 +215,7 @@ class CardReaderOnboardingFragment : BaseFragment(R.layout.fragment_card_reader_
                         R.string.card_reader_onboarding_cash_on_delivery_enable_failure
                     )
                 }
+
                 null -> {}
             }
         }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/cardreader/onboarding/CardReaderOnboardingViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/cardreader/onboarding/CardReaderOnboardingViewModel.kt
@@ -12,7 +12,6 @@ import com.woocommerce.android.model.UiString
 import com.woocommerce.android.tools.SelectedSite
 import com.woocommerce.android.ui.payments.cardreader.LearnMoreUrlProvider
 import com.woocommerce.android.ui.payments.cardreader.LearnMoreUrlProvider.LearnMoreUrlType.IN_PERSON_PAYMENTS
-import com.woocommerce.android.ui.payments.cardreader.onboarding.CardReaderOnboardingEvent.NavigateToUrlInBrowser
 import com.woocommerce.android.ui.payments.cardreader.onboarding.CardReaderOnboardingParams.Check
 import com.woocommerce.android.ui.payments.cardreader.onboarding.CardReaderOnboardingParams.Failed
 import com.woocommerce.android.ui.payments.cardreader.onboarding.CardReaderOnboardingState.ChoosePaymentGatewayProvider
@@ -134,7 +133,7 @@ class CardReaderOnboardingViewModel @Inject constructor(
                 }
 
                 is CardReaderOnboardingErrorCtaClickHandler.Reaction.OpenBrowser -> {
-                    triggerEvent(NavigateToUrlInBrowser(reaction.url))
+                    triggerEvent(Event.LaunchUrlInAuthenticatedWebView(reaction.url))
                     viewState.value = prevState!!
                 }
             }
@@ -438,7 +437,7 @@ class CardReaderOnboardingViewModel @Inject constructor(
 
     private fun onLearnMoreClicked() {
         paymentsFlowTracker.trackOnboardingLearnMoreTapped()
-        triggerEvent(NavigateToUrlInBrowser(learnMoreUrlProvider.provideLearnMoreUrlFor(IN_PERSON_PAYMENTS)))
+        triggerEvent(Event.LaunchUrlInChromeTab(learnMoreUrlProvider.provideLearnMoreUrlFor(IN_PERSON_PAYMENTS)))
     }
 
     private fun onSkipPendingRequirementsClicked() {

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/payments/cardreader/onboarding/CardReaderOnboardingViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/payments/cardreader/onboarding/CardReaderOnboardingViewModelTest.kt
@@ -308,7 +308,7 @@ class CardReaderOnboardingViewModelTest : BaseUnitTest() {
         }
 
     @Test
-    fun `given handler returned OpenWpComWebView, when clicked on wcpay not setup, then open wp webview`() =
+    fun `given handler returned OpenBrowser, when clicked on wcpay not setup, then open authenticated webview`() =
         testBlocking {
             val url = "url"
             whenever(errorClickHandler.invoke(CardReaderOnboardingCTAErrorType.WC_PAY_NOT_SETUP))
@@ -328,63 +328,12 @@ class CardReaderOnboardingViewModelTest : BaseUnitTest() {
                 .actionButtonActionPrimary.invoke()
 
             assertThat(viewModel.event.value).isEqualTo(
-                CardReaderOnboardingEvent.NavigateToUrlInBrowser(url)
+                MultiLiveEvent.Event.LaunchUrlInAuthenticatedWebView(url)
             )
         }
 
     @Test
-    fun `given handler returned OpenGenericWebView, when clicked on wcpay not setup, then open generic webview`() =
-        testBlocking {
-            val url = "url"
-            whenever(errorClickHandler.invoke(CardReaderOnboardingCTAErrorType.WC_PAY_NOT_SETUP))
-                .thenReturn(CardReaderOnboardingErrorCtaClickHandler.Reaction.OpenBrowser(url))
-
-            val viewModel = createVM(
-                CardReaderOnboardingFragmentArgs(
-                    CardReaderOnboardingParams.Failed(
-                        cardReaderFlowParam = CardReaderFlowParam.PaymentOrRefund.Payment(1L, ORDER),
-                        onboardingState = SetupNotCompleted(WOOCOMMERCE_PAYMENTS),
-                    ),
-                    cardReaderType = CardReaderType.EXTERNAL
-                ).toSavedStateHandle()
-            )
-
-            (viewModel.viewStateData.value as WCPayError.WCPayNotSetupState)
-                .actionButtonActionPrimary.invoke()
-
-            assertThat(viewModel.event.value).isEqualTo(
-                CardReaderOnboardingEvent.NavigateToUrlInBrowser(url)
-            )
-        }
-
-    @Test
-    fun `given handler returned OpenWpComWebView, when clicked on stripe req overdue, then open wpcom webview`() =
-        testBlocking {
-            val url = "url"
-            whenever(errorClickHandler.invoke(CardReaderOnboardingCTAErrorType.STRIPE_ACCOUNT_OVERDUE_REQUIREMENTS))
-                .thenReturn(CardReaderOnboardingErrorCtaClickHandler.Reaction.OpenBrowser(url))
-
-            val viewModel = createVM(
-                CardReaderOnboardingFragmentArgs(
-                    CardReaderOnboardingParams.Failed(
-                        cardReaderFlowParam =
-                        CardReaderFlowParam.PaymentOrRefund.Payment(1L, ORDER),
-                        onboardingState = StripeAccountOverdueRequirement(WOOCOMMERCE_PAYMENTS),
-                    ),
-                    cardReaderType = CardReaderType.EXTERNAL
-                ).toSavedStateHandle()
-            )
-
-            (viewModel.viewStateData.value as StripeAccountError.StripeAccountOverdueRequirementsState)
-                .actionButtonPrimary!!.action.invoke()
-
-            assertThat(viewModel.event.value).isEqualTo(
-                CardReaderOnboardingEvent.NavigateToUrlInBrowser(url)
-            )
-        }
-
-    @Test
-    fun `given handler returned OpenGenericWebView, when clicked on stripe req overdue, then open generic webview`() =
+    fun `given handler returned OpenBrowser, when clicked on stripe req overdue, then open authenticated webview`() =
         testBlocking {
             val url = "url"
             whenever(errorClickHandler.invoke(CardReaderOnboardingCTAErrorType.STRIPE_ACCOUNT_OVERDUE_REQUIREMENTS))
@@ -404,7 +353,7 @@ class CardReaderOnboardingViewModelTest : BaseUnitTest() {
                 .actionButtonPrimary!!.action.invoke()
 
             assertThat(viewModel.event.value).isEqualTo(
-                CardReaderOnboardingEvent.NavigateToUrlInBrowser(url)
+                MultiLiveEvent.Event.LaunchUrlInAuthenticatedWebView(url)
             )
         }
 
@@ -623,7 +572,7 @@ class CardReaderOnboardingViewModelTest : BaseUnitTest() {
             (viewModel.viewStateData.value as UnsupportedErrorState.WcPayInCountry)
                 .onLearnMoreActionClicked.invoke()
 
-            val event = viewModel.event.value as CardReaderOnboardingEvent.NavigateToUrlInBrowser
+            val event = viewModel.event.value as MultiLiveEvent.Event.LaunchUrlInChromeTab
             assertThat(event.url).isEqualTo(AppUrls.WOOCOMMERCE_LEARN_MORE_ABOUT_PAYMENTS)
         }
 
@@ -637,7 +586,7 @@ class CardReaderOnboardingViewModelTest : BaseUnitTest() {
             (viewModel.viewStateData.value as UnsupportedErrorState.Country)
                 .onLearnMoreActionClicked.invoke()
 
-            val event = viewModel.event.value as CardReaderOnboardingEvent.NavigateToUrlInBrowser
+            val event = viewModel.event.value as MultiLiveEvent.Event.LaunchUrlInChromeTab
             assertThat(event.url).isEqualTo(AppUrls.WOOCOMMERCE_LEARN_MORE_ABOUT_PAYMENTS)
         }
 
@@ -690,7 +639,7 @@ class CardReaderOnboardingViewModelTest : BaseUnitTest() {
 
             (viewModel.viewStateData.value as UnsupportedErrorState.Country).onLearnMoreActionClicked.invoke()
 
-            val event = viewModel.event.value as CardReaderOnboardingEvent.NavigateToUrlInBrowser
+            val event = viewModel.event.value as MultiLiveEvent.Event.LaunchUrlInChromeTab
             assertThat(event.url).isEqualTo(AppUrls.STRIPE_LEARN_MORE_ABOUT_PAYMENTS)
         }
 
@@ -706,7 +655,7 @@ class CardReaderOnboardingViewModelTest : BaseUnitTest() {
 
             (viewModel.viewStateData.value as UnsupportedErrorState.Country).onLearnMoreActionClicked.invoke()
 
-            val event = viewModel.event.value as CardReaderOnboardingEvent.NavigateToUrlInBrowser
+            val event = viewModel.event.value as MultiLiveEvent.Event.LaunchUrlInChromeTab
             assertThat(event.url).isEqualTo(AppUrls.WOOCOMMERCE_LEARN_MORE_ABOUT_PAYMENTS)
         }
 
@@ -720,7 +669,7 @@ class CardReaderOnboardingViewModelTest : BaseUnitTest() {
             (viewModel.viewStateData.value as UnsupportedErrorState.StripeAccountInUnsupportedCountry)
                 .onLearnMoreActionClicked.invoke()
 
-            val event = viewModel.event.value as CardReaderOnboardingEvent.NavigateToUrlInBrowser
+            val event = viewModel.event.value as MultiLiveEvent.Event.LaunchUrlInChromeTab
             assertThat(event.url).isEqualTo(AppUrls.WOOCOMMERCE_LEARN_MORE_ABOUT_PAYMENTS)
         }
 
@@ -1113,7 +1062,7 @@ class CardReaderOnboardingViewModelTest : BaseUnitTest() {
             (viewModel.viewStateData.value as CashOnDeliveryDisabledState)
                 .onLearnMoreActionClicked.invoke()
 
-            val event = viewModel.event.value as CardReaderOnboardingEvent.NavigateToUrlInBrowser
+            val event = viewModel.event.value as MultiLiveEvent.Event.LaunchUrlInChromeTab
             assertThat(event.url).isEqualTo(AppUrls.WOOCOMMERCE_LEARN_MORE_ABOUT_PAYMENTS)
         }
 


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

<!-- Id number of the Linear issue this PR addresses, e.g., WOOMOB-373. -->
part of WOOMOB-1585

### Description
During the CIAB project, we reviewed all WebView and Chrome custom tabs in the app and migrated all areas needing authentication to the Authenticated WebView (PRs: #14825 and #14826). However, I kept `CardReaderOnboardingFragment` due to the pop-up issue during setup (#12907).

This PR focuses on the  `CardReaderOnboardingFragment`, it adds the following changes:
- Updates the `WCWebView` composable to handle popups, the popups will be shown in full-screen and replace the parent WebView content, and when closed we'll restore the parent WebView. 84f20ad990162f614d4b2d154f4c928253391742
- Updates the `CardReaderOnboardingFragment` to use the `AuthenticatedWebViewLauncher` class that was added in the previous PRs.

> [!NOTE]
> I'm handling this as part of the CIAB project even though ipp is not supported in CIAB yet, since we will eventually support it in the future, and because this will also improve the experience for other users. 

### Test Steps
1. Use a site:
    - Supports Jetpack SSO (either atomic site, or self-hosted site with Jetpack SSO enabled from the settings)
    - WooPayments setup is not done yet, or use the Reset account button.
3. Open the Payments hub in the app.
4. Start the setup from the app.
5. Confirm it uses the Authenticated WebView, and the Stripe onboarding screen is opened without issues.

### Images/gif
https://github.com/user-attachments/assets/25f26d55-7642-422c-9247-32934774c6fc


- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
