### PR TITLE
[WOOMOB-1720] Add experimental feature toggle for WooPOS Local Catalog

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/AppPrefs.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/AppPrefs.kt
@@ -135,7 +135,8 @@ object AppPrefs {
         BLAZE_CAMPAIGN_SELECTED_OBJECTIVE,
         BLAZE_CAMPAIGN_OBJECTIVE_SWITCH_CHECKED,
         IS_SITE_WPCOM_SUSPENDED,
-        JETPACK_APP_PASSWORDS_ENABLED
+        JETPACK_APP_PASSWORDS_ENABLED,
+        WOO_POS_LOCAL_CATALOG_ENABLED
     }
 
     /**
@@ -309,6 +310,10 @@ object AppPrefs {
     var jetpackAppPasswordsEnabled: Boolean
         get() = getBoolean(DeletablePrefKey.JETPACK_APP_PASSWORDS_ENABLED, true)
         set(value) = setBoolean(DeletablePrefKey.JETPACK_APP_PASSWORDS_ENABLED, value)
+
+    var wooPosLocalCatalogEnabled: Boolean
+        get() = getBoolean(DeletablePrefKey.WOO_POS_LOCAL_CATALOG_ENABLED, true)
+        set(value) = setBoolean(DeletablePrefKey.WOO_POS_LOCAL_CATALOG_ENABLED, value)
 
     var isWooPosSurveyNotificationCurrentUserShown: Boolean
         get() = getBoolean(UndeletablePrefKey.WOO_POS_SURVEY_NOTIFICATION_CURRENT_USER_SHOWN, false)

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/BetaFeaturesFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/BetaFeaturesFragment.kt
@@ -45,6 +45,7 @@ class BetaFeaturesFragment : Fragment(R.layout.fragment_settings_beta) {
         with(FragmentSettingsBetaBinding.bind(view)) {
             bindProductAddonsToggle()
             bindJetpackAppPasswordsToggle()
+            bindWooPosLocalCatalogToggle()
         }
     }
 
@@ -74,6 +75,18 @@ class BetaFeaturesFragment : Fragment(R.layout.fragment_settings_beta) {
         jetpackAppPasswordsToggle.isChecked = AppPrefs.jetpackAppPasswordsEnabled
         jetpackAppPasswordsToggle.setOnCheckedChangeListener { _, isChecked ->
             AppPrefs.jetpackAppPasswordsEnabled = isChecked
+        }
+    }
+
+    private fun FragmentSettingsBetaBinding.bindWooPosLocalCatalogToggle() {
+        viewLifecycleOwner.lifecycleScope.launch {
+            wooPosLocalCatalogToggle.isVisible =
+                isRemoteFeatureFlagEnabled(RemoteFeatureFlag.REMOTE_WOO_POS_LOCAL_CATALOG_M1)
+        }
+
+        wooPosLocalCatalogToggle.isChecked = AppPrefs.wooPosLocalCatalogEnabled
+        wooPosLocalCatalogToggle.setOnCheckedChangeListener { _, isChecked ->
+            AppPrefs.wooPosLocalCatalogEnabled = isChecked
         }
     }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/featureflags/WooPosLocalCatalogM1Enabled.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/featureflags/WooPosLocalCatalogM1Enabled.kt
@@ -1,5 +1,6 @@
 package com.woocommerce.android.ui.woopos.featureflags
 
+import com.woocommerce.android.AppPrefs
 import com.woocommerce.android.util.IsRemoteFeatureFlagEnabled
 import com.woocommerce.android.util.RemoteFeatureFlag.REMOTE_WOO_POS_LOCAL_CATALOG_M1
 import javax.inject.Inject
@@ -9,6 +10,7 @@ class WooPosLocalCatalogM1Enabled @Inject constructor(
     private val isRemoteFeatureFlagEnabled: IsRemoteFeatureFlagEnabled
 ) {
     suspend operator fun invoke(): Boolean {
-        return isRemoteFeatureFlagEnabled(REMOTE_WOO_POS_LOCAL_CATALOG_M1)
+        return isRemoteFeatureFlagEnabled(REMOTE_WOO_POS_LOCAL_CATALOG_M1) &&
+            AppPrefs.wooPosLocalCatalogEnabled
     }
 }

--- a/WooCommerce/src/main/res/layout/fragment_settings_beta.xml
+++ b/WooCommerce/src/main/res/layout/fragment_settings_beta.xml
@@ -22,6 +22,13 @@
         app:toggleOptionDesc="@string/settings_enable_jetpack_app_passwords_message"
         app:toggleOptionTitle="@string/settings_enable_jetpack_app_passwords_title" />
 
+    <com.woocommerce.android.ui.prefs.WCSettingsToggleOptionView
+        android:id="@+id/wooPosLocalCatalogToggle"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        app:toggleOptionDesc="@string/settings_enable_woo_pos_local_catalog_message"
+        app:toggleOptionTitle="@string/settings_enable_woo_pos_local_catalog_title" />
+
     <View style="@style/Woo.Divider" />
 
 </LinearLayout>

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -2256,6 +2256,8 @@
     <string name="settings_enable_beta_feature_failed_snackbar_text">Sorry, we couldn\'t change this feature setting right now</string>
     <string name="settings_enable_product_addons_teaser_title">View Add-ons</string>
     <string name="settings_enable_product_addons_teaser_message">Test out viewing Order Add-ons as we get ready to launch</string>
+    <string name="settings_enable_woo_pos_local_catalog_title">POS Local Catalog</string>
+    <string name="settings_enable_woo_pos_local_catalog_message">Store your product catalog on this device for faster search, barcode scanning, and loading times.</string>
     <string name="settings_privacy_policy">Read privacy policy</string>
     <string name="settings_privacy_statement">We value your privacy. Your personal data is used to optimize our mobile apps, improve security, conduct analytics, and enhance your user experience.</string>
     <string name="settings_tracking_header">Tracking</string>


### PR DESCRIPTION
Fixes WOOMOB-1720

This needs to be merged into 23.7 - one reviewer is enough.

### Description
This PR adds an experimental feature toggle for the WooPOS Local Catalog feature. The toggle is added to the Experimental Features screen and makes the `WooPosLocalCatalogEnabled` feature dependent on both:
1. The remote feature flag (`REMOTE_WOO_POS_LOCAL_CATALOG_M1`)
2. The new experimental feature toggle (enabled by default)

This gives us more control over the feature rollout, allowing users to opt-out if needed while still respecting the remote feature flag.

### Test Steps
1. Go to Settings → Experimental Features
2. Verify that the "WooPOS Local Catalog" toggle appears
3. Toggle the setting off
4. Open POS and verify local catalog is not used
5. Toggle the setting on
6. Open POS and verify local catalog is used

### Images/gif
<img width="2560" height="1600" alt="Screenshot_1763111893" src="https://github.com/user-attachments/assets/9586643b-c7fe-4fc8-9833-38ca800584db" />


- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.