### PR TITLE
[Woo POS] Fix typo in `OrdersListSearchResultsFetched` analytics event

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/util/analytics/WooPosAnalyticsEvent.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/util/analytics/WooPosAnalyticsEvent.kt
@@ -210,13 +210,13 @@ sealed class WooPosAnalyticsEvent : IAnalyticsEvent {
             }
         }
 
-        data class OrdersListSearchResultsFetched(val milimetersSinceRequestSent: Long) : Event() {
+        data class OrdersListSearchResultsFetched(val millisecondsSinceRequestSent: Long) : Event() {
             override val name: String = "pos_orders_list_search_results_fetched"
 
             init {
                 addProperties(
                     mapOf(
-                        "milliseconds_since_request_sent" to milimetersSinceRequestSent.toString()
+                        "milliseconds_since_request_sent" to millisecondsSinceRequestSent.toString()
                     )
                 )
             }


### PR DESCRIPTION

<!-- Remember about a good descriptive title. -->

<!-- Id number of the Linear issue this PR addresses, e.g., WOOMOB-373. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
It's just a fix for a typo—argument rename:

* Rename `milimetersSinceRequestSent` to `millisecondsSinceRequestSent`.

### Test Steps
<!-- Describe how to test your changes. Include only what’s needed for the reviewer to validate the behavior.
For new features, outline the main user flow or goal rather than every tap or click — the reviewer should be able to complete the flow naturally.
If applicable, mention key devices, scenarios, or edge cases to verify. -->
N/A

### Images/gif
<!-- Include before and after images or gifs when appropriate. -->
N/A

- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
