### PR TITLE
[WOOMOB-1568] Fix order filter count not resetting after clear

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -6,6 +6,7 @@
 - [Internal] Improve WebView experience by using Authenticated WebView for more scenarios [https://github.com/woocommerce/woocommerce-android/pull/14826]
 - [Internal] Update In-Person Payments setup flow to use Authenticated WebView [https://github.com/woocommerce/woocommerce-android/pull/14827]
 - [*] Improved the Filters button colors on the Orders and Products screens [https://github.com/woocommerce/woocommerce-android/pull/14832]
+- [*] Fixed an issue where the count of the filters applied to the orders was not updated correctly [https://github.com/woocommerce/woocommerce-android/pull/14844]
 
 23.5
 -----

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/filters/OrderFilterCategoriesViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/filters/OrderFilterCategoriesViewModel.kt
@@ -115,6 +115,7 @@ class OrderFilterCategoriesViewModel @Inject constructor(
                 )
             }
         )
+        saveFiltersSelection(_categories.list)
     }
 
     fun onClearProductFilter() {


### PR DESCRIPTION
WOOMOB-1568

### Description
Fixes an issue where the order filters count was not properly reset after using the CLEAR button. When clearing filters and then adding a new filter, the count would incorrectly display the count of the old filters instead of just the new filter count.

The issue occurred because clearing filters only updated the UI state but did not persist the cleared state to the repository. This caused the filter count calculation to still include the old filter values.

### Test Steps
1. Navigate to Orders
2. Open Filters
3. Add two filters (e.g., Customer and Order Status)
4. Tap "Show Orders" - note that the button shows "Filters 2"
5. Tap Filters again
6. Tap CLEAR
7. Add a single filter (e.g., Order Status)
8. Tap "Show Orders"
9. Verify the button now correctly shows "Filters 1" instead of "Filters 2"


https://github.com/user-attachments/assets/4565605a-4b30-479b-9401-9e8cebc08507



- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.