### PR TITLE
[WOOMOB-1470] - Booking Date&Time filter #2

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/bookings/filter/BookingFilterListScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/bookings/filter/BookingFilterListScreen.kt
@@ -30,8 +30,8 @@ import androidx.navigation.compose.rememberNavController
 import com.woocommerce.android.R
 import com.woocommerce.android.ui.bookings.filter.attendancestatus.BookingAttendanceStatusFilterRoute
 import com.woocommerce.android.ui.bookings.filter.customer.BookingCustomerFilterPage
-import com.woocommerce.android.ui.bookings.filter.teammember.BookingTeamMemberFilterRoute
 import com.woocommerce.android.ui.bookings.filter.datetime.DateTimeFilterRoute
+import com.woocommerce.android.ui.bookings.filter.teammember.BookingTeamMemberFilterRoute
 import com.woocommerce.android.ui.bookings.filter.type.BookingTypeFilterRoute
 import com.woocommerce.android.ui.compose.Render
 import com.woocommerce.android.ui.compose.component.Toolbar

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/bookings/filter/BookingFilterListScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/bookings/filter/BookingFilterListScreen.kt
@@ -30,8 +30,8 @@ import androidx.navigation.compose.rememberNavController
 import com.woocommerce.android.R
 import com.woocommerce.android.ui.bookings.filter.attendancestatus.BookingAttendanceStatusFilterRoute
 import com.woocommerce.android.ui.bookings.filter.customer.BookingCustomerFilterPage
-import com.woocommerce.android.ui.bookings.filter.datetime.DateTimeFilterPage
 import com.woocommerce.android.ui.bookings.filter.teammember.BookingTeamMemberFilterRoute
+import com.woocommerce.android.ui.bookings.filter.datetime.DateTimeFilterRoute
 import com.woocommerce.android.ui.bookings.filter.type.BookingTypeFilterRoute
 import com.woocommerce.android.ui.compose.Render
 import com.woocommerce.android.ui.compose.component.Toolbar
@@ -131,6 +131,11 @@ private fun FiltersNavHost(
         composable(BookingFilterPage.List.route) {
             BookingFilterRootPage(state.items)
         }
+        composable(BookingFilterPage.DateTime.route) {
+            DateTimeFilterRoute { dateRange ->
+                state.onUpdateFilterOption(dateRange)
+            }
+        }
         composable(BookingFilterPage.TeamMember.route) {
             BookingTeamMemberFilterRoute(initialTeamMembers = state.updatedBookingFilters.teamMembers) { teamMember ->
                 state.onUpdateFilterOption(teamMember)
@@ -163,9 +168,6 @@ private fun FiltersNavHost(
                 }
                 state.onClose()
             }
-        }
-        composable(BookingFilterPage.DateTime.route) {
-            DateTimeFilterPage()
         }
         composable(BookingFilterPage.Location.route) {
         }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/bookings/filter/BookingFilterListScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/bookings/filter/BookingFilterListScreen.kt
@@ -132,7 +132,9 @@ private fun FiltersNavHost(
             BookingFilterRootPage(state.items)
         }
         composable(BookingFilterPage.DateTime.route) {
-            DateTimeFilterRoute { dateRange ->
+            DateTimeFilterRoute(
+                initialRange = state.updatedBookingFilters.dateRange
+            ) { dateRange ->
                 state.onUpdateFilterOption(dateRange)
             }
         }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/bookings/filter/BookingFilterListUiState.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/bookings/filter/BookingFilterListUiState.kt
@@ -83,9 +83,15 @@ data class BookingFilterListUiState(
                 UiString.UiStringText(name)
             }
 
+            BookingFilterPage.DateTime -> {
+                updatedBookingFilters.dateRange?.let {
+                    UiString.UiStringRes(R.string.bookings_filter_date_filter_value)
+                }
+            }
+
+            BookingFilterPage.TeamMember,
             BookingFilterPage.ServiceEvent,
             BookingFilterPage.PaymentStatus,
-            BookingFilterPage.DateTime,
             BookingFilterPage.Location,
             BookingFilterPage.List -> null
         } ?: UiString.UiStringRes(R.string.bookings_filter_default)

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/bookings/filter/BookingFilterListUiState.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/bookings/filter/BookingFilterListUiState.kt
@@ -50,7 +50,6 @@ data class BookingFilterListUiState(
             onClick = { openPage(page) },
         )
     }
