### PR TITLE
[WOOMOB-1075] Introduce Search functionality for Local Catalog - STEP 1

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/items/search/WooPosLocalCatalogSearchDataSource.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/items/search/WooPosLocalCatalogSearchDataSource.kt
@@ -1,0 +1,73 @@
+package com.woocommerce.android.ui.woopos.home.items.search
+
+import com.woocommerce.android.tools.SelectedSite
+import com.woocommerce.android.ui.woopos.common.data.models.WooPosProductModel
+import com.woocommerce.android.ui.woopos.common.data.models.WooPosProductModelMapper
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+import org.wordpress.android.fluxc.model.LocalOrRemoteId
+import org.wordpress.android.fluxc.store.pos.localcatalog.WooPosLocalCatalogStore
+import java.util.concurrent.atomic.AtomicBoolean
+import java.util.concurrent.atomic.AtomicInteger
+import javax.inject.Inject
+import javax.inject.Singleton
+
+@Singleton
+class WooPosLocalCatalogSearchDataSource @Inject constructor(
+    private val posLocalCatalogStore: WooPosLocalCatalogStore,
+    private val selectedSite: SelectedSite,
+    private val productMapper: WooPosProductModelMapper,
+) {
+    companion object {
+        private const val PAGE_SIZE = 15
+    }
+
+    private val searchOffset = AtomicInteger(0)
+    private val canLoadMoreResults = AtomicBoolean(false)
+
+    val hasMorePages: Boolean
+        get() = canLoadMoreResults.get()
+
+    suspend fun searchProducts(query: String): Result<List<WooPosProductModel>> = withContext(Dispatchers.IO) {
+        searchOffset.set(0)
+        performSearch(query)
+    }
+
+    suspend fun loadMore(query: String): Result<List<WooPosProductModel>> = withContext(Dispatchers.IO) {
+        if (!canLoadMoreResults.get()) {
+            return@withContext Result.success(emptyList())
+        }
+
+        performSearch(query)
+    }
+
+    private suspend fun performSearch(query: String): Result<List<WooPosProductModel>> {
+        val siteModel = selectedSite.getOrNull() ?: return Result.failure(
+            IllegalStateException("No site selected")
+        )
+        val siteId = LocalOrRemoteId.LocalId(siteModel.id)
+
+        val result = posLocalCatalogStore.searchProducts(
+            siteId = siteId,
+            searchQuery = query,
+            pageSize = PAGE_SIZE,
+            offset = searchOffset.get()
+        )
+
+        return result.fold(
+            onSuccess = { products ->
+                val mappedProducts = products.map { entity ->
+                    productMapper.fromEntity(entity)
+                }.sortedBy { it.name.lowercase() }
+
+                canLoadMoreResults.set(products.size == PAGE_SIZE)
+                searchOffset.addAndGet(PAGE_SIZE)
+
+                Result.success(mappedProducts)
+            },
+            onFailure = { error ->
+                Result.failure(error)
+            }
+        )
+    }
+}

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/home/items/search/WooPosLocalCatalogSearchDataSourceTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/home/items/search/WooPosLocalCatalogSearchDataSourceTest.kt
@@ -1,0 +1,231 @@
+package com.woocommerce.android.ui.woopos.home.items.search
+
+import com.woocommerce.android.tools.SelectedSite
+import com.woocommerce.android.ui.woopos.common.data.models.WooPosProductModelMapper
+import com.woocommerce.android.ui.woopos.util.WooPosCoroutineTestRule
+import com.woocommerce.android.ui.woopos.util.generateWooPosProduct
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.runTest
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.mockito.kotlin.any
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.whenever
+import org.wordpress.android.fluxc.model.LocalOrRemoteId
+import org.wordpress.android.fluxc.model.SiteModel
+import org.wordpress.android.fluxc.persistence.entity.pos.WooPosProductEntity
+import org.wordpress.android.fluxc.store.pos.localcatalog.WooPosLocalCatalogStore
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class WooPosLocalCatalogSearchDataSourceTest {
+    @get:Rule
+    val coroutineRule = WooPosCoroutineTestRule()
+
+    private val posLocalCatalogStore: WooPosLocalCatalogStore = mock()
+    private val selectedSite: SelectedSite = mock()
+    private val productMapper: WooPosProductModelMapper = mock()
+
+    private lateinit var sut: WooPosLocalCatalogSearchDataSource
+
+    private val siteModel = SiteModel().apply { id = 123 }
+    private val siteId = LocalOrRemoteId.LocalId(123)
+    private val defaultProduct = generateWooPosProduct()
+    private val defaultEntity = createProductEntity(1L)
+
+    @Before
+    fun setup() {
+        whenever(selectedSite.getOrNull()).thenReturn(siteModel)
+        whenever(productMapper.fromEntity(any())).thenReturn(defaultProduct)
+
+        sut = WooPosLocalCatalogSearchDataSource(
+            posLocalCatalogStore = posLocalCatalogStore,
+            selectedSite = selectedSite,
+            productMapper = productMapper
+        )
+    }
+
+    @Test
+    fun `given successful search, when searchProducts called, then returns mapped products`() = runTest {
+        // GIVEN
+        whenever(posLocalCatalogStore.searchProducts(siteId, "query", 15, 0))
+            .thenReturn(Result.success(listOf(defaultEntity)))
+
+        // WHEN
+        val result = sut.searchProducts("query")
+
+        // THEN
+        assertThat(result.isSuccess).isTrue()
+        assertThat(result.getOrThrow()).hasSize(1)
+    }
+
+    @Test
+    fun `given full page of results, when searchProducts called, then hasMorePages returns true`() = runTest {
+        // GIVEN
+        val entities = (1..15).map { createProductEntity(it.toLong()) }
+        whenever(productMapper.fromEntity(any())).thenReturn(generateWooPosProduct())
+        whenever(posLocalCatalogStore.searchProducts(siteId, "query", 15, 0))
+            .thenReturn(Result.success(entities))
+
+        // WHEN
+        sut.searchProducts("query")
+
+        // THEN
+        assertThat(sut.hasMorePages).isTrue()
+    }
+
+    @Test
+    fun `given partial page of results, when searchProducts called, then hasMorePages returns false`() = runTest {
+        // GIVEN
+        whenever(posLocalCatalogStore.searchProducts(siteId, "query", 15, 0))
+            .thenReturn(Result.success(listOf(defaultEntity)))
+
+        // WHEN
+        sut.searchProducts("query")
+
+        // THEN
+        assertThat(sut.hasMorePages).isFalse()
+    }
+
+    @Test
+    fun `given no site selected, when searchProducts called, then returns failure`() = runTest {
+        // GIVEN
+        whenever(selectedSite.getOrNull()).thenReturn(null)
+
+        // WHEN
+        val result = sut.searchProducts("query")
+
+        // THEN
+        assertThat(result.isFailure).isTrue()
+        assertThat(result.exceptionOrNull()).isInstanceOf(IllegalStateException::class.java)
+    }
+
+    @Test
+    fun `given store error, when searchProducts called, then returns failure`() = runTest {
+        // GIVEN
+        val error = Exception("Database error")
+        whenever(posLocalCatalogStore.searchProducts(siteId, "query", 15, 0))
+            .thenReturn(Result.failure(error))
+
+        // WHEN
+        val result = sut.searchProducts("query")
+
+        // THEN
+        assertThat(result.isFailure).isTrue()
+        assertThat(result.exceptionOrNull()).isEqualTo(error)
+    }
+
+    @Test
+    fun `given more pages available, when loadMore called, then loads next page`() = runTest {
+        // GIVEN
+        val firstPageEntities = (1..15).map { createProductEntity(it.toLong()) }
+        val secondPageEntities = listOf(createProductEntity(16L))
+        whenever(productMapper.fromEntity(any())).thenReturn(generateWooPosProduct())
+        whenever(posLocalCatalogStore.searchProducts(siteId, "query", 15, 0))
+            .thenReturn(Result.success(firstPageEntities))
+        whenever(posLocalCatalogStore.searchProducts(siteId, "query", 15, 15))
+            .thenReturn(Result.success(secondPageEntities))
+
+        // WHEN
+        sut.searchProducts("query")
+        val result = sut.loadMore("query")
+
+        // THEN
+        assertThat(result.isSuccess).isTrue()
+        assertThat(result.getOrThrow()).hasSize(1)
+    }
+
+    @Test
+    fun `given no more pages, when loadMore called, then returns empty list`() = runTest {
+        // GIVEN
+        whenever(posLocalCatalogStore.searchProducts(siteId, "query", 15, 0))
+            .thenReturn(Result.success(listOf(defaultEntity)))
+
+        // WHEN
+        sut.searchProducts("query")
+        val result = sut.loadMore("query")
+
+        // THEN
+        assertThat(result.isSuccess).isTrue()
+        assertThat(result.getOrThrow()).isEmpty()
+    }
+
+    @Test
+    fun `given products returned, when searchProducts called, then products are sorted by name`() = runTest {
+        // GIVEN
+        val entities = listOf(
+            createProductEntity(1L, "Zebra"),
+            createProductEntity(2L, "Apple"),
+            createProductEntity(3L, "Banana")
+        )
+        val products = listOf(
+            generateWooPosProduct(productId = 1L, productName = "Zebra"),
+            generateWooPosProduct(productId = 2L, productName = "Apple"),
+            generateWooPosProduct(productId = 3L, productName = "Banana")
+        )
+        entities.forEachIndexed { index, entity ->
+            whenever(productMapper.fromEntity(entity)).thenReturn(products[index])
+        }
+        whenever(posLocalCatalogStore.searchProducts(siteId, "query", 15, 0))
+            .thenReturn(Result.success(entities))
+
+        // WHEN
+        val result = sut.searchProducts("query")
+
+        // THEN
+        assertThat(result.getOrThrow().map { it.name }).containsExactly("Apple", "Banana", "Zebra")
+    }
+
+    @Test
+    fun `given multiple searches, when searchProducts called, then pagination resets`() = runTest {
+        // GIVEN
+        val fullPageEntities = (1..15).map { createProductEntity(it.toLong()) }
+        val singleEntity = listOf(createProductEntity(1L))
+        whenever(productMapper.fromEntity(any())).thenReturn(generateWooPosProduct())
+        whenever(posLocalCatalogStore.searchProducts(siteId, "query1", 15, 0))
+            .thenReturn(Result.success(fullPageEntities))
+        whenever(posLocalCatalogStore.searchProducts(siteId, "query2", 15, 0))
+            .thenReturn(Result.success(singleEntity))
+
+        // WHEN
+        sut.searchProducts("query1")
+        assertThat(sut.hasMorePages).isTrue()
+        sut.searchProducts("query2")
+
+        // THEN
+        assertThat(sut.hasMorePages).isFalse()
+    }
+
+    private fun createProductEntity(
+        remoteId: Long,
+        name: String = "Test Product"
+    ) = WooPosProductEntity(
+        localSiteId = siteId,
+        remoteId = LocalOrRemoteId.RemoteId(remoteId),
+        name = name,
+        sku = "",
+        globalUniqueId = "",
+        type = "simple",
+        price = "10.00",
+        downloadable = false,
+        images = "",
+        attributes = "",
+        parentId = 0,
+        status = "publish",
+        regularPrice = "10.00",
+        salePrice = "",
+        onSale = false,
+        description = "",
+        shortDescription = "",
+        manageStock = false,
+        stockQuantity = null,
+        stockStatus = "instock",
+        backordersAllowed = false,
+        backordered = false,
+        categories = "",
+        tags = "",
+        dateModified = "2024-01-01T00:00:00Z",
+        variations = ""
+    )
+}

