### PR TITLE
[WOOMOB-1575] Fix race condition and indefinite caching in WooPosGetTotalProductCount

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/util/analytics/WooPosGetTotalProductCount.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/util/analytics/WooPosGetTotalProductCount.kt
@@ -14,25 +14,39 @@ import javax.inject.Singleton
 class WooPosGetTotalProductCount @Inject constructor(
     private val productStore: WCProductStore,
     private val selectedSite: SelectedSite,
+    private val currentTime: CurrentTimeProvider,
     private val dispatchers: CoroutineDispatchers
 ) {
     private val mutex = Mutex()
 
     @Volatile private var totalProductCount: Int? = null
+    @Volatile private var cacheTimestamp: Long = 0
 
     suspend operator fun invoke(): Int? = withContext(dispatchers.io) {
         mutex.withLock {
-            totalProductCount?.let { return@withContext it }
-            fetchProductCount()
-            return@withContext totalProductCount
+            return@withContext if (isCacheValid()) {
+                totalProductCount
+            } else {
+                fetchProductCount()
+            }
         }
     }
 
-    private suspend fun fetchProductCount() {
+    private fun isCacheValid(): Boolean {
+        if (totalProductCount == null) return false
+        val elapsedTime = currentTime() - cacheTimestamp
+        return elapsedTime < CACHE_DURATION_ONE_HOUR_MS
+    }
+
+    private suspend fun fetchProductCount(): Int? {
         val site = selectedSite.get()
         val result = fetchTotalProductCount(site)
-        if (result.isSuccess) {
+        return if (result.isSuccess) {
             totalProductCount = result.getOrNull()
+            cacheTimestamp = currentTime()
+            totalProductCount
+        } else {
+            null
         }
     }
 
@@ -45,5 +59,13 @@ class WooPosGetTotalProductCount @Inject constructor(
             val count = response.model?.toInt()
             Result.success(count)
         }
+    }
+
+    companion object {
+        private const val CACHE_DURATION_ONE_HOUR_MS = 60 * 60 * 1000L
+    }
+
+    class CurrentTimeProvider @Inject constructor() {
+        operator fun invoke(): Long = System.currentTimeMillis()
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/util/analytics/WooPosGetTotalProductCount.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/util/analytics/WooPosGetTotalProductCount.kt
@@ -21,18 +21,18 @@ class WooPosGetTotalProductCount @Inject constructor(
     @Volatile private var totalProductCount: Int? = null
 
     suspend operator fun invoke(): Int? = withContext(dispatchers.io) {
-        totalProductCount?.let { return@withContext it }
-        fetchProductCount()
-        return@withContext totalProductCount
+        mutex.withLock {
+            totalProductCount?.let { return@withContext it }
+            fetchProductCount()
+            return@withContext totalProductCount
+        }
     }
 
     private suspend fun fetchProductCount() {
-        mutex.withLock {
-            val site = selectedSite.get()
-            val result = fetchTotalProductCount(site)
-            if (result.isSuccess) {
-                totalProductCount = result.getOrNull()
-            }
+        val site = selectedSite.get()
+        val result = fetchTotalProductCount(site)
+        if (result.isSuccess) {
+            totalProductCount = result.getOrNull()
         }
     }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/util/analytics/WooPosGetTotalProductCount.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/util/analytics/WooPosGetTotalProductCount.kt
@@ -19,8 +19,11 @@ class WooPosGetTotalProductCount @Inject constructor(
 ) {
     private val mutex = Mutex()
 
-    @Volatile private var totalProductCount: Int? = null
-    @Volatile private var cacheTimestamp: Long = 0
+    @Volatile
+    private var totalProductCount: Int? = null
+
+    @Volatile
+    private var cacheTimestamp: Long = 0
 
     suspend operator fun invoke(): Int? = withContext(dispatchers.io) {
         mutex.withLock {

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/util/analytics/WooPosGetTotalProductCountTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/util/analytics/WooPosGetTotalProductCountTest.kt
@@ -135,4 +135,3 @@ class WooPosGetTotalProductCountTest {
         verify(productStore, times(1)).fetchProductsCount(any())
     }
 }
-

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/util/analytics/WooPosGetTotalProductCountTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/util/analytics/WooPosGetTotalProductCountTest.kt
@@ -22,32 +22,27 @@ import kotlin.test.assertNull
 
 @ExperimentalCoroutinesApi
 class WooPosGetTotalProductCountTest {
-
-    private lateinit var productStore: WCProductStore
-    private lateinit var selectedSite: SelectedSite
-    private lateinit var dispatchers: CoroutineDispatchers
-    private lateinit var sut: WooPosGetTotalProductCount
-    private lateinit var site: SiteModel
-
-    private val testDispatchers = CoroutineDispatchers(
+    private val productStore: WCProductStore = mock()
+    private val selectedSite: SelectedSite = mock()
+    private val dispatchers: CoroutineDispatchers = CoroutineDispatchers(
         main = Dispatchers.Unconfined,
         computation = Dispatchers.Unconfined,
         io = Dispatchers.Unconfined
     )
+    private val currentTime: WooPosGetTotalProductCount.CurrentTimeProvider = mock()
+    private val site: SiteModel = mock()
+
+    private lateinit var sut: WooPosGetTotalProductCount
 
     @Before
     fun setup() {
-        productStore = mock()
-        selectedSite = mock()
-        dispatchers = testDispatchers
-        site = mock()
-
         whenever(selectedSite.get()).thenReturn(site)
 
         sut = WooPosGetTotalProductCount(
             productStore = productStore,
             selectedSite = selectedSite,
-            dispatchers = dispatchers
+            currentTime = currentTime,
+            dispatchers = dispatchers,
         )
     }
 
@@ -91,10 +86,53 @@ class WooPosGetTotalProductCountTest {
         whenever(productStore.fetchProductsCount(any())).thenReturn(successResult)
 
         // WHEN
-        sut.invoke() // First call
-        sut.invoke() // Second call
+        sut.invoke()
+        sut.invoke()
 
         // THEN
         verify(productStore, times(1)).fetchProductsCount(any())
     }
+
+    @Test
+    fun `given cached result expired, when invoke called, then fetches from network again`() = runTest {
+        // GIVEN
+        whenever(currentTime()).thenReturn(0L)
+        val firstCount = 42L
+        val secondCount = 100L
+        whenever(productStore.fetchProductsCount(any()))
+            .thenReturn(WooResult(model = firstCount))
+            .thenReturn(WooResult(model = secondCount))
+
+        // WHEN
+        val firstResult = sut.invoke()
+        whenever(currentTime()).thenReturn(60 * 60 * 1000L + 1L)
+        val secondResult = sut.invoke()
+
+        // THEN
+        assertEquals(firstCount.toInt(), firstResult)
+        assertEquals(secondCount.toInt(), secondResult)
+        verify(productStore, times(2)).fetchProductsCount(any())
+    }
+
+    @Test
+    fun `given cached result is not expired, when invoke called, then fetches from network once`() = runTest {
+        // GIVEN
+        whenever(currentTime()).thenReturn(0L)
+        val firstCount = 42L
+        val secondCount = 100L
+        whenever(productStore.fetchProductsCount(any()))
+            .thenReturn(WooResult(model = firstCount))
+            .thenReturn(WooResult(model = secondCount))
+
+        // WHEN
+        val firstResult = sut.invoke()
+        whenever(currentTime()).thenReturn(60 * 60 * 1000L - 1L)
+        val secondResult = sut.invoke()
+
+        // THEN
+        assertEquals(firstCount.toInt(), firstResult)
+        assertEquals(firstCount.toInt(), secondResult)
+        verify(productStore, times(1)).fetchProductsCount(any())
+    }
 }
+


### PR DESCRIPTION
WOOMOB-1575

### Description

Fixed two issues in `WooPosGetTotalProductCount`:

**1. Race condition causing duplicate network calls**

The mutex was positioned incorrectly - it wrapped only the fetch operation, not the cache check. This meant that multiple concurrent calls could all check the cache (finding it null), then queue up at the mutex and execute the fetch sequentially. Result: multiple unnecessary network requests for the same data.

**What was happening:**
- Thread 1: checks cache (null) → waits for mutex → fetches → updates cache
- Thread 2: checks cache (null) → waits for mutex → fetches again (duplicate!)
- Thread 3: checks cache (null) → waits for mutex → fetches again (duplicate!)

**The fix:**
Moved the mutex to wrap both the cache validation AND the fetch operation. Now only the first thread fetches, and subsequent threads get the cached value immediately.

**2. Indefinite cache with no expiration**

The cached product count persisted forever (until app restart), which could show stale data to users if product inventory changed.

**The fix:**
- Implemented 1-hour cache expiration using timestamp tracking
- Cache automatically refreshes after expiration
- Introduced `CurrentTimeProvider` interface for testable time handling

### Test Steps

1. Open Woo POS and navigate to product search
2. Verify product count displays correctly
3. Monitor logs to confirm only one network call is made on initial load
4. Test cache behavior remains consistent across searches

- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.