### PR TITLE
[WOOMOB-1622] Handle Bluetooth pairing removed disconnect reason

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -3,7 +3,7 @@
 *** For entries which are touching the Android Wear app's, start entry with `[WEAR]` too.
 23.7
 -----
-
+- [Internal] Handle BLUETOOTH_PEER_REMOVED_PAIRING_INFORMATION disconnect reason from Stripe SDK [https://github.com/woocommerce/woocommerce-android/pull/14886]
 
 23.6
 -----

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/cardreader/connect/CardReaderConnectViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/cardreader/connect/CardReaderConnectViewModel.kt
@@ -499,6 +499,8 @@ class CardReaderConnectViewModel @Inject constructor(
         val hintLabel = when (errorCode) {
             CardReaderStatus.NotConnected.ErrorCode.BATTERY_CRITICALLY_LOW ->
                 R.string.card_reader_connect_failed_battery_low_hint
+            CardReaderStatus.NotConnected.ErrorCode.BLUETOOTH_PEER_REMOVED_PAIRING ->
+                R.string.card_reader_connect_failed_bluetooth_pairing_removed_hint
             CardReaderStatus.NotConnected.ErrorCode.OTHER -> null
             null -> null
         }

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -1628,6 +1628,7 @@
     <string name="card_reader_connect_missing_bluetooth_permission_button">Open settings</string>
     <string name="card_reader_connect_learn_more">&lt;a href=\'\'&gt;Learn more&lt;/a&gt; about In-Person Payments</string>
     <string name="card_reader_connect_failed_battery_low_hint">The reader battery is low. Please charge the reader and try again</string>
+    <string name="card_reader_connect_failed_bluetooth_pairing_removed_hint">Forget the reader in Android Bluetooth Settings</string>
 
     <!--
         Card Reader Detail

--- a/libs/cardreader/src/main/java/com/woocommerce/android/cardreader/connection/CardReaderStatus.kt
+++ b/libs/cardreader/src/main/java/com/woocommerce/android/cardreader/connection/CardReaderStatus.kt
@@ -7,6 +7,7 @@ sealed class CardReaderStatus {
     ) : CardReaderStatus() {
         enum class ErrorCode {
             BATTERY_CRITICALLY_LOW,
+            BLUETOOTH_PEER_REMOVED_PAIRING,
             OTHER,
         }
     }

--- a/libs/cardreader/src/main/java/com/woocommerce/android/cardreader/internal/connection/BluetoothReaderListenerImpl.kt
+++ b/libs/cardreader/src/main/java/com/woocommerce/android/cardreader/internal/connection/BluetoothReaderListenerImpl.kt
@@ -108,8 +108,13 @@ internal class BluetoothReaderListenerImpl(
     }
 
     override fun onDisconnect(reason: DisconnectReason) {
-        logWrapper.d(LOG_TAG, "onDisconnect")
-        terminalListenerImpl.updateReaderStatus(CardReaderStatus.NotConnected())
+        logWrapper.d(LOG_TAG, "onDisconnect: $reason")
+        val errorCode = when (reason) {
+            DisconnectReason.BLUETOOTH_PEER_REMOVED_PAIRING_INFORMATION ->
+                CardReaderStatus.NotConnected.ErrorCode.BLUETOOTH_PEER_REMOVED_PAIRING
+            else -> null
+        }
+        terminalListenerImpl.updateReaderStatus(CardReaderStatus.NotConnected(errorCode = errorCode))
     }
 
     fun resetConnectionState() {


### PR DESCRIPTION
WOOMOB-1622

### Description
In Stripe SDK v4.7.0, a new disconnect reason `BLUETOOTH_PEER_REMOVED_PAIRING_INFORMATION` was added to provide better visibility into mobile reader disconnects. This PR adds handling for this disconnect reason by:

- Adding a new error code `BLUETOOTH_PEER_REMOVED_PAIRING` to `CardReaderStatus.NotConnected.ErrorCode`
- Mapping the SDK disconnect reason to our error code in `BluetoothReaderListenerImpl`
- Displaying the message "Forget the reader in Android Bluetooth Settings" to users when this error occurs, as recommended by Stripe's documentation

### Test Steps
I don't know how to reproduce this scenario, as it requires the Bluetooth pairing information to be removed by the peer device. Therefore, only code validation is possible for this change.

The AI says:

```
  This is likely a rare edge case that happens when:
  - The card reader's firmware encounters an error and clears pairings
  - The reader runs out of memory for storing pairings
  - A reader firmware bug causes pairing loss
  - Someone accidentally triggers a pairing reset on the reader
  - The reader battery dies completely and loses volatile pairing memory
```

To validate the code:
1. Review that the new error code is properly added to the enum
2. Verify the mapping in `BluetoothReaderListenerImpl.onDisconnect()`
3. Confirm the error message mapping in `CardReaderConnectViewModel`
4. Check that the user-facing message matches Stripe's recommendation

### Images/gif
N/A - Error handling only

- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.