### PR TITLE
[Woo POS][Refunds] Issue Refund Dialog - refundable items

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/common/composeui/component/WooPosDialogWrapper.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/common/composeui/component/WooPosDialogWrapper.kt
@@ -9,6 +9,8 @@ import androidx.compose.animation.slideInVertically
 import androidx.compose.animation.slideOutVertically
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.navigationBarsPadding
+import androidx.compose.foundation.layout.statusBarsPadding
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.runtime.Composable
@@ -27,7 +29,12 @@ fun WooPosDialogWrapper(
     onDismissRequest: () -> Unit,
     content: @Composable AnimatedVisibilityScope.() -> Unit
 ) {
-    Box(contentAlignment = Alignment.Center) {
+    Box(
+        contentAlignment = Alignment.Center,
+        modifier = Modifier
+            .statusBarsPadding()
+            .navigationBarsPadding()
+    ) {
         WooPosBackgroundOverlay(
             modifier = Modifier
                 .semantics {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/orders/WooPosGetRefundableItems.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/orders/WooPosGetRefundableItems.kt
@@ -1,0 +1,98 @@
+package com.woocommerce.android.ui.woopos.orders
+
+import com.woocommerce.android.model.Order
+import com.woocommerce.android.model.Refund
+import com.woocommerce.android.util.CurrencyFormatter
+import com.woocommerce.android.util.PriceUtils
+import java.math.BigDecimal
+import javax.inject.Inject
+
+class WooPosGetRefundableItems @Inject constructor(
+    private val currencyFormatter: CurrencyFormatter
+) {
+    operator fun invoke(
+        order: Order,
+        refunds: List<Refund>
+    ): List<WooPosRefundableItem> {
+        // Step 1: Filter to only product items (exclude fees, shipping, etc.)
+        val productItems = order.items.filter { it.productId != 0L }
+
+        if (productItems.isEmpty()) {
+            return emptyList()
+        }
+
+        // Step 2: Calculate max refundable quantities
+        val maxQuantities: Map<Long, Float> = calculateMaxRefundQuantities(refunds, productItems)
+
+        // Step 3: Expand items into individual rows
+        return productItems.flatMap { orderItem ->
+            val maxQuantity = maxQuantities[orderItem.itemId]?.toInt() ?: 0
+
+            if (maxQuantity <= 0) {
+                emptyList()
+            } else {
+                val unitPrice = calculateUnitPrice(orderItem)
+                val unitTax = calculateUnitTax(orderItem)
+                val formattedUnitPrice = PriceUtils.formatCurrency(unitPrice, order.currency, currencyFormatter)
+                val formattedUnitTax = PriceUtils.formatCurrency(unitTax, order.currency, currencyFormatter)
+
+                (0 until maxQuantity).map { index ->
+                    WooPosRefundableItem(
+                        orderItemId = orderItem.itemId,
+                        productId = orderItem.productId,
+                        variationId = orderItem.variationId,
+                        name = orderItem.name,
+                        unitPrice = unitPrice,
+                        unitTax = unitTax,
+                        formattedUnitPrice = formattedUnitPrice,
+                        formattedUnitTax = formattedUnitTax,
+                        rowIndex = index
+                    )
+                }
+            }
+        }
+    }
+
+    /**
+     * Calculate remaining refundable quantities for each order item.
+     */
+    private fun calculateMaxRefundQuantities(
+        refunds: List<Refund>,
+        productItems: List<Order.Item>
+    ): Map<Long, Float> {
+        val allRefundedItems = refunds.flatMap { it.items }
+
+        return productItems.mapNotNull { orderItem ->
+            val refundedQuantity = allRefundedItems
+                .filter { refundedItem ->
+                    refundedItem.productId == orderItem.productId &&
+                        refundedItem.variationId == orderItem.variationId
+                }
+                .sumOf { it.quantity }
+
+            val remainingQuantity = orderItem.quantity - refundedQuantity
+
+            if (remainingQuantity > 0) {
+                orderItem.itemId to remainingQuantity
+            } else {
+                null
+            }
+        }.toMap()
+    }
+
+    private fun calculateUnitPrice(item: Order.Item): BigDecimal {
+        return if (item.quantity == 0f) {
+            item.total
+        } else {
+            item.total / item.quantity.toBigDecimal()
+        }
+    }
+
+    private fun calculateUnitTax(item: Order.Item): BigDecimal {
+        return if (item.quantity == 0f) {
+            item.totalTax
+        } else {
+            item.totalTax / item.quantity.toBigDecimal()
+        }
+    }
+}

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/orders/WooPosIssueRefundDialog.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/orders/WooPosIssueRefundDialog.kt
@@ -162,7 +162,7 @@ private fun RefundDialogContent(
     Column(modifier = Modifier.fillMaxSize()) {
         RefundDialogHeader(onDismissRequest = onDismissRequest)
 
-        ItemsHeaderRow(itemsLabel = state.itemsLabel)
+        ItemsHeaderRow(itemsCount = state.itemsCount)
 
         HorizontalDivider(
             modifier = Modifier.padding(horizontal = WooPosSpacing.XLarge.value),
@@ -235,7 +235,7 @@ private fun RefundDialogHeader(onDismissRequest: () -> Unit) {
 }
 
 @Composable
-private fun ItemsHeaderRow(itemsLabel: String) {
+private fun ItemsHeaderRow(itemsCount: Int) {
     val selectAllContentDescription = stringResource(R.string.order_refunds_items_select_all)
     Row(
         modifier = Modifier
@@ -259,12 +259,24 @@ private fun ItemsHeaderRow(itemsLabel: String) {
             )
         )
         Spacer(modifier = Modifier.width(WooPosSpacing.Large.value))
-        WooPosText(
-            text = itemsLabel,
-            style = WooPosTypography.Caption,
-            fontWeight = FontWeight.Bold,
-            color = WooPosTheme.colors.onSurfaceVariantHighest
-        )
+        Row {
+            WooPosText(
+                text = stringResource(R.string.woopos_orders_select_all_items),
+                style = WooPosTypography.Caption,
+                fontWeight = FontWeight.Bold,
+                color = WooPosTheme.colors.onSurfaceVariantHighest
+            )
+            WooPosText(
+                text = " ",
+                style = WooPosTypography.Caption
+            )
+            WooPosText(
+                text = stringResource(R.string.woopos_orders_items_selected_count, itemsCount),
+                style = WooPosTypography.Caption,
+                fontWeight = FontWeight.Normal,
+                color = WooPosTheme.colors.onSurfaceVariantLowest
+            )
+        }
     }
 }
 
@@ -366,7 +378,7 @@ fun WooPosIssueRefundDialogPreview() {
         orderNumber = "#123",
         currency = "USD",
         refundableItems = sampleItems,
-        itemsLabel = "SELECT ALL ITEMS (3 SELECTED)",
+        itemsCount = 3,
         subtotal = BigDecimal("57.00"),
         taxes = BigDecimal("5.65"),
         total = BigDecimal("62.65")

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/orders/WooPosIssueRefundDialog.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/orders/WooPosIssueRefundDialog.kt
@@ -1,6 +1,7 @@
 package com.woocommerce.android.ui.woopos.orders
 
 import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
@@ -17,11 +18,13 @@ import androidx.compose.material.icons.filled.Close
 import androidx.compose.material.icons.outlined.Inventory2
 import androidx.compose.material3.Checkbox
 import androidx.compose.material3.CheckboxDefaults
+import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
@@ -32,6 +35,8 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
+import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.woocommerce.android.R
 import com.woocommerce.android.ui.woopos.common.composeui.WooPosPreview
 import com.woocommerce.android.ui.woopos.common.composeui.component.WooPosButton
@@ -42,152 +47,255 @@ import com.woocommerce.android.ui.woopos.common.composeui.designsystem.WooPosCor
 import com.woocommerce.android.ui.woopos.common.composeui.designsystem.WooPosSpacing
 import com.woocommerce.android.ui.woopos.common.composeui.designsystem.WooPosTheme
 import com.woocommerce.android.ui.woopos.common.composeui.designsystem.WooPosTypography
+import java.math.BigDecimal
 
 private val COLUMN_WIDTH = 104.dp
 
 @Composable
 fun WooPosIssueRefundDialog(
-    isVisible: Boolean,
-    lineItems: List<OrderDetailsViewState.Computed.Details.LineItemRow>,
-    itemsSelectedLabel: String,
+    orderId: Long,
     onDismissRequest: () -> Unit,
     onContinue: () -> Unit
 ) {
-    val selectAllContentDescription = stringResource(R.string.order_refunds_items_select_all)
+    val viewModel: WooPosRefundViewModel = hiltViewModel<WooPosRefundViewModel, WooPosRefundViewModel.Factory> { factory ->
+        factory.create(orderId)
+    }
+    val state by viewModel.state.collectAsStateWithLifecycle()
 
     WooPosDialogWrapper(
-        isVisible = isVisible,
+        isVisible = true,
         dialogBackgroundContentDescription = stringResource(
             R.string.woopos_orders_issue_refund_content_description
         ),
         onDismissRequest = onDismissRequest
     ) {
-        Column(modifier = Modifier.fillMaxSize()) {
-            Row(
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .padding(WooPosSpacing.XLarge.value),
-                horizontalArrangement = Arrangement.SpaceBetween,
-                verticalAlignment = Alignment.CenterVertically
-            ) {
-                WooPosText(
-                    text = stringResource(R.string.woopos_orders_select_items_to_refund),
-                    style = WooPosTypography.Heading,
-                    fontWeight = FontWeight.Bold,
-                    color = MaterialTheme.colorScheme.onSurface
+        when (val currentState = state) {
+            is WooPosRefundState.Loading -> {
+                LoadingContent()
+            }
+            is WooPosRefundState.Content -> {
+                RefundDialogContent(
+                    state = currentState,
+                    onDismissRequest = onDismissRequest,
+                    onContinue = onContinue
                 )
-                IconButton(
-                    modifier = Modifier.size(48.dp),
-                    onClick = onDismissRequest,
-                ) {
-                    Icon(
-                        modifier = Modifier.size(32.dp),
-                        imageVector = Icons.Default.Close,
-                        contentDescription = stringResource(R.string.close),
-                        tint = MaterialTheme.colorScheme.onSurface
+            }
+            is WooPosRefundState.Error -> {
+                ErrorContent(
+                    message = currentState.message,
+                    onDismissRequest = onDismissRequest
+                )
+            }
+            is WooPosRefundState.NoRefundableItems -> {
+                NoItemsContent(onDismissRequest = onDismissRequest)
+            }
+        }
+    }
+}
+
+@Composable
+private fun LoadingContent() {
+    Box(
+        modifier = Modifier
+            .fillMaxSize()
+            .padding(WooPosSpacing.XLarge.value),
+        contentAlignment = Alignment.Center
+    ) {
+        CircularProgressIndicator()
+    }
+}
+
+@Composable
+private fun ErrorContent(
+    message: String,
+    onDismissRequest: () -> Unit
+) {
+    Column(
+        modifier = Modifier
+            .fillMaxSize()
+            .padding(WooPosSpacing.XLarge.value),
+        horizontalAlignment = Alignment.CenterHorizontally,
+        verticalArrangement = Arrangement.Center
+    ) {
+        WooPosText(
+            text = message,
+            style = WooPosTypography.BodyLarge,
+            color = MaterialTheme.colorScheme.error,
+            textAlign = TextAlign.Center
+        )
+        Spacer(modifier = Modifier.size(WooPosSpacing.Large.value))
+        WooPosButton(
+            text = stringResource(R.string.close),
+            onClick = onDismissRequest
+        )
+    }
+}
+
+@Composable
+private fun NoItemsContent(onDismissRequest: () -> Unit) {
+    Column(
+        modifier = Modifier
+            .fillMaxSize()
+            .padding(WooPosSpacing.XLarge.value),
+        horizontalAlignment = Alignment.CenterHorizontally,
+        verticalArrangement = Arrangement.Center
+    ) {
+        WooPosText(
+            text = "No items available for refund",
+            style = WooPosTypography.BodyLarge,
+            color = MaterialTheme.colorScheme.onSurface,
+            textAlign = TextAlign.Center
+        )
+        Spacer(modifier = Modifier.size(WooPosSpacing.Large.value))
+        WooPosButton(
+            text = stringResource(R.string.close),
+            onClick = onDismissRequest
+        )
+    }
+}
+
+@Composable
+private fun RefundDialogContent(
+    state: WooPosRefundState.Content,
+    onDismissRequest: () -> Unit,
+    onContinue: () -> Unit
+) {
+    Column(modifier = Modifier.fillMaxSize()) {
+        RefundDialogHeader(onDismissRequest = onDismissRequest)
+
+        ItemsHeaderRow(itemsLabel = state.itemsLabel)
+
+        HorizontalDivider(
+            modifier = Modifier.padding(horizontal = WooPosSpacing.XLarge.value),
+            color = WooPosTheme.colors.outlineVariant,
+            thickness = 0.25.dp
+        )
+
+        LazyColumn(
+            modifier = Modifier
+                .weight(1f)
+                .fillMaxWidth()
+                .padding(horizontal = WooPosSpacing.XLarge.value)
+                .padding(vertical = WooPosSpacing.Medium.value),
+            verticalArrangement = Arrangement.spacedBy(WooPosSpacing.Medium.value)
+        ) {
+            itemsIndexed(state.refundableItems) { index, item ->
+                RefundableItemRow(item = item)
+                if (index < state.refundableItems.lastIndex) {
+                    HorizontalDivider(
+                        color = WooPosTheme.colors.outlineVariant,
+                        thickness = 0.25.dp
                     )
                 }
             }
+        }
 
-            Row(
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .padding(horizontal = WooPosSpacing.XLarge.value)
-                    .padding(bottom = WooPosSpacing.Medium.value),
-                verticalAlignment = Alignment.CenterVertically
-            ) {
-                Row(
-                    modifier = Modifier.weight(1f),
-                    verticalAlignment = Alignment.CenterVertically,
-                    horizontalArrangement = Arrangement.spacedBy(WooPosSpacing.Large.value)
-                ) {
-                    Checkbox(
-                        checked = true,
-                        onCheckedChange = null,
-                        modifier = Modifier
-                            .size(32.dp)
-                            .semantics {
-                                contentDescription = selectAllContentDescription
-                            },
-                        colors = CheckboxDefaults.colors(
-                            checkedColor = MaterialTheme.colorScheme.primary,
-                            checkmarkColor = MaterialTheme.colorScheme.onPrimary
-                        )
-                    )
-                    WooPosText(
-                        text = itemsSelectedLabel,
-                        style = WooPosTypography.Caption,
-                        fontWeight = FontWeight.Bold,
-                        color = WooPosTheme.colors.onSurfaceVariantHighest
-                    )
-                }
-                WooPosText(
-                    modifier = Modifier.width(COLUMN_WIDTH),
-                    text = stringResource(R.string.woopos_orders_amount),
-                    style = WooPosTypography.Caption,
-                    fontWeight = FontWeight.Bold,
-                    color = WooPosTheme.colors.onSurfaceVariantHighest,
-                    textAlign = TextAlign.End,
-                    overflow = TextOverflow.Ellipsis
-                )
-                Spacer(modifier = Modifier.width(WooPosSpacing.Medium.value))
-                WooPosText(
-                    modifier = Modifier.width(COLUMN_WIDTH),
-                    text = stringResource(R.string.woopos_orders_tax),
-                    style = WooPosTypography.Caption,
-                    fontWeight = FontWeight.Bold,
-                    color = WooPosTheme.colors.onSurfaceVariantHighest,
-                    textAlign = TextAlign.End,
-                    overflow = TextOverflow.Ellipsis
-                )
-            }
+        HorizontalDivider(
+            modifier = Modifier.padding(horizontal = WooPosSpacing.XLarge.value),
+            color = WooPosTheme.colors.outlineVariant,
+            thickness = 0.25.dp
+        )
 
-            HorizontalDivider(
-                modifier = Modifier.padding(horizontal = WooPosSpacing.XLarge.value),
-                color = WooPosTheme.colors.outlineVariant,
-                thickness = 0.25.dp
-            )
+        WooPosButton(
+            text = stringResource(R.string.continue_button),
+            onClick = onContinue,
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(WooPosSpacing.XLarge.value)
+        )
+    }
+}
 
-            LazyColumn(
-                modifier = Modifier
-                    .weight(1f)
-                    .fillMaxWidth()
-                    .padding(horizontal = WooPosSpacing.XLarge.value)
-                    .padding(vertical = WooPosSpacing.Medium.value),
-                verticalArrangement = Arrangement.spacedBy(WooPosSpacing.Medium.value)
-            ) {
-                itemsIndexed(lineItems) { index, item ->
-                    LineItemRow(item = item)
-                    if (index < lineItems.lastIndex) {
-                        HorizontalDivider(
-                            color = WooPosTheme.colors.outlineVariant,
-                            thickness = 0.25.dp
-                        )
-                    }
-                }
-            }
-
-            HorizontalDivider(
-                modifier = Modifier.padding(horizontal = WooPosSpacing.XLarge.value),
-                color = WooPosTheme.colors.outlineVariant,
-                thickness = 0.25.dp
-            )
-
-            WooPosButton(
-                text = stringResource(R.string.continue_button),
-                onClick = onContinue,
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .padding(WooPosSpacing.XLarge.value)
+@Composable
+private fun RefundDialogHeader(onDismissRequest: () -> Unit) {
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(WooPosSpacing.XLarge.value),
+        horizontalArrangement = Arrangement.SpaceBetween,
+        verticalAlignment = Alignment.CenterVertically
+    ) {
+        WooPosText(
+            text = stringResource(R.string.woopos_orders_select_items_to_refund),
+            style = WooPosTypography.Heading,
+            fontWeight = FontWeight.Bold,
+            color = MaterialTheme.colorScheme.onSurface
+        )
+        IconButton(
+            modifier = Modifier.size(48.dp),
+            onClick = onDismissRequest,
+        ) {
+            Icon(
+                modifier = Modifier.size(32.dp),
+                imageVector = Icons.Default.Close,
+                contentDescription = stringResource(R.string.close),
+                tint = MaterialTheme.colorScheme.onSurface
             )
         }
     }
 }
 
 @Composable
-private fun LineItemRow(
-    item: OrderDetailsViewState.Computed.Details.LineItemRow
-) {
+private fun ItemsHeaderRow(itemsLabel: String) {
+    val selectAllContentDescription = stringResource(R.string.order_refunds_items_select_all)
+
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(horizontal = WooPosSpacing.XLarge.value)
+            .padding(bottom = WooPosSpacing.Medium.value),
+        verticalAlignment = Alignment.CenterVertically
+    ) {
+        Row(
+            modifier = Modifier.weight(1f),
+            verticalAlignment = Alignment.CenterVertically,
+            horizontalArrangement = Arrangement.spacedBy(WooPosSpacing.Large.value)
+        ) {
+            Checkbox(
+                checked = true,
+                onCheckedChange = null,
+                modifier = Modifier
+                    .size(32.dp)
+                    .semantics {
+                        contentDescription = selectAllContentDescription
+                    },
+                colors = CheckboxDefaults.colors(
+                    checkedColor = MaterialTheme.colorScheme.primary,
+                    checkmarkColor = MaterialTheme.colorScheme.onPrimary,
+                    disabledCheckedColor = MaterialTheme.colorScheme.primary
+                )
+            )
+            WooPosText(
+                text = itemsLabel,
+                style = WooPosTypography.Caption,
+                fontWeight = FontWeight.Bold,
+                color = WooPosTheme.colors.onSurfaceVariantHighest
+            )
+        }
+        WooPosText(
+            modifier = Modifier.width(COLUMN_WIDTH),
+            text = stringResource(R.string.woopos_orders_amount),
+            style = WooPosTypography.Caption,
+            fontWeight = FontWeight.Bold,
+            color = WooPosTheme.colors.onSurfaceVariantHighest,
+            textAlign = TextAlign.End,
+            overflow = TextOverflow.Ellipsis
+        )
+        Spacer(modifier = Modifier.width(WooPosSpacing.Medium.value))
+        WooPosText(
+            modifier = Modifier.width(COLUMN_WIDTH),
+            text = stringResource(R.string.woopos_orders_tax),
+            style = WooPosTypography.Caption,
+            fontWeight = FontWeight.Bold,
+            color = WooPosTheme.colors.onSurfaceVariantHighest,
+            textAlign = TextAlign.End,
+            overflow = TextOverflow.Ellipsis
+        )
+    }
+}
+
+@Composable
+private fun RefundableItemRow(item: WooPosRefundableItem) {
     Row(
         modifier = Modifier
             .fillMaxWidth()
@@ -204,7 +312,8 @@ private fun LineItemRow(
                 },
             colors = CheckboxDefaults.colors(
                 checkedColor = MaterialTheme.colorScheme.primary,
-                checkmarkColor = MaterialTheme.colorScheme.onPrimary
+                checkmarkColor = MaterialTheme.colorScheme.onPrimary,
+                disabledCheckedColor = MaterialTheme.colorScheme.primary
             )
         )
         Spacer(modifier = Modifier.size(WooPosSpacing.Large.value))
@@ -213,32 +322,23 @@ private fun LineItemRow(
             modifier = Modifier
                 .size(56.dp)
                 .clip(RoundedCornerShape(WooPosCornerRadius.Small.value)),
-            imageUrl = item.imageUrl,
+            imageUrl = null,
             placeholderIcon = Icons.Outlined.Inventory2,
             placeholderIconSize = 24.dp
         )
         Spacer(modifier = Modifier.size(WooPosSpacing.Medium.value))
 
-        Column(
-            modifier = Modifier.weight(1f),
-        ) {
-            WooPosText(
-                text = item.name,
-                style = WooPosTypography.BodyLarge,
-                fontWeight = FontWeight.Bold,
-                color = MaterialTheme.colorScheme.onSurface,
-                maxLines = 1,
-                overflow = TextOverflow.Ellipsis
-            )
-            WooPosText(
-                text = item.qtyAndUnitPrice,
-                style = WooPosTypography.BodyMedium,
-                color = WooPosTheme.colors.onSurfaceVariantHighest
-            )
-        }
+        WooPosText(
+            text = item.name,
+            style = WooPosTypography.BodyLarge,
+            fontWeight = FontWeight.Bold,
+            color = MaterialTheme.colorScheme.onSurface,
+            maxLines = 1,
+            overflow = TextOverflow.Ellipsis
+        )
 
         WooPosText(
-            text = item.lineTotal,
+            text = item.formattedUnitPrice,
             style = WooPosTypography.BodyMedium,
             color = MaterialTheme.colorScheme.onSurface,
             textAlign = TextAlign.End,
@@ -248,7 +348,7 @@ private fun LineItemRow(
         )
         Spacer(modifier = Modifier.size(WooPosSpacing.Medium.value))
         WooPosText(
-            text = "-",
+            text = item.formattedUnitTax,
             style = WooPosTypography.BodyMedium,
             color = MaterialTheme.colorScheme.onSurface,
             textAlign = TextAlign.End,
@@ -262,35 +362,56 @@ private fun LineItemRow(
 @WooPosPreview
 @Composable
 fun WooPosIssueRefundDialogPreview() {
-    val sampleLineItems = listOf(
-        OrderDetailsViewState.Computed.Details.LineItemRow(
-            id = 1,
+    val sampleItems = listOf(
+        WooPosRefundableItem(
+            orderItemId = 1,
+            productId = 100,
+            variationId = 0,
             name = "Cup",
-            qtyAndUnitPrice = "1 X $18.00",
-            lineTotal = "$999999.00",
-            imageUrl = null
+            unitPrice = BigDecimal("18.00"),
+            unitTax = BigDecimal("1.80"),
+            formattedUnitPrice = "$18.00",
+            formattedUnitTax = "$1.80",
+            rowIndex = 0
         ),
-        OrderDetailsViewState.Computed.Details.LineItemRow(
-            id = 2,
+        WooPosRefundableItem(
+            orderItemId = 2,
+            productId = 200,
+            variationId = 0,
             name = "Coffee Storage Container",
-            qtyAndUnitPrice = "1 X $30.00",
-            lineTotal = "$30.00",
-            imageUrl = null
+            unitPrice = BigDecimal("30.00"),
+            unitTax = BigDecimal("3.00"),
+            formattedUnitPrice = "$30.00",
+            formattedUnitTax = "$3.00",
+            rowIndex = 0
         ),
-        OrderDetailsViewState.Computed.Details.LineItemRow(
-            id = 3,
+        WooPosRefundableItem(
+            orderItemId = 3,
+            productId = 300,
+            variationId = 0,
             name = "Enamel Mug",
-            qtyAndUnitPrice = "1 X $8.50",
-            lineTotal = "$8.50",
-            imageUrl = null
+            unitPrice = BigDecimal("8.50"),
+            unitTax = BigDecimal("0.85"),
+            formattedUnitPrice = "$8.50",
+            formattedUnitTax = "$0.85",
+            rowIndex = 0
         )
     )
 
+    val state = WooPosRefundState.Content(
+        orderId = 123,
+        orderNumber = "#123",
+        currency = "USD",
+        refundableItems = sampleItems,
+        itemsLabel = "ITEMS (3)",
+        subtotal = BigDecimal("57.00"),
+        taxes = BigDecimal("5.65"),
+        total = BigDecimal("62.65")
+    )
+
     WooPosTheme {
-        WooPosIssueRefundDialog(
-            isVisible = true,
-            lineItems = sampleLineItems,
-            itemsSelectedLabel = "ITEMS (${sampleLineItems.size} SELECTED)",
+        RefundDialogContent(
+            state = state,
             onDismissRequest = {},
             onContinue = {}
         )

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/orders/WooPosIssueRefundDialog.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/orders/WooPosIssueRefundDialog.kt
@@ -10,7 +10,7 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.lazy.LazyColumn
-import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.lazy.itemsIndexed
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Close
@@ -26,6 +26,8 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.semantics.contentDescription
+import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.text.style.TextOverflow
@@ -41,6 +43,8 @@ import com.woocommerce.android.ui.woopos.common.composeui.designsystem.WooPosSpa
 import com.woocommerce.android.ui.woopos.common.composeui.designsystem.WooPosTheme
 import com.woocommerce.android.ui.woopos.common.composeui.designsystem.WooPosTypography
 
+private val COLUMN_WIDTH = 104.dp
+
 @Composable
 fun WooPosIssueRefundDialog(
     isVisible: Boolean,
@@ -49,6 +53,8 @@ fun WooPosIssueRefundDialog(
     onDismissRequest: () -> Unit,
     onContinue: () -> Unit
 ) {
+    val selectAllContentDescription = stringResource(R.string.order_refunds_items_select_all)
+
     WooPosDialogWrapper(
         isVisible = isVisible,
         dialogBackgroundContentDescription = stringResource(
@@ -98,7 +104,11 @@ fun WooPosIssueRefundDialog(
                     Checkbox(
                         checked = true,
                         onCheckedChange = null,
-                        modifier = Modifier.size(32.dp),
+                        modifier = Modifier
+                            .size(32.dp)
+                            .semantics {
+                                contentDescription = selectAllContentDescription
+                            },
                         colors = CheckboxDefaults.colors(
                             checkedColor = MaterialTheme.colorScheme.primary,
                             checkmarkColor = MaterialTheme.colorScheme.onPrimary
@@ -112,7 +122,7 @@ fun WooPosIssueRefundDialog(
                     )
                 }
                 WooPosText(
-                    modifier = Modifier.width(104.dp),
+                    modifier = Modifier.width(COLUMN_WIDTH),
                     text = stringResource(R.string.woopos_orders_amount),
                     style = WooPosTypography.Caption,
                     fontWeight = FontWeight.Bold,
@@ -122,7 +132,7 @@ fun WooPosIssueRefundDialog(
                 )
                 Spacer(modifier = Modifier.width(WooPosSpacing.Medium.value))
                 WooPosText(
-                    modifier = Modifier.width(104.dp),
+                    modifier = Modifier.width(COLUMN_WIDTH),
                     text = stringResource(R.string.woopos_orders_tax),
                     style = WooPosTypography.Caption,
                     fontWeight = FontWeight.Bold,
@@ -146,9 +156,9 @@ fun WooPosIssueRefundDialog(
                     .padding(vertical = WooPosSpacing.Medium.value),
                 verticalArrangement = Arrangement.spacedBy(WooPosSpacing.Medium.value)
             ) {
-                items(lineItems) { item ->
+                itemsIndexed(lineItems) { index, item ->
                     LineItemRow(item = item)
-                    if (lineItems.last() != item) {
+                    if (index < lineItems.lastIndex) {
                         HorizontalDivider(
                             color = WooPosTheme.colors.outlineVariant,
                             thickness = 0.25.dp
@@ -187,7 +197,11 @@ private fun LineItemRow(
         Checkbox(
             checked = true,
             onCheckedChange = null,
-            modifier = Modifier.size(32.dp),
+            modifier = Modifier
+                .size(32.dp)
+                .semantics {
+                    contentDescription = item.name
+                },
             colors = CheckboxDefaults.colors(
                 checkedColor = MaterialTheme.colorScheme.primary,
                 checkmarkColor = MaterialTheme.colorScheme.onPrimary
@@ -220,7 +234,7 @@ private fun LineItemRow(
             style = WooPosTypography.BodyMedium,
             color = MaterialTheme.colorScheme.onSurface,
             textAlign = TextAlign.End,
-            modifier = Modifier.width(104.dp),
+            modifier = Modifier.width(COLUMN_WIDTH),
             maxLines = 1,
             overflow = TextOverflow.Ellipsis
         )
@@ -230,7 +244,7 @@ private fun LineItemRow(
             style = WooPosTypography.BodyMedium,
             color = MaterialTheme.colorScheme.onSurface,
             textAlign = TextAlign.End,
-            modifier = Modifier.width(104.dp),
+            modifier = Modifier.width(COLUMN_WIDTH),
             maxLines = 1,
             overflow = TextOverflow.Ellipsis
         )

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/orders/WooPosIssueRefundDialog.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/orders/WooPosIssueRefundDialog.kt
@@ -49,17 +49,16 @@ import com.woocommerce.android.ui.woopos.common.composeui.designsystem.WooPosThe
 import com.woocommerce.android.ui.woopos.common.composeui.designsystem.WooPosTypography
 import java.math.BigDecimal
 
-private val COLUMN_WIDTH = 104.dp
-
 @Composable
 fun WooPosIssueRefundDialog(
     orderId: Long,
     onDismissRequest: () -> Unit,
     onContinue: () -> Unit
 ) {
-    val viewModel: WooPosRefundViewModel = hiltViewModel<WooPosRefundViewModel, WooPosRefundViewModel.Factory> { factory ->
-        factory.create(orderId)
-    }
+    val viewModel: WooPosRefundViewModel =
+        hiltViewModel<WooPosRefundViewModel, WooPosRefundViewModel.Factory> { factory ->
+            factory.create(orderId)
+        }
     val state by viewModel.state.collectAsStateWithLifecycle()
 
     WooPosDialogWrapper(
@@ -238,7 +237,6 @@ private fun RefundDialogHeader(onDismissRequest: () -> Unit) {
 @Composable
 private fun ItemsHeaderRow(itemsLabel: String) {
     val selectAllContentDescription = stringResource(R.string.order_refunds_items_select_all)
-
     Row(
         modifier = Modifier
             .fillMaxWidth()
@@ -246,50 +244,26 @@ private fun ItemsHeaderRow(itemsLabel: String) {
             .padding(bottom = WooPosSpacing.Medium.value),
         verticalAlignment = Alignment.CenterVertically
     ) {
-        Row(
-            modifier = Modifier.weight(1f),
-            verticalAlignment = Alignment.CenterVertically,
-            horizontalArrangement = Arrangement.spacedBy(WooPosSpacing.Large.value)
-        ) {
-            Checkbox(
-                checked = true,
-                onCheckedChange = null,
-                modifier = Modifier
-                    .size(32.dp)
-                    .semantics {
-                        contentDescription = selectAllContentDescription
-                    },
-                colors = CheckboxDefaults.colors(
-                    checkedColor = MaterialTheme.colorScheme.primary,
-                    checkmarkColor = MaterialTheme.colorScheme.onPrimary,
-                    disabledCheckedColor = MaterialTheme.colorScheme.primary
-                )
+        Checkbox(
+            checked = true,
+            onCheckedChange = null,
+            modifier = Modifier
+                .size(32.dp)
+                .semantics {
+                    contentDescription = selectAllContentDescription
+                },
+            colors = CheckboxDefaults.colors(
+                checkedColor = MaterialTheme.colorScheme.primary,
+                checkmarkColor = MaterialTheme.colorScheme.onPrimary,
+                disabledCheckedColor = MaterialTheme.colorScheme.primary
             )
-            WooPosText(
-                text = itemsLabel,
-                style = WooPosTypography.Caption,
-                fontWeight = FontWeight.Bold,
-                color = WooPosTheme.colors.onSurfaceVariantHighest
-            )
-        }
-        WooPosText(
-            modifier = Modifier.width(COLUMN_WIDTH),
-            text = stringResource(R.string.woopos_orders_amount),
-            style = WooPosTypography.Caption,
-            fontWeight = FontWeight.Bold,
-            color = WooPosTheme.colors.onSurfaceVariantHighest,
-            textAlign = TextAlign.End,
-            overflow = TextOverflow.Ellipsis
         )
-        Spacer(modifier = Modifier.width(WooPosSpacing.Medium.value))
+        Spacer(modifier = Modifier.width(WooPosSpacing.Large.value))
         WooPosText(
-            modifier = Modifier.width(COLUMN_WIDTH),
-            text = stringResource(R.string.woopos_orders_tax),
+            text = itemsLabel,
             style = WooPosTypography.Caption,
             fontWeight = FontWeight.Bold,
-            color = WooPosTheme.colors.onSurfaceVariantHighest,
-            textAlign = TextAlign.End,
-            overflow = TextOverflow.Ellipsis
+            color = WooPosTheme.colors.onSurfaceVariantHighest
         )
     }
 }
@@ -340,31 +314,11 @@ private fun RefundableItemRow(item: WooPosRefundableItem) {
                 overflow = TextOverflow.Ellipsis
             )
             WooPosText(
-                text = "1",
+                text = item.formattedUnitPrice,
                 style = WooPosTypography.BodyMedium,
                 color = WooPosTheme.colors.onSurfaceVariantHighest
             )
         }
-
-        WooPosText(
-            text = item.formattedUnitPrice,
-            style = WooPosTypography.BodyMedium,
-            color = MaterialTheme.colorScheme.onSurface,
-            textAlign = TextAlign.End,
-            modifier = Modifier.width(COLUMN_WIDTH),
-            maxLines = 1,
-            overflow = TextOverflow.Ellipsis
-        )
-        Spacer(modifier = Modifier.size(WooPosSpacing.Medium.value))
-        WooPosText(
-            text = item.formattedUnitTax,
-            style = WooPosTypography.BodyMedium,
-            color = MaterialTheme.colorScheme.onSurface,
-            textAlign = TextAlign.End,
-            modifier = Modifier.width(COLUMN_WIDTH),
-            maxLines = 1,
-            overflow = TextOverflow.Ellipsis
-        )
     }
 }
 
@@ -412,7 +366,7 @@ fun WooPosIssueRefundDialogPreview() {
         orderNumber = "#123",
         currency = "USD",
         refundableItems = sampleItems,
-        itemsLabel = "ITEMS (3)",
+        itemsLabel = "SELECT ALL ITEMS (3 SELECTED)",
         subtotal = BigDecimal("57.00"),
         taxes = BigDecimal("5.65"),
         total = BigDecimal("62.65")

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/orders/WooPosIssueRefundDialog.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/orders/WooPosIssueRefundDialog.kt
@@ -328,14 +328,23 @@ private fun RefundableItemRow(item: WooPosRefundableItem) {
         )
         Spacer(modifier = Modifier.size(WooPosSpacing.Medium.value))
 
-        WooPosText(
-            text = item.name,
-            style = WooPosTypography.BodyLarge,
-            fontWeight = FontWeight.Bold,
-            color = MaterialTheme.colorScheme.onSurface,
-            maxLines = 1,
-            overflow = TextOverflow.Ellipsis
-        )
+        Column(
+            modifier = Modifier.weight(1f),
+        ) {
+            WooPosText(
+                text = item.name,
+                style = WooPosTypography.BodyLarge,
+                fontWeight = FontWeight.Bold,
+                color = MaterialTheme.colorScheme.onSurface,
+                maxLines = 1,
+                overflow = TextOverflow.Ellipsis
+            )
+            WooPosText(
+                text = "1",
+                style = WooPosTypography.BodyMedium,
+                color = WooPosTheme.colors.onSurfaceVariantHighest
+            )
+        }
 
         WooPosText(
             text = item.formattedUnitPrice,

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/orders/WooPosIssueRefundDialog.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/orders/WooPosIssueRefundDialog.kt
@@ -1,24 +1,42 @@
 package com.woocommerce.android.ui.woopos.orders
 
+import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Close
+import androidx.compose.material.icons.outlined.Inventory2
+import androidx.compose.material3.Checkbox
+import androidx.compose.material3.CheckboxDefaults
+import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.dp
 import com.woocommerce.android.R
 import com.woocommerce.android.ui.woopos.common.composeui.WooPosPreview
+import com.woocommerce.android.ui.woopos.common.composeui.component.WooPosButton
 import com.woocommerce.android.ui.woopos.common.composeui.component.WooPosDialogWrapper
+import com.woocommerce.android.ui.woopos.common.composeui.component.WooPosItemImage
 import com.woocommerce.android.ui.woopos.common.composeui.component.WooPosText
+import com.woocommerce.android.ui.woopos.common.composeui.designsystem.WooPosCornerRadius
 import com.woocommerce.android.ui.woopos.common.composeui.designsystem.WooPosSpacing
 import com.woocommerce.android.ui.woopos.common.composeui.designsystem.WooPosTheme
 import com.woocommerce.android.ui.woopos.common.composeui.designsystem.WooPosTypography
@@ -26,8 +44,10 @@ import com.woocommerce.android.ui.woopos.common.composeui.designsystem.WooPosTyp
 @Composable
 fun WooPosIssueRefundDialog(
     isVisible: Boolean,
-    orderId: Long,
-    onDismissRequest: () -> Unit
+    lineItems: List<OrderDetailsViewState.Computed.Details.LineItemRow>,
+    itemsSelectedLabel: String,
+    onDismissRequest: () -> Unit,
+    onContinue: () -> Unit
 ) {
     WooPosDialogWrapper(
         isVisible = isVisible,
@@ -36,53 +56,229 @@ fun WooPosIssueRefundDialog(
         ),
         onDismissRequest = onDismissRequest
     ) {
-        Column(
-            modifier = Modifier
-                .fillMaxWidth()
-                .padding(WooPosSpacing.Large.value),
-            horizontalAlignment = Alignment.CenterHorizontally
-        ) {
-            IconButton(
-                onClick = onDismissRequest,
-                modifier = Modifier.align(Alignment.End)
+        Column(modifier = Modifier.fillMaxSize()) {
+            Row(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(WooPosSpacing.XLarge.value),
+                horizontalArrangement = Arrangement.SpaceBetween,
+                verticalAlignment = Alignment.CenterVertically
             ) {
-                Icon(
-                    imageVector = Icons.Default.Close,
-                    contentDescription = stringResource(R.string.close),
-                    tint = MaterialTheme.colorScheme.onSurface
+                WooPosText(
+                    text = stringResource(R.string.woopos_orders_select_items_to_refund),
+                    style = WooPosTypography.Heading,
+                    fontWeight = FontWeight.Bold,
+                    color = MaterialTheme.colorScheme.onSurface
+                )
+                IconButton(
+                    modifier = Modifier.size(48.dp),
+                    onClick = onDismissRequest,
+                ) {
+                    Icon(
+                        modifier = Modifier.size(32.dp),
+                        imageVector = Icons.Default.Close,
+                        contentDescription = stringResource(R.string.close),
+                        tint = MaterialTheme.colorScheme.onSurface
+                    )
+                }
+            }
+
+            Row(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(horizontal = WooPosSpacing.XLarge.value)
+                    .padding(bottom = WooPosSpacing.Medium.value),
+                verticalAlignment = Alignment.CenterVertically
+            ) {
+                Row(
+                    modifier = Modifier.weight(1f),
+                    verticalAlignment = Alignment.CenterVertically,
+                    horizontalArrangement = Arrangement.spacedBy(WooPosSpacing.Large.value)
+                ) {
+                    Checkbox(
+                        checked = true,
+                        onCheckedChange = null,
+                        modifier = Modifier.size(32.dp),
+                        colors = CheckboxDefaults.colors(
+                            checkedColor = MaterialTheme.colorScheme.primary,
+                            checkmarkColor = MaterialTheme.colorScheme.onPrimary
+                        )
+                    )
+                    WooPosText(
+                        text = itemsSelectedLabel,
+                        style = WooPosTypography.Caption,
+                        fontWeight = FontWeight.Bold,
+                        color = WooPosTheme.colors.onSurfaceVariantHighest
+                    )
+                }
+                WooPosText(
+                    modifier = Modifier.width(104.dp),
+                    text = stringResource(R.string.woopos_orders_amount),
+                    style = WooPosTypography.Caption,
+                    fontWeight = FontWeight.Bold,
+                    color = WooPosTheme.colors.onSurfaceVariantHighest,
+                    textAlign = TextAlign.End,
+                    overflow = TextOverflow.Ellipsis
+                )
+                Spacer(modifier = Modifier.width(WooPosSpacing.Medium.value))
+                WooPosText(
+                    modifier = Modifier.width(104.dp),
+                    text = stringResource(R.string.woopos_orders_tax),
+                    style = WooPosTypography.Caption,
+                    fontWeight = FontWeight.Bold,
+                    color = WooPosTheme.colors.onSurfaceVariantHighest,
+                    textAlign = TextAlign.End,
+                    overflow = TextOverflow.Ellipsis
                 )
             }
 
-            Spacer(Modifier.height(WooPosSpacing.Medium.value))
-
-            WooPosText(
-                text = stringResource(R.string.orderdetail_issue_refund_button),
-                style = WooPosTypography.Heading,
-                fontWeight = FontWeight.Bold,
-                color = MaterialTheme.colorScheme.onSurface
+            HorizontalDivider(
+                modifier = Modifier.padding(horizontal = WooPosSpacing.XLarge.value),
+                color = WooPosTheme.colors.outlineVariant,
+                thickness = 0.25.dp
             )
 
-            Spacer(Modifier.height(WooPosSpacing.Large.value))
+            LazyColumn(
+                modifier = Modifier
+                    .weight(1f)
+                    .fillMaxWidth()
+                    .padding(horizontal = WooPosSpacing.XLarge.value)
+                    .padding(vertical = WooPosSpacing.Medium.value),
+                verticalArrangement = Arrangement.spacedBy(WooPosSpacing.Medium.value)
+            ) {
+                items(lineItems) { item ->
+                    LineItemRow(item = item)
+                    if (lineItems.last() != item) {
+                        HorizontalDivider(
+                            color = WooPosTheme.colors.outlineVariant,
+                            thickness = 0.25.dp
+                        )
+                    }
+                }
+            }
 
+            HorizontalDivider(
+                modifier = Modifier.padding(horizontal = WooPosSpacing.XLarge.value),
+                color = WooPosTheme.colors.outlineVariant,
+                thickness = 0.25.dp
+            )
+
+            WooPosButton(
+                text = stringResource(R.string.continue_button),
+                onClick = onContinue,
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(WooPosSpacing.XLarge.value)
+            )
+        }
+    }
+}
+
+@Composable
+private fun LineItemRow(
+    item: OrderDetailsViewState.Computed.Details.LineItemRow
+) {
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(vertical = WooPosSpacing.XSmall.value),
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        Checkbox(
+            checked = true,
+            onCheckedChange = null,
+            modifier = Modifier.size(32.dp),
+            colors = CheckboxDefaults.colors(
+                checkedColor = MaterialTheme.colorScheme.primary,
+                checkmarkColor = MaterialTheme.colorScheme.onPrimary
+            )
+        )
+        Spacer(modifier = Modifier.size(WooPosSpacing.Large.value))
+
+        WooPosItemImage(
+            modifier = Modifier
+                .size(56.dp)
+                .clip(RoundedCornerShape(WooPosCornerRadius.Small.value)),
+            imageUrl = item.imageUrl,
+            placeholderIcon = Icons.Outlined.Inventory2,
+            placeholderIconSize = 24.dp
+        )
+        Spacer(modifier = Modifier.size(WooPosSpacing.Medium.value))
+
+        Column(
+            modifier = Modifier.weight(1f),
+        ) {
             WooPosText(
-                text = "Refund flow coming soon for order #$orderId",
+                text = item.name,
+                style = WooPosTypography.BodyLarge,
+                fontWeight = FontWeight.Bold,
+                color = MaterialTheme.colorScheme.onSurface,
+                maxLines = 1,
+                overflow = TextOverflow.Ellipsis
+            )
+            WooPosText(
+                text = item.qtyAndUnitPrice,
                 style = WooPosTypography.BodyMedium,
                 color = WooPosTheme.colors.onSurfaceVariantHighest
             )
-
-            Spacer(Modifier.height(WooPosSpacing.Large.value))
         }
+
+        WooPosText(
+            text = item.lineTotal,
+            style = WooPosTypography.BodyMedium,
+            color = MaterialTheme.colorScheme.onSurface,
+            textAlign = TextAlign.End,
+            modifier = Modifier.width(104.dp),
+            maxLines = 1,
+            overflow = TextOverflow.Ellipsis
+        )
+        Spacer(modifier = Modifier.size(WooPosSpacing.Medium.value))
+        WooPosText(
+            text = "-",
+            style = WooPosTypography.BodyMedium,
+            color = MaterialTheme.colorScheme.onSurface,
+            textAlign = TextAlign.End,
+            modifier = Modifier.width(104.dp),
+            maxLines = 1,
+            overflow = TextOverflow.Ellipsis
+        )
     }
 }
 
 @WooPosPreview
 @Composable
 fun WooPosIssueRefundDialogPreview() {
+    val sampleLineItems = listOf(
+        OrderDetailsViewState.Computed.Details.LineItemRow(
+            id = 1,
+            name = "Cup",
+            qtyAndUnitPrice = "1 X $18.00",
+            lineTotal = "$999999.00",
+            imageUrl = null
+        ),
+        OrderDetailsViewState.Computed.Details.LineItemRow(
+            id = 2,
+            name = "Coffee Storage Container",
+            qtyAndUnitPrice = "1 X $30.00",
+            lineTotal = "$30.00",
+            imageUrl = null
+        ),
+        OrderDetailsViewState.Computed.Details.LineItemRow(
+            id = 3,
+            name = "Enamel Mug",
+            qtyAndUnitPrice = "1 X $8.50",
+            lineTotal = "$8.50",
+            imageUrl = null
+        )
+    )
+
     WooPosTheme {
         WooPosIssueRefundDialog(
             isVisible = true,
-            orderId = 123L,
-            onDismissRequest = {}
+            lineItems = sampleLineItems,
+            itemsSelectedLabel = "ITEMS (${sampleLineItems.size} SELECTED)",
+            onDismissRequest = {},
+            onContinue = {}
         )
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/orders/WooPosIssueRefundDialog.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/orders/WooPosIssueRefundDialog.kt
@@ -219,15 +219,23 @@ private fun LineItemRow(
         )
         Spacer(modifier = Modifier.size(WooPosSpacing.Medium.value))
 
-        WooPosText(
-            text = item.name,
-            style = WooPosTypography.BodyLarge,
-            fontWeight = FontWeight.Bold,
-            color = MaterialTheme.colorScheme.onSurface,
-            maxLines = 1,
-            overflow = TextOverflow.Ellipsis,
-            modifier = Modifier.weight(1f)
-        )
+        Column(
+            modifier = Modifier.weight(1f),
+        ) {
+            WooPosText(
+                text = item.name,
+                style = WooPosTypography.BodyLarge,
+                fontWeight = FontWeight.Bold,
+                color = MaterialTheme.colorScheme.onSurface,
+                maxLines = 1,
+                overflow = TextOverflow.Ellipsis
+            )
+            WooPosText(
+                text = item.qtyAndUnitPrice,
+                style = WooPosTypography.BodyMedium,
+                color = WooPosTheme.colors.onSurfaceVariantHighest
+            )
+        }
 
         WooPosText(
             text = item.lineTotal,
@@ -258,18 +266,21 @@ fun WooPosIssueRefundDialogPreview() {
         OrderDetailsViewState.Computed.Details.LineItemRow(
             id = 1,
             name = "Cup",
+            qtyAndUnitPrice = "1 X $18.00",
             lineTotal = "$999999.00",
             imageUrl = null
         ),
         OrderDetailsViewState.Computed.Details.LineItemRow(
             id = 2,
             name = "Coffee Storage Container",
+            qtyAndUnitPrice = "1 X $30.00",
             lineTotal = "$30.00",
             imageUrl = null
         ),
         OrderDetailsViewState.Computed.Details.LineItemRow(
             id = 3,
             name = "Enamel Mug",
+            qtyAndUnitPrice = "1 X $8.50",
             lineTotal = "$8.50",
             imageUrl = null
         )

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/orders/WooPosIssueRefundDialog.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/orders/WooPosIssueRefundDialog.kt
@@ -205,23 +205,15 @@ private fun LineItemRow(
         )
         Spacer(modifier = Modifier.size(WooPosSpacing.Medium.value))
 
-        Column(
-            modifier = Modifier.weight(1f),
-        ) {
-            WooPosText(
-                text = item.name,
-                style = WooPosTypography.BodyLarge,
-                fontWeight = FontWeight.Bold,
-                color = MaterialTheme.colorScheme.onSurface,
-                maxLines = 1,
-                overflow = TextOverflow.Ellipsis
-            )
-            WooPosText(
-                text = item.qtyAndUnitPrice,
-                style = WooPosTypography.BodyMedium,
-                color = WooPosTheme.colors.onSurfaceVariantHighest
-            )
-        }
+        WooPosText(
+            text = item.name,
+            style = WooPosTypography.BodyLarge,
+            fontWeight = FontWeight.Bold,
+            color = MaterialTheme.colorScheme.onSurface,
+            maxLines = 1,
+            overflow = TextOverflow.Ellipsis,
+            modifier = Modifier.weight(1f)
+        )
 
         WooPosText(
             text = item.lineTotal,
@@ -252,21 +244,18 @@ fun WooPosIssueRefundDialogPreview() {
         OrderDetailsViewState.Computed.Details.LineItemRow(
             id = 1,
             name = "Cup",
-            qtyAndUnitPrice = "1 X $18.00",
             lineTotal = "$999999.00",
             imageUrl = null
         ),
         OrderDetailsViewState.Computed.Details.LineItemRow(
             id = 2,
             name = "Coffee Storage Container",
-            qtyAndUnitPrice = "1 X $30.00",
             lineTotal = "$30.00",
             imageUrl = null
         ),
         OrderDetailsViewState.Computed.Details.LineItemRow(
             id = 3,
             name = "Enamel Mug",
-            qtyAndUnitPrice = "1 X $8.50",
             lineTotal = "$8.50",
             imageUrl = null
         )

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/orders/WooPosOrdersDataSource.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/orders/WooPosOrdersDataSource.kt
@@ -89,6 +89,15 @@ class WooPosOrdersDataSource @Inject constructor(
             }
         }
 
+    suspend fun getOrderById(orderId: Long): Result<Order> {
+        val cached = ordersCache.getAll().firstOrNull { it.id == orderId }
+        if (cached != null) {
+            return Result.success(cached)
+        }
+
+        return refreshOrderById(orderId)
+    }
+
     suspend fun refreshOrderById(orderId: Long): Result<Order> {
         val site = selectedSite.get()
         val payload = restClient.fetchSingleOrder(site, orderId)

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/orders/WooPosOrdersDetails.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/orders/WooPosOrdersDetails.kt
@@ -173,14 +173,13 @@ private fun OrdersProducts(lineItems: List<OrderDetailsViewState.Computed.Detail
 }
 
 @Composable
-@Suppress("DestructuringDeclarationWithTooManyEntries")
 private fun OrderProductItem(row: OrderDetailsViewState.Computed.Details.LineItemRow) {
     ConstraintLayout(
         modifier = Modifier
             .fillMaxWidth()
             .padding(vertical = WooPosSpacing.Small.value)
     ) {
-        val (image, nameText, qtyText, totalText) = createRefs()
+        val (image, nameText, totalText) = createRefs()
 
         OrderLineItemImage(
             imageUrl = row.imageUrl,
@@ -197,18 +196,6 @@ private fun OrderProductItem(row: OrderDetailsViewState.Computed.Details.LineIte
             modifier = Modifier.constrainAs(nameText) {
                 top.linkTo(image.top)
                 start.linkTo(image.end, margin = WooPosSpacing.Medium.value)
-                end.linkTo(totalText.start, margin = WooPosSpacing.Small.value)
-                width = Dimension.fillToConstraints
-            }
-        )
-
-        WooPosText(
-            text = row.qtyAndUnitPrice,
-            style = WooPosTypography.BodyMedium,
-            color = WooPosTheme.colors.onSurfaceVariantHighest,
-            modifier = Modifier.constrainAs(qtyText) {
-                top.linkTo(nameText.bottom, margin = WooPosSpacing.XSmall.value)
-                start.linkTo(nameText.start)
                 end.linkTo(totalText.start, margin = WooPosSpacing.Small.value)
                 width = Dimension.fillToConstraints
             }
@@ -448,13 +435,12 @@ fun WooPosOrderDetailsPreview() {
         customerEmail = "johndoe@mail.com",
         status = PosOrderStatus(text = "Completed", colorKey = OrderStatusColorKey.COMPLETED),
         lineItems = listOf(
-            OrderDetailsViewState.Computed.Details.LineItemRow(101, "Cup", "2 x $4.00", "$8.00", null),
-            OrderDetailsViewState.Computed.Details.LineItemRow(102, "Coffee Container", "1 x $10.00", "$10.00", null),
+            OrderDetailsViewState.Computed.Details.LineItemRow(101, "Cup", "$8.00", null),
+            OrderDetailsViewState.Computed.Details.LineItemRow(102, "Coffee Container", "$10.00", null),
             OrderDetailsViewState.Computed.Details.LineItemRow(
                 103,
                 "A vey tasty coffee that incidentally has a very long name " +
                     "and should go over a few lines without overlapping anything",
-                "1 x $5.00",
                 "$5.00",
                 null
             )

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/orders/WooPosOrdersDetails.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/orders/WooPosOrdersDetails.kt
@@ -173,13 +173,14 @@ private fun OrdersProducts(lineItems: List<OrderDetailsViewState.Computed.Detail
 }
 
 @Composable
+@Suppress("DestructuringDeclarationWithTooManyEntries")
 private fun OrderProductItem(row: OrderDetailsViewState.Computed.Details.LineItemRow) {
     ConstraintLayout(
         modifier = Modifier
             .fillMaxWidth()
             .padding(vertical = WooPosSpacing.Small.value)
     ) {
-        val (image, nameText, totalText) = createRefs()
+        val (image, nameText, qtyText, totalText) = createRefs()
 
         OrderLineItemImage(
             imageUrl = row.imageUrl,
@@ -196,6 +197,18 @@ private fun OrderProductItem(row: OrderDetailsViewState.Computed.Details.LineIte
             modifier = Modifier.constrainAs(nameText) {
                 top.linkTo(image.top)
                 start.linkTo(image.end, margin = WooPosSpacing.Medium.value)
+                end.linkTo(totalText.start, margin = WooPosSpacing.Small.value)
+                width = Dimension.fillToConstraints
+            }
+        )
+
+        WooPosText(
+            text = row.qtyAndUnitPrice,
+            style = WooPosTypography.BodyMedium,
+            color = WooPosTheme.colors.onSurfaceVariantHighest,
+            modifier = Modifier.constrainAs(qtyText) {
+                top.linkTo(nameText.bottom, margin = WooPosSpacing.XSmall.value)
+                start.linkTo(nameText.start)
                 end.linkTo(totalText.start, margin = WooPosSpacing.Small.value)
                 width = Dimension.fillToConstraints
             }
@@ -435,12 +448,13 @@ fun WooPosOrderDetailsPreview() {
         customerEmail = "johndoe@mail.com",
         status = PosOrderStatus(text = "Completed", colorKey = OrderStatusColorKey.COMPLETED),
         lineItems = listOf(
-            OrderDetailsViewState.Computed.Details.LineItemRow(101, "Cup", "$8.00", null),
-            OrderDetailsViewState.Computed.Details.LineItemRow(102, "Coffee Container", "$10.00", null),
+            OrderDetailsViewState.Computed.Details.LineItemRow(101, "Cup", "2 x $4.00", "$8.00", null),
+            OrderDetailsViewState.Computed.Details.LineItemRow(102, "Coffee Container", "1 x $10.00", "$10.00", null),
             OrderDetailsViewState.Computed.Details.LineItemRow(
                 103,
                 "A vey tasty coffee that incidentally has a very long name " +
                     "and should go over a few lines without overlapping anything",
+                "1 x $5.00",
                 "$5.00",
                 null
             )

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/orders/WooPosOrdersScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/orders/WooPosOrdersScreen.kt
@@ -172,9 +172,7 @@ private fun WooPosOrdersScreen(
             when (val dialogState = state.dialogState) {
                 is WooPosOrdersState.Content.DialogState.IssueRefund -> {
                     WooPosIssueRefundDialog(
-                        isVisible = true,
-                        lineItems = state.selectedDetails.lineItems,
-                        itemsSelectedLabel = dialogState.itemsSelectedLabel,
+                        orderId = dialogState.orderId,
                         onDismissRequest = onIssueRefundDialogDismissed,
                         onContinue = onIssueRefundDialogDismissed
                     )

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/orders/WooPosOrdersScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/orders/WooPosOrdersScreen.kt
@@ -677,9 +677,9 @@ private fun sampleOrderDetails(
     customerEmail = "johndoe@mail.com",
     status = PosOrderStatus(text = "Completed", colorKey = OrderStatusColorKey.COMPLETED),
     lineItems = listOf(
-        OrderDetailsViewState.Computed.Details.LineItemRow(101, "Cup", "$15.00", null),
-        OrderDetailsViewState.Computed.Details.LineItemRow(102, "Coffee Container", "$8.00", null),
-        OrderDetailsViewState.Computed.Details.LineItemRow(103, "Paper Filter", "$8.00", null)
+        OrderDetailsViewState.Computed.Details.LineItemRow(101, "Cup", "1 x $8.50", "$15.00", null),
+        OrderDetailsViewState.Computed.Details.LineItemRow(102, "Coffee Container", "1 x $10.00", "$8.00", null),
+        OrderDetailsViewState.Computed.Details.LineItemRow(103, "Paper Filter", "1 x $4.50", "$8.00", null)
     ),
     breakdown = OrderDetailsViewState.Computed.Details.TotalsBreakdown(
         products = "$23.00",

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/orders/WooPosOrdersScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/orders/WooPosOrdersScreen.kt
@@ -146,8 +146,7 @@ private fun WooPosOrdersScreen(
                 onSearchEvent = onSearchEvent,
                 onSearchErrorRetry = onSearchErrorRetry,
                 onEmailReceiptButtonClicked = onEmailReceiptButtonClicked,
-                onIssueRefundButtonClicked = onIssueRefundButtonClicked,
-                onIssueRefundDialogDismissed = onIssueRefundDialogDismissed
+                onIssueRefundButtonClicked = onIssueRefundButtonClicked
             )
 
             is WooPosOrdersState.Empty -> OrdersEmpty(
@@ -168,6 +167,21 @@ private fun WooPosOrdersScreen(
                 modifier = Modifier.fillMaxWidth()
             )
         }
+
+        if (state is WooPosOrdersState.Content) {
+            when (val dialogState = state.dialogState) {
+                is WooPosOrdersState.Content.DialogState.IssueRefund -> {
+                    WooPosIssueRefundDialog(
+                        isVisible = true,
+                        lineItems = state.selectedDetails.lineItems,
+                        itemsSelectedLabel = dialogState.itemsSelectedLabel,
+                        onDismissRequest = onIssueRefundDialogDismissed,
+                        onContinue = onIssueRefundDialogDismissed
+                    )
+                }
+                WooPosOrdersState.Content.DialogState.Hidden -> Unit
+            }
+        }
     }
 }
 
@@ -182,8 +196,7 @@ private fun OrdersContent(
     onSearchEvent: (WooPosSearchUIEvent) -> Unit,
     onSearchErrorRetry: () -> Unit,
     onEmailReceiptButtonClicked: (Long) -> Unit,
-    onIssueRefundButtonClicked: (Long) -> Unit,
-    onIssueRefundDialogDismissed: () -> Unit
+    onIssueRefundButtonClicked: (Long) -> Unit
 ) {
     Row(modifier = Modifier.fillMaxSize()) {
         OrdersListPane(
@@ -216,17 +229,6 @@ private fun OrdersContent(
                 onIssueRefundButtonClicked = onIssueRefundButtonClicked
             )
         }
-    }
-
-    when (val dialogState = state.dialogState) {
-        is WooPosOrdersState.Content.DialogState.IssueRefund -> {
-            WooPosIssueRefundDialog(
-                isVisible = true,
-                orderId = dialogState.orderId,
-                onDismissRequest = onIssueRefundDialogDismissed
-            )
-        }
-        WooPosOrdersState.Content.DialogState.Hidden -> Unit
     }
 }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/orders/WooPosOrdersScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/orders/WooPosOrdersScreen.kt
@@ -677,9 +677,9 @@ private fun sampleOrderDetails(
     customerEmail = "johndoe@mail.com",
     status = PosOrderStatus(text = "Completed", colorKey = OrderStatusColorKey.COMPLETED),
     lineItems = listOf(
-        OrderDetailsViewState.Computed.Details.LineItemRow(101, "Cup", "1 x $8.50", "$15.00", null),
-        OrderDetailsViewState.Computed.Details.LineItemRow(102, "Coffee Container", "1 x $10.00", "$8.00", null),
-        OrderDetailsViewState.Computed.Details.LineItemRow(103, "Paper Filter", "1 x $4.50", "$8.00", null)
+        OrderDetailsViewState.Computed.Details.LineItemRow(101, "Cup", "$15.00", null),
+        OrderDetailsViewState.Computed.Details.LineItemRow(102, "Coffee Container", "$8.00", null),
+        OrderDetailsViewState.Computed.Details.LineItemRow(103, "Paper Filter", "$8.00", null)
     ),
     breakdown = OrderDetailsViewState.Computed.Details.TotalsBreakdown(
         products = "$23.00",

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/orders/WooPosOrdersState.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/orders/WooPosOrdersState.kt
@@ -107,7 +107,10 @@ sealed class WooPosOrdersState {
 
         sealed class DialogState {
             data object Hidden : DialogState()
-            data class IssueRefund(val orderId: Long) : DialogState()
+            data class IssueRefund(
+                val orderId: Long,
+                val itemsSelectedLabel: String
+            ) : DialogState()
         }
     }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/orders/WooPosOrdersState.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/orders/WooPosOrdersState.kt
@@ -108,8 +108,7 @@ sealed class WooPosOrdersState {
         sealed class DialogState {
             data object Hidden : DialogState()
             data class IssueRefund(
-                val orderId: Long,
-                val itemsSelectedLabel: String
+                val orderId: Long
             ) : DialogState()
         }
     }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/orders/WooPosOrdersState.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/orders/WooPosOrdersState.kt
@@ -50,7 +50,6 @@ sealed class OrderDetailsViewState {
             data class LineItemRow(
                 val id: Long,
                 val name: String,
-                val qtyAndUnitPrice: String,
                 val lineTotal: String,
                 val imageUrl: String?,
             )

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/orders/WooPosOrdersState.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/orders/WooPosOrdersState.kt
@@ -50,6 +50,7 @@ sealed class OrderDetailsViewState {
             data class LineItemRow(
                 val id: Long,
                 val name: String,
+                val qtyAndUnitPrice: String,
                 val lineTotal: String,
                 val imageUrl: String?,
             )

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/orders/WooPosOrdersViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/orders/WooPosOrdersViewModel.kt
@@ -631,10 +631,17 @@ class WooPosOrdersViewModel @Inject constructor(
     ): List<OrderDetailsViewState.Computed.Details.LineItemRow> = coroutineScope {
         order.items.map { item ->
             async {
+                val unitPrice =
+                    if (item.quantity == 0f) {
+                        item.total
+                    } else {
+                        item.total / item.quantity.toBigDecimal()
+                    }
                 val product = getProductById(item.productId)
                 OrderDetailsViewState.Computed.Details.LineItemRow(
                     id = item.itemId,
                     name = item.name,
+                    qtyAndUnitPrice = "${item.quantity.toInt()} x ${formatPrice(unitPrice)}",
                     lineTotal = formatPrice(item.total),
                     imageUrl = product?.firstImageUrl
                 )

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/orders/WooPosOrdersViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/orders/WooPosOrdersViewModel.kt
@@ -194,8 +194,16 @@ class WooPosOrdersViewModel @Inject constructor(
 
     fun onIssueRefundButtonClicked(orderId: Long) {
         val currentState = _state.value as? WooPosOrdersState.Content ?: return
+        val itemsCount = currentState.selectedDetails.lineItems.size
+        val itemsSelectedLabel = resourceProvider.getString(
+            R.string.woopos_orders_items_selected,
+            itemsCount
+        )
         _state.value = currentState.copy(
-            dialogState = WooPosOrdersState.Content.DialogState.IssueRefund(orderId)
+            dialogState = WooPosOrdersState.Content.DialogState.IssueRefund(
+                orderId = orderId,
+                itemsSelectedLabel = itemsSelectedLabel
+            )
         )
     }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/orders/WooPosOrdersViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/orders/WooPosOrdersViewModel.kt
@@ -194,15 +194,9 @@ class WooPosOrdersViewModel @Inject constructor(
 
     fun onIssueRefundButtonClicked(orderId: Long) {
         val currentState = _state.value as? WooPosOrdersState.Content ?: return
-        val itemsCount = currentState.selectedDetails.lineItems.size
-        val itemsSelectedLabel = resourceProvider.getString(
-            R.string.woopos_orders_items_selected,
-            itemsCount
-        )
         _state.value = currentState.copy(
             dialogState = WooPosOrdersState.Content.DialogState.IssueRefund(
-                orderId = orderId,
-                itemsSelectedLabel = itemsSelectedLabel
+                orderId = orderId
             )
         )
     }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/orders/WooPosOrdersViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/orders/WooPosOrdersViewModel.kt
@@ -631,17 +631,10 @@ class WooPosOrdersViewModel @Inject constructor(
     ): List<OrderDetailsViewState.Computed.Details.LineItemRow> = coroutineScope {
         order.items.map { item ->
             async {
-                val unitPrice =
-                    if (item.quantity == 0f) {
-                        item.total
-                    } else {
-                        item.total / item.quantity.toBigDecimal()
-                    }
                 val product = getProductById(item.productId)
                 OrderDetailsViewState.Computed.Details.LineItemRow(
                     id = item.itemId,
                     name = item.name,
-                    qtyAndUnitPrice = "${item.quantity.toInt()} x ${formatPrice(unitPrice)}",
                     lineTotal = formatPrice(item.total),
                     imageUrl = product?.firstImageUrl
                 )

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/orders/WooPosRefundState.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/orders/WooPosRefundState.kt
@@ -1,0 +1,30 @@
+package com.woocommerce.android.ui.woopos.orders
+
+import androidx.compose.runtime.Immutable
+import java.math.BigDecimal
+
+@Immutable
+sealed class WooPosRefundState {
+    @Immutable
+    data object Loading : WooPosRefundState()
+
+    @Immutable
+    data class Content(
+        val orderId: Long,
+        val orderNumber: String,
+        val currency: String,
+        val refundableItems: List<WooPosRefundableItem>,
+        val itemsLabel: String,
+        val subtotal: BigDecimal,
+        val taxes: BigDecimal,
+        val total: BigDecimal
+    ) : WooPosRefundState()
+
+    @Immutable
+    data class Error(
+        val message: String
+    ) : WooPosRefundState()
+
+    @Immutable
+    data object NoRefundableItems : WooPosRefundState()
+}

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/orders/WooPosRefundState.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/orders/WooPosRefundState.kt
@@ -14,7 +14,7 @@ sealed class WooPosRefundState {
         val orderNumber: String,
         val currency: String,
         val refundableItems: List<WooPosRefundableItem>,
-        val itemsLabel: String,
+        val itemsCount: Int,
         val subtotal: BigDecimal,
         val taxes: BigDecimal,
         val total: BigDecimal

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/orders/WooPosRefundViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/orders/WooPosRefundViewModel.kt
@@ -1,0 +1,104 @@
+package com.woocommerce.android.ui.woopos.orders
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.woocommerce.android.R
+import com.woocommerce.android.model.Order
+import com.woocommerce.android.ui.woopos.common.data.WooPosRetrieveOrderRefunds
+import com.woocommerce.android.viewmodel.ResourceProvider
+import dagger.assisted.Assisted
+import dagger.assisted.AssistedFactory
+import dagger.assisted.AssistedInject
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.launch
+
+@HiltViewModel(assistedFactory = WooPosRefundViewModel.Factory::class)
+class WooPosRefundViewModel @AssistedInject constructor(
+    @Assisted private val orderId: Long,
+    private val ordersDataSource: WooPosOrdersDataSource,
+    private val retrieveOrderRefunds: WooPosRetrieveOrderRefunds,
+    private val getRefundableItems: WooPosGetRefundableItems,
+    private val resourceProvider: ResourceProvider
+) : ViewModel() {
+
+    @AssistedFactory
+    interface Factory {
+        fun create(orderId: Long): WooPosRefundViewModel
+    }
+
+    private val _state = MutableStateFlow<WooPosRefundState>(WooPosRefundState.Loading)
+    val state: StateFlow<WooPosRefundState> = _state.asStateFlow()
+
+    init {
+        loadRefundableItems()
+    }
+
+    private fun loadRefundableItems() {
+        viewModelScope.launch {
+            _state.value = WooPosRefundState.Loading
+
+            try {
+                val orderResult = ordersDataSource.getOrderById(orderId)
+                if (orderResult.isFailure) {
+                    _state.value = WooPosRefundState.Error(
+                        message = resourceProvider.getString(R.string.error_generic)
+                    )
+                    return@launch
+                }
+
+                val order = orderResult.getOrThrow()
+
+                val refundsResult = retrieveOrderRefunds(order)
+                val refunds = if (refundsResult.isSuccess) {
+                    refundsResult.getOrThrow()
+                } else {
+                    emptyList()
+                }
+
+                val refundableItems = getRefundableItems(order, refunds)
+
+                if (refundableItems.isEmpty()) {
+                    _state.value = WooPosRefundState.NoRefundableItems
+                    return@launch
+                }
+
+                _state.value = buildContentState(
+                    order = order,
+                    refundableItems = refundableItems
+                )
+            } catch (@Suppress("TooGenericExceptionCaught") e: Exception) {
+                _state.value = WooPosRefundState.Error(
+                    message = e.message ?: resourceProvider.getString(R.string.error_generic)
+                )
+            }
+        }
+    }
+
+    private fun buildContentState(
+        order: Order,
+        refundableItems: List<WooPosRefundableItem>
+    ): WooPosRefundState.Content {
+        val itemsLabel = resourceProvider.getString(
+            R.string.woopos_orders_items_count,
+            refundableItems.size
+        )
+
+        val subtotal = refundableItems.sumOf { it.lineTotal }
+        val taxes = refundableItems.sumOf { it.lineTax }
+        val total = subtotal + taxes
+
+        return WooPosRefundState.Content(
+            orderId = order.id,
+            orderNumber = "#${order.number}",
+            currency = order.currency,
+            refundableItems = refundableItems,
+            itemsLabel = itemsLabel,
+            subtotal = subtotal,
+            taxes = taxes,
+            total = total
+        )
+    }
+}

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/orders/WooPosRefundViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/orders/WooPosRefundViewModel.kt
@@ -81,11 +81,6 @@ class WooPosRefundViewModel @AssistedInject constructor(
         order: Order,
         refundableItems: List<WooPosRefundableItem>
     ): WooPosRefundState.Content {
-        val itemsLabel = resourceProvider.getString(
-            R.string.woopos_orders_items_count,
-            refundableItems.size
-        )
-
         val subtotal = refundableItems.sumOf { it.lineTotal }
         val taxes = refundableItems.sumOf { it.lineTax }
         val total = subtotal + taxes
@@ -95,7 +90,7 @@ class WooPosRefundViewModel @AssistedInject constructor(
             orderNumber = "#${order.number}",
             currency = order.currency,
             refundableItems = refundableItems,
-            itemsLabel = itemsLabel,
+            itemsCount = refundableItems.size,
             subtotal = subtotal,
             taxes = taxes,
             total = total

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/orders/WooPosRefundableItem.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/orders/WooPosRefundableItem.kt
@@ -1,0 +1,23 @@
+package com.woocommerce.android.ui.woopos.orders
+
+import androidx.compose.runtime.Immutable
+import java.math.BigDecimal
+
+@Immutable
+data class WooPosRefundableItem(
+    val orderItemId: Long,
+    val productId: Long,
+    val variationId: Long,
+    val name: String,
+    val unitPrice: BigDecimal,
+    val unitTax: BigDecimal,
+    val formattedUnitPrice: String,
+    val formattedUnitTax: String,
+    val rowIndex: Int,
+) {
+    val lineTotal: BigDecimal
+        get() = unitPrice
+
+    val lineTax: BigDecimal
+        get() = unitTax
+}

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -3798,6 +3798,10 @@
 
     <string name="woopos_orders_email_receipt">Email receipt</string>
     <string name="woopos_orders_issue_refund_content_description">Issue a refund for this order</string>
+    <string name="woopos_orders_select_items_to_refund">Select items to refund</string>
+    <string name="woopos_orders_items_selected">ITEMS (%1$d SELECTED)</string>
+    <string name="woopos_orders_amount">AMOUNT</string>
+    <string name="woopos_orders_tax">TAX</string>
     <string name="woopos_orders_details_placeholder_title">Select an order</string>
     <string name="woopos_orders_details_placeholder_message">Choose an order from the list to view details.</string>
     <string name="woopos_orders_details_products_title">Products</string>

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -3800,7 +3800,7 @@
     <string name="woopos_orders_issue_refund_content_description">Issue a refund for this order</string>
     <string name="woopos_orders_select_items_to_refund">Select items to refund</string>
     <string name="woopos_orders_items_selected">ITEMS (%1$d SELECTED)</string>
-    <string name="woopos_orders_items_count">ITEMS (%1$d)</string>
+    <string name="woopos_orders_items_count">SELECT ALL ITEMS (%1$d SELECTED)</string>
     <string name="woopos_orders_amount">AMOUNT</string>
     <string name="woopos_orders_tax">TAX</string>
     <string name="woopos_orders_details_placeholder_title">Select an order</string>

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -3800,7 +3800,8 @@
     <string name="woopos_orders_issue_refund_content_description">Issue a refund for this order</string>
     <string name="woopos_orders_select_items_to_refund">Select items to refund</string>
     <string name="woopos_orders_items_selected">ITEMS (%1$d SELECTED)</string>
-    <string name="woopos_orders_items_count">SELECT ALL ITEMS (%1$d SELECTED)</string>
+    <string name="woopos_orders_select_all_items">SELECT ALL ITEMS</string>
+    <string name="woopos_orders_items_selected_count">(%1$d SELECTED)</string>
     <string name="woopos_orders_amount">AMOUNT</string>
     <string name="woopos_orders_tax">TAX</string>
     <string name="woopos_orders_details_placeholder_title">Select an order</string>

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -3800,6 +3800,7 @@
     <string name="woopos_orders_issue_refund_content_description">Issue a refund for this order</string>
     <string name="woopos_orders_select_items_to_refund">Select items to refund</string>
     <string name="woopos_orders_items_selected">ITEMS (%1$d SELECTED)</string>
+    <string name="woopos_orders_items_count">ITEMS (%1$d)</string>
     <string name="woopos_orders_amount">AMOUNT</string>
     <string name="woopos_orders_tax">TAX</string>
     <string name="woopos_orders_details_placeholder_title">Select an order</string>

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/orders/WooPosOrdersViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/orders/WooPosOrdersViewModelTest.kt
@@ -95,6 +95,8 @@ class WooPosOrdersViewModelTest {
         whenever(resourceProvider.getString(R.string.woopos_orders_status_completed)).thenReturn("Completed")
         whenever(resourceProvider.getString(R.string.woopos_orders_status_refunded)).thenReturn("Refunded")
         whenever(resourceProvider.getString(R.string.woopos_search_orders)).thenReturn("Search orders")
+        whenever(resourceProvider.getString(eq(R.string.woopos_orders_items_selected), any()))
+            .thenAnswer { "ITEMS (${it.arguments[1]} SELECTED)" }
     }
 
     @Test
@@ -916,6 +918,31 @@ class WooPosOrdersViewModelTest {
         assertThat(state.dialogState).isInstanceOf(WooPosOrdersState.Content.DialogState.IssueRefund::class.java)
         val dialogState = state.dialogState as WooPosOrdersState.Content.DialogState.IssueRefund
         assertThat(dialogState.orderId).isEqualTo(123L)
+        verify(resourceProvider).getString(eq(R.string.woopos_orders_items_selected), any())
+    }
+
+    @Test
+    fun `given order with multiple line items, when onIssueRefundButtonClicked called, then itemsSelectedLabel is correctly formatted`() = runTest {
+        // GIVEN
+        val testOrder = order(123).copy(
+            items = OrderTestUtils.generateTestOrderItems(count = 3)
+        )
+        whenever(dataSource.loadOrders()).thenReturn(
+            flow { emit(LoadOrdersResult.SuccessRemote(ordersMap(testOrder))) }
+        )
+        whenever(resourceProvider.getString(eq(R.string.woopos_orders_items_selected), eq(3)))
+            .thenReturn("ITEMS (3 SELECTED)")
+        viewModel = createViewModel()
+        advanceUntilIdle()
+
+        // WHEN
+        viewModel.onIssueRefundButtonClicked(123L)
+        advanceUntilIdle()
+
+        // THEN
+        val state = viewModel.state.value as WooPosOrdersState.Content
+        val dialogState = state.dialogState as WooPosOrdersState.Content.DialogState.IssueRefund
+        assertThat(dialogState.itemsSelectedLabel).isEqualTo("ITEMS (3 SELECTED)")
     }
 
     @Test


### PR DESCRIPTION
## Summary
This PR introduces the create refund dialog's basic UI in `Woo POS > Orders` screen.

Note: This PR focuses on the basic UI implementation. 

💡 Note:
* The actual refund processing will be handled in the next PR.
* Item selection handling will be implemented in the next PR.
* Line item Tax values will be added in the next PR.
* Product images will be populated in the next PR.

### Test Steps

1. Click Isue Refund button in Woo POS > Orders.
2. Verify the UI layout of the dialog.

Figma specs: DK955L5K0bTfkjrHTBLmqo-fi-303_20712

### Images/gif

| Order Details | Issue Refund |
|---|---|
|<img width="700"  alt="Screenshot_20251129_002740" src="https://github.com/user-attachments/assets/d68ea1e4-a010-4f1e-9456-8ac144939951" />|<img width="700"  alt="Screenshot_20251129_002744" src="https://github.com/user-attachments/assets/3ac1f06e-cda8-456d-901d-33f3bdf099d6" />|

- [x]  I have considered if this change warrants release notes and have added them to RELEASE-NOTES.txt if necessary. Use the "[Internal]" label for non-user-facing changes.