-
     val updatedBookingFiltersCount = updatedBookingFilters.enabledFiltersCount
 
     val showClearButton: Boolean

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/bookings/filter/datetime/DateTimeFilterPage.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/bookings/filter/datetime/DateTimeFilterPage.kt
@@ -31,14 +31,20 @@ import com.woocommerce.android.ui.compose.component.DatePickerDialog
 import com.woocommerce.android.ui.compose.component.TimePickerDialog
 import com.woocommerce.android.ui.compose.preview.LightDarkThemePreviews
 import com.woocommerce.android.ui.compose.theme.WooTheme
+import org.wordpress.android.fluxc.network.rest.wpcom.wc.bookings.BookingsFilterOption
 import java.time.LocalDateTime
 import java.time.format.DateTimeFormatter
 import java.time.format.FormatStyle
 import java.util.Calendar
 
 @Composable
-fun DateTimeFilterPage() {
-    val viewModel: DateTimeFilterViewModel = hiltViewModel()
+fun DateTimeFilterRoute(
+    onDateTimeFilterChanged: (BookingsFilterOption.DateRange) -> Unit,
+) {
+    val viewModel = hiltViewModel<DateTimeFilterViewModel, DateTimeFilterViewModel.Factory> { factory ->
+        factory.create(onDateTimeFilterChanged)
+    }
+
     val state by viewModel.uiState.observeAsState()
     state?.let { DateTimeFilterPage(it) }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/bookings/filter/datetime/DateTimeFilterPage.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/bookings/filter/datetime/DateTimeFilterPage.kt
@@ -39,10 +39,11 @@ import java.util.Calendar
 
 @Composable
 fun DateTimeFilterRoute(
+    initialRange: BookingsFilterOption.DateRange? = null,
     onDateTimeFilterChanged: (BookingsFilterOption.DateRange) -> Unit,
 ) {
     val viewModel = hiltViewModel<DateTimeFilterViewModel, DateTimeFilterViewModel.Factory> { factory ->
-        factory.create(onDateTimeFilterChanged)
+        factory.create(onDateTimeFilterChanged, initialRange)
     }
 
     val state by viewModel.uiState.observeAsState()

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/bookings/filter/datetime/DateTimeFilterViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/bookings/filter/datetime/DateTimeFilterViewModel.kt
@@ -7,21 +7,26 @@ import com.woocommerce.android.ui.bookings.filter.datetime.PickerDialogState.Dat
 import com.woocommerce.android.ui.bookings.filter.datetime.PickerDialogState.TimeDialog
 import com.woocommerce.android.ui.compose.component.Time
 import com.woocommerce.android.viewmodel.ScopedViewModel
+import dagger.assisted.Assisted
+import dagger.assisted.AssistedFactory
+import dagger.assisted.AssistedInject
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.update
+import org.wordpress.android.fluxc.network.rest.wpcom.wc.bookings.BookingsFilterOption
 import java.time.Clock
 import java.time.Instant
 import java.time.LocalDateTime
 import java.time.ZoneId
+import java.time.ZoneOffset
 import java.time.format.DateTimeFormatter
 import java.time.format.FormatStyle
-import javax.inject.Inject
 
-@HiltViewModel
-class DateTimeFilterViewModel @Inject constructor(
+@HiltViewModel(assistedFactory = DateTimeFilterViewModel.Factory::class)
+class DateTimeFilterViewModel @AssistedInject constructor(
     savedStateHandle: SavedStateHandle,
     private val clock: Clock,
+    @Assisted private val onTypeFilterChanged: (BookingsFilterOption.DateRange) -> Unit,
 ) : ScopedViewModel(savedStateHandle) {
 
     private val zone: ZoneId = ZoneId.systemDefault()
@@ -114,6 +119,7 @@ class DateTimeFilterViewModel @Inject constructor(
                 }
             }
         }
+        emitTypeFilterChange()
     }
 
     private fun commitSelectedTime(dateBoundary: DateBoundary, time: Time) {
@@ -140,6 +146,23 @@ class DateTimeFilterViewModel @Inject constructor(
                 }
             }
         }
+        emitTypeFilterChange()
+    }
+
+    private fun emitTypeFilterChange() {
+        onTypeFilterChanged(
+            BookingsFilterOption.DateRange(
+                after = _uiState.value.fromDateTime?.toInstant(ZoneOffset.UTC),
+                before = _uiState.value.toDateTime?.toInstant(ZoneOffset.UTC),
+            )
+        )
+    }
+
+    @AssistedFactory
+    interface Factory {
+        fun create(
+            onTypeFilterChanged: (BookingsFilterOption.DateRange) -> Unit
+        ): DateTimeFilterViewModel
     }
 }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/bookings/filter/datetime/DateTimeFilterViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/bookings/filter/datetime/DateTimeFilterViewModel.kt
