### PR TITLE
[WOOMOB-1075] Introduce search functionality for Local Catalog - STEP 2

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/items/products/WooPosProductsDataSource.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/items/products/WooPosProductsDataSource.kt
@@ -13,6 +13,8 @@ import com.woocommerce.android.ui.woopos.common.data.models.WooPosProductModel
 import com.woocommerce.android.ui.woopos.common.data.models.WooPosProductModelMapper
 import com.woocommerce.android.ui.woopos.common.data.models.WooPosWCProductToWooPosProductModelMapper
 import com.woocommerce.android.ui.woopos.common.data.toWooPosVariation
+import com.woocommerce.android.ui.woopos.home.items.search.WooPosLocalCatalogSearchDataSource
+import com.woocommerce.android.ui.woopos.home.items.search.WooPosSearchProductsDataSource
 import com.woocommerce.android.ui.woopos.home.items.variations.WooPosVariationsLRUCache
 import com.woocommerce.android.ui.woopos.localcatalog.PosLocalCatalogProductSyncResult
 import com.woocommerce.android.ui.woopos.localcatalog.PosLocalCatalogVariationSyncResult
@@ -47,6 +49,7 @@ import java.util.concurrent.atomic.AtomicBoolean
 import java.util.concurrent.atomic.AtomicInteger
 import javax.inject.Inject
 import javax.inject.Singleton
