### PR TITLE
[WOOMOB-1604] Update WooPos Settings hardware screens design

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/settings/details/WooPosSettingsDetailsMenuItem.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/settings/details/WooPosSettingsDetailsMenuItem.kt
@@ -45,11 +45,11 @@ fun WooPosSettingsDetailsMenuItem(
                 color = MaterialTheme.colorScheme.onSurface,
                 fontWeight = FontWeight.Bold,
             )
+            Spacer(modifier = Modifier.size(WooPosSpacing.XSmall.value))
             WooPosText(
                 text = subtitle,
                 style = WooPosTypography.BodySmall,
-                color = MaterialTheme.colorScheme.outline,
-                modifier = Modifier.padding(top = WooPosSpacing.XSmall.value)
+                color = WooPosTheme.colors.onSurfaceVariantHighest,
             )
         }
     }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/settings/details/WooPosSettingsDetailsMenuItem.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/settings/details/WooPosSettingsDetailsMenuItem.kt
@@ -8,6 +8,8 @@ import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Store
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.ripple
@@ -17,17 +19,19 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.unit.dp
+import com.woocommerce.android.ui.woopos.common.composeui.WooPosPreview
 import com.woocommerce.android.ui.woopos.common.composeui.component.WooPosText
 import com.woocommerce.android.ui.woopos.common.composeui.designsystem.WooPosSpacing
