### PR TITLE
[WOOMOB-1695] Make catalog settings loading instant

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/settings/categories/WooPosSettingsCategoriesViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/settings/categories/WooPosSettingsCategoriesViewModel.kt
@@ -17,9 +17,10 @@ class WooPosSettingsCategoriesViewModel @Inject constructor(
 
     init {
         val categories = WooPosSettingsCategory.entries.filter {
-            when (productsDataSource.getCurrentSyncStrategy()) {
-                WooPosProductsDataSource.SyncStrategy.REMOTE -> it != WooPosSettingsCategory.LOCAL_CATALOG
-                WooPosProductsDataSource.SyncStrategy.LOCAL_CATALOG -> true
+            if (it == WooPosSettingsCategory.LOCAL_CATALOG) {
+                productsDataSource.getCurrentSyncStrategy() == WooPosProductsDataSource.SyncStrategy.LOCAL_CATALOG
+            } else {
+                true
             }
         }
         _state.value = WooPosSettingsCategoriesState(categories)

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/settings/categories/WooPosSettingsCategoriesViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/settings/categories/WooPosSettingsCategoriesViewModel.kt
@@ -1,40 +1,27 @@
 package com.woocommerce.android.ui.woopos.settings.categories
 
 import androidx.lifecycle.ViewModel
-import androidx.lifecycle.viewModelScope
-import com.woocommerce.android.tools.SelectedSite
-import com.woocommerce.android.ui.woopos.localcatalog.WooPosIsLocalCatalogSupported
+import com.woocommerce.android.ui.woopos.home.items.products.WooPosProductsDataSource
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
-import kotlinx.coroutines.launch
 import javax.inject.Inject
 
 @HiltViewModel
 class WooPosSettingsCategoriesViewModel @Inject constructor(
-    selectedSite: SelectedSite,
-    private val isLocalCatalogSupported: WooPosIsLocalCatalogSupported,
+    productsDataSource: WooPosProductsDataSource,
 ) : ViewModel() {
-    private val _state = MutableStateFlow(createInitialState())
+    private val _state = MutableStateFlow(WooPosSettingsCategoriesState(emptyList()))
     val state: StateFlow<WooPosSettingsCategoriesState> = _state.asStateFlow()
 
     init {
-        viewModelScope.launch {
-            val categories = WooPosSettingsCategory.entries.filter {
-                if (!isLocalCatalogSupported(selectedSite.get().localId())) {
-                    it != WooPosSettingsCategory.LOCAL_CATALOG
-                } else {
-                    true
-                }
+        val categories = WooPosSettingsCategory.entries.filter {
+            when (productsDataSource.getCurrentSyncStrategy()) {
+                WooPosProductsDataSource.SyncStrategy.REMOTE -> it != WooPosSettingsCategory.LOCAL_CATALOG
+                WooPosProductsDataSource.SyncStrategy.LOCAL_CATALOG -> true
             }
-            _state.value = WooPosSettingsCategoriesState(categories)
         }
-    }
-
-    private fun createInitialState(): WooPosSettingsCategoriesState {
-        return WooPosSettingsCategoriesState(
-            categories = WooPosSettingsCategory.entries.filter { it != WooPosSettingsCategory.LOCAL_CATALOG }
-        )
+        _state.value = WooPosSettingsCategoriesState(categories)
     }
 }

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/settings/categories/WooPosSettingsCategoriesViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/settings/categories/WooPosSettingsCategoriesViewModelTest.kt
@@ -1,18 +1,14 @@
 package com.woocommerce.android.ui.woopos.settings.categories
 
-import com.woocommerce.android.tools.SelectedSite
-import com.woocommerce.android.ui.woopos.localcatalog.WooPosIsLocalCatalogSupported
+import com.woocommerce.android.ui.woopos.home.items.products.WooPosProductsDataSource
 import com.woocommerce.android.ui.woopos.util.WooPosCoroutineTestRule
 import kotlinx.coroutines.ExperimentalCoroutinesApi
-import kotlinx.coroutines.test.advanceUntilIdle
 import kotlinx.coroutines.test.runTest
 import org.assertj.core.api.Assertions.assertThat
-import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.whenever
-import org.wordpress.android.fluxc.model.SiteModel
 
 @ExperimentalCoroutinesApi
 class WooPosSettingsCategoriesViewModelTest {
@@ -21,26 +17,18 @@ class WooPosSettingsCategoriesViewModelTest {
     @JvmField
     val coroutineTestRule = WooPosCoroutineTestRule()
 
-    private val isLocalCatalogSupported: WooPosIsLocalCatalogSupported = mock()
-    private val selectedSite: SelectedSite = mock()
-
-    private val mockSite = SiteModel().apply { id = 123 }
+    private val productDataSource: WooPosProductsDataSource = mock()
 
     private lateinit var sut: WooPosSettingsCategoriesViewModel
-
-    @Before
-    fun setUp() {
-        whenever(selectedSite.get()).thenReturn(mockSite)
-    }
 
     @Test
     fun `given local catalog not supported, when viewmodel is initialized, then LOCAL_CATALOG is hidden`() = runTest {
         // GIVEN
-        whenever(isLocalCatalogSupported(mockSite.localId())).thenReturn(false)
+        whenever(productDataSource.getCurrentSyncStrategy())
+            .thenReturn(WooPosProductsDataSource.SyncStrategy.REMOTE)
 
         // WHEN
         sut = createViewModel()
-        advanceUntilIdle()
 
         // THEN
         assertThat(sut.state.value.categories).doesNotContain(WooPosSettingsCategory.LOCAL_CATALOG)
@@ -49,41 +37,42 @@ class WooPosSettingsCategoriesViewModelTest {
     @Test
     fun `given local catalog supported, when viewmodel is initialized, then LOCAL_CATALOG is visible`() = runTest {
         // GIVEN
-        whenever(isLocalCatalogSupported(mockSite.localId())).thenReturn(true)
+        whenever(productDataSource.getCurrentSyncStrategy())
+            .thenReturn(WooPosProductsDataSource.SyncStrategy.LOCAL_CATALOG)
 
         // WHEN
         sut = createViewModel()
-        advanceUntilIdle()
 
         // THEN
         assertThat(sut.state.value.categories).contains(WooPosSettingsCategory.LOCAL_CATALOG)
     }
 
     @Test
-    fun `given local catalog not supported, when viewmodel is initialized, then other categories are visible`() = runTest {
-        // GIVEN
-        whenever(isLocalCatalogSupported(mockSite.localId())).thenReturn(false)
+    fun `given local catalog not supported, when viewmodel is initialized, then other categories are visible`() =
+        runTest {
+            // GIVEN
+            whenever(productDataSource.getCurrentSyncStrategy())
+                .thenReturn(WooPosProductsDataSource.SyncStrategy.REMOTE)
 
-        // WHEN
-        sut = createViewModel()
-        advanceUntilIdle()
+            // WHEN
+            sut = createViewModel()
 
-        // THEN
-        assertThat(sut.state.value.categories).contains(
-            WooPosSettingsCategory.STORE,
-            WooPosSettingsCategory.HARDWARE,
-            WooPosSettingsCategory.HELP
-        )
-    }
+            // THEN
+            assertThat(sut.state.value.categories).contains(
+                WooPosSettingsCategory.STORE,
+                WooPosSettingsCategory.HARDWARE,
+                WooPosSettingsCategory.HELP
+            )
+        }
 
     @Test
     fun `given local catalog supported, when viewmodel is initialized, then all categories are visible`() = runTest {
         // GIVEN
-        whenever(isLocalCatalogSupported(mockSite.localId())).thenReturn(true)
+        whenever(productDataSource.getCurrentSyncStrategy())
+            .thenReturn(WooPosProductsDataSource.SyncStrategy.LOCAL_CATALOG)
 
         // WHEN
         sut = createViewModel()
-        advanceUntilIdle()
 
         // THEN
         assertThat(sut.state.value.categories).containsExactlyInAnyOrder(
@@ -106,7 +95,6 @@ class WooPosSettingsCategoriesViewModelTest {
     }
 
     private fun createViewModel() = WooPosSettingsCategoriesViewModel(
-        selectedSite = selectedSite,
-        isLocalCatalogSupported = isLocalCatalogSupported,
+        productsDataSource = productDataSource,
     )
 }


### PR DESCRIPTION
Fixes WOOMOB-1695

Merge when target branch is trunk.

### Description
This PR makes the WooCommerce POS catalog settings loading instant by removing unnecessary async operations and directly using the data source's sync strategy. The settings screen now appears immediately instead of showing a loading state.


### Test Steps
1. Open WooCommerce POS settings - should appear instantly without loading delay
2. Verify Local catalog section is visible only on a store that uses local catalog (store with less than 1000 products)

### Images/gif
<!-- Focus on testing the instant loading of settings -->


https://github.com/user-attachments/assets/0659d6f7-eb00-4350-88da-42cbcef16147




- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.