### PR TITLE
[WOOMOB-1721] - Small updates to the Booking tab after design review

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/bookings/BookingMapper.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/bookings/BookingMapper.kt
@@ -148,7 +148,7 @@ class BookingMapper @Inject constructor(
         val date = detailsDateFormatter.format(booking.start)
         val time = timeRangeFormatter.format(booking.start)
         return UiString.UiStringRes(
-            R.string.booking_cancel_dialog_message,
+            R.string.booking_cancel_dialog_message_v2,
             listOf(
                 customerName,
                 UiString.UiStringText(serviceName),

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/bookings/BookingMapper.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/bookings/BookingMapper.kt
@@ -78,7 +78,6 @@ class BookingMapper @Inject constructor(
             staff = staffMemberStatus,
             // TODO replace mocked values when available from API
             location = "238 Willow Creek Drive, Montgomery AL 36109",
-            price = currencyFormatter.formatCurrency(cost, currency),
             cancelStatus = cancelStatus,
             cancelButtonVisible = isCancellable,
             duration = duration,

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/bookings/compose/BookingAppointmentDetails.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/bookings/compose/BookingAppointmentDetails.kt
@@ -33,7 +33,7 @@ fun BookingAppointmentDetails(
     modifier: Modifier = Modifier,
 ) {
     Column(modifier = modifier) {
-        BookingSectionHeader(R.string.booking_appointment_details_header)
+        BookingSectionHeader(R.string.booking_details_section_header)
         Column(modifier = Modifier.background(color = MaterialTheme.colorScheme.surfaceContainer)) {
             HorizontalDivider(thickness = 0.5.dp)
             AppointmentDetailsRow(
@@ -46,7 +46,7 @@ fun BookingAppointmentDetails(
             )
             model.staff?.let {
                 AppointmentDetailsRow(
-                    label = R.string.booking_appointment_label_staff
+                    label = R.string.booking_appointment_label_team_member
                 ) {
                     when (it) {
                         is BookingStaffMemberStatus.Loaded, is BookingStaffMemberStatus.Unavailable -> {
@@ -76,11 +76,7 @@ fun BookingAppointmentDetails(
             )
             AppointmentDetailsRow(
                 label = R.string.booking_appointment_label_duration,
-                value = model.duration
-            )
-            AppointmentDetailsRow(
-                label = R.string.booking_appointment_label_price,
-                value = model.price,
+                value = model.duration,
                 withDivider = model.cancelButtonVisible,
             )
             AnimatedVisibility(model.cancelButtonVisible) {
@@ -152,7 +148,6 @@ data class BookingAppointmentDetailsModel(
     val staff: BookingStaffMemberStatus?,
     val location: String,
     val duration: String,
-    val price: String,
     val cancelButtonVisible: Boolean,
     val cancelStatus: CancelStatus,
 ) {
@@ -177,7 +172,6 @@ private fun BookingAppointmentDetailsPreview() {
                 staff = BookingStaffMemberStatus.Loading,
                 location = "238 Willow Creek Drive, Montgomery AL 36109",
                 duration = "60 min",
-                price = "$55.00",
                 cancelButtonVisible = true,
                 cancelStatus = CancelStatus.Idle,
             ),
@@ -198,7 +192,6 @@ private fun BookingAppointmentDetailsCancelHiddenPreview() {
                 staff = BookingStaffMemberStatus.Loading,
                 location = "238 Willow Creek Drive, Montgomery AL 36109",
                 duration = "60 min",
-                price = "$55.00",
                 cancelButtonVisible = false,
                 cancelStatus = CancelStatus.Idle,
             ),

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/bookings/details/BookingDetailsScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/bookings/details/BookingDetailsScreen.kt
@@ -282,7 +282,6 @@ private fun BookingDetailsPreview() {
                         staff = BookingStaffMemberStatus.Loaded("Marianne Renoir"),
                         location = "238 Willow Creek Drive, Montgomery AL 36109",
                         duration = "60 min",
-                        price = "$55.00",
                         cancelButtonVisible = true,
                         cancelStatus = CancelStatus.Idle,
                     ),

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/bookings/details/BookingDetailsViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/bookings/details/BookingDetailsViewModel.kt
@@ -87,7 +87,7 @@ class BookingDetailsViewModel @Inject constructor(
         if (showCancelBooking && booking != null) {
             val message = bookingMapper.buildCancelDialogMessage(booking)
             DialogState(
-                title = UiString.UiStringRes(R.string.booking_cancel_dialog_title),
+                title = UiString.UiStringRes(R.string.booking_cancel_dialog_title_v2),
                 message = message,
                 positiveButton = DialogState.DialogButton(
                     text = UiString.UiStringRes(R.string.booking_cancel_dialog_confirm),

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/bookings/list/BookingListScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/bookings/list/BookingListScreen.kt
@@ -398,7 +398,11 @@ private fun EmptyListView(
             text = when (selectedTab) {
                 BookingListTab.Today -> stringResource(R.string.bookings_empty_state_title_today)
                 BookingListTab.Upcoming -> stringResource(R.string.bookings_empty_state_title_upcoming)
-                BookingListTab.All -> stringResource(R.string.bookings_empty_state_title_default)
+                BookingListTab.All -> if (areFiltersActive) {
+                    stringResource(R.string.bookings_empty_state_title_default)
+                } else {
+                    stringResource(R.string.bookings_empty_state_title_all)
+                }
             },
             style = MaterialTheme.typography.titleLarge,
             textAlign = TextAlign.Center
@@ -408,13 +412,13 @@ private fun EmptyListView(
 
         Text(
             text = when (selectedTab) {
-                BookingListTab.Today -> stringResource(R.string.bookings_empty_state_description_today)
-                BookingListTab.Upcoming -> stringResource(R.string.bookings_empty_state_description_upcoming)
+                BookingListTab.Today -> stringResource(R.string.bookings_empty_state_description_today_v2)
+                BookingListTab.Upcoming -> stringResource(R.string.bookings_empty_state_description_upcoming_v2)
                 else -> {
                     if (areFiltersActive) {
                         stringResource(R.string.bookings_empty_state_description_with_filters)
                     } else {
-                        stringResource(R.string.bookings_empty_state_description_default)
+                        stringResource(R.string.bookings_empty_state_description_all)
                     }
                 }
             },

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -4239,13 +4239,12 @@
 
     <!-- Booking details view-->
     <string name="booking_details_title">Booking #%s</string>
-    <string name="booking_appointment_details_header">APPOINTMENT DETAILS</string>
+    <string name="booking_details_section_header">BOOKING DETAILS</string>
     <string name="booking_appointment_label_date">Date</string>
     <string name="booking_appointment_label_time">Time</string>
-    <string name="booking_appointment_label_staff">Assigned staff</string>
+    <string name="booking_appointment_label_team_member">Team member</string>
     <string name="booking_appointment_label_location">Location</string>
     <string name="booking_appointment_label_duration">Duration</string>
-    <string name="booking_appointment_label_price">Price</string>
     <string name="booking_payment_status_unpaid">Unpaid</string>
     <string name="booking_payment_status_paid">Paid</string>
     <string name="booking_payment_status_pending_confirmation">Pending Confirmation</string>

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -4205,9 +4205,10 @@
     <string name="bookings_empty_state_title_default">No bookings found</string>
     <string name="bookings_empty_state_title_today">No bookings today</string>
     <string name="bookings_empty_state_title_upcoming">No upcoming bookings</string>
-    <string name="bookings_empty_state_description_default">Incoming bookings will appear here, where you can view and manage them.</string>
-    <string name="bookings_empty_state_description_today">You don’t have any appointments or events scheduled for today.</string>
-    <string name="bookings_empty_state_description_upcoming">You don’t have any future appointments or events scheduled yet.</string>
+    <string name="bookings_empty_state_title_all">No bookings yet</string>
+    <string name="bookings_empty_state_description_all">Bookings will appear here once customers start scheduling your services or registering for events.</string>
+    <string name="bookings_empty_state_description_today_v2">Any bookings scheduled for today will appear here.</string>
+    <string name="bookings_empty_state_description_upcoming_v2">New bookings will appear here as customers schedule your services or register for events.</string>
     <string name="bookings_search_no_results_without_filters">We couldn’t find any bookings with that name — try adjusting your search term to see more results.</string>
     <string name="bookings_search_no_results_with_filters">We couldn’t find any bookings with that name — try adjusting your search term or your filters to see more results.</string>
     <string name="bookings_empty_state_description_with_filters">No bookings match your filters. Try adjusting them to see more results.</string>

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -4287,8 +4287,9 @@
     <string name="booking_note_header">BOOKING NOTE</string>
     <string name="booking_note_label_add_note">Add note</string>
     <string name="booking_note_description_private">This is a private note. It’ll not be shared with the customer.</string>
-    <string name="booking_cancel_dialog_title">Cancel booking</string>
+    <string name="booking_cancel_dialog_title_v2">Cancel booking?</string>
     <string name="booking_cancel_dialog_message">%1$s will no longer be able to attend “%2$s” on %3$s at %4$s.</string>
+    <string name="booking_cancel_dialog_message_v2">%1$s can no longer attend “%2$s” on %3$s at %4$s.</string>
     <string name="booking_cancel_dialog_keep">No, keep it</string>
     <string name="booking_cancel_dialog_confirm">Yes, cancel it</string>
     <string name="booking_note_screen_title">Booking note</string>

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/bookings/BookingMapperTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/bookings/BookingMapperTest.kt
@@ -20,7 +20,6 @@ import org.mockito.kotlin.anyOrNull
 import org.mockito.kotlin.doAnswer
 import org.mockito.kotlin.eq
 import org.mockito.kotlin.mock
-import org.mockito.kotlin.whenever
 import org.wordpress.android.fluxc.model.LocalOrRemoteId
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.bookings.BookingCustomerInfo
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.bookings.BookingOrderInfo
@@ -119,8 +118,6 @@ class BookingMapperTest : BaseUnitTest() {
         )
         val staffMemberStatus = BookingStaffMemberStatus.Loaded("Marianne Renoir")
 
-        whenever(currencyFormatter.formatCurrency(eq("55.00"), eq("USD"), eq(true))).thenReturn("$55.00")
-
         val expectedDate = DateTimeFormatter.ofLocalizedDate(FormatStyle.FULL)
             .withZone(ZoneOffset.UTC)
             .format(start)
@@ -136,7 +133,6 @@ class BookingMapperTest : BaseUnitTest() {
         assertThat(model.staff).isEqualTo(staffMemberStatus)
         assertThat(model.location).isEqualTo("238 Willow Creek Drive, Montgomery AL 36109")
         assertThat(model.duration).isEqualTo("1 hour 30 minutes")
-        assertThat(model.price).isEqualTo("$55.00")
         assertThat(model.cancelStatus).isEqualTo(CancelStatus.Idle)
     }
 
@@ -217,7 +213,7 @@ class BookingMapperTest : BaseUnitTest() {
         assertThat(message)
             .isEqualTo(
                 UiString.UiStringRes(
-                    R.string.booking_cancel_dialog_message,
+                    R.string.booking_cancel_dialog_message_v2,
                     listOf(
                         UiString.UiStringText(customerName),
                         UiString.UiStringText("${booking.order.productInfo?.name}"),
@@ -243,7 +239,7 @@ class BookingMapperTest : BaseUnitTest() {
         assertThat(message)
             .isEqualTo(
                 UiString.UiStringRes(
-                    R.string.booking_cancel_dialog_message,
+                    R.string.booking_cancel_dialog_message_v2,
                     listOf(
                         UiString.UiStringRes(R.string.customer_detail_guest_customer),
                         UiString.UiStringText("${booking.order.productInfo?.name}"),
@@ -279,11 +275,6 @@ class BookingMapperTest : BaseUnitTest() {
 
     @Test
     fun `given cancellable statuses, when mapped to appointment details, then cancel button visible`() {
-        whenever(currencyFormatter.formatCurrency(any<String>(), any(), eq(true))).thenAnswer {
-            val amount = it.getArgument<String>(0)
-            val currency = it.getArgument<String>(1)
-            "$currency$amount"
-        }
         val statuses = listOf(
             BookingEntity.Status.Confirmed,
             BookingEntity.Status.Paid,
@@ -301,11 +292,6 @@ class BookingMapperTest : BaseUnitTest() {
 
     @Test
     fun `given non-cancellable statuses, when mapped to appointment details, then cancel button hidden`() {
-        whenever(currencyFormatter.formatCurrency(any<String>(), any(), eq(true))).thenAnswer {
-            val amount = it.getArgument<String>(0)
-            val currency = it.getArgument<String>(1)
-            "$currency$amount"
-        }
         val statuses = listOf(
             BookingEntity.Status.Cancelled,
             BookingEntity.Status.InCart,

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/bookings/details/BookingDetailsViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/bookings/details/BookingDetailsViewModelTest.kt
@@ -58,7 +58,6 @@ class BookingDetailsViewModelTest : BaseUnitTest() {
 
     @Before
     fun setup() {
-        whenever(currencyFormatter.formatCurrency(any<String>(), any<String>(), any())).thenReturn("$0.00")
         whenever(
             resourceProvider.getString(
                 eq(R.string.booking_details_title),


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

<!-- Id number of the Linear issue this PR addresses, e.g., WOOMOB-373. -->

WOOMOB-1721

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

Please refer to our doc 13gi1iGagzGHBOzTKfM4I0J4or4RdIJkOZu0qzRdOHR4-gdoc. Each commit should also have enough context to understand the change. 

I didn't touch stuff related to attendance and payment status. I want to be sure those are final before changing them in the app.

### Test Steps
<!-- Describe how to test your changes. Include only what’s needed for the reviewer to validate the behavior.
For new features, outline the main user flow or goal rather than every tap or click — the reviewer should be able to complete the flow naturally.
If applicable, mention key devices, scenarios, or edge cases to verify. -->

Go through each change and verify it matches i3 design and the doc description.

### Images/gif
<!-- Include before and after images or gifs when appropriate. -->

|  |  |  |  |
|---|---|---|---|
| Empty states | <img width="1280" height="2856" alt="Screenshot_20251114_144641" src="https://github.com/user-attachments/assets/3428ae87-3ab9-462c-aea9-656656ae4413" /> | <img width="1280" height="2856" alt="Screenshot_20251114_144701" src="https://github.com/user-attachments/assets/a80494c7-6308-4ad2-8972-90109682c1a8" /> | <img width="1280" height="2856" alt="Screenshot_20251114_144718" src="https://github.com/user-attachments/assets/98480bc1-31e4-4f8c-a9ac-93a009be1203" /> |
| Booking details | <img width="436" height="246" alt="Screenshot 2025-11-14 at 15 03 54" src="https://github.com/user-attachments/assets/58f4019b-862f-48fd-9e24-c66ddd303cf0" /> |
| Cancel dialog | <img width="1280" height="2856" alt="Screenshot_20251114_152207" src="https://github.com/user-attachments/assets/de080d3a-6d38-41fa-9c16-0694395d19c4" /> |

- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->