### PR TITLE
Fix shipping label rate mapping crash

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -10,6 +10,7 @@
 - [*][Woo POS] Fixed payment screen layout to properly position payment instructions text [https://github.com/woocommerce/woocommerce-android/pull/14991]
 - [*][Woo POS] Automatically scroll to newly created orders when returning to the Orders screen [https://github.com/woocommerce/woocommerce-android/pull/14990]
 - [Internal] Restore coupon drawable files mistakenly removed in previous release [https://github.com/woocommerce/woocommerce-android/pull/15005]
+- [*] Fixed a rare crash that occurred when displaying shipping rates for a selected package [https://github.com/woocommerce/woocommerce-android/pull/15032]
 
 23.7
 -----

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/rates/domain/WooShippingRatesDomainMapper.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/rates/domain/WooShippingRatesDomainMapper.kt
@@ -23,9 +23,14 @@ class WooShippingRatesDomainMapper @Inject constructor(
         rates: List<WooShippingRateOptionsModel>,
         currencyCode: String?
     ): Map<CarrierUI, List<ShippingRateUI>> {
-        return rates.groupBy { it.defaultRate.carrier }.map { entry ->
-            getCarrier(entry.key) to entry.value.map { getShippingRate(it, resourceProvider, currencyCode) }
-        }.toMap()
+        return rates.groupBy { it.defaultRate.carrier }
+            .map { (carrier, models) ->
+                getCarrier(carrier) to models
+                    .map { getShippingRate(it, resourceProvider, currencyCode) }
+                    .filter { it.options.containsKey(Option.DEFAULT) }
+            }
+            .filter { it.second.isNotEmpty() }
+            .toMap()
     }
 
     operator fun invoke(

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/rates/domain/WooShippingRatesDomainMapperTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/rates/domain/WooShippingRatesDomainMapperTest.kt
@@ -7,6 +7,7 @@ import com.woocommerce.android.util.CurrencyFormatter
 import com.woocommerce.android.viewmodel.BaseUnitTest
 import com.woocommerce.android.viewmodel.ResourceProvider
 import junit.framework.TestCase.assertEquals
+import junit.framework.TestCase.assertTrue
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import org.junit.Test
 import org.mockito.kotlin.any
@@ -276,6 +277,39 @@ class WooShippingRatesDomainMapperTest : BaseUnitTest() {
         val rate = mappedRates.values.first().first()
 
         assertEquals(3, rate.shippingRateIncludedOptions.size)
+    }
+
+    @Test
+    fun `when a shipping rate does not contain a DEFAULT option, then it is NOT included in the mapped rates`() {
+        val rates = listOf(
+            WooShippingRateOptionsModel(
+                mapOf(
+                    WooShippingRateModel.Option.SIGNATURE to WooShippingRateModel(
+                        carrier = WooShippingCarrier.DHL,
+                        deliveryDays = (1..10).random(),
+                        hasFreePickup = true,
+                        insurance = BigDecimal.TEN,
+                        isTrackingEnabled = true,
+                        carrierId = WooShippingCarrier.DHL.ordinal.toString(),
+                        option = WooShippingRateModel.Option.SIGNATURE,
+                        packageId = "1",
+                        price = BigDecimal.TEN,
+                        rateId = "1",
+                        shipmentId = "1",
+                        serviceId = "1",
+                        serviceName = "Signature Required",
+                        isSelected = true,
+                        listRate = BigDecimal.TEN,
+                        retailRate = BigDecimal.TEN,
+                        deliveryDate = null,
+                        isDeliveryDateGuaranteed = false
+                    )
+                )
+            )
+        )
+        val mappedRates = sut(rates, "USD")
+
+        assertTrue(mappedRates.isEmpty())
     }
 
     @Suppress("LongMethod")


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

<!-- Id number of the Linear issue this PR addresses, e.g., WOOMOB-373. -->
Closes WOOMOB-1807

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
Shipping rate responses sometimes do not contain a default option for a rate item. iOS and web already filter out these rates, but on Android this caused a crash.
This PR filters out shipping rate items that do not have a default option and prevents the crash.

### Test Steps
<!-- Describe how to test your changes. Include only what’s needed for the reviewer to validate the behavior.
For new features, outline the main user flow or goal rather than every tap or click — the reviewer should be able to complete the flow naturally.
If applicable, mention key devices, scenarios, or edge cases to verify. -->
1. Go to Orders.
2. Select an order that is eligible to create shipping labels. (I was only able to reproduce this on order 2218 on our testing site.)
3. Tap "Create shipping label" button.
4. Tap "Select a Package" button.
5. Enter values for a custom package. I used 11 x 11 x 2
6. If you still see the "DHL Express" tab, repeat steps 1-5 until you can reproduce it. I was always able to reproduce it within a maximum of 10 attempts.

### Images/gif
<!-- Include before and after images or gifs when appropriate. -->
|Happy case|Filtered out case|
|-|-|
|<img width="360" alt="happy" src="https://github.com/user-attachments/assets/dcd9c29f-de66-43cf-9b89-d40d0d72f47a" />|<img width="360" alt="no-default" src="https://github.com/user-attachments/assets/9f8cd4a8-60be-4bad-909c-06b749dbac22" />|


- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
