### PR TITLE
[Bookings] Add checkmark to attendance status sheet

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/bookings/compose/BookingAttendanceStatusBottomSheet.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/bookings/compose/BookingAttendanceStatusBottomSheet.kt
@@ -127,7 +127,7 @@ private fun AttendanceStatusRow(
             if (isSelected) {
                 Icon(
                     painter = painterResource(id = R.drawable.ic_done_secondary),
-                    contentDescription = null,
+                    contentDescription = stringResource(R.string.bookings_filters_selected_option_content_description),
                     tint = MaterialTheme.colorScheme.primary
                 )
             }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/bookings/compose/BookingAttendanceStatusBottomSheet.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/bookings/compose/BookingAttendanceStatusBottomSheet.kt
@@ -2,6 +2,7 @@ package com.woocommerce.android.ui.bookings.compose
 
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
@@ -34,6 +35,7 @@ fun BookingAttendanceStatusBottomSheet(
     onSelect: (BookingAttendanceStatus) -> Unit,
     onDismiss: () -> Unit,
     modifier: Modifier = Modifier,
+    selected: BookingAttendanceStatus? = null,
 ) {
     val sheetState = rememberModalBottomSheetState(skipPartiallyExpanded = true)
     val scope = rememberCoroutineScope()
@@ -48,6 +50,7 @@ fun BookingAttendanceStatusBottomSheet(
                 onSelect(status)
                 onDismiss()
             },
+            selected = selected,
             modifier = modifier
         )
     }
@@ -57,6 +60,7 @@ fun BookingAttendanceStatusBottomSheet(
 private fun BookingAttendanceStatusSelection(
     onSelect: (BookingAttendanceStatus) -> Unit,
     modifier: Modifier = Modifier,
+    selected: BookingAttendanceStatus? = null,
 ) {
     Column(
         modifier = modifier
@@ -74,9 +78,10 @@ private fun BookingAttendanceStatusSelection(
             BookingAttendanceStatus.Booked,
             BookingAttendanceStatus.CheckedIn,
             BookingAttendanceStatus.NoShow,
-        ).forEachIndexed { index, status ->
+        ).forEach { status ->
             AttendanceStatusRow(
                 status = status,
+                isSelected = status == selected,
                 onClick = { onSelect(status) }
             )
         }
@@ -86,6 +91,7 @@ private fun BookingAttendanceStatusSelection(
 @Composable
 private fun AttendanceStatusRow(
     status: BookingAttendanceStatus,
+    isSelected: Boolean,
     onClick: () -> Unit,
 ) {
     Row(
@@ -116,6 +122,15 @@ private fun AttendanceStatusRow(
                 style = MaterialTheme.typography.bodySmall,
                 color = MaterialTheme.colorScheme.onSurfaceVariant
             )
+        }
+        Box(Modifier.size(26.dp)) {
+            if (isSelected) {
+                Icon(
+                    painter = painterResource(id = R.drawable.ic_done_secondary),
+                    contentDescription = null,
+                    tint = MaterialTheme.colorScheme.primary
+                )
+            }
         }
     }
 }
@@ -152,6 +167,7 @@ private fun AttendanceStatusRowPreview() {
     WooThemeWithBackground {
         AttendanceStatusRow(
             status = BookingAttendanceStatus.CheckedIn,
+            isSelected = false,
             onClick = {}
         )
     }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/bookings/details/BookingDetailsScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/bookings/details/BookingDetailsScreen.kt
@@ -130,7 +130,8 @@ fun BookingDetailsScreen(
                                             onSelect = { status ->
                                                 viewState.bookingUiState.onAttendanceStatusSelected(status)
                                             },
-                                            onDismiss = { showAttendanceSheet.value = false }
+                                            onDismiss = { showAttendanceSheet.value = false },
+                                            selected = viewState.bookingUiState.bookingSummary.attendanceStatus
                                         )
                                     }
                                 }

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -4249,6 +4249,7 @@
     <string name="bookings_filter_default">Any</string>
     <string name="bookings_filter_type_service">Service</string>
     <string name="bookings_filter_type_event">Event</string>
+    <string name="bookings_filters_selected_option_content_description">Selected filter option</string>
 
     <!-- Booking details view-->
     <string name="booking_details_title">Booking #%s</string>


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

<!-- Id number of the Linear issue this PR addresses, e.g., WOOMOB-373. -->
Closes WOOMOB-1606

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
This adds a checkmark icon to the selected attendance stat on the sheet. 

### Test Steps
<!-- Describe how to test your changes. Include only what’s needed for the reviewer to validate the behavior.
For new features, outline the main user flow or goal rather than every tap or click — the reviewer should be able to complete the flow naturally.
If applicable, mention key devices, scenarios, or edge cases to verify. -->
1. Log in with a CIAB store.
2. Go to Bookings.
3. Select a booking.
4. Tap ATTENDANCE Status row.
5. Change the selected status.

### Images/gif
<!-- Include before and after images or gifs when appropriate. -->
|Before|After|After dark|
|-|-|-|
|<img width="360" src="https://github.com/user-attachments/assets/dc3ca4d3-a0b3-4cca-a631-20745c1db46d" />|<img width="360" src="https://github.com/user-attachments/assets/719b27f1-b381-4079-9797-1394527f3c4e" />|<img width="360" src="https://github.com/user-attachments/assets/34053808-38f1-4fe0-a6a3-99d088c61ef8" />|

- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
