### PR TITLE
[Woo POS][Surveys] Improve back navigation in feedback survey

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/feedback/FeedbackSurveyFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/feedback/FeedbackSurveyFragment.kt
@@ -7,6 +7,7 @@ import android.webkit.WebResourceRequest
 import android.webkit.WebSettings
 import android.webkit.WebView
 import android.webkit.WebViewClient
+import androidx.activity.OnBackPressedCallback
 import androidx.appcompat.app.AppCompatActivity
 import androidx.navigation.fragment.findNavController
 import androidx.navigation.fragment.navArgs
@@ -56,6 +57,7 @@ class FeedbackSurveyFragment : BaseFragment(R.layout.fragment_feedback_survey) {
     private var progressDialog: CustomProgressDialog? = null
     private var surveyCompleted: Boolean = false
     private val surveyWebViewClient = SurveyWebViewClient()
+    private var backPressedCallback: OnBackPressedCallback? = null
     private val arguments: FeedbackSurveyFragmentArgs by navArgs()
     private val feedbackContext by lazy {
         when (arguments.surveyType) {
@@ -77,6 +79,7 @@ class FeedbackSurveyFragment : BaseFragment(R.layout.fragment_feedback_survey) {
         _binding = FragmentFeedbackSurveyBinding.bind(view)
 
         setupToolbar(binding.toolbar)
+        setupBackPressHandling()
 
         configureWebView()
         savedInstanceState?.let {
@@ -93,6 +96,21 @@ class FeedbackSurveyFragment : BaseFragment(R.layout.fragment_feedback_survey) {
             findNavController().navigateUp()
         }
         activity?.invalidateOptionsMenu()
+    }
+
+    private fun setupBackPressHandling() {
+        backPressedCallback = object : OnBackPressedCallback(true) {
+            override fun handleOnBackPressed() {
+                if (binding.webView.canGoBack()) {
+                    binding.webView.goBack()
+                } else {
+                    isEnabled = false
+                    requireActivity().onBackPressedDispatcher.onBackPressed()
+                }
+            }
+        }.also {
+            requireActivity().onBackPressedDispatcher.addCallback(viewLifecycleOwner, it)
+        }
     }
 
     private fun getSurveyUrlFromArguments(): String = arguments.customUrl ?: arguments.surveyType.url
@@ -112,6 +130,8 @@ class FeedbackSurveyFragment : BaseFragment(R.layout.fragment_feedback_survey) {
 
     override fun onDestroyView() {
         super.onDestroyView()
+        backPressedCallback?.remove()
+        backPressedCallback = null
         _binding = null
     }
 


### PR DESCRIPTION
WOOMOB-1474

### Description
Previously, pressing the system back button while viewing a feedback survey would immediately exit the survey, even if the user had navigated through multiple survey pages. This caused frustration when users accidentally pressed back and lost their progress.

This change adds intelligent back navigation that:
- Navigates through webview history when the back button is pressed
- Only exits the survey when the webview is at the initial page
- Keeps the toolbar close button (X) behavior unchanged - it still exits immediately

The implementation uses OnBackPressedCallback to intercept back button presses and checks webView.canGoBack() to determine whether to navigate within the webview or exit the fragment.

### Test Steps
1. Open a feedback survey from any source (e.g., Woo POS surveys)
2. Navigate through multiple pages in the survey
3. Press the system back button
4. Verify it navigates back through survey pages
5. Continue pressing back until at the first page
6. Press back once more and verify it exits the survey
7. Test the toolbar X button - verify it still exits immediately regardless of webview history

- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.