### PR TITLE
Ensure sending most recent encrypted logs

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/util/crashlogging/EncryptedLogsFileProvider.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/util/crashlogging/EncryptedLogsFileProvider.kt
@@ -12,7 +12,7 @@ class EncryptedLogsFileProvider @Inject constructor(
 ) {
     suspend fun provide(): File {
         return withContext(dispatchers.io) {
-            val logs = wooLog.getCurrentLogEntries().take(LOG_ENTRIES_LIMIT)
+            val logs = wooLog.getCurrentLogEntries().takeLast(LOG_ENTRIES_LIMIT)
 
             File.createTempFile("log", "").apply {
                 appendText(logs.joinToString("\n"))

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/util/crashlogging/EncryptedLogsFileProviderTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/util/crashlogging/EncryptedLogsFileProviderTest.kt
@@ -33,4 +33,19 @@ class EncryptedLogsFileProviderTest : BaseUnitTest() {
             .isFile
             .hasContent(testLog.toString())
     }
+
+    @Test
+    fun `when requesting log files, then it should limit the number of log entries`() = testBlocking {
+        val logEntries = (1..1500).map {
+            LogEntry(WooLog.T.WP, WooLog.LogLevel.i, "Log entry $it")
+        }
+        whenever(wooLog.getCurrentLogEntries()).thenReturn(logEntries)
+
+        val resultFile = sut.provide()
+
+        val fileContent = resultFile.readLines()
+        assertThat(fileContent).hasSize(1000)
+        assertThat(fileContent.first()).contains("Log entry 501")
+        assertThat(fileContent.last()).contains("Log entry 1500")
+    }
 }


### PR DESCRIPTION
### Description
While reviewing the PR #14837, I noticed an issue that I caused when I worked on persisting logs to the disk, for encrypted logs, we want to limit the number of entries to 1000 log entries, but I accidenally used `take` instead of `takeLast` 🤦‍♂️, which means we don't send the last logs when we have more than 1000 entries.

### Test Steps
I think the unit test should be enough for confirming the behavior.

- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
