### PR TITLE
[WOOMOB-1722] - Properly clean the Bookings table for Today/Upcoming tabs' first page load

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/bookings/BookingsRepository.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/bookings/BookingsRepository.kt
@@ -24,7 +24,7 @@ class BookingsRepository @Inject constructor(
         page: Int,
         perPage: Int,
         query: String? = null,
-        filters: BookingFilters? = null,
+        filters: BookingFilters = BookingFilters.EMPTY,
         order: BookingsOrderOption
     ): Result<FetchResult> {
         val result = bookingsStore.fetchBookings(

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/bookings/list/BookingListFiltersBuilder.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/bookings/list/BookingListFiltersBuilder.kt
@@ -1,10 +1,8 @@
 package com.woocommerce.android.ui.bookings.list
 
+import org.wordpress.android.fluxc.network.rest.wpcom.wc.bookings.BookingsDateRangePresets
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.bookings.BookingsFilterOption
 import java.time.Clock
-import java.time.LocalDate
-import java.time.LocalTime
-import java.time.ZoneOffset
 import javax.inject.Inject
 
 class BookingListFiltersBuilder @Inject constructor(
@@ -12,27 +10,10 @@ class BookingListFiltersBuilder @Inject constructor(
 ) {
     /**
      * Returns a [BookingsFilterOption.DateRange] based on the selected [BookingListTab].
-     *
-     * We use UTC for the API calls, as the API stores the dates without timezone information, which means that
-     * when comparing dates, they are treated as UTC times.
-     * See p1759398245019489-slack-C09FHQNQERG
      */
-    fun BookingListTab.asDateRangeFilter(): BookingsFilterOption.DateRange? {
-        fun todayAtMidnight() = LocalDate.now(clock).atTime(LocalTime.MIDNIGHT).atOffset(ZoneOffset.UTC).toInstant()
-        fun todayAtEndOfDay() = LocalDate.now(clock).atTime(LocalTime.MAX).atOffset(ZoneOffset.UTC).toInstant()
-
-        return when (this) {
-            BookingListTab.Today -> BookingsFilterOption.DateRange(
-                before = todayAtEndOfDay(),
-                after = todayAtMidnight()
-            )
-
-            BookingListTab.Upcoming -> BookingsFilterOption.DateRange(
-                before = null,
-                after = todayAtEndOfDay()
-            )
-
-            BookingListTab.All -> null
-        }
+    fun BookingListTab.asDateRangeFilter(): BookingsFilterOption.DateRange? = when (this) {
+        BookingListTab.Today -> BookingsDateRangePresets.today(clock)
+        BookingListTab.Upcoming -> BookingsDateRangePresets.upcoming(clock)
+        BookingListTab.All -> null
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/bookings/list/BookingListHandler.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/bookings/list/BookingListHandler.kt
@@ -32,7 +32,7 @@ class BookingListHandler @Inject constructor(
     private val canLoadMore = AtomicBoolean(false)
 
     private val searchQuery = MutableStateFlow<String?>(null)
-    private val filters = MutableStateFlow<BookingFilters?>(null)
+    private val filters = MutableStateFlow(BookingFilters.EMPTY)
     private val sortBy = MutableStateFlow(BookingListSortOption.NewestToOldest)
 
     private val searchResults = MutableStateFlow(emptyList<Booking>())
@@ -57,7 +57,7 @@ class BookingListHandler @Inject constructor(
 
     suspend fun loadBookings(
         searchQuery: String? = null,
-        filters: BookingFilters? = null,
+        filters: BookingFilters = BookingFilters.EMPTY,
         sortBy: BookingListSortOption
     ): Result<Unit> = mutex.withLock {
         // Reset pagination attributes

--- a/libs/fluxc-plugin/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/bookings/BookingsDateRangePresets.kt
+++ b/libs/fluxc-plugin/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/bookings/BookingsDateRangePresets.kt
@@ -1,0 +1,47 @@
+package org.wordpress.android.fluxc.network.rest.wpcom.wc.bookings
+
+import java.time.Clock
+import java.time.LocalDate
+import java.time.LocalTime
+import java.time.ZoneOffset
+
+/**
+ * Factory for canonical booking date range presets used across app and data layers.
+ *
+ * Notes about time zone:
+ * The WC Bookings API stores dates without timezone information. To ensure
+ * consistent comparisons and filtering on both client and server, we construct
+ * ranges in UTC.
+ * See p1759398245019489-slack-C09FHQNQERG
+ */
+object BookingsDateRangePresets {
+    /**
+     * Returns a DateRange that spans the current day in UTC, inclusive of the
+     * full day when interpreted by the API (midnight to end-of-day).
+     */
+    fun today(clock: Clock): BookingsFilterOption.DateRange {
+        val start = LocalDate.now(clock)
+            .atTime(LocalTime.MIDNIGHT)
+            .atOffset(ZoneOffset.UTC)
+            .toInstant()
+        val end = LocalDate.now(clock)
+            .atTime(LocalTime.MAX)
+            .atOffset(ZoneOffset.UTC)
+            .toInstant()
+        return BookingsFilterOption.DateRange(before = end, after = start)
+    }
+
+    /**
+     * Returns a DateRange that includes bookings strictly after the end of the
+     * current day in UTC (i.e., upcoming bookings from tomorrow onwards).
+     *
+     * before = null and after = end-of-today.
+     */
+    fun upcoming(clock: Clock): BookingsFilterOption.DateRange {
+        val endOfToday = LocalDate.now(clock)
+            .atTime(LocalTime.MAX)
+            .atOffset(ZoneOffset.UTC)
+            .toInstant()
+        return BookingsFilterOption.DateRange(before = null, after = endOfToday)
+    }
+}

--- a/libs/fluxc-plugin/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/bookings/BookingsDateRangePresets.kt
+++ b/libs/fluxc-plugin/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/bookings/BookingsDateRangePresets.kt
@@ -1,6 +1,7 @@
 package org.wordpress.android.fluxc.network.rest.wpcom.wc.bookings
 
 import java.time.Clock
+import java.time.Instant
 import java.time.LocalDate
 import java.time.LocalTime
 import java.time.ZoneOffset
@@ -24,24 +25,23 @@ object BookingsDateRangePresets {
             .atTime(LocalTime.MIDNIGHT)
             .atOffset(ZoneOffset.UTC)
             .toInstant()
-        val end = LocalDate.now(clock)
-            .atTime(LocalTime.MAX)
-            .atOffset(ZoneOffset.UTC)
-            .toInstant()
+        val end = getEndOfToday(clock)
         return BookingsFilterOption.DateRange(before = end, after = start)
     }
 
     /**
      * Returns a DateRange that includes bookings strictly after the end of the
      * current day in UTC (i.e., upcoming bookings from tomorrow onwards).
-     *
-     * before = null and after = end-of-today.
      */
     fun upcoming(clock: Clock): BookingsFilterOption.DateRange {
-        val endOfToday = LocalDate.now(clock)
+        val endOfToday = getEndOfToday(clock)
+        return BookingsFilterOption.DateRange(before = null, after = endOfToday)
+    }
+
+    private fun getEndOfToday(clock: Clock): Instant {
+        return LocalDate.now(clock)
             .atTime(LocalTime.MAX)
             .atOffset(ZoneOffset.UTC)
             .toInstant()
-        return BookingsFilterOption.DateRange(before = null, after = endOfToday)
     }
 }

--- a/libs/fluxc-plugin/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/bookings/BookingsStore.kt
+++ b/libs/fluxc-plugin/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/bookings/BookingsStore.kt
@@ -66,13 +66,11 @@ class BookingsStore @Inject internal constructor(
                             }
 
                             filters.dateRange != null && filters.isTodayOrUpcoming -> {
-                                // Delete only the rows that match the applied date range filter for Today/Upcoming
-                                bookingsDao.deleteForSiteWithDateRangeFilter(
+                                bookingsDao.cleanAndUpsertBookings(
                                     site.localId(),
                                     filters.dateRange,
-                                    entities.map { it.id.value }
+                                    entities
                                 )
-                                bookingsDao.insertOrReplace(entities)
                             }
 
                             else -> {

--- a/libs/fluxc-plugin/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/bookings/BookingsStore.kt
+++ b/libs/fluxc-plugin/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/bookings/BookingsStore.kt
@@ -64,7 +64,8 @@ class BookingsStore @Inject internal constructor(
                             filters == BookingFilters.EMPTY -> {
                                 bookingsDao.replaceAllForSite(site.localId(), entities)
                             }
-                            filters.dateRange != null && isTodayOrUpcoming(filters.dateRange) -> {
+
+                            filters.dateRange != null && filters.isTodayOrUpcoming -> {
                                 // Delete only the rows that match the applied date range filter for Today/Upcoming
                                 bookingsDao.deleteForSiteWithDateRangeFilter(
                                     site.localId(),
@@ -73,6 +74,7 @@ class BookingsStore @Inject internal constructor(
                                 )
                                 bookingsDao.insertOrReplace(entities)
                             }
+
                             else -> {
                                 // For any other filters, avoid deletions to prevent removing unrelated cached items
                                 bookingsDao.insertOrReplace(entities)
@@ -98,11 +100,12 @@ class BookingsStore @Inject internal constructor(
         }
     }
 
-    private fun isTodayOrUpcoming(dateRange: BookingsFilterOption.DateRange): Boolean {
-        val today = BookingsDateRangePresets.today(clock)
-        val upcoming = BookingsDateRangePresets.upcoming(clock)
-        return dateRange == today || dateRange == upcoming
-    }
+    private val BookingFilters.isTodayOrUpcoming: Boolean
+        get() {
+            val today = BookingsDateRangePresets.today(clock)
+            val upcoming = BookingsDateRangePresets.upcoming(clock)
+            return (dateRange == today || dateRange == upcoming) && enabledFiltersCount == 1
+        }
 
     fun observeBookings(
         site: SiteModel,

--- a/libs/fluxc-plugin/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/bookings/BookingsStore.kt
+++ b/libs/fluxc-plugin/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/bookings/BookingsStore.kt
@@ -15,6 +15,7 @@ import org.wordpress.android.fluxc.store.WCOrderStore
 import org.wordpress.android.fluxc.tools.CoroutineEngine
 import org.wordpress.android.fluxc.utils.HeadersParser
 import org.wordpress.android.util.AppLog
+import java.time.Clock
 import javax.inject.Inject
 import javax.inject.Singleton
 
@@ -26,6 +27,7 @@ class BookingsStore @Inject internal constructor(
     private val bookingDtoMapper: BookingDtoMapper,
     private val headersParser: HeadersParser,
     private val coroutineEngine: CoroutineEngine,
+    private val clock: Clock,
 ) {
     suspend fun fetchBookings(
         site: SiteModel,
@@ -54,9 +56,28 @@ class BookingsStore @Inject internal constructor(
                             )
                         }
                     }
-                    if (page == 1 && filters == BookingFilters.EMPTY && query.isNullOrEmpty()) {
-                        // Clear existing bookings and insert new ones when fetching the first page
-                        bookingsDao.replaceAllForSite(site.localId(), entities)
+                    // Clear existing bookings when fetching the first page.
+                    // If filters are applied, only clear entries that match the applied filters,
+                    // otherwise (no filters) clear all entries for the site.
+                    if (page == 1 && query.isNullOrEmpty()) {
+                        when {
+                            filters == BookingFilters.EMPTY -> {
+                                bookingsDao.replaceAllForSite(site.localId(), entities)
+                            }
+                            filters.dateRange != null && isTodayOrUpcoming(filters.dateRange) -> {
+                                // Delete only the rows that match the applied date range filter for Today/Upcoming
+                                bookingsDao.deleteForSiteWithDateRangeFilter(
+                                    site.localId(),
+                                    filters.dateRange,
+                                    entities.map { it.id.value }
+                                )
+                                bookingsDao.insertOrReplace(entities)
+                            }
+                            else -> {
+                                // For any other filters, avoid deletions to prevent removing unrelated cached items
+                                bookingsDao.insertOrReplace(entities)
+                            }
+                        }
                     } else {
                         bookingsDao.insertOrReplace(entities)
                     }
@@ -75,6 +96,12 @@ class BookingsStore @Inject internal constructor(
                 else -> WooResult(WooError(GENERIC_ERROR, UNKNOWN))
             }
         }
+    }
+
+    private fun isTodayOrUpcoming(dateRange: BookingsFilterOption.DateRange): Boolean {
+        val today = BookingsDateRangePresets.today(clock)
+        val upcoming = BookingsDateRangePresets.upcoming(clock)
+        return dateRange == today || dateRange == upcoming
     }
 
     fun observeBookings(

--- a/libs/fluxc-plugin/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/bookings/BookingsStore.kt
+++ b/libs/fluxc-plugin/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/bookings/BookingsStore.kt
@@ -32,7 +32,7 @@ class BookingsStore @Inject internal constructor(
         perPage: Int = BookingsRestClient.DEFAULT_PER_PAGE,
         page: Int = 1,
         query: String? = null,
-        filters: BookingFilters?,
+        filters: BookingFilters,
         order: BookingsOrderOption
     ): WooResult<BookingsFetchResult> {
         return coroutineEngine.withDefaultContext(AppLog.T.API, this, "fetchBookings") {

--- a/libs/fluxc-plugin/src/main/kotlin/org/wordpress/android/fluxc/persistence/dao/BookingsDao.kt
+++ b/libs/fluxc-plugin/src/main/kotlin/org/wordpress/android/fluxc/persistence/dao/BookingsDao.kt
@@ -8,6 +8,7 @@ import androidx.room.Transaction
 import kotlinx.coroutines.flow.Flow
 import org.wordpress.android.fluxc.model.LocalOrRemoteId.LocalId
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.bookings.BookingFilters
+import org.wordpress.android.fluxc.network.rest.wpcom.wc.bookings.BookingsFilterOption
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.bookings.BookingsOrderOption
 import org.wordpress.android.fluxc.persistence.entity.BookingEntity
 import org.wordpress.android.fluxc.persistence.entity.BookingResourceEntity
@@ -68,6 +69,38 @@ interface BookingsDao {
     suspend fun replaceAllForSite(siteId: LocalId, entities: List<BookingEntity>) {
         deleteAllForSite(siteId)
         insertOrReplace(entities)
+    }
+
+    @Suppress("LongParameterList")
+    @Query(
+        """
+            DELETE FROM Bookings
+            WHERE localSiteId = :localSiteId
+            AND (:startDateBefore IS NULL OR start <= :startDateBefore)
+            AND (:startDateAfter IS NULL OR start >= :startDateAfter)
+            AND ((:idsSize = 0) OR id NOT IN (:ids))
+        """
+    )
+    suspend fun deleteForSiteWithDateRangeFilter(
+        localSiteId: LocalId,
+        startDateBefore: Long?,
+        startDateAfter: Long?,
+        ids: List<Long>,
+        idsSize: Int,
+    )
+
+    suspend fun deleteForSiteWithDateRangeFilter(
+        localSiteId: LocalId,
+        dateRange: BookingsFilterOption.DateRange,
+        ids: List<Long>
+    ) {
+        deleteForSiteWithDateRangeFilter(
+            localSiteId = localSiteId,
+            startDateBefore = dateRange.before?.epochSecond,
+            startDateAfter = dateRange.after?.epochSecond,
+            ids = ids,
+            idsSize = ids.size,
+        )
     }
 
     fun observeBookings(

--- a/libs/fluxc-plugin/src/main/kotlin/org/wordpress/android/fluxc/persistence/dao/BookingsDao.kt
+++ b/libs/fluxc-plugin/src/main/kotlin/org/wordpress/android/fluxc/persistence/dao/BookingsDao.kt
@@ -89,7 +89,7 @@ interface BookingsDao {
         idsSize: Int,
     )
 
-    suspend fun deleteForSiteWithDateRangeFilter(
+    private suspend fun deleteForSiteWithDateRangeFilter(
         localSiteId: LocalId,
         dateRange: BookingsFilterOption.DateRange,
         ids: List<Long>
@@ -101,6 +101,23 @@ interface BookingsDao {
             ids = ids,
             idsSize = ids.size,
         )
+    }
+
+    /**
+     * Delete Booking entities that are not present in the new list and then insert the new entities
+     */
+    @Transaction
+    suspend fun cleanAndUpsertBookings(
+        localSiteId: LocalId,
+        dateRange: BookingsFilterOption.DateRange,
+        entities: List<BookingEntity>,
+    ) {
+        deleteForSiteWithDateRangeFilter(
+            localSiteId = localSiteId,
+            dateRange = dateRange,
+            ids = entities.map { it.id.value },
+        )
+        insertOrReplace(entities)
     }
 
     fun observeBookings(

--- a/libs/fluxc-plugin/src/test/java/org/wordpress/android/fluxc/network/rest/wpcom/wc/bookings/BookingsStoreTest.kt
+++ b/libs/fluxc-plugin/src/test/java/org/wordpress/android/fluxc/network/rest/wpcom/wc/bookings/BookingsStoreTest.kt
@@ -26,6 +26,7 @@ import org.wordpress.android.fluxc.persistence.entity.OrderEntity
 import org.wordpress.android.fluxc.store.WCOrderStore
 import org.wordpress.android.fluxc.tools.CoroutineEngine
 import org.wordpress.android.fluxc.utils.HeadersParser
+import java.time.Clock
 import java.time.Instant
 import kotlin.coroutines.EmptyCoroutineContext
 
@@ -38,6 +39,7 @@ class BookingsStoreTest {
     private val bookingsDao: BookingsDao = mock()
     private val bookingDtoMapper: BookingDtoMapper = BookingDtoMapper(mock())
     private val headersParser: HeadersParser = mock()
+    private val clock: Clock = Clock.systemUTC()
 
     @Before
     fun setUp() {
@@ -47,63 +49,66 @@ class BookingsStoreTest {
             bookingsDao = bookingsDao,
             bookingDtoMapper = bookingDtoMapper,
             headersParser = headersParser,
-            coroutineEngine = CoroutineEngine(EmptyCoroutineContext, mock())
+            coroutineEngine = CoroutineEngine(EmptyCoroutineContext, mock()),
+            clock = clock,
         )
     }
 
     @Test
-    fun `given refreshOrder is false, when updateBooking succeeds, then inserts mapped entity and returns it`(): Unit = runBlocking {
-        // given
-        val site = SiteModel().apply { id = TEST_LOCAL_SITE_ID.value }
-        val dto = sampleBookingDto()
-        val storedBooking = sampleBookingEntity(order = BookingOrderInfo(productInfo = null))
-        whenever(bookingsDao.getBooking(TEST_LOCAL_SITE_ID, dto.id)).thenReturn(storedBooking)
-        whenever(bookingsRestClient.updateBooking(site, dto.id, BookingUpdatePayload(note = "n")))
-            .thenReturn(WooPayload(dto))
-        whenever(bookingsDao.insertOrReplace(any<BookingEntity>())).thenReturn(1L)
+    fun `given refreshOrder is false, when updateBooking succeeds, then inserts mapped entity and returns it`(): Unit =
+        runBlocking {
+            // given
+            val site = SiteModel().apply { id = TEST_LOCAL_SITE_ID.value }
+            val dto = sampleBookingDto()
+            val storedBooking = sampleBookingEntity(order = BookingOrderInfo(productInfo = null))
+            whenever(bookingsDao.getBooking(TEST_LOCAL_SITE_ID, dto.id)).thenReturn(storedBooking)
+            whenever(bookingsRestClient.updateBooking(site, dto.id, BookingUpdatePayload(note = "n")))
+                .thenReturn(WooPayload(dto))
+            whenever(bookingsDao.insertOrReplace(any<BookingEntity>())).thenReturn(1L)
 
-        // when
-        val result = sut.updateBooking(
-            site = site,
-            bookingId = dto.id,
-            bookingUpdatePayload = BookingUpdatePayload(note = "n"),
-            refreshOrder = false
-        )
+            // when
+            val result = sut.updateBooking(
+                site = site,
+                bookingId = dto.id,
+                bookingUpdatePayload = BookingUpdatePayload(note = "n"),
+                refreshOrder = false
+            )
 
-        // then
-        assertThat(result.isError).isFalse()
-        assertThat(result.model).isNotNull
-        // The store preserves the stored order on the mapped entity
-        verify(bookingsDao).insertOrReplace(argThat<BookingEntity> { this.order == storedBooking.order })
-    }
+            // then
+            assertThat(result.isError).isFalse()
+            assertThat(result.model).isNotNull
+            // The store preserves the stored order on the mapped entity
+            verify(bookingsDao).insertOrReplace(argThat<BookingEntity> { this.order == storedBooking.order })
+        }
 
     @Test
-    fun `given refreshOrder is true, when updateBooking succeeds, then refreshes order and inserts mapped entity`(): Unit = runBlocking {
-        // given
-        val site = SiteModel().apply { id = TEST_LOCAL_SITE_ID.value }
-        val dto = sampleBookingDto()
+    fun `given refreshOrder is true, when updateBooking succeeds, then refreshes order and inserts mapped entity`(): Unit =
+        runBlocking {
+            // given
+            val site = SiteModel().apply { id = TEST_LOCAL_SITE_ID.value }
+            val dto = sampleBookingDto()
 
-        val fetchedOrder = OrderEntity(orderId = dto.orderId, localSiteId = TEST_LOCAL_SITE_ID)
-        whenever(orderStore.fetchSingleOrderSync(site, dto.orderId)).thenReturn(WooResult(fetchedOrder))
-        whenever(bookingsRestClient.updateBooking(site, dto.id, BookingUpdatePayload(status = Status.Confirmed)))
-            .thenReturn(WooPayload(dto))
-        whenever(bookingsDao.insertOrReplace(any<BookingEntity>())).thenReturn(1L)
+            val fetchedOrder = OrderEntity(orderId = dto.orderId, localSiteId = TEST_LOCAL_SITE_ID)
+            whenever(orderStore.fetchSingleOrderSync(site, dto.orderId)).thenReturn(WooResult(fetchedOrder))
+            whenever(bookingsRestClient.updateBooking(site, dto.id, BookingUpdatePayload(status = Status.Confirmed)))
+                .thenReturn(WooPayload(dto))
+            whenever(bookingsDao.insertOrReplace(any<BookingEntity>())).thenReturn(1L)
 
-        // when
-        val result = sut.updateBooking(
-            site = site,
-            bookingId = dto.id,
-            bookingUpdatePayload = BookingUpdatePayload(status = Status.Confirmed),
-            refreshOrder = true
-        )
+            // when
+            val result = sut.updateBooking(
+                site = site,
+                bookingId = dto.id,
+                bookingUpdatePayload = BookingUpdatePayload(status = Status.Confirmed),
+                refreshOrder = true
+            )
 
-        // then
-        assertThat(result.isError).isFalse()
-        val expected = with(bookingDtoMapper) { dto.toEntity(TEST_LOCAL_SITE_ID, fetchedOrder) }
-        assertThat(result.model).isEqualTo(expected)
-        verify(bookingsDao).insertOrReplace(expected)
-        verify(bookingsDao, never()).getBooking(TEST_LOCAL_SITE_ID, dto.id)
-    }
+            // then
+            assertThat(result.isError).isFalse()
+            val expected = with(bookingDtoMapper) { dto.toEntity(TEST_LOCAL_SITE_ID, fetchedOrder) }
+            assertThat(result.model).isEqualTo(expected)
+            verify(bookingsDao).insertOrReplace(expected)
+            verify(bookingsDao, never()).getBooking(TEST_LOCAL_SITE_ID, dto.id)
+        }
 
     @Test
     fun `given rest client fails, when updateBooking, then returns error and does not insert`(): Unit = runBlocking {
@@ -167,6 +172,130 @@ class BookingsStoreTest {
             verify(bookingsDao).getBooking(TEST_LOCAL_SITE_ID, dto.id)
             // The store preserves the stored order on the mapped entity
             verify(bookingsDao).insertOrReplace(argThat<BookingEntity> { this.order == storedBooking.order })
+        }
+
+    @Test
+    fun `given page 1 and today date filter and no query, when fetchBookings, then delete matching and insert is called`(): Unit =
+        runBlocking {
+            // given
+            val site = SiteModel().apply { id = TEST_LOCAL_SITE_ID.value }
+            val dto = sampleBookingDto().copy(orderId = 0L) // avoid order fetch
+            val filters = BookingFilters(
+                dateRange = BookingsDateRangePresets.today(clock)
+            )
+            whenever(
+                bookingsRestClient.fetchBookings(
+                    site,
+                    perPage = 25,
+                    page = 1,
+                    query = null,
+                    filters = filters,
+                    order = BookingsOrderOption.DESC
+                )
+            )
+                .thenReturn(WooPayload(arrayOf(dto)))
+            whenever(headersParser.getTotalPages(any())).thenReturn(null)
+
+            // when
+            val result = sut.fetchBookings(
+                site = site,
+                perPage = 25,
+                page = 1,
+                query = null,
+                filters = filters,
+                order = BookingsOrderOption.DESC
+            )
+
+            // then
+            assertThat(result.isError).isFalse()
+            // We delete only matching filtered rows then insert the fetched page
+            verify(bookingsDao).deleteForSiteWithDateRangeFilter(
+                any(),
+                any<BookingsFilterOption.DateRange>(),
+                any<List<Long>>()
+            )
+            verify(bookingsDao).insertOrReplace(any<List<BookingEntity>>())
+            verify(bookingsDao, never()).replaceAllForSite(any(), any())
+        }
+
+    @Test
+    fun `given page greater than 1 with multiple filters, when fetchBookings, then insertOrReplace is called`(): Unit =
+        runBlocking {
+            // given
+            val site = SiteModel().apply { id = TEST_LOCAL_SITE_ID.value }
+            val dto = sampleBookingDto().copy(orderId = 0L)
+            val filters = BookingFilters(
+                dateRange = BookingsFilterOption.DateRange(before = Instant.now(), after = Instant.now()),
+                customer = BookingsFilterOption.Customer(customerId = 1L, customerName = "name")
+            )
+            whenever(
+                bookingsRestClient.fetchBookings(
+                    site,
+                    perPage = 25,
+                    page = 2,
+                    query = null,
+                    filters = filters,
+                    order = BookingsOrderOption.DESC
+                )
+            )
+                .thenReturn(WooPayload(arrayOf(dto)))
+            whenever(headersParser.getTotalPages(any())).thenReturn(null)
+
+            // when
+            val result = sut.fetchBookings(
+                site = site,
+                perPage = 25,
+                page = 2,
+                query = null,
+                filters = filters,
+                order = BookingsOrderOption.DESC
+            )
+
+            // then
+            assertThat(result.isError).isFalse()
+            verify(bookingsDao).insertOrReplace(any<List<BookingEntity>>())
+            verify(bookingsDao, never()).replaceAllForSite(any(), any())
+            verify(bookingsDao, never())
+                .deleteForSiteWithDateRangeFilter(any(), any<BookingsFilterOption.DateRange>(), any<List<Long>>())
+        }
+
+    @Test
+    fun `given page 1 with no filters and no query, when fetchBookings, then replaceAllForSite is called`(): Unit =
+        runBlocking {
+            // given
+            val site = SiteModel().apply { id = TEST_LOCAL_SITE_ID.value }
+            val dto = sampleBookingDto().copy(orderId = 0L)
+            val filters: BookingFilters = BookingFilters.EMPTY
+            whenever(
+                bookingsRestClient.fetchBookings(
+                    site,
+                    perPage = 25,
+                    page = 1,
+                    query = null,
+                    filters = filters,
+                    order = BookingsOrderOption.DESC
+                )
+            ).thenReturn(WooPayload(arrayOf(dto)))
+            whenever(headersParser.getTotalPages(any())).thenReturn(null)
+
+            // when
+            val result = sut.fetchBookings(
+                site = site,
+                perPage = 25,
+                page = 1,
+                query = null,
+                filters = filters,
+                order = BookingsOrderOption.DESC
+            )
+
+            // then
+            assertThat(result.isError).isFalse()
+            verify(bookingsDao).replaceAllForSite(any(), any())
+            verify(bookingsDao, never()).deleteForSiteWithDateRangeFilter(
+                any(),
+                any<BookingsFilterOption.DateRange>(),
+                any<List<Long>>()
+            )
         }
 
     private fun sampleBookingDto(): BookingDto = BookingDto(

--- a/libs/fluxc-plugin/src/test/java/org/wordpress/android/fluxc/network/rest/wpcom/wc/bookings/BookingsStoreTest.kt
+++ b/libs/fluxc-plugin/src/test/java/org/wordpress/android/fluxc/network/rest/wpcom/wc/bookings/BookingsStoreTest.kt
@@ -208,12 +208,11 @@ class BookingsStoreTest {
             // then
             assertThat(result.isError).isFalse()
             // We delete only matching filtered rows then insert the fetched page
-            verify(bookingsDao).deleteForSiteWithDateRangeFilter(
+            verify(bookingsDao).cleanAndUpsertBookings(
                 any(),
                 any<BookingsFilterOption.DateRange>(),
-                any<List<Long>>()
+                any<List<BookingEntity>>()
             )
-            verify(bookingsDao).insertOrReplace(any<List<BookingEntity>>())
             verify(bookingsDao, never()).replaceAllForSite(any(), any())
         }
 
@@ -253,10 +252,10 @@ class BookingsStoreTest {
             assertThat(result.isError).isFalse()
             // We delete only matching filtered rows then insert the fetched page
             verify(bookingsDao).insertOrReplace(any<List<BookingEntity>>())
-            verify(bookingsDao, never()).deleteForSiteWithDateRangeFilter(
+            verify(bookingsDao, never()).cleanAndUpsertBookings(
                 any(),
                 any<BookingsFilterOption.DateRange>(),
-                any<List<Long>>()
+                any<List<BookingEntity>>()
             )
             verify(bookingsDao, never()).replaceAllForSite(any(), any())
         }
@@ -295,12 +294,11 @@ class BookingsStoreTest {
             // then
             assertThat(result.isError).isFalse()
             // We delete only matching filtered rows then insert the fetched page
-            verify(bookingsDao).deleteForSiteWithDateRangeFilter(
+            verify(bookingsDao).cleanAndUpsertBookings(
                 any(),
                 any<BookingsFilterOption.DateRange>(),
-                any<List<Long>>()
+                any<List<BookingEntity>>()
             )
-            verify(bookingsDao).insertOrReplace(any<List<BookingEntity>>())
             verify(bookingsDao, never()).replaceAllForSite(any(), any())
         }
 
@@ -342,7 +340,7 @@ class BookingsStoreTest {
             verify(bookingsDao).insertOrReplace(any<List<BookingEntity>>())
             verify(bookingsDao, never()).replaceAllForSite(any(), any())
             verify(bookingsDao, never())
-                .deleteForSiteWithDateRangeFilter(any(), any<BookingsFilterOption.DateRange>(), any<List<Long>>())
+                .cleanAndUpsertBookings(any(), any<BookingsFilterOption.DateRange>(), any<List<BookingEntity>>())
         }
 
     @Test
@@ -377,10 +375,10 @@ class BookingsStoreTest {
             // then
             assertThat(result.isError).isFalse()
             verify(bookingsDao).replaceAllForSite(any(), any())
-            verify(bookingsDao, never()).deleteForSiteWithDateRangeFilter(
+            verify(bookingsDao, never()).cleanAndUpsertBookings(
                 any(),
                 any<BookingsFilterOption.DateRange>(),
-                any<List<Long>>()
+                any<List<BookingEntity>>()
             )
         }
 
@@ -420,10 +418,10 @@ class BookingsStoreTest {
             assertThat(result.isError).isFalse()
             verify(bookingsDao).insertOrReplace(any<List<BookingEntity>>())
             verify(bookingsDao, never()).replaceAllForSite(any(), any())
-            verify(bookingsDao, never()).deleteForSiteWithDateRangeFilter(
+            verify(bookingsDao, never()).cleanAndUpsertBookings(
                 any(),
                 any<BookingsFilterOption.DateRange>(),
-                any<List<Long>>()
+                any<List<BookingEntity>>()
             )
         }
 

--- a/libs/fluxc-plugin/src/test/java/org/wordpress/android/fluxc/network/rest/wpcom/wc/bookings/BookingsStoreTest.kt
+++ b/libs/fluxc-plugin/src/test/java/org/wordpress/android/fluxc/network/rest/wpcom/wc/bookings/BookingsStoreTest.kt
@@ -192,8 +192,94 @@ class BookingsStoreTest {
                     filters = filters,
                     order = BookingsOrderOption.DESC
                 )
+            ).thenReturn(WooPayload(arrayOf(dto)))
+            whenever(headersParser.getTotalPages(any())).thenReturn(null)
+
+            // when
+            val result = sut.fetchBookings(
+                site = site,
+                perPage = 25,
+                page = 1,
+                query = null,
+                filters = filters,
+                order = BookingsOrderOption.DESC
             )
-                .thenReturn(WooPayload(arrayOf(dto)))
+
+            // then
+            assertThat(result.isError).isFalse()
+            // We delete only matching filtered rows then insert the fetched page
+            verify(bookingsDao).deleteForSiteWithDateRangeFilter(
+                any(),
+                any<BookingsFilterOption.DateRange>(),
+                any<List<Long>>()
+            )
+            verify(bookingsDao).insertOrReplace(any<List<BookingEntity>>())
+            verify(bookingsDao, never()).replaceAllForSite(any(), any())
+        }
+
+    @Test
+    fun `given page 1, today date filter, customer filter and no query, when fetchBookings, then only insertOrReplace is called`(): Unit =
+        runBlocking {
+            // given
+            val site = SiteModel().apply { id = TEST_LOCAL_SITE_ID.value }
+            val dto = sampleBookingDto().copy(orderId = 0L) // avoid order fetch
+            val filters = BookingFilters(
+                dateRange = BookingsDateRangePresets.today(clock),
+                customer = BookingsFilterOption.Customer(customerId = 1L, customerName = "name"),
+            )
+            whenever(
+                bookingsRestClient.fetchBookings(
+                    site,
+                    perPage = 25,
+                    page = 1,
+                    query = null,
+                    filters = filters,
+                    order = BookingsOrderOption.DESC
+                )
+            ).thenReturn(WooPayload(arrayOf(dto)))
+            whenever(headersParser.getTotalPages(any())).thenReturn(null)
+
+            // when
+            val result = sut.fetchBookings(
+                site = site,
+                perPage = 25,
+                page = 1,
+                query = null,
+                filters = filters,
+                order = BookingsOrderOption.DESC
+            )
+
+            // then
+            assertThat(result.isError).isFalse()
+            // We delete only matching filtered rows then insert the fetched page
+            verify(bookingsDao).insertOrReplace(any<List<BookingEntity>>())
+            verify(bookingsDao, never()).deleteForSiteWithDateRangeFilter(
+                any(),
+                any<BookingsFilterOption.DateRange>(),
+                any<List<Long>>()
+            )
+            verify(bookingsDao, never()).replaceAllForSite(any(), any())
+        }
+
+    @Test
+    fun `given page 1 and upcoming date filter and no query, when fetchBookings, then delete matching and insert is called`(): Unit =
+        runBlocking {
+            // given
+            val site = SiteModel().apply { id = TEST_LOCAL_SITE_ID.value }
+            val dto = sampleBookingDto().copy(orderId = 0L) // avoid order fetch
+            val filters = BookingFilters(
+                dateRange = BookingsDateRangePresets.upcoming(clock)
+            )
+            whenever(
+                bookingsRestClient.fetchBookings(
+                    site,
+                    perPage = 25,
+                    page = 1,
+                    query = null,
+                    filters = filters,
+                    order = BookingsOrderOption.DESC
+                )
+            ).thenReturn(WooPayload(arrayOf(dto)))
             whenever(headersParser.getTotalPages(any())).thenReturn(null)
 
             // when
@@ -291,6 +377,49 @@ class BookingsStoreTest {
             // then
             assertThat(result.isError).isFalse()
             verify(bookingsDao).replaceAllForSite(any(), any())
+            verify(bookingsDao, never()).deleteForSiteWithDateRangeFilter(
+                any(),
+                any<BookingsFilterOption.DateRange>(),
+                any<List<Long>>()
+            )
+        }
+
+    @Test
+    fun `given page 1 with custom date range filter and no query, when fetchBookings, then only insertOrReplace is called`(): Unit =
+        runBlocking {
+            // given
+            val site = SiteModel().apply { id = TEST_LOCAL_SITE_ID.value }
+            val dto = sampleBookingDto().copy(orderId = 0L)
+            val filters = BookingFilters(
+                dateRange = BookingsFilterOption.DateRange(before = Instant.now(), after = Instant.now()),
+                customer = BookingsFilterOption.Customer(customerId = 1L, customerName = "name"),
+            )
+            whenever(
+                bookingsRestClient.fetchBookings(
+                    site,
+                    perPage = 25,
+                    page = 1,
+                    query = null,
+                    filters = filters,
+                    order = BookingsOrderOption.DESC
+                )
+            ).thenReturn(WooPayload(arrayOf(dto)))
+            whenever(headersParser.getTotalPages(any())).thenReturn(null)
+
+            // when
+            val result = sut.fetchBookings(
+                site = site,
+                perPage = 25,
+                page = 1,
+                query = null,
+                filters = filters,
+                order = BookingsOrderOption.DESC
+            )
+
+            // then
+            assertThat(result.isError).isFalse()
+            verify(bookingsDao).insertOrReplace(any<List<BookingEntity>>())
+            verify(bookingsDao, never()).replaceAllForSite(any(), any())
             verify(bookingsDao, never()).deleteForSiteWithDateRangeFilter(
                 any(),
                 any<BookingsFilterOption.DateRange>(),


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

<!-- Id number of the Linear issue this PR addresses, e.g., WOOMOB-373. -->

WOOMOB-1722

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

We had a small problem on Today/Upcoming tabs. If the booking displayed on one of those tabs would get deleted on the server, we wouldn't reflect that as the Booking would be cached locally and the app wouldn't delete it. 

This PR fixes it by making sure that we clear the table from the bookings that were not received in the first page load for both Today and Upcoming tabs. 

To do that, I extracted the creation of the Today/Upcoming `DateRange` filter so that I can create the same one in `BookingStore` and check if that's the one used. After that, the app will delete all the bookings that match the given `DateRange` filter and if the Booking ID is not in the newly loaded list. This was done that way to be the least destructive to the Bookings table, so we only clear the entities that are indeed unnecessary (most likely). 

### Test Steps
<!-- Describe how to test your changes. Include only what’s needed for the reviewer to validate the behavior.
For new features, outline the main user flow or goal rather than every tap or click — the reviewer should be able to complete the flow naturally.
If applicable, mention key devices, scenarios, or edge cases to verify. -->

1. Make sure you have some bookings in the Today and Upcoming tabs
2. Launch the app
3. Go to Today and load the bookings
4. Trash one of the booking from the Today tab via the web
5. Refresh the Today tab in the app
6. Verify the booking was removed

### Images/gif
<!-- Include before and after images or gifs when appropriate. -->


https://github.com/user-attachments/assets/51fe9cae-fe93-4d24-b0d8-21a91618cfd2



- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
