### PR TITLE
[Tooling] Use ReleasesV2 version as the source of truth during Code Freeze

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -1343,15 +1343,16 @@ platform :android do
     VERSION_FORMATTER.release_version(release_version_next)
   end
 
-  # Returns the beta version of the app in the format `1.2-rc-1`
+  # Returns the next beta version in the format `1.2-rc-2` (increments the build number)
   #
   def beta_version_next(version_name: nil)
+    # Use provided version or read the current version from version.properties
     version_name ||= VERSION_FILE.read_version_name
-    # Read the current release version from `version.properties` and parse it into an AppVersion object
+    # Parse the version string (e.g., "1.2-rc-1") into an AppVersion object
     current_version = VERSION_FORMATTER.parse(version_name)
-    # Calculate the next beta version
+    # Increment the build number to get the next beta version
     next_beta_version = VERSION_CALCULATOR.next_build_number(version: current_version)
-    # Return the formatted release version
+    # Format as beta version (e.g., "1.2-rc-2")
     VERSION_FORMATTER.beta_version(next_beta_version)
   end
 

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -121,18 +121,18 @@ platform :android do
     # Check out the up-to-date default branch, the designated starting point for the code freeze
     Fastlane::Helper::GitHelper.checkout_and_pull(DEFAULT_BRANCH)
 
-    # If version provided by release tool, use it as source of truth
-    UI.important("Using provided version: #{version}") if version
-
+    # If a new version is passed, use it as source of truth from now on
     new_version = version || release_version_next
     new_release_branch = "release/#{new_version}"
+    new_beta_version = beta_version_next(version_name: new_version)
 
     message = <<-MESSAGE
 
-    Code Freeze:
+      Code Freeze:
       • New release branch from #{DEFAULT_BRANCH}: #{new_release_branch}
+
       • Current release version and build code: #{release_version_current} (#{build_code_current}).
-      • New beta version and build code: #{beta_version_first} (#{build_code_next}).
+      • New beta version and build code: #{new_beta_version} (#{build_code_next}).
 
     MESSAGE
 
@@ -149,7 +149,7 @@ platform :android do
     # Bump the version and build code
     UI.message 'Bumping beta version and build code...'
     VERSION_FILE.write_version(
-      version_name: beta_version_first,
+      version_name: new_beta_version,
       version_code: build_code_next
     )
     commit_version_bump
@@ -180,7 +180,7 @@ platform :android do
     copy_branch_protection(
       repository: GITHUB_REPO,
       from_branch: DEFAULT_BRANCH,
-      to_branch: "release/#{new_version}"
+      to_branch: new_release_branch
     )
 
     begin
@@ -1343,29 +1343,16 @@ platform :android do
     VERSION_FORMATTER.release_version(release_version_next)
   end
 
-  # Returns the beta version that is used by the code freeze
-  # It first increments the minor number, which also resets the build number to 0
-  # It then bumps the build number so the -rc-1 can be appended to the code freeze version
-  def beta_version_first
-    # Read the current release version from `version.properties` and parse it into an AppVersion object
-    current_version = VERSION_FORMATTER.parse(VERSION_FILE.read_version_name)
-    # Calculate the next major version number
-    next_version = VERSION_CALCULATOR.next_release_version(version: current_version)
-    # Calculate the next build number
-    beta_version_first = VERSION_CALCULATOR.next_build_number(version: next_version)
-    # Return the formatted release version
-    VERSION_FORMATTER.beta_version(beta_version_first)
-  end
-
   # Returns the beta version of the app in the format `1.2-rc-1`
   #
-  def beta_version_next
+  def beta_version_next(version_name: nil)
+    version_name ||= VERSION_FILE.read_version_name
     # Read the current release version from `version.properties` and parse it into an AppVersion object
-    current_version = VERSION_FORMATTER.parse(VERSION_FILE.read_version_name)
+    current_version = VERSION_FORMATTER.parse(version_name)
     # Calculate the next beta version
-    beta_version_next = VERSION_CALCULATOR.next_build_number(version: current_version)
+    next_beta_version = VERSION_CALCULATOR.next_build_number(version: current_version)
     # Return the formatted release version
