### PR TITLE
Fix `trunk`: WooPosLocalCatalogSyncWorkerTest

### DIFF
--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/localcatalog/WooPosLocalCatalogSyncWorkerTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/localcatalog/WooPosLocalCatalogSyncWorkerTest.kt
@@ -333,8 +333,9 @@ class WooPosLocalCatalogSyncWorkerTest : BaseUnitTest() {
     @Test
     fun `given sync overdue, when validateSyncStatus is called, then proceeds with sync`() = testBlocking {
         // GIVEN
+        val lastSyncTimestamp = CURRENT_TIME_MILLIS - (8 * 24 * 60 * 60 * 1000L) // 8 days ago
         whenever(syncStatusChecker.checkSyncRequirement())
-            .thenReturn(WooPosFullSyncRequirement.Overdue)
+            .thenReturn(WooPosFullSyncRequirement.NonBlockingRequired(lastSyncTimestamp, isOverdue = true))
 
         val worker = createWorker()
 


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

<!-- Id number of the Linear issue this PR addresses, e.g., WOOMOB-373. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
Build fails on trunk due to https://github.com/woocommerce/woocommerce-android/pull/14894 being merged to `trunk` out of sync.

### Test Steps
<!-- Describe how to test your changes. Include only what’s needed for the reviewer to validate the behavior.
For new features, outline the main user flow or goal rather than every tap or click — the reviewer should be able to complete the flow naturally.
If applicable, mention key devices, scenarios, or edge cases to verify. -->
Green CI is enough

### Images/gif
<!-- Include before and after images or gifs when appropriate. -->
N/A

- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
