### PR TITLE
[Tooling] Improve `new_hotfix_release` lane to work when there's no release tag

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -386,6 +386,9 @@ platform :android do
     # Check tags
     UI.user_error!("Version '#{version_name}' already exists on the remote! Abort!") if git_tag_exists(tag: version_name, remote: true)
 
+    # Fetch the base ref to ensure it's available locally
+    sh('git', 'fetch', 'origin', base_ref_for_hotfix)
+
     # Create the hotfix branch
     UI.message("Creating hotfix branch from '#{base_ref_for_hotfix}'...")
     Fastlane::Helper::GitHelper.create_branch("release/#{version_name}", from: base_ref_for_hotfix)

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -389,9 +389,12 @@ platform :android do
     # Fetch the base ref to ensure it's available locally
     sh('git', 'fetch', 'origin', base_ref_for_hotfix)
 
+    hotfix_branch = "release/#{version_name}"
+    ensure_branch_does_not_exist!(hotfix_branch)
+
     # Create the hotfix branch
     UI.message("Creating hotfix branch from '#{base_ref_for_hotfix}'...")
-    Fastlane::Helper::GitHelper.create_branch("release/#{version_name}", from: base_ref_for_hotfix)
+    Fastlane::Helper::GitHelper.create_branch(hotfix_branch, from: base_ref_for_hotfix)
     UI.success("Done! New hotfix branch is: '#{git_branch}'")
 
     # Bump the hotfix version and build code and write it to the `version.properties` file

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -359,6 +359,7 @@ platform :android do
     base_ref_for_hotfix = if git_tag_exists(tag: previous_version)
                             previous_version
                           elsif Fastlane::Helper::GitHelper.branch_exists_on_remote?(branch_name: previous_release_branch)
+                            UI.message("ℹ️  Tag #{previous_version} not found. Using release branch #{previous_release_branch} as the base for hotfix instead.")
                             previous_release_branch
                           else
                             UI.user_error!("Neither tag #{previous_version} nor branch #{previous_release_branch} exists! A hotfix branch cannot be created.")

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -352,17 +352,19 @@ platform :android do
 
     # Parse the provided version into an AppVersion object
     parsed_version = VERSION_FORMATTER.parse(version_name)
+    # Validate that this is a hotfix version (must have a patch component > 0)
+    UI.user_error!("Invalid hotfix version '#{version_name}'. Must include a patch number.") unless parsed_version.patch.to_i.positive?
     previous_version = VERSION_FORMATTER.release_version(VERSION_CALCULATOR.previous_patch_version(version: parsed_version))
     previous_release_branch = "release/#{previous_version}"
 
     # Determine the base for the hotfix branch: either a tag or a release branch
-    base_ref_for_hotfix = if git_tag_exists(tag: previous_version)
+    base_ref_for_hotfix = if git_tag_exists(tag: previous_version, remote: true)
                             previous_version
                           elsif Fastlane::Helper::GitHelper.branch_exists_on_remote?(branch_name: previous_release_branch)
-                            UI.message("ℹ️  Tag #{previous_version} not found. Using release branch #{previous_release_branch} as the base for hotfix instead.")
+                            UI.message("ℹ️  Tag '#{previous_version}' not found on the remote. Using release branch '#{previous_release_branch}' as the base for hotfix instead.")
                             previous_release_branch
                           else
-                            UI.user_error!("Neither tag #{previous_version} nor branch #{previous_release_branch} exists! A hotfix branch cannot be created.")
+                            UI.user_error!("Neither tag '#{previous_version}' nor branch '#{previous_release_branch}' exists on the remote! A hotfix branch cannot be created.")
                           end
 
     # Check versions
@@ -382,12 +384,12 @@ platform :android do
     UI.user_error!("Terminating as requested. Don't forget to run the remainder of this automation manually.") unless skip_confirm || UI.confirm('Do you want to continue?')
 
     # Check tags
-    UI.user_error!("The version `#{version_name}` tag already exists!") if git_tag_exists(tag: version_name)
+    UI.user_error!("Version '#{version_name}' already exists on the remote! Abort!") if git_tag_exists(tag: version_name, remote: true)
 
     # Create the hotfix branch
-    UI.message("Creating hotfix branch from #{base_ref_for_hotfix}...")
+    UI.message("Creating hotfix branch from '#{base_ref_for_hotfix}'...")
     Fastlane::Helper::GitHelper.create_branch("release/#{version_name}", from: base_ref_for_hotfix)
