### PR TITLE
[WOOMOB-1731] Fix extra vertical space in the Bookings top bar

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/bookings/list/BookingListScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/bookings/list/BookingListScreen.kt
@@ -70,6 +70,7 @@ import com.woocommerce.android.ui.compose.component.WCOutlinedButton
 import com.woocommerce.android.ui.compose.component.WCPrimaryTabRow
 import com.woocommerce.android.ui.compose.component.WCPullToRefreshBox
 import com.woocommerce.android.ui.compose.component.WCSearchField
+import com.woocommerce.android.ui.compose.component.getText
 import com.woocommerce.android.ui.compose.preview.LightDarkThemePreviews
 import com.woocommerce.android.ui.compose.theme.WooThemeWithBackground
 import kotlinx.coroutines.launch
@@ -87,7 +88,7 @@ fun BookingListScreen(state: BookingListViewState) {
     Scaffold(
         topBar = {
             Toolbar(
-                title = stringResource(R.string.bookings_tab_title),
+                title = state.toolbarTitle.getText(),
                 navigationIcon = null,
                 actions = {
                     SearchSection(

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/bookings/list/BookingListViewState.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/bookings/list/BookingListViewState.kt
@@ -1,5 +1,7 @@
 package com.woocommerce.android.ui.bookings.list
 
+import com.woocommerce.android.R
+import com.woocommerce.android.model.UiString
 import com.woocommerce.android.ui.bookings.compose.BookingSummaryModel
 
 data class BookingListViewState(
@@ -8,7 +10,15 @@ data class BookingListViewState(
     val controlsState: BookingListControlsState,
     val sortBottomSheetState: BookingListSortBottomSheetState?,
     val searchState: BookingListSearchState,
-)
+) {
+
+    val toolbarTitle: UiString
+        get() = if (searchState.isSearchActive) {
+            UiString.UiStringText("")
+        } else {
+            UiString.UiStringRes(R.string.bookings_tab_title)
+        }
+}
 
 data class BookingListContentState(
     val bookings: List<BookingListItem>,


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

<!-- Id number of the Linear issue this PR addresses, e.g., WOOMOB-373. -->

WOOMOB-1731

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

This issue was likely caused by one of the recent compose library updates, because our code was not modified in the last two weeks at least. 

**What's happening?** 

With the search active, the `SearchSection` component takes the full width of the Toolbar, leaving no space for the Toolbar title. The problem is that this title is still in the UI tree, and because it doesn't fit in one line, it gets squized into multiple lines. This makes the whole Toolbar taller than it should be. 

I've decided to set the Toolbar title to an empty string as this is the most straightforward fix. Alternatively, we could replace the whole Toolbar when the search is active, but that would require a few more changes. 

### Test Steps
<!-- Describe how to test your changes. Include only what’s needed for the reviewer to validate the behavior.
For new features, outline the main user flow or goal rather than every tap or click — the reviewer should be able to complete the flow naturally.
If applicable, mention key devices, scenarios, or edge cases to verify. -->

1. Go to bookings tab
2. Tap on the search icon

### Images/gif
<!-- Include before and after images or gifs when appropriate. -->

| Before | After |
|---|---|
| <img width="1280" height="2856" alt="Screenshot_20251119_133345" src="https://github.com/user-attachments/assets/be1eb38b-508e-4ece-a649-87377d9b7837" /> | <img width="1280" height="2856" alt="Screenshot_20251119_133910" src="https://github.com/user-attachments/assets/27e4cd9a-f45e-422e-a04c-c16db24462ed" /> |

- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
