### PR TITLE
[WOOMOB-1421] Follow up PR with updates to the BookingDetailsViewModel state management

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/bookings/compose/BookingPaymentSection.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/bookings/compose/BookingPaymentSection.kt
@@ -1,6 +1,7 @@
 package com.woocommerce.android.ui.bookings.compose
 
 import androidx.annotation.StringRes
+import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
@@ -59,7 +60,7 @@ fun BookingPaymentSection(
                 modifier = Modifier.padding(start = 16.dp)
             )
             Spacer(modifier = Modifier.height(16.dp))
-            if (status == BookingStatus.Unpaid) {
+            AnimatedVisibility(status == BookingStatus.Unpaid) {
                 WCColoredButton(
                     onClick = onMarkAsPaid,
                     text = stringResource(id = R.string.booking_payment_mark_as_paid),

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/bookings/details/BookingDetailsFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/bookings/details/BookingDetailsFragment.kt
@@ -41,22 +41,6 @@ class BookingDetailsFragment : BaseFragment() {
             BookingDetailsScreen(
                 viewModel = viewModel,
                 onBack = { findNavController().popBackStack() },
-                onViewOrder = { orderId ->
-                    requireActivity().findNavController(R.id.nav_host_fragment_main).navigate(
-                        NavGraphMainDirections.actionGlobalOrderDetailFragment(
-                            orderId = orderId,
-                            ignoreTwoPaneLayoutLogic = true
-                        )
-                    )
-                },
-                onViewNotes = {
-                    (args.mode as? Mode.ShowBooking)?.bookingId?.let {
-                        findNavController().navigate(
-                            BookingDetailsFragmentDirections
-                                .actionBookingDetailsFragmentToBookingNoteFragment(it)
-                        )
-                    }
-                },
             )
         }
     }
@@ -72,6 +56,20 @@ class BookingDetailsFragment : BaseFragment() {
             when (event) {
                 is MultiLiveEvent.Event.ShowSnackbar -> {
                     uiMessageResolver.showSnack(event.message)
+                }
+                is BookingDetailsViewModel.NavigateToBookingNote -> {
+                    findNavController().navigate(
+                        BookingDetailsFragmentDirections
+                            .actionBookingDetailsFragmentToBookingNoteFragment(event.bookingId)
+                    )
+                }
+                is BookingDetailsViewModel.NavigateToOrder -> {
+                    requireActivity().findNavController(R.id.nav_host_fragment_main).navigate(
+                        NavGraphMainDirections.actionGlobalOrderDetailFragment(
+                            orderId = event.orderId,
+                            ignoreTwoPaneLayoutLogic = true
+                        )
+                    )
                 }
             }
         }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/bookings/details/BookingDetailsScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/bookings/details/BookingDetailsScreen.kt
@@ -124,25 +124,24 @@ fun BookingDetailsScreen(
                         viewState.bookingUiState != null -> {
                             BookingDetailsContent(
                                 booking = viewState.bookingUiState,
-                                onCancelBooking = viewState.onCancelBooking,
+                                onCancelBooking = viewState.bookingUiState.onCancelBooking,
                                 onViewOrder = onViewOrder,
                                 onAttendanceStatusClicked = { showAttendanceSheet.value = true },
                                 onViewNotes = onViewNotes,
-                                onMarkAsPaid = viewState.onMarkAsPaid,
-                                markAsPaidInProgress = viewState.paymentUpdateStatus == PaymentUpdateStatus.InProgress,
+                                onMarkAsPaid = viewState.bookingUiState.onMarkAsPaid,
                             )
+                            if (showAttendanceSheet.value) {
+                                BookingAttendanceStatusBottomSheet(
+                                    onSelect = { status ->
+                                        viewState.bookingUiState.onAttendanceStatusSelected(status)
+                                    },
+                                    onDismiss = { showAttendanceSheet.value = false }
+                                )
+                            }
                         }
                     }
                 }
             }
-        }
-        if (showAttendanceSheet.value) {
-            BookingAttendanceStatusBottomSheet(
-                onSelect = { status ->
-                    viewState.onAttendanceStatusSelected(status)
-                },
-                onDismiss = { showAttendanceSheet.value = false }
-            )
         }
         viewState.dialogState?.Render()
     }