-    UI.success("Done! New hotfix branch is: #{git_branch}")
+    UI.success("Done! New hotfix branch is: '#{git_branch}'")
 
     # Bump the hotfix version and build code and write it to the `version.properties` file
     UI.message('Bumping hotfix version and build code...')
@@ -396,7 +398,7 @@ platform :android do
       version_code: version_code
     )
     commit_version_bump
-    UI.success("Done! New Release Version: #{release_version_current}. New Build Code: #{build_code_current}")
+    UI.success("Done! New Release Version: '#{release_version_current}'. New Build Code: '#{build_code_current}'")
 
     UI.important('Pushing new hotfix branch to remote...')
 

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -353,6 +353,16 @@ platform :android do
     # Parse the provided version into an AppVersion object
     parsed_version = VERSION_FORMATTER.parse(version_name)
     previous_version = VERSION_FORMATTER.release_version(VERSION_CALCULATOR.previous_patch_version(version: parsed_version))
+    previous_release_branch = "release/#{previous_version}"
+
+    # Determine the base for the hotfix branch: either a tag or a release branch
+    base_ref_for_hotfix = if git_tag_exists(tag: previous_version)
+                            previous_version
+                          elsif Fastlane::Helper::GitHelper.branch_exists_on_remote?(branch_name: previous_release_branch)
+                            previous_release_branch
+                          else
+                            UI.user_error!("Neither tag #{previous_version} nor branch #{previous_release_branch} exists! A hotfix branch cannot be created.")
+                          end
 
     # Check versions
     message = <<-MESSAGE
@@ -363,7 +373,7 @@ platform :android do
       Current build code: #{build_code_current}
       New build code: #{version_code}
 
-      Branching from tag: #{previous_version}
+      Branching from #{base_ref_for_hotfix}
 
     MESSAGE
 
@@ -372,11 +382,10 @@ platform :android do
 
     # Check tags
     UI.user_error!("The version `#{version_name}` tag already exists!") if git_tag_exists(tag: version_name)
-    UI.user_error!("Version #{previous_version} is not tagged! A hotfix branch cannot be created.") unless git_tag_exists(tag: previous_version)
 
     # Create the hotfix branch
-    UI.message('Creating hotfix branch...')
-    Fastlane::Helper::GitHelper.create_branch("release/#{version_name}", from: previous_version)
+    UI.message("Creating hotfix branch from #{base_ref_for_hotfix}...")
+    Fastlane::Helper::GitHelper.create_branch("release/#{version_name}", from: base_ref_for_hotfix)
     UI.success("Done! New hotfix branch is: #{git_branch}")
 
     # Bump the hotfix version and build code and write it to the `version.properties` file


### PR DESCRIPTION
Related to AINFRA-1518

## Description

This PR aims to add more robustness and require less manual intervention to the hotfix creation lane `new_hotfix_release`.

We have observed that sometimes it is possible that the release has been finalized but a release tag isn't present yet for some reason (likely due to the fact that the release hasn't been published yet), so release managers will get an error and require manual intervention.

This PR changes the code so that it, if not release tag is present, we start the hotfix branch based on the corresponding release branch.

## Testing instructions

These are some test scenarios that can be simulated:
1. There is a release tag that can be used to create the hotfix branch
2. There's no tag, but there's still a release branch that can be used to create the hotfix branch
3. There's no tag or branch (error)
4. The provided version doesn't have a patch component like `30.6` instead of `30.6.1` (error)

To test it, you can create test branches / tags (⚠️ delete them later or, even better, use [this technique](https://github.com/bloom/DayOne-Apple/pull/27670#issuecomment-3553138802) of pointing your working copy’s `origin` remote to a local bare repo instead ⚠️ ) and run `bundle exec fastlane new_hotfix_release skip_confirm:false version_name:$VERSION version_code:$CODE` and then answer `no` after the prompt so that the lane execution stops and check the printed values.

For example:
1. Create and push release branch `release/30.6` (which doesn't exist and has no corresponding tag for that version)
2. Run `bundle exec fastlane new_hotfix_release skip_confirm:false version_name:30.6.1 version_code:9999`
3. It should use the `release/30.6` branch instead of trying to use a tag. It should print:
```
ℹ️  Tag '30.6' not found on the remote. Using release branch 'release/30.6' as the base for hotfix instead.

Current release version: 23.7
New hotfix version: 30.6.1

Current build code: 710
New build code: 9999

Branching from release/30.6


Do you want to continue? (y/n)
```
