### PR TITLE
[POS - Empty copies] Remove em dashes after feedback and update copy.

### DIFF
--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -3848,10 +3848,10 @@
     <string name="woopos_search_recent_searches_title">Recent searches</string>
     <string name="woopos_search_items_empty_title">No products found</string>
     <string name="woopos_search_coupons_empty_title">No coupons found</string>
-    <string name="woopos_search_empty_description">We couldn\'t find any matching products – try adjusting your search term.</string>
-    <string name="woopos_search_empty_coupons_description">We couldn\'t find any matching coupons – try adjusting your search term.</string>
+    <string name="woopos_search_empty_description">We couldn\'t find any matching products. Try adjusting your search term.</string>
+    <string name="woopos_search_empty_coupons_description">We couldn\'t find any matching coupons. Try adjusting your search term.</string>
     <string name="woopos_search_orders_empty_title">No orders found</string>
-    <string name="woopos_search_orders_empty_description">We couldn\'t find any matching orders – try adjusting your search term.</string>
+    <string name="woopos_search_orders_empty_description">We couldn\'t find any matching orders. Try adjusting your search term.</string>
     <string name="woopos_search_empty_image_content_description">No items found</string>
     <string name="woopos_search_items_error_title">Unable to load products</string>
     <string name="woopos_search_coupons_error_title">Unable to load coupons</string>

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -3851,7 +3851,7 @@
     <string name="woopos_search_empty_description">We couldn\'t find any matching products. Try adjusting your search term.</string>
     <string name="woopos_search_empty_coupons_description">We couldn\'t find any matching coupons. Try adjusting your search term.</string>
     <string name="woopos_search_orders_empty_title">No orders found</string>
-    <string name="woopos_search_orders_empty_description">We couldn\'t find any matching orders. Try adjusting your search term.</string>
+    <string name="woopos_search_orders_empty_description">We couldn\'t find any orders with that name. Try adjusting your search term.</string>
     <string name="woopos_search_empty_image_content_description">No items found</string>
     <string name="woopos_search_items_error_title">Unable to load products</string>
     <string name="woopos_search_coupons_error_title">Unable to load coupons</string>


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

<!-- Id number of the Linear issue this PR addresses, e.g., WOOMOB-373. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
After the feedback received here, pdfdoF-8lY-p2 we proceed to remove the em dashes from the empty search copy. Other than that, we adjust the copy to the latest designs. NFWCJetWSgHq2jPLKjpKYw-fi-8160_5862

### Test Steps
<!-- Describe how to test your changes. Include only what’s needed for the reviewer to validate the behavior.
For new features, outline the main user flow or goal rather than every tap or click — the reviewer should be able to complete the flow naturally.
If applicable, mention key devices, scenarios, or edge cases to verify. -->
Go to POS and enter terms that don't provide a result in Products, Coupons, and Orders. Check that the empty search copy doesn't show em dashes.

### Images/gif
<!-- Include before and after images or gifs when appropriate. -->

#### Products
![Screenshot_20251119_142028_Woo (Dev)](https://github.com/user-attachments/assets/93526897-0b90-4624-9261-1d89cd9f9356)

#### Coupons
![Screenshot_20251119_142056_Woo (Dev)](https://github.com/user-attachments/assets/5fa5840c-2c5f-440f-81bd-638932fb07e4)

#### Orders
![Screenshot_20251119_142129_Woo (Dev)](https://github.com/user-attachments/assets/67b3eba4-95ba-4aa2-ada2-eafbffbdc254)


- [X] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->