### PR TITLE
[WOOMOB-1647] Handle CardReaderStatus Reconnecting flow

### DIFF
--- a/WooCommerce/src/androidTest/kotlin/com/woocommerce/android/di/MockCardReaderManagerModule.kt
+++ b/WooCommerce/src/androidTest/kotlin/com/woocommerce/android/di/MockCardReaderManagerModule.kt
@@ -100,6 +100,8 @@ class MockCardReaderManagerModule {
 
         override fun cancelPayment(paymentData: PaymentData) {}
 
+        override fun cancelReconnection() {}
+
         override suspend fun startAsyncSoftwareUpdate() {}
 
         override suspend fun clearCachedCredentials() {}

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/cardreader/connect/CardReaderConnectViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/cardreader/connect/CardReaderConnectViewModel.kt
@@ -303,6 +303,10 @@ class CardReaderConnectViewModel @Inject constructor(
                     connectionStarted = true
                     viewState.value = provideConnectingState()
                 }
+
+                CardReaderStatus.Reconnecting -> {
+                    // Reconnecting is handled by the SDK, no action needed during connection flow
+                }
             }
         }
     }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/cardreader/detail/CardReaderDetailFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/cardreader/detail/CardReaderDetailFragment.kt
@@ -27,6 +27,7 @@ import com.woocommerce.android.ui.payments.cardreader.detail.CardReaderDetailVie
 import com.woocommerce.android.ui.payments.cardreader.detail.CardReaderDetailViewModel.ViewState.ConnectedState
 import com.woocommerce.android.ui.payments.cardreader.detail.CardReaderDetailViewModel.ViewState.Loading
 import com.woocommerce.android.ui.payments.cardreader.detail.CardReaderDetailViewModel.ViewState.NotConnectedState
+import com.woocommerce.android.ui.payments.cardreader.detail.CardReaderDetailViewModel.ViewState.ReconnectingState
 import com.woocommerce.android.ui.payments.cardreader.onboarding.CardReaderType.EXTERNAL
 import com.woocommerce.android.ui.payments.cardreader.update.CardReaderUpdateDialogFragment
 import com.woocommerce.android.ui.payments.cardreader.update.CardReaderUpdateViewModel.UpdateResult
@@ -180,6 +181,28 @@ class CardReaderDetailFragment : BaseFragment(R.layout.fragment_card_reader_deta
 
                 Loading -> {
                 }
+
+                is ReconnectingState -> {
+                    with(binding.readerDisconnectedState) {
+                        UiHelpers.setTextOrHide(cardReaderDetailConnectHeaderLabel, state.headerLabel)
+                        UiHelpers.setImageOrHideInLandscapeOnCompactScreenHeightSizeClass(
+                            cardReaderDetailIllustration,
+                            state.illustration
+                        )
+                        UiHelpers.setTextOrHide(cardReaderDetailFirstHintLabel, state.firstHintLabel)
+                        cardReaderDetailFirstHintNumberLabel.visibility = View.GONE
+                        cardReaderDetailSecondHintLabel.visibility = View.GONE
+                        cardReaderDetailSecondHintNumberLabel.visibility = View.GONE
+                        cardReaderDetailThirdHintLabel.visibility = View.GONE
+                        cardReaderDetailThirdHintNumberLabel.visibility = View.GONE
+                        cardReaderDetailConnectBtn.visibility = View.GONE
+                        with(cardReaderDetailLearnMoreTv.root) {
+                            movementMethod = LinkMovementMethod.getInstance()
+                            UiHelpers.setTextOrHide(this, state.learnMoreLabel)
+                            setOnClickListener { state.onLearnMoreClicked.invoke() }
+                        }
+                    }
+                }
             }
         }
     }
@@ -192,7 +215,10 @@ class CardReaderDetailFragment : BaseFragment(R.layout.fragment_card_reader_deta
 
     private fun makeStateVisible(binding: FragmentCardReaderDetailBinding, state: ViewState) {
         UiHelpers.updateVisibility(binding.readerConnectedState.root, state is ConnectedState)
-        UiHelpers.updateVisibility(binding.readerDisconnectedState.root, state is NotConnectedState)
+        UiHelpers.updateVisibility(
+            binding.readerDisconnectedState.root,
+            state is NotConnectedState || state is ReconnectingState
+        )
         UiHelpers.updateVisibility(binding.readerConnectedLoading, state is Loading)
     }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/cardreader/detail/CardReaderDetailFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/cardreader/detail/CardReaderDetailFragment.kt
@@ -189,18 +189,15 @@ class CardReaderDetailFragment : BaseFragment(R.layout.fragment_card_reader_deta
                             cardReaderDetailIllustration,
                             state.illustration
                         )
-                        UiHelpers.setTextOrHide(cardReaderDetailFirstHintLabel, state.firstHintLabel)
+                        cardReaderDetailFirstHintLabel.visibility = View.GONE
                         cardReaderDetailFirstHintNumberLabel.visibility = View.GONE
                         cardReaderDetailSecondHintLabel.visibility = View.GONE
                         cardReaderDetailSecondHintNumberLabel.visibility = View.GONE
                         cardReaderDetailThirdHintLabel.visibility = View.GONE
                         cardReaderDetailThirdHintNumberLabel.visibility = View.GONE
-                        cardReaderDetailConnectBtn.visibility = View.GONE
-                        with(cardReaderDetailLearnMoreTv.root) {
-                            movementMethod = LinkMovementMethod.getInstance()
-                            UiHelpers.setTextOrHide(this, state.learnMoreLabel)
-                            setOnClickListener { state.onLearnMoreClicked.invoke() }
-                        }
+                        UiHelpers.setTextOrHide(cardReaderDetailConnectBtn, state.cancelBtnLabel)
+                        cardReaderDetailConnectBtn.setOnClickListener { state.onCancelClicked.invoke() }
+                        cardReaderDetailLearnMoreTv.root.visibility = View.GONE
                     }
                 }
             }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/cardreader/detail/CardReaderDetailViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/cardreader/detail/CardReaderDetailViewModel.kt
