### PR TITLE
Enforce usage of Site LocalId since siteId is null for self-hosted sites

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/common/data/searchbyidentifier/WooPosSearchByIdentifier.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/common/data/searchbyidentifier/WooPosSearchByIdentifier.kt
@@ -23,7 +23,7 @@ class WooPosSearchByIdentifier @Inject constructor(
     private val wooPosLogWrapper: WooPosLogWrapper,
 ) {
     suspend operator fun invoke(identifier: String): WooPosSearchByIdentifierResult {
-        val isLocalCatalogSupported = localCatalogSupported.invoke(selectedSite.get().siteId)
+        val isLocalCatalogSupported = localCatalogSupported.invoke(selectedSite.get().localId())
         val localResult = localSearcher(identifier, isLocalCatalogSupported)
         // When product not found in local catalog, immediately return "not found" to avoid unnecessary remote call
         if (localResult.isSuccess || isLocalCatalogSupported) {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/items/products/WooPosProductsDataSource.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/items/products/WooPosProductsDataSource.kt
@@ -208,7 +208,7 @@ class WooPosProductsInDbDataSource @Inject constructor(
             emit(VariationsResult.Remote(Result.failure(Exception("Site not selected"))))
         }
 
-        return posLocalCatalogStore.observeVariationsForProduct(siteModel.id, productId)
+        return posLocalCatalogStore.observeVariationsForProduct(siteModel.localId(), productId)
             .map { result ->
                 val variations = result.getOrNull()?.map { it.toWooPosVariation(variationMapper) } ?: emptyList()
                 VariationsResult.Remote(Result.success(variations))
@@ -226,7 +226,7 @@ class WooPosProductsInDbDataSource @Inject constructor(
     override suspend fun getVariationById(productId: Long, variationId: Long): WooPosVariation? {
         val siteModel = selectedSite.getOrNull() ?: return null
         val result = posLocalCatalogStore.getVariation(
-            siteId = siteModel.id,
+            localSiteId = siteModel.localId(),
             productId = productId,
             variationId = variationId
         )

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/localcatalog/WooPosFullSyncStatusChecker.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/localcatalog/WooPosFullSyncStatusChecker.kt
@@ -25,7 +25,7 @@ class WooPosFullSyncStatusChecker @Inject constructor(
         val site = selectedSite.getOrNull()
             ?: error("No site selected")
 
-        if (!isLocalCatalogSupported(site.siteId)) {
+        if (!isLocalCatalogSupported(site.localId())) {
             wooPosLogWrapper.d("Full sync check skipped: Local catalog not supported for site")
             return WooPosFullSyncRequirement.LocalCatalogDisabled("Local catalog not supported for site")
         }
@@ -35,7 +35,7 @@ class WooPosFullSyncStatusChecker @Inject constructor(
                 .execute(site, maxTotalItems = WooPosLocalCatalogSyncRepository.MAX_TOTAL_ITEMS_FULL_SYNC)
 
             if (size is WooPosCheckCatalogSizeAction.WooPosCheckCatalogSizeResult.CatalogTooLarge) {
-                prefsRepo.disablePeriodicSyncForSite(site.siteId)
+                prefsRepo.disablePeriodicSyncForSite(site.localId())
                 return WooPosFullSyncRequirement.LocalCatalogDisabled("Catalog too large - ${size.error}")
             }
         }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/localcatalog/WooPosIsLocalCatalogSupported.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/localcatalog/WooPosIsLocalCatalogSupported.kt
@@ -2,6 +2,7 @@ package com.woocommerce.android.ui.woopos.localcatalog
 
 import com.woocommerce.android.ui.woopos.featureflags.WooPosLocalCatalogM1Enabled
 import com.woocommerce.android.ui.woopos.util.datastore.WooPosPreferencesRepository
+import org.wordpress.android.fluxc.model.LocalOrRemoteId
 import javax.inject.Inject
 
 /**
@@ -13,7 +14,7 @@ class WooPosIsLocalCatalogSupported @Inject constructor(
     private val isVariationsEndpointAvailable: WooPosIsLocalCatalogVariationsEndpointAvailable,
 ) {
     @Suppress("ReturnCount")
-    suspend operator fun invoke(siteId: Long): Boolean {
+    suspend operator fun invoke(localSiteId: LocalOrRemoteId.LocalId): Boolean {
         if (!wooPosLocalCatalogM1Enabled()) {
             return false
         }
@@ -22,7 +23,7 @@ class WooPosIsLocalCatalogSupported @Inject constructor(
             return false
         }
 
-        if (!prefsRepo.isPeriodicSyncEnabledForSite(siteId)) {
+        if (!prefsRepo.isPeriodicSyncEnabledForSite(localSiteId)) {
             return false
         }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/localcatalog/WooPosLocalCatalogSyncRepository.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/localcatalog/WooPosLocalCatalogSyncRepository.kt
@@ -54,7 +54,7 @@ class WooPosLocalCatalogSyncRepository @Inject constructor(
                 syncTimestampManager.storeFullSyncLastCompletedTimestamp(dateTimeProvider.now())
             }
             if (it is PosLocalCatalogSyncResult.Failure.CatalogTooLarge) {
-                preferencesRepository.disablePeriodicSyncForSite(site.siteId)
+                preferencesRepository.disablePeriodicSyncForSite(site.localId())
             }
         }
     }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/localcatalog/WooPosLocalCatalogSyncWorker.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/localcatalog/WooPosLocalCatalogSyncWorker.kt
@@ -106,7 +106,7 @@ constructor(
             return null
         }
 
-        if (!isLocalCatalogSupported(site.siteId)) {
+        if (!isLocalCatalogSupported(site.localId())) {
             logger.d("Local catalog not supported for site")
             return null
         }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/util/datastore/WooPosPreferencesRepository.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/util/datastore/WooPosPreferencesRepository.kt
@@ -10,6 +10,7 @@ import com.woocommerce.android.tools.SelectedSite
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.map
+import org.wordpress.android.fluxc.model.LocalOrRemoteId
 import javax.inject.Inject
 
 class WooPosPreferencesRepository @Inject constructor(
@@ -96,23 +97,23 @@ class WooPosPreferencesRepository @Inject constructor(
         }
     }
 
-    suspend fun isPeriodicSyncEnabledForSite(siteId: Long): Boolean {
+    suspend fun isPeriodicSyncEnabledForSite(siteId: LocalOrRemoteId.LocalId): Boolean {
         val key = buildPeriodicSyncEnabledKey(siteId)
         val preferences = dataStore.data.map { it[key] ?: true }.first()
         return preferences
     }
 
-    suspend fun disablePeriodicSyncForSite(siteId: Long) {
+    suspend fun disablePeriodicSyncForSite(siteId: LocalOrRemoteId.LocalId) {
         val key = buildPeriodicSyncEnabledKey(siteId)
         dataStore.edit { preferences ->
             preferences[key] = false
         }
     }
 
-    private fun buildPeriodicSyncEnabledKey(siteId: Long): Preferences.Key<Boolean> =
-        booleanPreferencesKey("pos_periodic_sync_enabled_$siteId")
+    private fun buildPeriodicSyncEnabledKey(siteId: LocalOrRemoteId.LocalId): Preferences.Key<Boolean> =
+        booleanPreferencesKey("pos_periodic_sync_enabled_v2_${siteId.value}")
     private fun buildSiteSpecificKey(key: String): Preferences.Key<String> =
-        stringPreferencesKey("${selectedSite.getOrNull()?.siteId}-$key")
+        stringPreferencesKey("${selectedSite.getOrNull()?.id}_v2_$key")
 
     private companion object {
         const val RECENT_PRODUCT_SEARCHES_KEY = "recent_product_searches_key"

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/common/data/searchbyidentifier/WooPosSearchByIdentifierTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/common/data/searchbyidentifier/WooPosSearchByIdentifierTest.kt
@@ -29,7 +29,10 @@ class WooPosSearchByIdentifierTest {
     private val localCatalogSupported: WooPosIsLocalCatalogSupported = mock()
     private val selectedSite: SelectedSite = mock()
     private val wooPosLogWrapper: WooPosLogWrapper = mock()
-    private val testSite = SiteModel().apply { siteId = 123L }
+    private val testSite = SiteModel().apply {
+        siteId = 123L
+        id = 123
+    }
 
     @Before
     fun setup() = runTest {
@@ -211,7 +214,7 @@ class WooPosSearchByIdentifierTest {
     fun `given local catalog enabled and product not found locally, when search called, then don't search remotely`() =
         runTest {
             // GIVEN
-            whenever(localCatalogSupported.invoke(testSite.siteId)).thenReturn(true)
+            whenever(localCatalogSupported.invoke(testSite.localId())).thenReturn(true)
             val identifier = "123456"
             whenever(localSearcher(identifier, isLocalCatalogSupported = true)).thenReturn(
                 WooPosSearchByIdentifierResult.Failure(WooPosSearchByIdentifierResult.Error.NotFound)

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/localcatalog/WooPosFullSyncStatusCheckerTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/localcatalog/WooPosFullSyncStatusCheckerTest.kt
@@ -57,7 +57,7 @@ class WooPosFullSyncStatusCheckerTest {
     fun setup() = runTest {
         val recentTimestamp = System.currentTimeMillis() - 1.days.inWholeMilliseconds
         whenever(selectedSite.getOrNull()).thenReturn(siteModel)
-        whenever(isLocalCatalogSupported(siteModel.siteId)).thenReturn(true)
+        whenever(isLocalCatalogSupported(siteModel.localId())).thenReturn(true)
         whenever(syncTimestampManager.getFullSyncLastCompletedTimestamp()).thenReturn(recentTimestamp)
         whenever(networkStatus.isConnected()).thenReturn(true)
         whenever(localCatalogStore.getProductCount(LocalOrRemoteId.LocalId(siteModel.id)))
@@ -70,7 +70,7 @@ class WooPosFullSyncStatusCheckerTest {
     fun `given local catalog not supported, when checkSyncRequirement called, then should return LocalCatalogDisabled`() =
         runTest {
             // GIVEN
-            whenever(isLocalCatalogSupported(siteModel.siteId)).thenReturn(false)
+            whenever(isLocalCatalogSupported(siteModel.localId())).thenReturn(false)
 
             val sut = createSut()
 
@@ -245,7 +245,7 @@ class WooPosFullSyncStatusCheckerTest {
             val result = sut.checkSyncRequirement()
 
             // THEN
-            verify(prefsRepo).disablePeriodicSyncForSite(siteModel.siteId)
+            verify(prefsRepo).disablePeriodicSyncForSite(siteModel.localId())
             assertThat(result).isInstanceOf(WooPosFullSyncRequirement.LocalCatalogDisabled::class.java)
         }
 

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/localcatalog/WooPosIsLocalCatalogSupportedTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/localcatalog/WooPosIsLocalCatalogSupportedTest.kt
@@ -12,6 +12,7 @@ import org.junit.Test
 import org.mockito.kotlin.any
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.whenever
+import org.wordpress.android.fluxc.model.LocalOrRemoteId
 
 @ExperimentalCoroutinesApi
 class WooPosIsLocalCatalogSupportedTest : BaseUnitTest() {
@@ -24,7 +25,7 @@ class WooPosIsLocalCatalogSupportedTest : BaseUnitTest() {
     private lateinit var isLocalCatalogSupported: WooPosIsLocalCatalogSupported
 
     companion object {
-        private const val SITE_ID = 123L
+        private val SITE_ID = LocalOrRemoteId.LocalId(123)
     }
 
     @Before

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/localcatalog/WooPosLocalCatalogSyncWorkerTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/localcatalog/WooPosLocalCatalogSyncWorkerTest.kt
@@ -66,7 +66,7 @@ class WooPosLocalCatalogSyncWorkerTest : BaseUnitTest() {
         }
 
         whenever(selectedSite.getOrNull()).thenReturn(site)
-        whenever(isLocalCatalogSupported(site.siteId)).thenReturn(true)
+        whenever(isLocalCatalogSupported(site.localId())).thenReturn(true)
 
         whenever(wooPosTabShouldBeVisible.invoke()).thenReturn(Result.success(true))
         whenever(preferencesRepository.getLastUsedTimestamp()).thenReturn(null)
@@ -107,7 +107,7 @@ class WooPosLocalCatalogSyncWorkerTest : BaseUnitTest() {
     @Test
     fun `given local catalog not supported, when sync is attempted, then returns failure`() = testBlocking {
         // GIVEN
-        whenever(isLocalCatalogSupported(site.siteId)).thenReturn(false)
+        whenever(isLocalCatalogSupported(site.localId())).thenReturn(false)
         val worker = createWorker()
 
         // WHEN

--- a/libs/fluxc-plugin/src/main/kotlin/org/wordpress/android/fluxc/store/pos/localcatalog/WooPosLocalCatalogStore.kt
+++ b/libs/fluxc-plugin/src/main/kotlin/org/wordpress/android/fluxc/store/pos/localcatalog/WooPosLocalCatalogStore.kt
@@ -261,15 +261,15 @@ class WooPosLocalCatalogStore @Inject constructor(
     /**
      * Observes all variations for a given product from the local database.
      *
-     * @param siteId The local site ID
+     * @param localSiteId The local site ID
      * @param productId The remote product ID
      * @return [Flow] of [Result] containing list of variations or error
      */
     fun observeVariationsForProduct(
-        siteId: Int,
+        localSiteId: LocalOrRemoteId.LocalId,
         productId: Long,
     ): Flow<Result<List<WooPosVariationEntity>>> =
-        posVariationsDao.observeVariationsForProduct(siteId, productId)
+        posVariationsDao.observeVariationsForProduct(localSiteId.value, productId)
             .map { variations ->
                 Result.success(variations)
             }
@@ -277,18 +277,18 @@ class WooPosLocalCatalogStore @Inject constructor(
     /**
      * Gets a single variation from the local database.
      *
-     * @param siteId The local site ID
+     * @param localSiteId The local site ID
      * @param productId The remote product ID
      * @param variationId The remote variation ID
      * @return [Result] containing the variation if found, null if not found, or error
      */
     suspend fun getVariation(
-        siteId: Int,
+        localSiteId: LocalOrRemoteId.LocalId,
         productId: Long,
         variationId: Long
     ): Result<WooPosVariationEntity?> =
         coroutineEngine.withDefaultContext(API, this, "getVariation") {
-            val variation = posVariationsDao.getVariation(siteId, productId, variationId)
+            val variation = posVariationsDao.getVariation(localSiteId.value, productId, variationId)
             Result.success(variation)
         }
 

--- a/libs/fluxc-plugin/src/test/java/org/wordpress/android/fluxc/store/pos/WooPosLocalCatalogStoreTest.kt
+++ b/libs/fluxc-plugin/src/test/java/org/wordpress/android/fluxc/store/pos/WooPosLocalCatalogStoreTest.kt
@@ -315,7 +315,7 @@ class WooPosLocalCatalogStoreTest {
             .thenReturn(flowOf(variations))
 
         // WHEN
-        val result = store.observeVariationsForProduct(testSiteId.value, testRemoteId.value).first().getOrThrow()
+        val result = store.observeVariationsForProduct(testSiteId, testRemoteId.value).first().getOrThrow()
 
         // THEN
         assertThat(result).hasSize(2)
@@ -331,7 +331,7 @@ class WooPosLocalCatalogStoreTest {
             .thenReturn(expectedVariation)
 
         // WHEN
-        val variation = store.getVariation(testSiteId.value, testRemoteId.value, variationId.value).getOrThrow()
+        val variation = store.getVariation(testSiteId, testRemoteId.value, variationId.value).getOrThrow()
 
         // THEN
         assertThat(variation).isNotNull()
@@ -403,7 +403,7 @@ class WooPosLocalCatalogStoreTest {
             .thenReturn(null)
 
         // WHEN
-        val variation = store.getVariation(testSiteId.value, testRemoteId.value, variationId.value).getOrThrow()
+        val variation = store.getVariation(testSiteId, testRemoteId.value, variationId.value).getOrThrow()
 
         // THEN
         assertThat(variation).isNull()


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

<!-- Id number of the Linear issue this PR addresses, e.g., WOOMOB-373. -->

#WOOMOB-1620

Do not merge label - target branch needs to be trunk.

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

Use SiteModel.LocalId throughout the POS. We have been using `siteId (remoteId)` in some places, however, I believe this doesn't work, since siteId is null/0 for self-hosted sites -> we either need to use `siteId for .com and jetpack sites` and `selfHostedSiteId` for selfhosted sites, or use local site id wherever possible instead (I opted for the local site id approach).


### Test Steps
<!-- Describe how to test your changes. Include only what’s needed for the reviewer to validate the behavior.
For new features, outline the main user flow or goal rather than every tap or click — the reviewer should be able to complete the flow naturally.
If applicable, mention key devices, scenarios, or edge cases to verify. -->

Smoke test the POS.

### Images/gif
<!-- Include before and after images or gifs when appropriate. -->

N/A

- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
