### PR TITLE
[Dependabot] Ignore wellsql in dependabot.yml

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -36,3 +36,5 @@ updates:
       - dependency-name: "com.fasterxml.jackson.core:jackson-databind"
       - dependency-name: "com.jayway.jsonpath:json-path"
       - dependency-name: "commons-fileupload:commons-fileupload"
+      - dependency-name: "org.wordpress:wellsql"
+      - dependency-name: "org.wordpress.wellsql:wellsql-processor"


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

<!-- Id number of the Linear issue this PR addresses, e.g., WOOMOB-373. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
This PR adds **wellsql** and **wellsql-processor** to the list of ignored dependencies. Wellsql was deprecated and dependabot creates PRs for intermediate PR build, which is not intended. Example os such PR: https://github.com/woocommerce/woocommerce-android/pull/14846

Discussion: p1761727167689069-slack-CC7L49W13

### Test Steps
<!-- Describe how to test your changes. Include only what’s needed for the reviewer to validate the behavior.
For new features, outline the main user flow or goal rather than every tap or click — the reviewer should be able to complete the flow naturally.
If applicable, mention key devices, scenarios, or edge cases to verify. -->
N/A

### Images/gif
<!-- Include before and after images or gifs when appropriate. -->
N/A

- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->