@@ -139,7 +139,13 @@ class CardReaderDetailViewModel @Inject constructor(
     }
 
     private fun handleReconnectingState() {
-        viewState.value = ViewState.ReconnectingState(onLearnMoreClicked = ::onLearnMoreClicked)
+        viewState.value = ViewState.ReconnectingState(
+            onCancelClicked = ::onCancelReconnectionClicked
+        )
+    }
+
+    private fun onCancelReconnectionClicked() {
+        cardReaderManager.cancelReconnection()
     }
 
     private fun cancelConnectedScopeJobs() {
@@ -317,14 +323,13 @@ class CardReaderDetailViewModel @Inject constructor(
         object Loading : ViewState()
 
         data class ReconnectingState(
-            val onLearnMoreClicked: (() -> Unit),
+            val onCancelClicked: (() -> Unit),
         ) : ViewState() {
             val headerLabel = UiStringRes(R.string.card_reader_detail_reconnecting_header)
 
             @DrawableRes
             val illustration = R.drawable.img_card_reader_not_connected
-            val firstHintLabel = UiStringRes(R.string.card_reader_detail_reconnecting_hint)
-            val learnMoreLabel = UiStringRes(R.string.card_reader_detail_learn_more, containsHtml = true)
+            val cancelBtnLabel = UiStringRes(R.string.card_reader_detail_reconnecting_cancel)
         }
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/cardreader/detail/CardReaderDetailViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/cardreader/detail/CardReaderDetailViewModel.kt
@@ -13,6 +13,7 @@ import com.woocommerce.android.cardreader.connection.CardReader
 import com.woocommerce.android.cardreader.connection.CardReaderStatus.Connected
 import com.woocommerce.android.cardreader.connection.CardReaderStatus.Connecting
 import com.woocommerce.android.cardreader.connection.CardReaderStatus.NotConnected
+import com.woocommerce.android.cardreader.connection.CardReaderStatus.Reconnecting
 import com.woocommerce.android.cardreader.connection.ReaderType
 import com.woocommerce.android.cardreader.connection.event.CardReaderBatteryStatus
 import com.woocommerce.android.cardreader.connection.event.CardReaderBatteryStatus.StatusChanged
@@ -85,6 +86,9 @@ class CardReaderDetailViewModel @Inject constructor(
                             )
                         )
                         handleNotConnectedState()
+                    }
+                    Reconnecting -> {
+                        // Keep current state while SDK attempts to reconnect
                     }
                 }
             }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/cardreader/detail/CardReaderDetailViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/cardreader/detail/CardReaderDetailViewModel.kt
@@ -88,7 +88,7 @@ class CardReaderDetailViewModel @Inject constructor(
                         handleNotConnectedState()
                     }
                     Reconnecting -> {
-                        // Keep current state while SDK attempts to reconnect
+                        handleReconnectingState()
                     }
                 }
             }
@@ -136,6 +136,10 @@ class CardReaderDetailViewModel @Inject constructor(
         cancelConnectedScopeJobs()
         viewState.value =
             NotConnectedState(onPrimaryActionClicked = ::onConnectBtnClicked, onLearnMoreClicked = ::onLearnMoreClicked)
+    }
+
+    private fun handleReconnectingState() {
+        viewState.value = ViewState.ReconnectingState(onLearnMoreClicked = ::onLearnMoreClicked)
     }
 
     private fun cancelConnectedScopeJobs() {
@@ -311,6 +315,17 @@ class CardReaderDetailViewModel @Inject constructor(
         }
 
         object Loading : ViewState()
+
+        data class ReconnectingState(
+            val onLearnMoreClicked: (() -> Unit),
+        ) : ViewState() {
+            val headerLabel = UiStringRes(R.string.card_reader_detail_reconnecting_header)
+
+            @DrawableRes
+            val illustration = R.drawable.img_card_reader_not_connected
+            val firstHintLabel = UiStringRes(R.string.card_reader_detail_reconnecting_hint)
+            val learnMoreLabel = UiStringRes(R.string.card_reader_detail_learn_more, containsHtml = true)
+        }
     }
 }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/cardreader/WooPosCardReaderFacade.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/cardreader/WooPosCardReaderFacade.kt
