### PR TITLE
[WOOMOB-1840] Add analytics tracking for stale catalog warning dialog

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -4,6 +4,7 @@
 
 23.9
 -----
+- [Internal][Woo POS] Add analytics tracking for stale catalog warning dialog display [https://github.com/woocommerce/woocommerce-android/pull/15055]
 
 
 23.8

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/items/WooPosItemsViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/items/WooPosItemsViewModel.kt
@@ -86,16 +86,14 @@ class WooPosItemsViewModel @Inject constructor(
         }
     }
 
-    private fun trackStaleWarningShown(lastSyncTimestamp: Long) {
-        viewModelScope.launch {
-            val currentTime = dateTimeProvider.now()
-            val timeDifferenceMs = currentTime - lastSyncTimestamp
-            val hoursSinceLastSync = timeDifferenceMs.milliseconds.inWholeHours.toInt()
+    private suspend fun trackStaleWarningShown(lastSyncTimestamp: Long) {
+        val currentTime = dateTimeProvider.now()
+        val timeDifferenceMs = currentTime - lastSyncTimestamp
+        val hoursSinceLastSync = timeDifferenceMs.milliseconds.inWholeHours.toInt()
 
-            analyticsTracker.track(
-                WooPosAnalyticsEvent.Event.LocalCatalogStaleWarningShown(hoursSinceLastSync)
-            )
-        }
+        analyticsTracker.track(
+            WooPosAnalyticsEvent.Event.LocalCatalogStaleWarningShown(hoursSinceLastSync)
+        )
     }
 
     fun onUIEvent(event: WooPosItemsUIEvent) {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/items/WooPosItemsViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/items/WooPosItemsViewModel.kt
@@ -28,6 +28,7 @@ import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.launch
 import kotlinx.parcelize.Parcelize
 import javax.inject.Inject
+import kotlin.time.Duration.Companion.milliseconds
 
 @HiltViewModel
 class WooPosItemsViewModel @Inject constructor(
@@ -89,7 +90,7 @@ class WooPosItemsViewModel @Inject constructor(
         viewModelScope.launch {
             val currentTime = dateTimeProvider.now()
             val timeDifferenceMs = currentTime - lastSyncTimestamp
-            val hoursSinceLastSync = (timeDifferenceMs / (1000 * 60 * 60)).toInt()
+            val hoursSinceLastSync = timeDifferenceMs.milliseconds.inWholeHours.toInt()
 
             analyticsTracker.track(
                 WooPosAnalyticsEvent.Event.LocalCatalogStaleWarningShown(hoursSinceLastSync)

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/items/WooPosItemsViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/items/WooPosItemsViewModel.kt
@@ -20,7 +20,6 @@ import com.woocommerce.android.ui.woopos.util.analytics.WooPosAnalyticsEvent.Eve
 import com.woocommerce.android.ui.woopos.util.analytics.WooPosAnalyticsEventConstant
 import com.woocommerce.android.ui.woopos.util.analytics.WooPosAnalyticsTracker
 import com.woocommerce.android.ui.woopos.util.datastore.WooPosPreferencesRepository
-import com.woocommerce.android.ui.woopos.util.datastore.WooPosSyncTimestampManager
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharingStarted
@@ -40,7 +39,6 @@ class WooPosItemsViewModel @Inject constructor(
     private val preferencesRepository: WooPosPreferencesRepository,
     private val analyticsTracker: WooPosAnalyticsTracker,
     private val syncStatusChecker: WooPosFullSyncStatusChecker,
-    private val syncTimestampManager: WooPosSyncTimestampManager,
     private val dateTimeProvider: DateTimeProvider,
 ) : ViewModel() {
     private var preservedStateBeforeOpeningVariations: WooPosItemsToolbarViewState? = null

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/items/WooPosItemsViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/items/WooPosItemsViewModel.kt
@@ -12,6 +12,7 @@ import com.woocommerce.android.ui.woopos.home.items.WooPosItemsToolbarViewState.
 import com.woocommerce.android.ui.woopos.home.items.WooPosItemsToolbarViewState.Tab
 import com.woocommerce.android.ui.woopos.home.items.coupons.creation.WooPosCouponCreationFacade
 import com.woocommerce.android.ui.woopos.home.items.variations.WooPosVariationsNavigationData
+import com.woocommerce.android.ui.woopos.localcatalog.DateTimeProvider
 import com.woocommerce.android.ui.woopos.localcatalog.WooPosFullSyncRequirement
 import com.woocommerce.android.ui.woopos.localcatalog.WooPosFullSyncStatusChecker
 import com.woocommerce.android.ui.woopos.util.analytics.WooPosAnalyticsEvent
@@ -19,6 +20,7 @@ import com.woocommerce.android.ui.woopos.util.analytics.WooPosAnalyticsEvent.Eve
 import com.woocommerce.android.ui.woopos.util.analytics.WooPosAnalyticsEventConstant
 import com.woocommerce.android.ui.woopos.util.analytics.WooPosAnalyticsTracker
 import com.woocommerce.android.ui.woopos.util.datastore.WooPosPreferencesRepository
+import com.woocommerce.android.ui.woopos.util.datastore.WooPosSyncTimestampManager
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharingStarted
@@ -38,6 +40,8 @@ class WooPosItemsViewModel @Inject constructor(
     private val preferencesRepository: WooPosPreferencesRepository,
     private val analyticsTracker: WooPosAnalyticsTracker,
     private val syncStatusChecker: WooPosFullSyncStatusChecker,
+    private val syncTimestampManager: WooPosSyncTimestampManager,
+    private val dateTimeProvider: DateTimeProvider,
 ) : ViewModel() {
     private var preservedStateBeforeOpeningVariations: WooPosItemsToolbarViewState? = null
     private val _viewState = MutableStateFlow<WooPosItemsToolbarViewState>(initialState())
@@ -72,6 +76,7 @@ class WooPosItemsViewModel @Inject constructor(
             _catalogSyncOverdueBannerState.value = when (requirement) {
                 is WooPosFullSyncRequirement.NonBlockingRequired -> {
                     if (requirement.isOverdue) {
+                        trackStaleWarningShown(requirement.lastSyncTimestamp)
                         CatalogSyncOverdueBannerState.Visible
                     } else {
                         CatalogSyncOverdueBannerState.Hidden
@@ -79,6 +84,18 @@ class WooPosItemsViewModel @Inject constructor(
                 }
                 else -> CatalogSyncOverdueBannerState.Hidden
             }
+        }
+    }
+
+    private fun trackStaleWarningShown(lastSyncTimestamp: Long) {
+        viewModelScope.launch {
+            val currentTime = dateTimeProvider.now()
+            val timeDifferenceMs = currentTime - lastSyncTimestamp
+            val hoursSinceLastSync = (timeDifferenceMs / (1000 * 60 * 60)).toInt()
+
+            analyticsTracker.track(
+                WooPosAnalyticsEvent.Event.LocalCatalogStaleWarningShown(hoursSinceLastSync)
+            )
         }
     }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/items/WooPosItemsViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/items/WooPosItemsViewModel.kt
@@ -118,6 +118,11 @@ class WooPosItemsViewModel @Inject constructor(
             is WooPosItemsUIEvent.AddCouponIconClicked -> createAndAddCoupon()
             WooPosItemsUIEvent.SyncOverdueBannerDismissed -> {
                 _catalogSyncOverdueBannerState.value = CatalogSyncOverdueBannerState.Hidden
+                viewModelScope.launch {
+                    analyticsTracker.track(
+                        WooPosAnalyticsEvent.Event.LocalCatalogStaleWarningDismissed
+                    )
+                }
             }
         }
     }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/util/analytics/WooPosAnalyticsEvent.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/util/analytics/WooPosAnalyticsEvent.kt
@@ -795,6 +795,18 @@ sealed class WooPosAnalyticsEvent : IAnalyticsEvent {
             override val name: String = "local_catalog_downloading_screen_exit_pos_tapped"
         }
 
+        data class LocalCatalogStaleWarningShown(val hoursSinceLastSync: Int) : Event() {
+            override val name: String = "local_catalog_stale_warning_shown"
+
+            init {
+                addProperties(
+                    mapOf(
+                        "hours_since_last_sync" to hoursSinceLastSync.toString()
+                    )
+                )
+            }
+        }
+
         data object SplashScreenErrorShown : Event() {
             override val name: String = "splash_screen_error_shown"
         }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/util/analytics/WooPosAnalyticsEvent.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/util/analytics/WooPosAnalyticsEvent.kt
@@ -807,6 +807,10 @@ sealed class WooPosAnalyticsEvent : IAnalyticsEvent {
             }
         }
 
+        data object LocalCatalogStaleWarningDismissed : Event() {
+            override val name: String = "local_catalog_stale_warning_dismissed"
+        }
+
         data object SplashScreenErrorShown : Event() {
             override val name: String = "splash_screen_error_shown"
         }

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/home/items/WooPosItemsViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/home/items/WooPosItemsViewModelTest.kt
@@ -18,7 +18,6 @@ import com.woocommerce.android.ui.woopos.util.analytics.WooPosAnalyticsEvent.Eve
 import com.woocommerce.android.ui.woopos.util.analytics.WooPosAnalyticsEventConstant
 import com.woocommerce.android.ui.woopos.util.analytics.WooPosAnalyticsTracker
 import com.woocommerce.android.ui.woopos.util.datastore.WooPosPreferencesRepository
-import com.woocommerce.android.ui.woopos.util.datastore.WooPosSyncTimestampManager
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.runBlocking
@@ -61,7 +60,6 @@ class WooPosItemsViewModelTest {
     private val parentToChildrenEventReceiver: WooPosParentToChildrenEventReceiver = mock()
     private val preferencesRepository: WooPosPreferencesRepository = mock()
     private val syncStatusChecker: WooPosFullSyncStatusChecker = mock()
-    private val syncTimestampManager: WooPosSyncTimestampManager = mock()
     private val dateTimeProvider: DateTimeProvider = mock()
 
     @Before
@@ -509,7 +507,6 @@ class WooPosItemsViewModelTest {
             preferencesRepository = preferencesRepository,
             analyticsTracker = analyticsTracker,
             syncStatusChecker = syncStatusChecker,
-            syncTimestampManager = syncTimestampManager,
             dateTimeProvider = dateTimeProvider,
         )
     }

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/home/items/WooPosItemsViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/home/items/WooPosItemsViewModelTest.kt
@@ -479,6 +479,27 @@ class WooPosItemsViewModelTest {
     }
 
     @Test
+    fun `given stale warning shown, when dismiss tapped, then stale warning dismissed event is sent`() = runTest {
+        // GIVEN
+        val currentTime = 1000000L
+        val lastSyncTime = currentTime - (25 * 60 * 60 * 1000L)
+        val expectedHours = 25
+
+        whenever(dateTimeProvider.now()).thenReturn(currentTime)
+        whenever(syncStatusChecker.checkSyncRequirement()).thenReturn(
+            WooPosFullSyncRequirement.NonBlockingRequired(lastSyncTime, isOverdue = true)
+        )
+        val vm = createViewModel()
+
+        // WHEN
+        vm.onUIEvent(WooPosItemsUIEvent.SyncOverdueBannerDismissed)
+        // THEN
+        verify(analyticsTracker).track(
+            eq(WooPosAnalyticsEvent.Event.LocalCatalogStaleWarningDismissed)
+        )
+    }
+
+    @Test
     fun `given sync not overdue, when view model created, then no stale warning tracking event is sent`() = runTest {
         // GIVEN
         whenever(syncStatusChecker.checkSyncRequirement()).thenReturn(

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/home/items/WooPosItemsViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/home/items/WooPosItemsViewModelTest.kt
@@ -9,6 +9,8 @@ import com.woocommerce.android.ui.woopos.home.WooPosChildrenToParentEventSender
 import com.woocommerce.android.ui.woopos.home.WooPosParentToChildrenEventReceiver
 import com.woocommerce.android.ui.woopos.home.items.WooPosItemsViewModel.ItemClickedData
 import com.woocommerce.android.ui.woopos.home.items.coupons.creation.WooPosCouponCreationFacade
+import com.woocommerce.android.ui.woopos.localcatalog.DateTimeProvider
+import com.woocommerce.android.ui.woopos.localcatalog.WooPosFullSyncRequirement
 import com.woocommerce.android.ui.woopos.localcatalog.WooPosFullSyncStatusChecker
 import com.woocommerce.android.ui.woopos.util.WooPosCoroutineTestRule
 import com.woocommerce.android.ui.woopos.util.analytics.WooPosAnalyticsEvent
@@ -16,8 +18,10 @@ import com.woocommerce.android.ui.woopos.util.analytics.WooPosAnalyticsEvent.Eve
 import com.woocommerce.android.ui.woopos.util.analytics.WooPosAnalyticsEventConstant
 import com.woocommerce.android.ui.woopos.util.analytics.WooPosAnalyticsTracker
 import com.woocommerce.android.ui.woopos.util.datastore.WooPosPreferencesRepository
+import com.woocommerce.android.ui.woopos.util.datastore.WooPosSyncTimestampManager
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.test.runTest
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.Before
@@ -57,15 +61,21 @@ class WooPosItemsViewModelTest {
     private val parentToChildrenEventReceiver: WooPosParentToChildrenEventReceiver = mock()
     private val preferencesRepository: WooPosPreferencesRepository = mock()
     private val syncStatusChecker: WooPosFullSyncStatusChecker = mock()
+    private val syncTimestampManager: WooPosSyncTimestampManager = mock()
+    private val dateTimeProvider: DateTimeProvider = mock()
 
     @Before
-    fun setup() {
+    fun setup() = runTest {
         whenever(searchHelper.getInitialSearchState()).thenReturn(
             WooPosItemsToolbarViewState.SearchState.Visible(
                 state = WooPosSearchInputState.Closed
             )
         )
         whenever(parentToChildrenEventReceiver.events).thenReturn(flowOf())
+        whenever(syncStatusChecker.checkSyncRequirement()).thenReturn(
+            WooPosFullSyncRequirement.NotRequired(System.currentTimeMillis())
+        )
+        whenever(dateTimeProvider.now()).thenReturn(1000)
     }
 
     @Test
@@ -450,6 +460,45 @@ class WooPosItemsViewModelTest {
         verify(preferencesRepository).setWasOpenedOnce(true)
     }
 
+    @Test
+    fun `given sync overdue, when view model created, then stale warning tracking event is sent`() = runTest {
+        // GIVEN
+        val currentTime = 1000000L
+        val lastSyncTime = currentTime - (25 * 60 * 60 * 1000L)
+        val expectedHours = 25
+
+        whenever(dateTimeProvider.now()).thenReturn(currentTime)
+        whenever(syncStatusChecker.checkSyncRequirement()).thenReturn(
+            WooPosFullSyncRequirement.NonBlockingRequired(lastSyncTime, isOverdue = true)
+        )
+
+        // WHEN
+        createViewModel()
+
+        // THEN
+        verify(analyticsTracker).track(
+            eq(WooPosAnalyticsEvent.Event.LocalCatalogStaleWarningShown(expectedHours))
+        )
+    }
+
+    @Test
+    fun `given sync not overdue, when view model created, then no stale warning tracking event is sent`() = runTest {
+        // GIVEN
+        runBlocking {
+            whenever(syncStatusChecker.checkSyncRequirement()).thenReturn(
+                WooPosFullSyncRequirement.NonBlockingRequired(System.currentTimeMillis(), isOverdue = false)
+            )
+        }
+
+        // WHEN
+        createViewModel()
+
+        // THEN
+        verify(analyticsTracker, org.mockito.kotlin.never()).track(
+            any<WooPosAnalyticsEvent.Event.LocalCatalogStaleWarningShown>()
+        )
+    }
+
     private fun createViewModel(): WooPosItemsViewModel {
         return WooPosItemsViewModel(
             searchHelper = searchHelper,
@@ -460,6 +509,8 @@ class WooPosItemsViewModelTest {
             preferencesRepository = preferencesRepository,
             analyticsTracker = analyticsTracker,
             syncStatusChecker = syncStatusChecker,
+            syncTimestampManager = syncTimestampManager,
+            dateTimeProvider = dateTimeProvider,
         )
     }
 }

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/home/items/WooPosItemsViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/home/items/WooPosItemsViewModelTest.kt
@@ -20,7 +20,6 @@ import com.woocommerce.android.ui.woopos.util.analytics.WooPosAnalyticsTracker
 import com.woocommerce.android.ui.woopos.util.datastore.WooPosPreferencesRepository
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.flowOf
-import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.test.runTest
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.Before
@@ -482,11 +481,9 @@ class WooPosItemsViewModelTest {
     @Test
     fun `given sync not overdue, when view model created, then no stale warning tracking event is sent`() = runTest {
         // GIVEN
-        runBlocking {
-            whenever(syncStatusChecker.checkSyncRequirement()).thenReturn(
-                WooPosFullSyncRequirement.NonBlockingRequired(System.currentTimeMillis(), isOverdue = false)
-            )
-        }
+        whenever(syncStatusChecker.checkSyncRequirement()).thenReturn(
+            WooPosFullSyncRequirement.NonBlockingRequired(System.currentTimeMillis(), isOverdue = false)
+        )
 
         // WHEN
         createViewModel()


### PR DESCRIPTION
Fixes WOOMOB-1840

### Description
This PR adds analytics tracking for when the stale catalog warning dialog is displayed and dismissed. The shown event tracks how long it's been since the last sync, which will help us understand user patterns and optimize the sync frequency thresholds.

The tracking events includes:
- Event name: `local_catalog_stale_warning_shown` + Attribute: `hours_since_last_sync` - calculated time difference between current time and last sync timestamp in hours
- Event name: `local_catalog_stale_warning_dismissed`

### Test Steps

1. Open the WooCommerce app with Wasabi build
2. Navigate to the POS tab
3. To test the stale warning display:
   - **Note for reviewer**: You may want to temporarily modify the threshold constants in `WooPosFullSyncStatusChecker.kt` to make testing easier:
     - Change `FULL_SYNC_OVERDUE_THRESHOLD` from `7.days` to something shorter like `1.minutes`
     - Change `FULL_SYNC_NOT_REQUIRED_THRESHOLD` from `23.hours` to something shorter like `30.seconds`
4. Wait for the sync to become overdue based on your modified thresholds
5. Navigate to POS tab or refresh the items list
6. Verify that the yellow warning banner appears at the top of the items list
7. Check analytics events in the logs
8. Dismiss the warning
9. Check analytics event in the logs

### Images/gif
N/A - Analytics tracking change only, no UI changes

- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.