### PR TITLE
[CIAB] Display filters status on the booking list screen

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/bookings/list/BookingListScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/bookings/list/BookingListScreen.kt
@@ -304,16 +304,33 @@ private fun BookingListControls(
             )
         }
         if (state.isFilterButtonVisible) {
+            val areFiltersEnabled = state.enabledFiltersCount > 0
             OutlinedButton(
                 modifier = Modifier.defaultMinSize(minWidth = 88.dp, minHeight = 36.dp),
                 contentPadding = PaddingValues(horizontal = 16.dp),
                 colors = ButtonDefaults.outlinedButtonColors().copy(
-                    contentColor = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.6f)
+                    containerColor = if (areFiltersEnabled) {
+                        MaterialTheme.colorScheme.primary
+                    } else {
+                        MaterialTheme.colorScheme.surface
+                    },
+                    contentColor = if (areFiltersEnabled) {
+                        MaterialTheme.colorScheme.onPrimary
+                    } else {
+                        MaterialTheme.colorScheme.onSurface.copy(alpha = 0.6f)
+                    }
                 ),
                 onClick = state.onFilterClick,
             ) {
                 Text(
-                    text = stringResource(R.string.bookings_filters_default_title),
+                    text = if (areFiltersEnabled) {
+                        stringResource(
+                            id = R.string.bookings_filters_enabled_title,
+                            state.enabledFiltersCount
+                        )
+                    } else {
+                        stringResource(R.string.bookings_filters_default_title)
+                    },
                     style = MaterialTheme.typography.bodyMedium,
                 )
             }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/bookings/list/BookingListScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/bookings/list/BookingListScreen.kt
@@ -88,7 +88,8 @@ fun BookingListScreen(state: BookingListViewState) {
                 actions = {
                     SearchSection(
                         searchState = state.searchState,
-                        areFiltersActive = state.areFiltersActive || state.tabState.selectedTab != BookingListTab.All
+                        areFiltersActive = state.controlsState.areFiltersActive ||
+                            state.tabState.selectedTab != BookingListTab.All
                     )
                 }
             )