--- a/libs/fluxc-plugin/src/main/kotlin/org/wordpress/android/fluxc/persistence/dao/pos/WooPosProductsDao.kt
+++ b/libs/fluxc-plugin/src/main/kotlin/org/wordpress/android/fluxc/persistence/dao/pos/WooPosProductsDao.kt
@@ -49,4 +49,23 @@ abstract class WooPosProductsDao {
             "LIMIT 1"
     )
     abstract suspend fun findProductByIdentifier(localSiteId: LocalId, identifier: String): WooPosProductEntity?
+
+    @Query(
+        "SELECT * FROM PosProductEntity " +
+            "WHERE localSiteId = :localSiteId " +
+            "AND status = '$PRODUCT_STATUS_PUBLISH' " +
+            "AND (type = '$PRODUCT_TYPE_SIMPLE' OR type = '$PRODUCT_TYPE_VARIABLE') " +
+            "AND downloadable = '$DOWNLOADABLE_FALSE' " +
+            "AND (name LIKE '%' || :searchQuery || '%' " +
+            "OR sku LIKE '%' || :searchQuery || '%' " +
+            "OR globalUniqueId LIKE '%' || :searchQuery || '%') " +
+            "ORDER BY LOWER(name) " +
+            "LIMIT :limit OFFSET :offset"
+    )
+    abstract suspend fun searchProducts(
+        localSiteId: LocalId,
+        searchQuery: String,
+        limit: Int,
+        offset: Int
+    ): List<WooPosProductEntity>
 }

