### PR TITLE
[Bookings] Unsaved changes dialog to Filters screen

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/bookings/filter/BookingFilterListScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/bookings/filter/BookingFilterListScreen.kt
@@ -13,7 +13,6 @@ import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
-import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
@@ -30,9 +29,9 @@ import androidx.navigation.compose.composable
 import androidx.navigation.compose.rememberNavController
 import com.woocommerce.android.R
 import com.woocommerce.android.ui.bookings.filter.type.BookingTypeFilterRoute
+import com.woocommerce.android.ui.compose.Render
 import com.woocommerce.android.ui.compose.component.Toolbar
 import com.woocommerce.android.ui.compose.component.WCColoredButton
-import com.woocommerce.android.ui.compose.component.WCTextButton
 import com.woocommerce.android.ui.compose.preview.LightDarkThemePreviews
 import com.woocommerce.android.ui.compose.theme.WooThemeWithBackground
 
@@ -75,24 +74,7 @@ fun BookingFilterListScreen(state: BookingFilterListUiState) {
                 .padding(innerPadding)
         )
 
-        if (state.unsavedChangesDialog.isVisible) {
-            AlertDialog(
-                onDismissRequest = state.unsavedChangesDialog.onDismiss,
-                text = { Text(stringResource(id = R.string.discard_message)) },
-                dismissButton = {
-                    WCTextButton(
-                        text = stringResource(id = R.string.keep_changes),
-                        onClick = state.unsavedChangesDialog.onDismiss
-                    )
-                },
-                confirmButton = {
-                    WCTextButton(
-                        text = stringResource(id = R.string.discard),
-                        onClick = state.unsavedChangesDialog.onDiscardChanges
-                    )
-                }
-            )
-        }
+        state.unsavedChangesDialogState?.Render()
 
         // The navigation is driven by the state, so we handle back navigation by calling onClose
         // We need to ensure that this called after NavHost to make sure we receive back events

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/bookings/filter/BookingFilterListScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/bookings/filter/BookingFilterListScreen.kt
@@ -13,6 +13,7 @@ import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
@@ -31,6 +32,7 @@ import com.woocommerce.android.R
 import com.woocommerce.android.ui.bookings.filter.type.BookingTypeFilterRoute
 import com.woocommerce.android.ui.compose.component.Toolbar
 import com.woocommerce.android.ui.compose.component.WCColoredButton
+import com.woocommerce.android.ui.compose.component.WCTextButton
 import com.woocommerce.android.ui.compose.preview.LightDarkThemePreviews
 import com.woocommerce.android.ui.compose.theme.WooThemeWithBackground
 
@@ -72,6 +74,25 @@ fun BookingFilterListScreen(state: BookingFilterListUiState) {
                 .fillMaxSize()
                 .padding(innerPadding)
         )
+
+        if (state.unsavedChangesDialog.isVisible) {
+            AlertDialog(
+                onDismissRequest = state.unsavedChangesDialog.onDismiss,
+                text = { Text(stringResource(id = R.string.discard_message)) },
+                dismissButton = {
+                    WCTextButton(
+                        text = stringResource(id = R.string.keep_changes),
+                        onClick = state.unsavedChangesDialog.onDismiss
+                    )
+                },
+                confirmButton = {
+                    WCTextButton(
+                        text = stringResource(id = R.string.discard),
+                        onClick = state.unsavedChangesDialog.onDiscardChanges
+                    )
+                }
+            )
+        }
 
         // The navigation is driven by the state, so we handle back navigation by calling onClose
         // We need to ensure that this called after NavHost to make sure we receive back events

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/bookings/filter/BookingFilterListScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/bookings/filter/BookingFilterListScreen.kt
@@ -74,7 +74,7 @@ fun BookingFilterListScreen(state: BookingFilterListUiState) {
                 .padding(innerPadding)
         )
 
-        state.unsavedChangesDialogState?.Render()
+        state.dialogState?.Render()
 
         // The navigation is driven by the state, so we handle back navigation by calling onClose
         // We need to ensure that this called after NavHost to make sure we receive back events

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/bookings/filter/BookingFilterListUiState.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/bookings/filter/BookingFilterListUiState.kt
@@ -20,10 +20,17 @@ enum class BookingFilterPage {
     Location,
 }
 
