### PR TITLE
Fix filter button text color

### DIFF
--- a/WooCommerce/src/main/res/color/button_outlined_text_selector.xml
+++ b/WooCommerce/src/main/res/color/button_outlined_text_selector.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8"?>
+<selector xmlns:android="http://schemas.android.com/apk/res/android">
+    <item
+        android:state_selected="true"
+        android:color="@color/color_surface"/>
+    <item
+        android:state_selected="false"
+        android:alpha="@dimen/alpha_emphasis_medium"
+        android:color="@color/color_on_surface"/>
+</selector>

--- a/WooCommerce/src/main/res/color/button_outlined_text_selector.xml
+++ b/WooCommerce/src/main/res/color/button_outlined_text_selector.xml
@@ -2,7 +2,7 @@
 <selector xmlns:android="http://schemas.android.com/apk/res/android">
     <item
         android:state_selected="true"
-        android:color="@color/color_surface"/>
+        android:color="@color/white"/>
     <item
         android:state_selected="false"
         android:alpha="@dimen/alpha_emphasis_medium"

--- a/WooCommerce/src/main/res/values/colors_base.xml
+++ b/WooCommerce/src/main/res/values/colors_base.xml
@@ -215,7 +215,6 @@
     <color name="light_colored_button_text_secondary">@color/color_primary</color>
     <color name="primary_colored_button_background">@color/woo_purple_40</color>
     <color name="text_button_over_bottom_sheet">@color/color_primary</color>
-    <color name="button_outlined_text">@color/white</color>
 
     <!--
     Analytics

--- a/WooCommerce/src/main/res/values/styles_base.xml
+++ b/WooCommerce/src/main/res/values/styles_base.xml
@@ -1,15 +1,14 @@
-<?xml version="1.0" encoding="utf-8"?><!--
+<?xml version="1.0" encoding="utf-8"?>
+<!--
 Base Woo Styles. Use these styles as a base for custom component styles and override only the
 properties necessary. The goal is to make as few modifications as possible to keep a consistent
 theme across the entire app. Overridden versions should be added to the styles.xml file.
 -->
-<resources xmlns:tools="http://schemas.android.com/tools">
-
-    <style name="Woo" />
-
-    <style name="Widget" />
-
-    <style name="Widget.Woo" />
+<resources
+    xmlns:tools="http://schemas.android.com/tools">
+    <style name="Woo"/>
+    <style name="Widget"/>
+    <style name="Widget.Woo"/>
 
     <!--
         Toolbar Styles
@@ -22,22 +21,18 @@ theme across the entire app. Overridden versions should be added to the styles.x
         <item name="android:paddingStart">0dp</item>
         <item name="android:paddingLeft">0dp</item>
     </style>
-
     <style name="Widget.Woo.Toolbar.Surface" parent="ThemeOverlay.MaterialComponents.Toolbar.Surface">
         <item name="actionMenuTextColor">@color/color_primary_selector</item>
     </style>
-
     <style name="TextAppearance.Woo.CollapsingToolbar.Expanded" parent="TextAppearance.MaterialComponents.Headline4">
         <item name="android:textColor">@color/color_on_surface</item>
         <item name="android:textStyle">bold</item>
         <item name="android:layout_height">@dimen/expanded_toolbar_height</item>
     </style>
-
     <style name="TextAppearance.Woo.CollapsingToolbar.Collapsed" parent="TextAppearance.MaterialComponents.Headline6">
         <item name="android:textColor">@color/color_on_surface</item>
         <item name="android:layout_height">@dimen/toolbar_height</item>
     </style>
-
     <style name="Woo.CollapsedToolbarLayout" parent="@style/Widget.Design.CollapsingToolbar">
         <item name="layout_scrollFlags">scroll|exitUntilCollapsed</item>
         <item name="android:background">@color/color_toolbar</item>
@@ -52,12 +47,10 @@ theme across the entire app. Overridden versions should be added to the styles.x
         <item name="expandedTitleMarginEnd">16dp</item>
         <item name="android:paddingEnd">4dp</item>
     </style>
-
     <style name="Woo.ActionMode.OverflowButtonStyle" parent="Widget.AppCompat.ActionButton.Overflow">
         <item name="tint">@color/color_primary</item>
         <item name="android:paddingEnd">16dp</item>
     </style>
-
     <style name="Woo.TextView.Subtitle1.ToolbarSubtitle">
         <item name="android:layout_gravity">bottom</item>
         <item name="android:layout_marginStart">16dp</item>
@@ -196,7 +189,7 @@ theme across the entire app. Overridden versions should be added to the styles.x
         <item name="android:textColor">@color/color_on_surface_high</item>
     </style>
 
-    <style name="Woo.Card.StatusMessage" parent="Woo.TextView.Subtitle1" />
+    <style name="Woo.Card.StatusMessage" parent="Woo.TextView.Subtitle1"/>
 
     <style name="Woo.Card.ListHeader" parent="Woo.TextView.Body2">
         <item name="android:layout_marginBottom">@dimen/major_75</item>
@@ -370,7 +363,8 @@ theme across the entire app. Overridden versions should be added to the styles.x
     <!--
         TextInputLayout styles
     -->
