### PR TITLE
Issue/woomob 1490 predictive back support for android 36

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -5,6 +5,7 @@
 -----
 - [Internal] Improve WebView experience by using Authenticated WebView for more scenarios [https://github.com/woocommerce/woocommerce-android/pull/14826]
 - [Internal] Update In-Person Payments setup flow to use Authenticated WebView [https://github.com/woocommerce/woocommerce-android/pull/14827]
+- [Internal] Upgrades app to target Android SDK 36 which impacts back navigation behaviors [https://github.com/woocommerce/woocommerce-android/pull/14861]
 - [*] Improved the Filters button colors on the Orders and Products screens [https://github.com/woocommerce/woocommerce-android/pull/14832]
 
 23.5

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/main/MainActivity.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/main/MainActivity.kt
@@ -378,7 +378,7 @@ class MainActivity :
     }
 
     private fun handleOnBackNavigationCompat() {
-        if (VERSION.SDK_INT >= 33) {
+        if (VERSION.SDK_INT >= VERSION_CODES.BAKLAVA) {
             onBackPressedDispatcher
                 .addCallback(this) {
                     AnalyticsTracker.trackBackPressed(this@MainActivity)

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/main/MainActivity.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/main/MainActivity.kt
@@ -391,7 +391,7 @@ class MainActivity :
                         updateAppBarVisibility(fragment)
                     }
                     if (isAtNavigationRoot()) {
-                        remove()
+                        remove() //Remove callback to avoid infinite recursion
                         onBackPressedDispatcher.onBackPressed()
                     }
                 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/main/MainActivity.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/main/MainActivity.kt
@@ -307,7 +307,7 @@ class MainActivity :
 
     override fun onCreate(savedInstanceState: Bundle?) {
         installSplashScreen()
-        handleOnBackNavigationCompat()
+        setOnBackNavigationCallback()
 
         super.onCreate(savedInstanceState)
 
@@ -377,26 +377,22 @@ class MainActivity :
         }
     }
 
-    private fun handleOnBackNavigationCompat() {
-        if (VERSION.SDK_INT >= VERSION_CODES.BAKLAVA) {
-            onBackPressedDispatcher
-                .addCallback(this) {
-                    AnalyticsTracker.trackBackPressed(this@MainActivity)
-                    getActiveChildFragment()?.let { fragment ->
-                        if (fragment is BackPressListener &&
-                            !(fragment as BackPressListener).onRequestAllowBackPress()
-                        ) {
-                            return@addCallback
-                        }
-                    }
-                    supportFragmentManager.primaryNavigationFragment?.let { fragment ->
-                        updateAppBarVisibility(fragment)
-                    }
-                    if (isAtNavigationRoot()) {
-                        remove() // Remove callback to avoid infinite recursion from onBackPressed() call below
-                        onBackPressedDispatcher.onBackPressed()
-                    }
-                }
+    private fun setOnBackNavigationCallback() {
+        onBackPressedDispatcher.addCallback(this) {
+            AnalyticsTracker.trackBackPressed(this@MainActivity)
+            val fragment = getActiveChildFragment()
+            if (fragment is BackPressListener && !fragment.onRequestAllowBackPress()) {
+                return@addCallback
+            }
+            supportFragmentManager.primaryNavigationFragment?.let {
+                updateAppBarVisibility(it)
+            }
+            // Disable this callback temporarily to prevent infinite recursion from onBackPressed() call below.
+            isEnabled = false
+            // Trigger the default back press behavior.
+            onBackPressedDispatcher.onBackPressed()
+            // Re-enable the callback for future custom back presses handling.
+            isEnabled = true
         }
     }
 
@@ -482,25 +478,6 @@ class MainActivity :
                 showOrderBadge(count)
             }
         }
-    }
-
-    /**
-     * The custom back navigation compatible with Android 33 onwards is provided in handleOnBackNavigationCompat()
-     * function from this class.
-     */
-    @Deprecated("This method has been deprecated in favor of using the OnBackPressedDispatcher")
-    override fun onBackPressed() {
-        AnalyticsTracker.trackBackPressed(this)
-        getActiveChildFragment()?.let { fragment ->
-            if (fragment is BackPressListener && !(fragment as BackPressListener).onRequestAllowBackPress()) {
-                return
-            }
-        }
-
-        supportFragmentManager.primaryNavigationFragment?.let { fragment ->
-            updateAppBarVisibility(fragment)
-        }
-        super.onBackPressed()
     }
 
     override fun onOptionsItemSelected(item: MenuItem): Boolean {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/main/MainActivity.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/main/MainActivity.kt
@@ -113,7 +113,6 @@ import com.woocommerce.android.util.ChromeCustomTabUtils
 import com.woocommerce.android.util.PackageUtils
 import com.woocommerce.android.util.WooAnimUtils.Duration
 import com.woocommerce.android.util.WooAnimUtils.animateBottomBar
-import com.woocommerce.android.util.WooLog
 import com.woocommerce.android.util.WooPermissionUtils
 import com.woocommerce.android.viewmodel.MultiLiveEvent
 import com.woocommerce.android.widgets.AppRatingDialog
@@ -384,7 +383,9 @@ class MainActivity :
                 .addCallback(this) {
                     AnalyticsTracker.trackBackPressed(this@MainActivity)
                     getActiveChildFragment()?.let { fragment ->
-                        if (fragment is BackPressListener && !(fragment as BackPressListener).onRequestAllowBackPress()) {
+                        if (fragment is BackPressListener &&
+                            !(fragment as BackPressListener).onRequestAllowBackPress()
+                        ) {
                             return@addCallback
                         }
                     }
@@ -392,7 +393,7 @@ class MainActivity :
                         updateAppBarVisibility(fragment)
                     }
                     if (isAtNavigationRoot()) {
-                        remove() //Remove callback to avoid infinite recursion from onBackPressed() call below
+                        remove() // Remove callback to avoid infinite recursion from onBackPressed() call below
                         onBackPressedDispatcher.onBackPressed()
                     }
                 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/main/MainActivity.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/main/MainActivity.kt
@@ -541,7 +541,7 @@ class MainActivity :
     /**
      * Get the actual primary navigation Fragment from the support manager
      */
-    fun getHostChildFragment(): Fragment? {
+    private fun getHostChildFragment(): Fragment? {
         val navHostFragment = supportFragmentManager.primaryNavigationFragment
         if (navHostFragment?.childFragmentManager?.fragments?.isNotEmpty() == true) {
             return navHostFragment.childFragmentManager.fragments[0]

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/main/MainActivity.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/main/MainActivity.kt
@@ -307,10 +307,8 @@ class MainActivity :
 
     override fun onCreate(savedInstanceState: Bundle?) {
         installSplashScreen()
-        setOnBackNavigationCallback()
-
         super.onCreate(savedInstanceState)
-
+        setOnBackNavigationCallback()
         ChromeCustomTabUtils.registerForPartialTabUsage(this)
 
         // Verify authenticated session

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/main/MainActivity.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/main/MainActivity.kt
@@ -26,7 +26,6 @@ import androidx.appcompat.widget.Toolbar
 import androidx.compose.ui.platform.ViewCompositionStrategy
 import androidx.coordinatorlayout.widget.CoordinatorLayout
 import androidx.core.content.ContextCompat
-import androidx.core.os.BuildCompat
 import androidx.core.splashscreen.SplashScreen.Companion.installSplashScreen
 import androidx.core.view.isVisible
 import androidx.core.view.updateLayoutParams
@@ -380,7 +379,7 @@ class MainActivity :
     }
 
     private fun handleOnBackNavigationCompat() {
-        if (BuildCompat.isAtLeastT()) {
+        if (VERSION.SDK_INT >= 33) {
             onBackPressedDispatcher
                 .addCallback(this) {
                     WooLog.d(WooLog.T.UTILS, "Predictive back: New back navigation callback")
@@ -490,12 +489,7 @@ class MainActivity :
      * The custom back navigation compatible with Android 33 onwards is provided in handleOnBackNavigationCompat()
      * function from this class.
      */
-    @Deprecated(
-        """This method has been deprecated in favor of using the
-      {@link OnBackPressedDispatcher} via {@link #getOnBackPressedDispatcher()}.
-      The OnBackPressedDispatcher controls how back button events are dispatched
-      to one or more {@link OnBackPressedCallback} objects."""
-    )
+    @Deprecated("This method has been deprecated in favor of using the OnBackPressedDispatcher")
     override fun onBackPressed() {
         WooLog.d(WooLog.T.UTILS, "Predictive back: Legacy OnBackPressed called")
         AnalyticsTracker.trackBackPressed(this)

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/main/MainActivity.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/main/MainActivity.kt
@@ -113,7 +113,6 @@ import com.woocommerce.android.util.ChromeCustomTabUtils
 import com.woocommerce.android.util.PackageUtils
 import com.woocommerce.android.util.WooAnimUtils.Duration
 import com.woocommerce.android.util.WooAnimUtils.animateBottomBar
-import com.woocommerce.android.util.WooLog
 import com.woocommerce.android.util.WooPermissionUtils
 import com.woocommerce.android.viewmodel.MultiLiveEvent
 import com.woocommerce.android.widgets.AppRatingDialog
@@ -382,8 +381,6 @@ class MainActivity :
         if (VERSION.SDK_INT >= 33) {
             onBackPressedDispatcher
                 .addCallback(this) {
-                    WooLog.d(WooLog.T.UTILS, "Predictive back: New back navigation callback")
-
                     AnalyticsTracker.trackBackPressed(this@MainActivity)
                     getActiveChildFragment()?.let { fragment ->
                         if (fragment is BackPressListener && !(fragment as BackPressListener).onRequestAllowBackPress()) {
@@ -491,9 +488,7 @@ class MainActivity :
      */
     @Deprecated("This method has been deprecated in favor of using the OnBackPressedDispatcher")
     override fun onBackPressed() {
-        WooLog.d(WooLog.T.UTILS, "Predictive back: Legacy OnBackPressed called")
         AnalyticsTracker.trackBackPressed(this)
-
         getActiveChildFragment()?.let { fragment ->
             if (fragment is BackPressListener && !(fragment as BackPressListener).onRequestAllowBackPress()) {
                 return

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/main/MainActivity.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/main/MainActivity.kt
@@ -113,6 +113,7 @@ import com.woocommerce.android.util.ChromeCustomTabUtils
 import com.woocommerce.android.util.PackageUtils
 import com.woocommerce.android.util.WooAnimUtils.Duration
 import com.woocommerce.android.util.WooAnimUtils.animateBottomBar
+import com.woocommerce.android.util.WooLog
 import com.woocommerce.android.util.WooPermissionUtils
 import com.woocommerce.android.viewmodel.MultiLiveEvent
 import com.woocommerce.android.widgets.AppRatingDialog
@@ -391,7 +392,7 @@ class MainActivity :
                         updateAppBarVisibility(fragment)
                     }
                     if (isAtNavigationRoot()) {
-                        remove() //Remove callback to avoid infinite recursion
+                        remove() //Remove callback to avoid infinite recursion from onBackPressed() call below
                         onBackPressedDispatcher.onBackPressed()
                     }
                 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/main/MainActivity.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/main/MainActivity.kt
@@ -17,6 +17,7 @@ import android.text.method.LinkMovementMethod
 import android.view.Menu
 import android.view.MenuItem
 import android.view.View
+import androidx.activity.addCallback
 import androidx.activity.result.contract.ActivityResultContracts.RequestPermission
 import androidx.activity.viewModels
 import androidx.annotation.StringRes
@@ -25,6 +26,7 @@ import androidx.appcompat.widget.Toolbar
 import androidx.compose.ui.platform.ViewCompositionStrategy
 import androidx.coordinatorlayout.widget.CoordinatorLayout
 import androidx.core.content.ContextCompat
+import androidx.core.os.BuildCompat
 import androidx.core.splashscreen.SplashScreen.Companion.installSplashScreen
 import androidx.core.view.isVisible
 import androidx.core.view.updateLayoutParams
@@ -112,6 +114,7 @@ import com.woocommerce.android.util.ChromeCustomTabUtils
 import com.woocommerce.android.util.PackageUtils
 import com.woocommerce.android.util.WooAnimUtils.Duration
 import com.woocommerce.android.util.WooAnimUtils.animateBottomBar
+import com.woocommerce.android.util.WooLog
 import com.woocommerce.android.util.WooPermissionUtils
 import com.woocommerce.android.viewmodel.MultiLiveEvent
 import com.woocommerce.android.widgets.AppRatingDialog
@@ -306,6 +309,7 @@ class MainActivity :
 
     override fun onCreate(savedInstanceState: Bundle?) {
         installSplashScreen()
+        handleOnBackNavigationCompat()
 
         super.onCreate(savedInstanceState)
 
@@ -372,6 +376,29 @@ class MainActivity :
             viewModel.handleIncomingAppLink(intent?.data)
             viewModel.handleShortcutAction(intent?.action?.lowercase(Locale.ROOT))
             handleIncomingImages()
+        }
+    }
+
+    private fun handleOnBackNavigationCompat() {
+        if (BuildCompat.isAtLeastT()) {
+            onBackPressedDispatcher
+                .addCallback(this) {
+                    WooLog.d(WooLog.T.UTILS, "Predictive back: New back navigation callback")
+
+                    AnalyticsTracker.trackBackPressed(this@MainActivity)
+                    getActiveChildFragment()?.let { fragment ->
+                        if (fragment is BackPressListener && !(fragment as BackPressListener).onRequestAllowBackPress()) {
+                            return@addCallback
+                        }
+                    }
+                    supportFragmentManager.primaryNavigationFragment?.let { fragment ->
+                        updateAppBarVisibility(fragment)
+                    }
+                    if (isAtNavigationRoot()) {
+                        remove()
+                        onBackPressedDispatcher.onBackPressed()
+                    }
+                }
         }
     }
 
@@ -459,8 +486,18 @@ class MainActivity :
         }
     }
 
-    @Deprecated("Deprecated in Java")
+    /**
+     * The custom back navigation compatible with Android 33 onwards is provided in handleOnBackNavigationCompat()
+     * function from this class.
+     */
+    @Deprecated(
+        """This method has been deprecated in favor of using the
+      {@link OnBackPressedDispatcher} via {@link #getOnBackPressedDispatcher()}.
+      The OnBackPressedDispatcher controls how back button events are dispatched
+      to one or more {@link OnBackPressedCallback} objects."""
+    )
     override fun onBackPressed() {
+        WooLog.d(WooLog.T.UTILS, "Predictive back: Legacy OnBackPressed called")
         AnalyticsTracker.trackBackPressed(this)
 
         getActiveChildFragment()?.let { fragment ->
@@ -472,7 +509,6 @@ class MainActivity :
         supportFragmentManager.primaryNavigationFragment?.let { fragment ->
             updateAppBarVisibility(fragment)
         }
-
         super.onBackPressed()
     }
 
@@ -537,7 +573,7 @@ class MainActivity :
     /**
      * Get the actual primary navigation Fragment from the support manager
      */
-    private fun getHostChildFragment(): Fragment? {
+    fun getHostChildFragment(): Fragment? {
         val navHostFragment = supportFragmentManager.primaryNavigationFragment
         if (navHostFragment?.childFragmentManager?.fragments?.isNotEmpty() == true) {
             return navHostFragment.childFragmentManager.fragments[0]

--- a/settings.gradle
+++ b/settings.gradle
@@ -186,7 +186,7 @@ gradle.ext.mediaPickerSourceGifBinaryPath = "org.wordpress.mediapicker:source-gi
 
 gradle.ext {
     compileSdkVersion = 36
-    targetSdkVersion = 35
+    targetSdkVersion = 36
     minSdkVersion = 26
 }
 


### PR DESCRIPTION
Closes: WOOMOB-1490

### Description
Last change needed to update project to `targetSdk=36`. Full review here: https://wp.me/p91TBi-dyf

When upgrading the codebase to support the upcoming version of Android 16 (`targetSdk = 36`), among other things the function `override fun onBackPressed()` from any [Activity isn't invoked anymore](https://developer.android.com/about/versions/16/behavior-changes-16#predictive-back). That means that the custom back navigation we heavily rely on in the app is broken. This PR adds the necessary changes for the app to behave the same in new Android version 36 than in prior versions. 

An example of the current problem when `targetSdk=36` with custom back navigation: 

| targetSdk = 35  | targetSdk=36 |
| ------------- | ------------- |
| <video src="https://github.com/user-attachments/assets/0508670b-f8d9-4e69-9e7f-c652b46dfc0a">  | <video src="https://github.com/user-attachments/assets/4a9cfce5-b4f2-44e2-9435-081a27fb44f9">  |



**Context on Custom Back Navigation in the App**
The app overrides the default onBackPressed behavior in multiple places by implementing custom `MainActivity.BackPressListener`: 
```kotlin
        interface BackPressListener {
            fun onRequestAllowBackPress(): Boolean
        }
```
If a Fragment implements `BackPressListener` then when the callback `onBackPressed()` from `MainActivity` (which hosts ~90% of the application screens/fragments) is invoked by the system, then `super.onBackPressed()` is never called because we have an early return: 
```kotlin
    override fun onBackPressed() {
        WooLog.d(WooLog.T.UTILS, "Predictive back: Legacy OnBackPressed called")
        AnalyticsTracker.trackBackPressed(this)

        getActiveChildFragment()?.let { fragment ->
            if (fragment is BackPressListener && !(fragment as BackPressListener).onRequestAllowBackPress()) {
                return
            }
        }

        supportFragmentManager.primaryNavigationFragment?.let { fragment ->
            updateAppBarVisibility(fragment)
        }
        super.onBackPressed()
    }
```

So this PR, migrates the above logic to a `OnBackPressedCallback`always. 

### Test Steps
Have an Android device with Android API 36 and another with API < 36 and go through the following steps: 
1. Open the app
2. Navigate to product details
3. Tap price
4. Edit the value
5. Swipe back to trigger back navigation and see how keyboard is hidden
6. Swipe back to trigger back navigation and see how you land on product detail screen with the price updated
7. Swipe back to trigger back navigation and see how a confirmation dialog to discard changes is shown. 
8. Open product detail again. 
9. Swipe back to navigate back and see it works as expected
10. Exit product detail screen (no need to save changes). 
11. Swipe back from product list and see how you are taken to dashboard tab
12. Swipe back one last time to close the app. 

In both versions the app should have the exact same behavior.


- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
