### PR TITLE
[POS Orders] Improve loading by doing it lazily

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/orders/WooPosOrdersDetails.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/orders/WooPosOrdersDetails.kt
@@ -45,7 +45,7 @@ import com.woocommerce.android.ui.woopos.common.composeui.designsystem.WooPosTyp
 @Composable
 fun WooPosOrderDetails(
     modifier: Modifier = Modifier,
-    details: OrderDetailsViewState,
+    details: OrderDetailsViewState.Computed.Details,
     onEmailReceiptButtonClicked: (Long) -> Unit
 ) {
     Column(
@@ -89,7 +89,7 @@ fun WooPosOrderDetails(
 }
 
 @Composable
-private fun OrdersHeader(details: OrderDetailsViewState) {
+private fun OrdersHeader(details: OrderDetailsViewState.Computed.Details) {
     Column(modifier = Modifier.fillMaxWidth()) {
         WooPosText(
             text = details.dateTime,
@@ -113,7 +113,7 @@ private fun OrdersHeader(details: OrderDetailsViewState) {
 }
 
 @Composable
-private fun OrdersProducts(lineItems: List<OrderDetailsViewState.LineItemRow>) {
+private fun OrdersProducts(lineItems: List<OrderDetailsViewState.Computed.Details.LineItemRow>) {
     WooPosCard(shadowType = ShadowType.Soft) {
         Column(Modifier.padding(WooPosSpacing.Medium.value)) {
             WooPosText(
@@ -137,7 +137,7 @@ private fun OrdersProducts(lineItems: List<OrderDetailsViewState.LineItemRow>) {
 
 @Composable
 @Suppress("DestructuringDeclarationWithTooManyEntries")
-private fun OrderProductItem(row: OrderDetailsViewState.LineItemRow) {
+private fun OrderProductItem(row: OrderDetailsViewState.Computed.Details.LineItemRow) {
     ConstraintLayout(
         modifier = Modifier
             .fillMaxWidth()
@@ -189,7 +189,7 @@ private fun OrderProductItem(row: OrderDetailsViewState.LineItemRow) {
 }
 
 @Composable
-private fun OrdersTotals(details: OrderDetailsViewState) {
+private fun OrdersTotals(details: OrderDetailsViewState.Computed.Details) {
     WooPosCard(shadowType = ShadowType.Soft) {
         Column(Modifier.padding(WooPosSpacing.Medium.value)) {
             WooPosText(
@@ -348,18 +348,18 @@ private fun DividerWithSpacing() {
 @WooPosPreview
 @Composable
 fun WooPosOrderDetailsPreview() {
-    val orderDetails = OrderDetailsViewState(
+    val orderDetails = OrderDetailsViewState.Computed.Details(
         id = 1L,
         number = "#014",
         dateTime = "Aug 28, 2025 at 10:31 AM",
         customerEmail = "johndoe@mail.com",
         status = PosOrderStatus(text = "Completed", colorKey = OrderStatusColorKey.COMPLETED),
         lineItems = listOf(
-            OrderDetailsViewState.LineItemRow(101, "Cup", "2 x $4.00", "$8.00", null),
-            OrderDetailsViewState.LineItemRow(102, "Coffee Container", "1 x $10.00", "$10.00", null),
-            OrderDetailsViewState.LineItemRow(103, "Paper Filter", "1 x $5.00", "$5.00", null)
+            OrderDetailsViewState.Computed.Details.LineItemRow(101, "Cup", "2 x $4.00", "$8.00", null),
+            OrderDetailsViewState.Computed.Details.LineItemRow(102, "Coffee Container", "1 x $10.00", "$10.00", null),
+            OrderDetailsViewState.Computed.Details.LineItemRow(103, "Paper Filter", "1 x $5.00", "$5.00", null)
         ),
-        breakdown = OrderDetailsViewState.TotalsBreakdown(
+        breakdown = OrderDetailsViewState.Computed.Details.TotalsBreakdown(
             products = "$23.00",
             discount = "-$5.00",
             discountCode = "SAVE5",

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/orders/WooPosOrdersScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/orders/WooPosOrdersScreen.kt
@@ -524,8 +524,8 @@ fun WooPosOrdersScreenPreview() {
             state = WooPosOrdersState.Content(
                 items = WooPosOrdersState.Content.Items.Loaded(
                     items = mapOf(
-                        item1 to details1,
-                        item2 to details2
+                        item1 to OrderDetailsViewState.Computed(orderId = 1L, details = details1),
+                        item2 to OrderDetailsViewState.Computed(orderId = 2L, details = details2)
                     )
                 ),
                 pullToRefreshState = WooPosPullToRefreshState.Enabled,
@@ -617,18 +617,18 @@ fun WooPosOrdersNothingFoundStatePreview() {
 private fun sampleOrderDetails(
     id: Long = 1L,
     number: String = "#014"
-) = OrderDetailsViewState(
+) = OrderDetailsViewState.Computed.Details(
     id = id,
     number = number,
     dateTime = "Aug 28, 2025 at 10:31 AM",
     customerEmail = "johndoe@mail.com",
     status = PosOrderStatus(text = "Completed", colorKey = OrderStatusColorKey.COMPLETED),
     lineItems = listOf(
-        OrderDetailsViewState.LineItemRow(101, "Cup", "1 x $8.50", "$15.00", null),
-        OrderDetailsViewState.LineItemRow(102, "Coffee Container", "1 x $10.00", "$8.00", null),
-        OrderDetailsViewState.LineItemRow(103, "Paper Filter", "1 x $4.50", "$8.00", null)
+        OrderDetailsViewState.Computed.Details.LineItemRow(101, "Cup", "1 x $8.50", "$15.00", null),
+        OrderDetailsViewState.Computed.Details.LineItemRow(102, "Coffee Container", "1 x $10.00", "$8.00", null),
+        OrderDetailsViewState.Computed.Details.LineItemRow(103, "Paper Filter", "1 x $4.50", "$8.00", null)
     ),
-    breakdown = OrderDetailsViewState.TotalsBreakdown(
+    breakdown = OrderDetailsViewState.Computed.Details.TotalsBreakdown(
         products = "$23.00",
         discount = "-$5.00",
         discountCode = "8qew4mnq",

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/orders/WooPosOrdersState.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/orders/WooPosOrdersState.kt
@@ -1,44 +1,62 @@
 package com.woocommerce.android.ui.woopos.orders
 
 import androidx.compose.runtime.Immutable
+import com.woocommerce.android.model.Order
 import com.woocommerce.android.model.Order.Status
 import com.woocommerce.android.ui.woopos.common.composeui.component.WooPosSearchInputState
 import com.woocommerce.android.ui.woopos.home.items.WooPosPaginationState
 import com.woocommerce.android.ui.woopos.home.items.WooPosPullToRefreshState
 
 @Immutable
-data class OrderDetailsViewState(
-    val id: Long,
-    val number: String,
-    val dateTime: String,
-    val customerEmail: String?,
-    val status: PosOrderStatus,
-
-    val lineItems: List<LineItemRow>,
-    val breakdown: TotalsBreakdown,
-    val total: String,
-    val totalPaid: String,
-    val paymentMethodTitle: String?,
-) {
-    @Immutable
-    data class LineItemRow(
-        val id: Long,
-        val name: String,
-        val qtyAndUnitPrice: String,
-        val lineTotal: String,
-        val imageUrl: String?,
-    )
+sealed class OrderDetailsViewState {
+    abstract val orderId: Long
 
     @Immutable
-    data class TotalsBreakdown(
-        val products: String,
-        val discount: String?,
-        val discountCode: String?,
-        val taxes: String,
-        val shipping: String?,
-        val refunds: List<String>,
-        val netPayment: String?
-    )
+    data class Lazy(
+        override val orderId: Long,
+        val order: Order
+    ) : OrderDetailsViewState()
+
+    @Immutable
+    data class Computed(
+        override val orderId: Long,
+        val details: Details
+    ) : OrderDetailsViewState() {
+        @Immutable
+        data class Details(
+            val id: Long,
+            val number: String,
+            val dateTime: String,
+            val customerEmail: String?,
+            val status: PosOrderStatus,
+
+            val lineItems: List<LineItemRow>,
+            val breakdown: TotalsBreakdown,
+            val total: String,
+            val totalPaid: String,
+            val paymentMethodTitle: String?,
+        ) {
+            @Immutable
+            data class LineItemRow(
+                val id: Long,
+                val name: String,
+                val qtyAndUnitPrice: String,
+                val lineTotal: String,
+                val imageUrl: String?,
+            )
+
+            @Immutable
+            data class TotalsBreakdown(
+                val products: String,
+                val discount: String?,
+                val discountCode: String?,
+                val taxes: String,
+                val shipping: String?,
+                val refunds: List<String>,
+                val netPayment: String?
+            )
+        }
+    }
 }
 
 @Immutable
@@ -64,7 +82,7 @@ sealed class WooPosOrdersState {
         val items: Items,
         override val pullToRefreshState: WooPosPullToRefreshState,
         override val searchInputState: WooPosSearchInputState,
-        val selectedDetails: OrderDetailsViewState,
+        val selectedDetails: OrderDetailsViewState.Computed.Details,
         val paginationState: WooPosPaginationState
     ) : WooPosOrdersState() {
         sealed class Items {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/orders/WooPosOrdersViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/orders/WooPosOrdersViewModel.kt
@@ -18,6 +18,9 @@ import com.woocommerce.android.ui.woopos.util.format.WooPosFormatPrice
 import com.woocommerce.android.viewmodel.ResourceProvider
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.Job
+import kotlinx.coroutines.async
+import kotlinx.coroutines.awaitAll
+import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -94,18 +97,26 @@ class WooPosOrdersViewModel @Inject constructor(
             }
         }
 
-        val updatedItems = loadedItems.items.mapKeys { (item, _) ->
-            item.copy(isSelected = item.id == orderId)
+        viewModelScope.launch {
+            val details = getOrComputeDetails(orderId)
+
+            val updatedItems = loadedItems.items.mapKeys { (item, _) ->
+                item.copy(isSelected = item.id == orderId)
+            }.mapValues { (item, orderDetails) ->
+                if (item.id == orderId && orderDetails is OrderDetailsViewState.Lazy) {
+                    OrderDetailsViewState.Computed(orderId = orderId, details = details)
+                } else {
+                    orderDetails
+                }
+            }
+
+            _state.value = current.copy(
+                items = WooPosOrdersState.Content.Items.Loaded(
+                    items = updatedItems
+                ),
+                selectedDetails = details
+            )
         }
-
-        val selectedEntry = updatedItems.entries.first { (item, _) -> item.isSelected }
-
-        _state.value = current.copy(
-            items = WooPosOrdersState.Content.Items.Loaded(
-                items = updatedItems
-            ),
-            selectedDetails = selectedEntry.value
-        )
     }
 
     fun onRefresh() {
@@ -282,7 +293,11 @@ class WooPosOrdersViewModel @Inject constructor(
 
         val selectedId = loaded.items.keys.firstOrNull { it.isSelected }?.id
         val newItem = mapOrderItem(updated, selectedId)
-        val newDetails = mapOrderDetails(updated)
+        val newDetailsViewState = mapOrderDetails(updated)
+        val newDetails = OrderDetailsViewState.Computed(
+            orderId = updated.id,
+            details = newDetailsViewState
+        )
 
         val newMap = loaded.items.entries.associate { (item, details) ->
             if (item.id == updated.id) newItem to newDetails else item to details
@@ -290,7 +305,7 @@ class WooPosOrdersViewModel @Inject constructor(
 
         _state.value = current.copy(
             items = WooPosOrdersState.Content.Items.Loaded(newMap),
-            selectedDetails = if (selectedId == updated.id) newDetails else current.selectedDetails
+            selectedDetails = if (selectedId == updated.id) newDetailsViewState else current.selectedDetails
         )
     }
 
@@ -406,6 +421,19 @@ class WooPosOrdersViewModel @Inject constructor(
         loadingMoreOrdersJob?.cancel()
     }
 
+    private suspend fun getOrComputeDetails(orderId: Long): OrderDetailsViewState.Computed.Details {
+        val current = _state.value as? WooPosOrdersState.Content ?: error("State is not Content")
+        val loadedItems = current.items as? WooPosOrdersState.Content.Items.Loaded ?: error("Items not loaded")
+
+        val orderDetails = loadedItems.items.values.firstOrNull { it.orderId == orderId }
+            ?: error("Order $orderId not found in state")
+
+        return when (orderDetails) {
+            is OrderDetailsViewState.Lazy -> mapOrderDetails(orderDetails.order)
+            is OrderDetailsViewState.Computed -> orderDetails.details
+        }
+    }
+
     private suspend fun replaceOrders(
         orders: List<Order>,
         paginationState: WooPosPaginationState = WooPosPaginationState.None
@@ -413,13 +441,17 @@ class WooPosOrdersViewModel @Inject constructor(
         val newSelectedId = requireNotNull(orders.firstOrNull()?.id) { "Content requires at least one order" }
         val items = buildItemsMap(orders, newSelectedId)
         val selectedEntry = items.entries.first { (item, _) -> item.isSelected }
+        val selectedDetails = when (val details = selectedEntry.value) {
+            is OrderDetailsViewState.Computed -> details.details
+            is OrderDetailsViewState.Lazy -> error("Selected order should have computed details")
+        }
 
         _state.value = WooPosOrdersState.Content(
             items = WooPosOrdersState.Content.Items.Loaded(
                 items = items
             ),
             pullToRefreshState = WooPosPullToRefreshState.Enabled,
-            selectedDetails = selectedEntry.value,
+            selectedDetails = selectedDetails,
             paginationState = paginationState,
             searchInputState = _state.value.searchInputState
         )
@@ -449,12 +481,20 @@ class WooPosOrdersViewModel @Inject constructor(
     private suspend fun buildItemsMap(
         orders: List<Order>,
         selectedId: Long?
-    ): Map<OrderItemViewState, OrderDetailsViewState> {
-        return orders.associate { order ->
-            val item = mapOrderItem(order, selectedId)
-            val details = mapOrderDetails(order)
-            item to details
-        }
+    ): Map<OrderItemViewState, OrderDetailsViewState> = coroutineScope {
+        orders.map { order ->
+            async {
+                val item = mapOrderItem(order, selectedId)
+                val details: OrderDetailsViewState = if (order.id == selectedId) {
+                    val fullDetails = mapOrderDetails(order)
+                    OrderDetailsViewState.Computed(orderId = order.id, details = fullDetails)
+                } else {
+                    OrderDetailsViewState.Lazy(orderId = order.id, order = order)
+                }
+
+                item to details
+            }
+        }.awaitAll().toMap()
     }
 
     private suspend fun mapOrderItem(order: Order, selectedId: Long?): OrderItemViewState {
@@ -478,7 +518,7 @@ class WooPosOrdersViewModel @Inject constructor(
         )
     }
 
-    private suspend fun mapOrderDetails(order: Order): OrderDetailsViewState {
+    private suspend fun mapOrderDetails(order: Order): OrderDetailsViewState.Computed.Details = coroutineScope {
         val statusText = order.status.localizedLabel(resourceProvider, locale)
 
         val status = PosOrderStatus(
@@ -486,21 +526,26 @@ class WooPosOrdersViewModel @Inject constructor(
             colorKey = OrderStatusColorKey.fromStatus(order.status)
         )
 
-        val lineItems = order.items.map { item ->
-            val unitPrice = if (item.quantity == 0f) item.total else item.total / item.quantity.toBigDecimal()
-            val product = getProductById(item.productId)
-            OrderDetailsViewState.LineItemRow(
-                id = item.itemId,
-                name = item.name,
-                qtyAndUnitPrice = "${item.quantity.toInt()} x ${formatPrice(unitPrice)}",
-                lineTotal = formatPrice(item.total),
-                imageUrl = product?.firstImageUrl
-            )
+        val lineItemsDeferred = order.items.map { item ->
+            async {
+                val unitPrice = if (item.quantity == 0f) item.total else item.total / item.quantity.toBigDecimal()
+                val product = getProductById(item.productId)
+                OrderDetailsViewState.Computed.Details.LineItemRow(
+                    id = item.itemId,
+                    name = item.name,
+                    qtyAndUnitPrice = "${item.quantity.toInt()} x ${formatPrice(unitPrice)}",
+                    lineTotal = formatPrice(item.total),
+                    imageUrl = product?.firstImageUrl
+                )
+            }
         }
 
         val discountCode = order.couponLines.firstOrNull()?.code
 
-        val refunds = getOrderRefunds(order.id)
+        val refundsDeferred = async { getOrderRefunds(order.id) }
+
+        val lineItems = lineItemsDeferred.awaitAll()
+        val refunds = refundsDeferred.await()
         val refundAmounts = refunds.map { "-${formatPrice(it.amount)}" }
         val totalRefunded = refunds.sumOf { it.amount }
         val netPayment = if (totalRefunded > BigDecimal.ZERO) {
@@ -509,7 +554,7 @@ class WooPosOrdersViewModel @Inject constructor(
             null
         }
 
-        val breakdown = OrderDetailsViewState.TotalsBreakdown(
+        val breakdown = OrderDetailsViewState.Computed.Details.TotalsBreakdown(
             products = formatPrice(order.productsTotal),
             discount = order.discountTotal.takeIf { it != BigDecimal.ZERO }?.let { "-${formatPrice(it)}" },
             discountCode = discountCode,
@@ -519,7 +564,7 @@ class WooPosOrdersViewModel @Inject constructor(
             netPayment = netPayment
         )
 
-        return OrderDetailsViewState(
+        OrderDetailsViewState.Computed.Details(
             id = order.id,
             number = "#${order.number}",
             dateTime = order.dateCreated.formatToMMMddYYYYAtHHmm(


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

<!-- Id number of the Linear issue this PR addresses, e.g., WOOMOB-373. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
With this PR we improve the loading times of the POS Orders screen by loading them lazily. See more about it here https://github.com/woocommerce/woocommerce-android/pull/14892

### Test Steps
<!-- Describe how to test your changes. Include only what’s needed for the reviewer to validate the behavior.
For new features, outline the main user flow or goal rather than every tap or click — the reviewer should be able to complete the flow naturally.
If applicable, mention key devices, scenarios, or edge cases to verify. -->

1. Go to POS
2. Open Orders
3. First time, it takes a while to load because it is fetching remotely
4. Go back to POS Homescreen and back to Orders
5. This time, we had the orders cached, so it should show almost immediately.
6. Select different orders to check that they are properly loaded.

### Images/gif
<!-- Include before and after images or gifs when appropriate. -->

https://github.com/user-attachments/assets/8f1ff8c5-b6c6-4d67-a34b-5fad076290a6


- [X] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
