### PR TITLE
[WOOMOB-1808] - Ensure a valid date range filter for booking is applied 

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/bookings/filter/datetime/DateTimeFilterPage.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/bookings/filter/datetime/DateTimeFilterPage.kt
@@ -75,12 +75,13 @@ fun DateTimeFilterPage(
 
     Scaffold(
         snackbarHost = { SnackbarHost(snackbarHostState) }
-    ) {
+    ) { innerPadding ->
         Column(
             modifier = Modifier
                 .background(MaterialTheme.colorScheme.background)
                 .verticalScroll(rememberScrollState())
-                .fillMaxSize(),
+                .fillMaxSize()
+                .padding(innerPadding),
             verticalArrangement = Arrangement.Top
         ) {
             DateTimeSection(

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/bookings/filter/datetime/DateTimeFilterPage.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/bookings/filter/datetime/DateTimeFilterPage.kt
@@ -16,14 +16,25 @@ import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.SnackbarHost
+import androidx.compose.material3.SnackbarHostState
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.livedata.observeAsState
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.unit.dp
 import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
+import androidx.lifecycle.LiveData
+import androidx.lifecycle.MutableLiveData
+import androidx.lifecycle.Observer
+import androidx.lifecycle.compose.LocalLifecycleOwner
 import com.woocommerce.android.R
 import com.woocommerce.android.ui.bookings.compose.BookingLabel
 import com.woocommerce.android.ui.bookings.compose.BookingSectionHeader
@@ -31,6 +42,9 @@ import com.woocommerce.android.ui.compose.component.DatePickerDialog
 import com.woocommerce.android.ui.compose.component.TimePickerDialog
 import com.woocommerce.android.ui.compose.preview.LightDarkThemePreviews
 import com.woocommerce.android.ui.compose.theme.WooTheme
+import com.woocommerce.android.viewmodel.MultiLiveEvent.Event
+import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.ShowSnackbar
+import kotlinx.coroutines.launch
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.bookings.BookingsFilterOption
 import java.time.LocalDateTime
 import java.time.format.DateTimeFormatter
@@ -47,34 +61,43 @@ fun DateTimeFilterRoute(
     }
 
     val state by viewModel.uiState.observeAsState()
-    state?.let { DateTimeFilterPage(it) }
+    state?.let { DateTimeFilterPage(it, viewModel.event) }
 }
 
 @Composable
 fun DateTimeFilterPage(
-    state: DateTimeFilterUiState
+    state: DateTimeFilterUiState,
+    event: LiveData<Event>,
 ) {
-    Column(
-        modifier = Modifier
-            .background(MaterialTheme.colorScheme.background)
-            .verticalScroll(rememberScrollState())
-            .fillMaxSize(),
-        verticalArrangement = Arrangement.Top
+    val snackbarHostState = remember { SnackbarHostState() }
+
+    HandleEvents(event, snackbarHostState)
+
+    Scaffold(
+        snackbarHost = { SnackbarHost(snackbarHostState) }
     ) {
-        DateTimeSection(
-            header = R.string.bookings_filter_date_from,
-            dateReadable = state.formattedFromDate,
-            timeReadable = state.formattedFromTime,
-            onDateClick = { state.onDateClick(DateBoundary.FROM) },
-            onTimeClick = { state.onTimeClick(DateBoundary.FROM) },
-        )
-        DateTimeSection(
-            header = R.string.bookings_filter_date_to,
-            dateReadable = state.formattedToDate,
-            timeReadable = state.formattedToTime,
-            onDateClick = { state.onDateClick(DateBoundary.TO) },
-            onTimeClick = { state.onTimeClick(DateBoundary.TO) },
-        )
+        Column(
+            modifier = Modifier
+                .background(MaterialTheme.colorScheme.background)
+                .verticalScroll(rememberScrollState())
+                .fillMaxSize(),
+            verticalArrangement = Arrangement.Top
+        ) {
+            DateTimeSection(
+                header = R.string.bookings_filter_date_from,
+                dateReadable = state.formattedFromDate,
+                timeReadable = state.formattedFromTime,
+                onDateClick = { state.onDateClick(DateBoundary.FROM) },
+                onTimeClick = { state.onTimeClick(DateBoundary.FROM) },
+            )
+            DateTimeSection(
+                header = R.string.bookings_filter_date_to,
+                dateReadable = state.formattedToDate,
+                timeReadable = state.formattedToTime,
+                onDateClick = { state.onDateClick(DateBoundary.TO) },
+                onTimeClick = { state.onTimeClick(DateBoundary.TO) },
+            )
+        }
     }
 
     // Render dialogs at the top level so state is controlled by the ViewModel
@@ -102,6 +125,27 @@ fun DateTimeFilterPage(
                 )
             }
         }
+    }
+}
+
+@Composable
+private fun HandleEvents(event: LiveData<Event>, snackbarHostState: SnackbarHostState) {
+    val lifecycleOwner = LocalLifecycleOwner.current
+    val context = LocalContext.current
+    val coroutineScope = rememberCoroutineScope()
+
+    DisposableEffect(event, lifecycleOwner) {
+        val observer = Observer { event: Event ->
+            when (event) {
+                is ShowSnackbar -> coroutineScope.launch {
+                    snackbarHostState.showSnackbar(context.getString(event.message))
+                }
+            }
+        }
+
+        event.observe(lifecycleOwner, observer)
+
+        onDispose { event.removeObserver(observer) }
     }
 }
 
@@ -180,7 +224,8 @@ private fun DateTimeFilterPagePreview() {
                     .format(later),
                 formattedToTime = DateTimeFormatter.ofLocalizedTime(FormatStyle.SHORT)
                     .format(later),
-            )
+            ),
+            event = MutableLiveData()
         )
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/bookings/filter/datetime/DateTimeFilterViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/bookings/filter/datetime/DateTimeFilterViewModel.kt
@@ -172,7 +172,7 @@ class DateTimeFilterViewModel @AssistedInject constructor(
                     val to = current.toDateTime
                     if (to != null && newDateTime.isAfter(to)) {
                         // If the new FROM is after TO, swap them
-                        triggerEvent(MultiLiveEvent.Event.ShowSnackbar(R.string.booing_filter_date_time_swap_info))
+                        triggerEvent(MultiLiveEvent.Event.ShowSnackbar(R.string.booking_filter_date_time_swap_info))
                         current.copyWithDates(
                             fromDate = to,
                             toDate = newDateTime,
@@ -190,7 +190,7 @@ class DateTimeFilterViewModel @AssistedInject constructor(
                     val from = current.fromDateTime
                     if (from != null && newDateTime.isBefore(from)) {
                         // If the new TO is before FROM, swap them
-                        triggerEvent(MultiLiveEvent.Event.ShowSnackbar(R.string.booing_filter_date_time_swap_info))
+                        triggerEvent(MultiLiveEvent.Event.ShowSnackbar(R.string.booking_filter_date_time_swap_info))
                         current.copyWithDates(
                             fromDate = newDateTime,
                             toDate = from,

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/bookings/filter/datetime/DateTimeFilterViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/bookings/filter/datetime/DateTimeFilterViewModel.kt
@@ -167,22 +167,36 @@ class DateTimeFilterViewModel @AssistedInject constructor(
             when (dateBoundary) {
                 DateBoundary.FROM -> {
                     val newDateTime = (current.fromDateTime ?: LocalDateTime.now(clock)).withTime(time)
-                    current.copy(
-                        fromDateTime = newDateTime,
-                        formattedFromTime = newDateTime.formatTime(),
-                        formattedFromDate = newDateTime.formatDate(),
-                        pickerDialogState = null,
-                    )
+                    val to = current.toDateTime
+                    if (to != null && newDateTime.isAfter(to)) {
+                        // If the new FROM is after TO, swap them
+                        current.copyWithDates(
+                            fromDate = to,
+                            toDate = newDateTime,
+                        )
+                    } else {
+                        current.copyWithDates(
+                            fromDate = newDateTime,
+                            toDate = to,
+                        )
+                    }
                 }
 
                 DateBoundary.TO -> {
                     val newDateTime = (current.toDateTime ?: LocalDateTime.now(clock)).withTime(time = time)
-                    current.copy(
-                        toDateTime = newDateTime,
-                        formattedToDate = newDateTime.formatDate(),
-                        formattedToTime = newDateTime.formatTime(),
-                        pickerDialogState = null,
-                    )
+                    val from = current.fromDateTime
+                    if (from != null && newDateTime.isBefore(from)) {
+                        // If the new TO is before FROM, swap them
+                        current.copyWithDates(
+                            fromDate = newDateTime,
+                            toDate = from,
+                        )
+                    } else {
+                        current.copyWithDates(
+                            fromDate = from,
+                            toDate = newDateTime,
+                        )
+                    }
                 }
             }
         }
@@ -195,6 +209,21 @@ class DateTimeFilterViewModel @AssistedInject constructor(
                 after = _uiState.value.fromDateTime?.atZone(zone)?.toInstant(),
                 before = _uiState.value.toDateTime?.atZone(zone)?.toInstant(),
             )
+        )
+    }
+
+    private fun DateTimeFilterUiState.copyWithDates(
+        fromDate: LocalDateTime?,
+        toDate: LocalDateTime?
+    ): DateTimeFilterUiState {
+        return copy(
+            fromDateTime = fromDate,
+            formattedFromDate = fromDate.formatDate(),
+            formattedFromTime = fromDate.formatTime(),
+            toDateTime = toDate,
+            formattedToDate = toDate.formatDate(),
+            formattedToTime = toDate.formatTime(),
+            pickerDialogState = null,
         )
     }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/bookings/filter/datetime/DateTimeFilterViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/bookings/filter/datetime/DateTimeFilterViewModel.kt
@@ -3,9 +3,11 @@ package com.woocommerce.android.ui.bookings.filter.datetime
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.asLiveData
+import com.woocommerce.android.R
 import com.woocommerce.android.ui.bookings.filter.datetime.PickerDialogState.DateDialog
 import com.woocommerce.android.ui.bookings.filter.datetime.PickerDialogState.TimeDialog
 import com.woocommerce.android.ui.compose.component.Time
+import com.woocommerce.android.viewmodel.MultiLiveEvent
 import com.woocommerce.android.viewmodel.ScopedViewModel
 import dagger.assisted.Assisted
 import dagger.assisted.AssistedFactory
@@ -170,6 +172,7 @@ class DateTimeFilterViewModel @AssistedInject constructor(
                     val to = current.toDateTime
                     if (to != null && newDateTime.isAfter(to)) {
                         // If the new FROM is after TO, swap them
+                        triggerEvent(MultiLiveEvent.Event.ShowSnackbar(R.string.booing_filter_date_time_swap_info))
                         current.copyWithDates(
                             fromDate = to,
                             toDate = newDateTime,
@@ -187,6 +190,7 @@ class DateTimeFilterViewModel @AssistedInject constructor(
                     val from = current.fromDateTime
                     if (from != null && newDateTime.isBefore(from)) {
                         // If the new TO is before FROM, swap them
+                        triggerEvent(MultiLiveEvent.Event.ShowSnackbar(R.string.booing_filter_date_time_swap_info))
                         current.copyWithDates(
                             fromDate = newDateTime,
                             toDate = from,

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -4238,7 +4238,7 @@
     <string name="bookings_filter_date_to">TO</string>
     <string name="bookings_filter_time_picker_title">Select time</string>
     <string name="bookings_filter_date_filter_value">Custom range</string>
-    <string name="booing_filter_date_time_swap_info">Your time selection was reordered to create a valid range</string>
+    <string name="booking_filter_date_time_swap_info">Your time selection was reordered to create a valid range</string>
 
     <!-- Booking details view-->
     <string name="booking_details_title">Booking #%s</string>

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -4238,6 +4238,7 @@
     <string name="bookings_filter_date_to">TO</string>
     <string name="bookings_filter_time_picker_title">Select time</string>
     <string name="bookings_filter_date_filter_value">Custom range</string>
+    <string name="booing_filter_date_time_swap_info">Your time selection was reordered to create a valid range</string>
 
     <!-- Booking details view-->
     <string name="booking_details_title">Booking #%s</string>

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/bookings/filter/datetime/DateTimeFilterViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/bookings/filter/datetime/DateTimeFilterViewModelTest.kt
@@ -308,7 +308,7 @@ class DateTimeFilterViewModelTest : BaseUnitTest() {
             assertThat(state.pickerDialogState).isNull()
 
             val event = vm.event.getOrAwaitValue()
-            assertThat(event).isEqualTo(MultiLiveEvent.Event.ShowSnackbar(R.string.booing_filter_date_time_swap_info))
+            assertThat(event).isEqualTo(MultiLiveEvent.Event.ShowSnackbar(R.string.booking_filter_date_time_swap_info))
         }
 
     @Test
@@ -343,7 +343,7 @@ class DateTimeFilterViewModelTest : BaseUnitTest() {
             assertThat(state.formattedToTime).isNotEmpty()
             assertThat(state.pickerDialogState).isNull()
             val event = vm.event.getOrAwaitValue()
-            assertThat(event).isEqualTo(MultiLiveEvent.Event.ShowSnackbar(R.string.booing_filter_date_time_swap_info))
+            assertThat(event).isEqualTo(MultiLiveEvent.Event.ShowSnackbar(R.string.booking_filter_date_time_swap_info))
         }
 
     @Test

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/bookings/filter/datetime/DateTimeFilterViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/bookings/filter/datetime/DateTimeFilterViewModelTest.kt
@@ -1,9 +1,11 @@
 package com.woocommerce.android.ui.bookings.filter.datetime
 
 import androidx.lifecycle.SavedStateHandle
+import com.woocommerce.android.R
 import com.woocommerce.android.ui.compose.component.Time
 import com.woocommerce.android.util.getOrAwaitValue
 import com.woocommerce.android.viewmodel.BaseUnitTest
+import com.woocommerce.android.viewmodel.MultiLiveEvent
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.Test
@@ -304,6 +306,9 @@ class DateTimeFilterViewModelTest : BaseUnitTest() {
             assertThat(state.formattedToDate).isNotEmpty()
             assertThat(state.formattedToTime).isNotEmpty()
             assertThat(state.pickerDialogState).isNull()
+
+            val event = vm.event.getOrAwaitValue()
+            assertThat(event).isEqualTo(MultiLiveEvent.Event.ShowSnackbar(R.string.booing_filter_date_time_swap_info))
         }
 
     @Test
@@ -337,6 +342,8 @@ class DateTimeFilterViewModelTest : BaseUnitTest() {
             assertThat(state.formattedToDate).isNotEmpty()
             assertThat(state.formattedToTime).isNotEmpty()
             assertThat(state.pickerDialogState).isNull()
+            val event = vm.event.getOrAwaitValue()
+            assertThat(event).isEqualTo(MultiLiveEvent.Event.ShowSnackbar(R.string.booing_filter_date_time_swap_info))
         }
 
     @Test

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/bookings/filter/datetime/DateTimeFilterViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/bookings/filter/datetime/DateTimeFilterViewModelTest.kt
@@ -274,6 +274,72 @@ class DateTimeFilterViewModelTest : BaseUnitTest() {
     }
 
     @Test
+    fun `given FROM and TO exist, when selecting a FROM time after TO, then values are swapped`() =
+        testBlocking {
+            // Given
+            val fromInitial = LocalDateTime.of(2025, 1, 1, 9, 0)
+            val toInitial = LocalDateTime.of(2025, 1, 1, 10, 0)
+            val vm = DateTimeFilterViewModel(
+                onTypeFilterChanged = { _ -> },
+                savedStateHandle = SavedStateHandle(),
+                clock = clock,
+                initialRange = BookingsFilterOption.DateRange(
+                    after = fromInitial.toInstant(ZoneOffset.UTC),
+                    before = toInitial.toInstant(ZoneOffset.UTC)
+                )
+            )
+
+            // When: user opens FROM time dialog and selects a time after current TO (11:00)
+            vm.uiState.getOrAwaitValue()!!.onTimeClick(DateBoundary.FROM)
+            val timeDialog = vm.uiState.getOrAwaitValue()!!.pickerDialogState as PickerDialogState.TimeDialog
+            timeDialog.onTimeSelected(Time(11, 0))
+
+            // Then: the values are swapped so that FROM = previous TO (10:00) and TO = new 11:00
+            val state = vm.uiState.getOrAwaitValue()!!
+            assertThat(state.fromDateTime).isEqualTo(toInitial)
+            assertThat(state.toDateTime).isEqualTo(fromInitial.withHour(11).withMinute(0).withSecond(0).withNano(0))
+            // formatted strings should be present and dialog dismissed
+            assertThat(state.formattedFromDate).isNotEmpty()
+            assertThat(state.formattedFromTime).isNotEmpty()
+            assertThat(state.formattedToDate).isNotEmpty()
+            assertThat(state.formattedToTime).isNotEmpty()
+            assertThat(state.pickerDialogState).isNull()
+        }
+
+    @Test
+    fun `given FROM and TO exist, when selecting a TO time before FROM, then values are swapped`() =
+        testBlocking {
+            // Given
+            val fromInitial = LocalDateTime.of(2025, 1, 1, 9, 0)
+            val toInitial = LocalDateTime.of(2025, 1, 1, 10, 0)
+            val vm = DateTimeFilterViewModel(
+                onTypeFilterChanged = { _ -> },
+                savedStateHandle = SavedStateHandle(),
+                clock = clock,
+                initialRange = BookingsFilterOption.DateRange(
+                    after = fromInitial.toInstant(ZoneOffset.UTC),
+                    before = toInitial.toInstant(ZoneOffset.UTC)
+                )
+            )
+
+            // When: user opens TO time dialog and selects a time before current FROM (08:00)
+            vm.uiState.getOrAwaitValue()!!.onTimeClick(DateBoundary.TO)
+            val timeDialog = vm.uiState.getOrAwaitValue()!!.pickerDialogState as PickerDialogState.TimeDialog
+            timeDialog.onTimeSelected(Time(8, 0))
+
+            // Then: the values are swapped so that FROM = new 08:00 and TO = previous FROM (09:00)
+            val state = vm.uiState.getOrAwaitValue()!!
+            assertThat(state.fromDateTime).isEqualTo(fromInitial.withHour(8).withMinute(0).withSecond(0).withNano(0))
+            assertThat(state.toDateTime).isEqualTo(fromInitial)
+            // formatted strings should be present and dialog dismissed
+            assertThat(state.formattedFromDate).isNotEmpty()
+            assertThat(state.formattedFromTime).isNotEmpty()
+            assertThat(state.formattedToDate).isNotEmpty()
+            assertThat(state.formattedToTime).isNotEmpty()
+            assertThat(state.pickerDialogState).isNull()
+        }
+
+    @Test
     fun `given no FROM date, when onDateClick(TO), then DateDialog minDate is null`() = testBlocking {
         val vm = createVm()
 


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

<!-- Id number of the Linear issue this PR addresses, e.g., WOOMOB-373. -->

WOOMOB-1808

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

The Jetpack Compose `TimePicker` component doesn't have an option to restrict possible options to select. This means the user can select a time for TO/FROM dates that will create a invalid range. For example ,20/02/2025 19:00 - 20/02/2025 11:00). This can only happen if the day is the same, as we are already ensuring a wrong date can't be selected.

In order to fix that, we made a decision to swap the times when we detect an incorrect range. This PR does that. See this for more details p1763985643210389-slack-C09FHQNQERG

### Test Steps
<!-- Describe how to test your changes. Include only what’s needed for the reviewer to validate the behavior.
For new features, outline the main user flow or goal rather than every tap or click — the reviewer should be able to complete the flow naturally.
If applicable, mention key devices, scenarios, or edge cases to verify. -->

1. Open the Booking tab -> All
2. Open the Filters 
3. Open Date & Time
4. Select a FROM date
5. Select a TO date with the same day and an earlier time
6. Confirm the times were swapped and the message was shown

### Images/gif
<!-- Include before and after images or gifs when appropriate. -->


https://github.com/user-attachments/assets/6b46e977-1319-4f49-a61a-832acee83743

- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->