### PR TITLE
[WOOMOB-1824] Fix local catalog settings alignment and category name

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/settings/details/localcatalog/WooPosSettingsLocalCatalogScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/settings/details/localcatalog/WooPosSettingsLocalCatalogScreen.kt
@@ -206,8 +206,8 @@ private fun CellularDataSection(
                     checkedTrackColor = MaterialTheme.colorScheme.primaryContainer
                 ),
                 modifier = Modifier.constrainAs(switch) {
-                    bottom.linkTo(subtitle.bottom)
-                    top.linkTo(subtitle.top)
+                    top.linkTo(parent.top)
+                    bottom.linkTo(parent.bottom)
                     end.linkTo(parent.end)
                 }
             )
@@ -264,8 +264,8 @@ private fun ManualUpdateSection(
                     WooPosSettingsLocalCatalogState.CatalogStatus.RefreshingCatalog -> WooPosButtonState.LOADING
                 },
                 modifier = Modifier.constrainAs(button) {
-                    bottom.linkTo(subtitle.bottom)
-                    top.linkTo(subtitle.top)
+                    top.linkTo(parent.top)
+                    bottom.linkTo(parent.bottom)
                     end.linkTo(parent.end)
                 }
             )

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -3634,7 +3634,7 @@
     <string name="woopos_settings_hardware_barcode_scanners_subtitle">Configure barcode scanner settings</string>
     <string name="woopos_settings_hardware_card_readers">Card Readers</string>
     <string name="woopos_settings_hardware_card_readers_subtitle">Manage card reader connections</string>
-    <string name="woopos_settings_local_catalog_category">Catalog</string>
+    <string name="woopos_settings_local_catalog_category">Product catalog</string>
     <string name="woopos_settings_local_catalog_category_subtitle">Manage catalog settings</string>
     <string name="woopos_settings_local_catalog_status">Catalog Status</string>
     <string name="woopos_settings_local_catalog_size">Size</string>


### PR DESCRIPTION
WOOMOB-1824

### Description

Caused by the in the design

Fixes two issues in the `WooPosSettingsLocalCatalogScreen`:

1. **Toggle and button alignment**: The toggle switch and refresh button were aligned to the bottom of their rows. Now they are vertically centered.

2. **Category name**: Changed the local catalog category name from "Catalog" to "Product catalog".

### Test Steps

1. Open POS settings
2. Navigate to Product catalog section
3. Verify the toggle switch and refresh button are vertically centered in their rows
4. Verify the category is labeled "Product catalog"

### Images/gif

<img width="1006" height="627" alt="image" src="https://github.com/user-attachments/assets/91165930-6249-4c35-aafd-59a5a0640319" />


- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.