### PR TITLE
[WOOMOB-1675] Remove page limit for incremental local catalog sync

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/WooPosHomeViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/WooPosHomeViewModel.kt
@@ -14,8 +14,6 @@ import com.woocommerce.android.ui.woopos.home.ParentToChildrenEvent.SearchEvent.
 import com.woocommerce.android.ui.woopos.home.ParentToChildrenEvent.SearchEvent.RecentSearchSelected
 import com.woocommerce.android.ui.woopos.home.WooPosHomeState.DialogState
 import com.woocommerce.android.ui.woopos.home.WooPosHomeState.ScreenPositionState
-import com.woocommerce.android.ui.woopos.localcatalog.WooPosIncrementalSyncReason
-import com.woocommerce.android.ui.woopos.localcatalog.WooPosPerformLocalCatalogIncrementalSync
 import com.woocommerce.android.ui.woopos.util.analytics.WooPosAnalyticsEvent
 import com.woocommerce.android.ui.woopos.util.analytics.WooPosAnalyticsEvent.Event.BackToCartTapped
 import com.woocommerce.android.ui.woopos.util.analytics.WooPosAnalyticsTracker
@@ -33,7 +31,6 @@ class WooPosHomeViewModel @Inject constructor(
     private val parentToChildrenEventSender: WooPosParentToChildrenEventSender,
     private val analyticsTracker: WooPosAnalyticsTracker,
     private val soundHelper: WooPosSoundHelper,
-    private val incrementalSync: WooPosPerformLocalCatalogIncrementalSync,
     savedStateHandle: SavedStateHandle,
 ) : ViewModel() {
     private val _state = savedStateHandle.getStateFlow(
@@ -57,7 +54,6 @@ class WooPosHomeViewModel @Inject constructor(
         viewModelScope.launch {
             soundHelper.preloadChaChing()
         }
-        incrementalSync.execute(WooPosIncrementalSyncReason.ON_POS_HOME)
     }
 
     override fun onCleared() {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/items/products/WooPosProductsViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/items/products/WooPosProductsViewModel.kt
@@ -64,7 +64,7 @@ class WooPosProductsViewModel @Inject constructor(
     init {
         listenEventsFromParent()
         loadProducts(forceRefreshProducts = false)
-        incrementalSync.execute(WooPosIncrementalSyncReason.ON_POS_HOME)
+        incrementalSync.execute(WooPosIncrementalSyncReason.ON_POS_PRODUCT_LIST)
     }
 
     private fun listenEventsFromParent() {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/items/products/WooPosProductsViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/items/products/WooPosProductsViewModel.kt
@@ -16,6 +16,8 @@ import com.woocommerce.android.ui.woopos.home.items.WooPosPullToRefreshState
 import com.woocommerce.android.ui.woopos.localcatalog.PosLocalCatalogProductSyncResult
 import com.woocommerce.android.ui.woopos.localcatalog.PosLocalCatalogSyncResult
 import com.woocommerce.android.ui.woopos.localcatalog.ProductsResult
+import com.woocommerce.android.ui.woopos.localcatalog.WooPosIncrementalSyncReason
+import com.woocommerce.android.ui.woopos.localcatalog.WooPosPerformLocalCatalogIncrementalSync
 import com.woocommerce.android.ui.woopos.util.analytics.WooPosAnalyticsEvent
 import com.woocommerce.android.ui.woopos.util.analytics.WooPosAnalyticsEvent.Event.PullToRefreshTriggered
 import com.woocommerce.android.ui.woopos.util.analytics.WooPosAnalyticsEventConstant
@@ -41,6 +43,7 @@ class WooPosProductsViewModel @Inject constructor(
     private val analyticsTracker: WooPosAnalyticsTracker,
     private val resourceProvider: ResourceProvider,
     private val dispatchers: CoroutineDispatchers,
+    incrementalSync: WooPosPerformLocalCatalogIncrementalSync,
 ) : ViewModel() {
 
     private var loadMoreProductsJob: Job? = null
@@ -61,6 +64,7 @@ class WooPosProductsViewModel @Inject constructor(
     init {
         listenEventsFromParent()
         loadProducts(forceRefreshProducts = false)
+        incrementalSync.execute(WooPosIncrementalSyncReason.ON_POS_HOME)
     }
 
     private fun listenEventsFromParent() {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/localcatalog/WooPosIncrementalSyncReason.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/localcatalog/WooPosIncrementalSyncReason.kt
@@ -8,6 +8,6 @@ package com.woocommerce.android.ui.woopos.localcatalog
  */
 enum class WooPosIncrementalSyncReason(val description: String) {
     AFTER_SUCCESSFUL_PAYMENT("after successful payment"),
-    ON_POS_HOME("on POS home"),
+    ON_POS_PRODUCT_LIST("on POS product list"),
     PERIODIC_HOURLY("periodic hourly"),
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/localcatalog/WooPosIsLocalCatalogVariationsEndpointAvailable.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/localcatalog/WooPosIsLocalCatalogVariationsEndpointAvailable.kt
@@ -3,17 +3,19 @@ package com.woocommerce.android.ui.woopos.localcatalog
 import com.woocommerce.android.extensions.semverCompareTo
 import com.woocommerce.android.ui.woopos.common.util.WooPosLogWrapper
 import com.woocommerce.android.util.CoroutineDispatchers
+import com.woocommerce.android.util.FetchActiveWCPluginVersion
 import com.woocommerce.android.util.GetWooCorePluginCachedVersion
 import kotlinx.coroutines.withContext
 import javax.inject.Inject
 
 class WooPosIsLocalCatalogVariationsEndpointAvailable @Inject constructor(
     private val getWooVersion: GetWooCorePluginCachedVersion,
+    private val fetchWooVersion: FetchActiveWCPluginVersion,
     private val logger: WooPosLogWrapper,
     private val dispatchers: CoroutineDispatchers,
 ) {
     suspend operator fun invoke(): Boolean = withContext(dispatchers.io) {
-        val currentWooCoreVersion = getWooVersion() ?: return@withContext false.also {
+        val currentWooCoreVersion = getWooVersion() ?: fetchWooVersion() ?: return@withContext false.also {
             logger.d("Unknown WooCommerce version - assuming variations endpoint not available.")
         }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/localcatalog/WooPosLocalCatalogSyncRepository.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/localcatalog/WooPosLocalCatalogSyncRepository.kt
@@ -25,9 +25,9 @@ class WooPosLocalCatalogSyncRepository @Inject constructor(
     companion object {
         const val PAGE_SIZE = 100
         const val MAX_PAGES_PER_FULL_SYNC = 10
-        const val MAX_PAGES_PER_INCREMENTAL_SYNC = 3
+        const val MAX_PAGES_PER_INCREMENTAL_SYNC = Int.MAX_VALUE
         const val MAX_TOTAL_ITEMS_FULL_SYNC = 1000
-        const val MAX_TOTAL_ITEMS_INCREMENTAL_SYNC = 300
+        const val MAX_TOTAL_ITEMS_INCREMENTAL_SYNC = Int.MAX_VALUE
     }
 
     suspend fun syncLocalCatalogFull(site: SiteModel): PosLocalCatalogSyncResult = withContext(dispatchers.io) {

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/home/WooPosHomeViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/home/WooPosHomeViewModelTest.kt
@@ -7,7 +7,6 @@ import com.woocommerce.android.ui.woopos.home.ParentToChildrenEvent.OrderSuccess
 import com.woocommerce.android.ui.woopos.home.WooPosHomeUIEvent.ExitPosClicked
 import com.woocommerce.android.ui.woopos.home.WooPosHomeUIEvent.SystemBackClicked
 import com.woocommerce.android.ui.woopos.home.items.WooPosItemsViewModel.ItemClickedData
-import com.woocommerce.android.ui.woopos.localcatalog.WooPosPerformLocalCatalogIncrementalSync
 import com.woocommerce.android.ui.woopos.util.WooPosCoroutineTestRule
 import com.woocommerce.android.ui.woopos.util.analytics.WooPosAnalyticsEvent.Event.BackToCartTapped
 import com.woocommerce.android.ui.woopos.util.analytics.WooPosAnalyticsEvent.Event.ExitConfirmed
@@ -38,7 +37,6 @@ class WooPosHomeViewModelTest {
     private val parentToChildrenEventSender: WooPosParentToChildrenEventSender = mock()
     private val analyticsTracker: WooPosAnalyticsTracker = mock()
     private val soundHelper: WooPosSoundHelper = mock()
-    private val incrementalSync: WooPosPerformLocalCatalogIncrementalSync = mock()
 
     @Test
     fun `when order created, then pass event to cart`() =
@@ -349,7 +347,6 @@ class WooPosHomeViewModelTest {
             parentToChildrenEventSender,
             analyticsTracker,
             soundHelper,
-            incrementalSync,
             SavedStateHandle()
         )
     }

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/home/items/products/WooPosProductsViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/home/items/products/WooPosProductsViewModelTest.kt
@@ -12,6 +12,7 @@ import com.woocommerce.android.ui.woopos.home.items.WooPosItemsViewModel
 import com.woocommerce.android.ui.woopos.home.items.WooPosPaginationState
 import com.woocommerce.android.ui.woopos.home.items.WooPosProductsViewState
 import com.woocommerce.android.ui.woopos.localcatalog.ProductsResult
+import com.woocommerce.android.ui.woopos.localcatalog.WooPosPerformLocalCatalogIncrementalSync
 import com.woocommerce.android.ui.woopos.util.WooPosCoroutineTestRule
 import com.woocommerce.android.ui.woopos.util.analytics.WooPosAnalyticsEvent
 import com.woocommerce.android.ui.woopos.util.analytics.WooPosAnalyticsEventConstant
@@ -55,6 +56,7 @@ class WooPosProductsViewModelTest {
     private val analyticsTracker: WooPosAnalyticsTracker = mock()
     private val productsDataSource: WooPosProductsDataSource = mock()
     private val resourceProvider: ResourceProvider = mock()
+    private val catalogIncrementalSync: WooPosPerformLocalCatalogIncrementalSync = mock()
 
     @Before
     fun setup() {
@@ -567,7 +569,8 @@ class WooPosProductsViewModelTest {
                 coroutinesTestRule.testDispatcher,
                 coroutinesTestRule.testDispatcher,
                 coroutinesTestRule.testDispatcher
-            )
+            ),
+            incrementalSync = catalogIncrementalSync,
         )
     }
 }

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/localcatalog/WooPosIsLocalCatalogSupportedTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/localcatalog/WooPosIsLocalCatalogSupportedTest.kt
@@ -6,6 +6,7 @@ import com.woocommerce.android.ui.woopos.tab.WooPosCanBeLaunchedInTab
 import com.woocommerce.android.ui.woopos.tab.WooPosLaunchability
 import com.woocommerce.android.ui.woopos.tab.WooPosTabShouldBeVisible
 import com.woocommerce.android.ui.woopos.util.datastore.WooPosPreferencesRepository
+import com.woocommerce.android.util.FetchActiveWCPluginVersion
 import com.woocommerce.android.util.GetWooCorePluginCachedVersion
 import com.woocommerce.android.viewmodel.BaseUnitTest
 import kotlinx.coroutines.ExperimentalCoroutinesApi
@@ -23,6 +24,7 @@ class WooPosIsLocalCatalogSupportedTest : BaseUnitTest() {
     private var featureFlagM1Enabled: WooPosLocalCatalogM1Enabled = mock()
     private var preferencesRepository: WooPosPreferencesRepository = mock()
     private var getWooVersion: GetWooCorePluginCachedVersion = mock()
+    private var fetchWooVersion: FetchActiveWCPluginVersion = mock()
     private var logger: WooPosLogWrapper = mock()
     private var posTabShouldBeVisible: WooPosTabShouldBeVisible = mock()
     private var posCanBeLaunchedInTab: WooPosCanBeLaunchedInTab = mock()
@@ -43,6 +45,7 @@ class WooPosIsLocalCatalogSupportedTest : BaseUnitTest() {
 
         val variationsEndpointChecker = WooPosIsLocalCatalogVariationsEndpointAvailable(
             getWooVersion = getWooVersion,
+            fetchWooVersion = fetchWooVersion,
             logger = logger,
             dispatchers = coroutinesTestRule.testDispatchers
         )

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/localcatalog/WooPosPerformLocalCatalogIncrementalSyncTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/localcatalog/WooPosPerformLocalCatalogIncrementalSyncTest.kt
@@ -109,7 +109,7 @@ class WooPosPerformLocalCatalogIncrementalSyncTest {
         advanceUntilIdle()
 
         // THEN
-        verify(wooPosLogWrapper).d("Starting incremental sync on POS home")
+        verify(wooPosLogWrapper).d("Starting incremental sync on POS product list")
         verify(wooPosLogWrapper).d(
             "Sync on POS home completed successfully: 15 products, 8 variations synced in 2500ms"
         )

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/localcatalog/WooPosPerformLocalCatalogIncrementalSyncTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/localcatalog/WooPosPerformLocalCatalogIncrementalSyncTest.kt
@@ -57,7 +57,7 @@ class WooPosPerformLocalCatalogIncrementalSyncTest {
         advanceUntilIdle()
 
         // THEN
-        verify(wooPosLogWrapper).d("Skipping sync on POS home: Local catalog not supported for site")
+        verify(wooPosLogWrapper).d("Skipping sync on POS product list: Local catalog not supported for site")
         verifyNoInteractions(localCatalogSyncRepository)
     }
 
@@ -111,7 +111,7 @@ class WooPosPerformLocalCatalogIncrementalSyncTest {
         // THEN
         verify(wooPosLogWrapper).d("Starting incremental sync on POS product list")
         verify(wooPosLogWrapper).d(
-            "Sync on POS home completed successfully: 15 products, 8 variations synced in 2500ms"
+            "Sync on POS product list completed successfully: 15 products, 8 variations synced in 2500ms"
         )
     }
 

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/localcatalog/WooPosPerformLocalCatalogIncrementalSyncTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/localcatalog/WooPosPerformLocalCatalogIncrementalSyncTest.kt
@@ -53,7 +53,7 @@ class WooPosPerformLocalCatalogIncrementalSyncTest {
         whenever(isLocalCatalogSupported(site.localId())).thenReturn(false)
 
         // WHEN
-        sut.execute(WooPosIncrementalSyncReason.ON_POS_HOME)
+        sut.execute(WooPosIncrementalSyncReason.ON_POS_PRODUCT_LIST)
         advanceUntilIdle()
 
         // THEN
@@ -105,7 +105,7 @@ class WooPosPerformLocalCatalogIncrementalSyncTest {
         whenever(localCatalogSyncRepository.syncLocalCatalogIncremental(site)).thenReturn(syncResult)
 
         // WHEN
-        sut.execute(WooPosIncrementalSyncReason.ON_POS_HOME)
+        sut.execute(WooPosIncrementalSyncReason.ON_POS_PRODUCT_LIST)
         advanceUntilIdle()
 
         // THEN
@@ -175,9 +175,9 @@ class WooPosPerformLocalCatalogIncrementalSyncTest {
         whenever(localCatalogSyncRepository.syncLocalCatalogIncremental(site)).thenReturn(syncResult)
 
         // WHEN & THEN
-        sut.execute(WooPosIncrementalSyncReason.ON_POS_HOME)
+        sut.execute(WooPosIncrementalSyncReason.ON_POS_PRODUCT_LIST)
         advanceUntilIdle()
-        verify(wooPosLogWrapper).d("Starting incremental sync on POS home")
+        verify(wooPosLogWrapper).d("Starting incremental sync on POS product list")
 
         sut.execute(WooPosIncrementalSyncReason.AFTER_SUCCESSFUL_PAYMENT)
         advanceUntilIdle()


### PR DESCRIPTION
Fixes WOOMOB-1675
Fixes WOOMOB-1681 

### Description
This PR removes the artificial page limit for incremental local catalog sync in the WooCommerce POS feature. Previously, incremental syncs were limited to 3 pages (300 items), which could cause issues when there were more modified products. Now the incremental sync can fetch all modified products without any page limit.

Related slack convo p1762784153019609-slack-C070SJRA8DP

The changes also move the incremental sync trigger from POS Home screen to the Product List screen and rename the sync reason from `ON_POS_HOME` to `ON_PRODUCTS_TAB` to better reflect where the sync is initiated. This is needed since HOME VM is initialized before the Splash screen, and we don't want to run incremental sync before the Splash screen verifies whether a full sync is needed or not.

Last but not least, this PR also modifies the check for availability of /variations endpoint - we fetch woo version if it's not already cached, to ensure the catalog sync is performed after login.

P.S. @samiuelson I usually try to avoid assigning PRs to folks who just came from AFK, however, it changes the core syncing logic and I might be missing some context.

### Test Steps
1. Clean apps data
2. Login
3. Notice the catalog sync is scheduled and starts
4. When it starts open the POS tab
5. Notice the splash screen "connects" to the ongoing background sync and listens for progress. Notice a standalone incremental sync is NOT performed (it's performed only as part of the full sync)
6. Notice when splash screen disappears and product list is displayed the incremental sync is performed

### Images/gif
N/A - Backend sync logic change

- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.