@@ -304,17 +305,16 @@ private fun BookingListControls(
             )
         }
         if (state.isFilterButtonVisible) {
-            val areFiltersEnabled = state.enabledFiltersCount > 0
             OutlinedButton(
                 modifier = Modifier.defaultMinSize(minWidth = 88.dp, minHeight = 36.dp),
                 contentPadding = PaddingValues(horizontal = 16.dp),
                 colors = ButtonDefaults.outlinedButtonColors().copy(
-                    containerColor = if (areFiltersEnabled) {
+                    containerColor = if (state.areFiltersActive) {
                         MaterialTheme.colorScheme.primary
                     } else {
                         MaterialTheme.colorScheme.surface
                     },
-                    contentColor = if (areFiltersEnabled) {
+                    contentColor = if (state.areFiltersActive) {
                         MaterialTheme.colorScheme.onPrimary
                     } else {
                         MaterialTheme.colorScheme.onSurface.copy(alpha = 0.6f)
@@ -323,7 +323,7 @@ private fun BookingListControls(
                 onClick = state.onFilterClick,
             ) {
                 Text(
-                    text = if (areFiltersEnabled) {
+                    text = if (state.areFiltersActive) {
                         stringResource(
                             id = R.string.bookings_filters_enabled_title,
                             state.enabledFiltersCount
@@ -356,13 +356,13 @@ private fun EmptyView(
 
         if (state.searchState.query?.isNotEmpty() == true) {
             EmptySearchResultsView(
-                areFiltersActive = state.areFiltersActive,
+                areFiltersActive = state.controlsState.areFiltersActive,
                 modifier = innerEmptyViewModifier
             )
         } else {
             EmptyListView(
                 selectedTab = state.tabState.selectedTab,
-                areFiltersActive = state.areFiltersActive,
+                areFiltersActive = state.controlsState.areFiltersActive,
                 onChangeFiltersClick = state.controlsState.onFilterClick,
                 onClearFiltersClick = state.controlsState.onClearFiltersClick,
                 modifier = innerEmptyViewModifier

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/bookings/list/BookingListScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/bookings/list/BookingListScreen.kt
@@ -363,6 +363,8 @@ private fun EmptyView(
             EmptyListView(
                 selectedTab = state.tabState.selectedTab,
                 areFiltersActive = state.areFiltersActive,
+                onChangeFiltersClick = state.controlsState.onFilterClick,
+                onClearFiltersClick = state.controlsState.onClearFiltersClick,
                 modifier = innerEmptyViewModifier
             )
         }
@@ -373,6 +375,8 @@ private fun EmptyView(
 private fun EmptyListView(
     selectedTab: BookingListTab,
     areFiltersActive: Boolean,
+    onChangeFiltersClick: () -> Unit,
+    onClearFiltersClick: () -> Unit,
     modifier: Modifier
 ) {
     Column(
@@ -421,13 +425,13 @@ private fun EmptyListView(
             Spacer(Modifier.height(24.dp))
             WCColoredButton(
                 text = stringResource(R.string.bookings_empty_state_change_filters_button),
-                onClick = { TODO() },
+                onClick = onChangeFiltersClick,
                 modifier = Modifier.fillMaxWidth()
             )
             Spacer(Modifier.height(8.dp))
             WCOutlinedButton(
                 text = stringResource(R.string.bookings_empty_state_clear_filters_button),
-                onClick = { TODO() },
+                onClick = onClearFiltersClick,
                 modifier = Modifier.fillMaxWidth()
             )
         }
@@ -507,7 +511,8 @@ private fun BookingListPreview() {
                     isFilterButtonVisible = true,
                     enabledFiltersCount = 0,
                     onSortClick = {},
-                    onFilterClick = {}
+                    onFilterClick = {},
+                    onClearFiltersClick = {},
                 ),
                 sortBottomSheetState = null,
                 searchState = BookingListSearchState(
@@ -542,6 +547,7 @@ private fun EmptyViewPreview() {
                     enabledFiltersCount = 0,
                     onSortClick = {},
                     onFilterClick = {},
+                    onClearFiltersClick = {},
                 ),
                 sortBottomSheetState = null,
                 searchState = BookingListSearchState(
@@ -576,6 +582,7 @@ private fun EmptySearchResultsViewPreview() {
                     enabledFiltersCount = 0,
                     onSortClick = {},
                     onFilterClick = {},
+                    onClearFiltersClick = {},
                 ),
                 sortBottomSheetState = null,
                 searchState = BookingListSearchState(

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/bookings/list/BookingListScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/bookings/list/BookingListScreen.kt
@@ -47,6 +47,8 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.focus.FocusRequester
 import androidx.compose.ui.focus.focusRequester
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.res.colorResource
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
@@ -310,12 +312,12 @@ private fun BookingListControls(
                 contentPadding = PaddingValues(horizontal = 16.dp),
                 colors = ButtonDefaults.outlinedButtonColors().copy(
                     containerColor = if (state.areFiltersActive) {
-                        MaterialTheme.colorScheme.primary
+                        colorResource(R.color.primary_colored_button_background)
                     } else {
                         MaterialTheme.colorScheme.surface
                     },
                     contentColor = if (state.areFiltersActive) {
-                        MaterialTheme.colorScheme.onPrimary
+                        Color.White
                     } else {
                         MaterialTheme.colorScheme.onSurface.copy(alpha = 0.6f)
                     }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/bookings/list/BookingListScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/bookings/list/BookingListScreen.kt
@@ -488,6 +488,7 @@ private fun BookingListPreview() {
                 controlsState = BookingListControlsState(
                     selectedSortOption = BookingListSortOption.NewestToOldest,
                     isFilterButtonVisible = true,
+                    enabledFiltersCount = 0,
                     onSortClick = {},
                     onFilterClick = {}
                 ),
@@ -520,9 +521,10 @@ private fun EmptyViewPreview() {
                 ),
                 controlsState = BookingListControlsState(
                     selectedSortOption = BookingListSortOption.NewestToOldest,
+                    isFilterButtonVisible = true,
+                    enabledFiltersCount = 0,
                     onSortClick = {},
                     onFilterClick = {},
-                    isFilterButtonVisible = true
                 ),
                 sortBottomSheetState = null,
                 searchState = BookingListSearchState(
@@ -553,9 +555,10 @@ private fun EmptySearchResultsViewPreview() {
                 ),
                 controlsState = BookingListControlsState(
                     selectedSortOption = BookingListSortOption.NewestToOldest,
+                    isFilterButtonVisible = true,
+                    enabledFiltersCount = 0,
                     onSortClick = {},
                     onFilterClick = {},
-                    isFilterButtonVisible = true
                 ),
                 sortBottomSheetState = null,
                 searchState = BookingListSearchState(

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/bookings/list/BookingListViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/bookings/list/BookingListViewModel.kt
@@ -35,7 +35,7 @@ import javax.inject.Inject
 @HiltViewModel
 class BookingListViewModel @Inject constructor(
     savedStateHandle: SavedStateHandle,
-    bookingFilterRepository: BookingFilterRepository,
+    private val bookingFilterRepository: BookingFilterRepository,
     private val bookingListHandler: BookingListHandler,
     private val filtersBuilder: BookingListFiltersBuilder,
     private val bookingMapper: BookingMapper,
@@ -98,7 +98,8 @@ class BookingListViewModel @Inject constructor(
             isFilterButtonVisible = tab == BookingListTab.All,
             enabledFiltersCount = filters.enabledFiltersCount,
             onSortClick = ::onSortClicked,
-            onFilterClick = ::onFilterClicked
+            onFilterClick = ::onFilterClicked,
+            onClearFiltersClick = ::onClearFiltersClicked
         )
     }
     private val listSortBottomSheetState = combine(
@@ -246,6 +247,12 @@ class BookingListViewModel @Inject constructor(
 
     private fun onFilterClicked() {
         triggerEvent(NavigateToFilters)
+    }
+
+    private fun onClearFiltersClicked() {
+        launch {
+            bookingFilterRepository.save(BookingFilters.EMPTY)
+        }
     }
 
     private fun FetchParams.prepareFilters(): List<BookingsFilterOption> = with(filtersBuilder) {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/bookings/list/BookingListViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/bookings/list/BookingListViewModel.kt
@@ -76,35 +76,50 @@ class BookingListViewModel @Inject constructor(
             }
         )
     }
+    private val tabsState = selectedTab.map {
+        BookingListTabState(
+            selectedTab = it,
+            onTabChanged = ::onTabChanged
+        )
+    }
+    private val controlsState = combine(
+        selectedTab,
+        sortOption,
+    ) { tab, sort ->
+        BookingListControlsState(
+            selectedSortOption = sort,
+            isFilterButtonVisible = tab == BookingListTab.All,
+            onSortClick = ::onSortClicked,
+            onFilterClick = ::onFilterClicked
+        )
+    }
+    private val listSortBottomSheetState = combine(
+        sortOption,
+        isSortSheetVisible
+    ) { sortOption, sheetVisible ->
+        if (sheetVisible) {
+            BookingListSortBottomSheetState(
+                selectedOption = sortOption,
+                onSelect = ::onSortOptionSelected,
+                onDismiss = ::onSortDismiss
+            )
+        } else {
+            null
+        }
+    }
 
     val state = combine(
         contentState,
-        selectedTab,
-        sortOption,
-        isSortSheetVisible,
+        tabsState,
+        controlsState,
+        listSortBottomSheetState,
         searchState
-    ) { contentState, selectedTab, sortOption, sheetVisible, searchState ->
+    ) { contentState, tabsState, controlsState, listSortBottomSheetState, searchState ->
         BookingListViewState(
             contentState = contentState,
-            tabState = BookingListTabState(
-                selectedTab = selectedTab,
-                onTabChanged = ::onTabChanged
-            ),
-            controlsState = BookingListControlsState(
-                selectedSortOption = sortOption,
-                isFilterButtonVisible = selectedTab == BookingListTab.All,
-                onSortClick = ::onSortClicked,
-                onFilterClick = ::onFilterClicked
-            ),
-            sortBottomSheetState = if (sheetVisible) {
-                BookingListSortBottomSheetState(
-                    selectedOption = sortOption,
-                    onSelect = ::onSortOptionSelected,
-                    onDismiss = ::onSortDismiss
-                )
-            } else {
-                null
-            },
+            tabState = tabsState,
+            controlsState = controlsState,
+            sortBottomSheetState = listSortBottomSheetState,
             searchState = searchState
         )
     }.asLiveData()

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/bookings/list/BookingListViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/bookings/list/BookingListViewModel.kt
@@ -17,22 +17,25 @@ import kotlinx.coroutines.FlowPreview
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.debounce
 import kotlinx.coroutines.flow.flatMapLatest
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.onStart
+import kotlinx.coroutines.flow.shareIn
 import kotlinx.coroutines.flow.withIndex
 import kotlinx.coroutines.launch
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.bookings.BookingFilters
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.bookings.BookingsFilterOption
 import javax.inject.Inject
 
+@OptIn(FlowPreview::class, ExperimentalCoroutinesApi::class)
 @HiltViewModel
 class BookingListViewModel @Inject constructor(
     savedStateHandle: SavedStateHandle,
-    private val bookingFilterRepository: BookingFilterRepository,
+    bookingFilterRepository: BookingFilterRepository,
     private val bookingListHandler: BookingListHandler,
     private val filtersBuilder: BookingListFiltersBuilder,
     private val bookingMapper: BookingMapper,
@@ -45,6 +48,9 @@ class BookingListViewModel @Inject constructor(
         clazz = String::class.java,
         key = "searchQuery"
     )
+    private val filters = bookingFilterRepository.bookingFiltersFlow
+        .shareIn(viewModelScope, started = SharingStarted.WhileSubscribed(), replay = 1)
+
     private val refreshTrigger = MutableSharedFlow<Unit>(extraBufferCapacity = 1)
 
     private val sortOption = savedStateHandle.getStateFlow(viewModelScope, BookingListSortOption.NewestToOldest)
@@ -85,10 +91,12 @@ class BookingListViewModel @Inject constructor(
     private val controlsState = combine(
         selectedTab,
         sortOption,
-    ) { tab, sort ->
+        filters
+    ) { tab, sort, filters ->
         BookingListControlsState(
             selectedSortOption = sort,
             isFilterButtonVisible = tab == BookingListTab.All,
+            enabledFiltersCount = filters.enabledFiltersCount,
             onSortClick = ::onSortClicked,
             onFilterClick = ::onFilterClicked
         )
@@ -131,7 +139,6 @@ class BookingListViewModel @Inject constructor(
         monitorSearchAndFilterChanges()
     }
 
-    @OptIn(FlowPreview::class, ExperimentalCoroutinesApi::class)
     private fun monitorSearchAndFilterChanges() {
         launch {
             var lastFetchParams: FetchParams? = null
@@ -147,7 +154,7 @@ class BookingListViewModel @Inject constructor(
                 selectedTab,
                 queryFlow,
                 sortOption,
-                bookingFilterRepository.bookingFiltersFlow
+                filters
             ) { tab, query, sort, filters ->
                 FetchParams(
                     searchQuery = query,

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/bookings/list/BookingListViewState.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/bookings/list/BookingListViewState.kt
@@ -7,7 +7,7 @@ data class BookingListViewState(
     val tabState: BookingListTabState,
     val controlsState: BookingListControlsState,
     val sortBottomSheetState: BookingListSortBottomSheetState?,
-    val searchState: BookingListSearchState
+    val searchState: BookingListSearchState,
 ) {
     val areFiltersActive: Boolean
         get() = controlsState.enabledFiltersCount > 0
@@ -41,7 +41,8 @@ data class BookingListControlsState(
     val isFilterButtonVisible: Boolean,
     val enabledFiltersCount: Int,
     val onSortClick: () -> Unit,
-    val onFilterClick: () -> Unit
+    val onFilterClick: () -> Unit,
+    val onClearFiltersClick: () -> Unit
 )
 
 data class BookingListItem(

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/bookings/list/BookingListViewState.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/bookings/list/BookingListViewState.kt
@@ -8,10 +8,7 @@ data class BookingListViewState(
     val controlsState: BookingListControlsState,
     val sortBottomSheetState: BookingListSortBottomSheetState?,
     val searchState: BookingListSearchState,
-) {
-    val areFiltersActive: Boolean
-        get() = controlsState.enabledFiltersCount > 0
-}
+)
 
 data class BookingListContentState(
     val bookings: List<BookingListItem>,
@@ -43,7 +40,10 @@ data class BookingListControlsState(
     val onSortClick: () -> Unit,
     val onFilterClick: () -> Unit,
     val onClearFiltersClick: () -> Unit
-)
+) {
+    val areFiltersActive: Boolean
+        get() = enabledFiltersCount > 0
+}
 
 data class BookingListItem(
     val id: Long,

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/bookings/list/BookingListViewState.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/bookings/list/BookingListViewState.kt
@@ -9,9 +9,8 @@ data class BookingListViewState(
     val sortBottomSheetState: BookingListSortBottomSheetState?,
     val searchState: BookingListSearchState
 ) {
-    // TODO use filters when available
     val areFiltersActive: Boolean
-        get() = false
+        get() = controlsState.enabledFiltersCount > 0
 }
 
 data class BookingListContentState(
@@ -40,6 +39,7 @@ data class BookingListTabState(
 data class BookingListControlsState(
     val selectedSortOption: BookingListSortOption,
     val isFilterButtonVisible: Boolean,
+    val enabledFiltersCount: Int,
     val onSortClick: () -> Unit,
     val onFilterClick: () -> Unit
 )

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -4227,6 +4227,7 @@
     <string name="bookings_empty_state_change_filters_button">Change filters</string>
     <string name="bookings_empty_state_clear_filters_button">Clear filters</string>
     <string name="bookings_filters_default_title">Filters</string>
+    <string name="bookings_filters_enabled_title">Filters • %d</string>
     <string name="bookings_filters_count_title">Filters (%d)</string>
     <string name="bookings_filters_show_bookings">Show bookings</string>
     <string name="bookings_filter_title_team_member">Assigned team member</string>

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/bookings/list/BookingListViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/bookings/list/BookingListViewModelTest.kt
@@ -330,6 +330,24 @@ class BookingListViewModelTest : BaseUnitTest() {
         )
     }
 
+    @Test
+    fun `given enabled filters, when controls state is observed, then enabledFiltersCount is correct`() = testBlocking {
+        // GIVEN
+        setup()
+        val customerFilter = BookingsFilterOption.Customer(1L, "Customer")
+        bookingFiltersFlow.emit(
+            BookingFilters(customer = customerFilter)
+        )
+
+        // WHEN
+        val initialState = viewModel.state.getOrAwaitValue()
+        initialState.tabState.onTabChanged(BookingListTab.All)
+
+        // THEN
+        val controlsState = viewModel.state.getOrAwaitValue().controlsState
+        assertThat(controlsState.enabledFiltersCount).isEqualTo(1)
+    }
+
     private fun getSampleBooking(id: Int): Booking {
         return BookingEntity(
             id = LocalOrRemoteId.RemoteId(id.toLong()),

--- a/libs/fluxc-plugin/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/bookings/BookingsFilterOption.kt
+++ b/libs/fluxc-plugin/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/bookings/BookingsFilterOption.kt
@@ -46,4 +46,8 @@ data class BookingFilters(
             if (serviceEvent != null) count++
             return count
         }
+
+    companion object {
+        val EMPTY = BookingFilters()
+    }
 }

--- a/libs/fluxc-plugin/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/bookings/BookingsFilterOption.kt
+++ b/libs/fluxc-plugin/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/bookings/BookingsFilterOption.kt
@@ -32,4 +32,18 @@ data class BookingFilters(
     val bookingType: BookingsFilterOption.BookingType? = null,
     val location: BookingsFilterOption.Location? = null,
     val serviceEvent: BookingsFilterOption.ServiceEvent? = null,
-)
+) {
+    val enabledFiltersCount: Int
+        get() {
+            var count = 0
+            if (dateRange != null) count++
+            if (customer != null) count++
+            if (teamMember != null) count++
+            if (attendanceStatus != null) count++
+            if (paymentStatus != null) count++
+            if (bookingType != null) count++
+            if (location != null) count++
+            if (serviceEvent != null) count++
+            return count
+        }
+}


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

<!-- Id number of the Linear issue this PR addresses, e.g., WOOMOB-373. -->
Closes WOOMOB-1600

### Description
This PR handles two changes:
1. Add logic to expose the count of enabled filters to the Bookings list screen, and update the UI of the filters button when there are enabled filters.
2. Add implementation for the filter CTAs in the empty state.

### Test Steps
1. Apply the following patch to simulate filters:
<details><summary>Patch</summary>

```patch
Index: WooCommerce/src/main/kotlin/com/woocommerce/android/ui/bookings/filter/data/BookingFilterRepository.kt
IDEA additional info:
Subsystem: com.intellij.openapi.diff.impl.patch.CharsetEP
<+>UTF-8
===================================================================
diff --git a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/bookings/filter/data/BookingFilterRepository.kt b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/bookings/filter/data/BookingFilterRepository.kt
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/bookings/filter/data/BookingFilterRepository.kt	(revision 3222c35a7107d4df97ecb23d06593e12dac00b3b)
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/bookings/filter/data/BookingFilterRepository.kt	(date 1761657115025)
@@ -8,11 +8,14 @@
 import com.woocommerce.android.datastore.DataStoreQualifier
 import com.woocommerce.android.datastore.DataStoreType.BOOKINGS_FILTERS
 import com.woocommerce.android.tools.SelectedSite
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.flatMapLatest
 import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.launch
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.bookings.BookingFilters
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.bookings.BookingsFilterOption
 import java.time.Instant
@@ -40,6 +43,19 @@
         }
     }
 
+    init {
+        CoroutineScope(Dispatchers.Main).launch {
+            save(
+                BookingFilters(
+                    customer = BookingsFilterOption.Customer(
+                        customerId = 10L,
+                        customerName = "John Doe"
+                    )
+                )
+            )
+        }
+    }
+
     suspend fun save(bookingFilters: BookingFilters) {
         val siteId = selectedSite.getSelectedSiteId()
         dataStore.edit { prefs ->
```

</details> 

2. Open the bookings list.
3. Confirm the filters button is shown correctly.
4. If needed, modify the `customerId` value to not match any existing bookings on your site.
5. Open the bookings list.
6. Test the empty state CTAs.

### Images/gif
| Non-empty state | Empty state |
| --- | --- |
| <img width="1080" height="2400" alt="Screenshot_20251028_141832" src="https://github.com/user-attachments/assets/7ae5860a-5d36-4aae-9573-38cd839c8c11" /> | <img width="1080" height="2400" alt="Screenshot_20251028_142314" src="https://github.com/user-attachments/assets/ebfd69e2-c7b6-4839-8d47-4c146f238ac5" /> |

- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
