### PR TITLE
Fix outlined button text color

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/filters/OrderFilterCategoriesViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/filters/OrderFilterCategoriesViewModel.kt
@@ -115,6 +115,7 @@ class OrderFilterCategoriesViewModel @Inject constructor(
                 )
             }
         )
+        saveFiltersSelection(_categories.list)
     }
 
     fun onClearProductFilter() {


### PR DESCRIPTION
## Summary
This PR fixes the outlined button text color issue where the button text was displaying as white on white background in light mode.

## Changes
- Reverts the change that removed the `button_outlined_text_selector.xml` 
- Updates the selector to use white text when selected (against colored background)
- Uses medium emphasis color when not selected (against transparent background)

## Related
- Fixes WOOMOB-1548