### PR TITLE
[CIAB] Fix case where the bookings tab is deleted when filtering products

### DIFF
--- a/libs/fluxc-plugin/src/main/kotlin/org/wordpress/android/fluxc/store/WCProductStore.kt
+++ b/libs/fluxc-plugin/src/main/kotlin/org/wordpress/android/fluxc/store/WCProductStore.kt
@@ -1703,7 +1703,9 @@ class WCProductStore @Inject internal constructor(
                     if (forceRefresh &&
                         offset == 0 &&
                         includedProductIds.isEmpty() &&
-                        excludedProductIds.isEmpty()
+                        excludedProductIds.isEmpty() &&
+                        filterOptions.isEmpty() &&
+                        includeTypes.isEmpty()
                     ) {
                         productStorageHelper.deleteProductsForSite(site)
                     }


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

<!-- Id number of the Linear issue this PR addresses, e.g., WOOMOB-373. -->
Closes WOOMOB-1603

### Description
This PR fixes an issue that caused the bookings tab to be deleted when filtering products, the cause is that we were missing some filter options in `WCProductStore` when deciding whether the products table should be cleared or not.

### Test Steps
1. Use a CIAB site.
2. Open the app and confirm the bookings tab is shown.
3. Switch to the products tab.
4. Apply the "Status" filter to an option that doesn't include any bookable product.
5. Confirm the bookings tab is still shown.
6. Apply the "Product Type = Simple" filter.
7. Confirm the bookings tab is still shown.

- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
