### PR TITLE
[Woo POS][Local Catalog] Do not run incremental sync with disabled local catalog

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/WooPosHomeViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/WooPosHomeViewModel.kt
@@ -57,13 +57,7 @@ class WooPosHomeViewModel @Inject constructor(
         viewModelScope.launch {
             soundHelper.preloadChaChing()
         }
-        performLocalCatalogIncrementalSync()
-    }
-
-    private fun performLocalCatalogIncrementalSync() {
-        viewModelScope.launch {
-            incrementalSync.execute(WooPosIncrementalSyncReason.ON_POS_HOME)
-        }
+        incrementalSync.execute(WooPosIncrementalSyncReason.ON_POS_HOME)
     }
 
     override fun onCleared() {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/localcatalog/WooPosPerformLocalCatalogIncrementalSync.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/localcatalog/WooPosPerformLocalCatalogIncrementalSync.kt
@@ -6,10 +6,8 @@ import com.woocommerce.android.ui.woopos.common.util.WooPosLogWrapper
 import com.woocommerce.android.ui.woopos.localcatalog.PosLocalCatalogSyncResult.Failure
 import com.woocommerce.android.ui.woopos.localcatalog.PosLocalCatalogSyncResult.Success
 import com.woocommerce.android.ui.woopos.util.WooPosNetworkStatus
-import com.woocommerce.android.util.CoroutineDispatchers
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.launch
-import kotlinx.coroutines.withContext
 import org.wordpress.android.fluxc.model.SiteModel
 import javax.inject.Inject
 
@@ -19,7 +17,6 @@ class WooPosPerformLocalCatalogIncrementalSync @Inject constructor(
     private val networkStatus: WooPosNetworkStatus,
     private val isLocalCatalogSupported: WooPosIsLocalCatalogSupported,
     private val wooPosLogWrapper: WooPosLogWrapper,
-    private val dispatchers: CoroutineDispatchers,
     @AppCoroutineScope private val appCoroutineScope: CoroutineScope
 ) {
     fun execute(reason: WooPosIncrementalSyncReason) {
@@ -46,21 +43,19 @@ class WooPosPerformLocalCatalogIncrementalSync @Inject constructor(
     }
 
     private suspend fun performSync(site: SiteModel, reasonDescription: String) {
-        withContext(dispatchers.io) {
-            wooPosLogWrapper.d("Starting incremental sync $reasonDescription")
-            val syncResult = localCatalogSyncRepository.syncLocalCatalogIncremental(site)
-            when (syncResult) {
-                is Success -> {
-                    wooPosLogWrapper.d(
-                        "Sync $reasonDescription completed successfully: " +
-                            "${syncResult.productsSynced} products, " +
-                            "${syncResult.variationsSynced} variations synced " +
-                            "in ${syncResult.syncDurationMs}ms"
-                    )
-                }
-                is Failure -> {
-                    wooPosLogWrapper.e("Sync $reasonDescription failed: ${syncResult.error}")
-                }
+        wooPosLogWrapper.d("Starting incremental sync $reasonDescription")
+        val syncResult = localCatalogSyncRepository.syncLocalCatalogIncremental(site)
+        when (syncResult) {
+            is Success -> {
+                wooPosLogWrapper.d(
+                    "Sync $reasonDescription completed successfully: " +
+                        "${syncResult.productsSynced} products, " +
+                        "${syncResult.variationsSynced} variations synced " +
+                        "in ${syncResult.syncDurationMs}ms"
+                )
+            }
+            is Failure -> {
+                wooPosLogWrapper.e("Sync $reasonDescription failed: ${syncResult.error}")
             }
         }
     }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/localcatalog/WooPosPerformLocalCatalogIncrementalSync.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/localcatalog/WooPosPerformLocalCatalogIncrementalSync.kt
@@ -1,11 +1,14 @@
 package com.woocommerce.android.ui.woopos.localcatalog
 
+import com.woocommerce.android.di.AppCoroutineScope
 import com.woocommerce.android.tools.SelectedSite
 import com.woocommerce.android.ui.woopos.common.util.WooPosLogWrapper
 import com.woocommerce.android.ui.woopos.localcatalog.PosLocalCatalogSyncResult.Failure
 import com.woocommerce.android.ui.woopos.localcatalog.PosLocalCatalogSyncResult.Success
 import com.woocommerce.android.ui.woopos.util.WooPosNetworkStatus
 import com.woocommerce.android.util.CoroutineDispatchers
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 import org.wordpress.android.fluxc.model.SiteModel
 import javax.inject.Inject
@@ -16,33 +19,34 @@ class WooPosPerformLocalCatalogIncrementalSync @Inject constructor(
     private val networkStatus: WooPosNetworkStatus,
     private val isLocalCatalogSupported: WooPosIsLocalCatalogSupported,
     private val wooPosLogWrapper: WooPosLogWrapper,
-    private val dispatchers: CoroutineDispatchers
+    private val dispatchers: CoroutineDispatchers,
+    @AppCoroutineScope private val appCoroutineScope: CoroutineScope
 ) {
-    @Suppress("ReturnCount")
-    suspend fun execute(reason: WooPosIncrementalSyncReason): PosLocalCatalogSyncResult? {
+    fun execute(reason: WooPosIncrementalSyncReason) {
         val reasonDescription = reason.description
-
         if (!networkStatus.isConnected()) {
             wooPosLogWrapper.d("Skipping sync $reasonDescription: No network connection")
-            return null
+            return
         }
 
-        val site = selectedSite.getOrNull()
-        if (site == null) {
-            wooPosLogWrapper.d("Skipping sync $reasonDescription: No site selected")
-            return null
-        }
+        appCoroutineScope.launch {
+            val site = selectedSite.getOrNull()
+            if (site == null) {
+                wooPosLogWrapper.d("Skipping sync $reasonDescription: No site selected")
+                return@launch
+            }
 
-        if (!isLocalCatalogSupported(site.localId())) {
-            wooPosLogWrapper.d("Skipping sync $reasonDescription: Local catalog not supported for site")
-            return null
-        }
+            if (!isLocalCatalogSupported(site.localId())) {
+                wooPosLogWrapper.d("Skipping sync $reasonDescription: Local catalog not supported for site")
+                return@launch
+            }
 
-        return performSync(site, reasonDescription)
+            performSync(site, reasonDescription)
+        }
     }
 
-    private suspend fun performSync(site: SiteModel, reasonDescription: String): PosLocalCatalogSyncResult {
-        return withContext(dispatchers.io) {
+    private suspend fun performSync(site: SiteModel, reasonDescription: String) {
+        withContext(dispatchers.io) {
             wooPosLogWrapper.d("Starting incremental sync $reasonDescription")
             val syncResult = localCatalogSyncRepository.syncLocalCatalogIncremental(site)
             when (syncResult) {
@@ -58,7 +62,6 @@ class WooPosPerformLocalCatalogIncrementalSync @Inject constructor(
                     wooPosLogWrapper.e("Sync $reasonDescription failed: ${syncResult.error}")
                 }
             }
-            syncResult
         }
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/localcatalog/WooPosPerformLocalCatalogIncrementalSync.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/localcatalog/WooPosPerformLocalCatalogIncrementalSync.kt
@@ -1,55 +1,64 @@
 package com.woocommerce.android.ui.woopos.localcatalog
 
-import com.woocommerce.android.di.AppCoroutineScope
 import com.woocommerce.android.tools.SelectedSite
 import com.woocommerce.android.ui.woopos.common.util.WooPosLogWrapper
-import com.woocommerce.android.ui.woopos.featureflags.WooPosLocalCatalogM1Enabled
 import com.woocommerce.android.ui.woopos.localcatalog.PosLocalCatalogSyncResult.Failure
 import com.woocommerce.android.ui.woopos.localcatalog.PosLocalCatalogSyncResult.Success
 import com.woocommerce.android.ui.woopos.util.WooPosNetworkStatus
-import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.launch
+import com.woocommerce.android.util.CoroutineDispatchers
+import kotlinx.coroutines.withContext
+import org.wordpress.android.fluxc.model.SiteModel
 import javax.inject.Inject
 
 class WooPosPerformLocalCatalogIncrementalSync @Inject constructor(
     private val localCatalogSyncRepository: WooPosLocalCatalogSyncRepository,
     private val selectedSite: SelectedSite,
     private val networkStatus: WooPosNetworkStatus,
-    private val wooPosLocalCatalogM1Enabled: WooPosLocalCatalogM1Enabled,
+    private val isLocalCatalogSupported: WooPosIsLocalCatalogSupported,
     private val wooPosLogWrapper: WooPosLogWrapper,
-    @AppCoroutineScope private val appCoroutineScope: CoroutineScope
+    private val dispatchers: CoroutineDispatchers
 ) {
-    fun execute(reason: WooPosIncrementalSyncReason) {
+    @Suppress("ReturnCount")
+    suspend fun execute(reason: WooPosIncrementalSyncReason): PosLocalCatalogSyncResult? {
         val reasonDescription = reason.description
-
-        if (!wooPosLocalCatalogM1Enabled()) {
-            wooPosLogWrapper.d("Skipping sync $reasonDescription: Local catalog feature not enabled")
-            return
-        }
 
         if (!networkStatus.isConnected()) {
             wooPosLogWrapper.d("Skipping sync $reasonDescription: No network connection")
-            return
+            return null
         }
 
-        appCoroutineScope.launch {
-            selectedSite.getOrNull()?.let { site ->
-                wooPosLogWrapper.d("Starting incremental sync $reasonDescription")
-                val syncResult = localCatalogSyncRepository.syncLocalCatalogIncremental(site)
-                when (syncResult) {
-                    is Success -> {
-                        wooPosLogWrapper.d(
-                            "Sync $reasonDescription completed successfully: " +
-                                "${syncResult.productsSynced} products, " +
-                                "${syncResult.variationsSynced} variations synced " +
-                                "in ${syncResult.syncDurationMs}ms"
-                        )
-                    }
-                    is Failure -> {
-                        wooPosLogWrapper.e("Sync $reasonDescription failed: ${syncResult.error}")
-                    }
+        val site = selectedSite.getOrNull()
+        if (site == null) {
+            wooPosLogWrapper.d("Skipping sync $reasonDescription: No site selected")
+            return null
+        }
+
+        if (!isLocalCatalogSupported(site.localId())) {
+            wooPosLogWrapper.d("Skipping sync $reasonDescription: Local catalog not supported for site")
+            return null
+        }
+
+        return performSync(site, reasonDescription)
+    }
+
+    private suspend fun performSync(site: SiteModel, reasonDescription: String): PosLocalCatalogSyncResult {
+        return withContext(dispatchers.io) {
+            wooPosLogWrapper.d("Starting incremental sync $reasonDescription")
+            val syncResult = localCatalogSyncRepository.syncLocalCatalogIncremental(site)
+            when (syncResult) {
+                is Success -> {
+                    wooPosLogWrapper.d(
+                        "Sync $reasonDescription completed successfully: " +
+                            "${syncResult.productsSynced} products, " +
+                            "${syncResult.variationsSynced} variations synced " +
+                            "in ${syncResult.syncDurationMs}ms"
+                    )
                 }
-            } ?: wooPosLogWrapper.d("Skipping sync $reasonDescription: No site selected")
+                is Failure -> {
+                    wooPosLogWrapper.e("Sync $reasonDescription failed: ${syncResult.error}")
+                }
+            }
+            syncResult
         }
     }
 }

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/localcatalog/WooPosPerformLocalCatalogIncrementalSyncTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/localcatalog/WooPosPerformLocalCatalogIncrementalSyncTest.kt
@@ -6,12 +6,14 @@ import com.woocommerce.android.ui.woopos.util.WooPosNetworkStatus
 import com.woocommerce.android.util.CoroutineDispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.TestScope
+import kotlinx.coroutines.test.advanceUntilIdle
 import kotlinx.coroutines.test.runTest
-import org.assertj.core.api.Assertions.assertThat
 import org.junit.Before
 import org.junit.Test
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.verify
+import org.mockito.kotlin.verifyNoInteractions
 import org.mockito.kotlin.whenever
 import org.wordpress.android.fluxc.model.SiteModel
 
@@ -29,6 +31,7 @@ class WooPosPerformLocalCatalogIncrementalSyncTest {
         computation = testDispatcher,
         io = testDispatcher
     )
+    private val testScope = TestScope(testDispatcher)
 
     private lateinit var sut: WooPosPerformLocalCatalogIncrementalSync
 
@@ -40,12 +43,13 @@ class WooPosPerformLocalCatalogIncrementalSyncTest {
             networkStatus = networkStatus,
             isLocalCatalogSupported = isLocalCatalogSupported,
             wooPosLogWrapper = wooPosLogWrapper,
-            dispatchers = dispatchers
+            dispatchers = dispatchers,
+            appCoroutineScope = testScope
         )
     }
 
     @Test
-    fun `given local catalog not supported, when execute called, then returns null`() = runTest(testDispatcher) {
+    fun `given local catalog not supported, when execute called, then skips sync`() = runTest(testDispatcher) {
         // GIVEN
         val site = SiteModel().apply { id = 123 }
         whenever(networkStatus.isConnected()).thenReturn(true)
@@ -53,42 +57,44 @@ class WooPosPerformLocalCatalogIncrementalSyncTest {
         whenever(isLocalCatalogSupported(site.localId())).thenReturn(false)
 
         // WHEN
-        val result = sut.execute(WooPosIncrementalSyncReason.ON_POS_HOME)
+        sut.execute(WooPosIncrementalSyncReason.ON_POS_HOME)
+        advanceUntilIdle()
 
         // THEN
-        assertThat(result).isNull()
         verify(wooPosLogWrapper).d("Skipping sync on POS home: Local catalog not supported for site")
+        verifyNoInteractions(localCatalogSyncRepository)
     }
 
     @Test
-    fun `given no network connection, when execute called, then returns null`() = runTest(testDispatcher) {
+    fun `given no network connection, when execute called, then skips sync`() = runTest(testDispatcher) {
         // GIVEN
         whenever(networkStatus.isConnected()).thenReturn(false)
 
         // WHEN
-        val result = sut.execute(WooPosIncrementalSyncReason.AFTER_SUCCESSFUL_PAYMENT)
+        sut.execute(WooPosIncrementalSyncReason.AFTER_SUCCESSFUL_PAYMENT)
 
         // THEN
-        assertThat(result).isNull()
         verify(wooPosLogWrapper).d("Skipping sync after successful payment: No network connection")
+        verifyNoInteractions(localCatalogSyncRepository)
     }
 
     @Test
-    fun `given no site selected, when execute called, then returns null`() = runTest(testDispatcher) {
+    fun `given no site selected, when execute called, then skips sync`() = runTest(testDispatcher) {
         // GIVEN
         whenever(networkStatus.isConnected()).thenReturn(true)
         whenever(selectedSite.getOrNull()).thenReturn(null)
 
         // WHEN
-        val result = sut.execute(WooPosIncrementalSyncReason.PERIODIC_HOURLY)
+        sut.execute(WooPosIncrementalSyncReason.PERIODIC_HOURLY)
+        advanceUntilIdle()
 
         // THEN
-        assertThat(result).isNull()
         verify(wooPosLogWrapper).d("Skipping sync periodic hourly: No site selected")
+        verifyNoInteractions(localCatalogSyncRepository)
     }
 
     @Test
-    fun `given sync succeeds, when execute called, then returns success result`() = runTest(testDispatcher) {
+    fun `given sync succeeds, when execute called, then performs sync successfully`() = runTest(testDispatcher) {
         // GIVEN
         val site = SiteModel().apply { id = 123 }
         val syncResult = PosLocalCatalogSyncResult.Success(
@@ -103,10 +109,10 @@ class WooPosPerformLocalCatalogIncrementalSyncTest {
         whenever(localCatalogSyncRepository.syncLocalCatalogIncremental(site)).thenReturn(syncResult)
 
         // WHEN
-        val result = sut.execute(WooPosIncrementalSyncReason.ON_POS_HOME)
+        sut.execute(WooPosIncrementalSyncReason.ON_POS_HOME)
+        advanceUntilIdle()
 
         // THEN
-        assertThat(result).isEqualTo(syncResult)
         verify(wooPosLogWrapper).d("Starting incremental sync on POS home")
         verify(wooPosLogWrapper).d(
             "Sync on POS home completed successfully: 15 products, 8 variations synced in 2500ms"
@@ -114,7 +120,7 @@ class WooPosPerformLocalCatalogIncrementalSyncTest {
     }
 
     @Test
-    fun `given sync fails with unexpected error, when execute called, then returns failure result`() = runTest(
+    fun `given sync fails with unexpected error, when execute called, then logs failure`() = runTest(
         testDispatcher
     ) {
         // GIVEN
@@ -127,16 +133,16 @@ class WooPosPerformLocalCatalogIncrementalSyncTest {
         whenever(localCatalogSyncRepository.syncLocalCatalogIncremental(site)).thenReturn(syncResult)
 
         // WHEN
-        val result = sut.execute(WooPosIncrementalSyncReason.AFTER_SUCCESSFUL_PAYMENT)
+        sut.execute(WooPosIncrementalSyncReason.AFTER_SUCCESSFUL_PAYMENT)
+        advanceUntilIdle()
 
         // THEN
-        assertThat(result).isEqualTo(syncResult)
         verify(wooPosLogWrapper).d("Starting incremental sync after successful payment")
         verify(wooPosLogWrapper).e("Sync after successful payment failed: Network timeout")
     }
 
     @Test
-    fun `given sync fails with catalog too large, when execute called, then returns failure result`() = runTest(
+    fun `given sync fails with catalog too large, when execute called, then logs failure`() = runTest(
         testDispatcher
     ) {
         // GIVEN
@@ -153,10 +159,10 @@ class WooPosPerformLocalCatalogIncrementalSyncTest {
         whenever(localCatalogSyncRepository.syncLocalCatalogIncremental(site)).thenReturn(syncResult)
 
         // WHEN
-        val result = sut.execute(WooPosIncrementalSyncReason.PERIODIC_HOURLY)
+        sut.execute(WooPosIncrementalSyncReason.PERIODIC_HOURLY)
+        advanceUntilIdle()
 
         // THEN
-        assertThat(result).isEqualTo(syncResult)
         verify(wooPosLogWrapper).d("Starting incremental sync periodic hourly")
         verify(wooPosLogWrapper).e("Sync periodic hourly failed: Catalog exceeds limit")
     }
@@ -180,12 +186,15 @@ class WooPosPerformLocalCatalogIncrementalSyncTest {
 
         // WHEN & THEN
         sut.execute(WooPosIncrementalSyncReason.ON_POS_HOME)
+        advanceUntilIdle()
         verify(wooPosLogWrapper).d("Starting incremental sync on POS home")
 
         sut.execute(WooPosIncrementalSyncReason.AFTER_SUCCESSFUL_PAYMENT)
+        advanceUntilIdle()
         verify(wooPosLogWrapper).d("Starting incremental sync after successful payment")
 
         sut.execute(WooPosIncrementalSyncReason.PERIODIC_HOURLY)
+        advanceUntilIdle()
         verify(wooPosLogWrapper).d("Starting incremental sync periodic hourly")
     }
 }

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/localcatalog/WooPosPerformLocalCatalogIncrementalSyncTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/localcatalog/WooPosPerformLocalCatalogIncrementalSyncTest.kt
@@ -3,9 +3,9 @@ package com.woocommerce.android.ui.woopos.localcatalog
 import com.woocommerce.android.tools.SelectedSite
 import com.woocommerce.android.ui.woopos.common.util.WooPosLogWrapper
 import com.woocommerce.android.ui.woopos.util.WooPosNetworkStatus
-import com.woocommerce.android.util.CoroutineDispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.TestCoroutineScheduler
 import kotlinx.coroutines.test.TestScope
 import kotlinx.coroutines.test.advanceUntilIdle
 import kotlinx.coroutines.test.runTest
@@ -25,12 +25,9 @@ class WooPosPerformLocalCatalogIncrementalSyncTest {
     private val networkStatus: WooPosNetworkStatus = mock()
     private val isLocalCatalogSupported: WooPosIsLocalCatalogSupported = mock()
     private val wooPosLogWrapper: WooPosLogWrapper = mock()
-    private val testDispatcher = StandardTestDispatcher()
-    private val dispatchers = CoroutineDispatchers(
-        main = testDispatcher,
-        computation = testDispatcher,
-        io = testDispatcher
-    )
+    private val testScheduler = TestCoroutineScheduler()
+    private val testDispatcher = StandardTestDispatcher(testScheduler)
+
     private val testScope = TestScope(testDispatcher)
 
     private lateinit var sut: WooPosPerformLocalCatalogIncrementalSync
@@ -43,13 +40,12 @@ class WooPosPerformLocalCatalogIncrementalSyncTest {
             networkStatus = networkStatus,
             isLocalCatalogSupported = isLocalCatalogSupported,
             wooPosLogWrapper = wooPosLogWrapper,
-            dispatchers = dispatchers,
             appCoroutineScope = testScope
         )
     }
 
     @Test
-    fun `given local catalog not supported, when execute called, then skips sync`() = runTest(testDispatcher) {
+    fun `given local catalog not supported, when execute called, then skips sync`() = runTest(testScheduler) {
         // GIVEN
         val site = SiteModel().apply { id = 123 }
         whenever(networkStatus.isConnected()).thenReturn(true)
@@ -66,7 +62,7 @@ class WooPosPerformLocalCatalogIncrementalSyncTest {
     }
 
     @Test
-    fun `given no network connection, when execute called, then skips sync`() = runTest(testDispatcher) {
+    fun `given no network connection, when execute called, then skips sync`() = runTest(testScheduler) {
         // GIVEN
         whenever(networkStatus.isConnected()).thenReturn(false)
 
@@ -79,7 +75,7 @@ class WooPosPerformLocalCatalogIncrementalSyncTest {
     }
 
     @Test
-    fun `given no site selected, when execute called, then skips sync`() = runTest(testDispatcher) {
+    fun `given no site selected, when execute called, then skips sync`() = runTest(testScheduler) {
         // GIVEN
         whenever(networkStatus.isConnected()).thenReturn(true)
         whenever(selectedSite.getOrNull()).thenReturn(null)
@@ -94,7 +90,7 @@ class WooPosPerformLocalCatalogIncrementalSyncTest {
     }
 
     @Test
-    fun `given sync succeeds, when execute called, then performs sync successfully`() = runTest(testDispatcher) {
+    fun `given sync succeeds, when execute called, then performs sync successfully`() = runTest(testScheduler) {
         // GIVEN
         val site = SiteModel().apply { id = 123 }
         val syncResult = PosLocalCatalogSyncResult.Success(
@@ -120,9 +116,7 @@ class WooPosPerformLocalCatalogIncrementalSyncTest {
     }
 
     @Test
-    fun `given sync fails with unexpected error, when execute called, then logs failure`() = runTest(
-        testDispatcher
-    ) {
+    fun `given sync fails with unexpected error, when execute called, then logs failure`() = runTest(testScheduler) {
         // GIVEN
         val site = SiteModel().apply { id = 456 }
         val syncResult = PosLocalCatalogSyncResult.Failure.UnexpectedError("Network timeout")
@@ -142,9 +136,7 @@ class WooPosPerformLocalCatalogIncrementalSyncTest {
     }
 
     @Test
-    fun `given sync fails with catalog too large, when execute called, then logs failure`() = runTest(
-        testDispatcher
-    ) {
+    fun `given sync fails with catalog too large, when execute called, then logs failure`() = runTest(testScheduler) {
         // GIVEN
         val site = SiteModel().apply { id = 789 }
         val syncResult = PosLocalCatalogSyncResult.Failure.CatalogTooLarge(
@@ -169,7 +161,7 @@ class WooPosPerformLocalCatalogIncrementalSyncTest {
 
     @Test
     fun `given different sync reasons, when execute called, then logs correct reason description`() = runTest(
-        testDispatcher
+        testScheduler
     ) {
         // GIVEN
         val site = SiteModel().apply { id = 123 }

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/localcatalog/WooPosPerformLocalCatalogIncrementalSyncTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/localcatalog/WooPosPerformLocalCatalogIncrementalSyncTest.kt
@@ -1,0 +1,191 @@
+package com.woocommerce.android.ui.woopos.localcatalog
+
+import com.woocommerce.android.tools.SelectedSite
+import com.woocommerce.android.ui.woopos.common.util.WooPosLogWrapper
+import com.woocommerce.android.ui.woopos.util.WooPosNetworkStatus
+import com.woocommerce.android.util.CoroutineDispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.runTest
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.Before
+import org.junit.Test
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
+import org.wordpress.android.fluxc.model.SiteModel
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class WooPosPerformLocalCatalogIncrementalSyncTest {
+
+    private val localCatalogSyncRepository: WooPosLocalCatalogSyncRepository = mock()
+    private val selectedSite: SelectedSite = mock()
+    private val networkStatus: WooPosNetworkStatus = mock()
+    private val isLocalCatalogSupported: WooPosIsLocalCatalogSupported = mock()
+    private val wooPosLogWrapper: WooPosLogWrapper = mock()
+    private val testDispatcher = StandardTestDispatcher()
+    private val dispatchers = CoroutineDispatchers(
+        main = testDispatcher,
+        computation = testDispatcher,
+        io = testDispatcher
+    )
+
+    private lateinit var sut: WooPosPerformLocalCatalogIncrementalSync
+
+    @Before
+    fun setUp() {
+        sut = WooPosPerformLocalCatalogIncrementalSync(
+            localCatalogSyncRepository = localCatalogSyncRepository,
+            selectedSite = selectedSite,
+            networkStatus = networkStatus,
+            isLocalCatalogSupported = isLocalCatalogSupported,
+            wooPosLogWrapper = wooPosLogWrapper,
+            dispatchers = dispatchers
+        )
+    }
+
+    @Test
+    fun `given local catalog not supported, when execute called, then returns null`() = runTest(testDispatcher) {
+        // GIVEN
+        val site = SiteModel().apply { id = 123 }
+        whenever(networkStatus.isConnected()).thenReturn(true)
+        whenever(selectedSite.getOrNull()).thenReturn(site)
+        whenever(isLocalCatalogSupported(site.localId())).thenReturn(false)
+
+        // WHEN
+        val result = sut.execute(WooPosIncrementalSyncReason.ON_POS_HOME)
+
+        // THEN
+        assertThat(result).isNull()
+        verify(wooPosLogWrapper).d("Skipping sync on POS home: Local catalog not supported for site")
+    }
+
+    @Test
+    fun `given no network connection, when execute called, then returns null`() = runTest(testDispatcher) {
+        // GIVEN
+        whenever(networkStatus.isConnected()).thenReturn(false)
+
+        // WHEN
+        val result = sut.execute(WooPosIncrementalSyncReason.AFTER_SUCCESSFUL_PAYMENT)
+
+        // THEN
+        assertThat(result).isNull()
+        verify(wooPosLogWrapper).d("Skipping sync after successful payment: No network connection")
+    }
+
+    @Test
+    fun `given no site selected, when execute called, then returns null`() = runTest(testDispatcher) {
+        // GIVEN
+        whenever(networkStatus.isConnected()).thenReturn(true)
+        whenever(selectedSite.getOrNull()).thenReturn(null)
+
+        // WHEN
+        val result = sut.execute(WooPosIncrementalSyncReason.PERIODIC_HOURLY)
+
+        // THEN
+        assertThat(result).isNull()
+        verify(wooPosLogWrapper).d("Skipping sync periodic hourly: No site selected")
+    }
+
+    @Test
+    fun `given sync succeeds, when execute called, then returns success result`() = runTest(testDispatcher) {
+        // GIVEN
+        val site = SiteModel().apply { id = 123 }
+        val syncResult = PosLocalCatalogSyncResult.Success(
+            productsSynced = 15,
+            variationsSynced = 8,
+            syncDurationMs = 2500L
+        )
+
+        whenever(networkStatus.isConnected()).thenReturn(true)
+        whenever(selectedSite.getOrNull()).thenReturn(site)
+        whenever(isLocalCatalogSupported(site.localId())).thenReturn(true)
+        whenever(localCatalogSyncRepository.syncLocalCatalogIncremental(site)).thenReturn(syncResult)
+
+        // WHEN
+        val result = sut.execute(WooPosIncrementalSyncReason.ON_POS_HOME)
+
+        // THEN
+        assertThat(result).isEqualTo(syncResult)
+        verify(wooPosLogWrapper).d("Starting incremental sync on POS home")
+        verify(wooPosLogWrapper).d(
+            "Sync on POS home completed successfully: 15 products, 8 variations synced in 2500ms"
+        )
+    }
+
+    @Test
+    fun `given sync fails with unexpected error, when execute called, then returns failure result`() = runTest(
+        testDispatcher
+    ) {
+        // GIVEN
+        val site = SiteModel().apply { id = 456 }
+        val syncResult = PosLocalCatalogSyncResult.Failure.UnexpectedError("Network timeout")
+
+        whenever(networkStatus.isConnected()).thenReturn(true)
+        whenever(selectedSite.getOrNull()).thenReturn(site)
+        whenever(isLocalCatalogSupported(site.localId())).thenReturn(true)
+        whenever(localCatalogSyncRepository.syncLocalCatalogIncremental(site)).thenReturn(syncResult)
+
+        // WHEN
+        val result = sut.execute(WooPosIncrementalSyncReason.AFTER_SUCCESSFUL_PAYMENT)
+
+        // THEN
+        assertThat(result).isEqualTo(syncResult)
+        verify(wooPosLogWrapper).d("Starting incremental sync after successful payment")
+        verify(wooPosLogWrapper).e("Sync after successful payment failed: Network timeout")
+    }
+
+    @Test
+    fun `given sync fails with catalog too large, when execute called, then returns failure result`() = runTest(
+        testDispatcher
+    ) {
+        // GIVEN
+        val site = SiteModel().apply { id = 789 }
+        val syncResult = PosLocalCatalogSyncResult.Failure.CatalogTooLarge(
+            error = "Catalog exceeds limit",
+            totalPages = 15,
+            maxPages = 3
+        )
+
+        whenever(networkStatus.isConnected()).thenReturn(true)
+        whenever(selectedSite.getOrNull()).thenReturn(site)
+        whenever(isLocalCatalogSupported(site.localId())).thenReturn(true)
+        whenever(localCatalogSyncRepository.syncLocalCatalogIncremental(site)).thenReturn(syncResult)
+
+        // WHEN
+        val result = sut.execute(WooPosIncrementalSyncReason.PERIODIC_HOURLY)
+
+        // THEN
+        assertThat(result).isEqualTo(syncResult)
+        verify(wooPosLogWrapper).d("Starting incremental sync periodic hourly")
+        verify(wooPosLogWrapper).e("Sync periodic hourly failed: Catalog exceeds limit")
+    }
+
+    @Test
+    fun `given different sync reasons, when execute called, then logs correct reason description`() = runTest(
+        testDispatcher
+    ) {
+        // GIVEN
+        val site = SiteModel().apply { id = 123 }
+        val syncResult = PosLocalCatalogSyncResult.Success(
+            productsSynced = 5,
+            variationsSynced = 2,
+            syncDurationMs = 1000L
+        )
+
+        whenever(networkStatus.isConnected()).thenReturn(true)
+        whenever(selectedSite.getOrNull()).thenReturn(site)
+        whenever(isLocalCatalogSupported(site.localId())).thenReturn(true)
+        whenever(localCatalogSyncRepository.syncLocalCatalogIncremental(site)).thenReturn(syncResult)
+
+        // WHEN & THEN
+        sut.execute(WooPosIncrementalSyncReason.ON_POS_HOME)
+        verify(wooPosLogWrapper).d("Starting incremental sync on POS home")
+
+        sut.execute(WooPosIncrementalSyncReason.AFTER_SUCCESSFUL_PAYMENT)
+        verify(wooPosLogWrapper).d("Starting incremental sync after successful payment")
+
+        sut.execute(WooPosIncrementalSyncReason.PERIODIC_HOURLY)
+        verify(wooPosLogWrapper).d("Starting incremental sync periodic hourly")
+    }
+}


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->
# Do not run incremental sync with disabled local catalog + refactor
WOOMOB-1564

💡 Don't merge until the parent branch is `trunk`
<!-- Id number of the Linear issue this PR addresses, e.g., WOOMOB-373. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
This PR:
1. Optimizes the `WooPosPerformLocalCatalogIncrementalSync` use case by adding `WooPosIsLocalCatalogSupported` check before attempting to perform incremental sync operation. 
2. Refactors `WooPosPerformLocalCatalogIncrementalSync` to make it a synchronous, testable function with better error handling and introduces comprehensive unit tests:
- Converted from fire-and-forget coroutine to a suspending function that returns `PosLocalCatalogSyncResult?`
- Replaced `WooPosLocalCatalogM1Enabled` feature flag check with `WooPosIsLocalCatalogSupported` for consolidated site-level support checking
- Replaced `AppCoroutineScope` with `CoroutineDispatchers` for testable coroutine management
3. Covers `WooPosPerformLocalCatalogIncrementalSync` with unit tests

### Test Steps
<!-- Describe how to test your changes. Include only what’s needed for the reviewer to validate the behavior.
For new features, outline the main user flow or goal rather than every tap or click — the reviewer should be able to complete the flow naturally.
If applicable, mention key devices, scenarios, or edge cases to verify. -->
1. Verify incremental sync runs as expected: 
- on payment success
- periodically
- upon POS opening

2. Verify incremental sync doesn't work at all in case local catalog is disabled.

### Images/gif
<!-- Include before and after images or gifs when appropriate. -->
N/A

- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
