### PR TITLE
  [WOOMOB-1701] Use sync strategy to optimize barcode scanning Local Catalog performance

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/common/data/searchbyidentifier/WooPosSearchByIdentifier.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/common/data/searchbyidentifier/WooPosSearchByIdentifier.kt
@@ -1,12 +1,11 @@
 package com.woocommerce.android.ui.woopos.common.data.searchbyidentifier
 
-import com.woocommerce.android.tools.SelectedSite
 import com.woocommerce.android.ui.woopos.common.data.WooPosProductsTypesFilterConfig
 import com.woocommerce.android.ui.woopos.common.data.WooPosVariation
 import com.woocommerce.android.ui.woopos.common.data.WooPosVariationsTypesFilterConfig
 import com.woocommerce.android.ui.woopos.common.data.models.WooPosProductModel
 import com.woocommerce.android.ui.woopos.common.util.WooPosLogWrapper
-import com.woocommerce.android.ui.woopos.localcatalog.WooPosIsLocalCatalogSupported
+import com.woocommerce.android.ui.woopos.home.items.products.WooPosProductsDataSource
 import org.wordpress.android.fluxc.store.WCProductStore
 import org.wordpress.android.fluxc.store.WCProductStore.DownloadableOptions
 import org.wordpress.android.fluxc.store.WCProductStore.ProductFilterOption
