### PR TITLE
Change the background color for the selected booking in split pane layout

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/bookings/compose/BookingSummary.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/bookings/compose/BookingSummary.kt
@@ -30,7 +30,6 @@ fun BookingSummary(
 ) {
     Column(
         modifier = modifier
-            .background(color = MaterialTheme.colorScheme.surfaceContainer)
             .padding(16.dp),
         verticalArrangement = Arrangement.spacedBy(2.dp),
     ) {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/bookings/details/BookingDetailsScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/bookings/details/BookingDetailsScreen.kt
@@ -150,7 +150,9 @@ private fun BookingDetailsContent(
 ) {
     BookingSummary(
         model = booking.bookingSummary,
-        modifier = Modifier.fillMaxWidth()
+        modifier = Modifier
+            .fillMaxWidth()
+            .background(color = MaterialTheme.colorScheme.surfaceContainer)
     )
     BookingAppointmentDetails(
         model = booking.bookingsAppointmentDetails,

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/bookings/list/BookingListScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/bookings/list/BookingListScreen.kt
@@ -48,6 +48,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.focus.FocusRequester
 import androidx.compose.ui.focus.focusRequester
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.colorResource
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
@@ -55,6 +56,7 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import com.woocommerce.android.R
+import com.woocommerce.android.extensions.isTwoPanesShouldBeUsed
 import com.woocommerce.android.ui.bookings.compose.BookingAttendanceStatus
 import com.woocommerce.android.ui.bookings.compose.BookingStatus
 import com.woocommerce.android.ui.bookings.compose.BookingSummary
@@ -206,6 +208,7 @@ private fun BookingList(
     listState: LazyListState,
     modifier: Modifier = Modifier
 ) {
+    val context = LocalContext.current
     WCPullToRefreshBox(
         isRefreshing = state.loadingState == BookingListLoadingState.Refreshing,
         onRefresh = state.onRefresh,
@@ -222,10 +225,16 @@ private fun BookingList(
             }
 
             itemsIndexed(state.bookings) { _, booking ->
+                val backgroundColor = if (context.isTwoPanesShouldBeUsed && booking.id == state.selectedBooking) {
+                    colorResource(R.color.color_item_selected)
+                } else {
+                    MaterialTheme.colorScheme.surfaceContainer
+                }
                 Column(modifier = Modifier.background(MaterialTheme.colorScheme.surfaceContainer)) {
                     BookingSummary(
                         model = booking.summary,
                         modifier = Modifier
+                            .background(backgroundColor)
                             .fillMaxWidth()
                             .clickable(onClick = { state.onBookingClick(booking.id) })
                     )

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/bookings/list/BookingListScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/bookings/list/BookingListScreen.kt
@@ -230,11 +230,12 @@ private fun BookingList(
                 } else {
                     MaterialTheme.colorScheme.surfaceContainer
                 }
-                Column(modifier = Modifier.background(MaterialTheme.colorScheme.surfaceContainer)) {
+                Column(
+                    modifier = Modifier.background(backgroundColor)
+                ) {
                     BookingSummary(
                         model = booking.summary,
                         modifier = Modifier
-                            .background(backgroundColor)
                             .fillMaxWidth()
                             .clickable(onClick = { state.onBookingClick(booking.id) })
                     )

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/bookings/list/BookingListViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/bookings/list/BookingListViewModel.kt
@@ -17,6 +17,7 @@ import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.FlowPreview
 import kotlinx.coroutines.Job
+import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharingStarted
@@ -70,6 +71,9 @@ class BookingListViewModel @Inject constructor(
         get() = stateHandle[KEY_BOOKING_SELECTED_ON_BIG_SCREEN]
         set(value) = stateHandle.set(KEY_BOOKING_SELECTED_ON_BIG_SCREEN, value)
 
+    private val selectedBookingIdFlow: Flow<Long?> =
+        stateHandle.getStateFlow(KEY_BOOKING_SELECTED_ON_BIG_SCREEN, null)
+
     private val isSortSheetVisible = MutableStateFlow(false)
 
     private var bookingsFetchJob: Job? = null
@@ -80,11 +84,13 @@ class BookingListViewModel @Inject constructor(
             openFirstLoadedBookingOnTablet(bookings)
             with(bookingMapper) { bookings.map { it.toListItem() } }
         },
-        loadingState
-    ) { bookings, loadingState ->
+        loadingState,
+        selectedBookingIdFlow,
+    ) { bookings, loadingState, selectedBookingId ->
         BookingListContentState(
             bookings = bookings,
             loadingState = loadingState,
+            selectedBooking = selectedBookingId,
             onRefresh = { refreshTrigger.tryEmit(Unit) },
             onLoadMore = ::loadMore,
             onBookingClick = ::onBookingClick

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/bookings/list/BookingListViewState.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/bookings/list/BookingListViewState.kt
@@ -13,6 +13,7 @@ data class BookingListViewState(
 data class BookingListContentState(
     val bookings: List<BookingListItem>,
     val loadingState: BookingListLoadingState,
+    val selectedBooking: Long? = null,
     val onRefresh: () -> Unit,
     val onLoadMore: () -> Unit,
     val onBookingClick: (Long) -> Unit,


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

<!-- Id number of the Linear issue this PR addresses, e.g., WOOMOB-373. -->

WOOMOB-1632

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

This PR updates the BookingList item's background color to `R.color.color_item_selected` if the booking is selected and we are in the split pane layout. 

### Test Steps
<!-- Describe how to test your changes. Include only what’s needed for the reviewer to validate the behavior.
For new features, outline the main user flow or goal rather than every tap or click — the reviewer should be able to complete the flow naturally.
If applicable, mention key devices, scenarios, or edge cases to verify. -->

**Single pane layout**
1. Launch the app on a phone
2. Go to booking
3. Select one
4. Go back
5. Confirm all booking items have the same background color

**Split pane layout**
1. Launch the app on a tablet
2. Go to booking
3. Confirm the selected item is highlighted in the list
4. Select another one
5. Confirm the highlighted item was changed

### Images/gif
<!-- Include before and after images or gifs when appropriate. -->

| Phone | Tablet |
|---|---|
| <video src="https://github.com/user-attachments/assets/255c4dda-7905-4bed-bf53-5f51a66543eb"/> | <video src="https://github.com/user-attachments/assets/04e9564d-0adc-46d4-94e0-b93ff8292c87"/> |

- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