-    <style name="Woo.TextInputLayout" parent="Widget.MaterialComponents.TextInputLayout.OutlinedBox">
+    <style name="Woo.TextInputLayout"
+        parent="Widget.MaterialComponents.TextInputLayout.OutlinedBox">
         <item name="android:layout_marginStart">@dimen/major_100</item>
         <item name="android:layout_marginEnd">@dimen/major_100</item>
         <item name="android:layout_marginTop">@dimen/minor_00</item>
@@ -378,7 +372,8 @@ theme across the entire app. Overridden versions should be added to the styles.x
         <item name="helperTextTextAppearance">@style/TextAppearance.Woo.Caption</item>
     </style>
 
-    <style name="Woo.TextInputEditText" parent="Widget.MaterialComponents.TextInputEditText.OutlinedBox">
+    <style name="Woo.TextInputEditText"
+        parent="Widget.MaterialComponents.TextInputEditText.OutlinedBox">
         <item name="android:textAppearance">?attr/textAppearanceSubtitle1</item>
         <item name="android:textColor">@color/color_on_surface_high</item>
         <item name="android:gravity">center_vertical|start</item>
@@ -554,7 +549,7 @@ theme across the entire app. Overridden versions should be added to the styles.x
         <item name="android:textSize">@dimen/text_minor_100</item>
         <item name="android:textStyle">normal</item>
         <item name="lineHeight">@dimen/line_height_minor_80</item>
-        <item name="android:textColor">@color/button_outlined_text</item>
+        <item name="android:textColor">@color/button_outlined_text_selector</item>
     </style>
 
     <!-- Set at the theme level so no need to set directly on the component -->
@@ -613,7 +608,7 @@ theme across the entire app. Overridden versions should be added to the styles.x
     <!--
         List Styles
     -->
-    <style name="Woo.ListHeader" parent="Woo.TextView.Subtitle2" />
+    <style name="Woo.ListHeader" parent="Woo.TextView.Subtitle2"/>
 
     <!--  Use with a list item container -->
     <style name="Woo.ListItem">
@@ -624,16 +619,11 @@ theme across the entire app. Overridden versions should be added to the styles.x
         <item name="android:paddingTop">@dimen/minor_100</item>
         <item name="android:paddingBottom">@dimen/minor_100</item>
     </style>
-
-    <style name="Woo.ListItem.Title" parent="Woo.TextView.Subtitle1" />
-
-    <style name="Woo.ListItem.Subtitle" parent="Woo.TextView.Subtitle2" />
-
-    <style name="Woo.ListItem.Overline" parent="Woo.TextView.Overline" />
-
-    <style name="Woo.ListItem.Caption" parent="Woo.TextView.Caption" />
-
-    <style name="Woo.ListItem.Body" parent="Woo.TextView.Body2" />
+    <style name="Woo.ListItem.Title" parent="Woo.TextView.Subtitle1"/>
+    <style name="Woo.ListItem.Subtitle" parent="Woo.TextView.Subtitle2"/>
+    <style name="Woo.ListItem.Overline" parent="Woo.TextView.Overline"/>
+    <style name="Woo.ListItem.Caption" parent="Woo.TextView.Caption"/>
+    <style name="Woo.ListItem.Body" parent="Woo.TextView.Body2"/>
 
     <!--
         FlowLayout Style
@@ -705,7 +695,7 @@ theme across the entire app. Overridden versions should be added to the styles.x
         <item name="android:paddingEnd">@dimen/major_100</item>
     </style>
 
-    <style name="Widget.Woo.Settings.OptionValue" />
+    <style name="Widget.Woo.Settings.OptionValue"/>
 
     <style name="Widget.Woo.Settings.OptionToggle">
         <item name="android:paddingStart">@dimen/major_100</item>
@@ -736,8 +726,7 @@ theme across the entire app. Overridden versions should be added to the styles.x
         <item name="android:layout_marginBottom">@dimen/major_75</item>
     </style>
 
-    <style name="Woo.Skeleton.ListItem" />
-
+    <style name="Woo.Skeleton.ListItem"/>
     <style name="Woo.Skeleton.ListItem.Single">
         <item name="android:layout_width">0dp</item>
         <item name="android:layout_height">@dimen/skeleton_text_height_200</item>


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

<!-- Id number of the Linear issue this PR addresses, e.g., WOOMOB-373. -->
Closes WOOMOB-1548

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
This fixes the text color of the passive filter button, which was mistakenly broken in the [previous PR](https://github.com/woocommerce/woocommerce-android/pull/14832).
- df6bbc09ab970ccdb83780247ac1114f7e29b9bb: The first commit only reverts the change from the previous PR.
- 09fc7c6d83054166197345c6219a397db8ae2878: The last commit introduces the actual fix.

### Test Steps
<!-- Describe how to test your changes. Include only what’s needed for the reviewer to validate the behavior.
For new features, outline the main user flow or goal rather than every tap or click — the reviewer should be able to complete the flow naturally.
If applicable, mention key devices, scenarios, or edge cases to verify. -->
1. Open the Orders and Products screens.
2. Test in both light and dark modes.

### Images/gif
<!-- Include before and after images or gifs when appropriate. -->
|Before|After|
|-|-|
|<img width="300" src="https://github.com/user-attachments/assets/d8e02df8-6669-4098-82f6-85524a0660e8" />|<img width="300"  src="https://github.com/user-attachments/assets/c894cdf7-46e2-45de-9b2d-3e1e1f47af8b" />|

- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
