### PR TITLE
[WOOMOB-1544] Fix POS Local Catalog settings toggle clickable area

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/settings/details/localcatalog/WooPosSettingsLocalCatalogScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/settings/details/localcatalog/WooPosSettingsLocalCatalogScreen.kt
@@ -2,6 +2,7 @@ package com.woocommerce.android.ui.woopos.settings.details.localcatalog
 
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
@@ -173,7 +174,13 @@ private fun SettingsSection(
         Spacer(modifier = Modifier.height(WooPosSpacing.Medium.value))
 
         Row(
-            modifier = Modifier.fillMaxWidth(),
+            modifier = Modifier
+                .fillMaxWidth()
+                .clip(RoundedCornerShape(WooPosCornerRadius.Medium.value))
+                .clickable(enabled = !isLoading) {
+                    onToggleCellularData(!allowCellularDataUpdate)
+                }
+                .padding(WooPosSpacing.Small.value),
             horizontalArrangement = Arrangement.SpaceBetween,
             verticalAlignment = Alignment.CenterVertically
         ) {
@@ -195,7 +202,7 @@ private fun SettingsSection(
 
             Switch(
                 checked = allowCellularDataUpdate,
-                onCheckedChange = { onToggleCellularData(it) },
+                onCheckedChange = null, // Disable direct interaction since the entire row is clickable
                 enabled = !isLoading,
                 colors = SwitchDefaults.colors(
                     checkedThumbColor = MaterialTheme.colorScheme.primary,


### PR DESCRIPTION
Fixes WOOMOB-1544

### Description
The "Allow full update on cellular data" toggle in POS Local catalog settings was only clickable on the toggle switch itself, not the entire row. This made it difficult for users to interact with the setting as they had to tap precisely on the toggle control.

This PR fixes the issue by making the entire row clickable with proper visual feedback.

### Test Steps
1. Open the WooCommerce POS app
2. Navigate to Settings
3. Go to Local Catalog settings
4. Tap anywhere on the "Allow full update on cellular data" row (not just the toggle)
5. Verify the toggle switches state when tapping anywhere on the row

### Images/gif

https://github.com/user-attachments/assets/381eb689-3af2-4559-a539-4f035e3218b9



- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.