### PR TITLE
[WOOMOB-1744] - Date&Time booking picker improvement

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/bookings/filter/datetime/DateTimeFilterPage.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/bookings/filter/datetime/DateTimeFilterPage.kt
@@ -29,8 +29,6 @@ import com.woocommerce.android.ui.bookings.compose.BookingLabel
 import com.woocommerce.android.ui.bookings.compose.BookingSectionHeader
 import com.woocommerce.android.ui.compose.component.DatePickerDialog
 import com.woocommerce.android.ui.compose.component.TimePickerDialog
-import com.woocommerce.android.ui.compose.component.datePickerDialogDefaultMaxDate
-import com.woocommerce.android.ui.compose.component.datePickerDialogDefaultMinDate
 import com.woocommerce.android.ui.compose.preview.LightDarkThemePreviews
 import com.woocommerce.android.ui.compose.theme.WooTheme
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.bookings.BookingsFilterOption
@@ -85,8 +83,8 @@ fun DateTimeFilterPage(
             is PickerDialogState.DateDialog -> {
                 DatePickerDialog(
                     currentDate = dialogState.date?.toCalendar(),
-                    minDate = dialogState.minDate?.toCalendar() ?: datePickerDialogDefaultMinDate,
-                    maxDate = dialogState.maxDate?.toCalendar() ?: datePickerDialogDefaultMaxDate,
+                    minDate = dialogState.minDate?.toCalendar(),
+                    maxDate = dialogState.maxDate?.toCalendar(),
                     onDateSelected = { calendar: Calendar ->
                         dialogState.onDateSelected(calendar.timeInMillis)
                     },

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/bookings/filter/datetime/DateTimeFilterPage.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/bookings/filter/datetime/DateTimeFilterPage.kt
@@ -29,6 +29,8 @@ import com.woocommerce.android.ui.bookings.compose.BookingLabel
 import com.woocommerce.android.ui.bookings.compose.BookingSectionHeader
 import com.woocommerce.android.ui.compose.component.DatePickerDialog
 import com.woocommerce.android.ui.compose.component.TimePickerDialog
+import com.woocommerce.android.ui.compose.component.datePickerDialogDefaultMaxDate
+import com.woocommerce.android.ui.compose.component.datePickerDialogDefaultMinDate
 import com.woocommerce.android.ui.compose.preview.LightDarkThemePreviews
 import com.woocommerce.android.ui.compose.theme.WooTheme
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.bookings.BookingsFilterOption
@@ -82,8 +84,10 @@ fun DateTimeFilterPage(
         when (dialogState) {
             is PickerDialogState.DateDialog -> {
                 DatePickerDialog(
-                    currentDate = dialogState.date?.let { Calendar.getInstance().apply { timeInMillis = it } },
-                    onDateSelected = { calendar ->
+                    currentDate = dialogState.date?.toCalendar(),
+                    minDate = dialogState.minDate?.toCalendar() ?: datePickerDialogDefaultMinDate,
+                    maxDate = dialogState.maxDate?.toCalendar() ?: datePickerDialogDefaultMaxDate,
+                    onDateSelected = { calendar: Calendar ->
                         dialogState.onDateSelected(calendar.timeInMillis)
                     },
                     onDismissRequest = dialogState.onDismiss,
@@ -154,6 +158,10 @@ private fun DateTimeRow(@StringRes labelRes: Int, value: String, onClick: () -> 
             color = MaterialTheme.colorScheme.onSurfaceVariant
         )
     }
+}
+
+private fun Long.toCalendar(): Calendar {
+    return Calendar.getInstance().apply { timeInMillis = this@toCalendar }
 }
 
 @LightDarkThemePreviews

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/bookings/filter/datetime/DateTimeFilterUiState.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/bookings/filter/datetime/DateTimeFilterUiState.kt
@@ -18,6 +18,8 @@ data class DateTimeFilterUiState(
 sealed interface PickerDialogState {
     data class DateDialog(
         val date: Long?,
+        val minDate: Long? = null,
+        val maxDate: Long? = null,
         val onDateSelected: (Long) -> Unit,
         val onDismiss: () -> Unit,
     ) : PickerDialogState

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/bookings/filter/datetime/DateTimeFilterViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/bookings/filter/datetime/DateTimeFilterViewModel.kt
@@ -17,6 +17,7 @@ import org.wordpress.android.fluxc.network.rest.wpcom.wc.bookings.BookingsFilter
 import java.time.Clock
 import java.time.Instant
 import java.time.LocalDateTime
+import java.time.LocalTime
 import java.time.ZoneId
 import java.time.ZoneOffset
 import java.time.format.DateTimeFormatter
@@ -130,6 +131,7 @@ class DateTimeFilterViewModel @AssistedInject constructor(
                     current.copy(
                         fromDateTime = newDateTime,
                         formattedFromDate = newDateTime.formatDate(),
+                        formattedFromTime = newDateTime.formatTime(),
                         pickerDialogState = null,
                     )
                 }
@@ -137,13 +139,14 @@ class DateTimeFilterViewModel @AssistedInject constructor(
                 DateBoundary.TO -> {
                     // Convert from UTC to local zone
                     val picked = Instant.ofEpochMilli(date).atZone(ZoneOffset.UTC).toLocalDate()
-                    val newDateTime = (current.toDateTime ?: picked.atStartOfDay())
+                    val newDateTime = (current.toDateTime ?: picked.atTime(LocalTime.MAX))
                         .withYear(picked.year)
                         .withMonth(picked.monthValue)
                         .withDayOfMonth(picked.dayOfMonth)
                     current.copy(
                         toDateTime = newDateTime,
                         formattedToDate = newDateTime.formatDate(),
+                        formattedToTime = newDateTime.formatTime(),
                         pickerDialogState = null,
                     )
                 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/bookings/filter/datetime/DateTimeFilterViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/bookings/filter/datetime/DateTimeFilterViewModel.kt
@@ -63,28 +63,35 @@ class DateTimeFilterViewModel @AssistedInject constructor(
 
     private fun openDateDialog(dateBoundary: DateBoundary) {
         _uiState.update { currentState ->
-            val dialogState = when (dateBoundary) {
-                DateBoundary.FROM -> DateDialog(
-                    // Convert to UTC for the Date picker
-                    date = currentState.fromDateTime
-                        ?.toLocalDate()
-                        ?.atStartOfDay(ZoneOffset.UTC)
-                        ?.toInstant()
-                        ?.toEpochMilli(),
-                    onDismiss = ::dismissPickerDialog,
-                    onDateSelected = { commitSelectedDate(dateBoundary, it) },
-                )
+            val fromDate = currentState.fromDateTime
+                ?.toLocalDate()
+                ?.atStartOfDay(ZoneOffset.UTC)
+                ?.toInstant()
+            val toDate = currentState.toDateTime
+                ?.toLocalDate()
+                ?.atStartOfDay(ZoneOffset.UTC)
+                ?.toInstant()
 
-                DateBoundary.TO -> DateDialog(
-                    // Convert to UTC for the Date picker
-                    date = currentState.toDateTime
-                        ?.toLocalDate()
-                        ?.atStartOfDay(ZoneOffset.UTC)
-                        ?.toInstant()
-                        ?.toEpochMilli(),
-                    onDismiss = ::dismissPickerDialog,
-                    onDateSelected = { commitSelectedDate(dateBoundary, it) },
-                )
+            val dialogState = when (dateBoundary) {
+                DateBoundary.FROM -> {
+                    DateDialog(
+                        // Convert to UTC for the Date picker
+                        date = fromDate?.toEpochMilli(),
+                        maxDate = toDate?.toEpochMilli(),
+                        onDismiss = ::dismissPickerDialog,
+                        onDateSelected = { commitSelectedDate(dateBoundary, it) },
+                    )
+                }
+
+                DateBoundary.TO -> {
+                    DateDialog(
+                        // Convert to UTC for the Date picker
+                        date = toDate?.toEpochMilli(),
+                        minDate = fromDate?.toEpochMilli(),
+                        onDismiss = ::dismissPickerDialog,
+                        onDateSelected = { commitSelectedDate(dateBoundary, it) },
+                    )
+                }
             }
             currentState.copy(
                 pickerDialogState = dialogState

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/compose/component/DatePickerDialog.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/compose/component/DatePickerDialog.kt
@@ -44,9 +44,6 @@ import java.util.GregorianCalendar
 private const val DEFAULT_MIN_YEAR = 1900
 private const val DEFAULT_MAX_YEAR = 2100
 
-val datePickerDialogDefaultMinDate = GregorianCalendar(DEFAULT_MIN_YEAR, 0, 1)
-val datePickerDialogDefaultMaxDate = GregorianCalendar(DEFAULT_MAX_YEAR, 0, 1)
-
 @Composable
 fun DatePickerDialog(
     currentDate: Date?,
@@ -54,8 +51,8 @@ fun DatePickerDialog(
     onDismissRequest: () -> Unit,
     neutralButton: (@Composable () -> Unit)? = null,
     shape: Shape = DatePickerDefaults.shape,
-    minDate: Date = datePickerDialogDefaultMinDate.time,
-    maxDate: Date = datePickerDialogDefaultMaxDate.time,
+    minDate: Date? = null,
+    maxDate: Date? = null,
     dateFormat: DateFormat = SimpleDateFormat.getDateInstance(SimpleDateFormat.MEDIUM),
     dialogProperties: DialogProperties = DialogProperties(usePlatformDefaultWidth = false)
 ) {
@@ -66,8 +63,8 @@ fun DatePickerDialog(
         onDismissRequest = onDismissRequest,
         shape = shape,
         neutralButton = neutralButton,
-        minDate = minDate.toCalendar(),
-        maxDate = maxDate.toCalendar(),
+        minDate = (minDate ?: GregorianCalendar(DEFAULT_MIN_YEAR, 0, 1).time).toCalendar(),
+        maxDate = (maxDate ?: GregorianCalendar(DEFAULT_MAX_YEAR, 0, 1).time).toCalendar(),
         dateFormat = dateFormat,
         dialogProperties = dialogProperties
     )
@@ -80,8 +77,8 @@ fun DatePickerDialog(
     onDismissRequest: () -> Unit,
     shape: Shape = DatePickerDefaults.shape,
     neutralButton: (@Composable () -> Unit)? = null,
-    minDate: Calendar = datePickerDialogDefaultMinDate,
-    maxDate: Calendar = datePickerDialogDefaultMaxDate,
+    minDate: Calendar? = null,
+    maxDate: Calendar? = null,
     dateFormat: DateFormat = SimpleDateFormat.getDateInstance(SimpleDateFormat.MEDIUM),
     dialogProperties: DialogProperties = DialogProperties(usePlatformDefaultWidth = false)
 ) {
@@ -89,7 +86,11 @@ fun DatePickerDialog(
         onDismissRequest = onDismissRequest,
         properties = dialogProperties
     ) {
-        val selectableDates = remember(minDate, maxDate) { createSelectableDates(minDate, maxDate) }
+        val minDefault = minDate ?: GregorianCalendar(DEFAULT_MIN_YEAR, 0, 1)
+        val maxDefault = maxDate ?: GregorianCalendar(DEFAULT_MAX_YEAR, 0, 1)
+        val selectableDates = remember(minDefault.timeInMillis, maxDefault.timeInMillis) {
+            createSelectableDates(minDefault, maxDefault)
+        }
         val dateFormatter = remember(dateFormat) { dateFormat.toDatePickerFormatter() }
 
         val state = rememberDatePickerState(

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/compose/component/DatePickerDialog.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/compose/component/DatePickerDialog.kt
@@ -44,6 +44,9 @@ import java.util.GregorianCalendar
 private const val DEFAULT_MIN_YEAR = 1900
 private const val DEFAULT_MAX_YEAR = 2100
 
+val datePickerDialogDefaultMinDate = GregorianCalendar(DEFAULT_MIN_YEAR, 0, 1)
+val datePickerDialogDefaultMaxDate = GregorianCalendar(DEFAULT_MAX_YEAR, 0, 1)
+
 @Composable
 fun DatePickerDialog(
     currentDate: Date?,
@@ -51,8 +54,8 @@ fun DatePickerDialog(
     onDismissRequest: () -> Unit,
     neutralButton: (@Composable () -> Unit)? = null,
     shape: Shape = DatePickerDefaults.shape,
-    minDate: Date = GregorianCalendar(DEFAULT_MIN_YEAR, 0, 1).time,
-    maxDate: Date = GregorianCalendar(DEFAULT_MAX_YEAR, 0, 1).time,
+    minDate: Date = datePickerDialogDefaultMinDate.time,
+    maxDate: Date = datePickerDialogDefaultMaxDate.time,
     dateFormat: DateFormat = SimpleDateFormat.getDateInstance(SimpleDateFormat.MEDIUM),
     dialogProperties: DialogProperties = DialogProperties(usePlatformDefaultWidth = false)
 ) {
@@ -77,8 +80,8 @@ fun DatePickerDialog(
     onDismissRequest: () -> Unit,
     shape: Shape = DatePickerDefaults.shape,
     neutralButton: (@Composable () -> Unit)? = null,
-    minDate: Calendar = GregorianCalendar(DEFAULT_MIN_YEAR, 0, 1),
-    maxDate: Calendar = GregorianCalendar(DEFAULT_MAX_YEAR, 0, 1),
+    minDate: Calendar = datePickerDialogDefaultMinDate,
+    maxDate: Calendar = datePickerDialogDefaultMaxDate,
     dateFormat: DateFormat = SimpleDateFormat.getDateInstance(SimpleDateFormat.MEDIUM),
     dialogProperties: DialogProperties = DialogProperties(usePlatformDefaultWidth = false)
 ) {

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/bookings/filter/datetime/DateTimeFilterViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/bookings/filter/datetime/DateTimeFilterViewModelTest.kt
@@ -213,6 +213,76 @@ class DateTimeFilterViewModelTest : BaseUnitTest() {
             assertThat(state.formattedToTime).isNotEmpty()
         }
 
+    @Test
+    fun `given existing TO date, when onDateClick(FROM), then DateDialog maxDate equals TO startOfDayUTC millis`() =
+        testBlocking {
+            val vm = createVm()
+
+            // First select TO date
+            vm.uiState.getOrAwaitValue()!!.onDateClick(DateBoundary.TO)
+            val toDialog = vm.uiState.getOrAwaitValue()!!.pickerDialogState as PickerDialogState.DateDialog
+            val toLocalDateTime = LocalDateTime.of(2025, 6, 15, 0, 0)
+            val toMillisInput = toLocalDateTime.atZone(zone).toInstant().toEpochMilli()
+            toDialog.onDateSelected(toMillisInput)
+
+            // Now open FROM dialog; it should constrain by maxDate = TO (startOfDay UTC)
+            vm.uiState.getOrAwaitValue()!!.onDateClick(DateBoundary.FROM)
+            val fromDialog = vm.uiState.getOrAwaitValue()!!.pickerDialogState as PickerDialogState.DateDialog
+
+            val expectedMaxMillis = toLocalDateTime
+                .toLocalDate()
+                .atStartOfDay(ZoneOffset.UTC)
+                .toInstant()
+                .toEpochMilli()
+
+            assertThat(fromDialog.maxDate).isEqualTo(expectedMaxMillis)
+        }
+
+    @Test
+    fun `given existing FROM date, when onDateClick(TO), then DateDialog minDate equals FROM startOfDayUTC millis`() =
+        testBlocking {
+            val vm = createVm()
+
+            // First select FROM date
+            vm.uiState.getOrAwaitValue()!!.onDateClick(DateBoundary.FROM)
+            val fromDialogInitial = vm.uiState.getOrAwaitValue()!!.pickerDialogState as PickerDialogState.DateDialog
+            val fromLocalDateTime = LocalDateTime.of(2025, 6, 1, 0, 0)
+            val fromMillisInput = fromLocalDateTime.atZone(zone).toInstant().toEpochMilli()
+            fromDialogInitial.onDateSelected(fromMillisInput)
+
+            // Now open TO dialog; it should constrain by minDate = FROM (startOfDay UTC)
+            vm.uiState.getOrAwaitValue()!!.onDateClick(DateBoundary.TO)
+            val toDialog = vm.uiState.getOrAwaitValue()!!.pickerDialogState as PickerDialogState.DateDialog
+
+            val expectedMinMillis = fromLocalDateTime
+                .toLocalDate()
+                .atStartOfDay(ZoneOffset.UTC)
+                .toInstant()
+                .toEpochMilli()
+
+            assertThat(toDialog.minDate).isEqualTo(expectedMinMillis)
+        }
+
+    @Test
+    fun `given no TO date, when onDateClick(FROM), then DateDialog maxDate is null`() = testBlocking {
+        val vm = createVm()
+
+        vm.uiState.getOrAwaitValue()!!.onDateClick(DateBoundary.FROM)
+        val dialog = vm.uiState.getOrAwaitValue()!!.pickerDialogState as PickerDialogState.DateDialog
+
+        assertThat(dialog.maxDate).isNull()
+    }
+
+    @Test
+    fun `given no FROM date, when onDateClick(TO), then DateDialog minDate is null`() = testBlocking {
+        val vm = createVm()
+
+        vm.uiState.getOrAwaitValue()!!.onDateClick(DateBoundary.TO)
+        val dialog = vm.uiState.getOrAwaitValue()!!.pickerDialogState as PickerDialogState.DateDialog
+
+        assertThat(dialog.minDate).isNull()
+    }
+
     private fun createVm(): DateTimeFilterViewModel {
         return DateTimeFilterViewModel(
             onTypeFilterChanged = { _ -> },

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/bookings/filter/datetime/DateTimeFilterViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/bookings/filter/datetime/DateTimeFilterViewModelTest.kt
@@ -51,7 +51,7 @@ class DateTimeFilterViewModelTest : BaseUnitTest() {
         }
 
     @Test
-    fun `given DateDialog opened for FROM, when a date is selected, then fromDateTime and formattedFromDate are updated`() =
+    fun `given DateDialog opened for FROM, when initial date is selected, then fromDateTime and formattedFromDate are updated`() =
         testBlocking {
             val vm = createVm()
 
@@ -68,17 +68,16 @@ class DateTimeFilterViewModelTest : BaseUnitTest() {
             assertThat(state.fromDateTime!!.year).isEqualTo(2024)
             assertThat(state.fromDateTime.monthValue).isEqualTo(5)
             assertThat(state.fromDateTime.dayOfMonth).isEqualTo(10)
-            // time should be preserved from picked (midnight)
+            // initial time should be set at start of day
             assertThat(state.fromDateTime.hour).isEqualTo(0)
             assertThat(state.fromDateTime.minute).isEqualTo(0)
             assertThat(state.formattedFromDate).isNotEmpty()
-            // time is not formatted on date selection
-            assertThat(state.formattedFromTime).isEmpty()
+            assertThat(state.formattedFromTime).isNotEmpty()
             assertThat(state.pickerDialogState).isNull()
         }
 
     @Test
-    fun `given DateDialog opened for TO, when a date is selected, then toDateTime and formattedToDate are updated`() =
+    fun `given DateDialog opened for TO, when initial date is selected, then toDateTime and formattedToDate are updated`() =
         testBlocking {
             val vm = createVm()
 
@@ -95,10 +94,11 @@ class DateTimeFilterViewModelTest : BaseUnitTest() {
             assertThat(state.toDateTime!!.year).isEqualTo(2024)
             assertThat(state.toDateTime.monthValue).isEqualTo(6)
             assertThat(state.toDateTime.dayOfMonth).isEqualTo(2)
-            assertThat(state.toDateTime.hour).isEqualTo(0)
-            assertThat(state.toDateTime.minute).isEqualTo(0)
+            // initial time should be set at end of day
+            assertThat(state.toDateTime.hour).isEqualTo(23)
+            assertThat(state.toDateTime.minute).isEqualTo(59)
             assertThat(state.formattedToDate).isNotEmpty()
-            assertThat(state.formattedToTime).isEmpty()
+            assertThat(state.formattedToTime).isNotEmpty()
             assertThat(state.pickerDialogState).isNull()
         }
 


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

<!-- Id number of the Linear issue this PR addresses, e.g., WOOMOB-373. -->

WOOMOB-1744

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

This PR adds two improvements to the date&time picker in the Booking filter:
1. Sets the time when the initial date was selected. Start of the day for `FROM` and end of day for `TO`. This only happens if the date hasn't been selected yet.
2. Limits the possible date the user can choose. From the commit message: 

>- When the user already selected FROM date, the TO date will have a min date equal to the FROM date
>- When the user already selected TO date, the FROM date will have a max date equal to the TO date

### Test Steps
<!-- Describe how to test your changes. Include only what’s needed for the reviewer to validate the behavior.
For new features, outline the main user flow or goal rather than every tap or click — the reviewer should be able to complete the flow naturally.
If applicable, mention key devices, scenarios, or edge cases to verify. -->

1. Launch the app
2. Open the Bookings tab - All
3. Tap filters
4. Clear filters (if any selected)
5. Tap Date & Time
6. Pick a FROM date
7. Confirm a time was shown as well (start of day)
8. Pick a TO date
9. Confirm a time was shown as well (end of day)
10. Change the TO time
11. Change the TO date
12. Confirm the time from step 10 stays 
13. While changing dates verify the min/max date restrictions

### Images/gif
<!-- Include before and after images or gifs when appropriate. -->

https://github.com/user-attachments/assets/8f0e8a36-aeb8-4e9f-b4a9-59cccf34f323


- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
