### PR TITLE
Issue/woomob 1313 use remote feature flag for local catalog

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/featureflags/WooPosLocalCatalogM1Enabled.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/featureflags/WooPosLocalCatalogM1Enabled.kt
@@ -1,11 +1,14 @@
 package com.woocommerce.android.ui.woopos.featureflags
 
-import com.woocommerce.android.util.FeatureFlag
+import com.woocommerce.android.util.IsRemoteFeatureFlagEnabled
+import com.woocommerce.android.util.RemoteFeatureFlag.REMOTE_WOO_POS_LOCAL_CATALOG_M1
 import javax.inject.Inject
 
 @Suppress("unused")
-class WooPosLocalCatalogM1Enabled @Inject constructor() {
-    operator fun invoke(): Boolean {
-        return FeatureFlag.WOO_POS_LOCAL_CATALOG_M1.isEnabled()
+class WooPosLocalCatalogM1Enabled @Inject constructor(
+    private val isRemoteFeatureFlagEnabled: IsRemoteFeatureFlagEnabled
+) {
+    suspend operator fun invoke(): Boolean {
+        return isRemoteFeatureFlagEnabled(REMOTE_WOO_POS_LOCAL_CATALOG_M1)
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/util/FeatureFlag.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/util/FeatureFlag.kt
@@ -10,7 +10,6 @@ enum class FeatureFlag {
     WC_SHIPPING_BANNER,
     BETTER_CUSTOMER_SEARCH_M2,
     ORDER_CREATION_AUTO_TAX_RATE,
-    WOO_POS_LOCAL_CATALOG_M1,
     BOOKINGS_MVP;
 
     fun isEnabled(context: Context? = null): Boolean {
@@ -22,7 +21,6 @@ enum class FeatureFlag {
             WC_SHIPPING_BANNER,
             BETTER_CUSTOMER_SEARCH_M2,
             ORDER_CREATION_AUTO_TAX_RATE,
-            WOO_POS_LOCAL_CATALOG_M1,
             BOOKINGS_MVP -> PackageUtils.isDebugBuild()
         }
     }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/util/IsRemoteFeatureFlagEnabled.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/util/IsRemoteFeatureFlagEnabled.kt
@@ -5,6 +5,7 @@ import com.woocommerce.android.util.RemoteFeatureFlag.APP_PASSWORDS_FOR_JETPACK_
 import com.woocommerce.android.util.RemoteFeatureFlag.LOCAL_NOTIFICATION_1D_AFTER_FREE_TRIAL_EXPIRES
 import com.woocommerce.android.util.RemoteFeatureFlag.LOCAL_NOTIFICATION_1D_BEFORE_FREE_TRIAL_EXPIRES
 import com.woocommerce.android.util.RemoteFeatureFlag.LOCAL_NOTIFICATION_STORE_CREATION_READY
+import com.woocommerce.android.util.RemoteFeatureFlag.REMOTE_WOO_POS_LOCAL_CATALOG_M1
 import com.woocommerce.android.util.RemoteFeatureFlag.WOO_POS
 import javax.inject.Inject
 
@@ -17,6 +18,7 @@ class IsRemoteFeatureFlagEnabled @Inject constructor(
             LOCAL_NOTIFICATION_1D_BEFORE_FREE_TRIAL_EXPIRES,
             LOCAL_NOTIFICATION_1D_AFTER_FREE_TRIAL_EXPIRES,
             WOO_POS,
+            REMOTE_WOO_POS_LOCAL_CATALOG_M1,
             APP_PASSWORDS_FOR_JETPACK_SITES ->
                 PackageUtils.isDebugBuild() ||
                     wpComRemoteFeatureFlagRepository.isRemoteFeatureFlagEnabled(featureFlag.remoteKey)

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/util/RemoteFeatureFlag.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/util/RemoteFeatureFlag.kt
@@ -5,5 +5,6 @@ enum class RemoteFeatureFlag(val remoteKey: String) {
     LOCAL_NOTIFICATION_1D_BEFORE_FREE_TRIAL_EXPIRES("woo_notification_1d_before_free_trial_expires"),
     LOCAL_NOTIFICATION_1D_AFTER_FREE_TRIAL_EXPIRES("woo_notification_1d_after_free_trial_expires"),
     WOO_POS("woo_pos"),
-    APP_PASSWORDS_FOR_JETPACK_SITES("woo_app_passwords_for_jetpack_sites")
+    APP_PASSWORDS_FOR_JETPACK_SITES("woo_app_passwords_for_jetpack_sites"),
+    REMOTE_WOO_POS_LOCAL_CATALOG_M1("woo_pos_local_catalog_m1"),
 }


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

<!-- Id number of the Linear issue this PR addresses, e.g., WOOMOB-373. -->
WOOMOB-1313

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

This PR replaces local FF with a remote FF that is currently enabled on debug builds and on Automattic accounts.

### Test Steps
<!-- Describe how to test your changes. Include only what’s needed for the reviewer to validate the behavior.
For new features, outline the main user flow or goal rather than every tap or click — the reviewer should be able to complete the flow naturally.
If applicable, mention key devices, scenarios, or edge cases to verify. -->

1. Verify POS is not accessible on non-automattic account on release build

### Images/gif
<!-- Include before and after images or gifs when appropriate. -->

N/A

- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
