### PR TITLE
Local catalog - Disable local catalog when POS disabled

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/eligibility/WooPosEligibilityScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/eligibility/WooPosEligibilityScreen.kt
@@ -60,7 +60,7 @@ fun WooPosEligibilityScreen(
 ) {
     LaunchedEffect(retryState) {
         if (retryState is WooPosEligibilityRetryState.Eligible) {
-            onNavigationEvent(WooPosNavigationEvent.OpenHomeFromSplash)
+            onNavigationEvent(WooPosNavigationEvent.OpenSplashScreen)
         }
     }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/localcatalog/WooPosIsLocalCatalogSupported.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/localcatalog/WooPosIsLocalCatalogSupported.kt
@@ -1,6 +1,10 @@
 package com.woocommerce.android.ui.woopos.localcatalog
 
+import com.woocommerce.android.ui.woopos.common.util.WooPosLogWrapper
 import com.woocommerce.android.ui.woopos.featureflags.WooPosLocalCatalogM1Enabled
+import com.woocommerce.android.ui.woopos.tab.WooPosCanBeLaunchedInTab
+import com.woocommerce.android.ui.woopos.tab.WooPosLaunchability
+import com.woocommerce.android.ui.woopos.tab.WooPosTabShouldBeVisible
 import com.woocommerce.android.ui.woopos.util.datastore.WooPosPreferencesRepository
 import org.wordpress.android.fluxc.model.LocalOrRemoteId
 import javax.inject.Inject
@@ -12,19 +16,42 @@ class WooPosIsLocalCatalogSupported @Inject constructor(
     private val wooPosLocalCatalogM1Enabled: WooPosLocalCatalogM1Enabled,
     private val prefsRepo: WooPosPreferencesRepository,
     private val isVariationsEndpointAvailable: WooPosIsLocalCatalogVariationsEndpointAvailable,
+    private val posTabShouldBeVisible: WooPosTabShouldBeVisible,
+    private val posCanBeLaunchedInTab: WooPosCanBeLaunchedInTab,
+    private val wooPosLogWrapper: WooPosLogWrapper,
 ) {
     @Suppress("ReturnCount")
     suspend operator fun invoke(localSiteId: LocalOrRemoteId.LocalId): Boolean {
         if (!wooPosLocalCatalogM1Enabled()) {
-            return false
+            return false.also {
+                wooPosLogWrapper.d("Local Catalog not supported: Feature flag disabled.")
+            }
         }
 
         if (!isVariationsEndpointAvailable()) {
-            return false
+            return false.also {
+                wooPosLogWrapper.d("Local Catalog not supported: Variations endpoint not available.")
+            }
         }
 
         if (!prefsRepo.isPeriodicSyncEnabledForSite(localSiteId)) {
-            return false
+            return false.also {
+                wooPosLogWrapper.d("Local Catalog not supported: Periodic sync disabled.")
+            }
+        }
+
+        val tabVisibleResult = posTabShouldBeVisible()
+        if (tabVisibleResult.isFailure || tabVisibleResult.getOrNull() != true) {
+            return false.also {
+                wooPosLogWrapper.d("Local Catalog not supported: POS Tab not visible.")
+            }
+        }
+
+        val launchability = posCanBeLaunchedInTab()
+        if (launchability !is WooPosLaunchability.Launchable) {
+            return false.also {
+                wooPosLogWrapper.d("Local Catalog not supported: POS not launchable: $launchability.")
+            }
         }
 
         return true

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/localcatalog/WooPosLocalCatalogSyncWorker.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/localcatalog/WooPosLocalCatalogSyncWorker.kt
@@ -6,7 +6,6 @@ import androidx.work.CoroutineWorker
 import androidx.work.WorkerParameters
 import com.woocommerce.android.tools.SelectedSite
 import com.woocommerce.android.ui.woopos.common.util.WooPosLogWrapper
-import com.woocommerce.android.ui.woopos.tab.WooPosTabShouldBeVisible
 import com.woocommerce.android.ui.woopos.util.datastore.WooPosPreferencesRepository
 import dagger.assisted.Assisted
 import dagger.assisted.AssistedInject
@@ -24,7 +23,6 @@ constructor(
     private val syncRepository: WooPosLocalCatalogSyncRepository,
     private val logger: WooPosLogWrapper,
     private val timeProvider: DateTimeProvider,
-    private val wooPosTabShouldBeVisible: WooPosTabShouldBeVisible,
     private val syncStatusChecker: WooPosFullSyncStatusChecker,
 ) : CoroutineWorker(appContext, workerParams) {
 
@@ -35,12 +33,6 @@ constructor(
 
     @Suppress("ReturnCount")
     override suspend fun doWork(): Result {
-        val isPosTabAvailable = wooPosTabShouldBeVisible()
-        if (isPosTabAvailable.isSuccess && isPosTabAvailable.getOrNull() == false) {
-            logger.d("POS tab is not visible, skipping local catalog sync")
-            return Result.success()
-        }
-
         if (isPosInactive()) {
             logger.d("POS has been inactive recently, skipping local catalog sync")
             return Result.success()

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/root/navigation/WooPosNavigationEvent.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/root/navigation/WooPosNavigationEvent.kt
@@ -3,6 +3,7 @@ package com.woocommerce.android.ui.woopos.root.navigation
 import com.woocommerce.android.ui.woopos.tab.WooPosLaunchability
 
 sealed class WooPosNavigationEvent {
+    data object OpenSplashScreen : WooPosNavigationEvent()
     data object ExitPosClicked : WooPosNavigationEvent()
     data object BackFromSplashClicked : WooPosNavigationEvent()
     data object OpenHomeFromSplash : WooPosNavigationEvent()

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/root/navigation/WooPosNavigationEventHandler.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/root/navigation/WooPosNavigationEventHandler.kt
@@ -10,12 +10,14 @@ import com.woocommerce.android.ui.woopos.home.navigateToHomeScreenAfterSuccessfu
 import com.woocommerce.android.ui.woopos.home.navigateToHomeScreenIfHomeScreenNotOpen
 import com.woocommerce.android.ui.woopos.orders.navigateToOrdersScreen
 import com.woocommerce.android.ui.woopos.settings.navigateToSettingsScreen
+import com.woocommerce.android.ui.woopos.splash.navigateToSplashScreen
 
 fun NavHostController.handleNavigationEvent(
     event: WooPosNavigationEvent,
     activity: ComponentActivity,
 ) {
     when (event) {
+        is WooPosNavigationEvent.OpenSplashScreen -> navigateToSplashScreen()
         is WooPosNavigationEvent.ExitPosClicked,
         is WooPosNavigationEvent.BackFromSplashClicked -> activity.finish()
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/splash/WooPosSplashNavigation.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/splash/WooPosSplashNavigation.kt
@@ -1,10 +1,16 @@
 package com.woocommerce.android.ui.woopos.splash
 
+import androidx.navigation.NavController
 import androidx.navigation.NavGraphBuilder
 import androidx.navigation.compose.composable
 import com.woocommerce.android.ui.woopos.root.navigation.WooPosNavigationEvent
+import com.woocommerce.android.ui.woopos.root.navigation.navigateOnce
 
 const val SPLASH_ROUTE = "splash"
+
+fun NavController.navigateToSplashScreen() {
+    navigateOnce(SPLASH_ROUTE)
+}
 
 fun NavGraphBuilder.splashScreen(
     onNavigationEvent: (WooPosNavigationEvent) -> Unit

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/localcatalog/WooPosIsLocalCatalogSupportedTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/localcatalog/WooPosIsLocalCatalogSupportedTest.kt
@@ -2,6 +2,9 @@ package com.woocommerce.android.ui.woopos.localcatalog
 
 import com.woocommerce.android.ui.woopos.common.util.WooPosLogWrapper
 import com.woocommerce.android.ui.woopos.featureflags.WooPosLocalCatalogM1Enabled
+import com.woocommerce.android.ui.woopos.tab.WooPosCanBeLaunchedInTab
+import com.woocommerce.android.ui.woopos.tab.WooPosLaunchability
+import com.woocommerce.android.ui.woopos.tab.WooPosTabShouldBeVisible
 import com.woocommerce.android.ui.woopos.util.datastore.WooPosPreferencesRepository
 import com.woocommerce.android.util.GetWooCorePluginCachedVersion
 import com.woocommerce.android.viewmodel.BaseUnitTest
@@ -21,6 +24,8 @@ class WooPosIsLocalCatalogSupportedTest : BaseUnitTest() {
     private var preferencesRepository: WooPosPreferencesRepository = mock()
     private var getWooVersion: GetWooCorePluginCachedVersion = mock()
     private var logger: WooPosLogWrapper = mock()
+    private var posTabShouldBeVisible: WooPosTabShouldBeVisible = mock()
+    private var posCanBeLaunchedInTab: WooPosCanBeLaunchedInTab = mock()
 
     private lateinit var isLocalCatalogSupported: WooPosIsLocalCatalogSupported
 
@@ -33,6 +38,8 @@ class WooPosIsLocalCatalogSupportedTest : BaseUnitTest() {
         whenever(featureFlagM1Enabled.invoke()).thenReturn(true)
         whenever(getWooVersion()).thenReturn("10.3.0")
         whenever(preferencesRepository.isPeriodicSyncEnabledForSite(any())).thenReturn(true)
+        whenever(posTabShouldBeVisible.invoke()).thenReturn(Result.success(true))
+        whenever(posCanBeLaunchedInTab.invoke()).thenReturn(WooPosLaunchability.Launchable)
 
         val variationsEndpointChecker = WooPosIsLocalCatalogVariationsEndpointAvailable(
             getWooVersion = getWooVersion,
@@ -43,7 +50,10 @@ class WooPosIsLocalCatalogSupportedTest : BaseUnitTest() {
         isLocalCatalogSupported = WooPosIsLocalCatalogSupported(
             wooPosLocalCatalogM1Enabled = featureFlagM1Enabled,
             prefsRepo = preferencesRepository,
-            isVariationsEndpointAvailable = variationsEndpointChecker
+            isVariationsEndpointAvailable = variationsEndpointChecker,
+            posTabShouldBeVisible = posTabShouldBeVisible,
+            posCanBeLaunchedInTab = posCanBeLaunchedInTab,
+            wooPosLogWrapper = logger,
         )
     }
 
@@ -84,6 +94,48 @@ class WooPosIsLocalCatalogSupportedTest : BaseUnitTest() {
     fun `given periodic sync disabled, when check invoked, then returns false`() = testBlocking {
         // GIVEN
         whenever(preferencesRepository.isPeriodicSyncEnabledForSite(SITE_ID)).thenReturn(false)
+
+        // WHEN
+        val result = isLocalCatalogSupported(SITE_ID)
+
+        // THEN
+        assertThat(result).isFalse()
+    }
+
+    @Test
+    fun `given POS tab should not be visible, when check invoked, then returns false`() = testBlocking {
+        // GIVEN
+        whenever(posTabShouldBeVisible.invoke()).thenReturn(Result.success(false))
+
+        // WHEN
+        val result = isLocalCatalogSupported(SITE_ID)
+
+        // THEN
+        assertThat(result).isFalse()
+    }
+
+    @Test
+    fun `given POS tab visibility check fails, when check invoked, then returns false`() = testBlocking {
+        // GIVEN
+        whenever(posTabShouldBeVisible.invoke()).thenReturn(
+            Result.failure(Exception("Visibility check failed"))
+        )
+
+        // WHEN
+        val result = isLocalCatalogSupported(SITE_ID)
+
+        // THEN
+        assertThat(result).isFalse()
+    }
+
+    @Test
+    fun `given POS cannot be launched in tab, when check invoked, then returns false`() = testBlocking {
+        // GIVEN
+        whenever(posCanBeLaunchedInTab.invoke()).thenReturn(
+            WooPosLaunchability.NotLaunchable(
+                WooPosLaunchability.NonLaunchabilityReason.UnsupportedCurrency
+            )
+        )
 
         // WHEN
         val result = isLocalCatalogSupported(SITE_ID)

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/localcatalog/WooPosLocalCatalogSyncWorkerTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/localcatalog/WooPosLocalCatalogSyncWorkerTest.kt
@@ -4,7 +4,6 @@ import android.content.Context
 import androidx.work.ListenableWorker
 import androidx.work.WorkerParameters
 import com.woocommerce.android.ui.woopos.common.util.WooPosLogWrapper
-import com.woocommerce.android.ui.woopos.tab.WooPosTabShouldBeVisible
 import com.woocommerce.android.ui.woopos.util.datastore.WooPosPreferencesRepository
 import com.woocommerce.android.viewmodel.BaseUnitTest
 import kotlinx.coroutines.ExperimentalCoroutinesApi
@@ -29,7 +28,6 @@ class WooPosLocalCatalogSyncWorkerTest : BaseUnitTest() {
     private var syncRepository: WooPosLocalCatalogSyncRepository = mock()
     private lateinit var site: SiteModel
     private var logger: WooPosLogWrapper = mock()
-    private var wooPosTabShouldBeVisible: WooPosTabShouldBeVisible = mock()
     private var syncStatusChecker: WooPosFullSyncStatusChecker = mock()
     private val mockTimeProvider: DateTimeProvider = mock {
         whenever(it.now()).thenReturn(CURRENT_TIME_MILLIS)
@@ -66,7 +64,6 @@ class WooPosLocalCatalogSyncWorkerTest : BaseUnitTest() {
         whenever(selectedSite.getOrNull()).thenReturn(site)
         whenever(syncStatusChecker.checkSyncRequirement()).thenReturn(WooPosFullSyncRequirement.BlockingRequired)
 
-        whenever(wooPosTabShouldBeVisible.invoke()).thenReturn(Result.success(true))
         whenever(preferencesRepository.getLastUsedTimestamp()).thenReturn(null)
         whenever(syncRepository.syncLocalCatalogFull(site))
             .thenReturn(successResponse)
@@ -83,7 +80,6 @@ class WooPosLocalCatalogSyncWorkerTest : BaseUnitTest() {
             syncRepository = syncRepository,
             logger = logger,
             timeProvider = mockTimeProvider,
-            wooPosTabShouldBeVisible = wooPosTabShouldBeVisible,
             syncStatusChecker = syncStatusChecker,
         )
     }
@@ -225,38 +221,6 @@ class WooPosLocalCatalogSyncWorkerTest : BaseUnitTest() {
         assertThat(result).isEqualTo(ListenableWorker.Result.failure())
         verify(syncRepository).syncLocalCatalogFull(eq(site))
         verify(syncRepository, never()).syncLocalCatalogIncremental(any())
-    }
-
-    @Test
-    fun `given POS tab is not available, when sync is attempted, then returns success without syncing`() = testBlocking {
-        // GIVEN
-        whenever(wooPosTabShouldBeVisible.invoke()).thenReturn(Result.success(false))
-
-        val worker = createWorker()
-
-        // WHEN
-        val result = worker.doWork()
-
-        // THEN
-        assertThat(result).isEqualTo(ListenableWorker.Result.success())
-        verify(syncRepository, never()).syncLocalCatalogFull(any())
-        verify(syncRepository, never()).syncLocalCatalogIncremental(any())
-    }
-
-    @Test
-    fun `given POS tab availability check fails, when sync is attempted, then continues to attempt sync`() = testBlocking {
-        // GIVEN
-        whenever(wooPosTabShouldBeVisible.invoke()).thenReturn(Result.failure(Exception("Failed to check POS tab")))
-
-        val worker = createWorker()
-
-        // WHEN
-        val result = worker.doWork()
-
-        // THEN
-        assertThat(result).isEqualTo(ListenableWorker.Result.success())
-        verify(syncRepository).syncLocalCatalogFull(eq(site))
-        verify(syncRepository).syncLocalCatalogIncremental(eq(site))
     }
 
     @Test


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

<!-- Id number of the Linear issue this PR addresses, e.g., WOOMOB-373. -->

WOOMOB-1313

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

This PR disabled Local Catalog, including periodic sync, when POS is not available (e.g. POS toggle is off in wpadmin or currency is not supported).

### Test Steps
<!-- Describe how to test your changes. Include only what’s needed for the reviewer to validate the behavior.
For new features, outline the main user flow or goal rather than every tap or click — the reviewer should be able to complete the flow naturally.
If applicable, mention key devices, scenarios, or edge cases to verify. -->

1. Change currency of your US store to non-USD currency
2. Login
3. Check logs and notice `Local Catalog not supported: POS not launchable: NotLaunchable(reason=UnsupportedCurrency).`
4. Tap on retry
5. Change currency of the store to USD
6. Tap on retry
7. Verify the POS loads and local catalog is used

### Images/gif
<!-- Include before and after images or gifs when appropriate. -->

N/A

- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
