### PR TITLE
[CIAB Bookings] Update filter screen navigation to use Compose Navigation

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/bookings/filter/BookingFilterListScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/bookings/filter/BookingFilterListScreen.kt
@@ -137,7 +137,7 @@ private fun FiltersNavHost(
 }
 
 private val BookingFilterPage.route: String
-    get() = this::class.java.simpleName
+    get() = name
 
 private fun slideIn(popNavigation: Boolean): EnterTransition {
     return slideInHorizontally(animationSpec = tween(durationMillis = TRANSITION_DURATION)) { fullWidth ->

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/bookings/filter/BookingFilterListScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/bookings/filter/BookingFilterListScreen.kt
@@ -1,6 +1,13 @@
 package com.woocommerce.android.ui.bookings.filter
 
 import androidx.activity.compose.BackHandler
+import androidx.compose.animation.EnterTransition
+import androidx.compose.animation.ExitTransition
+import androidx.compose.animation.core.tween
+import androidx.compose.animation.fadeIn
+import androidx.compose.animation.fadeOut
+import androidx.compose.animation.slideInHorizontally
+import androidx.compose.animation.slideOutHorizontally
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxSize
@@ -92,6 +99,10 @@ private fun FiltersNavHost(
     NavHost(
         navController = navController,
         startDestination = BookingFilterPage.List.route,
+        enterTransition = { slideIn(popNavigation = true) },
+        exitTransition = { slideOut(popNavigation = true) },
+        popEnterTransition = { slideIn(popNavigation = false) },
+        popExitTransition = { slideOut(popNavigation = false) },
         modifier = modifier
     ) {
         composable(BookingFilterPage.List.route) {
@@ -126,6 +137,20 @@ private fun FiltersNavHost(
 
 private val BookingFilterPage.route: String
     get() = this::class.java.simpleName
+
+private fun slideIn(popNavigation: Boolean): EnterTransition {
+    return slideInHorizontally(animationSpec = tween(durationMillis = TRANSITION_DURATION)) { fullWidth ->
+        if (popNavigation) fullWidth else -fullWidth
+    } + fadeIn(animationSpec = tween(durationMillis = TRANSITION_DURATION))
+}
+
+private fun slideOut(popNavigation: Boolean): ExitTransition {
+    return slideOutHorizontally(animationSpec = tween(durationMillis = TRANSITION_DURATION)) { fullWidth ->
+        if (popNavigation) -fullWidth else fullWidth
+    } + fadeOut(animationSpec = tween(durationMillis = TRANSITION_DURATION))
+}
+
+private const val TRANSITION_DURATION = 250
 
 @LightDarkThemePreviews
 @Composable

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/bookings/filter/BookingFilterListScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/bookings/filter/BookingFilterListScreen.kt
@@ -1,14 +1,6 @@
 package com.woocommerce.android.ui.bookings.filter
 
 import androidx.activity.compose.BackHandler
-import androidx.compose.animation.AnimatedContent
-import androidx.compose.animation.ContentTransform
-import androidx.compose.animation.core.tween
-import androidx.compose.animation.fadeIn
-import androidx.compose.animation.fadeOut
-import androidx.compose.animation.slideInHorizontally
-import androidx.compose.animation.slideOutHorizontally
-import androidx.compose.animation.togetherWith
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxSize
@@ -19,11 +11,15 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.res.vectorResource
 import androidx.compose.ui.unit.dp
+import androidx.navigation.compose.NavHost
+import androidx.navigation.compose.composable
+import androidx.navigation.compose.rememberNavController
 import com.woocommerce.android.R
 import com.woocommerce.android.ui.compose.component.Toolbar
 import com.woocommerce.android.ui.compose.component.WCColoredButton
@@ -32,10 +28,6 @@ import com.woocommerce.android.ui.compose.theme.WooThemeWithBackground
 
 @Composable
 fun BookingFilterListScreen(state: BookingFilterListUiState) {
-    BackHandler {
-        state.onClose()
-    }
-
     Scaffold(
         topBar = {
             Column {
@@ -66,61 +58,74 @@ fun BookingFilterListScreen(state: BookingFilterListUiState) {
         },
         containerColor = MaterialTheme.colorScheme.surface,
     ) { innerPadding ->
-        AnimatedContent(
-            targetState = state.currentPage,
-            transitionSpec = {
-                if (targetState is BookingFilterPage.List) {
-                    slideOut()
-                } else {
-                    slideIn()
-                }
-            },
-            label = "BookingFiltersAnimatedContent",
+        FiltersNavHost(
+            state = state,
             modifier = Modifier
                 .fillMaxSize()
                 .padding(innerPadding)
-        ) { page ->
-            when (page) {
-                is BookingFilterPage.List -> {
-                    BookingFilterRootPage(state.items)
-                }
+        )
 
-                BookingFilterPage.AttendanceStatus,
-                BookingFilterPage.BookingType,
-                BookingFilterPage.Customer,
-                BookingFilterPage.Location,
-                BookingFilterPage.PaymentStatus,
-                BookingFilterPage.ServiceEvent,
-                BookingFilterPage.TeamMember,
-                is BookingFilterPage.DateTime -> {
-                    DateTimeFilterPicker()
-                }
-            }
+        // Make sure this is called after the NavHost to properly receive back events
+        BackHandler {
+            state.onClose()
         }
     }
 }
 
-private const val TRANSITION_DURATION = 250
+@Composable
+private fun FiltersNavHost(
+    state: BookingFilterListUiState,
+    modifier: Modifier
+) {
+    val navController = rememberNavController()
 
-private fun slideIn(duration: Int = TRANSITION_DURATION): ContentTransform {
-    return (
-        slideInHorizontally(animationSpec = tween(durationMillis = duration)) { fullWidth -> fullWidth } +
-            fadeIn(animationSpec = tween(durationMillis = duration))
-        ) togetherWith (
-        slideOutHorizontally(animationSpec = tween(durationMillis = duration)) { fullWidth -> -fullWidth } +
-            fadeOut(animationSpec = tween(durationMillis = duration))
-        )
+    LaunchedEffect(state.currentPage) {
+        if (state.currentPage != BookingFilterPage.List) {
+            navController.navigate(state.currentPage.route) {
+                popUpTo(BookingFilterPage.List.route)
+            }
+        } else {
+            navController.popBackStack(BookingFilterPage.List.route, false)
+        }
+    }
+
+    NavHost(
+        navController = navController,
+        startDestination = BookingFilterPage.List.route,
+        modifier = modifier
+    ) {
+        composable(BookingFilterPage.List.route) {
+            BookingFilterRootPage(state.items)
+        }
+        composable(BookingFilterPage.DateTime.route) {
+            DateTimeFilterPicker()
+        }
+        composable(BookingFilterPage.TeamMember.route) {
+            TODO()
+        }
+        composable(BookingFilterPage.AttendanceStatus.route) {
+            TODO()
+        }
+        composable(BookingFilterPage.PaymentStatus.route) {
+            TODO()
+        }
+        composable(BookingFilterPage.BookingType.route) {
+            TODO()
+        }
+        composable(BookingFilterPage.Customer.route) {
+            TODO()
+        }
+        composable(BookingFilterPage.ServiceEvent.route) {
+            TODO()
+        }
+        composable(BookingFilterPage.Location.route) {
+            TODO()
+        }
+    }
 }
 
-private fun slideOut(duration: Int = TRANSITION_DURATION): ContentTransform {
-    return (
-        slideInHorizontally(animationSpec = tween(durationMillis = duration)) { fullWidth -> -fullWidth } +
-            fadeIn(animationSpec = tween(durationMillis = duration))
-        ) togetherWith (
-        slideOutHorizontally(animationSpec = tween(durationMillis = duration)) { fullWidth -> fullWidth } +
-            fadeOut(animationSpec = tween(durationMillis = duration))
-        )
-}
+private val BookingFilterPage.route: String
+    get() = this::class.java.simpleName
 
 @LightDarkThemePreviews
 @Composable

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/bookings/filter/BookingFilterListScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/bookings/filter/BookingFilterListScreen.kt
@@ -72,7 +72,8 @@ fun BookingFilterListScreen(state: BookingFilterListUiState) {
                 .padding(innerPadding)
         )
 
-        // Make sure this is called after the NavHost to properly receive back events
+        // The navigation is driven by the state, so we handle back navigation by calling onClose
+        // We need to ensure that this called after NavHost to make sure we receive back events
         BackHandler {
             state.onClose()
         }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/bookings/filter/BookingFilterListUiState.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/bookings/filter/BookingFilterListUiState.kt
@@ -6,16 +6,16 @@ import com.woocommerce.android.R
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.bookings.BookingFilters
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.bookings.BookingsFilterOption
 
-sealed interface BookingFilterPage {
-    data object List : BookingFilterPage
-    data object DateTime : BookingFilterPage
-    data object TeamMember : BookingFilterPage
-    data object AttendanceStatus : BookingFilterPage
-    data object PaymentStatus : BookingFilterPage
-    data object BookingType : BookingFilterPage
-    data object Customer : BookingFilterPage
-    data object ServiceEvent : BookingFilterPage
-    data object Location : BookingFilterPage
+enum class BookingFilterPage {
+    List,
+    DateTime,
+    TeamMember,
+    AttendanceStatus,
+    PaymentStatus,
+    BookingType,
+    Customer,
+    ServiceEvent,
+    Location,
 }
 
 data class BookingFilterListUiState(
@@ -37,7 +37,7 @@ data class BookingFilterListUiState(
 
     @DrawableRes
     val navigationIcon: Int = when (currentPage) {
-        is BookingFilterPage.List -> R.drawable.ic_gridicons_cross_24dp
+        BookingFilterPage.List -> R.drawable.ic_gridicons_cross_24dp
         else -> R.drawable.ic_back_24dp
     }
 


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

<!-- Id number of the Linear issue this PR addresses, e.g., WOOMOB-373. -->
Closes WOOMOB-1608

### Description
As discussed and agreed, this PR updates the filters internal navigation to use Compose Navigation, the navigation is still driven by the state of the `ViewModel`, the added `NavHost` and its graph will just reflect the selected page.
As stated, the benefit of this solution is that we'll have a correct lifecycle for the sub-ViewModels we use for the filter subscreens, as the navigation component will use a proper `ViewModelStore` tied to the composable destination.

To better test the solution, I rebased the draft customer filter [PR](https://github.com/woocommerce/woocommerce-android/pull/14834) on this branch, and this shows how we can instantiate the sub-ViewModels, and how we can navigate back.
For communication between the parent ViewModel (`BookingFilterListViewModel`) and other ViewModels, we'll use simple callbacks passed to the subscreen Composables, which then pass them back to their ViewModels. Assisted injection improves this solution, as shown in this [commit](https://github.com/woocommerce/woocommerce-android/pull/14834/commits/8a548c9d5125d8c3da68a03d4f16ffe49bc21ec2). This approach eliminates the need to rely on events for communication.

Please share your thoughts on the suggested approach.

### Test Steps
1. Test the changes in the PR https://github.com/woocommerce/woocommerce-android/pull/14834
2. Open the booking filters screen
3. Test navigation to the date time and customer filter screens (the other items will crash the app)
4. Test selecting a customer and confirm the result is returned

**Important:** For step 4, make sure that you select an actual customer, and not a guest, tapping on guests won't have any effect.

### Images/gif

https://github.com/user-attachments/assets/45ad5763-8935-4fd4-b30a-c89695ebbdaf


- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
