### PR TITLE
[WOOMOB-1814] Extract WooPosBackButton component

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/common/composeui/component/WooPosBackButton.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/common/composeui/component/WooPosBackButton.kt
@@ -1,0 +1,43 @@
+package com.woocommerce.android.ui.woopos.common.composeui.component
+
+import androidx.compose.foundation.layout.size
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.unit.dp
+import com.woocommerce.android.R
+import com.woocommerce.android.ui.woopos.common.composeui.WooPosPreview
+import com.woocommerce.android.ui.woopos.common.composeui.designsystem.WooPosTheme
+
+@Composable
+fun WooPosBackButton(
+    modifier: Modifier = Modifier,
+    contentDescription: String = stringResource(R.string.woopos_toolbar_icon_content_description),
+    iconModifier: Modifier = Modifier.size(28.dp),
+    onClick: () -> Unit
+) {
+    IconButton(
+        onClick = onClick,
+        modifier = modifier.size(48.dp)
+    ) {
+        Icon(
+            imageVector = Icons.AutoMirrored.Filled.ArrowBack,
+            contentDescription = contentDescription,
+            tint = MaterialTheme.colorScheme.onSurface,
+            modifier = iconModifier
+        )
+    }
+}
+
+@WooPosPreview
+@Composable
+fun WooPosBackButtonPreview() {
+    WooPosTheme {
+        WooPosBackButton {}
+    }
+}

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/common/composeui/component/WooPosSearchInput.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/common/composeui/component/WooPosSearchInput.kt
@@ -17,7 +17,6 @@ import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.text.KeyboardActions
 import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material.icons.filled.Search
 import androidx.compose.material.icons.outlined.Cancel
 import androidx.compose.material3.Icon
@@ -126,21 +125,10 @@ private fun SearchInput(
         verticalAlignment = Alignment.CenterVertically,
         modifier = Modifier.fillMaxWidth()
     ) {
-        IconButton(
-            onClick = { onEvent(WooPosSearchUIEvent.Close) },
-            modifier = Modifier
-                .size(48.dp)
-                .padding(start = WooPosSpacing.Small.value.toAdaptivePadding())
-        ) {
-            Icon(
-                imageVector = Icons.AutoMirrored.Filled.ArrowBack,
-                contentDescription = stringResource(
-                    R.string.woopos_search_back_content_description
-                ),
-                tint = MaterialTheme.colorScheme.onSurface,
-                modifier = Modifier.size(28.dp)
-            )
-        }
+        WooPosBackButton(
+            modifier = Modifier.padding(start = WooPosSpacing.Small.value.toAdaptivePadding()),
+            contentDescription = stringResource(R.string.woopos_search_back_content_description)
+        ) { onEvent(WooPosSearchUIEvent.Close) }
 
         Spacer(modifier = Modifier.width(WooPosSpacing.Small.value))
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/common/composeui/component/WooPosToolbar.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/common/composeui/component/WooPosToolbar.kt
@@ -10,20 +10,13 @@ import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.statusBarsPadding
-import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.automirrored.filled.ArrowBack
-import androidx.compose.material3.Icon
-import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.constraintlayout.compose.ConstraintLayout
-import com.woocommerce.android.R
 import com.woocommerce.android.ui.woopos.common.composeui.WooPosPreview
 import com.woocommerce.android.ui.woopos.common.composeui.designsystem.WooPosSpacing
 import com.woocommerce.android.ui.woopos.common.composeui.designsystem.WooPosTheme
@@ -56,20 +49,9 @@ fun WooPosToolbar(
                 top.linkTo(parent.top)
             }
         ) {
-            IconButton(
-                onClick = { onBackClicked?.invoke() },
-                modifier = Modifier
-                    .size(48.dp)
-                    .padding(start = WooPosSpacing.Small.value.toAdaptivePadding())
-            ) {
-                Icon(
-                    imageVector = Icons.AutoMirrored.Filled.ArrowBack,
-                    contentDescription = stringResource(R.string.woopos_toolbar_icon_content_description),
-                    tint = MaterialTheme.colorScheme.onSurface,
-                    modifier = Modifier
-                        .size(28.dp)
-                )
-            }
+            WooPosBackButton(
+                modifier = Modifier.padding(start = WooPosSpacing.Small.value.toAdaptivePadding())
+            ) { onBackClicked?.invoke() }
         }
 
         val startPadding = WooPosSpacing.Small.value.toAdaptivePadding()

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/cart/WooPosCartScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/cart/WooPosCartScreen.kt
@@ -34,7 +34,6 @@ import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material.icons.filled.DeleteOutline
 import androidx.compose.material.icons.outlined.AddShoppingCart
 import androidx.compose.material.icons.outlined.Delete
