### PR TITLE
[WOOMOB-1689] Add Exit POS button to catalog sync error screen

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/splash/WooPosSplashScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/splash/WooPosSplashScreen.kt
@@ -54,7 +54,10 @@ fun WooPosSplashScreen(onNavigationEvent: (WooPosNavigationEvent) -> Unit) {
         }
         is WooPosSplashState.SyncFailed -> {
             SyncFailed(
-                onRetryClicked = { viewModel.onRetrySync() }
+                onRetryClicked = { viewModel.onRetrySync() },
+                onExitPosClicked = {
+                    onNavigationEvent(WooPosNavigationEvent.BackFromSplashClicked)
+                }
             )
         }
         is WooPosSplashState.Loaded -> {
@@ -129,13 +132,20 @@ private fun SyncingCatalog(
 }
 
 @Composable
-private fun SyncFailed(onRetryClicked: () -> Unit) {
+private fun SyncFailed(
+    onRetryClicked: () -> Unit,
+    onExitPosClicked: () -> Unit
+) {
     WooPosErrorScreen(
         message = stringResource(R.string.woopos_home_sync_failed_title),
         reason = stringResource(R.string.woopos_home_sync_failed_message),
         primaryButton = WooPosErrorScreenButtonState(
             text = stringResource(R.string.woopos_home_sync_failed_retry_button),
             click = onRetryClicked
+        ),
+        secondaryButton = WooPosErrorScreenButtonState(
+            text = stringResource(R.string.woopos_home_syncing_catalog_exit_button),
+            click = onExitPosClicked
         )
     )
 }


### PR DESCRIPTION
Fixes WOOMOB-1689

**I'm targeting 23.8 - if this PR is merged before the codefreeze, please update the milestone.**

### Description
Added an "Exit POS" button with outline style below the retry button on the "Unable to sync catalog" error screen. This provides users with an additional way to exit POS when catalog sync fails, making the user experience consistent with iOS.

### Test Steps
1. Launch the WooCommerce app
2. Turn on airplane mode
3. Navigate to POS mode
5. Verify that the error screen shows both:
   - A primary "Retry" button
   - A secondary "Exit POS" button with outline style below it
6. Tap the "Exit POS" button
7. Verify that you are taken back out of POS mode

### Images/gif
<img width="2560" height="1600" alt="Screenshot_1763109134" src="https://github.com/user-attachments/assets/0f5f0510-d324-48ef-9d54-88314ca211df" />




- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.