### PR TITLE
Fix blank blaze campaign detail page

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -12,6 +12,7 @@
 - [Internal] Handle BLUETOOTH_PEER_REMOVED_PAIRING_INFORMATION disconnect reason from Stripe SDK [https://github.com/woocommerce/woocommerce-android/pull/14886]
 - [**] Faster POS performance - search, barcode scanning, and loading are now nearly instant. [https://github.com/woocommerce/woocommerce-android/pull/14926]
 - [*] Fixed a crash on app startup for users with the old shortcuts pinned. [https://github.com/woocommerce/woocommerce-android/pull/15007]
+- [*] Fixed a bug that cause blank blaze campaign detail page. [https://github.com/woocommerce/woocommerce-android/pull/15010]
 
 23.6
 -----

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/blaze/detail/BlazeCampaignDetailWebViewScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/blaze/detail/BlazeCampaignDetailWebViewScreen.kt
@@ -32,6 +32,7 @@ fun BlazeCampaignDetailWebViewScreen(
             userAgent = userAgent,
             authenticator = authenticator,
             onUrlLoaded = onUrlLoaded,
+            disablePopups = true,
             modifier = Modifier.padding(paddingValues)
         )
     }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/compose/component/web/WCWebView.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/compose/component/web/WCWebView.kt
@@ -45,6 +45,7 @@ fun WCWebView(
     onPageFinished: (String) -> Unit = {},
     onUrlFailed: (String, Int?) -> Unit = { _, _ -> },
     captureBackPresses: Boolean = true,
+    disablePopups: Boolean = false,
     authenticator: WebViewAuthenticator? = null,
     webViewNavigator: WebViewNavigator = rememberWebViewNavigator(),
     webViewClient: WCWebViewClient = remember { WCWebViewClient() },
@@ -105,7 +106,7 @@ fun WCWebView(
             webView.settings.loadWithOverviewMode = settings.loadWithOverviewMode
             webView.settings.javaScriptEnabled = settings.isJavaScriptEnabled
             webView.settings.domStorageEnabled = settings.isDomStorageEnabled
-            webView.settings.setSupportMultipleWindows(true)
+            if (!disablePopups) webView.settings.setSupportMultipleWindows(true)
         }
     }
 
@@ -143,8 +144,10 @@ fun WCWebView(
                     this.settings.userAgentString = userAgent.webViewUserAgent
                 }.also { webView = it }
 
-                FrameLayout(context).apply {
-                    addView(webView)
+                if (disablePopups) {
+                    webView
+                } else {
+                    FrameLayout(context).apply { addView(webView) }
                 }
             },
             modifier = Modifier


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

<!-- Id number of the Linear issue this PR addresses, e.g., WOOMOB-373. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
This commit (84f20ad990162f614d4b2d154f4c928253391742) in 23.6 introduced an issue where the Blaze campaign detail page appeared blank. The commit added multi-window (popup) support, but this caused the WebView to open a blank popup for the Blaze campaign page.
This PR fixes the issue by disabling popups specifically for Blaze screens.
This new parameter `disablePopups` also fixes WebViews in CIAB admin and product pages and I'll fix it for CIAB sites next week. (p1763397615377999-slack-C03L1NF1EA3)

### Test Steps
<!-- Describe how to test your changes. Include only what’s needed for the reviewer to validate the behavior.
For new features, outline the main user flow or goal rather than every tap or click — the reviewer should be able to complete the flow naturally.
If applicable, mention key devices, scenarios, or edge cases to verify. -->
1. Test "Test steps in #14827

> 1. Use a site:
>     - Supports Jetpack SSO (either atomic site, or self-hosted site with Jetpack SSO enabled from the settings)
>     - WooPayments setup is not done yet, or use the Reset account button.
> 3. Open the Payments hub in the app.
> 4. Start the setup from the app.
> 5. Confirm it uses the Authenticated WebView, and the Stripe onboarding screen is opened without issues.

2. Open the detail screen of a Blaze campaign.

### Images/gif
<!-- Include before and after images or gifs when appropriate. -->
|Before|After|
|-|-|
|<img width="300" src="https://github.com/user-attachments/assets/a6058cfd-b139-42a6-acdb-772363f12b91" />|<img width="300" src="https://github.com/user-attachments/assets/9148ca76-0cce-4941-b865-7675690a5fa3" />|

- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->