### PR TITLE
[CIAB] Hide Card Reader and TTP options

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ciab/CIABAffectedFeature.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ciab/CIABAffectedFeature.kt
@@ -2,7 +2,7 @@ package com.woocommerce.android.ciab
 
 enum class CIABAffectedFeature {
     Blaze,
-    Payments,
+    WooPayments,
     WooShippingSplitShipments,
     GroupedProducts,
     VariableProducts,

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/moremenu/MoreMenuViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/moremenu/MoreMenuViewModel.kt
@@ -452,7 +452,7 @@ class MoreMenuViewModel @Inject constructor(
             doCheckAvailability(MoreMenuItemButton.Type.Inbox) { moreMenuRepository.isInboxEnabled() },
             doCheckAvailability(MoreMenuItemButton.Type.Settings) { moreMenuRepository.isUpgradesEnabled() },
             doCheckAvailability(MoreMenuItemButton.Type.Payments) {
-                ciabSiteGateKeeper.isFeatureSupported(CIABAffectedFeature.Payments)
+                ciabSiteGateKeeper.isFeatureSupported(CIABAffectedFeature.WooPayments)
             }
         ).merge()
             .map { update ->

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/cardreader/payment/CardReaderPaymentCollectibilityChecker.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/cardreader/payment/CardReaderPaymentCollectibilityChecker.kt
@@ -1,5 +1,7 @@
 package com.woocommerce.android.ui.payments.cardreader.payment
 
+import com.woocommerce.android.ciab.CIABAffectedFeature
+import com.woocommerce.android.ciab.CIABSiteGateKeeper
 import com.woocommerce.android.extensions.CASH_ON_DELIVERY_PAYMENT_TYPE
 import com.woocommerce.android.extensions.STRIPE_PAYMENTS_PAYMENT_TYPE
 import com.woocommerce.android.extensions.WOOCOMMERCE_BOOKINGS_PAYMENT_TYPE
@@ -17,17 +19,19 @@ import javax.inject.Inject
 class CardReaderPaymentCollectibilityChecker @Inject constructor(
     private val orderDetailRepository: OrderDetailRepository,
     private val cardReaderPaymentCurrencySupportedChecker: CardReaderPaymentCurrencySupportedChecker,
+    private val ciabSiteGateKeeper: CIABSiteGateKeeper
 ) {
     suspend fun isCollectable(order: Order): Boolean {
-        return with(order) {
-            cardReaderPaymentCurrencySupportedChecker.isCurrencySupported(currency) &&
-                isStatusCollectable() &&
-                !isOrderPaid &&
-                order.total.compareTo(BigDecimal.ZERO) == 1 &&
-                BigDecimal.ZERO.compareTo(order.refundTotal) == 0 &&
-                isPaymentMethodCollectable() &&
-                !orderDetailRepository.hasSubscriptionProducts(order.getProductIds())
-        }
+        return ciabSiteGateKeeper.isFeatureSupported(CIABAffectedFeature.WooPayments) &&
+            with(order) {
+                cardReaderPaymentCurrencySupportedChecker.isCurrencySupported(currency) &&
+                    isStatusCollectable() &&
+                    !isOrderPaid &&
+                    order.total.compareTo(BigDecimal.ZERO) == 1 &&
+                    BigDecimal.ZERO.compareTo(order.refundTotal) == 0 &&
+                    isPaymentMethodCollectable() &&
+                    !orderDetailRepository.hasSubscriptionProducts(order.getProductIds())
+            }
     }
 
     private fun Order.isPaymentMethodCollectable() =

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/methodselection/SelectPaymentMethodFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/methodselection/SelectPaymentMethodFragment.kt
@@ -126,6 +126,7 @@ class SelectPaymentMethodFragment : BaseFragment(R.layout.fragment_select_paymen
         with(binding.learnMoreIppPaymentMethodsTv) {
             learnMore.setOnClickListener { state.learnMoreIpp.onClick.invoke() }
             UiHelpers.setTextOrHide(binding.learnMoreIppPaymentMethodsTv.learnMore, state.learnMoreIpp.label)
+            learnMore.isVisible = state.learnMoreIpp.isVisible
         }
     }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/methodselection/SelectPaymentMethodViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/methodselection/SelectPaymentMethodViewModel.kt
@@ -11,6 +11,8 @@ import com.woocommerce.android.analytics.AnalyticsTracker.Companion.VALUE_SIMPLE
 import com.woocommerce.android.analytics.AnalyticsTracker.Companion.VALUE_SIMPLE_PAYMENTS_COLLECT_CASH
 import com.woocommerce.android.analytics.AnalyticsTracker.Companion.VALUE_SIMPLE_PAYMENTS_COLLECT_LINK
 import com.woocommerce.android.cardreader.internal.payments.PaymentUtils
+import com.woocommerce.android.ciab.CIABAffectedFeature
+import com.woocommerce.android.ciab.CIABSiteGateKeeper
 import com.woocommerce.android.extensions.CASH_ON_DELIVERY_PAYMENT_TYPE
 import com.woocommerce.android.extensions.isNotNullOrEmpty
 import com.woocommerce.android.model.Order
@@ -78,6 +80,7 @@ class SelectPaymentMethodViewModel @Inject constructor(
     private val cardReaderTrackingInfoKeeper: CardReaderTrackingInfoKeeper,
     private val paymentsUtils: PaymentUtils,
     private val logOrderCurrencyMismatchWithSiteSettings: SelectPaymentMethodCurrencyMissMatchLog,
+    private val ciabSiteGateKeeper: CIABSiteGateKeeper
 ) : ScopedViewModel(savedState) {
     private val navArgs: SelectPaymentMethodFragmentArgs by savedState.navArgs()
 
@@ -173,7 +176,8 @@ class SelectPaymentMethodViewModel @Inject constructor(
                     R.string.card_reader_connect_learn_more,
                     containsHtml = true
                 ),
-                onClick = ::onLearnMoreIppClicked
+                onClick = ::onLearnMoreIppClicked,
+                isVisible = ciabSiteGateKeeper.isFeatureSupported(CIABAffectedFeature.WooPayments)
             )
         )
     }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/methodselection/SelectPaymentMethodViewState.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/methodselection/SelectPaymentMethodViewState.kt
@@ -30,6 +30,7 @@ sealed class SelectPaymentMethodViewState {
 
         data class LearnMoreIpp(
             val label: UiString,
+            val isVisible: Boolean,
             val onClick: () -> Unit,
         )
     }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/taptopay/TapToPayAvailabilityStatus.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/taptopay/TapToPayAvailabilityStatus.kt
@@ -3,6 +3,8 @@ package com.woocommerce.android.ui.payments.taptopay
 import com.woocommerce.android.cardreader.config.CardReaderConfigForSupportedCountry
 import com.woocommerce.android.cardreader.config.CardReaderConfigForUnsupportedCountry
 import com.woocommerce.android.cardreader.connection.ReaderType
+import com.woocommerce.android.ciab.CIABAffectedFeature
+import com.woocommerce.android.ciab.CIABSiteGateKeeper
 import com.woocommerce.android.tools.SelectedSite
 import com.woocommerce.android.ui.payments.cardreader.CardReaderCountryConfigProvider
 import com.woocommerce.android.util.DeviceFeatures
@@ -16,9 +18,11 @@ class TapToPayAvailabilityStatus @Inject constructor(
     private val systemVersionUtilsWrapper: SystemVersionUtilsWrapper,
     private val cardReaderCountryConfigProvider: CardReaderCountryConfigProvider,
     private val wooStore: WooCommerceStore,
+    private val ciabSiteGateKeeper: CIABSiteGateKeeper
 ) {
     operator fun invoke() =
         when {
+            ciabSiteGateKeeper.isFeatureUnsupported(CIABAffectedFeature.WooPayments) -> Result.Hidden
             !systemVersionUtilsWrapper.isAtLeastR() -> Result.NotAvailable.SystemVersionNotSupported
             !deviceFeatures.isGooglePlayServicesAvailable() -> Result.NotAvailable.GooglePlayServicesNotAvailable
             !deviceFeatures.isNFCAvailable() -> Result.NotAvailable.NfcNotAvailable
@@ -38,6 +42,7 @@ class TapToPayAvailabilityStatus @Inject constructor(
 
     sealed class Result {
         object Available : Result()
+        object Hidden : Result()
         sealed class NotAvailable : Result() {
             object SystemVersionNotSupported : NotAvailable()
             object GooglePlayServicesNotAvailable : NotAvailable()

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/moremenu/MoreMenuViewModelTests.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/moremenu/MoreMenuViewModelTests.kt
@@ -458,7 +458,7 @@ class MoreMenuViewModelTests : BaseUnitTest() {
     fun `given CIAB reports payments disabled, when building state, then payments button is hidden`() = testBlocking {
         // GIVEN
         setup {
-            whenever(ciabSiteGateKeeper.isFeatureSupported(CIABAffectedFeature.Payments))
+            whenever(ciabSiteGateKeeper.isFeatureSupported(CIABAffectedFeature.WooPayments))
                 .thenReturn(false)
         }
 

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/payments/SelectPaymentMethodViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/payments/SelectPaymentMethodViewModelTest.kt
@@ -3,6 +3,8 @@ package com.woocommerce.android.ui.payments
 import com.woocommerce.android.AppUrls
 import com.woocommerce.android.R
 import com.woocommerce.android.cardreader.internal.payments.PaymentUtils
+import com.woocommerce.android.ciab.CIABAffectedFeature
+import com.woocommerce.android.ciab.CIABSiteGateKeeper
 import com.woocommerce.android.extensions.CASH_ON_DELIVERY_PAYMENT_TYPE
 import com.woocommerce.android.model.Order
 import com.woocommerce.android.model.OrderMapper
@@ -45,6 +47,7 @@ import kotlinx.coroutines.test.runTest
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.Test
 import org.mockito.kotlin.any
+import org.mockito.kotlin.doReturn
 import org.mockito.kotlin.eq
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.never
@@ -113,6 +116,9 @@ class SelectPaymentMethodViewModelTest : BaseUnitTest() {
     private val paymentsUtils: PaymentUtils = mock()
     private val cardReaderTrackingInfoKeeper: CardReaderTrackingInfoKeeper = mock()
     private val logOrderCurrencyMismatchWithSiteSettings = mock<SelectPaymentMethodCurrencyMissMatchLog>()
+    private val ciabSiteGateKeeper: CIABSiteGateKeeper = mock {
+        on { isFeatureSupported(CIABAffectedFeature.WooPayments) } doReturn true
+    }
 
     @Test
     fun `given hub flow, when view model init, then navigate to hub flow emitted`() = testBlocking {
@@ -1190,24 +1196,41 @@ class SelectPaymentMethodViewModelTest : BaseUnitTest() {
         )
     }
 
+    @Test
+    fun `given WooPayments unsupported by CIAB, when view model initialized, then hide IPP learn more link`() =
+        testBlocking {
+            // GIVEN
+            whenever(ciabSiteGateKeeper.isFeatureSupported(CIABAffectedFeature.WooPayments)).thenReturn(false)
+
+            // WHEN
+            val viewModel = initViewModel(Payment(1L, ORDER))
+
+            // THEN
+            val state = (viewModel.viewStateData.value as Success).learnMoreIpp
+            assertThat(state.isVisible).isFalse()
+        }
+
     private fun initViewModel(cardReaderFlowParam: CardReaderFlowParam): SelectPaymentMethodViewModel {
         return SelectPaymentMethodViewModel(
-            SelectPaymentMethodFragmentArgs(cardReaderFlowParam = cardReaderFlowParam).toSavedStateHandle(),
-            selectedSite,
-            orderStore,
-            gatewayStore,
-            coroutinesTestRule.testDispatchers,
-            networkStatus,
-            currencyFormatter,
-            wooCommerceStore,
-            orderMapper,
-            cardPaymentCollectibilityChecker,
-            learnMoreUrlProvider,
-            paymentsFlowTracker,
-            tapToPayAvailabilityStatus,
-            cardReaderTrackingInfoKeeper,
-            paymentsUtils,
-            logOrderCurrencyMismatchWithSiteSettings,
+            savedState = SelectPaymentMethodFragmentArgs(
+                cardReaderFlowParam = cardReaderFlowParam
+            ).toSavedStateHandle(),
+            selectedSite = selectedSite,
+            orderStore = orderStore,
+            gatewayStore = gatewayStore,
+            dispatchers = coroutinesTestRule.testDispatchers,
+            networkStatus = networkStatus,
+            currencyFormatter = currencyFormatter,
+            wooCommerceStore = wooCommerceStore,
+            orderMapper = orderMapper,
+            cardPaymentCollectibilityChecker = cardPaymentCollectibilityChecker,
+            learnMoreUrlProvider = learnMoreUrlProvider,
+            paymentsFlowTracker = paymentsFlowTracker,
+            tapToPayAvailabilityStatus = tapToPayAvailabilityStatus,
+            cardReaderTrackingInfoKeeper = cardReaderTrackingInfoKeeper,
+            paymentsUtils = paymentsUtils,
+            logOrderCurrencyMismatchWithSiteSettings = logOrderCurrencyMismatchWithSiteSettings,
+            ciabSiteGateKeeper = ciabSiteGateKeeper
         )
     }
 

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/payments/cardreader/CardReaderPaymentCollectibilityCheckerTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/payments/cardreader/CardReaderPaymentCollectibilityCheckerTest.kt
@@ -1,5 +1,7 @@
 package com.woocommerce.android.ui.payments.cardreader
 
+import com.woocommerce.android.ciab.CIABAffectedFeature
+import com.woocommerce.android.ciab.CIABSiteGateKeeper
 import com.woocommerce.android.model.Order
 import com.woocommerce.android.ui.orders.OrderTestUtils
 import com.woocommerce.android.ui.orders.details.OrderDetailRepository
@@ -22,9 +24,13 @@ import java.util.Date
 class CardReaderPaymentCollectibilityCheckerTest : BaseUnitTest() {
     private val repository: OrderDetailRepository = mock()
     private val cardReaderPaymentCurrencySupportedChecker: CardReaderPaymentCurrencySupportedChecker = mock()
+    private val testCiabSiteGateKeeper: CIABSiteGateKeeper = mock {
+        on { isFeatureSupported(CIABAffectedFeature.WooPayments) } doReturn true
+    }
     private val checker: CardReaderPaymentCollectibilityChecker = CardReaderPaymentCollectibilityChecker(
-        repository,
-        cardReaderPaymentCurrencySupportedChecker,
+        orderDetailRepository = repository,
+        cardReaderPaymentCurrencySupportedChecker = cardReaderPaymentCurrencySupportedChecker,
+        ciabSiteGateKeeper = testCiabSiteGateKeeper
     )
 
     private val generatedOrder = OrderTestUtils.generateTestOrder()
@@ -342,6 +348,20 @@ class CardReaderPaymentCollectibilityCheckerTest : BaseUnitTest() {
 
             // THEN
             assertThat(isCollectable).isTrue()
+        }
+
+    @Test
+    fun `given WooPayments is not supported by CIAB, when check order is collectable, then returns false`() =
+        testBlocking {
+            // GIVEN
+            whenever(testCiabSiteGateKeeper.isFeatureSupported(CIABAffectedFeature.WooPayments)) doReturn false
+            val order = getOrder()
+
+            // WHEN
+            val isCollectable = checker.isCollectable(order)
+
+            // THEN
+            assertThat(isCollectable).isFalse()
         }
 
     private fun getOrder(

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/payments/taptopay/TapToPayAvailabilityStatusTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/payments/taptopay/TapToPayAvailabilityStatusTest.kt
@@ -3,6 +3,8 @@ package com.woocommerce.android.ui.payments.taptopay
 import com.woocommerce.android.cardreader.config.CardReaderConfigForCanada
 import com.woocommerce.android.cardreader.config.CardReaderConfigForUSA
 import com.woocommerce.android.cardreader.config.CardReaderConfigForUnsupportedCountry
+import com.woocommerce.android.ciab.CIABAffectedFeature
+import com.woocommerce.android.ciab.CIABSiteGateKeeper
 import com.woocommerce.android.tools.SelectedSite
 import com.woocommerce.android.ui.payments.cardreader.CardReaderCountryConfigProvider
 import com.woocommerce.android.util.DeviceFeatures
@@ -30,15 +32,18 @@ class TapToPayAvailabilityStatusTest {
     private val wooStore: WooCommerceStore = mock {
         on { getStoreCountryCode(siteModel) }.thenReturn("US")
     }
-
     private val deviceFeatures = mock<DeviceFeatures>()
+    private val ciabSiteGateKeeper: CIABSiteGateKeeper = mock {
+        on { isFeatureUnsupported(CIABAffectedFeature.WooPayments) }.thenReturn(false)
+    }
 
     private val availabilityStatus = TapToPayAvailabilityStatus(
-        selectedSite,
-        deviceFeatures,
-        systemVersionUtilsWrapper,
-        cardReaderCountryConfigProvider,
-        wooStore,
+        selectedSite = selectedSite,
+        deviceFeatures = deviceFeatures,
+        systemVersionUtilsWrapper = systemVersionUtilsWrapper,
+        cardReaderCountryConfigProvider = cardReaderCountryConfigProvider,
+        wooStore = wooStore,
+        ciabSiteGateKeeper = ciabSiteGateKeeper
     )
 
     @Test
@@ -95,5 +100,17 @@ class TapToPayAvailabilityStatusTest {
         val result = availabilityStatus.invoke()
 
         assertThat(result).isEqualTo(TapToPayAvailabilityStatus.Result.Available)
+    }
+
+    @Test
+    fun `given CIAB blocks WooPayments, when invoking, then tpp hidden returned`() {
+        whenever(deviceFeatures.isNFCAvailable()).thenReturn(true)
+        whenever(deviceFeatures.isGooglePlayServicesAvailable()).thenReturn(true)
+        whenever(systemVersionUtilsWrapper.isAtLeastR()).thenReturn(true)
+        whenever(ciabSiteGateKeeper.isFeatureUnsupported(CIABAffectedFeature.WooPayments)).thenReturn(true)
+
+        val result = availabilityStatus.invoke()
+
+        assertThat(result).isEqualTo(TapToPayAvailabilityStatus.Result.Hidden)
     }
 }


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

<!-- Id number of the Linear issue this PR addresses, e.g., WOOMOB-373. -->
Closes WOOMOB-1554

### Description
This PR handles the following changes:
- Disables card reader support for CIAB sites.
- Disables TTP support for CIAB sites.
- Hides the In-Person Payments "learn more" button in the payment method selection screen.

### Test Steps
1. Use a phyiscal device (to confirm TTP logic)
2. Open an existing order or create a new one.
3. Tap on Collect Payment.
4. Confirm that the unsupported options are hidden now.

### Images/gif
| Before | After |
| --- | --- |
| <img width="1080" height="2400" alt="Screenshot_20251026_123227" src="https://github.com/user-attachments/assets/6514f89d-ce13-4fa3-9a07-904740bb028f" /> | <img width="1080" height="2400" alt="Screenshot_20251026_143226" src="https://github.com/user-attachments/assets/48c1654a-e4a1-4546-b609-023d64c7196d" /> |

- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
