### PR TITLE
[WOOMOB-1754] Use different IDs for new dynamic shortcuts

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -11,6 +11,7 @@
 - [Internal][Woo POS] Survey for potential and current users of the POS delivered via local push notification. [https://github.com/woocommerce/woocommerce-android/pull/14751]
 - [Internal] Handle BLUETOOTH_PEER_REMOVED_PAIRING_INFORMATION disconnect reason from Stripe SDK [https://github.com/woocommerce/woocommerce-android/pull/14886]
 - [**] Faster POS performance - search, barcode scanning, and loading are now nearly instant. [https://github.com/woocommerce/woocommerce-android/pull/14926]
+- [*] Fixed a crash on app startup for users with the old shortcuts pinned. [https://github.com/woocommerce/woocommerce-android/pull/15007]
 
 23.6
 -----

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/shortcuts/AppShortcut.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/shortcuts/AppShortcut.kt
@@ -11,13 +11,13 @@ enum class AppShortcut(
     @DrawableRes val icon: Int
 ) {
     Payments(
-        id = "Payments",
+        id = "payments_dynamic",
         action = "com.woocommerce.android.payments",
         label = R.string.more_menu_button_payments,
         icon = R.drawable.ic_more_menu_payments
     ),
     CreateOrder(
-        id = "Create Order",
+        id = "create_order_dynamic",
         action = "com.woocommerce.android.ordercreation",
         label = R.string.orderlist_create_order_button_description,
         icon = R.drawable.ic_menu_orders_list


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

<!-- Id number of the Linear issue this PR addresses, e.g., WOOMOB-373. -->

WOOMOB-1754

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

We have a new crash related to shortcuts. We used to have static shortcuts defined in `shortcuts.xml` file, but[ recently they were migrated to dynamic ones](https://github.com/woocommerce/woocommerce-android/pull/14833) to show/hide them depending on the selected site. 

The problem is that we can't modify the static (immutable) shortcuts, hence the exception. The `shortcuts.xml` file was removed, but if a user pins the shortcut to the home screen, it is preserved and when the same ID is used the system thinks we want to update it, so it crashes. 

To fix this I have changed the IDs of the new dynamic shortcuts. The old static ones, even if pinned, are deactivate,d so this is safe.

### Test Steps
<!-- Describe how to test your changes. Include only what’s needed for the reviewer to validate the behavior.
For new features, outline the main user flow or goal rather than every tap or click — the reviewer should be able to complete the flow naturally.
If applicable, mention key devices, scenarios, or edge cases to verify. -->

**I recommend to first try and reproduc the issue by using release/23.7 branch, instead of this PR.**

1. Install 23.5
2. Login to the app (non-ciab site to have all the shortcuts)
3. Go to the home page and long press on the woo app icon
4. Long press on one of the shortcuts
5. Move it to the home screen to pin it
6. Install the app from this PR
7. Try to open the app

### Images/gif
<!-- Include before and after images or gifs when appropriate. -->

| Before | After |
|---|---|
| <video src="https://github.com/user-attachments/assets/771b7f9c-5f2a-4e28-9180-2f0618eafc76"/> | <video src="https://github.com/user-attachments/assets/a2fb4c18-990b-4dfc-ab08-6947a90630c3"/> |

- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
