### PR TITLE
[Bookings] Fix padding issue on booking filter pages

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/bookings/filter/datetime/DateTimeFilterPage.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/bookings/filter/datetime/DateTimeFilterPage.kt
@@ -8,6 +8,7 @@ import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
@@ -77,7 +78,8 @@ fun DateTimeFilterPage(
     HandleEvents(event, snackbarHostState)
 
     Scaffold(
-        snackbarHost = { SnackbarHost(snackbarHostState) }
+        snackbarHost = { SnackbarHost(snackbarHostState) },
+        contentWindowInsets = WindowInsets()
     ) { innerPadding ->
         Column(
             modifier = Modifier

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/bookings/filter/teammember/BookingTeamMemberFilterPage.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/bookings/filter/teammember/BookingTeamMemberFilterPage.kt
@@ -1,6 +1,7 @@
 package com.woocommerce.android.ui.bookings.filter.teammember
 
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
@@ -50,7 +51,8 @@ fun BookingTeamMemberFilterPage(state: BookingTeamMemberFilterUiState, event: Li
 
     Scaffold(
         containerColor = MaterialTheme.colorScheme.surface,
-        snackbarHost = { SnackbarHost(hostState = snackbarHostState) }
+        snackbarHost = { SnackbarHost(hostState = snackbarHostState) },
+        contentWindowInsets = WindowInsets()
     ) { paddingValues ->
         if (state.skeletonVisible) {
             BookingTeamMemberFilterPageLoading(modifier = Modifier.padding(paddingValues))


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

<!-- Id number of the Linear issue this PR addresses, e.g., WOOMOB-373. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
This fixes a padding issue that occurs when navigating to filter pages after tapping the search field.

The unwanted top gap was caused by nested Scaffolds, where the inner `Scaffold` was reapplying system window insets on top of the parent's padding. This is resolved by setting the inner Scaffold's `contentWindowInsets` to zero, preventing the double application of safe area insets.

### Test Steps
<!-- Describe how to test your changes. Include only what’s needed for the reviewer to validate the behavior.
For new features, outline the main user flow or goal rather than every tap or click — the reviewer should be able to complete the flow naturally.
If applicable, mention key devices, scenarios, or edge cases to verify. -->
I suggest you try this on `trunk` first.
**To reproduce the issue:**
1. Log in with a CIAB store.
2. Go to Bookings.
3. Tap the Search field.
4. While the text cursor is still active on the search field, tap the Filters button.
5. Tap Team Members.

### Images/gif
<!-- Include before and after images or gifs when appropriate. -->
|Before|After|
|-|-|
|<img width="360" alt="before-team" src="https://github.com/user-attachments/assets/50b1fddc-5401-4351-b2da-6c1bbb4bebcd" />|<img width="360" alt="after-team" src="https://github.com/user-attachments/assets/97556b94-e2b0-476d-bac7-3021f699e1f1" />|
|<img width="360" alt="before-date" src="https://github.com/user-attachments/assets/55a04e17-836f-444c-a2c8-a4cba3b02098" />|<img width="360" alt="after-date" src="https://github.com/user-attachments/assets/1dd93970-f1f5-406c-bc27-6523ce8d2798" />|

- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
