### PR TITLE
[WOOMOB-1712] Auto-scroll to newly added orders in POS Orders screen

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -5,6 +5,7 @@
 23.8
 -----
 - [Internal][Woo POS] Improve detection and handling of deleted products during checkout [https://github.com/woocommerce/woocommerce-android/pull/14981]
+- [*][Woo POS] Automatically scroll to newly created orders when returning to the Orders screen [https://github.com/woocommerce/woocommerce-android/pull/14990]
 
 23.7
 -----

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/orders/WooPosOrdersScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/orders/WooPosOrdersScreen.kt
@@ -67,6 +67,9 @@ import com.woocommerce.android.ui.woopos.home.items.WooPosPaginationState
 import com.woocommerce.android.ui.woopos.home.items.WooPosPullToRefreshState
 import com.woocommerce.android.ui.woopos.root.navigation.WooPosNavigationEvent
 import com.woocommerce.android.util.ChromeCustomTabUtils
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.flow.SharedFlow
 import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.filter
@@ -95,6 +98,7 @@ fun WooPosOrdersScreen(
 
     WooPosOrdersScreen(
         state = state,
+        scrollToTopEvent = viewModel.scrollToTopEvent,
         onBackClicked = { onNavigationEvent(WooPosNavigationEvent.GoBack) },
         onRefresh = viewModel::onRefresh,
         onOrderSelected = viewModel::onOrderSelected,
@@ -112,6 +116,7 @@ fun WooPosOrdersScreen(
 @Composable
 private fun WooPosOrdersScreen(
     state: WooPosOrdersState,
+    scrollToTopEvent: SharedFlow<Unit>,
     onBackClicked: () -> Unit,
     onRefresh: () -> Unit,
     onOrderSelected: (Long) -> Unit,
@@ -126,9 +131,10 @@ private fun WooPosOrdersScreen(
     BackHandler { onBackClicked() }
 
     Box(modifier = Modifier.fillMaxSize()) {
-        when (val currentState = state) {
+        when (state) {
             is WooPosOrdersState.Content -> OrdersContent(
-                state = currentState,
+                state = state,
+                scrollToTopEvent = scrollToTopEvent,
                 onRefresh = onRefresh,
                 onOrderSelected = onOrderSelected,
                 onEndOfOrdersListReached = onEndOfOrdersListReached,
@@ -162,6 +168,7 @@ private fun WooPosOrdersScreen(
 @Composable
 private fun OrdersContent(
     state: WooPosOrdersState.Content,
+    scrollToTopEvent: SharedFlow<Unit>,
     onRefresh: () -> Unit,
     onOrderSelected: (Long) -> Unit,
     onEndOfOrdersListReached: () -> Unit,
@@ -173,6 +180,7 @@ private fun OrdersContent(
     Row(modifier = Modifier.fillMaxSize()) {
         OrdersListPane(
             state = state,
+            scrollToTopEvent = scrollToTopEvent,
             onRefresh = onRefresh,
             isRefreshing = state.pullToRefreshState == WooPosPullToRefreshState.Refreshing,
             onOrderSelected = onOrderSelected,
@@ -205,6 +213,7 @@ private fun OrdersContent(
 @Composable
 private fun OrdersListPane(
     state: WooPosOrdersState.Content,
+    scrollToTopEvent: SharedFlow<Unit>,
     onRefresh: () -> Unit,
     isRefreshing: Boolean,
     onOrderSelected: (Long) -> Unit,
@@ -248,6 +257,7 @@ private fun OrdersListPane(
             OrdersList(
                 modifier = Modifier.fillMaxSize(),
                 state = state,
+                scrollToTopEvent = scrollToTopEvent,
                 onOrderSelected = onOrderSelected,
                 onEndOfOrdersListReached = onEndOfOrdersListReached,
                 onPaginationErrorTryAgain = onPaginationErrorTryAgain,
@@ -271,6 +281,7 @@ private fun OrdersListPane(
 private fun OrdersList(
     modifier: Modifier = Modifier,
     state: WooPosOrdersState.Content,
+    scrollToTopEvent: SharedFlow<Unit>,
     onOrderSelected: (Long) -> Unit,
     onEndOfOrdersListReached: () -> Unit,
     onPaginationErrorTryAgain: () -> Unit,
@@ -282,6 +293,7 @@ private fun OrdersList(
                 modifier = modifier,
                 items = items.items,
                 paginationState = state.paginationState,
+                scrollToTopEvent = scrollToTopEvent,
                 onOrderSelected = onOrderSelected,
                 onEndOfOrdersListReached = onEndOfOrdersListReached,
                 onPaginationErrorTryAgain = onPaginationErrorTryAgain
@@ -332,6 +344,7 @@ private fun LoadedOrdersList(
     modifier: Modifier = Modifier,
     items: Map<OrderItemViewState, OrderDetailsViewState>,
     paginationState: WooPosPaginationState,
+    scrollToTopEvent: SharedFlow<Unit>,
     onOrderSelected: (Long) -> Unit,
     onEndOfOrdersListReached: () -> Unit,
     onPaginationErrorTryAgain: () -> Unit
@@ -353,6 +366,13 @@ private fun LoadedOrdersList(
             .distinctUntilChanged()
             .filter { it }
             .collect { onEndOfOrdersListReached() }
+    }
+
+    LaunchedEffect(Unit) {
+        scrollToTopEvent.collect {
+            delay(100)
+            listState.animateScrollToItem(0)
+        }
     }
 
     WooPosLazyColumn(
@@ -533,6 +553,7 @@ fun WooPosOrdersScreenPreview() {
                 selectedDetails = details1,
                 paginationState = WooPosPaginationState.None
             ),
+            scrollToTopEvent = MutableSharedFlow(),
             onBackClicked = {},
             onRefresh = {},
             onOrderSelected = {},
@@ -566,6 +587,7 @@ fun WooPosOrdersSearchErrorStatePreview() {
                 selectedDetails = details,
                 paginationState = WooPosPaginationState.None
             ),
+            scrollToTopEvent = MutableSharedFlow(),
             onBackClicked = {},
             onRefresh = {},
             onOrderSelected = {},
@@ -599,6 +621,7 @@ fun WooPosOrdersNothingFoundStatePreview() {
                 selectedDetails = details,
                 paginationState = WooPosPaginationState.None
             ),
+            scrollToTopEvent = MutableSharedFlow(),
             onBackClicked = {},
             onRefresh = {},
             onOrderSelected = {},

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/orders/WooPosOrdersViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/orders/WooPosOrdersViewModel.kt
@@ -54,6 +54,9 @@ class WooPosOrdersViewModel @Inject constructor(
     private val _openUrlEvent = MutableSharedFlow<String>()
     val openUrlEvent: SharedFlow<String> = _openUrlEvent.asSharedFlow()
 
+    private val _scrollToTopEvent = MutableSharedFlow<Unit>()
+    val scrollToTopEvent: SharedFlow<Unit> = _scrollToTopEvent.asSharedFlow()
+
     private var searchJob: Job? = null
     private var loadingJob: Job? = null
     private var loadingMoreOrdersJob: Job? = null
@@ -443,8 +446,14 @@ class WooPosOrdersViewModel @Inject constructor(
         ordersWithRefunds: Map<Order, RefundFetchResult>,
         paginationState: WooPosPaginationState = WooPosPaginationState.None
     ) {
+        val currentState = _state.value
+        val currentFirstOrderId = (currentState as? WooPosOrdersState.Content)
+            ?.let { it.items as? WooPosOrdersState.Content.Items.Loaded }
+            ?.items?.keys?.firstOrNull()?.id
+
         val orders = ordersWithRefunds.keys.toList()
-        val newSelectedId = requireNotNull(orders.firstOrNull()?.id) { "Content requires at least one order" }
+        val newFirstOrderId = orders.firstOrNull()?.id
+        val newSelectedId = requireNotNull(newFirstOrderId) { "Content requires at least one order" }
         val items = buildItemsMap(ordersWithRefunds, newSelectedId)
         val selectedEntry = items.entries.first { (item, _) -> item.isSelected }
         val selectedDetails = when (val details = selectedEntry.value) {
@@ -461,6 +470,10 @@ class WooPosOrdersViewModel @Inject constructor(
             paginationState = paginationState,
             searchInputState = _state.value.searchInputState
         )
+
+        if (currentFirstOrderId != null && currentFirstOrderId != newFirstOrderId) {
+            _scrollToTopEvent.emit(Unit)
+        }
     }
 
     private suspend fun appendOrders(


### PR DESCRIPTION
WOOMOB-1712

### Description
When users create a new order in POS and return to the Orders screen, the newly added order appears at the top of the list but remains hidden because the list preserves its scroll position. This fix automatically scrolls the list to the top with a smooth animation when new orders are detected, ensuring users can immediately see their newly created order.

The implementation detects when new orders are added by comparing the first order ID before and after the list updates. When a change is detected, a scroll event is emitted and the list animates to position 0 after a brief delay to allow the composition to settle.

### Test Steps
1. Open the POS Orders screen
2. Navigate back and create a new order
3. Return to the Orders screen
4. Verify the list smoothly scrolls to the top, showing the newly created order


https://github.com/user-attachments/assets/39e0416e-e298-4648-86bf-f22ee28aba14



- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.