### PR TITLE
[Woo POS][Refunds] Display line item tax in POS refund dialog

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/orders/WooPosIssueRefundDialog.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/orders/WooPosIssueRefundDialog.kt
@@ -234,7 +234,7 @@ private fun LineItemRow(
         )
         Spacer(modifier = Modifier.size(WooPosSpacing.Medium.value))
         WooPosText(
-            text = "-",
+            text = item.lineTax,
             style = WooPosTypography.BodyMedium,
             color = MaterialTheme.colorScheme.onSurface,
             textAlign = TextAlign.End,
@@ -254,6 +254,7 @@ fun WooPosIssueRefundDialogPreview() {
             name = "Cup",
             qtyAndUnitPrice = "1 X $18.00",
             lineTotal = "$999999.00",
+            lineTax = "$1.80",
             imageUrl = null
         ),
         OrderDetailsViewState.Computed.Details.LineItemRow(
@@ -261,6 +262,7 @@ fun WooPosIssueRefundDialogPreview() {
             name = "Coffee Storage Container",
             qtyAndUnitPrice = "1 X $30.00",
             lineTotal = "$30.00",
+            lineTax = "$3.00",
             imageUrl = null
         ),
         OrderDetailsViewState.Computed.Details.LineItemRow(
@@ -268,6 +270,7 @@ fun WooPosIssueRefundDialogPreview() {
             name = "Enamel Mug",
             qtyAndUnitPrice = "1 X $8.50",
             lineTotal = "$8.50",
+            lineTax = "$0.85",
             imageUrl = null
         )
     )

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/orders/WooPosOrdersDetails.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/orders/WooPosOrdersDetails.kt
@@ -448,14 +448,22 @@ fun WooPosOrderDetailsPreview() {
         customerEmail = "johndoe@mail.com",
         status = PosOrderStatus(text = "Completed", colorKey = OrderStatusColorKey.COMPLETED),
         lineItems = listOf(
-            OrderDetailsViewState.Computed.Details.LineItemRow(101, "Cup", "2 x $4.00", "$8.00", null),
-            OrderDetailsViewState.Computed.Details.LineItemRow(102, "Coffee Container", "1 x $10.00", "$10.00", null),
+            OrderDetailsViewState.Computed.Details.LineItemRow(101, "Cup", "2 x $4.00", "$8.00", "$0.80", null),
+            OrderDetailsViewState.Computed.Details.LineItemRow(
+                102,
+                "Coffee Container",
+                "1 x $10.00",
+                "$10.00",
+                "$1.00",
+                null
+            ),
             OrderDetailsViewState.Computed.Details.LineItemRow(
                 103,
                 "A vey tasty coffee that incidentally has a very long name " +
                     "and should go over a few lines without overlapping anything",
                 "1 x $5.00",
                 "$5.00",
+                "$0.50",
                 null
             )
         ),

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/orders/WooPosOrdersScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/orders/WooPosOrdersScreen.kt
@@ -677,9 +677,16 @@ private fun sampleOrderDetails(
     customerEmail = "johndoe@mail.com",
     status = PosOrderStatus(text = "Completed", colorKey = OrderStatusColorKey.COMPLETED),
     lineItems = listOf(
-        OrderDetailsViewState.Computed.Details.LineItemRow(101, "Cup", "1 x $8.50", "$15.00", null),
-        OrderDetailsViewState.Computed.Details.LineItemRow(102, "Coffee Container", "1 x $10.00", "$8.00", null),
-        OrderDetailsViewState.Computed.Details.LineItemRow(103, "Paper Filter", "1 x $4.50", "$8.00", null)
+        OrderDetailsViewState.Computed.Details.LineItemRow(101, "Cup", "1 x $8.50", "$15.00", "$1.50", null),
+        OrderDetailsViewState.Computed.Details.LineItemRow(
+            102,
+            "Coffee Container",
+            "1 x $10.00",
+            "$8.00",
+            "$0.80",
+            null
+        ),
+        OrderDetailsViewState.Computed.Details.LineItemRow(103, "Paper Filter", "1 x $4.50", "$8.00", "$0.80", null)
     ),
     breakdown = OrderDetailsViewState.Computed.Details.TotalsBreakdown(
         products = "$23.00",

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/orders/WooPosOrdersState.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/orders/WooPosOrdersState.kt
@@ -52,6 +52,7 @@ sealed class OrderDetailsViewState {
                 val name: String,
                 val qtyAndUnitPrice: String,
                 val lineTotal: String,
+                val lineTax: String,
                 val imageUrl: String?,
             )
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/orders/WooPosOrdersViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/orders/WooPosOrdersViewModel.kt
@@ -643,6 +643,7 @@ class WooPosOrdersViewModel @Inject constructor(
                     name = item.name,
                     qtyAndUnitPrice = "${item.quantity.toInt()} x ${formatPrice(unitPrice)}",
                     lineTotal = formatPrice(item.total),
+                    lineTax = formatPrice(item.totalTax),
                     imageUrl = product?.firstImageUrl
                 )
             }


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

<!-- Id number of the Linear issue this PR addresses, e.g., WOOMOB-373. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

### Test Steps
<!-- Describe how to test your changes. Include only what’s needed for the reviewer to validate the behavior.
For new features, outline the main user flow or goal rather than every tap or click — the reviewer should be able to complete the flow naturally.
If applicable, mention key devices, scenarios, or edge cases to verify. -->

### Images/gif
<!-- Include before and after images or gifs when appropriate. -->

- [ ] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
