### PR TITLE
[POS Orders] Filter draft orders out

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/orders/WooPosOrdersDataSource.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/orders/WooPosOrdersDataSource.kt
@@ -122,7 +122,7 @@ class WooPosOrdersDataSource @Inject constructor(
         page = page,
         orderBy = OrderBy.DATE,
         sortOrder = OrderRestClient.SortOrder.DESCENDING,
-        statusFilter = null,
+        statusFilter = "pending,processing,on-hold,completed,cancelled,refunded,failed",
         createdVia = "pos-rest-api",
         searchQuery = searchQuery
     )

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/orders/WooPosOrdersDataSourceTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/orders/WooPosOrdersDataSourceTest.kt
@@ -220,7 +220,7 @@ class WooPosOrdersDataSourceTest {
                 page = 1,
                 orderBy = OrderRestClient.OrderBy.DATE,
                 sortOrder = OrderRestClient.SortOrder.DESCENDING,
-                statusFilter = null,
+                statusFilter = "pending,processing,on-hold,completed,cancelled,refunded,failed",
                 createdVia = "pos-rest-api",
                 searchQuery = query
             )
@@ -240,7 +240,7 @@ class WooPosOrdersDataSourceTest {
             page = 1,
             orderBy = OrderRestClient.OrderBy.DATE,
             sortOrder = OrderRestClient.SortOrder.DESCENDING,
-            statusFilter = null,
+            statusFilter = "pending,processing,on-hold,completed,cancelled,refunded,failed",
             createdVia = "pos-rest-api",
             searchQuery = query
         )
@@ -265,7 +265,7 @@ class WooPosOrdersDataSourceTest {
                 page = 1,
                 orderBy = OrderRestClient.OrderBy.DATE,
                 sortOrder = OrderRestClient.SortOrder.DESCENDING,
-                statusFilter = null,
+                statusFilter = "pending,processing,on-hold,completed,cancelled,refunded,failed",
                 createdVia = "pos-rest-api",
                 searchQuery = query
             )
@@ -295,7 +295,7 @@ class WooPosOrdersDataSourceTest {
                 page = 1,
                 orderBy = OrderRestClient.OrderBy.DATE,
                 sortOrder = OrderRestClient.SortOrder.DESCENDING,
-                statusFilter = null,
+                statusFilter = "pending,processing,on-hold,completed,cancelled,refunded,failed",
                 createdVia = "pos-rest-api",
                 searchQuery = query
             )
@@ -419,7 +419,7 @@ class WooPosOrdersDataSourceTest {
                 page = 1,
                 orderBy = OrderRestClient.OrderBy.DATE,
                 sortOrder = OrderRestClient.SortOrder.DESCENDING,
-                statusFilter = null,
+                statusFilter = "pending,processing,on-hold,completed,cancelled,refunded,failed",
                 createdVia = "pos-rest-api",
                 searchQuery = query
             )
@@ -445,7 +445,7 @@ class WooPosOrdersDataSourceTest {
                 page = 2,
                 orderBy = OrderRestClient.OrderBy.DATE,
                 sortOrder = OrderRestClient.SortOrder.DESCENDING,
-                statusFilter = null,
+                statusFilter = "pending,processing,on-hold,completed,cancelled,refunded,failed",
                 createdVia = "pos-rest-api",
                 searchQuery = query
             )
@@ -464,7 +464,7 @@ class WooPosOrdersDataSourceTest {
             page = 2,
             orderBy = OrderRestClient.OrderBy.DATE,
             sortOrder = OrderRestClient.SortOrder.DESCENDING,
-            statusFilter = null,
+            statusFilter = "pending,processing,on-hold,completed,cancelled,refunded,failed",
             createdVia = "pos-rest-api",
             searchQuery = query
         )


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

<!-- Id number of the Linear issue this PR addresses, e.g., WOOMOB-373. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
With this PR, we filter orders with draft statuses from the orders list, as they don't need to be shown to the users. 

### Test Steps
<!-- Describe how to test your changes. Include only what’s needed for the reviewer to validate the behavior.
For new features, outline the main user flow or goal rather than every tap or click — the reviewer should be able to complete the flow naturally.
If applicable, mention key devices, scenarios, or edge cases to verify. -->

- Open POS
- Add a product to the cart
- Tap on checkout
- Tap on back
- Tap on checkout
- Complete the order
- Open Order List – Before: there is one order in auto-draft and one completed. Now: Just one completed


- [X] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