+data class UnsavedChangesDialogState(
+    val isVisible: Boolean = false,
+    val onDismiss: () -> Unit = {},
+    val onDiscardChanges: () -> Unit = {},
+)
+
 data class BookingFilterListUiState(
     val initialBookingFilters: BookingFilters? = null,
     val newBookingFilters: Set<BookingsFilterOption> = emptySet(),
     val currentPage: BookingFilterPage = BookingFilterPage.List,
+    val unsavedChangesDialog: UnsavedChangesDialogState = UnsavedChangesDialogState(),
     val onClose: () -> Unit = {},
     val onShowBookings: () -> Unit = {},
     val openPage: (BookingFilterPage) -> Unit = {},

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/bookings/filter/BookingFilterListUiState.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/bookings/filter/BookingFilterListUiState.kt
@@ -25,7 +25,7 @@ data class BookingFilterListUiState(
     val initialBookingFilters: BookingFilters? = null,
     val newBookingFilters: Set<BookingsFilterOption> = emptySet(),
     val currentPage: BookingFilterPage = BookingFilterPage.List,
-    val unsavedChangesDialogState: DialogState? = null,
+    val dialogState: DialogState? = null,
     val onClose: () -> Unit = {},
     val onShowBookings: () -> Unit = {},
     val openPage: (BookingFilterPage) -> Unit = {},

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/bookings/filter/BookingFilterListUiState.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/bookings/filter/BookingFilterListUiState.kt
@@ -5,6 +5,7 @@ import androidx.annotation.StringRes
 import com.woocommerce.android.R
 import com.woocommerce.android.model.UiString
 import com.woocommerce.android.ui.bookings.filter.type.titleRes
+import com.woocommerce.android.ui.compose.DialogState
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.bookings.BookingFilters
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.bookings.BookingsFilterOption
 
@@ -20,17 +21,11 @@ enum class BookingFilterPage {
     Location,
 }
 
-data class UnsavedChangesDialogState(
-    val isVisible: Boolean = false,
-    val onDismiss: () -> Unit = {},
-    val onDiscardChanges: () -> Unit = {},
-)
-
 data class BookingFilterListUiState(
     val initialBookingFilters: BookingFilters? = null,
     val newBookingFilters: Set<BookingsFilterOption> = emptySet(),
     val currentPage: BookingFilterPage = BookingFilterPage.List,
-    val unsavedChangesDialog: UnsavedChangesDialogState = UnsavedChangesDialogState(),
+    val unsavedChangesDialogState: DialogState? = null,
     val onClose: () -> Unit = {},
     val onShowBookings: () -> Unit = {},
     val openPage: (BookingFilterPage) -> Unit = {},

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/bookings/filter/BookingFilterListViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/bookings/filter/BookingFilterListViewModel.kt
@@ -26,6 +26,11 @@ class BookingFilterListViewModel @Inject constructor(
             onShowBookings = ::onShowBookings,
             openPage = ::onOpenPage,
             onUpdateFilterOption = ::onUpdateFilterOption,
+            unsavedChangesDialog = UnsavedChangesDialogState(
+                isVisible = false,
+                onDismiss = ::onDismissUnsavedChangesDialog,
+                onDiscardChanges = ::onDiscardChanges,
+            )
         )
     )
     val uiState = _uiState.asLiveData()
@@ -66,8 +71,15 @@ class BookingFilterListViewModel @Inject constructor(
                 current.copy(currentPage = BookingFilterPage.List)
             }
         } else {
-            // TODO Verify unsaved changes and close
-            triggerEvent(MultiLiveEvent.Event.Exit)
+            if (hasUnsavedChanges()) {
+                _uiState.update { current ->
+                    current.copy(
+                        unsavedChangesDialog = current.unsavedChangesDialog.copy(isVisible = true)
+                    )
+                }
+            } else {
+                triggerEvent(MultiLiveEvent.Event.Exit)
+            }
         }
     }
 
@@ -76,6 +88,31 @@ class BookingFilterListViewModel @Inject constructor(
             bookingFilterRepository.save(_uiState.value.updatedBookingFilters)
         }
         triggerEvent(MultiLiveEvent.Event.Exit)
+    }
+
+    private fun onDismissUnsavedChangesDialog() {
+        _uiState.update { current ->
+            current.copy(
+                unsavedChangesDialog = current.unsavedChangesDialog.copy(isVisible = false)
+            )
+        }
+    }
+
+    private fun onDiscardChanges() {
+        // Hide dialog and exit without saving
+        _uiState.update { current ->
+            current.copy(
+                unsavedChangesDialog = current.unsavedChangesDialog.copy(isVisible = false),
+                newBookingFilters = emptySet()
+            )
+        }
+        triggerEvent(MultiLiveEvent.Event.Exit)
+    }
+
+    private fun hasUnsavedChanges(): Boolean {
+        val initial = _uiState.value.initialBookingFilters ?: BookingFilters()
+        val updated = _uiState.value.updatedBookingFilters
+        return updated != initial
     }
 }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/bookings/filter/BookingFilterListViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/bookings/filter/BookingFilterListViewModel.kt