+import com.woocommerce.android.ui.woopos.common.composeui.designsystem.WooPosTheme
 import com.woocommerce.android.ui.woopos.common.composeui.designsystem.WooPosTypography
 
 @Composable
 fun WooPosSettingsDetailsMenuItem(
+    modifier: Modifier = Modifier,
     icon: ImageVector,
     title: String,
     subtitle: String,
     onClick: (() -> Unit)? = null,
-    modifier: Modifier = Modifier
 ) {
     Row(
         modifier = modifier
@@ -70,5 +74,17 @@ fun WooPosSettingsDetailsMenuItem(
                 modifier = Modifier.padding(top = WooPosSpacing.XSmall.value)
             )
         }
+    }
+}
+
+@WooPosPreview
+@Composable
+fun WooPosSettingsDetailsMenuItemPreview() {
+    WooPosTheme {
+        WooPosSettingsDetailsMenuItem(
+            icon = Icons.Default.Store,
+            title = "Store name",
+            subtitle = "My WooCommerce Store"
+        )
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/settings/details/WooPosSettingsDetailsMenuItem.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/settings/details/WooPosSettingsDetailsMenuItem.kt
@@ -48,7 +48,7 @@ fun WooPosSettingsDetailsMenuItem(
             Spacer(modifier = Modifier.size(WooPosSpacing.XSmall.value))
             WooPosText(
                 text = subtitle,
-                style = WooPosTypography.BodySmall,
+                style = WooPosTypography.BodyMedium,
                 color = WooPosTheme.colors.onSurfaceVariantHighest,
             )
         }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/settings/details/WooPosSettingsDetailsMenuItem.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/settings/details/WooPosSettingsDetailsMenuItem.kt
@@ -2,24 +2,19 @@ package com.woocommerce.android.ui.woopos.settings.details
 
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.interaction.MutableInteractionSource
-import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
-import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.filled.Store
-import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.ripple
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.remember
-import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.graphics.vector.ImageVector
-import androidx.compose.ui.unit.dp
+import androidx.compose.ui.text.font.FontWeight
 import com.woocommerce.android.ui.woopos.common.composeui.WooPosPreview
+import com.woocommerce.android.ui.woopos.common.composeui.component.WooPosCard
 import com.woocommerce.android.ui.woopos.common.composeui.component.WooPosText
 import com.woocommerce.android.ui.woopos.common.composeui.designsystem.WooPosSpacing
 import com.woocommerce.android.ui.woopos.common.composeui.designsystem.WooPosTheme
@@ -28,44 +23,27 @@ import com.woocommerce.android.ui.woopos.common.composeui.designsystem.WooPosTyp
 @Composable
 fun WooPosSettingsDetailsMenuItem(
     modifier: Modifier = Modifier,
-    icon: ImageVector,
     title: String,
     subtitle: String,
-    onClick: (() -> Unit)? = null,
+    onClick: (() -> Unit),
 ) {
-    Row(
+    WooPosCard(
         modifier = modifier
             .fillMaxWidth()
-            .then(
-                if (onClick != null) {
-                    Modifier.clickable(
-                        interactionSource = remember { MutableInteractionSource() },
-                        indication = ripple()
-                    ) { onClick() }
-                } else {
-                    Modifier
-                }
-            )
-            .padding(WooPosSpacing.Medium.value),
-        verticalAlignment = Alignment.CenterVertically,
-        horizontalArrangement = Arrangement.Start
+            .clickable(
+                interactionSource = remember { MutableInteractionSource() },
+                indication = ripple()
+            ) { onClick() },
     ) {
-        Icon(
-            imageVector = icon,
-            contentDescription = null,
-            tint = MaterialTheme.colorScheme.onSurface,
-            modifier = Modifier.size(28.dp)
-        )
-
         Column(
             modifier = Modifier
-                .weight(1f)
-                .padding(start = WooPosSpacing.Medium.value)
+                .padding(WooPosSpacing.Medium.value)
         ) {
             WooPosText(
                 text = title,
                 style = WooPosTypography.BodyLarge,
-                color = MaterialTheme.colorScheme.onSurface
+                color = MaterialTheme.colorScheme.onSurface,
+                fontWeight = FontWeight.Bold,
             )
             WooPosText(
                 text = subtitle,
@@ -81,10 +59,20 @@ fun WooPosSettingsDetailsMenuItem(
 @Composable
 fun WooPosSettingsDetailsMenuItemPreview() {
     WooPosTheme {
-        WooPosSettingsDetailsMenuItem(
-            icon = Icons.Default.Store,
-            title = "Store name",
-            subtitle = "My WooCommerce Store"
-        )
+        Column {
+            WooPosSettingsDetailsMenuItem(
+                title = "Store name",
+                subtitle = "My WooCommerce Store",
+                onClick = {}
+            )
+
+            Spacer(modifier = Modifier.size(WooPosSpacing.Large.value))
+
+            WooPosSettingsDetailsMenuItem(
+                title = "Currency",
+                subtitle = "US Dollar (USD)",
+                onClick = {}
+            )
+        }
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/settings/details/hardware/WooPosSettingsHardwareScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/settings/details/hardware/WooPosSettingsHardwareScreen.kt
@@ -28,7 +28,6 @@ fun WooPosHardwareSettingsScreen(
     ) {
         state.items.forEach { item ->
             WooPosSettingsDetailsMenuItem(
-                icon = item.icon,
                 title = stringResource(item.titleRes),
                 subtitle = stringResource(item.subtitleRes),
                 onClick = {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/settings/details/hardware/WooPosSettingsHardwareScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/settings/details/hardware/WooPosSettingsHardwareScreen.kt
@@ -1,7 +1,9 @@
 package com.woocommerce.android.ui.woopos.settings.details.hardware
 
+import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.runtime.Composable
@@ -11,6 +13,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
 import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import com.woocommerce.android.R
+import com.woocommerce.android.ui.woopos.common.composeui.designsystem.WooPosSpacing
 import com.woocommerce.android.ui.woopos.settings.WooPosSettingsDetailDestination
 import com.woocommerce.android.ui.woopos.settings.details.WooPosSettingsDetailsMenuItem
 
@@ -24,10 +27,12 @@ fun WooPosHardwareSettingsScreen(
     Column(
         modifier = Modifier
             .fillMaxSize()
-            .verticalScroll(rememberScrollState())
+            .verticalScroll(rememberScrollState()),
+        verticalArrangement = Arrangement.spacedBy(WooPosSpacing.Medium.value)
     ) {
         state.items.forEach { item ->
             WooPosSettingsDetailsMenuItem(
+                modifier = Modifier.padding(horizontal = WooPosSpacing.Medium.value),
                 title = stringResource(item.titleRes),
                 subtitle = stringResource(item.subtitleRes),
                 onClick = {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/settings/details/hardware/WooPosSettingsHardwareState.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/settings/details/hardware/WooPosSettingsHardwareState.kt
@@ -11,12 +11,12 @@ data class HardwareSettingsItem(
 data class WooPosHardwareSettingsState(
     val items: List<HardwareSettingsItem> = listOf(
         HardwareSettingsItem(
+            titleRes = R.string.woopos_settings_hardware_card_readers,
+            subtitleRes = R.string.woopos_settings_hardware_card_readers_subtitle,
+        ),
+        HardwareSettingsItem(
             titleRes = R.string.woopos_settings_hardware_barcode_scanners,
             subtitleRes = R.string.woopos_settings_hardware_barcode_scanners_subtitle,
         ),
-        HardwareSettingsItem(
-            titleRes = R.string.woopos_settings_hardware_card_readers,
-            subtitleRes = R.string.woopos_settings_hardware_card_readers_subtitle,
-        )
     ),
 )

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/settings/details/hardware/WooPosSettingsHardwareState.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/settings/details/hardware/WooPosSettingsHardwareState.kt
@@ -1,16 +1,11 @@
 package com.woocommerce.android.ui.woopos.settings.details.hardware
 
 import androidx.annotation.StringRes
-import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.filled.CreditCard
-import androidx.compose.material.icons.filled.DocumentScanner
-import androidx.compose.ui.graphics.vector.ImageVector
 import com.woocommerce.android.R
 
 data class HardwareSettingsItem(
     @StringRes val titleRes: Int,
     @StringRes val subtitleRes: Int,
-    val icon: ImageVector,
 )
 
 data class WooPosHardwareSettingsState(
@@ -18,12 +13,10 @@ data class WooPosHardwareSettingsState(
         HardwareSettingsItem(
             titleRes = R.string.woopos_settings_hardware_barcode_scanners,
             subtitleRes = R.string.woopos_settings_hardware_barcode_scanners_subtitle,
-            icon = Icons.Default.DocumentScanner,
         ),
         HardwareSettingsItem(
             titleRes = R.string.woopos_settings_hardware_card_readers,
             subtitleRes = R.string.woopos_settings_hardware_card_readers_subtitle,
-            icon = Icons.Default.CreditCard
         )
     ),
 )

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/settings/details/hardware/barcodescanner/WooPosSettingsHardwareBarcodeScannerScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/settings/details/hardware/barcodescanner/WooPosSettingsHardwareBarcodeScannerScreen.kt
@@ -4,9 +4,6 @@ import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
-import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.filled.Description
-import androidx.compose.material.icons.filled.Settings
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.ui.Modifier
@@ -56,14 +53,12 @@ fun WooPosSettingsHardwareBarcodeScannerContent(
             .verticalScroll(rememberScrollState())
     ) {
         WooPosSettingsDetailsMenuItem(
-            icon = Icons.Default.Settings,
             title = stringResource(R.string.woopos_settings_barcode_scanner_setup_title),
             subtitle = stringResource(R.string.woopos_settings_barcode_scanner_setup_subtitle),
             onClick = onSetupScannerClicked
         )
 
         WooPosSettingsDetailsMenuItem(
-            icon = Icons.Default.Description,
             title = stringResource(R.string.woopos_settings_barcode_scanner_documentation_title),
             subtitle = stringResource(R.string.woopos_settings_barcode_scanner_documentation_subtitle),
             onClick = onDocumentationClicked

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/settings/details/hardware/barcodescanner/WooPosSettingsHardwareBarcodeScannerScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/settings/details/hardware/barcodescanner/WooPosSettingsHardwareBarcodeScannerScreen.kt
@@ -1,7 +1,9 @@
 package com.woocommerce.android.ui.woopos.settings.details.hardware.barcodescanner
 
+import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.runtime.Composable
@@ -12,6 +14,7 @@ import androidx.compose.ui.res.stringResource
 import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import com.woocommerce.android.R
 import com.woocommerce.android.ui.woopos.common.composeui.WooPosPreview
+import com.woocommerce.android.ui.woopos.common.composeui.designsystem.WooPosSpacing
 import com.woocommerce.android.ui.woopos.common.composeui.designsystem.WooPosTheme
 import com.woocommerce.android.ui.woopos.settings.details.WooPosSettingsDetailsMenuItem
 import com.woocommerce.android.util.ChromeCustomTabUtils
@@ -50,15 +53,18 @@ fun WooPosSettingsHardwareBarcodeScannerContent(
     Column(
         modifier = Modifier
             .fillMaxSize()
-            .verticalScroll(rememberScrollState())
+            .verticalScroll(rememberScrollState()),
+        verticalArrangement = Arrangement.spacedBy(WooPosSpacing.Medium.value)
     ) {
         WooPosSettingsDetailsMenuItem(
+            modifier = Modifier.padding(horizontal = WooPosSpacing.Medium.value),
             title = stringResource(R.string.woopos_settings_barcode_scanner_setup_title),
             subtitle = stringResource(R.string.woopos_settings_barcode_scanner_setup_subtitle),
             onClick = onSetupScannerClicked
         )
 
         WooPosSettingsDetailsMenuItem(
+            modifier = Modifier.padding(horizontal = WooPosSpacing.Medium.value),
             title = stringResource(R.string.woopos_settings_barcode_scanner_documentation_title),
             subtitle = stringResource(R.string.woopos_settings_barcode_scanner_documentation_subtitle),
             onClick = onDocumentationClicked

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/settings/details/hardware/cardreader/WooPosSettingsHardwareCardReaderScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/settings/details/hardware/cardreader/WooPosSettingsHardwareCardReaderScreen.kt
@@ -16,15 +16,6 @@ import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.filled.Battery0Bar
-import androidx.compose.material.icons.filled.Battery1Bar
-import androidx.compose.material.icons.filled.Battery2Bar
-import androidx.compose.material.icons.filled.Battery3Bar
-import androidx.compose.material.icons.filled.Battery4Bar
-import androidx.compose.material.icons.filled.Battery5Bar
-import androidx.compose.material.icons.filled.Battery6Bar
-import androidx.compose.material.icons.filled.BatteryFull
-import androidx.compose.material.icons.filled.Description
 import androidx.compose.material.icons.filled.SystemUpdate
 import androidx.compose.material3.Card
 import androidx.compose.material3.CardDefaults
@@ -36,7 +27,6 @@ import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
@@ -163,12 +153,12 @@ private fun ConnectedContent(
 
     if (batteryLevel != null) {
         WooPosSettingsDetailsMenuItem(
-            icon = getBatteryIcon(batteryLevel),
             title = stringResource(R.string.woopos_settings_card_reader_battery_title),
             subtitle = stringResource(
                 R.string.card_reader_detail_connected_battery_percentage,
                 (batteryLevel * 100).toInt()
-            )
+            ),
+            onClick = { }
         )
     }
 
@@ -239,7 +229,6 @@ private fun NotConnectedContent(
         Spacer(modifier = Modifier.height(WooPosSpacing.Large.value))
 
         WooPosSettingsDetailsMenuItem(
-            icon = Icons.Default.Description,
             title = stringResource(R.string.woopos_settings_card_reader_documentation_title),
             subtitle = stringResource(R.string.woopos_settings_card_reader_documentation_subtitle),
             onClick = onDocumentationClicked
@@ -322,20 +311,6 @@ private fun ConnectionHint(text: String) {
         style = WooPosTypography.BodyMedium,
         color = MaterialTheme.colorScheme.onSurfaceVariant
     )
-}
-
-@Composable
-private fun getBatteryIcon(batteryLevel: Float): ImageVector {
-    return when {
-        batteryLevel >= 1.0f -> Icons.Default.BatteryFull
-        batteryLevel >= 0.86f -> Icons.Default.Battery6Bar
-        batteryLevel >= 0.71f -> Icons.Default.Battery5Bar
-        batteryLevel >= 0.57f -> Icons.Default.Battery4Bar
-        batteryLevel >= 0.43f -> Icons.Default.Battery3Bar
-        batteryLevel >= 0.29f -> Icons.Default.Battery2Bar
-        batteryLevel >= 0.14f -> Icons.Default.Battery1Bar
-        else -> Icons.Default.Battery0Bar
-    }
 }
 
 @WooPosPreview

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/settings/details/hardware/cardreader/WooPosSettingsHardwareCardReaderScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/settings/details/hardware/cardreader/WooPosSettingsHardwareCardReaderScreen.kt
@@ -119,7 +119,8 @@ private fun ConnectedContent(
     firmwareVersion: String,
     isSoftwareUpdateAvailable: Boolean,
     onDisconnectClicked: () -> Unit,
-    onUpdateClick: () -> Unit
+    onUpdateClick: () -> Unit,
+    onDocumentationClicked: () -> Unit,
 ) {
     Column(
         verticalArrangement = Arrangement.spacedBy(WooPosSpacing.Medium.value)
@@ -226,7 +227,7 @@ private fun ConnectedContent(
             modifier = Modifier.padding(horizontal = WooPosSpacing.Medium.value),
             title = stringResource(R.string.woopos_settings_card_reader_documentation_title),
             subtitle = stringResource(R.string.woopos_settings_card_reader_documentation_subtitle),
-            onClick = {}
+            onClick = onDocumentationClicked
         )
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/settings/details/hardware/cardreader/WooPosSettingsHardwareCardReaderScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/settings/details/hardware/cardreader/WooPosSettingsHardwareCardReaderScreen.kt
@@ -157,7 +157,7 @@ private fun ConnectedContent(
                     )
                 }
 
-                if (batteryLevel != null || firmwareVersion.isNotEmpty()) {
+                if (batteryLevel != null) {
                     Spacer(modifier = Modifier.height(WooPosSpacing.Medium.value))
                     HorizontalDivider()
                 }
@@ -181,46 +181,42 @@ private fun ConnectedContent(
                         )
                     }
 
-                    if (firmwareVersion.isNotEmpty()) {
-                        Spacer(modifier = Modifier.height(WooPosSpacing.Medium.value))
-                        HorizontalDivider()
-                    }
+                    Spacer(modifier = Modifier.height(WooPosSpacing.Medium.value))
+                    HorizontalDivider()
                 }
 
-                if (firmwareVersion.isNotEmpty()) {
-                    Spacer(modifier = Modifier.height(WooPosSpacing.Medium.value))
+                Spacer(modifier = Modifier.height(WooPosSpacing.Medium.value))
 
+                Row(
+                    modifier = Modifier.fillMaxWidth(),
+                    horizontalArrangement = Arrangement.SpaceBetween,
+                    verticalAlignment = Alignment.CenterVertically
+                ) {
                     Row(
-                        modifier = Modifier.fillMaxWidth(),
-                        horizontalArrangement = Arrangement.SpaceBetween,
-                        verticalAlignment = Alignment.CenterVertically
+                        modifier = Modifier.weight(1f),
+                        horizontalArrangement = Arrangement.SpaceBetween
                     ) {
-                        Row(
-                            modifier = Modifier.weight(1f),
-                            horizontalArrangement = Arrangement.SpaceBetween
-                        ) {
-                            WooPosText(
-                                text = stringResource(R.string.woopos_settings_card_reader_firmware_title),
-                                style = WooPosTypography.BodyMedium,
-                                color = MaterialTheme.colorScheme.onSurfaceVariant
-                            )
-                            WooPosText(
-                                text = stringResource(
-                                    R.string.card_reader_detail_connected_firmware_version,
-                                    firmwareVersion
-                                ),
-                                style = WooPosTypography.BodyMedium,
-                                color = MaterialTheme.colorScheme.onSurface
-                            )
-                        }
+                        WooPosText(
+                            text = stringResource(R.string.woopos_settings_card_reader_firmware_title),
+                            style = WooPosTypography.BodyMedium,
+                            color = MaterialTheme.colorScheme.onSurfaceVariant
+                        )
+                        WooPosText(
+                            text = stringResource(
+                                R.string.card_reader_detail_connected_firmware_version,
+                                firmwareVersion
+                            ),
+                            style = WooPosTypography.BodyMedium,
+                            color = MaterialTheme.colorScheme.onSurface
+                        )
+                    }
 
-                        if (isSoftwareUpdateAvailable) {
-                            Spacer(modifier = Modifier.size(WooPosSpacing.Medium.value))
-                            WooPosButtonSmall(
-                                text = stringResource(R.string.woopos_settings_card_reader_update_button),
-                                onClick = onUpdateClick
-                            )
-                        }
+                    if (isSoftwareUpdateAvailable) {
+                        Spacer(modifier = Modifier.size(WooPosSpacing.Medium.value))
+                        WooPosButtonSmall(
+                            text = stringResource(R.string.woopos_settings_card_reader_update_button),
+                            onClick = onUpdateClick
+                        )
                     }
                 }
             }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/settings/details/hardware/cardreader/WooPosSettingsHardwareCardReaderScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/settings/details/hardware/cardreader/WooPosSettingsHardwareCardReaderScreen.kt
@@ -17,8 +17,6 @@ import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.outlined.Info
-import androidx.compose.material3.Card
-import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
@@ -36,6 +34,7 @@ import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import com.woocommerce.android.R
 import com.woocommerce.android.ui.woopos.common.composeui.WooPosPreview
 import com.woocommerce.android.ui.woopos.common.composeui.component.WooPosButtonSmall
+import com.woocommerce.android.ui.woopos.common.composeui.component.WooPosCard
 import com.woocommerce.android.ui.woopos.common.composeui.component.WooPosOutlinedButtonSmall
 import com.woocommerce.android.ui.woopos.common.composeui.component.WooPosText
 import com.woocommerce.android.ui.woopos.common.composeui.designsystem.WooPosSpacing
@@ -131,13 +130,10 @@ private fun ConnectedContent(
             )
         }
 
-        Card(
+        WooPosCard(
             modifier = Modifier
                 .fillMaxWidth()
                 .padding(horizontal = WooPosSpacing.Medium.value),
-            colors = CardDefaults.cardColors(
-                containerColor = MaterialTheme.colorScheme.surfaceContainerLowest,
-            )
         ) {
             Column(
                 modifier = Modifier
@@ -267,12 +263,7 @@ private fun NotConnectedContent(
 private fun UpdateFirmwareBanner(
     modifier: Modifier = Modifier
 ) {
-    Card(
-        modifier = modifier.fillMaxWidth(),
-        colors = CardDefaults.cardColors(
-            containerColor = MaterialTheme.colorScheme.surfaceContainerLow,
-        )
-    ) {
+    WooPosCard(modifier = modifier.fillMaxWidth()) {
         Row(
             modifier = Modifier
                 .fillMaxWidth()
@@ -284,13 +275,10 @@ private fun UpdateFirmwareBanner(
                 imageVector = Icons.Outlined.Info,
                 contentDescription = null,
                 tint = MaterialTheme.colorScheme.onSurface,
-                modifier = Modifier.size(48.dp)
+                modifier = Modifier.size(32.dp)
             )
 
-            Column(
-                modifier = Modifier.weight(1f),
-                verticalArrangement = Arrangement.spacedBy(WooPosSpacing.Small.value)
-            ) {
+            Column(modifier = Modifier.weight(1f)) {
                 WooPosText(
                     text = stringResource(R.string.woopos_settings_card_reader_update_firmware_title),
                     style = WooPosTypography.BodyLarge,
@@ -298,7 +286,7 @@ private fun UpdateFirmwareBanner(
                     color = MaterialTheme.colorScheme.onSurface
                 )
 
-                Spacer(modifier = Modifier.size(WooPosSpacing.XSmall.value))
+                Spacer(modifier = Modifier.height(WooPosSpacing.XSmall.value))
 
                 WooPosText(
                     text = stringResource(R.string.woopos_settings_card_reader_update_firmware_message),

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/settings/details/hardware/cardreader/WooPosSettingsHardwareCardReaderScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/settings/details/hardware/cardreader/WooPosSettingsHardwareCardReaderScreen.kt
@@ -298,7 +298,6 @@ private fun UpdateFirmwareBanner(
     }
 }
 
-
 @WooPosPreview
 @Composable
 fun WooPosSettingsHardwareCardReaderScreenNotConnectedPreview() {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/settings/details/hardware/cardreader/WooPosSettingsHardwareCardReaderScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/settings/details/hardware/cardreader/WooPosSettingsHardwareCardReaderScreen.kt
@@ -151,8 +151,11 @@ private fun ConnectedContent(
         }
     }
 
+    Spacer(modifier = Modifier.height(WooPosSpacing.Medium.value))
+
     if (batteryLevel != null) {
         WooPosSettingsDetailsMenuItem(
+            modifier = Modifier.padding(horizontal = WooPosSpacing.Medium.value),
             title = stringResource(R.string.woopos_settings_card_reader_battery_title),
             subtitle = stringResource(
                 R.string.card_reader_detail_connected_battery_percentage,
@@ -160,6 +163,8 @@ private fun ConnectedContent(
             ),
             onClick = { }
         )
+
+        Spacer(modifier = Modifier.height(WooPosSpacing.Medium.value))
     }
 
     FirmwareMenuItem(
@@ -168,7 +173,7 @@ private fun ConnectedContent(
         onUpdateClick = onUpdateClick
     )
 
-    Spacer(modifier = Modifier.height(WooPosSpacing.Small.value))
+    Spacer(modifier = Modifier.height(WooPosSpacing.Medium.value))
 
     WooPosOutlinedButton(
         modifier = Modifier
@@ -226,9 +231,10 @@ private fun NotConnectedContent(
             onClick = onConnectClicked
         )
 
-        Spacer(modifier = Modifier.height(WooPosSpacing.Large.value))
+        Spacer(modifier = Modifier.height(WooPosSpacing.Medium.value))
 
         WooPosSettingsDetailsMenuItem(
+            modifier = Modifier.padding(horizontal = WooPosSpacing.Medium.value),
             title = stringResource(R.string.woopos_settings_card_reader_documentation_title),
             subtitle = stringResource(R.string.woopos_settings_card_reader_documentation_subtitle),
             onClick = onDocumentationClicked

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/settings/details/hardware/cardreader/WooPosSettingsHardwareCardReaderScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/settings/details/hardware/cardreader/WooPosSettingsHardwareCardReaderScreen.kt
@@ -97,7 +97,8 @@ private fun WooPosSettingsHardwareCardReaderContent(
                         ),
                         isSoftwareUpdateAvailable = state.isSoftwareUpdateAvailable,
                         onDisconnectClicked = onDisconnectClicked,
-                        onUpdateClick = onUpdateClick
+                        onUpdateClick = onUpdateClick,
+                        onDocumentationClicked = onDocumentationClicked,
                     )
                 }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/settings/details/hardware/cardreader/WooPosSettingsHardwareCardReaderScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/settings/details/hardware/cardreader/WooPosSettingsHardwareCardReaderScreen.kt
@@ -16,9 +16,10 @@ import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.filled.SystemUpdate
+import androidx.compose.material.icons.outlined.Info
 import androidx.compose.material3.Card
 import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.runtime.Composable
@@ -34,9 +35,8 @@ import androidx.compose.ui.unit.dp
 import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import com.woocommerce.android.R
 import com.woocommerce.android.ui.woopos.common.composeui.WooPosPreview
-import com.woocommerce.android.ui.woopos.common.composeui.component.WooPosButton
 import com.woocommerce.android.ui.woopos.common.composeui.component.WooPosButtonSmall
-import com.woocommerce.android.ui.woopos.common.composeui.component.WooPosOutlinedButton
+import com.woocommerce.android.ui.woopos.common.composeui.component.WooPosOutlinedButtonSmall
 import com.woocommerce.android.ui.woopos.common.composeui.component.WooPosText
 import com.woocommerce.android.ui.woopos.common.composeui.designsystem.WooPosSpacing
 import com.woocommerce.android.ui.woopos.common.composeui.designsystem.WooPosTheme
@@ -44,6 +44,7 @@ import com.woocommerce.android.ui.woopos.common.composeui.designsystem.WooPosTyp
 import com.woocommerce.android.ui.woopos.settings.details.WooPosSettingsDetailsMenuItem
 import com.woocommerce.android.util.ChromeCustomTabUtils
 import kotlinx.coroutines.flow.collectLatest
+import kotlin.math.roundToInt
 
 @Composable
 fun WooPosSettingsHardwareCardReaderScreen(
@@ -121,67 +122,121 @@ private fun ConnectedContent(
     onDisconnectClicked: () -> Unit,
     onUpdateClick: () -> Unit
 ) {
-    Card(
-        modifier = Modifier
-            .fillMaxWidth()
-            .padding(horizontal = WooPosSpacing.Medium.value),
-        colors = CardDefaults.cardColors(
-            containerColor = MaterialTheme.colorScheme.surfaceContainerHigh,
-        )
+    Column(
+        verticalArrangement = Arrangement.spacedBy(WooPosSpacing.Medium.value)
     ) {
-        Column(
-            modifier = Modifier
-                .fillMaxWidth()
-                .padding(WooPosSpacing.Medium.value),
-            verticalArrangement = Arrangement.spacedBy(WooPosSpacing.Small.value)
-        ) {
-            WooPosText(
-                text = stringResource(R.string.woopos_settings_card_reader_connected_reader),
-                style = WooPosTypography.BodyXLarge,
-                fontWeight = FontWeight.Bold,
-                color = MaterialTheme.colorScheme.onSurface
-            )
-
-            WooPosText(
-                text = readerName,
-                style = WooPosTypography.BodyMedium,
-                color = MaterialTheme.colorScheme.onSurfaceVariant,
-                maxLines = 1,
+        if (isSoftwareUpdateAvailable) {
+            UpdateFirmwareBanner(
+                modifier = Modifier.padding(horizontal = WooPosSpacing.Medium.value)
             )
         }
-    }
 
-    Spacer(modifier = Modifier.height(WooPosSpacing.Medium.value))
+        Card(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(horizontal = WooPosSpacing.Medium.value),
+            colors = CardDefaults.cardColors(
+                containerColor = MaterialTheme.colorScheme.surfaceContainerLowest,
+            )
+        ) {
+            Column(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(WooPosSpacing.Medium.value)
+            ) {
+                Row(
+                    modifier = Modifier.fillMaxWidth(),
+                    horizontalArrangement = Arrangement.SpaceBetween,
+                    verticalAlignment = Alignment.CenterVertically
+                ) {
+                    WooPosText(
+                        text = readerName,
+                        style = WooPosTypography.BodyMedium,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    )
 
-    if (batteryLevel != null) {
+                    WooPosOutlinedButtonSmall(
+                        text = stringResource(R.string.card_reader_detail_connected_disconnect_reader),
+                        onClick = onDisconnectClicked
+                    )
+                }
+
+                if (batteryLevel != null || firmwareVersion.isNotEmpty()) {
+                    Spacer(modifier = Modifier.height(WooPosSpacing.Medium.value))
+                    HorizontalDivider()
+                }
+
+                if (batteryLevel != null) {
+                    Spacer(modifier = Modifier.height(WooPosSpacing.Medium.value))
+
+                    Row(
+                        modifier = Modifier.fillMaxWidth(),
+                        horizontalArrangement = Arrangement.SpaceBetween
+                    ) {
+                        WooPosText(
+                            text = stringResource(R.string.woopos_settings_card_reader_battery_title),
+                            style = WooPosTypography.BodyMedium,
+                            color = MaterialTheme.colorScheme.onSurfaceVariant
+                        )
+                        WooPosText(
+                            text = "${(batteryLevel * 100).roundToInt()}%",
+                            style = WooPosTypography.BodyMedium,
+                            color = MaterialTheme.colorScheme.onSurface
+                        )
+                    }
+
+                    if (firmwareVersion.isNotEmpty()) {
+                        Spacer(modifier = Modifier.height(WooPosSpacing.Medium.value))
+                        HorizontalDivider()
+                    }
+                }
+
+                if (firmwareVersion.isNotEmpty()) {
+                    Spacer(modifier = Modifier.height(WooPosSpacing.Medium.value))
+
+                    Row(
+                        modifier = Modifier.fillMaxWidth(),
+                        horizontalArrangement = Arrangement.SpaceBetween,
+                        verticalAlignment = Alignment.CenterVertically
+                    ) {
+                        Row(
+                            modifier = Modifier.weight(1f),
+                            horizontalArrangement = Arrangement.SpaceBetween
+                        ) {
+                            WooPosText(
+                                text = stringResource(R.string.woopos_settings_card_reader_firmware_title),
+                                style = WooPosTypography.BodyMedium,
+                                color = MaterialTheme.colorScheme.onSurfaceVariant
+                            )
+                            WooPosText(
+                                text = stringResource(
+                                    R.string.card_reader_detail_connected_firmware_version,
+                                    firmwareVersion
+                                ),
+                                style = WooPosTypography.BodyMedium,
+                                color = MaterialTheme.colorScheme.onSurface
+                            )
+                        }
+
+                        if (isSoftwareUpdateAvailable) {
+                            Spacer(modifier = Modifier.size(WooPosSpacing.Medium.value))
+                            WooPosButtonSmall(
+                                text = stringResource(R.string.woopos_settings_card_reader_update_button),
+                                onClick = onUpdateClick
+                            )
+                        }
+                    }
+                }
+            }
+        }
+
         WooPosSettingsDetailsMenuItem(
             modifier = Modifier.padding(horizontal = WooPosSpacing.Medium.value),
-            title = stringResource(R.string.woopos_settings_card_reader_battery_title),
-            subtitle = stringResource(
-                R.string.card_reader_detail_connected_battery_percentage,
-                (batteryLevel * 100).toInt()
-            ),
-            onClick = { }
+            title = stringResource(R.string.woopos_settings_card_reader_documentation_title),
+            subtitle = stringResource(R.string.woopos_settings_card_reader_documentation_subtitle),
+            onClick = {}
         )
-
-        Spacer(modifier = Modifier.height(WooPosSpacing.Medium.value))
     }
-
-    FirmwareMenuItem(
-        firmwareVersion = firmwareVersion,
-        isSoftwareUpdateAvailable = isSoftwareUpdateAvailable,
-        onUpdateClick = onUpdateClick
-    )
-
-    Spacer(modifier = Modifier.height(WooPosSpacing.Medium.value))
-
-    WooPosOutlinedButton(
-        modifier = Modifier
-            .fillMaxWidth()
-            .padding(horizontal = WooPosSpacing.Medium.value),
-        text = stringResource(R.string.card_reader_detail_connected_disconnect_reader),
-        onClick = onDisconnectClicked
-    )
 }
 
 @Composable
@@ -189,49 +244,15 @@ private fun NotConnectedContent(
     onConnectClicked: () -> Unit,
     onDocumentationClicked: () -> Unit,
 ) {
-    Column {
-        Card(
-            modifier = Modifier
-                .fillMaxWidth()
-                .padding(horizontal = WooPosSpacing.Medium.value),
-            colors = CardDefaults.cardColors(
-                containerColor = MaterialTheme.colorScheme.surfaceContainerHigh
-            )
-        ) {
-            Column(
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .padding(WooPosSpacing.Medium.value),
-                verticalArrangement = Arrangement.spacedBy(WooPosSpacing.Medium.value)
-            ) {
-                WooPosText(
-                    text = stringResource(R.string.card_reader_detail_not_connected_header),
-                    style = WooPosTypography.BodyXLarge,
-                    fontWeight = FontWeight.Bold,
-                    color = MaterialTheme.colorScheme.onSurface
-                )
-
-                Column(
-                    verticalArrangement = Arrangement.spacedBy(WooPosSpacing.Small.value)
-                ) {
-                    ConnectionHint(stringResource(R.string.card_reader_detail_not_connected_first_hint_label))
-                    ConnectionHint(stringResource(R.string.card_reader_detail_not_connected_second_hint_label))
-                    ConnectionHint(stringResource(R.string.card_reader_detail_not_connected_third_hint_label))
-                }
-            }
-        }
-
-        Spacer(modifier = Modifier.height(WooPosSpacing.Medium.value))
-
-        WooPosButton(
-            modifier = Modifier
-                .fillMaxWidth()
-                .padding(horizontal = WooPosSpacing.Medium.value),
-            text = stringResource(R.string.card_reader_details_not_connected_connect_button_label),
+    Column(
+        verticalArrangement = Arrangement.spacedBy(WooPosSpacing.Medium.value)
+    ) {
+        WooPosSettingsDetailsMenuItem(
+            modifier = Modifier.padding(horizontal = WooPosSpacing.Medium.value),
+            title = stringResource(R.string.card_reader_detail_not_connected_header),
+            subtitle = stringResource(R.string.card_reader_detail_not_connected_first_hint_label),
             onClick = onConnectClicked
         )
-
-        Spacer(modifier = Modifier.height(WooPosSpacing.Medium.value))
 
         WooPosSettingsDetailsMenuItem(
             modifier = Modifier.padding(horizontal = WooPosSpacing.Medium.value),
@@ -243,81 +264,52 @@ private fun NotConnectedContent(
 }
 
 @Composable
-private fun FirmwareMenuItem(
-    firmwareVersion: String,
-    isSoftwareUpdateAvailable: Boolean,
-    onUpdateClick: () -> Unit
+private fun UpdateFirmwareBanner(
+    modifier: Modifier = Modifier
 ) {
-    Row(
-        modifier = Modifier
-            .fillMaxWidth()
-            .padding(WooPosSpacing.Medium.value),
-        verticalAlignment = Alignment.CenterVertically,
-        horizontalArrangement = Arrangement.Start
-    ) {
-        Icon(
-            imageVector = Icons.Default.SystemUpdate,
-            contentDescription = null,
-            tint = MaterialTheme.colorScheme.onSurface,
-            modifier = Modifier.size(28.dp)
+    Card(
+        modifier = modifier.fillMaxWidth(),
+        colors = CardDefaults.cardColors(
+            containerColor = MaterialTheme.colorScheme.surfaceContainerLow,
         )
-
-        Column(
+    ) {
+        Row(
             modifier = Modifier
-                .weight(1f)
-                .padding(horizontal = WooPosSpacing.Medium.value)
+                .fillMaxWidth()
+                .padding(WooPosSpacing.Medium.value),
+            horizontalArrangement = Arrangement.spacedBy(WooPosSpacing.Medium.value),
+            verticalAlignment = Alignment.CenterVertically
         ) {
-            WooPosText(
-                text = stringResource(R.string.woopos_settings_card_reader_firmware_title),
-                style = WooPosTypography.BodyLarge,
-                color = MaterialTheme.colorScheme.onSurface
+            Icon(
+                imageVector = Icons.Outlined.Info,
+                contentDescription = null,
+                tint = MaterialTheme.colorScheme.onSurface,
+                modifier = Modifier.size(48.dp)
             )
-            Row(
-                verticalAlignment = Alignment.CenterVertically,
-                horizontalArrangement = Arrangement.spacedBy(WooPosSpacing.XSmall.value)
+
+            Column(
+                modifier = Modifier.weight(1f),
+                verticalArrangement = Arrangement.spacedBy(WooPosSpacing.Small.value)
             ) {
                 WooPosText(
-                    text = stringResource(
-                        R.string.card_reader_detail_connected_firmware_version,
-                        firmwareVersion
-                    ),
-                    style = WooPosTypography.BodySmall,
-                    color = if (isSoftwareUpdateAvailable) {
-                        MaterialTheme.colorScheme.error
-                    } else {
-                        MaterialTheme.colorScheme.outline
-                    },
-                    modifier = Modifier.padding(top = WooPosSpacing.XSmall.value)
+                    text = stringResource(R.string.woopos_settings_card_reader_update_firmware_title),
+                    style = WooPosTypography.BodyLarge,
+                    fontWeight = FontWeight.Bold,
+                    color = MaterialTheme.colorScheme.onSurface
                 )
-                if (isSoftwareUpdateAvailable) {
-                    WooPosText(
-                        text = stringResource(R.string.woopos_settings_card_reader_update_available),
-                        style = WooPosTypography.BodySmall,
-                        color = MaterialTheme.colorScheme.error,
-                        fontWeight = FontWeight.Medium,
-                        modifier = Modifier.padding(top = WooPosSpacing.XSmall.value)
-                    )
-                }
-            }
-        }
 
-        if (isSoftwareUpdateAvailable) {
-            WooPosButtonSmall(
-                text = stringResource(R.string.woopos_settings_card_reader_update_button),
-                onClick = onUpdateClick
-            )
+                Spacer(modifier = Modifier.size(WooPosSpacing.XSmall.value))
+
+                WooPosText(
+                    text = stringResource(R.string.woopos_settings_card_reader_update_firmware_message),
+                    style = WooPosTypography.BodySmall,
+                    color = WooPosTheme.colors.onSurfaceVariantHighest,
+                )
+            }
         }
     }
 }
 
-@Composable
-private fun ConnectionHint(text: String) {
-    WooPosText(
-        text = "• $text",
-        style = WooPosTypography.BodyMedium,
-        color = MaterialTheme.colorScheme.onSurfaceVariant
-    )
-}
 
 @WooPosPreview
 @Composable

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/settings/details/help/WooPosSettingsHelpDetailScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/settings/details/help/WooPosSettingsHelpDetailScreen.kt
@@ -1,7 +1,9 @@
 package com.woocommerce.android.ui.woopos.settings.details.help
 
+import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.runtime.Composable
@@ -12,6 +14,7 @@ import androidx.compose.ui.res.stringResource
 import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import com.woocommerce.android.R
 import com.woocommerce.android.ui.woopos.common.composeui.WooPosPreview
+import com.woocommerce.android.ui.woopos.common.composeui.designsystem.WooPosSpacing
 import com.woocommerce.android.ui.woopos.common.composeui.designsystem.WooPosTheme
 import com.woocommerce.android.ui.woopos.settings.details.WooPosSettingsDetailsMenuItem
 import com.woocommerce.android.util.ChromeCustomTabUtils
@@ -33,21 +36,25 @@ fun WooPosHelpDetailScreen(
     Column(
         modifier = Modifier
             .fillMaxSize()
-            .verticalScroll(rememberScrollState())
+            .verticalScroll(rememberScrollState()),
+        verticalArrangement = Arrangement.spacedBy(WooPosSpacing.Medium.value)
     ) {
         WooPosSettingsDetailsMenuItem(
+            modifier = Modifier.padding(horizontal = WooPosSpacing.Medium.value),
             title = stringResource(R.string.woopos_product_limitations_title),
             subtitle = stringResource(R.string.woopos_settings_help_product_limitations_subtitle),
             onClick = { onShowProductInfoDialog() }
         )
 
         WooPosSettingsDetailsMenuItem(
+            modifier = Modifier.padding(horizontal = WooPosSpacing.Medium.value),
             title = stringResource(R.string.woopos_documentation_title),
             subtitle = stringResource(R.string.woopos_settings_help_documentation_subtitle),
             onClick = { viewModel.onDocumentationClicked() }
         )
 
         WooPosSettingsDetailsMenuItem(
+            modifier = Modifier.padding(horizontal = WooPosSpacing.Medium.value),
             title = stringResource(R.string.woopos_get_support_title),
             subtitle = stringResource(R.string.woopos_settings_help_get_support_subtitle),
             onClick = { viewModel.onGetSupportClicked() }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/settings/details/help/WooPosSettingsHelpDetailScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/settings/details/help/WooPosSettingsHelpDetailScreen.kt
@@ -4,10 +4,6 @@ import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
-import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.automirrored.filled.Help
-import androidx.compose.material.icons.filled.Description
-import androidx.compose.material.icons.filled.SearchOff
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.ui.Modifier
@@ -40,21 +36,18 @@ fun WooPosHelpDetailScreen(
             .verticalScroll(rememberScrollState())
     ) {
         WooPosSettingsDetailsMenuItem(
-            icon = Icons.Default.SearchOff,
             title = stringResource(R.string.woopos_product_limitations_title),
             subtitle = stringResource(R.string.woopos_settings_help_product_limitations_subtitle),
             onClick = { onShowProductInfoDialog() }
         )
 
         WooPosSettingsDetailsMenuItem(
-            icon = Icons.Default.Description,
             title = stringResource(R.string.woopos_documentation_title),
             subtitle = stringResource(R.string.woopos_settings_help_documentation_subtitle),
             onClick = { viewModel.onDocumentationClicked() }
         )
 
         WooPosSettingsDetailsMenuItem(
-            icon = Icons.AutoMirrored.Filled.Help,
             title = stringResource(R.string.woopos_get_support_title),
             subtitle = stringResource(R.string.woopos_settings_help_get_support_subtitle),
             onClick = { viewModel.onGetSupportClicked() }
@@ -70,21 +63,18 @@ fun WooPosHelpDetailScreenPreview() {
             modifier = Modifier.fillMaxSize()
         ) {
             WooPosSettingsDetailsMenuItem(
-                icon = Icons.Default.SearchOff,
                 title = "Where are my products?",
                 subtitle = "Learn about which products are supported in POS",
                 onClick = { }
             )
 
             WooPosSettingsDetailsMenuItem(
-                icon = Icons.Default.Description,
                 title = "Documentation",
                 subtitle = "View guides and tutorials",
                 onClick = { }
             )
 
             WooPosSettingsDetailsMenuItem(
-                icon = Icons.AutoMirrored.Filled.Help,
                 title = "Get Support",
                 subtitle = "Contact our support team",
                 onClick = { }

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -1644,7 +1644,7 @@
     <string name="card_reader_detail_connected_firmware_version">Firmware: %s</string>
     <string name="card_reader_detail_connected_update_software">Update reader\'s software</string>
     <string name="card_reader_detail_connected_enforced_update_software">Please update your reader software to keep accepting payments</string>
-    <string name="card_reader_detail_connected_disconnect_reader">Disconnect</string>
+    <string name="card_reader_detail_connected_disconnect_reader">Disconnect reader</string>
     <string name="card_reader_detail_connected_reader_unknown">UNKNOWN CARD READER\'s NAME</string>
     <string name="card_reader_detail_connected_update_success">Reader\’s software updated</string>
     <string name="card_reader_detail_connected_update_failed">Reader\'s software update has failed</string>

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -1644,7 +1644,7 @@
     <string name="card_reader_detail_connected_firmware_version">Firmware: %s</string>
     <string name="card_reader_detail_connected_update_software">Update reader\'s software</string>
     <string name="card_reader_detail_connected_enforced_update_software">Please update your reader software to keep accepting payments</string>
-    <string name="card_reader_detail_connected_disconnect_reader">Disconnect reader</string>
+    <string name="card_reader_detail_connected_disconnect_reader">Disconnect</string>
     <string name="card_reader_detail_connected_reader_unknown">UNKNOWN CARD READER\'s NAME</string>
     <string name="card_reader_detail_connected_update_success">Reader\’s software updated</string>
     <string name="card_reader_detail_connected_update_failed">Reader\'s software update has failed</string>
@@ -3697,6 +3697,8 @@
     <string name="woopos_settings_card_reader_documentation_title">Documentation</string>
     <string name="woopos_settings_card_reader_documentation_subtitle">Learn more about accepting mobile payments</string>
     <string name="woopos_settings_card_reader_connected_reader">Connected reader</string>
+    <string name="woopos_settings_card_reader_update_firmware_title">Update firmware version</string>
+    <string name="woopos_settings_card_reader_update_firmware_message">Update the firmware version to continue accepting payments.</string>
     <string name="woopos_settings_help_category">Get help and support</string>
     <string name="woopos_settings_help_product_limitations_subtitle">Learn about which products are supported in POS</string>
     <string name="woopos_settings_help_documentation_subtitle">View guides and tutorials</string>


### PR DESCRIPTION
WOOMOB-1604

### Description
Updated the design of WooPos Settings hardware screens to align with the new design system. Refactored card reader and barcode scanner settings screens to use the WooPosCard component for consistent visual appearance. Simplified the WooPosSettingsDetailsMenuItem by removing icon parameters and adopting a card-based layout. Also reordered hardware settings items to display card readers first, followed by barcode scanners.

Note: The close icon on the firmware update banner was not implemented as it adds complexity without providing real value to users.

### Test Steps
- Open WooPos Settings and navigate to the Hardware section
- Verify the card reader settings screen displays with the updated card-based layout
- Connect a card reader and verify the connected state shows device info, battery level, and firmware version correctly
- Verify the firmware update banner appears when an update is available
- Test the barcode scanner settings screen and verify the updated layout
- Navigate through all hardware settings menu items


https://github.com/user-attachments/assets/5b4171fd-8134-4bc4-b361-f35135d5fb74



- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.