### PR TITLE
Ignore false positives in the unused dependencies report

### DIFF
--- a/WooCommerce-Wear/build.gradle
+++ b/WooCommerce-Wear/build.gradle
@@ -219,3 +219,16 @@ static def loadPropertiesFromFile(inputFile) {
     }
     return properties
 }
+
+dependencyAnalysis {
+    issues {
+        onUnusedDependencies {
+            // This dependency is actually needed otherwise the app will crash with a runtime exception.
+            exclude(libs.androidx.hilt.navigation.compose.get().module.toString())
+            // This dependency is actually needed otherwise the app will crash with a runtime exception.
+            exclude(libs.androidx.preference.ktx.get().module.toString())
+            // This dependency is actually needed otherwise the app will crash with a runtime exception.
+            exclude(libs.androidx.work.runtime.ktx.get().module.toString())
+        }
+    }
+}

--- a/WooCommerce/build.gradle
+++ b/WooCommerce/build.gradle
@@ -514,4 +514,19 @@ def isLeakCanaryEnabled() {
     return developerProperties.get("enable_leak_canary") ?: true
 }
 
+dependencyAnalysis {
+    issues {
+        onUnusedDependencies {
+            // This dependency is actually needed otherwise UI tests will crash with a runtime exception.
+            exclude(libs.apache.http.client.android.get().module.toString())
+            // This dependency is actually needed otherwise it will cause the app to fail to build.
+            exclude(libs.androidx.hilt.navigation.compose.get().module.toString())
+            // This dependency is actually needed otherwise it will cause the app to fail to build.
+            exclude(libs.androidx.work.runtime.ktx.get().module.toString())
+            // This dependency is actually needed otherwise it will cause the app to fail to build.
+            exclude(libs.google.protobuf.kotlinlite.get().module.toString())
+        }
+    }
+}
+
 apply from: '../config/gradle/build_optimization.gradle'

--- a/WooCommerce/build.gradle
+++ b/WooCommerce/build.gradle
@@ -349,6 +349,7 @@ dependencies {
         exclude group: 'asm', module: 'asm'
         exclude group: 'org.json', module: 'json'
     }
+    androidTestImplementation(libs.apache.http.client.android)
     constraints {
         androidTestImplementation(libs.wiremock) {
             because("newer versions of WireMock use Java APIs not available on Android")

--- a/WooCommerce/build.gradle
+++ b/WooCommerce/build.gradle
@@ -349,7 +349,6 @@ dependencies {
         exclude group: 'asm', module: 'asm'
         exclude group: 'org.json', module: 'json'
     }
-    androidTestImplementation(libs.apache.http.client.android)
     constraints {
         androidTestImplementation(libs.wiremock) {
             because("newer versions of WireMock use Java APIs not available on Android")

--- a/libs/apifaker/build.gradle
+++ b/libs/apifaker/build.gradle
@@ -56,3 +56,14 @@ dependencies {
     testImplementation(libs.mockito.kotlin)
     testImplementation(libs.kotlinx.coroutines.test)
 }
+
+dependencyAnalysis {
+    issues {
+        onUnusedDependencies {
+            // This dependency is actually needed otherwise the app will crash with a runtime exception.
+            exclude(libs.androidx.compose.material.icons.extended.get().module.toString())
+            // This dependency is actually needed otherwise the app will crash with a runtime exception.
+            exclude(libs.androidx.hilt.navigation.compose.get().module.toString())
+        }
+    }
+}

--- a/libs/fluxc-plugin/build.gradle
+++ b/libs/fluxc-plugin/build.gradle
@@ -103,3 +103,12 @@ dependencies {
     androidTestImplementation libs.androidx.test.ext.junit
     androidTestImplementation libs.assertj.core
 }
+
+dependencyAnalysis {
+    issues {
+        onUnusedDependencies {
+            // This dependency is actually needed otherwise it will cause the app to fail to build.
+            exclude(libs.androidx.core.ktx.get().module.toString())
+        }
+    }
+}

--- a/libs/fluxc-tests/build.gradle
+++ b/libs/fluxc-tests/build.gradle
@@ -50,3 +50,12 @@ dependencies {
     testImplementation libs.androidx.arch.core.testing
     testImplementation libs.androidx.paging.runtime
 }
+
+dependencyAnalysis {
+    issues {
+        onUnusedDependencies {
+            // This dependency is actually needed; otherwise, tests fail.
+            exclude(libs.androidx.paging.runtime.get().module.toString())
+        }
+    }
+}

--- a/libs/fluxc/build.gradle
+++ b/libs/fluxc/build.gradle
@@ -123,10 +123,12 @@ tasks.withType(KotlinCompile).configureEach {
 dependencyAnalysis {
     issues {
         onUnusedDependencies {
-            // This dependency is actually needed otherwise the app will crash with a runtime exception.
+            // This dependency is actually needed; otherwise, the app will crash with a runtime exception.
             exclude(libs.eventbus.android.get().module.toString())
-            // This dependency is actually needed otherwise UI tests will crash with a runtime exception.
+            // This dependency is actually needed; otherwise, UI tests will crash with a runtime exception.
             exclude(libs.apache.http.client.android.get().module.toString())
+            // This dependency is actually needed; otherwise, NoClassDefFoundError will be thrown during card reader connection flow.
+            exclude(libs.squareup.okhttp3.tls.get().module.toString())
         }
     }
 }


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

<!-- Id number of the Linear issue this PR addresses, e.g., WOOMOB-373. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
This excludes false positive dependencies from unused dependencies report.

For `libs.squareup.okhttp3.tls`, the project can still run without it, but it was [added recently](https://github.com/woocommerce/woocommerce-android/pull/14681) because the card connection flow crashes without it. So, I added an exception for it as well.

### Test Steps
<!-- Describe how to test your changes. Include only what’s needed for the reviewer to validate the behavior.
For new features, outline the main user flow or goal rather than every tap or click — the reviewer should be able to complete the flow naturally.
If applicable, mention key devices, scenarios, or edge cases to verify. -->
1. Run `./gradlew buildHealth `
2. Find the line in the terminal logs that says.
3. Click on it.
4. Verify that no unused dependencies are reported.

### Images/gif
<!-- Include before and after images or gifs when appropriate. -->

- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