@@ -2,7 +2,10 @@ package com.woocommerce.android.ui.bookings.filter
 
 import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.asLiveData
+import com.woocommerce.android.R
+import com.woocommerce.android.model.UiString
 import com.woocommerce.android.ui.bookings.filter.data.BookingFilterRepository
+import com.woocommerce.android.ui.compose.DialogState
 import com.woocommerce.android.viewmodel.MultiLiveEvent
 import com.woocommerce.android.viewmodel.ScopedViewModel
 import dagger.hilt.android.lifecycle.HiltViewModel
@@ -25,12 +28,7 @@ class BookingFilterListViewModel @Inject constructor(
             onClose = ::onClose,
             onShowBookings = ::onShowBookings,
             openPage = ::onOpenPage,
-            onUpdateFilterOption = ::onUpdateFilterOption,
-            unsavedChangesDialog = UnsavedChangesDialogState(
-                isVisible = false,
-                onDismiss = ::onDismissUnsavedChangesDialog,
-                onDiscardChanges = ::onDiscardChanges,
-            )
+            onUpdateFilterOption = ::onUpdateFilterOption
         )
     )
     val uiState = _uiState.asLiveData()
@@ -74,7 +72,17 @@ class BookingFilterListViewModel @Inject constructor(
             if (hasUnsavedChanges()) {
                 _uiState.update { current ->
                     current.copy(
-                        unsavedChangesDialog = current.unsavedChangesDialog.copy(isVisible = true)
+                        unsavedChangesDialogState = DialogState(
+                            message = R.string.discard_message,
+                            positiveButton = DialogState.DialogButton(
+                                text = UiString.UiStringRes(R.string.discard),
+                                onClick = ::onDiscardChanges
+                            ),
+                            negativeButton = DialogState.DialogButton(
+                                text = UiString.UiStringRes(R.string.keep_changes),
+                                onClick = ::onDismissUnsavedChangesDialog
+                            ),
+                        )
                     )
                 }
             } else {
@@ -91,18 +99,12 @@ class BookingFilterListViewModel @Inject constructor(
     }
 
     private fun onDismissUnsavedChangesDialog() {
-        _uiState.update { current ->
-            current.copy(
-                unsavedChangesDialog = current.unsavedChangesDialog.copy(isVisible = false)
-            )
-        }
+        _uiState.update { current -> current.copy(unsavedChangesDialogState = null) }
     }
 
     private fun onDiscardChanges() {
         // Hide dialog and exit without saving
-        _uiState.update { current ->
-            current.copy(unsavedChangesDialog = current.unsavedChangesDialog.copy(isVisible = false))
-        }
+        _uiState.update { current -> current.copy(unsavedChangesDialogState = null) }
         triggerEvent(MultiLiveEvent.Event.Exit)
     }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/bookings/filter/BookingFilterListViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/bookings/filter/BookingFilterListViewModel.kt
@@ -72,7 +72,7 @@ class BookingFilterListViewModel @Inject constructor(
             if (hasUnsavedChanges()) {
                 _uiState.update { current ->
                     current.copy(
-                        unsavedChangesDialogState = DialogState(
+                        dialogState = DialogState(
                             message = R.string.discard_message,
                             positiveButton = DialogState.DialogButton(
                                 text = UiString.UiStringRes(R.string.discard),
@@ -99,12 +99,12 @@ class BookingFilterListViewModel @Inject constructor(
     }
 
     private fun onDismissUnsavedChangesDialog() {
-        _uiState.update { current -> current.copy(unsavedChangesDialogState = null) }
+        _uiState.update { current -> current.copy(dialogState = null) }
     }
 
     private fun onDiscardChanges() {
         // Hide dialog and exit without saving
-        _uiState.update { current -> current.copy(unsavedChangesDialogState = null) }
+        _uiState.update { current -> current.copy(dialogState = null) }
         triggerEvent(MultiLiveEvent.Event.Exit)
     }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/bookings/filter/BookingFilterListViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/bookings/filter/BookingFilterListViewModel.kt
@@ -101,10 +101,7 @@ class BookingFilterListViewModel @Inject constructor(
     private fun onDiscardChanges() {
         // Hide dialog and exit without saving
         _uiState.update { current ->
-            current.copy(
-                unsavedChangesDialog = current.unsavedChangesDialog.copy(isVisible = false),
-                newBookingFilters = emptySet()
-            )
+            current.copy(unsavedChangesDialog = current.unsavedChangesDialog.copy(isVisible = false))
         }
         triggerEvent(MultiLiveEvent.Event.Exit)
     }

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/bookings/filter/BookingFilterListViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/bookings/filter/BookingFilterListViewModelTest.kt
@@ -13,6 +13,7 @@ import org.junit.Test
 import org.mockito.kotlin.doReturn
 import org.mockito.kotlin.mock
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.bookings.BookingFilters
+import org.wordpress.android.fluxc.network.rest.wpcom.wc.bookings.BookingsFilterOption
 
 @OptIn(ExperimentalCoroutinesApi::class)
 class BookingFilterListViewModelTest : BaseUnitTest() {
@@ -70,7 +71,7 @@ class BookingFilterListViewModelTest : BaseUnitTest() {
     }
 
     @Test
-    fun `given current page is List, when onClose, then Exit event is emitted`() {
+    fun `given current page is List, and no changes, when onClose, then Exit event is emitted`() {
         // GIVEN
         val events = mutableListOf<MultiLiveEvent.Event>()
         viewModel.event.observeForever { events.add(it) }
@@ -81,6 +82,60 @@ class BookingFilterListViewModelTest : BaseUnitTest() {
         initial.onClose()
 
         // THEN
+        assertThat(events).isNotEmpty
+        assertThat(events.last()).isEqualTo(MultiLiveEvent.Event.Exit)
+    }
+
+    @Test
+    fun `given unsaved changes on Filters, when onClose, then dialog becomes visible`() {
+        // GIVEN
+        val initial = viewModel.uiState.getOrAwaitValue()
+        // introduce a change different from initial filters (which are empty)
+        initial.onUpdateFilterOption(BookingsFilterOption.BookingType(BookingsFilterOption.BookingType.Type.SERVICE))
+        val changed = viewModel.uiState.getOrAwaitValue()
+
+        // WHEN
+        changed.onClose()
+
+        // THEN
+        val afterClose = viewModel.uiState.getOrAwaitValue()
+        assertThat(afterClose.unsavedChangesDialog.isVisible).isTrue()
+    }
+
+    @Test
+    fun `given dialog visible, when Keep Changes tapped, then dialog hides`() {
+        // GIVEN
+        val events = mutableListOf<MultiLiveEvent.Event>()
+        viewModel.event.observeForever { events.add(it) }
+        val initial = viewModel.uiState.getOrAwaitValue()
+        initial.onUpdateFilterOption(BookingsFilterOption.BookingType(BookingsFilterOption.BookingType.Type.SERVICE))
+        viewModel.uiState.getOrAwaitValue().onClose() // shows dialog
+
+        // WHEN: tap Keep Changes
+        val withDialog = viewModel.uiState.getOrAwaitValue()
+        withDialog.unsavedChangesDialog.onDismiss()
+
+        // THEN: dialog hidden
+        val afterDismiss = viewModel.uiState.getOrAwaitValue()
+        assertThat(afterDismiss.unsavedChangesDialog.isVisible).isFalse()
+    }
+
+    @Test
+    fun `given dialog visible, when Discard pressed, then dialog hides, and exit`() {
+        // GIVEN
+        val events = mutableListOf<MultiLiveEvent.Event>()
+        viewModel.event.observeForever { events.add(it) }
+        val initial = viewModel.uiState.getOrAwaitValue()
+        initial.onUpdateFilterOption(BookingsFilterOption.BookingType(BookingsFilterOption.BookingType.Type.SERVICE))
+        viewModel.uiState.getOrAwaitValue().onClose() // shows dialog
+
+        // WHEN: tap Discard
+        val withDialog = viewModel.uiState.getOrAwaitValue()
+        withDialog.unsavedChangesDialog.onDiscardChanges()
+
+        // THEN: dialog hidden and Exit event emitted
+        val afterDiscard = viewModel.uiState.getOrAwaitValue()
+        assertThat(afterDiscard.unsavedChangesDialog.isVisible).isFalse()
         assertThat(events).isNotEmpty
         assertThat(events.last()).isEqualTo(MultiLiveEvent.Event.Exit)
     }

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/bookings/filter/BookingFilterListViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/bookings/filter/BookingFilterListViewModelTest.kt
@@ -99,7 +99,7 @@ class BookingFilterListViewModelTest : BaseUnitTest() {
 
         // THEN
         val afterClose = viewModel.uiState.getOrAwaitValue()
-        assertThat(afterClose.unsavedChangesDialogState).isNotNull()
+        assertThat(afterClose.dialogState).isNotNull()
     }
 
     @Test
@@ -113,11 +113,11 @@ class BookingFilterListViewModelTest : BaseUnitTest() {
 
         // WHEN: tap Keep Changes
         val withDialog = viewModel.uiState.getOrAwaitValue()
-        withDialog.unsavedChangesDialogState?.negativeButton?.onClick()
+        withDialog.dialogState?.negativeButton?.onClick()
 
         // THEN: dialog hidden
         val afterDismiss = viewModel.uiState.getOrAwaitValue()
-        assertThat(afterDismiss.unsavedChangesDialogState).isNull()
+        assertThat(afterDismiss.dialogState).isNull()
     }
 
     @Test
@@ -131,11 +131,11 @@ class BookingFilterListViewModelTest : BaseUnitTest() {
 
         // WHEN: tap Discard
         val withDialog = viewModel.uiState.getOrAwaitValue()
-        withDialog.unsavedChangesDialogState?.positiveButton?.onClick()
+        withDialog.dialogState?.positiveButton?.onClick()
 
         // THEN: dialog hidden and Exit event emitted
         val afterDiscard = viewModel.uiState.getOrAwaitValue()
-        assertThat(afterDiscard.unsavedChangesDialogState).isNull()
+        assertThat(afterDiscard.dialogState).isNull()
         assertThat(events).isNotEmpty
         assertThat(events.last()).isEqualTo(MultiLiveEvent.Event.Exit)
     }

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/bookings/filter/BookingFilterListViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/bookings/filter/BookingFilterListViewModelTest.kt
@@ -99,7 +99,7 @@ class BookingFilterListViewModelTest : BaseUnitTest() {
 
         // THEN
         val afterClose = viewModel.uiState.getOrAwaitValue()
-        assertThat(afterClose.unsavedChangesDialog.isVisible).isTrue()
+        assertThat(afterClose.unsavedChangesDialogState).isNotNull()
     }
 
     @Test
@@ -113,11 +113,11 @@ class BookingFilterListViewModelTest : BaseUnitTest() {
 
         // WHEN: tap Keep Changes
         val withDialog = viewModel.uiState.getOrAwaitValue()
-        withDialog.unsavedChangesDialog.onDismiss()
+        withDialog.unsavedChangesDialogState?.negativeButton?.onClick()
 
         // THEN: dialog hidden
         val afterDismiss = viewModel.uiState.getOrAwaitValue()
-        assertThat(afterDismiss.unsavedChangesDialog.isVisible).isFalse()
+        assertThat(afterDismiss.unsavedChangesDialogState).isNull()
     }
 
     @Test
@@ -131,11 +131,11 @@ class BookingFilterListViewModelTest : BaseUnitTest() {
 
         // WHEN: tap Discard
         val withDialog = viewModel.uiState.getOrAwaitValue()
-        withDialog.unsavedChangesDialog.onDiscardChanges()
+        withDialog.unsavedChangesDialogState?.positiveButton?.onClick()
 
         // THEN: dialog hidden and Exit event emitted
         val afterDiscard = viewModel.uiState.getOrAwaitValue()
-        assertThat(afterDiscard.unsavedChangesDialog.isVisible).isFalse()
+        assertThat(afterDiscard.unsavedChangesDialogState).isNull()
         assertThat(events).isNotEmpty
         assertThat(events.last()).isEqualTo(MultiLiveEvent.Event.Exit)
     }


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

<!-- Id number of the Linear issue this PR addresses, e.g., WOOMOB-373. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
This adds an unsaved changes dialog to the Bookings Filters screen. When exiting the screen, if the saved filters have been modified, this new dialog will appear.
The KEEP CHANGES button simply hides the dialog.
DISCARD button discards the new changes and returns to the Booking List screen.

The dialog’s style differs from the Orders Filters dialog, but that’s expected, the Bookings screen is built with Compose, and there are also other visual differences between these screens for the same reason.

### Test Steps
<!-- Describe how to test your changes. Include only what’s needed for the reviewer to validate the behavior.
For new features, outline the main user flow or goal rather than every tap or click — the reviewer should be able to complete the flow naturally.
If applicable, mention key devices, scenarios, or edge cases to verify. -->
1 Log in with a CIAB store.
2. Go to Bookings.
3. Go to the All tab.
4. Tap the Filters button.
5. Select Booking type.
6. Select a type.
7. Navigate back.
8. Tap X (Close) button.

### Images/gif
<!-- Include before and after images or gifs when appropriate. -->
<img width="360" src="https://github.com/user-attachments/assets/54ea8658-3e3a-4d39-806f-5bae7719a4ba" />

- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