@@ -77,6 +76,7 @@ import com.woocommerce.android.R
 import com.woocommerce.android.extensions.isNotNullOrEmpty
 import com.woocommerce.android.ui.woopos.common.composeui.WooPosPreview
 import com.woocommerce.android.ui.woopos.common.composeui.component.ShadowType
+import com.woocommerce.android.ui.woopos.common.composeui.component.WooPosBackButton
 import com.woocommerce.android.ui.woopos.common.composeui.component.WooPosButton
 import com.woocommerce.android.ui.woopos.common.composeui.component.WooPosButtonState
 import com.woocommerce.android.ui.woopos.common.composeui.component.WooPosCard
@@ -361,25 +361,18 @@ private fun CartToolbar(
             enter = fadeIn(animationSpec = tween(300)) + expandHorizontally(),
             exit = fadeOut(animationSpec = tween(300)) + shrinkHorizontally()
         ) {
-            IconButton(
-                onClick = { onBackClicked() },
+            WooPosBackButton(
                 modifier = Modifier
                     .constrainAs(backButton) {
                         start.linkTo(parent.start)
                         centerVerticallyTo(parent)
                     }
-                    .size(48.dp)
-                    .padding(start = WooPosSpacing.Small.value.toAdaptivePadding())
-            ) {
-                Icon(
-                    imageVector = Icons.AutoMirrored.Filled.ArrowBack,
-                    contentDescription = stringResource(R.string.woopos_cart_back_content_description),
-                    tint = MaterialTheme.colorScheme.onSurface,
-                    modifier = Modifier
-                        .size(iconSize)
-                        .offset(y = 4.dp)
-                )
-            }
+                    .padding(start = WooPosSpacing.Small.value.toAdaptivePadding()),
+                contentDescription = stringResource(R.string.woopos_cart_back_content_description),
+                iconModifier = Modifier
+                    .size(iconSize)
+                    .offset(y = 4.dp)
+            ) { onBackClicked() }
         }
 
         WooPosText(

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/items/WooPosItemsToolbar.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/items/WooPosItemsToolbar.kt
@@ -7,14 +7,10 @@ import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.heightIn
-import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.lazy.LazyRow
 import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material.icons.filled.Add
-import androidx.compose.material3.Icon
-import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.remember
@@ -26,6 +22,7 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import com.woocommerce.android.R
 import com.woocommerce.android.ui.woopos.common.composeui.WooPosPreview
+import com.woocommerce.android.ui.woopos.common.composeui.component.WooPosBackButton
 import com.woocommerce.android.ui.woopos.common.composeui.component.WooPosCircularIconButton
 import com.woocommerce.android.ui.woopos.common.composeui.component.WooPosSearchInput
 import com.woocommerce.android.ui.woopos.common.composeui.component.WooPosSearchInputState
@@ -77,20 +74,7 @@ fun WooPosItemsToolbar(
                     verticalAlignment = Alignment.CenterVertically
                 ) {
                     Spacer(modifier = Modifier.width(WooPosSpacing.XSmall.value.toAdaptivePadding()))
-                    IconButton(
-                        onClick = { onBackClicked() },
-                        modifier = Modifier
-                            .size(48.dp)
-                    ) {
-                        Icon(
-                            imageVector = Icons.AutoMirrored.Filled.ArrowBack,
-                            contentDescription = stringResource(R.string.woopos_toolbar_icon_content_description),
-                            tint = MaterialTheme.colorScheme.onSurface,
-                            modifier = Modifier
-                                .size(28.dp)
-                        )
-                    }
-
+                    WooPosBackButton { onBackClicked() }
                     Spacer(modifier = Modifier.width(WooPosSpacing.XSmall.value.toAdaptivePadding()))
 
                     TabsRow(


### PR DESCRIPTION
WOOMOB-1814

### Description

Extracts duplicated back button code from 4 WooPos files into a reusable `WooPosBackButton` component. This reduces code duplication and ensures consistent styling across all back buttons in WooPos.

The new component is located in `common/composeui/component/WooPosBackButton.kt` and provides:
- Standard 48dp touch target with 28dp icon
- Consistent `ArrowBack` icon with proper tint
- Customizable modifier, content description, and icon modifier

### Test Steps

1. Open WooPos
2. Navigate to screens that show back buttons (Cart, Search, Variations)
3. Verify back buttons appear and function correctly
4. Test RTL layout to ensure arrow mirrors correctly

### Images/gif

N/A - No visual changes, refactoring only.

- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.