### PR TITLE
[WOOMOB-1739] Fix payment screen description positioning in Woo POS

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -5,6 +5,7 @@
 23.8
 -----
 - [Internal][Woo POS] Improve detection and handling of deleted products during checkout [https://github.com/woocommerce/woocommerce-android/pull/14981]
+- [*][Woo POS] Fixed payment screen layout to properly position payment instructions text [https://github.com/woocommerce/woocommerce-android/pull/14991]
 
 23.7
 -----

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/totals/WooPosTotalsScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/totals/WooPosTotalsScreen.kt
@@ -34,6 +34,7 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import androidx.core.text.HtmlCompat
 import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
@@ -284,7 +285,9 @@ private fun ReaderReadyForPayment(readerStatus: WooPosTotalsViewState.ReaderStat
     WooPosText(
         text = readerStatus.subtitle,
         style = WooPosTypography.Heading,
-        fontWeight = FontWeight.Bold
+        fontWeight = FontWeight.Bold,
+        textAlign = TextAlign.Center,
+        modifier = Modifier.padding(horizontal = WooPosSpacing.XLarge.value.toAdaptivePadding())
     )
 }
 
@@ -520,7 +523,7 @@ fun WooPosTotalsScreenPreview(modifier: Modifier = Modifier) {
                 ),
                 readerStatus = WooPosTotalsViewState.ReaderStatus.ReadyForPayment(
                     title = "Ready for payment",
-                    subtitle = "Tap, swipe or insert card"
+                    subtitle = "Tap, swipe or insert card, Tap, swipe or insert card, Tap, swipe or insert card"
                 ),
             ),
             onUIEvent = {},


### PR DESCRIPTION
WOOMOB-1739

### Description
Fixed the positioning of the payment instruction text ("Tap, swipe or insert card") on the Woo POS payment screen. The text was appearing without padding if long enough in other langauges/smaller screen sizes

The fix adds proper vertical spacing after the subtitle, centers the text, and adds horizontal padding to ensure proper display across different languages, especially those with longer translations.

### Test Steps
1. Open the Compose Preview for `WooPosTotalsScreenPreview` in Android Studio
2. Verify the "Tap, swipe or insert card" text is properly centered with adequate spacing above the totals section
3. Check that the preview with a long subtitle text displays correctly with proper text wrapping and padding

**Note:** The issue is particularly noticeable in languages where this string is longer. The preview includes a test case with a longer string to verify proper handling.

<img width="296" height="241" alt="Screenshot 2025-11-19 at 10 12 09" src="https://github.com/user-attachments/assets/b9e0cee5-cbb2-42f3-bee2-5eecbdce55e3" />
<img width="282" height="243" alt="Screenshot 2025-11-19 at 10 12 19" src="https://github.com/user-attachments/assets/769f0133-ac9d-456b-854e-070fbce39820" />


- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.