### PR TITLE
[Woo POS][Local Catalog] Disable Local Catalog immediately if catalog is too large

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/localcatalog/WooPosFullSyncStatusChecker.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/localcatalog/WooPosFullSyncStatusChecker.kt
@@ -38,7 +38,7 @@ class WooPosFullSyncStatusChecker @Inject constructor(
         val productCount = localCatalogStore.getProductCount(site.localId()).getOrElse { 0 }
         val variationsCount = localCatalogStore.getVariationCount(site.localId()).getOrElse { 0 }
         val itemsCount = productCount + variationsCount
-        if (productCount == 0 || itemsCount >= 1000) {
+        if (productCount == 0 || itemsCount >= WooPosLocalCatalogSyncRepository.MAX_TOTAL_ITEMS_FULL_SYNC) {
             val size = checkCatalogSizeAction
                 .execute(site, maxTotalItems = WooPosLocalCatalogSyncRepository.MAX_TOTAL_ITEMS_FULL_SYNC)
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/localcatalog/WooPosFullSyncStatusChecker.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/localcatalog/WooPosFullSyncStatusChecker.kt
@@ -35,7 +35,10 @@ class WooPosFullSyncStatusChecker @Inject constructor(
             return WooPosFullSyncRequirement.LocalCatalogDisabled("Local catalog not supported for site")
         }
 
-        if (localCatalogStore.getProductCount(site.localId()).getOrNull() == 0) {
+        val productCount = localCatalogStore.getProductCount(site.localId()).getOrElse { 0 }
+        val variationsCount = localCatalogStore.getVariationCount(site.localId()).getOrElse { 0 }
+        val itemsCount = productCount + variationsCount
+        if (productCount == 0 || itemsCount >= 1000) {
             val size = checkCatalogSizeAction
                 .execute(site, maxTotalItems = WooPosLocalCatalogSyncRepository.MAX_TOTAL_ITEMS_FULL_SYNC)
 
@@ -46,8 +49,6 @@ class WooPosFullSyncStatusChecker @Inject constructor(
         }
 
         val lastFullSyncTimestamp = syncTimestampManager.getFullSyncLastCompletedTimestamp()
-        val productCount = localCatalogStore.getProductCount(LocalOrRemoteId.LocalId(site.id))
-            .getOrElse { 0 }
         val catalogIsEmpty = productCount == 0
 
         if (lastFullSyncTimestamp == null) {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/localcatalog/WooPosFullSyncStatusChecker.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/localcatalog/WooPosFullSyncStatusChecker.kt
@@ -5,7 +5,6 @@ import com.woocommerce.android.ui.woopos.common.util.WooPosLogWrapper
 import com.woocommerce.android.ui.woopos.util.WooPosNetworkStatus
 import com.woocommerce.android.ui.woopos.util.datastore.WooPosPreferencesRepository
 import com.woocommerce.android.ui.woopos.util.datastore.WooPosSyncTimestampManager
-import org.wordpress.android.fluxc.model.LocalOrRemoteId
 import org.wordpress.android.fluxc.store.pos.localcatalog.WooPosLocalCatalogStore
 import javax.inject.Inject
 import kotlin.time.Duration.Companion.days

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/localcatalog/WooPosPerformLocalCatalogIncrementalSync.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/localcatalog/WooPosPerformLocalCatalogIncrementalSync.kt
@@ -6,6 +6,7 @@ import com.woocommerce.android.ui.woopos.common.util.WooPosLogWrapper
 import com.woocommerce.android.ui.woopos.localcatalog.PosLocalCatalogSyncResult.Failure
 import com.woocommerce.android.ui.woopos.localcatalog.PosLocalCatalogSyncResult.Success
 import com.woocommerce.android.ui.woopos.util.WooPosNetworkStatus
+import com.woocommerce.android.ui.woopos.util.datastore.WooPosPreferencesRepository
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.launch
 import org.wordpress.android.fluxc.model.SiteModel
@@ -17,6 +18,7 @@ class WooPosPerformLocalCatalogIncrementalSync @Inject constructor(
     private val networkStatus: WooPosNetworkStatus,
     private val isLocalCatalogSupported: WooPosIsLocalCatalogSupported,
     private val wooPosLogWrapper: WooPosLogWrapper,
+    private val prefsRepo: WooPosPreferencesRepository,
     @AppCoroutineScope private val appCoroutineScope: CoroutineScope
 ) {
     fun execute(reason: WooPosIncrementalSyncReason) {
@@ -56,6 +58,11 @@ class WooPosPerformLocalCatalogIncrementalSync @Inject constructor(
             }
             is Failure -> {
                 wooPosLogWrapper.e("Sync $reasonDescription failed: ${syncResult.error}")
+
+                if (syncResult is Failure.CatalogTooLarge) {
+                    wooPosLogWrapper.e("Disabling Local Catalog periodic sync for site due to catalog size too large")
+                    prefsRepo.disablePeriodicSyncForSite(site.localId())
+                }
             }
         }
     }

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/localcatalog/WooPosFullSyncStatusCheckerTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/localcatalog/WooPosFullSyncStatusCheckerTest.kt
@@ -70,6 +70,8 @@ class WooPosFullSyncStatusCheckerTest {
         whenever(time.now()).thenReturn(NOW)
         whenever(localCatalogStore.getProductCount(LocalOrRemoteId.LocalId(siteModel.id)))
             .thenReturn(Result.success(15))
+        whenever(localCatalogStore.getVariationCount(LocalOrRemoteId.LocalId(siteModel.id)))
+            .thenReturn(Result.success(5))
         whenever(checkCatalogSizeAction.execute(siteModel, null, 1000))
             .thenReturn(WooPosCheckCatalogSizeAction.WooPosCheckCatalogSizeResult.SizeAcceptable)
     }
@@ -186,6 +188,8 @@ class WooPosFullSyncStatusCheckerTest {
             whenever(networkStatus.isConnected()).thenReturn(false)
             whenever(localCatalogStore.getProductCount(LocalOrRemoteId.LocalId(siteModel.id)))
                 .thenReturn(Result.success(0))
+            whenever(localCatalogStore.getVariationCount(LocalOrRemoteId.LocalId(siteModel.id)))
+                .thenReturn(Result.success(0))
 
             val sut = createSut()
 
@@ -239,6 +243,8 @@ class WooPosFullSyncStatusCheckerTest {
             // GIVEN
             whenever(localCatalogStore.getProductCount(LocalOrRemoteId.LocalId(siteModel.id)))
                 .thenReturn(Result.failure(Exception("Database error")))
+            whenever(localCatalogStore.getVariationCount(LocalOrRemoteId.LocalId(siteModel.id)))
+                .thenReturn(Result.success(0))
 
             val sut = createSut()
 
@@ -254,6 +260,8 @@ class WooPosFullSyncStatusCheckerTest {
         runTest {
             // GIVEN
             whenever(localCatalogStore.getProductCount(LocalOrRemoteId.LocalId(siteModel.id)))
+                .thenReturn(Result.success(0))
+            whenever(localCatalogStore.getVariationCount(LocalOrRemoteId.LocalId(siteModel.id)))
                 .thenReturn(Result.success(0))
             whenever(checkCatalogSizeAction.execute(siteModel, null, 1000))
                 .thenReturn(
@@ -276,6 +284,8 @@ class WooPosFullSyncStatusCheckerTest {
             // GIVEN
             whenever(localCatalogStore.getProductCount(LocalOrRemoteId.LocalId(siteModel.id)))
                 .thenReturn(Result.success(0))
+            whenever(localCatalogStore.getVariationCount(LocalOrRemoteId.LocalId(siteModel.id)))
+                .thenReturn(Result.success(0))
             whenever(checkCatalogSizeAction.execute(siteModel, null, 1000))
                 .thenReturn(WooPosCheckCatalogSizeAction.WooPosCheckCatalogSizeResult.SizeAcceptable)
             val recentTimestamp = NOW - 1.days.inWholeMilliseconds
@@ -295,6 +305,8 @@ class WooPosFullSyncStatusCheckerTest {
         runTest {
             // GIVEN
             whenever(localCatalogStore.getProductCount(LocalOrRemoteId.LocalId(siteModel.id)))
+                .thenReturn(Result.success(0))
+            whenever(localCatalogStore.getVariationCount(LocalOrRemoteId.LocalId(siteModel.id)))
                 .thenReturn(Result.success(0))
             whenever(checkCatalogSizeAction.execute(siteModel, null, 1000))
                 .thenReturn(WooPosCheckCatalogSizeAction.WooPosCheckCatalogSizeResult.SizeUnknown)
@@ -316,6 +328,8 @@ class WooPosFullSyncStatusCheckerTest {
             // GIVEN
             whenever(localCatalogStore.getProductCount(LocalOrRemoteId.LocalId(siteModel.id)))
                 .thenReturn(Result.success(100))
+            whenever(localCatalogStore.getVariationCount(LocalOrRemoteId.LocalId(siteModel.id)))
+                .thenReturn(Result.success(50))
             val recentTimestamp = NOW - 1.days.inWholeMilliseconds
             whenever(syncTimestampManager.getFullSyncLastCompletedTimestamp()).thenReturn(recentTimestamp)
 

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/localcatalog/WooPosPerformLocalCatalogIncrementalSyncTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/localcatalog/WooPosPerformLocalCatalogIncrementalSyncTest.kt
@@ -3,6 +3,7 @@ package com.woocommerce.android.ui.woopos.localcatalog
 import com.woocommerce.android.tools.SelectedSite
 import com.woocommerce.android.ui.woopos.common.util.WooPosLogWrapper
 import com.woocommerce.android.ui.woopos.util.WooPosNetworkStatus
+import com.woocommerce.android.ui.woopos.util.datastore.WooPosPreferencesRepository
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.StandardTestDispatcher
 import kotlinx.coroutines.test.TestCoroutineScheduler
@@ -25,6 +26,7 @@ class WooPosPerformLocalCatalogIncrementalSyncTest {
     private val networkStatus: WooPosNetworkStatus = mock()
     private val isLocalCatalogSupported: WooPosIsLocalCatalogSupported = mock()
     private val wooPosLogWrapper: WooPosLogWrapper = mock()
+    private val prefsRepo: WooPosPreferencesRepository = mock()
     private val testScheduler = TestCoroutineScheduler()
     private val testDispatcher = StandardTestDispatcher(testScheduler)
 
@@ -40,6 +42,7 @@ class WooPosPerformLocalCatalogIncrementalSyncTest {
             networkStatus = networkStatus,
             isLocalCatalogSupported = isLocalCatalogSupported,
             wooPosLogWrapper = wooPosLogWrapper,
+            prefsRepo = prefsRepo,
             appCoroutineScope = testScope
         )
     }
@@ -136,7 +139,7 @@ class WooPosPerformLocalCatalogIncrementalSyncTest {
     }
 
     @Test
-    fun `given sync fails with catalog too large, when execute called, then logs failure`() = runTest(testScheduler) {
+    fun `given sync fails with catalog too large, when execute called, then logs failure and disables periodic sync`() = runTest(testScheduler) {
         // GIVEN
         val site = SiteModel().apply { id = 789 }
         val syncResult = PosLocalCatalogSyncResult.Failure.CatalogTooLarge(
@@ -155,6 +158,8 @@ class WooPosPerformLocalCatalogIncrementalSyncTest {
         // THEN
         verify(wooPosLogWrapper).d("Starting incremental sync periodic hourly")
         verify(wooPosLogWrapper).e("Sync periodic hourly failed: Catalog exceeds limit")
+        verify(wooPosLogWrapper).e("Disabling Local Catalog periodic sync for site due to catalog size too large")
+        verify(prefsRepo).disablePeriodicSyncForSite(site.localId())
     }
 
     @Test

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/localcatalog/WooPosPerformLocalCatalogIncrementalSyncTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/localcatalog/WooPosPerformLocalCatalogIncrementalSyncTest.kt
@@ -139,7 +139,9 @@ class WooPosPerformLocalCatalogIncrementalSyncTest {
     }
 
     @Test
-    fun `given sync fails with catalog too large, when execute called, then logs failure and disables periodic sync`() = runTest(testScheduler) {
+    fun `given sync fails with catalog too large, when execute called, then logs failure and disables periodic sync`() = runTest(
+        testScheduler
+    ) {
         // GIVEN
         val site = SiteModel().apply { id = 789 }
         val syncResult = PosLocalCatalogSyncResult.Failure.CatalogTooLarge(


### PR DESCRIPTION
# Disable Local Catalog immediately in case catalog becomes too large

WOOMOB-1717
<!-- Remember about a good descriptive title. -->

<!-- Id number of the Linear issue this PR addresses, e.g., WOOMOB-373. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
This PR implements fall back to remote data source in case number of items in the store's catalog increase to over 1000 (products + variations).

### Test Steps
<!-- Describe how to test your changes. Include only what’s needed for the reviewer to validate the behavior.
For new features, outline the main user flow or goal rather than every tap or click — the reviewer should be able to complete the flow naturally.
If applicable, mention key devices, scenarios, or edge cases to verify. -->
1. Verify you can access the POS and Local Catalog is enabled (0-1000 items in catalog)
2. Increase number of items to 1000+ (products + variations)
3. Reopen POS and wait for the incremental sync to complete 
5. Verify "Local Catalog" category is not showing up in POS Settings
6. Verify that when POS is reopened it switches to remote data source

### Images/gif
<!-- Include before and after images or gifs when appropriate. -->
—

- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
