### PR TITLE
[POS Orders] Analytics Improvement

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/orders/WooPosOrdersViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/orders/WooPosOrdersViewModel.kt
@@ -321,6 +321,8 @@ class WooPosOrdersViewModel @Inject constructor(
 
             val mark = Monotonic.markNow()
             val result = ordersDataSource.searchOrders(query)
+            val elapsedMs = mark.elapsedNow().inWholeMilliseconds
+            ordersAnalyticsTracker.trackOrdersListSearchResultsFetched(elapsedMs)
             when (result) {
                 is SearchOrdersResult.Error -> {
                     _state.value = WooPosOrdersState.Content(
@@ -336,9 +338,6 @@ class WooPosOrdersViewModel @Inject constructor(
                 }
 
                 is SearchOrdersResult.Success -> {
-                    val elapsedMs = mark.elapsedNow().inWholeMilliseconds
-                    ordersAnalyticsTracker.trackOrdersListSearchResultsFetched(elapsedMs)
-
                     if (result.orders.isEmpty()) {
                         _state.value = WooPosOrdersState.Content(
                             items = WooPosOrdersState.Content.Items.NothingFound(
@@ -365,6 +364,9 @@ class WooPosOrdersViewModel @Inject constructor(
             ordersDataSource.loadOrders().collect { result ->
                 when (result) {
                     is LoadOrdersResult.Error -> {
+                        val elapsedMs = mark.elapsedNow().inWholeMilliseconds
+                        ordersAnalyticsTracker.trackOrdersListFetched(elapsedMs)
+
                         _state.value = WooPosOrdersState.Error(
                             message = result.message,
                             searchInputState = WooPosSearchInputState.Closed


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

<!-- Id number of the Linear issue this PR addresses, e.g., WOOMOB-373. -->

WOOMOB-1155

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
With this PR we track `pos_orders_list_fetched` and `pos_orders_list_search_results_fetched`  when requests failed, as the original event intent. Read more [here](https://github.com/woocommerce/woocommerce-android/pull/14863#pullrequestreview-3403048012)

### Test Steps
<!-- Describe how to test your changes. Include only what’s needed for the reviewer to validate the behavior.
For new features, outline the main user flow or goal rather than every tap or click — the reviewer should be able to complete the flow naturally.
If applicable, mention key devices, scenarios, or edge cases to verify. -->

1. Go to POS
2. Turn device into flight mode to make the request fail -or find another way to make it so-
3. Go to Orders
4. See that `pos_orders_list_fetched` is also tracked in that case

Repeat the same with the search and the `pos_orders_list_search_results_fetched` event


- [X] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
