### PR TITLE
[Woo POS][Refunds] Refundable items dialog UI

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/common/composeui/component/WooPosDialogWrapper.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/common/composeui/component/WooPosDialogWrapper.kt
@@ -9,6 +9,8 @@ import androidx.compose.animation.slideInVertically
 import androidx.compose.animation.slideOutVertically
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.navigationBarsPadding
+import androidx.compose.foundation.layout.statusBarsPadding
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.runtime.Composable
@@ -27,7 +29,12 @@ fun WooPosDialogWrapper(
     onDismissRequest: () -> Unit,
     content: @Composable AnimatedVisibilityScope.() -> Unit
 ) {
-    Box(contentAlignment = Alignment.Center) {
+    Box(
+        contentAlignment = Alignment.Center,
+        modifier = Modifier
+            .statusBarsPadding()
+            .navigationBarsPadding()
+    ) {
         WooPosBackgroundOverlay(
             modifier = Modifier
                 .semantics {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/orders/WooPosIssueRefundDialog.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/orders/WooPosIssueRefundDialog.kt
@@ -1,76 +1,335 @@
 package com.woocommerce.android.ui.woopos.orders
 
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.itemsIndexed
+import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Close
+import androidx.compose.material.icons.outlined.Inventory2
+import androidx.compose.material3.Checkbox
+import androidx.compose.material3.CheckboxDefaults
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.semantics.contentDescription
+import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.dp
+import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.woocommerce.android.R
 import com.woocommerce.android.ui.woopos.common.composeui.WooPosPreview
+import com.woocommerce.android.ui.woopos.common.composeui.component.WooPosButton
 import com.woocommerce.android.ui.woopos.common.composeui.component.WooPosDialogWrapper
+import com.woocommerce.android.ui.woopos.common.composeui.component.WooPosItemImage
 import com.woocommerce.android.ui.woopos.common.composeui.component.WooPosText
+import com.woocommerce.android.ui.woopos.common.composeui.designsystem.WooPosCornerRadius
 import com.woocommerce.android.ui.woopos.common.composeui.designsystem.WooPosSpacing
 import com.woocommerce.android.ui.woopos.common.composeui.designsystem.WooPosTheme
 import com.woocommerce.android.ui.woopos.common.composeui.designsystem.WooPosTypography
+import java.math.BigDecimal
 
 @Composable
 fun WooPosIssueRefundDialog(
-    isVisible: Boolean,
     orderId: Long,
-    onDismissRequest: () -> Unit
+    onDismissRequest: () -> Unit,
+    onContinue: () -> Unit
 ) {
+    val viewModel: WooPosRefundViewModel =
+        hiltViewModel<WooPosRefundViewModel, WooPosRefundViewModel.Factory> { factory ->
+            factory.create(orderId)
+        }
+    val state by viewModel.state.collectAsStateWithLifecycle()
+
     WooPosDialogWrapper(
-        isVisible = isVisible,
+        isVisible = true,
         dialogBackgroundContentDescription = stringResource(
             R.string.woopos_orders_issue_refund_content_description
         ),
         onDismissRequest = onDismissRequest
     ) {
-        Column(
-            modifier = Modifier
-                .fillMaxWidth()
-                .padding(WooPosSpacing.Large.value),
-            horizontalAlignment = Alignment.CenterHorizontally
-        ) {
-            IconButton(
-                onClick = onDismissRequest,
-                modifier = Modifier.align(Alignment.End)
-            ) {
-                Icon(
-                    imageVector = Icons.Default.Close,
-                    contentDescription = stringResource(R.string.close),
-                    tint = MaterialTheme.colorScheme.onSurface
+        when (val currentState = state) {
+            is WooPosRefundState.Loading -> {
+                LoadingContent()
+            }
+            is WooPosRefundState.Content -> {
+                RefundDialogContent(
+                    state = currentState,
+                    onDismissRequest = onDismissRequest,
+                    onContinue = onContinue
                 )
             }
+            is WooPosRefundState.Error -> {
+                ErrorContent(
+                    message = currentState.message,
+                    onDismissRequest = onDismissRequest
+                )
+            }
+            is WooPosRefundState.NoRefundableItems -> {
+                NoItemsContent(onDismissRequest = onDismissRequest)
+            }
+        }
+    }
+}
 
-            Spacer(Modifier.height(WooPosSpacing.Medium.value))
+@Composable
+private fun LoadingContent() {
+    Box(
+        modifier = Modifier
+            .fillMaxSize()
+            .padding(WooPosSpacing.XLarge.value),
+        contentAlignment = Alignment.Center
+    ) {
+        CircularProgressIndicator()
+    }
+}
 
-            WooPosText(
-                text = stringResource(R.string.orderdetail_issue_refund_button),
-                style = WooPosTypography.Heading,
-                fontWeight = FontWeight.Bold,
-                color = MaterialTheme.colorScheme.onSurface
+@Composable
+private fun ErrorContent(
+    message: String,
+    onDismissRequest: () -> Unit
+) {
+    Column(
+        modifier = Modifier
+            .fillMaxSize()
+            .padding(WooPosSpacing.XLarge.value),
+        horizontalAlignment = Alignment.CenterHorizontally,
+        verticalArrangement = Arrangement.Center
+    ) {
+        WooPosText(
+            text = message,
+            style = WooPosTypography.BodyLarge,
+            color = MaterialTheme.colorScheme.error,
+            textAlign = TextAlign.Center
+        )
+        Spacer(modifier = Modifier.size(WooPosSpacing.Large.value))
+        WooPosButton(
+            text = stringResource(R.string.close),
+            onClick = onDismissRequest
+        )
+    }
+}
+
+@Composable
+private fun NoItemsContent(onDismissRequest: () -> Unit) {
+    Column(
+        modifier = Modifier
+            .fillMaxSize()
+            .padding(WooPosSpacing.XLarge.value),
+        horizontalAlignment = Alignment.CenterHorizontally,
+        verticalArrangement = Arrangement.Center
+    ) {
+        WooPosText(
+            text = "No items available for refund",
+            style = WooPosTypography.BodyLarge,
+            color = MaterialTheme.colorScheme.onSurface,
+            textAlign = TextAlign.Center
+        )
+        Spacer(modifier = Modifier.size(WooPosSpacing.Large.value))
+        WooPosButton(
+            text = stringResource(R.string.close),
+            onClick = onDismissRequest
+        )
+    }
+}
+
+@Composable
+private fun RefundDialogContent(
+    state: WooPosRefundState.Content,
+    onDismissRequest: () -> Unit,
+    onContinue: () -> Unit
+) {
+    Column(modifier = Modifier.fillMaxSize()) {
+        RefundDialogHeader(onDismissRequest = onDismissRequest)
+
+        ItemsHeaderRow(itemsCount = state.itemsCount)
+
+        HorizontalDivider(
+            modifier = Modifier.padding(horizontal = WooPosSpacing.XLarge.value),
+            color = WooPosTheme.colors.outlineVariant,
+            thickness = 0.25.dp
+        )
+
+        LazyColumn(
+            modifier = Modifier
+                .weight(1f)
+                .fillMaxWidth()
+                .padding(horizontal = WooPosSpacing.XLarge.value)
+                .padding(vertical = WooPosSpacing.Medium.value),
+            verticalArrangement = Arrangement.spacedBy(WooPosSpacing.Medium.value)
+        ) {
+            itemsIndexed(state.refundableItems) { index, item ->
+                RefundableItemRow(item = item)
+                if (index < state.refundableItems.lastIndex) {
+                    HorizontalDivider(
+                        color = WooPosTheme.colors.outlineVariant,
+                        thickness = 0.25.dp
+                    )
+                }
+            }
+        }
+
+        HorizontalDivider(
+            modifier = Modifier.padding(horizontal = WooPosSpacing.XLarge.value),
+            color = WooPosTheme.colors.outlineVariant,
+            thickness = 0.25.dp
+        )
+
+        WooPosButton(
+            text = stringResource(R.string.continue_button),
+            onClick = onContinue,
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(WooPosSpacing.XLarge.value)
+        )
+    }
+}
+
+@Composable
+private fun RefundDialogHeader(onDismissRequest: () -> Unit) {
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(WooPosSpacing.XLarge.value),
+        horizontalArrangement = Arrangement.SpaceBetween,
+        verticalAlignment = Alignment.CenterVertically
+    ) {
+        WooPosText(
+            text = stringResource(R.string.woopos_orders_select_items_to_refund),
+            style = WooPosTypography.Heading,
+            fontWeight = FontWeight.Bold,
+            color = MaterialTheme.colorScheme.onSurface
+        )
+        IconButton(
+            modifier = Modifier.size(48.dp),
+            onClick = onDismissRequest,
+        ) {
+            Icon(
+                modifier = Modifier.size(32.dp),
+                imageVector = Icons.Default.Close,
+                contentDescription = stringResource(R.string.close),
+                tint = MaterialTheme.colorScheme.onSurface
             )
+        }
+    }
+}
 
-            Spacer(Modifier.height(WooPosSpacing.Large.value))
-
+@Composable
+private fun ItemsHeaderRow(itemsCount: Int) {
+    val selectAllContentDescription = stringResource(R.string.order_refunds_items_select_all)
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(horizontal = WooPosSpacing.XLarge.value)
+            .padding(bottom = WooPosSpacing.Medium.value),
+        verticalAlignment = Alignment.CenterVertically
+    ) {
+        Checkbox(
+            checked = true,
+            onCheckedChange = null,
+            modifier = Modifier
+                .size(32.dp)
+                .semantics {
+                    contentDescription = selectAllContentDescription
+                },
+            colors = CheckboxDefaults.colors(
+                checkedColor = MaterialTheme.colorScheme.primary,
+                checkmarkColor = MaterialTheme.colorScheme.onPrimary,
+                disabledCheckedColor = MaterialTheme.colorScheme.primary
+            )
+        )
+        Spacer(modifier = Modifier.width(WooPosSpacing.Large.value))
+        Row {
             WooPosText(
-                text = "Refund flow coming soon for order #$orderId",
+                text = stringResource(R.string.woopos_orders_select_all_items),
+                style = WooPosTypography.Caption,
+                fontWeight = FontWeight.Bold,
+                color = WooPosTheme.colors.onSurfaceVariantHighest
+            )
+            WooPosText(
+                text = " ",
+                style = WooPosTypography.Caption
+            )
+            WooPosText(
+                text = stringResource(R.string.woopos_orders_items_selected_count, itemsCount),
+                style = WooPosTypography.Caption,
+                fontWeight = FontWeight.Normal,
+                color = WooPosTheme.colors.onSurfaceVariantLowest
+            )
+        }
+    }
+}
+
+@Composable
+private fun RefundableItemRow(item: WooPosRefundableItem) {
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(vertical = WooPosSpacing.XSmall.value),
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        Checkbox(
+            checked = true,
+            onCheckedChange = null,
+            modifier = Modifier
+                .size(32.dp)
+                .semantics {
+                    contentDescription = item.name
+                },
+            colors = CheckboxDefaults.colors(
+                checkedColor = MaterialTheme.colorScheme.primary,
+                checkmarkColor = MaterialTheme.colorScheme.onPrimary,
+                disabledCheckedColor = MaterialTheme.colorScheme.primary
+            )
+        )
+        Spacer(modifier = Modifier.size(WooPosSpacing.Large.value))
+
+        WooPosItemImage(
+            modifier = Modifier
+                .size(56.dp)
+                .clip(RoundedCornerShape(WooPosCornerRadius.Small.value)),
+            imageUrl = null,
+            placeholderIcon = Icons.Outlined.Inventory2,
+            placeholderIconSize = 24.dp
+        )
+        Spacer(modifier = Modifier.size(WooPosSpacing.Medium.value))
+
+        Column(
+            modifier = Modifier.weight(1f),
+        ) {
+            WooPosText(
+                text = item.name,
+                style = WooPosTypography.BodyLarge,
+                fontWeight = FontWeight.Bold,
+                color = MaterialTheme.colorScheme.onSurface,
+                maxLines = 1,
+                overflow = TextOverflow.Ellipsis
+            )
+            WooPosText(
+                text = item.formattedUnitPrice,
                 style = WooPosTypography.BodyMedium,
                 color = WooPosTheme.colors.onSurfaceVariantHighest
             )
-
-            Spacer(Modifier.height(WooPosSpacing.Large.value))
         }
     }
 }
@@ -78,11 +337,58 @@ fun WooPosIssueRefundDialog(
 @WooPosPreview
 @Composable
 fun WooPosIssueRefundDialogPreview() {
+    val sampleItems = listOf(
+        WooPosRefundableItem(
+            orderItemId = 1,
+            productId = 100,
+            variationId = 0,
+            name = "Cup",
+            unitPrice = BigDecimal("18.00"),
+            unitTax = BigDecimal("1.80"),
+            formattedUnitPrice = "$18.00",
+            formattedUnitTax = "$1.80",
+            rowIndex = 0
+        ),
+        WooPosRefundableItem(
+            orderItemId = 2,
+            productId = 200,
+            variationId = 0,
+            name = "Coffee Storage Container",
+            unitPrice = BigDecimal("30.00"),
+            unitTax = BigDecimal("3.00"),
+            formattedUnitPrice = "$30.00",
+            formattedUnitTax = "$3.00",
+            rowIndex = 0
+        ),
+        WooPosRefundableItem(
+            orderItemId = 3,
+            productId = 300,
+            variationId = 0,
+            name = "Enamel Mug",
+            unitPrice = BigDecimal("8.50"),
+            unitTax = BigDecimal("0.85"),
+            formattedUnitPrice = "$8.50",
+            formattedUnitTax = "$0.85",
+            rowIndex = 0
+        )
+    )
+
+    val state = WooPosRefundState.Content(
+        orderId = 123,
+        orderNumber = "#123",
+        currency = "USD",
+        refundableItems = sampleItems,
+        itemsCount = 3,
+        subtotal = BigDecimal("57.00"),
+        taxes = BigDecimal("5.65"),
+        total = BigDecimal("62.65")
+    )
+
     WooPosTheme {
-        WooPosIssueRefundDialog(
-            isVisible = true,
-            orderId = 123L,
-            onDismissRequest = {}
+        RefundDialogContent(
+            state = state,
+            onDismissRequest = {},
+            onContinue = {}
         )
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/orders/WooPosIssueRefundDialog.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/orders/WooPosIssueRefundDialog.kt
@@ -145,7 +145,7 @@ private fun NoItemsContent(onDismissRequest: () -> Unit) {
         verticalArrangement = Arrangement.Center
     ) {
         WooPosText(
-            text = "No items available for refund",
+            text = stringResource(R.string.woopos_orders_no_items_available_for_refund),
             style = WooPosTypography.BodyLarge,
             color = MaterialTheme.colorScheme.onSurface,
             textAlign = TextAlign.Center

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/orders/WooPosIssueRefundDialog.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/orders/WooPosIssueRefundDialog.kt
@@ -271,10 +271,7 @@ private fun ItemsHeaderRow(itemsCount: Int) {
                 fontWeight = FontWeight.Bold,
                 color = WooPosTheme.colors.onSurfaceVariantHighest
             )
-            WooPosText(
-                text = " ",
-                style = WooPosTypography.Caption
-            )
+            Spacer(modifier = Modifier.width(WooPosSpacing.XSmall.value))
             WooPosText(
                 text = stringResource(R.string.woopos_orders_items_selected_count, itemsCount),
                 style = WooPosTypography.Caption,

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/orders/WooPosIssueRefundDialog.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/orders/WooPosIssueRefundDialog.kt
@@ -94,13 +94,18 @@ fun WooPosIssueRefundDialog(
 
 @Composable
 private fun LoadingContent() {
+    val loadingDescription = stringResource(R.string.woopos_orders_loading_refund_items)
     Box(
         modifier = Modifier
             .fillMaxSize()
             .padding(WooPosSpacing.XLarge.value),
         contentAlignment = Alignment.Center
     ) {
-        CircularProgressIndicator()
+        CircularProgressIndicator(
+            modifier = Modifier.semantics {
+                contentDescription = loadingDescription
+            }
+        )
     }
 }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/orders/WooPosOrdersDetails.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/orders/WooPosOrdersDetails.kt
@@ -12,6 +12,7 @@ import androidx.compose.foundation.layout.heightIn
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.statusBarsPadding
+import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.verticalScroll

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/orders/WooPosOrdersScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/orders/WooPosOrdersScreen.kt
@@ -172,6 +172,19 @@ private fun WooPosOrdersScreen(
                     .statusBarsPadding()
             )
         }
+
+        if (state is WooPosOrdersState.Content) {
+            when (val dialogState = state.dialogState) {
+                is WooPosOrdersState.Content.DialogState.IssueRefund -> {
+                    WooPosIssueRefundDialog(
+                        orderId = dialogState.orderId,
+                        onDismissRequest = onIssueRefundDialogDismissed,
+                        onContinue = onIssueRefundDialogDismissed
+                    )
+                }
+                WooPosOrdersState.Content.DialogState.Hidden -> Unit
+            }
+        }
     }
 }
 
@@ -217,17 +230,6 @@ private fun OrdersContent(
                 onUIEvent = onUIEvent
             )
         }
-    }
-
-    when (val dialogState = state.dialogState) {
-        is WooPosOrdersState.Content.DialogState.IssueRefund -> {
-            WooPosIssueRefundDialog(
-                isVisible = true,
-                orderId = dialogState.orderId,
-                onDismissRequest = onIssueRefundDialogDismissed
-            )
-        }
-        WooPosOrdersState.Content.DialogState.Hidden -> Unit
     }
 }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/orders/WooPosOrdersScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/orders/WooPosOrdersScreen.kt
@@ -146,8 +146,7 @@ private fun WooPosOrdersScreen(
                 onPaginationErrorTryAgain = onPaginationErrorTryAgain,
                 onSearchEvent = onSearchEvent,
                 onSearchErrorRetry = onSearchErrorRetry,
-                onUIEvent = onUIEvent,
-                onIssueRefundDialogDismissed = onIssueRefundDialogDismissed
+                onUIEvent = onUIEvent
             )
 
             is WooPosOrdersState.Empty -> OrdersEmpty(
@@ -198,8 +197,7 @@ private fun OrdersContent(
     onPaginationErrorTryAgain: () -> Unit,
     onSearchEvent: (WooPosSearchUIEvent) -> Unit,
     onSearchErrorRetry: () -> Unit,
-    onUIEvent: (WooPosOrdersUIEvent) -> Unit,
-    onIssueRefundDialogDismissed: () -> Unit
+    onUIEvent: (WooPosOrdersUIEvent) -> Unit
 ) {
     Row(modifier = Modifier.fillMaxSize()) {
         OrdersListPane(

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/orders/WooPosOrdersState.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/orders/WooPosOrdersState.kt
@@ -108,7 +108,9 @@ sealed class WooPosOrdersState {
 
         sealed class DialogState {
             data object Hidden : DialogState()
-            data class IssueRefund(val orderId: Long) : DialogState()
+            data class IssueRefund(
+                val orderId: Long
+            ) : DialogState()
         }
     }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/orders/WooPosOrdersViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/orders/WooPosOrdersViewModel.kt
@@ -204,7 +204,9 @@ class WooPosOrdersViewModel @Inject constructor(
     fun onIssueRefundButtonClicked(orderId: Long) {
         val currentState = _state.value as? WooPosOrdersState.Content ?: return
         _state.value = currentState.copy(
-            dialogState = WooPosOrdersState.Content.DialogState.IssueRefund(orderId)
+            dialogState = WooPosOrdersState.Content.DialogState.IssueRefund(
+                orderId = orderId
+            )
         )
     }
 

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -3799,7 +3799,6 @@
     <string name="woopos_orders_email_receipt">Email receipt</string>
     <string name="woopos_orders_issue_refund_content_description">Issue a refund for this order</string>
     <string name="woopos_orders_select_items_to_refund">Select items to refund</string>
-    <string name="woopos_orders_items_selected">ITEMS (%1$d SELECTED)</string>
     <string name="woopos_orders_select_all_items">SELECT ALL ITEMS</string>
     <string name="woopos_orders_items_selected_count">(%1$d SELECTED)</string>
     <string name="woopos_orders_details_placeholder_title">Select an order</string>

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -3801,6 +3801,8 @@
     <string name="woopos_orders_select_items_to_refund">Select items to refund</string>
     <string name="woopos_orders_select_all_items">SELECT ALL ITEMS</string>
     <string name="woopos_orders_items_selected_count">(%1$d SELECTED)</string>
+    <string name="woopos_orders_loading_refund_items">Loading refundable items</string>
+    <string name="woopos_orders_no_items_available_for_refund">No items available for refund</string>
     <string name="woopos_orders_details_placeholder_title">Select an order</string>
     <string name="woopos_orders_details_placeholder_message">Choose an order from the list to view details.</string>
     <string name="woopos_orders_details_products_title">Products</string>

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -3802,8 +3802,6 @@
     <string name="woopos_orders_items_selected">ITEMS (%1$d SELECTED)</string>
     <string name="woopos_orders_select_all_items">SELECT ALL ITEMS</string>
     <string name="woopos_orders_items_selected_count">(%1$d SELECTED)</string>
-    <string name="woopos_orders_amount">AMOUNT</string>
-    <string name="woopos_orders_tax">TAX</string>
     <string name="woopos_orders_details_placeholder_title">Select an order</string>
     <string name="woopos_orders_details_placeholder_message">Choose an order from the list to view details.</string>
     <string name="woopos_orders_details_products_title">Products</string>

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -3798,6 +3798,12 @@
 
     <string name="woopos_orders_email_receipt">Email receipt</string>
     <string name="woopos_orders_issue_refund_content_description">Issue a refund for this order</string>
+    <string name="woopos_orders_select_items_to_refund">Select items to refund</string>
+    <string name="woopos_orders_items_selected">ITEMS (%1$d SELECTED)</string>
+    <string name="woopos_orders_select_all_items">SELECT ALL ITEMS</string>
+    <string name="woopos_orders_items_selected_count">(%1$d SELECTED)</string>
+    <string name="woopos_orders_amount">AMOUNT</string>
+    <string name="woopos_orders_tax">TAX</string>
     <string name="woopos_orders_details_placeholder_title">Select an order</string>
     <string name="woopos_orders_details_placeholder_message">Choose an order from the list to view details.</string>
     <string name="woopos_orders_details_products_title">Products</string>


### PR DESCRIPTION
## Description

WOOMOB-1802 part 2/2

This PR follows up on https://github.com/woocommerce/woocommerce-android/pull/15056, and adds UI - layout for the dialog showing refundable item list in `POS > Orders > Order Detail screen`.


**💡 Not included in this PR's scope:**
* Displaying items' images will be added in the next PR.
* Handling items' selection
* Handling system back press
* Loading, empty, error states

## Test Steps
1. Open POS
2. Create an order containing multiple quantities of a specific item
3. Go to Refunds and select that order
4. Tap "Issue Refund" in the order details pane
5. Observe the dialog shows correct list of items

## Images/gif
|grouped items|expanded|
|---|---|
|<img width="2076" height="2152" alt="Screenshot_20251203_180329" src="https://github.com/user-attachments/assets/fb3b7717-d7dd-44f9-bad4-dd5875d3feb1" />|<img width="2076" height="2152" alt="Screenshot_20251203_180336" src="https://github.com/user-attachments/assets/1b541f0c-f87b-47c5-97da-a41de3b59c15" />|

- [x] I have considered if this change warrants release notes and have added them to RELEASE-NOTES.txt if necessary. Use the "[Internal]" label for non-user-facing changes.