### PR TITLE
Improve performance of loading POS product list

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/items/products/WooPosProductsViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/items/products/WooPosProductsViewModel.kt
@@ -148,7 +148,7 @@ class WooPosProductsViewModel @Inject constructor(
     private fun loadProducts(forceRefreshProducts: Boolean) {
         loadProductsJob?.cancel()
         loadMoreProductsJob?.cancel()
-        loadProductsJob = viewModelScope.launch(dispatchers.computation) {
+        loadProductsJob = viewModelScope.launch(dispatchers.io) {
             _viewState.value = WooPosProductsViewState.Loading()
 
             dataSource.fetchFirstPage(forceRefresh = forceRefreshProducts).collect { result ->

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/items/products/WooPosProductsViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/items/products/WooPosProductsViewModel.kt
@@ -21,6 +21,7 @@ import com.woocommerce.android.ui.woopos.util.analytics.WooPosAnalyticsEvent.Eve
 import com.woocommerce.android.ui.woopos.util.analytics.WooPosAnalyticsEventConstant
 import com.woocommerce.android.ui.woopos.util.analytics.WooPosAnalyticsTracker
 import com.woocommerce.android.ui.woopos.util.format.WooPosFormatPrice
+import com.woocommerce.android.util.CoroutineDispatchers
 import com.woocommerce.android.viewmodel.ResourceProvider
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.Job
@@ -39,6 +40,7 @@ class WooPosProductsViewModel @Inject constructor(
     private val priceFormat: WooPosFormatPrice,
     private val analyticsTracker: WooPosAnalyticsTracker,
     private val resourceProvider: ResourceProvider,
+    private val dispatchers: CoroutineDispatchers,
 ) : ViewModel() {
 
     private var loadMoreProductsJob: Job? = null
@@ -146,7 +148,7 @@ class WooPosProductsViewModel @Inject constructor(
     private fun loadProducts(forceRefreshProducts: Boolean) {
         loadProductsJob?.cancel()
         loadMoreProductsJob?.cancel()
-        loadProductsJob = viewModelScope.launch {
+        loadProductsJob = viewModelScope.launch(dispatchers.computation) {
             _viewState.value = WooPosProductsViewState.Loading()
 
             dataSource.fetchFirstPage(forceRefresh = forceRefreshProducts).collect { result ->

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/util/format/WooPosFormatPrice.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/util/format/WooPosFormatPrice.kt
@@ -1,23 +1,16 @@
 package com.woocommerce.android.ui.woopos.util.format
 
-import com.woocommerce.android.tools.SelectedSite
+import com.woocommerce.android.ui.woopos.util.WooPosGetCachedStoreCurrency
 import com.woocommerce.android.util.CurrencyFormatter
 import com.woocommerce.android.util.PriceUtils
-import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.withContext
-import org.wordpress.android.fluxc.store.WooCommerceStore
 import java.math.BigDecimal
 import javax.inject.Inject
 
 class WooPosFormatPrice @Inject constructor(
     private val currencyFormatter: CurrencyFormatter,
-    private val wooCommerceStore: WooCommerceStore,
-    private val selectedSite: SelectedSite,
+    private val getCachedStoreCurrency: WooPosGetCachedStoreCurrency,
 ) {
     suspend operator fun invoke(price: BigDecimal?): String {
-        val currencyCode = withContext(Dispatchers.IO) {
-            wooCommerceStore.getSiteSettings(selectedSite.get())?.currencyCode
-        }
-        return PriceUtils.formatCurrency(price, currencyCode, currencyFormatter)
+        return PriceUtils.formatCurrency(price, getCachedStoreCurrency(), currencyFormatter)
     }
 }

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/home/items/products/WooPosProductsViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/home/items/products/WooPosProductsViewModelTest.kt
@@ -18,11 +18,13 @@ import com.woocommerce.android.ui.woopos.util.analytics.WooPosAnalyticsEventCons
 import com.woocommerce.android.ui.woopos.util.analytics.WooPosAnalyticsTracker
 import com.woocommerce.android.ui.woopos.util.format.WooPosFormatPrice
 import com.woocommerce.android.ui.woopos.util.generateWooPosProduct
+import com.woocommerce.android.util.CoroutineDispatchers
 import com.woocommerce.android.viewmodel.ResourceProvider
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
 import kotlinx.coroutines.test.advanceUntilIdle
 import kotlinx.coroutines.test.runTest
 import org.assertj.core.api.Assertions.assertThat
@@ -38,9 +40,9 @@ import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
 import java.math.BigDecimal
 
+@OptIn(ExperimentalCoroutinesApi::class)
 class WooPosProductsViewModelTest {
 
-    @OptIn(ExperimentalCoroutinesApi::class)
     @Rule
     @JvmField
     val coroutinesTestRule = WooPosCoroutineTestRule()
@@ -562,6 +564,11 @@ class WooPosProductsViewModelTest {
             priceFormat = priceFormat,
             analyticsTracker = analyticsTracker,
             resourceProvider = resourceProvider,
+            dispatchers = CoroutineDispatchers(
+                UnconfinedTestDispatcher(),
+                UnconfinedTestDispatcher(),
+                UnconfinedTestDispatcher()
+            )
         )
     }
 }

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/home/items/products/WooPosProductsViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/home/items/products/WooPosProductsViewModelTest.kt
@@ -24,7 +24,6 @@ import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.flow.flowOf
-import kotlinx.coroutines.test.UnconfinedTestDispatcher
 import kotlinx.coroutines.test.advanceUntilIdle
 import kotlinx.coroutines.test.runTest
 import org.assertj.core.api.Assertions.assertThat
@@ -565,9 +564,9 @@ class WooPosProductsViewModelTest {
             analyticsTracker = analyticsTracker,
             resourceProvider = resourceProvider,
             dispatchers = CoroutineDispatchers(
-                UnconfinedTestDispatcher(),
-                UnconfinedTestDispatcher(),
-                UnconfinedTestDispatcher()
+                coroutinesTestRule.testDispatcher,
+                coroutinesTestRule.testDispatcher,
+                coroutinesTestRule.testDispatcher
             )
         )
     }


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

<!-- Id number of the Linear issue this PR addresses, e.g., WOOMOB-373. -->

#WOOMOB-1670

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

This PR adds in-memory caching of sites currency and moves mapping of models to a bg thread to speed up performance of loading the POS product list. The initial load after opening the app takes a bit longer then follow up loadings. However, this PR improves performance of both initial load as well as follow up loads.

### Test Steps
<!-- Describe how to test your changes. Include only what’s needed for the reviewer to validate the behavior.
For new features, outline the main user flow or goal rather than every tap or click — the reviewer should be able to complete the flow naturally.
If applicable, mention key devices, scenarios, or edge cases to verify. -->

Smoke test the POS

### Images/gif
<!-- Include before and after images or gifs when appropriate. -->

Before

https://github.com/user-attachments/assets/c923ecc7-740e-4a9f-a145-0eded6f8e263

After

https://github.com/user-attachments/assets/b1bcffe3-19e7-433a-a7bd-0306b52fac7c


- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->

cc @samiuelson since we discussed the performance and seems like this PR fixes the issue.
