### PR TITLE
Fix serviceEvents filter condition

### DIFF
--- a/libs/fluxc-plugin/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/bookings/BookingsRestClient.kt
+++ b/libs/fluxc-plugin/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/bookings/BookingsRestClient.kt
@@ -128,7 +128,7 @@ class BookingsRestClient @Inject constructor(
             )
         }
         if (bookingType != null) TODO()
-        if (serviceEvents != null) {
+        if (serviceEvents != BookingsFilterOption.ServiceEvents.DEFAULT) {
             set("product", serviceEvents.values.joinToString(",") { it.productId.toString() })
         }
         if (attendanceStatuses != BookingsFilterOption.AttendanceStatuses.DEFAULT) {


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

<!-- Id number of the Linear issue this PR addresses, e.g., WOOMOB-373. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

All tab shows an empty page without filters set. This is because we pass an empty array of products due to wrong check. This PR fixes that. 

### Test Steps
<!-- Describe how to test your changes. Include only what’s needed for the reviewer to validate the behavior.
For new features, outline the main user flow or goal rather than every tap or click — the reviewer should be able to complete the flow naturally.
If applicable, mention key devices, scenarios, or edge cases to verify. -->

1. Launch the app
2. Go to booking tab -> All
3. Clear filters
4. Confirm you see results

### Images/gif
<!-- Include before and after images or gifs when appropriate. -->

- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
