### PR TITLE
[WOOMOB-1747] Fix search icon background color in Orders screen

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/common/composeui/component/WooPosButtons.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/common/composeui/component/WooPosButtons.kt
@@ -158,6 +158,7 @@ fun WooPosCircularIconButton(
     modifier: Modifier = Modifier,
     icon: ImageVector,
     contentDescription: String? = null,
+    backgroundColor: Color = MaterialTheme.colorScheme.surfaceContainerLow,
     onClick: () -> Unit
 ) {
     Box(
@@ -165,7 +166,7 @@ fun WooPosCircularIconButton(
         modifier = modifier
             .size(56.dp)
             .clip(CircleShape)
-            .background(MaterialTheme.colorScheme.surfaceContainerLow)
+            .background(backgroundColor)
     ) {
         IconButton(
             onClick = onClick,

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/common/composeui/component/WooPosSearchInput.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/common/composeui/component/WooPosSearchInput.kt
@@ -37,6 +37,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.focus.FocusRequester
 import androidx.compose.ui.focus.focusRequester
 import androidx.compose.ui.focus.onFocusChanged
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.lerp
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.TextRange
@@ -62,6 +63,7 @@ import kotlinx.parcelize.Parcelize
 fun WooPosSearchInput(
     modifier: Modifier = Modifier,
     state: WooPosSearchInputState = WooPosSearchInputState.Closed,
+    searchIconBackgroundColor: Color = MaterialTheme.colorScheme.surfaceContainerLow,
     onEvent: (WooPosSearchUIEvent) -> Unit = {},
 ) {
     BackHandler(
@@ -86,6 +88,7 @@ fun WooPosSearchInput(
                     contentDescription = stringResource(
                         id = R.string.woopos_search_products,
                     ),
+                    backgroundColor = searchIconBackgroundColor,
                     onClick = { onEvent(SearchIconClicked) }
                 )
             }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/orders/WooPosOrdersScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/orders/WooPosOrdersScreen.kt
@@ -223,6 +223,7 @@ private fun OrdersListPane(
         ) {
             WooPosSearchInput(
                 state = state.searchInputState,
+                searchIconBackgroundColor = MaterialTheme.colorScheme.surface,
                 onEvent = onSearchEvent,
                 modifier = Modifier
                     .statusBarsPadding()


### PR DESCRIPTION
WOOMOB-1747

### Description
The search icon background color in the Orders screen didn't match the Figma design. The icon was using `surfaceContainerLow` color instead of `surface` color.

Changes:
- Added optional `backgroundColor` parameter to `WooPosCircularIconButton` component to make it configurable
- Added `searchIconBackgroundColor` parameter to `WooPosSearchInput` component
- Set search icon background to `surface` color specifically in Orders screen
- Other screens (Products/Items) remain unchanged with default `surfaceContainerLow` background

### Test Steps
1. Build and install the app
2. Navigate to Woo POS Orders screen
3. Verify the search icon button background color matches the Figma design (uses lighter `surface` color)
4. Navigate to Products screen and verify the search icon still uses the default background color

### Images/gif
<img width="872" height="542" alt="Screenshot 2025-11-19 at 12 18 22" src="https://github.com/user-attachments/assets/c223407d-f6e1-41a9-acba-87641dd4aaf6" />
<img width="873" height="556" alt="Screenshot 2025-11-19 at 12 18 29" src="https://github.com/user-attachments/assets/63ec8373-cab5-42cd-b8f1-a7ea3498e602" />


- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.