### PR TITLE
[WOOMOB-1848] Fix coupon sharing message to display percentage correctly

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/coupons/details/CouponDetailsViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/coupons/details/CouponDetailsViewModel.kt
@@ -184,11 +184,8 @@ class CouponDetailsViewModel @Inject constructor(
     fun onShareButtonClick() {
         coupon.value?.let { coupon ->
             couponUtils.formatSharingMessage(
-                amount = coupon.amount,
-                currencyCode = currencyCode,
-                couponCode = coupon.code,
-                includedProducts = coupon.productIds.size,
-                excludedProducts = coupon.restrictions.excludedProductIds.size
+                coupon = coupon,
+                currencyCode = currencyCode
             )
         }?.let {
             triggerEvent(ShareCodeEvent(it))

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/util/CouponUtils.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/util/CouponUtils.kt
@@ -160,23 +160,26 @@ class CouponUtils @Inject constructor(
     - If only some products: "Apply 15% off to select products with the promo code ABCDE"
      */
     fun formatSharingMessage(
-        amount: BigDecimal?,
-        currencyCode: String?,
-        couponCode: String?,
-        includedProducts: Int,
-        excludedProducts: Int
+        coupon: Coupon,
+        currencyCode: String?
     ): String? {
+        val amount = coupon.amount
+        val couponCode = coupon.code
+        val includedProducts = coupon.productIds.size
+        val excludedProducts = coupon.restrictions.excludedProductIds.size
+
         return if (amount != null && currencyCode != null && couponCode != null) {
+            val formattedDiscount = formatDiscount(amount, coupon.type, currencyCode)
             if (includedProducts == 0 && excludedProducts == 0) {
                 resourceProvider.getString(
                     R.string.coupon_details_share_coupon_all,
-                    formatCurrency(amount, currencyCode),
+                    formattedDiscount,
                     couponCode
                 )
             } else {
                 resourceProvider.getString(
                     R.string.coupon_details_share_coupon_some,
-                    formatCurrency(amount, currencyCode),
+                    formattedDiscount,
                     couponCode
                 )
             }

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/util/CouponUtilsTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/util/CouponUtilsTest.kt
@@ -1,0 +1,220 @@
+package com.woocommerce.android.util
+
+import com.woocommerce.android.R
+import com.woocommerce.android.model.Coupon
+import com.woocommerce.android.ui.coupons.CouponTestUtils
+import com.woocommerce.android.viewmodel.BaseUnitTest
+import com.woocommerce.android.viewmodel.ResourceProvider
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.Before
+import org.junit.Test
+import org.mockito.kotlin.any
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.whenever
+import java.math.BigDecimal
+
+@ExperimentalCoroutinesApi
+class CouponUtilsTest : BaseUnitTest() {
+
+    private lateinit var couponUtils: CouponUtils
+    private val currencyFormatter: CurrencyFormatter = mock()
+    private val resourceProvider: ResourceProvider = mock()
+
+    @Before
+    fun setup() {
+        couponUtils = CouponUtils(
+            currencyFormatter = currencyFormatter,
+            resourceProvider = resourceProvider
+        )
+
+        whenever(currencyFormatter.formatCurrency(any<BigDecimal>(), any<String>(), any())).then { invocation ->
+            val amount = invocation.arguments[0] as BigDecimal
+            val currencyCode = invocation.arguments[1] as String
+            "$currencyCode${amount.toPlainString()}"
+        }
+
+        whenever(resourceProvider.getString(any(), any(), any())).then { invocation ->
+            when (invocation.arguments[0]) {
+                R.string.coupon_details_share_coupon_all -> {
+                    val discount = invocation.arguments[1] as String
+                    val code = invocation.arguments[2] as String
+                    "Apply $discount off to all products with the promo code $code"
+                }
+                R.string.coupon_details_share_coupon_some -> {
+                    val discount = invocation.arguments[1] as String
+                    val code = invocation.arguments[2] as String
+                    "Apply $discount off to select products with the promo code $code"
+                }
+                else -> ""
+            }
+        }
+    }
+
+    @Test
+    fun `given percentage coupon, when formatting sharing message, then shows percentage`() {
+        val coupon = CouponTestUtils.generateTestCoupon(1L, "PERCENT10").copy(
+            type = Coupon.Type.Percent,
+            amount = BigDecimal("10")
+        )
+
+        val result = couponUtils.formatSharingMessage(
+            coupon = coupon,
+            currencyCode = "USD"
+        )
+
+        assertThat(result).isEqualTo("Apply 10% off to all products with the promo code PERCENT10")
+    }
+
+    @Test
+    fun `given fixed cart coupon, when formatting sharing message, then shows currency amount`() {
+        val coupon = CouponTestUtils.generateTestCoupon(1L, "FIXED15").copy(
+            type = Coupon.Type.FixedCart,
+            amount = BigDecimal("15.00")
+        )
+
+        val result = couponUtils.formatSharingMessage(
+            coupon = coupon,
+            currencyCode = "USD"
+        )
+
+        assertThat(result).isEqualTo("Apply USD15.00 off to all products with the promo code FIXED15")
+    }
+
+    @Test
+    fun `given fixed product coupon, when formatting sharing message, then shows currency amount`() {
+        val coupon = CouponTestUtils.generateTestCoupon(1L, "PRODUCT20").copy(
+            type = Coupon.Type.FixedProduct,
+            amount = BigDecimal("20.00")
+        )
+
+        val result = couponUtils.formatSharingMessage(
+            coupon = coupon,
+            currencyCode = "EUR"
+        )
+
+        assertThat(result).isEqualTo("Apply EUR20.00 off to all products with the promo code PRODUCT20")
+    }
+
+    @Test
+    fun `given custom type coupon, when formatting sharing message, then shows plain amount`() {
+        val coupon = CouponTestUtils.generateTestCoupon(1L, "CUSTOM25").copy(
+            type = Coupon.Type.Custom("custom_discount"),
+            amount = BigDecimal("25")
+        )
+
+        val result = couponUtils.formatSharingMessage(
+            coupon = coupon,
+            currencyCode = "USD"
+        )
+
+        assertThat(result).isEqualTo("Apply 25 off to all products with the promo code CUSTOM25")
+    }
+
+    @Test
+    fun `given coupon with included products, when formatting sharing message, then shows select products`() {
+        val coupon = CouponTestUtils.generateTestCoupon(1L, "SELECT10").copy(
+            type = Coupon.Type.Percent,
+            amount = BigDecimal("10"),
+            productIds = listOf(1L, 2L, 3L)
+        )
+
+        val result = couponUtils.formatSharingMessage(
+            coupon = coupon,
+            currencyCode = "USD"
+        )
+
+        assertThat(result).isEqualTo("Apply 10% off to select products with the promo code SELECT10")
+    }
+
+    @Test
+    fun `given coupon with excluded products, when formatting sharing message, then shows select products`() {
+        val coupon = CouponTestUtils.generateTestCoupon(1L, "EXCLUDE5").copy(
+            type = Coupon.Type.Percent,
+            amount = BigDecimal("5"),
+            restrictions = CouponTestUtils.generateCouponRestrictions().copy(
+                excludedProductIds = listOf(4L, 5L)
+            )
+        )
+
+        val result = couponUtils.formatSharingMessage(
+            coupon = coupon,
+            currencyCode = "USD"
+        )
+
+        assertThat(result).isEqualTo("Apply 5% off to select products with the promo code EXCLUDE5")
+    }
+
+    @Test
+    fun `given coupon with null amount, when formatting sharing message, then returns null`() {
+        val coupon = CouponTestUtils.generateTestCoupon(1L, "NULLAMOUNT").copy(
+            amount = null
+        )
+
+        val result = couponUtils.formatSharingMessage(
+            coupon = coupon,
+            currencyCode = "USD"
+        )
+
+        assertThat(result).isNull()
+    }
+
+    @Test
+    fun `given coupon with null code, when formatting sharing message, then returns null`() {
+        val coupon = CouponTestUtils.generateTestCoupon(1L).copy(
+            code = null,
+            amount = BigDecimal("10")
+        )
+
+        val result = couponUtils.formatSharingMessage(
+            coupon = coupon,
+            currencyCode = "USD"
+        )
+
+        assertThat(result).isNull()
+    }
+
+    @Test
+    fun `given null currency code, when formatting sharing message, then returns null`() {
+        val coupon = CouponTestUtils.generateTestCoupon(1L, "NOCURRENCY").copy(
+            amount = BigDecimal("10")
+        )
+
+        val result = couponUtils.formatSharingMessage(
+            coupon = coupon,
+            currencyCode = null
+        )
+
+        assertThat(result).isNull()
+    }
+
+    @Test
+    fun `given percentage coupon with decimal, when formatting sharing message, then shows correct percentage`() {
+        val coupon = CouponTestUtils.generateTestCoupon(1L, "PERCENT7HALF").copy(
+            type = Coupon.Type.Percent,
+            amount = BigDecimal("7.5")
+        )
+
+        val result = couponUtils.formatSharingMessage(
+            coupon = coupon,
+            currencyCode = "USD"
+        )
+
+        assertThat(result).isEqualTo("Apply 7.5% off to all products with the promo code PERCENT7HALF")
+    }
+
+    @Test
+    fun `given coupon with null type, when formatting sharing message, then shows plain amount`() {
+        val coupon = CouponTestUtils.generateTestCoupon(1L, "NOTYPE").copy(
+            type = null,
+            amount = BigDecimal("30")
+        )
+
+        val result = couponUtils.formatSharingMessage(
+            coupon = coupon,
+            currencyCode = "USD"
+        )
+
+        assertThat(result).isEqualTo("Apply 30 off to all products with the promo code NOTYPE")
+    }
+}


### PR DESCRIPTION
Fixes WOOMOB-1848

### Description

Fixed an issue where coupon sharing messages always displayed discount amounts with a currency symbol (e.g., $10.00) even when the coupon was percentage-based. Now percentage coupons correctly display as percentages (e.g., 10%) while fixed amount coupons continue to show currency symbols.

**Changes made:**
- Updated `formatSharingMessage` method in `CouponUtils` to use the existing `formatDiscount` method which properly handles both percentage and currency formatting based on coupon type
- Refactored method signature to accept a `Coupon` object instead of individual parameters to reduce parameter count and fix detekt issues
- Updated the call in `CouponDetailsViewModel` to pass the coupon object and type

### Test Steps

1. Create a percentage-based coupon (e.g., 10% off)
2. Go to coupon details and tap the share button
3. Verify the sharing message shows "Apply 10% off..." instead of "Apply $10.00 off..."
4. Create a fixed amount coupon (e.g., $15 off)
5. Go to coupon details and tap the share button  
6. Verify the sharing message shows "Apply $15.00 off..." with currency symbol

### Images/gif
| Before | After |
| -- | -- |
| <img width="1400" height="1000" alt="Screenshot_20251204_092803" src="https://github.com/user-attachments/assets/70e4203e-64e0-4099-baa0-c9a42c0580ed" /> | <img width="1400" height="1000" alt="Screenshot_20251204_093041" src="https://github.com/user-attachments/assets/50cd2ada-f6a5-41eb-b28d-40c8fcbfc768" /> |



- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.