### PR TITLE
[WOOMOB-1630] Fix bottom padding on the booking details screen

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/bookings/details/BookingDetailsScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/bookings/details/BookingDetailsScreen.kt
@@ -96,46 +96,49 @@ fun BookingDetailsScreen(
             )
         }
     ) { innerPadding ->
-        when (viewState) {
-            BookingDetailsViewState.Empty -> BookingDetailsEmptyScreen()
-            is BookingDetailsViewState.ShowBooking -> {
-                val state = rememberPullToRefreshState()
-                WCPullToRefreshBox(
-                    isRefreshing = viewState.loadingState == BookingDetailsLoadingState.Refreshing,
-                    onRefresh = viewState.onRefresh,
-                    state = state,
-                    modifier = Modifier
-                        .fillMaxSize()
-                        .padding(innerPadding)
-                        .detailsPanePadding(),
-                ) {
-                    Column(
+        Box(
+            modifier = Modifier.padding(top = innerPadding.calculateTopPadding())
+        ) {
+            when (viewState) {
+                BookingDetailsViewState.Empty -> BookingDetailsEmptyScreen()
+                is BookingDetailsViewState.ShowBooking -> {
+                    val state = rememberPullToRefreshState()
+                    WCPullToRefreshBox(
+                        isRefreshing = viewState.loadingState == BookingDetailsLoadingState.Refreshing,
+                        onRefresh = viewState.onRefresh,
+                        state = state,
                         modifier = Modifier
                             .fillMaxSize()
-                            .verticalScroll(rememberScrollState())
+                            .detailsPanePadding(),
                     ) {
-                        when {
-                            viewState.shouldShowSkeleton -> BookingDetailsLoading()
-                            viewState.bookingUiState != null -> {
-                                BookingDetailsContent(
-                                    booking = viewState.bookingUiState,
-                                    onCancelBooking = viewState.bookingUiState.onCancelBooking,
-                                    onAttendanceStatusClicked = { showAttendanceSheet.value = true },
-                                    onMarkAsPaid = viewState.bookingUiState.onMarkAsPaid,
-                                )
-                                if (showAttendanceSheet.value) {
-                                    BookingAttendanceStatusBottomSheet(
-                                        onSelect = { status ->
-                                            viewState.bookingUiState.onAttendanceStatusSelected(status)
-                                        },
-                                        onDismiss = { showAttendanceSheet.value = false }
+                        Column(
+                            modifier = Modifier
+                                .fillMaxSize()
+                                .verticalScroll(rememberScrollState())
+                        ) {
+                            when {
+                                viewState.shouldShowSkeleton -> BookingDetailsLoading()
+                                viewState.bookingUiState != null -> {
+                                    BookingDetailsContent(
+                                        booking = viewState.bookingUiState,
+                                        onCancelBooking = viewState.bookingUiState.onCancelBooking,
+                                        onAttendanceStatusClicked = { showAttendanceSheet.value = true },
+                                        onMarkAsPaid = viewState.bookingUiState.onMarkAsPaid,
                                     )
+                                    if (showAttendanceSheet.value) {
+                                        BookingAttendanceStatusBottomSheet(
+                                            onSelect = { status ->
+                                                viewState.bookingUiState.onAttendanceStatusSelected(status)
+                                            },
+                                            onDismiss = { showAttendanceSheet.value = false }
+                                        )
+                                    }
                                 }
                             }
                         }
                     }
+                    viewState.dialogState?.Render()
                 }
-                viewState.dialogState?.Render()
             }
         }
     }


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

<!-- Id number of the Linear issue this PR addresses, e.g., WOOMOB-373. -->

WOOMOB-1630

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

When navigating back from the Booking Note fragment via the Toolbar back button, the `innerInsets` from the Scaffold would have non-zero bottom padding. This is wrong because the bottom padding should be 0. Because we don't have a bottom bar in the Scaffold, we can ignore the bottom padding and only apply the top. This fixes the issue locally, but the general problem remains. 

The general issue (in my opinion) is caused by [MainActivityEdgeToEdgeHelper](https://github.com/woocommerce/woocommerce-android/blob/trunk/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/main/MainActivityEdgeToEdgeHelper.kt). 

There's a timing issue in consuming the insets there. On top of that, we can't properly handle edge-to-edge. The above code applies the padding to the root, which means each screen doesn't have access to the part of the screen. That is a separate issue, though. 

### Test Steps
<!-- Describe how to test your changes. Include only what’s needed for the reviewer to validate the behavior.
For new features, outline the main user flow or goal rather than every tap or click — the reviewer should be able to complete the flow naturally.
If applicable, mention key devices, scenarios, or edge cases to verify. -->

1. Go to booking details
2. Scroll down
3. Open the note
4. Tap on the back button in the Toolbar 
5. Confirm the padding at the bottom is correct

### Images/gif
<!-- Include before and after images or gifs when appropriate. -->

| Before | After |
|---|---|
| <video src="https://github.com/user-attachments/assets/4c459b1b-1517-485b-bebe-026eac18c8a3"/> | <video src="https://github.com/user-attachments/assets/01455d77-d5b9-4efc-bbab-081aa98573b5"/> |

- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
