### PR TITLE
New `bookable-service` product type

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/bookings/BookingsRepository.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/bookings/BookingsRepository.kt
@@ -61,6 +61,8 @@ class BookingsRepository @Inject constructor(
             order = order
         )
 
+    fun observeBookingsCount(): Flow<Long> = bookingsStore.observeBookingCount(site = selectedSite.get())
+
     fun observeBooking(bookingId: Long): Flow<Booking?> =
         bookingsStore.observeBooking(
             site = selectedSite.get(),

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/bookings/tab/ObserveBookingsTabVisibility.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/bookings/tab/ObserveBookingsTabVisibility.kt
@@ -3,6 +3,7 @@ package com.woocommerce.android.ui.bookings.tab
 import com.woocommerce.android.di.AppCoroutineScope
 import com.woocommerce.android.extensions.isCIABSite
 import com.woocommerce.android.tools.SelectedSite
+import com.woocommerce.android.ui.bookings.BookingsRepository
 import com.woocommerce.android.ui.products.ProductStatus
 import com.woocommerce.android.ui.products.ProductType
 import com.woocommerce.android.ui.products.list.ProductListRepository
@@ -10,21 +11,25 @@ import com.woocommerce.android.util.FeatureFlag
 import com.woocommerce.android.util.WooLog
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.async
 import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.emitAll
 import kotlinx.coroutines.flow.filterNotNull
 import kotlinx.coroutines.flow.flatMapLatest
 import kotlinx.coroutines.flow.flow
-import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.onStart
+import kotlinx.coroutines.joinAll
 import kotlinx.coroutines.launch
 import org.wordpress.android.fluxc.model.SiteModel
+import org.wordpress.android.fluxc.network.rest.wpcom.wc.bookings.BookingsOrderOption
 import org.wordpress.android.fluxc.store.WCProductStore.ProductFilterOption
 import javax.inject.Inject
 
 class ObserveBookingsTabVisibility @Inject constructor(
     private val productListRepository: ProductListRepository,
+    private val bookingsRepository: BookingsRepository,
     private val selectedSite: SelectedSite,
     @AppCoroutineScope private val appCoroutineScope: CoroutineScope,
 ) {
@@ -43,24 +48,47 @@ class ObserveBookingsTabVisibility @Inject constructor(
             emit(false)
         } else {
             emitAll(
-                productListRepository.observeProductsCount(
-                    filterOptions = mapOf(
-                        ProductFilterOption.STATUS to ProductStatus.PUBLISH.value,
-                        ProductFilterOption.TYPE to ProductType.BOOKING.value
-                    ),
-                    excludeSampleProducts = true
-                )
-                    .map { count -> count > 0 }
-                    .onStart {
-                        appCoroutineScope.launch {
-                            productListRepository.fetchProductList(
-                                productFilterOptions = mapOf(ProductFilterOption.TYPE to ProductType.BOOKING.value)
-                            ).onFailure {
-                                WooLog.w(WooLog.T.BOOKINGS, "Failed to fetch bookable products")
-                            }
-                        }
-                    }.distinctUntilChanged()
+                bookableProductCountFlow()
+                    .combine(bookingsCountFlow()) { productCount, bookingCount ->
+                        productCount > 0 || bookingCount > 0
+                    }
+                    .onStart { fetchBookableInfo() }
+                    .distinctUntilChanged()
             )
         }
+    }
+
+    private fun bookableProductCountFlow(): Flow<Long> {
+        return productListRepository.observeProductsCount(
+            filterOptions = mapOf(
+                ProductFilterOption.STATUS to ProductStatus.PUBLISH.value,
+                ProductFilterOption.TYPE to ProductType.BOOKING.value
+            ),
+            excludeSampleProducts = true
+        )
+    }
+
+    private fun bookingsCountFlow(): Flow<Long> {
+        return bookingsRepository.observeBookingsCount()
+    }
+
+    private fun fetchBookableInfo() = appCoroutineScope.launch {
+        val products = async {
+            productListRepository.fetchProductList(
+                productFilterOptions = mapOf(ProductFilterOption.TYPE to ProductType.BOOKING.value)
+            ).onFailure {
+                WooLog.w(WooLog.T.BOOKINGS, "Failed to fetch bookable products")
+            }
+        }
+        val bookings = async {
+            bookingsRepository.fetchBookings(
+                page = 1,
+                perPage = 25,
+                order = BookingsOrderOption.ASC
+            ).onFailure {
+                WooLog.w(WooLog.T.BOOKINGS, "Failed to fetch bookings")
+            }
+        }
+        joinAll(products, bookings)
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/bookings/tab/ObserveBookingsTabVisibility.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/bookings/tab/ObserveBookingsTabVisibility.kt
@@ -1,10 +1,10 @@
 package com.woocommerce.android.ui.bookings.tab
 
-import androidx.annotation.VisibleForTesting
 import com.woocommerce.android.di.AppCoroutineScope
 import com.woocommerce.android.extensions.isCIABSite
 import com.woocommerce.android.tools.SelectedSite
 import com.woocommerce.android.ui.products.ProductStatus
+import com.woocommerce.android.ui.products.ProductType
 import com.woocommerce.android.ui.products.list.ProductListRepository
 import com.woocommerce.android.util.FeatureFlag
 import com.woocommerce.android.util.WooLog
@@ -46,7 +46,7 @@ class ObserveBookingsTabVisibility @Inject constructor(
                 productListRepository.observeProductsCount(
                     filterOptions = mapOf(
                         ProductFilterOption.STATUS to ProductStatus.PUBLISH.value,
-                        ProductFilterOption.TYPE to BOOKING_PRODUCT_TYPE
+                        ProductFilterOption.TYPE to ProductType.BOOKING.value
                     ),
                     excludeSampleProducts = true
                 )
@@ -54,7 +54,7 @@ class ObserveBookingsTabVisibility @Inject constructor(
                     .onStart {
                         appCoroutineScope.launch {
                             productListRepository.fetchProductList(
-                                productFilterOptions = mapOf(ProductFilterOption.TYPE to BOOKING_PRODUCT_TYPE)
+                                productFilterOptions = mapOf(ProductFilterOption.TYPE to ProductType.BOOKING.value)
                             ).onFailure {
                                 WooLog.w(WooLog.T.BOOKINGS, "Failed to fetch bookable products")
                             }
@@ -62,10 +62,5 @@ class ObserveBookingsTabVisibility @Inject constructor(
                     }.distinctUntilChanged()
             )
         }
-    }
-
-    companion object {
-        @VisibleForTesting
-        const val BOOKING_PRODUCT_TYPE = "booking"
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductType.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductType.kt
@@ -15,7 +15,7 @@ enum class ProductType(@StringRes val stringResource: Int = 0, val value: String
     BUNDLE(R.string.product_type_bundle, CoreProductType.BUNDLE.value),
     COMPOSITE(R.string.product_type_composite, "composite"),
     VARIATION(R.string.product_type_variation, "variation"),
-    BOOKING(R.string.product_type_booking, "booking"),
+    BOOKING(R.string.product_type_booking, "bookable-service"),
     OTHER;
 
     fun isVariableProduct() = this == VARIABLE || this == VARIABLE_SUBSCRIPTION

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductType.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductType.kt
@@ -35,7 +35,7 @@ enum class ProductType(@StringRes val stringResource: Int = 0, val value: String
                 "bundle" -> BUNDLE
                 "composite" -> COMPOSITE
                 "variation" -> VARIATION
-                "booking" -> BOOKING
+                "bookable-service" -> BOOKING
                 else -> OTHER
             }
         }

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/bookings/tab/ObserveBookingsTabVisibilityTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/bookings/tab/ObserveBookingsTabVisibilityTest.kt
@@ -2,8 +2,8 @@ package com.woocommerce.android.ui.bookings.tab
 
 import app.cash.turbine.test
 import com.woocommerce.android.tools.SelectedSite
-import com.woocommerce.android.ui.bookings.tab.ObserveBookingsTabVisibility.Companion.BOOKING_PRODUCT_TYPE
 import com.woocommerce.android.ui.products.ProductStatus
+import com.woocommerce.android.ui.products.ProductType
 import com.woocommerce.android.ui.products.list.ProductListRepository
 import com.woocommerce.android.viewmodel.BaseUnitTest
 import kotlinx.coroutines.ExperimentalCoroutinesApi
@@ -28,7 +28,7 @@ class ObserveBookingsTabVisibilityTest : BaseUnitTest() {
     private val selectedSiteFlow = MutableStateFlow<SiteModel?>(null)
     private val bookableProdsFilterOptions = mapOf(
         ProductFilterOption.STATUS to ProductStatus.PUBLISH.value,
-        ProductFilterOption.TYPE to BOOKING_PRODUCT_TYPE
+        ProductFilterOption.TYPE to ProductType.BOOKING.value
     )
     private val bookableProdsCountFlow = MutableStateFlow(0L)
 
@@ -62,7 +62,7 @@ class ObserveBookingsTabVisibilityTest : BaseUnitTest() {
         sut().test {
             verify(productListRepository).fetchProductList(
                 loadMore = any(),
-                productFilterOptions = eq(mapOf(ProductFilterOption.TYPE to BOOKING_PRODUCT_TYPE)),
+                productFilterOptions = eq(mapOf(ProductFilterOption.TYPE to ProductType.BOOKING.value)),
                 excludedProductIds = any(),
                 sortType = anyOrNull()
             )

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/bookings/tab/ObserveBookingsTabVisibilityTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/bookings/tab/ObserveBookingsTabVisibilityTest.kt
@@ -2,6 +2,7 @@ package com.woocommerce.android.ui.bookings.tab
 
 import app.cash.turbine.test
 import com.woocommerce.android.tools.SelectedSite
+import com.woocommerce.android.ui.bookings.BookingsRepository
 import com.woocommerce.android.ui.products.ProductStatus
 import com.woocommerce.android.ui.products.ProductType
 import com.woocommerce.android.ui.products.list.ProductListRepository
@@ -31,6 +32,7 @@ class ObserveBookingsTabVisibilityTest : BaseUnitTest() {
         ProductFilterOption.TYPE to ProductType.BOOKING.value
     )
     private val bookableProdsCountFlow = MutableStateFlow(0L)
+    private val bookingsCountFlow = MutableStateFlow(0L)
 
     private val productListRepository: ProductListRepository = mock {
         on {
@@ -41,6 +43,12 @@ class ObserveBookingsTabVisibilityTest : BaseUnitTest() {
         }.thenReturn(bookableProdsCountFlow)
     }
 
+    private val bookingsRepository: BookingsRepository = mock {
+        on {
+            observeBookingsCount()
+        }.thenReturn(bookingsCountFlow)
+    }
+
     private lateinit var sut: ObserveBookingsTabVisibility
 
     suspend fun setup(prepareMocks: suspend () -> Unit = {}) {
@@ -48,13 +56,14 @@ class ObserveBookingsTabVisibilityTest : BaseUnitTest() {
         whenever(selectedSite.observe()).thenReturn(selectedSiteFlow)
         sut = ObserveBookingsTabVisibility(
             productListRepository = productListRepository,
+            bookingsRepository = bookingsRepository,
             selectedSite = selectedSite,
             appCoroutineScope = testScope,
         )
     }
 
     @Test
-    fun `given site is CIAB, when invoke is called, then bookable products are fetched`() = testBlocking {
+    fun `given site is CIAB, when invoke is called, then bookable products and bookings are fetched`() = testBlocking {
         bookableProdsCountFlow.value = 2
         selectedSiteFlow.value = ciabSite()
         setup()
@@ -66,6 +75,7 @@ class ObserveBookingsTabVisibilityTest : BaseUnitTest() {
                 excludedProductIds = any(),
                 sortType = anyOrNull()
             )
+            verify(bookingsRepository).fetchBookings(any(), any(), anyOrNull(), anyOrNull(), any())
             cancelAndIgnoreRemainingEvents()
         }
     }
@@ -97,8 +107,22 @@ class ObserveBookingsTabVisibilityTest : BaseUnitTest() {
     }
 
     @Test
+    fun `given CIAB site with bookings, when invoke, then emits true`() = testBlocking {
+        bookingsCountFlow.value = 2
+        selectedSiteFlow.value = ciabSite()
+        setup()
+
+        sut().test {
+            val showBookingTabValue = awaitItem()
+            assertTrue(showBookingTabValue)
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    @Test
     fun `given non-CIAB site, when invoke, then emits false`() = testBlocking {
         bookableProdsCountFlow.value = 10
+        bookingsCountFlow.value = 4
         selectedSiteFlow.value = nonCiabSite()
         setup()
 
@@ -112,6 +136,7 @@ class ObserveBookingsTabVisibilityTest : BaseUnitTest() {
     @Test
     fun `given non-Commerce Garden CIAB site, when invoke, then emits false`() = testBlocking {
         bookableProdsCountFlow.value = 10
+        bookingsCountFlow.value = 10
         selectedSiteFlow.value = nonCommerceGardenSite()
         setup()
 

--- a/libs/fluxc-plugin/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/bookings/BookingsStore.kt
+++ b/libs/fluxc-plugin/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/bookings/BookingsStore.kt
@@ -84,6 +84,10 @@ class BookingsStore @Inject internal constructor(
         order: BookingsOrderOption
     ): Flow<List<BookingEntity>> = bookingsDao.observeBookings(site.localId(), limit, filters, order)
 
+    fun observeBookingCount(
+        site: SiteModel
+    ): Flow<Long> = bookingsDao.observeBookingsCount(site.localId())
+
     fun observeBooking(
         site: SiteModel,
         bookingId: Long

--- a/libs/fluxc-plugin/src/main/kotlin/org/wordpress/android/fluxc/persistence/dao/BookingsDao.kt
+++ b/libs/fluxc-plugin/src/main/kotlin/org/wordpress/android/fluxc/persistence/dao/BookingsDao.kt
@@ -48,6 +48,9 @@ interface BookingsDao {
     @Query("SELECT * FROM Bookings WHERE localSiteId = :localSiteId AND id = :bookingId LIMIT 1")
     fun observeBooking(localSiteId: LocalId, bookingId: Long): Flow<BookingEntity?>
 
+    @Query("SELECT COUNT(*) FROM Bookings WHERE localSiteId = :localSiteId")
+    fun observeBookingsCount(localSiteId: LocalId): Flow<Long>
+
     @Insert(onConflict = OnConflictStrategy.REPLACE)
     suspend fun insertOrReplace(entity: BookingEntity): Long
 


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

<!-- Id number of the Linear issue this PR addresses, e.g., WOOMOB-373. -->

WOOMOB-1736

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

We need to update the bookable product type from `booking` to `bookable-service`. This PR:
- updates the value we pass to the server when fetching products of type `Booking`
- uses the new value to determine the booking type in Product details
- add another check to determine the booking tab visibility - bookingsCount > 0

### Test Steps
<!-- Describe how to test your changes. Include only what’s needed for the reviewer to validate the behavior.
For new features, outline the main user flow or goal rather than every tap or click — the reviewer should be able to complete the flow naturally.
If applicable, mention key devices, scenarios, or edge cases to verify. -->

1. Launch the app and login to this test site p1763423349396019-slack-C03L1NF1EA3
2. Confirm you see the bookings tab
3. Go to products and tap on a bookable one
4. Confirm that it's shown in a web view

### Images/gif
<!-- Include before and after images or gifs when appropriate. -->

- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->