### PR TITLE
Support basic auth when fetching nonce with site credentials

### DIFF
--- a/libs/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpapi/NonceRestClient.kt
+++ b/libs/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpapi/NonceRestClient.kt
@@ -2,6 +2,7 @@ package org.wordpress.android.fluxc.network.rest.wpapi
 
 import com.android.volley.NoConnectionError
 import com.android.volley.RequestQueue
+import okhttp3.Credentials
 import org.wordpress.android.fluxc.Dispatcher
 import org.wordpress.android.fluxc.model.SiteModel
 import org.wordpress.android.fluxc.network.UserAgent
@@ -57,8 +58,14 @@ class NonceRestClient @Inject constructor(
             "pwd" to password,
             "redirect_to" to redirectUrl
         )
+        val authHeader = Credentials.basic(username, password)
         val response =
-            wpApiEncodedBodyRequestBuilder.syncPostRequest(this, wpLoginUrl, body = body)
+            wpApiEncodedBodyRequestBuilder.syncPostRequest(
+                this,
+                wpLoginUrl,
+                body = body,
+                authHeader = authHeader
+            )
         val nonce = when (response) {
             is Success -> {
                 // A success means we got 200 from the wp-login.php call, which means
@@ -92,7 +99,7 @@ class NonceRestClient @Inject constructor(
                 } else {
                     val networkResponse = response.error.volleyError?.networkResponse
                     if (networkResponse?.statusCode?.isRedirect() == true) {
-                        requestNonce(networkResponse.headers?.get("Location") ?: redirectUrl, username)
+                        requestNonceFromRedirect(networkResponse.headers?.get("Location") ?: redirectUrl, username, password)
                     } else {
                         FailedRequest(
                             timeOfResponse = currentTimeProvider.currentDate().time,
@@ -112,9 +119,14 @@ class NonceRestClient @Inject constructor(
         }
     }
 
-    private suspend fun requestNonce(redirectUrl: String, username: String): Nonce {
+    private suspend fun requestNonceFromRedirect(redirectUrl: String, username: String, password: String): Nonce {
+        val authHeader = Credentials.basic(username, password)
         return when (
-            val response = wpApiEncodedBodyRequestBuilder.syncGetRequest(this, redirectUrl)
+            val response = wpApiEncodedBodyRequestBuilder.syncGetRequest(
+                this,
+                redirectUrl,
+                authHeader = authHeader
+            )
         ) {
             is Success -> {
                 if (response.data?.matches("[0-9a-zA-Z]{2,}".toRegex()) == true) {

--- a/libs/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpapi/WPAPIEncodedBodyRequestBuilder.kt
+++ b/libs/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpapi/WPAPIEncodedBodyRequestBuilder.kt
@@ -17,9 +17,10 @@ class WPAPIEncodedBodyRequestBuilder @Inject constructor() {
         body: Map<String, String> = emptyMap(),
         enableCaching: Boolean = false,
         cacheTimeToLive: Int = BaseRequest.DEFAULT_CACHE_LIFETIME,
-        nonce: String? = null
+        nonce: String? = null,
+        authHeader: String? = null
     ) = suspendCancellableCoroutine<WPAPIResponse<String>> { cont ->
-        callMethod(Method.GET, url, params, body, cont, enableCaching, cacheTimeToLive, nonce, restClient)
+        callMethod(Method.GET, url, params, body, cont, enableCaching, cacheTimeToLive, nonce, authHeader, restClient)
     }
 
     suspend fun syncPostRequest(
@@ -29,9 +30,10 @@ class WPAPIEncodedBodyRequestBuilder @Inject constructor() {
         body: Map<String, String> = emptyMap(),
         enableCaching: Boolean = false,
         cacheTimeToLive: Int = BaseRequest.DEFAULT_CACHE_LIFETIME,
-        nonce: String? = null
+        nonce: String? = null,
+        authHeader: String? = null
     ) = suspendCancellableCoroutine<WPAPIResponse<String>> { cont ->
-        callMethod(Method.POST, url, params, body, cont, enableCaching, cacheTimeToLive, nonce, restClient)
+        callMethod(Method.POST, url, params, body, cont, enableCaching, cacheTimeToLive, nonce, authHeader, restClient)
     }
 
     @Suppress("LongParameterList")
@@ -44,6 +46,7 @@ class WPAPIEncodedBodyRequestBuilder @Inject constructor() {
         enableCaching: Boolean,
         cacheTimeToLive: Int,
         nonce: String?,
+        authHeader: String?,
         restClient: BaseWPAPIRestClient
     ) {
         val request = WPAPIEncodedBodyRequest(method, url, params, body, { response, headers ->
@@ -62,6 +65,10 @@ class WPAPIEncodedBodyRequestBuilder @Inject constructor() {
 
         if (nonce != null) {
             request.addHeader("x-wp-nonce", nonce)
+        }
+
+        if (authHeader != null) {
+            request.addHeader("Authorization", authHeader)
         }
 
         restClient.add(request)


### PR DESCRIPTION
Closes: WOOMOB-1702

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
Adds support for basic auth when fetching site nonce using site credentials

### Test Steps
<!-- Describe how to test your changes. Include only what’s needed for the reviewer to validate the behavior.
For new features, outline the main user flow or goal rather than every tap or click — the reviewer should be able to complete the flow naturally.
If applicable, mention key devices, scenarios, or edge cases to verify. -->

### Images/gif
<!-- Include before and after images or gifs when appropriate. -->

- [ ] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