@@ -49,6 +49,10 @@ class WooPosCardReaderFacade @Inject constructor(
         cardReaderManager.disconnectReader()
     }
 
+    fun cancelReconnection() {
+        cardReaderManager.cancelReconnection()
+    }
+
     @Suppress("DEPRECATION")
     private fun startActivity(intent: Intent) {
         val options = ActivityOptionsCompat.makeCustomAnimation(

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/toolbar/WooPosHomeFloatingToolbar.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/toolbar/WooPosHomeFloatingToolbar.kt
@@ -309,15 +309,11 @@ private fun CardReaderStatusButton(
         when (status) {
             WooPosCardReaderStatus.Connected -> WooPosTheme.colors.success
             WooPosCardReaderStatus.NotConnected -> WooPosTheme.colors.alert
+            WooPosCardReaderStatus.Reconnecting -> WooPosTheme.colors.alert
         }
     }
 
-    val title = stringResource(
-        id = when (state) {
-            WooPosCardReaderStatus.Connected -> WooPosCardReaderStatus.Connected.title
-            WooPosCardReaderStatus.NotConnected -> WooPosCardReaderStatus.NotConnected.title
-        }
-    )
+    val title = stringResource(id = state.title)
 
     val borderColor by transition.animateColor(
         transitionSpec = { tween(durationMillis = animationDuration) },
@@ -326,6 +322,7 @@ private fun CardReaderStatusButton(
         when (status) {
             WooPosCardReaderStatus.Connected -> Color.Transparent
             WooPosCardReaderStatus.NotConnected -> MaterialTheme.colorScheme.primary
+            WooPosCardReaderStatus.Reconnecting -> WooPosTheme.colors.alert
         }
     }
 
@@ -407,6 +404,9 @@ private fun getToolbarAccessibilityLabels(
         )
         WooPosCardReaderStatus.NotConnected -> stringResource(
             id = R.string.woopos_floating_toolbar_card_reader_not_connected_status_content_description
+        )
+        WooPosCardReaderStatus.Reconnecting -> stringResource(
+            id = R.string.woopos_reader_reconnecting
         )
     }
     val floatingToolbarMenuOverlayContentDescription = when (menuCardDisabled) {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/toolbar/WooPosHomeFloatingToolbarState.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/toolbar/WooPosHomeFloatingToolbarState.kt
@@ -11,6 +11,7 @@ data class WooPosHomeFloatingToolbarState(
     sealed class WooPosCardReaderStatus(@StringRes val title: Int) {
         data object NotConnected : WooPosCardReaderStatus(title = R.string.woopos_reader_disconnected)
         data object Connected : WooPosCardReaderStatus(title = R.string.woopos_reader_connected)
+        data object Reconnecting : WooPosCardReaderStatus(title = R.string.woopos_reader_reconnecting)
     }
 
     sealed class Menu {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/toolbar/WooPosHomeFloatingToolbarViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/toolbar/WooPosHomeFloatingToolbarViewModel.kt
@@ -131,7 +131,9 @@ class WooPosHomeFloatingToolbarViewModel @Inject constructor(
             }
 
             WooPosHomeFloatingToolbarState.WooPosCardReaderStatus.Reconnecting -> {
-                // Do nothing while reconnecting
+                viewModelScope.launch {
+                    cardReaderFacade.disconnectFromReader()
+                }
             }
         }
     }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/toolbar/WooPosHomeFloatingToolbarViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/toolbar/WooPosHomeFloatingToolbarViewModel.kt
@@ -131,9 +131,7 @@ class WooPosHomeFloatingToolbarViewModel @Inject constructor(
             }
 
             WooPosHomeFloatingToolbarState.WooPosCardReaderStatus.Reconnecting -> {
-                viewModelScope.launch {
-                    cardReaderFacade.disconnectFromReader()
-                }
+                cardReaderFacade.cancelReconnection()
             }
         }
     }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/toolbar/WooPosHomeFloatingToolbarViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/toolbar/WooPosHomeFloatingToolbarViewModel.kt
@@ -11,6 +11,7 @@ import com.woocommerce.android.cardreader.connection.CardReaderStatus
 import com.woocommerce.android.cardreader.connection.CardReaderStatus.Connected
 import com.woocommerce.android.cardreader.connection.CardReaderStatus.Connecting
 import com.woocommerce.android.cardreader.connection.CardReaderStatus.NotConnected
+import com.woocommerce.android.cardreader.connection.CardReaderStatus.Reconnecting
 import com.woocommerce.android.ui.woopos.cardreader.WooPosCardReaderFacade
 import com.woocommerce.android.ui.woopos.home.ChildToParentEvent
 import com.woocommerce.android.ui.woopos.home.WooPosChildrenToParentEventSender
@@ -128,12 +129,17 @@ class WooPosHomeFloatingToolbarViewModel @Inject constructor(
                     cardReaderFacade.connectToReader()
                 }
             }
