### PR TITLE
Issue/woomob 1075 woo poslocal catalog implement local search for products v2 step 2

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/items/products/WooPosProductsDataSource.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/items/products/WooPosProductsDataSource.kt
@@ -13,6 +13,8 @@ import com.woocommerce.android.ui.woopos.common.data.models.WooPosProductModel
 import com.woocommerce.android.ui.woopos.common.data.models.WooPosProductModelMapper
 import com.woocommerce.android.ui.woopos.common.data.models.WooPosWCProductToWooPosProductModelMapper
 import com.woocommerce.android.ui.woopos.common.data.toWooPosVariation
+import com.woocommerce.android.ui.woopos.home.items.search.WooPosProductsSearchInDbDataSource
+import com.woocommerce.android.ui.woopos.home.items.search.WooPosSearchProductsDataSource
 import com.woocommerce.android.ui.woopos.home.items.variations.WooPosVariationsLRUCache
 import com.woocommerce.android.ui.woopos.localcatalog.PosLocalCatalogProductSyncResult
 import com.woocommerce.android.ui.woopos.localcatalog.PosLocalCatalogVariationSyncResult
@@ -47,6 +49,7 @@ import java.util.concurrent.atomic.AtomicBoolean
 import java.util.concurrent.atomic.AtomicInteger
 import javax.inject.Inject
 import javax.inject.Singleton