@@ -50,11 +50,11 @@ class DateTimeFilterViewModel @AssistedInject constructor(
                 val toDateTime = range.before?.atZone(ZoneOffset.UTC)?.toLocalDateTime()
                 currentState.copy(
                     fromDateTime = fromDateTime,
-                    formattedFromDate = dateFormatter.format(fromDateTime),
-                    formattedFromTime = timeFormatter.format(fromDateTime),
+                    formattedFromDate = fromDateTime.formatDate(),
+                    formattedFromTime = fromDateTime.formatTime(),
                     toDateTime = toDateTime,
-                    formattedToDate = dateFormatter.format(toDateTime),
-                    formattedToTime = timeFormatter.format(toDateTime),
+                    formattedToDate = toDateTime.formatDate(),
+                    formattedToTime = toDateTime.formatTime(),
                 )
             }
         }
@@ -118,7 +118,7 @@ class DateTimeFilterViewModel @AssistedInject constructor(
                         .withDayOfMonth(picked.dayOfMonth)
                     current.copy(
                         fromDateTime = newDateTime,
-                        formattedFromDate = dateFormatter.format(newDateTime),
+                        formattedFromDate = newDateTime.formatDate(),
                         pickerDialogState = null,
                     )
                 }
@@ -131,7 +131,7 @@ class DateTimeFilterViewModel @AssistedInject constructor(
                         .withDayOfMonth(picked.dayOfMonth)
                     current.copy(
                         toDateTime = newDateTime,
-                        formattedToDate = dateFormatter.format(newDateTime),
+                        formattedToDate = newDateTime.formatDate(),
                         pickerDialogState = null,
                     )
                 }
@@ -147,8 +147,8 @@ class DateTimeFilterViewModel @AssistedInject constructor(
                     val newDateTime = (current.fromDateTime ?: LocalDateTime.now(clock)).withTime(time)
                     current.copy(
                         fromDateTime = newDateTime,
-                        formattedFromTime = timeFormatter.format(newDateTime),
-                        formattedFromDate = dateFormatter.format(newDateTime),
+                        formattedFromTime = newDateTime.formatTime(),
+                        formattedFromDate = newDateTime.formatDate(),
                         pickerDialogState = null,
                     )
                 }
@@ -157,8 +157,8 @@ class DateTimeFilterViewModel @AssistedInject constructor(
                     val newDateTime = (current.toDateTime ?: LocalDateTime.now(clock)).withTime(time = time)
                     current.copy(
                         toDateTime = newDateTime,
-                        formattedToDate = dateFormatter.format(newDateTime),
-                        formattedToTime = timeFormatter.format(newDateTime),
+                        formattedToDate = newDateTime.formatDate(),
+                        formattedToTime = newDateTime.formatTime(),
                         pickerDialogState = null,
                     )
                 }
@@ -175,6 +175,9 @@ class DateTimeFilterViewModel @AssistedInject constructor(
             )
         )
     }
