### PR TITLE
[POS Orders] Hide lines with zero value

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/orders/WooPosOrdersViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/orders/WooPosOrdersViewModel.kt
@@ -527,7 +527,7 @@ class WooPosOrdersViewModel @Inject constructor(
             createdAtMillis = order.dateCreated.time
         )
     }
-    
+
     private suspend fun mapOrderDetails(
         order: Order,
         refundResult: RefundFetchResult
@@ -625,10 +625,10 @@ class WooPosOrdersViewModel @Inject constructor(
 
         return OrderDetailsViewState.Computed.Details.TotalsBreakdown(
             products = formatPrice(order.productsTotal),
-            discount = order.discountTotal.takeIf { it != BigDecimal.ZERO }?.let { "-${formatPrice(it)}" },
+            discount = order.discountTotal.takeIf { !it.isZero() }?.let { "-${formatPrice(it)}" },
             discountCode = discountCode,
             taxes = formatPrice(order.totalTax),
-            shipping = order.shippingTotal.takeIf { it != BigDecimal.ZERO }?.let { formatPrice(it) },
+            shipping = order.shippingTotal.takeIf { !it.isZero() }?.let { formatPrice(it) },
             refunds = refundInfo.refundAmounts,
             netPayment = netPayment
         )
@@ -648,3 +648,5 @@ private fun Order.Status.localizedLabel(resourceProvider: ResourceProvider, loca
         Order.Status.Refunded -> resourceProvider.getString(R.string.woopos_orders_status_refunded)
     }
 }
+
+private fun BigDecimal.isZero() = this.compareTo(BigDecimal.ZERO) == 0

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -3826,8 +3826,8 @@
     <string name="woopos_orders_details_totals_title">Totals</string>
     <string name="woopos_orders_details_qty_unit_price_format">%1$d x %2$s</string>
     <string name="woopos_orders_details_breakdown_products_label">Products</string>
-    <string name="woopos_orders_details_breakdown_discount_label">Discount</string>
-    <string name="woopos_orders_details_breakdown_discount_with_code_label">Discount (%1$s)</string>
+    <string name="woopos_orders_details_breakdown_discount_label">Discount total</string>
+    <string name="woopos_orders_details_breakdown_discount_with_code_label">Discount total (%1$s)</string>
     <string name="woopos_orders_details_breakdown_taxes_label">Taxes</string>
     <string name="woopos_orders_details_breakdown_shipping_label">Shipping</string>
     <string name="woopos_orders_details_total_label">Total</string>

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/orders/WooPosOrdersViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/orders/WooPosOrdersViewModelTest.kt
@@ -844,4 +844,57 @@ class WooPosOrdersViewModelTest {
         // THEN
         verify(ordersAnalyticsTracker).trackOrdersListSearchResultsFetched(any())
     }
+
+    @Test
+    fun `given order with zero discount and zero shipping, when mapped, then discount and shipping are absent`() = runTest {
+        // GIVEN
+        val base = order(1)
+        val withZeros = base.copy(
+            discountTotal = BigDecimal("0.00"),
+            shippingTotal = BigDecimal("0.00")
+        )
+
+        // WHEN
+        whenever(dataSource.loadOrders()).thenReturn(
+            flow { emit(LoadOrdersResult.SuccessRemote(ordersMap(withZeros))) }
+        )
+
+        viewModel = createViewModel()
+        advanceUntilIdle()
+
+        // THEN
+        val content = viewModel.state.value as WooPosOrdersState.Content
+        val breakdown = content.selectedDetails.breakdown
+        assertThat(breakdown.discount).isNull()
+        assertThat(breakdown.shipping).isNull()
+    }
+
+    @Test
+    fun `given order with non-zero discount and shipping, when mapped, then discount and shipping are formatted`() = runTest {
+        // GIVEN
+        val base = order(2)
+        val withValues = base.copy(
+            discountTotal = BigDecimal("3.50"),
+            shippingTotal = BigDecimal("4.00")
+        )
+
+        // WHEN
+        runBlocking {
+            whenever(formatPrice.invoke(BigDecimal("3.50"))).thenReturn("$3.50")
+            whenever(formatPrice.invoke(BigDecimal("4.00"))).thenReturn("$4.00")
+        }
+
+        whenever(dataSource.loadOrders()).thenReturn(
+            flow { emit(LoadOrdersResult.SuccessRemote(ordersMap(withValues))) }
+        )
+
+        viewModel = createViewModel()
+        advanceUntilIdle()
+
+        // THEN
+        val content = viewModel.state.value as WooPosOrdersState.Content
+        val breakdown = content.selectedDetails.breakdown
+        assertThat(breakdown.discount).isEqualTo("-$3.50")
+        assertThat(breakdown.shipping).isEqualTo("$4.00")
+    }
 }


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

<!-- Id number of the Linear issue this PR addresses, e.g., WOOMOB-373. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
With this PR we hide those lines from the order lines which value is zero. The function used to compare `BigDecimal` wasn't giving our expected behavior, so fixing that solved the issue.

Other than that, we align with iOS on the Discount texts, now it's "Discount total".

### Test Steps
<!-- Describe how to test your changes. Include only what’s needed for the reviewer to validate the behavior.
For new features, outline the main user flow or goal rather than every tap or click — the reviewer should be able to complete the flow naturally.
If applicable, mention key devices, scenarios, or edge cases to verify. -->
With an order that doesn't have any shipping or discount:

1. Go to POS
2. Open Orders
3. Check that Order
4. See that shipping or discount are hidden

### Images/gif
<!-- Include before and after images or gifs when appropriate. -->

#### Before

<img width="1022" height="677" alt="image" src="https://github.com/user-attachments/assets/84f1fb4a-aec2-403f-b422-fd52d540a39d" />

#### After

![Screenshot_20251112_123830_Woo (Dev)](https://github.com/user-attachments/assets/415d46a6-5f37-42f9-9fbd-b140dae65a78)



- [X] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