--- a/libs/fluxc-plugin/src/main/kotlin/org/wordpress/android/fluxc/store/pos/localcatalog/WooPosLocalCatalogStore.kt
+++ b/libs/fluxc-plugin/src/main/kotlin/org/wordpress/android/fluxc/store/pos/localcatalog/WooPosLocalCatalogStore.kt
@@ -98,6 +98,31 @@ class WooPosLocalCatalogStore @Inject constructor(
         }
 
     /**
+     * Searches products in the local database by name, SKU, or global unique ID.
+     *
+     * @param [siteId] The local site ID
+     * @param [searchQuery] The search query string
+     * @param [pageSize] The number of results to return
+     * @param [offset] The offset for pagination
+     * @return Result containing the list of matching products or error
+     */
+    suspend fun searchProducts(
+        siteId: LocalOrRemoteId.LocalId,
+        searchQuery: String,
+        pageSize: Int = DEFAULT_PAGE_SIZE,
+        offset: Int = 0
+    ): Result<List<WooPosProductEntity>> =
+        coroutineEngine.withDefaultContext(API, this, "searchProducts") {
+            val products = posProductDao.searchProducts(
+                localSiteId = siteId,
+                searchQuery = searchQuery,
+                limit = pageSize.coerceAtMost(MAX_PAGE_SIZE),
+                offset = offset
+            )
+            Result.success(products)
+        }
+
+    /**
      * Gets the count of variations in the local database for a given site.
      *
      * @param [siteId] The local site ID


### PR DESCRIPTION
Fixes WOOMOB-1075

### Description
This PR introduces the foundational search infrastructure for WooPos local catalog functionality. It adds the ability to search products stored locally by name, SKU, or global unique ID, providing the groundwork for faster product lookup in POS scenarios.

**Key Changes:**
- Add `searchProducts` method to `WooPosProductsDao` with SQL query supporting name, SKU, and global unique ID search
- Add `searchProducts` method to `WooPosLocalCatalogStore` with pagination support
- Introduce `WooPosLocalCatalogSearchDataSource` - dedicated data source for local product search operations
- Comprehensive test coverage for the new search data source

This is part 1 of a 2-part implementation. Part 2 will integrate this infrastructure with existing UI components.

### Test Steps
1. Build the project to ensure compilation
2. Run unit tests: `./gradlew :WooCommerce:testWasabiDebugUnitTest --tests "*.WooPosLocalCatalogSearchDataSourceTest"`
3. Verify DAO and Store tests pass
4. Check that existing POS functionality remains unaffected

### Images/gif
N/A - Infrastructure changes only

- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.