### PR TITLE
[WOOMOB-1676] Pass modified_after when fetching trashed products in POS sync

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/localcatalog/WooPosSyncAction.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/localcatalog/WooPosSyncAction.kt
@@ -47,7 +47,7 @@ class WooPosSyncAction @Inject constructor(
                 // We run incremental sync right after completing full sync -> no need to fetch trash products
                 emptyList()
             } else {
-                fetchAllTrashProducts(site, pageSize)
+                fetchAllTrashProducts(site, modifiedAfterGmt, pageSize)
             }
         }
         val variationsDeferred = async {
@@ -158,6 +158,7 @@ class WooPosSyncAction @Inject constructor(
 
     private suspend fun fetchAllTrashProducts(
         site: SiteModel,
+        modifiedAfterGmt: String?,
         pageSize: Int
     ): List<WooPosProductEntity> {
         logger.d("Fetching all trash products for incremental sync")
@@ -169,7 +170,7 @@ class WooPosSyncAction @Inject constructor(
                 posLocalCatalogStore.fetchRecentlyModifiedProducts(
                     site = site,
                     pageSize = pageSize,
-                    modifiedAfterGmt = null,
+                    modifiedAfterGmt = modifiedAfterGmt,
                     page = page,
                     includeStatus = listOf(CoreProductStatus.TRASH)
                 )

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/localcatalog/WooPosSyncActionTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/localcatalog/WooPosSyncActionTest.kt
@@ -253,20 +253,42 @@ class WooPosSyncActionTest {
     // === TRASH PRODUCTS SYNC TESTS ===
 
     @Test
+    fun `when incremental sync, then passes modifiedAfterGmt to trash products fetch`() = runTest {
+        // GIVEN
+        val modifiedAfter = "2024-01-15T10:30:00Z"
+        mockFetchProductsSuccess(pages = listOf(5), serverDate = "2024-01-15T10:30:00Z")
+        mockFetchVariationsSuccess(pages = listOf(2), serverDate = "2024-01-15T10:30:00Z")
+        givenTrashProducts(count = 1)
+
+        // WHEN
+        sut.syncCatalog(site, modifiedAfter, PAGE_SIZE, 10)
+
+        // THEN
+        verify(posLocalCatalogStore).fetchRecentlyModifiedProducts(
+            eq(site),
+            eq(modifiedAfter),
+            any(),
+            any(),
+            eq(listOf(CoreProductStatus.TRASH))
+        )
+    }
+
+    @Test
     fun `when incremental sync, then fetches and includes trash products`() = runTest {
         // GIVEN
+        val modifiedAfter = "2024-01-01T12:00:00Z"
         mockFetchProductsSuccess(pages = listOf(10), serverDate = "2024-01-01T12:00:00Z")
         mockFetchVariationsSuccess(pages = listOf(5), serverDate = "2024-01-01T12:00:00Z")
         givenTrashProducts(count = 3)
 
         // WHEN
-        val result = sut.syncCatalog(site, "2024-01-01T12:00:00Z", PAGE_SIZE, 10)
+        val result = sut.syncCatalog(site, modifiedAfter, PAGE_SIZE, 10)
 
         // THEN
         assertThat((result as WooPosSyncResult.Success).productsSynced).isEqualTo(13) // 10 + 3 trash
         verify(posLocalCatalogStore).fetchRecentlyModifiedProducts(
             eq(site),
-            anyOrNull(),
+            eq(modifiedAfter),
             any(),
             any(),
             eq(listOf(CoreProductStatus.TRASH))


### PR DESCRIPTION
Fixes WOOMOB-1676

**I'm targeting 23.8, if this is merged before the codefreeze please update the milestone.**

### Description
Updated the POS local catalog sync to pass the `modified_after` parameter when fetching trashed products during incremental syncs. Previously, trashed products were always fetched without a time filter, which was inefficient and inconsistent with how we handle published products.

### Test Steps
2. Open POS
3. Pull to refresh
5. Verify that only recently trashed products are fetched (e.g. using App inspection) 
6. Verify the sync completes successfully

### Images/gif
N/A - Backend change only

- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.