### PR TITLE
Prevent crash when creating or adding logs to file

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/util/crashlogging/EncryptedLogsFileProvider.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/util/crashlogging/EncryptedLogsFileProvider.kt
@@ -12,10 +12,14 @@ class EncryptedLogsFileProvider @Inject constructor(
 ) {
     suspend fun provide(): File {
         return withContext(dispatchers.io) {
-            val logs = wooLog.getCurrentLogEntries().take(LOG_ENTRIES_LIMIT)
-
-            File.createTempFile("log", "").apply {
-                appendText(logs.joinToString("\n"))
+            runCatching {
+                val logs = wooLog.getCurrentLogEntries().take(LOG_ENTRIES_LIMIT)
+                File.createTempFile("log", "").apply {
+                    appendText(logs.joinToString("\n"))
+                }
+            }.getOrElse { exception ->
+                WooLog.e(WooLog.T.UTILS, "Could not create log file: ${exception.message}")
+                File.createTempFile("log_empty_file_due_to_error", "")
             }
         }
     }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/util/crashlogging/EncryptedLogsFileProvider.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/util/crashlogging/EncryptedLogsFileProvider.kt
@@ -10,17 +10,16 @@ class EncryptedLogsFileProvider @Inject constructor(
     private val wooLog: WooLog,
     private val dispatchers: CoroutineDispatchers
 ) {
-    suspend fun provide(): File {
+    suspend fun provide(): File? {
         return withContext(dispatchers.io) {
             runCatching {
                 val logs = wooLog.getCurrentLogEntries().take(LOG_ENTRIES_LIMIT)
                 File.createTempFile("log", "").apply {
                     appendText(logs.joinToString("\n"))
                 }
-            }.getOrElse { exception ->
+            }.onFailure { exception ->
                 WooLog.e(WooLog.T.UTILS, "Could not create log file: ${exception.message}")
-                File.createTempFile("log_empty_file_due_to_error", "")
-            }
+            }.getOrNull()
         }
     }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/util/crashlogging/EnqueueSendingEncryptedLogs.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/util/crashlogging/EnqueueSendingEncryptedLogs.kt
@@ -21,19 +21,22 @@ class EnqueueSendingEncryptedLogs @Inject constructor(
         eventLevel: EventLevel
     ) {
         if (eventLevel == FATAL) {
-            val logs = runBlocking { encryptedLogsFileProvider.provide() }
-            encryptedLogging.enqueueSendingEncryptedLogs(
-                uuid = uuid,
-                file = logs,
-                shouldUploadImmediately = false
-            )
-        } else {
-            appCoroutineScope.launch {
+            runBlocking { encryptedLogsFileProvider.provide() }?.let { logs ->
                 encryptedLogging.enqueueSendingEncryptedLogs(
                     uuid = uuid,
-                    file = encryptedLogsFileProvider.provide(),
-                    shouldUploadImmediately = networkStatus.isConnected()
+                    file = logs,
+                    shouldUploadImmediately = false
                 )
+            }
+        } else {
+            appCoroutineScope.launch {
+                encryptedLogsFileProvider.provide()?.let { logs ->
+                    encryptedLogging.enqueueSendingEncryptedLogs(
+                        uuid = uuid,
+                        file = logs,
+                        shouldUploadImmediately = networkStatus.isConnected()
+                    )
+                }
             }
         }
     }


### PR DESCRIPTION
Fixes: WOOMOB-1449

### Description
Avoid crashing the app when attempting to save logs into the disk and the device doesn't have space left: 
```
android.system.ErrnoException: write failed: ENOSPC (No space left on device)
    at libcore.io.Linux.writeBytes(Linux.java)
    at libcore.io.Linux.write(Linux.java:288)
    at libcore.io.BlockGuardOs.write(BlockGuardOs.java:345)
    at libcore.io.IoBridge.write(IoBridge.java:553)
    at java.io.FileOutputStream.write(FileOutputStream.java:326)
    at kotlin.io.FilesKt__FileReadWriteKt.writeTextImpl(FileReadWrite.kt:174)
    at kotlin.io.FilesKt__FileReadWriteKt.appendText(FileReadWrite.kt:150)
    at kotlin.io.FilesKt__FileReadWriteKt.appendText$default(FileReadWrite.kt:149)
    at com.woocommerce.android.util.crashlogging.EncryptedLogsFileProvider$provide$2.invokeSuspend(EncryptedLogsFileProvider.kt:18)
 ```

### Test Steps
I've tried replicating the bug as well as trying to see if I could make the logcat display `Could not create log file: ...` error log. But after filling up space on the device the app would start crashing for many issues realted to no space left:
```
Error writing Envelope /data/user/0/com.woocommerce.android.dev/cache/sentry/dd5244304f3c4c51 ...
java.io.IOException: write failed: ENOSPC (No space left on device)
	at libcore.io.IoBridge.write(IoBridge.java:651)


OR 

Error writing entry; local database full: android.database.sqlite.SQLiteFullException: database or disk is full
```

Which also validates the [point made](https://linear.app/a8c/issue/WOOMOB-1449/crash-due-to-encrypted-logs-writing#comment-acc5d466) in Linear Issue about disk space issues. 

