### PR TITLE
[Bookings] Show filter count on filters screen

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/bookings/filter/BookingFilterListScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/bookings/filter/BookingFilterListScreen.kt
@@ -32,6 +32,7 @@ import com.woocommerce.android.ui.bookings.filter.type.BookingTypeFilterRoute
 import com.woocommerce.android.ui.compose.Render
 import com.woocommerce.android.ui.compose.component.Toolbar
 import com.woocommerce.android.ui.compose.component.WCColoredButton
+import com.woocommerce.android.ui.compose.component.getText
 import com.woocommerce.android.ui.compose.preview.LightDarkThemePreviews
 import com.woocommerce.android.ui.compose.theme.WooThemeWithBackground
 
@@ -41,7 +42,7 @@ fun BookingFilterListScreen(state: BookingFilterListUiState) {
         topBar = {
             Column {
                 Toolbar(
-                    title = stringResource(state.currentPage.titleRes),
+                    title = state.title.getText(),
                     onNavigationButtonClick = state.onClose,
                     navigationIcon = ImageVector.vectorResource(id = state.navigationIcon)
                 )

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/bookings/filter/BookingFilterListUiState.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/bookings/filter/BookingFilterListUiState.kt
@@ -45,6 +45,21 @@ data class BookingFilterListUiState(
             initialBookingFilters?.bookingType
         ) ?: BookingsFilterOption.BookingType(BookingsFilterOption.BookingType.Type.ANY)
 
+    val updatedBookingFilters: BookingFilters
+        get() {
+            val initial = initialBookingFilters ?: BookingFilters()
+            return BookingFilters(
+                dateRange = newBookingFilters.getOrDefault(initial.dateRange),
+                customer = newBookingFilters.getOrDefault(initial.customer),
+                teamMember = newBookingFilters.getOrDefault(initial.teamMember),
+                attendanceStatus = newBookingFilters.getOrDefault(initial.attendanceStatus),
+                paymentStatus = newBookingFilters.getOrDefault(initial.paymentStatus),
+                bookingType = newBookingFilters.getOrDefault(initial.bookingType),
+                location = newBookingFilters.getOrDefault(initial.location),
+                serviceEvent = newBookingFilters.getOrDefault(initial.serviceEvent),
+            )
+        }
+
     @DrawableRes
     val navigationIcon: Int = when (currentPage) {
         BookingFilterPage.List -> R.drawable.ic_gridicons_cross_24dp

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/bookings/filter/BookingFilterListUiState.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/bookings/filter/BookingFilterListUiState.kt
@@ -60,6 +60,8 @@ data class BookingFilterListUiState(
             )
         }
 
+    val updatedBookingFiltersCount = updatedBookingFilters.enabledFiltersCount
+
     @DrawableRes
     val navigationIcon: Int = when (currentPage) {
         BookingFilterPage.List -> R.drawable.ic_gridicons_cross_24dp
@@ -87,6 +89,18 @@ data class BookingFilterListUiState(
             BookingFilterPage.ServiceEvent,
             BookingFilterPage.TeamMember,
             BookingFilterPage.List -> null
+        }
+
+    val title: UiString
+        get() = if (currentPage != BookingFilterPage.List) {
+            UiString.UiStringRes(currentPage.titleRes)
+        } else if (updatedBookingFiltersCount > 0) {
+            UiString.UiStringRes(
+                stringRes = R.string.bookings_filters_title_with_count,
+                params = listOf(UiString.UiStringText(updatedBookingFiltersCount.toString()))
+            )
+        } else {
+            UiString.UiStringRes(R.string.bookings_filters_default_title)
         }
 }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/bookings/filter/BookingFilterListViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/bookings/filter/BookingFilterListViewModel.kt
@@ -114,22 +114,3 @@ class BookingFilterListViewModel @Inject constructor(
         return updated != initial
     }
 }
-
-private val BookingFilterListUiState.updatedBookingFilters: BookingFilters
-    get() {
-        val initial = initialBookingFilters ?: BookingFilters()
-        val updates = this@updatedBookingFilters.newBookingFilters
-
-        return BookingFilters(
-            dateRange = updates.getOrDefault(initial.dateRange),
-            customer = updates.getOrDefault(initial.customer),
-            teamMember = updates.getOrDefault(
-                initial.teamMember
-            ),
-            attendanceStatus = updates.getOrDefault(initial.attendanceStatus),
-            paymentStatus = updates.getOrDefault(initial.paymentStatus),
-            bookingType = updates.getOrDefault(initial.bookingType),
-            location = updates.getOrDefault(initial.location),
-            serviceEvent = updates.getOrDefault(initial.serviceEvent),
-        )
-    }

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -4236,7 +4236,7 @@
     <string name="bookings_empty_state_clear_filters_button">Clear filters</string>
     <string name="bookings_filters_default_title">Filters</string>
     <string name="bookings_filters_enabled_title">Filters • %d</string>
-    <string name="bookings_filters_count_title">Filters (%d)</string>
+    <string name="bookings_filters_title_with_count">Filters (%s)</string>
     <string name="bookings_filters_show_bookings">Show bookings</string>
     <string name="bookings_filter_title_team_member">Assigned team member</string>
     <string name="bookings_filter_title_attendance_status">Attendance status</string>


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

<!-- Id number of the Linear issue this PR addresses, e.g., WOOMOB-373. -->
Part of WOOMOB-1239

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
This adds the active booking filter count to the title of the root filter list page.

### Test Steps
<!-- Describe how to test your changes. Include only what’s needed for the reviewer to validate the behavior.
For new features, outline the main user flow or goal rather than every tap or click — the reviewer should be able to complete the flow naturally.
If applicable, mention key devices, scenarios, or edge cases to verify. -->
1. Log in with a CIAB store.
2. Go to Bookings.
3. Go to the All tab.
4. Tap the Filters button.
5. Select Booking type.
6. Select a type.
7. Navigate back.

### Images/gif
<!-- Include before and after images or gifs when appropriate. -->
|Before|After|
|-|-|
|<img width="360" src="https://github.com/user-attachments/assets/274706f5-fb88-48a4-93d3-cca9a6c04507" />|<img width="360" src="https://github.com/user-attachments/assets/1738034d-9514-426c-a49a-515af5978d05" />|

- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
