### PR TITLE
Fix image visibility in card reader dialogs on tablets

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/cardreader/connect/CardReaderConnectDialogFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/cardreader/connect/CardReaderConnectDialogFragment.kt
@@ -170,7 +170,7 @@ class CardReaderConnectDialogFragment : PaymentsBaseDialogFragment(R.layout.card
 
     private fun moveToState(binding: CardReaderConnectDialogBinding, viewState: CardReaderConnectViewState) {
         UiHelpers.setTextOrHide(binding.headerLabel, viewState.headerLabel)
-        UiHelpers.setImageOrHideInLandscapeOnCompactScreenHeightSizeClass(binding.illustration, viewState.illustration)
+        UiHelpers.setImageOrHideOnCompactScreenHeightSizeClass(binding.illustration, viewState.illustration)
             .also {
                 if (binding.illustration.isVisible) {
                     binding.illustration.visibility =

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/cardreader/connect/adapter/MultipleCardReadersFoundViewHolder.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/cardreader/connect/adapter/MultipleCardReadersFoundViewHolder.kt
@@ -50,7 +50,7 @@ sealed class MultipleCardReadersFoundViewHolder(
         override fun onBind(uiState: ListItemViewState) {
             uiState as ScanningInProgressListItem
             UiHelpers.setTextOrHide(binding.cardReaderConnectProgressLabel, uiState.label)
-            UiHelpers.setImageOrHideInLandscapeOnCompactScreenHeightSizeClass(
+            UiHelpers.setImageOrHideOnCompactScreenHeightSizeClass(
                 binding.cardReaderConnectProgressIndicator,
                 uiState.scanningIcon
             )

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/cardreader/detail/CardReaderDetailFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/cardreader/detail/CardReaderDetailFragment.kt
@@ -158,7 +158,7 @@ class CardReaderDetailFragment : BaseFragment(R.layout.fragment_card_reader_deta
                 is NotConnectedState -> {
                     with(binding.readerDisconnectedState) {
                         UiHelpers.setTextOrHide(cardReaderDetailConnectHeaderLabel, state.headerLabel)
-                        UiHelpers.setImageOrHideInLandscapeOnCompactScreenHeightSizeClass(
+                        UiHelpers.setImageOrHideOnCompactScreenHeightSizeClass(
                             cardReaderDetailIllustration,
                             state.illustration
                         )

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/cardreader/onboarding/CardReaderOnboardingFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/cardreader/onboarding/CardReaderOnboardingFragment.kt
@@ -198,7 +198,7 @@ class CardReaderOnboardingFragment : BaseFragment(R.layout.fragment_card_reader_
         UiHelpers.setTextOrHide(binding.enableCashOnDelivery, state.enableCashOnDeliveryButtonLabel)
         UiHelpers.setTextOrHide(binding.textSupport, state.contactSupportLabel)
         UiHelpers.setTextOrHide(binding.learnMoreContainer.learnMore, state.learnMoreLabel)
-        UiHelpers.setImageOrHideInLandscapeOnCompactScreenHeightSizeClass(binding.illustration, state.cardIllustration)
+        UiHelpers.setImageOrHideOnCompactScreenHeightSizeClass(binding.illustration, state.cardIllustration)
 
         if (state.shouldShowProgress) {
             binding.enableCashOnDelivery.isEnabled = false
@@ -279,7 +279,7 @@ class CardReaderOnboardingFragment : BaseFragment(R.layout.fragment_card_reader_
         val binding = FragmentCardReaderOnboardingLoadingBinding.bind(view)
         UiHelpers.setTextOrHide(binding.textHeaderTv, state.headerLabel)
         UiHelpers.setTextOrHide(binding.hintTv, state.hintLabel)
-        UiHelpers.setImageOrHideInLandscapeOnCompactScreenHeightSizeClass(binding.illustrationIv, state.illustration)
+        UiHelpers.setImageOrHideOnCompactScreenHeightSizeClass(binding.illustrationIv, state.illustration)
     }
 
     private fun showGenericErrorState(
@@ -289,7 +289,7 @@ class CardReaderOnboardingFragment : BaseFragment(R.layout.fragment_card_reader_
         val binding = FragmentCardReaderOnboardingGenericErrorBinding.bind(view)
         UiHelpers.setTextOrHide(binding.textSupport, state.contactSupportLabel)
         UiHelpers.setTextOrHide(binding.learnMoreContainer.learnMore, state.learnMoreLabel)
-        UiHelpers.setImageOrHideInLandscapeOnCompactScreenHeightSizeClass(binding.illustration, state.illustration)
+        UiHelpers.setImageOrHideOnCompactScreenHeightSizeClass(binding.illustration, state.illustration)
         binding.textSupport.setOnClickListener {
             state.onContactSupportActionClicked.invoke()
         }
@@ -303,7 +303,7 @@ class CardReaderOnboardingFragment : BaseFragment(R.layout.fragment_card_reader_
         state: CardReaderOnboardingViewState.NoConnectionErrorState
     ) {
         val binding = FragmentCardReaderOnboardingNetworkErrorBinding.bind(view)
-        UiHelpers.setImageOrHideInLandscapeOnCompactScreenHeightSizeClass(binding.illustration, state.illustration)
+        UiHelpers.setImageOrHideOnCompactScreenHeightSizeClass(binding.illustration, state.illustration)
         binding.buttonRetry.setOnClickListener {
             state.onRetryButtonActionClicked.invoke()
         }
@@ -316,7 +316,7 @@ class CardReaderOnboardingFragment : BaseFragment(R.layout.fragment_card_reader_
         val binding = FragmentCardReaderOnboardingStripeBinding.bind(view)
         UiHelpers.setTextOrHide(binding.textHeader, state.headerLabel)
         UiHelpers.setTextOrHide(binding.textLabel, state.hintLabel)
-        UiHelpers.setImageOrHideInLandscapeOnCompactScreenHeightSizeClass(binding.illustration, state.illustration)
+        UiHelpers.setImageOrHideOnCompactScreenHeightSizeClass(binding.illustration, state.illustration)
 
         UiHelpers.setTextOrHide(binding.learnMoreContainer.learnMore, state.learnMoreButton.label)
         binding.learnMoreContainer.learnMore.setOnClickListener {
@@ -352,7 +352,7 @@ class CardReaderOnboardingFragment : BaseFragment(R.layout.fragment_card_reader_
         val binding = FragmentCardReaderOnboardingWcpayBinding.bind(view)
         UiHelpers.setTextOrHide(binding.textHeader, state.headerLabel)
         UiHelpers.setTextOrHide(binding.textLabel, state.hintLabel)
-        UiHelpers.setImageOrHideInLandscapeOnCompactScreenHeightSizeClass(binding.illustration, state.illustration)
+        UiHelpers.setImageOrHideOnCompactScreenHeightSizeClass(binding.illustration, state.illustration)
 
         UiHelpers.setTextOrHide(binding.primaryButton, state.actionButtonPrimary.label)
         binding.primaryButton.setWhiteIcon(state.actionButtonPrimary.icon)
@@ -382,7 +382,7 @@ class CardReaderOnboardingFragment : BaseFragment(R.layout.fragment_card_reader_
         binding.primaryButton.visibility = View.GONE
         UiHelpers.setTextOrHide(binding.secondaryButton, state.refreshButtonLabel)
         UiHelpers.setTextOrHide(binding.learnMoreContainer.learnMore, state.learnMoreLabel)
-        UiHelpers.setImageOrHideInLandscapeOnCompactScreenHeightSizeClass(binding.illustration, state.illustration)
+        UiHelpers.setImageOrHideOnCompactScreenHeightSizeClass(binding.illustration, state.illustration)
         binding.secondaryButton.setOnClickListener {
             state.refreshButtonAction.invoke()
         }
@@ -397,7 +397,7 @@ class CardReaderOnboardingFragment : BaseFragment(R.layout.fragment_card_reader_
     ) {
         val binding = FragmentCardReaderOnboardingUnsupportedBinding.bind(view)
         UiHelpers.setTextOrHide(binding.unsupportedCountryHeader, state.headerLabel)
-        UiHelpers.setImageOrHideInLandscapeOnCompactScreenHeightSizeClass(
+        UiHelpers.setImageOrHideOnCompactScreenHeightSizeClass(
             binding.unsupportedCountryIllustration,
             state.illustration
         )

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/cardreader/onboarding/CardReaderWelcomeDialogFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/cardreader/onboarding/CardReaderWelcomeDialogFragment.kt
@@ -23,7 +23,7 @@ class CardReaderWelcomeDialogFragment : PaymentsBaseDialogFragment(R.layout.card
 
     private fun initObservers(binding: CardReaderWelcomeDialogBinding) {
         viewModel.viewState.observe(viewLifecycleOwner) { viewState ->
-            UiHelpers.setImageOrHideInLandscapeOnCompactScreenHeightSizeClass(binding.illustration, viewState.img)
+            UiHelpers.setImageOrHideOnCompactScreenHeightSizeClass(binding.illustration, viewState.img)
             UiHelpers.setTextOrHide(binding.headerLabel, viewState.header)
             UiHelpers.setTextOrHide(binding.text, viewState.text)
             UiHelpers.setTextOrHide(binding.actionBtn, viewState.buttonLabel)

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/cardreader/payment/CardReaderPaymentDialogFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/cardreader/payment/CardReaderPaymentDialogFragment.kt
@@ -114,7 +114,7 @@ class CardReaderPaymentDialogFragment : PaymentsBaseDialogFragment(R.layout.card
             announceForAccessibility(binding, viewState)
             UiHelpers.setTextOrHide(binding.headerLabel, viewState.headerLabel)
             UiHelpers.setTextOrHide(binding.amountLabel, viewState.amountWithCurrencyLabel)
-            UiHelpers.setImageOrHideInLandscapeOnCompactScreenHeightSizeClass(
+            UiHelpers.setImageOrHideOnCompactScreenHeightSizeClass(
                 binding.illustration,
                 viewState.illustration
             ).also {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/cardreader/tutorial/CardReaderTutorialViewPagerItemFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/cardreader/tutorial/CardReaderTutorialViewPagerItemFragment.kt
@@ -21,7 +21,7 @@ class CardReaderTutorialViewPagerItemFragment :
             binding.labelTextView.setText(args.getInt(ARG_LABEL_ID))
             binding.detailTextView.setText(args.getInt(ARG_DETAIL_ID))
 
-            UiHelpers.setImageOrHideInLandscapeOnCompactScreenHeightSizeClass(
+            UiHelpers.setImageOrHideOnCompactScreenHeightSizeClass(
                 binding.imageView,
                 args.getInt(ARG_DRAWABLE_ID)
             )

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/cardreader/update/CardReaderUpdateDialogFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/cardreader/update/CardReaderUpdateDialogFragment.kt
@@ -89,7 +89,7 @@ class CardReaderUpdateDialogFragment : PaymentsBaseDialogFragment(R.layout.card_
                     UiHelpers.updateVisibility(this, state.progress != null)
                     currentProgressPercentage = state.progress ?: 0
                 }
-                UiHelpers.setImageOrHideInLandscapeOnCompactScreenHeightSizeClass(progressImageView, state.illustration)
+                UiHelpers.setImageOrHideOnCompactScreenHeightSizeClass(progressImageView, state.illustration)
                 actionButton.setOnClickListener { state.button?.onActionClicked?.invoke() }
             }
         }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/WCSettingsToggleOptionView.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/WCSettingsToggleOptionView.kt
@@ -59,7 +59,7 @@ class WCSettingsToggleOptionView @JvmOverloads constructor(
                     R.styleable.WCSettingsToggleOptionView_toggleOptionIcon,
                     R.styleable.WCSettingsToggleOptionView_tools_toggleOptionIcon
                 ).let {
-                    UiHelpers.setImageOrHideInLandscapeOnCompactScreenHeightSizeClass(
+                    UiHelpers.setImageOrHideOnCompactScreenHeightSizeClass(
                         binding.toggleSettingIcon,
                         it,
                         setInvisible = true

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/util/UiHelpers.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/util/UiHelpers.kt
@@ -87,15 +87,13 @@ object UiHelpers {
         }
     }
 
-    fun setImageOrHideInLandscapeOnCompactScreenHeightSizeClass(
+    fun setImageOrHideOnCompactScreenHeightSizeClass(
         imageView: ImageView,
         @DrawableRes resId: Int?,
         setInvisible: Boolean = false
     ) {
-        val isLandscape = DisplayUtils.isLandscape(imageView.context)
-        val isNotCompact = imageView.context.windowHeightSizeClass >= WindowSizeClass.Medium
-        val shouldShowBasedOnOrientationAndSize = !isLandscape || isNotCompact
-        val showImage = resId != null && shouldShowBasedOnOrientationAndSize
+        val largeHeightThanCompact = imageView.context.windowHeightSizeClass >= WindowSizeClass.Medium
+        val showImage = resId != null && largeHeightThanCompact
         updateVisibility(imageView, showImage, setInvisible)
         resId?.let {
             imageView.setImageResource(resId)


### PR DESCRIPTION
## Summary
- Fixed image visibility logic in card reader connection flow to display images on tablets regardless of orientation
- Renamed `setImageOrHideInLandscapeOnCompactScreenHeightSizeClass` to `setImageOrHideOnCompactScreenHeightSizeClass`
- Removed orientation check and kept only height-based visibility logic

## Changes
The previous logic was hiding images in landscape mode even on tablets with sufficient screen height. The function now only checks if the device has enough vertical space (Medium or larger height size class) to display images, ignoring the orientation.

This ensures that tablets with sufficient screen height will always show images in the card reader connection flow, whether in portrait or landscape orientation.

## Test plan
**Important:** This change needs to be tested on both phones and tablets in different orientations.

- [ ] Test on phone in portrait - images should be visible
- [ ] Test on phone in landscape - images should be hidden (compact height)
- [ ] Test on tablet in portrait - images should be visible
- [ ] Test on tablet in landscape - images should be visible (this is the fix)
- [ ] Verify card reader connection flow displays images correctly on all device configurations
- [ ] Test all affected screens: onboarding, connection, payment, tutorial, and update dialogs

Fixes WOOMOB-1547