### PR TITLE
[Bookings] Update empty list states

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/bookings/list/BookingListScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/bookings/list/BookingListScreen.kt
@@ -65,7 +65,6 @@ import com.woocommerce.android.ui.bookings.details.AttendanceUpdateStatus
 import com.woocommerce.android.ui.compose.component.InfiniteListHandler
 import com.woocommerce.android.ui.compose.component.Toolbar
 import com.woocommerce.android.ui.compose.component.WCColoredButton
-import com.woocommerce.android.ui.compose.component.WCOutlinedButton
 import com.woocommerce.android.ui.compose.component.WCPrimaryTabRow
 import com.woocommerce.android.ui.compose.component.WCPullToRefreshBox
 import com.woocommerce.android.ui.compose.component.WCSearchField
@@ -358,13 +357,13 @@ private fun EmptyView(
         if (state.searchState.query?.isNotEmpty() == true) {
             EmptySearchResultsView(
                 areFiltersActive = state.controlsState.areFiltersActive,
+                onClearFiltersClick = state.controlsState.onClearFiltersClick,
                 modifier = innerEmptyViewModifier
             )
         } else {
             EmptyListView(
                 selectedTab = state.tabState.selectedTab,
                 areFiltersActive = state.controlsState.areFiltersActive,
-                onChangeFiltersClick = state.controlsState.onFilterClick,
                 onClearFiltersClick = state.controlsState.onClearFiltersClick,
                 modifier = innerEmptyViewModifier
             )
@@ -376,7 +375,6 @@ private fun EmptyView(
 private fun EmptyListView(
     selectedTab: BookingListTab,
     areFiltersActive: Boolean,
-    onChangeFiltersClick: () -> Unit,
     onClearFiltersClick: () -> Unit,
     modifier: Modifier
 ) {
@@ -386,9 +384,11 @@ private fun EmptyListView(
         modifier = modifier
     ) {
         Image(
-            painter = painterResource(R.drawable.img_calendar_grey),
+            painter = painterResource(
+                if (areFiltersActive) R.drawable.img_empty_search else R.drawable.img_calendar_grey
+            ),
             contentDescription = null,
-            modifier = Modifier.size(64.dp)
+            modifier = Modifier.size(80.dp)
         )
 
         Spacer(modifier = Modifier.height(24.dp))
@@ -415,7 +415,7 @@ private fun EmptyListView(
                 BookingListTab.Upcoming -> stringResource(R.string.bookings_empty_state_description_upcoming_v2)
                 else -> {
                     if (areFiltersActive) {
-                        stringResource(R.string.bookings_empty_state_description_with_filters)
+                        stringResource(R.string.bookings_filtered_empty_state_description)
                     } else {
                         stringResource(R.string.bookings_empty_state_description_all)
                     }
@@ -429,12 +429,6 @@ private fun EmptyListView(
         if (areFiltersActive) {
             Spacer(Modifier.height(24.dp))
             WCColoredButton(
-                text = stringResource(R.string.bookings_empty_state_change_filters_button),
-                onClick = onChangeFiltersClick,
-                modifier = Modifier.fillMaxWidth()
-            )
-            Spacer(Modifier.height(8.dp))
-            WCOutlinedButton(
                 text = stringResource(R.string.bookings_empty_state_clear_filters_button),
                 onClick = onClearFiltersClick,
                 modifier = Modifier.fillMaxWidth()
@@ -446,6 +440,7 @@ private fun EmptyListView(
 @Composable
 private fun EmptySearchResultsView(
     areFiltersActive: Boolean,
+    onClearFiltersClick: () -> Unit,
     modifier: Modifier
 ) {
     Column(
@@ -480,6 +475,15 @@ private fun EmptySearchResultsView(
             textAlign = TextAlign.Center,
             color = MaterialTheme.colorScheme.onSurfaceVariant
         )
+
+        if (areFiltersActive) {
+            Spacer(Modifier.height(24.dp))
+            WCColoredButton(
+                text = stringResource(R.string.bookings_empty_state_clear_filters_button),
+                onClick = onClearFiltersClick,
+                modifier = Modifier.fillMaxWidth()
+            )
+        }
     }
 }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/bookings/list/BookingListScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/bookings/list/BookingListScreen.kt
@@ -92,8 +92,7 @@ fun BookingListScreen(state: BookingListViewState) {
                 actions = {
                     SearchSection(
                         searchState = state.searchState,
-                        areFiltersActive = state.controlsState.areFiltersActive ||
-                            state.tabState.selectedTab != BookingListTab.All
+                        areFiltersActive = state.controlsState.areFiltersActive
                     )
                 }
             )

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/bookings/list/BookingListScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/bookings/list/BookingListScreen.kt
@@ -52,7 +52,6 @@ import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.colorResource
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
-import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import com.woocommerce.android.R
@@ -463,6 +462,14 @@ private fun EmptySearchResultsView(
         Spacer(modifier = Modifier.height(24.dp))
 
         Text(
+            text = stringResource(R.string.bookings_empty_state_title_default),
+            style = MaterialTheme.typography.titleLarge,
+            textAlign = TextAlign.Center
+        )
+
+        Spacer(modifier = Modifier.height(8.dp))
+
+        Text(
             text = stringResource(
                 id = if (areFiltersActive) {
                     R.string.bookings_search_no_results_with_filters
@@ -470,9 +477,9 @@ private fun EmptySearchResultsView(
                     R.string.bookings_search_no_results_without_filters
                 }
             ),
-            style = MaterialTheme.typography.titleLarge,
-            fontWeight = FontWeight.Normal,
-            textAlign = TextAlign.Center
+            style = MaterialTheme.typography.titleMedium,
+            textAlign = TextAlign.Center,
+            color = MaterialTheme.colorScheme.onSurfaceVariant
         )
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/bookings/list/BookingListViewState.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/bookings/list/BookingListViewState.kt
@@ -53,7 +53,7 @@ data class BookingListControlsState(
     val onClearFiltersClick: () -> Unit
 ) {
     val areFiltersActive: Boolean
-        get() = enabledFiltersCount > 0
+        get() = enabledFiltersCount > 0 && isFilterButtonVisible
 }
 
 data class BookingListItem(

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -4210,8 +4210,8 @@
     <string name="bookings_empty_state_description_all">Bookings will appear here once customers start scheduling your services or registering for events.</string>
     <string name="bookings_empty_state_description_today_v2">Any bookings scheduled for today will appear here.</string>
     <string name="bookings_empty_state_description_upcoming_v2">New bookings will appear here as customers schedule your services or register for events.</string>
-    <string name="bookings_search_no_results_without_filters">We couldn’t find any bookings with that name — try adjusting your search term to see more results.</string>
-    <string name="bookings_search_no_results_with_filters">We couldn’t find any bookings with that name — try adjusting your search term or your filters to see more results.</string>
+    <string name="bookings_search_no_results_without_filters">Try adjusting your search term to see more results.</string>
+    <string name="bookings_search_no_results_with_filters">Try adjusting your search term or filters to see more results.</string>
     <string name="bookings_empty_state_description_with_filters">No bookings match your filters. Try adjusting them to see more results.</string>
     <string name="bookings_empty_state_change_filters_button">Change filters</string>
     <string name="bookings_empty_state_clear_filters_button">Clear filters</string>

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -4212,7 +4212,7 @@
     <string name="bookings_empty_state_description_upcoming_v2">New bookings will appear here as customers schedule your services or register for events.</string>
     <string name="bookings_search_no_results_without_filters">Try adjusting your search term to see more results.</string>
     <string name="bookings_search_no_results_with_filters">Try adjusting your search term or filters to see more results.</string>
-    <string name="bookings_empty_state_description_with_filters">No bookings match your filters. Try adjusting them to see more results.</string>
+    <string name="bookings_filtered_empty_state_description">Try adjusting or clearing your filters to see more results.</string>
     <string name="bookings_empty_state_change_filters_button">Change filters</string>
     <string name="bookings_empty_state_clear_filters_button">Clear filters</string>
     <string name="bookings_filters_default_title">Filters</string>


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

<!-- Id number of the Linear issue this PR addresses, e.g., WOOMOB-373. -->
Closes WOOMOB-1758

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
This updates the empty booking list states. It includes i3 design (lxixW6aBBNkCd9ooBK70Z1-fi-2011_4755) changes and fixes an issue where filter buttons were incorrectly shown for empty **Today** and **Upcoming** tabs.

### Test Steps
<!-- Describe how to test your changes. Include only what’s needed for the reviewer to validate the behavior.
For new features, outline the main user flow or goal rather than every tap or click — the reviewer should be able to complete the flow naturally.
If applicable, mention key devices, scenarios, or edge cases to verify. -->
1. Log in with a CIAB store.
2. Go to Bookings.
3. Compare screens below with the designs
- No filter - Empty tabs: lxixW6aBBNkCd9ooBK70Z1-fi-2172_7117
- Filtered - Empty All tab: lxixW6aBBNkCd9ooBK70Z1-fi-2170_6668
- No filter - Searched - Empty All tab: lxixW6aBBNkCd9ooBK70Z1-fi-2168_5605
- Filtered - Searched - Empty All tab: lxixW6aBBNkCd9ooBK70Z1-fi-2168_5945
- Searched - Today, Upcoming tabs: lxixW6aBBNkCd9ooBK70Z1-fi-2168_5847

### Images/gif
<!-- Include before and after images or gifs when appropriate. -->
|Before|After|
|-|-|
|<img width="360" alt="before-today-empty" src="https://github.com/user-attachments/assets/1d2cbc3a-da6a-444a-a46d-1b179a110ec9" />|<img width="360" alt="Screenshot_20251202_170026" src="https://github.com/user-attachments/assets/3eeb0ace-9885-468a-92e7-6677fc2893fd" />|
|<img width="360" alt="Screenshot_20251202_170331" src="https://github.com/user-attachments/assets/4768ab49-0215-46b1-b8e4-1284d3129434" />|<img width="360" alt="Screenshot_20251202_170224" src="https://github.com/user-attachments/assets/aa1c11c8-5a15-4e64-b64b-3002430995b2" />|
|<img width="360" alt="before-all-buttons" src="https://github.com/user-attachments/assets/14e13a01-6e81-4c09-8d61-30f3ab29b499" />|<img width="360" alt="after-filtered-all-buttons" src="https://github.com/user-attachments/assets/c23c286e-fe56-40bd-aa93-af4165ccc579" />|
|<img width="360" alt="before-empty-filtered-search" src="https://github.com/user-attachments/assets/3bfe3d56-237d-4143-9727-68c5521aa2ff" />|<img width="360" alt="after-empty-filtered-search" src="https://github.com/user-attachments/assets/6e66b1b3-c41d-4db1-8792-38989065aa7a" />|

- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->