+
+            WooPosHomeFloatingToolbarState.WooPosCardReaderStatus.Reconnecting -> {
+                // Do nothing while reconnecting
+            }
         }
     }
 
     private fun mapCardReaderStatusToUiState(status: CardReaderStatus) = when (status) {
         is Connected -> WooPosHomeFloatingToolbarState.WooPosCardReaderStatus.Connected
         is NotConnected, Connecting -> WooPosHomeFloatingToolbarState.WooPosCardReaderStatus.NotConnected
+        Reconnecting -> WooPosHomeFloatingToolbarState.WooPosCardReaderStatus.Reconnecting
     }
 
     private val toolbarMenuItems by lazy {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/totals/WooPosTotalsViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/totals/WooPosTotalsViewModel.kt
@@ -9,6 +9,7 @@ import com.woocommerce.android.WooException
 import com.woocommerce.android.cardreader.connection.CardReaderStatus.Connected
 import com.woocommerce.android.cardreader.connection.CardReaderStatus.Connecting
 import com.woocommerce.android.cardreader.connection.CardReaderStatus.NotConnected
+import com.woocommerce.android.cardreader.connection.CardReaderStatus.Reconnecting
 import com.woocommerce.android.model.Order
 import com.woocommerce.android.ui.payments.cardreader.onboarding.CardReaderFlowParam.PaymentOrRefund
 import com.woocommerce.android.ui.payments.cardreader.payment.controller.CardReaderPaymentController
@@ -120,6 +121,10 @@ class WooPosTotalsViewModel @Inject constructor(
                         if (state !is WooPosTotalsViewState.Checkout) return@collect
                         uiState.value = state.copy(readerStatus = buildTotalsReaderNotConnectedError())
                         cancelPaymentAction()
+                    }
+
+                    Reconnecting -> {
+                        // Keep current state while SDK attempts to reconnect
                     }
 
                     is Connected -> {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/totals/WooPosTotalsViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/totals/WooPosTotalsViewModel.kt
@@ -124,7 +124,7 @@ class WooPosTotalsViewModel @Inject constructor(
                     }
 
                     Reconnecting -> {
-                        // Keep current state while SDK attempts to reconnect
+                        // We start payment right away so this state not worth handling
                     }
 
                     is Connected -> {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/settings/details/hardware/cardreader/WooPosSettingsHardwareCardReaderViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/settings/details/hardware/cardreader/WooPosSettingsHardwareCardReaderViewModel.kt
@@ -115,6 +115,11 @@ class WooPosSettingsHardwareCardReaderViewModel @Inject constructor(
                         currentSoftwareUpdateAvailable = false
                         WooPosSettingsHardwareCardReaderUiState.Disconnected
                     }
+
+                    CardReaderStatus.Reconnecting -> {
+                        // Keep current state while SDK attempts to reconnect
+                        _uiState.value
+                    }
                 }
             }
         }

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -1634,6 +1634,8 @@
         Card Reader Detail
     -->
     <string name="card_reader_detail_not_connected_header">Connect your card reader</string>
+    <string name="card_reader_detail_reconnecting_header">Reconnecting to card reader…</string>
+    <string name="card_reader_detail_reconnecting_hint">Please wait while we attempt to reconnect</string>
     <string name="card_reader_detail_learn_more">&lt;a href=\'\'&gt;Learn more&lt;/a&gt; about accepting mobile payments and ordering card readers</string>
     <string name="card_reader_detail_not_connected_first_hint_label">Make sure card reader is charged</string>
     <string name="card_reader_detail_not_connected_second_hint_label">Turn card reader on and place it next to mobile device</string>

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -1635,7 +1635,7 @@
     -->
     <string name="card_reader_detail_not_connected_header">Connect your card reader</string>
     <string name="card_reader_detail_reconnecting_header">Reconnecting to card reader…</string>
-    <string name="card_reader_detail_reconnecting_hint">Please wait while we attempt to reconnect</string>
+    <string name="card_reader_detail_reconnecting_cancel">Cancel reconnection</string>
     <string name="card_reader_detail_learn_more">&lt;a href=\'\'&gt;Learn more&lt;/a&gt; about accepting mobile payments and ordering card readers</string>
     <string name="card_reader_detail_not_connected_first_hint_label">Make sure card reader is charged</string>
     <string name="card_reader_detail_not_connected_second_hint_label">Turn card reader on and place it next to mobile device</string>

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -3590,6 +3590,7 @@
 
     <string name="woopos_reader_connected">Reader connected</string>
     <string name="woopos_reader_disconnected">Connect your reader</string>
