### PR TITLE
Update UI of POS splash screen syncing state

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/splash/WooPosSplashScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/splash/WooPosSplashScreen.kt
@@ -108,7 +108,7 @@ private fun SyncingCatalog(
             ) {
                 Text(
                     text = stringResource(R.string.woopos_home_syncing_catalog_exit_button),
-                    style = MaterialTheme.typography.labelLarge,
+                    style = MaterialTheme.typography.bodySmall,
                     color = MaterialTheme.colorScheme.onSurface,
                     textDecoration = TextDecoration.Underline
                 )

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/splash/WooPosSplashScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/splash/WooPosSplashScreen.kt
@@ -1,21 +1,23 @@
 package com.woocommerce.android.ui.woopos.splash
 
 import androidx.activity.compose.BackHandler
-import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.offset
+import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.text.style.TextDecoration
 import androidx.compose.ui.unit.dp
 import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import com.woocommerce.android.R
@@ -23,7 +25,9 @@ import com.woocommerce.android.ui.woopos.common.composeui.WooPosPreview
 import com.woocommerce.android.ui.woopos.common.composeui.component.WooPosCircularLoadingIndicator
 import com.woocommerce.android.ui.woopos.common.composeui.component.WooPosErrorScreen
 import com.woocommerce.android.ui.woopos.common.composeui.component.WooPosErrorScreenButtonState
+import com.woocommerce.android.ui.woopos.common.composeui.designsystem.WooPosSpacing
 import com.woocommerce.android.ui.woopos.common.composeui.designsystem.WooPosTheme
+import com.woocommerce.android.ui.woopos.common.composeui.designsystem.toAdaptivePadding
 import com.woocommerce.android.ui.woopos.root.navigation.WooPosNavigationEvent
 
 @Composable
@@ -40,7 +44,9 @@ fun WooPosSplashScreen(onNavigationEvent: (WooPosNavigationEvent) -> Unit) {
             Loading()
         }
         is WooPosSplashState.Syncing -> {
-            SyncingCatalog()
+            SyncingCatalog(
+                onExitPosClicked = { onNavigationEvent(WooPosNavigationEvent.BackFromSplashClicked) }
+            )
         }
         is WooPosSplashState.SyncFailed -> {
             SyncFailed(
@@ -69,23 +75,51 @@ private fun Loading() {
 
 @Suppress("WooPosDesignSystemSpacingUsageRule", "WooPosDesignSystemTextUsageRule")
 @Composable
-private fun SyncingCatalog() {
+private fun SyncingCatalog(
+    onExitPosClicked: () -> Unit
+) {
+    val loadingIndicatorSize = 160.dp
     Box(
-        modifier = Modifier.fillMaxSize(),
-        contentAlignment = Alignment.Center
+        modifier = Modifier.fillMaxSize()
     ) {
+        WooPosCircularLoadingIndicator(
+            modifier = Modifier
+                .size(loadingIndicatorSize)
+                .align(Alignment.Center)
+        )
+
+        Text(
+            text = stringResource(R.string.woopos_home_syncing_catalog_title),
+            style = MaterialTheme.typography.headlineMedium.copy(fontWeight = FontWeight.Bold),
+            textAlign = TextAlign.Center,
+            modifier = Modifier
+                .align(Alignment.Center)
+                .offset(y = (loadingIndicatorSize / 2 + WooPosSpacing.XLarge.value))
+        )
+
         Column(
-            horizontalAlignment = Alignment.CenterHorizontally,
-            verticalArrangement = Arrangement.Center
+            modifier = Modifier
+                .align(Alignment.BottomCenter)
+                .padding(bottom = WooPosSpacing.XLarge.value.toAdaptivePadding()),
+            horizontalAlignment = Alignment.CenterHorizontally
         ) {
-            WooPosCircularLoadingIndicator(modifier = Modifier.size(160.dp))
-            Spacer(modifier = Modifier.height(32.dp))
+            TextButton(
+                onClick = onExitPosClicked
+            ) {
+                Text(
+                    text = stringResource(R.string.woopos_home_syncing_catalog_exit_button),
+                    style = MaterialTheme.typography.labelLarge,
+                    color = MaterialTheme.colorScheme.onSurface,
+                    textDecoration = TextDecoration.Underline
+                )
+            }
+
             Text(
-                text = stringResource(R.string.woopos_home_syncing_catalog_title),
-                style = MaterialTheme.typography.headlineSmall,
-                textAlign = TextAlign.Center
+                text = stringResource(R.string.woopos_home_syncing_catalog_subtitle),
+                style = MaterialTheme.typography.bodySmall,
+                textAlign = TextAlign.Center,
+                color = WooPosTheme.colors.onSurfaceVariantLowest
             )
-            Spacer(modifier = Modifier.height(16.dp))
         }
     }
 }
@@ -114,6 +148,8 @@ fun WooPosSplashScreenLoadingPreview() {
 @WooPosPreview
 fun WooPosSplashScreenSyncingPreview() {
     WooPosTheme {
-        SyncingCatalog()
+        SyncingCatalog(
+            onExitPosClicked = {}
+        )
     }
 }

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -3604,7 +3604,9 @@
     <!--
     Woo POS
     -->
-    <string name="woopos_home_syncing_catalog_title">Syncing product catalog</string>
+    <string name="woopos_home_syncing_catalog_title">Syncing catalog</string>
+    <string name="woopos_home_syncing_catalog_subtitle">Syncing will continue in the background.</string>
+    <string name="woopos_home_syncing_catalog_exit_button">Exit POS</string>
     <string name="woopos_home_sync_failed_title">Unable to sync</string>
     <string name="woopos_home_sync_failed_message">We are unable to sync your product catalog. Please check your internet connection and retry.</string>
     <string name="woopos_home_sync_failed_retry_button">Retry</string>


### PR DESCRIPTION
 Fixes WOOMOB-1060

  ### Description
  Updated the WooPosSplashScreen SyncingCatalog state to match the new design requirements:
  - Added Exit POS button with underline styling positioned at the bottom
  - Added "Syncing will continue in the background" subtitle below the Exit POS button
  - Updated "Syncing product catalog" title to "Syncing catalog"
  - Progress indicator remains centered on screen with proper spacing - fixes jumping content during transition

  ### Test Steps
  1. Launch WooCommerce app and navigate to POS
  2. Trigger a catalog sync to see the SyncingCatalog state (either by adding a delay to Splash screen or clearing POS products database)
  3. Verify the progress indicator is centered on screen
  4. Verify "Syncing catalog" title appears below the progress indicator
  5. Verify Exit POS button with underline appears at the bottom
  6. Verify "Syncing will continue in the background" subtitle appears below the Exit POS button
  7. Tap Exit POS button to verify it exits the sync screen

  ### Images/gif
  <!-- Updated splash screen design with Exit POS button and subtitle -->


https://github.com/user-attachments/assets/31483aa1-6d8c-482e-a240-294212c0d99b

<img width="400" height="500" alt="Screenshot_20251030_093143" src="https://github.com/user-attachments/assets/5fc3dce6-c252-4753-a76a-60e09b9b606a" />

<img width="400" height="500" alt="Screenshot_20251030_093157" src="https://github.com/user-attachments/assets/54ddbedf-3abd-4780-8caa-93b6b7809eea" />


  - [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.
