### PR TITLE
Remove redundant exception logging in currency symbol retrieval

### DIFF
--- a/libs/fluxc-plugin/src/main/kotlin/org/wordpress/android/fluxc/utils/WCCurrencyUtils.kt
+++ b/libs/fluxc-plugin/src/main/kotlin/org/wordpress/android/fluxc/utils/WCCurrencyUtils.kt
@@ -63,9 +63,11 @@ object WCCurrencyUtils {
     fun getLocalizedCurrencySymbolForCode(currencyCode: String, locale: Locale): String {
         return try {
             Currency.getInstance(currencyCode).getSymbol(locale)
-        } catch (e: IllegalArgumentException) {
-            AppLog.e(T.UTILS,
-                    "Error finding valid currency symbol for currency code [$currencyCode] in locale [$locale]", e)
+        } catch (_: IllegalArgumentException) {
+            AppLog.e(
+                T.UTILS,
+                "Error finding valid currency symbol for currency code [$currencyCode] in locale [$locale]"
+            )
             currencyCode
         }
     }


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

<!-- Id number of the Linear issue this PR addresses, e.g., WOOMOB-373. -->
Closes WOOMOB-1743

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
This removes redundant exception logging when converting a currency code to a currency symbol.
I checked the error, and it turns out the behavior is expected, but we were logging the exception unnecessarily. In some cases, we receive the currency code as `$` while we expect `USD`. When we try to convert the `$` to a currency symbol, it throws an exception because the value is already a symbol. I removed the exception logging to keep the logs cleaner, and since we already manually log the message `"Error finding valid currency symbol for currency code [$currencyCode] in locale [$locale]"`, that should be sufficient.

### Test Steps
<!-- Describe how to test your changes. Include only what’s needed for the reviewer to validate the behavior.
For new features, outline the main user flow or goal rather than every tap or click — the reviewer should be able to complete the flow naturally.
If applicable, mention key devices, scenarios, or edge cases to verify. -->
1. Open an order in the Android app.
2. Tap Create shipping label.
3. Select a package (manual entry or template).

### Images/gif
<!-- Include before and after images or gifs when appropriate. -->

- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
