### PR TITLE
[Woo POS][Local Catalog] Handle specific errors in Local Catalog sync error tracking

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/localcatalog/WooPosLocalCatalogSyncRepository.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/localcatalog/WooPosLocalCatalogSyncRepository.kt
@@ -58,11 +58,10 @@ class WooPosLocalCatalogSyncRepository @Inject constructor(
                     syncTimestampManager.storeFullSyncLastCompletedTimestamp(dateTimeProvider.now())
                     trackSyncCompleted(site, SyncType.FULL, result)
                 }
-                is PosLocalCatalogSyncResult.Failure.CatalogTooLarge -> {
-                    preferencesRepository.disablePeriodicSyncForSite(site.localId())
-                    trackSyncFailed(SyncType.FULL, result)
-                }
-                is PosLocalCatalogSyncResult.Failure.UnexpectedError -> {
+                is PosLocalCatalogSyncResult.Failure -> {
+                    if (result is PosLocalCatalogSyncResult.Failure.CatalogTooLarge) {
+                        preferencesRepository.disablePeriodicSyncForSite(site.localId())
+                    }
                     trackSyncFailed(SyncType.FULL, result)
                 }
             }
@@ -124,6 +123,9 @@ class WooPosLocalCatalogSyncRepository @Inject constructor(
     ) {
         val errorType = when (result) {
             is PosLocalCatalogSyncResult.Failure.CatalogTooLarge -> SyncErrorType.CATALOG_TOO_LARGE
+            is PosLocalCatalogSyncResult.Failure.NetworkError -> SyncErrorType.NETWORK_ERROR
+            is PosLocalCatalogSyncResult.Failure.DatabaseError -> SyncErrorType.DATABASE_ERROR
+            is PosLocalCatalogSyncResult.Failure.InvalidResponse -> SyncErrorType.INVALID_RESPONSE
             is PosLocalCatalogSyncResult.Failure.UnexpectedError -> SyncErrorType.UNEXPECTED_ERROR
         }
 
@@ -203,8 +205,20 @@ private fun WooPosSyncResult.Failed.toPosLocalCatalogSyncFailure(): PosLocalCata
             )
         }
 
+        is WooPosSyncResult.Failed.NetworkError -> {
+            PosLocalCatalogSyncResult.Failure.NetworkError(error)
+        }
+
+        is WooPosSyncResult.Failed.DatabaseError -> {
+            PosLocalCatalogSyncResult.Failure.DatabaseError(error)
+        }
+
+        is WooPosSyncResult.Failed.InvalidResponse -> {
+            PosLocalCatalogSyncResult.Failure.InvalidResponse(error)
+        }
+
         is WooPosSyncResult.Failed.UnexpectedError -> {
-            PosLocalCatalogSyncResult.Failure.UnexpectedError(errorMessage)
+            PosLocalCatalogSyncResult.Failure.UnexpectedError(error)
         }
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/localcatalog/WooPosLocalCatalogSyncWorker.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/localcatalog/WooPosLocalCatalogSyncWorker.kt
@@ -66,17 +66,20 @@ constructor(
                 Result.success()
             }
 
-            is PosLocalCatalogSyncResult.Failure.UnexpectedError -> {
-                logger.e("Local catalog FULL sync failed: ${fullSyncResult.error}. Retrying ...")
-                Result.retry()
-            }
-
             is PosLocalCatalogSyncResult.Failure.CatalogTooLarge -> {
                 logger.e(
                     "Local catalog FULL sync failed: ${fullSyncResult.error}. Permanently " +
                         "disabling periodic sync for site ${site.url}."
                 )
                 Result.failure()
+            }
+
+            is PosLocalCatalogSyncResult.Failure.NetworkError,
+            is PosLocalCatalogSyncResult.Failure.DatabaseError,
+            is PosLocalCatalogSyncResult.Failure.InvalidResponse,
+            is PosLocalCatalogSyncResult.Failure.UnexpectedError -> {
+                logger.e("Local catalog FULL sync failed: ${fullSyncResult.error}. Retrying ...")
+                Result.retry()
             }
         }
     }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/localcatalog/WooPosSyncAction.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/localcatalog/WooPosSyncAction.kt
@@ -7,6 +7,7 @@ import org.wordpress.android.fluxc.model.SiteModel
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.product.CoreProductStatus
 import org.wordpress.android.fluxc.persistence.entity.pos.WooPosProductEntity
 import org.wordpress.android.fluxc.persistence.entity.pos.WooPosVariationEntity
