### PR TITLE
[Bookings] Update booking filters data models

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/bookings/BookingsRepository.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/bookings/BookingsRepository.kt
@@ -7,8 +7,8 @@ import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.async
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.flowOf
+import org.wordpress.android.fluxc.network.rest.wpcom.wc.bookings.BookingFilters
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.bookings.BookingUpdatePayload
-import org.wordpress.android.fluxc.network.rest.wpcom.wc.bookings.BookingsFilterOption
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.bookings.BookingsOrderOption
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.bookings.BookingsStore
 import org.wordpress.android.fluxc.persistence.entity.BookingEntity
@@ -24,7 +24,7 @@ class BookingsRepository @Inject constructor(
         page: Int,
         perPage: Int,
         query: String? = null,
-        filters: List<BookingsFilterOption> = emptyList(),
+        filters: BookingFilters? = null,
         order: BookingsOrderOption
     ): Result<FetchResult> {
         val result = bookingsStore.fetchBookings(
@@ -51,7 +51,7 @@ class BookingsRepository @Inject constructor(
 
     fun observeBookings(
         limit: Int? = null,
-        filters: List<BookingsFilterOption> = emptyList(),
+        filters: BookingFilters? = null,
         order: BookingsOrderOption
     ): Flow<List<Booking>> =
         bookingsStore.observeBookings(

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/bookings/list/BookingListFiltersBuilder.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/bookings/list/BookingListFiltersBuilder.kt
@@ -1,6 +1,5 @@
 package com.woocommerce.android.ui.bookings.list
 
-import org.wordpress.android.fluxc.network.rest.wpcom.wc.bookings.BookingFilters
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.bookings.BookingsFilterOption
 import java.time.Clock
 import java.time.LocalDate
@@ -37,18 +36,5 @@ class BookingListFiltersBuilder @Inject constructor(
 
             BookingListTab.All -> null
         }
-    }
-
-    fun BookingFilters.asList(): List<BookingsFilterOption> {
-        val filters = mutableListOf<BookingsFilterOption>()
-        customer?.let { filters.add(it) }
-        dateRange?.let { filters.add(it) }
-        teamMember?.let { filters.add(it) }
-        filters.add(attendanceStatuses)
-        paymentStatus?.let { filters.add(it) }
-        bookingType?.let { filters.add(it) }
-        location?.let { filters.add(it) }
-        serviceEvent?.let { filters.add(it) }
-        return filters
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/bookings/list/BookingListHandler.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/bookings/list/BookingListHandler.kt
@@ -13,7 +13,7 @@ import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
-import org.wordpress.android.fluxc.network.rest.wpcom.wc.bookings.BookingsFilterOption
+import org.wordpress.android.fluxc.network.rest.wpcom.wc.bookings.BookingFilters
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.bookings.BookingsOrderOption
 import java.util.concurrent.atomic.AtomicBoolean
 import javax.inject.Inject
@@ -32,7 +32,7 @@ class BookingListHandler @Inject constructor(
     private val canLoadMore = AtomicBoolean(false)
 
     private val searchQuery = MutableStateFlow<String?>(null)
-    private val filters = MutableStateFlow<List<BookingsFilterOption>>(emptyList())
+    private val filters = MutableStateFlow<BookingFilters?>(null)
     private val sortBy = MutableStateFlow(BookingListSortOption.NewestToOldest)
 
     private val searchResults = MutableStateFlow(emptyList<Booking>())
@@ -57,7 +57,7 @@ class BookingListHandler @Inject constructor(
 
     suspend fun loadBookings(
         searchQuery: String? = null,
-        filters: List<BookingsFilterOption> = emptyList(),
+        filters: BookingFilters? = null,
         sortBy: BookingListSortOption
     ): Result<Unit> = mutex.withLock {
         // Reset pagination attributes

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/bookings/list/BookingListViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/bookings/list/BookingListViewModel.kt
@@ -31,7 +31,6 @@ import kotlinx.coroutines.flow.shareIn
 import kotlinx.coroutines.flow.withIndex
 import kotlinx.coroutines.launch
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.bookings.BookingFilters
-import org.wordpress.android.fluxc.network.rest.wpcom.wc.bookings.BookingsFilterOption
 import org.wordpress.android.fluxc.persistence.entity.BookingEntity
 import javax.inject.Inject
 
@@ -288,14 +287,12 @@ class BookingListViewModel @Inject constructor(
         }
     }
 
-    private fun FetchParams.prepareFilters(): List<BookingsFilterOption> = with(filtersBuilder) {
+    private fun FetchParams.prepareFilters(): BookingFilters = with(filtersBuilder) {
         when (selectedTab) {
             BookingListTab.Today,
-            BookingListTab.Upcoming -> listOfNotNull(
-                selectedTab.asDateRangeFilter()
-            )
+            BookingListTab.Upcoming -> BookingFilters(dateRange = selectedTab.asDateRangeFilter())
 
-            BookingListTab.All -> filters.asList()
+            BookingListTab.All -> filters
         }
     }
 

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/bookings/list/BookingListHandlerTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/bookings/list/BookingListHandlerTest.kt
@@ -36,7 +36,7 @@ class BookingListHandlerTest : BaseUnitTest() {
     private val availablePages = 3
     private val bookingsRepository: BookingsRepository = mock {
         val results = MutableStateFlow(emptyList<Booking>())
-        on { observeBookings(any(), any(), any()) } doAnswer { invocation ->
+        on { observeBookings(any(), anyOrNull(), any()) } doAnswer { invocation ->
             val limit = invocation.getArgument<Int>(0)
             results.map { it.take(limit) }
         }
@@ -45,7 +45,7 @@ class BookingListHandlerTest : BaseUnitTest() {
                 any(),
                 any(),
                 anyOrNull(),
-                any(),
+                anyOrNull(),
                 any()
             )
         } doAnswer InlineClassesAnswer { invocation ->
@@ -68,7 +68,7 @@ class BookingListHandlerTest : BaseUnitTest() {
     @Test
     fun `given repository returns bookings, when observing bookings flow, then returns bookings`() = testBlocking {
         val sampleBookings = List(10) { getSampleBooking(it) }
-        given(bookingsRepository.observeBookings(any(), any(), any())).willReturn(flowOf(sampleBookings))
+        given(bookingsRepository.observeBookings(any(), anyOrNull(), any())).willReturn(flowOf(sampleBookings))
 
         val bookings = bookingListHandler.bookingsFlow.first()
 
@@ -97,7 +97,7 @@ class BookingListHandlerTest : BaseUnitTest() {
                     page = any(),
                     perPage = any(),
                     query = anyOrNull(),
-                    filters = any(),
+                    filters = anyOrNull(),
                     order = any()
                 )
             )
@@ -122,7 +122,7 @@ class BookingListHandlerTest : BaseUnitTest() {
                 page = any(),
                 perPage = any(),
                 query = anyOrNull(),
-                filters = any(),
+                filters = anyOrNull(),
                 order = any()
             )
         }
@@ -152,7 +152,7 @@ class BookingListHandlerTest : BaseUnitTest() {
             page = intThat { it > availablePages },
             perPage = any(),
             query = anyOrNull(),
-            filters = any(),
+            filters = anyOrNull(),
             order = any()
         )
     }
@@ -183,7 +183,7 @@ class BookingListHandlerTest : BaseUnitTest() {
         @Suppress("UnusedFlow")
         verify(bookingsRepository).observeBookings(
             limit = eq(2 * BookingListHandler.PAGE_SIZE),
-            filters = any(),
+            filters = anyOrNull(),
             order = any()
         )
         assertThat(moreBookings).hasSize(2 * BookingListHandler.PAGE_SIZE)
@@ -209,7 +209,7 @@ class BookingListHandlerTest : BaseUnitTest() {
         val searchQuery = "Sample"
         val firstResults = List(BookingListHandler.PAGE_SIZE) { getSampleBooking(it) }
         val refreshedResults = List(BookingListHandler.PAGE_SIZE - 2) { getSampleBooking(it) }
-        given(bookingsRepository.fetchBookings(any(), any(), eq(searchQuery), any(), any()))
+        given(bookingsRepository.fetchBookings(any(), any(), eq(searchQuery), anyOrNull(), any()))
             .willReturn(
                 Result.success(
                     BookingsRepository.FetchResult(firstResults, false)
@@ -250,13 +250,13 @@ class BookingListHandlerTest : BaseUnitTest() {
         val firstResults = List(BookingListHandler.PAGE_SIZE) { getSampleBooking(it) }
         val newResults = List(BookingListHandler.PAGE_SIZE - 3) { getSampleBooking(it) }
 
-        given(bookingsRepository.fetchBookings(any(), any(), eq(initialQuery), any(), any()))
+        given(bookingsRepository.fetchBookings(any(), any(), eq(initialQuery), anyOrNull(), any()))
             .willReturn(
                 Result.success(
                     BookingsRepository.FetchResult(firstResults, false)
                 )
             )
-        given(bookingsRepository.fetchBookings(any(), any(), eq(newQuery), any(), any()))
+        given(bookingsRepository.fetchBookings(any(), any(), eq(newQuery), anyOrNull(), any()))
             .willSuspendableAnswer {
                 delay(10) // To allow checking intermediate state
                 Result.success(

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/bookings/list/BookingListViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/bookings/list/BookingListViewModelTest.kt
@@ -236,10 +236,8 @@ class BookingListViewModelTest : BaseUnitTest() {
         verify(bookingListHandler).loadBookings(
             searchQuery = eq(null),
             filters = eq(
-                listOfNotNull(
-                    with(filtersBuilder) {
-                        BookingListTab.Upcoming.asDateRangeFilter()
-                    }
+                BookingFilters().copy(
+                    dateRange = with(filtersBuilder) { BookingListTab.Upcoming.asDateRangeFilter() }
                 )
             ),
             sortBy = any()
@@ -332,7 +330,7 @@ class BookingListViewModelTest : BaseUnitTest() {
         // THEN
         verify(bookingListHandler).loadBookings(
             searchQuery = anyOrNull(),
-            filters = argThat { any { it == customerFilter } },
+            filters = argThat { customer == customerFilter },
             sortBy = any()
         )
     }

--- a/libs/fluxc-plugin/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/bookings/BookingsRestClient.kt
+++ b/libs/fluxc-plugin/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/bookings/BookingsRestClient.kt
@@ -62,7 +62,7 @@ class BookingsRestClient @Inject constructor(
         perPage: Int,
         page: Int,
         query: String?,
-        filters: List<BookingsFilterOption>,
+        filters: BookingFilters?,
         order: BookingsOrderOption
     ): WooPayload<Array<BookingDto>> {
         val endpoint = WOOCOMMERCE.bookings.pathV2Bookings
@@ -77,7 +77,7 @@ class BookingsRestClient @Inject constructor(
                 "per_page" to perPage.toString(),
                 "page" to page.toString(),
                 "search" to query
-            ).filterNotNull() + filters.toQueryParams()
+            ).filterNotNull() + filters?.toQueryParams().orEmpty()
         )
         return when (response) {
             is Success -> WooPayload(response.data)
@@ -103,29 +103,20 @@ class BookingsRestClient @Inject constructor(
         }
     }
 
-    private fun List<BookingsFilterOption>.toQueryParams(): Map<String, String> = buildMap {
-        this@toQueryParams.forEach { filter ->
-            when (filter) {
-                BookingsFilterOption.TeamMember -> TODO()
-                is BookingsFilterOption.BookingType -> {
-                    // TODO add query for booking type filtering
-                }
-
-                BookingsFilterOption.ServiceEvent -> TODO()
-                is BookingsFilterOption.AttendanceStatuses -> if (filter.values.isNotEmpty()) {
-                    set("attendance_status", filter.values.joinToString(",") { it.key })
-                }
-
-                BookingsFilterOption.PaymentStatus -> TODO()
-                is BookingsFilterOption.Customer -> set("customer", filter.customerId.toString())
-                is BookingsFilterOption.DateRange -> {
-                    filter.before?.let { set("start_date_before", it.toString()) }
-                    filter.after?.let { set("start_date_after", it.toString()) }
-                }
-
-                BookingsFilterOption.Location -> TODO()
-            }
+    private fun BookingFilters.toQueryParams(): Map<String, String> = buildMap {
+        if (teamMember != null) TODO()
+        if (bookingType != null) TODO()
+        if (serviceEvent != null) TODO()
+        if (attendanceStatuses != BookingsFilterOption.AttendanceStatuses.DEFAULT) {
+            set("attendance_status", attendanceStatuses.values.joinToString(",") { it.key })
         }
+        if (paymentStatus != null) TODO()
+        if (customer != null) TODO()
+        if (dateRange != null) {
+            dateRange.before?.let { set("start_date_before", it.toString()) }
+            dateRange.after?.let { set("start_date_after", it.toString()) }
+        }
+        if (location != null) TODO()
     }
 }
 

--- a/libs/fluxc-plugin/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/bookings/BookingsStore.kt
+++ b/libs/fluxc-plugin/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/bookings/BookingsStore.kt
@@ -32,7 +32,7 @@ class BookingsStore @Inject internal constructor(
         perPage: Int = BookingsRestClient.DEFAULT_PER_PAGE,
         page: Int = 1,
         query: String? = null,
-        filters: List<BookingsFilterOption> = emptyList(),
+        filters: BookingFilters?,
         order: BookingsOrderOption
     ): WooResult<BookingsFetchResult> {
         return coroutineEngine.withDefaultContext(AppLog.T.API, this, "fetchBookings") {
@@ -54,7 +54,7 @@ class BookingsStore @Inject internal constructor(
                             )
                         }
                     }
-                    if (page == 1 && filters.isEmpty() && query.isNullOrEmpty()) {
+                    if (page == 1 && filters == BookingFilters.EMPTY && query.isNullOrEmpty()) {
                         // Clear existing bookings and insert new ones when fetching the first page
                         bookingsDao.replaceAllForSite(site.localId(), entities)
                     } else {
@@ -80,7 +80,7 @@ class BookingsStore @Inject internal constructor(
     fun observeBookings(
         site: SiteModel,
         limit: Int? = null,
-        filters: List<BookingsFilterOption> = emptyList(),
+        filters: BookingFilters? = null,
         order: BookingsOrderOption
     ): Flow<List<BookingEntity>> = bookingsDao.observeBookings(site.localId(), limit, filters, order)
 

--- a/libs/fluxc-plugin/src/main/kotlin/org/wordpress/android/fluxc/persistence/dao/BookingsDao.kt
+++ b/libs/fluxc-plugin/src/main/kotlin/org/wordpress/android/fluxc/persistence/dao/BookingsDao.kt
@@ -7,7 +7,7 @@ import androidx.room.Query
 import androidx.room.Transaction
 import kotlinx.coroutines.flow.Flow
 import org.wordpress.android.fluxc.model.LocalOrRemoteId.LocalId
-import org.wordpress.android.fluxc.network.rest.wpcom.wc.bookings.BookingsFilterOption
+import org.wordpress.android.fluxc.network.rest.wpcom.wc.bookings.BookingFilters
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.bookings.BookingsOrderOption
 import org.wordpress.android.fluxc.persistence.entity.BookingEntity
 import org.wordpress.android.fluxc.persistence.entity.BookingResourceEntity
@@ -76,21 +76,16 @@ interface BookingsDao {
     fun observeBookings(
         localSiteId: LocalId,
         limit: Int? = null,
-        filters: List<BookingsFilterOption> = emptyList(),
+        filters: BookingFilters? = null,
         order: BookingsOrderOption
     ): Flow<List<BookingEntity>> {
-        val dateRangeFilter = filters.filterIsInstance<BookingsFilterOption.DateRange>().firstOrNull()
-        val customerFilter = filters.filterIsInstance<BookingsFilterOption.Customer>().firstOrNull()
-        val attendanceStatusKeySet = filters.filterIsInstance<BookingsFilterOption.AttendanceStatuses>()
-            .firstOrNull()?.values
-            ?.map { it.key }
-            .orEmpty()
+        val attendanceStatusKeySet = filters?.attendanceStatuses?.values?.map { it.key }.orEmpty()
         return observeBookings(
             localSiteId = localSiteId,
             limit = limit,
-            startDateBefore = dateRangeFilter?.before?.epochSecond,
-            startDateAfter = dateRangeFilter?.after?.epochSecond,
-            customerId = customerFilter?.customerId,
+            startDateBefore = filters?.dateRange?.before?.epochSecond,
+            startDateAfter = filters?.dateRange?.after?.epochSecond,
+            customerId = filters?.customer?.customerId,
             attendanceStatuses = attendanceStatusKeySet.toList(),
             attendanceStatusesSize = attendanceStatusKeySet.size,
             order = order

--- a/libs/fluxc-plugin/src/main/kotlin/org/wordpress/android/fluxc/persistence/dao/BookingsDao.kt
+++ b/libs/fluxc-plugin/src/main/kotlin/org/wordpress/android/fluxc/persistence/dao/BookingsDao.kt
@@ -42,19 +42,6 @@ interface BookingsDao {
         order: BookingsOrderOption
     ): Flow<List<BookingEntity>>
 
-    @Suppress("LongParameterList")
-    @Query(DEFAULT_SELECT_QUERY)
-    suspend fun getBookings(
-        localSiteId: LocalId,
-        limit: Int?,
-        startDateBefore: Long?,
-        startDateAfter: Long?,
-        customerId: Long?,
-        attendanceStatuses: List<String>,
-        attendanceStatusesSize: Int,
-        order: BookingsOrderOption
-    ): List<BookingEntity>
-
     @Query("SELECT * FROM Bookings WHERE localSiteId = :localSiteId AND id = :bookingId LIMIT 1")
     fun observeBooking(localSiteId: LocalId, bookingId: Long): Flow<BookingEntity?>
 
@@ -87,31 +74,6 @@ interface BookingsDao {
             startDateAfter = filters?.dateRange?.after?.epochSecond,
             customerId = filters?.customer?.customerId,
             attendanceStatuses = attendanceStatusKeySet.toList(),
-            attendanceStatusesSize = attendanceStatusKeySet.size,
-            order = order
-        )
-    }
-
-    suspend fun getBookings(
-        localSiteId: LocalId,
-        limit: Int? = null,
-        filters: List<BookingsFilterOption> = emptyList(),
-        order: BookingsOrderOption
-    ): List<BookingEntity> {
-        val dateRangeFilter = filters.filterIsInstance<BookingsFilterOption.DateRange>().firstOrNull()
-        val customerFilter = filters.filterIsInstance<BookingsFilterOption.Customer>().firstOrNull()
-        val attendanceStatusKeySet = filters.filterIsInstance<BookingsFilterOption.AttendanceStatuses>()
-            .firstOrNull()?.values
-            ?.map { it.key }
-            .orEmpty()
-
-        return getBookings(
-            localSiteId = localSiteId,
-            limit = limit,
-            startDateBefore = dateRangeFilter?.before?.epochSecond,
-            startDateAfter = dateRangeFilter?.after?.epochSecond,
-            customerId = customerFilter?.customerId,
-            attendanceStatuses = attendanceStatusKeySet,
             attendanceStatusesSize = attendanceStatusKeySet.size,
             order = order
         )


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

<!-- Id number of the Linear issue this PR addresses, e.g., WOOMOB-373. -->
Closes WOOMOB-1467

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
In the UI layer, we use `BookingFilters` which is a data class containing all filter types as fields. However, in the fluxc layer, this is converted into a list using the `BookingFilters.asList()` function. This leads to two different filter formats, which causes inconsistencies, especially when checking whether a filter type is selected.

I updated all usages of `List<BookingsFilterOption>` to `BookingFilters` and removed `BookingFilters.asList()` function. Managing filters is now simpler, and we no longer need to use `.filterIsInstance<BookingsFilterOption.DateRange>` to access the date filter.

### Test Steps
<!-- Describe how to test your changes. Include only what’s needed for the reviewer to validate the behavior.
For new features, outline the main user flow or goal rather than every tap or click — the reviewer should be able to complete the flow naturally.
If applicable, mention key devices, scenarios, or edge cases to verify. -->
1. Log in with a CIAB store.
2. Go to Bookings.
3. Go to the All tab.
4. Tap the Filters button.
5. Change the implemented filters and verify the filtered bookings list.

### Images/gif
<!-- Include before and after images or gifs when appropriate. -->

- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
