### PR TITLE
[Bookings] Clear filters action

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/bookings/filter/BookingFilterListScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/bookings/filter/BookingFilterListScreen.kt
@@ -140,7 +140,7 @@ private fun FiltersNavHost(
             TODO()
         }
         composable(BookingFilterPage.BookingType.route) {
-            BookingTypeFilterRoute(initialType = state.currentBookingType) { type ->
+            BookingTypeFilterRoute(initialType = state.initialBookingFilters.bookingType) { type ->
                 state.onUpdateFilterOption(type)
             }
         }
@@ -190,7 +190,7 @@ private fun BookingFilterListScreenPreview() {
     WooThemeWithBackground {
         BookingFilterListScreen(
             state = BookingFilterListUiState(
-                initialBookingFilters = null,
+                initialBookingFilters = BookingFilters(),
             )
         )
     }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/bookings/filter/BookingFilterListScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/bookings/filter/BookingFilterListScreen.kt
@@ -23,6 +23,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.res.vectorResource
+import java.util.Locale
 import androidx.compose.ui.unit.dp
 import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.composable
@@ -50,7 +51,7 @@ fun BookingFilterListScreen(state: BookingFilterListUiState) {
                         onNavigationButtonClick = state.onClose,
                         navigationIcon = ImageVector.vectorResource(id = state.navigationIcon),
                         onActionButtonClick = state.onClear,
-                        actionButtonText = stringResource(id = R.string.bookings_filters_clear_button)
+                        actionButtonText = stringResource(id = R.string.clear).uppercase(Locale.getDefault())
                     )
                 } else {
                     Toolbar(

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/bookings/filter/BookingFilterListScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/bookings/filter/BookingFilterListScreen.kt
@@ -140,7 +140,7 @@ private fun FiltersNavHost(
             TODO()
         }
         composable(BookingFilterPage.BookingType.route) {
-            BookingTypeFilterRoute(initialType = state.initialBookingFilters.bookingType) { type ->
+            BookingTypeFilterRoute(initialType = state.updatedBookingFilters.bookingType) { type ->
                 state.onUpdateFilterOption(type)
             }
         }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/bookings/filter/BookingFilterListScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/bookings/filter/BookingFilterListScreen.kt
@@ -23,7 +23,6 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.res.vectorResource
-import java.util.Locale
 import androidx.compose.ui.unit.dp
 import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.composable
@@ -39,6 +38,7 @@ import com.woocommerce.android.ui.compose.preview.LightDarkThemePreviews
 import com.woocommerce.android.ui.compose.theme.WooThemeWithBackground
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.bookings.BookingFilters
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.bookings.BookingsFilterOption
+import java.util.Locale
 
 @Composable
 fun BookingFilterListScreen(state: BookingFilterListUiState) {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/bookings/filter/BookingFilterListScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/bookings/filter/BookingFilterListScreen.kt
@@ -36,6 +36,7 @@ import com.woocommerce.android.ui.compose.component.WCColoredButton
 import com.woocommerce.android.ui.compose.component.getText
 import com.woocommerce.android.ui.compose.preview.LightDarkThemePreviews
 import com.woocommerce.android.ui.compose.theme.WooThemeWithBackground
+import org.wordpress.android.fluxc.network.rest.wpcom.wc.bookings.BookingFilters
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.bookings.BookingsFilterOption
 
 @Composable
@@ -43,11 +44,21 @@ fun BookingFilterListScreen(state: BookingFilterListUiState) {
     Scaffold(
         topBar = {
             Column {
-                Toolbar(
-                    title = state.title.getText(),
-                    onNavigationButtonClick = state.onClose,
-                    navigationIcon = ImageVector.vectorResource(id = state.navigationIcon)
-                )
+                if (state.showClearButton) {
+                    Toolbar(
+                        title = state.title.getText(),
+                        onNavigationButtonClick = state.onClose,
+                        navigationIcon = ImageVector.vectorResource(id = state.navigationIcon),
+                        onActionButtonClick = state.onClear,
+                        actionButtonText = stringResource(id = R.string.bookings_filters_clear_button)
+                    )
+                } else {
+                    Toolbar(
+                        title = state.title.getText(),
+                        onNavigationButtonClick = state.onClose,
+                        navigationIcon = ImageVector.vectorResource(id = state.navigationIcon)
+                    )
+                }
                 HorizontalDivider(thickness = 0.5.dp)
             }
         },

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/bookings/filter/BookingFilterListUiState.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/bookings/filter/BookingFilterListUiState.kt
@@ -65,7 +65,10 @@ data class BookingFilterListUiState(
                 UiString.UiStringText(name)
             }
 
-            BookingFilterPage.BookingType -> UiString.UiStringRes(updatedBookingFilters.bookingType.titleRes)
+            BookingFilterPage.BookingType -> {
+                updatedBookingFilters.bookingType?.titleRes?.let { UiString.UiStringRes(it) }
+            }
+
             BookingFilterPage.DateTime,
             BookingFilterPage.Location,
             BookingFilterPage.AttendanceStatus,

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/bookings/filter/BookingFilterListUiState.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/bookings/filter/BookingFilterListUiState.kt
@@ -30,6 +30,7 @@ data class BookingFilterListUiState(
     val onShowBookings: () -> Unit = {},
     val openPage: (BookingFilterPage) -> Unit = {},
     val onUpdateFilterOption: (BookingsFilterOption) -> Unit = {},
+    val onClear: () -> Unit = {},
 ) {
 
     val items: List<BookingFilterListItem> = availableBookingFilters().map { page ->
@@ -61,6 +62,9 @@ data class BookingFilterListUiState(
         }
 
     val updatedBookingFiltersCount = updatedBookingFilters.enabledFiltersCount
+
+    val showClearButton: Boolean
+        get() = currentPage == BookingFilterPage.List && updatedBookingFiltersCount > 0
 
     @DrawableRes
     val navigationIcon: Int = when (currentPage) {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/bookings/filter/BookingFilterListUiState.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/bookings/filter/BookingFilterListUiState.kt
@@ -21,9 +21,16 @@ enum class BookingFilterPage {
     Location,
 }
 
+/**
+ * UI state for the Bookings Filters screen.
+ *
+ * @property initialBookingFilters The stored filters loaded from storage DataStore and shown when the screen opens.
+ * @property updatedBookingFilters The in-memory working copy reflecting user changes; not persisted until the user
+ * saves.
+ */
 data class BookingFilterListUiState(
-    val initialBookingFilters: BookingFilters? = null,
-    val newBookingFilters: Set<BookingsFilterOption> = emptySet(),
+    val initialBookingFilters: BookingFilters = BookingFilters(),
+    val updatedBookingFilters: BookingFilters = initialBookingFilters,
     val currentPage: BookingFilterPage = BookingFilterPage.List,
     val dialogState: DialogState? = null,
     val onClose: () -> Unit = {},
@@ -41,26 +48,6 @@ data class BookingFilterListUiState(
         )
     }
 
-    val currentBookingType: BookingsFilterOption.BookingType
-        get() = newBookingFilters.getOrDefault<BookingsFilterOption.BookingType>(
-            initialBookingFilters?.bookingType
-        ) ?: BookingsFilterOption.BookingType(BookingsFilterOption.BookingType.Type.ANY)
-
-    val updatedBookingFilters: BookingFilters
-        get() {
-            val initial = initialBookingFilters ?: BookingFilters()
-            return BookingFilters(
-                dateRange = newBookingFilters.getOrDefault(initial.dateRange),
-                customer = newBookingFilters.getOrDefault(initial.customer),
-                teamMember = newBookingFilters.getOrDefault(initial.teamMember),
-                attendanceStatus = newBookingFilters.getOrDefault(initial.attendanceStatus),
-                paymentStatus = newBookingFilters.getOrDefault(initial.paymentStatus),
-                bookingType = newBookingFilters.getOrDefault(initial.bookingType),
-                location = newBookingFilters.getOrDefault(initial.location),
-                serviceEvent = newBookingFilters.getOrDefault(initial.serviceEvent),
-            )
-        }
-
     val updatedBookingFiltersCount = updatedBookingFilters.enabledFiltersCount
 
     val showClearButton: Boolean
@@ -74,18 +61,11 @@ data class BookingFilterListUiState(
 
     val BookingFilterPage.filterValue: UiString?
         get() = when (this) {
-            BookingFilterPage.Customer -> {
-                newBookingFilters.getOrDefault<BookingsFilterOption.Customer>(
-                    initialBookingFilters?.customer
-                )?.customerName?.let { name -> UiString.UiStringText(name) }
+            BookingFilterPage.Customer -> updatedBookingFilters.customer?.customerName?.let { name ->
+                UiString.UiStringText(name)
             }
 
-            BookingFilterPage.BookingType -> {
-                newBookingFilters.getOrDefault<BookingsFilterOption.BookingType>(
-                    initialBookingFilters?.bookingType
-                )?.titleRes?.let { res -> UiString.UiStringRes(res) }
-            }
-
+            BookingFilterPage.BookingType -> UiString.UiStringRes(updatedBookingFilters.bookingType.titleRes)
             BookingFilterPage.DateTime,
             BookingFilterPage.Location,
             BookingFilterPage.AttendanceStatus,
@@ -132,6 +112,18 @@ private fun availableBookingFilters(): List<BookingFilterPage> = listOf(
     BookingFilterPage.Location,
 )
 
-inline fun <reified T> Set<BookingsFilterOption>.getOrDefault(default: T?): T? {
-    return this.filterIsInstance<T>().firstOrNull() ?: default
-}
+/**
+ * Update and return a copy of this BookingFilters by setting the field that corresponds to the type of
+ * [bookingsFilterOption].
+ */
+fun BookingFilters.updateFilterOption(bookingsFilterOption: BookingsFilterOption): BookingFilters =
+    when (bookingsFilterOption) {
+        is BookingsFilterOption.DateRange -> copy(dateRange = bookingsFilterOption)
+        is BookingsFilterOption.Customer -> copy(customer = bookingsFilterOption)
+        is BookingsFilterOption.TeamMember -> copy(teamMember = bookingsFilterOption)
+        is BookingsFilterOption.AttendanceStatus -> copy(attendanceStatus = bookingsFilterOption)
+        is BookingsFilterOption.PaymentStatus -> copy(paymentStatus = bookingsFilterOption)
+        is BookingsFilterOption.BookingType -> copy(bookingType = bookingsFilterOption)
+        is BookingsFilterOption.Location -> copy(location = bookingsFilterOption)
+        is BookingsFilterOption.ServiceEvent -> copy(serviceEvent = bookingsFilterOption)
+    }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/bookings/filter/BookingFilterListViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/bookings/filter/BookingFilterListViewModel.kt
@@ -53,6 +53,7 @@ class BookingFilterListViewModel @Inject constructor(
     }
 
     private fun onClear() {
+        _uiState.update { it.copy(updatedBookingFilters = BookingFilters()) }
     }
 
     private fun getBookingFilter() {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/bookings/filter/BookingFilterListViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/bookings/filter/BookingFilterListViewModel.kt
@@ -47,9 +47,7 @@ class BookingFilterListViewModel @Inject constructor(
     private fun onUpdateFilterOption(option: BookingsFilterOption) {
         _uiState.update { current ->
             current.copy(
-                newBookingFilters = current.newBookingFilters.filterNot { it::class == option::class }
-                    .plus(option)
-                    .toSet()
+                updatedBookingFilters = current.updatedBookingFilters.updateFilterOption(option)
             )
         }
     }
@@ -60,9 +58,9 @@ class BookingFilterListViewModel @Inject constructor(
     private fun getBookingFilter() {
         launch {
             // We don't observe changes here, just get the current value once
-            val bookingFilters = bookingFilterRepository.bookingFiltersFlow.firstOrNull()
+            val bookingFilters = bookingFilterRepository.bookingFiltersFlow.firstOrNull() ?: BookingFilters()
             _uiState.update { current ->
-                current.copy(initialBookingFilters = bookingFilters)
+                current.copy(initialBookingFilters = bookingFilters, updatedBookingFilters = bookingFilters)
             }
         }
     }
@@ -112,9 +110,5 @@ class BookingFilterListViewModel @Inject constructor(
         triggerEvent(MultiLiveEvent.Event.Exit)
     }
 
-    private fun hasUnsavedChanges(): Boolean {
-        val initial = _uiState.value.initialBookingFilters ?: BookingFilters()
-        val updated = _uiState.value.updatedBookingFilters
-        return updated != initial
-    }
+    private fun hasUnsavedChanges() = _uiState.value.initialBookingFilters != _uiState.value.updatedBookingFilters
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/bookings/filter/BookingFilterListViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/bookings/filter/BookingFilterListViewModel.kt
@@ -28,7 +28,8 @@ class BookingFilterListViewModel @Inject constructor(
             onClose = ::onClose,
             onShowBookings = ::onShowBookings,
             openPage = ::onOpenPage,
-            onUpdateFilterOption = ::onUpdateFilterOption
+            onUpdateFilterOption = ::onUpdateFilterOption,
+            onClear = ::onClear
         )
     )
     val uiState = _uiState.asLiveData()
@@ -51,6 +52,9 @@ class BookingFilterListViewModel @Inject constructor(
                     .toSet()
             )
         }
+    }
+
+    private fun onClear() {
     }
 
     private fun getBookingFilter() {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/bookings/filter/data/BookingFilterRepository.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/bookings/filter/data/BookingFilterRepository.kt
@@ -48,7 +48,12 @@ class BookingFilterRepository @Inject constructor(
             // Booking type
             val bookingTypeKey = bookingTypeKey(siteId)
             val bookingType = bookingFilters.bookingType
-            prefs[bookingTypeKey] = bookingType.value.name
+            if (bookingType != null) {
+                prefs[bookingTypeKey] = bookingType.value.name
+            } else {
+                // Clear if not provided
+                prefs.remove(bookingTypeKey)
+            }
 
             // Customer
             val customerIdKey = customerIdKey(siteId)
@@ -84,12 +89,10 @@ class BookingFilterRepository @Inject constructor(
         }
     }
 
-    private fun Preferences.getBookingType(siteId: Int): BookingsFilterOption.BookingType {
-        val stored = this[bookingTypeKey(siteId)] ?: return BookingsFilterOption.BookingType.DEFAULT
-        val type = runCatching {
-            BookingsFilterOption.BookingType.Type.valueOf(stored)
-        }.getOrElse { BookingsFilterOption.BookingType.DEFAULT.value }
-        return BookingsFilterOption.BookingType(value = type)
+    private fun Preferences.getBookingType(siteId: Int): BookingsFilterOption.BookingType? {
+        val stored = this[bookingTypeKey(siteId)] ?: return null
+        val type = runCatching { BookingsFilterOption.BookingType.Type.valueOf(stored) }.getOrNull()
+        return type?.let { BookingsFilterOption.BookingType(value = it) }
     }
 
     private fun Preferences.getCustomerValue(siteId: Int): BookingsFilterOption.Customer? {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/bookings/filter/data/BookingFilterRepository.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/bookings/filter/data/BookingFilterRepository.kt
@@ -47,9 +47,9 @@ class BookingFilterRepository @Inject constructor(
         dataStore.edit { prefs ->
             // Booking type
             val bookingTypeKey = bookingTypeKey(siteId)
-            val bookingType = bookingFilters.bookingType
-            if (bookingType != null) {
-                prefs[bookingTypeKey] = bookingType.value.name
+            val bookingTypeValue = bookingFilters.bookingType?.value?.name
+            if (bookingTypeValue != null) {
+                prefs[bookingTypeKey] = bookingTypeValue
             } else {
                 // Clear if not provided
                 prefs.remove(bookingTypeKey)

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/bookings/filter/data/BookingFilterRepository.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/bookings/filter/data/BookingFilterRepository.kt
@@ -48,12 +48,7 @@ class BookingFilterRepository @Inject constructor(
             // Booking type
             val bookingTypeKey = bookingTypeKey(siteId)
             val bookingType = bookingFilters.bookingType
-            if (bookingType != null) {
-                prefs[bookingTypeKey] = bookingType.value.name
-            } else {
-                // Clear if not provided
-                prefs.remove(bookingTypeKey)
-            }
+            prefs[bookingTypeKey] = bookingType.value.name
 
             // Customer
             val customerIdKey = customerIdKey(siteId)
@@ -89,10 +84,12 @@ class BookingFilterRepository @Inject constructor(
         }
     }
 
-    private fun Preferences.getBookingType(siteId: Int): BookingsFilterOption.BookingType? {
-        val stored = this[bookingTypeKey(siteId)] ?: return null
-        val type = runCatching { BookingsFilterOption.BookingType.Type.valueOf(stored) }.getOrNull()
-        return type?.let { BookingsFilterOption.BookingType(value = it) }
+    private fun Preferences.getBookingType(siteId: Int): BookingsFilterOption.BookingType {
+        val stored = this[bookingTypeKey(siteId)] ?: return BookingsFilterOption.BookingType.DEFAULT
+        val type = runCatching {
+            BookingsFilterOption.BookingType.Type.valueOf(stored)
+        }.getOrElse { BookingsFilterOption.BookingType.DEFAULT.value }
+        return BookingsFilterOption.BookingType(value = type)
     }
 
     private fun Preferences.getCustomerValue(siteId: Int): BookingsFilterOption.Customer? {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/bookings/filter/type/BookingTypeFilterPage.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/bookings/filter/type/BookingTypeFilterPage.kt
@@ -9,7 +9,7 @@ import org.wordpress.android.fluxc.network.rest.wpcom.wc.bookings.BookingsFilter
 
 @Composable
 fun BookingTypeFilterRoute(
-    initialType: BookingsFilterOption.BookingType,
+    initialType: BookingsFilterOption.BookingType?,
     onTypeFilterChanged: (BookingsFilterOption.BookingType) -> Unit,
 ) {
     val viewModel = hiltViewModel<BookingTypeFilterViewModel, BookingTypeFilterViewModel.Factory> { factory ->

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/bookings/filter/type/BookingTypeFilterUiState.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/bookings/filter/type/BookingTypeFilterUiState.kt
@@ -6,7 +6,7 @@ import com.woocommerce.android.ui.bookings.filter.BookingFilterListItem
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.bookings.BookingsFilterOption.BookingType
 
 data class BookingTypeFilterUiState(
-    val selectedType: BookingType = BookingType(BookingType.Type.ANY),
+    val selectedType: BookingType = BookingType.DEFAULT,
     val onTypeSelected: (BookingType) -> Unit = {},
 ) {
     val items: List<BookingFilterListItem> = availableBookingTypes().map { type ->

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/bookings/filter/type/BookingTypeFilterUiState.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/bookings/filter/type/BookingTypeFilterUiState.kt
@@ -6,7 +6,7 @@ import com.woocommerce.android.ui.bookings.filter.BookingFilterListItem
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.bookings.BookingsFilterOption.BookingType
 
 data class BookingTypeFilterUiState(
-    val selectedType: BookingType = BookingType.DEFAULT,
+    val selectedType: BookingType = BookingType(BookingType.Type.ANY),
     val onTypeSelected: (BookingType) -> Unit = {},
 ) {
     val items: List<BookingFilterListItem> = availableBookingTypes().map { type ->

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/bookings/filter/type/BookingTypeFilterUiState.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/bookings/filter/type/BookingTypeFilterUiState.kt
@@ -6,7 +6,7 @@ import com.woocommerce.android.ui.bookings.filter.BookingFilterListItem
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.bookings.BookingsFilterOption.BookingType
 
 data class BookingTypeFilterUiState(
-    val selectedType: BookingType = BookingType(BookingType.Type.ANY),
+    val selectedType: BookingType = BookingType(null),
     val onTypeSelected: (BookingType) -> Unit = {},
 ) {
     val items: List<BookingFilterListItem> = availableBookingTypes().map { type ->
@@ -18,7 +18,7 @@ data class BookingTypeFilterUiState(
     }
 
     private fun availableBookingTypes(): List<BookingType> = listOf(
-        BookingType(BookingType.Type.ANY),
+        BookingType(null),
         BookingType(BookingType.Type.SERVICE),
         BookingType(BookingType.Type.EVENT),
     )
@@ -26,7 +26,7 @@ data class BookingTypeFilterUiState(
 
 val BookingType.titleRes: Int
     @StringRes get() = when (this.value) {
-        BookingType.Type.ANY -> R.string.bookings_filter_default
+        null -> R.string.bookings_filter_default
         BookingType.Type.SERVICE -> R.string.bookings_filter_type_service
         BookingType.Type.EVENT -> R.string.bookings_filter_type_event
     }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/bookings/filter/type/BookingTypeFilterViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/bookings/filter/type/BookingTypeFilterViewModel.kt
@@ -9,21 +9,24 @@ import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.update
-import org.wordpress.android.fluxc.network.rest.wpcom.wc.bookings.BookingsFilterOption
+import org.wordpress.android.fluxc.network.rest.wpcom.wc.bookings.BookingsFilterOption.BookingType
 
 @HiltViewModel(assistedFactory = BookingTypeFilterViewModel.Factory::class)
 class BookingTypeFilterViewModel @AssistedInject constructor(
-    @Assisted private val initialType: BookingsFilterOption.BookingType,
-    @Assisted private val onTypeFilterChanged: (BookingsFilterOption.BookingType) -> Unit,
+    @Assisted private val initialType: BookingType?,
+    @Assisted private val onTypeFilterChanged: (BookingType) -> Unit,
     savedStateHandle: SavedStateHandle
 ) : ScopedViewModel(savedStateHandle) {
 
     private val _uiState = MutableStateFlow(
-        BookingTypeFilterUiState(selectedType = initialType, onTypeSelected = ::onTypeSelected)
+        BookingTypeFilterUiState(
+            selectedType = initialType ?: BookingType(BookingType.Type.ANY),
+            onTypeSelected = ::onTypeSelected
+        )
     )
     val uiState: StateFlow<BookingTypeFilterUiState> = _uiState
 
-    private fun onTypeSelected(type: BookingsFilterOption.BookingType) {
+    private fun onTypeSelected(type: BookingType) {
         if (_uiState.value.selectedType != type) {
             _uiState.update { current -> current.copy(selectedType = type) }
         }
@@ -33,8 +36,8 @@ class BookingTypeFilterViewModel @AssistedInject constructor(
     @AssistedFactory
     interface Factory {
         fun create(
-            initialType: BookingsFilterOption.BookingType,
-            onTypeFilterChanged: (BookingsFilterOption.BookingType) -> Unit
+            initialType: BookingType?,
+            onTypeFilterChanged: (BookingType) -> Unit
         ): BookingTypeFilterViewModel
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/bookings/filter/type/BookingTypeFilterViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/bookings/filter/type/BookingTypeFilterViewModel.kt
@@ -20,7 +20,7 @@ class BookingTypeFilterViewModel @AssistedInject constructor(
 
     private val _uiState = MutableStateFlow(
         BookingTypeFilterUiState(
-            selectedType = initialType ?: BookingType(BookingType.Type.ANY),
+            selectedType = initialType ?: BookingType(null),
             onTypeSelected = ::onTypeSelected
         )
     )

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/bookings/list/BookingListFiltersBuilder.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/bookings/list/BookingListFiltersBuilder.kt
@@ -45,7 +45,7 @@ class BookingListFiltersBuilder @Inject constructor(
         teamMember?.let { filters.add(it) }
         attendanceStatus?.let { filters.add(it) }
         paymentStatus?.let { filters.add(it) }
-        bookingType?.let { filters.add(it) }
+        filters.add(bookingType)
         location?.let { filters.add(it) }
         serviceEvent?.let { filters.add(it) }
         return filters

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/bookings/list/BookingListFiltersBuilder.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/bookings/list/BookingListFiltersBuilder.kt
@@ -21,6 +21,7 @@ class BookingListFiltersBuilder @Inject constructor(
     fun BookingListTab.asDateRangeFilter(): BookingsFilterOption.DateRange? {
         fun todayAtMidnight() = LocalDate.now(clock).minusDays(1).atTime(LocalTime.MAX)
             .atOffset(ZoneOffset.UTC).toInstant()
+
         fun todayAtEndOfDay() = LocalDate.now(clock).atTime(LocalTime.MAX).atOffset(ZoneOffset.UTC).toInstant()
 
         return when (this) {
@@ -45,7 +46,7 @@ class BookingListFiltersBuilder @Inject constructor(
         teamMember?.let { filters.add(it) }
         attendanceStatus?.let { filters.add(it) }
         paymentStatus?.let { filters.add(it) }
-        filters.add(bookingType)
+        bookingType?.let { filters.add(it) }
         location?.let { filters.add(it) }
         serviceEvent?.let { filters.add(it) }
         return filters

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -4250,6 +4250,7 @@
     <string name="bookings_filter_type_service">Service</string>
     <string name="bookings_filter_type_event">Event</string>
     <string name="bookings_filters_selected_option_content_description">Selected filter option</string>
+    <string name="bookings_filters_clear_button">CLEAR</string>
 
     <!-- Booking details view-->
     <string name="booking_details_title">Booking #%s</string>

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -4250,7 +4250,6 @@
     <string name="bookings_filter_type_service">Service</string>
     <string name="bookings_filter_type_event">Event</string>
     <string name="bookings_filters_selected_option_content_description">Selected filter option</string>
-    <string name="bookings_filters_clear_button">CLEAR</string>
 
     <!-- Booking details view-->
     <string name="booking_details_title">Booking #%s</string>

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/bookings/filter/BookingFilterListViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/bookings/filter/BookingFilterListViewModelTest.kt
@@ -146,13 +146,13 @@ class BookingFilterListViewModelTest : BaseUnitTest() {
         val initial = viewModel.uiState.getOrAwaitValue()
         initial.onUpdateFilterOption(BookingType(BookingType.Type.SERVICE))
         val changed = viewModel.uiState.getOrAwaitValue()
-        assertThat(changed.updatedBookingFilters.bookingType).isNotEqualTo(BookingType.DEFAULT)
+        assertThat(changed.updatedBookingFilters.bookingType).isNotEqualTo(null)
 
         // WHEN: clear is invoked
         changed.onClear()
 
         // THEN: updated filters become the default
         val afterClear = viewModel.uiState.getOrAwaitValue()
-        assertThat(afterClear.updatedBookingFilters.bookingType).isEqualTo(BookingType.DEFAULT)
+        assertThat(afterClear.updatedBookingFilters.bookingType).isEqualTo(null)
     }
 }

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/bookings/filter/BookingFilterListViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/bookings/filter/BookingFilterListViewModelTest.kt
@@ -13,7 +13,7 @@ import org.junit.Test
 import org.mockito.kotlin.doReturn
 import org.mockito.kotlin.mock
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.bookings.BookingFilters
-import org.wordpress.android.fluxc.network.rest.wpcom.wc.bookings.BookingsFilterOption
+import org.wordpress.android.fluxc.network.rest.wpcom.wc.bookings.BookingsFilterOption.BookingType
 
 @OptIn(ExperimentalCoroutinesApi::class)
 class BookingFilterListViewModelTest : BaseUnitTest() {
@@ -91,7 +91,7 @@ class BookingFilterListViewModelTest : BaseUnitTest() {
         // GIVEN
         val initial = viewModel.uiState.getOrAwaitValue()
         // introduce a change different from initial filters (which are empty)
-        initial.onUpdateFilterOption(BookingsFilterOption.BookingType(BookingsFilterOption.BookingType.Type.SERVICE))
+        initial.onUpdateFilterOption(BookingType(BookingType.Type.SERVICE))
         val changed = viewModel.uiState.getOrAwaitValue()
 
         // WHEN
@@ -108,7 +108,7 @@ class BookingFilterListViewModelTest : BaseUnitTest() {
         val events = mutableListOf<MultiLiveEvent.Event>()
         viewModel.event.observeForever { events.add(it) }
         val initial = viewModel.uiState.getOrAwaitValue()
-        initial.onUpdateFilterOption(BookingsFilterOption.BookingType(BookingsFilterOption.BookingType.Type.SERVICE))
+        initial.onUpdateFilterOption(BookingType(BookingType.Type.SERVICE))
         viewModel.uiState.getOrAwaitValue().onClose() // shows dialog
 
         // WHEN: tap Keep Changes
@@ -126,7 +126,7 @@ class BookingFilterListViewModelTest : BaseUnitTest() {
         val events = mutableListOf<MultiLiveEvent.Event>()
         viewModel.event.observeForever { events.add(it) }
         val initial = viewModel.uiState.getOrAwaitValue()
-        initial.onUpdateFilterOption(BookingsFilterOption.BookingType(BookingsFilterOption.BookingType.Type.SERVICE))
+        initial.onUpdateFilterOption(BookingType(BookingType.Type.SERVICE))
         viewModel.uiState.getOrAwaitValue().onClose() // shows dialog
 
         // WHEN: tap Discard

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/bookings/filter/BookingFilterListViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/bookings/filter/BookingFilterListViewModelTest.kt
@@ -139,4 +139,20 @@ class BookingFilterListViewModelTest : BaseUnitTest() {
         assertThat(events).isNotEmpty
         assertThat(events.last()).isEqualTo(MultiLiveEvent.Event.Exit)
     }
+
+    @Test
+    fun `when onClear is invoked, then updated filters reset to default`() {
+        // GIVEN: a changed filter state
+        val initial = viewModel.uiState.getOrAwaitValue()
+        initial.onUpdateFilterOption(BookingType(BookingType.Type.SERVICE))
+        val changed = viewModel.uiState.getOrAwaitValue()
+        assertThat(changed.updatedBookingFilters.bookingType).isNotEqualTo(BookingType.DEFAULT)
+
+        // WHEN: clear is invoked
+        changed.onClear()
+
+        // THEN: updated filters become the default
+        val afterClear = viewModel.uiState.getOrAwaitValue()
+        assertThat(afterClear.updatedBookingFilters.bookingType).isEqualTo(BookingType.DEFAULT)
+    }
 }

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/bookings/list/BookingListViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/bookings/list/BookingListViewModelTest.kt
@@ -20,6 +20,7 @@ import kotlinx.coroutines.test.advanceUntilIdle
 import org.assertj.core.api.Assertions.assertThat
 import org.mockito.kotlin.any
 import org.mockito.kotlin.anyOrNull
+import org.mockito.kotlin.argThat
 import org.mockito.kotlin.doReturn
 import org.mockito.kotlin.eq
 import org.mockito.kotlin.mock
@@ -331,7 +332,7 @@ class BookingListViewModelTest : BaseUnitTest() {
         // THEN
         verify(bookingListHandler).loadBookings(
             searchQuery = anyOrNull(),
-            filters = eq(listOf(customerFilter)),
+            filters = argThat { any { it == customerFilter } },
             sortBy = any()
         )
     }

--- a/libs/fluxc-plugin/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/bookings/BookingsFilterOption.kt
+++ b/libs/fluxc-plugin/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/bookings/BookingsFilterOption.kt
@@ -19,10 +19,6 @@ sealed interface BookingsFilterOption {
 
     data class BookingType(val value: Type) : BookingsFilterOption {
         enum class Type { ANY, SERVICE, EVENT }
-
-        companion object {
-            val DEFAULT = BookingType(Type.ANY)
-        }
     }
 
     data class Customer(val customerId: Long, val customerName: String) : BookingsFilterOption
@@ -43,7 +39,7 @@ data class BookingFilters(
     val teamMember: TeamMember? = null,
     val attendanceStatus: AttendanceStatus? = null,
     val paymentStatus: PaymentStatus? = null,
-    val bookingType: BookingType = BookingType.DEFAULT,
+    val bookingType: BookingType? = null,
     val location: Location? = null,
     val serviceEvent: ServiceEvent? = null,
 ) {
@@ -55,7 +51,7 @@ data class BookingFilters(
             if (teamMember != null) count++
             if (attendanceStatus != null) count++
             if (paymentStatus != null) count++
-            if (bookingType.value != BookingType.DEFAULT.value) count++
+            if (bookingType != null && bookingType.value != BookingType.Type.ANY) count++
             if (location != null) count++
             if (serviceEvent != null) count++
             return count

--- a/libs/fluxc-plugin/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/bookings/BookingsFilterOption.kt
+++ b/libs/fluxc-plugin/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/bookings/BookingsFilterOption.kt
@@ -17,8 +17,13 @@ sealed interface BookingsFilterOption {
 
     object PaymentStatus : BookingsFilterOption
 
-    data class BookingType(val value: Type) : BookingsFilterOption {
-        enum class Type { ANY, SERVICE, EVENT }
+    /**
+     * Booking type filter.
+     *
+     * [value] == null means “Any” (no filter is applied); otherwise a concrete [Type] is selected.
+     */
+    data class BookingType(val value: Type?) : BookingsFilterOption {
+        enum class Type { SERVICE, EVENT }
     }
 
     data class Customer(val customerId: Long, val customerName: String) : BookingsFilterOption
@@ -51,7 +56,7 @@ data class BookingFilters(
             if (teamMember != null) count++
             if (attendanceStatus != null) count++
             if (paymentStatus != null) count++
-            if (bookingType != null && bookingType.value != BookingType.Type.ANY) count++
+            if (bookingType?.value != null) count++
             if (location != null) count++
             if (serviceEvent != null) count++
             return count

--- a/libs/fluxc-plugin/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/bookings/BookingsFilterOption.kt
+++ b/libs/fluxc-plugin/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/bookings/BookingsFilterOption.kt
@@ -1,5 +1,13 @@
 package org.wordpress.android.fluxc.network.rest.wpcom.wc.bookings
 
+import org.wordpress.android.fluxc.network.rest.wpcom.wc.bookings.BookingsFilterOption.AttendanceStatus
+import org.wordpress.android.fluxc.network.rest.wpcom.wc.bookings.BookingsFilterOption.BookingType
+import org.wordpress.android.fluxc.network.rest.wpcom.wc.bookings.BookingsFilterOption.Customer
+import org.wordpress.android.fluxc.network.rest.wpcom.wc.bookings.BookingsFilterOption.DateRange
+import org.wordpress.android.fluxc.network.rest.wpcom.wc.bookings.BookingsFilterOption.Location
+import org.wordpress.android.fluxc.network.rest.wpcom.wc.bookings.BookingsFilterOption.PaymentStatus
+import org.wordpress.android.fluxc.network.rest.wpcom.wc.bookings.BookingsFilterOption.ServiceEvent
+import org.wordpress.android.fluxc.network.rest.wpcom.wc.bookings.BookingsFilterOption.TeamMember
 import java.time.Instant
 
 sealed interface BookingsFilterOption {
@@ -11,6 +19,10 @@ sealed interface BookingsFilterOption {
 
     data class BookingType(val value: Type) : BookingsFilterOption {
         enum class Type { ANY, SERVICE, EVENT }
+
+        companion object {
+            val DEFAULT = BookingType(Type.ANY)
+        }
     }
 
     data class Customer(val customerId: Long, val customerName: String) : BookingsFilterOption
@@ -26,14 +38,14 @@ sealed interface BookingsFilterOption {
 }
 
 data class BookingFilters(
-    val dateRange: BookingsFilterOption.DateRange? = null,
-    val customer: BookingsFilterOption.Customer? = null,
-    val teamMember: BookingsFilterOption.TeamMember? = null,
-    val attendanceStatus: BookingsFilterOption.AttendanceStatus? = null,
-    val paymentStatus: BookingsFilterOption.PaymentStatus? = null,
-    val bookingType: BookingsFilterOption.BookingType? = null,
-    val location: BookingsFilterOption.Location? = null,
-    val serviceEvent: BookingsFilterOption.ServiceEvent? = null,
+    val dateRange: DateRange? = null,
+    val customer: Customer? = null,
+    val teamMember: TeamMember? = null,
+    val attendanceStatus: AttendanceStatus? = null,
+    val paymentStatus: PaymentStatus? = null,
+    val bookingType: BookingType = BookingType.DEFAULT,
+    val location: Location? = null,
+    val serviceEvent: ServiceEvent? = null,
 ) {
     val enabledFiltersCount: Int
         get() {
@@ -43,7 +55,7 @@ data class BookingFilters(
             if (teamMember != null) count++
             if (attendanceStatus != null) count++
             if (paymentStatus != null) count++
-            if (bookingType != null && bookingType.value != BookingsFilterOption.BookingType.Type.ANY) count++
+            if (bookingType.value != BookingType.DEFAULT.value) count++
             if (location != null) count++
             if (serviceEvent != null) count++
             return count


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

<!-- Id number of the Linear issue this PR addresses, e.g., WOOMOB-373. -->
Closes WOOMOB-1473

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
This adds a CLEAR button to the Bookings filter screen and updates the filter logic and data model for the clear function.

I changed my mind and added more commits after my original plan, so I suggest not following the commits.
For my last commit (23c9069722718f23e13a8175826cbadb94058f20), I removed `BookingType.ANY` and use `null` for the same purpose. I believe this approach is cleaner, though I’m not strongly opinionated about it. Feel free to share your thoughts.

The style of the CLEAR button should match the one used on the Order filters screen.

### Test Steps
<!-- Describe how to test your changes. Include only what’s needed for the reviewer to validate the behavior.
For new features, outline the main user flow or goal rather than every tap or click — the reviewer should be able to complete the flow naturally.
If applicable, mention key devices, scenarios, or edge cases to verify. -->
1. Log in with a CIAB store.
2. Go to Bookings.
3. Go to the All tab.
4. Tap the Filters button.
5. Select Booking type.
6. Select a type.
7. Navigate back.
8. Tap the CLEAR button.
9. Tap the X button to verify that the unsaved changes dialog is displayed.
10. Tap KEEP CHANGES.
11. Tap Show bookings button.
12. Verify that the filter has been reset.

### Images/gif
<!-- Include before and after images or gifs when appropriate. -->
<img width="360" src="https://github.com/user-attachments/assets/4361a6cf-6c21-4cb3-b9b9-10d3ba6c678d" />

- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