+import kotlin.system.measureTimeMillis
 
 @Singleton
 class WooPosProductsDataSource @Inject constructor(
@@ -150,6 +153,17 @@ class WooPosProductsDataSource @Inject constructor(
         return activeSource?.getVariationById(productId, variationId)
     }
 
+    fun searchProducts(query: String): Flow<SearchProductsResult> =
+        activeSource?.searchProducts(query)
+            ?: error("searchProducts - Data source not selected")
+
+    suspend fun loadMoreSearchResults(query: String): Result<List<WooPosProductModel>> =
+        activeSource?.loadMoreSearchResults(query)
+            ?: error("loadMoreSearchResults - Data source not selected")
+
+    val hasMoreSearchPages: Boolean
+        get() = activeSource?.hasMoreSearchPages ?: error("hasMoreSearchPages - Data source not selected")
+
     sealed class WooPosPrepopulatingDataStatus {
         data object Syncing : WooPosPrepopulatingDataStatus()
         data object Completed : WooPosPrepopulatingDataStatus()
@@ -164,6 +178,7 @@ class WooPosProductsInDbDataSource @Inject constructor(
     private val variationMapper: WooPosVariationMapper,
     private val performInstantCatalogFullSync: WooPosPerformInstantCatalogFullSync,
     private val localCatalogSyncRepository: WooPosLocalCatalogSyncRepository,
+    private val localCatalogSearchDataSource: WooPosLocalCatalogSearchDataSource,
 ) : WooPosProductsDataSourceInterface {
 
     private fun getProductsFromDatabaseFlow(): Flow<List<WooPosProductModel>> {
@@ -254,6 +269,27 @@ class WooPosProductsInDbDataSource @Inject constructor(
             Result.success(PosLocalCatalogVariationSyncResult(syncResult))
         } ?: Result.failure(IllegalStateException("No site selected"))
     }
+
+    override fun searchProducts(query: String): Flow<SearchProductsResult> = flow {
+        val result = localCatalogSearchDataSource.searchProducts(query)
+
+        result.fold(
+            onSuccess = { products ->
+                emit(SearchProductsResult.Local(products))
+            },
+            onFailure = { error ->
+                emit(SearchProductsResult.Remote(Result.failure(error), 0L))
+            }
+        )
+    }.flowOn(Dispatchers.IO)
+
+    override suspend fun loadMoreSearchResults(query: String): Result<List<WooPosProductModel>> =
+        withContext(Dispatchers.IO) {
+            localCatalogSearchDataSource.loadMore(query)
+        }
+
+    override val hasMoreSearchPages: Boolean
+        get() = localCatalogSearchDataSource.hasMorePages
 }
 
 class WooPosProductsRemoteDataSource @Inject constructor(
@@ -268,6 +304,7 @@ class WooPosProductsRemoteDataSource @Inject constructor(
     private val variationCache: WooPosVariationsLRUCache,
     private val variationFilterConfig: WooPosVariationsTypesFilterConfig,
     private val variationMapper: WooPosVariationMapper,
+    private val searchProductsDataSource: WooPosSearchProductsDataSource,
 ) : WooPosProductsDataSourceInterface {
     private val canLoadMore = AtomicBoolean(false)
     private val offset = AtomicInteger(0)
@@ -527,6 +564,27 @@ class WooPosProductsRemoteDataSource @Inject constructor(
         val variationsResult = fetchFirstVariationsPage(productId, forceRefresh = true).last()
         Result.success(variationsResult)
     }
+
+    override fun searchProducts(query: String): Flow<SearchProductsResult> = flow {
+        val localProducts = searchProductsDataSource.searchLocalProducts(query)
+        if (localProducts.isNotEmpty()) {
+            emit(SearchProductsResult.Local(localProducts))
+        }
+
+        var remoteResult: Result<List<WooPosProductModel>>
+        val searchTimeMillis = measureTimeMillis {
+            remoteResult = searchProductsDataSource.searchRemoteProducts(query)
+        }
+        emit(SearchProductsResult.Remote(remoteResult, searchTimeMillis))
+    }.flowOn(Dispatchers.IO)
+
+    override suspend fun loadMoreSearchResults(query: String): Result<List<WooPosProductModel>> =
+        withContext(Dispatchers.IO) {
+            searchProductsDataSource.loadMore(query)
+        }
+
+    override val hasMoreSearchPages: Boolean
+        get() = searchProductsDataSource.hasMorePages
 
     companion object {
         private const val NORMAL_PAGE_SIZE = 25

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/items/products/WooPosProductsDataSourceInterface.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/items/products/WooPosProductsDataSourceInterface.kt
@@ -9,6 +9,14 @@ import com.woocommerce.android.ui.woopos.localcatalog.WooPosSyncVariationResult
 import kotlinx.coroutines.flow.Flow
 import org.wordpress.android.fluxc.model.LocalOrRemoteId
 
+sealed class SearchProductsResult {
+    data class Local(val products: List<WooPosProductModel>) : SearchProductsResult()
+    data class Remote(
+        val productsResult: Result<List<WooPosProductModel>>,
+        val searchTimeMillis: Long = 0L
+    ) : SearchProductsResult()
+}
+
 interface WooPosProductsDataSourceInterface {
     fun fetchFirstProductsPage(
         forceRefresh: Boolean
@@ -38,4 +46,10 @@ interface WooPosProductsDataSourceInterface {
     suspend fun refreshProducts(): Result<WooPosSyncProductResult>
 
     suspend fun refreshVariations(productId: Long): Result<WooPosSyncVariationResult>
+
+    fun searchProducts(query: String): Flow<SearchProductsResult>
+    
+    suspend fun loadMoreSearchResults(query: String): Result<List<WooPosProductModel>>
+    
+    val hasMoreSearchPages: Boolean
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/items/products/WooPosProductsDataSourceInterface.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/items/products/WooPosProductsDataSourceInterface.kt
@@ -48,8 +48,8 @@ interface WooPosProductsDataSourceInterface {
     suspend fun refreshVariations(productId: Long): Result<WooPosSyncVariationResult>
 
     fun searchProducts(query: String): Flow<SearchProductsResult>
-    
+
     suspend fun loadMoreSearchResults(query: String): Result<List<WooPosProductModel>>
-    
+
     val hasMoreSearchPages: Boolean
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/items/search/WooPosItemsSearchViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/items/search/WooPosItemsSearchViewModel.kt
@@ -12,6 +12,8 @@ import com.woocommerce.android.ui.woopos.home.items.WooPosItemSelectionViewState
 import com.woocommerce.android.ui.woopos.home.items.WooPosItemsSearchHelper
 import com.woocommerce.android.ui.woopos.home.items.WooPosItemsViewModel.ItemClickedData
 import com.woocommerce.android.ui.woopos.home.items.WooPosPaginationState
+import com.woocommerce.android.ui.woopos.home.items.products.SearchProductsResult
+import com.woocommerce.android.ui.woopos.home.items.products.WooPosProductsDataSource
 import com.woocommerce.android.ui.woopos.util.analytics.WooPosAnalyticsEvent
 import com.woocommerce.android.ui.woopos.util.analytics.WooPosAnalyticsEventConstant
 import com.woocommerce.android.ui.woopos.util.format.WooPosFormatPrice
@@ -22,17 +24,17 @@ import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.launch
 import java.util.concurrent.atomic.AtomicReference
 import javax.inject.Inject
-import kotlin.system.measureTimeMillis
 
 @HiltViewModel
 class WooPosItemsSearchViewModel @Inject constructor(
     private val emptyStateRepository: WooPosItemsSearchEmptyStateRepository,
     private val priceFormat: WooPosFormatPrice,
-    private val dataSource: WooPosSearchProductsDataSource,
+    private val dataSource: WooPosProductsDataSource,
     private val childToParentEventSender: WooPosChildrenToParentEventSender,
     private val parentToChildrenEventReceiver: WooPosParentToChildrenEventReceiver,
     private val searchHelper: WooPosItemsSearchHelper,
@@ -53,8 +55,7 @@ class WooPosItemsSearchViewModel @Inject constructor(
         )
 
     private var loadMoreJob: Job? = null
-    private var localSearchJob: Job? = null
-    private var remoteSearchJob: Job? = null
+    private var searchJob: Job? = null
 
     private val currentQuery = AtomicReference("")
 
@@ -101,76 +102,69 @@ class WooPosItemsSearchViewModel @Inject constructor(
         val currentState = _viewState.value as? WooPosItemsSearchViewState.Error ?: return
 
         _viewState.value = WooPosItemsSearchViewState.Loading
-        performRemoteSearch(currentState.searchQuery)
+        performSearch(currentState.searchQuery)
     }
 
     private fun performSearch(query: String) {
-        localSearchJob?.cancel()
-        remoteSearchJob?.cancel()
+        searchJob?.cancel()
 
         currentQuery.set(query)
 
         if (query.isEmpty()) {
             setEmptySearchQueryState()
         } else {
-            performLocalSearch(query)
-            performRemoteSearch(query)
-        }
-    }
+            searchJob = viewModelScope.launch {
+                delay(SEARCH_DEBOUNCING_TIME)
 
-    private fun performLocalSearch(query: String) {
-        localSearchJob?.cancel()
-        localSearchJob = viewModelScope.launch {
-            val localProducts = dataSource.searchLocalProducts(query)
+                if (query != currentQuery.get()) return@launch
 
-            if (query != currentQuery.get()) return@launch
+                childToParentEventSender.sendToParent(ChildToParentEvent.SearchEvent.Started)
 
-            analyticsTracker.storedLocalSearchResultIds(localProducts.map { it.remoteId })
+                var hasEmittedResult = false
+                
+                dataSource.searchProducts(query).collectLatest { searchResult ->
+                    if (query != currentQuery.get()) {
+                        childToParentEventSender.sendToParent(ChildToParentEvent.SearchEvent.Finished)
+                        return@collectLatest
+                    }
+                    
+                    hasEmittedResult = true
 
-            if (localProducts.isEmpty()) {
-                _viewState.value = WooPosItemsSearchViewState.Loading
-            } else {
-                _viewState.value = localProducts.toContentState(
-                    searchQuery = query,
-                )
-            }
-        }
-    }
+                    when (searchResult) {
+                        is SearchProductsResult.Local -> {
+                            analyticsTracker.storedLocalSearchResultIds(searchResult.products.map { it.remoteId })
 
-    private fun performRemoteSearch(query: String) {
-        remoteSearchJob?.cancel()
-        remoteSearchJob = viewModelScope.launch {
-            delay(SEARCH_DEBOUNCING_TIME)
+                            if (searchResult.products.isEmpty()) {
+                                _viewState.value = WooPosItemsSearchViewState.Loading
+                            } else {
+                                _viewState.value = searchResult.products.toContentState(
+                                    searchQuery = query,
+                                )
+                            }
+                        }
 
-            if (query != currentQuery.get()) {
-                return@launch
-            }
+                        is SearchProductsResult.Remote -> {
+                            if (searchResult.productsResult.isSuccess) {
+                                val products = searchResult.productsResult.getOrThrow()
+                                if (products.isEmpty()) {
+                                    _viewState.value = WooPosItemsSearchViewState.Empty
+                                } else {
+                                    _viewState.value = products.toContentState(searchQuery = query)
+                                }
 
-            childToParentEventSender.sendToParent(ChildToParentEvent.SearchEvent.Started)
-            var result: Result<List<WooPosProductModel>>
-            val searchTimeMillis = measureTimeMillis {
-                result = dataSource.searchRemoteProducts(query)
-            }
-
-            if (query != currentQuery.get()) {
-                childToParentEventSender.sendToParent(ChildToParentEvent.SearchEvent.Finished)
-                return@launch
-            }
-
-            if (result.isSuccess) {
-                val searchResult = result.getOrThrow()
-                if (searchResult.isEmpty()) {
-                    _viewState.value = WooPosItemsSearchViewState.Empty
-                } else {
-                    _viewState.value = searchResult.toContentState(searchQuery = query)
+                                analyticsTracker.trackSearchPerformance(searchResult.searchTimeMillis)
+                            } else {
+                                _viewState.value = WooPosItemsSearchViewState.Error(searchQuery = query)
+                            }
+                            childToParentEventSender.sendToParent(ChildToParentEvent.SearchEvent.Finished)
+                        }
+                    }
                 }
-
-                analyticsTracker.trackSearchPerformance(searchTimeMillis)
-            } else {
-                _viewState.value = WooPosItemsSearchViewState.Error(searchQuery = query)
+                
+                if (hasEmittedResult && query == currentQuery.get()) {
+                    childToParentEventSender.sendToParent(ChildToParentEvent.SearchEvent.Finished)
+                }
             }
-
-            childToParentEventSender.sendToParent(ChildToParentEvent.SearchEvent.Finished)
         }
     }
 
@@ -210,7 +204,7 @@ class WooPosItemsSearchViewModel @Inject constructor(
             return
         }
 
-        if (!dataSource.hasMorePages) {
+        if (!dataSource.hasMoreSearchPages) {
             return
         }
 
@@ -218,7 +212,7 @@ class WooPosItemsSearchViewModel @Inject constructor(
 
         loadMoreJob?.cancel()
         loadMoreJob = viewModelScope.launch {
-            val result = dataSource.loadMore(query = currentState.searchQuery)
+            val result = dataSource.loadMoreSearchResults(currentState.searchQuery)
             _viewState.value = if (result.isSuccess) {
                 analyticsTracker.trackItemsNextPageLoaded()
                 result.getOrThrow().toContentState(
@@ -330,6 +324,6 @@ class WooPosItemsSearchViewModel @Inject constructor(
 
     private companion object {
         const val MAX_ITEMS_COUNT = 10
-        const val SEARCH_DEBOUNCING_TIME = 500L
+        const val SEARCH_DEBOUNCING_TIME = 250L
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/items/search/WooPosItemsSearchViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/items/search/WooPosItemsSearchViewModel.kt
@@ -120,15 +120,11 @@ class WooPosItemsSearchViewModel @Inject constructor(
 
                 childToParentEventSender.sendToParent(ChildToParentEvent.SearchEvent.Started)
 
-                var hasEmittedResult = false
-                
                 dataSource.searchProducts(query).collectLatest { searchResult ->
                     if (query != currentQuery.get()) {
                         childToParentEventSender.sendToParent(ChildToParentEvent.SearchEvent.Finished)
                         return@collectLatest
                     }
-                    
-                    hasEmittedResult = true
 
                     when (searchResult) {
                         is SearchProductsResult.Local -> {
@@ -156,13 +152,15 @@ class WooPosItemsSearchViewModel @Inject constructor(
                             } else {
                                 _viewState.value = WooPosItemsSearchViewState.Error(searchQuery = query)
                             }
-                            childToParentEventSender.sendToParent(ChildToParentEvent.SearchEvent.Finished)
                         }
                     }
                 }
-                
-                if (hasEmittedResult && query == currentQuery.get()) {
+
+                if (query == currentQuery.get()) {
                     childToParentEventSender.sendToParent(ChildToParentEvent.SearchEvent.Finished)
+                    if (_viewState.value is WooPosItemsSearchViewState.Loading) {
+                        _viewState.value = WooPosItemsSearchViewState.Empty
+                    }
                 }
             }
         }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/items/search/WooPosLocalCatalogSearchDataSource.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/items/search/WooPosLocalCatalogSearchDataSource.kt
@@ -24,18 +24,22 @@ class WooPosLocalCatalogSearchDataSource @Inject constructor(
 
     private val searchOffset = AtomicInteger(0)
     private val canLoadMoreResults = AtomicBoolean(false)
+    private var currentQuery: String = ""
+    private val accumulatedResults = mutableListOf<WooPosProductModel>()
 
     val hasMorePages: Boolean
         get() = canLoadMoreResults.get()
 
     suspend fun searchProducts(query: String): Result<List<WooPosProductModel>> = withContext(Dispatchers.IO) {
         searchOffset.set(0)
+        currentQuery = query
+        accumulatedResults.clear()
         performSearch(query)
     }
 
     suspend fun loadMore(query: String): Result<List<WooPosProductModel>> = withContext(Dispatchers.IO) {
-        if (!canLoadMoreResults.get()) {
-            return@withContext Result.success(emptyList())
+        if (!canLoadMoreResults.get() || query != currentQuery) {
+            return@withContext Result.success(accumulatedResults.toList())
         }
 
         performSearch(query)
@@ -60,10 +64,11 @@ class WooPosLocalCatalogSearchDataSource @Inject constructor(
                     productMapper.fromEntity(entity)
                 }.sortedBy { it.name.lowercase() }
 
+                accumulatedResults.addAll(mappedProducts)
                 canLoadMoreResults.set(products.size == PAGE_SIZE)
                 searchOffset.addAndGet(PAGE_SIZE)
 
-                Result.success(mappedProducts)
+                Result.success(accumulatedResults)
             },
             onFailure = { error ->
                 Result.failure(error)

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/root/WooPosPeriodicSyncFacade.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/root/WooPosPeriodicSyncFacade.kt
@@ -51,7 +51,7 @@ class WooPosPeriodicSyncFacade @Inject constructor(
     private fun startPeriodicSync(owner: LifecycleOwner) {
         periodicSyncJob = owner.lifecycleScope.launch {
             val site = selectedSite.getOrNull() ?: return@launch
-            if (!isLocalCatalogSupported(site.siteId)) return@launch
+            if (!isLocalCatalogSupported(site.localId())) return@launch
 
             while (isActive) {
                 delay(SYNC_STATUS_CHECK_INTERVAL)

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/home/items/WooPosProductsRemoteDataSourceTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/home/items/WooPosProductsRemoteDataSourceTest.kt
@@ -1082,7 +1082,8 @@ class WooPosProductsRemoteDataSourceTest {
             variationsHandler,
             variationsCache,
             WooPosVariationsTypesFilterConfig(),
-            variationMapper
+            variationMapper,
+            mock()
         )
         return sut
     }

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/home/items/products/WooPosProductsInDbDataSourceTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/home/items/products/WooPosProductsInDbDataSourceTest.kt
@@ -4,6 +4,7 @@ import com.woocommerce.android.tools.SelectedSite
 import com.woocommerce.android.ui.woopos.common.data.WooPosVariationMapper
 import com.woocommerce.android.ui.woopos.common.data.models.WooPosProductModel
 import com.woocommerce.android.ui.woopos.common.data.models.WooPosProductModelMapper
+import com.woocommerce.android.ui.woopos.home.items.search.WooPosLocalCatalogSearchDataSource
 import com.woocommerce.android.ui.woopos.localcatalog.ProductsResult
 import com.woocommerce.android.ui.woopos.localcatalog.WooPosLocalCatalogSyncRepository
 import com.woocommerce.android.ui.woopos.localcatalog.WooPosPerformInstantCatalogFullSync
@@ -74,7 +75,7 @@ class WooPosProductsInDbDataSourceTest {
             performInstantCatalogFullSync = performInstantCatalogFullSync,
             variationMapper = mock<WooPosVariationMapper>(),
             localCatalogSyncRepository = mock<WooPosLocalCatalogSyncRepository>(),
-            localCatalogSearchDataSource = mock<com.woocommerce.android.ui.woopos.home.items.search.WooPosLocalCatalogSearchDataSource>(),
+            localCatalogSearchDataSource = mock<WooPosLocalCatalogSearchDataSource>(),
         )
     }
 

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/home/items/products/WooPosProductsInDbDataSourceTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/home/items/products/WooPosProductsInDbDataSourceTest.kt
@@ -1,9 +1,11 @@
 package com.woocommerce.android.ui.woopos.home.items.products
 
 import com.woocommerce.android.tools.SelectedSite
+import com.woocommerce.android.ui.woopos.common.data.WooPosVariationMapper
 import com.woocommerce.android.ui.woopos.common.data.models.WooPosProductModel
 import com.woocommerce.android.ui.woopos.common.data.models.WooPosProductModelMapper
 import com.woocommerce.android.ui.woopos.localcatalog.ProductsResult
+import com.woocommerce.android.ui.woopos.localcatalog.WooPosLocalCatalogSyncRepository
 import com.woocommerce.android.ui.woopos.localcatalog.WooPosPerformInstantCatalogFullSync
 import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.flow.toList
@@ -70,8 +72,9 @@ class WooPosProductsInDbDataSourceTest {
             selectedSite = selectedSite,
             productMapper = mapper,
             performInstantCatalogFullSync = performInstantCatalogFullSync,
-            variationMapper = mock(),
-            localCatalogSyncRepository = mock(),
+            variationMapper = mock<WooPosVariationMapper>(),
+            localCatalogSyncRepository = mock<WooPosLocalCatalogSyncRepository>(),
+            localCatalogSearchDataSource = mock<com.woocommerce.android.ui.woopos.home.items.search.WooPosLocalCatalogSearchDataSource>(),
         )
     }
 

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/home/items/search/WooPosItemsSearchViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/home/items/search/WooPosItemsSearchViewModelTest.kt
@@ -9,6 +9,8 @@ import com.woocommerce.android.ui.woopos.home.WooPosParentToChildrenEventReceive
 import com.woocommerce.android.ui.woopos.home.items.WooPosItemSelectionViewState.Product
 import com.woocommerce.android.ui.woopos.home.items.WooPosItemsViewModel.ItemClickedData
 import com.woocommerce.android.ui.woopos.home.items.WooPosPaginationState
+import com.woocommerce.android.ui.woopos.home.items.products.SearchProductsResult
+import com.woocommerce.android.ui.woopos.home.items.products.WooPosProductsDataSource
 import com.woocommerce.android.ui.woopos.util.WooPosCoroutineTestRule
 import com.woocommerce.android.ui.woopos.util.analytics.WooPosAnalyticsEvent
 import com.woocommerce.android.ui.woopos.util.analytics.WooPosAnalyticsEventConstant
@@ -33,7 +35,6 @@ import org.mockito.kotlin.mock
 import org.mockito.kotlin.never
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
-import org.mockito.kotlin.wheneverBlocking
 import java.math.BigDecimal
 
 @ExperimentalCoroutinesApi
@@ -45,7 +46,7 @@ class WooPosItemsSearchViewModelTest {
 
     private val mockEmptyStateProvider: WooPosItemsSearchEmptyStateRepository = mock()
     private val mockPriceFormat: WooPosFormatPrice = mock()
-    private val mockDataSource: WooPosSearchProductsDataSource = mock()
+    private val mockDataSource: WooPosProductsDataSource = mock()
     private val mockChildToParentEventSender: WooPosChildrenToParentEventSender = mock()
     private val mockParentToChildrenEventReceiver: WooPosParentToChildrenEventReceiver = mock()
     private val mockSearchHelper: com.woocommerce.android.ui.woopos.home.items.WooPosItemsSearchHelper = mock()
@@ -414,6 +415,10 @@ class WooPosItemsSearchViewModelTest {
 
         // THEN
         viewModel.viewState.test {
+            skipItems(1) // Skip initial EmptySearchQuery state
+
+            advanceUntilIdle()
+
             val cachedState = awaitItem() as WooPosItemsSearchViewState.Content
             assertThat(cachedState.items).hasSize(1)
             assertThat((cachedState.items[0] as Product.Simple).name).isEqualTo("Cached Product")
@@ -445,10 +450,15 @@ class WooPosItemsSearchViewModelTest {
             )
         )
 
-        whenever(mockDataSource.searchLocalProducts(query1)).thenReturn(emptyList())
-        whenever(mockDataSource.searchRemoteProducts(query1)).thenReturn(Result.success(emptyList()))
-        whenever(mockDataSource.searchLocalProducts(query2)).thenReturn(emptyList())
-        whenever(mockDataSource.searchRemoteProducts(query2)).thenReturn(Result.success(products))
+        whenever(mockDataSource.searchProducts(query1)).thenReturn(flowOf(
+            SearchProductsResult.Local(emptyList()),
+            SearchProductsResult.Remote(Result.success(emptyList()), 100L)
+        ))
+        whenever(mockDataSource.searchProducts(query2)).thenReturn(flowOf(
+            SearchProductsResult.Local(emptyList()),
+            SearchProductsResult.Remote(Result.success(products), 100L)
+        ))
+        whenever(mockDataSource.hasMoreSearchPages).thenReturn(false)
 
         whenever(mockPriceFormat(BigDecimal("10.0"))).thenReturn("$10.0")
 
@@ -462,11 +472,12 @@ class WooPosItemsSearchViewModelTest {
 
         // WHEN
         val viewModel = createViewModel()
-        advanceTimeBy(600)
 
         // THEN
         viewModel.viewState.test {
-            skipItems(1)
+            skipItems(1) // Skip initial EmptySearchQuery state
+
+            advanceUntilIdle()
 
             val contentState = awaitItem() as WooPosItemsSearchViewState.Content
             assertThat(contentState.searchQuery).isEqualTo(query2)
@@ -490,8 +501,11 @@ class WooPosItemsSearchViewModelTest {
         whenever(mockEmptyStateProvider.getPopularItems()).thenReturn(emptyList())
         whenever(mockEmptyStateProvider.getLastSearches()).thenReturn(emptyList())
 
-        whenever(mockDataSource.searchLocalProducts(query)).thenReturn(emptyList())
-        whenever(mockDataSource.searchRemoteProducts(query)).thenReturn(Result.success(products))
+        whenever(mockDataSource.searchProducts(query)).thenReturn(flow {
+            emit(SearchProductsResult.Local(emptyList()))
+            delay(100)
+            emit(SearchProductsResult.Remote(Result.success(products), 100L))
+        })
 
         whenever(mockPriceFormat(BigDecimal("10.0"))).thenReturn("$10.0")
         whenever(mockParentToChildrenEventReceiver.events).thenReturn(
@@ -503,6 +517,10 @@ class WooPosItemsSearchViewModelTest {
 
         // THEN
         viewModel.viewState.test {
+            skipItems(1) // Skip initial EmptySearchQuery state
+
+            advanceUntilIdle()
+
             val loadingState = awaitItem()
             assertThat(loadingState).isInstanceOf(WooPosItemsSearchViewState.Loading::class.java)
 
@@ -528,10 +546,10 @@ class WooPosItemsSearchViewModelTest {
             whenever(mockEmptyStateProvider.getPopularItems()).thenReturn(emptyList())
             whenever(mockEmptyStateProvider.getLastSearches()).thenReturn(emptyList())
 
-            whenever(mockDataSource.searchLocalProducts(query)).thenReturn(emptyList())
-            whenever(mockDataSource.searchRemoteProducts(query)).thenReturn(Result.success(products))
-
-            whenever(mockDataSource.hasMorePages).thenReturn(false)
+            whenever(mockDataSource.searchProducts(query)).thenReturn(flowOf(
+                SearchProductsResult.Remote(Result.success(products), 100L)
+            ))
+            whenever(mockDataSource.hasMoreSearchPages).thenReturn(false)
 
             whenever(mockPriceFormat(BigDecimal("10.0"))).thenReturn("$10.0")
             whenever(mockParentToChildrenEventReceiver.events).thenReturn(
@@ -540,7 +558,7 @@ class WooPosItemsSearchViewModelTest {
 
             // WHEN
             val viewModel = createViewModel()
-            advanceTimeBy(600)
+            advanceUntilIdle()
 
             // THEN
             viewModel.viewState.test {
@@ -568,11 +586,11 @@ class WooPosItemsSearchViewModelTest {
         whenever(mockEmptyStateProvider.getPopularItems()).thenReturn(emptyList())
         whenever(mockEmptyStateProvider.getLastSearches()).thenReturn(emptyList())
 
-        whenever(mockDataSource.searchLocalProducts(query)).thenReturn(emptyList())
-        whenever(mockDataSource.searchRemoteProducts(query)).thenReturn(
-            Result.failure(Exception("Search failed")),
-            Result.success(products)
-        )
+        whenever(mockDataSource.searchProducts(query)).thenReturn(flowOf(
+            SearchProductsResult.Remote(Result.failure(Exception("Search failed")), 100L)
+        )).thenReturn(flowOf(
+            SearchProductsResult.Remote(Result.success(products), 100L)
+        ))
 
         whenever(mockPriceFormat(BigDecimal("10.0"))).thenReturn("$10.0")
         whenever(mockParentToChildrenEventReceiver.events).thenReturn(
@@ -581,7 +599,7 @@ class WooPosItemsSearchViewModelTest {
 
         // WHEN
         val viewModel = createViewModel()
-        advanceTimeBy(600)
+        advanceUntilIdle()
 
         // THEN
         viewModel.viewState.test {
@@ -684,7 +702,7 @@ class WooPosItemsSearchViewModelTest {
 
             // WHEN
             val viewModel = createViewModel()
-            advanceTimeBy(600)
+            advanceUntilIdle()
             viewModel.onUIEvent(WooPosItemsSearchUiEvent.OnItemClicked(simpleProduct))
 
             // THEN
@@ -785,31 +803,35 @@ class WooPosItemsSearchViewModelTest {
         }
 
     private fun mockSuccessfulSearch(query: String, products: List<WooPosProductModel>) {
-        wheneverBlocking { mockDataSource.searchLocalProducts(query) }.thenReturn(emptyList())
-        wheneverBlocking { mockDataSource.searchRemoteProducts(query) }.thenReturn(Result.success(products))
+        whenever(mockDataSource.searchProducts(query)).thenReturn(flowOf(
+            SearchProductsResult.Local(emptyList()),
+            SearchProductsResult.Remote(Result.success(products), 100L)
+        ))
         whenever(mockParentToChildrenEventReceiver.events).thenReturn(
             flowOf(ParentToChildrenEvent.SearchEvent.ChangedQuery(query))
         )
     }
 
     private fun mockFailedSearch(query: String, error: Exception) {
-        wheneverBlocking { mockDataSource.searchLocalProducts(query) }.thenReturn(emptyList())
-        wheneverBlocking { mockDataSource.searchRemoteProducts(query) }.thenReturn(Result.failure(error))
+        whenever(mockDataSource.searchProducts(query)).thenReturn(flowOf(
+            SearchProductsResult.Local(emptyList()),
+            SearchProductsResult.Remote(Result.failure(error), 100L)
+        ))
         whenever(mockParentToChildrenEventReceiver.events).thenReturn(
             flowOf(ParentToChildrenEvent.SearchEvent.ChangedQuery(query))
         )
     }
 
     private suspend fun mockSuccessfulPagination(query: String, products: List<WooPosProductModel>) {
-        whenever(mockDataSource.hasMorePages).thenReturn(true)
-        whenever(mockDataSource.loadMore(query)).thenReturn(
+        whenever(mockDataSource.hasMoreSearchPages).thenReturn(true)
+        whenever(mockDataSource.loadMoreSearchResults(query)).thenReturn(
             Result.success(products)
         )
     }
 
     private suspend fun mockFailedPagination(query: String, error: Exception) {
-        whenever(mockDataSource.hasMorePages).thenReturn(true)
-        whenever(mockDataSource.loadMore(query)).thenReturn(
+        whenever(mockDataSource.hasMoreSearchPages).thenReturn(true)
+        whenever(mockDataSource.loadMoreSearchResults(query)).thenReturn(
             Result.failure(error)
         )
     }
@@ -819,12 +841,11 @@ class WooPosItemsSearchViewModelTest {
         cachedProduct: WooPosProductModel,
         remoteProduct: WooPosProductModel
     ) {
-        wheneverBlocking { mockDataSource.searchLocalProducts(query) }.thenReturn(listOf(cachedProduct))
-        wheneverBlocking {
-            mockDataSource.searchRemoteProducts(
-                query
-            )
-        }.thenReturn(Result.success(listOf(remoteProduct)))
+        whenever(mockDataSource.searchProducts(query)).thenReturn(flow {
+            emit(SearchProductsResult.Local(listOf(cachedProduct)))
+            delay(100) // Small delay between emissions
+            emit(SearchProductsResult.Remote(Result.success(listOf(remoteProduct)), 100L))
+        })
         whenever(mockParentToChildrenEventReceiver.events).thenReturn(
             flowOf(ParentToChildrenEvent.SearchEvent.ChangedQuery(query))
         )

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/home/items/search/WooPosItemsSearchViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/home/items/search/WooPosItemsSearchViewModelTest.kt
@@ -40,8 +40,7 @@ import java.math.BigDecimal
 @ExperimentalCoroutinesApi
 class WooPosItemsSearchViewModelTest {
 
-    @Rule
-    @JvmField
+    @Rule @JvmField
     val coroutinesTestRule = WooPosCoroutineTestRule()
 
     private val mockEmptyStateProvider: WooPosItemsSearchEmptyStateRepository = mock()
@@ -281,14 +280,13 @@ class WooPosItemsSearchViewModelTest {
     fun `given variable product in search results, when search performed, then mapped correctly to view state`() =
         runTest {
             // GIVEN
-            val variableProduct =
-                generateWooPosProduct(
-                    productId = 1,
-                    productName = "Variable Product",
-                    amount = "10.0",
-                    productType = WooPosProductModel.WooPosProductType.VARIABLE,
-                    variationIds = listOf(101L, 102L, 103L)
-                )
+            val variableProduct = generateWooPosProduct(
+                productId = 1,
+                productName = "Variable Product",
+                amount = "10.0",
+                productType = WooPosProductModel.WooPosProductType.VARIABLE,
+                variationIds = listOf(101L, 102L, 103L)
+            )
 
             mockSuccessfulSearch(defaultQuery, listOf(variableProduct))
 
@@ -450,14 +448,18 @@ class WooPosItemsSearchViewModelTest {
             )
         )
 
-        whenever(mockDataSource.searchProducts(query1)).thenReturn(flowOf(
-            SearchProductsResult.Local(emptyList()),
-            SearchProductsResult.Remote(Result.success(emptyList()), 100L)
-        ))
-        whenever(mockDataSource.searchProducts(query2)).thenReturn(flowOf(
-            SearchProductsResult.Local(emptyList()),
-            SearchProductsResult.Remote(Result.success(products), 100L)
-        ))
+        whenever(mockDataSource.searchProducts(query1)).thenReturn(
+            flowOf(
+                SearchProductsResult.Local(emptyList()),
+                SearchProductsResult.Remote(Result.success(emptyList()), 100L)
+            )
+        )
+        whenever(mockDataSource.searchProducts(query2)).thenReturn(
+            flowOf(
+                SearchProductsResult.Local(emptyList()),
+                SearchProductsResult.Remote(Result.success(products), 100L)
+            )
+        )
         whenever(mockDataSource.hasMoreSearchPages).thenReturn(false)
 
         whenever(mockPriceFormat(BigDecimal("10.0"))).thenReturn("$10.0")
@@ -501,11 +503,13 @@ class WooPosItemsSearchViewModelTest {
         whenever(mockEmptyStateProvider.getPopularItems()).thenReturn(emptyList())
         whenever(mockEmptyStateProvider.getLastSearches()).thenReturn(emptyList())
 
-        whenever(mockDataSource.searchProducts(query)).thenReturn(flow {
-            emit(SearchProductsResult.Local(emptyList()))
-            delay(100)
-            emit(SearchProductsResult.Remote(Result.success(products), 100L))
-        })
+        whenever(mockDataSource.searchProducts(query)).thenReturn(
+            flow {
+                emit(SearchProductsResult.Local(emptyList()))
+                delay(100)
+                emit(SearchProductsResult.Remote(Result.success(products), 100L))
+            }
+        )
 
         whenever(mockPriceFormat(BigDecimal("10.0"))).thenReturn("$10.0")
         whenever(mockParentToChildrenEventReceiver.events).thenReturn(
@@ -546,9 +550,11 @@ class WooPosItemsSearchViewModelTest {
             whenever(mockEmptyStateProvider.getPopularItems()).thenReturn(emptyList())
             whenever(mockEmptyStateProvider.getLastSearches()).thenReturn(emptyList())
 
-            whenever(mockDataSource.searchProducts(query)).thenReturn(flowOf(
-                SearchProductsResult.Remote(Result.success(products), 100L)
-            ))
+            whenever(mockDataSource.searchProducts(query)).thenReturn(
+                flowOf(
+                    SearchProductsResult.Remote(Result.success(products), 100L)
+                )
+            )
             whenever(mockDataSource.hasMoreSearchPages).thenReturn(false)
 
             whenever(mockPriceFormat(BigDecimal("10.0"))).thenReturn("$10.0")
@@ -586,11 +592,15 @@ class WooPosItemsSearchViewModelTest {
         whenever(mockEmptyStateProvider.getPopularItems()).thenReturn(emptyList())
         whenever(mockEmptyStateProvider.getLastSearches()).thenReturn(emptyList())
 
-        whenever(mockDataSource.searchProducts(query)).thenReturn(flowOf(
-            SearchProductsResult.Remote(Result.failure(Exception("Search failed")), 100L)
-        )).thenReturn(flowOf(
-            SearchProductsResult.Remote(Result.success(products), 100L)
-        ))
+        whenever(mockDataSource.searchProducts(query)).thenReturn(
+            flowOf(
+                SearchProductsResult.Remote(Result.failure(Exception("Search failed")), 100L)
+            )
+        ).thenReturn(
+            flowOf(
+                SearchProductsResult.Remote(Result.success(products), 100L)
+            )
+        )
 
         whenever(mockPriceFormat(BigDecimal("10.0"))).thenReturn("$10.0")
         whenever(mockParentToChildrenEventReceiver.events).thenReturn(
@@ -803,20 +813,24 @@ class WooPosItemsSearchViewModelTest {
         }
 
     private fun mockSuccessfulSearch(query: String, products: List<WooPosProductModel>) {
-        whenever(mockDataSource.searchProducts(query)).thenReturn(flowOf(
-            SearchProductsResult.Local(emptyList()),
-            SearchProductsResult.Remote(Result.success(products), 100L)
-        ))
+        whenever(mockDataSource.searchProducts(query)).thenReturn(
+            flowOf(
+                SearchProductsResult.Local(emptyList()),
+                SearchProductsResult.Remote(Result.success(products), 100L)
+            )
+        )
         whenever(mockParentToChildrenEventReceiver.events).thenReturn(
             flowOf(ParentToChildrenEvent.SearchEvent.ChangedQuery(query))
         )
     }
 
     private fun mockFailedSearch(query: String, error: Exception) {
-        whenever(mockDataSource.searchProducts(query)).thenReturn(flowOf(
-            SearchProductsResult.Local(emptyList()),
-            SearchProductsResult.Remote(Result.failure(error), 100L)
-        ))
+        whenever(mockDataSource.searchProducts(query)).thenReturn(
+            flowOf(
+                SearchProductsResult.Local(emptyList()),
+                SearchProductsResult.Remote(Result.failure(error), 100L)
+            )
+        )
         whenever(mockParentToChildrenEventReceiver.events).thenReturn(
             flowOf(ParentToChildrenEvent.SearchEvent.ChangedQuery(query))
         )
@@ -841,11 +855,13 @@ class WooPosItemsSearchViewModelTest {
         cachedProduct: WooPosProductModel,
         remoteProduct: WooPosProductModel
     ) {
-        whenever(mockDataSource.searchProducts(query)).thenReturn(flow {
-            emit(SearchProductsResult.Local(listOf(cachedProduct)))
-            delay(100) // Small delay between emissions
-            emit(SearchProductsResult.Remote(Result.success(listOf(remoteProduct)), 100L))
-        })
+        whenever(mockDataSource.searchProducts(query)).thenReturn(
+            flow {
+                emit(SearchProductsResult.Local(listOf(cachedProduct)))
+                delay(100) // Small delay between emissions
+                emit(SearchProductsResult.Remote(Result.success(listOf(remoteProduct)), 100L))
+            }
+        )
         whenever(mockParentToChildrenEventReceiver.events).thenReturn(
             flowOf(ParentToChildrenEvent.SearchEvent.ChangedQuery(query))
         )

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/home/items/search/WooPosLocalCatalogSearchDataSourceTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/home/items/search/WooPosLocalCatalogSearchDataSourceTest.kt
@@ -34,10 +34,30 @@ class WooPosLocalCatalogSearchDataSourceTest {
     private val defaultProduct = generateWooPosProduct()
     private val defaultEntity = createProductEntity(1L)
 
+    private val firstPageEntities = (1..15).map { createProductEntity(it.toLong()) }
+    private val firstPageProducts = (1..15).map { generateWooPosProduct(productId = it.toLong()) }
+    private val secondPageEntities = (16..20).map { createProductEntity(it.toLong()) }
+    private val secondPageProducts = (16..20).map { generateWooPosProduct(productId = it.toLong()) }
+
     @Before
-    fun setup() {
+    fun setup() = runTest {
+        // Setup happy path mocks
         whenever(selectedSite.getOrNull()).thenReturn(siteModel)
         whenever(productMapper.fromEntity(any())).thenReturn(defaultProduct)
+
+        // Setup mapping for pagination test data
+        firstPageEntities.forEachIndexed { index, entity ->
+            whenever(productMapper.fromEntity(entity)).thenReturn(firstPageProducts[index])
+        }
+        secondPageEntities.forEachIndexed { index, entity ->
+            whenever(productMapper.fromEntity(entity)).thenReturn(secondPageProducts[index])
+        }
+
+        // Setup happy path search results
+        whenever(posLocalCatalogStore.searchProducts(siteId, "query", 15, 0))
+            .thenReturn(Result.success(firstPageEntities))
+        whenever(posLocalCatalogStore.searchProducts(siteId, "query", 15, 15))
+            .thenReturn(Result.success(secondPageEntities))
 
         sut = WooPosLocalCatalogSearchDataSource(
             posLocalCatalogStore = posLocalCatalogStore,
@@ -47,27 +67,20 @@ class WooPosLocalCatalogSearchDataSourceTest {
     }
 
     @Test
-    fun `given successful search, when searchProducts called, then returns mapped products`() = runTest {
-        // GIVEN
-        whenever(posLocalCatalogStore.searchProducts(siteId, "query", 15, 0))
-            .thenReturn(Result.success(listOf(defaultEntity)))
-
+    fun `when searchProducts called, then returns first page of results`() = runTest {
         // WHEN
         val result = sut.searchProducts("query")
 
         // THEN
         assertThat(result.isSuccess).isTrue()
-        assertThat(result.getOrThrow()).hasSize(1)
+        assertThat(result.getOrThrow()).hasSize(15)
+        assertThat(result.getOrThrow().map { it.remoteId }).containsExactlyInAnyOrder(
+            *((1L..15L).toList().toTypedArray())
+        )
     }
 
     @Test
     fun `given full page of results, when searchProducts called, then hasMorePages returns true`() = runTest {
-        // GIVEN
-        val entities = (1..15).map { createProductEntity(it.toLong()) }
-        whenever(productMapper.fromEntity(any())).thenReturn(generateWooPosProduct())
-        whenever(posLocalCatalogStore.searchProducts(siteId, "query", 15, 0))
-            .thenReturn(Result.success(entities))
-
         // WHEN
         sut.searchProducts("query")
 
@@ -117,38 +130,56 @@ class WooPosLocalCatalogSearchDataSourceTest {
     }
 
     @Test
-    fun `given more pages available, when loadMore called, then loads next page`() = runTest {
+    fun `when loadMore called after initial search, then returns accumulated results`() = runTest {
         // GIVEN
-        val firstPageEntities = (1..15).map { createProductEntity(it.toLong()) }
-        val secondPageEntities = listOf(createProductEntity(16L))
-        whenever(productMapper.fromEntity(any())).thenReturn(generateWooPosProduct())
-        whenever(posLocalCatalogStore.searchProducts(siteId, "query", 15, 0))
-            .thenReturn(Result.success(firstPageEntities))
-        whenever(posLocalCatalogStore.searchProducts(siteId, "query", 15, 15))
-            .thenReturn(Result.success(secondPageEntities))
+        sut.searchProducts("query")
 
         // WHEN
-        sut.searchProducts("query")
         val result = sut.loadMore("query")
 
         // THEN
         assertThat(result.isSuccess).isTrue()
-        assertThat(result.getOrThrow()).hasSize(1)
+        assertThat(result.getOrThrow()).hasSize(20) // 15 from first page + 5 from second page
     }
 
     @Test
-    fun `given no more pages, when loadMore called, then returns empty list`() = runTest {
+    fun `when loadMore called, then accumulated results contain all products`() = runTest {
+        // GIVEN
+        sut.searchProducts("query")
+
+        // WHEN
+        val result = sut.loadMore("query")
+
+        // THEN
+        val productIds = result.getOrThrow().map { it.remoteId }
+        assertThat(productIds).containsExactlyInAnyOrder(*((1L..20L).toList().toTypedArray()))
+    }
+
+    @Test
+    fun `given last page has less than page size, when loadMore called, then hasMorePages returns false`() = runTest {
+        // GIVEN
+        sut.searchProducts("query")
+
+        // WHEN
+        sut.loadMore("query")
+
+        // THEN
+        assertThat(sut.hasMorePages).isFalse()
+    }
+
+    @Test
+    fun `given no more pages, when loadMore called, then returns current accumulated results`() = runTest {
         // GIVEN
         whenever(posLocalCatalogStore.searchProducts(siteId, "query", 15, 0))
             .thenReturn(Result.success(listOf(defaultEntity)))
+        sut.searchProducts("query")
 
         // WHEN
-        sut.searchProducts("query")
         val result = sut.loadMore("query")
 
         // THEN
         assertThat(result.isSuccess).isTrue()
-        assertThat(result.getOrThrow()).isEmpty()
+        assertThat(result.getOrThrow()).hasSize(1) // Returns the accumulated single item
     }
 
     @Test
@@ -178,19 +209,34 @@ class WooPosLocalCatalogSearchDataSourceTest {
     }
 
     @Test
-    fun `given multiple searches, when searchProducts called, then pagination resets`() = runTest {
+    fun `when new search started, then resets accumulated results`() = runTest {
         // GIVEN
-        val fullPageEntities = (1..15).map { createProductEntity(it.toLong()) }
-        val singleEntity = listOf(createProductEntity(1L))
-        whenever(productMapper.fromEntity(any())).thenReturn(generateWooPosProduct())
-        whenever(posLocalCatalogStore.searchProducts(siteId, "query1", 15, 0))
-            .thenReturn(Result.success(fullPageEntities))
+        sut.searchProducts("query")
+        sut.loadMore("query")
+        val singleEntity = listOf(createProductEntity(99L))
+        val singleProduct = generateWooPosProduct(productId = 99L)
+        whenever(productMapper.fromEntity(singleEntity[0])).thenReturn(singleProduct)
+        whenever(posLocalCatalogStore.searchProducts(siteId, "newQuery", 15, 0))
+            .thenReturn(Result.success(singleEntity))
+
+        // WHEN
+        val result = sut.searchProducts("newQuery")
+
+        // THEN
+        assertThat(result.getOrThrow()).hasSize(1)
+        assertThat(result.getOrThrow()[0].remoteId).isEqualTo(99L)
+    }
+
+    @Test
+    fun `when new search started, then resets hasMorePages flag`() = runTest {
+        // GIVEN
+        sut.searchProducts("query")
+        assertThat(sut.hasMorePages).isTrue()
+        val singleEntity = listOf(createProductEntity(99L))
         whenever(posLocalCatalogStore.searchProducts(siteId, "query2", 15, 0))
             .thenReturn(Result.success(singleEntity))
 
         // WHEN
-        sut.searchProducts("query1")
-        assertThat(sut.hasMorePages).isTrue()
         sut.searchProducts("query2")
 
         // THEN


### PR DESCRIPTION
Fixes WOOMOB-1075

### Description
This PR completes the local catalog search implementation by integrating the search infrastructure (from part 1) with existing UI components and ViewModels.

**Key Changes:**
- Add search interface definitions to `WooPosProductsDataSourceInterface`
- Integrate local search functionality in `WooPosProductsDataSource`
- Refactor `WooPosItemsSearchViewModel` to use unified search approach
- Fix sync facade ID issue in `WooPosPeriodicSyncFacade`
- Update all related tests for modified components
- Handle load-more functionality with accumulated results

This is part 2 of 2, building on the search infrastructure added in part 1. The feature is now fully functional end-to-end.

### Test Steps
1. Build the project to ensure compilation
2. Run unit tests: `./gradlew :WooCommerce:testWasabiDebugUnitTest --tests "*Search*"`
3. Test local search functionality in WooPos
4. Verify pagination and load-more work correctly
5. Check that existing POS flows remain unaffected

### Images/gif
N/A - Backend functionality changes

- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.