### PR TITLE
Fix overlapping texts by pinning to the text bottom

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/orders/WooPosOrdersDetails.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/orders/WooPosOrdersDetails.kt
@@ -170,7 +170,7 @@ private fun OrderProductItem(row: OrderDetailsViewState.Computed.Details.LineIte
             style = WooPosTypography.BodyMedium,
             color = WooPosTheme.colors.onSurfaceVariantHighest,
             modifier = Modifier.constrainAs(qtyText) {
-                bottom.linkTo(image.bottom)
+                top.linkTo(nameText.bottom, margin = WooPosSpacing.XSmall.value)
                 start.linkTo(nameText.start)
                 end.linkTo(totalText.start, margin = WooPosSpacing.Small.value)
                 width = Dimension.fillToConstraints

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/orders/WooPosOrdersDetails.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/orders/WooPosOrdersDetails.kt
@@ -357,7 +357,7 @@ fun WooPosOrderDetailsPreview() {
         lineItems = listOf(
             OrderDetailsViewState.Computed.Details.LineItemRow(101, "Cup", "2 x $4.00", "$8.00", null),
             OrderDetailsViewState.Computed.Details.LineItemRow(102, "Coffee Container", "1 x $10.00", "$10.00", null),
-            OrderDetailsViewState.Computed.Details.LineItemRow(103, "Paper Filter", "1 x $5.00", "$5.00", null)
+            OrderDetailsViewState.Computed.Details.LineItemRow(103, "A vey tasty coffee that incidentally has a very long name and should go over a few lines without overlapping anything", "1 x $5.00", "$5.00", null)
         ),
         breakdown = OrderDetailsViewState.Computed.Details.TotalsBreakdown(
             products = "$23.00",


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

<!-- Id number of the Linear issue this PR addresses, e.g., WOOMOB-373. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
With this quick PR we fix a glitch happening when the product has a long title in POS Orders. With two lines, it overlaps the bottom text of quantity. We fix it by pinning the quantity text to the title, instead of to the image.

### Test Steps
<!-- Describe how to test your changes. Include only what’s needed for the reviewer to validate the behavior.
For new features, outline the main user flow or goal rather than every tap or click — the reviewer should be able to complete the flow naturally.
If applicable, mention key devices, scenarios, or edge cases to verify. -->
With a long product title and a POS Order containing that product:

- Go to POS Orders
- Check that the title doesn't overlap the quantity text

### Images/gif
<!-- Include before and after images or gifs when appropriate. -->

#### Before
![Screenshot_20251111_162453_Woo (Dev)](https://github.com/user-attachments/assets/573ea58e-f8de-4335-978b-2388fb9e8988)

#### After
![Screenshot_20251111_162244_Woo (Dev)](https://github.com/user-attachments/assets/596b527e-a393-44cc-80dc-d27cc891e47b)



- [X] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
