### PR TITLE
[Woo POS][Local Catalog] Refine sync status checker states

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/items/WooPosItemsViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/items/WooPosItemsViewModel.kt
@@ -63,14 +63,20 @@ class WooPosItemsViewModel @Inject constructor(
             preferencesRepository.setWasOpenedOnce(true)
         }
 
-        checkSyncStatusAndUpdateBanner()
+        refreshSyncOverdueBannerState()
     }
 
-    private fun checkSyncStatusAndUpdateBanner() {
+    private fun refreshSyncOverdueBannerState() {
         viewModelScope.launch {
             val requirement = syncStatusChecker.checkSyncRequirement()
             _catalogSyncOverdueBannerState.value = when (requirement) {
-                is WooPosFullSyncRequirement.Overdue -> CatalogSyncOverdueBannerState.Visible
+                is WooPosFullSyncRequirement.NonBlockingRequired -> {
+                    if (requirement.isOverdue) {
+                        CatalogSyncOverdueBannerState.Visible
+                    } else {
+                        CatalogSyncOverdueBannerState.Hidden
+                    }
+                }
                 else -> CatalogSyncOverdueBannerState.Hidden
             }
         }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/items/products/WooPosProductsDataSource.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/items/products/WooPosProductsDataSource.kt
@@ -74,7 +74,7 @@ class WooPosProductsDataSource @Inject constructor(
             }
 
             is WooPosFullSyncRequirement.NotRequired,
-            is WooPosFullSyncRequirement.Overdue -> {
+            is WooPosFullSyncRequirement.NonBlockingRequired -> {
                 activeSource = localDbDataSource
                 emit(WooPosPrepopulatingDataStatus.Completed)
             }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/localcatalog/WooPosFullSyncStatusChecker.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/localcatalog/WooPosFullSyncStatusChecker.kt
@@ -18,7 +18,8 @@ class WooPosFullSyncStatusChecker @Inject constructor(
     private val prefsRepo: WooPosPreferencesRepository,
     private val checkCatalogSizeAction: WooPosCheckCatalogSizeAction,
     private val isLocalCatalogSupported: WooPosIsLocalCatalogSupported,
-    private val wooPosLogWrapper: WooPosLogWrapper
+    private val wooPosLogWrapper: WooPosLogWrapper,
+    private val time: DateTimeProvider,
 ) {
     @Suppress("ReturnCount")
     suspend fun checkSyncRequirement(): WooPosFullSyncRequirement {
@@ -54,44 +55,46 @@ class WooPosFullSyncStatusChecker @Inject constructor(
             return WooPosFullSyncRequirement.BlockingRequired
         }
 
-        return when {
-            isFullSyncOverdue(lastFullSyncTimestamp) -> {
-                if (!networkStatus.isConnected()) {
-                    wooPosLogWrapper.d(
-                        "Full sync overdue but offline - allowing POS to load with cached data " +
-                            "(${if (catalogIsEmpty) "empty catalog" else "$productCount products"})"
-                    )
-                }
-                wooPosLogWrapper.d("Full sync overdue (last sync: $lastFullSyncTimestamp)")
-                WooPosFullSyncRequirement.Overdue
-            }
+        val now = time.now()
+        val timeElapsedSinceLastSync = now - lastFullSyncTimestamp
 
-            else -> {
+        return when {
+            timeElapsedSinceLastSync < FULL_SYNC_NOT_REQUIRED_THRESHOLD -> {
                 wooPosLogWrapper.d(
                     "Full sync not required: Recent sync at $lastFullSyncTimestamp " +
                         "(${if (catalogIsEmpty) "empty catalog" else "$productCount products"})"
                 )
                 WooPosFullSyncRequirement.NotRequired(lastFullSyncTimestamp)
             }
+            else -> {
+                if (!networkStatus.isConnected()) {
+                    wooPosLogWrapper.d(
+                        "Full sync required but offline - allowing POS to load with cached data " +
+                            "(${if (catalogIsEmpty) "empty catalog" else "$productCount products"})"
+                    )
+                }
+                val isFullSyncOverdue = timeElapsedSinceLastSync > FULL_SYNC_OVERDUE_THRESHOLD
+                if (isFullSyncOverdue) {
+                    wooPosLogWrapper.d("Full sync overdue (last sync: $lastFullSyncTimestamp)")
+                }
+                WooPosFullSyncRequirement.NonBlockingRequired(lastFullSyncTimestamp, isFullSyncOverdue)
+            }
         }
     }
 
-    private fun isFullSyncOverdue(lastSyncTimestamp: Long): Boolean {
-        val currentTime = System.currentTimeMillis()
-        val timeSinceLastSync = currentTime - lastSyncTimestamp
-        val overdueThreshold = FULL_SYNC_OVERDUE_THRESHOLD.inWholeMilliseconds
-        return timeSinceLastSync >= overdueThreshold
-    }
-
     companion object {
-        private val FULL_SYNC_OVERDUE_THRESHOLD = 7.days
+        private val FULL_SYNC_OVERDUE_THRESHOLD = 7.days.inWholeMilliseconds
+        private val FULL_SYNC_NOT_REQUIRED_THRESHOLD = 2.days.inWholeMilliseconds
     }
 }
 
 sealed class WooPosFullSyncRequirement {
     data class NotRequired(val lastSyncTimestamp: Long) : WooPosFullSyncRequirement()
-    data object Overdue : WooPosFullSyncRequirement()
+    data class NonBlockingRequired(
+        val lastSyncTimestamp: Long,
+        val isOverdue: Boolean) : WooPosFullSyncRequirement()
     data object BlockingRequired : WooPosFullSyncRequirement()
     data class Error(val message: String) : WooPosFullSyncRequirement()
     data class LocalCatalogDisabled(val message: String) : WooPosFullSyncRequirement()
+
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/localcatalog/WooPosFullSyncStatusChecker.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/localcatalog/WooPosFullSyncStatusChecker.kt
@@ -92,9 +92,9 @@ sealed class WooPosFullSyncRequirement {
     data class NotRequired(val lastSyncTimestamp: Long) : WooPosFullSyncRequirement()
     data class NonBlockingRequired(
         val lastSyncTimestamp: Long,
-        val isOverdue: Boolean) : WooPosFullSyncRequirement()
+        val isOverdue: Boolean
+    ) : WooPosFullSyncRequirement()
     data object BlockingRequired : WooPosFullSyncRequirement()
     data class Error(val message: String) : WooPosFullSyncRequirement()
     data class LocalCatalogDisabled(val message: String) : WooPosFullSyncRequirement()
-
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/localcatalog/WooPosFullSyncStatusChecker.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/localcatalog/WooPosFullSyncStatusChecker.kt
@@ -9,6 +9,7 @@ import org.wordpress.android.fluxc.model.LocalOrRemoteId
 import org.wordpress.android.fluxc.store.pos.localcatalog.WooPosLocalCatalogStore
 import javax.inject.Inject
 import kotlin.time.Duration.Companion.days
+import kotlin.time.Duration.Companion.hours
 
 class WooPosFullSyncStatusChecker @Inject constructor(
     private val syncTimestampManager: WooPosSyncTimestampManager,
@@ -84,7 +85,7 @@ class WooPosFullSyncStatusChecker @Inject constructor(
 
     companion object {
         private val FULL_SYNC_OVERDUE_THRESHOLD = 7.days.inWholeMilliseconds
-        private val FULL_SYNC_NOT_REQUIRED_THRESHOLD = 2.days.inWholeMilliseconds
+        private val FULL_SYNC_NOT_REQUIRED_THRESHOLD = 23.hours.inWholeMilliseconds
     }
 }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/localcatalog/WooPosLocalCatalogSyncWorker.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/localcatalog/WooPosLocalCatalogSyncWorker.kt
@@ -107,7 +107,7 @@ constructor(
                 Result.retry()
             }
             is WooPosFullSyncRequirement.BlockingRequired,
-            is WooPosFullSyncRequirement.Overdue -> {
+            is WooPosFullSyncRequirement.NonBlockingRequired -> {
                 logger.d("Proceeding with sync (requirement: $syncRequirement)")
                 null
             }

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/home/items/products/WooPosProductsDataSourceTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/home/items/products/WooPosProductsDataSourceTest.kt
@@ -75,7 +75,7 @@ class WooPosProductsDataSourceTest {
     fun `given sync overdue, when prepopulate cache, then uses local db data source`() = runTest {
         // GIVEN
         whenever(syncStatusChecker.checkSyncRequirement()).thenReturn(
-            WooPosFullSyncRequirement.Overdue
+            WooPosFullSyncRequirement.NonBlockingRequired(lastSyncTimestamp = 0L, isOverdue = true)
         )
         whenever(localDbDataSource.fetchFirstProductsPage(false)).thenReturn(
             flowOf(ProductsResult.Remote(Result.success(emptyList())))

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/localcatalog/WooPosFullSyncStatusCheckerTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/localcatalog/WooPosFullSyncStatusCheckerTest.kt
@@ -149,7 +149,9 @@ class WooPosFullSyncStatusCheckerTest {
             val result = sut.checkSyncRequirement()
 
             // THEN
-            assertThat(result).isEqualTo(WooPosFullSyncRequirement.NonBlockingRequired(overdueTimestamp, isOverdue = true))
+            assertThat(
+                result
+            ).isEqualTo(WooPosFullSyncRequirement.NonBlockingRequired(overdueTimestamp, isOverdue = true))
         }
 
     @Test
@@ -167,7 +169,9 @@ class WooPosFullSyncStatusCheckerTest {
             val result = sut.checkSyncRequirement()
 
             // THEN
-            assertThat(result).isEqualTo(WooPosFullSyncRequirement.NonBlockingRequired(overdueTimestamp, isOverdue = true))
+            assertThat(
+                result
+            ).isEqualTo(WooPosFullSyncRequirement.NonBlockingRequired(overdueTimestamp, isOverdue = true))
         }
 
     @Test
@@ -187,7 +191,9 @@ class WooPosFullSyncStatusCheckerTest {
             val result = sut.checkSyncRequirement()
 
             // THEN
-            assertThat(result).isEqualTo(WooPosFullSyncRequirement.NonBlockingRequired(overdueTimestamp, isOverdue = true))
+            assertThat(
+                result
+            ).isEqualTo(WooPosFullSyncRequirement.NonBlockingRequired(overdueTimestamp, isOverdue = true))
         }
 
     @Test
@@ -220,7 +226,9 @@ class WooPosFullSyncStatusCheckerTest {
             val result = sut.checkSyncRequirement()
 
             // THEN
-            assertThat(result).isEqualTo(WooPosFullSyncRequirement.NonBlockingRequired(exactThresholdTimestamp, isOverdue = false))
+            assertThat(
+                result
+            ).isEqualTo(WooPosFullSyncRequirement.NonBlockingRequired(exactThresholdTimestamp, isOverdue = false))
         }
 
     @Test

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/localcatalog/WooPosFullSyncStatusCheckerTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/localcatalog/WooPosFullSyncStatusCheckerTest.kt
@@ -21,6 +21,7 @@ import org.wordpress.android.fluxc.model.SiteModel
 import org.wordpress.android.fluxc.store.pos.localcatalog.WooPosLocalCatalogStore
 import kotlin.test.Test
 import kotlin.time.Duration.Companion.days
+import kotlin.time.Duration.Companion.hours
 
 @ExperimentalCoroutinesApi
 class WooPosFullSyncStatusCheckerTest {
@@ -200,7 +201,7 @@ class WooPosFullSyncStatusCheckerTest {
     fun `given sync not overdue, when checkSyncRequirement called, then should return NotRequired`() =
         runTest {
             // GIVEN
-            val recentTimestamp = NOW - 1.days.inWholeMilliseconds
+            val recentTimestamp = NOW - 10.hours.inWholeMilliseconds
             whenever(syncTimestampManager.getFullSyncLastCompletedTimestamp()).thenReturn(recentTimestamp)
 
             val sut = createSut()
@@ -244,7 +245,7 @@ class WooPosFullSyncStatusCheckerTest {
             val result = sut.checkSyncRequirement()
 
             // THEN
-            assertThat(result).isInstanceOf(WooPosFullSyncRequirement.NotRequired::class.java)
+            assertThat(result).isInstanceOf(WooPosFullSyncRequirement.NonBlockingRequired::class.java)
         }
 
     @Test
@@ -285,7 +286,7 @@ class WooPosFullSyncStatusCheckerTest {
             val result = sut.checkSyncRequirement()
 
             // THEN
-            assertThat(result).isEqualTo(WooPosFullSyncRequirement.NotRequired(recentTimestamp))
+            assertThat(result).isEqualTo(WooPosFullSyncRequirement.NonBlockingRequired(recentTimestamp, false))
         }
 
     @Test
@@ -305,7 +306,7 @@ class WooPosFullSyncStatusCheckerTest {
             val result = sut.checkSyncRequirement()
 
             // THEN
-            assertThat(result).isEqualTo(WooPosFullSyncRequirement.NotRequired(recentTimestamp))
+            assertThat(result).isEqualTo(WooPosFullSyncRequirement.NonBlockingRequired(recentTimestamp, false))
         }
 
     @Test

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/localcatalog/WooPosFullSyncStatusCheckerTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/localcatalog/WooPosFullSyncStatusCheckerTest.kt
@@ -36,10 +36,15 @@ class WooPosFullSyncStatusCheckerTest {
     private val prefsRepo: WooPosPreferencesRepository = mock()
     private val checkCatalogSizeAction: WooPosCheckCatalogSizeAction = mock()
     private val isLocalCatalogSupported: WooPosIsLocalCatalogSupported = mock()
+    private val time: DateTimeProvider = mock()
 
     private val siteModel = SiteModel().apply {
         id = 123
         siteId = 456L
+    }
+
+    companion object {
+        private const val NOW = 1609459200000L // 2021-01-01 00:00:00 UTC
     }
 
     private fun createSut() = WooPosFullSyncStatusChecker(
@@ -50,16 +55,18 @@ class WooPosFullSyncStatusCheckerTest {
         prefsRepo = prefsRepo,
         checkCatalogSizeAction = checkCatalogSizeAction,
         isLocalCatalogSupported = isLocalCatalogSupported,
-        wooPosLogWrapper = wooPosLogWrapper
+        wooPosLogWrapper = wooPosLogWrapper,
+        time = time
     )
 
     @Before
     fun setup() = runTest {
-        val recentTimestamp = System.currentTimeMillis() - 1.days.inWholeMilliseconds
+        val recentTimestamp = NOW - 1.days.inWholeMilliseconds
         whenever(selectedSite.getOrNull()).thenReturn(siteModel)
         whenever(isLocalCatalogSupported(siteModel.localId())).thenReturn(true)
         whenever(syncTimestampManager.getFullSyncLastCompletedTimestamp()).thenReturn(recentTimestamp)
         whenever(networkStatus.isConnected()).thenReturn(true)
+        whenever(time.now()).thenReturn(NOW)
         whenever(localCatalogStore.getProductCount(LocalOrRemoteId.LocalId(siteModel.id)))
             .thenReturn(Result.success(15))
         whenever(checkCatalogSizeAction.execute(siteModel, null, 1000))
@@ -128,10 +135,11 @@ class WooPosFullSyncStatusCheckerTest {
         }
 
     @Test
-    fun `given sync overdue and network connected, when checkSyncRequirement called, then should return Overdue`() =
+    fun `given sync overdue and network connected, when checkSyncRequirement called, then should return NonBlockingRequired with isOverdue true`() =
         runTest {
             // GIVEN
-            val overdueTimestamp = System.currentTimeMillis() - 8.days.inWholeMilliseconds
+            val overdueTimestamp = NOW - 8.days.inWholeMilliseconds
+            whenever(time.now()).thenReturn(NOW)
             whenever(syncTimestampManager.getFullSyncLastCompletedTimestamp()).thenReturn(overdueTimestamp)
             whenever(networkStatus.isConnected()).thenReturn(true)
 
@@ -141,14 +149,15 @@ class WooPosFullSyncStatusCheckerTest {
             val result = sut.checkSyncRequirement()
 
             // THEN
-            assertThat(result).isEqualTo(WooPosFullSyncRequirement.Overdue)
+            assertThat(result).isEqualTo(WooPosFullSyncRequirement.NonBlockingRequired(overdueTimestamp, isOverdue = true))
         }
 
     @Test
-    fun `given sync overdue and no network, when checkSyncRequirement called, then should return Overdue`() =
+    fun `given sync overdue and no network, when checkSyncRequirement called, then should return NonBlockingRequired with isOverdue true`() =
         runTest {
             // GIVEN
-            val overdueTimestamp = System.currentTimeMillis() - 8.days.inWholeMilliseconds
+            val overdueTimestamp = NOW - 8.days.inWholeMilliseconds
+            whenever(time.now()).thenReturn(NOW)
             whenever(syncTimestampManager.getFullSyncLastCompletedTimestamp()).thenReturn(overdueTimestamp)
             whenever(networkStatus.isConnected()).thenReturn(false)
 
@@ -158,14 +167,15 @@ class WooPosFullSyncStatusCheckerTest {
             val result = sut.checkSyncRequirement()
 
             // THEN
-            assertThat(result).isEqualTo(WooPosFullSyncRequirement.Overdue)
+            assertThat(result).isEqualTo(WooPosFullSyncRequirement.NonBlockingRequired(overdueTimestamp, isOverdue = true))
         }
 
     @Test
-    fun `given sync overdue with empty catalog and no network, when checkSyncRequirement called, then should return Overdue`() =
+    fun `given sync overdue with empty catalog and no network, when checkSyncRequirement called, then should return NonBlockingRequired with isOverdue true`() =
         runTest {
             // GIVEN
-            val overdueTimestamp = System.currentTimeMillis() - 8.days.inWholeMilliseconds
+            val overdueTimestamp = NOW - 8.days.inWholeMilliseconds
+            whenever(time.now()).thenReturn(NOW)
             whenever(syncTimestampManager.getFullSyncLastCompletedTimestamp()).thenReturn(overdueTimestamp)
             whenever(networkStatus.isConnected()).thenReturn(false)
             whenever(localCatalogStore.getProductCount(LocalOrRemoteId.LocalId(siteModel.id)))
@@ -177,14 +187,14 @@ class WooPosFullSyncStatusCheckerTest {
             val result = sut.checkSyncRequirement()
 
             // THEN
-            assertThat(result).isEqualTo(WooPosFullSyncRequirement.Overdue)
+            assertThat(result).isEqualTo(WooPosFullSyncRequirement.NonBlockingRequired(overdueTimestamp, isOverdue = true))
         }
 
     @Test
     fun `given sync not overdue, when checkSyncRequirement called, then should return NotRequired`() =
         runTest {
             // GIVEN
-            val recentTimestamp = System.currentTimeMillis() - 1.days.inWholeMilliseconds
+            val recentTimestamp = NOW - 1.days.inWholeMilliseconds
             whenever(syncTimestampManager.getFullSyncLastCompletedTimestamp()).thenReturn(recentTimestamp)
 
             val sut = createSut()
@@ -197,10 +207,11 @@ class WooPosFullSyncStatusCheckerTest {
         }
 
     @Test
-    fun `given sync at exact threshold, when checkSyncRequirement called, then should return Overdue`() =
+    fun `given sync at exact threshold, when checkSyncRequirement called, then should return NonBlockingRequired with isOverdue false`() =
         runTest {
             // GIVEN
-            val exactThresholdTimestamp = System.currentTimeMillis() - 7.days.inWholeMilliseconds
+            val exactThresholdTimestamp = NOW - 7.days.inWholeMilliseconds
+            whenever(time.now()).thenReturn(NOW)
             whenever(syncTimestampManager.getFullSyncLastCompletedTimestamp()).thenReturn(exactThresholdTimestamp)
 
             val sut = createSut()
@@ -209,7 +220,7 @@ class WooPosFullSyncStatusCheckerTest {
             val result = sut.checkSyncRequirement()
 
             // THEN
-            assertThat(result).isEqualTo(WooPosFullSyncRequirement.Overdue)
+            assertThat(result).isEqualTo(WooPosFullSyncRequirement.NonBlockingRequired(exactThresholdTimestamp, isOverdue = false))
         }
 
     @Test
@@ -257,7 +268,7 @@ class WooPosFullSyncStatusCheckerTest {
                 .thenReturn(Result.success(0))
             whenever(checkCatalogSizeAction.execute(siteModel, null, 1000))
                 .thenReturn(WooPosCheckCatalogSizeAction.WooPosCheckCatalogSizeResult.SizeAcceptable)
-            val recentTimestamp = System.currentTimeMillis() - 1.days.inWholeMilliseconds
+            val recentTimestamp = NOW - 1.days.inWholeMilliseconds
             whenever(syncTimestampManager.getFullSyncLastCompletedTimestamp()).thenReturn(recentTimestamp)
 
             val sut = createSut()
@@ -277,7 +288,7 @@ class WooPosFullSyncStatusCheckerTest {
                 .thenReturn(Result.success(0))
             whenever(checkCatalogSizeAction.execute(siteModel, null, 1000))
                 .thenReturn(WooPosCheckCatalogSizeAction.WooPosCheckCatalogSizeResult.SizeUnknown)
-            val recentTimestamp = System.currentTimeMillis() - 1.days.inWholeMilliseconds
+            val recentTimestamp = NOW - 1.days.inWholeMilliseconds
             whenever(syncTimestampManager.getFullSyncLastCompletedTimestamp()).thenReturn(recentTimestamp)
 
             val sut = createSut()
@@ -295,7 +306,7 @@ class WooPosFullSyncStatusCheckerTest {
             // GIVEN
             whenever(localCatalogStore.getProductCount(LocalOrRemoteId.LocalId(siteModel.id)))
                 .thenReturn(Result.success(100))
-            val recentTimestamp = System.currentTimeMillis() - 1.days.inWholeMilliseconds
+            val recentTimestamp = NOW - 1.days.inWholeMilliseconds
             whenever(syncTimestampManager.getFullSyncLastCompletedTimestamp()).thenReturn(recentTimestamp)
 
             val sut = createSut()


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

<!-- Id number of the Linear issue this PR addresses, e.g., WOOMOB-373. -->
💡 Don't merge until parent branch is `trunk`

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
This pull request refactors the sync requirement logic to introduce a more granular distinction between "overdue" and "required but not yet overdue" sync states. It replaces the previous `Overdue` state with a new `NonBlockingRequired` state that includes an `isOverdue` boolean flag, allowing the system to differentiate between syncs that are simply due (between 2-7 days) versus those that are overdue (>7 days).

**Key changes:**
* Introduced a DateTimeProvider dependency and fixed timestamp in tests to eliminate flaky time-dependent test behavior
* Replaced `WooPosFullSyncRequirement.Overdue` with `NonBlockingRequired(lastSyncTimestamp, isOverdue)` to support intermediate sync states
* Added a new `FULL_SYNC_NOT_REQUIRED_THRESHOLD` (2 days) to complement the existing `FULL_SYNC_OVERDUE_THRESHOLD` (7 days)

### Test Steps
<!-- Describe how to test your changes. Include only what’s needed for the reviewer to validate the behavior.
For new features, outline the main user flow or goal rather than every tap or click — the reviewer should be able to complete the flow naturally.
If applicable, mention key devices, scenarios, or edge cases to verify. -->
N/A

### Images/gif
<!-- Include before and after images or gifs when appropriate. -->
N/A

- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