@@ -156,7 +155,6 @@ private fun BookingDetailsContent(
     onAttendanceStatusClicked: () -> Unit,
     onViewNotes: () -> Unit,
     onMarkAsPaid: () -> Unit,
-    markAsPaidInProgress: Boolean,
 ) {
     BookingSummary(
         model = booking.bookingSummary,
@@ -186,7 +184,7 @@ private fun BookingDetailsContent(
             onMarkAsPaid = onMarkAsPaid,
             onViewOrder = { onViewOrder(booking.orderId) },
             modifier = Modifier.fillMaxWidth(),
-            markAsPaidInProgress = markAsPaidInProgress,
+            markAsPaidInProgress = booking.paymentUpdateStatus == PaymentUpdateStatus.InProgress,
         )
     }
     BookingNoteSection(

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/bookings/details/BookingDetailsScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/bookings/details/BookingDetailsScreen.kt
@@ -67,8 +67,6 @@ import com.woocommerce.android.ui.compose.theme.WooThemeWithBackground
 fun BookingDetailsScreen(
     viewModel: BookingDetailsViewModel,
     onBack: () -> Unit,
-    onViewOrder: (Long) -> Unit,
-    onViewNotes: () -> Unit,
 ) {
     val viewState by viewModel.state.observeAsState()
 
@@ -76,8 +74,6 @@ fun BookingDetailsScreen(
         BookingDetailsScreen(
             viewState = it,
             onBack = onBack,
-            onViewOrder = onViewOrder,
-            onViewNotes = onViewNotes,
         )
     }
 }
@@ -87,8 +83,6 @@ fun BookingDetailsScreen(
 fun BookingDetailsScreen(
     viewState: BookingDetailsViewState,
     onBack: () -> Unit,
-    onViewOrder: (Long) -> Unit,
-    onViewNotes: () -> Unit,
 ) {
     val context = LocalContext.current
     val showAttendanceSheet = remember { mutableStateOf(false) }
@@ -125,9 +119,7 @@ fun BookingDetailsScreen(
                                 BookingDetailsContent(
                                     booking = viewState.bookingUiState,
                                     onCancelBooking = viewState.bookingUiState.onCancelBooking,
-                                    onViewOrder = onViewOrder,
                                     onAttendanceStatusClicked = { showAttendanceSheet.value = true },
-                                    onViewNotes = onViewNotes,
                                     onMarkAsPaid = viewState.bookingUiState.onMarkAsPaid,
                                 )
                                 if (showAttendanceSheet.value) {
@@ -152,9 +144,7 @@ fun BookingDetailsScreen(
 private fun BookingDetailsContent(
     booking: BookingUiState,
     onCancelBooking: () -> Unit,
-    onViewOrder: (Long) -> Unit,
     onAttendanceStatusClicked: () -> Unit,
-    onViewNotes: () -> Unit,
     onMarkAsPaid: () -> Unit,
 ) {
     BookingSummary(
@@ -183,14 +173,14 @@ private fun BookingDetailsContent(
             model = it,
             status = booking.bookingSummary.status,
             onMarkAsPaid = onMarkAsPaid,
-            onViewOrder = { onViewOrder(booking.orderId) },
+            onViewOrder = booking.onViewOrderClicked,
             modifier = Modifier.fillMaxWidth(),
             markAsPaidInProgress = booking.paymentUpdateStatus == PaymentUpdateStatus.InProgress,
         )
     }
     BookingNoteSection(
         note = booking.note,
-        onClick = onViewNotes,
+        onClick = booking.onNoteClicked,
         modifier = Modifier.fillMaxWidth()
     )
 }
@@ -310,8 +300,6 @@ private fun BookingDetailsPreview() {
                 ),
             ),
             onBack = {},
-            onViewOrder = {},
-            onViewNotes = {},
         )
     }
 }
@@ -327,8 +315,6 @@ private fun BookingDetailsLoadingPreview() {
                 loadingState = BookingDetailsLoadingState.Refreshing,
             ),
             onBack = {},
-            onViewOrder = {},
-            onViewNotes = {},
         )
     }
 }
