### PR TITLE
[Bookings] Hide unsupported booking filters

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/bookings/filter/BookingFilterListScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/bookings/filter/BookingFilterListScreen.kt
@@ -132,13 +132,10 @@ private fun FiltersNavHost(
             DateTimeFilterPicker()
         }
         composable(BookingFilterPage.TeamMember.route) {
-            TODO()
         }
         composable(BookingFilterPage.AttendanceStatus.route) {
-            TODO()
         }
         composable(BookingFilterPage.PaymentStatus.route) {
-            TODO()
         }
         composable(BookingFilterPage.BookingType.route) {
             BookingTypeFilterRoute(initialType = state.updatedBookingFilters.bookingType) { type ->
@@ -160,10 +157,8 @@ private fun FiltersNavHost(
             }
         }
         composable(BookingFilterPage.ServiceEvent.route) {
-            TODO()
         }
         composable(BookingFilterPage.Location.route) {
-            TODO()
         }
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/bookings/filter/BookingFilterListUiState.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/bookings/filter/BookingFilterListUiState.kt
@@ -106,13 +106,13 @@ val BookingFilterPage.titleRes: Int
 
 private fun availableBookingFilters(): List<BookingFilterPage> = listOf(
     BookingFilterPage.TeamMember,
-    BookingFilterPage.BookingType,
+//    BookingFilterPage.BookingType,
     BookingFilterPage.ServiceEvent,
     BookingFilterPage.AttendanceStatus,
-    BookingFilterPage.PaymentStatus,
+//    BookingFilterPage.PaymentStatus,
     BookingFilterPage.Customer,
     BookingFilterPage.DateTime,
-    BookingFilterPage.Location,
+//    BookingFilterPage.Location,
 )
 
 /**


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

<!-- Id number of the Linear issue this PR addresses, e.g., WOOMOB-373. -->
Closes WOOMOB-1710

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
This PR disables the booking filters that are not supported on the backend for Alpha II. It also removes the `TODO()` calls from the unimplemented filter screens, so navigating to those screens no longer causes a crash.

### Test Steps
<!-- Describe how to test your changes. Include only what’s needed for the reviewer to validate the behavior.
For new features, outline the main user flow or goal rather than every tap or click — the reviewer should be able to complete the flow naturally.
If applicable, mention key devices, scenarios, or edge cases to verify. -->
1. Log in with a CIAB store.
2. Go to Bookings.
3. Go to the All tab.
4. Tap the Filters button.
5. Select filters and verify it doesn't crash.

### Images/gif
<!-- Include before and after images or gifs when appropriate. -->

- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
