### PR TITLE
[Tooling] Update hotfix pipeline to to get version code directly from the release tool

### DIFF
--- a/.buildkite/release-pipelines/new-hotfix-release.yml
+++ b/.buildkite/release-pipelines/new-hotfix-release.yml
@@ -2,11 +2,6 @@
 ---
 
 steps:
-  - block: "What version code do you want to use for the new hotfix release?"
-    fields:
-      - text: "Version Code"
-        key: "version_code"
-        format: "[0-9]+" # Only allow numbers
   - label: "New Hotfix Release"
     plugins: [$CI_TOOLKIT]
     command: |
@@ -16,12 +11,8 @@ steps:
       echo '--- :ruby: Setup Ruby Tools'
       install_gems
 
-      # Get the version code from the Buildkite 'block' step
-      VERSION_CODE=$(buildkite-agent meta-data get version_code)
-
       echo '--- :fire: Start New Hotfix Release'
-      # Note: we need to double the dollar sign in front of `{VERSION_CODE}` below, so that the env var is interpreted *at runtime*, instead of too soon during `pipeline upload`
-      bundle exec fastlane new_hotfix_release version_name:$${VERSION} version_code:$${VERSION_CODE} skip_confirm:true
+      bundle exec fastlane new_hotfix_release version_name:"$RELEASE_VERSION" version_code:"$VERSION_CODE" skip_confirm:true
     agents:
         queue: "tumblr-metal"
     retry:


### PR DESCRIPTION
Fixes AINFRA-1524
See https://github.a8c.com/Automattic/wpcom/pull/196874

### Description

We're currently using a [Buildkite block step](https://github.com/woocommerce/woocommerce-android/blob/09080efeabdcf86a3250c147d165d23464ff3d09/.buildkite/release-pipelines/new-hotfix-release.yml#L5) to get the version code.

This PR changes the automation code so that it accepts the version code directly from ReleasesV2.

⚠️ We need to be careful when merging this PR to make sure it aligns with the changes done on ReleasesV2 ⚠️ 