+import org.wordpress.android.fluxc.store.pos.localcatalog.WooPosLocalCatalogError
 import org.wordpress.android.fluxc.store.pos.localcatalog.WooPosLocalCatalogStore
 import org.wordpress.android.fluxc.store.pos.localcatalog.WooPosPaginatedFetchResult
 import javax.inject.Inject
@@ -96,6 +97,23 @@ class WooPosSyncAction @Inject constructor(
             is CatalogTooLargeException -> WooPosSyncResult.Failed.CatalogTooLarge(
                 error.totalPages,
                 error.maxPages
+            )
+
+            is WooPosLocalCatalogError.NetworkError -> WooPosSyncResult.Failed.NetworkError(
+                errorMessage = error.errorMessage
+            )
+
+            is WooPosLocalCatalogError.DatabaseError -> WooPosSyncResult.Failed.DatabaseError(
+                errorMessage = error.errorMessage,
+                throwable = error.throwable
+            )
+
+            is WooPosLocalCatalogError.InvalidResponse -> WooPosSyncResult.Failed.InvalidResponse(
+                errorMessage = error.errorMessage
+            )
+
+            is WooPosLocalCatalogError.EmptyResponse -> WooPosSyncResult.Failed.InvalidResponse(
+                errorMessage = error.message
             )
 
             else -> WooPosSyncResult.Failed.UnexpectedError(
@@ -188,6 +206,14 @@ class WooPosSyncAction @Inject constructor(
                 WooPosSyncResult.Failed.CatalogTooLarge(error.totalPages, error.maxPages)
             }
 
+            is WooPosLocalCatalogError.DatabaseError -> {
+                logger.e("Local Catalog Transaction failed and was rolled back: ${error.message}")
+                WooPosSyncResult.Failed.DatabaseError(
+                    errorMessage = error.errorMessage,
+                    throwable = error.throwable
+                )
+            }
+
             else -> {
                 logger.e("Local Catalog Transaction failed and was rolled back: ${error.message}")
                 WooPosSyncResult.Failed.UnexpectedError(
@@ -225,6 +251,19 @@ sealed interface WooPosSyncResult {
             val totalPages: Int,
             val maxPages: Int
         ) : Failed("Local Catalog too large: $totalPages pages exceed maximum of $maxPages pages")
+
+        data class NetworkError(
+            val errorMessage: String
+        ) : Failed(errorMessage)
+
+        data class DatabaseError(
+            val errorMessage: String,
+            val throwable: Throwable? = null
+        ) : Failed(errorMessage)
+
+        data class InvalidResponse(
+            val errorMessage: String
+        ) : Failed(errorMessage)
 
         data class UnexpectedError(
             val errorMessage: String

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/localcatalog/WooPosSyncResult.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/localcatalog/WooPosSyncResult.kt
@@ -12,6 +12,9 @@ sealed class PosLocalCatalogSyncResult {
 
     sealed class Failure(val error: String) : PosLocalCatalogSyncResult() {
         class CatalogTooLarge(error: String) : Failure(error)
+        class NetworkError(error: String) : Failure(error)
+        class DatabaseError(error: String) : Failure(error)
+        class InvalidResponse(error: String) : Failure(error)
         class UnexpectedError(error: String) : Failure(error)
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/util/analytics/WooPosAnalyticsEventConstant.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/util/analytics/WooPosAnalyticsEventConstant.kt
@@ -99,6 +99,9 @@ object WooPosAnalyticsEventConstant {
 
     enum class SyncErrorType(val value: String) {
         CATALOG_TOO_LARGE("catalog_too_large"),
+        NETWORK_ERROR("network_error"),
+        DATABASE_ERROR("database_error"),
+        INVALID_RESPONSE("invalid_response"),
         UNEXPECTED_ERROR("unexpected_error");
 
         override fun toString(): String {

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/localcatalog/WooPosSyncActionTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/localcatalog/WooPosSyncActionTest.kt
@@ -20,6 +20,7 @@ import org.wordpress.android.fluxc.model.SiteModel
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.product.CoreProductStatus
 import org.wordpress.android.fluxc.persistence.entity.pos.WooPosProductEntity
 import org.wordpress.android.fluxc.persistence.entity.pos.WooPosVariationEntity
+import org.wordpress.android.fluxc.store.pos.localcatalog.WooPosLocalCatalogError
 import org.wordpress.android.fluxc.store.pos.localcatalog.WooPosLocalCatalogStore
 import org.wordpress.android.fluxc.store.pos.localcatalog.WooPosPaginatedFetchResult
 import kotlin.Result as KotlinResult
@@ -645,6 +646,93 @@ class WooPosSyncActionTest {
         assertThat(success.variationsSynced).isEqualTo(0)
     }
 
+    // === ERROR TYPE TESTS ===
+
+    @Test
+    fun `given network error on product fetch, when sync catalog, then returns NetworkError result`() = runTest {
+        // GIVEN
+        givenProductFetchFailsWithNetworkError(page = 1, "Network timeout")
+
+        // WHEN
+        val result = sut.syncCatalog(site, null, PAGE_SIZE, 10)
+
+        // THEN
+        assertThat(result).isInstanceOf(WooPosSyncResult.Failed.NetworkError::class.java)
+        val networkError = result as WooPosSyncResult.Failed.NetworkError
+        assertThat(networkError.errorMessage).isEqualTo("Network timeout")
+    }
+
+    @Test
+    fun `given database error on product fetch, when sync catalog, then returns DatabaseError result`() = runTest {
+        // GIVEN
+        givenProductFetchFailsWithDatabaseError(page = 1, "Database constraint violation")
+
+        // WHEN
+        val result = sut.syncCatalog(site, null, PAGE_SIZE, 10)
+
+        // THEN
+        assertThat(result).isInstanceOf(WooPosSyncResult.Failed.DatabaseError::class.java)
+        val databaseError = result as WooPosSyncResult.Failed.DatabaseError
+        assertThat(databaseError.errorMessage).isEqualTo("Database constraint violation")
+    }
+
+    @Test
+    fun `given invalid response on product fetch, when sync catalog, then returns InvalidResponse result`() = runTest {
+        // GIVEN
+        givenProductFetchFailsWithInvalidResponse(page = 1, "Missing required header: X-WP-Total")
+
+        // WHEN
+        val result = sut.syncCatalog(site, null, PAGE_SIZE, 10)
+
+        // THEN
+        assertThat(result).isInstanceOf(WooPosSyncResult.Failed.InvalidResponse::class.java)
+        val invalidResponse = result as WooPosSyncResult.Failed.InvalidResponse
+        assertThat(invalidResponse.errorMessage).isEqualTo("Missing required header: X-WP-Total")
+    }
+
+    @Test
+    fun `given empty response on product fetch, when sync catalog, then returns InvalidResponse result`() = runTest {
+        // GIVEN
+        givenProductFetchFailsWithEmptyResponse(page = 1)
+
+        // WHEN
+        val result = sut.syncCatalog(site, null, PAGE_SIZE, 10)
+
+        // THEN
+        assertThat(result).isInstanceOf(WooPosSyncResult.Failed.InvalidResponse::class.java)
+    }
+
+    @Test
+    fun `given network error on variation fetch, when sync catalog, then returns NetworkError result`() = runTest {
+        // GIVEN
+        mockFetchProductsSuccess(pages = listOf(10), serverDate = "2024-01-01T12:00:00Z")
+        givenVariationFetchFailsWithNetworkError(page = 1, "No network connection")
+
+        // WHEN
+        val result = sut.syncCatalog(site, null, PAGE_SIZE, 10)
+
+        // THEN
+        assertThat(result).isInstanceOf(WooPosSyncResult.Failed.NetworkError::class.java)
+        val networkError = result as WooPosSyncResult.Failed.NetworkError
+        assertThat(networkError.errorMessage).isEqualTo("No network connection")
+    }
+
+    @Test
+    fun `given database error on transaction, when sync catalog, then returns DatabaseError result`() = runTest {
+        // GIVEN
+        mockFetchProductsSuccess(pages = listOf(10), serverDate = "2024-01-01T12:00:00Z")
+        mockFetchVariationsSuccess(pages = listOf(5), serverDate = "2024-01-01T12:00:00Z")
+        givenTransactionFailsWithDatabaseError("Transaction rollback due to constraint violation")
+
+        // WHEN
+        val result = sut.syncCatalog(site, null, PAGE_SIZE, 10)
+
+        // THEN
+        assertThat(result).isInstanceOf(WooPosSyncResult.Failed.DatabaseError::class.java)
+        val databaseError = result as WooPosSyncResult.Failed.DatabaseError
+        assertThat(databaseError.errorMessage).isEqualTo("Transaction rollback due to constraint violation")
+    }
+
     // === HELPER METHODS ===
 
     private fun mockFetchProductsSuccess(pages: List<Int>, serverDate: String) = runBlocking {
@@ -881,5 +969,65 @@ class WooPosSyncActionTest {
                 stockQuantity = 1.0
             )
         }
+    }
+
+    private fun givenProductFetchFailsWithNetworkError(page: Int, errorMessage: String) = runBlocking {
+        whenever(
+            posLocalCatalogStore.fetchRecentlyModifiedProducts(eq(site), anyOrNull(), eq(page), any(), eq(null))
+        ).thenReturn(
+            KotlinResult.failure(
+                WooPosLocalCatalogError.NetworkError(errorMessage = errorMessage)
+            )
+        )
+    }
+
+    private fun givenProductFetchFailsWithDatabaseError(page: Int, errorMessage: String) = runBlocking {
+        whenever(
+            posLocalCatalogStore.fetchRecentlyModifiedProducts(eq(site), anyOrNull(), eq(page), any(), eq(null))
+        ).thenReturn(
+            KotlinResult.failure(
+                WooPosLocalCatalogError.DatabaseError(errorMessage = errorMessage)
+            )
+        )
+    }
+
+    private fun givenProductFetchFailsWithInvalidResponse(page: Int, errorMessage: String) = runBlocking {
+        whenever(
+            posLocalCatalogStore.fetchRecentlyModifiedProducts(eq(site), anyOrNull(), eq(page), any(), eq(null))
+        ).thenReturn(
+            KotlinResult.failure(
+                WooPosLocalCatalogError.InvalidResponse(errorMessage = errorMessage)
+            )
+        )
+    }
+
+    private fun givenProductFetchFailsWithEmptyResponse(page: Int) = runBlocking {
+        whenever(
+            posLocalCatalogStore.fetchRecentlyModifiedProducts(eq(site), anyOrNull(), eq(page), any(), eq(null))
+        ).thenReturn(
+            KotlinResult.failure(WooPosLocalCatalogError.EmptyResponse)
+        )
+    }
+
+    private fun givenVariationFetchFailsWithNetworkError(
+        page: Int,
+        errorMessage: String
+    ) = runBlocking {
+        whenever(
+            posLocalCatalogStore.fetchRecentlyModifiedVariations(eq(site), anyOrNull(), eq(page), any())
+        ).thenReturn(
+            KotlinResult.failure(
+                WooPosLocalCatalogError.NetworkError(errorMessage = errorMessage)
+            )
+        )
+    }
+
+    @Suppress("UNCHECKED_CAST")
+    private fun givenTransactionFailsWithDatabaseError(errorMessage: String) = runBlocking {
+        whenever(
+            posLocalCatalogStore.executeInTransaction(any<suspend () -> KotlinResult<Unit>>())
+        ).thenReturn(
+            KotlinResult.failure(WooPosLocalCatalogError.DatabaseError(errorMessage = errorMessage))
+        )
     }
 }


### PR DESCRIPTION
## Description

Improves error tracking for WooPos local catalog sync by adding granular error categorization. Previously, all errors except `CATALOG_TOO_LARGE` were lumped into a generic `UNEXPECTED_ERROR` category, making it difficult to diagnose production issues.

WOOMOB-1691

## Changes

#### 1. Extended Error Types
Added three new `SyncErrorType` values for better categorization:
- `NETWORK_ERROR` - Network failures (timeout, no connection, API errors)
- `DATABASE_ERROR` - Database transaction/operation failures  
- `INVALID_RESPONSE` - Missing headers, malformed responses, empty responses

#### 2. Enhanced Error Result Types
- Updated `WooPosSyncResult.Failed` with specific subclasses: `NetworkError`, `DatabaseError`, `InvalidResponse`
- Updated `PosLocalCatalogSyncResult.Failure` with matching types to preserve error information through conversion
- Updated `WooPosSyncAction` to map `WooPosLocalCatalogError` types to corresponding result types

#### 3. Improved Analytics Tracking
- Moved error tracking from `performSync()` to caller sites for better separation of concerns
- `trackSyncFailed()` now maps structured error types to analytics instead of parsing error message strings
- All error types properly tracked with granular categorization

#### 4. Updated Worker Behavior
- `WooPosLocalCatalogSyncWorker` handles all new error types appropriately
- Network/Database/Response errors trigger retry behavior
- CatalogTooLarge still triggers permanent failure

## Test Steps
Verify the `local_catalog_sync_failed` is tracked without any changes, but it includes additional error type param.

- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.