@@ -18,15 +17,15 @@ class WooPosSearchByIdentifier @Inject constructor(
     private val remoteSearcher: WooPosSearchByIdentifierRemote,
     private val filterConfig: WooPosProductsTypesFilterConfig,
     private val variationFilterConfig: WooPosVariationsTypesFilterConfig,
-    private val localCatalogSupported: WooPosIsLocalCatalogSupported,
-    private val selectedSite: SelectedSite,
+    private val productDataSource: WooPosProductsDataSource,
     private val wooPosLogWrapper: WooPosLogWrapper,
 ) {
     suspend operator fun invoke(identifier: String): WooPosSearchByIdentifierResult {
-        val isLocalCatalogSupported = localCatalogSupported.invoke(selectedSite.get().localId())
-        val localResult = localSearcher(identifier, isLocalCatalogSupported)
+        val syncStrategy = productDataSource.getCurrentSyncStrategy()
+
+        val localResult = localSearcher(identifier, syncStrategy)
         // When product not found in local catalog, immediately return "not found" to avoid unnecessary remote call
-        if (localResult.isSuccess || isLocalCatalogSupported) {
+        if (localResult.isSuccess || syncStrategy == WooPosProductsDataSource.SyncStrategy.LOCAL_CATALOG) {
             return filterUnsupportedProductResult(localResult)
         }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/common/data/searchbyidentifier/WooPosSearchByIdentifierLocal.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/common/data/searchbyidentifier/WooPosSearchByIdentifierLocal.kt
@@ -4,6 +4,7 @@ import com.woocommerce.android.tools.SelectedSite
 import com.woocommerce.android.ui.woopos.common.data.WooPosProductsCache
 import com.woocommerce.android.ui.woopos.common.data.WooPosVariationMapper
 import com.woocommerce.android.ui.woopos.common.data.models.WooPosProductModelMapper
+import com.woocommerce.android.ui.woopos.home.items.products.WooPosProductsDataSource.SyncStrategy
 import com.woocommerce.android.ui.woopos.home.items.variations.WooPosVariationsLRUCache
 import org.wordpress.android.fluxc.model.LocalOrRemoteId
 import org.wordpress.android.fluxc.store.pos.localcatalog.WooPosLocalCatalogStore
@@ -17,13 +18,15 @@ class WooPosSearchByIdentifierLocal @Inject constructor(
     private val variationMapper: WooPosVariationMapper,
     private val selectedSite: SelectedSite,
 ) {
-    suspend operator fun invoke(identifier: String, isLocalCatalogSupported: Boolean): WooPosSearchByIdentifierResult {
+    suspend operator fun invoke(
+        identifier: String,
+        syncStrategy: SyncStrategy
+    ): WooPosSearchByIdentifierResult {
         val siteId = selectedSite.get().localId()
 
-        return if (isLocalCatalogSupported) {
-            searchInLocalCatalog(identifier, siteId)
-        } else {
-            searchInMemoryCache(identifier)
+        return when (syncStrategy) {
+            SyncStrategy.LOCAL_CATALOG -> searchInLocalCatalog(identifier, siteId)
+            SyncStrategy.REMOTE -> searchInMemoryCache(identifier)
         }
     }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/items/products/WooPosProductsDataSource.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/items/products/WooPosProductsDataSource.kt
@@ -26,7 +26,6 @@ import com.woocommerce.android.ui.woopos.localcatalog.WooPosLocalCatalogSyncRepo
 import com.woocommerce.android.ui.woopos.localcatalog.WooPosPerformInstantCatalogFullSync
 import com.woocommerce.android.ui.woopos.localcatalog.WooPosSyncProductResult
 import com.woocommerce.android.ui.woopos.localcatalog.WooPosSyncVariationResult
-import com.woocommerce.android.ui.woopos.util.analytics.WooPosAnalyticsEventConstant
 import com.woocommerce.android.util.WooLog
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.async
@@ -58,12 +57,17 @@ class WooPosProductsDataSource @Inject constructor(
     private val localDbDataSource: WooPosProductsInDbDataSource,
     private val syncStatusChecker: WooPosFullSyncStatusChecker,
 ) {
+    enum class SyncStrategy {
+        REMOTE,
+        LOCAL_CATALOG;
+    }
+
     private var activeSource: WooPosProductsDataSourceInterface? = null
 
-    fun getCurrentSyncStrategy(): WooPosAnalyticsEventConstant.SyncStrategy {
+    fun getCurrentSyncStrategy(): SyncStrategy {
         return when (activeSource) {
-            localDbDataSource -> WooPosAnalyticsEventConstant.SyncStrategy.LOCAL_CATALOG
-            remoteDataSource -> WooPosAnalyticsEventConstant.SyncStrategy.REMOTE
+            localDbDataSource -> SyncStrategy.LOCAL_CATALOG
+            remoteDataSource -> SyncStrategy.REMOTE
             else -> error("Unknown sync strategy")
         }
     }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/items/products/WooPosProductsDataSource.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/items/products/WooPosProductsDataSource.kt
@@ -59,7 +59,7 @@ class WooPosProductsDataSource @Inject constructor(
 ) {
     enum class SyncStrategy {
         REMOTE,
-        LOCAL_CATALOG;
+        LOCAL_CATALOG,
     }
 
     private var activeSource: WooPosProductsDataSourceInterface? = null

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/util/analytics/WooPosAnalyticsEvent.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/util/analytics/WooPosAnalyticsEvent.kt
@@ -405,7 +405,7 @@ sealed class WooPosAnalyticsEvent : IAnalyticsEvent {
             init {
                 addProperties(
                     mapOf(
-                        "sync_strategy" to when(syncStrategy) {
+                        "sync_strategy" to when (syncStrategy) {
                             SyncStrategy.REMOTE -> "remote"
                             SyncStrategy.LOCAL_CATALOG -> "local_catalog"
                         }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/util/analytics/WooPosAnalyticsEvent.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/util/analytics/WooPosAnalyticsEvent.kt
@@ -3,6 +3,7 @@ package com.woocommerce.android.ui.woopos.util.analytics
 import com.woocommerce.android.analytics.IAnalyticsEvent
 import com.woocommerce.android.ui.woopos.home.cart.WooPosCartItemViewState
 import com.woocommerce.android.ui.woopos.home.items.WooPosItemsViewModel
+import com.woocommerce.android.ui.woopos.home.items.products.WooPosProductsDataSource.*
 import com.woocommerce.android.ui.woopos.tab.WooPosLaunchability
 import com.woocommerce.android.ui.woopos.util.ConnectionType
 import com.woocommerce.android.ui.woopos.util.analytics.WooPosAnalyticsEventConstant.CartSource
@@ -398,13 +399,16 @@ sealed class WooPosAnalyticsEvent : IAnalyticsEvent {
             }
         }
 
-        data class Loaded(val syncStrategy: WooPosAnalyticsEventConstant.SyncStrategy) : Event() {
+        data class Loaded(val syncStrategy: SyncStrategy) : Event() {
             override val name: String = "loaded"
 
             init {
                 addProperties(
                     mapOf(
-                        WooPosAnalyticsEventConstant.SyncStrategy.SYNC_STRATEGY to syncStrategy.toString()
+                        "sync_strategy" to when(syncStrategy) {
+                            SyncStrategy.REMOTE -> "remote"
+                            SyncStrategy.LOCAL_CATALOG -> "local_catalog"
+                        }
                     )
                 )
             }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/util/analytics/WooPosAnalyticsEvent.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/util/analytics/WooPosAnalyticsEvent.kt
@@ -3,7 +3,7 @@ package com.woocommerce.android.ui.woopos.util.analytics
 import com.woocommerce.android.analytics.IAnalyticsEvent
 import com.woocommerce.android.ui.woopos.home.cart.WooPosCartItemViewState
 import com.woocommerce.android.ui.woopos.home.items.WooPosItemsViewModel
-import com.woocommerce.android.ui.woopos.home.items.products.WooPosProductsDataSource.*
+import com.woocommerce.android.ui.woopos.home.items.products.WooPosProductsDataSource.SyncStrategy
 import com.woocommerce.android.ui.woopos.tab.WooPosLaunchability
 import com.woocommerce.android.ui.woopos.util.ConnectionType
 import com.woocommerce.android.ui.woopos.util.analytics.WooPosAnalyticsEventConstant.CartSource

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/util/analytics/WooPosAnalyticsEventConstant.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/util/analytics/WooPosAnalyticsEventConstant.kt
@@ -84,19 +84,6 @@ object WooPosAnalyticsEventConstant {
         }
     }
 
-    enum class SyncStrategy(val value: String) {
-        REMOTE("remote"),
-        LOCAL_CATALOG("local_catalog");
-
-        override fun toString(): String {
-            return value
-        }
-
-        companion object {
-            const val SYNC_STRATEGY = "sync_strategy"
-        }
-    }
-
     enum class SyncType(val value: String) {
         FULL("full"),
         INCREMENTAL("incremental");

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/common/data/searchbyidentifier/WooPosSearchByIdentifierLocalTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/common/data/searchbyidentifier/WooPosSearchByIdentifierLocalTest.kt
@@ -5,6 +5,7 @@ import com.woocommerce.android.ui.woopos.common.data.WooPosProductsCache
 import com.woocommerce.android.ui.woopos.common.data.WooPosVariationMapper
 import com.woocommerce.android.ui.woopos.common.data.models.WooPosProductModel
 import com.woocommerce.android.ui.woopos.common.data.models.WooPosProductModelMapper
+import com.woocommerce.android.ui.woopos.home.items.products.WooPosProductsDataSource.SyncStrategy
 import com.woocommerce.android.ui.woopos.home.items.variations.WooPosVariationsLRUCache
 import com.woocommerce.android.ui.woopos.util.generateWooPosProduct
 import com.woocommerce.android.ui.woopos.util.generateWooPosVariation
@@ -68,7 +69,7 @@ class WooPosSearchByIdentifierLocalTest {
         whenever(productsCache.getAll()).thenReturn(listOf(product))
 
         // WHEN
-        val result = sut(identifier, isLocalCatalogSupported = false)
+        val result = sut(identifier, syncStrategy = SyncStrategy.REMOTE)
 
         // THEN
         assertEquals(WooPosSearchByIdentifierResult.Success(product), result)
@@ -82,7 +83,7 @@ class WooPosSearchByIdentifierLocalTest {
         whenever(variationsCache.getAll()).thenReturn(emptyList())
 
         // WHEN
-        val result = sut(identifier, isLocalCatalogSupported = false)
+        val result = sut(identifier, syncStrategy = SyncStrategy.REMOTE)
 
         // THEN
         assertEquals(WooPosSearchByIdentifierResult.Failure(WooPosSearchByIdentifierResult.Error.NotFound), result)
@@ -96,7 +97,7 @@ class WooPosSearchByIdentifierLocalTest {
         whenever(productsCache.getAll()).thenReturn(listOf(product))
 
         // WHEN
-        val result = sut(identifier, isLocalCatalogSupported = false)
+        val result = sut(identifier, syncStrategy = SyncStrategy.REMOTE)
 
         // THEN
         assertEquals(WooPosSearchByIdentifierResult.Success(product), result)
@@ -120,7 +121,7 @@ class WooPosSearchByIdentifierLocalTest {
         whenever(variationsCache.getAll()).thenReturn(listOf(variation))
 
         // WHEN
-        val result = sut(identifier, isLocalCatalogSupported = false)
+        val result = sut(identifier, syncStrategy = SyncStrategy.REMOTE)
 
         // THEN
         assertTrue(result is WooPosSearchByIdentifierResult.VariationSuccess)
@@ -151,7 +152,7 @@ class WooPosSearchByIdentifierLocalTest {
         whenever(variationsCache.getAll()).thenReturn(listOf(variation1, variation2))
 
         // WHEN
-        val result = sut(identifier, isLocalCatalogSupported = false)
+        val result = sut(identifier, syncStrategy = SyncStrategy.REMOTE)
 
         // THEN
         assertTrue(result is WooPosSearchByIdentifierResult.VariationSuccess)
@@ -177,7 +178,7 @@ class WooPosSearchByIdentifierLocalTest {
         whenever(variationsCache.getAll()).thenReturn(listOf(variation))
 
         // WHEN
-        val result = sut(identifier, isLocalCatalogSupported = false)
+        val result = sut(identifier, syncStrategy = SyncStrategy.REMOTE)
 
         // THEN
         assertTrue(result is WooPosSearchByIdentifierResult.VariationSuccess)
@@ -199,7 +200,7 @@ class WooPosSearchByIdentifierLocalTest {
         whenever(productsCache.getProductById(productId)).thenReturn(null)
 
         // WHEN
-        val result = sut(identifier, isLocalCatalogSupported = false)
+        val result = sut(identifier, syncStrategy = SyncStrategy.REMOTE)
 
         // THEN
         assertTrue(result is WooPosSearchByIdentifierResult.Failure)
@@ -224,7 +225,7 @@ class WooPosSearchByIdentifierLocalTest {
             whenever(productModelMapper.fromEntity(productEntity)).thenReturn(productModel)
 
             // WHEN
-            val result = sut(identifier, isLocalCatalogSupported = true)
+            val result = sut(identifier, syncStrategy = SyncStrategy.LOCAL_CATALOG)
 
             // THEN
             assertEquals(WooPosSearchByIdentifierResult.Success(productModel), result)
@@ -263,7 +264,7 @@ class WooPosSearchByIdentifierLocalTest {
             whenever(productModelMapper.fromEntity(parentEntity)).thenReturn(parentProduct)
 
             // WHEN
-            val result = sut(identifier, isLocalCatalogSupported = true)
+            val result = sut(identifier, syncStrategy = SyncStrategy.LOCAL_CATALOG)
 
             // THEN
             assertTrue(result is WooPosSearchByIdentifierResult.VariationSuccess)
@@ -292,7 +293,7 @@ class WooPosSearchByIdentifierLocalTest {
                 .thenReturn(Result.failure(Exception("Parent not found")))
 
             // WHEN
-            val result = sut(identifier, isLocalCatalogSupported = true)
+            val result = sut(identifier, syncStrategy = SyncStrategy.LOCAL_CATALOG)
 
             // THEN
             assertTrue(result is WooPosSearchByIdentifierResult.Failure)
@@ -310,7 +311,7 @@ class WooPosSearchByIdentifierLocalTest {
             .thenReturn(Result.failure(Exception("Not found")))
 
         // WHEN
-        val result = sut(identifier, isLocalCatalogSupported = true)
+        val result = sut(identifier, syncStrategy = SyncStrategy.LOCAL_CATALOG)
 
         // THEN
         assertTrue(result is WooPosSearchByIdentifierResult.Failure)

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/common/data/searchbyidentifier/WooPosSearchByIdentifierTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/common/data/searchbyidentifier/WooPosSearchByIdentifierTest.kt
@@ -1,23 +1,21 @@
 package com.woocommerce.android.ui.woopos.common.data.searchbyidentifier
 
-import com.woocommerce.android.tools.SelectedSite
 import com.woocommerce.android.ui.woopos.common.data.WooPosProductsTypesFilterConfig
 import com.woocommerce.android.ui.woopos.common.data.WooPosVariationsTypesFilterConfig
 import com.woocommerce.android.ui.woopos.common.data.models.WooPosProductModel
 import com.woocommerce.android.ui.woopos.common.util.WooPosLogWrapper
-import com.woocommerce.android.ui.woopos.localcatalog.WooPosIsLocalCatalogSupported
+import com.woocommerce.android.ui.woopos.home.items.products.WooPosProductsDataSource
+import com.woocommerce.android.ui.woopos.home.items.products.WooPosProductsDataSource.SyncStrategy
 import com.woocommerce.android.ui.woopos.util.generateWooPosProduct
 import kotlinx.coroutines.test.runTest
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Test
-import org.mockito.kotlin.any
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.never
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
-import org.wordpress.android.fluxc.model.SiteModel
 
 class WooPosSearchByIdentifierTest {
 
@@ -26,26 +24,19 @@ class WooPosSearchByIdentifierTest {
     private val remoteSearcher: WooPosSearchByIdentifierRemote = mock()
     private val filterConfig: WooPosProductsTypesFilterConfig = WooPosProductsTypesFilterConfig()
     private val variationFilterConfig: WooPosVariationsTypesFilterConfig = WooPosVariationsTypesFilterConfig()
-    private val localCatalogSupported: WooPosIsLocalCatalogSupported = mock()
-    private val selectedSite: SelectedSite = mock()
+    private val productDataSource: WooPosProductsDataSource = mock()
     private val wooPosLogWrapper: WooPosLogWrapper = mock()
-    private val testSite = SiteModel().apply {
-        siteId = 123L
-        id = 123
-    }
 
     @Before
     fun setup() = runTest {
-        whenever(selectedSite.get()).thenReturn(testSite)
-        whenever(localCatalogSupported.invoke(any())).thenReturn(false)
-
+        whenever(productDataSource.getCurrentSyncStrategy())
+            .thenReturn(SyncStrategy.REMOTE)
         sut = WooPosSearchByIdentifier(
             localSearcher,
             remoteSearcher,
             filterConfig,
             variationFilterConfig,
-            localCatalogSupported,
-            selectedSite,
+            productDataSource,
             wooPosLogWrapper
         )
     }
@@ -57,7 +48,7 @@ class WooPosSearchByIdentifierTest {
             val identifier = "123456"
             val localProduct = generateWooPosProduct()
             val localResult = WooPosSearchByIdentifierResult.Success(localProduct)
-            whenever(localSearcher(identifier, false)).thenReturn(localResult)
+            whenever(localSearcher(identifier, SyncStrategy.REMOTE)).thenReturn(localResult)
 
             // WHEN
             val result = sut(identifier)
@@ -73,7 +64,7 @@ class WooPosSearchByIdentifierTest {
         // GIVEN
         val identifier = "123456"
         val remoteProduct = generateWooPosProduct()
-        whenever(localSearcher(identifier, false)).thenReturn(
+        whenever(localSearcher(identifier, SyncStrategy.REMOTE)).thenReturn(
             WooPosSearchByIdentifierResult.Failure(WooPosSearchByIdentifierResult.Error.NotFound)
         )
         whenever(remoteSearcher(identifier))
@@ -92,7 +83,7 @@ class WooPosSearchByIdentifierTest {
     fun `given product not found anywhere, when search called, then return failure`() = runTest {
         // GIVEN
         val identifier = "NOTFOUND"
-        whenever(localSearcher(identifier, false)).thenReturn(
+        whenever(localSearcher(identifier, SyncStrategy.REMOTE)).thenReturn(
             WooPosSearchByIdentifierResult.Failure(WooPosSearchByIdentifierResult.Error.NotFound)
         )
         whenever(remoteSearcher(identifier))
@@ -113,7 +104,7 @@ class WooPosSearchByIdentifierTest {
     fun `given remote search returns network error, when search called, then return network error`() = runTest {
         // GIVEN
         val identifier = "123456"
-        whenever(localSearcher(identifier, false)).thenReturn(
+        whenever(localSearcher(identifier, SyncStrategy.REMOTE)).thenReturn(
             WooPosSearchByIdentifierResult.Failure(WooPosSearchByIdentifierResult.Error.NotFound)
         )
         whenever(remoteSearcher(identifier))
@@ -139,7 +130,7 @@ class WooPosSearchByIdentifierTest {
             status = WooPosProductModel.WooPosProductStatus.PUBLISH
         )
 
-        whenever(localSearcher(identifier, false))
+        whenever(localSearcher(identifier, SyncStrategy.REMOTE))
             .thenReturn(WooPosSearchByIdentifierResult.Success(product))
 
         // WHEN
@@ -156,7 +147,7 @@ class WooPosSearchByIdentifierTest {
         val identifier = "123456"
         val product = generateWooPosProduct(status = WooPosProductModel.WooPosProductStatus.DRAFT)
 
-        whenever(localSearcher(identifier, false))
+        whenever(localSearcher(identifier, SyncStrategy.REMOTE))
             .thenReturn(WooPosSearchByIdentifierResult.Success(product))
 
         // WHEN
@@ -176,7 +167,7 @@ class WooPosSearchByIdentifierTest {
         val identifier = "123456"
         val product = generateWooPosProduct(isDownloadable = true)
 
-        whenever(localSearcher(identifier, false))
+        whenever(localSearcher(identifier, SyncStrategy.REMOTE))
             .thenReturn(WooPosSearchByIdentifierResult.Success(product))
 
         // WHEN
@@ -196,7 +187,7 @@ class WooPosSearchByIdentifierTest {
         val identifier = "123456"
         val product = generateWooPosProduct(productType = WooPosProductModel.WooPosProductType.VARIABLE)
 
-        whenever(localSearcher(identifier, false))
+        whenever(localSearcher(identifier, SyncStrategy.REMOTE))
             .thenReturn(WooPosSearchByIdentifierResult.Success(product))
 
         // WHEN
@@ -214,9 +205,15 @@ class WooPosSearchByIdentifierTest {
     fun `given local catalog enabled and product not found locally, when search called, then don't search remotely`() =
         runTest {
             // GIVEN
-            whenever(localCatalogSupported.invoke(testSite.localId())).thenReturn(true)
+            whenever(productDataSource.getCurrentSyncStrategy())
+                .thenReturn(SyncStrategy.LOCAL_CATALOG)
             val identifier = "123456"
-            whenever(localSearcher(identifier, isLocalCatalogSupported = true)).thenReturn(
+            whenever(
+                localSearcher(
+                    identifier,
+                    syncStrategy = SyncStrategy.LOCAL_CATALOG
+                )
+            ).thenReturn(
                 WooPosSearchByIdentifierResult.Failure(WooPosSearchByIdentifierResult.Error.NotFound)
             )
 

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/splash/WooPosSplashViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/splash/WooPosSplashViewModelTest.kt
@@ -8,7 +8,6 @@ import com.woocommerce.android.ui.woopos.tab.WooPosCanBeLaunchedInTab
 import com.woocommerce.android.ui.woopos.tab.WooPosLaunchability
 import com.woocommerce.android.ui.woopos.util.WooPosCoroutineTestRule
 import com.woocommerce.android.ui.woopos.util.analytics.WooPosAnalyticsEvent
-import com.woocommerce.android.ui.woopos.util.analytics.WooPosAnalyticsEventConstant
 import com.woocommerce.android.ui.woopos.util.analytics.WooPosAnalyticsTracker
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.flowOf
@@ -46,7 +45,7 @@ class WooPosSplashViewModelTest {
             flowOf(WooPosPrepopulatingDataStatus.Completed)
         )
         whenever(productsDataSource.getCurrentSyncStrategy())
-            .thenReturn(WooPosAnalyticsEventConstant.SyncStrategy.LOCAL_CATALOG)
+            .thenReturn(WooPosProductsDataSource.SyncStrategy.LOCAL_CATALOG)
     }
 
     @Test


### PR DESCRIPTION
  Fixes WOOMOB-1701

  ### Description
  This PR optimizes barcode scanning performance by using the data source's sync strategy directly instead of checking if local catalog is supported. This eliminates unnecessary checks during barcode scanning  operations, making the scanning more instant.

  Key changes:
  - Replace `WooPosIsLocalCatalogSupported` check with direct `WooPosProductsDataSource.getCurrentSyncStrategy()` call
  - Move `SyncStrategy` enum to `WooPosProductsDataSource` for better architectural organization

  **Performance impact**: Barcode scanning is now more instant as it avoids the overhead of checking local catalog support through multiple dependency layers.

  ### Test Steps
  1. Test barcode scanning functionality - it should be noticeably more responsive/instant

  ### Images/gif
  <!-- Focus on testing the improved scanning performance -->

https://github.com/user-attachments/assets/62ac4ddc-c8a6-408d-94c8-7c8f7ac4da1f


  - [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.