+
+    private fun LocalDateTime?.formatDate(): String = this?.let { dateFormatter.format(it) }.orEmpty()
+    private fun LocalDateTime?.formatTime(): String = this?.let { timeFormatter.format(it) }.orEmpty()
 
     @AssistedFactory
     interface Factory {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/bookings/filter/datetime/DateTimeFilterViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/bookings/filter/datetime/DateTimeFilterViewModel.kt
@@ -26,6 +26,7 @@ import java.time.format.FormatStyle
 class DateTimeFilterViewModel @AssistedInject constructor(
     savedStateHandle: SavedStateHandle,
     private val clock: Clock,
+    @Assisted private val initialRange: BookingsFilterOption.DateRange? = null,
     @Assisted private val onTypeFilterChanged: (BookingsFilterOption.DateRange) -> Unit,
 ) : ScopedViewModel(savedStateHandle) {
 
@@ -41,6 +42,23 @@ class DateTimeFilterViewModel @AssistedInject constructor(
         )
     )
     val uiState: LiveData<DateTimeFilterUiState?> = _uiState.asLiveData()
+
+    init {
+        initialRange?.let { range ->
+            _uiState.update { currentState ->
+                val fromDateTime = range.after?.atZone(ZoneOffset.UTC)?.toLocalDateTime()
+                val toDateTime = range.before?.atZone(ZoneOffset.UTC)?.toLocalDateTime()
+                currentState.copy(
+                    fromDateTime = fromDateTime,
+                    formattedFromDate = dateFormatter.format(fromDateTime),
+                    formattedFromTime = timeFormatter.format(fromDateTime),
+                    toDateTime = toDateTime,
+                    formattedToDate = dateFormatter.format(toDateTime),
+                    formattedToTime = timeFormatter.format(toDateTime),
+                )
+            }
+        }
+    }
 
     private fun openDateDialog(dateBoundary: DateBoundary) {
         _uiState.update { currentState ->
@@ -161,7 +179,8 @@ class DateTimeFilterViewModel @AssistedInject constructor(
     @AssistedFactory
     interface Factory {
         fun create(
-            onTypeFilterChanged: (BookingsFilterOption.DateRange) -> Unit
+            onTypeFilterChanged: (BookingsFilterOption.DateRange) -> Unit,
+            initialRange: BookingsFilterOption.DateRange? = null,
         ): DateTimeFilterViewModel
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/bookings/list/BookingListFiltersBuilder.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/bookings/list/BookingListFiltersBuilder.kt
@@ -19,9 +19,7 @@ class BookingListFiltersBuilder @Inject constructor(
      * See p1759398245019489-slack-C09FHQNQERG
      */
     fun BookingListTab.asDateRangeFilter(): BookingsFilterOption.DateRange? {
-        fun todayAtMidnight() = LocalDate.now(clock).minusDays(1).atTime(LocalTime.MAX)
-            .atOffset(ZoneOffset.UTC).toInstant()
-
+        fun todayAtMidnight() = LocalDate.now(clock).atTime(LocalTime.MIDNIGHT).atOffset(ZoneOffset.UTC).toInstant()
         fun todayAtEndOfDay() = LocalDate.now(clock).atTime(LocalTime.MAX).atOffset(ZoneOffset.UTC).toInstant()
 
         return when (this) {

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -4234,6 +4234,7 @@
     <string name="bookings_filter_date_from">FROM</string>
     <string name="bookings_filter_date_to">TO</string>
     <string name="bookings_filter_time_picker_title">Select time</string>
+    <string name="bookings_filter_date_filter_value">Custom range</string>
 
     <!-- Booking details view-->
     <string name="booking_details_title">Booking #%s</string>

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/bookings/filter/datetime/DateTimeFilterViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/bookings/filter/datetime/DateTimeFilterViewModelTest.kt
@@ -7,6 +7,7 @@ import com.woocommerce.android.viewmodel.BaseUnitTest
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.Test
+import org.wordpress.android.fluxc.network.rest.wpcom.wc.bookings.BookingsFilterOption
 import java.time.Clock
 import java.time.Instant
 import java.time.LocalDateTime
@@ -180,6 +181,39 @@ class DateTimeFilterViewModelTest : BaseUnitTest() {
             val providedMillis = dialog2.date
             val expectedMillis = vm.uiState.getOrAwaitValue()!!.fromDateTime!!.atZone(zone).toInstant().toEpochMilli()
             assertThat(providedMillis).isEqualTo(expectedMillis)
+        }
+
+    @Test
+    fun `given initialRange with after and before, when ViewModel is created, then state reflects range`() =
+        testBlocking {
+            // Given a specific range
+            val after = LocalDateTime.of(2025, 1, 2, 3, 4).toInstant(ZoneOffset.UTC)
+            val before = LocalDateTime.of(2025, 2, 3, 4, 5).toInstant(ZoneOffset.UTC)
+            val range = BookingsFilterOption.DateRange(
+                before = before,
+                after = after
+            )
+
+            // When
+            val vm = DateTimeFilterViewModel(
+                onTypeFilterChanged = { _ -> },
+                savedStateHandle = SavedStateHandle(),
+                clock = clock,
+                initialRange = range,
+            )
+
+            // Then
+            val zone = ZoneId.systemDefault()
+            val expectedFrom = after.atZone(zone).toLocalDateTime()
+            val expectedTo = before.atZone(zone).toLocalDateTime()
+            val state = vm.uiState.getOrAwaitValue()!!
+            assertThat(state.fromDateTime).isEqualTo(expectedFrom)
+            assertThat(state.toDateTime).isEqualTo(expectedTo)
+            // formatted strings should be populated
+            assertThat(state.formattedFromDate).isNotEmpty()
+            assertThat(state.formattedFromTime).isNotEmpty()
+            assertThat(state.formattedToDate).isNotEmpty()
+            assertThat(state.formattedToTime).isNotEmpty()
         }
 
     private fun createVm(): DateTimeFilterViewModel {

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/bookings/filter/datetime/DateTimeFilterViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/bookings/filter/datetime/DateTimeFilterViewModelTest.kt
@@ -184,6 +184,7 @@ class DateTimeFilterViewModelTest : BaseUnitTest() {
 
     private fun createVm(): DateTimeFilterViewModel {
         return DateTimeFilterViewModel(
+            onTypeFilterChanged = { _ -> },
             savedStateHandle = SavedStateHandle(),
             clock = clock,
         )

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/bookings/list/BookingListFilterBuilderTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/bookings/list/BookingListFilterBuilderTest.kt
@@ -21,7 +21,7 @@ class BookingListFilterBuilderTest {
         }
 
         assertThat(filter).isNotNull()
-        assertThat(filter?.after).isEqualTo(Instant.parse("2024-12-31T23:59:59.999999999Z"))
+        assertThat(filter?.after).isEqualTo(Instant.parse("2025-01-01T00:00:00Z"))
         assertThat(filter?.before).isEqualTo(Instant.parse("2025-01-01T23:59:59.999999999+00:00"))
     }
 

--- a/libs/fluxc-plugin/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/bookings/BookingsRestClient.kt
+++ b/libs/fluxc-plugin/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/bookings/BookingsRestClient.kt
@@ -9,6 +9,7 @@ import org.wordpress.android.fluxc.network.rest.wpcom.wc.WooPayload
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.toWooError
 import org.wordpress.android.fluxc.utils.extensions.filterNotNull
 import org.wordpress.android.fluxc.utils.extensions.putIfNotNull
+import java.time.ZoneOffset
 import javax.inject.Inject
 import javax.inject.Singleton
 
@@ -143,8 +144,15 @@ class BookingsRestClient @Inject constructor(
                 BookingsFilterOption.PaymentStatus -> TODO()
                 is BookingsFilterOption.Customer -> set("customer", filter.customerId.toString())
                 is BookingsFilterOption.DateRange -> {
-                    filter.before?.let { set("start_date_before", it.toString()) }
-                    filter.after?.let { set("start_date_after", it.toString()) }
+                    // Plus/minus one minute to make the range inclusive
+                    filter.before?.let {
+                        val inclusiveBefore = it.atZone(ZoneOffset.UTC).plusMinutes(1).toInstant()
+                        set("start_date_before", inclusiveBefore.toString())
+                    }
+                    filter.after?.let {
+                        val inclusiveAfter = it.atZone(ZoneOffset.UTC).minusMinutes(1).toInstant()
+                        set("start_date_after", inclusiveAfter.toString())
+                    }
                 }
 
                 BookingsFilterOption.Location -> TODO()

--- a/libs/fluxc-plugin/src/main/kotlin/org/wordpress/android/fluxc/persistence/dao/BookingsDao.kt
+++ b/libs/fluxc-plugin/src/main/kotlin/org/wordpress/android/fluxc/persistence/dao/BookingsDao.kt
@@ -18,8 +18,8 @@ interface BookingsDao {
         const val DEFAULT_SELECT_QUERY = """
             SELECT * FROM Bookings
             WHERE localSiteId = :localSiteId
-            AND (:startDateBefore IS NULL OR start < :startDateBefore)
-            AND (:startDateAfter IS NULL OR start > :startDateAfter)
+            AND (:startDateBefore IS NULL OR start <= :startDateBefore)
+            AND (:startDateAfter IS NULL OR start >= :startDateAfter)
             AND (:customerId IS NULL OR customerId = :customerId)
             AND ((:attendanceStatusesSize = 0) OR attendanceStatus IN (:attendanceStatuses))
             AND ((:resourceIdsSize = 0) OR resourceId IN (:resourceIds))


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

<!-- Id number of the Linear issue this PR addresses, e.g., WOOMOB-373. -->

Part of WOOMOB-1470

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

Part 2 of the Date&Time filter. This PR adds all the necessary bindings to pass the filter to the Root page, store it and also pass the currently selected one as the initial for the picker. The Root page will now show `Custom range` if date filter is applied. 

Additionally, this PR modifies both the REST client and the BookingDao to make sure the date filtering is inclusive - see p1763116036412419-slack-C09FHQNQERG

### Test Steps
<!-- Describe how to test your changes. Include only what’s needed for the reviewer to validate the behavior.
For new features, outline the main user flow or goal rather than every tap or click — the reviewer should be able to complete the flow naturally.
If applicable, mention key devices, scenarios, or edge cases to verify. -->

1. Launch the app
2. Go to Booking -> All tab
3. Tap filters 
4. Play with it, make sure it filters correctly, especially test the inclusiveness of the `date range.

### Images/gif
<!-- Include before and after images or gifs when appropriate. -->


https://github.com/user-attachments/assets/273e4811-2bc5-4d5d-adce-68a562bec926



- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->