### PR TITLE
[WOOMOB-1767] Fix system back press not working in OrderCreateEditFormFragment

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -4,6 +4,7 @@
 
 23.8
 -----
+- [*] Fixed system back button not working on Order Creation screen [https://github.com/woocommerce/woocommerce-android/pull/15016]
 - [*] Optimized POS Local Catalog Settings screen [https://github.com/woocommerce/woocommerce-android/pull/14971]
 - [Internal][Woo POS] Improve detection and handling of deleted products during checkout [https://github.com/woocommerce/woocommerce-android/pull/14981]
 - [*][Woo POS] Fixed payment screen layout to properly position payment instructions text [https://github.com/woocommerce/woocommerce-android/pull/14991]

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/OrderCreateEditFormFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/OrderCreateEditFormFragment.kt
@@ -4,6 +4,7 @@ import android.annotation.SuppressLint
 import android.os.Bundle
 import android.view.MenuItem
 import android.view.View
+import androidx.activity.OnBackPressedCallback
 import androidx.compose.foundation.border
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.padding
@@ -58,7 +59,6 @@ import com.woocommerce.android.ui.compose.theme.WooThemeWithBackground
 import com.woocommerce.android.ui.coupons.selector.CouponSelectorFragment.Companion.KEY_COUPON_SELECTOR_RESULT
 import com.woocommerce.android.ui.feedback.SurveyType
 import com.woocommerce.android.ui.main.AppBarStatus
-import com.woocommerce.android.ui.main.MainActivity.Companion.BackPressListener
 import com.woocommerce.android.ui.orders.CustomAmountTypeBottomSheetDialog
 import com.woocommerce.android.ui.orders.CustomAmountUIModel
 import com.woocommerce.android.ui.orders.OrderNavigationTarget.ViewOrderStatusSelector
@@ -114,8 +114,7 @@ private const val ANIMATION_DURATION = 200L
 @Suppress("LargeClass")
 @AndroidEntryPoint
 class OrderCreateEditFormFragment :
-    BaseFragment(R.layout.fragment_order_create_edit_form),
-    BackPressListener {
+    BaseFragment(R.layout.fragment_order_create_edit_form) {
     private companion object {
         private const val TABLET_PANES_WIDTH_RATIO = 0.5F
     }
@@ -138,6 +137,12 @@ class OrderCreateEditFormFragment :
 
     private val args: OrderCreateEditFormFragmentArgs by navArgs()
 
+    private val backPressedCallback = object : OnBackPressedCallback(true) {
+        override fun handleOnBackPressed() {
+            viewModel.onBackButtonClicked()
+        }
+    }
+
     override val activityAppBarStatus: AppBarStatus
         get() = AppBarStatus.Hidden
 
@@ -157,6 +162,12 @@ class OrderCreateEditFormFragment :
             orderCurrency = args.orderCurrency
         )
         navController?.setGraph(R.navigation.nav_graph_product_selector, args.toBundle())
+    }
+
+    override fun onResume() {
+        super.onResume()
+        // Register in onResume to ensure our callback has higher priority than nested NavHostFragment's (LIFO order)
+        requireActivity().onBackPressedDispatcher.addCallback(viewLifecycleOwner, backPressedCallback)
     }
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
@@ -1267,11 +1278,6 @@ class OrderCreateEditFormFragment :
     private fun hideProgressDialog() {
         progressDialog?.dismiss()
         progressDialog = null
-    }
-
-    override fun onRequestAllowBackPress(): Boolean {
-        viewModel.onBackButtonClicked()
-        return false
     }
 
     private fun FragmentOrderCreateEditFormBinding.showEditableControls(


### PR DESCRIPTION
WOOMOB-1767

### Description

The system back button/gesture was not working in `OrderCreateEditFormFragment` while it worked correctly in other fragments. The issue was caused by the nested `NavHostFragment` (used for product selector) registering its own `OnBackPressedCallback` with higher priority, consuming the back press before the fragment's `BackPressListener` could handle it.

Fixed by adding a custom `OnBackPressedCallback` registered in `onResume()` to ensure it has higher priority (LIFO order) than the nested NavHostFragment's callback. This allows the fragment to properly intercept back press and show the discard changes dialog when needed.

### Test Steps

1. Open the app and navigate to Order Creation (Menu → Orders → Create Order (FAB))
2. Add a product or make any change to the order
3. Press the system back button or use the back gesture
4. Verify the discard changes dialog appears
5. **Test on tablet**: Repeat steps 1-4 on a tablet device to verify the fix works with the two-pane layout

### Images/gif


https://github.com/user-attachments/assets/f0e6a3bf-07ae-479d-99af-92d2bc6f51ae



- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.