@@ -340,8 +326,6 @@ private fun BookingDetailsEmptyPreview() {
         BookingDetailsScreen(
             viewState = BookingDetailsViewState.Empty,
             onBack = {},
-            onViewOrder = {},
-            onViewNotes = {},
         )
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/bookings/details/BookingDetailsScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/bookings/details/BookingDetailsScreen.kt
@@ -102,48 +102,49 @@ fun BookingDetailsScreen(
             )
         }
     ) { innerPadding ->
-        if (viewState.shouldShowEmptyState) {
-            BookingDetailsEmptyScreen()
-        } else {
-            WCPullToRefreshBox(
-                isRefreshing = viewState.loadingState == BookingDetailsLoadingState.Refreshing,
-                onRefresh = viewState.onRefresh,
-                state = rememberPullToRefreshState(),
-                modifier = Modifier
-                    .fillMaxSize()
-                    .padding(innerPadding)
-                    .detailsPanePadding(),
-            ) {
-                Column(
+        when (viewState) {
+            BookingDetailsViewState.Empty -> BookingDetailsEmptyScreen()
+            is BookingDetailsViewState.ShowBooking -> {
+                WCPullToRefreshBox(
+                    isRefreshing = viewState.loadingState == BookingDetailsLoadingState.Refreshing,
+                    onRefresh = viewState.onRefresh,
+                    state = rememberPullToRefreshState(),
                     modifier = Modifier
                         .fillMaxSize()
-                        .verticalScroll(rememberScrollState())
+                        .padding(innerPadding)
+                        .detailsPanePadding(),
                 ) {
-                    when {
-                        viewState.shouldShowSkeleton -> BookingDetailsLoading()
-                        viewState.bookingUiState != null -> {
-                            BookingDetailsContent(
-                                booking = viewState.bookingUiState,
-                                onCancelBooking = viewState.bookingUiState.onCancelBooking,
-                                onViewOrder = onViewOrder,
-                                onAttendanceStatusClicked = { showAttendanceSheet.value = true },
-                                onViewNotes = onViewNotes,
-                                onMarkAsPaid = viewState.bookingUiState.onMarkAsPaid,
-                            )
-                            if (showAttendanceSheet.value) {
-                                BookingAttendanceStatusBottomSheet(
-                                    onSelect = { status ->
-                                        viewState.bookingUiState.onAttendanceStatusSelected(status)
-                                    },
-                                    onDismiss = { showAttendanceSheet.value = false }
+                    Column(
+                        modifier = Modifier
+                            .fillMaxSize()
+                            .verticalScroll(rememberScrollState())
+                    ) {
+                        when {
+                            viewState.shouldShowSkeleton -> BookingDetailsLoading()
+                            viewState.bookingUiState != null -> {
+                                BookingDetailsContent(
+                                    booking = viewState.bookingUiState,
+                                    onCancelBooking = viewState.bookingUiState.onCancelBooking,
+                                    onViewOrder = onViewOrder,
+                                    onAttendanceStatusClicked = { showAttendanceSheet.value = true },
+                                    onViewNotes = onViewNotes,
+                                    onMarkAsPaid = viewState.bookingUiState.onMarkAsPaid,
                                 )
+                                if (showAttendanceSheet.value) {
+                                    BookingAttendanceStatusBottomSheet(
+                                        onSelect = { status ->
+                                            viewState.bookingUiState.onAttendanceStatusSelected(status)
+                                        },
+                                        onDismiss = { showAttendanceSheet.value = false }
+                                    )
+                                }
                             }
                         }
                     }
                 }
+                viewState.dialogState?.Render()
             }
         }
-        viewState.dialogState?.Render()
     }
 }
 
@@ -266,7 +267,7 @@ fun BookingDetailsEmptyScreen(
 private fun BookingDetailsPreview() {
     WooThemeWithBackground {
         BookingDetailsScreen(
-            viewState = BookingDetailsViewState(
+            viewState = BookingDetailsViewState.ShowBooking(
                 toolbarTitle = "Booking #12345",
                 bookingUiState = BookingUiState(
                     orderId = 1L,
@@ -320,7 +321,7 @@ private fun BookingDetailsPreview() {
 private fun BookingDetailsLoadingPreview() {
     WooThemeWithBackground {
         BookingDetailsScreen(
-            viewState = BookingDetailsViewState(
+            viewState = BookingDetailsViewState.ShowBooking(
                 toolbarTitle = "",
                 bookingUiState = null,
                 loadingState = BookingDetailsLoadingState.Refreshing,
@@ -337,10 +338,7 @@ private fun BookingDetailsLoadingPreview() {
 private fun BookingDetailsEmptyPreview() {
     WooThemeWithBackground {
         BookingDetailsScreen(
-            viewState = BookingDetailsViewState(
-                toolbarTitle = "",
-                bookingUiState = null,
-            ),
+            viewState = BookingDetailsViewState.Empty,
             onBack = {},
             onViewOrder = {},
             onViewNotes = {},

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/bookings/details/BookingDetailsScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/bookings/details/BookingDetailsScreen.kt
@@ -99,10 +99,11 @@ fun BookingDetailsScreen(
         when (viewState) {
             BookingDetailsViewState.Empty -> BookingDetailsEmptyScreen()
             is BookingDetailsViewState.ShowBooking -> {
+                val state = rememberPullToRefreshState()
                 WCPullToRefreshBox(
                     isRefreshing = viewState.loadingState == BookingDetailsLoadingState.Refreshing,
                     onRefresh = viewState.onRefresh,
-                    state = rememberPullToRefreshState(),
+                    state = state,
                     modifier = Modifier
                         .fillMaxSize()
                         .padding(innerPadding)

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/bookings/details/BookingDetailsViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/bookings/details/BookingDetailsViewModel.kt
@@ -37,6 +37,7 @@ import kotlinx.coroutines.launch
 import org.wordpress.android.fluxc.persistence.entity.BookingEntity
 import org.wordpress.android.fluxc.persistence.entity.isAttendanceStatusEditable
 import javax.inject.Inject
+import com.woocommerce.android.extensions.combine as woocombine
 
 @OptIn(ExperimentalCoroutinesApi::class)
 @HiltViewModel
@@ -102,15 +103,23 @@ class BookingDetailsViewModel @Inject constructor(
         }
     }
 
-    private val bookingUiStateFlow = combine(
+    private val bookingUiStateFlow = woocombine(
         booking,
         attendanceUpdateStatus,
         loadingState,
         resource,
         cancelStatusState,
-    ) { booking, attendanceUpdate, loadingState, resource, cancelStatus ->
+        paymentUpdateStatus,
+    ) { booking, attendanceUpdate, loadingState, resource, cancelStatus, paymentUpdate ->
         if (booking != null) {
-            bookingMapper.buildBookingUiState(booking, attendanceUpdate, resource, loadingState, cancelStatus)
+            bookingMapper.buildBookingUiState(
+                booking = booking,
+                attendanceUpdateStatus = attendanceUpdate,
+                resource = resource,
+                loadingState = loadingState,
+                cancelStatus = cancelStatus,
+                paymentUpdateStatus = paymentUpdate,
+            )
         } else {
             null
         }
@@ -129,14 +138,6 @@ class BookingDetailsViewModel @Inject constructor(
                     resourceProvider.getString(R.string.booking_details_title, id)
                 } ?: "",
                 bookingUiState = bookingUiState,
-                onCancelBooking = ::onCancelBooking,
-                onAttendanceStatusSelected = { attendanceStatus ->
-                    if (attendanceStatus.toDataModel() != booking?.attendanceStatus) {
-                        onAttendanceStatusSelected(attendanceStatus)
-                    }
-                },
-                onMarkAsPaid = ::onMarkAsPaid,
-                paymentUpdateStatus = paymentUpdateStatus,
                 dialogState = cancelBookingDialog,
                 loadingState = loadingState,
                 onRefresh = ::fetchBooking,
@@ -234,12 +235,14 @@ class BookingDetailsViewModel @Inject constructor(
         paymentUpdateStatus.value = PaymentUpdateStatus.Idle
     }
 
+    @Suppress("LongParameterList")
     private suspend fun BookingMapper.buildBookingUiState(
         booking: Booking,
         attendanceUpdateStatus: AttendanceUpdateStatus,
         resource: BookingResource?,
         loadingState: BookingDetailsLoadingState,
         cancelStatus: CancelStatus,
+        paymentUpdateStatus: PaymentUpdateStatus,
     ): BookingUiState = BookingUiState(
         orderId = booking.orderId,
         bookingSummary = booking.toBookingSummaryModel(attendanceUpdateStatus),
@@ -254,7 +257,15 @@ class BookingDetailsViewModel @Inject constructor(
         bookingCustomerDetails = booking.order.customerInfo.toCustomerDetailsModel(),
         bookingPaymentDetails = booking.order.paymentInfo?.toPaymentDetailsModel(booking.currency),
         note = booking.note,
-        isAttendanceStatusEditable = booking.isAttendanceStatusEditable
+        isAttendanceStatusEditable = booking.isAttendanceStatusEditable,
+        onCancelBooking = ::onCancelBooking,
+        onAttendanceStatusSelected = { attendanceStatus ->
+            if (attendanceStatus.toDataModel() != booking.attendanceStatus) {
+                onAttendanceStatusSelected(attendanceStatus)
+            }
+        },
+        onMarkAsPaid = ::onMarkAsPaid,
+        paymentUpdateStatus = paymentUpdateStatus,
     )
 
     private fun buildStaffMemberStatus(

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/bookings/details/BookingDetailsViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/bookings/details/BookingDetailsViewModel.kt
@@ -252,6 +252,14 @@ class BookingDetailsViewModel @Inject constructor(
         paymentUpdateStatus.value = PaymentUpdateStatus.Idle
     }
 
+    private fun openBookingNote(bookingId: Long) {
+        triggerEvent(NavigateToBookingNote(bookingId))
+    }
+
+    private fun openOrderDetails(orderId: Long) {
+        triggerEvent(NavigateToOrder(orderId))
+    }
+
     @Suppress("LongParameterList")
     private suspend fun BookingMapper.buildBookingUiState(
         booking: Booking,
@@ -260,30 +268,36 @@ class BookingDetailsViewModel @Inject constructor(
         loadingState: BookingDetailsLoadingState,
         cancelStatus: CancelStatus,
         paymentUpdateStatus: PaymentUpdateStatus,
-    ): BookingUiState = BookingUiState(
-        orderId = booking.orderId,
-        bookingSummary = booking.toBookingSummaryModel(attendanceUpdateStatus),
-        bookingsAppointmentDetails = booking.toAppointmentDetailsModel(
-            staffMemberStatus = buildStaffMemberStatus(
-                resourceId = booking.resourceId,
-                resource = resource,
-                loadingState = loadingState
+    ): BookingUiState {
+        val bookingId = booking.id.value
+        val orderId = booking.orderId
+        return BookingUiState(
+            orderId = orderId,
+            bookingSummary = booking.toBookingSummaryModel(attendanceUpdateStatus),
+            bookingsAppointmentDetails = booking.toAppointmentDetailsModel(
+                staffMemberStatus = buildStaffMemberStatus(
+                    resourceId = booking.resourceId,
+                    resource = resource,
+                    loadingState = loadingState
+                ),
+                cancelStatus = cancelStatus
             ),
-            cancelStatus = cancelStatus
-        ),
-        bookingCustomerDetails = booking.order.customerInfo.toCustomerDetailsModel(),
-        bookingPaymentDetails = booking.order.paymentInfo?.toPaymentDetailsModel(booking.currency),
-        note = booking.note,
-        isAttendanceStatusEditable = booking.isAttendanceStatusEditable,
-        onCancelBooking = ::onCancelBooking,
-        onAttendanceStatusSelected = { attendanceStatus ->
-            if (attendanceStatus.toDataModel() != booking.attendanceStatus) {
-                onAttendanceStatusSelected(booking.id.value, attendanceStatus)
-            }
-        },
-        onMarkAsPaid = { onMarkAsPaid(booking.id.value) },
-        paymentUpdateStatus = paymentUpdateStatus,
-    )
+            bookingCustomerDetails = booking.order.customerInfo.toCustomerDetailsModel(),
+            bookingPaymentDetails = booking.order.paymentInfo?.toPaymentDetailsModel(booking.currency),
+            note = booking.note,
+            isAttendanceStatusEditable = booking.isAttendanceStatusEditable,
+            onCancelBooking = ::onCancelBooking,
+            onAttendanceStatusSelected = { attendanceStatus ->
+                if (attendanceStatus.toDataModel() != booking.attendanceStatus) {
+                    onAttendanceStatusSelected(bookingId, attendanceStatus)
+                }
+            },
+            onMarkAsPaid = { onMarkAsPaid(bookingId) },
+            paymentUpdateStatus = paymentUpdateStatus,
+            onViewOrderClicked = { openOrderDetails(orderId) },
+            onNoteClicked = { openBookingNote(bookingId) }
+        )
+    }
 
     private fun buildStaffMemberStatus(
         resourceId: Long,
@@ -299,4 +313,7 @@ class BookingDetailsViewModel @Inject constructor(
             else -> BookingStaffMemberStatus.Unavailable
         }
     }
+
+    data class NavigateToOrder(val orderId: Long) : MultiLiveEvent.Event()
+    data class NavigateToBookingNote(val bookingId: Long) : MultiLiveEvent.Event()
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/bookings/details/BookingDetailsViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/bookings/details/BookingDetailsViewModel.kt
@@ -132,16 +132,21 @@ class BookingDetailsViewModel @Inject constructor(
         cancelBookingDialogState,
         paymentUpdateStatus,
     ) { booking, bookingUiState, loadingState, cancelBookingDialog, paymentUpdateStatus ->
-        with(bookingMapper) {
-            BookingDetailsViewState(
-                toolbarTitle = booking?.id?.value?.let { id ->
-                    resourceProvider.getString(R.string.booking_details_title, id)
-                } ?: "",
-                bookingUiState = bookingUiState,
-                dialogState = cancelBookingDialog,
-                loadingState = loadingState,
-                onRefresh = ::fetchBooking,
-            )
+        when (navArgs.mode) {
+            BookingDetailsFragment.Mode.Empty -> BookingDetailsViewState.Empty
+            is BookingDetailsFragment.Mode.ShowBooking -> {
+                with(bookingMapper) {
+                    BookingDetailsViewState.ShowBooking(
+                        toolbarTitle = booking?.id?.value?.let { id ->
+                            resourceProvider.getString(R.string.booking_details_title, id)
+                        } ?: "",
+                        bookingUiState = bookingUiState,
+                        dialogState = cancelBookingDialog,
+                        loadingState = loadingState,
+                        onRefresh = ::fetchBooking,
+                    )
+                }
+            }
         }
     }.asLiveData()
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/bookings/details/BookingDetailsViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/bookings/details/BookingDetailsViewModel.kt
@@ -59,7 +59,7 @@ class BookingDetailsViewModel @Inject constructor(
             .distinctUntilChanged()
             .onEach {
                 if (it == null) {
-                    fetchBooking(BookingDetailsLoadingState.Loading)
+                    fetchBooking(bookingId, BookingDetailsLoadingState.Loading)
                 }
             }
             .shareIn(scope = viewModelScope, started = SharingStarted.WhileSubscribed(), replay = 1)
@@ -91,7 +91,7 @@ class BookingDetailsViewModel @Inject constructor(
                 message = message,
                 positiveButton = DialogState.DialogButton(
                     text = UiString.UiStringRes(R.string.booking_cancel_dialog_confirm),
-                    onClick = ::onConfirmCancelBooking
+                    onClick = { onConfirmCancelBooking(booking.id.value) }
                 ),
                 negativeButton = DialogState.DialogButton(
                     text = UiString.UiStringRes(R.string.booking_cancel_dialog_keep),
@@ -132,7 +132,7 @@ class BookingDetailsViewModel @Inject constructor(
         cancelBookingDialogState,
         paymentUpdateStatus,
     ) { booking, bookingUiState, loadingState, cancelBookingDialog, paymentUpdateStatus ->
-        when (navArgs.mode) {
+        when (val mode = navArgs.mode) {
             BookingDetailsFragment.Mode.Empty -> BookingDetailsViewState.Empty
             is BookingDetailsFragment.Mode.ShowBooking -> {
                 with(bookingMapper) {
@@ -143,7 +143,7 @@ class BookingDetailsViewModel @Inject constructor(
                         bookingUiState = bookingUiState,
                         dialogState = cancelBookingDialog,
                         loadingState = loadingState,
-                        onRefresh = ::fetchBooking,
+                        onRefresh = { fetchBooking(mode.bookingId) },
                     )
                 }
             }
@@ -151,10 +151,19 @@ class BookingDetailsViewModel @Inject constructor(
     }.asLiveData()
 
     init {
-        fetchBooking(BookingDetailsLoadingState.Loading)
+        when (val mode = navArgs.mode) {
+            is BookingDetailsFragment.Mode.ShowBooking -> {
+                fetchBooking(mode.bookingId, BookingDetailsLoadingState.Loading)
+            }
+
+            else -> Unit
+        }
     }
 
-    private fun fetchBooking(initialLoadingState: BookingDetailsLoadingState = BookingDetailsLoadingState.Refreshing) {
+    private fun fetchBooking(
+        bookingId: Long,
+        initialLoadingState: BookingDetailsLoadingState = BookingDetailsLoadingState.Refreshing
+    ) {
         bookingFetchJob?.cancel()
         bookingFetchJob = launch {
             if (navArgs.mode !is BookingDetailsFragment.Mode.ShowBooking) {
@@ -168,7 +177,7 @@ class BookingDetailsViewModel @Inject constructor(
 
             coroutineScope {
                 val bookingTask = async {
-                    bookingsRepository.fetchBooking(bookingId ?: 0L)
+                    bookingsRepository.fetchBooking(bookingId)
                 }
                 val resourceTask = async {
                     val booking = booking.first() ?: bookingTask.await().getOrNull()
@@ -184,7 +193,10 @@ class BookingDetailsViewModel @Inject constructor(
         }
     }
 
-    private fun onAttendanceStatusSelected(status: BookingAttendanceStatus) {
+    private fun onAttendanceStatusSelected(
+        bookingId: Long,
+        status: BookingAttendanceStatus
+    ) {
         launch {
             if (!networkStatus.isConnected()) {
                 triggerEvent(MultiLiveEvent.Event.ShowSnackbar(R.string.offline_error))
@@ -193,7 +205,7 @@ class BookingDetailsViewModel @Inject constructor(
             attendanceUpdateStatus.value = AttendanceUpdateStatus.InProgress
             val attendanceStatus = status.toDataModel() ?: return@launch
             bookingsRepository.updateAttendanceStatus(
-                bookingId = bookingId ?: 0L,
+                bookingId = bookingId,
                 attendanceStatus = attendanceStatus
             ).onFailure {
                 triggerEvent(MultiLiveEvent.Event.ShowSnackbar(R.string.booking_attendance_status_error))
@@ -217,23 +229,23 @@ class BookingDetailsViewModel @Inject constructor(
         showCancelBookingDialog.value = false
     }
 
-    private fun onConfirmCancelBooking() = launch {
+    private fun onConfirmCancelBooking(bookingId: Long) = launch {
         showCancelBookingDialog.value = false
         cancelStatusState.value = CancelStatus.InProgress
-        bookingsRepository.cancelBooking(bookingId ?: 0L)
+        bookingsRepository.cancelBooking(bookingId)
             .onFailure {
                 triggerEvent(MultiLiveEvent.Event.ShowSnackbar(R.string.booking_cancel_error))
             }
         cancelStatusState.value = CancelStatus.Idle
     }
 
-    private fun onMarkAsPaid() = launch {
+    private fun onMarkAsPaid(bookingId: Long) = launch {
         if (!networkStatus.isConnected()) {
             triggerEvent(MultiLiveEvent.Event.ShowSnackbar(R.string.offline_error))
             return@launch
         }
         paymentUpdateStatus.value = PaymentUpdateStatus.InProgress
-        bookingsRepository.markAsPaid(bookingId ?: 0L)
+        bookingsRepository.markAsPaid(bookingId)
             .onFailure {
                 triggerEvent(MultiLiveEvent.Event.ShowSnackbar(R.string.booking_mark_as_paid_error))
             }
@@ -266,10 +278,10 @@ class BookingDetailsViewModel @Inject constructor(
         onCancelBooking = ::onCancelBooking,
         onAttendanceStatusSelected = { attendanceStatus ->
             if (attendanceStatus.toDataModel() != booking.attendanceStatus) {
-                onAttendanceStatusSelected(attendanceStatus)
+                onAttendanceStatusSelected(booking.id.value, attendanceStatus)
             }
         },
-        onMarkAsPaid = ::onMarkAsPaid,
+        onMarkAsPaid = { onMarkAsPaid(booking.id.value) },
         paymentUpdateStatus = paymentUpdateStatus,
     )
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/bookings/details/BookingDetailsViewState.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/bookings/details/BookingDetailsViewState.kt
@@ -11,10 +11,6 @@ data class BookingDetailsViewState(
     val toolbarTitle: String = "",
     val bookingUiState: BookingUiState? = null,
     val loadingState: BookingDetailsLoadingState = BookingDetailsLoadingState.Idle,
-    val onCancelBooking: () -> Unit = {},
-    val onAttendanceStatusSelected: (BookingAttendanceStatus) -> Unit = { _ -> },
-    val onMarkAsPaid: () -> Unit = {},
-    val paymentUpdateStatus: PaymentUpdateStatus = PaymentUpdateStatus.Idle,
     val dialogState: DialogState? = null,
     val onRefresh: () -> Unit = {},
 ) {
@@ -29,7 +25,11 @@ data class BookingUiState(
     val bookingCustomerDetails: BookingCustomerDetailsModel,
     val bookingPaymentDetails: BookingPaymentDetailsModel?,
     val note: String,
-    val isAttendanceStatusEditable: Boolean
+    val isAttendanceStatusEditable: Boolean,
+    val onCancelBooking: () -> Unit = {},
+    val onAttendanceStatusSelected: (BookingAttendanceStatus) -> Unit = { _ -> },
+    val onMarkAsPaid: () -> Unit = {},
+    val paymentUpdateStatus: PaymentUpdateStatus = PaymentUpdateStatus.Idle,
 )
 
 sealed interface BookingDetailsLoadingState {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/bookings/details/BookingDetailsViewState.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/bookings/details/BookingDetailsViewState.kt
@@ -37,6 +37,8 @@ data class BookingUiState(
     val onAttendanceStatusSelected: (BookingAttendanceStatus) -> Unit = { _ -> },
     val onMarkAsPaid: () -> Unit = {},
     val paymentUpdateStatus: PaymentUpdateStatus = PaymentUpdateStatus.Idle,
+    val onNoteClicked: () -> Unit = {},
+    val onViewOrderClicked: () -> Unit = {},
 )
 
 sealed interface BookingDetailsLoadingState {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/bookings/details/BookingDetailsViewState.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/bookings/details/BookingDetailsViewState.kt
@@ -7,15 +7,22 @@ import com.woocommerce.android.ui.bookings.compose.BookingPaymentDetailsModel
 import com.woocommerce.android.ui.bookings.compose.BookingSummaryModel
 import com.woocommerce.android.ui.compose.DialogState
 
-data class BookingDetailsViewState(
-    val toolbarTitle: String = "",
-    val bookingUiState: BookingUiState? = null,
-    val loadingState: BookingDetailsLoadingState = BookingDetailsLoadingState.Idle,
-    val dialogState: DialogState? = null,
-    val onRefresh: () -> Unit = {},
+sealed class BookingDetailsViewState(
+    open val toolbarTitle: String = "",
 ) {
-    val shouldShowSkeleton: Boolean = bookingUiState == null && loadingState == BookingDetailsLoadingState.Loading
-    val shouldShowEmptyState: Boolean = bookingUiState == null && loadingState == BookingDetailsLoadingState.Idle
+    data object Empty : BookingDetailsViewState()
+
+    data class ShowBooking(
+        override val toolbarTitle: String = "",
+        val bookingUiState: BookingUiState? = null,
+        val loadingState: BookingDetailsLoadingState = BookingDetailsLoadingState.Idle,
+        val dialogState: DialogState? = null,
+        val onRefresh: () -> Unit = {},
+    ) : BookingDetailsViewState() {
+
+        val shouldShowSkeleton: Boolean =
+            bookingUiState == null && loadingState == BookingDetailsLoadingState.Loading
+    }
 }
 
 data class BookingUiState(

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/bookings/details/BookingDetailsViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/bookings/details/BookingDetailsViewModelTest.kt
@@ -96,7 +96,7 @@ class BookingDetailsViewModelTest : BaseUnitTest() {
 
         // When
         val state = viewModel.state.getOrAwaitValue()
-        state.onAttendanceStatusSelected(BookingAttendanceStatus.NoShow)
+        state.bookingUiState?.onAttendanceStatusSelected(BookingAttendanceStatus.NoShow)
 
         // Then
         verify(bookingsRepository, times(1)).updateAttendanceStatus(
@@ -211,7 +211,7 @@ class BookingDetailsViewModelTest : BaseUnitTest() {
         val state = viewModel.state.getOrAwaitValue()
 
         // When
-        state.onCancelBooking()
+        state.bookingUiState?.onCancelBooking()
 
         // Then
         val updated = viewModel.state.getOrAwaitValue()
@@ -223,7 +223,7 @@ class BookingDetailsViewModelTest : BaseUnitTest() {
         // Given
         val viewModel = createViewModel()
         val state = viewModel.state.getOrAwaitValue()
-        state.onCancelBooking()
+        state.bookingUiState?.onCancelBooking()
         val stateWithDialog = viewModel.state.getOrAwaitValue()
         assertThat(stateWithDialog.dialogState).isNotNull
 
@@ -240,7 +240,7 @@ class BookingDetailsViewModelTest : BaseUnitTest() {
         // Given
         val viewModel = createViewModel()
         val state = viewModel.state.getOrAwaitValue()
-        state.onCancelBooking()
+        state.bookingUiState?.onCancelBooking()
         val stateWithDialog = viewModel.state.getOrAwaitValue()
         assertThat(stateWithDialog.dialogState).isNotNull()
 
@@ -261,7 +261,7 @@ class BookingDetailsViewModelTest : BaseUnitTest() {
         }
         val viewModel = createViewModel()
         val state = viewModel.state.getOrAwaitValue()
-        state.onCancelBooking()
+        state.bookingUiState?.onCancelBooking()
         val stateWithDialog = viewModel.state.getOrAwaitValue()
 
         // When
@@ -284,7 +284,7 @@ class BookingDetailsViewModelTest : BaseUnitTest() {
         whenever(bookingsRepository.cancelBooking(any())).thenReturn(Result.failure(Exception("Cancel failed")))
         val viewModel = createViewModel()
         val state = viewModel.state.getOrAwaitValue()
-        state.onCancelBooking()
+        state.bookingUiState?.onCancelBooking()
         val stateWithDialog = viewModel.state.getOrAwaitValue()
 
         // When
@@ -309,17 +309,17 @@ class BookingDetailsViewModelTest : BaseUnitTest() {
         val state = viewModel.state.getOrAwaitValue()
 
         // When
-        state.onMarkAsPaid()
+        state.bookingUiState?.onMarkAsPaid()
 
         // Then: immediately after click (operation in progress)
         val during = viewModel.state.getOrAwaitValue()
-        assertThat(during.paymentUpdateStatus).isEqualTo(PaymentUpdateStatus.InProgress)
+        assertThat(during.bookingUiState?.paymentUpdateStatus).isEqualTo(PaymentUpdateStatus.InProgress)
         verify(bookingsRepository, times(1)).markAsPaid(bookingId)
 
         // And after operation completes, status returns to idle
         advanceUntilIdle()
         val after = viewModel.state.getOrAwaitValue()
-        assertThat(after.paymentUpdateStatus).isEqualTo(PaymentUpdateStatus.Idle)
+        assertThat(after.bookingUiState?.paymentUpdateStatus).isEqualTo(PaymentUpdateStatus.Idle)
     }
 
     @Test
@@ -330,7 +330,7 @@ class BookingDetailsViewModelTest : BaseUnitTest() {
         val state = viewModel.state.getOrAwaitValue()
 
         // When
-        state.onMarkAsPaid()
+        state.bookingUiState?.onMarkAsPaid()
 
         // Then
         val event = viewModel.event.getOrAwaitValue()
@@ -346,14 +346,14 @@ class BookingDetailsViewModelTest : BaseUnitTest() {
         val state = viewModel.state.getOrAwaitValue()
 
         // When
-        state.onMarkAsPaid()
+        state.bookingUiState?.onMarkAsPaid()
 
         // Then
         val event = viewModel.event.getOrAwaitValue()
         assertThat(event).isEqualTo(MultiLiveEvent.Event.ShowSnackbar(R.string.booking_mark_as_paid_error))
         advanceUntilIdle()
         val after = viewModel.state.getOrAwaitValue()
-        assertThat(after.paymentUpdateStatus).isEqualTo(PaymentUpdateStatus.Idle)
+        assertThat(after.bookingUiState?.paymentUpdateStatus).isEqualTo(PaymentUpdateStatus.Idle)
     }
 
     @Test

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/bookings/details/BookingDetailsViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/bookings/details/BookingDetailsViewModelTest.kt
@@ -9,6 +9,7 @@ import com.woocommerce.android.ui.bookings.BookingMapper
 import com.woocommerce.android.ui.bookings.BookingsRepository
 import com.woocommerce.android.ui.bookings.compose.BookingAttendanceStatus
 import com.woocommerce.android.ui.bookings.compose.BookingStaffMemberStatus
+import com.woocommerce.android.ui.compose.DialogState
 import com.woocommerce.android.util.CurrencyFormatter
 import com.woocommerce.android.util.getOrAwaitValue
 import com.woocommerce.android.viewmodel.BaseUnitTest
@@ -163,7 +164,7 @@ class BookingDetailsViewModelTest : BaseUnitTest() {
 
         // When
         val state = viewModel.state.getOrAwaitValue()
-        state.onRefresh()
+        state.asShowBooking?.onRefresh()
 
         // Then
         verify(bookingsRepository, times(2)).fetchBooking(bookingId)
@@ -253,30 +254,31 @@ class BookingDetailsViewModelTest : BaseUnitTest() {
     }
 
     @Test
-    fun `given cancel dialog shown, when confirm, then repository cancelBooking called and cancel status shows progress then idle`() = testBlocking {
-        // Given
-        whenever(bookingsRepository.cancelBooking(any())).doSuspendableAnswer {
-            delay(100)
-            Result.success(Unit)
+    fun `given cancel dialog shown, when confirm, then repository cancelBooking called and cancel status shows progress then idle`() =
+        testBlocking {
+            // Given
+            whenever(bookingsRepository.cancelBooking(any())).doSuspendableAnswer {
+                delay(100)
+                Result.success(Unit)
+            }
+            val viewModel = createViewModel()
+            val state = viewModel.state.getOrAwaitValue()
+            state.bookingUiState?.onCancelBooking()
+            val stateWithDialog = viewModel.state.getOrAwaitValue()
+
+            // When
+            stateWithDialog.dialogState?.positiveButton?.onClick()
+
+            // Then: immediately after click (operation in progress)
+            val during = viewModel.state.getOrAwaitValue()
+            assertThat(during.bookingUiState?.bookingsAppointmentDetails?.cancelInProgressShown).isTrue()
+            verify(bookingsRepository, times(1)).cancelBooking(bookingId)
+
+            // And after operation completes, status returns to idle
+            advanceUntilIdle()
+            val after = viewModel.state.getOrAwaitValue()
+            assertThat(after.bookingUiState?.bookingsAppointmentDetails?.cancelInProgressShown).isFalse()
         }
-        val viewModel = createViewModel()
-        val state = viewModel.state.getOrAwaitValue()
-        state.bookingUiState?.onCancelBooking()
-        val stateWithDialog = viewModel.state.getOrAwaitValue()
-
-        // When
-        stateWithDialog.dialogState?.positiveButton?.onClick()
-
-        // Then: immediately after click (operation in progress)
-        val during = viewModel.state.getOrAwaitValue()
-        assertThat(during.bookingUiState?.bookingsAppointmentDetails?.cancelInProgressShown).isTrue()
-        verify(bookingsRepository, times(1)).cancelBooking(bookingId)
-
-        // And after operation completes, status returns to idle
-        advanceUntilIdle()
-        val after = viewModel.state.getOrAwaitValue()
-        assertThat(after.bookingUiState?.bookingsAppointmentDetails?.cancelInProgressShown).isFalse()
-    }
 
     @Test
     fun `given cancel fails, when confirm, then show error snackbar and status returns idle`() = testBlocking {
@@ -299,28 +301,29 @@ class BookingDetailsViewModelTest : BaseUnitTest() {
     }
 
     @Test
-    fun `when onMarkAsPaid invoked, then repository markAsPaid called and payment status shows progress then idle`() = testBlocking {
-        // Given
-        whenever(bookingsRepository.markAsPaid(any())).doSuspendableAnswer {
-            delay(100)
-            Result.success(Unit)
+    fun `when onMarkAsPaid invoked, then repository markAsPaid called and payment status shows progress then idle`() =
+        testBlocking {
+            // Given
+            whenever(bookingsRepository.markAsPaid(any())).doSuspendableAnswer {
+                delay(100)
+                Result.success(Unit)
+            }
+            val viewModel = createViewModel()
+            val state = viewModel.state.getOrAwaitValue()
+
+            // When
+            state.bookingUiState?.onMarkAsPaid()
+
+            // Then: immediately after click (operation in progress)
+            val during = viewModel.state.getOrAwaitValue()
+            assertThat(during.bookingUiState?.paymentUpdateStatus).isEqualTo(PaymentUpdateStatus.InProgress)
+            verify(bookingsRepository, times(1)).markAsPaid(bookingId)
+
+            // And after operation completes, status returns to idle
+            advanceUntilIdle()
+            val after = viewModel.state.getOrAwaitValue()
+            assertThat(after.bookingUiState?.paymentUpdateStatus).isEqualTo(PaymentUpdateStatus.Idle)
         }
-        val viewModel = createViewModel()
-        val state = viewModel.state.getOrAwaitValue()
-
-        // When
-        state.bookingUiState?.onMarkAsPaid()
-
-        // Then: immediately after click (operation in progress)
-        val during = viewModel.state.getOrAwaitValue()
-        assertThat(during.bookingUiState?.paymentUpdateStatus).isEqualTo(PaymentUpdateStatus.InProgress)
-        verify(bookingsRepository, times(1)).markAsPaid(bookingId)
-
-        // And after operation completes, status returns to idle
-        advanceUntilIdle()
-        val after = viewModel.state.getOrAwaitValue()
-        assertThat(after.bookingUiState?.paymentUpdateStatus).isEqualTo(PaymentUpdateStatus.Idle)
-    }
 
     @Test
     fun `when offline and onMarkAsPaid invoked, then offline snackbar shown and repo not called`() = testBlocking {
@@ -410,3 +413,12 @@ class BookingDetailsViewModelTest : BaseUnitTest() {
         )
     }
 }
+
+private val BookingDetailsViewState.bookingUiState: BookingUiState?
+    get() = (this as? BookingDetailsViewState.ShowBooking)?.bookingUiState
+
+private val BookingDetailsViewState.dialogState: DialogState?
+    get() = (this as? BookingDetailsViewState.ShowBooking)?.dialogState
+
+private val BookingDetailsViewState.asShowBooking: BookingDetailsViewState.ShowBooking?
+    get() = this as? BookingDetailsViewState.ShowBooking


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

<!-- Id number of the Linear issue this PR addresses, e.g., WOOMOB-373. -->

Closes WOOMOB-1421

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

As mentioned [here](https://github.com/woocommerce/woocommerce-android/pull/14720#discussion_r2478360297) this PR tries to clean up the booking details VM state after introducing two modes `showbooking/empty` to support split pane layout. 

The changes here are aimed at removing stuff like `bookingId :? 0L` and making sure we only invoke functions that require certain data if that data is available. 

### Test Steps
<!-- Describe how to test your changes. Include only what’s needed for the reviewer to validate the behavior.
For new features, outline the main user flow or goal rather than every tap or click — the reviewer should be able to complete the flow naturally.
If applicable, mention key devices, scenarios, or edge cases to verify. -->

No UI changes, please test as much functionality of the booking details screen as possible. 

- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