+    <string name="woopos_reader_reconnecting">Reconnecting…</string>
     <string name="woopos_checkout_button">Check out</string>
     <string name="woopos_remove_item_button_from_cart_content_description">Remove %s from cart</string>
     <string name="woopos_product_item_content_description">Product %s, Price %s</string>

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/payments/cardreader/detail/CardReaderDetailViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/payments/cardreader/detail/CardReaderDetailViewModelTest.kt
@@ -22,6 +22,7 @@ import com.woocommerce.android.ui.payments.cardreader.detail.CardReaderDetailVie
 import com.woocommerce.android.ui.payments.cardreader.detail.CardReaderDetailViewModel.ViewState.ConnectedState
 import com.woocommerce.android.ui.payments.cardreader.detail.CardReaderDetailViewModel.ViewState.Loading
 import com.woocommerce.android.ui.payments.cardreader.detail.CardReaderDetailViewModel.ViewState.NotConnectedState
+import com.woocommerce.android.ui.payments.cardreader.detail.CardReaderDetailViewModel.ViewState.ReconnectingState
 import com.woocommerce.android.ui.payments.cardreader.onboarding.CardReaderFlowParam
 import com.woocommerce.android.ui.payments.cardreader.onboarding.PluginType.STRIPE_EXTENSION_GATEWAY
 import com.woocommerce.android.ui.payments.cardreader.onboarding.PluginType.WOOCOMMERCE_PAYMENTS
@@ -619,6 +620,33 @@ class CardReaderDetailViewModelTest : BaseUnitTest() {
             assertThat((viewModel.event.value as NavigateToUrlInGenericWebView).url)
                 .isEqualTo(AppUrls.STRIPE_LEARN_MORE_ABOUT_PAYMENTS)
         }
