### PR TITLE
[WOOMOB-1563] Add analytics tracking for Local Catalog splash screen events

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/splash/WooPosSplashScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/splash/WooPosSplashScreen.kt
@@ -36,6 +36,7 @@ fun WooPosSplashScreen(onNavigationEvent: (WooPosNavigationEvent) -> Unit) {
     val state = viewModel.state.collectAsState()
 
     BackHandler {
+        viewModel.onExitPosClicked()
         onNavigationEvent(WooPosNavigationEvent.BackFromSplashClicked)
     }
 
@@ -45,7 +46,10 @@ fun WooPosSplashScreen(onNavigationEvent: (WooPosNavigationEvent) -> Unit) {
         }
         is WooPosSplashState.Syncing -> {
             SyncingCatalog(
-                onExitPosClicked = { onNavigationEvent(WooPosNavigationEvent.BackFromSplashClicked) }
+                onExitPosClicked = {
+                    viewModel.onExitPosClicked()
+                    onNavigationEvent(WooPosNavigationEvent.BackFromSplashClicked)
+                }
             )
         }
         is WooPosSplashState.SyncFailed -> {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/splash/WooPosSplashViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/splash/WooPosSplashViewModel.kt
@@ -69,6 +69,7 @@ class WooPosSplashViewModel @Inject constructor(
         when (state) {
             WooPosPrepopulatingDataStatus.Syncing -> {
                 _state.value = WooPosSplashState.Syncing
+                analyticsTracker.track(LocalCatalogDownloadingScreenShown)
             }
 
             WooPosPrepopulatingDataStatus.Completed -> {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/splash/WooPosSplashViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/splash/WooPosSplashViewModel.kt
@@ -58,6 +58,7 @@ class WooPosSplashViewModel @Inject constructor(
 
     fun onRetrySync() {
         viewModelScope.launch {
+            analyticsTracker.track(LocalCatalogDownloadingFailedRetryTapped)
             val retryStartTime = System.currentTimeMillis()
             productsDataSource.prepopulateCache().collect(syncStateCollector(retryStartTime))
         }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/splash/WooPosSplashViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/splash/WooPosSplashViewModel.kt
@@ -78,6 +78,9 @@ class WooPosSplashViewModel @Inject constructor(
             }
 
             is WooPosPrepopulatingDataStatus.Failed -> {
+                if (_state.value is WooPosSplashState.Syncing) {
+                    analyticsTracker.track(LocalCatalogDownloadingFailedScreenShown)
+                }
                 _state.value = WooPosSplashState.SyncFailed(state.error)
             }
         }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/splash/WooPosSplashViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/splash/WooPosSplashViewModel.kt
@@ -9,9 +9,9 @@ import com.woocommerce.android.ui.woopos.orders.WooPosOrdersInMemoryCache
 import com.woocommerce.android.ui.woopos.tab.WooPosCanBeLaunchedInTab
 import com.woocommerce.android.ui.woopos.tab.WooPosLaunchability
 import com.woocommerce.android.ui.woopos.util.analytics.WooPosAnalyticsEvent.Event.Loaded
-import com.woocommerce.android.ui.woopos.util.analytics.WooPosAnalyticsEvent.Event.LocalCatalogDownloadingFailedScreenShown
 import com.woocommerce.android.ui.woopos.util.analytics.WooPosAnalyticsEvent.Event.LocalCatalogDownloadingScreenExitPosTapped
 import com.woocommerce.android.ui.woopos.util.analytics.WooPosAnalyticsEvent.Event.LocalCatalogDownloadingScreenShown
+import com.woocommerce.android.ui.woopos.util.analytics.WooPosAnalyticsEvent.Event.SplashScreenErrorShown
 import com.woocommerce.android.ui.woopos.util.analytics.WooPosAnalyticsEvent.Event.SplashScreenRetryTapped
 import com.woocommerce.android.ui.woopos.util.analytics.WooPosAnalyticsTracker
 import com.woocommerce.android.ui.woopos.util.datastore.WooPosPreferencesRepository
@@ -91,9 +91,7 @@ class WooPosSplashViewModel @Inject constructor(
             }
 
             is WooPosPrepopulatingDataStatus.Failed -> {
-                if (_state.value is WooPosSplashState.Syncing) {
-                    analyticsTracker.track(LocalCatalogDownloadingFailedScreenShown)
-                }
+                analyticsTracker.track(SplashScreenErrorShown)
                 _state.value = WooPosSplashState.SyncFailed(state.error)
             }
         }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/splash/WooPosSplashViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/splash/WooPosSplashViewModel.kt
@@ -9,10 +9,10 @@ import com.woocommerce.android.ui.woopos.orders.WooPosOrdersInMemoryCache
 import com.woocommerce.android.ui.woopos.tab.WooPosCanBeLaunchedInTab
 import com.woocommerce.android.ui.woopos.tab.WooPosLaunchability
 import com.woocommerce.android.ui.woopos.util.analytics.WooPosAnalyticsEvent.Event.Loaded
-import com.woocommerce.android.ui.woopos.util.analytics.WooPosAnalyticsEvent.Event.LocalCatalogDownloadingFailedRetryTapped
 import com.woocommerce.android.ui.woopos.util.analytics.WooPosAnalyticsEvent.Event.LocalCatalogDownloadingFailedScreenShown
 import com.woocommerce.android.ui.woopos.util.analytics.WooPosAnalyticsEvent.Event.LocalCatalogDownloadingScreenExitPosTapped
 import com.woocommerce.android.ui.woopos.util.analytics.WooPosAnalyticsEvent.Event.LocalCatalogDownloadingScreenShown
+import com.woocommerce.android.ui.woopos.util.analytics.WooPosAnalyticsEvent.Event.SplashScreenRetryTapped
 import com.woocommerce.android.ui.woopos.util.analytics.WooPosAnalyticsTracker
 import com.woocommerce.android.ui.woopos.util.datastore.WooPosPreferencesRepository
 import dagger.hilt.android.lifecycle.HiltViewModel
@@ -62,7 +62,7 @@ class WooPosSplashViewModel @Inject constructor(
 
     fun onRetrySync() {
         viewModelScope.launch {
-            analyticsTracker.track(LocalCatalogDownloadingFailedRetryTapped)
+            analyticsTracker.track(SplashScreenRetryTapped)
             val retryStartTime = System.currentTimeMillis()
             productsDataSource.prepopulateCache().collect(syncStateCollector(retryStartTime))
         }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/splash/WooPosSplashViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/splash/WooPosSplashViewModel.kt
@@ -9,6 +9,10 @@ import com.woocommerce.android.ui.woopos.orders.WooPosOrdersInMemoryCache
 import com.woocommerce.android.ui.woopos.tab.WooPosCanBeLaunchedInTab
 import com.woocommerce.android.ui.woopos.tab.WooPosLaunchability
 import com.woocommerce.android.ui.woopos.util.analytics.WooPosAnalyticsEvent.Event.Loaded
+import com.woocommerce.android.ui.woopos.util.analytics.WooPosAnalyticsEvent.Event.LocalCatalogDownloadingFailedRetryTapped
+import com.woocommerce.android.ui.woopos.util.analytics.WooPosAnalyticsEvent.Event.LocalCatalogDownloadingFailedScreenShown
+import com.woocommerce.android.ui.woopos.util.analytics.WooPosAnalyticsEvent.Event.LocalCatalogDownloadingScreenExitPosTapped
+import com.woocommerce.android.ui.woopos.util.analytics.WooPosAnalyticsEvent.Event.LocalCatalogDownloadingScreenShown
 import com.woocommerce.android.ui.woopos.util.analytics.WooPosAnalyticsTracker
 import com.woocommerce.android.ui.woopos.util.datastore.WooPosPreferencesRepository
 import dagger.hilt.android.lifecycle.HiltViewModel
@@ -61,6 +65,14 @@ class WooPosSplashViewModel @Inject constructor(
             analyticsTracker.track(LocalCatalogDownloadingFailedRetryTapped)
             val retryStartTime = System.currentTimeMillis()
             productsDataSource.prepopulateCache().collect(syncStateCollector(retryStartTime))
+        }
+    }
+
+    fun onExitPosClicked() {
+        viewModelScope.launch {
+            if (_state.value is WooPosSplashState.Syncing) {
+                analyticsTracker.track(LocalCatalogDownloadingScreenExitPosTapped)
+            }
         }
     }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/util/analytics/WooPosAnalyticsEvent.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/util/analytics/WooPosAnalyticsEvent.kt
@@ -688,8 +688,8 @@ sealed class WooPosAnalyticsEvent : IAnalyticsEvent {
             override val name: String = "local_catalog_downloading_screen_exit_pos_tapped"
         }
 
-        data object LocalCatalogDownloadingFailedScreenShown : Event() {
-            override val name: String = "local_catalog_downloading_failed_screen_shown"
+        data object SplashScreenErrorShown : Event() {
+            override val name: String = "splash_screen_error_shown"
         }
 
         data object SplashScreenRetryTapped : Event() {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/util/analytics/WooPosAnalyticsEvent.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/util/analytics/WooPosAnalyticsEvent.kt
@@ -692,8 +692,8 @@ sealed class WooPosAnalyticsEvent : IAnalyticsEvent {
             override val name: String = "local_catalog_downloading_failed_screen_shown"
         }
 
-        data object LocalCatalogDownloadingFailedRetryTapped : Event() {
-            override val name: String = "local_catalog_downloading_failed_retry_tapped"
+        data object SplashScreenRetryTapped : Event() {
+            override val name: String = "splash_screen_retry_tapped"
         }
     }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/util/analytics/WooPosAnalyticsEvent.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/util/analytics/WooPosAnalyticsEvent.kt
@@ -679,6 +679,22 @@ sealed class WooPosAnalyticsEvent : IAnalyticsEvent {
                 )
             }
         }
+
+        data object LocalCatalogDownloadingScreenShown : Event() {
+            override val name: String = "local_catalog_downloading_screen_shown"
+        }
+
+        data object LocalCatalogDownloadingScreenExitPosTapped : Event() {
+            override val name: String = "local_catalog_downloading_screen_exit_pos_tapped"
+        }
+
+        data object LocalCatalogDownloadingFailedScreenShown : Event() {
+            override val name: String = "local_catalog_downloading_failed_screen_shown"
+        }
+
+        data object LocalCatalogDownloadingFailedRetryTapped : Event() {
+            override val name: String = "local_catalog_downloading_failed_retry_tapped"
+        }
     }
 
     sealed class PaymentFlowTrackerEvent : WooPosAnalyticsEvent() {

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/splash/WooPosSplashViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/splash/WooPosSplashViewModelTest.kt
@@ -17,7 +17,6 @@ import org.junit.Before
 import org.junit.Rule
 import org.mockito.kotlin.any
 import org.mockito.kotlin.mock
-import org.mockito.kotlin.never
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
 import kotlin.test.Test
@@ -225,7 +224,7 @@ class WooPosSplashViewModelTest {
     }
 
     @Test
-    fun `given local catalog sync fails, when vm created, then tracks LocalCatalogDownloadingFailedScreenShown`() = runTest {
+    fun `given local catalog sync fails, when vm created, then tracks SplashScreenErrorShown`() = runTest {
         // GIVEN
         whenever(productsDataSource.prepopulateCache()).thenReturn(
             flowOf(WooPosPrepopulatingDataStatus.Syncing, WooPosPrepopulatingDataStatus.Failed("Sync error"))
@@ -235,21 +234,7 @@ class WooPosSplashViewModelTest {
         createSut()
 
         // THEN
-        verify(analyticsTracker).track(WooPosAnalyticsEvent.Event.LocalCatalogDownloadingFailedScreenShown)
-    }
-
-    @Test
-    fun `given legacy sync fails, when vm created, then does NOT track LocalCatalogDownloadingFailedScreenShown`() = runTest {
-        // GIVEN
-        whenever(productsDataSource.prepopulateCache()).thenReturn(
-            flowOf(WooPosPrepopulatingDataStatus.Failed("Sync error"))
-        )
-
-        // WHEN
-        createSut()
-
-        // THEN
-        verify(analyticsTracker, never()).track(WooPosAnalyticsEvent.Event.LocalCatalogDownloadingFailedScreenShown)
+        verify(analyticsTracker).track(WooPosAnalyticsEvent.Event.SplashScreenErrorShown)
     }
 
     @Test

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/splash/WooPosSplashViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/splash/WooPosSplashViewModelTest.kt
@@ -7,6 +7,7 @@ import com.woocommerce.android.ui.woopos.orders.WooPosOrdersInMemoryCache
 import com.woocommerce.android.ui.woopos.tab.WooPosCanBeLaunchedInTab
 import com.woocommerce.android.ui.woopos.tab.WooPosLaunchability
 import com.woocommerce.android.ui.woopos.util.WooPosCoroutineTestRule
+import com.woocommerce.android.ui.woopos.util.analytics.WooPosAnalyticsEvent
 import com.woocommerce.android.ui.woopos.util.analytics.WooPosAnalyticsTracker
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.flowOf
@@ -16,6 +17,7 @@ import org.junit.Before
 import org.junit.Rule
 import org.mockito.kotlin.any
 import org.mockito.kotlin.mock
+import org.mockito.kotlin.never
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
 import kotlin.test.Test
@@ -206,6 +208,83 @@ class WooPosSplashViewModelTest {
 
         // THEN
         assertThat(sut.state.value).isEqualTo(WooPosSplashState.SyncFailed("Network error"))
+    }
+
+    @Test
+    fun `given local catalog enabled and sync required, when sync starts, then tracks LocalCatalogDownloadingScreenShown`() = runTest {
+        // GIVEN
+        whenever(productsDataSource.prepopulateCache()).thenReturn(
+            flowOf(WooPosPrepopulatingDataStatus.Syncing)
+        )
+
+        // WHEN
+        createSut()
+
+        // THEN
+        verify(analyticsTracker).track(WooPosAnalyticsEvent.Event.LocalCatalogDownloadingScreenShown)
+    }
+
+    @Test
+    fun `given local catalog sync fails, when vm created, then tracks LocalCatalogDownloadingFailedScreenShown`() = runTest {
+        // GIVEN
+        whenever(productsDataSource.prepopulateCache()).thenReturn(
+            flowOf(WooPosPrepopulatingDataStatus.Syncing, WooPosPrepopulatingDataStatus.Failed("Sync error"))
+        )
+
+        // WHEN
+        createSut()
+
+        // THEN
+        verify(analyticsTracker).track(WooPosAnalyticsEvent.Event.LocalCatalogDownloadingFailedScreenShown)
+    }
+
+    @Test
+    fun `given legacy sync fails, when vm created, then does NOT track LocalCatalogDownloadingFailedScreenShown`() = runTest {
+        // GIVEN
+        whenever(productsDataSource.prepopulateCache()).thenReturn(
+            flowOf(WooPosPrepopulatingDataStatus.Failed("Sync error"))
+        )
+
+        // WHEN
+        createSut()
+
+        // THEN
+        verify(analyticsTracker, never()).track(WooPosAnalyticsEvent.Event.LocalCatalogDownloadingFailedScreenShown)
+    }
+
+    @Test
+    fun `when retry sync is clicked, then tracks LocalCatalogDownloadingFailedRetryTapped`() = runTest {
+        // GIVEN
+        whenever(productsDataSource.prepopulateCache()).thenReturn(
+            flowOf(WooPosPrepopulatingDataStatus.Failed(""))
+        )
+        val sut = createSut()
+
+        whenever(productsDataSource.prepopulateCache()).thenReturn(
+            flowOf(WooPosPrepopulatingDataStatus.Completed)
+        )
+
+        // WHEN
+        sut.onRetrySync()
+
+        // THEN
+        verify(analyticsTracker).track(WooPosAnalyticsEvent.Event.LocalCatalogDownloadingFailedRetryTapped)
+    }
+
+    @Test
+    fun `given state is Syncing, when exit POS is clicked, then tracks LocalCatalogDownloadingScreenExitPosTapped`() = runTest {
+        // GIVEN
+        whenever(productsDataSource.prepopulateCache()).thenReturn(
+            flowOf(WooPosPrepopulatingDataStatus.Syncing)
+        )
+        val sut = createSut()
+        assertThat(sut.state.value).isEqualTo(WooPosSplashState.Syncing)
+
+        // WHEN
+        sut.onExitPosClicked()
+
+        // THEN
+        verify(analyticsTracker).track(WooPosAnalyticsEvent.Event.LocalCatalogDownloadingScreenExitPosTapped)
     }
 
     private fun createSut(): WooPosSplashViewModel {

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/splash/WooPosSplashViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/splash/WooPosSplashViewModelTest.kt
@@ -253,7 +253,7 @@ class WooPosSplashViewModelTest {
     }
 
     @Test
-    fun `when retry sync is clicked, then tracks LocalCatalogDownloadingFailedRetryTapped`() = runTest {
+    fun `when retry sync is clicked, then tracks SplashScreenRetryTapped`() = runTest {
         // GIVEN
         whenever(productsDataSource.prepopulateCache()).thenReturn(
             flowOf(WooPosPrepopulatingDataStatus.Failed(""))
@@ -268,7 +268,7 @@ class WooPosSplashViewModelTest {
         sut.onRetrySync()
 
         // THEN
-        verify(analyticsTracker).track(WooPosAnalyticsEvent.Event.LocalCatalogDownloadingFailedRetryTapped)
+        verify(analyticsTracker).track(WooPosAnalyticsEvent.Event.SplashScreenRetryTapped)
     }
 
     @Test


### PR DESCRIPTION
Fixes WOOMOB-1563

### Description
This PR adds analytics tracking for Local Catalog synchronization events on the POS splash screen. These events help track when users encounter the local catalog download process and how they interact with it.

The following analytics events have been implemented:
- `woo_pos_local_catalog_downloading_screen_shown` - Tracked when the app doesn't have the local catalog and displays the "sync in progress" screen.
- `woo_pos_local_catalog_downloading_screen_exit_pos_tapped` - Tracked when the user presses exit POS or presses back during sync.
- `woo_pos_splash_screen_error_shown` - Tracked when opening the POS fails (e.g. catalog is empty and there is no internet connection)
- `woo_pos_splash_screen_retry_tapped` - Tracked when the user taps retry on the error screen.

### Test Steps
1. Clear app data or use a fresh install
2. Log in
3. Open POS mode
4. Observe the splash screen shows "Syncing catalog..." message
5. Verify `local_catalog_downloading_screen_shown` event is tracked
6. Tap on 'Exit POS'
7. Verify `local_catalog_downloading_screen_exit_pos_tapped` is tracked.
8. Open POS
10. Turn on airplane mode. 
11.  Verify `splash_screen_error_shown ` is tracked.
12. Tap on retry and verify `splash_screen_retry_tapped` event is tracked

### Images/gif
N/A - Analytics tracking changes only

- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.