-    VERSION_FORMATTER.beta_version(beta_version_next)
+    VERSION_FORMATTER.beta_version(next_beta_version)
   end
 
   # Returns the current build code of the app

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -125,15 +125,17 @@ platform :android do
     computed_version = release_version_next
     new_version = version || computed_version
 
-    # Warn if provided version differs from computed version
+    # Fail if provided version differs from computed version
     if version && version != computed_version
-      warning_message = <<~WARNING
-        ⚠️ Version mismatch: The explicitly-provided version was '#{version}' while new computed version would have been '#{computed_version}'.
-        If this is unexpected, you might want to investigate the discrepency.
-        Continuing with the explicitly-provided verison '#{version}'.
-      WARNING
-      UI.important(warning_message)
-      buildkite_annotate(style: 'warning', context: 'start-code-freeze-version-mismatch', message: warning_message) if is_ci
+      error_message = <<~ERROR
+        ❌ Version mismatch detected!
+
+        The explicitly-provided version from the release tool is '#{version}' but the computed version from the codebase is '#{computed_version}'.
+
+        This mismatch must be resolved before proceeding with the code freeze. Please investigate and ensure the versions are aligned.
+      ERROR
+      buildkite_annotate(style: 'error', context: 'start-code-freeze-version-mismatch', message: error_message) if is_ci
+      UI.user_error!(error_message)
     end
 
     message = <<-MESSAGE

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -121,27 +121,16 @@ platform :android do
     # Check out the up-to-date default branch, the designated starting point for the code freeze
     Fastlane::Helper::GitHelper.checkout_and_pull(DEFAULT_BRANCH)
 
-    # Use provided version from release tool, or fall back to computed version
-    computed_version = release_version_next
-    new_version = version || computed_version
+    # If version provided by release tool, use it as source of truth
+    UI.important("Using provided version: #{version}") if version
 
-    # Fail if provided version differs from computed version
-    if version && version != computed_version
-      error_message = <<~ERROR
-        ❌ Version mismatch detected!
-
-        The explicitly-provided version from the release tool is '#{version}' but the computed version from the codebase is '#{computed_version}'.
-
-        This mismatch must be resolved before proceeding with the code freeze. Please investigate and ensure the versions are aligned.
-      ERROR
-      buildkite_annotate(style: 'error', context: 'start-code-freeze-version-mismatch', message: error_message) if is_ci
-      UI.user_error!(error_message)
-    end
+    new_version = version || release_version_next
+    new_release_branch = "release/#{new_version}"
 
     message = <<-MESSAGE
 
     Code Freeze:
-      • New release branch from #{DEFAULT_BRANCH}: release/#{new_version}
+      • New release branch from #{DEFAULT_BRANCH}: #{new_release_branch}
       • Current release version and build code: #{release_version_current} (#{build_code_current}).
       • New beta version and build code: #{beta_version_first} (#{build_code_next}).
 
@@ -151,7 +140,6 @@ platform :android do
     UI.user_error!("Terminating as requested. Don't forget to run the remainder of this automation manually.") unless skip_confirm || UI.confirm('Do you want to continue?')
 
     # Create the release branch
-    new_release_branch = "release/#{new_version}"
     ensure_branch_does_not_exist!(new_release_branch)
 
     UI.message 'Creating release branch...'


### PR DESCRIPTION
See AINFRA-1478

## Description

This PR enhances the version handling added in the previous iteration to assume the version received by the code freeze lane as the source of truth, ignoring potential mismatches between the ReleasesV2 version and the project's computed version.

## Testing

You can make sure the calculated release branch, current version and the next version are correctly shown in the "Continue" prompt. Just **remember to answer `N` when asked to continue**, to cancel the actual code freeze.

To avoid unexpected results, comment out the lines doing `ensure_git_status_clean` and `Fastlane::Helper::GitHelper.checkout_and_pull(DEFAULT_BRANCH)` at the beginning of the lane.

You can run the `start_code_freeze` lane, with and without the version parameters:
- Run `bundle exec fastlane start_code_freeze` 
- Run `bundle exec fastlane start_code_freeze version:30.6`

This will be fully tested in the next release cycle during code freeze.