+
+    @Test
+    fun `given reconnecting state, when view model init, then should emit reconnecting view state`() {
+        // GIVEN
+        val status = MutableStateFlow(CardReaderStatus.Reconnecting)
+        whenever(cardReaderManager.readerStatus).thenReturn(status)
+
+        // WHEN
+        val viewModel = createViewModel()
+
+        // THEN
+        assertThat(viewModel.viewStateData.value).isInstanceOf(ReconnectingState::class.java)
+    }
+
+    @Test
+    fun `given reconnecting state, when cancel clicked, then should call cancelReconnection`() {
+        // GIVEN
+        val status = MutableStateFlow(CardReaderStatus.Reconnecting)
+        whenever(cardReaderManager.readerStatus).thenReturn(status)
+        val viewModel = createViewModel()
+
+        // WHEN
+        (viewModel.viewStateData.value as ReconnectingState).onCancelClicked.invoke()
+
+        // THEN
+        verify(cardReaderManager).cancelReconnection()
+    }
 
     private fun verifyNotConnectedState(viewModel: CardReaderDetailViewModel) {
         val state = viewModel.viewStateData.value as NotConnectedState

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/home/toolbar/WooPosHomeFloatingToolbarViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/home/toolbar/WooPosHomeFloatingToolbarViewModelTest.kt
@@ -257,6 +257,31 @@ class WooPosHomeFloatingToolbarViewModelTest {
         assertThat(viewModel.state.value.menu).isEqualTo(WooPosHomeFloatingToolbarState.Menu.Hidden)
     }
 
+    @Test
+    fun `given card reader status is Reconnecting, when initialized, then state should be Reconnecting`() = runTest {
+        // GIVEN
+        whenever(cardReaderFacade.readerStatus).thenReturn(MutableStateFlow(CardReaderStatus.Reconnecting))
+        val viewModel = createViewModel()
+
+        // THEN
+        assertThat(viewModel.state.value.cardReaderStatus)
+            .isEqualTo(WooPosHomeFloatingToolbarState.WooPosCardReaderStatus.Reconnecting)
+    }
+
+    @Test
+    fun `given card reader status is Reconnecting, when OnCardReaderStatusClicked, then cancelReconnection should be called`() =
+        runTest {
+            // GIVEN
+            whenever(cardReaderFacade.readerStatus).thenReturn(MutableStateFlow(CardReaderStatus.Reconnecting))
+            val viewModel = createViewModel()
+
+            // WHEN
+            viewModel.onUiEvent(WooPosHomeFloatingToolbarUIEvent.OnCardReaderStatusClicked)
+
+            // THEN
+            verify(cardReaderFacade).cancelReconnection()
+        }
+
     private fun createViewModel() = WooPosHomeFloatingToolbarViewModel(
         cardReaderFacade,
         childrenToParentEventSender,

--- a/libs/cardreader/src/main/java/com/woocommerce/android/cardreader/CardReaderManager.kt
+++ b/libs/cardreader/src/main/java/com/woocommerce/android/cardreader/CardReaderManager.kt
@@ -47,6 +47,7 @@ interface CardReaderManager {
 
     fun startConnectionToReader(cardReader: CardReader, locationId: String)
     suspend fun disconnectReader(): Boolean
+    fun cancelReconnection()
 
     suspend fun collectPayment(paymentInfo: PaymentInfo): Flow<CardPaymentStatus>
     suspend fun refundInteracPayment(

--- a/libs/cardreader/src/main/java/com/woocommerce/android/cardreader/CardReaderManagerFactory.kt
+++ b/libs/cardreader/src/main/java/com/woocommerce/android/cardreader/CardReaderManagerFactory.kt
@@ -42,7 +42,7 @@ object CardReaderManagerFactory {
             UpdateErrorMapper(batteryLevelProvider),
             terminalListener
         )
-        val tapToPayReaderListener = TapToPayReaderListenerImpl(logWrapper)
+        val tapToPayReaderListener = TapToPayReaderListenerImpl(logWrapper, terminalListener)
         val cardReaderConfigFactory = CardReaderConfigFactory()
         val paymentUtils = PaymentUtils(logWrapper)
 

--- a/libs/cardreader/src/main/java/com/woocommerce/android/cardreader/connection/CardReaderStatus.kt
+++ b/libs/cardreader/src/main/java/com/woocommerce/android/cardreader/connection/CardReaderStatus.kt
@@ -13,4 +13,5 @@ sealed class CardReaderStatus {
     }
     data class Connected(val cardReader: CardReader) : CardReaderStatus()
     data object Connecting : CardReaderStatus()
+    data object Reconnecting : CardReaderStatus()
 }

--- a/libs/cardreader/src/main/java/com/woocommerce/android/cardreader/internal/CardReaderManagerImpl.kt
+++ b/libs/cardreader/src/main/java/com/woocommerce/android/cardreader/internal/CardReaderManagerImpl.kt
@@ -103,6 +103,11 @@ internal class CardReaderManagerImpl(
         return connectionManager.disconnectReader()
     }
 
+    override fun cancelReconnection() {
+        if (!terminal.isInitialized()) error("Terminal not initialized")
+        connectionManager.cancelReconnection()
+    }
+
     override suspend fun collectPayment(paymentInfo: PaymentInfo): Flow<CardPaymentStatus> {
         resetBluetoothDisplayMessage()
         return paymentManager.acceptPayment(paymentInfo)

--- a/libs/cardreader/src/main/java/com/woocommerce/android/cardreader/internal/connection/BluetoothReaderListenerImpl.kt
+++ b/libs/cardreader/src/main/java/com/woocommerce/android/cardreader/internal/connection/BluetoothReaderListenerImpl.kt
@@ -1,5 +1,6 @@
 package com.woocommerce.android.cardreader.internal.connection
 
+import com.stripe.stripeterminal.external.callable.Callback
 import com.stripe.stripeterminal.external.callable.Cancelable
 import com.stripe.stripeterminal.external.callable.MobileReaderListener
 import com.stripe.stripeterminal.external.models.BatteryStatus
@@ -47,6 +48,7 @@ internal class BluetoothReaderListenerImpl(
     val batteryStatusEvents = _batteryStatusEvents.asStateFlow()
 
     var cancelUpdateAction: Cancelable? = null
+    var cancelReconnectAction: Cancelable? = null
 
     override fun onFinishInstallingUpdate(update: ReaderSoftwareUpdate?, e: TerminalException?) {
         logWrapper.d(LOG_TAG, "onFinishInstallingUpdate: $update $e")
@@ -121,6 +123,7 @@ internal class BluetoothReaderListenerImpl(
 
     override fun onReaderReconnectFailed(reader: Reader) {
         logWrapper.d(LOG_TAG, "onReaderReconnectFailed")
+        cancelReconnectAction = null
         terminalListenerImpl.updateReaderStatus(CardReaderStatus.NotConnected())
     }
 
@@ -130,11 +133,13 @@ internal class BluetoothReaderListenerImpl(
         reason: DisconnectReason
     ) {
         logWrapper.d(LOG_TAG, "onReaderReconnectStarted: reason=$reason")
+        cancelReconnectAction = cancelReconnect
         terminalListenerImpl.updateReaderStatus(CardReaderStatus.Reconnecting)
     }
 
     override fun onReaderReconnectSucceeded(reader: Reader) {
         logWrapper.d(LOG_TAG, "onReaderReconnectSucceeded")
+        cancelReconnectAction = null
         terminalListenerImpl.updateReaderStatus(CardReaderStatus.Connected(CardReaderImpl(reader)))
     }
 
@@ -145,5 +150,10 @@ internal class BluetoothReaderListenerImpl(
 
     fun resetDisplayMessage() {
         _displayMessagesEvents.value = CardReaderNoMessage
+    }
+
+    fun cancelReconnection(callback: Callback) {
+        cancelReconnectAction?.cancel(callback)
+        cancelReconnectAction = null
     }
 }

--- a/libs/cardreader/src/main/java/com/woocommerce/android/cardreader/internal/connection/BluetoothReaderListenerImpl.kt
+++ b/libs/cardreader/src/main/java/com/woocommerce/android/cardreader/internal/connection/BluetoothReaderListenerImpl.kt
@@ -4,12 +4,14 @@ import com.stripe.stripeterminal.external.callable.Cancelable
 import com.stripe.stripeterminal.external.callable.MobileReaderListener
 import com.stripe.stripeterminal.external.models.BatteryStatus
 import com.stripe.stripeterminal.external.models.DisconnectReason
+import com.stripe.stripeterminal.external.models.Reader
 import com.stripe.stripeterminal.external.models.ReaderDisplayMessage
 import com.stripe.stripeterminal.external.models.ReaderEvent
 import com.stripe.stripeterminal.external.models.ReaderInputOptions
 import com.stripe.stripeterminal.external.models.ReaderSoftwareUpdate
 import com.stripe.stripeterminal.external.models.TerminalException
 import com.woocommerce.android.cardreader.LogWrapper
+import com.woocommerce.android.cardreader.connection.CardReaderImpl
 import com.woocommerce.android.cardreader.connection.CardReaderStatus
 import com.woocommerce.android.cardreader.connection.event.BluetoothCardReaderMessages
 import com.woocommerce.android.cardreader.connection.event.BluetoothCardReaderMessages.CardReaderNoMessage
@@ -115,6 +117,25 @@ internal class BluetoothReaderListenerImpl(
             else -> null
         }
         terminalListenerImpl.updateReaderStatus(CardReaderStatus.NotConnected(errorCode = errorCode))
+    }
+
+    override fun onReaderReconnectFailed(reader: Reader) {
+        logWrapper.d(LOG_TAG, "onReaderReconnectFailed")
+        terminalListenerImpl.updateReaderStatus(CardReaderStatus.NotConnected())
+    }
+
+    override fun onReaderReconnectStarted(
+        reader: Reader,
+        cancelReconnect: Cancelable,
+        reason: DisconnectReason
+    ) {
+        logWrapper.d(LOG_TAG, "onReaderReconnectStarted: reason=$reason")
+        terminalListenerImpl.updateReaderStatus(CardReaderStatus.Reconnecting)
+    }
+
+    override fun onReaderReconnectSucceeded(reader: Reader) {
+        logWrapper.d(LOG_TAG, "onReaderReconnectSucceeded")
+        terminalListenerImpl.updateReaderStatus(CardReaderStatus.Connected(CardReaderImpl(reader)))
     }
 
     fun resetConnectionState() {

--- a/libs/cardreader/src/main/java/com/woocommerce/android/cardreader/internal/connection/ConnectionManager.kt
+++ b/libs/cardreader/src/main/java/com/woocommerce/android/cardreader/internal/connection/ConnectionManager.kt
@@ -163,6 +163,20 @@ internal class ConnectionManager(
         })
     }
 
+    fun cancelReconnection() {
+        val callback = object : Callback {
+            override fun onFailure(e: TerminalException) {
+                updateReaderStatus(CardReaderStatus.NotConnected())
+            }
+
+            override fun onSuccess() {
+                updateReaderStatus(CardReaderStatus.NotConnected())
+            }
+        }
+        bluetoothReaderListener.cancelReconnection(callback)
+        tapToPayReaderListener.cancelReconnection(callback)
+    }
+
     private fun startStateResettingJobIfNeeded(currentStatus: CardReaderStatus) {
         if (currentStatus !is CardReaderStatus.Connecting) return
 

--- a/libs/cardreader/src/main/java/com/woocommerce/android/cardreader/internal/connection/TapToPayReaderListenerImpl.kt
+++ b/libs/cardreader/src/main/java/com/woocommerce/android/cardreader/internal/connection/TapToPayReaderListenerImpl.kt
@@ -5,17 +5,22 @@ import com.stripe.stripeterminal.external.callable.TapToPayReaderListener
 import com.stripe.stripeterminal.external.models.DisconnectReason
 import com.stripe.stripeterminal.external.models.Reader
 import com.woocommerce.android.cardreader.LogWrapper
+import com.woocommerce.android.cardreader.connection.CardReaderImpl
+import com.woocommerce.android.cardreader.connection.CardReaderStatus
 import com.woocommerce.android.cardreader.internal.LOG_TAG
 
-class TapToPayReaderListenerImpl(
-    private val logWrapper: LogWrapper
+internal class TapToPayReaderListenerImpl(
+    private val logWrapper: LogWrapper,
+    private val terminalListenerImpl: TerminalListenerImpl
 ) : TapToPayReaderListener {
     override fun onDisconnect(reason: DisconnectReason) {
-        logWrapper.d(LOG_TAG, "onDisconnect")
+        logWrapper.d(LOG_TAG, "onDisconnect: reason=$reason")
+        terminalListenerImpl.updateReaderStatus(CardReaderStatus.NotConnected())
     }
 
     override fun onReaderReconnectFailed(reader: Reader) {
         logWrapper.d(LOG_TAG, "onReaderReconnectFailed")
+        terminalListenerImpl.updateReaderStatus(CardReaderStatus.NotConnected())
     }
 
     override fun onReaderReconnectStarted(
@@ -23,10 +28,12 @@ class TapToPayReaderListenerImpl(
         cancelReconnect: Cancelable,
         reason: DisconnectReason
     ) {
-        logWrapper.d(LOG_TAG, "onReaderReconnectStarted")
+        logWrapper.d(LOG_TAG, "onReaderReconnectStarted: reason=$reason")
+        terminalListenerImpl.updateReaderStatus(CardReaderStatus.Reconnecting)
     }
 
     override fun onReaderReconnectSucceeded(reader: Reader) {
         logWrapper.d(LOG_TAG, "onReaderReconnectSucceeded")
+        terminalListenerImpl.updateReaderStatus(CardReaderStatus.Connected(CardReaderImpl(reader)))
     }
 }

--- a/libs/cardreader/src/main/java/com/woocommerce/android/cardreader/internal/connection/TapToPayReaderListenerImpl.kt
+++ b/libs/cardreader/src/main/java/com/woocommerce/android/cardreader/internal/connection/TapToPayReaderListenerImpl.kt
@@ -1,5 +1,6 @@
 package com.woocommerce.android.cardreader.internal.connection
 
+import com.stripe.stripeterminal.external.callable.Callback
 import com.stripe.stripeterminal.external.callable.Cancelable
 import com.stripe.stripeterminal.external.callable.TapToPayReaderListener
 import com.stripe.stripeterminal.external.models.DisconnectReason
@@ -13,6 +14,8 @@ internal class TapToPayReaderListenerImpl(
     private val logWrapper: LogWrapper,
     private val terminalListenerImpl: TerminalListenerImpl
 ) : TapToPayReaderListener {
+    var cancelReconnectAction: Cancelable? = null
+
     override fun onDisconnect(reason: DisconnectReason) {
         logWrapper.d(LOG_TAG, "onDisconnect: reason=$reason")
         terminalListenerImpl.updateReaderStatus(CardReaderStatus.NotConnected())
@@ -20,6 +23,7 @@ internal class TapToPayReaderListenerImpl(
 
     override fun onReaderReconnectFailed(reader: Reader) {
         logWrapper.d(LOG_TAG, "onReaderReconnectFailed")
+        cancelReconnectAction = null
         terminalListenerImpl.updateReaderStatus(CardReaderStatus.NotConnected())
     }
 
@@ -29,11 +33,18 @@ internal class TapToPayReaderListenerImpl(
         reason: DisconnectReason
     ) {
         logWrapper.d(LOG_TAG, "onReaderReconnectStarted: reason=$reason")
+        cancelReconnectAction = cancelReconnect
         terminalListenerImpl.updateReaderStatus(CardReaderStatus.Reconnecting)
     }
 
     override fun onReaderReconnectSucceeded(reader: Reader) {
         logWrapper.d(LOG_TAG, "onReaderReconnectSucceeded")
+        cancelReconnectAction = null
         terminalListenerImpl.updateReaderStatus(CardReaderStatus.Connected(CardReaderImpl(reader)))
+    }
+
+    fun cancelReconnection(callback: Callback) {
+        cancelReconnectAction?.cancel(callback)
+        cancelReconnectAction = null
     }
 }


### PR DESCRIPTION
WOOMOB-1647

### Description

This PR implements proper handling of the card reader reconnecting status introduced in Stripe SDK 5.0.0. When the SDK automatically attempts to reconnect to a card reader, users now see a "Reconnecting…" status message in the UI with cancelation option

Changes:
- Add `CardReaderStatus.Reconnecting` to the sealed class
- Implement reconnect callbacks in `BluetoothReaderListenerImpl` and `TapToPayReaderListenerImpl`
- Display reconnecting status in WooPos floating toolbar with amber indicator
- Handle reconnecting status in all relevant ViewModels

### Test Steps

1. Connect a card reader in WooPos/IPP
2. Simulate a connection interruption (e.g., turn it off while connected)
3. Observe  "Reconnecting…" status
4. Verify status returns to "Connected" when reconnection succeeds
5. Verify reconnection is cancelable

### Images/gif

<img width="518" height="571" alt="Screenshot 2025-12-02 at 19 06 12" src="https://github.com/user-attachments/assets/d0062825-b286-47ab-b466-874c90f552d3" />
<img width="521" height="574" alt="Screenshot 2025-12-02 at 18 31 11" src="https://github.com/user-attachments/assets/57d7a766-54ec-4294-9e0f-244cb09c3f51" />


- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.