### PR TITLE
[Woo POS][Bug] Incorrect `activeSource` non-null checks

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/items/products/WooPosProductsDataSource.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/items/products/WooPosProductsDataSource.kt
@@ -102,8 +102,8 @@ class WooPosProductsDataSource @Inject constructor(
         get() = activeSource?.hasMoreProductsPages ?: error("hasMorePages - Data source not selected")
 
     suspend fun getProductById(productId: LocalOrRemoteId.RemoteId): WooPosProductModel? {
+        checkNotNull(activeSource) { "GetProductById - Data source not selected" }
         return activeSource?.getProductById(productId)
-            ?: error("GetProductById - Data source not selected")
     }
 
     suspend fun resetVariationsListHandler() {
@@ -131,8 +131,8 @@ class WooPosProductsDataSource @Inject constructor(
         productId: Long,
         variationId: Long
     ): WooPosVariation? {
+        checkNotNull(activeSource) { "GetVariationById - Data source not selected" }
         return activeSource?.getVariationById(productId, variationId)
-            ?: error("GetVariationById - Data source not selected")
     }
 
     sealed class ProductsResult {


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

<!-- Id number of the Linear issue this PR addresses, e.g., WOOMOB-373. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
This PR fixes incorrect checks for `activeSource` being null in `WooPosProductsDataSource`. Before, the code was not really checking if `activeSource` is null, but the result returned by `activeSource.getProductById()` and `activeSource.getVariationById()`.

### Test Steps
<!-- Describe how to test your changes. Include only what’s needed for the reviewer to validate the behavior.
For new features, outline the main user flow or goal rather than every tap or click — the reviewer should be able to complete the flow naturally.
If applicable, mention key devices, scenarios, or edge cases to verify. -->
Check if the code is correct.

### Images/gif
<!-- Include before and after images or gifs when appropriate. -->
N/A

- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