+import kotlin.system.measureTimeMillis
 
 @Singleton
 class WooPosProductsDataSource @Inject constructor(
@@ -150,6 +153,17 @@ class WooPosProductsDataSource @Inject constructor(
         return activeSource?.getVariationById(productId, variationId)
     }
 
+    fun searchProducts(query: String): Flow<SearchProductsResult> =
+        activeSource?.searchProducts(query)
+            ?: error("searchProducts - Data source not selected")
+
+    suspend fun loadMoreSearchResults(query: String): Result<List<WooPosProductModel>> =
+        activeSource?.loadMoreSearchResults(query)
+            ?: error("loadMoreSearchResults - Data source not selected")
+
+    val hasMoreSearchPages: Boolean
+        get() = activeSource?.hasMoreSearchPages ?: error("hasMoreSearchPages - Data source not selected")
+
     sealed class WooPosPrepopulatingDataStatus {
         data object Syncing : WooPosPrepopulatingDataStatus()
         data object Completed : WooPosPrepopulatingDataStatus()
@@ -164,6 +178,7 @@ class WooPosProductsInDbDataSource @Inject constructor(
     private val variationMapper: WooPosVariationMapper,
     private val performInstantCatalogFullSync: WooPosPerformInstantCatalogFullSync,
     private val localCatalogSyncRepository: WooPosLocalCatalogSyncRepository,
+    private val localCatalogSearchDataSource: WooPosProductsSearchInDbDataSource,
 ) : WooPosProductsDataSourceInterface {
 
     private fun getProductsFromDatabaseFlow(): Flow<List<WooPosProductModel>> {
@@ -254,6 +269,25 @@ class WooPosProductsInDbDataSource @Inject constructor(
             Result.success(PosLocalCatalogVariationSyncResult(syncResult))
         } ?: Result.failure(IllegalStateException("No site selected"))
     }
+
+    override fun searchProducts(query: String): Flow<SearchProductsResult> = flow {
+        val result = localCatalogSearchDataSource.searchProducts(query)
+
+        result.fold(
+            onSuccess = { products ->
+                emit(SearchProductsResult.Local(products))
+            },
+            onFailure = { error ->
+                emit(SearchProductsResult.Remote(Result.failure(error), 0L))
+            }
+        )
+    }.flowOn(Dispatchers.IO)
+
+    override suspend fun loadMoreSearchResults(query: String): Result<List<WooPosProductModel>> =
+        localCatalogSearchDataSource.loadMore(query)
+
+    override val hasMoreSearchPages: Boolean
+        get() = localCatalogSearchDataSource.hasMorePages
 }
 
 class WooPosProductsRemoteDataSource @Inject constructor(
@@ -268,6 +302,7 @@ class WooPosProductsRemoteDataSource @Inject constructor(
     private val variationCache: WooPosVariationsLRUCache,
     private val variationFilterConfig: WooPosVariationsTypesFilterConfig,
     private val variationMapper: WooPosVariationMapper,
+    private val searchProductsDataSource: WooPosSearchProductsDataSource,
 ) : WooPosProductsDataSourceInterface {
     private val canLoadMore = AtomicBoolean(false)
     private val offset = AtomicInteger(0)
@@ -527,6 +562,27 @@ class WooPosProductsRemoteDataSource @Inject constructor(
         val variationsResult = fetchFirstVariationsPage(productId, forceRefresh = true).last()
         Result.success(variationsResult)
     }
+
+    override fun searchProducts(query: String): Flow<SearchProductsResult> = flow {
+        val localProducts = searchProductsDataSource.searchLocalProducts(query)
+        if (localProducts.isNotEmpty()) {
+            emit(SearchProductsResult.Local(localProducts))
+        }
+
+        var remoteResult: Result<List<WooPosProductModel>>
+        val searchTimeMillis = measureTimeMillis {
+            remoteResult = searchProductsDataSource.searchRemoteProducts(query)
+        }
+        emit(SearchProductsResult.Remote(remoteResult, searchTimeMillis))
+    }.flowOn(Dispatchers.IO)
+
+    override suspend fun loadMoreSearchResults(query: String): Result<List<WooPosProductModel>> =
+        withContext(Dispatchers.IO) {
+            searchProductsDataSource.loadMore(query)
+        }
+
+    override val hasMoreSearchPages: Boolean
+        get() = searchProductsDataSource.hasMorePages
 
     companion object {
         private const val NORMAL_PAGE_SIZE = 25

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/items/products/WooPosProductsDataSourceInterface.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/items/products/WooPosProductsDataSourceInterface.kt
@@ -9,6 +9,14 @@ import com.woocommerce.android.ui.woopos.localcatalog.WooPosSyncVariationResult
 import kotlinx.coroutines.flow.Flow
 import org.wordpress.android.fluxc.model.LocalOrRemoteId
 
+sealed class SearchProductsResult {
+    data class Local(val products: List<WooPosProductModel>) : SearchProductsResult()
+    data class Remote(
+        val productsResult: Result<List<WooPosProductModel>>,
+        val searchTimeMillis: Long = 0L
+    ) : SearchProductsResult()
+}
+
 interface WooPosProductsDataSourceInterface {
     fun fetchFirstProductsPage(
         forceRefresh: Boolean
@@ -38,4 +46,10 @@ interface WooPosProductsDataSourceInterface {
     suspend fun refreshProducts(): Result<WooPosSyncProductResult>
 
     suspend fun refreshVariations(productId: Long): Result<WooPosSyncVariationResult>
+
+    fun searchProducts(query: String): Flow<SearchProductsResult>
+
+    suspend fun loadMoreSearchResults(query: String): Result<List<WooPosProductModel>>
+
+    val hasMoreSearchPages: Boolean
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/items/search/WooPosItemsSearchViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/items/search/WooPosItemsSearchViewModel.kt
@@ -12,6 +12,8 @@ import com.woocommerce.android.ui.woopos.home.items.WooPosItemSelectionViewState
 import com.woocommerce.android.ui.woopos.home.items.WooPosItemsSearchHelper
 import com.woocommerce.android.ui.woopos.home.items.WooPosItemsViewModel.ItemClickedData
 import com.woocommerce.android.ui.woopos.home.items.WooPosPaginationState
+import com.woocommerce.android.ui.woopos.home.items.products.SearchProductsResult
+import com.woocommerce.android.ui.woopos.home.items.products.WooPosProductsDataSource
 import com.woocommerce.android.ui.woopos.util.analytics.WooPosAnalyticsEvent
 import com.woocommerce.android.ui.woopos.util.analytics.WooPosAnalyticsEventConstant
 import com.woocommerce.android.ui.woopos.util.format.WooPosFormatPrice
@@ -22,17 +24,17 @@ import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.launch
 import java.util.concurrent.atomic.AtomicReference
 import javax.inject.Inject
-import kotlin.system.measureTimeMillis
 
 @HiltViewModel
 class WooPosItemsSearchViewModel @Inject constructor(
     private val emptyStateRepository: WooPosItemsSearchEmptyStateRepository,
     private val priceFormat: WooPosFormatPrice,
-    private val dataSource: WooPosSearchProductsDataSource,
+    private val dataSource: WooPosProductsDataSource,
     private val childToParentEventSender: WooPosChildrenToParentEventSender,
     private val parentToChildrenEventReceiver: WooPosParentToChildrenEventReceiver,
     private val searchHelper: WooPosItemsSearchHelper,
@@ -53,8 +55,7 @@ class WooPosItemsSearchViewModel @Inject constructor(
         )
 
     private var loadMoreJob: Job? = null
-    private var localSearchJob: Job? = null
-    private var remoteSearchJob: Job? = null
+    private var searchJob: Job? = null
 
     private val currentQuery = AtomicReference("")
 
@@ -101,76 +102,67 @@ class WooPosItemsSearchViewModel @Inject constructor(
         val currentState = _viewState.value as? WooPosItemsSearchViewState.Error ?: return
 
         _viewState.value = WooPosItemsSearchViewState.Loading
-        performRemoteSearch(currentState.searchQuery)
+        performSearch(currentState.searchQuery)
     }
 
     private fun performSearch(query: String) {
-        localSearchJob?.cancel()
-        remoteSearchJob?.cancel()
+        searchJob?.cancel()
 
         currentQuery.set(query)
 
         if (query.isEmpty()) {
             setEmptySearchQueryState()
         } else {
-            performLocalSearch(query)
-            performRemoteSearch(query)
-        }
-    }
+            searchJob = viewModelScope.launch {
+                delay(SEARCH_DEBOUNCING_TIME)
 
-    private fun performLocalSearch(query: String) {
-        localSearchJob?.cancel()
-        localSearchJob = viewModelScope.launch {
-            val localProducts = dataSource.searchLocalProducts(query)
+                if (query != currentQuery.get()) return@launch
 
-            if (query != currentQuery.get()) return@launch
+                childToParentEventSender.sendToParent(ChildToParentEvent.SearchEvent.Started)
 
-            analyticsTracker.storedLocalSearchResultIds(localProducts.map { it.remoteId })
+                dataSource.searchProducts(query).collectLatest { searchResult ->
+                    if (query != currentQuery.get()) {
+                        childToParentEventSender.sendToParent(ChildToParentEvent.SearchEvent.Finished)
+                        return@collectLatest
+                    }
 
-            if (localProducts.isEmpty()) {
-                _viewState.value = WooPosItemsSearchViewState.Loading
-            } else {
-                _viewState.value = localProducts.toContentState(
-                    searchQuery = query,
-                )
-            }
-        }
-    }
+                    when (searchResult) {
+                        is SearchProductsResult.Local -> {
+                            analyticsTracker.storedLocalSearchResultIds(searchResult.products.map { it.remoteId })
 
-    private fun performRemoteSearch(query: String) {
-        remoteSearchJob?.cancel()
-        remoteSearchJob = viewModelScope.launch {
-            delay(SEARCH_DEBOUNCING_TIME)
+                            if (searchResult.products.isEmpty()) {
+                                _viewState.value = WooPosItemsSearchViewState.Loading
+                            } else {
+                                _viewState.value = searchResult.products.toContentState(
+                                    searchQuery = query,
+                                )
+                            }
+                        }
 
-            if (query != currentQuery.get()) {
-                return@launch
-            }
+                        is SearchProductsResult.Remote -> {
+                            if (searchResult.productsResult.isSuccess) {
+                                val products = searchResult.productsResult.getOrThrow()
+                                if (products.isEmpty()) {
+                                    _viewState.value = WooPosItemsSearchViewState.Empty
+                                } else {
+                                    _viewState.value = products.toContentState(searchQuery = query)
+                                }
 
-            childToParentEventSender.sendToParent(ChildToParentEvent.SearchEvent.Started)
-            var result: Result<List<WooPosProductModel>>
-            val searchTimeMillis = measureTimeMillis {
-                result = dataSource.searchRemoteProducts(query)
-            }
-
-            if (query != currentQuery.get()) {
-                childToParentEventSender.sendToParent(ChildToParentEvent.SearchEvent.Finished)
-                return@launch
-            }
-
-            if (result.isSuccess) {
-                val searchResult = result.getOrThrow()
-                if (searchResult.isEmpty()) {
-                    _viewState.value = WooPosItemsSearchViewState.Empty
-                } else {
-                    _viewState.value = searchResult.toContentState(searchQuery = query)
+                                analyticsTracker.trackSearchPerformance(searchResult.searchTimeMillis)
+                            } else {
+                                _viewState.value = WooPosItemsSearchViewState.Error(searchQuery = query)
+                            }
+                        }
+                    }
                 }
 
-                analyticsTracker.trackSearchPerformance(searchTimeMillis)
-            } else {
-                _viewState.value = WooPosItemsSearchViewState.Error(searchQuery = query)
+                if (query == currentQuery.get()) {
+                    childToParentEventSender.sendToParent(ChildToParentEvent.SearchEvent.Finished)
+                    if (_viewState.value is WooPosItemsSearchViewState.Loading) {
+                        _viewState.value = WooPosItemsSearchViewState.Empty
+                    }
+                }
             }
-
-            childToParentEventSender.sendToParent(ChildToParentEvent.SearchEvent.Finished)
         }
     }
 
@@ -210,7 +202,7 @@ class WooPosItemsSearchViewModel @Inject constructor(
             return
         }
 
-        if (!dataSource.hasMorePages) {
+        if (!dataSource.hasMoreSearchPages) {
             return
         }
 
@@ -218,7 +210,7 @@ class WooPosItemsSearchViewModel @Inject constructor(
 
         loadMoreJob?.cancel()
         loadMoreJob = viewModelScope.launch {
-            val result = dataSource.loadMore(query = currentState.searchQuery)
+            val result = dataSource.loadMoreSearchResults(currentState.searchQuery)
             _viewState.value = if (result.isSuccess) {
                 analyticsTracker.trackItemsNextPageLoaded()
                 result.getOrThrow().toContentState(
@@ -330,6 +322,6 @@ class WooPosItemsSearchViewModel @Inject constructor(
 
     private companion object {
         const val MAX_ITEMS_COUNT = 10
-        const val SEARCH_DEBOUNCING_TIME = 500L
+        const val SEARCH_DEBOUNCING_TIME = 250L
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/items/search/WooPosItemsSearchViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/items/search/WooPosItemsSearchViewModel.kt
@@ -114,6 +114,7 @@ class WooPosItemsSearchViewModel @Inject constructor(
             setEmptySearchQueryState()
         } else {
             searchJob = viewModelScope.launch {
+                _viewState.value = WooPosItemsSearchViewState.Loading
                 delay(SEARCH_DEBOUNCING_TIME)
 
                 if (query != currentQuery.get()) return@launch

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/home/items/WooPosProductsRemoteDataSourceTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/home/items/WooPosProductsRemoteDataSourceTest.kt
@@ -16,8 +16,10 @@ import com.woocommerce.android.ui.woopos.common.data.models.WooPosProductModel.W
 import com.woocommerce.android.ui.woopos.common.data.models.WooPosProductModel.WooPosProductType
 import com.woocommerce.android.ui.woopos.common.data.models.WooPosWCProductToWooPosProductModelMapper
 import com.woocommerce.android.ui.woopos.common.data.toWooPosVariation
+import com.woocommerce.android.ui.woopos.home.items.products.SearchProductsResult
 import com.woocommerce.android.ui.woopos.home.items.products.WooPosProductsIndex
 import com.woocommerce.android.ui.woopos.home.items.products.WooPosProductsRemoteDataSource
+import com.woocommerce.android.ui.woopos.home.items.search.WooPosSearchProductsDataSource
 import com.woocommerce.android.ui.woopos.home.items.variations.WooPosVariationsLRUCache
 import com.woocommerce.android.ui.woopos.localcatalog.ProductsResult
 import com.woocommerce.android.ui.woopos.localcatalog.VariationsResult
@@ -31,6 +33,7 @@ import kotlinx.coroutines.flow.toList
 import kotlinx.coroutines.test.runTest
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.Rule
+import org.junit.Test
 import org.mockito.kotlin.any
 import org.mockito.kotlin.doAnswer
 import org.mockito.kotlin.eq
@@ -48,10 +51,9 @@ import org.wordpress.android.fluxc.network.rest.wpcom.wc.WooErrorType
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.WooResult
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.product.ProductRestClient
 import org.wordpress.android.fluxc.store.WCProductStore
-import kotlin.test.Test
 
-@ExperimentalCoroutinesApi
-class WooPosProductsRemoteDataSourceTest {
+class Blabla {
+    @OptIn(ExperimentalCoroutinesApi::class)
     @Rule
     @JvmField
     val coroutinesTestRule = WooPosCoroutineTestRule()
@@ -101,6 +103,7 @@ class WooPosProductsRemoteDataSourceTest {
     )
 
     private val productStore: WCProductStore = mock()
+    private val searchProductsDataSource: WooPosSearchProductsDataSource = mock()
     private val siteModel: SiteModel = mock()
     private val productRestClient: ProductRestClient = mock()
     private val selectedSite: SelectedSite = mock {
@@ -1047,6 +1050,59 @@ class WooPosProductsRemoteDataSourceTest {
             assertFalse(cachedResult.data.any { it.remoteVariationId == 1L })
         }
 
+
+    @Test
+    fun `when local products exist, then searchProducts emits Local then Remote success`() = runTest {
+        // GIVEN
+        whenever(searchProductsDataSource.searchLocalProducts("query"))
+            .thenReturn(sampleProducts)
+        whenever(searchProductsDataSource.searchRemoteProducts("query"))
+            .thenReturn(Result.success(sampleProducts + additionalProducts))
+        val sut = createSUT()
+
+        // WHEN
+        val results = sut.searchProducts("query").toList()
+
+        // THEN
+        assertThat(results[0]).isInstanceOf(SearchProductsResult.Local::class.java)
+        assertThat(results[1]).isInstanceOf(SearchProductsResult.Remote::class.java)
+    }
+
+    @Test
+    fun `when no local products, then searchProducts emits only Remote`() = runTest {
+        // GIVEN
+        whenever(searchProductsDataSource.searchLocalProducts("query"))
+            .thenReturn(emptyList())
+        whenever(searchProductsDataSource.searchRemoteProducts("query"))
+            .thenReturn(Result.success(sampleProducts))
+        val sut = createSUT()
+
+        // WHEN
+        val results = sut.searchProducts("query").toList()
+
+        // THEN
+        assertThat(results[0]).isInstanceOf(SearchProductsResult.Remote::class.java)
+    }
+
+    @Test
+    fun `when remote fails, then searchProducts emits Remote failure`() = runTest {
+        // GIVEN
+        val exception = Exception("Network error")
+        whenever(searchProductsDataSource.searchLocalProducts("query"))
+            .thenReturn(sampleProducts)
+        whenever(searchProductsDataSource.searchRemoteProducts("query"))
+            .thenReturn(Result.failure(exception))
+        val sut = createSUT()
+
+        // WHEN
+        val results = sut.searchProducts("query").toList()
+
+        // THEN
+        val remoteResult = results[1] as SearchProductsResult.Remote
+        assertThat(remoteResult.productsResult.isFailure).isTrue()
+        assertThat(remoteResult.productsResult.exceptionOrNull()).isEqualTo(exception)
+    }
+
     private fun generateProduct(
         productId: Long = 1,
         productName: String = "Product 1",
@@ -1082,7 +1138,8 @@ class WooPosProductsRemoteDataSourceTest {
             variationsHandler,
             variationsCache,
             WooPosVariationsTypesFilterConfig(),
-            variationMapper
+            variationMapper,
+            searchProductsDataSource
         )
         return sut
     }

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/home/items/WooPosProductsRemoteDataSourceTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/home/items/WooPosProductsRemoteDataSourceTest.kt
@@ -52,7 +52,7 @@ import org.wordpress.android.fluxc.network.rest.wpcom.wc.WooResult
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.product.ProductRestClient
 import org.wordpress.android.fluxc.store.WCProductStore
 
-class Blabla {
+class WooPosProductsRemoteDataSourceTest {
     @OptIn(ExperimentalCoroutinesApi::class)
     @Rule
     @JvmField
@@ -1049,7 +1049,6 @@ class Blabla {
 
             assertFalse(cachedResult.data.any { it.remoteVariationId == 1L })
         }
-
 
     @Test
     fun `when local products exist, then searchProducts emits Local then Remote success`() = runTest {

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/home/items/products/WooPosProductsInDbDataSourceTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/home/items/products/WooPosProductsInDbDataSourceTest.kt
@@ -1,9 +1,12 @@
 package com.woocommerce.android.ui.woopos.home.items.products
 
 import com.woocommerce.android.tools.SelectedSite
+import com.woocommerce.android.ui.woopos.common.data.WooPosVariationMapper
 import com.woocommerce.android.ui.woopos.common.data.models.WooPosProductModel
 import com.woocommerce.android.ui.woopos.common.data.models.WooPosProductModelMapper
+import com.woocommerce.android.ui.woopos.home.items.search.WooPosProductsSearchInDbDataSource
 import com.woocommerce.android.ui.woopos.localcatalog.ProductsResult
+import com.woocommerce.android.ui.woopos.localcatalog.WooPosLocalCatalogSyncRepository
 import com.woocommerce.android.ui.woopos.localcatalog.WooPosPerformInstantCatalogFullSync
 import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.flow.toList
@@ -70,8 +73,9 @@ class WooPosProductsInDbDataSourceTest {
             selectedSite = selectedSite,
             productMapper = mapper,
             performInstantCatalogFullSync = performInstantCatalogFullSync,
-            variationMapper = mock(),
-            localCatalogSyncRepository = mock(),
+            variationMapper = mock<WooPosVariationMapper>(),
+            localCatalogSyncRepository = mock<WooPosLocalCatalogSyncRepository>(),
+            localCatalogSearchDataSource = mock<WooPosProductsSearchInDbDataSource>(),
         )
     }
 

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/home/items/search/WooPosItemsSearchViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/home/items/search/WooPosItemsSearchViewModelTest.kt
@@ -9,6 +9,8 @@ import com.woocommerce.android.ui.woopos.home.WooPosParentToChildrenEventReceive
 import com.woocommerce.android.ui.woopos.home.items.WooPosItemSelectionViewState.Product
 import com.woocommerce.android.ui.woopos.home.items.WooPosItemsViewModel.ItemClickedData
 import com.woocommerce.android.ui.woopos.home.items.WooPosPaginationState
+import com.woocommerce.android.ui.woopos.home.items.products.SearchProductsResult
+import com.woocommerce.android.ui.woopos.home.items.products.WooPosProductsDataSource
 import com.woocommerce.android.ui.woopos.util.WooPosCoroutineTestRule
 import com.woocommerce.android.ui.woopos.util.analytics.WooPosAnalyticsEvent
 import com.woocommerce.android.ui.woopos.util.analytics.WooPosAnalyticsEventConstant
@@ -33,19 +35,17 @@ import org.mockito.kotlin.mock
 import org.mockito.kotlin.never
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
-import org.mockito.kotlin.wheneverBlocking
 import java.math.BigDecimal
 
 @ExperimentalCoroutinesApi
 class WooPosItemsSearchViewModelTest {
 
-    @Rule
-    @JvmField
+    @Rule @JvmField
     val coroutinesTestRule = WooPosCoroutineTestRule()
 
     private val mockEmptyStateProvider: WooPosItemsSearchEmptyStateRepository = mock()
     private val mockPriceFormat: WooPosFormatPrice = mock()
-    private val mockDataSource: WooPosSearchProductsDataSource = mock()
+    private val mockDataSource: WooPosProductsDataSource = mock()
     private val mockChildToParentEventSender: WooPosChildrenToParentEventSender = mock()
     private val mockParentToChildrenEventReceiver: WooPosParentToChildrenEventReceiver = mock()
     private val mockSearchHelper: com.woocommerce.android.ui.woopos.home.items.WooPosItemsSearchHelper = mock()
@@ -280,14 +280,13 @@ class WooPosItemsSearchViewModelTest {
     fun `given variable product in search results, when search performed, then mapped correctly to view state`() =
         runTest {
             // GIVEN
-            val variableProduct =
-                generateWooPosProduct(
-                    productId = 1,
-                    productName = "Variable Product",
-                    amount = "10.0",
-                    productType = WooPosProductModel.WooPosProductType.VARIABLE,
-                    variationIds = listOf(101L, 102L, 103L)
-                )
+            val variableProduct = generateWooPosProduct(
+                productId = 1,
+                productName = "Variable Product",
+                amount = "10.0",
+                productType = WooPosProductModel.WooPosProductType.VARIABLE,
+                variationIds = listOf(101L, 102L, 103L)
+            )
 
             mockSuccessfulSearch(defaultQuery, listOf(variableProduct))
 
@@ -414,6 +413,10 @@ class WooPosItemsSearchViewModelTest {
 
         // THEN
         viewModel.viewState.test {
+            skipItems(1) // Skip initial EmptySearchQuery state
+
+            advanceUntilIdle()
+
             val cachedState = awaitItem() as WooPosItemsSearchViewState.Content
             assertThat(cachedState.items).hasSize(1)
             assertThat((cachedState.items[0] as Product.Simple).name).isEqualTo("Cached Product")
@@ -445,10 +448,19 @@ class WooPosItemsSearchViewModelTest {
             )
         )
 
-        whenever(mockDataSource.searchLocalProducts(query1)).thenReturn(emptyList())
-        whenever(mockDataSource.searchRemoteProducts(query1)).thenReturn(Result.success(emptyList()))
-        whenever(mockDataSource.searchLocalProducts(query2)).thenReturn(emptyList())
-        whenever(mockDataSource.searchRemoteProducts(query2)).thenReturn(Result.success(products))
+        whenever(mockDataSource.searchProducts(query1)).thenReturn(
+            flowOf(
+                SearchProductsResult.Local(emptyList()),
+                SearchProductsResult.Remote(Result.success(emptyList()), 100L)
+            )
+        )
+        whenever(mockDataSource.searchProducts(query2)).thenReturn(
+            flowOf(
+                SearchProductsResult.Local(emptyList()),
+                SearchProductsResult.Remote(Result.success(products), 100L)
+            )
+        )
+        whenever(mockDataSource.hasMoreSearchPages).thenReturn(false)
 
         whenever(mockPriceFormat(BigDecimal("10.0"))).thenReturn("$10.0")
 
@@ -462,11 +474,12 @@ class WooPosItemsSearchViewModelTest {
 
         // WHEN
         val viewModel = createViewModel()
-        advanceTimeBy(600)
 
         // THEN
         viewModel.viewState.test {
-            skipItems(1)
+            skipItems(1) // Skip initial EmptySearchQuery state
+
+            advanceUntilIdle()
 
             val contentState = awaitItem() as WooPosItemsSearchViewState.Content
             assertThat(contentState.searchQuery).isEqualTo(query2)
@@ -490,8 +503,13 @@ class WooPosItemsSearchViewModelTest {
         whenever(mockEmptyStateProvider.getPopularItems()).thenReturn(emptyList())
         whenever(mockEmptyStateProvider.getLastSearches()).thenReturn(emptyList())
 
-        whenever(mockDataSource.searchLocalProducts(query)).thenReturn(emptyList())
-        whenever(mockDataSource.searchRemoteProducts(query)).thenReturn(Result.success(products))
+        whenever(mockDataSource.searchProducts(query)).thenReturn(
+            flow {
+                emit(SearchProductsResult.Local(emptyList()))
+                delay(100)
+                emit(SearchProductsResult.Remote(Result.success(products), 100L))
+            }
+        )
 
         whenever(mockPriceFormat(BigDecimal("10.0"))).thenReturn("$10.0")
         whenever(mockParentToChildrenEventReceiver.events).thenReturn(
@@ -503,6 +521,10 @@ class WooPosItemsSearchViewModelTest {
 
         // THEN
         viewModel.viewState.test {
+            skipItems(1) // Skip initial EmptySearchQuery state
+
+            advanceUntilIdle()
+
             val loadingState = awaitItem()
             assertThat(loadingState).isInstanceOf(WooPosItemsSearchViewState.Loading::class.java)
 
@@ -528,10 +550,12 @@ class WooPosItemsSearchViewModelTest {
             whenever(mockEmptyStateProvider.getPopularItems()).thenReturn(emptyList())
             whenever(mockEmptyStateProvider.getLastSearches()).thenReturn(emptyList())
 
-            whenever(mockDataSource.searchLocalProducts(query)).thenReturn(emptyList())
-            whenever(mockDataSource.searchRemoteProducts(query)).thenReturn(Result.success(products))
-
-            whenever(mockDataSource.hasMorePages).thenReturn(false)
+            whenever(mockDataSource.searchProducts(query)).thenReturn(
+                flowOf(
+                    SearchProductsResult.Remote(Result.success(products), 100L)
+                )
+            )
+            whenever(mockDataSource.hasMoreSearchPages).thenReturn(false)
 
             whenever(mockPriceFormat(BigDecimal("10.0"))).thenReturn("$10.0")
             whenever(mockParentToChildrenEventReceiver.events).thenReturn(
@@ -540,7 +564,7 @@ class WooPosItemsSearchViewModelTest {
 
             // WHEN
             val viewModel = createViewModel()
-            advanceTimeBy(600)
+            advanceUntilIdle()
 
             // THEN
             viewModel.viewState.test {
@@ -568,10 +592,14 @@ class WooPosItemsSearchViewModelTest {
         whenever(mockEmptyStateProvider.getPopularItems()).thenReturn(emptyList())
         whenever(mockEmptyStateProvider.getLastSearches()).thenReturn(emptyList())
 
-        whenever(mockDataSource.searchLocalProducts(query)).thenReturn(emptyList())
-        whenever(mockDataSource.searchRemoteProducts(query)).thenReturn(
-            Result.failure(Exception("Search failed")),
-            Result.success(products)
+        whenever(mockDataSource.searchProducts(query)).thenReturn(
+            flowOf(
+                SearchProductsResult.Remote(Result.failure(Exception("Search failed")), 100L)
+            )
+        ).thenReturn(
+            flowOf(
+                SearchProductsResult.Remote(Result.success(products), 100L)
+            )
         )
 
         whenever(mockPriceFormat(BigDecimal("10.0"))).thenReturn("$10.0")
@@ -581,7 +609,7 @@ class WooPosItemsSearchViewModelTest {
 
         // WHEN
         val viewModel = createViewModel()
-        advanceTimeBy(600)
+        advanceUntilIdle()
 
         // THEN
         viewModel.viewState.test {
@@ -684,7 +712,7 @@ class WooPosItemsSearchViewModelTest {
 
             // WHEN
             val viewModel = createViewModel()
-            advanceTimeBy(600)
+            advanceUntilIdle()
             viewModel.onUIEvent(WooPosItemsSearchUiEvent.OnItemClicked(simpleProduct))
 
             // THEN
@@ -785,31 +813,39 @@ class WooPosItemsSearchViewModelTest {
         }
 
     private fun mockSuccessfulSearch(query: String, products: List<WooPosProductModel>) {
-        wheneverBlocking { mockDataSource.searchLocalProducts(query) }.thenReturn(emptyList())
-        wheneverBlocking { mockDataSource.searchRemoteProducts(query) }.thenReturn(Result.success(products))
+        whenever(mockDataSource.searchProducts(query)).thenReturn(
+            flowOf(
+                SearchProductsResult.Local(emptyList()),
+                SearchProductsResult.Remote(Result.success(products), 100L)
+            )
+        )
         whenever(mockParentToChildrenEventReceiver.events).thenReturn(
             flowOf(ParentToChildrenEvent.SearchEvent.ChangedQuery(query))
         )
     }
 
     private fun mockFailedSearch(query: String, error: Exception) {
-        wheneverBlocking { mockDataSource.searchLocalProducts(query) }.thenReturn(emptyList())
-        wheneverBlocking { mockDataSource.searchRemoteProducts(query) }.thenReturn(Result.failure(error))
+        whenever(mockDataSource.searchProducts(query)).thenReturn(
+            flowOf(
+                SearchProductsResult.Local(emptyList()),
+                SearchProductsResult.Remote(Result.failure(error), 100L)
+            )
+        )
         whenever(mockParentToChildrenEventReceiver.events).thenReturn(
             flowOf(ParentToChildrenEvent.SearchEvent.ChangedQuery(query))
         )
     }
 
     private suspend fun mockSuccessfulPagination(query: String, products: List<WooPosProductModel>) {
-        whenever(mockDataSource.hasMorePages).thenReturn(true)
-        whenever(mockDataSource.loadMore(query)).thenReturn(
+        whenever(mockDataSource.hasMoreSearchPages).thenReturn(true)
+        whenever(mockDataSource.loadMoreSearchResults(query)).thenReturn(
             Result.success(products)
         )
     }
 
     private suspend fun mockFailedPagination(query: String, error: Exception) {
-        whenever(mockDataSource.hasMorePages).thenReturn(true)
-        whenever(mockDataSource.loadMore(query)).thenReturn(
+        whenever(mockDataSource.hasMoreSearchPages).thenReturn(true)
+        whenever(mockDataSource.loadMoreSearchResults(query)).thenReturn(
             Result.failure(error)
         )
     }
@@ -819,12 +855,13 @@ class WooPosItemsSearchViewModelTest {
         cachedProduct: WooPosProductModel,
         remoteProduct: WooPosProductModel
     ) {
-        wheneverBlocking { mockDataSource.searchLocalProducts(query) }.thenReturn(listOf(cachedProduct))
-        wheneverBlocking {
-            mockDataSource.searchRemoteProducts(
-                query
-            )
-        }.thenReturn(Result.success(listOf(remoteProduct)))
+        whenever(mockDataSource.searchProducts(query)).thenReturn(
+            flow {
+                emit(SearchProductsResult.Local(listOf(cachedProduct)))
+                delay(100) // Small delay between emissions
+                emit(SearchProductsResult.Remote(Result.success(listOf(remoteProduct)), 100L))
+            }
+        )
         whenever(mockParentToChildrenEventReceiver.events).thenReturn(
             flowOf(ParentToChildrenEvent.SearchEvent.ChangedQuery(query))
         )

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/home/items/search/WooPosItemsSearchViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/home/items/search/WooPosItemsSearchViewModelTest.kt
@@ -521,13 +521,10 @@ class WooPosItemsSearchViewModelTest {
 
         // THEN
         viewModel.viewState.test {
-            skipItems(1) // Skip initial EmptySearchQuery state
-
-            advanceUntilIdle()
-
             val loadingState = awaitItem()
             assertThat(loadingState).isInstanceOf(WooPosItemsSearchViewState.Loading::class.java)
 
+            advanceUntilIdle()
             val contentState = awaitItem() as WooPosItemsSearchViewState.Content
             assertThat(contentState.items).hasSize(1)
         }


### PR DESCRIPTION
Fixes WOOMOB-1075

Do not merge - target branch must be trunk.

### Description
This PR completes the local catalog search implementation by integrating the search infrastructure (from part 1) with existing UI components and ViewModels.

**Key Changes:**
- Add search interface definitions to `WooPosProductsDataSourceInterface`
- Integrate local search functionality in `WooPosProductsDataSource`
- Refactor `WooPosItemsSearchViewModel` to use unified search approach
- Update all related tests for modified components

This is part 2 of 2, building on the search infrastructure added in part 1. The feature is now fully functional end-to-end.

### Test Steps
Test with site with local catalog enabled
- Test search works when you enter a valid query
- Test empty result is shown when you enter a query that has no results
- Compare results returned by this version of the app compared to production version

Test the above on site with local catalog disabled. Also verify the search returns cached result first and then results from remote. 


### Images/gif

No user facing changes - just faster search with local catalog.

- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.